### PR TITLE
Update forum links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for taking the time to contribute! 🎉 We've established a set of [community guidelines](https://hash.ai/legal/community) to enable as many people as possible to contribute to and benefit from HASH. Please follow these when interacting with this repo.
 
-We have a [Discord server](https://hash.ai/discord) and [forum](https://community.hash.ai/) where you can ask questions about contributing, and where the community can chime in with helpful advice. If you'd like to make a significant change or re-architecture, please first discuss the change there (or create an [issue](https://github.com/hashintel/hash/issues)) to get feedback before spending too much time.
+We have a communuty [Discord server](https://hash.ai/discord) and [support forum](https://hash.community/) where you can ask questions about contributing, and where the community can chime in with helpful advice. If you'd like to make a significant change or re-architecture, please first discuss the change there (or create an [issue](https://github.com/hashintel/hash/issues)) to get feedback before spending too much time.
 
 ## HASH Public Monorepo
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for taking the time to contribute! 🎉 We've established a set of [community guidelines](https://hash.ai/legal/community) to enable as many people as possible to contribute to and benefit from HASH. Please follow these when interacting with this repo.
 
-We have a communuty [Discord server](https://hash.ai/discord) and [support forum](https://hash.community/) where you can ask questions about contributing, and where the community can chime in with helpful advice. If you'd like to make a significant change or re-architecture, please first discuss the change there (or create an [issue](https://github.com/hashintel/hash/issues)) to get feedback before spending too much time.
+We have a community [Discord server](https://hash.ai/discord) and [support forum](https://hash.community/) where you can ask questions about contributing, and where the community can chime in with helpful advice. If you'd like to make a significant change or re-architecture, please first discuss the change there (or create an [issue](https://github.com/hashintel/hash/issues)) to get feedback before spending too much time.
 
 ## HASH Public Monorepo
 

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -18,4 +18,4 @@ Our [docs](https://docs.hash.ai/?utm_medium=organic&utm_source=github_readme_eng
 The [HASH wiki](https://hash.ai/wiki?utm_medium=organic&utm_source=github_readme_engine) contains helpful explainers around key modeling, simulation and AI-related terms and concepts.
 
 ## Questions & Support
-We're building a community of people who care about enabling better decision-making through modeling and simulation. Our [online forum](https://community.hash.ai/?utm_medium=organic&utm_source=github_readme_engine) and [HASH Discord server](https://hash.ai/discord?utm_medium=organic&utm_source=github_readme_engine) (requires login) are both great places to meet other modelers and get help.
+We're building a community of people who care about enabling better decision-making through modeling and simulation. Our [support forum](https://hash.community/?utm_medium=organic&utm_source=github_readme_engine) and [HASH community Discord server](https://hash.ai/discord?utm_medium=organic&utm_source=github_readme_engine) (requires login) are both great places to meet other modelers and get help.

--- a/packages/engine/stdlib/CONTRIBUTING.md
+++ b/packages/engine/stdlib/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 Please note we have established a set of [community guidelines](https://hash.ai/legal/community). Please follow these in your interactions with the project.
 
-We have a [Discord server](https://hash.ai/discord) and a [community forum](https://community.hash.ai/) where you can ask questions about contributing, and where the community can chime in with helpful advice. If you'd like to make a significant change or re-architecture, please first discuss the change there (or create an [issue](https://github.com/hashintel/hash/issues)) to get feedback.
+We have a [community Discord server](https://hash.ai/discord) and a [support forum](https://hash.community/) where you can ask questions about contributing, and where the community can chime in with helpful advice. If you'd like to make a significant change or re-architecture, please first discuss the change there (or create an [issue](https://github.com/hashintel/hash/issues)) to get feedback.
 
 ## What belongs in the HASH Standard Library
 

--- a/packages/engine/stdlib/README.md
+++ b/packages/engine/stdlib/README.md
@@ -51,4 +51,4 @@ mypy ./src/py
 
 
 ## Discussion
-You can get support with or discuss HASH and the HASH stdlib on our [community forum](https://community.hash.ai/) or [Discord server](https://hash.ai/discord).
+You can get support with or discuss HASH and the HASH stdlib on our [support forum](https://hash.community/) or community [Discord server](https://hash.ai/discord).

--- a/resources/docs/simulation/README.md
+++ b/resources/docs/simulation/README.md
@@ -27,7 +27,7 @@ If you want to experiment with pre-built models, check out our examples on the [
 
 ## Community & Support
 
-If you need help or support, check out the [community forum](https://community.hash.ai/) or [join our Discord](/discord) \(this tends to be the fastest means of getting help\). You can also reach out to us directly via our [contact page](https://hash.ai/contact).
+If you need help or support, check out the [support forum](https://hash.community/) or [join our community Discord](/discord) \(this tends to be the fastest means of getting help\). You can also reach out to us directly via our [contact page](https://hash.ai/contact).
 
 ## Upcoming Features
 

--- a/resources/docs/simulation/extra/performance.md
+++ b/resources/docs/simulation/extra/performance.md
@@ -14,7 +14,7 @@ There are several possible reasons your simulation is running slowly. Broadly we
 
 Below we explain these common performance bottlenecks and solutions you can use to improve your simulation's performance. Alternatively you can use [hCloud](/docs/simulation/creating-simulations/h.cloud) to run simulations on dedicated remote hardware and stream these results back to your local machine.
 
-We're also happy to chat through techniques to improve your simulation's performance in our [Discord](/discord) and [Forum](https://community.hash.ai/).
+We're also happy to chat through techniques to improve your simulation's performance in our [HASH community Discord](/discord) and [support forum](https://hash.community/).
 
 ## Data
 

--- a/resources/docs/simulation/tutorials/building-process-models/README.md
+++ b/resources/docs/simulation/tutorials/building-process-models/README.md
@@ -44,7 +44,7 @@ You can start building right away, and to learn more continue reading our how-to
 
 Along with our video tutorial on building your first process model.
 
-We'd love to know what you build. Contact us via [the website](/contact), post on [the forum](https://community.hash.ai/) or share on our public [HASH Discord server](/discord).
+We'd love to know what you build. Contact us via [the website](/contact), post on the [HASH support forum](https://hash.community/) or share on our public [HASH community Discord](/discord) server.
 
 <Hint style="info">
 Given that HASH is a general platform for simulations, specific simulation 'tools' can be built on top of it. Just like with modern computers, HASH can be the OS for quickly creating domain specific applications. [Using the HASH API you can create your own interfaces.](/docs/simulation/creating-simulations/views/api-1)


### PR DESCRIPTION
Changes community.hash.ai to hash.community in the HASH public monorepo content. Other CMS updates will be pushed separately.