### PR TITLE
Migrating to abide by the rust std for acronyms in camel cases

### DIFF
--- a/packages/engine/bin/cli/src/exsrv.rs
+++ b/packages/engine/bin/cli/src/exsrv.rs
@@ -4,10 +4,10 @@ use anyhow::{bail, format_err, Context, Result};
 use hash_engine::{nano, proto};
 use tokio::sync::{mpsc, oneshot};
 
-type ExperimentID = String;
+type ExperimentId = String;
 type ResultSender = oneshot::Sender<Result<()>>;
-type CloseReceiver = mpsc::UnboundedReceiver<ExperimentID>;
-type CloseSender = mpsc::UnboundedSender<ExperimentID>;
+type CloseReceiver = mpsc::UnboundedReceiver<ExperimentId>;
+type CloseSender = mpsc::UnboundedSender<ExperimentId>;
 type MsgSender = mpsc::UnboundedSender<proto::EngineStatus>;
 type MsgReceiver = mpsc::UnboundedReceiver<proto::EngineStatus>;
 type CtrlSender = mpsc::Sender<(Ctrl, ResultSender)>;
@@ -24,12 +24,12 @@ pub fn create_server(url: &str) -> Result<(Server, Handler)> {
 }
 
 enum Ctrl {
-    Register { id: ExperimentID, msg_tx: MsgSender },
+    Register { id: ExperimentId, msg_tx: MsgSender },
     Stop,
 }
 
 pub struct Handle {
-    id: ExperimentID,
+    id: ExperimentId,
     msg_rx: MsgReceiver,
     close_tx: CloseSender,
 }
