### PR TITLE
Remove unneeded bold from code

### DIFF
--- a/resources/docs/simulation/concepts/designing-with-system-dynamics-models.md
+++ b/resources/docs/simulation/concepts/designing-with-system-dynamics-models.md
@@ -81,7 +81,7 @@ Some rates will only have one of "to" or "from" if they are coming from a sink, 
 
 ### Globals
 
-As a final step, set the resolution of your time step in **`globals.json`** with a `dt` property. The smaller the value, the finer the resolution of your model will be \(but the more time steps it will take to run\).
+As a final step, set the resolution of your time step in `globals.json` with a `dt` property. The smaller the value, the finer the resolution of your model will be \(but the more time steps it will take to run\).
 
 ```javascript
 {

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/business-collect-and-update.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/business-collect-and-update.md
@@ -6,7 +6,7 @@ objectId: 62f732ca-a109-4c8b-8c07-40e3781199ff
 
 # Business Collect and Update
 
-The final step for this simulation is for the Businesses to collect the Customer replies and update their position and price to the combination that produced the largest profit. Create a `collect_customer_data()` function in **`business.js`** and add the following code.
+The final step for this simulation is for the Businesses to collect the Customer replies and update their position and price to the combination that produced the largest profit. Create a `collect_customer_data()` function in `business.js` and add the following code.
 
 ```javascript
  const collect_customer_data = (messages) => {

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/customer-reply.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/customer-reply.md
@@ -6,7 +6,7 @@ objectId: 91eaa467-7855-4948-adc0-5d325d839f4d
 
 # Customer Reply
 
-Now that Business agents are communicating with Customers, we need the Customers to send a reply back. To do this, let’s look at **`customer.js`**. Every time a Customer agent receives a batch of messages, it will:
+Now that Business agents are communicating with Customers, we need the Customers to send a reply back. To do this, let’s look at `customer.js`. Every time a Customer agent receives a batch of messages, it will:
 
 - Run the message data through a cost function to determine the change with the lowest cost for each Business
 - Notify each Business where they would choose to shop given all the possibilities
@@ -19,7 +19,7 @@ The cost function will be as follows, where price is the Business’s `item_pric
 
 <Math formula="D(p) = \sqrt{p_x^2+p_y^2}" />
 
-Create the function `calculate_cost()` in **`customer.js`**.
+Create the function `calculate_cost()` in `customer.js`.
 
 <Tabs>
 <Tab title="customer.js" >
@@ -183,7 +183,7 @@ state.addMessage(individual_min.agent_id, "customer_cost", {
 });
 ```
 
-All that’s left to do now for **`customer.js`** is to update the agent’s color to the `overall_min`’s color. This signifies that the Customer decided it would want to purchase from that particular business. Set the agent’s color after the closing of the object key iterator \(on line 89\).
+All that’s left to do now for `customer.js` is to update the agent’s color to the `overall_min`’s color. This signifies that the Customer decided it would want to purchase from that particular business. Set the agent’s color after the closing of the object key iterator \(on line 89\).
 
 ```javascript
 // Only update color if min cost was determined during this time step
@@ -199,7 +199,7 @@ const businesses = collect_business_data(context.messages());
 find_min(businesses);
 ```
 
-The **`customer.js`** behavior is finally complete!
+The `customer.js` behavior is finally complete!
 
 <Hint style="success">
 To see **customer.js** in full, navigate to bottom of this section or click on ‘**Phase 1** **Final Code**’ in the sidebar.

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/initialization.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/initialization.md
@@ -17,9 +17,9 @@ Now, open up init.json. This is where we will be writing our [agent creator](/do
 
 Customers begin evenly distributed in a grid across the environment. Thanks to HASH’s published behavior feature, we can do this easily by adding those three behaviors to our creator agent:
 
-* **`@hash/create-grids/create_grids.js`** - populates our creator’s `agents` field with Customer agents we define in our `grid_templates` field. 
-* **`@hash/create-agents/create_agents.js`**- creates the Customers in the model environment.
-* **`@hash/remove-self/remove_self.js`** - removes the creator agent from the simulation after all agents have been initialized.
+* `@hash/create-grids/create_grids.js` - populates our creator’s `agents` field with Customer agents we define in our `grid_templates` field. 
+* `@hash/create-agents/create_agents.js`- creates the Customers in the model environment.
+* `@hash/remove-self/remove_self.js` - removes the creator agent from the simulation after all agents have been initialized.
 
 ** init.json **
 
@@ -64,8 +64,8 @@ Now to create Business agents:
 1. Add the published behavior **Create Scatters** to your Project.
 2. Create two new files - `business.js` and `update_businesses.js`.
 3. Add the `scatter_templates` property and two behaviors to the creator agent
-   1. **`@hash/create-scatters/create_scatters.js`**
-   2. **`update_businesses.js`**
+   1. `@hash/create-scatters/create_scatters.js`
+   2. `update_businesses.js`
 
 ** init.json **
 

--- a/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/query-customers.md
+++ b/resources/docs/simulation/tutorials/phase-1-building-a-simple-hotelling-model-in-2d/query-customers.md
@@ -85,8 +85,8 @@ Find the messages field for a Business agent and it should be filled with “bus
 
 Since Business agents are sending around 100 \(neighbors\) x 6 \(positions\) x 3 \(prices\) messages at one time, we don’t want this to occur every time step. We'll add a counter to ensure it happens at the rate we want.
 
-1. Add the HASH shared behavior **Counter** \(shortname: @hash/counter/counter.rs\) to your simulation and add the counter behavior to your business agents BEFORE your behavior **`business.js`**. \(You want the counter to increment before **`business.js`** is called\)
-2. In **`init.json`** give your Business agents three more variables:
+1. Add the HASH shared behavior **Counter** \(shortname: @hash/counter/counter.rs\) to your simulation and add the counter behavior to your business agents BEFORE your behavior `business.js`. \(You want the counter to increment before `business.js` is called\)
+2. In `init.json` give your Business agents three more variables:
 3. counter: 0
 4. counter_reset_at: 2
 5. counter_reset_to: 0


### PR DESCRIPTION
This PR removes bold modifiers from code, which were used to style filenames before. [This PR](https://github.com/hashintel/internal/pull/3172) makes it redundant, allowing filenames in code to be displayed as filenames directly.