### PR TITLE
Change log severity for experiment message

### DIFF
--- a/packages/engine/bin/cli/src/experiment.rs
+++ b/packages/engine/bin/cli/src/experiment.rs
@@ -124,7 +124,7 @@ async fn run_experiment_with_manifest(
             m = engine_handle.recv() => { msg = Some(m) },
         }
         let msg = msg.unwrap();
-        info!("Got message from experiment run with type: {}", msg.kind());
+        debug!("Got message from experiment run with type: {}", msg.kind());
 
         match msg {
             proto::EngineStatus::Stopping => {
@@ -157,11 +157,15 @@ async fn run_experiment_with_manifest(
             proto::EngineStatus::Logs(sim_id, logs) => {
                 if let Some(sim_id) = sim_id {
                     for log in logs {
-                        info!("[{sim_id}]: {log}");
+                        if !log.is_empty() {
+                            info!("[{sim_id}]: {log}");
+                        }
                     }
                 } else {
                     for log in logs {
-                        info!("{log}");
+                        if !log.is_empty() {
+                            info!("{log}");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Change the log severity for experiment messages do debug, so the Javascript `console.log` can be filtered better.
In order to see the logging output from Javascript, set the environment variable `RUST_LOG=cli::experiment=info`.

## 🔗 Related links

- [Asana task description](https://app.asana.com/0/1199550852792314/1201524950327107/f)

## 🛡 Tests

- ✅ Manual Tests