### PR TITLE
Improve CLI arguments parsing and help-output

### DIFF
--- a/packages/engine/Cargo.lock
+++ b/packages/engine/Cargo.lock
@@ -72,6 +72,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,11 +426,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
 name = "cli"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "argh",
  "async-trait",
  "hash_engine",
  "lazy_static",
@@ -432,6 +455,7 @@ dependencies = [
  "serde",
  "serde_json",
  "server",
+ "structopt",
  "tokio",
 ]
 
@@ -1795,6 +1819,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2372,6 +2420,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "strum"
 version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2465,6 +2543,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -2707,6 +2794,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2760,6 +2853,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/packages/engine/bin/cli/Cargo.toml
+++ b/packages/engine/bin/cli/Cargo.toml
@@ -11,7 +11,6 @@ hash_engine = { path = "../.." }
 server = { path = "../server", artifact = "bin" }
 
 anyhow = "1.0.51"
-argh = "0.1.4"
 async-trait = "0.1.48"
 lazy_static = "1.4.0"
 log = "0.4.11"
@@ -20,4 +19,5 @@ rand = "0.8.3"
 rand_distr = "0.4.2"
 serde = { version = "1.0.111", features = ["derive"] }
 serde_json = "1.0.59"
+structopt = "0.3.25"
 tokio = { version = "1.5.0", features = ["macros", "rt-multi-thread", "sync", "process", "io-util", "net", "rt", "fs"] }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Greatly improve parameter handling at the command line interface. As with most CLI programs, a short and a long version for parameters is available and the short parameter list can be shorten (i.e. `-w 4` > `-w4`).

## 🔗 Related links

- [Asana task description](https://app.asana.com/0/1199550852792314/1201487105179315/f)

## 🔍 What does this change?

- Uses the [StructOpt crate](https://crates.io/crates/structopt) to generate CLI parser and help page
- Remove the old crate we used

## 🛡 Tests

- ✅ Manual Tests

## ❓ How to test this?

1. Run the CLI with different parameters and enjoy the beautiful output
2. Profit

## 📹 Demo
```
$ cli
```
```text
cli 0.0.0
The hEngine Command line interface.

Can run single or simple experiments.

USAGE:
    cli [OPTIONS] <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -w, --num-workers <num-workers>    Max number of parallel workers (must be power of 2) [env: HASH_WORKERS=]
                                       [default: 4]
    -o, --output <output>              (Unimplemented) Project output path folder [env: HASH_OUTPUT=]  [default:
                                       ./output]
    -p, --project <project>            Path to the project to be run [env: HASH_PROJECT=]  [default: .]

SUBCOMMANDS:
    help          Prints this message or the help of the given subcommand(s)
    simple        Run a simple experiment
    single-run    Run a single run experiment
```

---

```
$ cli --help
```
```
cli 0.0.0
The hEngine Command line interface.

Can run single or simple experiments.

USAGE:
    cli [OPTIONS] <SUBCOMMAND>

FLAGS:
    -h, --help       
            Prints help information

    -V, --version    
            Prints version information


OPTIONS:
    -w, --num-workers <num-workers>    
            Max number of parallel workers (must be power of 2) [env: HASH_WORKERS=]  [default: 4]

    -o, --output <output>              
            (Unimplemented) Project output path folder.
            
            The folder will be created if it's missing. [env: HASH_OUTPUT=]  [default: ./output]
    -p, --project <project>            
            Path to the project to be run [env: HASH_PROJECT=]  [default: .]


SUBCOMMANDS:
    help          Prints this message or the help of the given subcommand(s)
    simple        Run a simple experiment
    single-run    Run a single run experiment
```

---

```
$ cli help simple
```
```
cli-simple 0.0.0
Run a simple experiment

USAGE:
    cli simple --experiment-name <experiment-name>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -n, --experiment-name <experiment-name>    Name of the experiment to be run [env: HASH_EXPERIMENT=]
```

---

```
$ cli help single-run
```
```
cli-single-run 0.0.0
Run a single run experiment

USAGE:
    cli single-run --num-steps <num-steps>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -n, --num-steps <num-steps>    Number of steps to run [env: HASH_NUM_STEPS=]
```

---

```
cli single-run
```
```
error: The following required arguments were not provided:
    --num-steps <num-steps>

USAGE:
    cli single-run --num-steps <num-steps>

For more information try --help
```