### PR TITLE
In-repo documentation updates for open-sourcing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,36 +12,24 @@ This repository contains HASH's open-source and public code, documentation, and 
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 
-
-
-<!-- CONTRIBUTING -->
 ## Contributing
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md) if you're interested in getting involved in the design or development of HASH
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 
-
-
-<!-- LICENSE -->
 ## License
 
 Please see [LICENSE.md](LICENSE.md) for more information about the terms under which the various parts of this repository are made available
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 
-
-
-<!-- SECURITY -->
 ## Security
 
 Please see [SECURITY.md](SECURITY.md) for instructions around reporting issues, and details of which package versions we actively support
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 
-
-
-<!-- CONTACT -->
 ## Contact
 
 Find us on Twitter at [@hashintel](https://twitter.com/hashintel), join our [Discord server](https://hash.ai/discord) for quick help and support, or post in our [community forum](https://hash.community/).

--- a/README.md
+++ b/README.md
@@ -1,15 +1,51 @@
+<div id="top"></div>
+
 # HASH
 
 This repository contains HASH's open-source and public code, documentation, and other key resources, including:
 
-- `packages/hash`: The codebase for HASH ([Info](https://hash.ai/platform/index)) - coming soon, available under an Apache 2.0 compatible license
+- `packages/hash`: The codebase for HASH - an open-source, data-centric workspace based on the [Block Protocol](https://github.com/blockprotocol/blockprotocol), coming soon
 - `packages/engine`: The codebase for [hEngine](packages/engine) ([Info](https://hash.ai/platform/engine)) - available under the Server Side Public License
 - `packages/engine/stdlib`: The [standard library](packages/engine/stdlib) of helper functions available in all HASH simulations
 - `resources/docs`: A user guide to the whole HASH platform ([hash.ai/docs](https://hash.ai/docs))
 - `resources/glossary`: A glossary of terms explaining common concepts relevant to the use of HASH ([hash.ai/glossary](https://hash.ai/glossary))
 
-Please see:
+<p align="right">(<a href="#top">back to top</a>)</p>
 
-- [LICENSE.md](LICENSE.md) for more information about the terms under which the various parts of this repository are made available
-- [CONTRIBUTING.md](CONTRIBUTING.md) if you're interested in getting involved in the design or development of HASH
-- [SECURITY.md](SECURITY.md) for instructions around reporting issues, and details of which package versions we actively support
+
+
+<!-- CONTRIBUTING -->
+## Contributing
+
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) if you're interested in getting involved in the design or development of HASH
+
+<p align="right">(<a href="#top">back to top</a>)</p>
+
+
+
+<!-- LICENSE -->
+## License
+
+Please see [LICENSE.md](LICENSE.md) for more information about the terms under which the various parts of this repository are made available
+
+<p align="right">(<a href="#top">back to top</a>)</p>
+
+
+
+<!-- SECURITY -->
+## Security
+
+Please see [SECURITY.md](SECURITY.md) for instructions around reporting issues, and details of which package versions we actively support
+
+<p align="right">(<a href="#top">back to top</a>)</p>
+
+
+
+<!-- CONTACT -->
+## Contact
+
+Find us on Twitter at [@hashintel](https://twitter.com/hashintel), join our [Discord server](https://hash.ai/discord) for quick help and support, or post in our [community forum](https://hash.community/).
+
+Project Link: [https://github.com/hashintel/hash](https://github.com/hashintel/hash)
+
+<p align="right">(<a href="#top">back to top</a>)</p>


### PR DESCRIPTION
This PR will serve as a catch-all for various updates to documentation ahead of our open-sourcing of **HASH** in January 2022, our eponymous, open-source, data-centred workspace.