### PR TITLE
Add unique objectIDs to each markdown-rendered page

### DIFF
--- a/resources/docs/simulation/README.md
+++ b/resources/docs/simulation/README.md
@@ -1,7 +1,7 @@
 ---
 title: Overview
 slug: simulation
-objectID: d9e39386-bfd1-4bfb-a647-4d07e93b6150
+objectId: d9e39386-bfd1-4bfb-a647-4d07e93b6150
 description: Getting started with simulations in HASH
 ---
 

--- a/resources/docs/simulation/README.md
+++ b/resources/docs/simulation/README.md
@@ -1,4 +1,5 @@
 ---
+objectID: d9e39386-bfd1-4bfb-a647-4d07e93b6150
 description: Getting started with simulations in HASH
 ---
 

--- a/resources/docs/simulation/README.md
+++ b/resources/docs/simulation/README.md
@@ -1,4 +1,6 @@
 ---
+title: Overview
+slug: simulation
 objectID: d9e39386-bfd1-4bfb-a647-4d07e93b6150
 description: Getting started with simulations in HASH
 ---

--- a/resources/docs/simulation/api/hcore.md
+++ b/resources/docs/simulation/api/hcore.md
@@ -1,4 +1,6 @@
 ---
+title: hCore Message API
+slug: simulation/api/hcore
 objectID: c722c4f7-8dfe-4a9b-8565-54cdf19b403c
 ---
 

--- a/resources/docs/simulation/api/hcore.md
+++ b/resources/docs/simulation/api/hcore.md
@@ -1,7 +1,7 @@
 ---
 title: hCore Message API
 slug: simulation/api/hcore
-objectID: c722c4f7-8dfe-4a9b-8565-54cdf19b403c
+objectId: 6388d0b1-43c3-4331-9cd7-8a70feaa0d16}
 ---
 
 # hCore Message API

--- a/resources/docs/simulation/api/hcore.md
+++ b/resources/docs/simulation/api/hcore.md
@@ -1,3 +1,7 @@
+---
+objectID: c722c4f7-8dfe-4a9b-8565-54cdf19b403c
+---
+
 # hCore Message API
 
 hCore provides a messaging API for embedded instances of hCore. You can use the messaging API to edit and set a simulation files and to read the state of a simulation. We'd love your [feedback](/contact) on this feature.

--- a/resources/docs/simulation/api/register-for-access.md
+++ b/resources/docs/simulation/api/register-for-access.md
@@ -1,7 +1,7 @@
 ---
 title: Register for Access
 slug: simulation/api/register-for-access
-objectID: 63347826-b678-4169-88b2-9e644f577cde
+objectId: f0423ea5-4609-4a26-a40c-e03b1230684b
 description: Register for beta access
 ---
 

--- a/resources/docs/simulation/api/register-for-access.md
+++ b/resources/docs/simulation/api/register-for-access.md
@@ -1,4 +1,5 @@
 ---
+objectID: 63347826-b678-4169-88b2-9e644f577cde
 description: Register for beta access
 ---
 

--- a/resources/docs/simulation/api/register-for-access.md
+++ b/resources/docs/simulation/api/register-for-access.md
@@ -1,4 +1,6 @@
 ---
+title: Register for Access
+slug: simulation/api/register-for-access
 objectID: 63347826-b678-4169-88b2-9e644f577cde
 description: Register for beta access
 ---

--- a/resources/docs/simulation/concepts/design-considerations/README.md
+++ b/resources/docs/simulation/concepts/design-considerations/README.md
@@ -1,7 +1,7 @@
 ---
 title: Actor Model
 slug: simulation/concepts/design-considerations
-objectID: 10b70ddb-a88c-4a29-856d-e5a736b6867f
+objectId: d36e9198-f292-4e12-8dbb-7c7f937a7306
 description: >-
   Understanding how agents communicate, influence the world and resolve
   conflicts

--- a/resources/docs/simulation/concepts/design-considerations/README.md
+++ b/resources/docs/simulation/concepts/design-considerations/README.md
@@ -1,4 +1,6 @@
 ---
+title: Actor Model
+slug: simulation/concepts/design-considerations
 objectID: 10b70ddb-a88c-4a29-856d-e5a736b6867f
 description: >-
   Understanding how agents communicate, influence the world and resolve

--- a/resources/docs/simulation/concepts/design-considerations/README.md
+++ b/resources/docs/simulation/concepts/design-considerations/README.md
@@ -1,4 +1,5 @@
 ---
+objectID: 10b70ddb-a88c-4a29-856d-e5a736b6867f
 description: >-
   Understanding how agents communicate, influence the world and resolve
   conflicts

--- a/resources/docs/simulation/concepts/design-considerations/managing-resource-access.md
+++ b/resources/docs/simulation/concepts/design-considerations/managing-resource-access.md
@@ -1,7 +1,7 @@
 ---
 title: Managing Resource Access
 slug: simulation/concepts/design-considerations/managing-resource-access
-objectID: a4b71af2-3608-45e2-b42c-46fda6ad728d
+objectId: 92a2661e-3fc1-4a67-a1ea-152b0ab4dbdf}
 ---
 
 # Managing Resource Access

--- a/resources/docs/simulation/concepts/design-considerations/managing-resource-access.md
+++ b/resources/docs/simulation/concepts/design-considerations/managing-resource-access.md
@@ -1,3 +1,7 @@
+---
+objectID: a4b71af2-3608-45e2-b42c-46fda6ad728d
+---
+
 # Managing Resource Access
 
 Managing shared resource access is a common software design challenge. For instance [mutexes](https://en.wikipedia.org/wiki/Lock_%28computer_science%29) and similar locking mechanisms might be implemented to ensure only one process is modifying the resource at once. To avoid the need for this, **HASH manages state through the actor model, with each individual actor controlling its own state.**

--- a/resources/docs/simulation/concepts/design-considerations/managing-resource-access.md
+++ b/resources/docs/simulation/concepts/design-considerations/managing-resource-access.md
@@ -1,4 +1,6 @@
 ---
+title: Managing Resource Access
+slug: simulation/concepts/design-considerations/managing-resource-access
 objectID: a4b71af2-3608-45e2-b42c-46fda6ad728d
 ---
 

--- a/resources/docs/simulation/concepts/designing-for-different-timescales.md
+++ b/resources/docs/simulation/concepts/designing-for-different-timescales.md
@@ -1,4 +1,6 @@
 ---
+title: Managing Timescales
+slug: simulation/concepts/designing-for-different-timescales
 objectID: 4609d2db-6a33-453a-90b6-4d4212bb4268
 description: Building complex multi-timescale simulations
 ---

--- a/resources/docs/simulation/concepts/designing-for-different-timescales.md
+++ b/resources/docs/simulation/concepts/designing-for-different-timescales.md
@@ -1,7 +1,7 @@
 ---
 title: Managing Timescales
 slug: simulation/concepts/designing-for-different-timescales
-objectID: 4609d2db-6a33-453a-90b6-4d4212bb4268
+objectId: 892fd7c4-b442-44da-8d22-cc5c0fdf58ac
 description: Building complex multi-timescale simulations
 ---
 

--- a/resources/docs/simulation/concepts/designing-for-different-timescales.md
+++ b/resources/docs/simulation/concepts/designing-for-different-timescales.md
@@ -1,4 +1,5 @@
 ---
+objectID: 4609d2db-6a33-453a-90b6-4d4212bb4268
 description: Building complex multi-timescale simulations
 ---
 

--- a/resources/docs/simulation/concepts/designing-with-distributions.md
+++ b/resources/docs/simulation/concepts/designing-with-distributions.md
@@ -1,7 +1,7 @@
 ---
 title: Probability Distributions
 slug: simulation/concepts/designing-with-distributions
-objectID: 1036af0b-5a51-4210-8321-70743e4273cc
+objectId: 692fd35b-3ada-43be-8d32-79c939111f48}
 ---
 
 # Probability Distributions

--- a/resources/docs/simulation/concepts/designing-with-distributions.md
+++ b/resources/docs/simulation/concepts/designing-with-distributions.md
@@ -1,3 +1,7 @@
+---
+objectID: 1036af0b-5a51-4210-8321-70743e4273cc
+---
+
 # Probability Distributions
 
 Multi-Agent Simulation approaches problem-solving from a stochastic lens. Instead of quantitatively or numerically determining the solution to a set of equations representing a system, HASH will let you approximate messy, complex real-world systems, and empirically and statistically come to conclusions about how they behave. In order to better approximate the real world, you'll often want to initialize agents with heterogeneous properties, and ensure your behaviors properly randomize when necessary. Here are a number of ways you can incorporate stochasticity into your HASH simulations.

--- a/resources/docs/simulation/concepts/designing-with-distributions.md
+++ b/resources/docs/simulation/concepts/designing-with-distributions.md
@@ -1,4 +1,6 @@
 ---
+title: Probability Distributions
+slug: simulation/concepts/designing-with-distributions
 objectID: 1036af0b-5a51-4210-8321-70743e4273cc
 ---
 

--- a/resources/docs/simulation/concepts/designing-with-process-models/README.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/README.md
@@ -1,4 +1,6 @@
 ---
+title: Process Modeling
+slug: simulation/concepts/designing-with-process-models
 objectID: 1bd99770-3a6c-4c96-950d-e14bb6820671
 ---
 

--- a/resources/docs/simulation/concepts/designing-with-process-models/README.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/README.md
@@ -1,3 +1,7 @@
+---
+objectID: 1bd99770-3a6c-4c96-950d-e14bb6820671
+---
+
 # Process Modeling
 
 Process models allow you to represent systems or organizations which perform sequences of tasks. By chaining together delays, resource allocations, and other blocks representing real-life tasks and events, you can simulate processes such as assembly lines, company workflows, and supply chains.

--- a/resources/docs/simulation/concepts/designing-with-process-models/README.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/README.md
@@ -1,7 +1,7 @@
 ---
 title: Process Modeling
 slug: simulation/concepts/designing-with-process-models
-objectID: 1bd99770-3a6c-4c96-950d-e14bb6820671
+objectId: 35b4192a-b378-480f-a904-be39061eefdd}
 ---
 
 # Process Modeling

--- a/resources/docs/simulation/concepts/designing-with-process-models/analyzing-process-models.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/analyzing-process-models.md
@@ -1,7 +1,7 @@
 ---
 title: Analyzing Process Models
 slug: simulation/concepts/designing-with-process-models/analyzing-process-models
-objectID: 8d3c274d-4e34-442a-bd33-c67b5c9229e9
+objectId: 498a6df9-0208-419a-99c0-a3581bcdf839}
 ---
 
 # Analyzing Process Models

--- a/resources/docs/simulation/concepts/designing-with-process-models/analyzing-process-models.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/analyzing-process-models.md
@@ -1,3 +1,7 @@
+---
+objectID: 8d3c274d-4e34-442a-bd33-c67b5c9229e9
+---
+
 # Analyzing Process Models
 
 Once you've created your process model, you'll want to use it to answer questions about its performance. Creating plots will make it easy and visually engaging to interpret the results of your simulation runs.

--- a/resources/docs/simulation/concepts/designing-with-process-models/analyzing-process-models.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/analyzing-process-models.md
@@ -1,4 +1,6 @@
 ---
+title: Analyzing Process Models
+slug: simulation/concepts/designing-with-process-models/analyzing-process-models
 objectID: 8d3c274d-4e34-442a-bd33-c67b5c9229e9
 ---
 

--- a/resources/docs/simulation/concepts/designing-with-process-models/custom-behaviors.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/custom-behaviors.md
@@ -1,4 +1,6 @@
 ---
+title: Custom Behaviors
+slug: simulation/concepts/designing-with-process-models/custom-behaviors
 objectID: 4a50695e-0d35-4098-b978-35374f3dd597
 ---
 

--- a/resources/docs/simulation/concepts/designing-with-process-models/custom-behaviors.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/custom-behaviors.md
@@ -1,7 +1,7 @@
 ---
 title: Custom Behaviors
 slug: simulation/concepts/designing-with-process-models/custom-behaviors
-objectID: 4a50695e-0d35-4098-b978-35374f3dd597
+objectId: 0f610147-152c-410e-87c6-ace0321664bd}
 ---
 
 # Custom Behaviors

--- a/resources/docs/simulation/concepts/designing-with-process-models/custom-behaviors.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/custom-behaviors.md
@@ -1,3 +1,7 @@
+---
+objectID: 4a50695e-0d35-4098-b978-35374f3dd597
+---
+
 # Custom Behaviors
 
 Once in a while you'll want to customize your process model with a new type of functionality. Custom behaviors can be placed anywhere in your behavior chain

--- a/resources/docs/simulation/concepts/designing-with-process-models/experimenting-with-process-models.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/experimenting-with-process-models.md
@@ -1,4 +1,6 @@
 ---
+title: Experimenting with Process Models
+slug: simulation/concepts/designing-with-process-models/experimenting-with-process-models
 objectID: 5bc61681-0c32-42e1-a701-108f5ad7ab91
 ---
 

--- a/resources/docs/simulation/concepts/designing-with-process-models/experimenting-with-process-models.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/experimenting-with-process-models.md
@@ -1,3 +1,7 @@
+---
+objectID: 5bc61681-0c32-42e1-a701-108f5ad7ab91
+---
+
 # Experimenting with Process Models
 
 You can use experiments to explore different potential scenarios with a process model. For example if you want to understand how a process will run when it has half the people working on it, or double the people, you can automatically generate and compare simulation runs with those parameters.

--- a/resources/docs/simulation/concepts/designing-with-process-models/experimenting-with-process-models.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/experimenting-with-process-models.md
@@ -1,7 +1,7 @@
 ---
 title: Experimenting with Process Models
 slug: simulation/concepts/designing-with-process-models/experimenting-with-process-models
-objectID: 5bc61681-0c32-42e1-a701-108f5ad7ab91
+objectId: 7de9fbe8-8ae6-4753-9ec1-7ca22e56e377}
 ---
 
 # Experimenting with Process Models

--- a/resources/docs/simulation/concepts/designing-with-process-models/process-blocks.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/process-blocks.md
@@ -1,7 +1,7 @@
 ---
 title: Process Blocks
 slug: simulation/concepts/designing-with-process-models/process-blocks
-objectID: d08a0dff-88bc-4fa3-a522-c463a7784bbd
+objectId: f6e0fbfe-7d87-43fe-a26b-76358bf9bac4}
 ---
 
 # Process Blocks

--- a/resources/docs/simulation/concepts/designing-with-process-models/process-blocks.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/process-blocks.md
@@ -1,4 +1,6 @@
 ---
+title: Process Blocks
+slug: simulation/concepts/designing-with-process-models/process-blocks
 objectID: d08a0dff-88bc-4fa3-a522-c463a7784bbd
 ---
 

--- a/resources/docs/simulation/concepts/designing-with-process-models/process-blocks.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/process-blocks.md
@@ -1,3 +1,7 @@
+---
+objectID: d08a0dff-88bc-4fa3-a522-c463a7784bbd
+---
+
 # Process Blocks
 
 ## Source

--- a/resources/docs/simulation/concepts/designing-with-process-models/process-model-concepts.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/process-model-concepts.md
@@ -1,4 +1,6 @@
 ---
+title: Process Model Concepts
+slug: simulation/concepts/designing-with-process-models/process-model-concepts
 objectID: 21951603-2120-44a5-b104-360e0de03e2c
 ---
 

--- a/resources/docs/simulation/concepts/designing-with-process-models/process-model-concepts.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/process-model-concepts.md
@@ -1,7 +1,7 @@
 ---
 title: Process Model Concepts
 slug: simulation/concepts/designing-with-process-models/process-model-concepts
-objectID: 21951603-2120-44a5-b104-360e0de03e2c
+objectId: 810f5897-976f-4c31-886f-f3526ddffd84}
 ---
 
 # Process Model Concepts

--- a/resources/docs/simulation/concepts/designing-with-process-models/process-model-concepts.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/process-model-concepts.md
@@ -1,3 +1,7 @@
+---
+objectID: 21951603-2120-44a5-b104-360e0de03e2c
+---
+
 # Process Model Concepts
 
 Process modeling is designing a process as a series of discrete, executable steps, and then analyzing and optimizing the design.

--- a/resources/docs/simulation/concepts/designing-with-process-models/structuring-a-process-model.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/structuring-a-process-model.md
@@ -1,7 +1,7 @@
 ---
 title: Structuring a Process Model
 slug: simulation/concepts/designing-with-process-models/structuring-a-process-model
-objectID: 8f7a46a1-9513-4de7-ab75-acd0c6cd1ad1
+objectId: b4c1cda6-a614-4b68-9484-a5d264bf76a5}
 ---
 
 # Structuring a Process Model

--- a/resources/docs/simulation/concepts/designing-with-process-models/structuring-a-process-model.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/structuring-a-process-model.md
@@ -1,3 +1,7 @@
+---
+objectID: 8f7a46a1-9513-4de7-ab75-acd0c6cd1ad1
+---
+
 # Structuring a Process Model
 
 <Hint style="info">

--- a/resources/docs/simulation/concepts/designing-with-process-models/structuring-a-process-model.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/structuring-a-process-model.md
@@ -1,4 +1,6 @@
 ---
+title: Structuring a Process Model
+slug: simulation/concepts/designing-with-process-models/structuring-a-process-model
 objectID: 8f7a46a1-9513-4de7-ab75-acd0c6cd1ad1
 ---
 

--- a/resources/docs/simulation/concepts/designing-with-process-models/theory-of-constraints-and-simulations-a-framework-for-process-optimization.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/theory-of-constraints-and-simulations-a-framework-for-process-optimization.md
@@ -1,3 +1,7 @@
+---
+objectID: 39959dcc-df1c-4b35-bf7f-a7efdcc94a88
+---
+
 # Theory of Constraints and Simulations: A framework for process optimization
 
 Simulating process models is a powerful technique for understanding and optimizing work processes. And like most powerful techniques, it's important to have a framework for applying it, to help use it in a way that's beneficial and aligned with management objectives.

--- a/resources/docs/simulation/concepts/designing-with-process-models/theory-of-constraints-and-simulations-a-framework-for-process-optimization.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/theory-of-constraints-and-simulations-a-framework-for-process-optimization.md
@@ -1,5 +1,5 @@
 ---
-title: Theory of Constraints and Simulations: A framework for process optimization
+title: "Theory of Constraints and Simulations: A framework for process optimization"
 slug: simulation/concepts/designing-with-process-models/theory-of-constraints-and-simulations-a-framework-for-process-optimization
 objectId: bc91289d-975c-4bc5-8a54-6e3fc2810de7}
 ---

--- a/resources/docs/simulation/concepts/designing-with-process-models/theory-of-constraints-and-simulations-a-framework-for-process-optimization.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/theory-of-constraints-and-simulations-a-framework-for-process-optimization.md
@@ -1,5 +1,7 @@
 ---
-objectID: 39959dcc-df1c-4b35-bf7f-a7efdcc94a88
+title: Theory of Constraints and Simulations: A framework for process optimization
+slug: simulation/concepts/designing-with-process-models/theory-of-constraints-and-simulations-a-framework-for-process-optimization
+objectId: bc91289d-975c-4bc5-8a54-6e3fc2810de7}
 ---
 
 # Theory of Constraints and Simulations: A framework for process optimization

--- a/resources/docs/simulation/concepts/designing-with-process-models/using-data-in-a-process-model.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/using-data-in-a-process-model.md
@@ -1,3 +1,7 @@
+---
+objectID: e0baab40-a3d8-44bd-8abc-ec81a38ef327
+---
+
 # Adding Data to a Process Model
 
 You can use your real world business data to power your process model and create a digital twin of your business process.

--- a/resources/docs/simulation/concepts/designing-with-process-models/using-data-in-a-process-model.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/using-data-in-a-process-model.md
@@ -1,4 +1,6 @@
 ---
+title: Adding Data to a Process Model
+slug: simulation/concepts/designing-with-process-models/using-data-in-a-process-model
 objectID: e0baab40-a3d8-44bd-8abc-ec81a38ef327
 ---
 

--- a/resources/docs/simulation/concepts/designing-with-process-models/using-data-in-a-process-model.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/using-data-in-a-process-model.md
@@ -1,7 +1,7 @@
 ---
 title: Adding Data to a Process Model
 slug: simulation/concepts/designing-with-process-models/using-data-in-a-process-model
-objectID: e0baab40-a3d8-44bd-8abc-ec81a38ef327
+objectId: 887d2242-a88b-4ec1-b6fc-45d4df52eb6a}
 ---
 
 # Adding Data to a Process Model

--- a/resources/docs/simulation/concepts/designing-with-process-models/using-the-process-model-builder.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/using-the-process-model-builder.md
@@ -1,7 +1,7 @@
 ---
 title: Using the Process Model Visual Interface
 slug: simulation/concepts/designing-with-process-models/using-the-process-model-builder
-objectID: 9e881ed4-e1b3-4e1a-a1b3-dd37b5bcef8e
+objectId: 09140f39-a6fe-44e3-be22-d86d9c39be0b}
 ---
 
 # Using the Process Model Visual Interface

--- a/resources/docs/simulation/concepts/designing-with-process-models/using-the-process-model-builder.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/using-the-process-model-builder.md
@@ -1,3 +1,7 @@
+---
+objectID: 9e881ed4-e1b3-4e1a-a1b3-dd37b5bcef8e
+---
+
 # Using the Process Model Visual Interface
 
 The process model visual interface lets you diagram your desired process model and, in one click, create a functioning HASH simulation. In this how-to guide we'll walk through the visual interface and how to build a process model with it.

--- a/resources/docs/simulation/concepts/designing-with-process-models/using-the-process-model-builder.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/using-the-process-model-builder.md
@@ -1,4 +1,6 @@
 ---
+title: Using the Process Model Visual Interface
+slug: simulation/concepts/designing-with-process-models/using-the-process-model-builder
 objectID: 9e881ed4-e1b3-4e1a-a1b3-dd37b5bcef8e
 ---
 

--- a/resources/docs/simulation/concepts/designing-with-system-dynamics-models.md
+++ b/resources/docs/simulation/concepts/designing-with-system-dynamics-models.md
@@ -1,4 +1,6 @@
 ---
+title: System Dynamics
+slug: simulation/concepts/designing-with-system-dynamics-models
 objectID: 06cb22f3-1bd4-4962-b0df-74d5151345fb
 ---
 

--- a/resources/docs/simulation/concepts/designing-with-system-dynamics-models.md
+++ b/resources/docs/simulation/concepts/designing-with-system-dynamics-models.md
@@ -1,7 +1,7 @@
 ---
 title: System Dynamics
 slug: simulation/concepts/designing-with-system-dynamics-models
-objectID: 06cb22f3-1bd4-4962-b0df-74d5151345fb
+objectId: aef10a45-182a-486c-96b4-079ac06bb72d}
 ---
 
 # System Dynamics

