### PR TITLE
Add experiment Id to logging output

### DIFF
--- a/packages/engine/bin/cli/src/experiment.rs
+++ b/packages/engine/bin/cli/src/experiment.rs
@@ -127,7 +127,7 @@ async fn run_experiment_with_manifest(
 
         match msg {
             proto::EngineStatus::Stopping => {
-                debug!("Stopping experiment");
+                debug!("Stopping experiment {experiment_id}");
             }
             proto::EngineStatus::SimStart { sim_id, globals: _ } => {
                 debug!("Started simulation: {sim_id}");
@@ -148,7 +148,7 @@ async fn run_experiment_with_manifest(
             proto::EngineStatus::Logs(sim_id, logs) => {
                 for log in logs {
                     if !log.is_empty() {
-                        info!("[{sim_id}]: {log}");
+                        info!(target: "behaviors", "[{experiment_id}][{sim_id}]: {log}");
                     }
                 }
             }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

https://github.com/hashintel/hash/pull/93 implemented logging from JS behaviors. However when the logs appear they only have a `SimulationID` attached, and do not contain information about what file, location, behavior, task, function, etc. that it came from:
```
INFO  cli::experiment > [1]: 0,50
```

This also adds the current experiment id and changes the log targets to `behaviors`:
```
INFO  behaviors > [single_run-e073f2][1]: 0,50
```

## 🔗 Related links

<!-- Add links to Asana, Slack, Notion or whatever originated this PR -->
<!-- This will be _super_ handy 6 months from now.  -->

- [Asana task description](https://app.asana.com/0/1199550852792314/1201533886101103/f)

## 🛡 Tests

<!-- Delete as appropriate -->

- ✅ Manual Tests

