### PR TITLE
Ns/doc fixes

### DIFF
--- a/resources/docs/simulation/concepts/designing-with-process-models/experimenting-with-process-models.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/experimenting-with-process-models.md
@@ -60,6 +60,6 @@ The [Globals](/docs/simulation/creating-simulations/configuration/) section desc
 
 Now when we run the experiment, we can see how varying the number of service agents effects the descriptive metrics of the process model.
 
-![](https://lh5.googleusercontent.com/EOBydAKWL0GoGZQAZMqFj_weIFdVjdLVtcPX1Q3mtftPQiOfQoPPVk0hc3lS4j1mVp_T2A-ByLBYk9yWlmzMm74sjcALRnyfhLAX-taDlfrpbmcwWsbEs3fTnKg4E1_f6_1fLF4X)
+![](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/process+experiment.png)
 
 After adding metrics and charts, we can see what happens to the queue in the experiment. Provided the number of agents stays above 1, the queue will remain flat.

--- a/resources/docs/simulation/concepts/designing-with-process-models/experimenting-with-process-models.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/experimenting-with-process-models.md
@@ -56,10 +56,10 @@ The [Globals](/docs/simulation/creating-simulations/configuration/) section desc
 
 1. Create an experiment and use the parameter as the field for the experiment
 
-![Experiment model](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/process+models+experiment.png)
+![Experiment model](https://cdn-us1.hash.ai/site/docs/process+models+experiment.png)
 
 Now when we run the experiment, we can see how varying the number of service agents effects the descriptive metrics of the process model.
 
-![](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/process+experiment.png)
+![](https://cdn-us1.hash.ai/site/docs/process+experiment.png)
 
 After adding metrics and charts, we can see what happens to the queue in the experiment. Provided the number of agents stays above 1, the queue will remain flat.

--- a/resources/docs/simulation/concepts/designing-with-process-models/experimenting-with-process-models.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/experimenting-with-process-models.md
@@ -23,6 +23,7 @@ To run an experiment, you'll want to first identify the parameter of the process
        "track_wait": true
      },
    "service_agents": 6
+```
 
 
 In this model we could run experiments with the “service_agents” property and see how it responds to different numbers of agents.
@@ -41,6 +42,7 @@ The [Globals](/docs/simulation/creating-simulations/configuration/) section desc
 {
  "num_service_agents": 6
 }
+```
 
 
 1. Replace the property on the process model with the global parameter.
@@ -49,11 +51,12 @@ The [Globals](/docs/simulation/creating-simulations/configuration/) section desc
 // create_process.js
 
 "service_agents": Math.floor(context.globals().num_service_agents),
+```
 
 
 1. Create an experiment and use the parameter as the field for the experiment
 
-![Experiment model](https://lh5.googleusercontent.com/9fJKOO9RlHGjnmFrS4gX2mAWDjXLHlHLTTbfYbFIxBsJ_PWIToyh9N-s0kRCSJU_jWi3sQ1v1bQISW774tbTqy_C7apNVzbr3lEJFxhJndlzWnYlXdWzrAqq2rQOssuLLdw4hP3j)
+![Experiment model](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/process+models+experiment.png)
 
 Now when we run the experiment, we can see how varying the number of service agents effects the descriptive metrics of the process model.
 

--- a/resources/docs/simulation/concepts/designing-with-process-models/process-model-concepts.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/process-model-concepts.md
@@ -12,7 +12,7 @@ Process models, when built with the process library, are represented as a flowch
 
 You can think of it like a flowchart - objects start at the source, travel through different blocks, and end at the sink.
 
-![A process model diagram](https://lh3.googleusercontent.com/k_z-PgMKN4gVmoQ2NKQQaLmUUI9dHI-zqQeHQ3EqJ6MtqLdo0omkikAaPKG7puxStikT5fpk9FBKCfiheTXvDbSo9FxkHMKrH95O5pfRXYQ5naqQuiegg9hxkj9U_jghjRCvVSam)
+![A process model diagram](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/hash-bpmn-example.png)
 
 When designing your own process models, your primary task is to factor the real world process into discrete steps, and then match those steps to blocks in the process library \(or build your own!\)
 

--- a/resources/docs/simulation/concepts/designing-with-process-models/process-model-concepts.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/process-model-concepts.md
@@ -12,7 +12,7 @@ Process models, when built with the process library, are represented as a flowch
 
 You can think of it like a flowchart - objects start at the source, travel through different blocks, and end at the sink.
 
-![A process model diagram](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/hash-bpmn-example.png)
+![A process model diagram](https://cdn-us1.hash.ai/site/docs/hash-bpmn-example.png)
 
 When designing your own process models, your primary task is to factor the real world process into discrete steps, and then match those steps to blocks in the process library \(or build your own!\)
 

--- a/resources/docs/simulation/concepts/designing-with-process-models/theory-of-constraints-and-simulations-a-framework-for-process-optimization.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/theory-of-constraints-and-simulations-a-framework-for-process-optimization.md
@@ -32,7 +32,7 @@ It's ironic that when trying to improve a process, people have a tendency to foc
 
 For example, consider a [Billing Department](https://core.hash.ai/@hash/billing-department-process/stable), which needs to process, send out, and occasionally audit two types of bills.
 
-![](https://lh4.googleusercontent.com/W6wazlGHPZVxkEuWCl8DIkw66P44qrgvMbIAUs0VfgGwiY-taiU1PgVnr5dhkeBTc-kpCzm5Xhajs7-VMhGsOaG6CcKhbQ6uQMXH-z-hCxf6zRtmEqeIel3_JyHRVjIxgObDla47)
+![](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/billing-department-flow.png)
 
 <Hint style="info">
 [Learn how to build a process model simulation using a visual interface.](/docs/simulation/tutorials/building-process-models/using-the-process-model-builder)
@@ -40,13 +40,13 @@ For example, consider a [Billing Department](https://core.hash.ai/@hash/billing-
 
 Once we've represented the department as a process model and generated a simulation, we can use the Analysis view to inspect the process models to identify bottlenecks based on resource utilization or through times. There are four different resources in use in model: senior_billers, account_billers, billing_clerks, and printers. Visualizing the average utilization of these resources will allow us to determine which, if any, are responsible for any bottlenecks:
 
-![Percent of a resource being utilized](https://lh4.googleusercontent.com/4TECbNGY8Cumj3fY8fBvne8etXwC75T-9AiXbUqyuuXbqRM5jh4LzxMD65aTjfw-IOumLH9W8lCTU4Bprq5cyQ5FSfJBU_ODEPGurWDs81Fmi-qs4gIGUgsRS6ehRW3h7w1lrElU)
+![Percent of a resource being utilized](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/billng-department-resource-utilization.png)
 
 We can see that Senior Billers are almost constantly occupied, compared to other resources, which have more reasonable usage rates.
 
 Paradoxically, having a resource fully occupied implies that a system is not running effectively. We can confirm that by looking at the average time it is taking to process a bill:
 
-![](https://lh4.googleusercontent.com/IvqcW9PjBSvBiRcYhZavyzeJoqOMZsKeWLUgGuqWFxn-1YweXxew7K5djCYRW1Zk9mTkLTVIsIhnV0QqQvbvctp9hGjxwd5N7uFjJhm3cL-NwSZKFANZPCNmtDZ4hyh78GyJhYSr)
+![](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/avg-process-time-increases.png)
 
 The average time continues to increase as the model runs, instead of reaching a stable value. This means that eventually the system will take infinitely long to process a bill!
 

--- a/resources/docs/simulation/concepts/designing-with-process-models/theory-of-constraints-and-simulations-a-framework-for-process-optimization.md
+++ b/resources/docs/simulation/concepts/designing-with-process-models/theory-of-constraints-and-simulations-a-framework-for-process-optimization.md
@@ -32,7 +32,7 @@ It's ironic that when trying to improve a process, people have a tendency to foc
 
 For example, consider a [Billing Department](https://core.hash.ai/@hash/billing-department-process/stable), which needs to process, send out, and occasionally audit two types of bills.
 
-![](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/billing-department-flow.png)
+![](https://cdn-us1.hash.ai/site/docs/billing-department-flow.png)
 
 <Hint style="info">
 [Learn how to build a process model simulation using a visual interface.](/docs/simulation/tutorials/building-process-models/using-the-process-model-builder)
@@ -40,13 +40,13 @@ For example, consider a [Billing Department](https://core.hash.ai/@hash/billing-
 
 Once we've represented the department as a process model and generated a simulation, we can use the Analysis view to inspect the process models to identify bottlenecks based on resource utilization or through times. There are four different resources in use in model: senior_billers, account_billers, billing_clerks, and printers. Visualizing the average utilization of these resources will allow us to determine which, if any, are responsible for any bottlenecks:
 
-![Percent of a resource being utilized](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/billng-department-resource-utilization.png)
+![Percent of a resource being utilized](https://cdn-us1.hash.ai/site/docs/billng-department-resource-utilization.png)
 
 We can see that Senior Billers are almost constantly occupied, compared to other resources, which have more reasonable usage rates.
 
 Paradoxically, having a resource fully occupied implies that a system is not running effectively. We can confirm that by looking at the average time it is taking to process a bill:
 
-![](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/avg-process-time-increases.png)
+![](https://cdn-us1.hash.ai/site/docs/avg-process-time-increases.png)
 
 The average time continues to increase as the model runs, instead of reaching a stable value. This means that eventually the system will take infinitely long to process a bill!
 

--- a/resources/docs/simulation/creating-simulations/agent-messages/README.md
+++ b/resources/docs/simulation/creating-simulations/agent-messages/README.md
@@ -53,12 +53,12 @@ If you want to jump right into code you can take a look at our [Message Passing 
 
 You'll notice that each message is comprised of three fields: "to", "type", and "data."
 
-* `to`:  the `agent_name` or `agent_id` of the agent that the message will be deliever to
+* `to`:  the `agent_name` or `agent_id` of the agent that the message will be deliever to (this can also be an array of agents)
 * `type`: the type of message being sent for the message handler to select the right course of action
 * `data`: any data you want to send along with the message
 
 <Hint style="info">
-You can use the helper function state.addMessage\(to&lt;String&gt;, type&lt;String&gt;, data&lt;Dict&gt;\) to add messages directly to the state messages field.
+You can use the helper function state.addMessage\(to&lt;String&gt;, type&lt;String&gt;, data&lt;Dict&gt;\) to add messages directly to the state messages field (the helper function can only take one agent as a "to" argument).
 </Hint>
 
 <Tabs>

--- a/resources/docs/simulation/creating-simulations/agent-messages/sending-messages.md
+++ b/resources/docs/simulation/creating-simulations/agent-messages/sending-messages.md
@@ -12,7 +12,7 @@ Agents send messages by adding JSON objects to their `messages` array. The objec
 
 ```javascript
 {
-    to: "string" // an agent_id or agent_name
+    to: "string" || "string"[]// an agent_id or agent_name
     type: "string" // a string that defines the type of the message
     data: {} // an object that serves as the payload 
 }

--- a/resources/docs/simulation/extra/migrating/anylogic/main-loop.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/main-loop.md
@@ -17,6 +17,6 @@ In this simulation it’s the process of delivering oil from tankers, through th
 5. Which triggers fuel tankers to go to the storage agents load oil
 6. And deliver it to retailers
 
-![](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/anylogic-oil-main-loop.png)
+![](https://cdn-us1.hash.ai/site/docs/anylogic-oil-main-loop.png)
 
 It looks like we don’t have to initialize a special agent to handle any high-level functions here. The Main agent in AnyLogic is only responsible for initialization, which our creator agent will take care of.

--- a/resources/docs/simulation/extra/migrating/anylogic/main-loop.md
+++ b/resources/docs/simulation/extra/migrating/anylogic/main-loop.md
@@ -17,6 +17,6 @@ In this simulation it’s the process of delivering oil from tankers, through th
 5. Which triggers fuel tankers to go to the storage agents load oil
 6. And deliver it to retailers
 
-![](https://lh6.googleusercontent.com/smDMCG9NqVz4Hg3VFdiQr95oNibC9mvxEYmxugc2ckHSkZ1vOd8qrUyodV3___N3UzSXpuVI9UpnYr6uOSmrN_DoOAvAOPfjl7-xYyIRUzEwHSg6GaBdQizKsLRWdj6i2F3NcSgy)
+![](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/anylogic-oil-main-loop.png)
 
 It looks like we don’t have to initialize a special agent to handle any high-level functions here. The Main agent in AnyLogic is only responsible for initialization, which our creator agent will take care of.

--- a/resources/docs/simulation/tutorials/building-process-models/README.md
+++ b/resources/docs/simulation/tutorials/building-process-models/README.md
@@ -8,8 +8,6 @@ objectId: e46938a4-1a49-414c-9e27-fb4d41614526
 
 Business processes are the cornerstone of every company's operations. Defined and repeatable plans for satisfying business objectives differentiate a focused, efficient machine from a disorganized mess.
 
-![](https://lh6.googleusercontent.com/YxvT0V_yKdQM6dZLULbg5q7soOq0NKhBj9BmkALtWCeloWysqG2RrzBvdFuaJN9mWz7tybRh6wEMwvgf8kxHlLtrf1BFQwfyfWIbKF2mR4yQeSdxNqV8eRIZvCfSTd5LbR25gtvh)
-
 However, given the complexity and scale of modern businesses, it can be hard to create and optimize business processes. When dealing with tens of thousands of people managing hundred-step processes, we rapidly approach the limits of what any one person can design or understand.
 
 At HASH we're excited about the potential of computer-aided decision making - using the computer as a partner in deliberation and understanding, helping us find ideas and solutions that we couldn't otherwise. Our approach is to use simulations of the real world to find the best outcomes, and maybe even more importantly, help people understand why a given choice, out of all the alternatives, is the right one to make.

--- a/resources/docs/simulation/tutorials/building-process-models/analyzing-process-models.md
+++ b/resources/docs/simulation/tutorials/building-process-models/analyzing-process-models.md
@@ -12,17 +12,17 @@ Once you've created your process model, you'll want to use it to answer question
 
 ## Task Completions
 
-![Counting objects that make it from a source to a sink](https://lh6.googleusercontent.com/FpkhPVYVzOMsDXWZ5GU1pMJ1NLUEI0ddJ4pIFFN1BNcdJjnQRByxupbwkzVPgNpyVqJL1eVOq3A0HJdNlWnQJ7oXQAURcIoBHqh4y9-SgEpiXDlX2VyKLL74XOV4NB0hn_SRHsK9)
+![Counting objects that make it from a source to a sink](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/analysis-pizzas-delivered.png)
 
 Sink blocks are end-points in a process model. As objects reach them they are counted, representing completed tasks on a production line, a delivery chain, a quality inspection, etc.. The Sink block automatically stores information about objects it receives in the process_data field on your agent.
 
 You can easily build plots to access this information. Each Sink stores its data under a key formatted as '&lt;sink_name&gt;\_count'. A metric which accesses the data for the above graph would look like:
 
-![The Pizzas Delivered chart can be generated using this metric definition.](https://lh3.googleusercontent.com/c_DmTlg1_LZtwGVB5Nx8VSDsXmiOtYmgYpBkPci3eJwzm250_Z45MTRtBjE8YP3lmMRTp99Z7G2xYRR5B1URmNOxJz2CUs0bSLM9EI2nw1txwu85iElGZdWJofiq5iUUysiSt-xY)
+![The Pizzas Delivered chart can be generated using this metric definition.](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/analysis-pizza-delivery-metric.png)
 
 ## Timing
 
-![Recording the average time objects spend in the process model](https://lh5.googleusercontent.com/vWCTGpdXJcm8TnBCjvXwJo5PnIM6zdX5jvnv26x4FOpd68NI9w6XGYa2Mv8smTUedHJCc3gnHRcf30O1CMnTxZQS9qkViqioaZs8BgPIUoARfymyZeEuKC5UPmzKJ80Ddm4DeY0Q)
+![Recording the average time objects spend in the process model](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/analysis-times-plot.png)
 
 Process models are useful for timing complex chains of actions. Service blocks will record the time spent waiting for resources to become available.
 
@@ -32,7 +32,7 @@ Sink blocks will record all the waits an object experienced, as well as the tota
 
 ## Resource Usage
 
-![Visualizing the utilization of different resources in a process model](https://lh5.googleusercontent.com/2uML2JYITbiTbPOJb6ajbO_bQcScgO_7UwA_7umszwbeC5zlxcH6bpQ_0kojqRoXVaABEJnS8ZHkddVMwf4qZMW2hMv_tzFr0idCyNvKBRfq-DSxeO6RPX3hb2IiNGD27Ds_QT6y)
+![Visualizing the utilization of different resources in a process model](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/analysis-resource-utilization.png)
 
 Each Service, Seize, or Release block in your process model has an associated resource property specified in its parameters.
 

--- a/resources/docs/simulation/tutorials/building-process-models/analyzing-process-models.md
+++ b/resources/docs/simulation/tutorials/building-process-models/analyzing-process-models.md
@@ -12,17 +12,17 @@ Once you've created your process model, you'll want to use it to answer question
 
 ## Task Completions
 
-![Counting objects that make it from a source to a sink](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/analysis-pizzas-delivered.png)
+![Counting objects that make it from a source to a sink](https://cdn-us1.hash.ai/site/docs/analysis-pizzas-delivered.png)
 
 Sink blocks are end-points in a process model. As objects reach them they are counted, representing completed tasks on a production line, a delivery chain, a quality inspection, etc.. The Sink block automatically stores information about objects it receives in the process_data field on your agent.
 
 You can easily build plots to access this information. Each Sink stores its data under a key formatted as '&lt;sink_name&gt;\_count'. A metric which accesses the data for the above graph would look like:
 
-![The Pizzas Delivered chart can be generated using this metric definition.](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/analysis-pizza-delivery-metric.png)
+![The Pizzas Delivered chart can be generated using this metric definition.](https://cdn-us1.hash.ai/site/docs/analysis-pizza-delivery-metric.png)
 
 ## Timing
 
-![Recording the average time objects spend in the process model](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/analysis-times-plot.png)
+![Recording the average time objects spend in the process model](https://cdn-us1.hash.ai/site/docs/analysis-times-plot.png)
 
 Process models are useful for timing complex chains of actions. Service blocks will record the time spent waiting for resources to become available.
 
@@ -32,7 +32,7 @@ Sink blocks will record all the waits an object experienced, as well as the tota
 
 ## Resource Usage
 
-![Visualizing the utilization of different resources in a process model](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/analysis-resource-utilization.png)
+![Visualizing the utilization of different resources in a process model](https://cdn-us1.hash.ai/site/docs/analysis-resource-utilization.png)
 
 Each Service, Seize, or Release block in your process model has an associated resource property specified in its parameters.
 

--- a/resources/docs/simulation/tutorials/building-process-models/experimenting-with-process-models.md
+++ b/resources/docs/simulation/tutorials/building-process-models/experimenting-with-process-models.md
@@ -53,10 +53,10 @@ The [Globals](/docs/simulation/creating-simulations/configuration/) section desc
 
 3. Create an experiment and use the parameter as the field for the experiment
 
-![Experiment model](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/process+models+experiment.png)
+![Experiment model](https://cdn-us1.hash.ai/site/docs/process+models+experiment.png)
 
 Now when we run the experiment, we can see how varying the number of service agents affects the descriptive metrics of the process model.
 
-![](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/process+experiment.png)
+![](https://cdn-us1.hash.ai/site/docs/process+experiment.png)
 
 After adding metrics and charts, we can see what happens to the queue in the experiment. Provided the number of agents stays above 1, the queue will remain flat.

--- a/resources/docs/simulation/tutorials/building-process-models/experimenting-with-process-models.md
+++ b/resources/docs/simulation/tutorials/building-process-models/experimenting-with-process-models.md
@@ -57,6 +57,6 @@ The [Globals](/docs/simulation/creating-simulations/configuration/) section desc
 
 Now when we run the experiment, we can see how varying the number of service agents affects the descriptive metrics of the process model.
 
-![](https://lh5.googleusercontent.com/EOBydAKWL0GoGZQAZMqFj_weIFdVjdLVtcPX1Q3mtftPQiOfQoPPVk0hc3lS4j1mVp_T2A-ByLBYk9yWlmzMm74sjcALRnyfhLAX-taDlfrpbmcwWsbEs3fTnKg4E1_f6_1fLF4X)
+![](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/process+experiment.png)
 
 After adding metrics and charts, we can see what happens to the queue in the experiment. Provided the number of agents stays above 1, the queue will remain flat.

--- a/resources/docs/simulation/tutorials/building-process-models/experimenting-with-process-models.md
+++ b/resources/docs/simulation/tutorials/building-process-models/experimenting-with-process-models.md
@@ -53,7 +53,7 @@ The [Globals](/docs/simulation/creating-simulations/configuration/) section desc
 
 3. Create an experiment and use the parameter as the field for the experiment
 
-![Experiment model](https://lh5.googleusercontent.com/9fJKOO9RlHGjnmFrS4gX2mAWDjXLHlHLTTbfYbFIxBsJ_PWIToyh9N-s0kRCSJU_jWi3sQ1v1bQISW774tbTqy_C7apNVzbr3lEJFxhJndlzWnYlXdWzrAqq2rQOssuLLdw4hP3j)
+![Experiment model](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/process+models+experiment.png)
 
 Now when we run the experiment, we can see how varying the number of service agents affects the descriptive metrics of the process model.
 

--- a/resources/docs/simulation/tutorials/building-process-models/process-model-concepts.md
+++ b/resources/docs/simulation/tutorials/building-process-models/process-model-concepts.md
@@ -12,7 +12,7 @@ Process models, when built with the process library, are represented as a flowch
 
 You can think of it like a flowchart - objects start at the source, travel through elements, and end at the sink.
 
-![A process model diagram](https://lh3.googleusercontent.com/k_z-PgMKN4gVmoQ2NKQQaLmUUI9dHI-zqQeHQ3EqJ6MtqLdo0omkikAaPKG7puxStikT5fpk9FBKCfiheTXvDbSo9FxkHMKrH95O5pfRXYQ5naqQuiegg9hxkj9U_jghjRCvVSam)
+![A process model diagram](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/hash-bpmn-example.png)
 
 When designing your own process models, your primary task is to factor the real world process into discrete steps, and then match those steps to elements in the process library \(or build your own!\)
 

--- a/resources/docs/simulation/tutorials/building-process-models/process-model-concepts.md
+++ b/resources/docs/simulation/tutorials/building-process-models/process-model-concepts.md
@@ -12,7 +12,7 @@ Process models, when built with the process library, are represented as a flowch
 
 You can think of it like a flowchart - objects start at the source, travel through elements, and end at the sink.
 
-![A process model diagram](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/hash-bpmn-example.png)
+![A process model diagram](https://cdn-us1.hash.ai/site/docs/hash-bpmn-example.png)
 
 When designing your own process models, your primary task is to factor the real world process into discrete steps, and then match those steps to elements in the process library \(or build your own!\)
 

--- a/resources/docs/simulation/tutorials/extending-an-epidemic-model/create-an-icu.md
+++ b/resources/docs/simulation/tutorials/extending-an-epidemic-model/create-an-icu.md
@@ -61,7 +61,7 @@ _Note: Your init.json might look different if you used `create_stacks or create_
 
 If you reset the simulation and click on the hospital agent the inspect modal will now display the value for `icu_beds`. Click the inverted pyramid to select/deselect displayed attributes.
 
-![](https://lh4.googleusercontent.com/PqbkGFIaaymIjL1HVPBW6Ca1abWdk_VAS46jf5hFyUlCGu6wAcPy7v0oZtApKkSP_ewJjWj3yg4YDJ0bQCGQGFuSMJ7T_Cd_RLu8Px8gbFoVmhhsLClTrSe_GlDHIFFx-Ps8tVME)
+![](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/tutorial-extending-epidemic-icu-beds.png)
 
 Open the `check_infected` file. A person agent is sending a request to the hospital to test them; now they should also send personal information to the hospital. In particular we want to know how likely it is they're `at_risk` of complications from the disease. It’s a little bit of a hand-wave that they are directly sending their `at_risk` level - you can imagine they’re sending a blood/spit sample and don’t know what it contains, or providing demographic info like their age or pre-existing conditions. In a more complicated model we'd likely determine their `at_risk` degree from a variety of different measures.
 

--- a/resources/docs/simulation/tutorials/extending-an-epidemic-model/create-an-icu.md
+++ b/resources/docs/simulation/tutorials/extending-an-epidemic-model/create-an-icu.md
@@ -61,7 +61,7 @@ _Note: Your init.json might look different if you used `create_stacks or create_
 
 If you reset the simulation and click on the hospital agent the inspect modal will now display the value for `icu_beds`. Click the inverted pyramid to select/deselect displayed attributes.
 
-![](https://s3.amazonaws.com/cdn-us1.hash.ai/site/docs/tutorial-extending-epidemic-icu-beds.png)
+![](https://cdn-us1.hash.ai/site/docs/tutorial-extending-epidemic-icu-beds.png)
 
 Open the `check_infected` file. A person agent is sending a request to the hospital to test them; now they should also send personal information to the hospital. In particular we want to know how likely it is they're `at_risk` of complications from the disease. It’s a little bit of a hand-wave that they are directly sending their `at_risk` level - you can imagine they’re sending a blood/spit sample and don’t know what it contains, or providing demographic info like their age or pre-existing conditions. In a more complicated model we'd likely determine their `at_risk` degree from a variety of different measures.
 

--- a/resources/docs/url_map.json
+++ b/resources/docs/url_map.json
@@ -304,16 +304,16 @@
                 "slug": "simulation/concepts/designing-with-process-models/using-the-process-model-builder"
               },
               {
-                "title": "Adding Data to a Process Model",
-                "slug": "simulation/concepts/designing-with-process-models/using-data-in-a-process-model"
-              },
-              {
                 "title": "Analyzing Process Models",
                 "slug": "simulation/concepts/designing-with-process-models/analyzing-process-models"
               },
               {
                 "title": "Experimenting with Process Models",
                 "slug": "simulation/concepts/designing-with-process-models/experimenting-with-process-models"
+              },
+              {
+                "title": "Adding Data to a Process Model",
+                "slug": "simulation/concepts/designing-with-process-models/using-data-in-a-process-model"
               },
               {
                 "title": "Structuring a Process Model",
@@ -363,24 +363,24 @@
             "slug": "simulation/tutorials/building-process-models",
             "urldata": [
               {
+                "title": "Process Model Concepts",
+                "slug": "simulation/tutorials/building-process-models/process-model-concepts"
+              },
+              {
                 "title": "Using the Process Model Visual Interface",
                 "slug": "simulation/tutorials/building-process-models/using-the-process-model-builder"
               },
               {
-                "title": "Adding Data to a Process Model",
-                "slug": "simulation/tutorials/building-process-models/using-data-in-a-process-model"
-              },
-              {
-                "title": "Process Model Concepts",
-                "slug": "simulation/tutorials/building-process-models/process-model-concepts"
+                "title": "Analyzing Process Models",
+                "slug": "simulation/tutorials/building-process-models/analyzing-process-models"
               },
               {
                 "title": "Experimenting with Process Models",
                 "slug": "simulation/tutorials/building-process-models/experimenting-with-process-models"
               },
               {
-                "title": "Analyzing Process Models",
-                "slug": "simulation/tutorials/building-process-models/analyzing-process-models"
+                "title": "Adding Data to a Process Model",
+                "slug": "simulation/tutorials/building-process-models/using-data-in-a-process-model"
               }
             ]
           },
@@ -484,29 +484,27 @@
                   },
                   {
                     "title": "Building the Simulation",
-                    "slug": "simulation/extra/migrating/anylogic/building-the-simulation",
-                    "urldata": [
-                      {
-                        "title": "Tankers to Port",
-                        "slug": "simulation/extra/migrating/anylogic/building-the-simulation/tankers-to-port"
-                      },
-                      {
-                        "title": "Through the Pipeline",
-                        "slug": "simulation/extra/migrating/anylogic/building-the-simulation/through-the-pipeline"
-                      },
-                      {
-                        "title": "Trucks on the Move",
-                        "slug": "simulation/extra/migrating/anylogic/building-the-simulation/trucks-on-the-move"
-                      },
-                      {
-                        "title": "Full Initialization",
-                        "slug": "simulation/extra/migrating/anylogic/building-the-simulation/full-initialization"
-                      },
-                      {
-                        "title": "Improving our Visualization",
-                        "slug": "simulation/extra/migrating/anylogic/building-the-simulation/improving-our-visualization"
-                      }
-                    ]
+                    "slug": "simulation/extra/migrating/anylogic/building-the-simulation"
+                  },
+                  {
+                    "title": "Tankers to Port",
+                    "slug": "simulation/extra/migrating/anylogic/building-the-simulation/tankers-to-port"
+                  },
+                  {
+                    "title": "Through the Pipeline",
+                    "slug": "simulation/extra/migrating/anylogic/building-the-simulation/through-the-pipeline"
+                  },
+                  {
+                    "title": "Trucks on the Move",
+                    "slug": "simulation/extra/migrating/anylogic/building-the-simulation/trucks-on-the-move"
+                  },
+                  {
+                    "title": "Full Initialization",
+                    "slug": "simulation/extra/migrating/anylogic/building-the-simulation/full-initialization"
+                  },
+                  {
+                    "title": "Improving our Visualization",
+                    "slug": "simulation/extra/migrating/anylogic/building-the-simulation/improving-our-visualization"
                   }
                 ]
               }


### PR DESCRIPTION
Fixes to docs
- Replacing images that Ben Goldhaber had uploaded, but are no longer available
- Fixing content around messages' "to" field
- Reordering sections of tutorials that were out of order
- Exposing sections of the docs that weren't displaying because they were too nested