--- a/resources/docs/simulation/concepts/designing-with-system-dynamics-models.md
+++ b/resources/docs/simulation/concepts/designing-with-system-dynamics-models.md
@@ -1,3 +1,7 @@
+---
+objectID: 06cb22f3-1bd4-4962-b0df-74d5151345fb
+---
+
 # System Dynamics
 
 System dynamics model allow you to understand non-linear complex systems based on rates of change. Also known as stock-and-flow models, they consist of a set of "stocks" and the "flows" between them. These models allow you to understand the feedback loops inherent in a system.

--- a/resources/docs/simulation/concepts/designing-with-the-material-handling-libraries.md
+++ b/resources/docs/simulation/concepts/designing-with-the-material-handling-libraries.md
@@ -1,7 +1,7 @@
 ---
 title: Material Handling
 slug: simulation/concepts/designing-with-the-material-handling-libraries
-objectID: c0578fe5-4555-4e28-bd84-298fca28c44f
+objectId: d465e54a-a108-43b7-a2c1-fe8778c40230}
 ---
 
 # Material Handling

--- a/resources/docs/simulation/concepts/designing-with-the-material-handling-libraries.md
+++ b/resources/docs/simulation/concepts/designing-with-the-material-handling-libraries.md
@@ -1,3 +1,7 @@
+---
+objectID: c0578fe5-4555-4e28-bd84-298fca28c44f
+---
+
 # Material Handling
 
 When designing simulations, you might want certain agents to be able to manipulate other agents. Picking up, moving, and placing agents is an extremely common task in warehouse models, and many others. The Material Handling Libraries make it easy for you to import and extend these capabilities into your simulations.

--- a/resources/docs/simulation/concepts/designing-with-the-material-handling-libraries.md
+++ b/resources/docs/simulation/concepts/designing-with-the-material-handling-libraries.md
@@ -1,4 +1,6 @@
 ---
+title: Material Handling
+slug: simulation/concepts/designing-with-the-material-handling-libraries
 objectID: c0578fe5-4555-4e28-bd84-298fca28c44f
 ---
 

--- a/resources/docs/simulation/concepts/physics.md
+++ b/resources/docs/simulation/concepts/physics.md
@@ -1,4 +1,6 @@
 ---
+title: Physics
+slug: simulation/concepts/physics
 objectID: 4c9a1714-3c48-4d5b-b4d3-84b96785e824
 ---
 

--- a/resources/docs/simulation/concepts/physics.md
+++ b/resources/docs/simulation/concepts/physics.md
@@ -1,3 +1,7 @@
+---
+objectID: 4c9a1714-3c48-4d5b-b4d3-84b96785e824
+---
+
 # Physics
 
 The HASH [Physics Library](/@hash/physics) contains behaviors to help you create simulated physics environments. They are written in Rust, which means they are optimized to run in the HASH Engine.

--- a/resources/docs/simulation/concepts/physics.md
+++ b/resources/docs/simulation/concepts/physics.md
@@ -1,7 +1,7 @@
 ---
 title: Physics
 slug: simulation/concepts/physics
-objectID: 4c9a1714-3c48-4d5b-b4d3-84b96785e824
+objectId: d715d3b8-451c-47ca-aae3-c0faee9c09ac}
 ---
 
 # Physics

--- a/resources/docs/simulation/concepts/verification-and-validation.md
+++ b/resources/docs/simulation/concepts/verification-and-validation.md
@@ -1,7 +1,7 @@
 ---
 title: Verification and Validation
 slug: simulation/concepts/verification-and-validation
-objectID: 4923d018-38b9-4d7a-8531-5efed43da62f
+objectId: 78ba7242-a732-466c-b9fe-7e983b120100}
 ---
 
 # Verification and Validation

--- a/resources/docs/simulation/concepts/verification-and-validation.md
+++ b/resources/docs/simulation/concepts/verification-and-validation.md
@@ -1,3 +1,7 @@
+---
+objectID: 4923d018-38b9-4d7a-8531-5efed43da62f
+---
+
 # Verification and Validation
 
 Before putting a simulation into production it's important to confirm its trustworthiness and authenticate that it works as intended. This process of quality assurance is made up of two separate procedures:

--- a/resources/docs/simulation/concepts/verification-and-validation.md
+++ b/resources/docs/simulation/concepts/verification-and-validation.md
@@ -1,4 +1,6 @@
 ---
+title: Verification and Validation
+slug: simulation/concepts/verification-and-validation
 objectID: 4923d018-38b9-4d7a-8531-5efed43da62f
 ---
 

--- a/resources/docs/simulation/creating-simulations/agent-based-modeling-basics-1.md
+++ b/resources/docs/simulation/creating-simulations/agent-based-modeling-basics-1.md
@@ -1,4 +1,6 @@
 ---
+title: Agent-Based Modeling Basics
+slug: simulation/creating-simulations/agent-based-modeling-basics-1
 objectID: d6864752-4fb2-45de-ae5d-deb52158a78b
 description: Learn the basic terminology
 ---

--- a/resources/docs/simulation/creating-simulations/agent-based-modeling-basics-1.md
+++ b/resources/docs/simulation/creating-simulations/agent-based-modeling-basics-1.md
@@ -1,7 +1,7 @@
 ---
 title: Agent-Based Modeling Basics
 slug: simulation/creating-simulations/agent-based-modeling-basics-1
-objectID: d6864752-4fb2-45de-ae5d-deb52158a78b
+objectId: f53e9d6f-902c-4fc1-b560-c9339f37ca5d
 description: Learn the basic terminology
 ---
 

--- a/resources/docs/simulation/creating-simulations/agent-based-modeling-basics-1.md
+++ b/resources/docs/simulation/creating-simulations/agent-based-modeling-basics-1.md
@@ -1,4 +1,5 @@
 ---
+objectID: d6864752-4fb2-45de-ae5d-deb52158a78b
 description: Learn the basic terminology
 ---
 

--- a/resources/docs/simulation/creating-simulations/agent-messages/README.md
+++ b/resources/docs/simulation/creating-simulations/agent-messages/README.md
@@ -1,3 +1,7 @@
+---
+objectID: 2b59be71-8ec8-44fe-a62a-1d34e425b1b9
+---
+
 # Messages
 
 Information in a simulation can propagate in one of two ways - either through neighbors which we cover in [Behaviors](/docs/simulation/creating-simulations/behaviors/) and [Topology](/docs/simulation/creating-simulations/configuration/topology/), or through message passing.

--- a/resources/docs/simulation/creating-simulations/agent-messages/README.md
+++ b/resources/docs/simulation/creating-simulations/agent-messages/README.md
@@ -1,4 +1,6 @@
 ---
+title: Messages
+slug: simulation/creating-simulations/agent-messages
 objectID: 2b59be71-8ec8-44fe-a62a-1d34e425b1b9
 ---
 

--- a/resources/docs/simulation/creating-simulations/agent-messages/README.md
+++ b/resources/docs/simulation/creating-simulations/agent-messages/README.md
@@ -1,7 +1,7 @@
 ---
 title: Messages
 slug: simulation/creating-simulations/agent-messages
-objectID: 2b59be71-8ec8-44fe-a62a-1d34e425b1b9
+objectId: 0d485ed3-efcc-4f4b-a8f0-0d886e688802}
 ---
 
 # Messages

--- a/resources/docs/simulation/creating-simulations/agent-messages/built-in-message-handlers.md
+++ b/resources/docs/simulation/creating-simulations/agent-messages/built-in-message-handlers.md
@@ -1,4 +1,5 @@
 ---
+objectID: 6479d550-45cb-4eda-9946-00f1f8d62bcd
 description: Add and remove agents by interacting with hCore
 ---
 

--- a/resources/docs/simulation/creating-simulations/agent-messages/built-in-message-handlers.md
+++ b/resources/docs/simulation/creating-simulations/agent-messages/built-in-message-handlers.md
@@ -1,4 +1,6 @@
 ---
+title: Built-in message handlers
+slug: simulation/creating-simulations/agent-messages/built-in-message-handlers
 objectID: 6479d550-45cb-4eda-9946-00f1f8d62bcd
 description: Add and remove agents by interacting with hCore
 ---

--- a/resources/docs/simulation/creating-simulations/agent-messages/built-in-message-handlers.md
+++ b/resources/docs/simulation/creating-simulations/agent-messages/built-in-message-handlers.md
@@ -1,7 +1,7 @@
 ---
 title: Built-in message handlers
 slug: simulation/creating-simulations/agent-messages/built-in-message-handlers
-objectID: 6479d550-45cb-4eda-9946-00f1f8d62bcd
+objectId: c38f31e7-519c-4e5a-ba60-267c33c859ba
 description: Add and remove agents by interacting with hCore
 ---
 

--- a/resources/docs/simulation/creating-simulations/agent-messages/handling-messages.md
+++ b/resources/docs/simulation/creating-simulations/agent-messages/handling-messages.md
@@ -1,4 +1,6 @@
 ---
+title: Handling Messages
+slug: simulation/creating-simulations/agent-messages/handling-messages
 objectID: 9163334b-f855-45bc-aaad-450b1c8a49fa
 ---
 

--- a/resources/docs/simulation/creating-simulations/agent-messages/handling-messages.md
+++ b/resources/docs/simulation/creating-simulations/agent-messages/handling-messages.md
@@ -1,3 +1,7 @@
+---
+objectID: 9163334b-f855-45bc-aaad-450b1c8a49fa
+---
+
 # Handling Messages
 
 **What happens when an agent receives a message?**

--- a/resources/docs/simulation/creating-simulations/agent-messages/handling-messages.md
+++ b/resources/docs/simulation/creating-simulations/agent-messages/handling-messages.md
@@ -1,7 +1,7 @@
 ---
 title: Handling Messages
 slug: simulation/creating-simulations/agent-messages/handling-messages
-objectID: 9163334b-f855-45bc-aaad-450b1c8a49fa
+objectId: 115d9a68-381f-4b08-8765-4a17be0a1afe}
 ---
 
 # Handling Messages

--- a/resources/docs/simulation/creating-simulations/agent-messages/sending-messages.md
+++ b/resources/docs/simulation/creating-simulations/agent-messages/sending-messages.md
@@ -1,7 +1,7 @@
 ---
 title: Sending Messages
 slug: simulation/creating-simulations/agent-messages/sending-messages
-objectID: ddb8664a-2214-4a60-8403-3ef93be48d1f
+objectId: 66ddabba-469f-4e2d-b6cd-1755d0eb9ac7}
 ---
 
 # Sending Messages

--- a/resources/docs/simulation/creating-simulations/agent-messages/sending-messages.md
+++ b/resources/docs/simulation/creating-simulations/agent-messages/sending-messages.md
@@ -1,3 +1,7 @@
+---
+objectID: ddb8664a-2214-4a60-8403-3ef93be48d1f
+---
+
 # Sending Messages
 
 ## Message Structure

--- a/resources/docs/simulation/creating-simulations/agent-messages/sending-messages.md
+++ b/resources/docs/simulation/creating-simulations/agent-messages/sending-messages.md
@@ -1,4 +1,6 @@
 ---
+title: Sending Messages
+slug: simulation/creating-simulations/agent-messages/sending-messages
 objectID: ddb8664a-2214-4a60-8403-3ef93be48d1f
 ---
 

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/README.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/README.md
@@ -1,7 +1,7 @@
 ---
 title: Agents
 slug: simulation/creating-simulations/anatomy-of-an-agent
-objectID: f753ef9c-d687-4d56-85d3-b927917428f6
+objectId: 177727f1-acbd-4f2d-811c-cebb25e7b3e5
 description: The beating hearts of agent-based models
 ---
 

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/README.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/README.md
@@ -1,4 +1,5 @@
 ---
+objectID: f753ef9c-d687-4d56-85d3-b927917428f6
 description: The beating hearts of agent-based models
 ---
 

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/README.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/README.md
@@ -1,4 +1,6 @@
 ---
+title: Agents
+slug: simulation/creating-simulations/anatomy-of-an-agent
 objectID: f753ef9c-d687-4d56-85d3-b927917428f6
 description: The beating hearts of agent-based models
 ---

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/context.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/context.md
@@ -1,4 +1,6 @@
 ---
+title: Context
+slug: simulation/creating-simulations/anatomy-of-an-agent/context
 objectID: 8b1b7ff0-7c67-4a38-8810-1c6a85b1a686
 ---
 

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/context.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/context.md
@@ -1,7 +1,7 @@
 ---
 title: Context
 slug: simulation/creating-simulations/anatomy-of-an-agent/context
-objectID: 8b1b7ff0-7c67-4a38-8810-1c6a85b1a686
+objectId: 4645bf7c-a7a7-4928-82fe-3298ad3ff584}
 ---
 
 # Context

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/context.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/context.md
@@ -1,3 +1,7 @@
+---
+objectID: 8b1b7ff0-7c67-4a38-8810-1c6a85b1a686
+---
+
 # Context
 
 Besides their [**state**](/docs/simulation/creating-simulations/anatomy-of-an-agent/state), an agent always has access to their **context**. The context is the parts of the simulation that the agent is exposed to; another way of thinking about it is that an agent's context are the parts of the simulation that the agent "can see".

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/initial-state.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/initial-state.md
@@ -1,4 +1,6 @@
 ---
+title: Initializing Agents
+slug: simulation/creating-simulations/anatomy-of-an-agent/initial-state
 objectID: 8f7cf860-94d2-484a-8c08-c86c1b8df5a2
 description: Where simulated life begins
 ---

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/initial-state.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/initial-state.md
@@ -1,7 +1,7 @@
 ---
 title: Initializing Agents
 slug: simulation/creating-simulations/anatomy-of-an-agent/initial-state
-objectID: 8f7cf860-94d2-484a-8c08-c86c1b8df5a2
+objectId: e7dddeb1-246b-4287-b26c-b91d79fde3c4
 description: Where simulated life begins
 ---
 

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/initial-state.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/initial-state.md
@@ -1,4 +1,5 @@
 ---
+objectID: 8f7cf860-94d2-484a-8c08-c86c1b8df5a2
 description: Where simulated life begins
 ---
 

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/programmable-initial-states.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/programmable-initial-states.md
@@ -1,5 +1,7 @@
 ---
-objectID: 7b315c20-26fb-42ec-8611-65a5960a9f02
+title: Programmable Initialization
+slug: simulation/creating-simulations/anatomy-of-an-agent/programmable-initial-states
+objectId: 13e5ee9e-1c0e-4ffe-be93-739606ed9af6
 description: Initializing simulations with JavaScript and Python
 ---
 

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/programmable-initial-states.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/programmable-initial-states.md
@@ -1,4 +1,5 @@
 ---
+objectID: 7b315c20-26fb-42ec-8611-65a5960a9f02
 description: Initializing simulations with JavaScript and Python
 ---
 

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/state.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/state.md
@@ -1,3 +1,7 @@
+---
+objectID: aba75f1a-1768-427f-9521-c514acc3ddf0
+---
+
 # State
 
 Every agent has a private **state**. Is the agent of height 1 or height 2? Is the agent's name "foo" or is its name "bar"? These properties are expressed and saved on the agent's state.

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/state.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/state.md
@@ -1,7 +1,7 @@
 ---
 title: State
 slug: simulation/creating-simulations/anatomy-of-an-agent/state
-objectID: aba75f1a-1768-427f-9521-c514acc3ddf0
+objectId: 3d62b426-d773-4982-9b3c-6b20a270b564}
 ---
 
 # State

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/state.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/state.md
@@ -1,4 +1,6 @@
 ---
+title: State
+slug: simulation/creating-simulations/anatomy-of-an-agent/state
 objectID: aba75f1a-1768-427f-9521-c514acc3ddf0
 ---
 

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/README.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/README.md
@@ -1,4 +1,6 @@
 ---
+title: Visualization
+slug: simulation/creating-simulations/anatomy-of-an-agent/visualization
 objectID: 4e160de3-a797-475e-90c7-9b85d515118f
 ---
 

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/README.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/README.md
@@ -1,7 +1,7 @@
 ---
 title: Visualization
 slug: simulation/creating-simulations/anatomy-of-an-agent/visualization
-objectID: 4e160de3-a797-475e-90c7-9b85d515118f
+objectId: 2b67bcfb-525f-4f39-951c-fc98ee009384}
 ---
 
 # Visualization

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/README.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/README.md
@@ -1,3 +1,7 @@
+---
+objectID: 4e160de3-a797-475e-90c7-9b85d515118f
+---
+
 # Visualization
 
 Once you've developed and tested the logic and functioning of your model, it can be helpful to create a compelling visualization that clearly turns your model into an explanatory tool.

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/networks.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/networks.md
@@ -1,4 +1,5 @@
 ---
+objectID: 129d3f0d-f776-4095-bd95-c28d0fd284b9
 description: Visualizing network connections between agents in the 3D viewer
 ---
 

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/networks.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/networks.md
@@ -1,4 +1,6 @@
 ---
+title: Networks
+slug: simulation/creating-simulations/anatomy-of-an-agent/visualization/networks
 objectID: 129d3f0d-f776-4095-bd95-c28d0fd284b9
 description: Visualizing network connections between agents in the 3D viewer
 ---

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/networks.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/networks.md
@@ -1,7 +1,7 @@
 ---
 title: Networks
 slug: simulation/creating-simulations/anatomy-of-an-agent/visualization/networks
-objectID: 129d3f0d-f776-4095-bd95-c28d0fd284b9
+objectId: 9427eb8c-bdd0-4ed5-b71f-f535ad8c71d9
 description: Visualizing network connections between agents in the 3D viewer
 ---
 

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/published-behaviors.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/published-behaviors.md
@@ -1,7 +1,7 @@
 ---
 title: Published Behaviors
 slug: simulation/creating-simulations/anatomy-of-an-agent/visualization/published-behaviors
-objectID: d79352c0-c359-42c3-b89d-9a142b5e33eb
+objectId: 2d1fb8c7-1ab3-481c-897e-cdd613c49402}
 ---
 
 # Published Behaviors

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/published-behaviors.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/published-behaviors.md
@@ -1,3 +1,7 @@
+---
+objectID: d79352c0-c359-42c3-b89d-9a142b5e33eb
+---
+
 # Published Behaviors
 
 A number of behaviors on hIndex will help you complete more complicated visualization tasks. The behaviors below, for instance, allow you to link a property of your agent to one of the reserved display fields. When the driving property is updated, the display property will be as well.

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/published-behaviors.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/published-behaviors.md
@@ -1,4 +1,6 @@
 ---
+title: Published Behaviors
+slug: simulation/creating-simulations/anatomy-of-an-agent/visualization/published-behaviors
 objectID: d79352c0-c359-42c3-b89d-9a142b5e33eb
 ---
 

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/shapes.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/shapes.md
@@ -1,7 +1,7 @@
 ---
 title: Shapes
 slug: simulation/creating-simulations/anatomy-of-an-agent/visualization/shapes
-objectID: eda3264d-1c70-4017-99cb-69c40007ec39
+objectId: 1f39e725-319c-42a3-805d-223e63e872fd}
 ---
 
 # Shapes

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/shapes.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/shapes.md
@@ -1,3 +1,7 @@
+---
+objectID: eda3264d-1c70-4017-99cb-69c40007ec39
+---
+
 # Shapes
 
 ## Geometric Shapes

--- a/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/shapes.md
+++ b/resources/docs/simulation/creating-simulations/anatomy-of-an-agent/visualization/shapes.md
@@ -1,4 +1,6 @@
 ---
+title: Shapes
+slug: simulation/creating-simulations/anatomy-of-an-agent/visualization/shapes
 objectID: eda3264d-1c70-4017-99cb-69c40007ec39
 ---
 

--- a/resources/docs/simulation/creating-simulations/behaviors/README.md
+++ b/resources/docs/simulation/creating-simulations/behaviors/README.md
@@ -1,4 +1,6 @@
 ---
+title: Behaviors
+slug: simulation/creating-simulations/behaviors
 objectID: d914123e-7c69-4bcb-96e5-6b87f836ae12
 description: Giving agents agency and specifying laws of the universe
 ---

--- a/resources/docs/simulation/creating-simulations/behaviors/README.md
+++ b/resources/docs/simulation/creating-simulations/behaviors/README.md
@@ -1,7 +1,7 @@
 ---
 title: Behaviors
 slug: simulation/creating-simulations/behaviors
-objectID: d914123e-7c69-4bcb-96e5-6b87f836ae12
+objectId: 98e7aaf1-5ff1-47a6-bec4-b6bfe7415fd9
 description: Giving agents agency and specifying laws of the universe
 ---
 

--- a/resources/docs/simulation/creating-simulations/behaviors/README.md
+++ b/resources/docs/simulation/creating-simulations/behaviors/README.md
@@ -1,4 +1,5 @@
 ---
+objectID: d914123e-7c69-4bcb-96e5-6b87f836ae12
 description: Giving agents agency and specifying laws of the universe
 ---
 

--- a/resources/docs/simulation/creating-simulations/behaviors/behavior-index.md
+++ b/resources/docs/simulation/creating-simulations/behaviors/behavior-index.md
@@ -1,3 +1,7 @@
+---
+objectID: 00f6b05d-a4bf-4236-8a71-a8bd854b59bf
+---
+
 # Getting the Behavior Index
 
 Sometimes behaviors may need to know which behaviors executed before it, and which behaviors will execute after it, in the agent's behavior chain. For this, the agent's `state` has a special method — `state.behaviorIndex()` in Javascript and `state.behavior_index()` in Python — which returns the index of the currently executing behavior in the agent's behavior chain.

--- a/resources/docs/simulation/creating-simulations/behaviors/behavior-index.md
+++ b/resources/docs/simulation/creating-simulations/behaviors/behavior-index.md
@@ -1,4 +1,6 @@
 ---
+title: Getting the Behavior Index
+slug: simulation/creating-simulations/behaviors/behavior-index
 objectID: 00f6b05d-a4bf-4236-8a71-a8bd854b59bf
 ---
 

--- a/resources/docs/simulation/creating-simulations/behaviors/behavior-index.md
+++ b/resources/docs/simulation/creating-simulations/behaviors/behavior-index.md
@@ -1,7 +1,7 @@
 ---
 title: Getting the Behavior Index
 slug: simulation/creating-simulations/behaviors/behavior-index
-objectID: 00f6b05d-a4bf-4236-8a71-a8bd854b59bf
+objectId: e884821d-d244-48e5-ba49-7fee10b98d3d}
 ---
 
 # Getting the Behavior Index

--- a/resources/docs/simulation/creating-simulations/behaviors/behavior-keys/README.md
+++ b/resources/docs/simulation/creating-simulations/behaviors/behavior-keys/README.md
@@ -1,3 +1,7 @@
+---
+objectID: 04f8acd9-acc9-4689-ac04-9abe870865b0
+---
+
 # Behavior Keys
 
 Behavior Keys define the **data** **type** of the fields that a behavior accesses on an agent's state. HASH uses behavior keys to improve the runtime performance of simulations. To view the behavior keys associated with a file, click the button containing the _brain_ icon, located next to the help button, to toggle the key panel's visibility \(highlighted in green below\).

