### PR TITLE
Fixing Simulation termination logic and output bug

### DIFF
--- a/packages/engine/src/datastore/storage/memory.rs
+++ b/packages/engine/src/datastore/storage/memory.rs
@@ -221,7 +221,7 @@ impl Memory {
 
     // We can't resize memory on macos
     #[cfg(target_os = "macos")]
-    pub fn shrink_memory_with_data_length(&mut self, data_length: usize) -> Result<BufferChange> {
+    pub fn shrink_memory_with_data_length(&mut self, _data_length: usize) -> Result<BufferChange> {
         Ok(BufferChange(false, false))
     }
 

--- a/packages/engine/src/experiment/controller/controller.rs
+++ b/packages/engine/src/experiment/controller/controller.rs
@@ -346,7 +346,7 @@ impl<P: OutputPersistenceCreatorRepr> ExperimentController<P> {
                         return Ok(())
                     } else {
                         log::trace!("sim_run_tasks wasn't empty, starting a wait and warn loop");
-                        waiting_for_completion = Some(Box::pin(tokio::time::sleep(Duration::from_secs(1))));
+                        waiting_for_completion = Some(Box::pin(tokio::time::sleep(Duration::from_secs(time_to_wait))));
                     }
                 }
                 _ = async { waiting_for_completion.as_mut().expect("must be some").await }, if waiting_for_completion.is_some() => {

--- a/packages/engine/src/output/local/sim.rs
+++ b/packages/engine/src/output/local/sim.rs
@@ -41,12 +41,10 @@ impl SimulationOutputPersistenceRepr for LocalSimulationOutputPersistence {
         log::trace!("Finalizing output");
         // JSON state
         let (_, parts) = self.buffers.json_state.finalize()?;
-        let mut path = self.config.output_folder.clone();
-
-        path.join(&self.exp_id);
+        let path = self.config.output_folder.clone().join(&self.exp_id);
 
         log::trace!("Making new output directory directory: {:?}", path);
-        std::fs::create_dir(&path)?;
+        std::fs::create_dir_all(&path)?;
 
         parts.into_iter().try_for_each(|v| -> Result<()> {
             let mut new = path.clone();

--- a/packages/engine/src/simulation/controller/runs.rs
+++ b/packages/engine/src/simulation/controller/runs.rs
@@ -1,4 +1,4 @@
-use futures::stream::{FuturesOrdered, StreamExt};
+use futures::stream::{FusedStream, FuturesOrdered, StreamExt};
 use tokio::task::JoinHandle;
 
 use super::Result;
@@ -12,6 +12,10 @@ pub struct SimulationRuns {
 impl SimulationRuns {
     pub fn new_run(&mut self, handle: JoinHandle<Result<SimulationShortId>>) {
         self.inner.push(handle);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
     }
 
     pub async fn next(&mut self) -> Result<Option<Result<SimulationShortId>>>

--- a/packages/engine/src/simulation/controller/runs.rs
+++ b/packages/engine/src/simulation/controller/runs.rs
@@ -1,4 +1,4 @@
-use futures::stream::{FusedStream, FuturesOrdered, StreamExt};
+use futures::stream::{FuturesOrdered, StreamExt};
 use tokio::task::JoinHandle;
 
 use super::Result;


### PR DESCRIPTION
* Fixes the experiment controller ending too early and therefore dropping simulations before their output persistence is finished.
* Fixes a bug with the output persistence paths introduced in a previous PR.
* Two small drive-by fixes for warnings