### PR TITLE
Associating messages from workers with simulation IDs

### DIFF
--- a/packages/engine/bin/cli/src/experiment.rs
+++ b/packages/engine/bin/cli/src/experiment.rs
@@ -141,31 +141,15 @@ async fn run_experiment_with_manifest(
                 debug!("Simulation stopped: {sim_id}");
             }
             proto::EngineStatus::Errors(sim_id, errs) => {
-                if let Some(sim_id) = sim_id {
-                    error!("There were errors when running simulation [{sim_id}]: {errs:?}");
-                } else {
-                    error!("Errors occurred within the engine: {errs:?}");
-                }
+                error!("There were errors when running simulation [{sim_id}]: {errs:?}");
             }
             proto::EngineStatus::Warnings(sim_id, warnings) => {
-                if let Some(sim_id) = sim_id {
-                    warn!("There were warnings when running simulation [{sim_id}]: {warnings:?}");
-                } else {
-                    warn!("Warnings occurred within the engine: {warnings:?}");
-                }
+                warn!("There were warnings when running simulation [{sim_id}]: {warnings:?}");
             }
             proto::EngineStatus::Logs(sim_id, logs) => {
-                if let Some(sim_id) = sim_id {
-                    for log in logs {
-                        if !log.is_empty() {
-                            info!("[{sim_id}]: {log}");
-                        }
-                    }
-                } else {
-                    for log in logs {
-                        if !log.is_empty() {
-                            info!("{log}");
-                        }
+                for log in logs {
+                    if !log.is_empty() {
+                        info!("[{sim_id}]: {log}");
                     }
                 }
             }

--- a/packages/engine/src/experiment/controller/controller.rs
+++ b/packages/engine/src/experiment/controller/controller.rs
@@ -136,7 +136,7 @@ impl<P: OutputPersistenceCreatorRepr> ExperimentController<P> {
 
     async fn handle_worker_pool_controller_msg(
         &mut self,
-        id: Option<SimulationShortId>,
+        id: SimulationShortId,
         msg: WorkerPoolToExpCtlMsg,
     ) -> Result<()> {
         let engine_status = match msg {

--- a/packages/engine/src/proto.rs
+++ b/packages/engine/src/proto.rs
@@ -33,9 +33,9 @@ pub enum EngineStatus {
     },
     SimStop(SimulationShortId),
     // TODO: OS - Confirm are these only Runner/Simulation errors, if so rename
-    Errors(Option<SimulationShortId>, Vec<RunnerError>),
-    Warnings(Option<SimulationShortId>, Vec<RunnerError>),
-    Logs(Option<SimulationShortId>, Vec<String>),
+    Errors(SimulationShortId, Vec<RunnerError>),
+    Warnings(SimulationShortId, Vec<RunnerError>),
+    Logs(SimulationShortId, Vec<String>),
 }
 
 /// The message type sent from the orchestrator to the engine.

--- a/packages/engine/src/workerpool/comms/mod.rs
+++ b/packages/engine/src/workerpool/comms/mod.rs
@@ -101,7 +101,7 @@ pub enum WorkerToWorkerPoolMsg {
 
 pub struct WorkerCommsWithWorkerPool {
     index: WorkerIndex,
-    send_to_wp: UnboundedSender<(WorkerIndex, WorkerToWorkerPoolMsg)>,
+    send_to_wp: UnboundedSender<(WorkerIndex, SimulationShortId, WorkerToWorkerPoolMsg)>,
     recv_from_wp: Option<UnboundedReceiver<WorkerPoolToWorkerMsg>>,
     terminate_recv: TerminateRecv,
 }
@@ -111,8 +111,12 @@ impl WorkerCommsWithWorkerPool {
         &self.index
     }
 
-    pub fn send(&self, msg: WorkerToWorkerPoolMsg) -> crate::worker::error::Result<()> {
-        self.send_to_wp.send((self.index, msg))?;
+    pub fn send(
+        &self,
+        sim_id: SimulationShortId,
+        msg: WorkerToWorkerPoolMsg,
+    ) -> crate::worker::error::Result<()> {
+        self.send_to_wp.send((self.index, sim_id, msg))?;
         Ok(())
     }
 
@@ -146,7 +150,7 @@ pub struct WorkerPoolCommsWithWorkers {
         UnboundedSender<WorkerPoolToWorkerMsg>,
         terminate::TerminateSend,
     )>,
-    recv_from_w: UnboundedReceiver<(WorkerIndex, WorkerToWorkerPoolMsg)>,
+    recv_from_w: UnboundedReceiver<(WorkerIndex, SimulationShortId, WorkerToWorkerPoolMsg)>,
 }
 
 impl WorkerPoolCommsWithWorkers {
@@ -211,7 +215,9 @@ impl WorkerPoolCommsWithWorkers {
         Ok(())
     }
 
-    pub async fn recv(&mut self) -> Option<(WorkerIndex, WorkerToWorkerPoolMsg)> {
+    pub async fn recv(
+        &mut self,
+    ) -> Option<(WorkerIndex, SimulationShortId, WorkerToWorkerPoolMsg)> {
         self.recv_from_w.recv().await
     }
 }

--- a/packages/engine/src/workerpool/comms/top.rs
+++ b/packages/engine/src/workerpool/comms/top.rs
@@ -5,17 +5,17 @@ use crate::{proto::SimulationShortId, worker::runner::comms::outbound::RunnerErr
 // Mainly used only for passing errors and warnings.
 
 pub struct WorkerPoolMsgRecv {
-    pub inner: UnboundedReceiver<(Option<SimulationShortId>, WorkerPoolToExpCtlMsg)>,
+    pub inner: UnboundedReceiver<(SimulationShortId, WorkerPoolToExpCtlMsg)>,
 }
 
 impl WorkerPoolMsgRecv {
-    pub async fn recv(&mut self) -> Option<(Option<SimulationShortId>, WorkerPoolToExpCtlMsg)> {
+    pub async fn recv(&mut self) -> Option<(SimulationShortId, WorkerPoolToExpCtlMsg)> {
         self.inner.recv().await
     }
 }
 
 pub struct WorkerPoolMsgSend {
-    pub inner: UnboundedSender<(Option<SimulationShortId>, WorkerPoolToExpCtlMsg)>,
+    pub inner: UnboundedSender<(SimulationShortId, WorkerPoolToExpCtlMsg)>,
 }
 
 #[derive(Debug)]

--- a/packages/engine/src/workerpool/mod.rs
+++ b/packages/engine/src/workerpool/mod.rs
@@ -166,9 +166,9 @@ impl WorkerPoolController {
                     log::debug!("Handle experiment message: {:?}", msg);
                     self.handle_exp_msg(msg).await?;
                 }
-                Some((worker_index, msg)) = self.comms.recv() => {
-                    log::debug!("Handle comms message for worker [{}]: {:?}", worker_index, msg);
-                    self.handle_worker_msg(worker_index, msg).await?;
+                Some((worker_index, sim_id, msg)) = self.comms.recv() => {
+                    log::debug!("Handle comms message for worker [{}] and simulation [{}]: {:?}", worker_index, sim_id, msg);
+                    self.handle_worker_msg(worker_index, sim_id, msg).await?;
                 }
                 // TODO: Revisit this
                 // cancel_msgs = self.pending_tasks.run_cancel_check() => {
@@ -260,6 +260,7 @@ impl WorkerPoolController {
     async fn handle_worker_msg(
         &mut self,
         worker: WorkerIndex,
+        sim_id: SimulationShortId,
         worker_msg: WorkerToWorkerPoolMsg,
     ) -> Result<()> {
         match worker_msg {
@@ -280,19 +281,19 @@ impl WorkerPoolController {
                 log::debug!("Received RunnerErrors Message from Worker");
                 self.top_send
                     .inner
-                    .send((None, WorkerPoolToExpCtlMsg::Errors(errors)))?;
+                    .send((Some(sim_id), WorkerPoolToExpCtlMsg::Errors(errors)))?;
             }
             WorkerToWorkerPoolMsg::RunnerWarnings(warnings) => {
                 log::debug!("Received RunnerWarnings Message from Worker");
                 self.top_send
                     .inner
-                    .send((None, WorkerPoolToExpCtlMsg::Warnings(warnings)))?;
+                    .send((Some(sim_id), WorkerPoolToExpCtlMsg::Warnings(warnings)))?;
             }
             WorkerToWorkerPoolMsg::RunnerLogs(logs) => {
                 log::debug!("Received RunnerLogs Message from Worker");
                 self.top_send
                     .inner
-                    .send((None, WorkerPoolToExpCtlMsg::Logs(logs)))?;
+                    .send((Some(sim_id), WorkerPoolToExpCtlMsg::Logs(logs)))?;
             }
         }
         Ok(())

--- a/packages/engine/src/workerpool/mod.rs
+++ b/packages/engine/src/workerpool/mod.rs
@@ -281,19 +281,19 @@ impl WorkerPoolController {
                 log::debug!("Received RunnerErrors Message from Worker");
                 self.top_send
                     .inner
-                    .send((Some(sim_id), WorkerPoolToExpCtlMsg::Errors(errors)))?;
+                    .send((sim_id, WorkerPoolToExpCtlMsg::Errors(errors)))?;
             }
             WorkerToWorkerPoolMsg::RunnerWarnings(warnings) => {
                 log::debug!("Received RunnerWarnings Message from Worker");
                 self.top_send
                     .inner
-                    .send((Some(sim_id), WorkerPoolToExpCtlMsg::Warnings(warnings)))?;
+                    .send((sim_id, WorkerPoolToExpCtlMsg::Warnings(warnings)))?;
             }
             WorkerToWorkerPoolMsg::RunnerLogs(logs) => {
                 log::debug!("Received RunnerLogs Message from Worker");
                 self.top_send
                     .inner
-                    .send((Some(sim_id), WorkerPoolToExpCtlMsg::Logs(logs)))?;
+                    .send((sim_id, WorkerPoolToExpCtlMsg::Logs(logs)))?;
             }
         }
         Ok(())


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Messages from workers (such as those containing logs and warnings from user behaviors) weren't associated with a simulationID. This fixes that

## 🔗 Related links

<!-- Add links to Asana, Slack, Notion or whatever originated this PR -->
<!-- This will be _super_ handy 6 months from now.  -->

- [Asana task description](https://app.asana.com/0/1199550852792314/1201533886101099/f)

## 🔍 What does this change?

- The message sender from Worker has been expanded to also send the simulationId
- Worker handle methods pass the SimId
- The WorkerPool receiver correctly propagates that SimId

## 🛡 Tests

- ✅ Manual Tests 