--- a/resources/docs/simulation/creating-simulations/behaviors/behavior-keys/README.md
+++ b/resources/docs/simulation/creating-simulations/behaviors/behavior-keys/README.md
@@ -1,7 +1,7 @@
 ---
 title: Behavior Keys
 slug: simulation/creating-simulations/behaviors/behavior-keys
-objectID: 04f8acd9-acc9-4689-ac04-9abe870865b0
+objectId: 87c9a2d6-cf71-4194-ae1c-a7db3e4643b2}
 ---
 
 # Behavior Keys

--- a/resources/docs/simulation/creating-simulations/behaviors/behavior-keys/README.md
+++ b/resources/docs/simulation/creating-simulations/behaviors/behavior-keys/README.md
@@ -1,4 +1,6 @@
 ---
+title: Behavior Keys
+slug: simulation/creating-simulations/behaviors/behavior-keys
 objectID: 04f8acd9-acc9-4689-ac04-9abe870865b0
 ---
 

--- a/resources/docs/simulation/creating-simulations/behaviors/behavior-keys/advanced-scenarios.md
+++ b/resources/docs/simulation/creating-simulations/behaviors/behavior-keys/advanced-scenarios.md
@@ -1,7 +1,7 @@
 ---
 title: Advanced Scenarios
 slug: simulation/creating-simulations/behaviors/behavior-keys/advanced-scenarios
-objectID: 11fef41b-378c-442d-9200-b50d04b5ad96
+objectId: ea0981ad-6f6c-4c43-9d9f-156e86cc71eb}
 ---
 
 # Advanced Scenarios

--- a/resources/docs/simulation/creating-simulations/behaviors/behavior-keys/advanced-scenarios.md
+++ b/resources/docs/simulation/creating-simulations/behaviors/behavior-keys/advanced-scenarios.md
@@ -1,3 +1,7 @@
+---
+objectID: 11fef41b-378c-442d-9200-b50d04b5ad96
+---
+
 # Advanced Scenarios
 
 ## How do I use a field defined in another behavior?

--- a/resources/docs/simulation/creating-simulations/behaviors/behavior-keys/advanced-scenarios.md
+++ b/resources/docs/simulation/creating-simulations/behaviors/behavior-keys/advanced-scenarios.md
@@ -1,4 +1,6 @@
 ---
+title: Advanced Scenarios
+slug: simulation/creating-simulations/behaviors/behavior-keys/advanced-scenarios
 objectID: 11fef41b-378c-442d-9200-b50d04b5ad96
 ---
 

--- a/resources/docs/simulation/creating-simulations/behaviors/behavior-keys/types.md
+++ b/resources/docs/simulation/creating-simulations/behaviors/behavior-keys/types.md
@@ -1,4 +1,6 @@
 ---
+title: Types
+slug: simulation/creating-simulations/behaviors/behavior-keys/types
 objectID: affe1017-9008-4d1b-b2f2-15d97282aa1b
 ---
 

--- a/resources/docs/simulation/creating-simulations/behaviors/behavior-keys/types.md
+++ b/resources/docs/simulation/creating-simulations/behaviors/behavior-keys/types.md
@@ -1,7 +1,7 @@
 ---
 title: Types
 slug: simulation/creating-simulations/behaviors/behavior-keys/types
-objectID: affe1017-9008-4d1b-b2f2-15d97282aa1b
+objectId: b713ff2f-2b68-4f5a-8cf3-e7a1f1d54760}
 ---
 
 # Types

--- a/resources/docs/simulation/creating-simulations/behaviors/behavior-keys/types.md
+++ b/resources/docs/simulation/creating-simulations/behaviors/behavior-keys/types.md
@@ -1,3 +1,7 @@
+---
+objectID: affe1017-9008-4d1b-b2f2-15d97282aa1b
+---
+
 # Types
 
 If you've used a statically defined language before - like Rust, Go, or Clojure then you'll already be familiar with strong type systems. You select the type - `string`, `number`, `list`, etc. - of data that a field will store. This improves memory allocation and access speed, as well as making sure that if you assign an incorrect type to the field an error is thrown. **If you are unsure about typing a field, assign it an 'any' type - or ask us for help!**

--- a/resources/docs/simulation/creating-simulations/behaviors/composable-behaviors.md
+++ b/resources/docs/simulation/creating-simulations/behaviors/composable-behaviors.md
@@ -1,3 +1,7 @@
+---
+objectID: 861085ec-a981-4778-be27-c95ed450e1df
+---
+
 # Composable Behaviors
 
 **All user-authored behaviors, regardless of language, are** _**composable**_**.** This means they can be combined in any fashion with any number of others behaviors.

--- a/resources/docs/simulation/creating-simulations/behaviors/composable-behaviors.md
+++ b/resources/docs/simulation/creating-simulations/behaviors/composable-behaviors.md
@@ -1,4 +1,6 @@
 ---
+title: Composable Behaviors
+slug: simulation/creating-simulations/behaviors/composable-behaviors
 objectID: 861085ec-a981-4778-be27-c95ed450e1df
 ---
 

--- a/resources/docs/simulation/creating-simulations/behaviors/composable-behaviors.md
+++ b/resources/docs/simulation/creating-simulations/behaviors/composable-behaviors.md
@@ -1,7 +1,7 @@
 ---
 title: Composable Behaviors
 slug: simulation/creating-simulations/behaviors/composable-behaviors
-objectID: 861085ec-a981-4778-be27-c95ed450e1df
+objectId: eaa33255-8efa-4fa0-a37e-90781a2bc889}
 ---
 
 # Composable Behaviors

--- a/resources/docs/simulation/creating-simulations/behaviors/inheritance.md
+++ b/resources/docs/simulation/creating-simulations/behaviors/inheritance.md
@@ -1,7 +1,7 @@
 ---
 title: Inheriting Behaviors
 slug: simulation/creating-simulations/behaviors/inheritance
-objectID: e4e6ab19-5957-4179-98fb-35c6a707a905
+objectId: 5e2af55a-b595-4fb4-8cd4-7a10916695f6
 description: Agent Types in HASH
 ---
 

--- a/resources/docs/simulation/creating-simulations/behaviors/inheritance.md
+++ b/resources/docs/simulation/creating-simulations/behaviors/inheritance.md
@@ -1,4 +1,6 @@
 ---
+title: Inheriting Behaviors
+slug: simulation/creating-simulations/behaviors/inheritance
 objectID: e4e6ab19-5957-4179-98fb-35c6a707a905
 description: Agent Types in HASH
 ---

--- a/resources/docs/simulation/creating-simulations/behaviors/inheritance.md
+++ b/resources/docs/simulation/creating-simulations/behaviors/inheritance.md
@@ -1,4 +1,5 @@
 ---
+objectID: e4e6ab19-5957-4179-98fb-35c6a707a905
 description: Agent Types in HASH
 ---
 

--- a/resources/docs/simulation/creating-simulations/collaboration/README.md
+++ b/resources/docs/simulation/creating-simulations/collaboration/README.md
@@ -1,7 +1,7 @@
 ---
 title: Collaboration
 slug: simulation/creating-simulations/collaboration
-objectID: 86f90edc-be28-4ca7-a982-c9030cfa5986
+objectId: 61e7ee8f-8760-489e-98d5-6827a02c7de7
 description: Speed development and experimentation by working with others
 ---
 

--- a/resources/docs/simulation/creating-simulations/collaboration/README.md
+++ b/resources/docs/simulation/creating-simulations/collaboration/README.md
@@ -1,4 +1,5 @@
 ---
+objectID: 86f90edc-be28-4ca7-a982-c9030cfa5986
 description: Speed development and experimentation by working with others
 ---
 

--- a/resources/docs/simulation/creating-simulations/collaboration/README.md
+++ b/resources/docs/simulation/creating-simulations/collaboration/README.md
@@ -1,4 +1,6 @@
 ---
+title: Collaboration
+slug: simulation/creating-simulations/collaboration
 objectID: 86f90edc-be28-4ca7-a982-c9030cfa5986
 description: Speed development and experimentation by working with others
 ---

--- a/resources/docs/simulation/creating-simulations/collaboration/forking-and-merging.md
+++ b/resources/docs/simulation/creating-simulations/collaboration/forking-and-merging.md
@@ -1,3 +1,7 @@
+---
+objectID: 2c756def-5d03-4a67-a85b-b3548557a886
+---
+
 # Forking and Merging
 
 HASH supports forking and merging operations. You can fork a simulation, make changes, and then create a merge request to merge the changes back into the main simulation.

--- a/resources/docs/simulation/creating-simulations/collaboration/forking-and-merging.md
+++ b/resources/docs/simulation/creating-simulations/collaboration/forking-and-merging.md
@@ -1,4 +1,6 @@
 ---
+title: Forking and Merging
+slug: simulation/creating-simulations/collaboration/forking-and-merging
 objectID: 2c756def-5d03-4a67-a85b-b3548557a886
 ---
 

--- a/resources/docs/simulation/creating-simulations/collaboration/forking-and-merging.md
+++ b/resources/docs/simulation/creating-simulations/collaboration/forking-and-merging.md
@@ -1,7 +1,7 @@
 ---
 title: Forking and Merging
 slug: simulation/creating-simulations/collaboration/forking-and-merging
-objectID: 2c756def-5d03-4a67-a85b-b3548557a886
+objectId: 514b0840-5158-4e13-a151-58dcf65ee584}
 ---
 
 # Forking and Merging

--- a/resources/docs/simulation/creating-simulations/collaboration/organizations.md
+++ b/resources/docs/simulation/creating-simulations/collaboration/organizations.md
@@ -1,3 +1,7 @@
+---
+objectID: 20c18665-201c-402e-9f0b-c4a11f7adea0
+---
+
 # Organizations
 
 Organizations exist in HASH to allow you to create private spaces with other users for permissioned sharing and collaboration on projects. They are free to create, and can contain unlimited number of members.

--- a/resources/docs/simulation/creating-simulations/collaboration/organizations.md
+++ b/resources/docs/simulation/creating-simulations/collaboration/organizations.md
@@ -1,4 +1,6 @@
 ---
+title: Organizations
+slug: simulation/creating-simulations/collaboration/organizations
 objectID: 20c18665-201c-402e-9f0b-c4a11f7adea0
 ---
 

--- a/resources/docs/simulation/creating-simulations/collaboration/organizations.md
+++ b/resources/docs/simulation/creating-simulations/collaboration/organizations.md
@@ -1,7 +1,7 @@
 ---
 title: Organizations
 slug: simulation/creating-simulations/collaboration/organizations
-objectID: 20c18665-201c-402e-9f0b-c4a11f7adea0
+objectId: 8907a843-8e7c-40c9-9734-cbe9a89016fe}
 ---
 
 # Organizations

--- a/resources/docs/simulation/creating-simulations/collaboration/sharing-releasing.md
+++ b/resources/docs/simulation/creating-simulations/collaboration/sharing-releasing.md
@@ -1,4 +1,6 @@
 ---
+title: Sharing Simulations
+slug: simulation/creating-simulations/collaboration/sharing-releasing
 objectID: 1eefac3f-a8bf-46db-adc0-b768681b4e3d
 ---
 

--- a/resources/docs/simulation/creating-simulations/collaboration/sharing-releasing.md
+++ b/resources/docs/simulation/creating-simulations/collaboration/sharing-releasing.md
@@ -1,7 +1,7 @@
 ---
 title: Sharing Simulations
 slug: simulation/creating-simulations/collaboration/sharing-releasing
-objectID: 1eefac3f-a8bf-46db-adc0-b768681b4e3d
+objectId: 5254c8d8-7b2f-4220-b033-dc1f428cbe88}
 ---
 
 # Sharing Simulations

--- a/resources/docs/simulation/creating-simulations/collaboration/sharing-releasing.md
+++ b/resources/docs/simulation/creating-simulations/collaboration/sharing-releasing.md
@@ -1,3 +1,7 @@
+---
+objectID: 1eefac3f-a8bf-46db-adc0-b768681b4e3d
+---
+
 # Sharing Simulations
 
 HASH isn't just about building your own simulations. It's also about sharing them so that other users can run them, learn from them, ask questions and make suggestions.

--- a/resources/docs/simulation/creating-simulations/configuration/README.md
+++ b/resources/docs/simulation/creating-simulations/configuration/README.md
@@ -1,7 +1,7 @@
 ---
 title: Globals
 slug: simulation/creating-simulations/configuration
-objectID: 73151c8e-8af8-40c8-b1ba-9c857ea656ab
+objectId: c24c4485-292d-46a8-9c72-8c66aab52e23
 description: Globals are variables which are accessible to all agents in a simulation
 ---
 

--- a/resources/docs/simulation/creating-simulations/configuration/README.md
+++ b/resources/docs/simulation/creating-simulations/configuration/README.md
@@ -1,4 +1,5 @@
 ---
+objectID: 73151c8e-8af8-40c8-b1ba-9c857ea656ab
 description: Globals are variables which are accessible to all agents in a simulation
 ---
 

--- a/resources/docs/simulation/creating-simulations/configuration/README.md
+++ b/resources/docs/simulation/creating-simulations/configuration/README.md
@@ -1,4 +1,6 @@
 ---
+title: Globals
+slug: simulation/creating-simulations/configuration
 objectID: 73151c8e-8af8-40c8-b1ba-9c857ea656ab
 description: Globals are variables which are accessible to all agents in a simulation
 ---

--- a/resources/docs/simulation/creating-simulations/configuration/basic-properties.md
+++ b/resources/docs/simulation/creating-simulations/configuration/basic-properties.md
@@ -1,4 +1,6 @@
 ---
+title: Simulation Parameters
+slug: simulation/creating-simulations/configuration/basic-properties
 objectID: a2c18af4-9cd2-443b-a048-54974e3188b9
 description: >-
   Capture truths or assumptions about the state of your world which can easily

--- a/resources/docs/simulation/creating-simulations/configuration/basic-properties.md
+++ b/resources/docs/simulation/creating-simulations/configuration/basic-properties.md
@@ -1,4 +1,5 @@
 ---
+objectID: a2c18af4-9cd2-443b-a048-54974e3188b9
 description: >-
   Capture truths or assumptions about the state of your world which can easily
   be varied

--- a/resources/docs/simulation/creating-simulations/configuration/basic-properties.md
+++ b/resources/docs/simulation/creating-simulations/configuration/basic-properties.md
@@ -1,7 +1,7 @@
 ---
 title: Simulation Parameters
 slug: simulation/creating-simulations/configuration/basic-properties
-objectID: a2c18af4-9cd2-443b-a048-54974e3188b9
+objectId: aaf900cd-674f-4aa6-b575-21167ffd8b3a
 description: >-
   Capture truths or assumptions about the state of your world which can easily
   be varied

--- a/resources/docs/simulation/creating-simulations/configuration/topology/README.md
+++ b/resources/docs/simulation/creating-simulations/configuration/topology/README.md
@@ -1,4 +1,6 @@
 ---
+title: Topology
+slug: simulation/creating-simulations/configuration/topology
 objectID: ee7af53b-b141-4261-8f6c-193ec9e22d31
 ---
 

--- a/resources/docs/simulation/creating-simulations/configuration/topology/README.md
+++ b/resources/docs/simulation/creating-simulations/configuration/topology/README.md
@@ -1,7 +1,7 @@
 ---
 title: Topology
 slug: simulation/creating-simulations/configuration/topology
-objectID: ee7af53b-b141-4261-8f6c-193ec9e22d31
+objectId: dceb2b2a-ef0f-4950-9e26-c4ab04f34346}
 ---
 
 # Topology

--- a/resources/docs/simulation/creating-simulations/configuration/topology/README.md
+++ b/resources/docs/simulation/creating-simulations/configuration/topology/README.md
@@ -1,3 +1,7 @@
+---
+objectID: ee7af53b-b141-4261-8f6c-193ec9e22d31
+---
+
 # Topology
 
 An important keyword recognized by the [hEngine](/platform/engine) is `topology`.

--- a/resources/docs/simulation/creating-simulations/configuration/topology/bounds-and-wrapping.md
+++ b/resources/docs/simulation/creating-simulations/configuration/topology/bounds-and-wrapping.md
@@ -1,7 +1,7 @@
 ---
 title: Bounds and Wrapping
 slug: simulation/creating-simulations/configuration/topology/bounds-and-wrapping
-objectID: d2371288-735b-4244-80d9-3776cc4e651b
+objectId: 8ecc00e9-25de-43be-ad10-900e51bd2ad3}
 ---
 
 # Bounds and Wrapping

--- a/resources/docs/simulation/creating-simulations/configuration/topology/bounds-and-wrapping.md
+++ b/resources/docs/simulation/creating-simulations/configuration/topology/bounds-and-wrapping.md
@@ -1,4 +1,6 @@
 ---
+title: Bounds and Wrapping
+slug: simulation/creating-simulations/configuration/topology/bounds-and-wrapping
 objectID: d2371288-735b-4244-80d9-3776cc4e651b
 ---
 

--- a/resources/docs/simulation/creating-simulations/configuration/topology/bounds-and-wrapping.md
+++ b/resources/docs/simulation/creating-simulations/configuration/topology/bounds-and-wrapping.md
@@ -1,3 +1,7 @@
+---
+objectID: d2371288-735b-4244-80d9-3776cc4e651b
+---
+
 # Bounds and Wrapping
 
 Often, you don't want your agents to move ad infinitum. You might be simulating gas particles in a closed box, or flights across the globe. In these situations, you need to define how big the world is, and how the agent operates as it nears the borders.

--- a/resources/docs/simulation/creating-simulations/configuration/topology/distance-functions.md
+++ b/resources/docs/simulation/creating-simulations/configuration/topology/distance-functions.md
@@ -1,4 +1,6 @@
 ---
+title: Distance Functions
+slug: simulation/creating-simulations/configuration/topology/distance-functions
 objectID: 18dad1da-18d1-4315-b778-d141b7e6e8ca
 description: How far away is one agent from another?
 ---

--- a/resources/docs/simulation/creating-simulations/configuration/topology/distance-functions.md
+++ b/resources/docs/simulation/creating-simulations/configuration/topology/distance-functions.md
@@ -1,4 +1,5 @@
 ---
+objectID: 18dad1da-18d1-4315-b778-d141b7e6e8ca
 description: How far away is one agent from another?
 ---
 

--- a/resources/docs/simulation/creating-simulations/configuration/topology/distance-functions.md
+++ b/resources/docs/simulation/creating-simulations/configuration/topology/distance-functions.md
@@ -1,7 +1,7 @@
 ---
 title: Distance Functions
 slug: simulation/creating-simulations/configuration/topology/distance-functions
-objectID: 18dad1da-18d1-4315-b778-d141b7e6e8ca
+objectId: f34a19b1-0bd7-44dc-97e0-c371d63ab6c0
 description: How far away is one agent from another?
 ---
 

--- a/resources/docs/simulation/creating-simulations/configuration/topology/wrapping-presets-and-flags.md
+++ b/resources/docs/simulation/creating-simulations/configuration/topology/wrapping-presets-and-flags.md
@@ -1,7 +1,7 @@
 ---
 title: Wrapping Presets and Flags
 slug: simulation/creating-simulations/configuration/topology/wrapping-presets-and-flags
-objectID: 8bc66c86-74df-47a6-b8bf-4f066096c009
+objectId: 1e6551fa-f571-448d-a5f6-6327a0674ab8
 description: Granular control of how the world is presented to hCore
 ---
 

--- a/resources/docs/simulation/creating-simulations/configuration/topology/wrapping-presets-and-flags.md
+++ b/resources/docs/simulation/creating-simulations/configuration/topology/wrapping-presets-and-flags.md
@@ -1,4 +1,6 @@
 ---
+title: Wrapping Presets and Flags
+slug: simulation/creating-simulations/configuration/topology/wrapping-presets-and-flags
 objectID: 8bc66c86-74df-47a6-b8bf-4f066096c009
 description: Granular control of how the world is presented to hCore
 ---

--- a/resources/docs/simulation/creating-simulations/configuration/topology/wrapping-presets-and-flags.md
+++ b/resources/docs/simulation/creating-simulations/configuration/topology/wrapping-presets-and-flags.md
@@ -1,4 +1,5 @@
 ---
+objectID: 8bc66c86-74df-47a6-b8bf-4f066096c009
 description: Granular control of how the world is presented to hCore
 ---
 

--- a/resources/docs/simulation/creating-simulations/datasets/README.md
+++ b/resources/docs/simulation/creating-simulations/datasets/README.md
@@ -1,4 +1,6 @@
 ---
+title: Datasets
+slug: simulation/creating-simulations/datasets
 objectID: 06945f04-7459-4141-b433-0bad8f78cc20
 ---
 

--- a/resources/docs/simulation/creating-simulations/datasets/README.md
+++ b/resources/docs/simulation/creating-simulations/datasets/README.md
@@ -1,3 +1,7 @@
+---
+objectID: 06945f04-7459-4141-b433-0bad8f78cc20
+---
+
 # Datasets
 
 **Data can be used in HASH to instantiate agents in a simulation, to set the properties of agents, or to influence any part of the simulation.**

--- a/resources/docs/simulation/creating-simulations/datasets/README.md
+++ b/resources/docs/simulation/creating-simulations/datasets/README.md
@@ -1,7 +1,7 @@
 ---
 title: Datasets
 slug: simulation/creating-simulations/datasets
-objectID: 06945f04-7459-4141-b433-0bad8f78cc20
+objectId: d784acc8-ffd5-4299-8e54-ab64011b3cea}
 ---
 
 # Datasets

--- a/resources/docs/simulation/creating-simulations/datasets/publishing-data-to-index.md
+++ b/resources/docs/simulation/creating-simulations/datasets/publishing-data-to-index.md
@@ -1,3 +1,7 @@
+---
+objectID: f5736a9e-8732-4b49-b0a5-b72389262991
+---
+
 # Publishing Datasets to Index
 
 You can share your datasets with others by publishing them to hIndex.

--- a/resources/docs/simulation/creating-simulations/datasets/publishing-data-to-index.md
+++ b/resources/docs/simulation/creating-simulations/datasets/publishing-data-to-index.md
@@ -1,5 +1,7 @@
 ---
-objectID: f5736a9e-8732-4b49-b0a5-b72389262991
+title: Publishing Datasets to Index
+slug: simulation/creating-simulations/datasets/publishing-data-to-index
+objectId: d8103bea-2124-494a-a852-c38e8e1d0f9d}
 ---
 
 # Publishing Datasets to Index

--- a/resources/docs/simulation/creating-simulations/experiments/README.md
+++ b/resources/docs/simulation/creating-simulations/experiments/README.md
@@ -1,7 +1,7 @@
 ---
 title: Experiments
 slug: simulation/creating-simulations/experiments
-objectID: 6b512e3a-db0b-4134-b787-b0123e3bc68e
+objectId: d8aaa790-5ce3-45cd-95e7-9e1024be7305
 description: 'Sweep parameters, explore a search space, and find optimal configurations'
 ---
 

