### PR TITLE
Migrate to Rust 2021 and apply rustfmt

### DIFF
--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hash_engine"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 
 [workspace]
 members = ["bin/*"]

--- a/packages/engine/bin/cli/Cargo.toml
+++ b/packages/engine/bin/cli/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "cli"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 hash_engine = { path = "../.." }

--- a/packages/engine/bin/cli/src/experiment.rs
+++ b/packages/engine/bin/cli/src/experiment.rs
@@ -14,7 +14,6 @@ use hash_engine::proto::ExecutionEnvironment;
 use hash_engine::utils::parse_env_duration;
 use serde_json::json;
 use std::env::VarError;
-use std::iter::FromIterator;
 use std::path::PathBuf;
 use std::time::Duration;
 use tokio::time::{self, timeout};

--- a/packages/engine/bin/server/Cargo.toml
+++ b/packages/engine/bin/server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "server"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 hash_engine = { path = "../.." }

--- a/packages/engine/src/config/package.rs
+++ b/packages/engine/src/config/package.rs
@@ -1,5 +1,3 @@
-use std::iter::FromIterator;
-
 use crate::simulation::package::{context, init, output, state};
 
 use super::{Error, Result};

--- a/packages/engine/src/datastore/arrow/field_conversion.rs
+++ b/packages/engine/src/datastore/arrow/field_conversion.rs
@@ -191,7 +191,6 @@ pub mod tests {
     use super::*;
     use crate::datastore::schema::{FieldScope, FieldSpecMapBuilder};
     use crate::hash_types::state::AgentStateField;
-    use std::convert::TryInto;
 
     #[test]
     fn get_schema() -> Result<()> {

--- a/packages/engine/src/datastore/arrow/meta_conversion.rs
+++ b/packages/engine/src/datastore/arrow/meta_conversion.rs
@@ -18,7 +18,7 @@ use arrow::ipc::{
     MetadataVersion, RecordBatch, RecordBatchBuilder,
 };
 
-use std::{convert::TryFrom, sync::Arc};
+use std::sync::Arc;
 
 use super::util::FlatBufferWrapper;
 

--- a/packages/engine/src/datastore/mod.rs
+++ b/packages/engine/src/datastore/mod.rs
@@ -69,7 +69,6 @@ pub mod tests {
     //
     // use rand::Rng;
     // use std::borrow::Cow;
-    // use std::convert::TryInto;
     //
     // use crate::datastore::batch::DynamicBatch;
     // use crate::datastore::schema::{FieldScope, FieldSource, RootFieldSpec};

--- a/packages/engine/src/datastore/schema/field_spec/mod.rs
+++ b/packages/engine/src/datastore/schema/field_spec/mod.rs
@@ -1,6 +1,5 @@
 use std::collections::hash_map::Iter;
 use std::collections::HashMap;
-use std::convert::TryInto;
 use std::fmt::{Display, Formatter};
 
 use crate::hash_types::state::AgentStateField;

--- a/packages/engine/src/hash_types/vec.rs
+++ b/packages/engine/src/hash_types/vec.rs
@@ -1,9 +1,6 @@
 #![allow(clippy::unsafe_derive_deserialize)]
 use serde::{Deserialize, Serialize};
-use std::{
-    convert::TryFrom,
-    ops::{Add, AddAssign, Div, DivAssign, Index, IndexMut, Mul, MulAssign, Sub, SubAssign},
-};
+use std::ops::{Add, AddAssign, Div, DivAssign, Index, IndexMut, Mul, MulAssign, Sub, SubAssign};
 
 // We are rolling out our own Vec3 implementation to better support
 // deserialization from non-3D vectors. With this Vec3, you can do

--- a/packages/engine/src/output/buffer/mod.rs
+++ b/packages/engine/src/output/buffer/mod.rs
@@ -32,11 +32,7 @@ impl Buffers {
         output_packages_sim_config: &OutputPackagesSimConfig,
     ) -> Result<Buffers> {
         Ok(Buffers {
-            json_state: OutputPartBuffer::new(
-                "json_state",
-                exp_id,
-                sim_id
-            )?,
+            json_state: OutputPartBuffer::new("json_state", exp_id, sim_id)?,
             analysis: AnalysisBuffer::new(output_packages_sim_config)?,
         })
     }

--- a/packages/engine/src/simulation/package/context/packages/agent_messages/fields.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/fields.rs
@@ -19,10 +19,6 @@ pub(super) fn add_context(field_spec_map_builder: &mut FieldSpecMapBuilder) -> R
     // has custom getters in the language runners that
     // return the actual messages that the agent received,
     // not just their indices.
-    field_spec_map_builder.add_field_spec(
-        "messages".into(),
-        agent_messages,
-        FieldScope::Agent,
-    )?;
+    field_spec_map_builder.add_field_spec("messages".into(), agent_messages, FieldScope::Agent)?;
     Ok(())
 }

--- a/packages/engine/src/simulation/package/context/packages/agent_messages/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/mod.rs
@@ -3,13 +3,13 @@ mod fields;
 mod indices;
 mod writer;
 
-use arrow::array::{FixedSizeListBuilder, ListBuilder};
 use self::collected::Messages;
 use crate::datastore::schema::accessor::GetFieldSpec;
 use crate::{
     datastore::{batch::iterators, table::state::ReadState},
     simulation::comms::package::PackageComms,
 };
+use arrow::array::{FixedSizeListBuilder, ListBuilder};
 use serde_json::Value;
 
 use super::super::*;

--- a/packages/engine/src/simulation/package/context/packages/agent_messages/writer.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/writer.rs
@@ -14,9 +14,7 @@ const NUM_BUFFERS: usize = 5;
 
 impl ContextColumnWriter for Messages {
     fn get_dynamic_metadata(&self) -> DatastoreResult<ColumnDynamicMetadata> {
-        let mut builder = ColumnDynamicMetadataBuilder::with_capacities(
-            NUM_NODES, NUM_BUFFERS
-        );
+        let mut builder = ColumnDynamicMetadataBuilder::with_capacities(NUM_NODES, NUM_BUFFERS);
         // TODO: Implement and use `builder.add_offset_buffer` convenience function;
         //       maybe also `builder.add_null_buffer`.
 
@@ -33,9 +31,8 @@ impl ContextColumnWriter for Messages {
         let total_number_indices = total_messages * super::MESSAGE_INDEX_COUNT;
         builder.add_node(total_number_indices, 0); // Index
         builder.add_static_bit_buffer(total_number_indices); // Null buffer for index
-        builder.add_static_byte_buffer(
-            total_number_indices * std::mem::size_of::<super::IndexType>()
-        );
+        builder
+            .add_static_byte_buffer(total_number_indices * std::mem::size_of::<super::IndexType>());
         Ok(builder.finish())
     }
 
@@ -51,7 +48,8 @@ impl ContextColumnWriter for Messages {
         // Offsets
         // `iter` yields the number of incoming messages an agent has for each agent.
         let iter = self.indices.iter().map(|i| i.num_messages());
-        data.from_offset(&meta.buffers[1]).write_i32_offsets_from_iter(iter);
+        data.from_offset(&meta.buffers[1])
+            .write_i32_offsets_from_iter(iter);
 
         // Null buffer
         data.from_offset(&meta.buffers[2]).fill_with_ones();

--- a/packages/engine/src/simulation/package/context/packages/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/mod.rs
@@ -11,15 +11,15 @@ use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use strum_macros::IntoStaticStr;
 
+use super::PackageCreator;
 use crate::simulation::enum_dispatch::*;
 use crate::simulation::package::{id::PackageIdGenerator, PackageMetadata, PackageType};
 use crate::simulation::{Error, Result};
 use crate::ExperimentConfig;
-use super::PackageCreator;
 
 /// All context package names are registered in this enum
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
-#[serde(rename_all="snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum Name {
     AgentMessages,
     APIRequests,
@@ -28,7 +28,11 @@ pub enum Name {
 
 impl std::fmt::Display for Name {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", serde_json::to_string(self).map_err(|_| std::fmt::Error)?)
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(self).map_err(|_| std::fmt::Error)?
+        )
     }
 }
 

--- a/packages/engine/src/simulation/package/creator.rs
+++ b/packages/engine/src/simulation/package/creator.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::convert::TryInto;
 use std::sync::Arc;
 
 use crate::config::{Globals, PackageConfig};

--- a/packages/engine/src/simulation/package/init/packages/mod.rs
+++ b/packages/engine/src/simulation/package/init/packages/mod.rs
@@ -20,7 +20,7 @@ pub mod jspy;
 
 /// All init package names are registered in this enum
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
-#[serde(rename_all="snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum Name {
     JSON,
     JSPY,
@@ -28,7 +28,11 @@ pub enum Name {
 
 impl std::fmt::Display for Name {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", serde_json::to_string(self).map_err(|_| std::fmt::Error)?)
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(self).map_err(|_| std::fmt::Error)?
+        )
     }
 }
 

--- a/packages/engine/src/simulation/package/name.rs
+++ b/packages/engine/src/simulation/package/name.rs
@@ -22,8 +22,8 @@ impl Display for PackageName {
         // TODO: Is there some serde/serde_json option to not put the quotes in the first place?
         debug_assert!(s.len() >= 2);
         debug_assert!(s.as_bytes()[0] == ('"' as u8));
-        debug_assert!(s.as_bytes()[s.len()-1] == ('"' as u8));
-        let substr = &s.as_bytes()[1 .. s.len()-1];
+        debug_assert!(s.as_bytes()[s.len() - 1] == ('"' as u8));
+        let substr = &s.as_bytes()[1..s.len() - 1];
         let substr = std::str::from_utf8(substr);
         write!(f, "{}", substr.map_err(|_| std::fmt::Error)?)
     }

--- a/packages/engine/src/simulation/package/output/packages/analysis/config.rs
+++ b/packages/engine/src/simulation/package/output/packages/analysis/config.rs
@@ -1,7 +1,6 @@
 use super::analyzer::AnalysisOperationRepr;
 use super::Result;
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::sync::Arc;
 
 use crate::proto::ExperimentRunTrait;

--- a/packages/engine/src/simulation/package/output/packages/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/mod.rs
@@ -19,7 +19,7 @@ use strum_macros::IntoStaticStr;
 
 /// All output package names are registered in this enum
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
-#[serde(rename_all="snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum Name {
     Analysis,
     JSONState,
@@ -27,7 +27,11 @@ pub enum Name {
 
 impl std::fmt::Display for Name {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", serde_json::to_string(self).map_err(|_| std::fmt::Error)?)
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(self).map_err(|_| std::fmt::Error)?
+        )
     }
 }
 

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/config.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/config.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-// use std::convert::TryFrom;
 use std::ops::Deref;
 
 use serde::{Deserialize, Serialize};

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/fields/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/fields/mod.rs
@@ -1,7 +1,5 @@
 pub mod behavior;
 
-use std::convert::TryInto;
-
 use behavior::add_fields_from_behavior_keys;
 
 use arrow::datatypes::DataType;

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/mod.rs
@@ -17,7 +17,6 @@ use crate::simulation::task::Task;
 use crate::Language;
 use reset_index_col::reset_index_col;
 use serde_json::Value;
-use std::convert::TryFrom;
 
 use super::super::*;
 

--- a/packages/engine/src/simulation/package/state/packages/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/mod.rs
@@ -21,7 +21,7 @@ use self::behavior_execution::tasks::{ExecuteBehaviorsTask, ExecuteBehaviorsTask
 
 /// All state package names are registered in this enum
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
-#[serde(rename_all="snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum Name {
     BehaviorExecution,
     Topology,
@@ -29,7 +29,11 @@ pub enum Name {
 
 impl std::fmt::Display for Name {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", serde_json::to_string(self).map_err(|_| std::fmt::Error)?)
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(self).map_err(|_| std::fmt::Error)?
+        )
     }
 }
 

--- a/packages/engine/src/worker/runner/javascript/mini_v8/value.rs
+++ b/packages/engine/src/worker/runner/javascript/mini_v8/value.rs
@@ -1,5 +1,4 @@
 use super::*;
-use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};
 use std::{fmt, slice, vec};
 

--- a/packages/engine/src/worker/runner/mod.rs
+++ b/packages/engine/src/worker/runner/mod.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 pub mod javascript;
 pub mod python;
 pub mod rust;


### PR DESCRIPTION
[Rust 2021](https://doc.rust-lang.org/edition-guide/rust-2021/index.html) comes with a new Cargo-Resolver for workspaces and some more Items in the prelude. The new cargo-resolver may or may not speed up our compilation time.