### PR TITLE
Temporarily disable paths on rust-lints.yml to enable PRs on non-Rust changes

### DIFF
--- a/.github/workflows/rust-lints.yml
+++ b/.github/workflows/rust-lints.yml
@@ -2,10 +2,10 @@ name: Rust-Lint
 
 on:
   pull_request:
-    paths:
-      - '**.rs'
-      - '**.toml'
-      - '**Cargo.*'
+#    paths:
+#      - '**.rs'
+#      - '**.toml'
+#      - '**Cargo.*'
 
 defaults:
   run:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We currently require the Rust-Lint CI to pass, but it's not executed when non-Rust changes are made.