--- a/resources/docs/simulation/creating-simulations/experiments/README.md
+++ b/resources/docs/simulation/creating-simulations/experiments/README.md
@@ -1,4 +1,5 @@
 ---
+objectID: 6b512e3a-db0b-4134-b787-b0123e3bc68e
 description: 'Sweep parameters, explore a search space, and find optimal configurations'
 ---
 

--- a/resources/docs/simulation/creating-simulations/experiments/README.md
+++ b/resources/docs/simulation/creating-simulations/experiments/README.md
@@ -1,4 +1,6 @@
 ---
+title: Experiments
+slug: simulation/creating-simulations/experiments
 objectID: 6b512e3a-db0b-4134-b787-b0123e3bc68e
 description: 'Sweep parameters, explore a search space, and find optimal configurations'
 ---

--- a/resources/docs/simulation/creating-simulations/experiments/experiment-types.md
+++ b/resources/docs/simulation/creating-simulations/experiments/experiment-types.md
@@ -1,7 +1,7 @@
 ---
 title: Standard Experiments
 slug: simulation/creating-simulations/experiments/experiment-types
-objectID: 1184d917-bf71-47bb-8adc-e3463e9ce26c
+objectId: eeee40ed-8215-4464-86be-b8314a8239fc
 description: Reference for different experiment options
 ---
 

--- a/resources/docs/simulation/creating-simulations/experiments/experiment-types.md
+++ b/resources/docs/simulation/creating-simulations/experiments/experiment-types.md
@@ -1,4 +1,6 @@
 ---
+title: Standard Experiments
+slug: simulation/creating-simulations/experiments/experiment-types
 objectID: 1184d917-bf71-47bb-8adc-e3463e9ce26c
 description: Reference for different experiment options
 ---

--- a/resources/docs/simulation/creating-simulations/experiments/experiment-types.md
+++ b/resources/docs/simulation/creating-simulations/experiments/experiment-types.md
@@ -1,4 +1,5 @@
 ---
+objectID: 1184d917-bf71-47bb-8adc-e3463e9ce26c
 description: Reference for different experiment options
 ---
 

--- a/resources/docs/simulation/creating-simulations/experiments/optimization-experiments.md
+++ b/resources/docs/simulation/creating-simulations/experiments/optimization-experiments.md
@@ -1,4 +1,6 @@
 ---
+title: Optimization Experiments
+slug: simulation/creating-simulations/experiments/optimization-experiments
 objectID: 3e7e7895-d9b3-4fdd-9760-4d70ade862af
 description: How to use HASH to optimize your simulation's parameters
 ---

--- a/resources/docs/simulation/creating-simulations/experiments/optimization-experiments.md
+++ b/resources/docs/simulation/creating-simulations/experiments/optimization-experiments.md
@@ -1,4 +1,5 @@
 ---
+objectID: 3e7e7895-d9b3-4fdd-9760-4d70ade862af
 description: How to use HASH to optimize your simulation's parameters
 ---
 

--- a/resources/docs/simulation/creating-simulations/experiments/optimization-experiments.md
+++ b/resources/docs/simulation/creating-simulations/experiments/optimization-experiments.md
@@ -1,7 +1,7 @@
 ---
 title: Optimization Experiments
 slug: simulation/creating-simulations/experiments/optimization-experiments
-objectID: 3e7e7895-d9b3-4fdd-9760-4d70ade862af
+objectId: c6db0e46-61e0-4500-97e0-7e5159bb5800
 description: How to use HASH to optimize your simulation's parameters
 ---
 

--- a/resources/docs/simulation/creating-simulations/experiments/optimization-experiments/README.md
+++ b/resources/docs/simulation/creating-simulations/experiments/optimization-experiments/README.md
@@ -1,4 +1,5 @@
 ---
+objectID: 6858bbfc-2506-47be-8107-abf9ff1ce62d
 description: How to use HASH to optimize your simulation's parameters
 ---
 

--- a/resources/docs/simulation/creating-simulations/experiments/optimization-experiments/README.md
+++ b/resources/docs/simulation/creating-simulations/experiments/optimization-experiments/README.md
@@ -1,4 +1,6 @@
 ---
+title: Optimization Experiments
+slug: simulation/creating-simulations/experiments/optimization-experiments
 objectID: 6858bbfc-2506-47be-8107-abf9ff1ce62d
 description: How to use HASH to optimize your simulation's parameters
 ---

--- a/resources/docs/simulation/creating-simulations/experiments/optimization-experiments/README.md
+++ b/resources/docs/simulation/creating-simulations/experiments/optimization-experiments/README.md
@@ -1,7 +1,7 @@
 ---
 title: Optimization Experiments
 slug: simulation/creating-simulations/experiments/optimization-experiments
-objectID: 6858bbfc-2506-47be-8107-abf9ff1ce62d
+objectId: 6858bbfc-2506-47be-8107-abf9ff1ce62d
 description: How to use HASH to optimize your simulation's parameters
 ---
 

--- a/resources/docs/simulation/creating-simulations/experiments/optimization-experiments/complex-metrics.md
+++ b/resources/docs/simulation/creating-simulations/experiments/optimization-experiments/complex-metrics.md
@@ -1,4 +1,6 @@
 ---
+title: Complex Metrics
+slug: simulation/creating-simulations/experiments/optimization-experiments/complex-metrics
 objectID: 1771ca79-b0c1-406a-9169-99228bc3846f
 ---
 

--- a/resources/docs/simulation/creating-simulations/experiments/optimization-experiments/complex-metrics.md
+++ b/resources/docs/simulation/creating-simulations/experiments/optimization-experiments/complex-metrics.md
@@ -1,3 +1,7 @@
+---
+objectID: 1771ca79-b0c1-406a-9169-99228bc3846f
+---
+
 # Complex Metrics
 
 HASH has a robust analysis system in place, allowing users to gather data from their simulation with metrics, and plot them in numerous different graph types. By defining an agent in your simulation that performs its own data collection and transformation, you can generate more complex metrics which represent weighted combinations of other metrics and datasets. This can unlock additional functionality in your HASH simulations.

--- a/resources/docs/simulation/creating-simulations/experiments/optimization-experiments/complex-metrics.md
+++ b/resources/docs/simulation/creating-simulations/experiments/optimization-experiments/complex-metrics.md
@@ -1,7 +1,7 @@
 ---
 title: Complex Metrics
 slug: simulation/creating-simulations/experiments/optimization-experiments/complex-metrics
-objectID: 1771ca79-b0c1-406a-9169-99228bc3846f
+objectId: 299b81a3-c732-4528-bba3-88bf765bb114}
 ---
 
 # Complex Metrics

--- a/resources/docs/simulation/creating-simulations/h.cloud.md
+++ b/resources/docs/simulation/creating-simulations/h.cloud.md
@@ -1,4 +1,6 @@
 ---
+title: Cloud Compute
+slug: simulation/creating-simulations/h.cloud
 objectID: 43201ebd-3dad-4806-8ad2-b1b5b0c49bf7
 description: Run simulations on our hCloud infrastructure
 ---

--- a/resources/docs/simulation/creating-simulations/h.cloud.md
+++ b/resources/docs/simulation/creating-simulations/h.cloud.md
@@ -1,4 +1,5 @@
 ---
+objectID: 43201ebd-3dad-4806-8ad2-b1b5b0c49bf7
 description: Run simulations on our hCloud infrastructure
 ---
 

--- a/resources/docs/simulation/creating-simulations/h.cloud.md
+++ b/resources/docs/simulation/creating-simulations/h.cloud.md
@@ -1,7 +1,7 @@
 ---
 title: Cloud Compute
 slug: simulation/creating-simulations/h.cloud
-objectID: 43201ebd-3dad-4806-8ad2-b1b5b0c49bf7
+objectId: 32b300a1-02a7-44ac-9db9-8300ef180496
 description: Run simulations on our hCloud infrastructure
 ---
 

--- a/resources/docs/simulation/creating-simulations/libraries/README.md
+++ b/resources/docs/simulation/creating-simulations/libraries/README.md
@@ -1,7 +1,7 @@
 ---
 title: Libraries
 slug: simulation/creating-simulations/libraries
-objectID: 960497c8-9d8b-42d9-afed-f76c6c55a4cb
+objectId: b5d41ca2-e55b-4040-98dd-4d7035d6b7c9}
 ---
 
 # Libraries

--- a/resources/docs/simulation/creating-simulations/libraries/README.md
+++ b/resources/docs/simulation/creating-simulations/libraries/README.md
@@ -1,3 +1,7 @@
+---
+objectID: 960497c8-9d8b-42d9-afed-f76c6c55a4cb
+---
+
 # Libraries
 
 ## HASH Standard Library

--- a/resources/docs/simulation/creating-simulations/libraries/README.md
+++ b/resources/docs/simulation/creating-simulations/libraries/README.md
@@ -1,4 +1,6 @@
 ---
+title: Libraries
+slug: simulation/creating-simulations/libraries
 objectID: 960497c8-9d8b-42d9-afed-f76c6c55a4cb
 ---
 

--- a/resources/docs/simulation/creating-simulations/libraries/hash/README.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/README.md
@@ -1,7 +1,7 @@
 ---
 title: HASH
 slug: simulation/creating-simulations/libraries/hash
-objectID: 6e62ef1b-d7c5-435c-948a-c5c8a28d2b05
+objectId: fa7eb71c-7119-4abb-8d6d-226590d6dec1}
 ---
 
 # HASH

--- a/resources/docs/simulation/creating-simulations/libraries/hash/README.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/README.md
@@ -1,3 +1,7 @@
+---
+objectID: 6e62ef1b-d7c5-435c-948a-c5c8a28d2b05
+---
+
 # HASH
 
 There are a number of functions that are accessible through the built-in `hstd` . These are specifically designed to make frequent operations in HASH more streamlined. These libraries will be growing as we explore new ways to make it easier for you to build models in HASH.

--- a/resources/docs/simulation/creating-simulations/libraries/hash/README.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/README.md
@@ -1,4 +1,6 @@
 ---
+title: HASH
+slug: simulation/creating-simulations/libraries/hash
 objectID: 6e62ef1b-d7c5-435c-948a-c5c8a28d2b05
 ---
 

--- a/resources/docs/simulation/creating-simulations/libraries/hash/agent.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/agent.md
@@ -1,7 +1,7 @@
 ---
 title: Agent
 slug: simulation/creating-simulations/libraries/hash/agent
-objectID: 8d5b91b9-6aac-45d8-a5a1-3df383d257a6
+objectId: 34c98a57-c201-48ef-bb76-5abcd714fea9}
 ---
 
 # Agent

--- a/resources/docs/simulation/creating-simulations/libraries/hash/agent.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/agent.md
@@ -1,3 +1,7 @@
+---
+objectID: 8d5b91b9-6aac-45d8-a5a1-3df383d257a6
+---
+
 # Agent
 
 ## generateAgentID()

--- a/resources/docs/simulation/creating-simulations/libraries/hash/agent.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/agent.md
@@ -1,4 +1,6 @@
 ---
+title: Agent
+slug: simulation/creating-simulations/libraries/hash/agent
 objectID: 8d5b91b9-6aac-45d8-a5a1-3df383d257a6
 ---
 

--- a/resources/docs/simulation/creating-simulations/libraries/hash/init.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/init.md
@@ -1,7 +1,7 @@
 ---
 title: Init
 slug: simulation/creating-simulations/libraries/hash/init
-objectID: 893cb298-60fe-4b1d-a084-a9bd1cf695d3
+objectId: 45499e0d-98af-4a99-9353-fddc8b3ca79e}
 ---
 
 # Init

--- a/resources/docs/simulation/creating-simulations/libraries/hash/init.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/init.md
@@ -1,3 +1,7 @@
+---
+objectID: 893cb298-60fe-4b1d-a084-a9bd1cf695d3
+---
+
 # Init
 
 When using `init.js` or `init.py` to initialize your simulation, these standard library functions can help you easily initialize agents in predefined patterns.

--- a/resources/docs/simulation/creating-simulations/libraries/hash/init.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/init.md
@@ -1,4 +1,6 @@
 ---
+title: Init
+slug: simulation/creating-simulations/libraries/hash/init
 objectID: 893cb298-60fe-4b1d-a084-a9bd1cf695d3
 ---
 

--- a/resources/docs/simulation/creating-simulations/libraries/hash/javascript-libraries.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/javascript-libraries.md
@@ -1,7 +1,7 @@
 ---
 title: Statistics
 slug: simulation/creating-simulations/libraries/hash/javascript-libraries
-objectID: f9456b3b-7297-48bd-b478-65afd139c4c8
+objectId: 5343334f-4494-48e8-846a-ac22a38b9ea5
 description: Statistics packages and libraries support in HASH
 ---
 

--- a/resources/docs/simulation/creating-simulations/libraries/hash/javascript-libraries.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/javascript-libraries.md
@@ -1,4 +1,6 @@
 ---
+title: Statistics
+slug: simulation/creating-simulations/libraries/hash/javascript-libraries
 objectID: f9456b3b-7297-48bd-b478-65afd139c4c8
 description: Statistics packages and libraries support in HASH
 ---

--- a/resources/docs/simulation/creating-simulations/libraries/hash/javascript-libraries.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/javascript-libraries.md
@@ -1,4 +1,5 @@
 ---
+objectID: f9456b3b-7297-48bd-b478-65afd139c4c8
 description: Statistics packages and libraries support in HASH
 ---
 

--- a/resources/docs/simulation/creating-simulations/libraries/hash/neighbors.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/neighbors.md
@@ -1,7 +1,7 @@
 ---
 title: Neighbors
 slug: simulation/creating-simulations/libraries/hash/neighbors
-objectID: b2a7f76d-a8b6-4f09-a344-0d84a93872ce
+objectId: c1c7f910-08cb-4d8f-a5ef-60a4c1c76ab1}
 ---
 
 # Neighbors

--- a/resources/docs/simulation/creating-simulations/libraries/hash/neighbors.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/neighbors.md
@@ -1,4 +1,6 @@
 ---
+title: Neighbors
+slug: simulation/creating-simulations/libraries/hash/neighbors
 objectID: b2a7f76d-a8b6-4f09-a344-0d84a93872ce
 ---
 

--- a/resources/docs/simulation/creating-simulations/libraries/hash/neighbors.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/neighbors.md
@@ -1,3 +1,7 @@
+---
+objectID: b2a7f76d-a8b6-4f09-a344-0d84a93872ce
+---
+
 # Neighbors
 
 ## neighborsOnPosition(agentA, neighbors)

--- a/resources/docs/simulation/creating-simulations/libraries/hash/random.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/random.md
@@ -1,7 +1,7 @@
 ---
 title: Random
 slug: simulation/creating-simulations/libraries/hash/random
-objectID: 3101bc8c-5af5-49d3-b7b1-fa5e41424ac6
+objectId: b1f18a3b-9454-49c7-8dbf-70eceb24b940
 description: hstd functions for generating pseudo-random numbers.
 ---
 

--- a/resources/docs/simulation/creating-simulations/libraries/hash/random.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/random.md
@@ -1,4 +1,6 @@
 ---
+title: Random
+slug: simulation/creating-simulations/libraries/hash/random
 objectID: 3101bc8c-5af5-49d3-b7b1-fa5e41424ac6
 description: hstd functions for generating pseudo-random numbers.
 ---

--- a/resources/docs/simulation/creating-simulations/libraries/hash/random.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/random.md
@@ -1,4 +1,5 @@
 ---
+objectID: 3101bc8c-5af5-49d3-b7b1-fa5e41424ac6
 description: hstd functions for generating pseudo-random numbers.
 ---
 

--- a/resources/docs/simulation/creating-simulations/libraries/hash/spatial.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/spatial.md
@@ -1,7 +1,7 @@
 ---
 title: Spatial
 slug: simulation/creating-simulations/libraries/hash/spatial
-objectID: 591aa401-375e-49b1-b3c5-8816b1f2b77e
+objectId: 3b8ec1aa-6569-45dd-860e-2a52692ab603}
 ---
 
 # Spatial

--- a/resources/docs/simulation/creating-simulations/libraries/hash/spatial.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/spatial.md
@@ -1,4 +1,6 @@
 ---
+title: Spatial
+slug: simulation/creating-simulations/libraries/hash/spatial
 objectID: 591aa401-375e-49b1-b3c5-8816b1f2b77e
 ---
 

--- a/resources/docs/simulation/creating-simulations/libraries/hash/spatial.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/spatial.md
@@ -1,3 +1,7 @@
+---
+objectID: 591aa401-375e-49b1-b3c5-8816b1f2b77e
+---
+
 # Spatial
 
 ## distanceBetween(agentA, agentB, distanceFunction)

--- a/resources/docs/simulation/creating-simulations/libraries/python-packages.md
+++ b/resources/docs/simulation/creating-simulations/libraries/python-packages.md
@@ -1,7 +1,7 @@
 ---
 title: Python
 slug: simulation/creating-simulations/libraries/python-packages
-objectID: a48d4f8e-d98b-40e6-8f2d-689a05b2b452
+objectId: cf9de4ff-0f99-45e2-bcfc-b78c3f652745
 description: Python packages and libraries support in HASH
 ---
 

--- a/resources/docs/simulation/creating-simulations/libraries/python-packages.md
+++ b/resources/docs/simulation/creating-simulations/libraries/python-packages.md
@@ -1,4 +1,6 @@
 ---
+title: Python
+slug: simulation/creating-simulations/libraries/python-packages
 objectID: a48d4f8e-d98b-40e6-8f2d-689a05b2b452
 description: Python packages and libraries support in HASH
 ---

--- a/resources/docs/simulation/creating-simulations/libraries/python-packages.md
+++ b/resources/docs/simulation/creating-simulations/libraries/python-packages.md
@@ -1,4 +1,5 @@
 ---
+objectID: a48d4f8e-d98b-40e6-8f2d-689a05b2b452
 description: Python packages and libraries support in HASH
 ---
 

--- a/resources/docs/simulation/creating-simulations/views/3d-viewer.md
+++ b/resources/docs/simulation/creating-simulations/views/3d-viewer.md
@@ -1,3 +1,7 @@
+---
+objectID: 728dc2ce-c48a-4923-bae2-b8e83cdcb077
+---
+
 # 3D
 
 The 3D viewer in HASH is designed to make viewing simulation data as fast and convenient as possible.

--- a/resources/docs/simulation/creating-simulations/views/3d-viewer.md
+++ b/resources/docs/simulation/creating-simulations/views/3d-viewer.md
@@ -1,7 +1,7 @@
 ---
 title: 3D
 slug: simulation/creating-simulations/views/3d-viewer
-objectID: 728dc2ce-c48a-4923-bae2-b8e83cdcb077
+objectId: b1a70631-35af-46e7-a1a9-6e66c0031f36}
 ---
 
 # 3D

--- a/resources/docs/simulation/creating-simulations/views/3d-viewer.md
+++ b/resources/docs/simulation/creating-simulations/views/3d-viewer.md
@@ -1,4 +1,6 @@
 ---
+title: 3D
+slug: simulation/creating-simulations/views/3d-viewer
 objectID: 728dc2ce-c48a-4923-bae2-b8e83cdcb077
 ---
 

--- a/resources/docs/simulation/creating-simulations/views/README.md
+++ b/resources/docs/simulation/creating-simulations/views/README.md
@@ -1,7 +1,7 @@
 ---
 title: Simulation Outputs
 slug: simulation/creating-simulations/views
-objectID: d5cb459e-3523-4fc8-b29e-c5068eff32fc
+objectId: 521d303e-aa5c-4203-b7c4-43e27ea2914b
 description: Accessing data and insights from simulation runs
 ---
 

--- a/resources/docs/simulation/creating-simulations/views/README.md
+++ b/resources/docs/simulation/creating-simulations/views/README.md
@@ -1,4 +1,6 @@
 ---
+title: Simulation Outputs
+slug: simulation/creating-simulations/views
 objectID: d5cb459e-3523-4fc8-b29e-c5068eff32fc
 description: Accessing data and insights from simulation runs
 ---

--- a/resources/docs/simulation/creating-simulations/views/README.md
+++ b/resources/docs/simulation/creating-simulations/views/README.md
@@ -1,4 +1,5 @@
 ---
+objectID: d5cb459e-3523-4fc8-b29e-c5068eff32fc
 description: Accessing data and insights from simulation runs
 ---
 

--- a/resources/docs/simulation/creating-simulations/views/activity-history.md
+++ b/resources/docs/simulation/creating-simulations/views/activity-history.md
@@ -1,7 +1,7 @@
 ---
 title: Activity History
 slug: simulation/creating-simulations/views/activity-history
-objectID: 3e168a66-e844-4f05-8cfa-35733e100450
+objectId: b80e9f3f-9445-4c53-922d-ef9a643c4b32}
 ---
 
 # Activity History

--- a/resources/docs/simulation/creating-simulations/views/activity-history.md
+++ b/resources/docs/simulation/creating-simulations/views/activity-history.md
@@ -1,4 +1,6 @@
 ---
+title: Activity History
+slug: simulation/creating-simulations/views/activity-history
 objectID: 3e168a66-e844-4f05-8cfa-35733e100450
 ---
 

--- a/resources/docs/simulation/creating-simulations/views/activity-history.md
+++ b/resources/docs/simulation/creating-simulations/views/activity-history.md
@@ -1,3 +1,7 @@
+---
+objectID: 3e168a66-e844-4f05-8cfa-35733e100450
+---
+
 # Activity History
 
 When you make changes to files in a project, create a release, or run a simulation/experiment, HASH automatically records the action and output within the _Activity_ panel \(by default the right-hand sidebar in hCore\). You can revisit earlier versions of a project, view previously computed results, or re-run a simulation or experiment with its original values in order to reproduce the run.

--- a/resources/docs/simulation/creating-simulations/views/analysis/README.md
+++ b/resources/docs/simulation/creating-simulations/views/analysis/README.md
@@ -1,3 +1,7 @@
+---
+objectID: 48bdebba-4327-4e1d-9f7b-25b127c2ec19
+---
+
 # Analysis
 
 ## What is Simulation Analysis?

--- a/resources/docs/simulation/creating-simulations/views/analysis/README.md
+++ b/resources/docs/simulation/creating-simulations/views/analysis/README.md
@@ -1,4 +1,6 @@
 ---
+title: Analysis
+slug: simulation/creating-simulations/views/analysis
 objectID: 48bdebba-4327-4e1d-9f7b-25b127c2ec19
 ---
 

--- a/resources/docs/simulation/creating-simulations/views/analysis/README.md
+++ b/resources/docs/simulation/creating-simulations/views/analysis/README.md
@@ -1,7 +1,7 @@
 ---
 title: Analysis
 slug: simulation/creating-simulations/views/analysis
-objectID: 48bdebba-4327-4e1d-9f7b-25b127c2ec19
+objectId: be31030c-4021-4a21-81d1-3e845a53be5e}
 ---
 
 # Analysis

--- a/resources/docs/simulation/creating-simulations/views/analysis/metrics-syntax-reference.md
+++ b/resources/docs/simulation/creating-simulations/views/analysis/metrics-syntax-reference.md
@@ -1,4 +1,6 @@
 ---
