### PR TITLE
Writing globals.json to the output folder alongside simulation results

### DIFF
--- a/packages/engine/src/output/buffer/mod.rs
+++ b/packages/engine/src/output/buffer/mod.rs
@@ -34,12 +34,14 @@ impl Buffers {
         output_packages_sim_config: &OutputPackagesSimConfig,
     ) -> Result<Buffers> {
         Ok(Buffers {
+            // TODO: This should be dynamically created by the output packages
             json_state: OutputPartBuffer::new("json_state", exp_id, sim_id)?,
             analysis: AnalysisBuffer::new(output_packages_sim_config)?,
         })
     }
 }
 
+// TODO: These should live in the respective output package really
 #[derive(Serialize)]
 pub struct AnalysisBuffer {
     pub manifest: String,

--- a/packages/engine/src/output/local/sim.rs
+++ b/packages/engine/src/output/local/sim.rs
@@ -5,6 +5,7 @@ use crate::{
     output::{buffer::Buffers, error::Result, SimulationOutputPersistenceRepr},
     proto::{ExperimentRegisteredId, SimulationShortId},
     simulation::{package::output::packages::Output, step_output::SimulationStepOutput},
+    SimRunConfig,
 };
 
 #[derive(derive_new::new)]
@@ -35,7 +36,7 @@ impl SimulationOutputPersistenceRepr for LocalSimulationOutputPersistence {
         Ok(())
     }
 
-    async fn finalize(mut self) -> Result<Self::OutputPersistenceResult> {
+    async fn finalize(mut self, config: &SimRunConfig) -> Result<Self::OutputPersistenceResult> {
         log::trace!("Finalizing output");
         // JSON state
         let (_, parts) = self.buffers.json_state.finalize()?;
@@ -71,6 +72,11 @@ impl SimulationOutputPersistenceRepr for LocalSimulationOutputPersistence {
             &analysis_path,
             serde_json::to_string(&self.buffers.analysis)?,
         )?;
+
+        // Globals
+        let globals_path = path.join("globals.json");
+        std::fs::File::create(&globals_path)?;
+        std::fs::write(&globals_path, serde_json::to_string(&config.sim.globals)?)?;
 
         Ok(LocalPersistenceResult::new(
             path.canonicalize()?.to_string_lossy().to_string(),

--- a/packages/engine/src/output/mod.rs
+++ b/packages/engine/src/output/mod.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::{
     config::PersistenceConfig, proto::SimulationShortId,
-    simulation::step_output::SimulationStepOutput,
+    simulation::step_output::SimulationStepOutput, SimRunConfig,
 };
 
 pub mod buffer;
@@ -26,7 +26,7 @@ pub trait OutputPersistenceCreatorRepr: Send + Sync + 'static {
 pub trait SimulationOutputPersistenceRepr: Send + Sync + 'static {
     type OutputPersistenceResult: OutputPersistenceResultRepr;
     async fn add_step_output(&mut self, output: SimulationStepOutput) -> Result<()>;
-    async fn finalize(self) -> Result<Self::OutputPersistenceResult>;
+    async fn finalize(mut self, config: &SimRunConfig) -> Result<Self::OutputPersistenceResult>;
 }
 
 pub trait OutputPersistenceResultRepr: Serialize + Send + Sync {

--- a/packages/engine/src/output/mod.rs
+++ b/packages/engine/src/output/mod.rs
@@ -26,7 +26,7 @@ pub trait OutputPersistenceCreatorRepr: Send + Sync + 'static {
 pub trait SimulationOutputPersistenceRepr: Send + Sync + 'static {
     type OutputPersistenceResult: OutputPersistenceResultRepr;
     async fn add_step_output(&mut self, output: SimulationStepOutput) -> Result<()>;
-    async fn finalize(mut self, config: &SimRunConfig) -> Result<Self::OutputPersistenceResult>;
+    async fn finalize(self, config: &SimRunConfig) -> Result<Self::OutputPersistenceResult>;
 }
 
 pub trait OutputPersistenceResultRepr: Serialize + Send + Sync {

--- a/packages/engine/src/output/none.rs
+++ b/packages/engine/src/output/none.rs
@@ -6,6 +6,7 @@ use crate::{
     output::{error::Result, OutputPersistenceResultRepr},
     proto::SimulationShortId,
     simulation::step_output::SimulationStepOutput,
+    SimRunConfig,
 };
 
 #[derive(Default)]
@@ -39,7 +40,7 @@ impl SimulationOutputPersistenceRepr for NoSimulationOutputPersistence {
         Ok(())
     }
 
-    async fn finalize(self) -> Result<Self::OutputPersistenceResult> {
+    async fn finalize(mut self, _config: &SimRunConfig) -> Result<Self::OutputPersistenceResult> {
         Ok(())
     }
 }

--- a/packages/engine/src/output/none.rs
+++ b/packages/engine/src/output/none.rs
@@ -40,7 +40,7 @@ impl SimulationOutputPersistenceRepr for NoSimulationOutputPersistence {
         Ok(())
     }
 
-    async fn finalize(mut self, _config: &SimRunConfig) -> Result<Self::OutputPersistenceResult> {
+    async fn finalize(self, _config: &SimRunConfig) -> Result<Self::OutputPersistenceResult> {
         Ok(())
     }
 }

--- a/packages/engine/src/simulation/controller/run.rs
+++ b/packages/engine/src/simulation/controller/run.rs
@@ -76,7 +76,7 @@ pub async fn sim_run<P: SimulationOutputPersistenceRepr>(
             Err(error) => {
                 log::error!("Got error within the engine step process: {:?}", error);
                 // Try to persist before exiting
-                let persistence_result = Some(persistence_service.finalize().await?);
+                let persistence_result = Some(persistence_service.finalize(&config).await?);
                 let runner_error = RunnerError {
                     message: Some(format!("{:?}", error)),
                     code: None,
@@ -147,7 +147,7 @@ pub async fn sim_run<P: SimulationOutputPersistenceRepr>(
         })?;
 
     let now = std::time::Instant::now();
-    let persistence_result = persistence_service.finalize().await?;
+    let persistence_result = persistence_service.finalize(&config).await?;
     sims_to_exp
         .send(
             SimStatus::ended(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Simulation outputs were tied to their project, experiment run, and simulation run, but there was no easy way of knowing which parameters were used for which run. In the case of experiments, this poses a large problem as the user provided `globals.json` can have properties overridden by the experiment. 

This PR outputs each simulation's respective globals.json alongside the json_state.json and analysis_outputs.json.

## 🔗 Related links

<!-- Add links to Asana, Slack, Notion or whatever originated this PR -->
<!-- This will be _super_ handy 6 months from now.  -->

- [Asana task description](https://app.asana.com/0/1199550852792314/1201533886101107/f)

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If possible, link to the specific commit.-->

- Writes the simulation globals to a globals.json in the output folder for the simulation

## 🛡 Tests

<!-- Delete as appropriate -->
- ✅ Manual Tests

## ❓ How to test this?

1. Run any simulation (preferably an experiment with multiple simulations)
2. Check the output folder and verify that there is a globals.json, and the respective globals.json for the simulations have differing parameters in the case of experiments.

## 📹 Demo

![image](https://user-images.githubusercontent.com/25749103/146928764-8c4c800c-19a4-46c4-8bb5-6f971650c7a9.png)
