### PR TITLE
Fix line numbers in Python tracebacks

### DIFF
--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/package.py
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/package.py
@@ -39,7 +39,7 @@ def load_behaviors(behavior_descs):
             # Have to catch generic `Exception`, because user's code could throw anything.
             n_pkg_fns = 2
             e = str(traceback.format_exception(*sys.exc_info())[n_pkg_fns:])
-            warnings.append("Couldn't load behavior `{}`: {}".format(desc['name'], e))
+            warnings.append(f"Couldn't load behavior `{desc['name']}`: {e}")
 
         # With the current implementation, failing to load a behavior
         # isn't an error if the behavior is never actually used. This

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/package.py
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/package.py
@@ -58,7 +58,7 @@ def start_experiment(experiment, init_message, experiment_context):
 
 def format_behavior_error(behavior_name, exc_info):
     n_pkg_fns = 2
-    return "Behavior error: " + str(traceback.format_exception(*exc_info)[n_pkg_fns:])
+    return f"Behavior error: {traceback.format_exception(*exc_info)[n_pkg_fns:]}"
 
 
 def postprocess(agent_state):

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/package.py
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/package.py
@@ -32,7 +32,7 @@ def load_behaviors(behavior_descs):
                 }
             else:
                 warnings.append(
-                    "Couldn't load behavior: No function named 'behavior': " + desc['name']
+                    f"Couldn't load behavior: No function named 'behavior': {desc['name']}"
                 )
             
         except Exception:

--- a/packages/engine/src/worker/runner/python/package.py
+++ b/packages/engine/src/worker/runner/python/package.py
@@ -1,9 +1,10 @@
-import importlib
+import logging
 from pathlib import Path
 import sys
 import traceback
 
-import logging
+import hash_util
+
 
 def get_pkg_path(pkg_name, pkg_type):
     # The engine should be started from the engine's root directory in the repo.
@@ -17,21 +18,13 @@ def load_fns(pkg_name, pkg_type):
     path = get_pkg_path(pkg_name, pkg_type)
 
     try:
-        # TODO: Discuss whether there is some significant drawback to
-        #       changing `sys.path` here (vs some more complicated way
-        #       of importing files from parent directories of the
-        #       package file's directory).
-        code = ("import pathlib\n" +
-                "import sys\n" +
-                "sys.path.insert(1, pathlib.Path.cwd()/'worker'/'runner'/'python')\n" +
-                "import hash_util\n" +
-                path.read_text())
+        code = path.read_text()
     except IOError:
         logging.info("`" + str(path) + "` doesn't exist, possibly intentionally")
         return [None, None, None]
 
     # Run code.
-    pkg_globals = {}
+    pkg_globals = {"hash_util": hash_util}
     try:
         bytecode = compile(code, pkg_name, "exec")
         exec(bytecode, pkg_globals)

--- a/packages/engine/src/worker/runner/python/runner.py
+++ b/packages/engine/src/worker/runner/python/runner.py
@@ -76,15 +76,14 @@ class Runner:
             # TODO: Pass `task_id` to package?
             continuation = pkg.run_task(pkg.experiment, pkg.sims[sim_id], task_msg, state, ctx) or {}
 
-        except Exception as e:
+        except Exception:
             # Have to catch generic Exception, because package could throw anything.
-
-            tb = str(traceback.format_exception(type(e), e, sys.exc_info()))
-            error = "Package {} error: {}".format(pkg.name, tb)
+            e = str(traceback.format_exception(*sys.exc_info()))
+            e = "Package {} error: {}".format(pkg.name, e)
             # TODO: Custom log level(s) for non-engine (i.e. package/user) errors/warnings,
             #       e.g. `logging.external_error`?
-            logging.error(error)
-            self.messenger.send_pkg_error(error)
+            logging.error(e)
+            self.messenger.send_pkg_error(e)
             return
 
         changes = state.flush_changes(sim.schema)

--- a/packages/engine/src/worker/runner/python/runner.py
+++ b/packages/engine/src/worker/runner/python/runner.py
@@ -79,7 +79,7 @@ class Runner:
         except Exception:
             # Have to catch generic Exception, because package could throw anything.
             e = str(traceback.format_exception(*sys.exc_info()))
-            e = "Package {} error: {}".format(pkg.name, e)
+            e = f"Package {pkg.name} error: {e}"
             # TODO: Custom log level(s) for non-engine (i.e. package/user) errors/warnings,
             #       e.g. `logging.external_error`?
             logging.error(e)


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Python init PR `#3`

Previously line numbers were incorrect if an exception occurred inside a package, due to the runner automatically prepending imports. The PR fixes this by propagating imports in a better way.

## 🔗 Related links

- [Asana task description](https://app.asana.com/0/0/1201539039235283/f)

## 🔍 What does this change?

* Changes how imports are propagated to Python components of packages

## 🛡 Tests

- ✅ Manual Tests

## ❓ How to test this?

1. Run any experiment with a package that has a Python component
2. Raise an exception during package init
3. The resulting traceback should have correct line numbers