+title: Metrics Syntax Reference
+slug: simulation/creating-simulations/views/analysis/metrics-syntax-reference
 objectID: 39ff713b-299d-4bf5-afbd-6c3d183803ee
 ---
 

--- a/resources/docs/simulation/creating-simulations/views/analysis/metrics-syntax-reference.md
+++ b/resources/docs/simulation/creating-simulations/views/analysis/metrics-syntax-reference.md
@@ -1,7 +1,7 @@
 ---
 title: Metrics Syntax Reference
 slug: simulation/creating-simulations/views/analysis/metrics-syntax-reference
-objectID: 39ff713b-299d-4bf5-afbd-6c3d183803ee
+objectId: 909dde86-3681-4653-be0e-105c79ed564f}
 ---
 
 # Metrics Syntax Reference

--- a/resources/docs/simulation/creating-simulations/views/analysis/metrics-syntax-reference.md
+++ b/resources/docs/simulation/creating-simulations/views/analysis/metrics-syntax-reference.md
@@ -1,3 +1,7 @@
+---
+objectID: 39ff713b-299d-4bf5-afbd-6c3d183803ee
+---
+
 # Metrics Syntax Reference
 
 We recommend using hCore's fully featured wizards to define metrics and generate plots. If you would like to define them manually for any reason, you can reference the below for an explanation of the structure and syntax of the **analysis.json** file.

--- a/resources/docs/simulation/creating-simulations/views/analysis/metrics.md
+++ b/resources/docs/simulation/creating-simulations/views/analysis/metrics.md
@@ -1,3 +1,7 @@
+---
+objectID: 5b84538b-1e4f-4dae-afa7-e9a2f978f33d
+---
+
 # Metrics
 
 Your first step is to define Metrics that you are interested in plotting. Each Metric is an output of your simulation, represented as an array of data. Metrics are defined as a series of Operations which transform your simulation data into an array of specific data, typically by filtering for specific agents, then retrieving a certain value from each agent. The available Operations are listed below.

--- a/resources/docs/simulation/creating-simulations/views/analysis/metrics.md
+++ b/resources/docs/simulation/creating-simulations/views/analysis/metrics.md
@@ -1,4 +1,6 @@
 ---
+title: Metrics
+slug: simulation/creating-simulations/views/analysis/metrics
 objectID: 5b84538b-1e4f-4dae-afa7-e9a2f978f33d
 ---
 

--- a/resources/docs/simulation/creating-simulations/views/analysis/metrics.md
+++ b/resources/docs/simulation/creating-simulations/views/analysis/metrics.md
@@ -1,7 +1,7 @@
 ---
 title: Metrics
 slug: simulation/creating-simulations/views/analysis/metrics
-objectID: 5b84538b-1e4f-4dae-afa7-e9a2f978f33d
+objectId: 28ad0ee6-385d-4c3d-9bd8-71bb5e7f239b}
 ---
 
 # Metrics

--- a/resources/docs/simulation/creating-simulations/views/analysis/plots-syntax-reference.md
+++ b/resources/docs/simulation/creating-simulations/views/analysis/plots-syntax-reference.md
@@ -1,4 +1,6 @@
 ---
+title: Plots Syntax Reference
+slug: simulation/creating-simulations/views/analysis/plots-syntax-reference
 objectID: da162d92-b496-46e7-9f99-d58a00efa594
 ---
 

--- a/resources/docs/simulation/creating-simulations/views/analysis/plots-syntax-reference.md
+++ b/resources/docs/simulation/creating-simulations/views/analysis/plots-syntax-reference.md
@@ -1,3 +1,7 @@
+---
+objectID: da162d92-b496-46e7-9f99-d58a00efa594
+---
+
 # Plots Syntax Reference
 
 ## Histograms

--- a/resources/docs/simulation/creating-simulations/views/analysis/plots-syntax-reference.md
+++ b/resources/docs/simulation/creating-simulations/views/analysis/plots-syntax-reference.md
@@ -1,7 +1,7 @@
 ---
 title: Plots Syntax Reference
 slug: simulation/creating-simulations/views/analysis/plots-syntax-reference
-objectID: da162d92-b496-46e7-9f99-d58a00efa594
+objectId: 563b072a-2228-451d-a731-8c0e6c0d5f02}
 ---
 
 # Plots Syntax Reference

--- a/resources/docs/simulation/creating-simulations/views/analysis/plots.md
+++ b/resources/docs/simulation/creating-simulations/views/analysis/plots.md
@@ -1,4 +1,6 @@
 ---
+title: Plots
+slug: simulation/creating-simulations/views/analysis/plots
 objectID: 14f7bd20-5f98-4d16-a5f0-569a7c350d62
 ---
 

--- a/resources/docs/simulation/creating-simulations/views/analysis/plots.md
+++ b/resources/docs/simulation/creating-simulations/views/analysis/plots.md
@@ -1,3 +1,7 @@
+---
+objectID: 14f7bd20-5f98-4d16-a5f0-569a7c350d62
+---
+
 # Plots
 
 ## What are Plots?

--- a/resources/docs/simulation/creating-simulations/views/analysis/plots.md
+++ b/resources/docs/simulation/creating-simulations/views/analysis/plots.md
@@ -1,7 +1,7 @@
 ---
 title: Plots
 slug: simulation/creating-simulations/views/analysis/plots
-objectID: 14f7bd20-5f98-4d16-a5f0-569a7c350d62
+objectId: f14b16d1-1cc0-463a-923c-92efa40be340}
 ---
 
 # Plots

--- a/resources/docs/simulation/creating-simulations/views/api-1.md
+++ b/resources/docs/simulation/creating-simulations/views/api-1.md
@@ -1,3 +1,7 @@
+---
+objectID: 0b354340-2b00-443c-b5b4-54cf8caf0bb8
+---
+
 # API
 
 If you run an experiment or simulation in hCloud, it's possible to get access the results of those runs via HASH's API.

--- a/resources/docs/simulation/creating-simulations/views/api-1.md
+++ b/resources/docs/simulation/creating-simulations/views/api-1.md
@@ -1,7 +1,7 @@
 ---
 title: API
 slug: simulation/creating-simulations/views/api-1
-objectID: 0b354340-2b00-443c-b5b4-54cf8caf0bb8
+objectId: 218e40ad-3932-4e97-a1ab-fe86739c8a12}
 ---
 
 # API

--- a/resources/docs/simulation/creating-simulations/views/api-1.md
+++ b/resources/docs/simulation/creating-simulations/views/api-1.md
@@ -1,4 +1,6 @@
 ---
+title: API
+slug: simulation/creating-simulations/views/api-1
 objectID: 0b354340-2b00-443c-b5b4-54cf8caf0bb8
 ---
 

--- a/resources/docs/simulation/creating-simulations/views/geospatial-viewer.md
+++ b/resources/docs/simulation/creating-simulations/views/geospatial-viewer.md
@@ -1,4 +1,6 @@
 ---
+title: Geospatial
+slug: simulation/creating-simulations/views/geospatial-viewer
 objectID: 92d1ed76-7119-48c7-904e-039d96f9e20b
 ---
 

--- a/resources/docs/simulation/creating-simulations/views/geospatial-viewer.md
+++ b/resources/docs/simulation/creating-simulations/views/geospatial-viewer.md
@@ -1,3 +1,7 @@
+---
+objectID: 92d1ed76-7119-48c7-904e-039d96f9e20b
+---
+
 # Geospatial
 
 The geospatial viewer provides a realtime view of a simulation running inside any geographic area — a neighborhood, a city, a country, or the whole world. It's great for visualizing simulations in which agents occupy a position on a map. Take a look at the [City Infection Model](/@hash/city-infection-model-with-vaccine) for an example simulation using the geospatial viewer.

--- a/resources/docs/simulation/creating-simulations/views/geospatial-viewer.md
+++ b/resources/docs/simulation/creating-simulations/views/geospatial-viewer.md
@@ -1,7 +1,7 @@
 ---
 title: Geospatial
 slug: simulation/creating-simulations/views/geospatial-viewer
-objectID: 92d1ed76-7119-48c7-904e-039d96f9e20b
+objectId: 5c60988f-abb9-4eff-bded-fb8616dc7d93}
 ---
 
 # Geospatial

--- a/resources/docs/simulation/creating-simulations/views/raw-data.md
+++ b/resources/docs/simulation/creating-simulations/views/raw-data.md
@@ -1,4 +1,6 @@
 ---
+title: Raw Data
+slug: simulation/creating-simulations/views/raw-data
 objectID: b2068487-4ee9-40a4-ba60-31eb3892fe6d
 ---
 

--- a/resources/docs/simulation/creating-simulations/views/raw-data.md
+++ b/resources/docs/simulation/creating-simulations/views/raw-data.md
@@ -1,7 +1,7 @@
 ---
 title: Raw Data
 slug: simulation/creating-simulations/views/raw-data
-objectID: b2068487-4ee9-40a4-ba60-31eb3892fe6d
+objectId: 0aa39b69-df1b-4834-915e-aeb86e846077}
 ---
 
 # Raw Data

--- a/resources/docs/simulation/creating-simulations/views/raw-data.md
+++ b/resources/docs/simulation/creating-simulations/views/raw-data.md
@@ -1,3 +1,7 @@
+---
+objectID: b2068487-4ee9-40a4-ba60-31eb3892fe6d
+---
+
 # Raw Data
 
 There are two ways that you can access the raw data which makes up a simulation. The **Raw Output** View will allow you to inspect the state of the simulation at the current time step, and hCore also allows you to export the full simulation as JSON.

--- a/resources/docs/simulation/extra/design-considerations.md
+++ b/resources/docs/simulation/extra/design-considerations.md
@@ -1,7 +1,7 @@
 ---
 title: Design Considerations
 slug: simulation/extra/design-considerations
-objectID: 0fd004a1-84fb-4974-94ee-2b3144d74be6
+objectId: 0fd004a1-84fb-4974-94ee-2b3144d74be6
 description: Important considerations to keep in mind when building your simulation
 ---
 

--- a/resources/docs/simulation/extra/design-considerations.md
+++ b/resources/docs/simulation/extra/design-considerations.md
@@ -1,4 +1,6 @@
 ---
+title: Design Considerations
+slug: simulation/extra/design-considerations
 objectID: 0fd004a1-84fb-4974-94ee-2b3144d74be6
 description: Important considerations to keep in mind when building your simulation
 ---

--- a/resources/docs/simulation/extra/design-considerations.md
+++ b/resources/docs/simulation/extra/design-considerations.md
@@ -1,4 +1,5 @@
 ---
+objectID: 0fd004a1-84fb-4974-94ee-2b3144d74be6
 description: Important considerations to keep in mind when building your simulation
 ---
 

--- a/resources/docs/simulation/extra/determinism.md
+++ b/resources/docs/simulation/extra/determinism.md
@@ -1,7 +1,7 @@
 ---
 title: Determinism
 slug: simulation/extra/determinism
-objectID: 1ea0b8cf-019e-4df4-818e-aa82c8bc906e
+objectId: 6504d150-4a11-411b-a413-5a721dbc2d41}
 ---
 
 # Determinism

--- a/resources/docs/simulation/extra/determinism.md
+++ b/resources/docs/simulation/extra/determinism.md
@@ -1,4 +1,6 @@
 ---
+title: Determinism
+slug: simulation/extra/determinism
 objectID: 1ea0b8cf-019e-4df4-818e-aa82c8bc906e
 ---
 

--- a/resources/docs/simulation/extra/determinism.md
+++ b/resources/docs/simulation/extra/determinism.md
@@ -1,3 +1,7 @@
+---
+objectID: 1ea0b8cf-019e-4df4-818e-aa82c8bc906e
+---
+
 # Determinism
 
 ## Why is determinism important?

--- a/resources/docs/simulation/extra/migrating/README.md
+++ b/resources/docs/simulation/extra/migrating/README.md
@@ -1,4 +1,6 @@
 ---
+title: Switching to HASH
+slug: simulation/extra/migrating
 objectID: 9bf17889-9535-4a79-9321-0aed40f8c5a9
 ---
 

--- a/resources/docs/simulation/extra/migrating/README.md
+++ b/resources/docs/simulation/extra/migrating/README.md
@@ -1,3 +1,7 @@
+---
+objectID: 9bf17889-9535-4a79-9321-0aed40f8c5a9
+---
+
 # Switching to HASH
 
 One of the most common questions we hear from users is “We want to use HASH because it’s free, fast, and integrates with my other tools - but we’ve already built a simulation in another package. How can we easily port it over into HASH?”

--- a/resources/docs/simulation/extra/migrating/README.md
+++ b/resources/docs/simulation/extra/migrating/README.md
@@ -1,7 +1,7 @@
 ---
 title: Switching to HASH
 slug: simulation/extra/migrating
-objectID: 9bf17889-9535-4a79-9321-0aed40f8c5a9
+objectId: 0a257bb5-c96f-44b9-b00e-3a2ebb777b83}
 ---
 
 # Switching to HASH

--- a/resources/docs/simulation/extra/migrating/anylogic/README.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/README.md
@@ -1,4 +1,6 @@
 ---
+title: Migrating from AnyLogic
+slug: simulation/extra/migrating/anylogic
 objectID: 103ccd0a-8ecf-49f6-ba1c-1ca33e688abc
 ---
 

--- a/resources/docs/simulation/extra/migrating/anylogic/README.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/README.md
@@ -1,7 +1,7 @@
 ---
 title: Migrating from AnyLogic
 slug: simulation/extra/migrating/anylogic
-objectID: 103ccd0a-8ecf-49f6-ba1c-1ca33e688abc
+objectId: 8844aee0-4d75-4e81-a9df-924c6fecc695}
 ---
 
 # Migrating from AnyLogic

--- a/resources/docs/simulation/extra/migrating/anylogic/README.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/README.md
@@ -1,3 +1,7 @@
+---
+objectID: 103ccd0a-8ecf-49f6-ba1c-1ca33e688abc
+---
+
 # Migrating from AnyLogic
 
 AnyLogic is a 20+ year old desktop application that lets programmers write object-oriented Java to create simulations. AnyLogic also has limited support for visual programming, allowing non-programmers to create basic simulations.

--- a/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/README.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/README.md
@@ -1,4 +1,6 @@
 ---
+title: Building the Simulation
+slug: simulation/extra/migrating/anylogic/building-the-simulation
 objectID: 53dece1f-b1d9-49d4-989e-2bf5964b134e
 ---
 

--- a/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/README.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/README.md
@@ -1,3 +1,7 @@
+---
+objectID: 53dece1f-b1d9-49d4-989e-2bf5964b134e
+---
+
 # Building the Simulation
 
 Working outside in, we will start with **Tankers**. We’ll point out key pieces of logic contained in each agent’s behaviors, show you some code snippets, and call out when we made use of published behaviors in hIndex. We encourage you to follow along in the [existing simulation](/@hash/oil-supply-chain) to see how these snippets fit into the full behaviors and simulation.

--- a/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/README.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/README.md
@@ -1,7 +1,7 @@
 ---
 title: Building the Simulation
 slug: simulation/extra/migrating/anylogic/building-the-simulation
-objectID: 53dece1f-b1d9-49d4-989e-2bf5964b134e
+objectId: 6c28dc07-a85d-4cea-a6a0-0b7c8bf10ee1}
 ---
 
 # Building the Simulation

--- a/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/full-initialization.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/full-initialization.md
@@ -1,3 +1,7 @@
+---
+objectID: 6ccd70fb-b09e-481a-96e1-520e15e60c37
+---
+
 # Full Initialization
 
 We've built all our logic to run this simulation, but we want to have more than just one agent of each type in our model. We're going to create a dataset to represent a network of ports, refineries, storages, etc. and use it to initialize our model. We'll also import some historical oil supply data to populate the demand gas stations experience.

--- a/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/full-initialization.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/full-initialization.md
@@ -1,7 +1,7 @@
 ---
 title: Full Initialization
 slug: simulation/extra/migrating/anylogic/building-the-simulation/full-initialization
-objectID: 6ccd70fb-b09e-481a-96e1-520e15e60c37
+objectId: aadcc558-465d-4877-b859-c777344d5dca}
 ---
 
 # Full Initialization

--- a/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/full-initialization.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/full-initialization.md
@@ -1,4 +1,6 @@
 ---
+title: Full Initialization
+slug: simulation/extra/migrating/anylogic/building-the-simulation/full-initialization
 objectID: 6ccd70fb-b09e-481a-96e1-520e15e60c37
 ---
 

--- a/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/improving-our-visualization.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/improving-our-visualization.md
@@ -1,3 +1,7 @@
+---
+objectID: 83b5f923-aea4-4a39-941a-a33c71b202e6
+---
+
 # Improving our Visualization
 
 Now let's add some more involved visualization to our simulation. Visualizations allow users of your simulation to better understand your model, and includes generating graphs in the **Plots** view, and improving the visuals in the **3D Viewer**.

--- a/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/improving-our-visualization.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/improving-our-visualization.md
@@ -1,4 +1,6 @@
 ---
+title: Improving our Visualization
+slug: simulation/extra/migrating/anylogic/building-the-simulation/improving-our-visualization
 objectID: 83b5f923-aea4-4a39-941a-a33c71b202e6
 ---
 

--- a/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/improving-our-visualization.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/improving-our-visualization.md
@@ -1,7 +1,7 @@
 ---
 title: Improving our Visualization
 slug: simulation/extra/migrating/anylogic/building-the-simulation/improving-our-visualization
-objectID: 83b5f923-aea4-4a39-941a-a33c71b202e6
+objectId: 03f86810-5714-4ab3-a71e-5829698d12ed}
 ---
 
 # Improving our Visualization

--- a/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/tankers-to-port.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/tankers-to-port.md
@@ -1,7 +1,7 @@
 ---
 title: Tankers to Port
 slug: simulation/extra/migrating/anylogic/building-the-simulation/tankers-to-port
-objectID: c2099950-ee5c-4efd-b975-ff7b9284f006
+objectId: a83de86e-50f5-4651-b290-33ab9a3e6265}
 ---
 
 # Tankers to Port

--- a/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/tankers-to-port.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/tankers-to-port.md
@@ -1,4 +1,6 @@
 ---
+title: Tankers to Port
+slug: simulation/extra/migrating/anylogic/building-the-simulation/tankers-to-port
 objectID: c2099950-ee5c-4efd-b975-ff7b9284f006
 ---
 

--- a/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/tankers-to-port.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/tankers-to-port.md
@@ -1,3 +1,7 @@
+---
+objectID: c2099950-ee5c-4efd-b975-ff7b9284f006
+---
+
 # Tankers to Port
 
 We’ve identified **Tankers** as a good place to start in this simulation. Let’s build one, along with a **Port** agent for it to interact with!

--- a/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/through-the-pipeline.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/through-the-pipeline.md
@@ -1,4 +1,6 @@
 ---
+title: Through the Pipeline
+slug: simulation/extra/migrating/anylogic/building-the-simulation/through-the-pipeline
 objectID: eb609efe-27a8-43c4-8018-80b61658ea7e
 ---
 

--- a/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/through-the-pipeline.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/through-the-pipeline.md
@@ -1,7 +1,7 @@
 ---
 title: Through the Pipeline
 slug: simulation/extra/migrating/anylogic/building-the-simulation/through-the-pipeline
-objectID: eb609efe-27a8-43c4-8018-80b61658ea7e
+objectId: 8c2cbfe4-fdc9-4121-a660-0edca6b24012}
 ---
 
 # Through the Pipeline

--- a/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/through-the-pipeline.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/through-the-pipeline.md
@@ -1,3 +1,7 @@
+---
+objectID: eb609efe-27a8-43c4-8018-80b61658ea7e
+---
+
 # Through the Pipeline
 
 ## Refinery

--- a/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/trucks-on-the-move.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/trucks-on-the-move.md
@@ -1,4 +1,6 @@
 ---
+title: Trucks on the Move
+slug: simulation/extra/migrating/anylogic/building-the-simulation/trucks-on-the-move
 objectID: e7a0b14f-660b-4844-841e-6cd50b0dd9c9
 ---
 

--- a/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/trucks-on-the-move.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/trucks-on-the-move.md
@@ -1,7 +1,7 @@
 ---
 title: Trucks on the Move
 slug: simulation/extra/migrating/anylogic/building-the-simulation/trucks-on-the-move
-objectID: e7a0b14f-660b-4844-841e-6cd50b0dd9c9
+objectId: caf5c3c1-c940-41a8-a21b-5ae15760c305}
 ---
 
 # Trucks on the Move

--- a/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/trucks-on-the-move.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/building-the-simulation/trucks-on-the-move.md
@@ -1,3 +1,7 @@
+---
+objectID: e7a0b14f-660b-4844-841e-6cd50b0dd9c9
+---
+
 # Trucks on the Move
 
 A few more agents will allow us to bring the oil all the way to its final location, the **Retailer**.

--- a/resources/docs/simulation/extra/migrating/anylogic/main-loop.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/main-loop.md
@@ -1,7 +1,7 @@
 ---
 title: Main Loop
 slug: simulation/extra/migrating/anylogic/main-loop
-objectID: 753e9821-fd1f-4c12-8c1f-24312712fcfe
+objectId: 1b7b0aef-f6b7-4e7a-9c28-6c8a2de3e63d}
 ---
 
 # Main Loop

--- a/resources/docs/simulation/extra/migrating/anylogic/main-loop.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/main-loop.md
@@ -1,3 +1,7 @@
+---
+objectID: 753e9821-fd1f-4c12-8c1f-24312712fcfe
+---
+
 # Main Loop
 
 Now that we have our list of agents, we move to step 2 - understanding the main loop. The main loop is a broad term meant to convey the general process of the simulation. While sophisticated simulations can and do evolve over time, there is always a process or set of processes that directs the agent interactions.

--- a/resources/docs/simulation/extra/migrating/anylogic/main-loop.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/main-loop.md
@@ -1,4 +1,6 @@
 ---
+title: Main Loop
+slug: simulation/extra/migrating/anylogic/main-loop
 objectID: 753e9821-fd1f-4c12-8c1f-24312712fcfe
 ---
 

--- a/resources/docs/simulation/extra/migrating/anylogic/mental-models.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/mental-models.md
@@ -1,4 +1,6 @@
 ---
+title: Mental Models
+slug: simulation/extra/migrating/anylogic/mental-models
 objectID: 0ac7dd77-9d1c-405d-9452-d0ac6ecb1d99
 ---
 

--- a/resources/docs/simulation/extra/migrating/anylogic/mental-models.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/mental-models.md
@@ -1,3 +1,7 @@
+---
+objectID: 0ac7dd77-9d1c-405d-9452-d0ac6ecb1d99
+---
+
 # Mental Models
 
 Mental models are conceptual frameworks, or ways of thinking, that can be applied to help solve problems.

--- a/resources/docs/simulation/extra/migrating/anylogic/mental-models.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/mental-models.md
@@ -1,7 +1,7 @@
 ---
 title: Mental Models
 slug: simulation/extra/migrating/anylogic/mental-models