@@ -111,7 +111,7 @@ pub struct Server {
     url: String,
     ctrl_rx: CtrlReceiver,
     close_rx: CloseReceiver,
-    routes: HashMap<ExperimentID, MsgSender>,
+    routes: HashMap<ExperimentId, MsgSender>,
 }
 
 impl Server {
@@ -127,7 +127,7 @@ impl Server {
     }
 
     /// Add an experiment to the server's routes.
-    fn register_experiment(&mut self, id: ExperimentID, msg_tx: MsgSender) -> Result<()> {
+    fn register_experiment(&mut self, id: ExperimentId, msg_tx: MsgSender) -> Result<()> {
         if self.routes.contains_key(&id) {
             bail!("Experiment already registered: {id}")
         } else {
@@ -137,7 +137,7 @@ impl Server {
         }
     }
 
-    fn deregister_experiment(&mut self, id: ExperimentID) {
+    fn deregister_experiment(&mut self, id: ExperimentId) {
         match self.routes.remove(&id) {
             None => error!("Experiment {id} not found"),
             Some(_) => debug!("De-registered experiment {id}"),

--- a/packages/engine/format/init.fbs
+++ b/packages/engine/format/init.fbs
@@ -2,7 +2,7 @@ include "shared_context.fbs";
 include "package_config.fbs";
 
 // Experiment UUID as bytes
-struct ExperimentID {
+struct ExperimentId {
   inner:[byte:16];
 }
 
@@ -12,7 +12,7 @@ struct ExperimentID {
 //    `package_config`       : configuration about which simulation packages are used in this
 //                             experiment run 
 table Init {
-  experiment_id:ExperimentID;
+  experiment_id:ExperimentId;
   worker_index:uint64;
   shared_context:SharedContext (required);
   package_config:PackageConfig (required);

--- a/packages/engine/format/runner_inbound_msg.fbs
+++ b/packages/engine/format/runner_inbound_msg.fbs
@@ -12,7 +12,7 @@ include "new_simulation_run.fbs";
 //
 // fields:
 //    `inner` : the uuid as bytes 
-struct TaskID {
+struct TaskId {
   inner:[byte:16];
 }
 
@@ -27,7 +27,7 @@ struct TaskID {
 //    `payload`        : payload for the task message (json)
 table TaskMsg {
   package_sid:uint64;
-  task_id:TaskID;
+  task_id:TaskId;
   metaversioning:StateInterimSync;
   payload:Serialized (required);
 }
@@ -37,7 +37,7 @@ table TaskMsg {
 // fields:
 //    `task_id`        : the uuid for the task
 table CancelTask {
-  task_id:TaskID;
+  task_id:TaskId;
 }
 
 // `TerminateRunner` Message Body Type.

--- a/packages/engine/format/runner_outbound_msg.fbs
+++ b/packages/engine/format/runner_outbound_msg.fbs
@@ -16,7 +16,7 @@ include "target.fbs";
 //
 // fields:
 //    `inner` : the uuid as bytes
-struct TaskID {
+struct TaskId {
   inner:[byte:16];
 }
 
@@ -31,7 +31,7 @@ struct TaskID {
 //    `payload`        : payload for the task message (json)
 table TaskMsg {
   package_sid:uint64;
-  task_id:TaskID;
+  task_id:TaskId;
   target:Target;
   metaversioning:StateInterimSync;
   payload:Serialized (required);
@@ -43,7 +43,7 @@ table TaskMsg {
 // fields:
 //    `task_id`        : the uuid for the task
 table TaskCancelled {
-  task_id:TaskID;
+  task_id:TaskId;
 }
 
 

--- a/packages/engine/src/config/experiment.rs
+++ b/packages/engine/src/config/experiment.rs
@@ -3,14 +3,14 @@ use std::sync::Arc;
 use super::{package, worker, worker_pool, Result};
 use crate::{
     config::globals::Globals,
-    proto::{ExperimentID, ExperimentRunRepr, ExperimentRunTrait},
+    proto::{ExperimentId, ExperimentRunRepr, ExperimentRunTrait},
 };
 
 #[derive(Clone)]
 /// Experiment level configuration
 pub struct Config {
     // we need this only for non-pod runs TODO remove and create random internal ids?
-    pub run_id: Arc<ExperimentID>,
+    pub run_id: Arc<ExperimentId>,
     pub packages: Arc<package::Config>,
     pub run: Arc<ExperimentRunRepr>,
     pub worker_pool: Arc<worker_pool::Config>,

--- a/packages/engine/src/config/mod.rs
+++ b/packages/engine/src/config/mod.rs
@@ -26,7 +26,7 @@ pub use topology::Config as TopologyConfig;
 pub use worker::{Config as WorkerConfig, SpawnConfig as WorkerSpawnConfig};
 pub use worker_pool::Config as WorkerPoolConfig;
 
-use crate::{proto::SimulationShortID, Args, Environment};
+use crate::{proto::SimulationShortId, Args, Environment};
 
 #[derive(Clone)]
 pub struct SimRunConfig {
@@ -44,7 +44,7 @@ pub async fn experiment_config(args: &Args, env: &Environment) -> Result<Experim
 impl SimRunConfig {
     pub fn new(
         global: &Arc<ExperimentConfig>,
-        id: SimulationShortID,
+        id: SimulationShortId,
         globals: Globals,
         engine: EngineConfig,
         store: StoreConfig,
@@ -68,7 +68,7 @@ impl SimRunConfig {
 }
 
 fn simulation_config(
-    id: SimulationShortID,
+    id: SimulationShortId,
     globals: Globals,
     engine: EngineConfig,
     _global: &ExperimentConfig,

--- a/packages/engine/src/config/package.rs
+++ b/packages/engine/src/config/package.rs
@@ -23,14 +23,14 @@ pub struct Config {
 
 impl Config {
     fn default_init_packages() -> Vec<InitPackage> {
-        let default = [InitPackage::JSON];
+        let default = [InitPackage::Json];
         Vec::from_iter(default.iter().cloned())
     }
 
     fn default_context_packages() -> Vec<ContextPackage> {
         let default = [
             ContextPackage::Neighbors,
-            ContextPackage::APIRequests,
+            ContextPackage::ApiRequests,
             ContextPackage::AgentMessages,
         ];
         Vec::from_iter(default.iter().cloned())
@@ -41,7 +41,7 @@ impl Config {
     }
 
     fn default_output_packages() -> Vec<OutputPackage> {
-        let default = [OutputPackage::JSONState, OutputPackage::Analysis];
+        let default = [OutputPackage::JsonState, OutputPackage::Analysis];
         Vec::from_iter(default.iter().cloned())
     }
 

--- a/packages/engine/src/config/simulation.rs
+++ b/packages/engine/src/config/simulation.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use super::{EngineConfig, PersistenceConfig, StoreConfig};
-use crate::{config::Globals, proto::SimulationShortID};
+use crate::{config::Globals, proto::SimulationShortId};
 
 pub struct Config {
-    pub id: SimulationShortID,
+    pub id: SimulationShortId,
     pub globals: Arc<Globals>,
     pub store: Arc<StoreConfig>,
     pub engine: Arc<EngineConfig>,

--- a/packages/engine/src/datastore/arrow/field_conversion.rs
+++ b/packages/engine/src/datastore/arrow/field_conversion.rs
@@ -18,8 +18,8 @@ use crate::datastore::{
 impl PresetFieldType {
     fn is_fixed_size(&self) -> bool {
         match self {
-            PresetFieldType::UInt32 => true,
-            PresetFieldType::UInt16 => true,
+            PresetFieldType::Uint32 => true,
+            PresetFieldType::Uint16 => true,
             PresetFieldType::Id => true,
         }
     }
@@ -27,8 +27,8 @@ impl PresetFieldType {
     #[must_use]
     pub fn get_arrow_data_type(&self) -> ArrowDataType {
         match self {
-            PresetFieldType::UInt32 => ArrowDataType::UInt32,
-            PresetFieldType::UInt16 => ArrowDataType::UInt16,
+            PresetFieldType::Uint32 => ArrowDataType::UInt32,
+            PresetFieldType::Uint16 => ArrowDataType::UInt16,
             PresetFieldType::Id => {
                 ArrowDataType::FixedSizeBinary(crate::datastore::UUID_V4_LEN as i32)
             }

--- a/packages/engine/src/datastore/arrow/meta_conversion.rs
+++ b/packages/engine/src/datastore/arrow/meta_conversion.rs
@@ -32,10 +32,10 @@ pub enum SupportedArrowDataTypes {
     Int32,
     Int64,
 
-    UInt8,
-    UInt16,
-    UInt32,
-    UInt64,
+    Uint8,
+    Uint16,
+    Uint32,
+    Uint64,
 
     Float32,
     Float64,
@@ -70,10 +70,10 @@ impl TryFrom<ArrowDataType> for SupportedArrowDataTypes {
             ArrowDataType::Int32 => Ok(Self::Int32),
             ArrowDataType::Int64 => Ok(Self::Int64),
 
-            ArrowDataType::UInt8 => Ok(Self::UInt8),
-            ArrowDataType::UInt16 => Ok(Self::UInt16),
-            ArrowDataType::UInt32 => Ok(Self::UInt32),
-            ArrowDataType::UInt64 => Ok(Self::UInt64),
+            ArrowDataType::UInt8 => Ok(Self::Uint8),
+            ArrowDataType::UInt16 => Ok(Self::Uint16),
+            ArrowDataType::UInt32 => Ok(Self::Uint32),
+            ArrowDataType::UInt64 => Ok(Self::Uint64),
 
             ArrowDataType::Float32 => Ok(Self::Float32),
             ArrowDataType::Float64 => Ok(Self::Float64),
@@ -393,10 +393,10 @@ pub fn data_type_to_metadata(
         D::Int32 => data_type_metadata(is_parent_growable, multiplier, 4),
         D::Int64 => data_type_metadata(is_parent_growable, multiplier, 8),
 
-        D::UInt8 => data_type_metadata(is_parent_growable, multiplier, 1),
-        D::UInt16 => data_type_metadata(is_parent_growable, multiplier, 2),
-        D::UInt32 => data_type_metadata(is_parent_growable, multiplier, 4),
-        D::UInt64 => data_type_metadata(is_parent_growable, multiplier, 8),
+        D::Uint8 => data_type_metadata(is_parent_growable, multiplier, 1),
+        D::Uint16 => data_type_metadata(is_parent_growable, multiplier, 2),
+        D::Uint32 => data_type_metadata(is_parent_growable, multiplier, 4),
+        D::Uint64 => data_type_metadata(is_parent_growable, multiplier, 8),
 
         D::Float32 => data_type_metadata(is_parent_growable, multiplier, 4),
         D::Float64 => data_type_metadata(is_parent_growable, multiplier, 8),

--- a/packages/engine/src/datastore/batch/agent.rs
+++ b/packages/engine/src/datastore/batch/agent.rs
@@ -27,7 +27,7 @@ use crate::{
         POSITION_DIM, UUID_V4_LEN,
     },
     hash_types::state::AgentStateField,
-    proto::ExperimentID,
+    proto::ExperimentId,
     simulation::package::creator::PREVIOUS_INDEX_FIELD_KEY,
 };
 
@@ -142,7 +142,7 @@ impl Batch {
     pub fn from_agent_states<K: IntoRecordBatch>(
         agents: K,
         schema: &Arc<AgentSchema>,
-        experiment_run_id: &ExperimentID,
+        experiment_run_id: &ExperimentId,
     ) -> Result<Batch> {
         let rb = agents.into_agent_batch(schema)?;
         Batch::from_record_batch(&rb, &schema, experiment_run_id)
@@ -159,7 +159,7 @@ impl Batch {
     pub fn duplicate_from(
         batch: &Batch,
         schema: &AgentSchema,
-        experiment_run_id: &ExperimentID,
+        experiment_run_id: &ExperimentId,
     ) -> Result<Batch> {
         let memory = Memory::duplicate_from(&batch.memory, experiment_run_id)?;
         Self::from_memory(memory, Some(schema), Some(batch.affinity))
@@ -169,7 +169,7 @@ impl Batch {
     pub fn from_record_batch(
         record_batch: &RecordBatch,
         schema: &AgentSchema,
-        experiment_run_id: &ExperimentID,
+        experiment_run_id: &ExperimentId,
     ) -> Result<Batch> {
         let schema_buffer = schema_to_bytes(&schema.arrow);
 
@@ -242,7 +242,7 @@ impl Batch {
     pub fn get_prepared_memory_for_data(
         schema: &Arc<AgentSchema>,
         dynamic_meta: &DynamicMeta,
-        experiment_run_id: &ExperimentID,
+        experiment_run_id: &ExperimentId,
     ) -> Result<Memory> {
         let schema_buffer = schema_to_bytes(&schema.arrow);
         let header_buffer = vec![];

--- a/packages/engine/src/datastore/batch/context.rs
+++ b/packages/engine/src/datastore/batch/context.rs
@@ -15,7 +15,7 @@ use crate::{
         },
         prelude::*,
     },
-    proto::ExperimentID,
+    proto::ExperimentId,
     simulation::package::context::ContextColumn,
 };
 
@@ -63,7 +63,7 @@ impl Batch {
     pub fn from_record_batch(
         record_batch: &RecordBatch,
         schema: Option<&Arc<ArrowSchema>>,
-        experiment_run_id: &Arc<ExperimentID>,
+        experiment_run_id: &Arc<ExperimentId>,
         group_start_indices: Vec<usize>,
     ) -> Result<Batch> {
         let (meta_buffer, data_buffer) = static_record_batch_to_bytes(record_batch);
@@ -99,7 +99,7 @@ impl Batch {
         };
         let rb_msg = arrow_ipc::get_root_as_message(meta_buffer)
             .header_as_record_batch()
-            .ok_or(Error::InvalidRecordBatchIPCMessage)?;
+            .ok_or(Error::InvalidRecordBatchIpcMessage)?;
         let batch = match read_record_batch(data_buffer, &rb_msg, schema, &[]) {
             Ok(rb) => rb.unwrap(),
             Err(e) => return Err(Error::from(e)),
@@ -168,7 +168,7 @@ impl Batch {
         let (_, _, meta_buffer, data_buffer) = self.memory.get_batch_buffers()?;
         let rb_msg = &arrow_ipc::get_root_as_message(meta_buffer)
             .header_as_record_batch()
-            .ok_or(Error::InvalidRecordBatchIPCMessage)?;
+            .ok_or(Error::InvalidRecordBatchIpcMessage)?;
         self.batch = match read_record_batch(data_buffer, rb_msg, self.batch.schema(), &[]) {
             Ok(rb) => rb.unwrap(),
             Err(e) => return Err(Error::from(e)),

--- a/packages/engine/src/datastore/batch/migration/mod.rs
+++ b/packages/engine/src/datastore/batch/migration/mod.rs
@@ -7,7 +7,7 @@ use arrow::util::bit_util;
 use super::ArrowBatch;
 use crate::{
     datastore::{batch::AgentBatch, prelude::*, schema::state::AgentSchema},
-    proto::ExperimentID,
+    proto::ExperimentId,
 };
 
 type Offset = i32;
@@ -166,7 +166,7 @@ impl<'a> BufferActions<'a> {
     pub fn new_batch(
         &self,
         schema: &Arc<AgentSchema>,
-        experiment_run_id: &ExperimentID,
+        experiment_run_id: &ExperimentId,
         affinity: usize,
     ) -> Result<AgentBatch> {
         let mut memory = AgentBatch::get_prepared_memory_for_data(

--- a/packages/engine/src/datastore/batch/mod.rs
+++ b/packages/engine/src/datastore/batch/mod.rs
@@ -123,7 +123,7 @@ mod load {
         let (_, _, meta_buffer, _) = batch.memory().get_batch_buffers()?;
         arrow_ipc::get_root_as_message(meta_buffer)
             .header_as_record_batch()
-            .ok_or(Error::InvalidRecordBatchIPCMessage)
+            .ok_or(Error::InvalidRecordBatchIpcMessage)
     }
 
     pub fn record_batch<'a, K: Batch>(

--- a/packages/engine/src/datastore/error.rs
+++ b/packages/engine/src/datastore/error.rs
@@ -8,7 +8,7 @@ use thiserror::Error as ThisError;
 
 use super::prelude::*;
 use crate::{
-    datastore::schema::{FieldKey, FieldType, RootFieldSpec, ShortJSONError},
+    datastore::schema::{FieldKey, FieldType, RootFieldSpec, ShortJsonError},
     hash_types,
     hash_types::state::AgentStateField,
 };
@@ -167,7 +167,7 @@ pub enum Error {
     BooleanSerdeValueExpected,
 
     #[error("Unable to read IPC message as record batch")]
-    InvalidRecordBatchIPCMessage,
+    InvalidRecordBatchIpcMessage,
 
     #[error("Expected new data buffer length to be smaller than current. Id: {0}")]
     ExpectedSmallerNewDataSize(String),
@@ -215,7 +215,7 @@ pub enum Error {
     UnexpectedUndefinedCommand,
 
     #[error("Field Spec Short JSON repr error: {0}")]
-    ShortJSONError(#[from] ShortJSONError),
+    ShortJsonError(#[from] ShortJsonError),
 
     #[error(
         "Key clash when attempting to insert a new agent-scoped field with key: {0:?}. The new \

--- a/packages/engine/src/datastore/schema/field_spec/mod.rs
+++ b/packages/engine/src/datastore/schema/field_spec/mod.rs
@@ -31,9 +31,9 @@ const PRIVATE_PREFIX: &str = "_PRIVATE_";
 /// field types we allow users to set
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum PresetFieldType {
-    UInt16,
+    Uint16,
     // Used to refer to an agent from the previous state
-    UInt32,
+    Uint32,
     // Represents AgentId
     Id,
 }

--- a/packages/engine/src/datastore/schema/field_spec/short_json.rs
+++ b/packages/engine/src/datastore/schema/field_spec/short_json.rs
@@ -7,7 +7,7 @@ use crate::datastore::{
 };
 
 #[derive(thiserror::Error, Debug)]
-pub enum ShortJSONError {
+pub enum ShortJsonError {
     #[error("Could not find 'fields' field in input")]
     MissingFields,
     #[error("'fields' field in input is not an object")]
@@ -102,7 +102,7 @@ impl FieldType {
                 "string" => Ok(FieldType::new(FieldTypeVariant::String, is_nullable)),
                 "any" => {
                     if depth != 0 {
-                        return Err(ShortJSONError::InvalidAnyTypeLevel.into());
+                        return Err(ShortJsonError::InvalidAnyTypeLevel.into());
                     }
                     Ok(FieldType::new(FieldTypeVariant::AnyType, is_nullable))
                 }
@@ -111,7 +111,7 @@ impl FieldType {
                         Ok(key.field_type.clone())
                     } else {
                         return Err(
-                            ShortJSONError::InvalidFieldType(ExpectedFieldType::String).into()
+                            ShortJsonError::InvalidFieldType(ExpectedFieldType::String).into()
                         );
                     }
                 }
@@ -140,7 +140,7 @@ impl FieldSpec {
                 };
                 Ok(spec)
             }
-            _ => Err(ShortJSONError::InvalidFieldType(ExpectedFieldType::Custom).into()),
+            _ => Err(ShortJsonError::InvalidFieldType(ExpectedFieldType::Custom).into()),
         }
     }
 
@@ -161,7 +161,7 @@ impl FieldSpec {
                 Ok(spec)
             }
             Value::Object(_) => FieldSpec::from_short_json_object(name, value, definitions),
-            _ => Err(ShortJSONError::InvalidFieldType(ExpectedFieldType::StringOrCustom).into()),
+            _ => Err(ShortJsonError::InvalidFieldType(ExpectedFieldType::StringOrCustom).into()),
         }
     }
 }
@@ -201,13 +201,13 @@ impl FieldSpecMap {
                     }
                     Ok(field_spec_map)
                 } else {
-                    Err(ShortJSONError::FieldsIsNotObject.into())
+                    Err(ShortJsonError::FieldsIsNotObject.into())
                 }
             } else {
-                Err(ShortJSONError::MissingFields.into())
+                Err(ShortJsonError::MissingFields.into())
             }
         } else {
-            Err(ShortJSONError::InvalidFormatForFieldsObject.into())
+            Err(ShortJsonError::InvalidFormatForFieldsObject.into())
         }
     }
 }

--- a/packages/engine/src/datastore/schema/mod.rs
+++ b/packages/engine/src/datastore/schema/mod.rs
@@ -4,7 +4,7 @@ pub mod state;
 mod field_spec;
 
 pub use field_spec::{
-    accessor, built_in::IsRequired, creator::RootFieldSpecCreator, short_json::ShortJSONError,
+    accessor, built_in::IsRequired, creator::RootFieldSpecCreator, short_json::ShortJsonError,
     FieldKey, FieldScope, FieldSource, FieldSpec, FieldSpecMap, FieldType, FieldTypeVariant,
     PresetFieldType, RootFieldSpec,
 };

--- a/packages/engine/src/datastore/table/context/mod.rs
+++ b/packages/engine/src/datastore/table/context/mod.rs
@@ -8,7 +8,7 @@ use super::{
     state::view::StateSnapshot,
 };
 use crate::{
-    config::StoreConfig, datastore::prelude::*, proto::ExperimentID,
+    config::StoreConfig, datastore::prelude::*, proto::ExperimentId,
     simulation::package::context::ContextColumn,
 };
 
@@ -34,7 +34,7 @@ impl Context {
     pub fn new_from_columns(
         cols: Vec<Arc<dyn arrow::array::Array>>,
         config: Arc<StoreConfig>,
-        experiment_run_id: &Arc<ExperimentID>,
+        experiment_run_id: &Arc<ExperimentId>,
         group_start_indices: Vec<usize>,
     ) -> Result<Context> {
         let context_record_batch = RecordBatch::try_new(config.context_schema.arrow.clone(), cols)?;

--- a/packages/engine/src/datastore/table/state/mod.rs
+++ b/packages/engine/src/datastore/table/state/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     datastore::{
         batch::DynamicBatch, prelude::*, schema::state::AgentSchema, table::pool::BatchPool,
     },
-    proto::ExperimentID,
+    proto::ExperimentId,
     simulation::{command::CreateRemoveCommands, package::state::StateColumn},
     SimRunConfig,
 };
@@ -136,7 +136,7 @@ impl ExState {
         &self,
         context: &mut ExContext,
         agent_schema: &AgentSchema,
-        experiment_run_id: &ExperimentID,
+        experiment_run_id: &ExperimentId,
     ) -> Result<()> {
         let mut static_pool = context.inner_mut().agent_pool_mut().write_batches()?;
         let dynamic_pool = self.agent_pool().read_batches()?;

--- a/packages/engine/src/experiment/controller/controller.rs
+++ b/packages/engine/src/experiment/controller/controller.rs
@@ -19,7 +19,7 @@ use crate::{
         ExperimentControl,
     },
     output::OutputPersistenceCreatorRepr,
-    proto::{EngineMsg, EngineStatus, SimulationShortID},
+    proto::{EngineMsg, EngineStatus, SimulationShortId},
     simulation::{
         comms::Comms,
         controller::{runs::SimulationRuns, sim_control::SimControl, SimulationController},
@@ -51,7 +51,7 @@ pub struct ExperimentController<P: OutputPersistenceCreatorRepr> {
     experiment_package_comms: ExperimentPackageComms,
     output_persistence_service_creator: P,
     sim_run_tasks: SimulationRuns,
-    sim_senders: HashMap<SimulationShortID, SimCtlSend>,
+    sim_senders: HashMap<SimulationShortId, SimCtlSend>,
     worker_pool_send_base: workerpool::comms::main::MainMsgSendBase,
     package_creators: PackageCreators,
     sim_id_store: SimIdStore,
@@ -129,13 +129,13 @@ impl<P: OutputPersistenceCreatorRepr> ExperimentController<P> {
             .await?)
     }
 
-    async fn handle_sim_run_stop(&mut self, id: SimulationShortID) -> Result<()> {
+    async fn handle_sim_run_stop(&mut self, id: SimulationShortId) -> Result<()> {
         Ok(self.orch_client().send(EngineStatus::SimStop(id)).await?)
     }
 
     async fn handle_worker_pool_controller_msg(
         &mut self,
-        id: Option<SimulationShortID>,
+        id: Option<SimulationShortId>,
         msg: WorkerPoolToExpCtlMsg,
     ) -> Result<()> {
         let engine_status = match msg {
@@ -159,7 +159,7 @@ impl<P: OutputPersistenceCreatorRepr> ExperimentController<P> {
 
     async fn start_new_sim_run(
         &mut self,
-        sim_short_id: SimulationShortID,
+        sim_short_id: SimulationShortId,
         changed_properties: serde_json::Value,
         max_num_steps: usize,
     ) -> Result<()> {
@@ -244,22 +244,22 @@ impl<P: OutputPersistenceCreatorRepr> ExperimentController<P> {
         Ok(())
     }
 
-    async fn pause_sim_run(&mut self, sim_short_id: SimulationShortID) -> Result<()> {
+    async fn pause_sim_run(&mut self, sim_short_id: SimulationShortId) -> Result<()> {
         self.send_sim(sim_short_id, SimControl::Pause).await?;
         Ok(())
     }
 
-    async fn resume_sim_run(&mut self, sim_short_id: SimulationShortID) -> Result<()> {
+    async fn resume_sim_run(&mut self, sim_short_id: SimulationShortId) -> Result<()> {
         self.send_sim(sim_short_id, SimControl::Resume).await?;
         Ok(())
     }
 
-    async fn stop_sim_run(&mut self, sim_short_id: SimulationShortID) -> Result<()> {
+    async fn stop_sim_run(&mut self, sim_short_id: SimulationShortId) -> Result<()> {
         self.send_sim(sim_short_id, SimControl::Stop).await?;
         Ok(())
     }
 
-    async fn send_sim(&mut self, sim_short_id: SimulationShortID, msg: SimControl) -> Result<()> {
+    async fn send_sim(&mut self, sim_short_id: SimulationShortId, msg: SimControl) -> Result<()> {
         if let Some(sender) = self.sim_senders.get_mut(&sim_short_id) {
             sender.send(msg).await?;
             Ok(())
@@ -282,7 +282,7 @@ impl<P: OutputPersistenceCreatorRepr> ExperimentController<P> {
 
     fn add_sim_sender(
         &mut self,
-        sim_short_id: SimulationShortID,
+        sim_short_id: SimulationShortId,
         sender: SimCtlSend,
     ) -> Result<()> {
         if self.sim_senders.contains_key(&sim_short_id) {

--- a/packages/engine/src/experiment/controller/sim_configurer.rs
+++ b/packages/engine/src/experiment/controller/sim_configurer.rs
@@ -5,7 +5,7 @@ use crate::{
     config::{
         EngineConfig, ExperimentConfig, Globals, PersistenceConfig, StoreConfig, WorkerAllocation,
     },
-    proto::{ExperimentPackageConfig, SimulationShortID},
+    proto::{ExperimentPackageConfig, SimulationShortId},
     SimRunConfig,
 };
 
@@ -35,7 +35,7 @@ impl SimConfigurer {
     pub fn configure_next(
         &mut self,
         exp_config: &Arc<ExperimentConfig>,
-        id: SimulationShortID,
+        id: SimulationShortId,
         globals: Globals,
         store_config: StoreConfig,
         persistence_config: PersistenceConfig,

--- a/packages/engine/src/experiment/error.rs
+++ b/packages/engine/src/experiment/error.rs
@@ -16,7 +16,7 @@ pub enum Error {
     NoSimulationRuns,
 
     #[error("Unexpected simulation run id ({0}) received")]
-    MissingSimulationRun(super::SimulationShortID),
+    MissingSimulationRun(super::SimulationShortId),
 
     #[error("Unexpected opt client id received: {0:?}")]
     MissingClient(String, String),

--- a/packages/engine/src/experiment/mod.rs
+++ b/packages/engine/src/experiment/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     config::{ExperimentConfig, Globals},
     experiment::controller::comms::{exp_pkg_ctl::ExpPkgCtlSend, exp_pkg_update::ExpPkgUpdateRecv},
     proto,
-    proto::{ExperimentPackageConfig, SimulationShortID},
+    proto::{ExperimentPackageConfig, SimulationShortId},
 };
 
 pub type SharedDataset = proto::SharedDataset;
@@ -87,13 +87,13 @@ pub struct Initializer {
 #[derive(Debug)]
 pub enum ExperimentControl {
     StartSim {
-        sim_id: SimulationShortID,
+        sim_id: SimulationShortId,
         changed_properties: serde_json::Value,
         max_num_steps: usize,
     },
-    PauseSim(SimulationShortID),
-    ResumeSim(SimulationShortID),
-    StopSim(SimulationShortID),
+    PauseSim(SimulationShortId),
+    ResumeSim(SimulationShortId),
+    StopSim(SimulationShortId),
 }
 
 pub fn init_exp_package(

--- a/packages/engine/src/experiment/package/mod.rs
+++ b/packages/engine/src/experiment/package/mod.rs
@@ -12,7 +12,7 @@ use super::{
 use crate::{
     config::ExperimentConfig,
     init_exp_package,
-    proto::{ExperimentRunTrait, PackageConfig, SimulationShortID},
+    proto::{ExperimentRunTrait, PackageConfig, SimulationShortId},
 };
 
 pub struct ExperimentPackageComms {
@@ -51,7 +51,7 @@ impl ExperimentPackage {
 
 #[derive(Debug)]
 pub struct StepUpdate {
-    pub sim_id: SimulationShortID,
+    pub sim_id: SimulationShortId,
     pub was_error: bool,
     pub stop_signal: bool,
 }

--- a/packages/engine/src/experiment/package/simple.rs
+++ b/packages/engine/src/experiment/package/simple.rs
@@ -4,7 +4,7 @@ use super::super::{Error, ExperimentControl, Result};
 use crate::{
     config::ExperimentConfig,
     experiment::controller::comms::{exp_pkg_ctl::ExpPkgCtlSend, exp_pkg_update::ExpPkgUpdateRecv},
-    proto::{SimpleExperimentConfig, SimulationShortID},
+    proto::{SimpleExperimentConfig, SimulationShortId},
 };
 
 pub struct SimpleExperiment {
@@ -44,13 +44,13 @@ impl SimpleExperiment {
         let mut n_sims_steps = HashMap::new();
         let num_sims = self.config.changed_properties.len();
         for (sim_index, changed_properties) in self.config.changed_properties.iter().enumerate() {
-            let sim_id = sim_index + 1; // We sometimes use 0 as a default/null value, therefore it's not a valid SimulationShortID
-            n_sims_steps.insert(sim_id as SimulationShortID, StepProgress {
+            let sim_id = sim_index + 1; // We sometimes use 0 as a default/null value, therefore it's not a valid SimulationShortId
+            n_sims_steps.insert(sim_id as SimulationShortId, StepProgress {
                 n_steps: 0,
                 stopped: false,
             });
             let msg = ExperimentControl::StartSim {
-                sim_id: sim_id as SimulationShortID,
+                sim_id: sim_id as SimulationShortId,
                 changed_properties: changed_properties.clone(),
                 max_num_steps,
             };

--- a/packages/engine/src/experiment/package/single.rs
+++ b/packages/engine/src/experiment/package/single.rs
@@ -4,7 +4,7 @@ use super::super::{Error, ExperimentControl, Result};
 use crate::{
     config::ExperimentConfig,
     experiment::controller::comms::{exp_pkg_ctl::ExpPkgCtlSend, exp_pkg_update::ExpPkgUpdateRecv},
-    proto::{SimulationShortID, SingleRunExperimentConfig},
+    proto::{SimulationShortId, SingleRunExperimentConfig},
 };
 
 pub struct SingleRunExperiment {
@@ -29,7 +29,7 @@ impl SingleRunExperiment {
         mut pkg_from_exp: ExpPkgUpdateRecv,
     ) -> Result<()> {
         let msg = ExperimentControl::StartSim {
-            sim_id: 1 as SimulationShortID,
+            sim_id: 1 as SimulationShortId,
             changed_properties: serde_json::Map::new().into(), // Don't change properties
             max_num_steps: self.config.num_steps,
         };

--- a/packages/engine/src/gen/init_generated.rs
+++ b/packages/engine/src/gen/init_generated.rs
@@ -21,65 +21,65 @@ use super::{
 extern crate flatbuffers;
 use self::flatbuffers::{EndianScalar, Follow};
 
-// struct ExperimentID, aligned to 1
+// struct ExperimentId, aligned to 1
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
-pub struct ExperimentID(pub [u8; 16]);
-impl Default for ExperimentID {
+pub struct ExperimentId(pub [u8; 16]);
+impl Default for ExperimentId {
     fn default() -> Self {
         Self([0; 16])
     }
 }
-impl std::fmt::Debug for ExperimentID {
+impl std::fmt::Debug for ExperimentId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.debug_struct("ExperimentID")
+        f.debug_struct("ExperimentId")
             .field("inner", &self.inner())
             .finish()
     }
 }
 
-impl flatbuffers::SimpleToVerifyInSlice for ExperimentID {}
-impl flatbuffers::SafeSliceAccess for ExperimentID {}
-impl<'a> flatbuffers::Follow<'a> for ExperimentID {
-    type Inner = &'a ExperimentID;
+impl flatbuffers::SimpleToVerifyInSlice for ExperimentId {}
+impl flatbuffers::SafeSliceAccess for ExperimentId {}
+impl<'a> flatbuffers::Follow<'a> for ExperimentId {
+    type Inner = &'a ExperimentId;
 
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        <&'a ExperimentID>::follow(buf, loc)
+        <&'a ExperimentId>::follow(buf, loc)
     }
 }
-impl<'a> flatbuffers::Follow<'a> for &'a ExperimentID {
-    type Inner = &'a ExperimentID;
+impl<'a> flatbuffers::Follow<'a> for &'a ExperimentId {
+    type Inner = &'a ExperimentId;
 
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        flatbuffers::follow_cast_ref::<ExperimentID>(buf, loc)
+        flatbuffers::follow_cast_ref::<ExperimentId>(buf, loc)
     }
 }
-impl<'b> flatbuffers::Push for ExperimentID {
-    type Output = ExperimentID;
+impl<'b> flatbuffers::Push for ExperimentId {
+    type Output = ExperimentId;
 
     #[inline]
     fn push(&self, dst: &mut [u8], _rest: &[u8]) {
         let src = unsafe {
-            ::std::slice::from_raw_parts(self as *const ExperimentID as *const u8, Self::size())
+            ::std::slice::from_raw_parts(self as *const ExperimentId as *const u8, Self::size())
         };
         dst.copy_from_slice(src);
     }
 }
-impl<'b> flatbuffers::Push for &'b ExperimentID {
-    type Output = ExperimentID;
+impl<'b> flatbuffers::Push for &'b ExperimentId {
+    type Output = ExperimentId;
 
     #[inline]
     fn push(&self, dst: &mut [u8], _rest: &[u8]) {
         let src = unsafe {
-            ::std::slice::from_raw_parts(*self as *const ExperimentID as *const u8, Self::size())
+            ::std::slice::from_raw_parts(*self as *const ExperimentId as *const u8, Self::size())
         };
         dst.copy_from_slice(src);
     }
 }
 
-impl<'a> flatbuffers::Verifiable for ExperimentID {
+impl<'a> flatbuffers::Verifiable for ExperimentId {
     #[inline]
     fn run_verifier(
         v: &mut flatbuffers::Verifier,
@@ -89,7 +89,7 @@ impl<'a> flatbuffers::Verifiable for ExperimentID {
         v.in_buffer::<Self>(pos)
     }
 }
-impl<'a> ExperimentID {
+impl<'a> ExperimentId {
     #[allow(clippy::too_many_arguments)]
     pub fn new(inner: &[i8; 16]) -> Self {
         let mut s = Self([0; 16]);
@@ -155,8 +155,8 @@ impl<'a> Init<'a> {
     }
 
     #[inline]
-    pub fn experiment_id(&self) -> Option<&'a ExperimentID> {
-        self._tab.get::<ExperimentID>(Init::VT_EXPERIMENT_ID, None)
+    pub fn experiment_id(&self) -> Option<&'a ExperimentId> {
+        self._tab.get::<ExperimentId>(Init::VT_EXPERIMENT_ID, None)
     }
 
     #[inline]
@@ -189,7 +189,7 @@ impl flatbuffers::Verifiable for Init<'_> {
     ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
         use self::flatbuffers::Verifiable;
         v.visit_table(pos)?
-            .visit_field::<ExperimentID>(&"experiment_id", Self::VT_EXPERIMENT_ID, false)?
+            .visit_field::<ExperimentId>(&"experiment_id", Self::VT_EXPERIMENT_ID, false)?
             .visit_field::<u64>(&"worker_index", Self::VT_WORKER_INDEX, false)?
             .visit_field::<flatbuffers::ForwardsUOffset<SharedContext>>(
                 &"shared_context",
@@ -206,7 +206,7 @@ impl flatbuffers::Verifiable for Init<'_> {
     }
 }
 pub struct InitArgs<'a> {
-    pub experiment_id: Option<&'a ExperimentID>,
+    pub experiment_id: Option<&'a ExperimentId>,
     pub worker_index: u64,
     pub shared_context: Option<flatbuffers::WIPOffset<SharedContext<'a>>>,
     pub package_config: Option<flatbuffers::WIPOffset<PackageConfig<'a>>>,
@@ -228,9 +228,9 @@ pub struct InitBuilder<'a: 'b, 'b> {
 }
 impl<'a: 'b, 'b> InitBuilder<'a, 'b> {
     #[inline]
-    pub fn add_experiment_id(&mut self, experiment_id: &ExperimentID) {
+    pub fn add_experiment_id(&mut self, experiment_id: &ExperimentId) {
         self.fbb_
-            .push_slot_always::<&ExperimentID>(Init::VT_EXPERIMENT_ID, experiment_id);
+            .push_slot_always::<&ExperimentId>(Init::VT_EXPERIMENT_ID, experiment_id);
     }
 
     #[inline]

--- a/packages/engine/src/gen/runner_inbound_msg_generated.rs
+++ b/packages/engine/src/gen/runner_inbound_msg_generated.rs
@@ -157,65 +157,65 @@ impl<'a> flatbuffers::Verifiable for RunnerInboundMsgPayload {
 impl flatbuffers::SimpleToVerifyInSlice for RunnerInboundMsgPayload {}
 pub struct RunnerInboundMsgPayloadUnionTableOffset {}
 
-// struct TaskID, aligned to 1
+// struct TaskId, aligned to 1
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
-pub struct TaskID(pub [u8; 16]);
-impl Default for TaskID {
+pub struct TaskId(pub [u8; 16]);
+impl Default for TaskId {
     fn default() -> Self {
         Self([0; 16])
     }
 }
-impl std::fmt::Debug for TaskID {
+impl std::fmt::Debug for TaskId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.debug_struct("TaskID")
+        f.debug_struct("TaskId")
             .field("inner", &self.inner())
             .finish()
     }
 }
 
-impl flatbuffers::SimpleToVerifyInSlice for TaskID {}
-impl flatbuffers::SafeSliceAccess for TaskID {}
-impl<'a> flatbuffers::Follow<'a> for TaskID {
-    type Inner = &'a TaskID;
+impl flatbuffers::SimpleToVerifyInSlice for TaskId {}
+impl flatbuffers::SafeSliceAccess for TaskId {}
+impl<'a> flatbuffers::Follow<'a> for TaskId {
+    type Inner = &'a TaskId;
 
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        <&'a TaskID>::follow(buf, loc)
+        <&'a TaskId>::follow(buf, loc)
     }
 }
-impl<'a> flatbuffers::Follow<'a> for &'a TaskID {
-    type Inner = &'a TaskID;
+impl<'a> flatbuffers::Follow<'a> for &'a TaskId {
+    type Inner = &'a TaskId;
 
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        flatbuffers::follow_cast_ref::<TaskID>(buf, loc)
+        flatbuffers::follow_cast_ref::<TaskId>(buf, loc)
     }
 }
-impl<'b> flatbuffers::Push for TaskID {
-    type Output = TaskID;
+impl<'b> flatbuffers::Push for TaskId {
+    type Output = TaskId;
 
     #[inline]
     fn push(&self, dst: &mut [u8], _rest: &[u8]) {
         let src = unsafe {
-            ::std::slice::from_raw_parts(self as *const TaskID as *const u8, Self::size())
+            ::std::slice::from_raw_parts(self as *const TaskId as *const u8, Self::size())
         };
         dst.copy_from_slice(src);
     }
 }
-impl<'b> flatbuffers::Push for &'b TaskID {
-    type Output = TaskID;
+impl<'b> flatbuffers::Push for &'b TaskId {
+    type Output = TaskId;
 
     #[inline]
     fn push(&self, dst: &mut [u8], _rest: &[u8]) {
         let src = unsafe {
-            ::std::slice::from_raw_parts(*self as *const TaskID as *const u8, Self::size())
+            ::std::slice::from_raw_parts(*self as *const TaskId as *const u8, Self::size())
         };
         dst.copy_from_slice(src);
     }
 }
 
-impl<'a> flatbuffers::Verifiable for TaskID {
+impl<'a> flatbuffers::Verifiable for TaskId {
     #[inline]
     fn run_verifier(
         v: &mut flatbuffers::Verifier,
@@ -225,7 +225,7 @@ impl<'a> flatbuffers::Verifiable for TaskID {
         v.in_buffer::<Self>(pos)
     }
 }
-impl<'a> TaskID {
+impl<'a> TaskId {
     #[allow(clippy::too_many_arguments)]
     pub fn new(inner: &[i8; 16]) -> Self {
         let mut s = Self([0; 16]);
@@ -298,8 +298,8 @@ impl<'a> TaskMsg<'a> {
     }
 
     #[inline]
-    pub fn task_id(&self) -> Option<&'a TaskID> {
-        self._tab.get::<TaskID>(TaskMsg::VT_TASK_ID, None)
+    pub fn task_id(&self) -> Option<&'a TaskId> {
+        self._tab.get::<TaskId>(TaskMsg::VT_TASK_ID, None)
     }
 
     #[inline]
@@ -325,7 +325,7 @@ impl flatbuffers::Verifiable for TaskMsg<'_> {
         use self::flatbuffers::Verifiable;
         v.visit_table(pos)?
             .visit_field::<u64>(&"package_sid", Self::VT_PACKAGE_SID, false)?
-            .visit_field::<TaskID>(&"task_id", Self::VT_TASK_ID, false)?
+            .visit_field::<TaskId>(&"task_id", Self::VT_TASK_ID, false)?
             .visit_field::<flatbuffers::ForwardsUOffset<StateInterimSync>>(
                 &"metaversioning",
                 Self::VT_METAVERSIONING,
@@ -342,7 +342,7 @@ impl flatbuffers::Verifiable for TaskMsg<'_> {
 }
 pub struct TaskMsgArgs<'a> {
     pub package_sid: u64,
-    pub task_id: Option<&'a TaskID>,
+    pub task_id: Option<&'a TaskId>,
     pub metaversioning: Option<flatbuffers::WIPOffset<StateInterimSync<'a>>>,
     pub payload: Option<flatbuffers::WIPOffset<Serialized<'a>>>,
 }
@@ -369,9 +369,9 @@ impl<'a: 'b, 'b> TaskMsgBuilder<'a, 'b> {
     }
 
     #[inline]
-    pub fn add_task_id(&mut self, task_id: &TaskID) {
+    pub fn add_task_id(&mut self, task_id: &TaskId) {
         self.fbb_
-            .push_slot_always::<&TaskID>(TaskMsg::VT_TASK_ID, task_id);
+            .push_slot_always::<&TaskId>(TaskMsg::VT_TASK_ID, task_id);
     }
 
     #[inline]
@@ -458,8 +458,8 @@ impl<'a> CancelTask<'a> {
     }
 
     #[inline]
-    pub fn task_id(&self) -> Option<&'a TaskID> {
-        self._tab.get::<TaskID>(CancelTask::VT_TASK_ID, None)
+    pub fn task_id(&self) -> Option<&'a TaskId> {
+        self._tab.get::<TaskId>(CancelTask::VT_TASK_ID, None)
     }
 }
 
@@ -471,13 +471,13 @@ impl flatbuffers::Verifiable for CancelTask<'_> {
     ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
         use self::flatbuffers::Verifiable;
         v.visit_table(pos)?
-            .visit_field::<TaskID>(&"task_id", Self::VT_TASK_ID, false)?
+            .visit_field::<TaskId>(&"task_id", Self::VT_TASK_ID, false)?
             .finish();
         Ok(())
     }
 }
 pub struct CancelTaskArgs<'a> {
-    pub task_id: Option<&'a TaskID>,
+    pub task_id: Option<&'a TaskId>,
 }
 impl<'a> Default for CancelTaskArgs<'a> {
     #[inline]
@@ -491,9 +491,9 @@ pub struct CancelTaskBuilder<'a: 'b, 'b> {
 }
 impl<'a: 'b, 'b> CancelTaskBuilder<'a, 'b> {
     #[inline]
-    pub fn add_task_id(&mut self, task_id: &TaskID) {
+    pub fn add_task_id(&mut self, task_id: &TaskId) {
         self.fbb_
-            .push_slot_always::<&TaskID>(CancelTask::VT_TASK_ID, task_id);
+            .push_slot_always::<&TaskId>(CancelTask::VT_TASK_ID, task_id);
     }
 
     #[inline]

--- a/packages/engine/src/gen/runner_outbound_msg_generated.rs
+++ b/packages/engine/src/gen/runner_outbound_msg_generated.rs
@@ -158,65 +158,65 @@ impl<'a> flatbuffers::Verifiable for RunnerOutboundMsgPayload {
 impl flatbuffers::SimpleToVerifyInSlice for RunnerOutboundMsgPayload {}
 pub struct RunnerOutboundMsgPayloadUnionTableOffset {}
 
-// struct TaskID, aligned to 1
+// struct TaskId, aligned to 1
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
-pub struct TaskID(pub [u8; 16]);
-impl Default for TaskID {
+pub struct TaskId(pub [u8; 16]);
+impl Default for TaskId {
     fn default() -> Self {
         Self([0; 16])
     }
 }
-impl std::fmt::Debug for TaskID {
+impl std::fmt::Debug for TaskId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.debug_struct("TaskID")
+        f.debug_struct("TaskId")
             .field("inner", &self.inner())
             .finish()
     }
 }
 
-impl flatbuffers::SimpleToVerifyInSlice for TaskID {}
-impl flatbuffers::SafeSliceAccess for TaskID {}
-impl<'a> flatbuffers::Follow<'a> for TaskID {
-    type Inner = &'a TaskID;
+impl flatbuffers::SimpleToVerifyInSlice for TaskId {}
+impl flatbuffers::SafeSliceAccess for TaskId {}
+impl<'a> flatbuffers::Follow<'a> for TaskId {
+    type Inner = &'a TaskId;
 
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        <&'a TaskID>::follow(buf, loc)
+        <&'a TaskId>::follow(buf, loc)
     }
 }
-impl<'a> flatbuffers::Follow<'a> for &'a TaskID {
-    type Inner = &'a TaskID;
+impl<'a> flatbuffers::Follow<'a> for &'a TaskId {
+    type Inner = &'a TaskId;
 
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        flatbuffers::follow_cast_ref::<TaskID>(buf, loc)
+        flatbuffers::follow_cast_ref::<TaskId>(buf, loc)
     }
 }
-impl<'b> flatbuffers::Push for TaskID {
-    type Output = TaskID;
+impl<'b> flatbuffers::Push for TaskId {
+    type Output = TaskId;
 
     #[inline]
     fn push(&self, dst: &mut [u8], _rest: &[u8]) {
         let src = unsafe {
-            ::std::slice::from_raw_parts(self as *const TaskID as *const u8, Self::size())
+            ::std::slice::from_raw_parts(self as *const TaskId as *const u8, Self::size())
         };
         dst.copy_from_slice(src);
     }
 }
-impl<'b> flatbuffers::Push for &'b TaskID {
-    type Output = TaskID;
+impl<'b> flatbuffers::Push for &'b TaskId {
+    type Output = TaskId;
 
     #[inline]
     fn push(&self, dst: &mut [u8], _rest: &[u8]) {
         let src = unsafe {
-            ::std::slice::from_raw_parts(*self as *const TaskID as *const u8, Self::size())
+            ::std::slice::from_raw_parts(*self as *const TaskId as *const u8, Self::size())
         };
         dst.copy_from_slice(src);
     }
 }
 
-impl<'a> flatbuffers::Verifiable for TaskID {
+impl<'a> flatbuffers::Verifiable for TaskId {
     #[inline]
     fn run_verifier(
         v: &mut flatbuffers::Verifier,
@@ -226,7 +226,7 @@ impl<'a> flatbuffers::Verifiable for TaskID {
         v.in_buffer::<Self>(pos)
     }
 }
-impl<'a> TaskID {
+impl<'a> TaskId {
     #[allow(clippy::too_many_arguments)]
     pub fn new(inner: &[i8; 16]) -> Self {
         let mut s = Self([0; 16]);
@@ -301,8 +301,8 @@ impl<'a> TaskMsg<'a> {
     }
 
     #[inline]
-    pub fn task_id(&self) -> Option<&'a TaskID> {
-        self._tab.get::<TaskID>(TaskMsg::VT_TASK_ID, None)
+    pub fn task_id(&self) -> Option<&'a TaskId> {
+        self._tab.get::<TaskId>(TaskMsg::VT_TASK_ID, None)
     }
 
     #[inline]
@@ -335,7 +335,7 @@ impl flatbuffers::Verifiable for TaskMsg<'_> {
         use self::flatbuffers::Verifiable;
         v.visit_table(pos)?
             .visit_field::<u64>(&"package_sid", Self::VT_PACKAGE_SID, false)?
-            .visit_field::<TaskID>(&"task_id", Self::VT_TASK_ID, false)?
+            .visit_field::<TaskId>(&"task_id", Self::VT_TASK_ID, false)?
             .visit_field::<Target>(&"target", Self::VT_TARGET, false)?
             .visit_field::<flatbuffers::ForwardsUOffset<StateInterimSync>>(
                 &"metaversioning",
@@ -353,7 +353,7 @@ impl flatbuffers::Verifiable for TaskMsg<'_> {
 }
 pub struct TaskMsgArgs<'a> {
     pub package_sid: u64,
-    pub task_id: Option<&'a TaskID>,
+    pub task_id: Option<&'a TaskId>,
     pub target: Target,
     pub metaversioning: Option<flatbuffers::WIPOffset<StateInterimSync<'a>>>,
     pub payload: Option<flatbuffers::WIPOffset<Serialized<'a>>>,
@@ -382,9 +382,9 @@ impl<'a: 'b, 'b> TaskMsgBuilder<'a, 'b> {
     }
 
     #[inline]
-    pub fn add_task_id(&mut self, task_id: &TaskID) {
+    pub fn add_task_id(&mut self, task_id: &TaskId) {
         self.fbb_
-            .push_slot_always::<&TaskID>(TaskMsg::VT_TASK_ID, task_id);
+            .push_slot_always::<&TaskId>(TaskMsg::VT_TASK_ID, task_id);
     }
 
     #[inline]
@@ -478,8 +478,8 @@ impl<'a> TaskCancelled<'a> {
     }
 
     #[inline]
-    pub fn task_id(&self) -> Option<&'a TaskID> {
-        self._tab.get::<TaskID>(TaskCancelled::VT_TASK_ID, None)
+    pub fn task_id(&self) -> Option<&'a TaskId> {
+        self._tab.get::<TaskId>(TaskCancelled::VT_TASK_ID, None)
     }
 }
 
@@ -491,13 +491,13 @@ impl flatbuffers::Verifiable for TaskCancelled<'_> {
     ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
         use self::flatbuffers::Verifiable;
         v.visit_table(pos)?
-            .visit_field::<TaskID>(&"task_id", Self::VT_TASK_ID, false)?
+            .visit_field::<TaskId>(&"task_id", Self::VT_TASK_ID, false)?
             .finish();
         Ok(())
     }
 }
 pub struct TaskCancelledArgs<'a> {
-    pub task_id: Option<&'a TaskID>,
+    pub task_id: Option<&'a TaskId>,
 }
 impl<'a> Default for TaskCancelledArgs<'a> {
     #[inline]
@@ -511,9 +511,9 @@ pub struct TaskCancelledBuilder<'a: 'b, 'b> {
 }
 impl<'a: 'b, 'b> TaskCancelledBuilder<'a, 'b> {
     #[inline]
-    pub fn add_task_id(&mut self, task_id: &TaskID) {
+    pub fn add_task_id(&mut self, task_id: &TaskId) {
         self.fbb_
-            .push_slot_always::<&TaskID>(TaskCancelled::VT_TASK_ID, task_id);
+            .push_slot_always::<&TaskId>(TaskCancelled::VT_TASK_ID, task_id);
     }
 
     #[inline]

--- a/packages/engine/src/output/buffer/mod.rs
+++ b/packages/engine/src/output/buffer/mod.rs
@@ -6,7 +6,7 @@ pub use util::cleanup_experiment;
 
 use crate::{
     output::error::{Error, Result},
-    proto::{ExperimentID, SimulationShortID},
+    proto::{ExperimentId, SimulationShortId},
     simulation::package::{
         name::PackageName,
         output,
@@ -29,8 +29,8 @@ pub struct Buffers {
 
 impl Buffers {
     pub(crate) fn new(
-        exp_id: ExperimentID,
-        sim_id: SimulationShortID,
+        exp_id: ExperimentId,
+        sim_id: SimulationShortId,
         output_packages_sim_config: &OutputPackagesSimConfig,
     ) -> Result<Buffers> {
         Ok(Buffers {

--- a/packages/engine/src/output/buffer/part.rs
+++ b/packages/engine/src/output/buffer/part.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use super::RELATIVE_PARTS_FOLDER;
 use crate::{
     output::error::Result,
-    proto::{ExperimentID, SimulationShortID},
+    proto::{ExperimentId, SimulationShortId},
 };
 
 /// Maximum size of a string kept in memory.
@@ -31,8 +31,8 @@ pub struct OutputPartBuffer {
 impl OutputPartBuffer {
     pub fn new(
         output_type_name: &'static str,
-        experiment_id: ExperimentID,
-        simulation_run_id: SimulationShortID,
+        experiment_id: ExperimentId,
+        simulation_run_id: SimulationShortId,
     ) -> Result<OutputPartBuffer> {
         let mut base_path = PathBuf::from(RELATIVE_PARTS_FOLDER);
         base_path.push(experiment_id);

--- a/packages/engine/src/output/local/mod.rs
+++ b/packages/engine/src/output/local/mod.rs
@@ -7,12 +7,12 @@ use super::{buffer::Buffers, OutputPersistenceCreatorRepr};
 use crate::{
     config::PersistenceConfig,
     output::error::Result,
-    proto::{ExperimentID, SimulationShortID},
+    proto::{ExperimentId, SimulationShortId},
 };
 
 #[derive(new)]
 pub struct LocalOutputPersistence {
-    exp_id: ExperimentID,
+    exp_id: ExperimentId,
     config: LocalPersistenceConfig,
 }
 
@@ -21,7 +21,7 @@ impl OutputPersistenceCreatorRepr for LocalOutputPersistence {
 
     fn new_simulation(
         &self,
-        sim_id: SimulationShortID,
+        sim_id: SimulationShortId,
         persistence_config: &PersistenceConfig,
     ) -> Result<Self::SimulationOutputPersistence> {
         let buffers = Buffers::new(

--- a/packages/engine/src/output/local/sim.rs
+++ b/packages/engine/src/output/local/sim.rs
@@ -5,14 +5,14 @@ use crate::{
         error::{Error, Result},
         SimulationOutputPersistenceRepr,
     },
-    proto::{ExperimentID, SimulationShortID},
+    proto::{ExperimentId, SimulationShortId},
     simulation::{package::output::packages::Output, step_output::SimulationStepOutput},
 };
 
 #[derive(new)]
 pub struct LocalSimulationOutputPersistence {
-    exp_id: ExperimentID,
-    _sim_id: SimulationShortID, // TODO: Should this be unused? If so remove
+    exp_id: ExperimentId,
+    _sim_id: SimulationShortId, // TODO: Should this be unused? If so remove
     buffers: Buffers,
     config: LocalPersistenceConfig,
 }
@@ -27,7 +27,7 @@ impl SimulationOutputPersistenceRepr for LocalSimulationOutputPersistence {
                 Output::AnalysisOutput(output) => {
                     self.buffers.analysis.add(output)?;
                 }
-                Output::JSONStateOutput(output) => {
+                Output::JsonStateOutput(output) => {
                     self.buffers.json_state.append_step(output.inner)?;
                 }
             }

--- a/packages/engine/src/output/mod.rs
+++ b/packages/engine/src/output/mod.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 
 use crate::{
-    config::PersistenceConfig, proto::SimulationShortID,
+    config::PersistenceConfig, proto::SimulationShortId,
     simulation::step_output::SimulationStepOutput,
 };
 
@@ -17,7 +17,7 @@ pub trait OutputPersistenceCreatorRepr: Send + Sync + 'static {
     type SimulationOutputPersistence: SimulationOutputPersistenceRepr;
     fn new_simulation(
         &self,
-        sim_id: SimulationShortID,
+        sim_id: SimulationShortId,
         persistence_config: &PersistenceConfig,
     ) -> Result<Self::SimulationOutputPersistence>;
 }

--- a/packages/engine/src/output/none.rs
+++ b/packages/engine/src/output/none.rs
@@ -4,7 +4,7 @@ use super::{OutputPersistenceCreatorRepr, SimulationOutputPersistenceRepr};
 use crate::{
     config::PersistenceConfig,
     output::{error::Result, OutputPersistenceResultRepr},
-    proto::SimulationShortID,
+    proto::SimulationShortId,
     simulation::step_output::SimulationStepOutput,
 };
 
@@ -21,7 +21,7 @@ impl OutputPersistenceCreatorRepr for NoOutputPersistence {
 
     fn new_simulation(
         &self,
-        _sim_id: SimulationShortID,
+        _sim_id: SimulationShortId,
         _persistence_config: &PersistenceConfig,
     ) -> Result<Self::SimulationOutputPersistence> {
         Ok(NoSimulationOutputPersistence {})

--- a/packages/engine/src/proto.rs
+++ b/packages/engine/src/proto.rs
@@ -7,9 +7,9 @@ use crate::{config::Globals, hash_types::worker::RunnerError, simulation::status
 
 pub type SerdeMap = serde_json::Map<String, SerdeValue>;
 
-pub type ExperimentRegisteredID = String;
-pub type SimulationRegisteredID = String;
-pub type SimulationShortID = u32;
+pub type ExperimentRegisteredId = String;
+pub type SimulationRegisteredId = String;
+pub type SimulationShortId = u32;
 
 use crate::simulation::enum_dispatch::*;
 
@@ -28,20 +28,20 @@ pub enum EngineStatus {
     ProcessError(String),
     Stopping,
     SimStart {
-        sim_id: SimulationShortID,
+        sim_id: SimulationShortId,
         globals: Globals,
     },
-    SimStop(SimulationShortID),
+    SimStop(SimulationShortId),
     // TODO: OS - Confirm are these only Runner/Simulation errors, if so rename
-    Errors(Option<SimulationShortID>, Vec<RunnerError>),
-    Warnings(Option<SimulationShortID>, Vec<RunnerError>),
+    Errors(Option<SimulationShortId>, Vec<RunnerError>),
+    Warnings(Option<SimulationShortId>, Vec<RunnerError>),
 }
 
 /// The message type sent from the orchestrator to the engine.
 #[derive(Serialize, Deserialize, Debug)]
 pub enum EngineMsg {
     Init(InitMessage),
-    SimRegistered(SimulationShortID, SimulationRegisteredID),
+    SimRegistered(SimulationShortId, SimulationRegisteredId),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -297,7 +297,7 @@ pub enum ExperimentRunRepr {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct ExperimentRunBase {
-    pub id: ExperimentRegisteredID,
+    pub id: ExperimentRegisteredId,
     pub project_base: ProjectBase,
 }
 
@@ -377,7 +377,7 @@ pub struct ProcessedExperimentRun {
 }
 
 // TODO: Replace with UUID?
-pub type ExperimentID = String;
+pub type ExperimentId = String;
 
 /// A wrapper around an Option to avoid displaying the inner for Debug outputs,
 /// i.e. debug::Debug now outputs: `Some(..)`

--- a/packages/engine/src/simulation/comms/message.rs
+++ b/packages/engine/src/simulation/comms/message.rs
@@ -1,14 +1,14 @@
 use super::active::ActiveTaskExecutorComms;
 use crate::{
     datastore::table::{sync::SyncPayload, task_shared_store::TaskSharedStore},
-    proto::SimulationShortID,
+    proto::SimulationShortId,
     simulation::{package::id::PackageId, task::Task},
-    types::TaskID,
+    types::TaskId,
 };
 
 #[derive(new, Debug)]
 pub struct WrappedTask {
-    pub task_id: TaskID,
+    pub task_id: TaskId,
     pub package_id: PackageId,
     pub inner: Task,
     pub comms: ActiveTaskExecutorComms,
@@ -17,19 +17,19 @@ pub struct WrappedTask {
 
 #[derive(Debug)]
 pub struct EngineToWorkerPoolMsg {
-    pub sim_id: SimulationShortID,
+    pub sim_id: SimulationShortId,
     pub payload: EngineToWorkerPoolMsgPayload,
 }
 
 impl EngineToWorkerPoolMsg {
-    pub fn task(sim_id: SimulationShortID, task: WrappedTask) -> Self {
+    pub fn task(sim_id: SimulationShortId, task: WrappedTask) -> Self {
         Self {
             sim_id,
             payload: EngineToWorkerPoolMsgPayload::Task(task),
         }
     }
 
-    pub fn sync(sim_id: SimulationShortID, sync_msg: SyncPayload) -> Self {
+    pub fn sync(sim_id: SimulationShortId, sync_msg: SyncPayload) -> Self {
         Self {
             sim_id,
             payload: EngineToWorkerPoolMsgPayload::Sync(sync_msg),

--- a/packages/engine/src/simulation/comms/mod.rs
+++ b/packages/engine/src/simulation/comms/mod.rs
@@ -45,21 +45,21 @@ use crate::{
         },
     },
     hash_types::Agent,
-    proto::SimulationShortID,
-    types::TaskID,
+    proto::SimulationShortId,
+    types::TaskId,
     workerpool::comms::MainMsgSend,
 };
 
 #[derive(Clone)]
 /// All relevant to communication between the Loop and the Language Runtime(s)
 pub struct Comms {
-    sim_id: SimulationShortID,
+    sim_id: SimulationShortId,
     cmds: Arc<RwLock<CreateRemoveCommands>>,
     worker_pool_sender: MainMsgSend,
 }
 
 impl Comms {
-    pub fn new(sim_id: SimulationShortID, worker_pool_sender: MainMsgSend) -> Result<Comms> {
+    pub fn new(sim_id: SimulationShortId, worker_pool_sender: MainMsgSend) -> Result<Comms> {
         Ok(Comms {
             sim_id,
             cmds: Arc::new(RwLock::new(CreateRemoveCommands::default())),
@@ -151,7 +151,7 @@ impl Comms {
 }
 
 fn wrap_task<T: Into<Task>>(
-    task_id: TaskID,
+    task_id: TaskId,
     package_id: PackageId,
     task: T,
     shared_store: TaskSharedStore,

--- a/packages/engine/src/simulation/controller/mod.rs
+++ b/packages/engine/src/simulation/controller/mod.rs
@@ -17,14 +17,14 @@ use crate::{
         simulation::{new_pair, SimCtlRecv, SimCtlSend},
     },
     output::SimulationOutputPersistenceRepr,
-    proto::SimulationShortID,
+    proto::SimulationShortId,
     simulation::package::run::Packages,
     SimRunConfig,
 };
 
 pub struct SimulationController {
     pub sender: SimCtlSend,
-    pub task_handle: JoinHandle<Result<SimulationShortID>>,
+    pub task_handle: JoinHandle<Result<SimulationShortId>>,
 }
 
 impl SimulationController {
@@ -62,7 +62,7 @@ fn new_task_handle<P: SimulationOutputPersistenceRepr>(
     packages: Packages,
     shared_store: Arc<SharedStore>,
     persistence_service: P,
-) -> Result<JoinHandle<Result<SimulationShortID>>> {
+) -> Result<JoinHandle<Result<SimulationShortId>>> {
     let task = Box::pin(run::sim_run(
         config,
         shared_store,

--- a/packages/engine/src/simulation/controller/run.rs
+++ b/packages/engine/src/simulation/controller/run.rs
@@ -9,7 +9,7 @@ use crate::{
     experiment::controller::comms::{sim_status::SimStatusSend, simulation::SimCtlRecv},
     hash_types::worker::RunnerError,
     output::SimulationOutputPersistenceRepr,
-    proto::SimulationShortID,
+    proto::SimulationShortId,
     simulation::{
         agent_control::AgentControl, comms::Comms, controller::sim_control::SimControl,
         engine::Engine, package::run::Packages, status::SimStatus,
@@ -31,7 +31,7 @@ pub async fn sim_run<P: SimulationOutputPersistenceRepr>(
     mut sim_from_exp: SimCtlRecv,
     mut sims_to_exp: SimStatusSend,
     mut persistence_service: P,
-) -> Result<SimulationShortID> {
+) -> Result<SimulationShortId> {
     // TODO: This is (sometimes?) 0, why?
     let sim_run_id = config.sim.id;
     let max_num_steps = config.sim.max_num_steps;

--- a/packages/engine/src/simulation/controller/runs.rs
+++ b/packages/engine/src/simulation/controller/runs.rs
@@ -2,19 +2,19 @@ use futures::stream::{FuturesOrdered, StreamExt};
 use tokio::task::JoinHandle;
 
 use super::Result;
-use crate::proto::SimulationShortID;
+use crate::proto::SimulationShortId;
 
 #[derive(Default)]
 pub struct SimulationRuns {
-    inner: FuturesOrdered<JoinHandle<Result<SimulationShortID>>>,
+    inner: FuturesOrdered<JoinHandle<Result<SimulationShortId>>>,
 }
 
 impl SimulationRuns {
-    pub fn new_run(&mut self, handle: JoinHandle<Result<SimulationShortID>>) {
+    pub fn new_run(&mut self, handle: JoinHandle<Result<SimulationShortId>>) {
         self.inner.push(handle);
     }
 
-    pub async fn next(&mut self) -> Result<Option<Result<SimulationShortID>>>
+    pub async fn next(&mut self) -> Result<Option<Result<SimulationShortId>>>
     where
         Self: Unpin,
     {

--- a/packages/engine/src/simulation/error.rs
+++ b/packages/engine/src/simulation/error.rs
@@ -137,8 +137,8 @@ pub enum Error {
     KdTree(#[from] kdtree::ErrorKind),
 
     #[error("{0}")]
-    CustomAPIMessageError(
-        #[from] super::package::context::packages::api_requests::CustomAPIMessageError,
+    CustomApiMessageError(
+        #[from] super::package::context::packages::api_requests::CustomApiMessageError,
     ),
 
     #[error("Tokio Join Error: {0}")]

--- a/packages/engine/src/simulation/package/context/mod.rs
+++ b/packages/engine/src/simulation/package/context/mod.rs
@@ -4,7 +4,7 @@ pub use packages::{ContextTask, ContextTaskMessage, Name, PACKAGE_CREATORS};
 
 use super::{
     deps::Dependencies,
-    ext_traits::{GetWorkerSimStartMsg, MaybeCPUBound},
+    ext_traits::{GetWorkerSimStartMsg, MaybeCpuBound},
     prelude::*,
 };
 pub use crate::config::Globals;
@@ -25,7 +25,7 @@ use crate::{
 pub mod packages;
 
 #[async_trait]
-pub trait Package: MaybeCPUBound + GetWorkerSimStartMsg + Send + Sync {
+pub trait Package: MaybeCpuBound + GetWorkerSimStartMsg + Send + Sync {
     async fn run<'s>(
         &mut self,
         state: Arc<State>,

--- a/packages/engine/src/simulation/package/context/packages/agent_messages/fields.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/fields.rs
@@ -8,7 +8,7 @@ pub(super) const MESSAGES_FIELD_NAME: &str = "messages";
 fn agent_messages() -> FieldType {
     let variant = VariableLengthArray(Box::new(FieldType::new(
         FixedLengthArray {
-            kind: Box::new(FieldType::new(Preset(PresetFieldType::UInt32), false)),
+            kind: Box::new(FieldType::new(Preset(PresetFieldType::Uint32), false)),
             len: MESSAGE_INDEX_COUNT,
         },
         false,

--- a/packages/engine/src/simulation/package/context/packages/agent_messages/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/mod.rs
@@ -64,7 +64,7 @@ struct AgentMessages {
     context_field_spec_accessor: FieldSpecMapAccessor,
 }
 
-impl MaybeCPUBound for AgentMessages {
+impl MaybeCpuBound for AgentMessages {
     fn cpu_bound(&self) -> bool {
         CPU_BOUND
     }

--- a/packages/engine/src/simulation/package/context/packages/api_requests/handlers.rs
+++ b/packages/engine/src/simulation/package/context/packages/api_requests/handlers.rs
@@ -34,15 +34,15 @@ pub fn gather_requests<'a>(
     Ok(Requests { inner })
 }
 
-pub async fn run_custom_message_handler(name: &str, requests: Requests) -> Result<APIResponseMap> {
+pub async fn run_custom_message_handler(name: &str, requests: Requests) -> Result<ApiResponseMap> {
     match name {
         "mapbox" => handlers::mapbox::get(requests).await,
-        _ => Err(CustomAPIMessageError::InvalidCustomMessageHandler(name.to_string()).into()),
+        _ => Err(CustomApiMessageError::InvalidCustomMessageHandler(name.to_string()).into()),
     }
 }
 
 #[derive(ThisError, Debug)]
-pub enum CustomAPIMessageError {
+pub enum CustomApiMessageError {
     #[error("Mapbox error: {0}")]
     Mapbox(#[from] mapbox::MapboxError),
 
@@ -50,7 +50,7 @@ pub enum CustomAPIMessageError {
     InvalidCustomMessageHandler(String),
 }
 
-trait CustomError: Into<CustomAPIMessageError> {
+trait CustomError: Into<CustomApiMessageError> {
     fn conv(self) -> Error {
         self.into().into()
     }
@@ -96,7 +96,7 @@ pub mod mapbox {
         //     .map(|s| (from, s))
     }
 
-    pub async fn get<'a>(requests: Requests) -> Result<APIResponseMap> {
+    pub async fn get<'a>(requests: Requests) -> Result<ApiResponseMap> {
         let responses =
             futures::stream::iter(requests.inner.into_iter().map(|request| get_(request)))
                 .buffer_unordered(ACTIVE_REQUESTS)
@@ -114,7 +114,7 @@ pub mod mapbox {
             }
         });
 
-        return Ok(APIResponseMap {
+        return Ok(ApiResponseMap {
             from: "mapbox",
             r#type: "mapbox_response",
             map,

--- a/packages/engine/src/simulation/package/context/packages/api_requests/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/api_requests/mod.rs
@@ -5,8 +5,8 @@ mod writer;
 
 use arrow::datatypes::DataType;
 use futures::{stream::FuturesOrdered, StreamExt};
-pub use handlers::CustomAPIMessageError;
-use response::{APIResponseMap, APIResponses};
+pub use handlers::CustomApiMessageError;
+use response::{ApiResponseMap, ApiResponses};
 use serde_json::Value;
 
 use super::super::*;
@@ -40,7 +40,7 @@ impl PackageCreator for Creator {
         context_field_spec_accessor: FieldSpecMapAccessor,
     ) -> Result<Box<dyn ContextPackage>> {
         let custom_message_handlers = custom_message_handlers_from_properties(&config.sim.globals)?;
-        Ok(Box::new(APIRequests {
+        Ok(Box::new(ApiRequests {
             custom_message_handlers,
             context_field_spec_accessor,
         }))
@@ -64,25 +64,25 @@ impl GetWorkerExpStartMsg for Creator {
     }
 }
 
-struct APIRequests {
+struct ApiRequests {
     custom_message_handlers: Option<Vec<String>>,
     context_field_spec_accessor: FieldSpecMapAccessor,
 }
 
-impl MaybeCPUBound for APIRequests {
+impl MaybeCpuBound for ApiRequests {
     fn cpu_bound(&self) -> bool {
         CPU_BOUND
     }
 }
 
-impl GetWorkerSimStartMsg for APIRequests {
+impl GetWorkerSimStartMsg for ApiRequests {
     fn get_worker_sim_start_msg(&self) -> Result<Value> {
         Ok(Value::Null)
     }
 }
 
 #[async_trait]
-impl Package for APIRequests {
+impl Package for ApiRequests {
     async fn run<'s>(
         &mut self,
         state: Arc<State>,
@@ -107,7 +107,7 @@ impl Package for APIRequests {
                 })?;
             }
 
-            futs.collect::<Vec<Result<APIResponseMap>>>()
+            futs.collect::<Vec<Result<ApiResponseMap>>>()
                 .await
                 .into_iter()
                 .collect::<Result<_>>()
@@ -127,7 +127,7 @@ impl Package for APIRequests {
             })
             .collect::<Vec<_>>();
 
-        let api_responses = APIResponses::from(responses_per_agent);
+        let api_responses = ApiResponses::from(responses_per_agent);
         let field_key = self
             .context_field_spec_accessor
             .get_local_hidden_scoped_field_spec(API_RESPONSES_FIELD_NAME)?

--- a/packages/engine/src/simulation/package/context/packages/api_requests/response.rs
+++ b/packages/engine/src/simulation/package/context/packages/api_requests/response.rs
@@ -2,26 +2,26 @@ use std::{collections::HashMap, marker::PhantomData};
 
 use crate::datastore::UUID_V4_LEN;
 
-pub struct APIResponseToAnonymous {
+pub struct ApiResponseToAnonymous {
     pub from: &'static str,
     pub r#type: &'static str,
     pub data: String,
 }
 
 /// Struct returned by a custom message handler
-pub struct APIResponseMap {
+pub struct ApiResponseMap {
     pub from: &'static str,
     pub r#type: &'static str,
     pub map: HashMap<[u8; UUID_V4_LEN], Vec<String>>,
 }
 
-impl APIResponseMap {
-    pub fn take_for_agent(&mut self, id: &[u8; UUID_V4_LEN]) -> Vec<APIResponseToAnonymous> {
+impl ApiResponseMap {
+    pub fn take_for_agent(&mut self, id: &[u8; UUID_V4_LEN]) -> Vec<ApiResponseToAnonymous> {
         self.map
             .remove(id)
             .map(|v| {
                 v.into_iter()
-                    .map(|data| APIResponseToAnonymous {
+                    .map(|data| ApiResponseToAnonymous {
                         from: self.from,
                         r#type: self.r#type,
                         data,
@@ -47,7 +47,7 @@ pub struct SizedStringColumn {
 }
 
 /// Columnar native representation of external API responses
-pub struct APIResponses<'a> {
+pub struct ApiResponses<'a> {
     pub from: SizedStaticStringColumn,
     pub r#type: SizedStaticStringColumn,
     pub data: SizedStringColumn,
@@ -56,10 +56,10 @@ pub struct APIResponses<'a> {
     phantom: PhantomData<&'a ()>,
 }
 
-impl<'a> From<Vec<Vec<APIResponseToAnonymous>>> for APIResponses<'a> {
-    fn from(v: Vec<Vec<APIResponseToAnonymous>>) -> Self {
+impl<'a> From<Vec<Vec<ApiResponseToAnonymous>>> for ApiResponses<'a> {
+    fn from(v: Vec<Vec<ApiResponseToAnonymous>>) -> Self {
         // TODO: performance: into_iter to access fields at same time and avoid clones
-        APIResponses {
+        ApiResponses {
             from: SizedStaticStringColumn {
                 data: v
                     .iter()

--- a/packages/engine/src/simulation/package/context/packages/api_requests/writer.rs
+++ b/packages/engine/src/simulation/package/context/packages/api_requests/writer.rs
@@ -1,4 +1,4 @@
-use super::response::APIResponses;
+use super::response::ApiResponses;
 use crate::{
     datastore::{
         arrow::util::DataSliceUtils,
@@ -11,7 +11,7 @@ use crate::{
 const NUM_NODES: usize = 5;
 const NUM_BUFFERS: usize = 12;
 
-impl<'s> ContextColumnWriter for APIResponses<'s> {
+impl<'s> ContextColumnWriter for ApiResponses<'s> {
     fn get_dynamic_metadata(&self) -> DatastoreResult<ColumnDynamicMetadata> {
         let mut builder = ColumnDynamicMetadataBuilder::with_capacities(NUM_NODES, NUM_BUFFERS);
 

--- a/packages/engine/src/simulation/package/context/packages/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/mod.rs
@@ -27,7 +27,7 @@ use crate::{
 #[serde(rename_all = "snake_case")]
 pub enum Name {
     AgentMessages,
-    APIRequests,
+    ApiRequests,
     Neighbors,
 }
 
@@ -78,7 +78,7 @@ impl PackageCreators {
             AgentMessages,
             agent_messages::Creator::new(experiment_config)?,
         );
-        m.insert(APIRequests, api_requests::Creator::new(experiment_config)?);
+        m.insert(ApiRequests, api_requests::Creator::new(experiment_config)?);
         m.insert(Neighbors, neighbors::Creator::new(experiment_config)?);
         self.0
             .set(m)
@@ -120,7 +120,7 @@ lazy_static! {
             id: id_creator.next(),
             dependencies: agent_messages::Creator::dependencies()
         });
-        m.insert(APIRequests, PackageMetadata{
+        m.insert(ApiRequests, PackageMetadata{
             id: id_creator.next(),
             dependencies: api_requests::Creator::dependencies()
         });

--- a/packages/engine/src/simulation/package/context/packages/neighbors/fields.rs
+++ b/packages/engine/src/simulation/package/context/packages/neighbors/fields.rs
@@ -9,7 +9,7 @@ pub(super) const SEARCH_RADIUS_FIELD_NAME: &str = "search_radius";
 fn neighbors() -> FieldType {
     let variant = VariableLengthArray(Box::new(FieldType::new(
         FixedLengthArray {
-            kind: Box::new(FieldType::new(Preset(PresetFieldType::UInt32), false)),
+            kind: Box::new(FieldType::new(Preset(PresetFieldType::Uint32), false)),
             len: NEIGHBOR_INDEX_COUNT,
         },
         false,

--- a/packages/engine/src/simulation/package/context/packages/neighbors/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/neighbors/mod.rs
@@ -23,7 +23,7 @@ use crate::{
                 packages::neighbors::fields::NEIGHBORS_FIELD_NAME, ContextColumn, Package,
                 PackageCreator,
             },
-            ext_traits::{GetWorkerExpStartMsg, GetWorkerSimStartMsg, MaybeCPUBound},
+            ext_traits::{GetWorkerExpStartMsg, GetWorkerSimStartMsg, MaybeCpuBound},
             prelude::{ArrowArray, ContextPackage},
         },
         Result,
@@ -108,7 +108,7 @@ impl Neighbors {
     }
 }
 
-impl MaybeCPUBound for Neighbors {
+impl MaybeCpuBound for Neighbors {
     fn cpu_bound(&self) -> bool {
         CPU_BOUND
     }

--- a/packages/engine/src/simulation/package/creator.rs
+++ b/packages/engine/src/simulation/package/creator.rs
@@ -424,7 +424,7 @@ pub fn get_base_agent_fields() -> Result<Vec<RootFieldSpec>> {
             field_type: FieldType::new(
                 FieldTypeVariant::FixedLengthArray {
                     kind: Box::new(FieldType::new(
-                        FieldTypeVariant::Preset(PresetFieldType::UInt32),
+                        FieldTypeVariant::Preset(PresetFieldType::Uint32),
                         false,
                     )),
                     len: 2,
@@ -445,7 +445,7 @@ pub fn get_base_agent_fields() -> Result<Vec<RootFieldSpec>> {
         FieldSpec {
             name: CONTEXT_INDEX_FIELD_NAME.to_string(),
             field_type: FieldType::new(
-                FieldTypeVariant::Preset(PresetFieldType::UInt32),
+                FieldTypeVariant::Preset(PresetFieldType::Uint32),
                 // This key is not nullable because all agents have a context
                 false,
             ),

--- a/packages/engine/src/simulation/package/ext_traits.rs
+++ b/packages/engine/src/simulation/package/ext_traits.rs
@@ -29,6 +29,6 @@ pub trait GetWorkerSimStartMsg {
     fn get_worker_sim_start_msg(&self) -> Result<serde_json::Value>;
 }
 
-pub trait MaybeCPUBound {
+pub trait MaybeCpuBound {
     fn cpu_bound(&self) -> bool;
 }

--- a/packages/engine/src/simulation/package/init/mod.rs
+++ b/packages/engine/src/simulation/package/init/mod.rs
@@ -4,7 +4,7 @@ pub use packages::{InitTask, InitTaskMessage, Name, PACKAGE_CREATORS};
 
 use super::{
     deps::Dependencies,
-    ext_traits::{GetWorkerSimStartMsg, MaybeCPUBound},
+    ext_traits::{GetWorkerSimStartMsg, MaybeCpuBound},
     prelude::*,
 };
 pub use crate::{config::Globals, hash_types::Agent};
@@ -17,7 +17,7 @@ use crate::{
 pub mod packages;
 
 #[async_trait]
-pub trait Package: MaybeCPUBound + GetWorkerSimStartMsg + Send + Sync {
+pub trait Package: MaybeCpuBound + GetWorkerSimStartMsg + Send + Sync {
     async fn run(&mut self) -> Result<Vec<Agent>>;
 }
 

--- a/packages/engine/src/simulation/package/init/packages/json/mod.rs
+++ b/packages/engine/src/simulation/package/init/packages/json/mod.rs
@@ -45,7 +45,7 @@ pub struct Package {
     initial_state_src: String,
 }
 
-impl MaybeCPUBound for Package {
+impl MaybeCpuBound for Package {
     fn cpu_bound(&self) -> bool {
         false
     }

--- a/packages/engine/src/simulation/package/init/packages/jspy/mod.rs
+++ b/packages/engine/src/simulation/package/init/packages/jspy/mod.rs
@@ -60,7 +60,7 @@ pub struct Package {
     comms: PackageComms,
 }
 
-impl MaybeCPUBound for Package {
+impl MaybeCpuBound for Package {
     fn cpu_bound(&self) -> bool {
         false
     }

--- a/packages/engine/src/simulation/package/init/packages/mod.rs
+++ b/packages/engine/src/simulation/package/init/packages/mod.rs
@@ -26,8 +26,8 @@ pub mod jspy;
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Name {
-    JSON,
-    JSPY,
+    Json,
+    JsPy,
 }
 
 impl std::fmt::Display for Name {
@@ -67,8 +67,8 @@ impl PackageCreators {
         log::debug!("Initializing Init Package Creators");
         use Name::*;
         let mut m = HashMap::new();
-        m.insert(JSON, json::Creator::new(experiment_config)?);
-        m.insert(JSPY, jspy::Creator::new(experiment_config)?);
+        m.insert(Json, json::Creator::new(experiment_config)?);
+        m.insert(JsPy, jspy::Creator::new(experiment_config)?);
         self.0
             .set(m)
             .map_err(|_| Error::from("Failed to initialize Init Package Creators"))?;
@@ -104,11 +104,11 @@ lazy_static! {
         use Name::*;
         let mut id_creator = PackageIdGenerator::new(PackageType::Init);
         let mut m = HashMap::new();
-        m.insert(JSON, PackageMetadata {
+        m.insert(Json, PackageMetadata {
             id: id_creator.next(),
             dependencies: json::Creator::dependencies(),
         });
-        m.insert(JSPY, PackageMetadata {
+        m.insert(JsPy, PackageMetadata {
             id: id_creator.next(),
             dependencies: jspy::Creator::dependencies(),
         });

--- a/packages/engine/src/simulation/package/output/mod.rs
+++ b/packages/engine/src/simulation/package/output/mod.rs
@@ -7,7 +7,7 @@ pub use packages::{Name, OutputTask, OutputTaskMessage, PACKAGE_CREATORS};
 use self::packages::Output;
 use super::{
     deps::Dependencies,
-    ext_traits::{GetWorkerSimStartMsg, MaybeCPUBound},
+    ext_traits::{GetWorkerSimStartMsg, MaybeCpuBound},
     prelude::*,
 };
 pub use crate::config::Globals;
@@ -58,6 +58,6 @@ pub trait PackageCreator: GetWorkerExpStartMsg + Sync + Send {
 }
 
 #[async_trait]
-pub trait Package: MaybeCPUBound + GetWorkerSimStartMsg + Send + Sync {
+pub trait Package: MaybeCpuBound + GetWorkerSimStartMsg + Send + Sync {
     async fn run(&mut self, state: Arc<State>, context: Arc<Context>) -> Result<Output>;
 }

--- a/packages/engine/src/simulation/package/output/packages/analysis/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/analysis/mod.rs
@@ -66,7 +66,7 @@ struct Analysis {
     analyzer: Analyzer,
 }
 
-impl MaybeCPUBound for Analysis {
+impl MaybeCpuBound for Analysis {
     fn cpu_bound(&self) -> bool {
         true
     }

--- a/packages/engine/src/simulation/package/output/packages/json_state/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/json_state/mod.rs
@@ -37,7 +37,7 @@ struct JsonState {
     config: Arc<SimRunConfig>,
 }
 
-impl MaybeCPUBound for JsonState {
+impl MaybeCpuBound for JsonState {
     fn cpu_bound(&self) -> bool {
         true
     }
@@ -65,13 +65,13 @@ impl Package for JsonState {
 
         let agent_states: Vec<_> = agent_states?.into_iter().flatten().collect();
 
-        Ok(Output::JSONStateOutput(JSONStateOutput {
+        Ok(Output::JsonStateOutput(JsonStateOutput {
             inner: agent_states,
         }))
     }
 }
 
 #[derive(Debug)]
-pub struct JSONStateOutput {
+pub struct JsonStateOutput {
     pub inner: Vec<Agent>,
 }

--- a/packages/engine/src/simulation/package/output/packages/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/mod.rs
@@ -11,7 +11,7 @@ use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use strum_macros::IntoStaticStr;
 
-use self::{analysis::AnalysisOutput, json_state::JSONStateOutput};
+use self::{analysis::AnalysisOutput, json_state::JsonStateOutput};
 use super::PackageCreator;
 use crate::{
     simulation::{
@@ -27,7 +27,7 @@ use crate::{
 #[serde(rename_all = "snake_case")]
 pub enum Name {
     Analysis,
-    JSONState,
+    JsonState,
 }
 
 impl std::fmt::Display for Name {
@@ -49,7 +49,7 @@ pub struct OutputPackagesSimConfig {
 #[derive(Debug)]
 pub enum Output {
     AnalysisOutput,
-    JSONStateOutput,
+    JsonStateOutput,
 }
 
 /// All output package tasks are registered in this enum
@@ -85,7 +85,7 @@ impl PackageCreators {
         use Name::*;
         let mut m = HashMap::new();
         m.insert(Analysis, analysis::Creator::new(experiment_config)?);
-        m.insert(JSONState, json_state::Creator::new(experiment_config)?);
+        m.insert(JsonState, json_state::Creator::new(experiment_config)?);
         self.0
             .set(m)
             .map_err(|_| Error::from("Failed to initialize Output Package Creators"))?;
@@ -125,7 +125,7 @@ lazy_static! {
             id: id_creator.next(),
             dependencies: analysis::Creator::dependencies(),
         });
-        m.insert(JSONState, PackageMetadata {
+        m.insert(JsonState, PackageMetadata {
             id: id_creator.next(),
             dependencies: json_state::Creator::dependencies(),
         });

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/fields/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/fields/mod.rs
@@ -37,7 +37,7 @@ fn get_behavior_index_field_spec(
 }
 
 fn behavior_id_inner_field_type() -> FieldType {
-    FieldType::new(FTV::Preset(PresetFieldType::UInt16), false)
+    FieldType::new(FTV::Preset(PresetFieldType::Uint16), false)
 }
 
 fn behavior_id_field_type() -> FieldType {

--- a/packages/engine/src/simulation/status.rs
+++ b/packages/engine/src/simulation/status.rs
@@ -2,13 +2,13 @@ use serde::{Deserialize, Serialize};
 
 use super::Result;
 use crate::{
-    hash_types::worker::RunnerError, output::OutputPersistenceResultRepr, proto::SimulationShortID,
+    hash_types::worker::RunnerError, output::OutputPersistenceResultRepr, proto::SimulationShortId,
 };
 
 // Sent from sim runs to experiment main loop.
 #[derive(Default, Debug, Serialize, Deserialize, PartialEq)]
 pub struct SimStatus {
-    pub sim_id: SimulationShortID,
+    pub sim_id: SimulationShortId,
     pub steps_taken: isize,
     pub early_stop: bool,
     pub stop_msg: Option<serde_json::Value>,
@@ -22,7 +22,7 @@ pub struct SimStatus {
 }
 
 impl SimStatus {
-    pub fn running(sim_id: SimulationShortID, steps_taken: isize) -> SimStatus {
+    pub fn running(sim_id: SimulationShortId, steps_taken: isize) -> SimStatus {
         SimStatus {
             sim_id,
             steps_taken,
@@ -32,7 +32,7 @@ impl SimStatus {
     }
 
     // TODO: Check this makes sense, default gives misleading amount of steps etc.
-    pub fn stop_signal(sim_id: SimulationShortID) -> SimStatus {
+    pub fn stop_signal(sim_id: SimulationShortId) -> SimStatus {
         SimStatus {
             sim_id,
             running: false,
@@ -42,7 +42,7 @@ impl SimStatus {
     }
 
     pub fn ended<P: OutputPersistenceResultRepr>(
-        sim_id: SimulationShortID,
+        sim_id: SimulationShortId,
         steps_taken: isize,
         early_stop: bool,
         stop_msg: Option<serde_json::Value>,
@@ -61,7 +61,7 @@ impl SimStatus {
     }
 
     pub fn error<P: OutputPersistenceResultRepr>(
-        sim_id: SimulationShortID,
+        sim_id: SimulationShortId,
         steps_taken: isize,
         error: RunnerError,
         persistence_result: Option<P>,

--- a/packages/engine/src/simulation/step_result.rs
+++ b/packages/engine/src/simulation/step_result.rs
@@ -1,8 +1,8 @@
 use super::{agent_control::AgentControl, step_output::SimulationStepOutput};
-use crate::{hash_types::worker::RunnerError, proto::SimulationShortID};
+use crate::{hash_types::worker::RunnerError, proto::SimulationShortId};
 
 pub struct SimulationStepResult {
-    pub sim_id: SimulationShortID,
+    pub sim_id: SimulationShortId,
     pub output: SimulationStepOutput,
     pub errors: Vec<RunnerError>,
     pub warnings: Vec<RunnerError>,

--- a/packages/engine/src/types.rs
+++ b/packages/engine/src/types.rs
@@ -1,5 +1,5 @@
 pub const BATCH_ID_LENGTH: usize = 32;
-pub type BatchID = [u8; BATCH_ID_LENGTH];
+pub type BatchId = [u8; BATCH_ID_LENGTH];
 
 pub type WorkerIndex = usize;
-pub type TaskID = u128;
+pub type TaskId = u128;

--- a/packages/engine/src/worker/error.rs
+++ b/packages/engine/src/worker/error.rs
@@ -17,7 +17,7 @@ pub enum Error {
     Datastore(#[from] crate::datastore::Error),
 
     #[error("Task already exists (id: {0})")]
-    TaskAlreadyExists(crate::types::TaskID),
+    TaskAlreadyExists(crate::types::TaskId),
 
     #[error("Python runner error: {0}")]
     Python(#[from] PythonError),

--- a/packages/engine/src/worker/mod.rs
+++ b/packages/engine/src/worker/mod.rs
@@ -25,7 +25,7 @@ use self::{
 use crate::{
     config::{WorkerConfig, WorkerSpawnConfig},
     datastore::table::sync::SyncPayload,
-    proto::SimulationShortID,
+    proto::SimulationShortId,
     simulation::{
         enum_dispatch::TaskSharedStore,
         package::id::PackageId,
@@ -34,7 +34,7 @@ use crate::{
             msg::{TaskMessage, TaskResultOrCancelled},
         },
     },
-    types::TaskID,
+    types::TaskId,
     worker::{
         pending::{CancelState, PendingWorkerTask},
         runner::comms::{inbound::InboundToRunnerMsgPayload, MessageTarget},
@@ -283,7 +283,7 @@ impl WorkerController {
 
     async fn finish_task(
         &mut self,
-        task_id: TaskID,
+        task_id: TaskId,
         source: Language,
         message: TaskMessage,
         shared_store: TaskSharedStore,
@@ -318,7 +318,7 @@ impl WorkerController {
     }
 
     fn inbound_from_task_msg(
-        task_id: TaskID,
+        task_id: TaskId,
         package_id: PackageId,
         shared_store: TaskSharedStore,
         task_msg: TaskMessage,
@@ -333,7 +333,7 @@ impl WorkerController {
 
     async fn run_task_handler_on_outbound(
         &mut self,
-        sim_id: SimulationShortID,
+        sim_id: SimulationShortId,
         msg: RunnerTaskMsg,
         source: Language,
     ) -> Result<()> {
@@ -398,7 +398,7 @@ impl WorkerController {
 
     async fn handle_cancel_task_confirmation(
         &mut self,
-        task_id: TaskID,
+        task_id: TaskId,
         source: Language,
     ) -> Result<()> {
         if let Some(task) = self.tasks.inner.get_mut(&task_id) {
@@ -439,7 +439,7 @@ impl WorkerController {
         Ok(())
     }
 
-    async fn spawn_task(&mut self, sim_id: SimulationShortID, task: WorkerTask) -> Result<()> {
+    async fn spawn_task(&mut self, sim_id: SimulationShortId, task: WorkerTask) -> Result<()> {
         use MessageTarget::*;
         let task_id = task.task_id;
         let init_msg = WorkerHandler::start_message(&task.inner as _)?;
@@ -483,7 +483,7 @@ impl WorkerController {
 
     async fn sync_runners(
         &mut self,
-        sim_id: Option<SimulationShortID>,
+        sim_id: Option<SimulationShortId>,
         sync_msg: SyncPayload,
     ) -> Result<()> {
         tokio::try_join!(
@@ -494,7 +494,7 @@ impl WorkerController {
         Ok(())
     }
 
-    async fn cancel_task(&mut self, task_id: TaskID) -> Result<()> {
+    async fn cancel_task(&mut self, task_id: TaskId) -> Result<()> {
         self.tasks
             .inner
             .get_mut(&task_id)
@@ -512,7 +512,7 @@ impl WorkerController {
 
     async fn cancel_task_except_for_runner(
         &self,
-        task_id: TaskID,
+        task_id: TaskId,
         runner_language: Language,
     ) -> Result<()> {
         if matches!(runner_language, Language::Python) {

--- a/packages/engine/src/worker/pending.rs
+++ b/packages/engine/src/worker/pending.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::{simulation::task::Task, types::TaskID, Language};
+use crate::{simulation::task::Task, types::TaskId, Language};
 
 pub enum CancelState {
     Active(Vec<Language>),
@@ -23,5 +23,5 @@ pub struct PendingWorkerTask {
 
 #[derive(Default)]
 pub struct PendingWorkerTasks {
-    pub inner: HashMap<TaskID, PendingWorkerTask>,
+    pub inner: HashMap<TaskId, PendingWorkerTask>,
 }

--- a/packages/engine/src/worker/runner/comms/inbound.rs
+++ b/packages/engine/src/worker/runner/comms/inbound.rs
@@ -3,13 +3,13 @@ use std::fmt;
 use super::{NewSimulationRun, RunnerTaskMsg, StateInterimSync};
 use crate::{
     datastore::table::sync::{ContextBatchSync, StateSync},
-    proto::SimulationShortID,
-    types::TaskID,
+    proto::SimulationShortId,
+    types::TaskId,
 };
 
 pub enum InboundToRunnerMsgPayload {
     TaskMsg(RunnerTaskMsg),
-    CancelTask(TaskID),
+    CancelTask(TaskId),
     StateSync(StateSync),
     StateSnapshotSync(StateSync),
     ContextBatchSync(ContextBatchSync),
@@ -42,6 +42,6 @@ impl fmt::Debug for InboundToRunnerMsgPayload {
 }
 
 pub struct InboundToRunnerMsg {
-    pub sim_id: SimulationShortID,
+    pub sim_id: SimulationShortId,
     pub payload: InboundToRunnerMsgPayload,
 }

--- a/packages/engine/src/worker/runner/comms/mod.rs
+++ b/packages/engine/src/worker/runner/comms/mod.rs
@@ -8,13 +8,13 @@ use std::{
 use crate::{
     config::{EngineConfig, Globals},
     datastore::{prelude::ArrowSchema, schema::state::AgentSchema, shared_store::SharedStore},
-    proto::{ExperimentID, SimulationShortID},
+    proto::{ExperimentId, SimulationShortId},
     simulation::{
         enum_dispatch::TaskSharedStore,
         package::{id::PackageId, worker_init::PackageInitMsgForWorker},
         task::msg::TaskMessage,
     },
-    types::{TaskID, WorkerIndex},
+    types::{TaskId, WorkerIndex},
     worker::{Error, Result},
     Language,
 };
@@ -71,7 +71,7 @@ impl From<crate::gen::target_generated::Target> for MessageTarget {
 #[derive(Debug)]
 pub struct RunnerTaskMsg {
     pub package_id: PackageId,
-    pub task_id: TaskID,
+    pub task_id: TaskId,
     pub payload: TaskMessage,
     pub shared_store: TaskSharedStore,
 }
@@ -85,7 +85,7 @@ pub struct TargetedRunnerTaskMsg {
 impl TargetedRunnerTaskMsg {
     pub fn try_from_fbs(
         task_msg: crate::gen::runner_outbound_msg_generated::TaskMsg,
-        sent_tasks: &mut HashMap<TaskID, SentTask>,
+        sent_tasks: &mut HashMap<TaskId, SentTask>,
     ) -> Result<Self> {
         let task_id = task_msg.task_id().ok_or_else(|| {
             Error::from("The TaskMessage from the runner didn't have a required task_id field")
@@ -140,7 +140,7 @@ pub struct PackageMsgs(pub HashMap<PackageId, PackageInitMsgForWorker>);
 
 #[derive(Debug, Clone)]
 pub struct NewSimulationRun {
-    pub short_id: SimulationShortID,
+    pub short_id: SimulationShortId,
     pub engine_config: Arc<EngineConfig>,
     pub packages: PackageMsgs,
     pub datastore: DatastoreSimulationPayload,
@@ -163,14 +163,14 @@ impl Debug for DatastoreSimulationPayload {
 
 #[derive(Clone)]
 pub struct ExperimentInitRunnerMsgBase {
-    pub experiment_id: ExperimentID,
+    pub experiment_id: ExperimentId,
     pub shared_context: Arc<SharedStore>,
     pub package_config: Arc<PackageMsgs>,
 }
 
 #[derive(Clone)]
 pub struct ExperimentInitRunnerMsg {
-    pub experiment_id: ExperimentID,
+    pub experiment_id: ExperimentId,
     pub worker_index: WorkerIndex,
     pub shared_context: Arc<SharedStore>,
     pub package_config: Arc<PackageMsgs>,

--- a/packages/engine/src/worker/runner/comms/outbound.rs
+++ b/packages/engine/src/worker/runner/comms/outbound.rs
@@ -4,8 +4,8 @@ use super::TargetedRunnerTaskMsg;
 use crate::{
     gen::runner_outbound_msg_generated::root_as_runner_outbound_msg,
     hash_types::worker,
-    proto::SimulationShortID,
-    types::TaskID,
+    proto::SimulationShortId,
+    types::TaskId,
     worker::{runner::comms::SentTask, Error, Result},
     Language,
 };
@@ -59,7 +59,7 @@ impl From<crate::gen::runner_warning_generated::RunnerWarning<'_>> for RunnerErr
 #[derive(Debug)]
 pub enum OutboundFromRunnerMsgPayload {
     TaskMsg(TargetedRunnerTaskMsg),
-    TaskCancelled(TaskID),
+    TaskCancelled(TaskId),
     RunnerError(RunnerError),
     RunnerErrors(Vec<RunnerError>),
     RunnerWarning(RunnerError),
@@ -73,7 +73,7 @@ pub enum OutboundFromRunnerMsgPayload {
 impl OutboundFromRunnerMsgPayload {
     pub fn try_from_fbs(
         parsed_msg: crate::gen::runner_outbound_msg_generated::RunnerOutboundMsg,
-        sent_tasks: &mut HashMap<TaskID, SentTask>,
+        sent_tasks: &mut HashMap<TaskId, SentTask>,
     ) -> Result<Self> {
         Ok(match parsed_msg.payload_type() {
             crate::gen::runner_outbound_msg_generated::RunnerOutboundMsgPayload::NONE => {
@@ -188,7 +188,7 @@ impl OutboundFromRunnerMsgPayload {
 #[derive(Debug)]
 pub struct OutboundFromRunnerMsg {
     pub source: Language,
-    pub sim_id: SimulationShortID,
+    pub sim_id: SimulationShortId,
     pub payload: OutboundFromRunnerMsgPayload,
     // shared state
 }
@@ -197,7 +197,7 @@ impl OutboundFromRunnerMsg {
     pub fn try_from_nng(
         msg: nng::Message,
         source: Language,
-        sent_tasks: &mut HashMap<TaskID, SentTask>,
+        sent_tasks: &mut HashMap<TaskId, SentTask>,
     ) -> Result<Self> {
         let msg = msg.as_slice();
         let msg = root_as_runner_outbound_msg(msg);

--- a/packages/engine/src/worker/runner/javascript/error.rs
+++ b/packages/engine/src/worker/runner/javascript/error.rs
@@ -4,7 +4,7 @@ use tokio::sync::mpsc::error::SendError;
 
 use super::mini_v8 as mv8;
 use crate::{
-    proto::SimulationShortID,
+    proto::SimulationShortId,
     simulation::package::id::PackageId,
     worker::runner::comms::{
         inbound::InboundToRunnerMsgPayload,
@@ -52,10 +52,10 @@ pub enum Error {
     V8(String),
 
     #[error("Missing simulation run with id {0}")]
-    MissingSimulationRun(SimulationShortID),
+    MissingSimulationRun(SimulationShortId),
 
     #[error("Couldn't terminate missing simulation run with id {0}")]
-    TerminateMissingSimulationRun(SimulationShortID),
+    TerminateMissingSimulationRun(SimulationShortId),
 
     #[error("User JavaScript errors: {0:?}")]
     User(Vec<RunnerError>),
@@ -64,7 +64,7 @@ pub enum Error {
     DuplicatePackage(PackageId, String),
 
     #[error("Duplicate simulation run id: {0}")]
-    DuplicateSimulationRun(SimulationShortID),
+    DuplicateSimulationRun(SimulationShortId),
 
     #[error("Error in embedded JavaScript: {0}")]
     Embedded(String),
@@ -73,7 +73,7 @@ pub enum Error {
     UnknownTarget(String),
 
     #[error("Couldn't send inbound message to runner: {0}")]
-    InboundSend(#[from] SendError<(Option<SimulationShortID>, InboundToRunnerMsgPayload)>),
+    InboundSend(#[from] SendError<(Option<SimulationShortId>, InboundToRunnerMsgPayload)>),
 
     #[error("Couldn't send outbound message from runner: {0}")]
     OutboundSend(#[from] SendError<OutboundFromRunnerMsg>),
@@ -82,7 +82,7 @@ pub enum Error {
     OutboundReceive,
 
     #[error("Message type '{0}' must have a simulation run id")]
-    SimulationIDRequired(&'static str),
+    SimulationIdRequired(&'static str),
 
     #[error("serde: {0:?}")]
     Serde(#[from] serde_json::Error),

--- a/packages/engine/src/worker/runner/javascript/mini_v8/ffi.rs
+++ b/packages/engine/src/worker/runner/javascript/mini_v8/ffi.rs
@@ -83,7 +83,7 @@ extern "C" {
     // Can't make an ArrayBuffer with const contents in Javascript,
     // so `mem` has to be a `*mut`, even if it won't be mutated.
     pub(super) fn mv8_arraybuffer_new(_: Interface, mem: *mut u8, n_bytes: usize) -> ValuePtr;
-    pub(super) fn mv8_data_node_from_js(_: Interface, data: ValueDesc) -> DataFFI;
+    pub(super) fn mv8_data_node_from_js(_: Interface, data: ValueDesc) -> DataFfi;
 }
 
 #[repr(transparent)]

--- a/packages/engine/src/worker/runner/javascript/mini_v8/mini_v8.rs
+++ b/packages/engine/src/worker/runner/javascript/mini_v8/mini_v8.rs
@@ -22,7 +22,7 @@ pub struct MiniV8 {
 
 /// C representation of Arrow array data nodes
 #[repr(C)]
-pub struct DataFFI {
+pub struct DataFfi {
     pub len: usize,
     pub null_count: usize,
     pub n_buffers: usize,
@@ -255,7 +255,7 @@ impl MiniV8 {
         }))
     }
 
-    pub fn data_node_from_js(&self, data: &Value) -> DataFFI {
+    pub fn data_node_from_js(&self, data: &Value) -> DataFfi {
         unsafe { mv8_data_node_from_js(self.interface, value_to_desc(self, data)) }
     }
 }

--- a/packages/engine/src/worker/runner/mod.rs
+++ b/packages/engine/src/worker/runner/mod.rs
@@ -8,19 +8,19 @@ use self::comms::{
     inbound::InboundToRunnerMsgPayload, outbound::OutboundFromRunnerMsg, ExperimentInitRunnerMsg,
 };
 pub use super::error::{Error, Result};
-use crate::proto::SimulationShortID;
+use crate::proto::SimulationShortId;
 
 #[async_trait::async_trait]
 pub trait LanguageWorker {
     async fn new(spawn: bool, exp_init: ExperimentInitRunnerMsg) -> Self;
     async fn send<K: TryInto<InboundToRunnerMsgPayload>>(
         &self,
-        sim_id: Option<SimulationShortID>,
+        sim_id: Option<SimulationShortId>,
         msg: K,
     ) -> Result<()>;
     async fn send_if_spawned<K: TryInto<InboundToRunnerMsgPayload>>(
         &self,
-        sim_id: Option<SimulationShortID>,
+        sim_id: Option<SimulationShortId>,
         msg: K,
     ) -> Result<()>;
     async fn recv(&mut self) -> Result<OutboundFromRunnerMsg>;

--- a/packages/engine/src/worker/runner/python/error.rs
+++ b/packages/engine/src/worker/runner/python/error.rs
@@ -1,7 +1,7 @@
 use thiserror::Error as ThisError;
 use tokio::sync::mpsc::error::SendError;
 
-use crate::{proto::SimulationShortID, worker::runner::comms::inbound::InboundToRunnerMsgPayload};
+use crate::{proto::SimulationShortId, worker::runner::comms::inbound::InboundToRunnerMsgPayload};
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -20,7 +20,7 @@ pub enum Error {
     PackageImport(String, String), // First element is path/name.
 
     #[error("Missing simulation run with id {0}")]
-    MissingSimRun(crate::proto::SimulationShortID),
+    MissingSimRun(crate::proto::SimulationShortId),
 
     #[error("Couldn't spawn Python child process: {0:?}")]
     Spawn(std::io::Error),
@@ -29,7 +29,7 @@ pub enum Error {
     TerminateSend(tokio::sync::mpsc::error::SendError<()>),
 
     #[error("Couldn't send inbound message to runner: {0}")]
-    InboundSend(#[from] SendError<(Option<SimulationShortID>, InboundToRunnerMsgPayload)>),
+    InboundSend(#[from] SendError<(Option<SimulationShortId>, InboundToRunnerMsgPayload)>),
 
     #[error("Couldn't send message {0:?} to Python process: {1:?}")]
     NngSend(nng::Message, nng::Error),

--- a/packages/engine/src/worker/runner/python/fbs/CancelTask.py
+++ b/packages/engine/src/worker/runner/python/fbs/CancelTask.py
@@ -29,8 +29,8 @@ class CancelTask(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             x = o + self._tab.Pos
-            from TaskID import TaskID
-            obj = TaskID()
+            from TaskId import TaskId
+            obj = TaskId()
             obj.Init(self._tab.Bytes, x)
             return obj
         return None

--- a/packages/engine/src/worker/runner/python/fbs/ExperimentID.py
+++ b/packages/engine/src/worker/runner/python/fbs/ExperimentID.py
@@ -6,33 +6,33 @@ import flatbuffers
 from flatbuffers.compat import import_numpy
 np = import_numpy()
 
-class ExperimentID(object):
+class ExperimentId(object):
     __slots__ = ['_tab']
 
     @classmethod
     def SizeOf(cls):
         return 16
 
-    # ExperimentID
+    # ExperimentId
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)
 
-    # ExperimentID
+    # ExperimentId
     def Inner(self): return [self._tab.Get(flatbuffers.number_types.Int8Flags, self._tab.Pos + flatbuffers.number_types.UOffsetTFlags.py_type(0 + i * 1)) for i in range(16)]
-    # ExperimentID
+    # ExperimentId
     def InnerLength(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(0))
         if o != 0:
             return self._tab.VectorLen(o)
         return 0
 
-    # ExperimentID
+    # ExperimentId
     def InnerIsNone(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(0))
         return o == 0
 
 
-def CreateExperimentID(builder, inner):
+def CreateExperimentId(builder, inner):
     builder.Prep(1, 16)
     for _idx0 in range(16 , 0, -1):
         builder.PrependInt8(inner[_idx0-1])

--- a/packages/engine/src/worker/runner/python/fbs/Init.py
+++ b/packages/engine/src/worker/runner/python/fbs/Init.py
@@ -29,8 +29,8 @@ class Init(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             x = o + self._tab.Pos
-            from ExperimentID import ExperimentID
-            obj = ExperimentID()
+            from ExperimentId import ExperimentId
+            obj = ExperimentId()
             obj.Init(self._tab.Bytes, x)
             return obj
         return None

--- a/packages/engine/src/worker/runner/python/fbs/TaskCancelled.py
+++ b/packages/engine/src/worker/runner/python/fbs/TaskCancelled.py
@@ -29,8 +29,8 @@ class TaskCancelled(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             x = o + self._tab.Pos
-            from TaskID import TaskID
-            obj = TaskID()
+            from TaskId import TaskId
+            obj = TaskId()
             obj.Init(self._tab.Bytes, x)
             return obj
         return None

--- a/packages/engine/src/worker/runner/python/fbs/TaskID.py
+++ b/packages/engine/src/worker/runner/python/fbs/TaskID.py
@@ -6,33 +6,33 @@ import flatbuffers
 from flatbuffers.compat import import_numpy
 np = import_numpy()
 
-class TaskID(object):
+class TaskId(object):
     __slots__ = ['_tab']
 
     @classmethod
     def SizeOf(cls):
         return 16
 
-    # TaskID
+    # TaskId
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)
 
-    # TaskID
+    # TaskId
     def Inner(self): return [self._tab.Get(flatbuffers.number_types.Int8Flags, self._tab.Pos + flatbuffers.number_types.UOffsetTFlags.py_type(0 + i * 1)) for i in range(16)]
-    # TaskID
+    # TaskId
     def InnerLength(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(0))
         if o != 0:
             return self._tab.VectorLen(o)
         return 0
 
-    # TaskID
+    # TaskId
     def InnerIsNone(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(0))
         return o == 0
 
 
-def CreateTaskID(builder, inner):
+def CreateTaskId(builder, inner):
     builder.Prep(1, 16)
     for _idx0 in range(16 , 0, -1):
         builder.PrependInt8(inner[_idx0-1])

--- a/packages/engine/src/worker/runner/python/fbs/TaskMsg.py
+++ b/packages/engine/src/worker/runner/python/fbs/TaskMsg.py
@@ -36,8 +36,8 @@ class TaskMsg(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             x = o + self._tab.Pos
-            from TaskID import TaskID
-            obj = TaskID()
+            from TaskId import TaskId
+            obj = TaskId()
             obj.Init(self._tab.Bytes, x)
             return obj
         return None

--- a/packages/engine/src/worker/runner/python/mod.rs
+++ b/packages/engine/src/worker/runner/python/mod.rs
@@ -20,17 +20,17 @@ use super::comms::{
     RunnerTaskMsg, SentTask,
 };
 use crate::{
-    proto::SimulationShortID,
-    types::TaskID,
+    proto::SimulationShortId,
+    types::TaskId,
     worker::{Error as WorkerError, Result as WorkerResult},
     Language,
 };
 
 pub struct PythonRunner {
     init_msg: Arc<ExperimentInitRunnerMsg>, // Args to RunnerImpl::new
-    inbound_sender: UnboundedSender<(Option<SimulationShortID>, InboundToRunnerMsgPayload)>,
+    inbound_sender: UnboundedSender<(Option<SimulationShortId>, InboundToRunnerMsgPayload)>,
     inbound_receiver:
-        Option<UnboundedReceiver<(Option<SimulationShortID>, InboundToRunnerMsgPayload)>>,
+        Option<UnboundedReceiver<(Option<SimulationShortId>, InboundToRunnerMsgPayload)>>,
     outbound_sender: Option<UnboundedSender<OutboundFromRunnerMsg>>,
     outbound_receiver: UnboundedReceiver<OutboundFromRunnerMsg>,
     spawn: bool,
@@ -52,7 +52,7 @@ impl PythonRunner {
 
     pub async fn send(
         &self,
-        sim_id: Option<SimulationShortID>,
+        sim_id: Option<SimulationShortId>,
         msg: InboundToRunnerMsgPayload,
     ) -> WorkerResult<()> {
         log::trace!("Sending message to Python: {:?}", &msg);
@@ -63,7 +63,7 @@ impl PythonRunner {
 
     pub async fn send_if_spawned(
         &self,
-        sim_id: Option<SimulationShortID>,
+        sim_id: Option<SimulationShortId>,
         msg: InboundToRunnerMsgPayload,
     ) -> WorkerResult<()> {
         if self.spawned() {
@@ -112,7 +112,7 @@ impl PythonRunner {
 
 async fn _run(
     init_msg: Arc<ExperimentInitRunnerMsg>,
-    mut inbound_receiver: UnboundedReceiver<(Option<SimulationShortID>, InboundToRunnerMsgPayload)>,
+    mut inbound_receiver: UnboundedReceiver<(Option<SimulationShortId>, InboundToRunnerMsgPayload)>,
     outbound_sender: UnboundedSender<OutboundFromRunnerMsg>,
 ) -> WorkerResult<()> {
     // Open sockets for Python process to connect to (i.e. start listening).
@@ -134,7 +134,7 @@ async fn _run(
     nng_sender.init()?;
 
     log::debug!("Waiting for messages to Python runner");
-    let mut sent_tasks: HashMap<TaskID, SentTask> = HashMap::new();
+    let mut sent_tasks: HashMap<TaskId, SentTask> = HashMap::new();
     'select_loop: loop {
         // TODO: Send errors instead of immediately stopping?
         tokio::select! {

--- a/packages/engine/src/worker/runner/python/receiver.rs
+++ b/packages/engine/src/worker/runner/python/receiver.rs
@@ -9,14 +9,14 @@ use super::{
     fbs::{pkgs_to_fbs, shared_ctx_to_fbs},
 };
 use crate::{
-    gen, proto::ExperimentID, types::WorkerIndex, worker::runner::comms::ExperimentInitRunnerMsg,
+    gen, proto::ExperimentId, types::WorkerIndex, worker::runner::comms::ExperimentInitRunnerMsg,
 };
 
 fn experiment_init_to_nng(init: &ExperimentInitRunnerMsg) -> Result<nng::Message> {
     // TODO: initial buffer size
     let mut fbb = flatbuffers::FlatBufferBuilder::new();
     let experiment_id =
-        gen::init_generated::ExperimentID(*(Uuid::from_str(&init.experiment_id)?.as_bytes()));
+        gen::init_generated::ExperimentId(*(Uuid::from_str(&init.experiment_id)?.as_bytes()));
 
     // Build the SharedContext Flatbuffer Batch objects and collect their offsets in a vec
     let shared_context = shared_ctx_to_fbs(&mut fbb, &init.shared_context);
@@ -51,7 +51,7 @@ pub struct NngReceiver {
 }
 
 impl NngReceiver {
-    pub fn new(experiment_id: ExperimentID, worker_index: WorkerIndex) -> Result<Self> {
+    pub fn new(experiment_id: ExperimentId, worker_index: WorkerIndex) -> Result<Self> {
         let route = format!("ipc://{}-frompy{}", experiment_id, worker_index);
         let from_py = Socket::new(nng::Protocol::Pair0)?;
         from_py.listen(&route)?;

--- a/packages/engine/src/worker/runner/python/sender.rs
+++ b/packages/engine/src/worker/runner/python/sender.rs
@@ -16,7 +16,7 @@ use crate::{
         },
     },
     gen::sync_state_interim_generated::StateInterimSyncArgs,
-    proto::{ExperimentID, SimulationShortID},
+    proto::{ExperimentId, SimulationShortId},
     simulation::enum_dispatch::TaskSharedStore,
     types::WorkerIndex,
     worker::runner::comms::inbound::InboundToRunnerMsgPayload,
@@ -33,7 +33,7 @@ pub struct NngSender {
 }
 
 impl NngSender {
-    pub fn new(experiment_id: ExperimentID, worker_index: WorkerIndex) -> Result<Self> {
+    pub fn new(experiment_id: ExperimentId, worker_index: WorkerIndex) -> Result<Self> {
         let route = format!("ipc://{}-topy{}", experiment_id, worker_index);
         let to_py = Socket::new(nng::Protocol::Pair0)?;
         to_py.set_opt::<nng::options::SendBufferSize>(30)?;
@@ -93,7 +93,7 @@ impl NngSender {
 
     pub fn send(
         &self,
-        sim_id: Option<SimulationShortID>,
+        sim_id: Option<SimulationShortId>,
         msg: &InboundToRunnerMsgPayload,
         task_payload_json: &Option<serde_json::Value>,
     ) -> Result<()> {
@@ -123,7 +123,7 @@ impl Drop for NngSender {
 
 // TODO: Make this function shorter.
 fn inbound_to_nng(
-    sim_id: Option<SimulationShortID>,
+    sim_id: Option<SimulationShortId>,
     msg: &InboundToRunnerMsgPayload,
     task_payload_json: &Option<serde_json::Value>,
 ) -> Result<nng::Message> {
@@ -141,7 +141,7 @@ fn inbound_to_nng(
             let payload = str_to_serialized(fbb, &payload);
 
             let task_id =
-                crate::gen::runner_inbound_msg_generated::TaskID(msg.task_id.to_le_bytes());
+                crate::gen::runner_inbound_msg_generated::TaskId(msg.task_id.to_le_bytes());
 
             let msg = crate::gen::runner_inbound_msg_generated::TaskMsg::create(
                 fbb,

--- a/packages/engine/src/worker/runner/rust/behaviors/mod.rs
+++ b/packages/engine/src/worker/runner/rust/behaviors/mod.rs
@@ -2,22 +2,24 @@
 pub mod accessors;
 pub mod error;
 
-use crate::experiment::SharedBehavior;
-use crate::hash_types::Vec3;
-use crate::{datastore::batch::AgentBatch, worker::runner::rust::Column};
-
-use accessors::{Accessors, OptionNativeColumnExt};
-
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
 };
 
-use super::behavior_execution::BehaviorID;
-use super::context::AgentContext;
-use super::error::{Error, Result};
-use super::neighbor::Neighbor;
-use super::state::{AgentState, GroupState};
+use accessors::{Accessors, OptionNativeColumnExt};
+
+use super::{
+    behavior_execution::BehaviorId,
+    context::AgentContext,
+    error::{Error, Result},
+    neighbor::Neighbor,
+    state::{AgentState, GroupState},
+};
+use crate::{
+    datastore::batch::AgentBatch, experiment::SharedBehavior, hash_types::Vec3,
+    worker::runner::rust::Column,
+};
 
 // TODO: Change Rust behaviors to make these type aliases unnecessary.
 type State<'s> = AgentState<'s>;
@@ -36,8 +38,8 @@ accessors!(
 );
 
 accessors!(
-    Vec<BehaviorID>,
-    BehaviorIDsColumn,
+    Vec<BehaviorId>,
+    BehaviorIdsColumn,
     __behaviors,
     __behaviors_set,
     __behaviors_mut,
@@ -468,7 +470,7 @@ pub struct NativeColumn<T> {
 pub struct NativeState {
     // Engine:
     __i_behavior: Option<NativeColumn<usize>>,
-    __behaviors: Option<NativeColumn<BehaviorID>>,
+    __behaviors: Option<NativeColumn<BehaviorId>>,
     behaviors: Option<NativeColumn<Vec<String>>>,
     position: Option<NativeColumn<Vec3>>,
     direction: Option<NativeColumn<Vec3>>,

--- a/packages/engine/src/worker/runner/rust/error.rs
+++ b/packages/engine/src/worker/runner/rust/error.rs
@@ -1,10 +1,11 @@
-use crate::worker::runner::comms::inbound::InboundToRunnerMsgPayload;
-use crate::worker::runner::rust::behaviors::error::SimulationError;
 use arrow::error::ArrowError;
 use thiserror::Error as ThisError;
 use tokio::sync::mpsc::error::SendError;
 
-use crate::worker::SimulationShortID;
+use crate::worker::{
+    runner::{comms::inbound::InboundToRunnerMsgPayload, rust::behaviors::error::SimulationError},
+    SimulationShortId,
+};
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -24,13 +25,13 @@ pub enum Error {
     PackageImport(String, String), // First element is path/name.
 
     #[error("Missing simulation run with id {0}")]
-    MissingSimRun(crate::proto::SimulationShortID),
+    MissingSimRun(crate::proto::SimulationShortId),
 
     #[error("Task target must be py, js, rs, dyn or main, not {0}")]
     UnknownTarget(String),
 
     #[error("Couldn't send inbound message to runner: {0}")]
-    InboundSend(SendError<(Option<SimulationShortID>, InboundToRunnerMsgPayload)>),
+    InboundSend(SendError<(Option<SimulationShortId>, InboundToRunnerMsgPayload)>),
 
     #[error("Couldn't receive outbound message from runner")]
     OutboundReceive,

--- a/packages/engine/src/worker/task.rs
+++ b/packages/engine/src/worker/task.rs
@@ -4,12 +4,12 @@ use crate::{
         package::id::PackageId,
         task::{msg::TaskResultOrCancelled, Task},
     },
-    types::TaskID,
+    types::TaskId,
 };
 
 #[derive(new, Debug)]
 pub struct WorkerTask {
-    pub task_id: TaskID,
+    pub task_id: TaskId,
     pub package_id: PackageId,
     pub inner: Task,
     pub shared_store: TaskSharedStore,
@@ -17,6 +17,6 @@ pub struct WorkerTask {
 
 #[derive(Debug, Clone)]
 pub struct WorkerTaskResultOrCancelled {
-    pub task_id: TaskID,
+    pub task_id: TaskId,
     pub payload: TaskResultOrCancelled,
 }

--- a/packages/engine/src/workerpool/comms/main.rs
+++ b/packages/engine/src/workerpool/comms/main.rs
@@ -1,7 +1,7 @@
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 use super::Result;
-use crate::{proto::SimulationShortID, simulation::comms::message::EngineToWorkerPoolMsg};
+use crate::{proto::SimulationShortId, simulation::comms::message::EngineToWorkerPoolMsg};
 
 pub struct MainMsgRecv {
     inner: UnboundedReceiver<EngineToWorkerPoolMsg>,
@@ -13,7 +13,7 @@ pub struct MainMsgSendBase {
 
 #[derive(Clone)]
 pub struct MainMsgSend {
-    _sim_id: SimulationShortID, // TODO: field never read, delete?
+    _sim_id: SimulationShortId, // TODO: field never read, delete?
     inner: UnboundedSender<EngineToWorkerPoolMsg>,
 }
 
@@ -31,7 +31,7 @@ impl MainMsgSend {
 }
 
 impl MainMsgSendBase {
-    pub fn sender_with_sim_id(&self, sim_id: SimulationShortID) -> MainMsgSend {
+    pub fn sender_with_sim_id(&self, sim_id: SimulationShortId) -> MainMsgSend {
         MainMsgSend {
             _sim_id: sim_id,
             inner: self.inner.clone(),

--- a/packages/engine/src/workerpool/comms/mod.rs
+++ b/packages/engine/src/workerpool/comms/mod.rs
@@ -14,8 +14,8 @@ use tokio::sync::{
 pub use super::{Error, Result};
 use crate::{
     datastore::table::sync::SyncPayload,
-    proto::SimulationShortID,
-    types::{TaskID, WorkerIndex},
+    proto::SimulationShortId,
+    types::{TaskId, WorkerIndex},
     worker::{
         runner::comms::{outbound::RunnerError, NewSimulationRun},
         task::{WorkerTask, WorkerTaskResultOrCancelled},
@@ -27,13 +27,13 @@ use crate::{
 pub enum WorkerPoolToWorkerMsgPayload {
     Task(WorkerTask),
     Sync(SyncPayload),
-    CancelTask(TaskID),
+    CancelTask(TaskId),
     NewSimulationRun(NewSimulationRun),
 }
 
 #[derive(Debug)]
 pub struct WorkerPoolToWorkerMsg {
-    pub sim_id: Option<SimulationShortID>,
+    pub sim_id: Option<SimulationShortId>,
     pub payload: WorkerPoolToWorkerMsgPayload,
 }
 
@@ -62,21 +62,21 @@ impl WorkerPoolToWorkerMsg {
 }
 
 impl WorkerPoolToWorkerMsg {
-    pub fn sync(sim_id: SimulationShortID, sync_payload: SyncPayload) -> WorkerPoolToWorkerMsg {
+    pub fn sync(sim_id: SimulationShortId, sync_payload: SyncPayload) -> WorkerPoolToWorkerMsg {
         WorkerPoolToWorkerMsg {
             sim_id: Some(sim_id),
             payload: WorkerPoolToWorkerMsgPayload::Sync(sync_payload),
         }
     }
 
-    pub fn task(sim_id: SimulationShortID, task_payload: WorkerTask) -> WorkerPoolToWorkerMsg {
+    pub fn task(sim_id: SimulationShortId, task_payload: WorkerTask) -> WorkerPoolToWorkerMsg {
         WorkerPoolToWorkerMsg {
             sim_id: Some(sim_id),
             payload: WorkerPoolToWorkerMsgPayload::Task(task_payload),
         }
     }
 
-    pub fn cancel_task(task_id: TaskID) -> WorkerPoolToWorkerMsg {
+    pub fn cancel_task(task_id: TaskId) -> WorkerPoolToWorkerMsg {
         WorkerPoolToWorkerMsg {
             sim_id: None,
             payload: WorkerPoolToWorkerMsgPayload::CancelTask(task_id),

--- a/packages/engine/src/workerpool/comms/top.rs
+++ b/packages/engine/src/workerpool/comms/top.rs
@@ -1,21 +1,21 @@
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
-use crate::{proto::SimulationShortID, worker::runner::comms::outbound::RunnerError};
+use crate::{proto::SimulationShortId, worker::runner::comms::outbound::RunnerError};
 // This is for communications between the worker pool and the simulation top-level controller.
 // Mainly used only for passing errors and warnings.
 
 pub struct WorkerPoolMsgRecv {
-    pub inner: UnboundedReceiver<(Option<SimulationShortID>, WorkerPoolToExpCtlMsg)>,
+    pub inner: UnboundedReceiver<(Option<SimulationShortId>, WorkerPoolToExpCtlMsg)>,
 }
 
 impl WorkerPoolMsgRecv {
-    pub async fn recv(&mut self) -> Option<(Option<SimulationShortID>, WorkerPoolToExpCtlMsg)> {
+    pub async fn recv(&mut self) -> Option<(Option<SimulationShortId>, WorkerPoolToExpCtlMsg)> {
         self.inner.recv().await
     }
 }
 
 pub struct WorkerPoolMsgSend {
-    pub inner: UnboundedSender<(Option<SimulationShortID>, WorkerPoolToExpCtlMsg)>,
+    pub inner: UnboundedSender<(Option<SimulationShortId>, WorkerPoolToExpCtlMsg)>,
 }
 
 #[derive(Debug)]

--- a/packages/engine/src/workerpool/error.rs
+++ b/packages/engine/src/workerpool/error.rs
@@ -38,7 +38,7 @@ pub enum Error {
     TerminateConfirmAlreadySent,
 
     #[error("Missing simulation with id {0}")]
-    MissingSimulationWithID(proto::SimulationShortID),
+    MissingSimulationWithId(proto::SimulationShortId),
 
     #[error("Channel for sending cancel task messages has unexpectedly closed")]
     CancelClosed,
@@ -50,7 +50,7 @@ pub enum Error {
     UnexpectedWorkerCommsDrop,
 
     #[error("Missing pending task with id {0}")]
-    MissingPendingTask(crate::types::TaskID),
+    MissingPendingTask(crate::types::TaskId),
 
     #[error("Missing one-shot task result sender to send result with")]
     NoResultSender,

--- a/packages/engine/src/workerpool/mod.rs
+++ b/packages/engine/src/workerpool/mod.rs
@@ -23,13 +23,13 @@ use crate::{
     config,
     config::{TaskDistributionConfig, Worker, WorkerPoolConfig},
     datastore::table::task_shared_store::TaskSharedStore,
-    proto::SimulationShortID,
+    proto::SimulationShortId,
     simulation::{
         comms::message::{EngineToWorkerPoolMsg, EngineToWorkerPoolMsgPayload},
         package::id::PackageId,
         task::{args::GetTaskArgs, handler::WorkerPoolHandler, Task},
     },
-    types::{TaskID, WorkerIndex},
+    types::{TaskId, WorkerIndex},
     worker::{
         runner::comms::{ExperimentInitRunnerMsg, ExperimentInitRunnerMsgBase, NewSimulationRun},
         task::WorkerTask,
@@ -255,7 +255,7 @@ impl WorkerPoolController {
 
     // TODO: delete or use when cancel is revisited
     #[allow(dead_code)]
-    async fn handle_cancel_msgs(&mut self, cancel_msgs: Vec<TaskID>) -> Result<()> {
+    async fn handle_cancel_msgs(&mut self, cancel_msgs: Vec<TaskId>) -> Result<()> {
         for id in cancel_msgs {
             log::trace!("Handling cancel msg for task with id: {}", id);
             if let Some(task) = self.pending_tasks.inner.get(&id) {
@@ -295,8 +295,8 @@ impl WorkerPoolController {
 
     fn new_worker_tasks(
         &self,
-        sim_id: SimulationShortID,
-        task_id: TaskID,
+        sim_id: SimulationShortId,
+        task_id: TaskId,
         package_id: PackageId,
         shared_store: TaskSharedStore,
         task: Task,

--- a/packages/engine/src/workerpool/pending.rs
+++ b/packages/engine/src/workerpool/pending.rs
@@ -14,7 +14,7 @@ use crate::{
             Task,
         },
     },
-    types::TaskID,
+    types::TaskId,
     worker::task::WorkerTaskResultOrCancelled,
 };
 
@@ -33,7 +33,7 @@ pub enum DistributionController {
 
 #[derive(new)]
 pub struct PendingWorkerPoolTask {
-    pub task_id: TaskID,
+    pub task_id: TaskId,
     pub comms: ActiveTaskExecutorComms,
     pub distribution_controller: DistributionController,
     #[new(default)]
@@ -44,7 +44,7 @@ impl PendingWorkerPoolTask {
     fn handle_result_state(
         &mut self,
         worker: Worker,
-        _task_id: TaskID,
+        _task_id: TaskId,
         result: TaskMessage,
     ) -> Result<HasTerminated> {
         if let DistributionController::Distributed {
@@ -82,7 +82,7 @@ impl PendingWorkerPoolTask {
         }
     }
 
-    fn handle_cancel_state(&mut self, worker: Worker, _task_id: TaskID) -> Result<HasTerminated> {
+    fn handle_cancel_state(&mut self, worker: Worker, _task_id: TaskId) -> Result<HasTerminated> {
         if let DistributionController::Distributed {
             active_workers: active_workers_comms,
             received_results: _,
@@ -155,13 +155,13 @@ impl PendingWorkerPoolTask {
 
 #[derive(Default)]
 pub struct PendingWorkerPoolTasks {
-    pub inner: HashMap<TaskID, PendingWorkerPoolTask>,
+    pub inner: HashMap<TaskId, PendingWorkerPoolTask>,
 }
 
 impl PendingWorkerPoolTasks {
     // TODO: delete or use when cancel is revisited
     #[allow(dead_code)]
-    pub async fn run_cancel_check(&mut self) -> Vec<TaskID> {
+    pub async fn run_cancel_check(&mut self) -> Vec<TaskId> {
         self.inner
             .iter_mut()
             .filter_map(|(id, task)| {

--- a/packages/engine/src/workerpool/runs.rs
+++ b/packages/engine/src/workerpool/runs.rs
@@ -1,18 +1,18 @@
 use std::collections::HashMap;
 
 use super::error::{Error, Result};
-use crate::{config::WorkerAllocation, proto::SimulationShortID};
+use crate::{config::WorkerAllocation, proto::SimulationShortId};
 
 #[derive(Default)]
 pub struct SimulationRuns {
     // Associates a simulation run with the workers available to it
-    worker_allocations: HashMap<SimulationShortID, WorkerAllocation>,
+    worker_allocations: HashMap<SimulationShortId, WorkerAllocation>,
 }
 
 impl SimulationRuns {
     pub fn push(
         &mut self,
-        sim_id: SimulationShortID,
+        sim_id: SimulationShortId,
         worker_allocation: &WorkerAllocation,
     ) -> Result<()> {
         self.worker_allocations
@@ -21,9 +21,9 @@ impl SimulationRuns {
         Ok(())
     }
 
-    pub fn get_worker_allocation(&self, id: SimulationShortID) -> Result<&WorkerAllocation> {
+    pub fn get_worker_allocation(&self, id: SimulationShortId) -> Result<&WorkerAllocation> {
         self.worker_allocations
             .get(&id)
-            .ok_or_else(|| Error::MissingSimulationWithID(id))
+            .ok_or_else(|| Error::MissingSimulationWithId(id))
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Renames (as many as I could find) acronyms in CamelCase to abide by the [rust convention](https://rust-lang.github.io/api-guidelines/naming.html)

> In UpperCamelCase, acronyms and contractions of compound words count as one word: use Uuid rather than UUID, Usize rather than USize or Stdin rather than StdIn. In snake_case, acronyms and contractions are lower-cased: is_xid_start.

## 🔗 Related links

This was something I've wanted to do for a while as we've been inconsistent, but was prioritised as Serde was incorrectly parsing "APIRequests" as "a_p_i_requests" for: 

- [Fix snake-case and camel-case conversion for package imports in runners](https://app.asana.com/0/1199550852792314/1201481006654681/f)

## 🔍 What does this change?

(Focusing on Rust and Flatbuffers) this code changes acronyms in CamelCase to not be all caps. This was done using CLions refactoring capabilities and a search across files for these two regex's:
`[A-Z][A-Z][a-z]`
`[a-z][A-Z][A-Z]`

The search was struggling due to it being across literally hundreds of files so it's possible some have been missed and will only appear when we run those code-paths.
- ...

## 🛡 Tests
- ✅ Unit Tests
The ones that were running still seem to be running
- ✅ Manual Tests
The (Rust) project compiles, and the JS-only sims we were running are still getting as far as they were.

A repeat of the above:
> The search was struggling due to it being across literally hundreds of files so it's possible some have been missed and will only appear when we run those code-paths.

(Possibly specifically within Python as we aren't really testing the FlatBuffers code at the moment)
