### PR TITLE
Making message-sending case sensitive for the target of the message

### DIFF
--- a/packages/engine/src/simulation/package/context/packages/agent_messages/collected.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/collected.rs
@@ -24,7 +24,7 @@ impl Messages {
                         .to_string(), //TODO[6](optimization) lose the string creation
                 );
 
-                let by_name = agent_name.map(|val| message_map.get_msg_refs(&val.to_lowercase()));
+                let by_name = agent_name.map(|val| message_map.get_msg_refs(val));
 
                 let mut indices = AgentMessageIndices::new();
                 indices.add(by_id);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Sending a message to an agent with a capitalised letter was broken as we had half implemented case-*in*sensitivity. This PR removes it and makes agent_name case _sensitive_ for message passing

## 🔗 Related links

- [Asana task description](https://app.asana.com/0/0/1201532662164416/f)

## 🔍 What does this change?

- Removes a `to_lowercase()` call where we were turning the message target to lowercase, but only in one side of the logic rather than the other

## 🛡 Tests

<!-- Delete as appropriate -->

- ✅ Manual Tests (Confirmed a message to "Fred" now correctly goes to the "Fred" agent whereas before it didn't)