-objectID: 0ac7dd77-9d1c-405d-9452-d0ac6ecb1d99
+objectId: 89895f63-effb-4a53-b543-653d9e5637e3}
 ---
 
 # Mental Models

--- a/resources/docs/simulation/extra/migrating/anylogic/planning-the-build.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/planning-the-build.md
@@ -1,7 +1,7 @@
 ---
 title: Planning the Build
 slug: simulation/extra/migrating/anylogic/planning-the-build
-objectID: c7d0e36d-43bd-42be-a489-2cd52f79aff8
+objectId: c5053645-5e04-49a3-99ad-239296c6ce7b}
 ---
 
 # Planning the Build

--- a/resources/docs/simulation/extra/migrating/anylogic/planning-the-build.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/planning-the-build.md
@@ -1,4 +1,6 @@
 ---
+title: Planning the Build
+slug: simulation/extra/migrating/anylogic/planning-the-build
 objectID: c7d0e36d-43bd-42be-a489-2cd52f79aff8
 ---
 

--- a/resources/docs/simulation/extra/migrating/anylogic/planning-the-build.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/planning-the-build.md
@@ -1,3 +1,7 @@
+---
+objectID: c7d0e36d-43bd-42be-a489-2cd52f79aff8
+---
+
 # Planning the Build
 
 Let’s apply this mental model to the [Oil Supply Chain](/@hash/oil-supply-chain) model.

--- a/resources/docs/simulation/extra/performance.md
+++ b/resources/docs/simulation/extra/performance.md
@@ -1,4 +1,6 @@
 ---
+title: Performance
+slug: simulation/extra/performance
 objectID: 2b53b54d-ef04-4bbf-867b-a8f194066373
 ---
 

--- a/resources/docs/simulation/extra/performance.md
+++ b/resources/docs/simulation/extra/performance.md
@@ -1,3 +1,7 @@
+---
+objectID: 2b53b54d-ef04-4bbf-867b-a8f194066373
+---
+
 # Performance
 
 There are several possible reasons your simulation is running slowly. Broadly we bucket them in three categories: data, compute, and hardware.

--- a/resources/docs/simulation/extra/performance.md
+++ b/resources/docs/simulation/extra/performance.md
@@ -1,7 +1,7 @@
 ---
 title: Performance
 slug: simulation/extra/performance
-objectID: 2b53b54d-ef04-4bbf-867b-a8f194066373
+objectId: beaf7fe2-b926-452c-a38a-3299e74a34e4}
 ---
 
 # Performance

--- a/resources/docs/simulation/extra/shortcuts.md
+++ b/resources/docs/simulation/extra/shortcuts.md
@@ -1,3 +1,7 @@
+---
+objectID: 221397af-708b-4f57-af04-c6a4176163fa
+---
+
 # Shortcuts
 
 ## In the editor pane

--- a/resources/docs/simulation/extra/shortcuts.md
+++ b/resources/docs/simulation/extra/shortcuts.md
@@ -1,7 +1,7 @@
 ---
 title: Shortcuts
 slug: simulation/extra/shortcuts
-objectID: 221397af-708b-4f57-af04-c6a4176163fa
+objectId: d3b822a4-2329-4bde-b3bb-a05b1d6819a6}
 ---
 
 # Shortcuts

--- a/resources/docs/simulation/extra/shortcuts.md
+++ b/resources/docs/simulation/extra/shortcuts.md
@@ -1,4 +1,6 @@
 ---
+title: Shortcuts
+slug: simulation/extra/shortcuts
 objectID: 221397af-708b-4f57-af04-c6a4176163fa
 ---
 

--- a/resources/docs/simulation/extra/specs-requirements.md
+++ b/resources/docs/simulation/extra/specs-requirements.md
@@ -1,7 +1,7 @@
 ---
 title: System Requirements
 slug: simulation/extra/specs-requirements
-objectID: c80ee10c-be50-4cc0-9e27-e6abed2785c3
+objectId: 41414b73-3d57-4d53-bf43-79d4007e9660}
 ---
 
 # System Requirements

--- a/resources/docs/simulation/extra/specs-requirements.md
+++ b/resources/docs/simulation/extra/specs-requirements.md
@@ -1,3 +1,7 @@
+---
+objectID: c80ee10c-be50-4cc0-9e27-e6abed2785c3
+---
+
 # System Requirements
 
 Certain HASH features rely on cutting-edge technology that may not be supported in every browser and on every platform. For whatever browser you choose to use, we recommend the latest and greatest version to ensure support. We have found the best performance and user experience on the latest Chrome release.

--- a/resources/docs/simulation/extra/specs-requirements.md
+++ b/resources/docs/simulation/extra/specs-requirements.md
@@ -1,4 +1,6 @@
 ---
+title: System Requirements
+slug: simulation/extra/specs-requirements
 objectID: c80ee10c-be50-4cc0-9e27-e6abed2785c3
 ---
 

--- a/resources/docs/simulation/extra/troubleshooting/README.md
+++ b/resources/docs/simulation/extra/troubleshooting/README.md
@@ -1,4 +1,5 @@
 ---
+objectID: 9e74664f-d438-47ec-86cf-2c7883a67d8c
 description: Debugging simulation logic and application crashes
 ---
 

--- a/resources/docs/simulation/extra/troubleshooting/README.md
+++ b/resources/docs/simulation/extra/troubleshooting/README.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting & Debugging
 slug: simulation/extra/troubleshooting
-objectID: 9e74664f-d438-47ec-86cf-2c7883a67d8c
+objectId: 114101d4-8aab-4aad-b191-d19f260a3cc3
 description: Debugging simulation logic and application crashes
 ---
 

--- a/resources/docs/simulation/extra/troubleshooting/README.md
+++ b/resources/docs/simulation/extra/troubleshooting/README.md
@@ -1,4 +1,6 @@
 ---
+title: Troubleshooting & Debugging
+slug: simulation/extra/troubleshooting
 objectID: 9e74664f-d438-47ec-86cf-2c7883a67d8c
 description: Debugging simulation logic and application crashes
 ---

--- a/resources/docs/simulation/extra/troubleshooting/error-reference.md
+++ b/resources/docs/simulation/extra/troubleshooting/error-reference.md
@@ -1,4 +1,5 @@
 ---
+objectID: 95d4a11b-c7f4-4807-a788-2b73f08d57b5
 description: Errors you may encounter and how to fix them
 ---
 

--- a/resources/docs/simulation/extra/troubleshooting/error-reference.md
+++ b/resources/docs/simulation/extra/troubleshooting/error-reference.md
@@ -1,4 +1,6 @@
 ---
+title: Error reference
+slug: simulation/extra/troubleshooting/error-reference
 objectID: 95d4a11b-c7f4-4807-a788-2b73f08d57b5
 description: Errors you may encounter and how to fix them
 ---

--- a/resources/docs/simulation/extra/troubleshooting/error-reference.md
+++ b/resources/docs/simulation/extra/troubleshooting/error-reference.md
@@ -1,7 +1,7 @@
 ---
 title: Error reference
 slug: simulation/extra/troubleshooting/error-reference
-objectID: 95d4a11b-c7f4-4807-a788-2b73f08d57b5
+objectId: 90dca8e5-ac3b-46d8-a0e9-e4224c2b953c
 description: Errors you may encounter and how to fix them
 ---
 

--- a/resources/docs/simulation/tutorials/building-process-models.md
+++ b/resources/docs/simulation/tutorials/building-process-models.md
@@ -1,4 +1,5 @@
 ---
+objectID: ae60b9c4-b6e3-4b46-bc3d-80c040cfc752
 description: Using the HASH process chart interface to build a ticketing queue simulation
 ---
 

--- a/resources/docs/simulation/tutorials/building-process-models.md
+++ b/resources/docs/simulation/tutorials/building-process-models.md
@@ -1,7 +1,7 @@
 ---
 title: Building Process Models
 slug: simulation/tutorials/building-process-models
-objectID: ae60b9c4-b6e3-4b46-bc3d-80c040cfc752
+objectId: 4cdfbcbf-a733-44d7-b1bd-14c9b8e96b65
 description: Using the HASH process chart interface to build a ticketing queue simulation
 ---
 

--- a/resources/docs/simulation/tutorials/building-process-models.md
+++ b/resources/docs/simulation/tutorials/building-process-models.md
@@ -1,4 +1,6 @@
 ---
+title: Building Process Models
+slug: simulation/tutorials/building-process-models
 objectID: ae60b9c4-b6e3-4b46-bc3d-80c040cfc752
 description: Using the HASH process chart interface to build a ticketing queue simulation
 ---

--- a/resources/docs/simulation/tutorials/building-process-models/README.md
+++ b/resources/docs/simulation/tutorials/building-process-models/README.md
@@ -1,7 +1,7 @@
 ---
 title: Building Process Models
 slug: simulation/tutorials/building-process-models
-objectID: e46938a4-1a49-414c-9e27-fb4d41614526
+objectId: e46938a4-1a49-414c-9e27-fb4d41614526
 ---
 
 # Building Process Models

--- a/resources/docs/simulation/tutorials/building-process-models/README.md
+++ b/resources/docs/simulation/tutorials/building-process-models/README.md
@@ -1,3 +1,7 @@
+---
+objectID: e46938a4-1a49-414c-9e27-fb4d41614526
+---
+
 # Building Process Models
 
 Business processes are the cornerstone of every company's operations. Defined and repeatable plans for satisfying business objectives differentiate a focused, efficient machine from a disorganized mess.

--- a/resources/docs/simulation/tutorials/building-process-models/README.md
+++ b/resources/docs/simulation/tutorials/building-process-models/README.md
@@ -1,4 +1,6 @@
 ---
+title: Building Process Models
+slug: simulation/tutorials/building-process-models
 objectID: e46938a4-1a49-414c-9e27-fb4d41614526
 ---
 

--- a/resources/docs/simulation/tutorials/building-process-models/analyzing-process-models.md
+++ b/resources/docs/simulation/tutorials/building-process-models/analyzing-process-models.md
@@ -1,3 +1,7 @@
+---
+objectID: d6ccbd88-f12f-4433-99f3-d65c17d2f0a2
+---
+
 # Analyzing Process Models
 
 Once you've created your process model, you'll want to use it to answer questions about its performance. Creating plots will make it easy and visually engaging to interpret the results of your simulation runs.

--- a/resources/docs/simulation/tutorials/building-process-models/analyzing-process-models.md
+++ b/resources/docs/simulation/tutorials/building-process-models/analyzing-process-models.md
@@ -1,5 +1,7 @@
 ---
-objectID: d6ccbd88-f12f-4433-99f3-d65c17d2f0a2
+title: Analyzing Process Models
+slug: simulation/tutorials/building-process-models/analyzing-process-models
+objectId: 71393281-6569-46d3-a308-8445c79a3553}
 ---
 
 # Analyzing Process Models

--- a/resources/docs/simulation/tutorials/building-process-models/experimenting-with-process-models.md
+++ b/resources/docs/simulation/tutorials/building-process-models/experimenting-with-process-models.md
@@ -1,5 +1,7 @@
 ---
-objectID: 1a38c1ef-b396-40b2-9215-f8c95758253f
+title: Experimenting with Process Models
+slug: simulation/tutorials/building-process-models/experimenting-with-process-models
+objectId: 6879e8d3-7aa0-4b12-b6b1-38c3975fbd66}
 ---
 
 # Experimenting with Process Models

--- a/resources/docs/simulation/tutorials/building-process-models/experimenting-with-process-models.md
+++ b/resources/docs/simulation/tutorials/building-process-models/experimenting-with-process-models.md
@@ -1,3 +1,7 @@
+---
+objectID: 1a38c1ef-b396-40b2-9215-f8c95758253f
+---
+
 # Experimenting with Process Models
 
 You can use experiments to explore different potential scenarios with a process model. For example, if you want to understand how a process will run when it has half the people working on it, or double the people, you can automatically generate and compare simulation runs with those parameters.

--- a/resources/docs/simulation/tutorials/building-process-models/process-model-concepts.md
+++ b/resources/docs/simulation/tutorials/building-process-models/process-model-concepts.md
@@ -1,5 +1,7 @@
 ---
-objectID: 56a0c46b-584b-41dc-8995-9711fbd389fb
+title: Process Model Concepts
+slug: simulation/tutorials/building-process-models/process-model-concepts
+objectId: 9f6ec0b6-c84e-4ab7-9e36-a0d843a32e3e}
 ---
 
 # Process Model Concepts

--- a/resources/docs/simulation/tutorials/building-process-models/process-model-concepts.md
+++ b/resources/docs/simulation/tutorials/building-process-models/process-model-concepts.md
@@ -1,3 +1,7 @@
+---
+objectID: 56a0c46b-584b-41dc-8995-9711fbd389fb
+---
+
 # Process Model Concepts
 
 Process modeling is designing a process as a series of discrete, executable steps, and then optimizing and analyzing the design.

--- a/resources/docs/simulation/tutorials/building-process-models/using-data-in-a-process-model.md
+++ b/resources/docs/simulation/tutorials/building-process-models/using-data-in-a-process-model.md
@@ -1,5 +1,7 @@
 ---
-objectID: 693d89c7-884f-4b71-9325-7d375ccf74c7
+title: Adding Data to a Process Model
+slug: simulation/tutorials/building-process-models/using-data-in-a-process-model
+objectId: ee3bd846-664d-46f7-bf31-196fa6f57a17}
 ---
 
 # Adding Data to a Process Model

--- a/resources/docs/simulation/tutorials/building-process-models/using-data-in-a-process-model.md
+++ b/resources/docs/simulation/tutorials/building-process-models/using-data-in-a-process-model.md
@@ -1,3 +1,7 @@
+---
+objectID: 693d89c7-884f-4b71-9325-7d375ccf74c7
+---
+
 # Adding Data to a Process Model
 
 You can use your real world business data to power your process model and create a digital twin of your business process.

--- a/resources/docs/simulation/tutorials/building-process-models/using-the-process-model-builder.md
+++ b/resources/docs/simulation/tutorials/building-process-models/using-the-process-model-builder.md
@@ -1,5 +1,7 @@
 ---
-objectID: 6b10dbe9-577f-47d4-b4fa-8621f4efc6f1
+title: Using the Process Model Visual Interface
+slug: simulation/tutorials/building-process-models/using-the-process-model-builder
+objectId: 94b05ca6-53c7-47dd-a22d-8c8f1a76d78f}
 ---
 
 # Using the Process Model Visual Interface

--- a/resources/docs/simulation/tutorials/building-process-models/using-the-process-model-builder.md
+++ b/resources/docs/simulation/tutorials/building-process-models/using-the-process-model-builder.md
@@ -1,3 +1,7 @@
+---
+objectID: 6b10dbe9-577f-47d4-b4fa-8621f4efc6f1
+---
+
 # Using the Process Model Visual Interface
 
 The process model visual interface lets you diagram your desired process model and, in one click, create a functioning HASH simulation. In this how-to guide we'll walk through the visual interface and how to build a process model with it.

--- a/resources/docs/simulation/tutorials/create-a-simulation-dashboard.md
+++ b/resources/docs/simulation/tutorials/create-a-simulation-dashboard.md
@@ -1,7 +1,7 @@
 ---
 title: Create a Simulation Dashboard
 slug: simulation/tutorials/create-a-simulation-dashboard
-objectID: db2517a6-b57f-432d-89a8-d7175c987671
+objectId: c565e7db-89db-4bbb-b75a-9a954ef87a6b}
 ---
 
 # Create a Simulation Dashboard

--- a/resources/docs/simulation/tutorials/create-a-simulation-dashboard.md
+++ b/resources/docs/simulation/tutorials/create-a-simulation-dashboard.md
@@ -1,4 +1,6 @@
 ---
+title: Create a Simulation Dashboard
+slug: simulation/tutorials/create-a-simulation-dashboard
 objectID: db2517a6-b57f-432d-89a8-d7175c987671
 ---
 

--- a/resources/docs/simulation/tutorials/create-a-simulation-dashboard.md
+++ b/resources/docs/simulation/tutorials/create-a-simulation-dashboard.md
@@ -1,3 +1,7 @@
+---
+objectID: db2517a6-b57f-432d-89a8-d7175c987671
+---
+
 # Create a Simulation Dashboard
 
 Simulations are powerful ways to model the world, but they won't do any good if they're not used! It's important to build presentations of simulations in anticipation of how the end user will want to interact with it, helping them to explore the parameters of the simulation and derive insights.

--- a/resources/docs/simulation/tutorials/extending-an-epidemic-model/README.md
+++ b/resources/docs/simulation/tutorials/extending-an-epidemic-model/README.md
@@ -1,7 +1,7 @@
 ---
 title: Extending an Epidemic Model
 slug: simulation/tutorials/extending-an-epidemic-model
-objectID: 3b6927d3-84f0-4166-8833-c99da427701f
+objectId: 4cbcaf50-fd13-40c1-abb2-b70d30bc0dfe
 description: Adding and extending features in a simulation.
 ---
 

--- a/resources/docs/simulation/tutorials/extending-an-epidemic-model/README.md
+++ b/resources/docs/simulation/tutorials/extending-an-epidemic-model/README.md
@@ -1,4 +1,6 @@
 ---
+title: Extending an Epidemic Model
+slug: simulation/tutorials/extending-an-epidemic-model
 objectID: 3b6927d3-84f0-4166-8833-c99da427701f
 description: Adding and extending features in a simulation.
 ---

--- a/resources/docs/simulation/tutorials/extending-an-epidemic-model/README.md
+++ b/resources/docs/simulation/tutorials/extending-an-epidemic-model/README.md
@@ -1,4 +1,5 @@
 ---
+objectID: 3b6927d3-84f0-4166-8833-c99da427701f
 description: Adding and extending features in a simulation.
 ---
 

--- a/resources/docs/simulation/tutorials/extending-an-epidemic-model/add-heterogeneity.md
+++ b/resources/docs/simulation/tutorials/extending-an-epidemic-model/add-heterogeneity.md
@@ -1,7 +1,7 @@
 ---
 title: Add heterogeneity
 slug: simulation/tutorials/extending-an-epidemic-model/add-heterogeneity
-objectID: 3c8075a5-b7f8-4b0d-87ad-9c6eb7c80536
+objectId: a8d95e6d-22d0-4628-aab0-ad34f1af3e2a}
 ---
 
 # Add heterogeneity

--- a/resources/docs/simulation/tutorials/extending-an-epidemic-model/add-heterogeneity.md
+++ b/resources/docs/simulation/tutorials/extending-an-epidemic-model/add-heterogeneity.md
@@ -1,3 +1,7 @@
+---
+objectID: 3c8075a5-b7f8-4b0d-87ad-9c6eb7c80536
+---
+
 # Add heterogeneity
 
 One thing that sets agent-based modeling apart from analytic techniques or system dynamic models is the ease with which you can add 'heterogeneity'. This means that our population of agents can have different demographic features; for example in HASH you can easily create a distribution of age by adding a property and assigning different age values to different agents.

--- a/resources/docs/simulation/tutorials/extending-an-epidemic-model/add-heterogeneity.md
+++ b/resources/docs/simulation/tutorials/extending-an-epidemic-model/add-heterogeneity.md
@@ -1,4 +1,6 @@
 ---
+title: Add heterogeneity
+slug: simulation/tutorials/extending-an-epidemic-model/add-heterogeneity
 objectID: 3c8075a5-b7f8-4b0d-87ad-9c6eb7c80536
 ---
 

--- a/resources/docs/simulation/tutorials/extending-an-epidemic-model/create-a-hospital.md
+++ b/resources/docs/simulation/tutorials/extending-an-epidemic-model/create-a-hospital.md
@@ -1,7 +1,7 @@
 ---
 title: Create a Hospital
 slug: simulation/tutorials/extending-an-epidemic-model/create-a-hospital
-objectID: a2b80dda-09bb-4b27-9685-79d49e852a72
+objectId: 0982767e-dc5c-41c8-9f7c-09a192a5fd9a}
 ---
 
 # Create a Hospital

--- a/resources/docs/simulation/tutorials/extending-an-epidemic-model/create-a-hospital.md
+++ b/resources/docs/simulation/tutorials/extending-an-epidemic-model/create-a-hospital.md
@@ -1,4 +1,6 @@
 ---
+title: Create a Hospital
+slug: simulation/tutorials/extending-an-epidemic-model/create-a-hospital
 objectID: a2b80dda-09bb-4b27-9685-79d49e852a72
 ---
 

--- a/resources/docs/simulation/tutorials/extending-an-epidemic-model/create-a-hospital.md
+++ b/resources/docs/simulation/tutorials/extending-an-epidemic-model/create-a-hospital.md
@@ -1,3 +1,7 @@
+---
+objectID: a2b80dda-09bb-4b27-9685-79d49e852a72
+---
+
 # Create a Hospital
 
 Open up the `init.json` file. It should look like:

--- a/resources/docs/simulation/tutorials/extending-an-epidemic-model/create-an-icu.md
+++ b/resources/docs/simulation/tutorials/extending-an-epidemic-model/create-an-icu.md
@@ -1,3 +1,7 @@
+---
+objectID: 258b6a4a-b5a3-4b3f-87a2-39174597d381
+---
+
 # Create an ICU
 
 So now we can tell people they’re sick, and when they hear they’re sick they go home. But we also want to account for another function of a hospital - providing treatment for severe cases.

--- a/resources/docs/simulation/tutorials/extending-an-epidemic-model/create-an-icu.md
+++ b/resources/docs/simulation/tutorials/extending-an-epidemic-model/create-an-icu.md
@@ -1,7 +1,7 @@
 ---
 title: Create an ICU
 slug: simulation/tutorials/extending-an-epidemic-model/create-an-icu
-objectID: 258b6a4a-b5a3-4b3f-87a2-39174597d381
+objectId: 56e39f54-05c5-492e-bf42-75143e76e0a9}
 ---
 
 # Create an ICU

--- a/resources/docs/simulation/tutorials/extending-an-epidemic-model/create-an-icu.md
+++ b/resources/docs/simulation/tutorials/extending-an-epidemic-model/create-an-icu.md
@@ -1,4 +1,6 @@
 ---
+title: Create an ICU
+slug: simulation/tutorials/extending-an-epidemic-model/create-an-icu
 objectID: 258b6a4a-b5a3-4b3f-87a2-39174597d381
 ---
 

--- a/resources/docs/simulation/tutorials/extending-an-epidemic-model/create-testing-behavior.md
+++ b/resources/docs/simulation/tutorials/extending-an-epidemic-model/create-testing-behavior.md
@@ -1,3 +1,7 @@
+---
+objectID: 8a3a6551-945f-4385-8fdb-e47d8c405556
+---
+
 # Create Testing Behavior
 
 To start let**'**s create a message from the Person agent that contains the basics - they’re requesting a test. In the `check_infected` behavior file, add a [message](/docs/simulation/creating-simulations/agent-messages/) function:

