### PR TITLE
Adding a project name arg and using it to build the output folder

### DIFF
--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -160,7 +160,7 @@ In order to run the demo:
     cargo run --bin cli -- --project 'path/to/ageing-agents' single-run --num-steps 5
     ```
 
-After a short time, the simulation should complete and the process will end. Once this is done, an `./outputs` folder should have been created. Within that folder a directory is created for every simulation. For a deeper explanation of the output, please take a look at [Simulation Outputs](#simulation-outputs).
+After a short time, the simulation should complete and the process will end. Once this is done, an `./output` folder should have been created. Within that, a directory is created for each combination of [project/experiment/simulation]. For a deeper explanation of the output, please take a look at [Simulation Outputs](#simulation-outputs).
 
 The ageing simulation increases the age of each agent by one every step. Looking in the _json_state.json_ file, one can see the outputted JSON state has an `"age"` field for each agent. It should be apparent that the age is increasing with each snapshot of state.
 
@@ -210,7 +210,9 @@ $ export RUST_LOG=debug
 > **WIP** - This section is a work-in-progress. More in-depth documentation is in the works for describing all output formats and options. As such some functionality may not be mentioned here, and some functionality alluded to here might not be complete at present. 
 Currently the engine has two main form of outputs, one coming from the [json_state package](./src/simulation/package/output/packages/json_state) and the other from the [analysis package](./src/simulation/package/output/packages/analysis).
 
-At the end of each simulation run, various outputs appear within the `./<OUTPUT FOLDER>/<EXPERIMENT ID>/<SIMULATION ID>` directories. (At the moment `<OUTPUT FOLDER>` is always `./output`)
+At the end of each simulation run, various outputs appear within the `./<OUTPUT FOLDER>/<PROJECT NAME>/<EXPERIMENT ID>/<SIMULATION ID>` directories.
+
+There are overrides ([CLI Arguments and Options](#cli-arguments-and-options)) for the defaults of the output folder and project name.
 
 #### JSON-State [`json_state.json`]
 > Better documentation describing the structure of the file is planned

--- a/packages/engine/bin/cli/src/experiment.rs
+++ b/packages/engine/bin/cli/src/experiment.rs
@@ -32,7 +32,7 @@ pub async fn run_experiment(args: Args, handler: Handler) -> Result<()> {
             .file_name()
             .with_context(|| format!("Project path didn't point to a directory: {absolute_project_path:?}"))? // Shouldn't be able to fail as we canonicalize above
             .to_str()
-            .with_context(|| format!("Project directory name wasn't UTF-8 formatted"))?
+            .with_context(|| "Project directory name wasn't UTF-8 formatted")?
             .to_string(),
     );
 

--- a/packages/engine/bin/cli/src/experiment.rs
+++ b/packages/engine/bin/cli/src/experiment.rs
@@ -27,8 +27,17 @@ pub async fn run_experiment(args: Args, handler: Handler) -> Result<()> {
     let absolute_project_path = PathBuf::from(project)
         .canonicalize()
         .with_context(|| format!("Could not canonicalize project path: {project:?}"))?;
+    let project_name = args.project_name.clone().unwrap_or(
+        absolute_project_path
+            .file_name()
+            .with_context(|| format!("Project path didn't point to a directory: {absolute_project_path:?}"))? // Shouldn't be able to fail as we canonicalize above
+            .to_str()
+            .with_context(|| format!("Project directory name wasn't UTF-8 formatted"))?
+            .to_string(),
+    );
+
     let experiment_run = read_manifest(&absolute_project_path, &args.r#type)?;
-    run_experiment_with_manifest(args, experiment_run, handler).await?;
+    run_experiment_with_manifest(args, experiment_run, project_name, handler).await?;
     Ok(())
 }
 
@@ -48,6 +57,7 @@ fn create_engine_command(
 async fn run_experiment_with_manifest(
     args: Args,
     experiment_run: proto::ExperimentRun,
+    project_name: String,
     mut handler: Handler,
 ) -> Result<()> {
     let experiment_id = experiment_run.base.id.clone();
@@ -84,11 +94,13 @@ async fn run_experiment_with_manifest(
     };
     debug!("Received start message from {experiment_id}");
 
+    let mut output_folder = PathBuf::from(args.output);
+    output_folder.push(project_name);
+
     let map_iter = [(
         OUTPUT_PERSISTENCE_KEY.to_string(),
-        // TODO: Make this a CLI arg:
         json!(OutputPersistenceConfig::Local(LocalPersistenceConfig {
-            output_folder: PathBuf::from(r"./output")
+            output_folder
         })),
     )];
     // Now we can send the init message

--- a/packages/engine/bin/cli/src/experiment.rs
+++ b/packages/engine/bin/cli/src/experiment.rs
@@ -31,8 +31,7 @@ pub async fn run_experiment(args: Args, handler: Handler) -> Result<()> {
         absolute_project_path
             .file_name()
             .with_context(|| format!("Project path didn't point to a directory: {absolute_project_path:?}"))? // Shouldn't be able to fail as we canonicalize above
-            .to_str()
-            .context("Project directory name wasn't UTF-8 formatted")?
+            .to_string_lossy()
             .to_string(),
     );
 

--- a/packages/engine/bin/cli/src/experiment.rs
+++ b/packages/engine/bin/cli/src/experiment.rs
@@ -32,7 +32,7 @@ pub async fn run_experiment(args: Args, handler: Handler) -> Result<()> {
             .file_name()
             .with_context(|| format!("Project path didn't point to a directory: {absolute_project_path:?}"))? // Shouldn't be able to fail as we canonicalize above
             .to_str()
-            .with_context(|| "Project directory name wasn't UTF-8 formatted")?
+            .context("Project directory name wasn't UTF-8 formatted")?
             .to_string(),
     );
 

--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -26,11 +26,17 @@ pub struct Args {
     #[structopt(short, long, env = "HASH_PROJECT")]
     project: String,
 
-    /// (Unimplemented) Project output path folder.
+    /// The Project Name.
+    ///
+    /// If not provided, the name of the project directory will be used.
+    #[structopt(short = "n", long)]
+    project_name: Option<String>,
+
+    /// Project output path folder.
     ///
     /// The folder will be created if it's missing.
     #[structopt(short, long, default_value = "./output", env = "HASH_OUTPUT")]
-    _output: String, // TODO - unused
+    output: String,
 
     /// Experiment type to be run.
     #[structopt(subcommand)]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Improves usability and readability of the output folder. (Both for human and machine consumption)

## 🔗 Related links

- [Asana task description](https://app.asana.com/0/1199550852792314/1201514365398449/f)

## 🔍 What does this change?

- Adds a CLI argument to set the Project name
  * Defaults to the name of the final directory in the project path 
- Changes the output folder structure to group experiments by given project name

## 🛡 Tests

- ✅ Manual Tests

## 📹 Demo

![image](https://user-images.githubusercontent.com/25749103/146179187-de5f0508-c5d3-444c-9617-38d5acdccb8c.png)
