### PR TITLE
Changing output log to info instead of trace

### DIFF
--- a/packages/engine/src/output/local/sim.rs
+++ b/packages/engine/src/output/local/sim.rs
@@ -45,7 +45,7 @@ impl SimulationOutputPersistenceRepr for LocalSimulationOutputPersistence {
             .join(&self.exp_id)
             .join(self.sim_id.to_string());
 
-        log::trace!("Making new output directory directory: {:?}", path);
+        log::info!("Making new output directory directory: {:?}", path);
         std::fs::create_dir_all(&path)?;
 
         let json_state_path = path.join("json_state.json");


### PR DESCRIPTION
We log where the outputs are being written to. This was a trace log, it's useful info for almost any run so it makes sense to change the level to info.

Before:
```TRACE hash_engine::output::local::sim > Making new output directory directory: "./output/3551d8c1-1e55-4c7a-bb8f-192fe6c54037/1"```

After:
```INFO hash_engine::output::local::sim > Making new output directory directory: "./output/3551d8c1-1e55-4c7a-bb8f-192fe6c54037/1"```

Asana: https://app.asana.com/0/1199550852792314/1201499989227961/f