--- a/resources/docs/simulation/tutorials/extending-an-epidemic-model/create-testing-behavior.md
+++ b/resources/docs/simulation/tutorials/extending-an-epidemic-model/create-testing-behavior.md
@@ -1,4 +1,6 @@
 ---
+title: Create Testing Behavior
+slug: simulation/tutorials/extending-an-epidemic-model/create-testing-behavior
 objectID: 8a3a6551-945f-4385-8fdb-e47d8c405556
 ---
 

--- a/resources/docs/simulation/tutorials/extending-an-epidemic-model/create-testing-behavior.md
+++ b/resources/docs/simulation/tutorials/extending-an-epidemic-model/create-testing-behavior.md
@@ -1,7 +1,7 @@
 ---
 title: Create Testing Behavior
 slug: simulation/tutorials/extending-an-epidemic-model/create-testing-behavior
-objectID: 8a3a6551-945f-4385-8fdb-e47d8c405556
+objectId: 23f25cd1-3577-40ad-9bdf-d2e5c3e56e39}
 ---
 
 # Create Testing Behavior

--- a/resources/docs/simulation/tutorials/hello-hash.md
+++ b/resources/docs/simulation/tutorials/hello-hash.md
@@ -1,4 +1,5 @@
 ---
+objectID: 33f18677-9747-46be-9ec9-406cac11a2fb
 description: 'Get started creating agents in our Hello, HASH tutorial!'
 ---
 

--- a/resources/docs/simulation/tutorials/hello-hash.md
+++ b/resources/docs/simulation/tutorials/hello-hash.md
@@ -1,4 +1,6 @@
 ---
+title: Hello, HASH!
+slug: simulation/tutorials/hello-hash
 objectID: 33f18677-9747-46be-9ec9-406cac11a2fb
 description: 'Get started creating agents in our Hello, HASH tutorial!'
 ---

--- a/resources/docs/simulation/tutorials/hello-hash.md
+++ b/resources/docs/simulation/tutorials/hello-hash.md
@@ -1,7 +1,7 @@
 ---
 title: Hello, HASH!
 slug: simulation/tutorials/hello-hash
-objectID: 33f18677-9747-46be-9ec9-406cac11a2fb
+objectId: 96392257-39b5-46e2-b655-6a4a78ab1450
 description: 'Get started creating agents in our Hello, HASH tutorial!'
 ---
 

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/README.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/README.md
@@ -1,7 +1,7 @@
 ---
 title: Building a Simple Hotelling Model in 2D
 slug: simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d
-objectID: 8fd4f61b-e2b8-4219-8bf4-d16ee657eece
+objectId: e179c5c1-bd46-43f3-a374-6fa3ce7cfc02}
 ---
 
 # Building a Simple Hotelling Model in 2D

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/README.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/README.md
@@ -1,3 +1,7 @@
+---
+objectID: 8fd4f61b-e2b8-4219-8bf4-d16ee657eece
+---
+
 # Building a Simple Hotelling Model in 2D
 
 This tutorial simulates businesses competing for customers based on location and price. This extends the principles of the [Hotelling model](http://www.math.toronto.edu/mccann/assignments/477/Hotelling29.pdf) which analyzed the optimal locations of businesses along a one-dimensional line. We will use HASH to build it in a 2D space.

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/README.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/README.md
@@ -1,4 +1,6 @@
 ---
+title: Building a Simple Hotelling Model in 2D
+slug: simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d
 objectID: 8fd4f61b-e2b8-4219-8bf4-d16ee657eece
 ---
 

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/building-the-local-competition-model.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/building-the-local-competition-model.md
@@ -1,4 +1,6 @@
 ---
+title: Extending the Model
+slug: simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/building-the-local-competition-model
 objectID: c5f2cc40-92f8-4dae-aa30-95732ae0b16e
 description: Adding complexity to the simulation
 ---

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/building-the-local-competition-model.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/building-the-local-competition-model.md
@@ -1,4 +1,5 @@
 ---
+objectID: c5f2cc40-92f8-4dae-aa30-95732ae0b16e
 description: Adding complexity to the simulation
 ---
 

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/building-the-local-competition-model.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/building-the-local-competition-model.md
@@ -1,7 +1,7 @@
 ---
 title: Extending the Model
 slug: simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/building-the-local-competition-model
-objectID: c5f2cc40-92f8-4dae-aa30-95732ae0b16e
+objectId: 6936eac9-32d4-4593-8dde-ce45ceba8d39
 description: Adding complexity to the simulation
 ---
 

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/business-collect-and-update.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/business-collect-and-update.md
@@ -1,4 +1,6 @@
 ---
+title: Business Collect and Update
+slug: simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/business-collect-and-update
 objectID: 2d7bff0b-a1f6-4e19-b2de-c81eac036ecc
 ---
 

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/business-collect-and-update.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/business-collect-and-update.md
@@ -1,3 +1,7 @@
+---
+objectID: 2d7bff0b-a1f6-4e19-b2de-c81eac036ecc
+---
+
 # Business Collect and Update
 
 The final step for this simulation is for the Businesses to collect the Customer replies and update their position and price to the combination that produced the largest profit. Create a `collect_customer_data()` function in **`business.js`** and add the following code.

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/business-collect-and-update.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/business-collect-and-update.md
@@ -1,7 +1,7 @@
 ---
 title: Business Collect and Update
 slug: simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/business-collect-and-update
-objectID: 2d7bff0b-a1f6-4e19-b2de-c81eac036ecc
+objectId: 62f732ca-a109-4c8b-8c07-40e3781199ff}
 ---
 
 # Business Collect and Update

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/customer-reply.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/customer-reply.md
@@ -1,3 +1,7 @@
+---
+objectID: bf73b412-2626-4b98-9b39-91dad739a0ba
+---
+
 # Customer Reply
 
 Now that Business agents are communicating with Customers, we need the Customers to send a reply back. To do this, let’s look at **`customer.js`**. Every time a Customer agent receives a batch of messages, it will:

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/customer-reply.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/customer-reply.md
@@ -1,7 +1,7 @@
 ---
 title: Customer Reply
 slug: simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/customer-reply
-objectID: bf73b412-2626-4b98-9b39-91dad739a0ba
+objectId: 91eaa467-7855-4948-adc0-5d325d839f4d}
 ---
 
 # Customer Reply

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/customer-reply.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/customer-reply.md
@@ -1,4 +1,6 @@
 ---
+title: Customer Reply
+slug: simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/customer-reply
 objectID: bf73b412-2626-4b98-9b39-91dad739a0ba
 ---
 

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/initialization.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/initialization.md
@@ -1,7 +1,7 @@
 ---
 title: Agent Initialization
 slug: simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/initialization
-objectID: 7ad7c073-86b4-4c5e-aaed-c4a1fb16e85a
+objectId: efaaffde-1671-45fe-afc1-bb68fa364cd3}
 ---
 
 # Agent Initialization

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/initialization.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/initialization.md
@@ -1,3 +1,7 @@
+---
+objectID: 7ad7c073-86b4-4c5e-aaed-c4a1fb16e85a
+---
+
 # Agent Initialization
 
 Now, open up init.json. This is where we will be writing our [agent creator](/docs/simulation/creating-simulations/anatomy-of-an-agent/initial-state) that will generate all our simulation agents. First, generate the Customer agents.

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/initialization.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/initialization.md
@@ -1,4 +1,6 @@
 ---
+title: Agent Initialization
+slug: simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/initialization
 objectID: 7ad7c073-86b4-4c5e-aaed-c4a1fb16e85a
 ---
 

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/phase-1-final-code.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/phase-1-final-code.md
@@ -1,3 +1,7 @@
+---
+objectID: 9ccda572-e8b4-4db7-9b6f-dd2ffe8d5bf1
+---
+
 # Final Code
 
 Check out the model \(Local Competition Phase 1\) in [hIndex](/@hash/local-competition-phase-1)

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/phase-1-final-code.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/phase-1-final-code.md
@@ -1,7 +1,7 @@
 ---
 title: Final Code
 slug: simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/phase-1-final-code
-objectID: 9ccda572-e8b4-4db7-9b6f-dd2ffe8d5bf1
+objectId: f7ea6fbf-e228-4bf8-afef-833b83861317}
 ---
 
 # Final Code

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/phase-1-final-code.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/phase-1-final-code.md
@@ -1,4 +1,6 @@
 ---
+title: Final Code
+slug: simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/phase-1-final-code
 objectID: 9ccda572-e8b4-4db7-9b6f-dd2ffe8d5bf1
 ---
 

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/query-customers.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/query-customers.md
@@ -1,7 +1,7 @@
 ---
 title: Query Customers
 slug: simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/query-customers
-objectID: a3c49945-87ab-4279-b843-b0ff8fecec0c
+objectId: 72bc9a10-e87a-457a-bb7b-0ae5f366f5f0}
 ---
 
 # Query Customers

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/query-customers.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/query-customers.md
@@ -1,4 +1,6 @@
 ---
+title: Query Customers
+slug: simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/query-customers
 objectID: a3c49945-87ab-4279-b843-b0ff8fecec0c
 ---
 

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/query-customers.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/query-customers.md
@@ -1,3 +1,7 @@
+---
+objectID: a3c49945-87ab-4279-b843-b0ff8fecec0c
+---
+
 # Query Customers
 
 Businesses will perform two actions in this model: query customers and collect customer responses to update their position and item price.

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/set-up-environment.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/set-up-environment.md
@@ -1,7 +1,7 @@
 ---
 title: Environment Setup
 slug: simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/set-up-environment
-objectID: e9bbf446-7d3d-438b-a757-9bf0776de92a
+objectId: 91bc373a-7049-4375-ac7d-31fa440ca059}
 ---
 
 # Environment Setup

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/set-up-environment.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/set-up-environment.md
@@ -1,3 +1,7 @@
+---
+objectID: e9bbf446-7d3d-438b-a757-9bf0776de92a
+---
+
 # Environment Setup
 
 After opening up a new simulation in HASH, navigate to globals.json. First, we are going to set up the [**Topology**](/docs/simulation/configuration/topology), or the environment, of the model.

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/set-up-environment.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/set-up-environment.md
@@ -1,4 +1,6 @@
 ---
+title: Environment Setup
+slug: simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/set-up-environment
 objectID: e9bbf446-7d3d-438b-a757-9bf0776de92a
 ---
 

--- a/resources/docs/url_map.json
+++ b/resources/docs/url_map.json
@@ -537,6 +537,10 @@
           {
             "title": "Shortcuts",
             "slug": "simulation/extra/shortcuts"
+          },
+          {
+            "title": "Design Considerations",
+            "slug": "simulation/extra/design-considerations"
           }
         ]
       }

--- a/resources/docs/url_map.json
+++ b/resources/docs/url_map.json
@@ -27,6 +27,10 @@
                 "slug": "simulation/creating-simulations/anatomy-of-an-agent/initial-state"
               },
               {
+                "title": "Programmable Initialization",
+                "slug": "simulation/creating-simulations/anatomy-of-an-agent/programmable-initial-states"
+              },
+              {
                 "title": "Visualization",
                 "slug": "simulation/creating-simulations/anatomy-of-an-agent/visualization",
                 "urldata": [
@@ -126,7 +130,13 @@
           },
           {
             "title": "Datasets",
-            "slug": "simulation/creating-simulations/datasets"
+            "slug": "simulation/creating-simulations/datasets",
+            "urldata": [
+              {
+                "title": "Publishing Datasets to Index",
+                "slug": "simulation/creating-simulations/datasets/publishing-data-to-index"
+              }
+            ]
           },
           {
             "title": "Simulation Outputs",
@@ -316,6 +326,10 @@
               {
                 "title": "Custom Behaviors",
                 "slug": "simulation/concepts/designing-with-process-models/custom-behaviors"
+              },
+              {
+                "title": "Theory of Constraints and Simulations: A framework for process optimization",
+                "slug": "simulation/concepts/designing-with-process-models/theory-of-constraints-and-simulations-a-framework-for-process-optimization"
               }
             ]
           },
