### PR TITLE
Allowing context packages to have multiple columns, fixing bug where column ordering didn't match schema

### DIFF
--- a/packages/engine/bin/cli/src/process/local.rs
+++ b/packages/engine/bin/cli/src/process/local.rs
@@ -109,7 +109,7 @@ impl process::Command for LocalCommand {
 
         let child = cmd
             .spawn()
-            .with_context(|| format!("Could not run commad: {process_path:?}"))?;
+            .with_context(|| format!("Could not run command: {process_path:?}"))?;
         debug!(
             "Spawned local engine process for experiment {}",
             &self.experiment_id

--- a/packages/engine/src/simulation/comms/mod.rs
+++ b/packages/engine/src/simulation/comms/mod.rs
@@ -93,6 +93,7 @@ impl Comms {
 impl Comms {
     // TODO: Docstring, explain why and how this would be used. As it is not currently.
     pub async fn state_sync(&self, state: &State) -> Result<()> {
+        log::trace!("Synchronizing state");
         // Synchronize the state batches
         let agents = state.agent_pool().clone();
         let agent_messages = state.message_pool().clone();
@@ -107,6 +108,7 @@ impl Comms {
     }
 
     pub async fn state_snapshot_sync(&self, state: &StateSnapshot) -> Result<()> {
+        log::trace!("Synchronizing state snapshot");
         // Synchronize the state snapshot batches
         let agents = state.agent_pool().clone();
         let agent_messages = state.message_pool().clone();
@@ -121,6 +123,7 @@ impl Comms {
     }
 
     pub async fn context_batch_sync(&self, context: &Context) -> Result<()> {
+        log::trace!("Synchronizing context batch");
         // Synchronize the context batch
         let batch = context.batch();
         let sync_msg = ContextBatchSync::new(batch);

--- a/packages/engine/src/simulation/engine.rs
+++ b/packages/engine/src/simulation/engine.rs
@@ -33,7 +33,7 @@ impl Engine {
     ) -> Result<Engine> {
         let comms = Arc::new(comms);
 
-        let state = packages.init.run(config.clone()).await?;
+        let state = packages.init.run(Arc::clone(&config.clone())).await?;
         let context = packages.step.empty_context(&config, state.num_agents())?;
         uninitialized_store.set(state, context);
         let store = uninitialized_store;
@@ -87,6 +87,7 @@ impl Engine {
     /// dependent on each other, then all context packages are run in parallel
     /// and their outputs are merged into one Context object.
     async fn run_context_packages(&mut self) -> Result<()> {
+        log::trace!("Starting run context packages stage");
         let (mut state, mut context) = self.store.take_upgraded()?;
         let snapshot = self.prepare_for_context_packages(&mut state, &mut context)?;
         self.comms.state_snapshot_sync(&snapshot); // Synchronize snapshot with workers
@@ -175,6 +176,7 @@ impl Engine {
         state: &mut ExState,
         context: &mut ExContext,
     ) -> Result<StateSnapshot> {
+        log::trace!("Preparing for context packages");
         let message_map = state.message_map()?;
         self.add_remove_agents(state, &message_map)?;
         let message_pool = self.finalize_agent_messages(state, context)?;

--- a/packages/engine/src/simulation/package/context/mod.rs
+++ b/packages/engine/src/simulation/package/context/mod.rs
@@ -33,12 +33,12 @@ pub trait Package: MaybeCPUBound + GetWorkerSimStartMsg + Send + Sync {
         &mut self,
         state: Arc<State>,
         snapshot: Arc<StateSnapshot>,
-    ) -> Result<ContextColumn>;
-    fn get_empty_arrow_column(
+    ) -> Result<Vec<ContextColumn>>;
+    fn get_empty_arrow_columns(
         &self,
         num_agents: usize,
         context_schema: &ContextSchema,
-    ) -> Result<(FieldKey, Arc<dyn arrow::array::Array>)>;
+    ) -> Result<Vec<(FieldKey, Arc<dyn arrow::array::Array>)>>;
 }
 
 pub trait PackageCreator: GetWorkerExpStartMsg + Sync + Send {
@@ -91,6 +91,7 @@ pub trait PackageCreator: GetWorkerExpStartMsg + Sync + Send {
 }
 
 pub struct ContextColumn {
+    pub(crate) field_key: FieldKey,
     inner: Box<dyn ContextColumnWriter + Send + Sync>,
 }
 

--- a/packages/engine/src/simulation/package/context/packages/agent_messages/collected.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/collected.rs
@@ -2,7 +2,7 @@ use crate::datastore::{table::references::MessageMap, UUID_V4_LEN};
 
 use super::{indices::AgentMessageIndices, *};
 
-/// Columnar native representation of indicies to messages
+/// Columnar native representation of indices to messages
 #[derive(Debug)]
 pub struct Messages {
     pub indices: Vec<AgentMessageIndices>,

--- a/packages/engine/src/simulation/package/context/packages/agent_messages/fields.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/fields.rs
@@ -4,6 +4,8 @@ use crate::datastore::schema::{
 
 use super::*;
 
+pub(super) const MESSAGES_FIELD_NAME: &str = "messages";
+
 fn agent_messages() -> FieldType {
     let variant = VariableLengthArray(Box::new(FieldType::new(
         FixedLengthArray {
@@ -23,5 +25,9 @@ pub(super) fn get_messages_field_spec(
     // has custom getters in the language runners that
     // return the actual messages that the agent received,
     // not just their indices.
-    Ok(field_spec_creator.create("messages".into(), agent_messages, FieldScope::Agent))
+    Ok(field_spec_creator.create(
+        MESSAGES_FIELD_NAME.into(),
+        agent_messages,
+        FieldScope::Agent,
+    ))
 }

--- a/packages/engine/src/simulation/package/context/packages/agent_messages/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/mod.rs
@@ -77,24 +77,29 @@ impl Package for AgentMessages {
         &mut self,
         state: Arc<State>,
         snapshot: Arc<StateSnapshot>,
-    ) -> Result<ContextColumn> {
+    ) -> Result<Vec<ContextColumn>> {
         let agent_pool = state.agent_pool();
         let batches = agent_pool.read_batches()?;
         let id_name_iter = iterators::agent::agent_id_iter(&batches)?
             .zip(iterators::agent::agent_name_iter(&batches)?);
 
         let messages = Messages::gather(snapshot.message_map(), id_name_iter)?;
+        let field_key = self
+            .context_field_spec_accessor
+            .get_agent_scoped_field_spec("messages")?
+            .to_key()?;
 
-        Ok(ContextColumn {
+        Ok(vec![ContextColumn {
+            field_key,
             inner: Box::new(messages),
-        })
+        }])
     }
 
-    fn get_empty_arrow_column(
+    fn get_empty_arrow_columns(
         &self,
         num_agents: usize,
         _schema: &ContextSchema,
-    ) -> Result<(FieldKey, Arc<dyn ArrowArray>)> {
+    ) -> Result<Vec<(FieldKey, Arc<dyn ArrowArray>)>> {
         let index_builder = ArrowIndexBuilder::new(1024);
         let loc_builder = FixedSizeListBuilder::new(index_builder, 3);
         let mut messages_builder = ListBuilder::new(loc_builder);
@@ -108,9 +113,9 @@ impl Package for AgentMessages {
             .get_agent_scoped_field_spec("messages")?
             .to_key()?;
 
-        Ok((
+        Ok(vec![(
             field_key,
             Arc::new(messages_builder.finish()) as Arc<dyn ArrowArray>,
-        ))
+        )])
     }
 }

--- a/packages/engine/src/simulation/package/context/packages/agent_messages/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/mod.rs
@@ -6,6 +6,7 @@ mod writer;
 use self::collected::Messages;
 use crate::datastore::schema::accessor::GetFieldSpec;
 use crate::datastore::schema::RootFieldSpec;
+use crate::simulation::package::context::packages::agent_messages::fields::MESSAGES_FIELD_NAME;
 use crate::{
     datastore::{batch::iterators, table::state::ReadState},
     simulation::comms::package::PackageComms,
@@ -86,7 +87,7 @@ impl Package for AgentMessages {
         let messages = Messages::gather(snapshot.message_map(), id_name_iter)?;
         let field_key = self
             .context_field_spec_accessor
-            .get_agent_scoped_field_spec("messages")?
+            .get_agent_scoped_field_spec(MESSAGES_FIELD_NAME)?
             .to_key()?;
 
         Ok(vec![ContextColumn {
@@ -106,11 +107,9 @@ impl Package for AgentMessages {
 
         (0..num_agents).try_for_each(|_| messages_builder.append(true))?;
 
-        // TODO, this is unclean, we won't have to do this if we move empty arrow
-        //   initialisation to be done per schema instead of per package
         let field_key = self
             .context_field_spec_accessor
-            .get_agent_scoped_field_spec("messages")?
+            .get_agent_scoped_field_spec(MESSAGES_FIELD_NAME)?
             .to_key()?;
 
         Ok(vec![(

--- a/packages/engine/src/simulation/package/context/packages/api_requests/fields.rs
+++ b/packages/engine/src/simulation/package/context/packages/api_requests/fields.rs
@@ -2,11 +2,16 @@ use crate::datastore::schema::{FieldScope, FieldType, FieldTypeVariant::*};
 
 use super::*;
 
+pub(super) const FROM_FIELD_NAME: &str = "from";
+pub(super) const TYPE_FIELD_NAME: &str = "type";
+pub(super) const DATA_FIELD_NAME: &str = "data";
+pub(super) const API_RESPONSES_FIELD_NAME: &str = "api_responses";
+
 pub fn api_response_fields() -> Vec<FieldSpec> {
     vec![
-        FieldSpec::new("from".into(), FieldType::new(String, false)),
-        FieldSpec::new("type".into(), FieldType::new(String, false)),
-        FieldSpec::new("data".into(), FieldType::new(String, true)),
+        FieldSpec::new(FROM_FIELD_NAME.into(), FieldType::new(String, false)),
+        FieldSpec::new(TYPE_FIELD_NAME.into(), FieldType::new(String, false)),
+        FieldSpec::new(DATA_FIELD_NAME.into(), FieldType::new(String, true)),
     ]
 }
 
@@ -22,5 +27,9 @@ pub(super) fn get_api_responses_field_spec(
     field_spec_creator: &RootFieldSpecCreator,
 ) -> Result<RootFieldSpec> {
     let api_responses = api_responses();
-    Ok(field_spec_creator.create("api_responses".into(), api_responses, FieldScope::Hidden))
+    Ok(field_spec_creator.create(
+        API_RESPONSES_FIELD_NAME.into(),
+        api_responses,
+        FieldScope::Hidden,
+    ))
 }

--- a/packages/engine/src/simulation/package/context/packages/api_requests/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/api_requests/mod.rs
@@ -18,6 +18,7 @@ use serde_json::Value;
 use crate::datastore::schema::accessor::GetFieldSpec;
 use crate::datastore::schema::FieldKey;
 
+use crate::simulation::package::context::packages::api_requests::fields::API_RESPONSES_FIELD_NAME;
 pub use handlers::CustomAPIMessageError;
 
 const CPU_BOUND: bool = false;
@@ -127,7 +128,7 @@ impl Package for APIRequests {
         let api_responses = APIResponses::from(responses_per_agent);
         let field_key = self
             .context_field_spec_accessor
-            .get_local_hidden_scoped_field_spec("api_responses")?
+            .get_local_hidden_scoped_field_spec(API_RESPONSES_FIELD_NAME)?
             .to_key()?;
 
         Ok(vec![ContextColumn {
@@ -147,7 +148,7 @@ impl Package for APIRequests {
 
         let field_key = self
             .context_field_spec_accessor
-            .get_local_hidden_scoped_field_spec("api_responses")?
+            .get_local_hidden_scoped_field_spec(API_RESPONSES_FIELD_NAME)?
             .to_key()?;
         let arrow_fields = context_schema
             .arrow

--- a/packages/engine/src/simulation/package/context/packages/neighbors/fields.rs
+++ b/packages/engine/src/simulation/package/context/packages/neighbors/fields.rs
@@ -3,6 +3,9 @@ use crate::datastore::schema::{
     FieldScope, FieldType, FieldTypeVariant::*, PresetFieldType, RootFieldSpec,
 };
 
+pub(super) const NEIGHBORS_FIELD_NAME: &str = "neighbors";
+pub(super) const SEARCH_RADIUS_FIELD_NAME: &str = "search_radius";
+
 fn neighbors() -> FieldType {
     let variant = VariableLengthArray(Box::new(FieldType::new(
         FixedLengthArray {
@@ -18,7 +21,7 @@ pub(super) fn get_neighbors_field_spec(
     field_spec_creator: &RootFieldSpecCreator,
 ) -> Result<RootFieldSpec> {
     let neighbors = neighbors();
-    Ok(field_spec_creator.create("neighbors".into(), neighbors, FieldScope::Hidden))
+    Ok(field_spec_creator.create(NEIGHBORS_FIELD_NAME.into(), neighbors, FieldScope::Hidden))
 }
 
 pub(super) fn get_search_radius_field_spec(
@@ -26,7 +29,7 @@ pub(super) fn get_search_radius_field_spec(
 ) -> Result<RootFieldSpec> {
     let search_radius = FieldType::new(Number, true);
     Ok(field_spec_creator.create(
-        "search_radius".to_string(),
+        SEARCH_RADIUS_FIELD_NAME.to_string(),
         search_radius,
         FieldScope::Agent,
     ))

--- a/packages/engine/src/simulation/package/context/packages/neighbors/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/neighbors/mod.rs
@@ -9,6 +9,7 @@ use crate::datastore::table::state::view::StateSnapshot;
 use crate::datastore::table::state::State;
 use crate::datastore::{batch::iterators, table::state::ReadState};
 use crate::simulation::comms::package::PackageComms;
+use crate::simulation::package::context::packages::neighbors::fields::NEIGHBORS_FIELD_NAME;
 use crate::simulation::package::context::{ContextColumn, Package, PackageCreator};
 use crate::simulation::package::ext_traits::{
     GetWorkerExpStartMsg, GetWorkerSimStartMsg, MaybeCPUBound,
@@ -125,7 +126,7 @@ impl Package for Neighbors {
 
         let field_key = self
             .context_field_spec_accessor
-            .get_local_hidden_scoped_field_spec("neighbors")?
+            .get_local_hidden_scoped_field_spec(NEIGHBORS_FIELD_NAME)?
             .to_key()?;
 
         Ok(vec![ContextColumn {
@@ -150,7 +151,7 @@ impl Package for Neighbors {
         //   initialisation to be done per schema instead of per package
         let field_key = self
             .context_field_spec_accessor
-            .get_local_hidden_scoped_field_spec("neighbors")?
+            .get_local_hidden_scoped_field_spec(NEIGHBORS_FIELD_NAME)?
             .to_key()?;
 
         Ok(vec![(

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/fields/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/fields/mod.rs
@@ -13,19 +13,27 @@ use crate::datastore::schema::{
 };
 use crate::simulation::Result;
 
+pub(super) const BEHAVIORS_FIELD_NAME: &str = "behaviors";
+pub(super) const BEHAVIOR_INDEX_FIELD_NAME: &str = "behavior_index";
+pub(super) const BEHAVIOR_IDS_FIELD_NAME: &str = "behavior_ids";
+
 fn get_behaviors_field_spec(field_spec_creator: &RootFieldSpecCreator) -> Result<RootFieldSpec> {
     let field_type = FieldType::new(
         FTV::VariableLengthArray(Box::new(FieldType::new(FTV::String, false))),
         false,
     );
-    Ok(field_spec_creator.create("behaviors".into(), field_type, FieldScope::Agent))
+    Ok(field_spec_creator.create(BEHAVIORS_FIELD_NAME.into(), field_type, FieldScope::Agent))
 }
 
 fn get_behavior_index_field_spec(
     field_spec_creator: &RootFieldSpecCreator,
 ) -> Result<RootFieldSpec> {
     let field_type = FieldType::new(FTV::Number, false);
-    Ok(field_spec_creator.create("behavior_index".into(), field_type, FieldScope::Agent))
+    Ok(field_spec_creator.create(
+        BEHAVIOR_INDEX_FIELD_NAME.into(),
+        field_type,
+        FieldScope::Agent,
+    ))
 }
 
 fn behavior_id_inner_field_type() -> FieldType {
@@ -49,7 +57,11 @@ fn behavior_ids_field_type() -> FieldType {
 
 fn get_behavior_ids_field_spec(field_spec_creator: &RootFieldSpecCreator) -> Result<RootFieldSpec> {
     let field_type = behavior_ids_field_type();
-    Ok(field_spec_creator.create("behavior_ids".into(), field_type, FieldScope::Private))
+    Ok(field_spec_creator.create(
+        BEHAVIOR_IDS_FIELD_NAME.into(),
+        field_type,
+        FieldScope::Private,
+    ))
 }
 
 pub(super) fn get_state_field_specs(

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/mod.rs
@@ -13,6 +13,9 @@ use crate::datastore::table::state::ReadState;
 use crate::datastore::table::task_shared_store::TaskSharedStoreBuilder;
 use crate::simulation::package::name::PackageName;
 use crate::simulation::package::state::packages::behavior_execution::config::BehaviorIds;
+use crate::simulation::package::state::packages::behavior_execution::fields::{
+    BEHAVIOR_IDS_FIELD_NAME, BEHAVIOR_INDEX_FIELD_NAME,
+};
 use crate::simulation::package::state::packages::behavior_execution::tasks::ExecuteBehaviorsTask;
 use crate::simulation::task::active::ActiveTask;
 use crate::simulation::task::Task;
@@ -77,7 +80,7 @@ impl PackageCreator for Creator {
         let behavior_ids_col_data_types = fields::id_column_data_types()?;
         // TODO - probably just rename the actual field key to behavior_ids (rather than behavior indices) to avoid confusion with "behavior_index" col
         let behavior_ids_col = accessor
-            .get_local_private_scoped_field_spec("behavior_ids")?
+            .get_local_private_scoped_field_spec(BEHAVIOR_IDS_FIELD_NAME)?
             .to_key()?;
 
         let behavior_ids_col_index = config
@@ -88,7 +91,7 @@ impl PackageCreator for Creator {
             .index_of(behavior_ids_col.value())?;
 
         let behavior_index_col = accessor
-            .get_agent_scoped_field_spec("behavior_index")?
+            .get_agent_scoped_field_spec(BEHAVIOR_INDEX_FIELD_NAME)?
             .to_key()?;
         let behavior_index_col_index = config
             .sim


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This allows context packages to return / maintain multiple columns. Although this isn't currently useful.
It also does a somewhat messy re-ordering of the return values relating to columns of context packages to fix a pretty nasty bug.

## 🔗 Related links

- [Asana task description](https://app.asana.com/0/1199550852792314/1201481007343173/f)

## 🔍 What does this change?

* Changes the signatures of the traits for Context Packages to return Vecs instead of single elements
* Adds an ordering and look-up step with those return values, that reads through the columns present in the schema and selects the relevant column from the package's column writers. This ensures that the ordering is the same, and we additionally get some better error handling if it's missing or unexpected things happen. Nevertheless, this is still pretty sloppy and I hope to come up with a better idea in time.


## 🛡 Tests

Project is still compiling, have successfully ran a number of sims and have confirmed that the previous errors/bugs are no longer present.

