### PR TITLE
Fix headings for code

### DIFF
--- a/resources/docs/simulation/creating-simulations/libraries/hash/neighbors.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/neighbors.md
@@ -6,7 +6,7 @@ objectId: c1c7f910-08cb-4d8f-a5ef-60a4c1c76ab1
 
 # Neighbors
 
-## neighborsOnPosition(agentA, neighbors)
+**`neighborsOnPosition(agentA, neighbors)`**
 
 This function returns all neighbors that share the same position as `agentA`. The current agent's `state` can be passed in as `agentA`, and dummy agents can be used as well.
 
@@ -28,7 +28,7 @@ function behavior(state, context) {
 }
 ```
 
-## neighborsInRadius(agentA, neighbors, max_radius, min_radius, z_axis)
+**`neighborsInRadius(agentA, neighbors, max_radius, min_radius, z_axis)`**
 
 This function returns all neighbors within the specified radii. The current agent's `state` can be passed in as `agentA`, and dummy agents can be used as well. By default the max and min radii are \[1, 0\]. `z_axis` is false by default, but by passing true you can enable search in a spherical, as opposed to circular radius.
 
@@ -42,7 +42,7 @@ function behavior(state, context) {
 }
 ```
 
-## neighborsInFront(agentA, neighbors, colinear)
+**`neighborsInFront(agentA, neighbors, colinear)`**
 
 This function returns all neighbors located in front of an agent. `agentA` must have a "direction" property since "in front" is determined by the plane perpendicular to that vector. `colinear` defaults to false, but by passing true the function will only return agents on the same _line_ as the "direction". The current agent's `state` can be passed in as `agentA`, and dummy agents can be used as well.
 
@@ -60,7 +60,7 @@ function behavior(state, context) {
 }
 ```
 
-## neighborsBehind(agentA, neighbors, colinear)
+**`neighborsBehind(agentA, neighbors, colinear)`**
 
 This function returns all neighbors located behind the agent. It functions identically to **neighborsInFront** but returns agents behind the plane of `agentA`. The current agent's `state` can be passed in as `agentA`, and dummy agents can be used as well.
 

--- a/resources/docs/simulation/creating-simulations/libraries/hash/neighbors.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/neighbors.md
@@ -6,7 +6,7 @@ objectId: c1c7f910-08cb-4d8f-a5ef-60a4c1c76ab1
 
 # Neighbors
 
-**`neighborsOnPosition(agentA, neighbors)`**
+### `neighborsOnPosition(agentA, neighbors)`
 
 This function returns all neighbors that share the same position as `agentA`. The current agent's `state` can be passed in as `agentA`, and dummy agents can be used as well.
 
@@ -28,7 +28,7 @@ function behavior(state, context) {
 }
 ```
 
-**`neighborsInRadius(agentA, neighbors, max_radius, min_radius, z_axis)`**
+### `neighborsInRadius(agentA, neighbors, max_radius, min_radius, z_axis)`
 
 This function returns all neighbors within the specified radii. The current agent's `state` can be passed in as `agentA`, and dummy agents can be used as well. By default the max and min radii are \[1, 0\]. `z_axis` is false by default, but by passing true you can enable search in a spherical, as opposed to circular radius.
 
@@ -42,7 +42,7 @@ function behavior(state, context) {
 }
 ```
 
-**`neighborsInFront(agentA, neighbors, colinear)`**
+### `neighborsInFront(agentA, neighbors, colinear)`
 
 This function returns all neighbors located in front of an agent. `agentA` must have a "direction" property since "in front" is determined by the plane perpendicular to that vector. `colinear` defaults to false, but by passing true the function will only return agents on the same _line_ as the "direction". The current agent's `state` can be passed in as `agentA`, and dummy agents can be used as well.
 
@@ -60,7 +60,7 @@ function behavior(state, context) {
 }
 ```
 
-**`neighborsBehind(agentA, neighbors, colinear)`**
+### `neighborsBehind(agentA, neighbors, colinear)`
 
 This function returns all neighbors located behind the agent. It functions identically to **neighborsInFront** but returns agents behind the plane of `agentA`. The current agent's `state` can be passed in as `agentA`, and dummy agents can be used as well.
 

--- a/resources/docs/simulation/creating-simulations/libraries/hash/neighbors.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/neighbors.md
@@ -6,7 +6,7 @@ objectId: c1c7f910-08cb-4d8f-a5ef-60a4c1c76ab1
 
 # Neighbors
 
-### `neighborsOnPosition(agentA, neighbors)`
+## `neighborsOnPosition(agentA, neighbors)`
 
 This function returns all neighbors that share the same position as `agentA`. The current agent's `state` can be passed in as `agentA`, and dummy agents can be used as well.
 
@@ -28,7 +28,7 @@ function behavior(state, context) {
 }
 ```
 
-### `neighborsInRadius(agentA, neighbors, max_radius, min_radius, z_axis)`
+## `neighborsInRadius(agentA, neighbors, max_radius, min_radius, z_axis)`
 
 This function returns all neighbors within the specified radii. The current agent's `state` can be passed in as `agentA`, and dummy agents can be used as well. By default the max and min radii are \[1, 0\]. `z_axis` is false by default, but by passing true you can enable search in a spherical, as opposed to circular radius.
 
@@ -42,7 +42,7 @@ function behavior(state, context) {
 }
 ```
 
-### `neighborsInFront(agentA, neighbors, colinear)`
+## `neighborsInFront(agentA, neighbors, colinear)`
 
 This function returns all neighbors located in front of an agent. `agentA` must have a "direction" property since "in front" is determined by the plane perpendicular to that vector. `colinear` defaults to false, but by passing true the function will only return agents on the same _line_ as the "direction". The current agent's `state` can be passed in as `agentA`, and dummy agents can be used as well.
 
@@ -60,7 +60,7 @@ function behavior(state, context) {
 }
 ```
 
-### `neighborsBehind(agentA, neighbors, colinear)`
+## `neighborsBehind(agentA, neighbors, colinear)`
 
 This function returns all neighbors located behind the agent. It functions identically to **neighborsInFront** but returns agents behind the plane of `agentA`. The current agent's `state` can be passed in as `agentA`, and dummy agents can be used as well.
 


### PR DESCRIPTION
This PR updates the `neighbors.md` docs file to display inside code marks `, to maintain each function name's case.

~Although it's possible to use MD inside headings in markdown, it jumbles up the underlying HTML, which means we can't read the current heading which is being passed from the markdown. So, I've converted it to bold code blocks, like I've done earlier elsewhere.~

The above is now fixed, we can use headings with code, bold or italics in HASH docs.