### PR TITLE
Sanitize output for JsonState

### DIFF
--- a/packages/engine/src/datastore/schema/field_spec/mod.rs
+++ b/packages/engine/src/datastore/schema/field_spec/mod.rs
@@ -18,8 +18,8 @@ pub mod creator;
 pub mod display;
 pub mod short_json;
 
-const HIDDEN_PREFIX: &str = "_HIDDEN_";
-const PRIVATE_PREFIX: &str = "_PRIVATE_";
+pub const HIDDEN_PREFIX: &str = "_HIDDEN_";
+pub const PRIVATE_PREFIX: &str = "_PRIVATE_";
 
 // TODO: better encapsulate the supported underlying field types, and the selection of those that
 //   we expose to the user compared to this thing where we have a variant and an 'extension'. So

--- a/packages/engine/src/datastore/schema/mod.rs
+++ b/packages/engine/src/datastore/schema/mod.rs
@@ -6,5 +6,5 @@ mod field_spec;
 pub use field_spec::{
     accessor, built_in::IsRequired, creator::RootFieldSpecCreator, short_json::ShortJsonError,
     FieldKey, FieldScope, FieldSource, FieldSpec, FieldSpecMap, FieldType, FieldTypeVariant,
-    PresetFieldType, RootFieldSpec,
+    PresetFieldType, RootFieldSpec, HIDDEN_PREFIX, PRIVATE_PREFIX,
 };

--- a/packages/engine/src/simulation/package/output/packages/json_state/config.rs
+++ b/packages/engine/src/simulation/package/output/packages/json_state/config.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{simulation::Result, ExperimentConfig};
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct JsonStateOutputConfig {
+    pub retain_hidden: bool,
+    pub retain_private: bool,
+}
+
+impl JsonStateOutputConfig {
+    pub fn new(_config: &ExperimentConfig) -> Result<JsonStateOutputConfig> {
+        // TODO: make this configurable
+        Ok(JsonStateOutputConfig::default())
+    }
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Filters hidden and private fields from JSON output.

## 🔗 Related links

- [Asana task description](https://app.asana.com/0/1199550852792314/1201481006654696/f)

## 🔍 What does this change?

- It's using the `FieldSpec` constants to filter for hidden and private fields.

## 🛡 Tests

✅ Manual Tests

## ❓ How to test this?

1. Run a simulation
2. Check, that _./parts_ output neither contain `"_HIDDEN_"`, nor `"_PRIVATE_"` fields
