### PR TITLE
Improving info-level logging, cleaning up TODOs, and unused code, 

### DIFF
--- a/packages/engine/bin/cli/src/experiment.rs
+++ b/packages/engine/bin/cli/src/experiment.rs
@@ -48,7 +48,6 @@ fn create_engine_command(
     Ok(Box::new(process::LocalCommand::new(
         experiment_id,
         args.num_workers as usize,
-        true,
         controller_url,
     )?))
 }
@@ -106,7 +105,7 @@ async fn run_experiment_with_manifest(
     let init_message = proto::InitMessage {
         experiment: experiment_run.clone().into(),
         env: ExecutionEnvironment::None, // We don't connect to the API
-        dyn_payloads: serde_json::Map::from_iter(map_iter), // TODO
+        dyn_payloads: serde_json::Map::from_iter(map_iter),
     };
     engine_process
         .send(&proto::EngineMsg::Init(init_message))

--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -76,10 +76,6 @@ pub struct SimpleExperimentArgs {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // TODO: project conversion into manifest...
-    // TODO: persist output
-    //   1) send absolute path to engine process
-    //   2) within engine process, save to folder
     pretty_env_logger::init();
     let args = Args::from_args();
 

--- a/packages/engine/bin/cli/src/process/local.rs
+++ b/packages/engine/bin/cli/src/process/local.rs
@@ -55,16 +55,10 @@ pub struct LocalCommand {
     experiment_id: String,
     controller_url: String,
     max_num_workers: usize,
-    persist_data: bool,
 }
 
 impl LocalCommand {
-    pub fn new(
-        experiment_id: &str,
-        max_num_workers: usize,
-        persist_data: bool,
-        controller_url: &str,
-    ) -> Result<Self> {
+    pub fn new(experiment_id: &str, max_num_workers: usize, controller_url: &str) -> Result<Self> {
         // The NNG URL that the engine process will listen on
         let engine_url = format!("ipc://run-{experiment_id}");
 
@@ -73,7 +67,6 @@ impl LocalCommand {
             experiment_id: experiment_id.to_string(),
             controller_url: controller_url.to_string(),
             max_num_workers,
-            persist_data,
         })
     }
 }
@@ -100,9 +93,6 @@ impl process::Command for LocalCommand {
             .stdout(std::process::Stdio::inherit())
             .stderr(std::process::Stdio::inherit());
         debug!("Running `{cmd:?}`");
-        if self.persist_data {
-            cmd.arg("--persist");
-        }
 
         let child = cmd
             .spawn()

--- a/packages/engine/src/args.rs
+++ b/packages/engine/src/args.rs
@@ -16,10 +16,6 @@ pub struct Args {
     /// max number of workers per simulation run (optional).
     #[argh(option)]
     pub max_workers: Option<usize>,
-
-    /// persist data to S3
-    #[argh(switch)]
-    pub persist: bool,
 }
 
 pub fn args() -> Args {

--- a/packages/engine/src/datastore/schema/field_spec/mod.rs
+++ b/packages/engine/src/datastore/schema/field_spec/mod.rs
@@ -265,10 +265,9 @@ impl FieldSpecMap {
         let field_key = new_field.to_key()?;
         if let Some(existing_field) = self.field_specs.get(&field_key) {
             if existing_field == &new_field {
-                log::warn!(
-                    "FieldSpec: [{}], already exists within the FieldSpecMap",
-                    field_key
-                );
+                // This likely only happens when behaviors declare duplicate keys, it can't cause
+                // problems as the fields are equal and therefore the sources (and types) are the
+                // same, meaning the field can't override another package's field
                 return Ok(());
             }
             if existing_field.scope == FieldScope::Agent

--- a/packages/engine/src/env.rs
+++ b/packages/engine/src/env.rs
@@ -85,7 +85,6 @@ pub async fn env<E>(args: &Args) -> Result<Environment>
 where
     E: ExperimentRunTrait + for<'de> Deserialize<'de>,
 {
-    log::info!("Persist data to S3: {}", args.persist); // TODO: Doesn't look like it does anything
     let mut orch_client = OrchClient::new(&args.orchestrator_url, &args.experiment_id)?;
     log::debug!("Connected to orchestrator at {}", &args.orchestrator_url);
 

--- a/packages/engine/src/experiment/controller/controller.rs
+++ b/packages/engine/src/experiment/controller/controller.rs
@@ -309,7 +309,7 @@ impl<P: OutputPersistenceCreatorRepr> ExperimentController<P> {
         let mut terminate_recv = self.terminate_recv.take_recv()?;
 
         let mut waiting_for_completion = None;
-        let mut time_to_wait = 1;
+        let mut time_to_wait = 3;
         const WAITING_MULTIPLIER: u64 = 3;
 
         loop {
@@ -355,7 +355,7 @@ impl<P: OutputPersistenceCreatorRepr> ExperimentController<P> {
                 }
                 _ = async { waiting_for_completion.as_mut().expect("must be some").await }, if waiting_for_completion.is_some() => {
                     time_to_wait *= WAITING_MULTIPLIER;
-                    log::warn!("Experiment Controller received a termination message, waiting {} seconds for sim run tasks to complete", time_to_wait);
+                    log::warn!("Experiment Controller received a termination message, but simulation runs haven't finished, waiting {} seconds", time_to_wait);
                     waiting_for_completion = Some(Box::pin(tokio::time::sleep(Duration::from_secs(time_to_wait))));
                 }
             }

--- a/packages/engine/src/experiment/package/single.rs
+++ b/packages/engine/src/experiment/package/single.rs
@@ -46,7 +46,7 @@ impl SingleRunExperiment {
                 break;
             }
         }
-        log::info!("Experiment package exiting");
+        log::debug!("Experiment package exiting");
         Ok(())
     }
 }

--- a/packages/engine/src/proto.rs
+++ b/packages/engine/src/proto.rs
@@ -42,6 +42,7 @@ pub enum EngineStatus {
 #[derive(Serialize, Deserialize, Debug)]
 pub enum EngineMsg {
     Init(InitMessage),
+    // TODO: this is unused, is that intended
     SimRegistered(SimulationShortId, SimulationRegisteredId),
 }
 

--- a/packages/engine/src/worker/runner/javascript/mod.rs
+++ b/packages/engine/src/worker/runner/javascript/mod.rs
@@ -439,8 +439,13 @@ fn get_user_warnings(_mv8: &MiniV8, r: &mv8::Object<'_>) -> Option<Vec<RunnerErr
 }
 
 fn get_print(_mv8: &MiniV8, r: &mv8::Object<'_>) -> Option<Vec<String>> {
-    if let Ok(mv8::Value::String(e)) = r.get("print") {
-        Some(e.to_string().split('\n').map(|s| s.to_string()).collect())
+    if let Ok(mv8::Value::String(printed_val)) = r.get("print") {
+        let printed_val = printed_val.to_string();
+        if !printed_val.is_empty() {
+            Some(printed_val.split('\n').map(|s| s.to_string()).collect())
+        } else {
+            None
+        }
     } else {
         None
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific changes. -->

Changes some log levels and clears up info-level logging to improve readability of running experiments in normal use. Also clears up unused parts of the code-base and some other drive-bys

## 🔗 Related links

<!-- Add links to Asana, Slack, Notion or whatever originated this PR -->
<!-- This will be _super_ handy 6 months from now.  -->

- [Asana task description](https://app.asana.com/0/1199550852792314/1201526606175188/f)

## 🔍 What does this change?

- Removes unused (and legacy) persist argument for the CLI
- Replaces a warning message when adding FieldSpecs that already exist with a comment explaining why it's okay to ignore
- Increases the initial wait time for the Experiment Controller exit logic to avoid logs that aren't useful
- Removes empty print (e.g. console.log in behaviors) from task messages at an earlier point

## 🛡 Tests

- ✅ Manual Tests

## 📹 Demo

Example output for an experiment, logging at info-level, is as follows (now cleaner and only showing useful information):
```
 INFO  hash_engine > HASH Engine process started for experiment agent_density_linspace-155ff1
 INFO  hash_engine::experiment::controller::run > Running experiment agent_density_linspace-155ff1
 INFO  hash_engine::simulation::controller::run > Beginning simulation run with id 1 for a maximum of 25 steps
 INFO  hash_engine::simulation::controller::run > Beginning simulation run with id 2 for a maximum of 25 steps
 INFO  hash_engine::simulation::controller::run > Beginning simulation run with id 3 for a maximum of 25 steps
 INFO  cli::experiment > [2]: 0,50 
 INFO  cli::experiment > [1]: 0,50 
 INFO  cli::experiment > [3]: 0,50 
 INFO  hash_engine::output::local::sim          > Making new output directory directory: "./output/sugarscape/agent_density_linspace-155ff1/1"
 INFO  hash_engine::simulation::controller::run > Finished simulation run. Main loop took 57190 ms. Persistence took: 41 ms
 INFO  hash_engine::output::local::sim          > Making new output directory directory: "./output/sugarscape/agent_density_linspace-155ff1/2"
 INFO  hash_engine::simulation::controller::run > Finished simulation run. Main loop took 58397 ms. Persistence took: 41 ms
 INFO  hash_engine::output::local::sim          > Making new output directory directory: "./output/sugarscape/agent_density_linspace-155ff1/3"
 INFO  hash_engine::simulation::controller::run > Finished simulation run. Main loop took 59061 ms. Persistence took: 33 ms
 ```