### PR TITLE
[TOOL] Add GitHub action to attach PR to Asana task

### DIFF
--- a/.github/workflows/attach-pr-to-asana-task.yml
+++ b/.github/workflows/attach-pr-to-asana-task.yml
@@ -1,0 +1,11 @@
+name: Attach pull request to Asana task
+on: pull_request
+
+jobs:
+  create-asana-attachment-job:
+    runs-on: ubuntu-latest
+    name:
+    steps:
+      - uses: Asana/create-app-attachment-github-action@latest
+        with:
+          asana-secret: ${{ secrets.ASANA_SECRET }}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
Adds a GitHub action [[source](https://github.com/Asana/create-app-attachment-github-action)] which will scan PR descriptions for Asana tasks, and attach the PR info to the Asana task.

## 🔗 Related links

- [This Asana task should have this PR automatically attached](https://app.asana.com/0/1199550852792314/1201473331768997/f)

## ❓ How to test this?

1. Visit the Asana task URL above
2. Check it has this PR attached
3. Trust me that I didn't attach it manually

## Demo
![Screenshot 2021-12-06 at 19 11 15](https://user-images.githubusercontent.com/37743469/144907346-ddf1bd03-0c74-438f-8d4f-3c66edd3c347.png)


