### PR TITLE
Combining parts into a single json_state file in the output

### DIFF
--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -210,13 +210,20 @@ $ export RUST_LOG=debug
 > **WIP** - This section is a work-in-progress. More in-depth documentation is in the works for describing all output formats and options. As such some functionality may not be mentioned here, and some functionality alluded to here might not be complete at present. 
 Currently the engine has two main form of outputs, one coming from the [json_state package](./src/simulation/package/output/packages/json_state) and the other from the [analysis package](./src/simulation/package/output/packages/analysis).
 
-#### JSON-State
-By default, the engine outputs a serialized snapshot of Agent state every step. This is written to the `./parts` folder. At the present it's possible that these files will not be valid JSON as the resultant blob may be split across multiple files (hence `part`) for buffering purposes. Development is planned for a different output format that ensures a valid JSON blob in a single file.
+At the end of each simulation run, various outputs appear within the `./<OUTPUT FOLDER>/<EXPERIMENT ID>/<SIMULATION ID>` directories. (At the moment `<OUTPUT FOLDER>` is always `./output`)
 
-#### Analysis
+#### JSON-State [`json_state.json`]
+> Better documentation describing the structure of the file is planned
+
+By default, the engine outputs a serialized snapshot of Agent state every step.
+
+During the run, the output may be buffered into the `./parts` folder in multiple files. These files are not necessarily valid JSON as the resultant state blob that appears within `json_state.json` is split up (hence `part`) for buffering purposes. 
+
+#### Analysis [`analysis_outputs.json`]
 > **WIP** - This feature is currently unstable
 
 [hCore] currently provides functionality where simulations can apply custom analysis on user-defined metrics. The functionality has been ported across to this codebase in the [analysis package](./src/simulation/package/output/packages/analysis), however development is planned to stabilise it. As such, this functionality is neither tested, nor considered supported.
+
 
 ## Main Concepts
 

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -23,7 +23,7 @@
   * [Possible Dependencies and Debugging](#possible-dependencies-and-debugging)
   * [Project Setup / Building](#project-setup--building)
   * [Running for development](#running-for-development)
-- [Quick start](#quick-start)
+- [Quick Start Guide](#quick-start-guide)
 - [Usage](#usage)
   * [CLI Arguments and Options](#cli-arguments-and-options)
   * [Run a simulation](#run-a-simulation)
@@ -143,7 +143,7 @@ Where CLI args are described below in the [Usage](#usage) section, an example of
 * `cargo run --bin cli -- <CLI ARGS> -p  "<PATH TO HASH PROJECT DIR>" single-run --num-steps <NUM-STEPS>`
 
 
-## Quick start
+## Quick Start Guide
 
 This guide will walk you through downloading a [demo simulation], running it, and then finding and verifying its output.
 
@@ -160,9 +160,9 @@ In order to run the demo:
     cargo run --bin cli -- --project 'path/to/ageing-agents' single-run --num-steps 5
     ```
 
-After a short time, the simulation should complete and the process will end. Once this is done, a `./parts` folder should have been created. In the parts folder for every simulation a directory is created. For a deeper explanation of the output, please take a look at [Simulation Outputs](#simulation-outputs).
+After a short time, the simulation should complete and the process will end. Once this is done, an `./outputs` folder should have been created. Within that folder a directory is created for every simulation. For a deeper explanation of the output, please take a look at [Simulation Outputs](#simulation-outputs).
 
-The ageing simulation increases the age of each agent by one every step. Looking in the _json_state-0.part_ file, one can see the outputted JSON state has an `"age"` field for each agent. It should be apparent that the age is increasing with each snapshot of state.
+The ageing simulation increases the age of each agent by one every step. Looking in the _json_state.json_ file, one can see the outputted JSON state has an `"age"` field for each agent. It should be apparent that the age is increasing with each snapshot of state.
 
 **Congratulations!** 🎉 , you just ran your first simulation with the hEngine!
 

--- a/packages/engine/src/experiment/controller/controller.rs
+++ b/packages/engine/src/experiment/controller/controller.rs
@@ -350,8 +350,8 @@ impl<P: OutputPersistenceCreatorRepr> ExperimentController<P> {
                     }
                 }
                 _ = async { waiting_for_completion.as_mut().expect("must be some").await }, if waiting_for_completion.is_some() => {
-                    log::warn!("Experiment Controller received a termination message, waiting {} seconds for sim run tasks to complete", time_to_wait);
                     time_to_wait *= WAITING_MULTIPLIER;
+                    log::warn!("Experiment Controller received a termination message, waiting {} seconds for sim run tasks to complete", time_to_wait);
                     waiting_for_completion = Some(Box::pin(tokio::time::sleep(Duration::from_secs(time_to_wait))));
                 }
             }

--- a/packages/engine/src/output/local/sim.rs
+++ b/packages/engine/src/output/local/sim.rs
@@ -14,7 +14,7 @@ use crate::{
 #[derive(derive_new::new)]
 pub struct LocalSimulationOutputPersistence {
     exp_id: ExperimentId,
-    _sim_id: SimulationShortId,
+    sim_id: SimulationShortId,
     // TODO: Should this be unused? If so remove
     buffers: Buffers,
     config: LocalPersistenceConfig,
@@ -43,7 +43,11 @@ impl SimulationOutputPersistenceRepr for LocalSimulationOutputPersistence {
         log::trace!("Finalizing output");
         // JSON state
         let (_, parts) = self.buffers.json_state.finalize()?;
-        let path = self.config.output_folder.join(&self.exp_id);
+        let path = self
+            .config
+            .output_folder
+            .join(&self.exp_id)
+            .join(self.sim_id.to_string());
 
         log::trace!("Making new output directory directory: {:?}", path);
         std::fs::create_dir_all(&path)?;

--- a/packages/engine/src/output/local/sim.rs
+++ b/packages/engine/src/output/local/sim.rs
@@ -1,12 +1,8 @@
-use std::io::{BufReader, BufWriter, Read, Write};
+use std::io::{BufReader, BufWriter};
 
 use super::{config::LocalPersistenceConfig, result::LocalPersistenceResult};
 use crate::{
-    output::{
-        buffer::Buffers,
-        error::{Error, Result},
-        SimulationOutputPersistenceRepr,
-    },
+    output::{buffer::Buffers, error::Result, SimulationOutputPersistenceRepr},
     proto::{ExperimentId, SimulationShortId},
     simulation::{package::output::packages::Output, step_output::SimulationStepOutput},
 };
@@ -55,7 +51,7 @@ impl SimulationOutputPersistenceRepr for LocalSimulationOutputPersistence {
         let json_state_path = path.join("json_state.json");
         std::fs::File::create(&json_state_path)?;
 
-        let mut file_out = std::fs::OpenOptions::new()
+        let file_out = std::fs::OpenOptions::new()
             .append(true)
             .open(json_state_path)?;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We were only exposing the JSON state output in parts, this was mostly done for S3 persistence reasons on cloud as uploading it in one large blob could fail. There are currently no persistence methods implemented in this repo aside from to file, so we can combine them into one.

Outputs are now persisted in `./output/<EXPERIMENT ID>/<SIMULATION ID>`

Also contains a drive-by fix where a warn statement uses the incorrect value.

## 🛡 Tests

<!-- Delete as appropriate -->

- ✅ Manual Tests
![image](https://user-images.githubusercontent.com/25749103/145999617-494d5990-b22f-4b6a-b0bb-94f19f94f10c.png)
