### PR TITLE
Fix behavior execution package Python component init

### DIFF
--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/package.py
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/package.py
@@ -7,7 +7,7 @@ def hash_behavior_id(behavior_id):
     # TODO: Either keep in sync with behavior id generation in Rust part of
     #       behavior execution package or change Rust part to generate
     #       single numbers (rather than pairs of numbers) in the first place.
-    return behavior_id[0]*10 + behavior_id[1]
+    return (behavior_id[0] * 10) + behavior_id[1]
 
 
 # `behavior_descs` should be a list of objects that have fields `id`, `name`, `source`, `columns`,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Python init PR #4

## 🔗 Related links

- [Asana task description](https://app.asana.com/0/0/1201539039235285/f)

## 🔍 What does this change?

* Fixes {behavior id --> behavior} mapping in Python
* Changes `dict.field` to `dict['field']`, as is correct in Python

## 🛡 Tests

- ✅ Manual Tests

## ❓ How to test this?

1. Run any experiment.
2. Python should get through behavior execution package init and reach messages package init.
