### PR TITLE
README improvements ahead of HASH open-sourcing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # HASH
 
-**[Visit our new docs site here!](https://hash.ai/docs/simulation)**
-
 This repository contains HASH's open-source and public code, documentation, and other key resources, including:
 
 - `packages/hash`: The codebase for HASH ([Info](https://hash.ai/platform/index)) - coming soon, available under an Apache 2.0 compatible license
 - `packages/engine`: The codebase for [hEngine](packages/engine) ([Info](https://hash.ai/platform/engine)) - available under the Server Side Public License
 - `packages/engine/stdlib`: The [standard library](packages/engine/stdlib) of helper functions available in all HASH simulations
-- `resources/docs`: Product docs covering the whole HASH platform
-- `resources/glossary`: A glossary of terms explaining common concepts relevant to the use of HASH
+- `resources/docs`: A user guide to the whole HASH platform ([hash.ai/docs](https://hash.ai/docs))
+- `resources/glossary`: A glossary of terms explaining common concepts relevant to the use of HASH ([hash.ai/glossary](https://hash.ai/glossary))
 
 Please see the [LICENSE](LICENSE.md) file for more information on the terms under which the various parts of this repository are made available.

--- a/README.md
+++ b/README.md
@@ -8,4 +8,8 @@ This repository contains HASH's open-source and public code, documentation, and 
 - `resources/docs`: A user guide to the whole HASH platform ([hash.ai/docs](https://hash.ai/docs))
 - `resources/glossary`: A glossary of terms explaining common concepts relevant to the use of HASH ([hash.ai/glossary](https://hash.ai/glossary))
 
-Please see the [LICENSE](LICENSE.md) file for more information on the terms under which the various parts of this repository are made available.
+Please see:
+
+- [LICENSE.md](LICENSE.md) for more information about the terms under which the various parts of this repository are made available
+- [CONTRIBUTING.md](CONTRIBUTING.md) if you're interested in getting involved in the design or development of HASH
+- [SECURITY.md](SECURITY.md) for instructions around reporting issues, and details of which package versions we actively support


### PR DESCRIPTION
We're in the process of restructuring this repo, ahead of the open-source release of HASH's workspace product, and following the publication of the code behind our next-gen [hEngine](https://hash.ai/platform/engine).