### PR TITLE
Adding `step()` method for contexts in JS

### DIFF
--- a/packages/engine/format/sync_context_batch.fbs
+++ b/packages/engine/format/sync_context_batch.fbs
@@ -10,6 +10,7 @@ include "batch.fbs";
 table ContextBatchSync {
   context_batch:Batch (required);
   current_step:int64;
+  // TODO: state_group_start_indices
 }
 
 root_type ContextBatchSync;

--- a/packages/engine/src/datastore/table/sync.rs
+++ b/packages/engine/src/datastore/table/sync.rs
@@ -25,6 +25,7 @@ impl fmt::Debug for StateSync {
 #[derive(derive_new::new, Clone)]
 pub struct ContextBatchSync {
     pub context_batch: Arc<RwLock<ContextBatch>>,
+    pub current_step: usize,
     pub state_group_start_indices: Arc<Vec<usize>>,
 }
 

--- a/packages/engine/src/simulation/comms/mod.rs
+++ b/packages/engine/src/simulation/comms/mod.rs
@@ -119,16 +119,18 @@ impl Comms {
         Ok(())
     }
 
+    /// TODO: docstring
     pub async fn context_batch_sync(
         &self,
         context: &Context,
+        current_step: usize,
         state_group_start_indices: &Arc<Vec<usize>>,
     ) -> Result<()> {
         log::trace!("Synchronizing context batch");
         // Synchronize the context batch
         let batch = context.batch();
         let indices = Arc::clone(state_group_start_indices);
-        let sync_msg = ContextBatchSync::new(batch, indices);
+        let sync_msg = ContextBatchSync::new(batch, current_step, indices);
         self.worker_pool_sender
             .send(EngineToWorkerPoolMsg::sync(
                 self.sim_id,

--- a/packages/engine/src/simulation/comms/mod.rs
+++ b/packages/engine/src/simulation/comms/mod.rs
@@ -119,7 +119,7 @@ impl Comms {
         Ok(())
     }
 
-    /// TODO: docstring
+    /// TODO: DOC
     pub async fn context_batch_sync(
         &self,
         context: &Context,

--- a/packages/engine/src/simulation/controller/run.rs
+++ b/packages/engine/src/simulation/controller/run.rs
@@ -58,9 +58,9 @@ pub async fn sim_run<P: SimulationOutputPersistenceRepr>(
     let mut early_stop = false;
     let mut stop_msg = None;
     'sim_main: loop {
-        // `sim.current_step` is -1 if `next` has not been called
-        let next_step_index = steps_taken;
-        if next_step_index >= max_num_steps {
+        // Behaviors expect context.step() to give the current step rather than steps_taken
+        let current_step = steps_taken + 1;
+        if current_step >= max_num_steps {
             break;
         }
 
@@ -70,7 +70,7 @@ pub async fn sim_run<P: SimulationOutputPersistenceRepr>(
         }
 
         // Take a step in the simulation
-        let step_result = match engine.next().await {
+        let step_result = match engine.next(current_step).await {
             Ok(step_result) => step_result,
             Err(error) => {
                 log::error!("Got error within the engine step process: {:?}", error);
@@ -119,6 +119,7 @@ pub async fn sim_run<P: SimulationOutputPersistenceRepr>(
             break 'sim_main;
         }
 
+        // TODO: should the SimStatus be current_step here or steps_taken (it is after .next())
         sims_to_exp
             .send(SimStatus::running(config.sim.id, steps_taken as isize))
             .await

--- a/packages/engine/src/worker/runner/javascript/runner.js
+++ b/packages/engine/src/worker/runner/javascript/runner.js
@@ -185,13 +185,13 @@ function run_task(sim_id, i_group, pkg_id, task_message) {
 /// Invalidates existing `GroupContext` and `AgentContext` objects.
 /// (NB: Any `GroupContext` or `AgentContext` objects must be forgotten at
 /// the end of a `run_task` call.)
-function ctx_batch_sync(sim_id, ctx_batch, state_group_start_idxs) {
+function ctx_batch_sync(sim_id, ctx_batch, state_group_start_idxs, current_step) {
     const sim = this.sims[sim_id];
 
     ctx_batch = this.batches.sync(ctx_batch, sim.schema.ctx);
     ctx_batch.load_missing_cols(sim.schema.ctx, sim.context_loaders);
-    
-    sim.ctx.set_batch(ctx_batch, state_group_start_idxs);
+
+    sim.ctx.set_batch(ctx_batch, state_group_start_idxs, current_step);
 }
 
 const _sync_pools = (sim, batches, agent_pool, message_pool) => {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We support a `context.step()` method in the legacy hEngine used within hCore/hCloud today, which provides the current step of the simulation. This PR implements the same in our new open hEngine.

## 🔗 Related links

- [Asana task description](https://app.asana.com/0/1199550852792314/1201525968072827/f)

## 🛡 Tests

<!-- Delete as appropriate -->

- ✅ Manual Tests

## ❓ How to test this?

1. Download the step simulation from https://core.hash.ai/@alfie/steps/stable
2. Run a single_run with a few steps and check that the current_step field is correctly incremented in the outputted json_state.json