### PR TITLE
Fixing missing messages from context 

### DIFF
--- a/packages/engine/src/datastore/batch/context.rs
+++ b/packages/engine/src/datastore/batch/context.rs
@@ -152,6 +152,8 @@ impl Batch {
             .zip_eq(column_dynamic_meta_list.par_iter())
             .try_for_each(|((column_writer, buffer), meta)| column_writer.write(buffer, meta))?;
 
+        self.metaversion.increment_batch();
+
         let meta_buffer = get_dynamic_meta_flatbuffers(&dynamic)?;
         self.memory.set_metadata(&meta_buffer)?;
 

--- a/packages/engine/src/datastore/storage/mod.rs
+++ b/packages/engine/src/datastore/storage/mod.rs
@@ -5,6 +5,8 @@ mod visitor;
 pub struct BufferChange(bool, bool);
 
 impl BufferChange {
+    /// TODO: DOC possibly that this buffer itself didn't change but moved in memory due to another
+    ///   buffer possibly growing or shrinking
     pub fn shifted(&self) -> bool {
         self.0
     }

--- a/packages/engine/src/simulation/controller/run.rs
+++ b/packages/engine/src/simulation/controller/run.rs
@@ -60,6 +60,7 @@ pub async fn sim_run<P: SimulationOutputPersistenceRepr>(
     'sim_main: loop {
         // Behaviors expect context.step() to give the current step rather than steps_taken
         let current_step = steps_taken + 1;
+        log::trace!("Current step: {}", current_step);
         if current_step >= max_num_steps {
             break;
         }

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/package.js
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/package.js
@@ -173,8 +173,8 @@ const run_task = (experiment, sim, task_message, group_state, group_context) => 
     for (var i_agent = 0; i_agent < n_agents_in_group; ++i_agent) {
         // TODO: Reuse `agent_state` objects. When using the old `agent_state`, the indices for behaviors are borked
         agent_state = group_state.get_agent(i_agent, null);
-        // Reuse `agent_ctx` objects.
-        agent_ctx = group_context.get_agent(i_agent, agent_ctx);
+        // TODO: Reuse `agent_ctx` objects. When using the old `agent_ctx`
+        agent_ctx = group_context.get_agent(i_agent, null);
 
         const behavior_ids = agent_state[behavior_ids_field_key];
         const n_behaviors = behavior_ids.length;
@@ -195,7 +195,12 @@ const run_task = (experiment, sim, task_message, group_state, group_context) => 
             }
             
             agent_state.set_dynamic_access(behavior.dyn_access);
-            behavior.fn(agent_state, agent_ctx);
+            try {
+                behavior.fn(agent_state, agent_ctx);
+            } catch (e) {
+                // TODO expose/return user error properly
+                throw Error(behavior.name + "\n" + e.stack);
+            }
             postprocess(agent_state);
         }
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Messages were missing from the context, despite being written to the batch. This was due to the runners not reloading the memory as the batch metaversion wasn't incremented, thus the runners didn't think data had changed

## 🔗 Related links

- [Asana task description](https://app.asana.com/0/0/1201532662164415/f)

## 🔍 What does this change?

- Increments the context batch metaversion when we finish writing
- Removes a potentially problematic context optimisation to be revisited alongside an existing TODO for the same optimisation for state

## 🛡 Tests

<!-- Delete as appropriate -->

- ✅ Manual Tests (Ran a basic sim with 3 agents that send messages to another agent and confirmed that the context.messages() length is now 3)
