### PR TITLE
Fix behavior execution for Javascript runners

### DIFF
--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/package.js
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/package.js
@@ -171,14 +171,14 @@ const run_task = (experiment, sim, task_message, group_state, group_context) => 
 
     const n_agents_in_group = group_state.n_agents();
     for (var i_agent = 0; i_agent < n_agents_in_group; ++i_agent) {
-        
-        // Reuse `agent_state` and `agent_ctx` objects.
-        agent_state = group_state.get_agent(i_agent, agent_state);
+        // TODO: Reuse `agent_state` objects. When using the old `agent_state`, the indices for behaviors are borked
+        agent_state = group_state.get_agent(i_agent, null);
+        // Reuse `agent_ctx` objects.
         agent_ctx = group_context.get_agent(i_agent, agent_ctx);
 
         const behavior_ids = agent_state[behavior_ids_field_key];
         const n_behaviors = behavior_ids.length;
-        for (var i_behavior = agent_state.behavior_index; i_behavior < n_behaviors; ++i_behavior) {
+        for (var i_behavior = 0; i_behavior < n_behaviors; ++i_behavior) {
             agent_state.behavior_index = i_behavior;
 
             const key = behavior_ids.get(i_behavior)
@@ -198,7 +198,6 @@ const run_task = (experiment, sim, task_message, group_state, group_context) => 
             behavior.fn(agent_state, agent_ctx);
             postprocess(agent_state);
         }
-        agent_state.behavior_index = i_behavior;
     }
     
     return {

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/package.js
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/package.js
@@ -178,7 +178,7 @@ const run_task = (experiment, sim, task_message, group_state, group_context) => 
 
         const behavior_ids = agent_state[behavior_ids_field_key];
         const n_behaviors = behavior_ids.length;
-        for (var i_behavior = 0; i_behavior < n_behaviors; ++i_behavior) {
+        for (var i_behavior = agent_state.behavior_index; i_behavior < n_behaviors; ++i_behavior) {
             agent_state.behavior_index = i_behavior;
 
             const key = behavior_ids.get(i_behavior)


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Only behaviors for the first agents are executed. This is a fix to this.

## 🔗 Related links

- [Asana task description](https://app.asana.com/0/1199550852792314/1201524950327102/f)

## 🔍 What does this change?

For optimization, the `agent_state` was reused in the javascript runner. This PR removes the optimization, as behavior indices were borked after reusing.

## 🛡 Tests

<!-- Delete as appropriate -->

- ✅ Manual Tests