@@ -346,7 +360,29 @@
           },
           {
             "title": "Building Process Models",
-            "slug": "simulation/tutorials/building-process-models"
+            "slug": "simulation/tutorials/building-process-models",
+            "urldata": [
+              {
+                "title": "Using the Process Model Visual Interface",
+                "slug": "simulation/tutorials/building-process-models/using-the-process-model-builder"
+              },
+              {
+                "title": "Adding Data to a Process Model",
+                "slug": "simulation/tutorials/building-process-models/using-data-in-a-process-model"
+              },
+              {
+                "title": "Process Model Concepts",
+                "slug": "simulation/tutorials/building-process-models/process-model-concepts"
+              },
+              {
+                "title": "Experimenting with Process Models",
+                "slug": "simulation/tutorials/building-process-models/experimenting-with-process-models"
+              },
+              {
+                "title": "Analyzing Process Models",
+                "slug": "simulation/tutorials/building-process-models/analyzing-process-models"
+              }
+            ]
           },
           {
             "title": "Create a Simulation Dashboard",

--- a/resources/glossary/actor-model.mdx
+++ b/resources/glossary/actor-model.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 892f3d53-8d6c-46d3-b62b-69cdde165bd3
 title: Actor Model
 description: "There are two main approaches to building agent-based simulations: object-oriented programming and the actor-based model."
 slug: actor-model

--- a/resources/glossary/actor-model.mdx
+++ b/resources/glossary/actor-model.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 892f3d53-8d6c-46d3-b62b-69cdde165bd3
+objectId: 5d7d8d88-0205-4043-a46b-0ba3791f4616
 title: Actor Model
 description: "There are two main approaches to building agent-based simulations: object-oriented programming and the actor-based model."
 slug: actor-model

--- a/resources/glossary/agent-based-modeling.mdx
+++ b/resources/glossary/agent-based-modeling.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 6f1f5b9f-382b-4a71-96c0-25a1f57d48f8
+objectId: c400601a-059c-4e37-9ed9-f619f9f3911a
 title: Agent-Based Modeling
 description: ABMs simulate entities in virtual environments, or digital twins, in order to help better understand both entities and their environments.
 slug: agent-based-modeling

--- a/resources/glossary/agent-based-modeling.mdx
+++ b/resources/glossary/agent-based-modeling.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 6f1f5b9f-382b-4a71-96c0-25a1f57d48f8
 title: Agent-Based Modeling
 description: ABMs simulate entities in virtual environments, or digital twins, in order to help better understand both entities and their environments.
 slug: agent-based-modeling

--- a/resources/glossary/applicant-tracking-system.mdx
+++ b/resources/glossary/applicant-tracking-system.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 3319969d-5c7e-42e1-83ed-1074e1ef7a27
+objectId: 49f2e3a3-40ab-4a1f-955d-d99d346cb57c
 title: Applicant Tracking System
 description: "Applicant tracking systems help employers manage recruitment and hiring."
 slug: applicant-tracking-system

--- a/resources/glossary/applicant-tracking-system.mdx
+++ b/resources/glossary/applicant-tracking-system.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 3319969d-5c7e-42e1-83ed-1074e1ef7a27
 title: Applicant Tracking System
 description: "Applicant tracking systems help employers manage recruitment and hiring."
 slug: applicant-tracking-system

--- a/resources/glossary/autocorrelation.mdx
+++ b/resources/glossary/autocorrelation.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 6d8a4118-cd44-4691-831f-203cff8b10ef
+objectId: 97a3fd23-0c83-411e-885f-709c57dd16ef
 title: Autocorrelation
 description: Autocorrelation is a measure of the degree of similarity between any time series and a lagged or offset version of itself over successive time intervals.
 slug: autocorrelation

--- a/resources/glossary/autocorrelation.mdx
+++ b/resources/glossary/autocorrelation.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 6d8a4118-cd44-4691-831f-203cff8b10ef
 title: Autocorrelation
 description: Autocorrelation is a measure of the degree of similarity between any time series and a lagged or offset version of itself over successive time intervals.
 slug: autocorrelation

--- a/resources/glossary/business-intelligence.mdx
+++ b/resources/glossary/business-intelligence.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 31d3fe74-4d5e-4c82-9703-4fd49595dba1
+objectId: d4fdddf4-1158-4746-9582-6f388d5eb377
 title: Business Intelligence
 description: "Business Intelligence allows companies to make data-driven decisions."
 slug: business-intelligence

--- a/resources/glossary/business-intelligence.mdx
+++ b/resources/glossary/business-intelligence.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 31d3fe74-4d5e-4c82-9703-4fd49595dba1
 title: Business Intelligence
 description: "Business Intelligence allows companies to make data-driven decisions."
 slug: business-intelligence

--- a/resources/glossary/business-process-modeling.mdx
+++ b/resources/glossary/business-process-modeling.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 3df5156a-125e-4fa0-babb-5f4002140b74
+objectId: efd4a6d9-6f85-47ff-ac6d-8d1d89680202
 title: Business Process Modeling
 description: Business Process Modeling (BPM) helps organizations catalog, understand and improve their processes.
 slug: business-process-modeling

--- a/resources/glossary/business-process-modeling.mdx
+++ b/resources/glossary/business-process-modeling.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 3df5156a-125e-4fa0-babb-5f4002140b74
 title: Business Process Modeling
 description: Business Process Modeling (BPM) helps organizations catalog, understand and improve their processes.
 slug: business-process-modeling

--- a/resources/glossary/content-management-system.mdx
+++ b/resources/glossary/content-management-system.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 8c5bc6c1-6c30-4446-8741-b6fb77b28886
+objectId: 4b50396d-a7a8-4fbb-a28c-d3f55dfed779
 title: Content Management System
 description: "Content management systems allow you to build and manage websites."
 slug: content-management-system

--- a/resources/glossary/content-management-system.mdx
+++ b/resources/glossary/content-management-system.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 8c5bc6c1-6c30-4446-8741-b6fb77b28886
 title: Content Management System
 description: "Content management systems allow you to build and manage websites."
 slug: content-management-system

--- a/resources/glossary/customer-relationship-management-system.mdx
+++ b/resources/glossary/customer-relationship-management-system.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 7d14059e-bbe0-4eea-98c4-a93d5eeb55aa
+objectId: 1626982c-5f49-4200-9135-833853fd1db1
 title: Customer Relationship Management System
 description: "Customer relationship management systems track and coordinate interactions between a company and its customers."
 slug: customer-relationship-management-system

--- a/resources/glossary/customer-relationship-management-system.mdx
+++ b/resources/glossary/customer-relationship-management-system.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 7d14059e-bbe0-4eea-98c4-a93d5eeb55aa
 title: Customer Relationship Management System
 description: "Customer relationship management systems track and coordinate interactions between a company and its customers."
 slug: customer-relationship-management-system

--- a/resources/glossary/dag.mdx
+++ b/resources/glossary/dag.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: c5bcb70e-b3a6-4c2e-927c-e792f226f7c1
+objectId: e27d8e2a-da7b-4a32-b4df-3233208fa506
 title: Directed Acyclic Graphs
 description: If you don’t know your DAGs from your dogs, you can finally get some clarity and sleep easily tonight. Learn what makes a Directed Acyclic Graph a DAG.
 slug: dag

--- a/resources/glossary/dag.mdx
+++ b/resources/glossary/dag.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: c5bcb70e-b3a6-4c2e-927c-e792f226f7c1
 title: Directed Acyclic Graphs
 description: If you don’t know your DAGs from your dogs, you can finally get some clarity and sleep easily tonight. Learn what makes a Directed Acyclic Graph a DAG.
 slug: dag

--- a/resources/glossary/data-drift.mdx
+++ b/resources/glossary/data-drift.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 123f8fb2-b3ed-4f2a-9ddc-d937e39434fa
+objectId: b258a3f4-ca3c-460d-9171-bb06b0c5604e
 title: Data Drift
 description: Data Drift is the phenomenon where changes to data degrade model performance. 
 slug: data-drift

--- a/resources/glossary/data-drift.mdx
+++ b/resources/glossary/data-drift.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 123f8fb2-b3ed-4f2a-9ddc-d937e39434fa
 title: Data Drift
 description: Data Drift is the phenomenon where changes to data degrade model performance. 
 slug: data-drift

--- a/resources/glossary/data-mesh.mdx
+++ b/resources/glossary/data-mesh.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: d5561e7a-bc48-43c6-af91-f84884f5cdd2
 title: Data Mesh
 description: "Data meshes are decentralized database solutions."
 slug: data-mesh

--- a/resources/glossary/data-mesh.mdx
+++ b/resources/glossary/data-mesh.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: d5561e7a-bc48-43c6-af91-f84884f5cdd2
+objectId: bcddca8d-72a6-487f-9c11-fb910765dc2a
 title: Data Mesh
 description: "Data meshes are decentralized database solutions."
 slug: data-mesh

--- a/resources/glossary/data-mining.mdx
+++ b/resources/glossary/data-mining.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 115aa5cc-0b4a-46bf-99f2-fb8194b7cfa5
+objectId: 22e6f47e-a1b3-4c90-acfc-b18c6e486693
 title: Data Mining
 description: Data Mining is a process applied to find unknown patterns, correlations, and anomalies in data. Through mining, meaningful insights can be extracted from data.
 slug: data-mining

--- a/resources/glossary/data-mining.mdx
+++ b/resources/glossary/data-mining.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 115aa5cc-0b4a-46bf-99f2-fb8194b7cfa5
 title: Data Mining
 description: Data Mining is a process applied to find unknown patterns, correlations, and anomalies in data. Through mining, meaningful insights can be extracted from data.
 slug: data-mining

--- a/resources/glossary/data-pipelines.mdx
+++ b/resources/glossary/data-pipelines.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: a63c1237-e7e2-44d0-8cef-7985ec69f253
 title: Data Pipelines
 description: Data pipelines are processes that result in the production of data products, including datasets and models.
 slug: data-pipelines

--- a/resources/glossary/data-pipelines.mdx
+++ b/resources/glossary/data-pipelines.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: a63c1237-e7e2-44d0-8cef-7985ec69f253
+objectId: 6562db50-453a-457d-9861-589773fa9fa8
 title: Data Pipelines
 description: Data pipelines are processes that result in the production of data products, including datasets and models.
 slug: data-pipelines

--- a/resources/glossary/deep-reinforcement-learning.mdx
+++ b/resources/glossary/deep-reinforcement-learning.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 3a2945f2-c5c2-45e8-a7f5-56f7e2acec97
 title: Deep Reinforcement Learning
 description: DRL is a subset of Machine Learning in which agents are allowed to solve tasks on their own, and thus discover new solutions independent of human intuition.
 slug: deep-reinforcement-learning

--- a/resources/glossary/deep-reinforcement-learning.mdx
+++ b/resources/glossary/deep-reinforcement-learning.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 3a2945f2-c5c2-45e8-a7f5-56f7e2acec97
+objectId: 18b03d37-f394-4d18-9c0d-a579b2554a80
 title: Deep Reinforcement Learning
 description: DRL is a subset of Machine Learning in which agents are allowed to solve tasks on their own, and thus discover new solutions independent of human intuition.
 slug: deep-reinforcement-learning

--- a/resources/glossary/diff.mdx
+++ b/resources/glossary/diff.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 442b51e9-9044-46db-81d2-ea98238a2af0
 title: Diffing
 description: Diffs are used to track changes between different versions or forks of a project, providing an overview regarding files changed, and the nature of those changes.
 slug: diff

--- a/resources/glossary/diff.mdx
+++ b/resources/glossary/diff.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 442b51e9-9044-46db-81d2-ea98238a2af0
+objectId: bee82166-5cf3-4041-ae68-e7bf9d6c34ac
 title: Diffing
 description: Diffs are used to track changes between different versions or forks of a project, providing an overview regarding files changed, and the nature of those changes.
 slug: diff

--- a/resources/glossary/digital-twin.mdx
+++ b/resources/glossary/digital-twin.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 61966690-3395-4f32-ba61-1b04d9a203c1
 title: Digital Twin
 description: "Digital twins are a detailed simulated analogue to a real-world system"
 slug: digital-twin

--- a/resources/glossary/digital-twin.mdx
+++ b/resources/glossary/digital-twin.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 61966690-3395-4f32-ba61-1b04d9a203c1
+objectId: 9e5f378b-25d4-4497-aaa4-ecb288aa27b0
 title: Digital Twin
 description: "Digital twins are a detailed simulated analogue to a real-world system"
 slug: digital-twin

--- a/resources/glossary/discrete-event-modeling.mdx
+++ b/resources/glossary/discrete-event-modeling.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: fde1031a-612c-4663-96e4-d52bfe4fff67
 title: Discrete Event Simulation
 description: DES is a modeling approach that focuses on the occurrence of events in a simulation, separately and instantaneously, rather than on any chronological-scale.
 slug: discrete-event-modeling

--- a/resources/glossary/discrete-event-modeling.mdx
+++ b/resources/glossary/discrete-event-modeling.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: fde1031a-612c-4663-96e4-d52bfe4fff67
+objectId: ccf86bae-1d38-4ded-8885-561ca43bb513
 title: Discrete Event Simulation
 description: DES is a modeling approach that focuses on the occurrence of events in a simulation, separately and instantaneously, rather than on any chronological-scale.
 slug: discrete-event-modeling

--- a/resources/glossary/ego-networks.mdx
+++ b/resources/glossary/ego-networks.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 43a6fd61-ff87-4979-b0d7-fe4ea4e6280e
 title: Ego Networks
 description: "Ego networks are a framework for local analysis of larger graphs."
 slug: ego-networks

--- a/resources/glossary/ego-networks.mdx
+++ b/resources/glossary/ego-networks.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 43a6fd61-ff87-4979-b0d7-fe4ea4e6280e
+objectId: 8aa4e93d-7d89-4d87-8562-0fe386008a1b
 title: Ego Networks
 description: "Ego networks are a framework for local analysis of larger graphs."
 slug: ego-networks

--- a/resources/glossary/enterprise-resource-planning.mdx
+++ b/resources/glossary/enterprise-resource-planning.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 54375abf-b745-48c2-8ee1-107e4af639b6
 title: Enterprise Resource Planning
 description: "Enterprise resource planning uses an integrated software system to manage a business' daily tasks."
 slug: enterprise-resource-planning

--- a/resources/glossary/enterprise-resource-planning.mdx
+++ b/resources/glossary/enterprise-resource-planning.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 54375abf-b745-48c2-8ee1-107e4af639b6
+objectId: bae0fe50-099f-4150-b9fc-c3cb36f9ad58
 title: Enterprise Resource Planning
 description: "Enterprise resource planning uses an integrated software system to manage a business' daily tasks."
 slug: enterprise-resource-planning

--- a/resources/glossary/fork.mdx
+++ b/resources/glossary/fork.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 3a51ba11-66a8-4667-a0d0-a7b4ea908b42
+objectId: 84720a83-0797-494b-879f-49041cf09ede
 title: Forking
 description: Forking something means to create a copy of it, allowing individual developers or teams to work on their own versions of it, in safe isolation.
 slug: fork

--- a/resources/glossary/fork.mdx
+++ b/resources/glossary/fork.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 3a51ba11-66a8-4667-a0d0-a7b4ea908b42
 title: Forking
 description: Forking something means to create a copy of it, allowing individual developers or teams to work on their own versions of it, in safe isolation.
 slug: fork

--- a/resources/glossary/graph-databases.mdx
+++ b/resources/glossary/graph-databases.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 85bd65b1-4af1-46b3-8fc4-09dcc9ab42ef
 title: Graph Databases
 description: Graph Databases are a type of database that emphasizes the relationships between data. 
 slug: graph-databases

--- a/resources/glossary/graph-databases.mdx
+++ b/resources/glossary/graph-databases.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 85bd65b1-4af1-46b3-8fc4-09dcc9ab42ef
+objectId: 1b1f5527-2868-4cf6-b5d2-a2b154fa4ca1
 title: Graph Databases
 description: Graph Databases are a type of database that emphasizes the relationships between data. 
 slug: graph-databases

--- a/resources/glossary/graph-representation-learning.mdx
+++ b/resources/glossary/graph-representation-learning.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 7dea5ebc-6811-4d8d-af0b-0b509c14a94a
+objectId: 5e4f377a-bfe1-4af5-ac9e-12702d07c4e5
 title: Graph Representation Learning
 description: "Graph representation learning is a more tailored way of applying machine learning algorithms to graphs and networks."
 slug: graph-representation-learning

--- a/resources/glossary/graph-representation-learning.mdx
+++ b/resources/glossary/graph-representation-learning.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 7dea5ebc-6811-4d8d-af0b-0b509c14a94a
 title: Graph Representation Learning
 description: "Graph representation learning is a more tailored way of applying machine learning algorithms to graphs and networks."
 slug: graph-representation-learning

--- a/resources/glossary/knowledge-graph-machine-learning.mdx
+++ b/resources/glossary/knowledge-graph-machine-learning.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 51fe38f4-fdbf-45ff-b1fc-bd094769a01e
+objectId: 6b370d16-0b81-4582-91b7-277790131728
 title: Knowledge Graph Machine Learning
 description: "Knowledge graphs are information-dense inputs to machine learning algorithms, and can capture more human-readable outputs of algorithms."
 slug: knowledge-graph-machine-learning

--- a/resources/glossary/knowledge-graph-machine-learning.mdx
+++ b/resources/glossary/knowledge-graph-machine-learning.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 51fe38f4-fdbf-45ff-b1fc-bd094769a01e
 title: Knowledge Graph Machine Learning
 description: "Knowledge graphs are information-dense inputs to machine learning algorithms, and can capture more human-readable outputs of algorithms."
 slug: knowledge-graph-machine-learning

--- a/resources/glossary/knowledge-graphs.mdx
+++ b/resources/glossary/knowledge-graphs.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 6ac2cefa-a97f-41e7-900e-a14280ccfc74
+objectId: 8e0998b0-0a8c-40a0-9c4e-c50846229443
 title: Knowledge Graphs
 description: Knowledge Graphs contextualize data and power insight generation.
 slug: knowledge-graphs

--- a/resources/glossary/knowledge-graphs.mdx
+++ b/resources/glossary/knowledge-graphs.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 6ac2cefa-a97f-41e7-900e-a14280ccfc74
 title: Knowledge Graphs
 description: Knowledge Graphs contextualize data and power insight generation.
 slug: knowledge-graphs

--- a/resources/glossary/machine-learning.mdx
+++ b/resources/glossary/machine-learning.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 234d4cae-7739-45fd-bce3-7268c8e14066
 title: Machine Learning
 description: Machine Learning is a subfield of Artificial Intelligence where parameters of an algorithm are updated from data inputs or by interacting with an environment.
 slug: machine-learning

--- a/resources/glossary/machine-learning.mdx
+++ b/resources/glossary/machine-learning.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 234d4cae-7739-45fd-bce3-7268c8e14066
+objectId: 133cfd8b-9eea-4961-94c3-16e21614ad34
 title: Machine Learning
 description: Machine Learning is a subfield of Artificial Intelligence where parameters of an algorithm are updated from data inputs or by interacting with an environment.
 slug: machine-learning

--- a/resources/glossary/merge.mdx
+++ b/resources/glossary/merge.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 41162a25-acbf-434a-968e-3dca29b841d8
 title: Merging
 description: Merging is the process of reconciling two projects together. In HASH merging projects is handled by submitting, reviewing and approving “merge requests”.
 slug: merge

--- a/resources/glossary/merge.mdx
+++ b/resources/glossary/merge.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 41162a25-acbf-434a-968e-3dca29b841d8
+objectId: c4cc8423-cbef-47ef-8966-4c1af34b6470
 title: Merging
 description: Merging is the process of reconciling two projects together. In HASH merging projects is handled by submitting, reviewing and approving “merge requests”.
 slug: merge

--- a/resources/glossary/metadata.mdx
+++ b/resources/glossary/metadata.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 7759db1c-3e9a-4972-92e6-53155cd7a643
 title: Metadata
 description: Metadata is data about data. It’s quite simple, really. Learn more about how it’s used within.
 slug: metadata

--- a/resources/glossary/metadata.mdx
+++ b/resources/glossary/metadata.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 7759db1c-3e9a-4972-92e6-53155cd7a643
+objectId: 8e817ec2-2369-4001-8230-dcfee5eb6fab
 title: Metadata
 description: Metadata is data about data. It’s quite simple, really. Learn more about how it’s used within.
 slug: metadata

--- a/resources/glossary/model-drift.mdx
+++ b/resources/glossary/model-drift.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 0980ba22-aa01-4feb-b7f9-f3717443b1a0
+objectId: 68b25999-99bc-455a-a48e-4537390ce600
 title: Model Drift
 description: Models tend to become less accurate over time.
 slug: model-drift

--- a/resources/glossary/model-drift.mdx
+++ b/resources/glossary/model-drift.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 0980ba22-aa01-4feb-b7f9-f3717443b1a0
 title: Model Drift
 description: Models tend to become less accurate over time.
 slug: model-drift

--- a/resources/glossary/model-licensing.mdx
+++ b/resources/glossary/model-licensing.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: f036847d-94ea-47fd-bde0-309371fca0db
+objectId: 1ecc72a6-5511-46c3-9819-9ea9766dea07
 title: Model Licensing
 description: There are lots of ways to license simulation models. Here we outline some key considerations and things to be aware of.
 slug: model-licensing

--- a/resources/glossary/model-licensing.mdx
+++ b/resources/glossary/model-licensing.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: f036847d-94ea-47fd-bde0-309371fca0db
 title: Model Licensing
 description: There are lots of ways to license simulation models. Here we outline some key considerations and things to be aware of.
 slug: model-licensing

--- a/resources/glossary/model-sharing.mdx
+++ b/resources/glossary/model-sharing.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 7f079539-a889-40df-9ee6-7a0e14680171
+objectId: c99042a0-784a-48d1-817e-bdf071beece0
 title: Model Sharing
 description: "There are lots of ways to share simulation models: blackbox, greybox, closed, open, transparent, and output-only. Here we explain what these terms all mean."
 slug: model-sharing

--- a/resources/glossary/model-sharing.mdx
+++ b/resources/glossary/model-sharing.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 7f079539-a889-40df-9ee6-7a0e14680171
 title: Model Sharing
 description: "There are lots of ways to share simulation models: blackbox, greybox, closed, open, transparent, and output-only. Here we explain what these terms all mean."
 slug: model-sharing

--- a/resources/glossary/multi-agent-systems.mdx
+++ b/resources/glossary/multi-agent-systems.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 1696ee68-ea6e-4ab8-be38-4ec825fd3bad
+objectId: 64fbfcc8-2048-499c-83d5-34940c0fdcb3
 title: Multi-Agent Systems
 description: "Multi-Agent Systems represent real-world systems as collections of intelligent agents."
 slug: multi-agent-systems

--- a/resources/glossary/multi-agent-systems.mdx
+++ b/resources/glossary/multi-agent-systems.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 1696ee68-ea6e-4ab8-be38-4ec825fd3bad
 title: Multi-Agent Systems
 description: "Multi-Agent Systems represent real-world systems as collections of intelligent agents."
 slug: multi-agent-systems

--- a/resources/glossary/neural-nets.mdx
+++ b/resources/glossary/neural-nets.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: c9abf74c-386f-4c14-ac16-2f524000421a
+objectId: d9ddf22d-4dfb-482b-b6c4-d28beb6d5920
 title: Artificial Neural Networks
 description: Artificial Neural Networks are computer models inspired by animal brains. They consist of collections of nodes, arranged in layers, which transfer signals.
 slug: neural-nets

--- a/resources/glossary/neural-nets.mdx
+++ b/resources/glossary/neural-nets.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: c9abf74c-386f-4c14-ac16-2f524000421a
 title: Artificial Neural Networks
 description: Artificial Neural Networks are computer models inspired by animal brains. They consist of collections of nodes, arranged in layers, which transfer signals.
 slug: neural-nets

--- a/resources/glossary/optimization-methods.mdx
+++ b/resources/glossary/optimization-methods.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 13423ea5-8dac-4c1d-82d6-f47e0b5d120f
 title: Optimization Methods
 description: The key to finding the best solution to any problem.
 slug: optimization-methods

--- a/resources/glossary/optimization-methods.mdx
+++ b/resources/glossary/optimization-methods.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 13423ea5-8dac-4c1d-82d6-f47e0b5d120f
+objectId: 68395abb-2b07-41c3-bb77-3e3b31b25edc
 title: Optimization Methods
 description: The key to finding the best solution to any problem.
 slug: optimization-methods

--- a/resources/glossary/parameters.mdx
+++ b/resources/glossary/parameters.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 8b87c3ae-ea64-479a-b069-85f4dfef436f
+objectId: af3dccd2-fa83-4510-bbf0-af424a9593fa
 title: Parameters
 description: "Parameters control specific parts of a system's behavior."
 slug: parameters

--- a/resources/glossary/parameters.mdx
+++ b/resources/glossary/parameters.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 8b87c3ae-ea64-479a-b069-85f4dfef436f
 title: Parameters
 description: "Parameters control specific parts of a system's behavior."
 slug: parameters

--- a/resources/glossary/process-mining.mdx
+++ b/resources/glossary/process-mining.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: bf0156aa-7a08-4741-b209-45b6608182fa
 title: Process Mining
 description: Process mining is an application of data mining with the purpose of mapping an organization’s processes. It is used to optimize operations, and identify weaknesses.
 slug: process-mining

--- a/resources/glossary/process-mining.mdx
+++ b/resources/glossary/process-mining.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: bf0156aa-7a08-4741-b209-45b6608182fa
+objectId: 05270087-f09c-4340-b839-903e49600e58
 title: Process Mining
 description: Process mining is an application of data mining with the purpose of mapping an organization’s processes. It is used to optimize operations, and identify weaknesses.
 slug: process-mining

--- a/resources/glossary/project-management-software.mdx
+++ b/resources/glossary/project-management-software.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 0ca03871-0467-452a-892d-b32ad143de3b
+objectId: a58dbd87-d0ed-435e-b2ba-517d83dafcb9
 title: Project Management Software
 description: "Project management software is used to manage teams completing complex projects."
 slug: project-management-software

--- a/resources/glossary/project-management-software.mdx
+++ b/resources/glossary/project-management-software.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 0ca03871-0467-452a-892d-b32ad143de3b
 title: Project Management Software
 description: "Project management software is used to manage teams completing complex projects."
 slug: project-management-software

--- a/resources/glossary/robotic-process-automation.mdx
+++ b/resources/glossary/robotic-process-automation.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: faa594f6-d374-463b-9e7c-da71396af41b
 title: Robotic Process Automation
 description: "Robotic process automation uses software to perform repeatable business tasks."
 slug: robotic-process-automation

--- a/resources/glossary/robotic-process-automation.mdx
+++ b/resources/glossary/robotic-process-automation.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: faa594f6-d374-463b-9e7c-da71396af41b
+objectId: 82c73812-da69-4c80-aca3-eae6c5aedc58
 title: Robotic Process Automation
 description: "Robotic process automation uses software to perform repeatable business tasks."
 slug: robotic-process-automation

--- a/resources/glossary/robustness.mdx
+++ b/resources/glossary/robustness.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 03162207-609f-4e02-9560-cec5bc504405
 title: Robustness
 description: "Robustness is a measure of a model's accuracy when presented with novel data."
 slug: robustness

--- a/resources/glossary/robustness.mdx
+++ b/resources/glossary/robustness.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 03162207-609f-4e02-9560-cec5bc504405
+objectId: b53097d1-d327-4663-8e86-dc1803c1b59c
 title: Robustness
 description: "Robustness is a measure of a model's accuracy when presented with novel data."
 slug: robustness

--- a/resources/glossary/schemas.mdx
+++ b/resources/glossary/schemas.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: d3614fc7-77d8-47fc-a6ab-717f13e999f5
 title: Schemas
 description: "Schemas are descriptions of things: agents in simulations, and the actions they take. They help make simulations interoperable, and data more easily understood."
 slug: schemas

--- a/resources/glossary/schemas.mdx
+++ b/resources/glossary/schemas.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: d3614fc7-77d8-47fc-a6ab-717f13e999f5
+objectId: 9f03591a-59e1-4894-81ed-8653b334bee3
 title: Schemas
 description: "Schemas are descriptions of things: agents in simulations, and the actions they take. They help make simulations interoperable, and data more easily understood."
 slug: schemas

--- a/resources/glossary/simulation.mdx
+++ b/resources/glossary/simulation.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 4bb6fbdf-c8e1-4eb7-8644-d481d6d7c814
 title: Simulation Modeling
 description: Simulation Models seek to demonstrate what happens to environments and agents within them, over time, under varying conditions.
 slug: simulation

--- a/resources/glossary/simulation.mdx
+++ b/resources/glossary/simulation.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 4bb6fbdf-c8e1-4eb7-8644-d481d6d7c814
+objectId: 0a87b38d-0f82-41f2-aae5-29f4a6a8cf62
 title: Simulation Modeling
 description: Simulation Models seek to demonstrate what happens to environments and agents within them, over time, under varying conditions.
 slug: simulation

--- a/resources/glossary/single-synthetic-environment.mdx
+++ b/resources/glossary/single-synthetic-environment.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: b74181f7-ca63-4811-a153-085d169e84aa
 title: Single Synthetic Environment
 description: "Single synthetic environments allow you to build, run, and analyze data-driven models and simulations."
 slug: single-synthetic-environment

--- a/resources/glossary/single-synthetic-environment.mdx
+++ b/resources/glossary/single-synthetic-environment.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: b74181f7-ca63-4811-a153-085d169e84aa
+objectId: 9071fc61-32ce-4de7-95fa-cc7a47ec7d69
 title: Single Synthetic Environment
 description: "Single synthetic environments allow you to build, run, and analyze data-driven models and simulations."
 slug: single-synthetic-environment

--- a/resources/glossary/stochasticity.mdx
+++ b/resources/glossary/stochasticity.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: e09516b0-1d8b-48f8-bb6d-d853cb96d8ea
+objectId: cecc8280-13a4-4165-8057-3e1f172e5837
 title: Stochasticity
 description: Stochasticity is a measure of randomness. The state of a stochastic system can be modeled but not precisely predicted.
 slug: stochasticity

--- a/resources/glossary/stochasticity.mdx
+++ b/resources/glossary/stochasticity.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: e09516b0-1d8b-48f8-bb6d-d853cb96d8ea
 title: Stochasticity
 description: Stochasticity is a measure of randomness. The state of a stochastic system can be modeled but not precisely predicted.
 slug: stochasticity

--- a/resources/glossary/synthetic-data-generation.mdx
+++ b/resources/glossary/synthetic-data-generation.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 72e816aa-470e-4d2c-b120-6a762d3a9429
+objectId: 5497de5f-7855-4369-9844-f7e262212a74
 title: Synthetic Data Generation
 description: Generating data that mimics real data for use in machine learning.
 slug: synthetic-data-generation

--- a/resources/glossary/synthetic-data-generation.mdx
+++ b/resources/glossary/synthetic-data-generation.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 72e816aa-470e-4d2c-b120-6a762d3a9429
 title: Synthetic Data Generation
 description: Generating data that mimics real data for use in machine learning.
 slug: synthetic-data-generation

--- a/resources/glossary/system-dynamics.mdx
+++ b/resources/glossary/system-dynamics.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 54f5b03f-1569-4064-ae7c-b92033754fdc
 title: System Dynamics
 description: System Dynamics models represent a system as a set of stocks and the rates of flows between them.
 slug: system-dynamics

--- a/resources/glossary/system-dynamics.mdx
+++ b/resources/glossary/system-dynamics.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 54f5b03f-1569-4064-ae7c-b92033754fdc
+objectId: d29a720f-7d10-4dd1-bc8c-3add73f865d3
 title: System Dynamics
 description: System Dynamics models represent a system as a set of stocks and the rates of flows between them.
 slug: system-dynamics

--- a/resources/glossary/time-series.mdx
+++ b/resources/glossary/time-series.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: ca8dabff-b52c-45b8-b724-6747c887adcb
+objectId: 0e5be5bf-1fa3-4a7d-893f-751004a3ebd3
 title: Time Series Data
 description: Time series data is data that has been indexed, listed, or graphed in time order. For example, the daily closing value of the NASDAQ, or a single step in a simulation run.
 slug: time-series

--- a/resources/glossary/time-series.mdx
+++ b/resources/glossary/time-series.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: ca8dabff-b52c-45b8-b724-6747c887adcb
 title: Time Series Data
 description: Time series data is data that has been indexed, listed, or graphed in time order. For example, the daily closing value of the NASDAQ, or a single step in a simulation run.
 slug: time-series

--- a/resources/glossary/time.mdx
+++ b/resources/glossary/time.mdx
@@ -1,4 +1,5 @@
 ---
+objectID: 0699e65f-434f-4ce3-94cc-fd44313e56b6
 title: Discrete vs Continuous Time
 description: In continuous time, variables may have specific values for only infinitesimally short amounts of time. In discrete time, values are measured once per time interval.
 slug: time

--- a/resources/glossary/time.mdx
+++ b/resources/glossary/time.mdx
@@ -1,5 +1,5 @@
 ---
-objectID: 0699e65f-434f-4ce3-94cc-fd44313e56b6
+objectId: 8e33b29f-2b5b-411f-8029-1eb5a5e2850c
 title: Discrete vs Continuous Time
 description: In continuous time, variables may have specific values for only infinitesimally short amounts of time. In discrete time, values are measured once per time interval.
 slug: time


### PR DESCRIPTION
At HASH, we are currently indexing all of our MDX-rendered web pages under Algolia search, so that we can have a search bar present for all our articles in the [learning set of pages](https://hash.ai/docs/simulation).

To do that, we need to have a unique ID attached to each element so that they are automatically updated whenever we make a change to the page. So, this PR adds a `objectID` to each of these pages, which would primarily be used for Algolia indexing, but can be used for other purposes like analytics as well.