### PR TITLE
Fixing output-persistence logic where extend was replacing the path

### DIFF
--- a/packages/engine/.gitignore
+++ b/packages/engine/.gitignore
@@ -11,3 +11,4 @@ src/worker/runner/python/wrappers.c*
 *-frompy*
 *hash-orchestrator-*
 parts/
+output/

--- a/packages/engine/src/output/buffer/part.rs
+++ b/packages/engine/src/output/buffer/part.rs
@@ -58,6 +58,7 @@ impl OutputPartBuffer {
     }
 
     pub fn persist_current_on_disk(&mut self) -> Result<()> {
+        log::trace!("Persisting current output to disk");
         let mut next_i = self.parts.len();
 
         let current = std::mem::replace(
@@ -107,7 +108,7 @@ impl OutputPartBuffer {
 
     pub fn finalize(mut self) -> Result<(Vec<u8>, Vec<PathBuf>)> {
         self.current.push(CHAR_OPEN_RIGHT_SQUARE_BRACKET);
-        self.persist_current_on_disk();
+        self.persist_current_on_disk()?;
         Ok((self.current, self.parts))
     }
 }

--- a/packages/engine/src/output/local/sim.rs
+++ b/packages/engine/src/output/local/sim.rs
@@ -37,12 +37,17 @@ impl SimulationOutputPersistenceRepr for LocalSimulationOutputPersistence {
     }
 
     async fn finalize(mut self) -> Result<Self::OutputPersistenceResult> {
+        log::trace!("Finalizing output");
         // JSON state
         let (_, parts) = self.buffers.json_state.finalize()?;
         let mut path = self.config.output_folder.clone();
-        path.extend(["/", &self.exp_id]);
+
+        path.join(&self.exp_id);
+
+        log::trace!("Making new output directory directory: {:?}", path);
         std::fs::create_dir(&path)?;
-        parts.iter().try_for_each(|v| -> Result<()> {
+
+        parts.into_iter().try_for_each(|v| -> Result<()> {
             let mut new = path.clone();
             new.push(
                 v.file_name()


### PR DESCRIPTION
We called `.extend` with a path starting with `"/"` which replaces the path rather than appending it. This is why we were getting permission denied errors, because we were trying to write into the root.

Fixing this correctly produces an `/output` directory now.

![image](https://user-images.githubusercontent.com/25749103/145805428-09731ad2-6c56-485d-ad3e-87f219788a4c.png)
