### PR TITLE
Update Discord links

### DIFF
--- a/resources/docs/simulation/README.md
+++ b/resources/docs/simulation/README.md
@@ -22,7 +22,7 @@ If you want to experiment with pre-built models, check out our examples on the [
 
 ## Community & Support
 
-If you need help or support, check out the [community forum](https://community.hash.ai/) or [join our Discord](https://discord.gg/S3GfQaDbrM) \(this tends to be the fastest means of getting help\). You can also reach out to us directly via our [contact page](https://hash.ai/contact).
+If you need help or support, check out the [community forum](https://community.hash.ai/) or [join our Discord](https://hash.ai/discord) \(this tends to be the fastest means of getting help\). You can also reach out to us directly via our [contact page](https://hash.ai/contact).
 
 ## Upcoming Features
 

--- a/resources/docs/simulation/extra/performance.md
+++ b/resources/docs/simulation/extra/performance.md
@@ -8,7 +8,7 @@ There are several possible reasons your simulation is running slowly. Broadly we
 
 Below we explain these common performance bottlenecks and solutions you can use to improve your simulation's performance. Alternatively you can use [hCloud](../creating-simulations/h.cloud.md) to run simulations on dedicated remote hardware and stream these results back to your local machine.
 
-We're also happy to chat through techniques to improve your simulation's performance in our [Discord](https://discord.gg/S3GfQaDbrM) and [Forum](https://community.hash.ai/).
+We're also happy to chat through techniques to improve your simulation's performance in our [Discord](https://hash.ai/discord) and [Forum](https://community.hash.ai/).
 
 ## Data
 


### PR DESCRIPTION
We have a few legacy Discord links scattered around the docs that will soon hit invite caps. This PR replaces them with a link to https://hash.ai/discord which allows users to sign up without limitation.