### PR TITLE
Add `Provider` API for context information on errors (and possibly other things)

### DIFF
--- a/packages/engine/Cargo.lock
+++ b/packages/engine/Cargo.lock
@@ -1615,6 +1615,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "provider"
+version = "0.0.0"
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/packages/engine/lib/provider/Cargo.toml
+++ b/packages/engine/lib/provider/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "provider"
+version = "0.0.0"
+edition = "2021"
+description = "`Provider` trait and accompanying API"
+publish = false

--- a/packages/engine/lib/provider/src/internal.rs
+++ b/packages/engine/lib/provider/src/internal.rs
@@ -6,8 +6,8 @@ use super::{TypeId, TypeTag};
 ///
 /// # Safety
 ///
-/// This trait must be exclusively implemented by the [`TagValue`] type as [`Tagged::is`] relies on
-/// `tag_id` and the [`TypeId`] must not be overwritten.
+/// This trait must be exclusively implemented by [`TagValue`] as [`Tagged::is`] relies on `tag_id`
+/// and the [`TypeId`] must not be overwritten.
 ///
 /// [`Tagged::is`]: #method.is
 pub(super) unsafe trait Tagged<'p>: 'p {

--- a/packages/engine/lib/provider/src/internal.rs
+++ b/packages/engine/lib/provider/src/internal.rs
@@ -4,7 +4,7 @@ use super::{TypeId, TypeTag};
 ///
 /// # Safety
 ///
-/// This trait must be  exclusively implemented by the `TagValue` type.
+/// This trait must be exclusively implemented by the `TagValue` type.
 pub(super) unsafe trait Tagged<'p>: 'p {
     /// The `TypeId` of the `TypeTag` this value was tagged with.
     fn tag_id(&self) -> TypeId;
@@ -45,8 +45,7 @@ impl<'p> dyn Tagged<'p> {
         I: TypeTag<'p>,
     {
         if self.is::<I>() {
-            // SAFETY: Just checked whether we're pointing to a
-            // `TagValue<'p, I>`.
+            // SAFETY: Just checked whether we're pointing to a `TagValue<'p, I>`
             unsafe { Some(&mut *(self as *mut Self).cast::<TagValue<'p, I>>()) }
         } else {
             None

--- a/packages/engine/lib/provider/src/internal.rs
+++ b/packages/engine/lib/provider/src/internal.rs
@@ -6,7 +6,10 @@ use super::{TypeId, TypeTag};
 ///
 /// # Safety
 ///
-/// This trait must be exclusively implemented by the [`TagValue`] type.
+/// This trait must be exclusively implemented by the [`TagValue`] type as [`Tagged::is`] relies on
+/// `tag_id` and the [`TypeId`] must not be overwritten.
+///
+/// [`Tagged::is`]: #method.is
 pub(super) unsafe trait Tagged<'p>: 'p {
     /// The [`TypeId`] of the [`TypeTag`] this value was tagged with.
     fn tag_id(&self) -> TypeId;

--- a/packages/engine/lib/provider/src/internal.rs
+++ b/packages/engine/lib/provider/src/internal.rs
@@ -1,0 +1,55 @@
+use super::{TypeId, TypeTag};
+
+/// Sealed trait representing a type-erased tagged object.
+///
+/// # Safety
+///
+/// This trait must be  exclusively implemented by the `TagValue` type.
+pub(super) unsafe trait Tagged<'p>: 'p {
+    /// The `TypeId` of the `TypeTag` this value was tagged with.
+    fn tag_id(&self) -> TypeId;
+}
+
+/// A concrete tagged value for a given tag `I`.
+///
+/// This is the only type which implements the `Tagged` trait, and encodes additional information
+/// about the specific `TypeTag` into the type. This allows for multiple different tags to support
+/// overlapping value ranges, for example, both the `Ref<str>` and `Value<&'static str>` tags can be
+/// used to tag a value of type `&'static str`.
+#[repr(transparent)]
+pub(super) struct TagValue<'p, I: TypeTag<'p>>(pub(super) I::Type);
+
+unsafe impl<'p, I> Tagged<'p> for TagValue<'p, I>
+where
+    I: TypeTag<'p>,
+{
+    fn tag_id(&self) -> TypeId {
+        TypeId::of::<I>()
+    }
+}
+
+impl<'p> dyn Tagged<'p> {
+    /// Returns `true` if the dynamic type is tagged with `I`.
+    #[inline]
+    pub(super) fn is<I>(&self) -> bool
+    where
+        I: TypeTag<'p>,
+    {
+        self.tag_id() == TypeId::of::<I>()
+    }
+
+    /// Returns some reference to the dynamic value if it is tagged with `I`, or `None` if it isn't.
+    #[inline]
+    pub(super) fn downcast_mut<I>(&mut self) -> Option<&mut TagValue<'p, I>>
+    where
+        I: TypeTag<'p>,
+    {
+        if self.is::<I>() {
+            // SAFETY: Just checked whether we're pointing to a
+            // `TagValue<'p, I>`.
+            unsafe { Some(&mut *(self as *mut Self).cast::<TagValue<'p, I>>()) }
+        } else {
+            None
+        }
+    }
+}

--- a/packages/engine/lib/provider/src/internal.rs
+++ b/packages/engine/lib/provider/src/internal.rs
@@ -1,21 +1,27 @@
+//! Internal API
+
 use super::{TypeId, TypeTag};
 
 /// Sealed trait representing a type-erased tagged object.
 ///
 /// # Safety
 ///
-/// This trait must be exclusively implemented by the `TagValue` type.
+/// This trait must be exclusively implemented by the [`TagValue`] type.
 pub(super) unsafe trait Tagged<'p>: 'p {
-    /// The `TypeId` of the `TypeTag` this value was tagged with.
+    /// The [`TypeId`] of the [`TypeTag`] this value was tagged with.
     fn tag_id(&self) -> TypeId;
 }
 
 /// A concrete tagged value for a given tag `I`.
 ///
-/// This is the only type which implements the `Tagged` trait, and encodes additional information
-/// about the specific `TypeTag` into the type. This allows for multiple different tags to support
-/// overlapping value ranges, for example, both the `Ref<str>` and `Value<&'static str>` tags can be
-/// used to tag a value of type `&'static str`.
+/// This is the only type which implements the [`Tagged`] trait, and encodes additional information
+/// about the specific [`TypeTag`] into the type. This allows for multiple different tags to support
+/// overlapping value ranges, for example, both the [`Ref<str>`] and [`Value<&'static str>`] tags
+/// can be used to tag a value of type [`&'static str`].
+///
+/// [`Ref<str>`]: crate::tags::Ref
+/// [`Value<&'static str>`]: crate::tags::Value
+/// [`&'static str`]: str
 #[repr(transparent)]
 pub(super) struct TagValue<'p, I: TypeTag<'p>>(pub(super) I::Type);
 
@@ -38,7 +44,8 @@ impl<'p> dyn Tagged<'p> {
         self.tag_id() == TypeId::of::<I>()
     }
 
-    /// Returns some reference to the dynamic value if it is tagged with `I`, or `None` if it isn't.
+    /// Returns some reference to the dynamic value if it is tagged with `I`, or [`None`] if it
+    /// isn't.
     #[inline]
     pub(super) fn downcast_mut<I>(&mut self) -> Option<&mut TagValue<'p, I>>
     where

--- a/packages/engine/lib/provider/src/internal.rs
+++ b/packages/engine/lib/provider/src/internal.rs
@@ -55,8 +55,9 @@ impl<'p> dyn Tagged<'p> {
         I: TypeTag<'p>,
     {
         if self.is::<I>() {
+            let tag_value = (self as *mut Self).cast::<TagValue<'p, I>>();
             // SAFETY: Just checked whether we're pointing to a `TagValue<'p, I>`
-            unsafe { Some(&mut *(self as *mut Self).cast::<TagValue<'p, I>>()) }
+            unsafe { Some(&mut *tag_value) }
         } else {
             None
         }

--- a/packages/engine/lib/provider/src/lib.rs
+++ b/packages/engine/lib/provider/src/lib.rs
@@ -156,7 +156,7 @@ pub trait TypeTag<'p>: Sized + 'static {
 /// A helper object for providing objects by type.
 ///
 /// An object provider provides values by calling this type's provide methods. Note, that
-/// `Requisition` is a wrapper around a mutable reference to a [`TypeTag`]ed value.
+/// `Requisition` is a wrapper around a mutable reference to a [`TypeTag`]ged value.
 #[allow(missing_debug_implementations)]
 pub struct Requisition<'p, 'r>(&'r mut RequisitionImpl<dyn Tagged<'p> + 'p>);
 

--- a/packages/engine/lib/provider/src/lib.rs
+++ b/packages/engine/lib/provider/src/lib.rs
@@ -157,7 +157,6 @@ pub trait TypeTag<'p>: Sized + 'static {
 ///
 /// An object provider provides values by calling this type's provide methods. Note, that
 /// `Requisition` is a wrapper around a mutable reference to a [`TypeTag`]ged value.
-#[allow(missing_debug_implementations)]
 pub struct Requisition<'p, 'r>(&'r mut RequisitionImpl<dyn Tagged<'p> + 'p>);
 
 #[cfg(test)]
@@ -230,5 +229,25 @@ pub(crate) mod tests {
     #[test]
     fn provide() {
         assert_eq!(crate::request_by_type_tag::<CustomTagB, _>(&ERR), Some(4));
+    }
+
+    #[test]
+    fn tags() {
+        assert_eq!(
+            crate::request_by_type_tag::<tags::OptionTag<tags::Value<usize>>, _>(&ERR),
+            Some(Some(5))
+        );
+        assert_eq!(
+            crate::request_by_type_tag::<tags::ResultTag<tags::Value<u32>, tags::Value<i32>>, _>(
+                &ERR
+            ),
+            Some(Ok(6))
+        );
+        assert_eq!(
+            crate::request_by_type_tag::<tags::ResultTag<tags::Value<i32>, tags::Value<u32>>, _>(
+                &ERR
+            ),
+            Some(Err(7))
+        );
     }
 }

--- a/packages/engine/lib/provider/src/lib.rs
+++ b/packages/engine/lib/provider/src/lib.rs
@@ -1,0 +1,230 @@
+//! Contains the `Provider` trait and accompanying API, which enable trait objects to provide data
+//! based on typed requests, an alternate form of runtime reflection.
+//!
+//! `Provider` and the associated APIs support generic, type-driven access to data, and a mechanism
+//! for implementers to provide such data. The key parts of the interface are the `Provider` trait
+//! for objects which can provide data, and the [`request_by_type_tag`] function for data from an
+//! object which implements `Provider`. Note that end users should not call requesting
+//! `request_by_type_tag` directly, it is a helper function for intermediate implementers to use to
+//! implement a user-facing interface.
+//!
+//! Typically, a data provider is a trait object of a trait which extends `Provider`. A user will
+//! request data from the trait object by specifying the type or a type tag (a type tag is a type
+//! used only as a type parameter to identify the type which the user wants to receive).
+//!
+//! ## Data flow
+//!
+//! * A user requests an object, which is delegated to `request_by_type_tag`
+//! * `request_by_type_tag` creates a `Requisition` object and passes it to `Provider::provide`
+//! * The object provider's implementation of `Provider::provide` tries providing values of
+//!   different types using `Requisition::provide_*`. If the type tag matches the type requested by
+//!   the user, it will be stored in the `Requisition` object.
+//! * `request_by_type_tag` unpacks the `Requisition` object and returns any stored value to the
+//!   user.
+//!
+//! # Examples
+// Taken from https://github.com/rust-lang/rfcs/pull/3192
+//!
+//! To provide data for example on an error type, the `Provider` API enables:
+//!
+//! ```rust
+//! # #![feature(backtrace)]
+//! use std::backtrace::Backtrace;
+//!
+//! use provider::{tags, Provider, Requisition, TypeTag};
+//!
+//! struct MyError {
+//!     backtrace: Backtrace,
+//!     suggestion: String,
+//! }
+//!
+//! impl Provider for MyError {
+//!     fn provide<'p>(&'p self, mut req: Requisition<'p, '_>) {
+//!         req.provide_ref(&self.backtrace)
+//!             .provide_ref(self.suggestion.as_str());
+//!     }
+//! }
+//!
+//! trait MyErrorTrait: Provider {}
+//!
+//! impl MyErrorTrait for MyError {}
+//!
+//! impl dyn MyErrorTrait {
+//!     fn request_ref<T: ?Sized + 'static>(&self) -> Option<&T> {
+//!         provider::request_by_type_tag::<'_, tags::Ref<T>, _>(self)
+//!     }
+//! }
+//! ```
+//!
+//! In another module or crate, this can be requested for any `dyn MyErrorTrait`, not just
+//! `MyError`:
+//! ```rust
+//! # #![feature(backtrace)]
+//! # use std::backtrace::Backtrace;
+//! # use provider::{Provider, Requisition, TypeTag, tags};
+//! # struct MyError { backtrace: Backtrace, suggestion: String }
+//! # impl Provider for MyError {
+//! #     fn provide<'p>(&'p self, mut req: Requisition<'p, '_>) {
+//! #         req.provide_ref(&self.backtrace)
+//! #             .provide_ref(self.suggestion.as_str());
+//! #     }
+//! # }
+//! # trait MyErrorTrait: Provider {}
+//! # impl MyErrorTrait for MyError {}
+//! # impl dyn MyErrorTrait {
+//! #     fn request_ref<T: ?Sized + 'static>(&self) -> Option<&T> {
+//! #         provider::request_by_type_tag::<'_, tags::Ref<T>, _>(self)
+//! #     }
+//! # }
+//! fn report_error(e: &(dyn MyErrorTrait + 'static)) {
+//!     // Generic error handling
+//!     // ...
+//!
+//!     // print backtrace
+//!     if let Some(backtrace) = e.request_ref::<Backtrace>() {
+//!         println!("{backtrace:?}")
+//!     }
+//!     # assert!(e.request_ref::<Backtrace>().is_some());
+//!
+//!     // print suggestion text
+//!     if let Some(suggestions) = e.request_ref::<str>() {
+//!         println!("Suggestion: {suggestions}")
+//!     }
+//!     # assert_eq!(e.request_ref::<str>().unwrap(), "Do it correctly next time!");
+//! }
+//!
+//! fn main() {
+//!     let error = MyError {
+//!         backtrace: Backtrace::capture(),
+//!         suggestion: "Do it correctly next time!".to_string(),
+//!     };
+//!
+//!     report_error(&error);
+//! }
+//! ```
+
+// Heavily inspired by https://github.com/rust-lang/project-error-handling/issues/3:
+//   The project-error-handling tries to improves the error trait. In order to move the trait into
+//   `core`, an alternative solution to backtrace provisioning had to be found. This is, where the
+//   provider API comes from.
+//
+//   TODO: replace library with https://github.com/rust-lang/project-error-handling/issues/3.
+
+pub mod tags;
+
+mod internal;
+mod requisition;
+
+use core::any::TypeId;
+
+use self::internal::{TagValue, Tagged};
+use crate::requisition::{ConcreteRequisition, RequisitionImpl};
+
+/// Trait implemented by a type which can dynamically provide tagged values.
+pub trait Provider {
+    /// Object providers should implement this method to provide *all* values they are able to
+    /// provide using `req`.
+    fn provide<'p>(&'p self, req: Requisition<'p, '_>);
+}
+
+/// Request a specific value by a given tag from the `Provider`.
+pub fn request_by_type_tag<'p, I, P: Provider + ?Sized>(provider: &'p P) -> Option<I::Type>
+where
+    I: TypeTag<'p>,
+{
+    let mut req: ConcreteRequisition<'p, I> = RequisitionImpl {
+        tagged: TagValue(None),
+    };
+    provider.provide(Requisition(&mut req));
+    req.tagged.0
+}
+
+/// This trait is implemented by specific `TypeTag` types in order to allow describing a type which
+/// can be requested for a given lifetime `'p`.
+///
+/// A few example implementations for type-driven `TypeTag`s can be found in the [`tags`] module,
+/// although crates may also implement their own tags for more complex types with internal
+/// lifetimes.
+pub trait TypeTag<'p>: Sized + 'static {
+    /// The type of values which may be tagged by this `TypeTag` for the given lifetime.
+    type Type: 'p;
+}
+
+/// A helper object for providing objects by type.
+///
+/// An object provider provides values by calling this type's provide methods.
+#[allow(missing_debug_implementations)]
+pub struct Requisition<'p, 'r>(&'r mut RequisitionImpl<dyn Tagged<'p> + 'p>);
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use crate::{tags, Provider, Requisition, TypeTag};
+
+    struct CustomTagA;
+    impl<'p> TypeTag<'p> for CustomTagA {
+        type Type = usize;
+    }
+
+    struct CustomTagB;
+    impl<'p> TypeTag<'p> for CustomTagB {
+        type Type = usize;
+    }
+
+    pub(crate) struct MyError {
+        value: usize,
+        reference: usize,
+        custom_tag_a: usize,
+        custom_tag_b: usize,
+        option: Option<usize>,
+        result_ok: Result<u32, i32>,
+        result_err: Result<i32, u32>,
+    }
+
+    impl Provider for MyError {
+        fn provide<'p>(&'p self, mut req: Requisition<'p, '_>) {
+            req.provide_value(|| self.value)
+                .provide_ref(&self.reference)
+                .provide_with::<CustomTagA, _>(|| self.custom_tag_a)
+                .provide::<CustomTagB>(self.custom_tag_b)
+                .provide::<tags::OptionTag<tags::Value<usize>>>(self.option)
+                .provide::<tags::ResultTag<tags::Value<u32>, tags::Value<i32>>>(self.result_ok)
+                .provide::<tags::ResultTag<tags::Value<i32>, tags::Value<u32>>>(self.result_err);
+        }
+    }
+
+    pub(crate) const ERR: MyError = MyError {
+        value: 1,
+        reference: 2,
+        custom_tag_a: 3,
+        custom_tag_b: 4,
+        option: Some(5),
+        result_ok: Ok(6),
+        result_err: Err(7),
+    };
+
+    #[test]
+    fn provide_value() {
+        assert_eq!(
+            crate::request_by_type_tag::<tags::Value<usize>, _>(&ERR),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn provide_ref() {
+        assert_eq!(
+            crate::request_by_type_tag::<tags::Ref<usize>, _>(&ERR),
+            Some(&2)
+        );
+    }
+
+    #[test]
+    fn provide_with() {
+        assert_eq!(crate::request_by_type_tag::<CustomTagA, _>(&ERR), Some(3));
+    }
+
+    #[test]
+    fn provide() {
+        assert_eq!(crate::request_by_type_tag::<CustomTagB, _>(&ERR), Some(4));
+    }
+}

--- a/packages/engine/lib/provider/src/lib.rs
+++ b/packages/engine/lib/provider/src/lib.rs
@@ -1,31 +1,32 @@
-//! Contains the `Provider` trait and accompanying API, which enable trait objects to provide data
+//! Contains the [`Provider`] trait and accompanying API, which enable trait objects to provide data
 //! based on typed requests, an alternate form of runtime reflection.
 //!
-//! `Provider` and the associated APIs support generic, type-driven access to data, and a mechanism
-//! for implementers to provide such data. The key parts of the interface are the `Provider` trait
-//! for objects which can provide data, and the [`request_by_type_tag`] function for data from an
-//! object which implements `Provider`. Note that end users should not call requesting
-//! `request_by_type_tag` directly, it is a helper function for intermediate implementers to use to
-//! implement a user-facing interface.
+//! [`Provider`] and the associated APIs support generic, type-driven access to data, and a
+//! mechanism for implementers to provide such data. The key parts of the interface are the
+//! [`Provider`] trait for objects which can provide data, and the [`request_by_type_tag`] function
+//! for data from an object which implements [`Provider`]. Note that end users should not call
+//! requesting [`request_by_type_tag`] directly, it is a helper function for intermediate
+//! implementers to use to implement a user-facing interface.
 //!
-//! Typically, a data provider is a trait object of a trait which extends `Provider`. A user will
+//! Typically, a data provider is a trait object of a trait which extends [`Provider`]. A user will
 //! request data from the trait object by specifying the type or a type tag (a type tag is a type
 //! used only as a type parameter to identify the type which the user wants to receive).
 //!
 //! ## Data flow
 //!
-//! * A user requests an object, which is delegated to `request_by_type_tag`
-//! * `request_by_type_tag` creates a `Requisition` object and passes it to `Provider::provide`
+//! * A user requests an object, which is delegated to [`request_by_type_tag`]
+//! * [`request_by_type_tag`] creates a [`Requisition`] object and passes it to
+//!   [`Provider::provide`]
 //! * The object provider's implementation of `Provider::provide` tries providing values of
 //!   different types using `Requisition::provide_*`. If the type tag matches the type requested by
-//!   the user, it will be stored in the `Requisition` object.
-//! * `request_by_type_tag` unpacks the `Requisition` object and returns any stored value to the
+//!   the user, it will be stored in the [`Requisition`] object.
+//! * [`request_by_type_tag`] unpacks the [`Requisition`] object and returns any stored value to the
 //!   user.
 //!
 //! # Examples
 // Taken from https://github.com/rust-lang/rfcs/pull/3192
 //!
-//! To provide data for example on an error type, the `Provider` API enables:
+//! To provide data for example on an error type, the [`Provider`] API enables:
 //!
 //! ```rust
 //! # #![feature(backtrace)]
@@ -154,7 +155,8 @@ pub trait TypeTag<'p>: Sized + 'static {
 
 /// A helper object for providing objects by type.
 ///
-/// An object provider provides values by calling this type's provide methods.
+/// An object provider provides values by calling this type's provide methods. Note, that
+/// `Requisition` is a wrapper around a mutable reference to a [`TypeTag`]ed value.
 #[allow(missing_debug_implementations)]
 pub struct Requisition<'p, 'r>(&'r mut RequisitionImpl<dyn Tagged<'p> + 'p>);
 

--- a/packages/engine/lib/provider/src/lib.rs
+++ b/packages/engine/lib/provider/src/lib.rs
@@ -110,6 +110,8 @@
 //
 //   TODO: replace library with https://github.com/rust-lang/project-error-handling/issues/3.
 
+#![warn(clippy::pedantic, clippy::nursery)]
+
 pub mod tags;
 
 mod internal;

--- a/packages/engine/lib/provider/src/requisition.rs
+++ b/packages/engine/lib/provider/src/requisition.rs
@@ -1,0 +1,58 @@
+use crate::{tags, Requisition, TagValue, TypeTag};
+
+impl<'p> Requisition<'p, '_> {
+    /// Provide a value with the given `TypeTag`.
+    pub fn provide<I>(&mut self, value: I::Type) -> &mut Self
+    where
+        I: TypeTag<'p>,
+    {
+        if let Some(res @ TagValue(Option::None)) =
+            self.0.tagged.downcast_mut::<tags::OptionTag<I>>()
+        {
+            res.0 = Some(value);
+        }
+        self
+    }
+
+    /// Provide a value or other type with only static lifetimes.
+    pub fn provide_value<T, F>(&mut self, f: F) -> &mut Self
+    where
+        T: 'static,
+        F: FnOnce() -> T,
+    {
+        self.provide_with::<tags::Value<T>, F>(f)
+    }
+
+    /// Provide a reference, note that the referee type must be bounded by `'static`, but may be
+    /// unsized.
+    pub fn provide_ref<T: ?Sized + 'static>(&mut self, value: &'p T) -> &mut Self {
+        self.provide::<tags::Ref<T>>(value)
+    }
+
+    /// Provide a value with the given `TypeTag`, using a closure to prevent unnecessary work.
+    pub fn provide_with<I, F>(&mut self, f: F) -> &mut Self
+    where
+        I: TypeTag<'p>,
+        F: FnOnce() -> I::Type,
+    {
+        if let Some(res @ TagValue(Option::None)) =
+            self.0.tagged.downcast_mut::<tags::OptionTag<I>>()
+        {
+            res.0 = Some(f());
+        }
+        self
+    }
+}
+
+/// A concrete request for a tagged value. Can be coerced to `Requisition` to be passed to provider
+/// methods.
+pub(super) type ConcreteRequisition<'p, I> = RequisitionImpl<TagValue<'p, tags::OptionTag<I>>>;
+
+/// Implementation detail shared between `Requisition` and `ConcreteRequisition`.
+///
+/// Generally this value is used through the `Requisition` type as an `&mut Requisition<'p>` out
+/// parameter, or constructed with the `ConcreteRequisition<'p, I>` type alias.
+#[repr(transparent)]
+pub(super) struct RequisitionImpl<T: ?Sized> {
+    pub(super) tagged: T,
+}

--- a/packages/engine/lib/provider/src/requisition.rs
+++ b/packages/engine/lib/provider/src/requisition.rs
@@ -25,8 +25,7 @@ impl<'p> Requisition<'p, '_> {
         self.provide_with::<tags::Value<T>, F>(f)
     }
 
-    /// Provide a reference, note that the referee type must be bounded by `'static`, but may be
-    /// unsized.
+    /// Provide a reference, note that `T` must be bounded by `'static`, but may be unsized.
     pub fn provide_ref<T: ?Sized + 'static>(&mut self, value: &'p T) -> &mut Self {
         self.provide::<tags::Ref<T>>(value)
     }

--- a/packages/engine/lib/provider/src/requisition.rs
+++ b/packages/engine/lib/provider/src/requisition.rs
@@ -1,7 +1,9 @@
+//! Internal API
+
 use crate::{tags, Requisition, TagValue, TypeTag};
 
 impl<'p> Requisition<'p, '_> {
-    /// Provide a value with the given `TypeTag`.
+    /// Provide a value with the given [`TypeTag`].
     pub fn provide<I>(&mut self, value: I::Type) -> &mut Self
     where
         I: TypeTag<'p>,
@@ -29,7 +31,7 @@ impl<'p> Requisition<'p, '_> {
         self.provide::<tags::Ref<T>>(value)
     }
 
-    /// Provide a value with the given `TypeTag`, using a closure to prevent unnecessary work.
+    /// Provide a value with the given [`TypeTag`], using a closure to prevent unnecessary work.
     pub fn provide_with<I, F>(&mut self, f: F) -> &mut Self
     where
         I: TypeTag<'p>,
@@ -44,13 +46,13 @@ impl<'p> Requisition<'p, '_> {
     }
 }
 
-/// A concrete request for a tagged value. Can be coerced to `Requisition` to be passed to provider
-/// methods.
+/// A concrete request for a tagged value. Can be coerced to [`Requisition`] to be passed to
+/// provider methods.
 pub(super) type ConcreteRequisition<'p, I> = RequisitionImpl<TagValue<'p, tags::OptionTag<I>>>;
 
-/// Implementation detail shared between `Requisition` and `ConcreteRequisition`.
+/// Implementation detail shared between [`Requisition`] and [`ConcreteRequisition`].
 ///
-/// Generally this value is used through the `Requisition` type as an `&mut Requisition<'p>` out
+/// Generally this value is used through the [`Requisition`] type as an `&mut Requisition<'p>` out
 /// parameter, or constructed with the `ConcreteRequisition<'p, I>` type alias.
 #[repr(transparent)]
 pub(super) struct RequisitionImpl<T: ?Sized> {

--- a/packages/engine/lib/provider/src/tags.rs
+++ b/packages/engine/lib/provider/src/tags.rs
@@ -9,7 +9,7 @@ use core::marker::PhantomData;
 
 use crate::TypeTag;
 
-/// Type-based `TypeTag` for `&'p T` types.
+/// Type-based [`TypeTag`] for `&'p T` types.
 #[derive(Debug)]
 pub struct Ref<T: ?Sized + 'static>(PhantomData<T>);
 
@@ -17,7 +17,7 @@ impl<'p, T: ?Sized + 'static> TypeTag<'p> for Ref<T> {
     type Type = &'p T;
 }
 
-/// Type-based `TypeTag` for static `T` types.
+/// Type-based [`TypeTag`] for static `T` types.
 #[derive(Debug)]
 pub struct Value<T: 'static>(PhantomData<T>);
 
@@ -25,7 +25,7 @@ impl<'p, T: 'static> TypeTag<'p> for Value<T> {
     type Type = T;
 }
 
-/// Tag combinator to wrap the given tag's value in an `Option<T>`
+/// Tag combinator to wrap the given tag's value in an [`Option<T>`][Option]
 #[derive(Debug)]
 pub struct OptionTag<I>(PhantomData<I>);
 
@@ -33,7 +33,7 @@ impl<'p, I: TypeTag<'p>> TypeTag<'p> for OptionTag<I> {
     type Type = Option<I::Type>;
 }
 
-/// Tag combinator to wrap the given tag's value in an `Result<T, E>`
+/// Tag combinator to wrap the given tag's value in an [`Result<T, E>`][Result]
 #[derive(Debug)]
 pub struct ResultTag<I, E>(PhantomData<I>, PhantomData<E>);
 

--- a/packages/engine/lib/provider/src/tags.rs
+++ b/packages/engine/lib/provider/src/tags.rs
@@ -41,47 +41,4 @@ impl<'p, I: TypeTag<'p>, E: TypeTag<'p>> TypeTag<'p> for ResultTag<I, E> {
     type Type = Result<I::Type, E::Type>;
 }
 
-#[cfg(test)]
-mod tests {
-    use crate::{tags, tests::ERR};
-
-    #[test]
-    fn reference() {
-        assert_eq!(
-            crate::request_by_type_tag::<tags::Ref<usize>, _>(&ERR),
-            Some(&2)
-        );
-    }
-
-    #[test]
-    fn value() {
-        assert_eq!(
-            crate::request_by_type_tag::<tags::Value<usize>, _>(&ERR),
-            Some(1)
-        );
-    }
-
-    #[test]
-    fn option() {
-        assert_eq!(
-            crate::request_by_type_tag::<tags::OptionTag<tags::Value<usize>>, _>(&ERR),
-            Some(Some(5))
-        );
-    }
-
-    #[test]
-    fn result() {
-        assert_eq!(
-            crate::request_by_type_tag::<tags::ResultTag<tags::Value<u32>, tags::Value<i32>>, _>(
-                &ERR
-            ),
-            Some(Ok(6))
-        );
-        assert_eq!(
-            crate::request_by_type_tag::<tags::ResultTag<tags::Value<i32>, tags::Value<u32>>, _>(
-                &ERR
-            ),
-            Some(Err(7))
-        );
-    }
-}
+// Tested in `crate::tests`

--- a/packages/engine/lib/provider/src/tags.rs
+++ b/packages/engine/lib/provider/src/tags.rs
@@ -1,0 +1,87 @@
+//! Type tags are used to identify a type using a separate value. This module includes type tags for
+//! some very common types.
+//!
+//! Many users of the provider APIs will not need to use type tags at all. But if you want to use
+//! them with more complex types (typically those including lifetime parameters), you will
+//! need to write your own tags.
+
+use core::marker::PhantomData;
+
+use crate::TypeTag;
+
+/// Type-based `TypeTag` for `&'p T` types.
+#[derive(Debug)]
+pub struct Ref<T: ?Sized + 'static>(PhantomData<T>);
+
+impl<'p, T: ?Sized + 'static> TypeTag<'p> for Ref<T> {
+    type Type = &'p T;
+}
+
+/// Type-based `TypeTag` for static `T` types.
+#[derive(Debug)]
+pub struct Value<T: 'static>(PhantomData<T>);
+
+impl<'p, T: 'static> TypeTag<'p> for Value<T> {
+    type Type = T;
+}
+
+/// Tag combinator to wrap the given tag's value in an `Option<T>`
+#[derive(Debug)]
+pub struct OptionTag<I>(PhantomData<I>);
+
+impl<'p, I: TypeTag<'p>> TypeTag<'p> for OptionTag<I> {
+    type Type = Option<I::Type>;
+}
+
+/// Tag combinator to wrap the given tag's value in an `Result<T, E>`
+#[derive(Debug)]
+pub struct ResultTag<I, E>(PhantomData<I>, PhantomData<E>);
+
+impl<'p, I: TypeTag<'p>, E: TypeTag<'p>> TypeTag<'p> for ResultTag<I, E> {
+    type Type = Result<I::Type, E::Type>;
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{tags, tests::ERR};
+
+    #[test]
+    fn reference() {
+        assert_eq!(
+            crate::request_by_type_tag::<tags::Ref<usize>, _>(&ERR),
+            Some(&2)
+        );
+    }
+
+    #[test]
+    fn value() {
+        assert_eq!(
+            crate::request_by_type_tag::<tags::Value<usize>, _>(&ERR),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn option() {
+        assert_eq!(
+            crate::request_by_type_tag::<tags::OptionTag<tags::Value<usize>>, _>(&ERR),
+            Some(Some(5))
+        );
+    }
+
+    #[test]
+    fn result() {
+        assert_eq!(
+            crate::request_by_type_tag::<tags::ResultTag<tags::Value<u32>, tags::Value<i32>>, _>(
+                &ERR
+            ),
+            Some(Ok(6))
+        );
+        assert_eq!(
+            crate::request_by_type_tag::<tags::ResultTag<tags::Value<i32>, tags::Value<u32>>, _>(
+                &ERR
+            ),
+            Some(Err(7))
+        );
+    }
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Contains the `Provider` trait and accompanying API, which enable trait objects to provide data based on typed requests, an alternate form of runtime reflection.

Currently, we use `thiserror` in hEngine, which just wraps every error in another error. Errors may (or may not) contain additional information on the cause or the context. It's very hard to track down the exact cause with all it's information (without huge, nested `match error` statements). It's even harder to add more general information like the [`Location`](https://doc.rust-lang.org/stable/std/panic/struct.Location.html), where the error/cause/context happened. We want to replace our error handling with a more generic approach like shown in #134. 

The provider API was proposed by the official error handling project of Rust (originally to move `Error` into `core`). This PR effectively reimplements the proposed `Provider`, so we can use it until/if it's merged into the language, I only added a few tests (which should have a code coverage of 100%).

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1199550852792314/1201600029668236/f)
- [RFC for the provider API](https://github.com/nrc/rfcs/blob/dyno/text/0000-dyno.md) which would replace this library as soon as it has landed/implemented.
- The project-error-handling tries to improves the error trait. In order to move the trait into `core`, an alternative solution to backtrace provisioning had to be found. This is, where the provider API comes from. 

    https://github.com/rust-lang/project-error-handling/issues/3

## 🔍 What does this change?

`Provider` and the associated APIs support generic, type-driven access to data, and a mechanism
for implementers to provide such data. The key parts of the interface are the `Provider` trait
for objects which can provide data, and the `request_by_type_tag` function for data from an
object which implements `Provider`. Note that end users should not call requesting
`request_by_type_tag` directly, it is a helper function for intermediate implementers to use to
implement a user-facing interface.

Typically, a data provider is a trait object of a trait which extends `Provider`. A user will
request data from the trait object by specifying the type or a type tag (a type tag is a type
used only as a type parameter to identify the type which the user wants to receive).

We pointed out (at least) the following points for our error handling:
1. provide context information
2. play well with async
3. has parsable errors to be used for logging
4. needs to be human readable

Looking at the dataflow of the provider API:

* A user requests an object, which is delegated to `request_by_type_tag`
* `request_by_type_tag` creates a `Requisition` object and passes it to `Provider::provide`
* The object provider's implementation of `Provider::provide` tries providing values of
  different types using `Requisition::provide_*`. If the type tag matches the type requested by
  the user, it will be stored in the `Requisition` object.
* `request_by_type_tag` unpacks the `Requisition` object and returns any stored value to the
  user.

All these steps happen in Error handling, not in Error generation, i.e. everything is independent of threads/async etc. (2. :white_check_mark:). Obviously context information is passed. This can be everything from an error message, over backtraces or spantraces up to file/line/column, where the error occurred (1. :white_check_mark:). Since all information can be encoded, the error handler can do what it wants with it. E.g. put it into a nice logging entry (3. :white_check_mark:) or output it nicely to the console (4. :white_check_mark:).

## 🛡 Tests

- ✅ Unit Tests (100% code coverage)
- ✅ Miri
- ✅ Manual Tests