### PR TITLE
[Priority] Only index md and mdx files into Algolia

### DIFF
--- a/.github/workflows/algolia/src/syncAlgoliaIndex.ts
+++ b/.github/workflows/algolia/src/syncAlgoliaIndex.ts
@@ -38,7 +38,9 @@ const getFileInfos = (
         "/",
         file
       )}`;
-      arrayOfFiles.push({ inputPath, outputPath, type });
+      if (inputPath.endsWith(".md") || inputPath.endsWith(".mdx")) {
+        arrayOfFiles.push({ inputPath, outputPath, type });
+      }
     }
   });
 


### PR DESCRIPTION
#51 added `url_map.json` to the glossary folder. However, it's being incorrectly indexed by the Algolia GitHub Action, and displaying a garbage search result. This PR only allows `.md` and `.mdx` files to be picked up by the Algolia indexing code, hence stopping wrong files from being indexed.

---
- [Asana task](https://app.asana.com/0/0/1201449675033652)