### PR TITLE
Changing timeout default values and removing unused one.

### DIFF
--- a/packages/engine/bin/cli/src/experiment.rs
+++ b/packages/engine/bin/cli/src/experiment.rs
@@ -14,9 +14,8 @@ use super::process;
 use crate::{exsrv::Handler, manifest::read_manifest, Args};
 
 lazy_static::lazy_static! {
-    static ref ENGINE_START_TIMEOUT: Duration = parse_env_duration("ENGINE_START_TIMEOUT", 180);
-    static ref ENGINE_WAIT_TIMEOUT: Duration = parse_env_duration("ENGINE_WAIT_TIMEOUT", if cfg!(debug_assertions) { 3600 } else { 60 });
-    static ref PING_INTERVAL: Duration = parse_env_duration("PING_INTERVAL", 5);
+    static ref ENGINE_START_TIMEOUT: Duration = parse_env_duration("ENGINE_START_TIMEOUT", 2);
+    static ref ENGINE_WAIT_TIMEOUT: Duration = parse_env_duration("ENGINE_WAIT_TIMEOUT", 60);
 }
 
 /// `run_experiment` will build a queue of tokio tasks attached to the simulation workers. Any


### PR DESCRIPTION
I don't think we want the 3600 time to be based on debug builds (i.e. without optimisations). I think we only want that ridiculous timeout when using a debugger, in which case it's fine to set the envvar in the IDE run config.

PING_INTERVAL also seems to not exist anywhere in the codebase so I removed.