### PR TITLE
Make the project path required when calling the CLI

### DIFF
--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -21,7 +21,7 @@ use crate::exsrv::create_server;
 #[derive(Debug, StructOpt)]
 pub struct Args {
     /// Path to the project to be run.
-    #[structopt(short, long, default_value = ".", env = "HASH_PROJECT")]
+    #[structopt(short, long, env = "HASH_PROJECT")]
     project: String,
 
     /// (Unimplemented) Project output path folder.


### PR DESCRIPTION


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201499937429459