### PR TITLE
Fixing NNG-building on everything that isn't an ARM-based Mac

### DIFF
--- a/packages/engine/Cargo.lock
+++ b/packages/engine/Cargo.lock
@@ -436,6 +436,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b858541263efe664aead4a5209a4ae5c5d2811167d4ed4ee0944503f8d2089"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,6 +1534,7 @@ version = "1.4.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d0e7f39a8fd1792a710da9351320e864dc799cf439960e332c977b2f876da6"
 dependencies = [
+ "cmake",
  "version_check",
 ]
 

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -69,9 +69,6 @@ nng = { version = "1.0.1", default-features = false }
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 nng = { version = "1.0.1", default-features = true }
 
-[target.'cfg(not(target_os = "macos"))'.features]
-default = ["build-nng"]
-
 [features]
 build-nng = ["nng/build-nng"]
 

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -35,7 +35,6 @@ kdtree = "0.6.0"
 lazy_static = "1.4.0"
 log = "0.4.11"
 nix = "0.19.0"
-nng = { version = "1.0.1", default-features = false }
 num_cpus = "1.13.0"
 parking_lot = "0.11.1"
 pretty_env_logger = "0.4.0"
@@ -59,6 +58,22 @@ tokio-stream = "0.1.5"
 tokio-util = { version = "0.6.6", features = ["codec"]}
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 wait-timeout = "0.2.0"
+
+# The nng compilation functionality of nng-sys doesn't compile on Arch-based Mac's so it's necessary to
+# disable default-features on nng (which calls nng-sys's build step). We currently have to build on arm Macs by
+# targetting x86, so we can't use a cfg conditional to check for arm as the target. So, Intel Mac users will
+# just have to manually enable the build-nng feature flag. Or they will have to set an NNG_PATH (see README).
+[target.'cfg(target_os = "macos")'.dependencies]
+nng = { version = "1.0.1", default-features = false }
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+nng = { version = "1.0.1", default-features = true }
+
+[target.'cfg(not(target_os = "macos"))'.features]
+default = ["build-nng"]
+
+[features]
+build-nng = ["nng/build-nng"]
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -58,6 +58,23 @@ Building this project requires the following:
     ```
   * With the V8 folder containing `include` and `out.gn` you can then set the variable for your terminal session with `export V8_PATH=<path to folder>` or you can set it permanently by [adding it to your shell's environment](https://unix.stackexchange.com/questions/117467/how-to-permanently-set-environmental-variables)
 
+### MacOS Developer Specific Instructions:
+
+Due to ARM-Based Macs, the `macos` `target_os` has some added complications for development. 
+
+#### For Intel Macs:
+Due to limitations in Cargo at the moment we can't properly check if it's being built _on_ an ARM Mac (rather than _for_ an ARM Mac). Due to this it's necessary to:
+* Enable the `build-nng` feature by passing `--features "build-nng"` to any cargo commands such as `cargo build`
+
+#### For ARM-Based Macs:
+At the moment the project only seems to be compiling if you use the `x86_64-apple-darwin` target. This has some added complexity, especially due to the fact that rustc fails to link 'fat-binaries' in certain scenarios.
+* It's necessary to acquire an x86 version of `nng`. Currently the easiest known way to do this is through:
+  * Creating a homebrew installation under Rosetta, [an example guide is here](https://stackoverflow.com/questions/64882584/how-to-run-the-homebrew-installer-under-rosetta-2-on-m1-macbook) 
+  * Using the x86 brew to install `nng` (which will then install an x86 version). This should result in an nng installation at: `/usr/local/Cellar/nng/1.5.2`
+* It's then necessary to set the `NNG_PATH` environment variable, similar to `V8_PATH`
+  * The command is likely to be: `export NNG_PATH=/usr/local/Cellar/nng/1.5.2`
+* If the V8 monolith is failing to link due to symbol errors, it might be necessary to download the gem for the "darwin_universal" version.
+
 #### Possible Dependencies and Debugging
 Depending on how lightweight your OS install is, you may be missing some low level dependencies, so try the following (examples given for Ubuntu/Debian-based Unix systems):
 * `apt-get install build-essentials` - Includes the GCC/g++ compilers, libraries, and some other utilities

--- a/packages/engine/build.rs
+++ b/packages/engine/build.rs
@@ -7,11 +7,14 @@ fn main() {
     println!("cargo:rustc-link-search=native={}/out.gn/libv8/obj", v8);
     println!("cargo:rustc-link-lib=static=v8_monolith");
 
-    if cfg!(not(feature = "build-nng")) {
-        let nng_path =
-            std::env::var("NNG_PATH").expect("`NNG_PATH` environment variable wasn't set,");
-        println!("cargo:rustc-link-search={nng_path}/lib");
-        println!("cargo:rustc-link-lib=dylib=nng");
+    if let Ok(host) = std::env::var("HOST") {
+        // So far we only require (and allow) manual nng linking for ARM-based Macs
+        if &host == "aarch64-apple-darwin" {
+            let nng_path =
+                std::env::var("NNG_PATH").expect("`NNG_PATH` environment variable wasn't set,");
+            println!("cargo:rustc-link-search={nng_path}/lib");
+            println!("cargo:rustc-link-lib=dylib=nng");
+        }
     }
 
     cc::Build::new()

--- a/packages/engine/build.rs
+++ b/packages/engine/build.rs
@@ -9,7 +9,7 @@ fn main() {
 
     if let Ok(host) = std::env::var("HOST") {
         // So far we only require (and allow) manual nng linking for ARM-based Macs
-        if &host == "aarch64-apple-darwin" {
+        if host == "aarch64-apple-darwin" {
             let nng_path =
                 std::env::var("NNG_PATH").expect("`NNG_PATH` environment variable wasn't set,");
             println!("cargo:rustc-link-search={nng_path}/lib");

--- a/packages/engine/build.rs
+++ b/packages/engine/build.rs
@@ -1,11 +1,19 @@
 extern crate cc;
 
 fn main() {
-    let v8 = std::env::var("V8_PATH").unwrap();
-
+    let v8 = std::env::var("V8_PATH")
+        .expect("`V8_PATH` environment variable wasn't set, refer to README");
     println!("cargo:rerun-if-changed=src/worker/runner/javascript/mini_v8/ffi.cc");
     println!("cargo:rustc-link-search=native={}/out.gn/libv8/obj", v8);
     println!("cargo:rustc-link-lib=static=v8_monolith");
+
+    if cfg!(not(feature = "build-nng")) {
+        let nng_path =
+            std::env::var("NNG_PATH").expect("`NNG_PATH` environment variable wasn't set,");
+        println!("cargo:rustc-link-search={nng_path}/lib");
+        println!("cargo:rustc-link-lib=dylib=nng");
+    }
+
     cc::Build::new()
         .flag(&format!("-isystem{}/include", v8))
         .flag("-Wno-unused-result")


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
The `nng` dependency has an optional feature to compile nng. This does not work on ARM Macs.
To get around this it's necessary to acquire a compiled version of NNG.

To avoid making this a dependency for the majority of users, we want to conditionally require the external NNG dependency.

This adds the relevant conditional logic, and expands the README to explain the reasoning.

## 🔗 Related links

https://gitlab.com/neachdainn/nng-rs/-/issues/55

## 🔍 What does this change?

* Cargo.toml checks to see if the target_os is macos and then either:
  * _Isn't_ macos
    * Adds nng as a dependency _with_ default-features (i.e. the nng build feature)
  * _Is_ macos
    * adds nng as a dependency _without_ default-features
  * We attempted to implement this entirely with a _default_ feature-flag but it seems that currently nightly is broken where `--no-default-features` doesn't do anything and the feature is always enabled in `build.rs` which breaks the conditional check for `NNG_PATH`
* `build.rs` has a conditional check using the HOST environment variable to check if it's running on an ARM-based Mac, where it will add linking arguments for nng searching on the `NNG_PATH` environment variable.

## 🛡 Tests

Compilation has been tested on both Linux and an ARM-Mac, in absence of an Intel-mac we have to hope for the best.
