### PR TITLE
Add PREVIOUS_INDEX to `short_json`

### DIFF
--- a/packages/engine/src/datastore/schema/field_spec/mod.rs
+++ b/packages/engine/src/datastore/schema/field_spec/mod.rs
@@ -9,7 +9,7 @@ use std::{
 use crate::{
     datastore::error::{Error, Result},
     hash_types::state::AgentStateField,
-    simulation::package::{creator::PREVIOUS_INDEX_FIELD_NAME, name::PackageName},
+    simulation::package::name::PackageName,
 };
 
 pub mod accessor;
@@ -20,6 +20,7 @@ pub mod short_json;
 
 pub const HIDDEN_PREFIX: &str = "_HIDDEN_";
 pub const PRIVATE_PREFIX: &str = "_PRIVATE_";
+pub const PREVIOUS_INDEX_FIELD_NAME: &str = "previous_index";
 
 // TODO: better encapsulate the supported underlying field types, and the selection of those that
 //   we expose to the user compared to this thing where we have a variant and an 'extension'. So

--- a/packages/engine/src/datastore/schema/field_spec/short_json.rs
+++ b/packages/engine/src/datastore/schema/field_spec/short_json.rs
@@ -199,6 +199,12 @@ impl FieldSpecMap {
                         };
                         field_spec_map.add(root)?;
                     }
+                    let previous_index_spec = RootFieldSpec {
+                        inner: FieldSpec::last_state_index_key(),
+                        source: FieldSource::Engine,
+                        scope: FieldScope::Hidden,
+                    };
+                    field_spec_map.add(previous_index_spec)?;
                     Ok(field_spec_map)
                 } else {
                     Err(ShortJsonError::FieldsIsNotObject.into())

--- a/packages/engine/src/simulation/package/creator.rs
+++ b/packages/engine/src/simulation/package/creator.rs
@@ -402,35 +402,7 @@ pub fn get_base_agent_fields() -> Result<Vec<RootFieldSpec>> {
         ));
     }
 
-    // This key is required for accessing neighbors' outboxes (new inboxes).
-    // Since the neighbor agent state is always the previous step state of the
-    // agent, then we need to know where its outbox is. This would be
-    // straightforward if we didn't add/remove/move agents between batches.
-    // This means `AgentBatch` ordering gets changed at the beginning of the step
-    // meaning agents are not aligned with their `OutboxBatch` anymore.
-    #[must_use]
-    // TODO: migrate this to be logic handled by the Engine
-    pub fn last_state_index_key() -> FieldSpec {
-        // There are 2 indices for every agent: 1) Group index 2) Row (agent) index. This points
-        // to the relevant old outbox (i.e. new inbox)
-        FieldSpec {
-            name: PREVIOUS_INDEX_FIELD_NAME.to_string(),
-            field_type: FieldType::new(
-                FieldTypeVariant::FixedLengthArray {
-                    kind: Box::new(FieldType::new(
-                        FieldTypeVariant::Preset(PresetFieldType::Uint32),
-                        false,
-                    )),
-                    len: 2,
-                },
-                // This key is nullable because new agents
-                // do not get an index (their outboxes are empty by default)
-                true,
-            ),
-        }
-    }
-
-    let last_state_index = last_state_index_key();
+    let last_state_index = FieldSpec::last_state_index_key();
 
     field_specs.push(field_spec_creator.create(
         last_state_index.name.into(),

--- a/packages/engine/src/simulation/package/creator.rs
+++ b/packages/engine/src/simulation/package/creator.rs
@@ -380,7 +380,6 @@ impl PackageCreators {
     }
 }
 
-pub const PREVIOUS_INDEX_FIELD_NAME: &str = "previous_index";
 // TODO: this should be deleted, i.e. if this value is required use
 //      something like `get_hidden_column_name(PREVIOUS_INDEX_FIELD_NAME)`
 pub const PREVIOUS_INDEX_FIELD_KEY: &str = "_HIDDEN_0_previous_index";


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When generating `FieldSpec` from short_json, "PREVIOUS_INDEX" was not added

## 🔗 Related links

<!-- Add links to Asana, Slack, Notion or whatever originated this PR -->
<!-- This will be _super_ handy 6 months from now.  -->

- [Asana task description](https://app.asana.com/0/1199550852792314/1201481006654684/f)

## 🛡 Tests

<!-- Delete as appropriate -->

- ✅ Unit Tests
- ✅ Manual Tests

