### PR TITLE
Include messages within json_state output

### DIFF
--- a/packages/engine/src/simulation/package/output/packages/json_state/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/json_state/mod.rs
@@ -79,9 +79,9 @@ impl Package for JsonState {
             .agent_pool()
             .read_batches()?
             .into_iter()
-            .map(|batch| {
-                batch
-                    .record_batch()
+            .zip(state.message_pool().read_batches()?.into_iter())
+            .map(|(agent_batch, message_batch)| {
+                (agent_batch.record_batch(), message_batch.record_batch())
                     .into_agent_states(Some(&self.sim_run_config.sim.store.agent_schema))
             })
             .collect();


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The JSON output of Agent state includes messages within hCore/hCloud. Until this PR we were only serializing the AgentBatch rather than also the more dynamic messages batch.

## 🔗 Related links

- [Asana task description](https://app.asana.com/0/1199550852792314/1201521491107069/f)

## 🔍 What does this change?

* Uses the message batch as well as the agent batch for serializing AgentState

## 🛡 Tests

✅ Manual Tests

## ❓ How to test this?

1. Run any experiment that utilises messages (e.g. sugarscape)
2. Check the json_state.json output file and verify that the agents have a messages field.
