### PR TITLE
Fix: formatting for process blocks docs

### DIFF
--- a/resources/docs/simulation/concepts/designing-with-process-models/process-blocks.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/process-blocks.md
@@ -33,7 +33,7 @@ The source behavior is the entry point to a process model. It can generate objec
     // instead of the subsequent one in the behaviors array 
     "next_block": string 
 }
-
+```
 
 ## Sink
 
@@ -57,7 +57,7 @@ The sink behavior is generally the endpoint of a process model. It disposes of o
     // Record the average in `state.process_data.avg_wait_times.<block_name>`
     "record_wait_times": boolean
 }
-
+```
 
 ## Delay
 
@@ -83,7 +83,7 @@ The delay behavior causes objects in the process model to wait a certain amount 
     // instead of the subsequent one in the behaviors array 
     "next_block": string 
 }
-
+```
 
 ## Seize
 
@@ -107,7 +107,7 @@ The name of the resource being seized should match that of a resource recovered 
     // instead of the subsequent one in the behaviors array 
     "next_block": string 
 }
-
+```
 
 ## Release
 
@@ -128,7 +128,7 @@ The name of the resource being seized **must** match that of a resource reserved
     // instead of the subsequent one in the behaviors array 
     "next_block": string 
 }
-
+```
 
 ## Service
 
@@ -160,7 +160,7 @@ The service behavior seizes resources, delays the object, and then releases the 
     // instead of the subsequent one in the behaviors array.
     "next_block": string 
 }
-
+```
 
 ## Select Output
 
@@ -201,7 +201,7 @@ On the final block of the "true" path, specify the first block where the two pat
     // Remove the field checked in "condition_field"
     "remove_condition_field": boolean
 }
-
+```
 
 ## Exit
 
@@ -232,7 +232,7 @@ Exit blocks can also be used to send arbitrary messages to other agents, or even
     "next_block": string
 
 }
-
+```
 
 ## Enter
 
@@ -255,7 +255,7 @@ An agent can do so by sending a message with the following fields:
     "next_block": string
 
 }
-
+```
 
 ## Time Measure Start
 
@@ -271,7 +271,7 @@ This behavior records the time an object reached it, to enable calculating the e
     // instead of the subsequent one in the behaviors array.
     "next_block": string 
 }
-
+```
 
 ## Time Measure End
 
@@ -290,7 +290,7 @@ The process label of this behavior must match that of its corresponding Time Mea
     // instead of the subsequent one in the behaviors array.
     "next_block": string 
 }
-
+```
 
 ## Resource Data
 


### PR DESCRIPTION
Add missing code blocks delimiters to fix the docs formatting which is currently very hard to read