### PR TITLE
Adding an initial CONTRIBUTING.md in packages/engine

### DIFF
--- a/packages/engine/CONTRIBUTING.md
+++ b/packages/engine/CONTRIBUTING.md
@@ -1,0 +1,115 @@
+[comment]: <> (This CONTRIBUTING guide was heavily inspired by the great one provided by the lovely folks at Atom [https://github.com/atom/atom/blob/master/CONTRIBUTING.md])
+
+# Contributing to hEngine
+
+Thank you for your interest in adding to the hEngine!
+
+We've provided the following guidelines to help you with contributions, in addition to the ones described below, we've
+also established a set of [community guidelines](https://hash.ai/legal/community) to enable as many people as possible
+to contribute to and benefit from HASH. Please follow these when interacting with this repo.
+
+#### Table Of Contents
+
+- [I have a question, where do I go?](#i-have-a-question--where-do-i-go-)
+
+- [Getting started, what do I need to know?](#getting-started--what-do-i-need-to-know-)
+    * [Design Decisions](#design-decisions)
+
+- [How Can I Contribute?](#how-can-i-contribute-)
+    * [Reporting Bugs](#reporting-bugs)
+        + [Before Submitting A Bug Report](#before-submitting-a-bug-report)
+        + [How Do I Submit A (Good) Bug Report?](#how-do-i-submit-a--good--bug-report-)
+    * [Suggesting Enhancements](#suggesting-enhancements)
+        + [Before Submitting An Enhancement Suggestion](#before-submitting-an-enhancement-suggestion)
+        + [How Do I Submit A (Good) Enhancement Suggestion?](#how-do-i-submit-a--good--enhancement-suggestion-)
+    * [Your First Code Contribution](#your-first-code-contribution)
+        + [Local development](#local-development)
+    * [Pull Requests](#pull-requests)
+
+- [Styleguides](#styleguides)
+    * [Rust Styleguide](#rust-styleguide)
+    * [JavaScript Styleguide](#javascript-styleguide)
+    * [Python Styleguide](#python-styleguide)
+    * [Documentation Styleguide](#documentation-styleguide)
+        + [Example](#example)
+
+- [Additional Notes](#additional-notes)
+    * [Issue and Pull Request Labels](#issue-and-pull-request-labels)
+
+## I have a question, where do I go?
+
+> **Note:** Please don't use GitHub issues for help, we have a friendly community on... TODO links to Discord, etc.
+
+* TODO
+
+## Getting started, what do I need to know?
+
+### Design Decisions
+
+> TODO
+
+## How Can I Contribute?
+
+### Reporting Bugs
+
+> TODO
+
+#### Before Submitting A Bug Report
+
+> TODO
+
+#### How Do I Submit A (Good) Bug Report?
+
+> TODO
+
+### Suggesting Enhancements
+
+> TODO
+
+#### Before Submitting An Enhancement Suggestion
+
+> TODO
+
+#### How Do I Submit A (Good) Enhancement Suggestion?
+
+> TODO
+
+### Your First Code Contribution
+
+> TODO
+
+#### Local development
+
+> TODO
+
+### Pull Requests
+
+> TODO
+
+## Styleguides
+
+### Rust Styleguide
+
+> TODO
+
+### JavaScript Styleguide
+
+> TODO
+
+### Python Styleguide
+
+> TODO
+
+### Documentation Styleguide
+
+> TODO
+
+#### Example
+
+> TODO
+
+## Additional Notes
+
+### Issue and Pull Request Labels
+
+> TODO

--- a/packages/engine/CONTRIBUTING.md
+++ b/packages/engine/CONTRIBUTING.md
@@ -17,13 +17,8 @@ to contribute to and benefit from HASH. Please follow these when interacting wit
 
 - [How Can I Contribute?](#how-can-i-contribute-)
     * [Reporting Bugs](#reporting-bugs)
-        + [Before Submitting A Bug Report](#before-submitting-a-bug-report)
-        + [How Do I Submit A (Good) Bug Report?](#how-do-i-submit-a--good--bug-report-)
     * [Suggesting Enhancements](#suggesting-enhancements)
-        + [Before Submitting An Enhancement Suggestion](#before-submitting-an-enhancement-suggestion)
-        + [How Do I Submit A (Good) Enhancement Suggestion?](#how-do-i-submit-a--good--enhancement-suggestion-)
     * [Your First Code Contribution](#your-first-code-contribution)
-        + [Local development](#local-development)
     * [Pull Requests](#pull-requests)
 
 - [Styleguides](#styleguides)
@@ -31,16 +26,19 @@ to contribute to and benefit from HASH. Please follow these when interacting wit
     * [JavaScript Styleguide](#javascript-styleguide)
     * [Python Styleguide](#python-styleguide)
     * [Documentation Styleguide](#documentation-styleguide)
-        + [Example](#example)
 
 - [Additional Notes](#additional-notes)
     * [Issue and Pull Request Labels](#issue-and-pull-request-labels)
 
+> **WIP** This document is a work in-progress, if the section you need isn't finished, please feel free to reach out to us for clarification!
+
 ## I have a question, where do I go?
 
-> **Note:** Please don't use GitHub issues for help, we have a friendly community on... TODO links to Discord, etc.
+> **Note:** Please don't use GitHub issues for help, we have a friendly community on...
 
-* TODO
+* [Discord](https://discord.com/invite/BPMrGAhjPh)
+* [Our Forum](https://community.hash.ai/)
+* And any other methods outlined on [our site](https://hash.ai/contact)
 
 ## Getting started, what do I need to know?
 
@@ -52,15 +50,35 @@ to contribute to and benefit from HASH. Please follow these when interacting wit
 
 ### Reporting Bugs
 
-> TODO
+While using our products, you may encounter unwanted behavior, and if that should happen, please do report it to us! No project is perfect, and helping us keeping track of problems is always appreciated. 
+
+To help you help us, we've written this section to give some guidelines on the sort of information that will help us investigate and hopefully help you.
 
 #### Before Submitting A Bug Report
 
-> TODO
+Try and check to see if it's already been reported, the main place to look would be the [Github Issues board](https://github.com/hashintel/hash/issues). If you can't find something similar, then feel free to create a new one! Be sure to label it with the `hengine` label to help the right team find it.
 
 #### How Do I Submit A (Good) Bug Report?
 
-> TODO
+So you've found a bug, next up is collecting useful information to give us to investigate.
+
+* **Give a clear title of what the problem is** (or what you believe it to be)
+* If you can, **describe how to reproduce it**, otherwise try and give as much information about how it happened. (What you did, _how_ you did it, etc.) As an example of some useful information depending on the context:
+  * Runtime parameters
+  * The simulation you were running
+  * The step of the build you were at
+  * Any configuration you've supplied
+* **Describe the environment it was running in**
+  * What hardware, as an example:
+    * Your computer manufacturer
+    * Amount of RAM
+    * CPU model
+  * What operating system was it running on
+  * What versions of the dependencies are you running
+    * e.g. tell us your version of Rust, Python, cmake, etc.
+  * Any environment variables that might have affected it
+* **Provide _all_ relevant logs**
+  * Try not to just provide summarised descriptions of what was logged, we like full log-outputs. If you can reproduce it, try running it with trace logs (RUST_LOG=trace)
 
 ### Suggesting Enhancements
 

--- a/packages/engine/CONTRIBUTING.md
+++ b/packages/engine/CONTRIBUTING.md
@@ -114,6 +114,9 @@ If you have ideas of how to improve the hEngine, feel free to submit them on the
 
 ## Styleguides
 
+[comment]: <> (Cross-link to global style guides for the repo when they're added)
+
+
 ### Rust Styleguide
 
 > WIP

--- a/packages/engine/CONTRIBUTING.md
+++ b/packages/engine/CONTRIBUTING.md
@@ -56,7 +56,7 @@ To help you help us, we've written this section to give some guidelines on the s
 
 #### Before Submitting A Bug Report
 
-Try and check to see if it's already been reported, the main place to look would be the [Github Issues board](https://github.com/hashintel/hash/issues). If you can't find something similar, then feel free to create a new one! Be sure to label it with the `hengine` label to help the right team find it.
+Try and check to see if it's already been reported, the main place to look would be the [Github Issues board](https://github.com/hashintel/hash/issues). If you can't find something similar, then feel free to create a new one! Be sure to label it with the `A-engine + C-bug` label to help the right team find it.
 
 #### How Do I Submit A (Good) Bug Report?
 

--- a/packages/engine/CONTRIBUTING.md
+++ b/packages/engine/CONTRIBUTING.md
@@ -110,6 +110,14 @@ So you've found a bug, next up is collecting useful information to give us to in
 
 > TODO
 
+We are using [`cargo fmt`](https://github.com/rust-lang/rustfmt) and [`cargo clippy`](https://github.com/rust-lang/rust-clippy) to apply linting rules to our Rust codebase. In order to run those, you need to install them first (unless they are already installed, which is the default):
+* `rustup component add rustfmt`
+* `rustup component add clippy`
+
+Then simply run them with:
+* `cargo fmt`
+* `cargo clippy`
+
 ### JavaScript Styleguide
 
 > TODO

--- a/packages/engine/CONTRIBUTING.md
+++ b/packages/engine/CONTRIBUTING.md
@@ -82,15 +82,17 @@ So you've found a bug, next up is collecting useful information to give us to in
 
 ### Suggesting Enhancements
 
-> TODO
+If you have ideas of how to improve the hEngine, feel free to submit them on the [Product Feedback section of our community forum](https://community.hash.ai/c/product-feedback/2). If you want a more informal discussion around your ideas feel free to start a conversation on the Discord!
 
-#### Before Submitting An Enhancement Suggestion
 
-> TODO
+[comment]: <> (The following sections are comments until the wishlist section of the new website is live)
+[comment]: <> (#### Before Submitting An Enhancement Suggestion)
 
-#### How Do I Submit A (Good) Enhancement Suggestion?
+[comment]: <> (> TODO)
 
-> TODO
+[comment]: <> (#### How Do I Submit A &#40;Good&#41; Enhancement Suggestion?)
+
+[comment]: <> (> TODO)
 
 ### Your First Code Contribution
 
@@ -102,13 +104,19 @@ So you've found a bug, next up is collecting useful information to give us to in
 
 ### Pull Requests
 
-> TODO
+> WIP - More information incoming regarding PR description formatting, etc. 
+
+#### Some good practices
+
+- Have well encapsulated commits on your PR, this helps with reviewing. If you're comfortable with it, rebasing before opening your PR can help with cleaning up WIP commits.
+- Write unit-tests _as_ you write code. Submitting unit-tests alongside the code within commits improves confidence in your changes and helps us understand your intentions with the code.
+
 
 ## Styleguides
 
 ### Rust Styleguide
 
-> TODO
+> WIP
 
 We are using [`cargo fmt`](https://github.com/rust-lang/rustfmt) and [`cargo clippy`](https://github.com/rust-lang/rust-clippy) to apply linting rules to our Rust codebase. In order to run those, you need to install them first (unless they are already installed, which is the default):
 * `rustup component add rustfmt`


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds the start of a contribution guide for hEngine.
Currently heavily inspired (mostly copied) from Atom as [theirs](https://github.com/atom/atom/blob/master/CONTRIBUTING.md) is pretty great

## 🔗 Related links

<!-- Add links to Asana, Slack, Notion or whatever originated this PR -->
<!-- This will be _super_ handy 6 months from now.  -->

- [Asana task description](https://app.asana.com/0/1199550852792314/1201533886101109/f)

## 🔍 What does this change?
- Adds CONTRIBUTING.md

## ❓ How to test this?

1. [Open the README on Github](https://github.com/hashintel/hash/blob/engine/contributions/packages/engine/CONTRIBUTING.md) (link is valid until PR is merged and branch is deleted, after merging open the README in main)