### PR TITLE
Implementing limiting on number of parallel sims

### DIFF
--- a/packages/engine/bin/cli/src/manifest.rs
+++ b/packages/engine/bin/cli/src/manifest.rs
@@ -561,11 +561,10 @@ fn get_simple_experiment_config(
     let plan = create_experiment_plan(&parsed, &args.experiment_name)
         .wrap_err("Could not read experiment plan")?;
 
-    let max_sims_in_parallel = if let Some(val) = parsed.get("max_sims_in_parallel") {
-        val.as_u64().map(|val| val as usize)
-    } else {
-        None
-    };
+    let max_sims_in_parallel = parsed
+        .get("max_sims_in_parallel")
+        .and_then(|val| val.as_u64())
+        .map(|val| val as usize);
 
     let config = SimpleExperimentConfig {
         experiment_name: args.experiment_name.clone(),

--- a/packages/engine/bin/cli/src/manifest.rs
+++ b/packages/engine/bin/cli/src/manifest.rs
@@ -560,6 +560,13 @@ fn get_simple_experiment_config(
         .wrap_err("Could not parse experiment manifest")?;
     let plan = create_experiment_plan(&parsed, &args.experiment_name)
         .wrap_err("Could not read experiment plan")?;
+
+    let max_sims_in_parallel = if let Some(val) = parsed.get("max_sims_in_parallel") {
+        val.as_u64().map(|val| val as usize)
+    } else {
+        None
+    };
+
     let config = SimpleExperimentConfig {
         experiment_name: args.experiment_name.clone(),
         changed_properties: plan
@@ -572,6 +579,7 @@ fn get_simple_experiment_config(
             })
             .collect(),
         num_steps: plan.num_steps,
+        max_sims_in_parallel,
     };
     Ok(config)
 }

--- a/packages/engine/bin/cli/src/manifest.rs
+++ b/packages/engine/bin/cli/src/manifest.rs
@@ -564,7 +564,7 @@ fn get_simple_experiment_config(
     let max_sims_in_parallel = parsed
         .get("max_sims_in_parallel")
         .map(|val| {
-            val.as_u64().ok_or_else(|| {
+            val.as_u64().map(|val| val as usize).ok_or_else(|| {
                 report!("max_sims_in_parallel in globals.json was set, but wasn't a valid integer")
             })
         })

--- a/packages/engine/bin/cli/src/manifest.rs
+++ b/packages/engine/bin/cli/src/manifest.rs
@@ -561,10 +561,15 @@ fn get_simple_experiment_config(
     let plan = create_experiment_plan(&parsed, &args.experiment_name)
         .wrap_err("Could not read experiment plan")?;
 
-    let max_sims_in_parallel = parsed
-        .get("max_sims_in_parallel")
-        .and_then(|val| val.as_u64())
-        .map(|val| val as usize);
+    let max_sims_in_parallel = match parsed.get("max_sims_in_parallel") {
+        Some(val) => {
+            let num = val.as_u64().ok_or_else(|| {
+                report!("max_sims_in_parallel in globals.json must be set to a valid integer")
+            })?;
+            Some(num as usize)
+        }
+        None => None,
+    };
 
     let config = SimpleExperimentConfig {
         experiment_name: args.experiment_name.clone(),

--- a/packages/engine/bin/cli/src/manifest.rs
+++ b/packages/engine/bin/cli/src/manifest.rs
@@ -568,8 +568,7 @@ fn get_simple_experiment_config(
                 report!("max_sims_in_parallel in globals.json was set, but wasn't a valid integer")
             })
         })
-        // Report error if not a valid integer, ignore if key is not set
-        .transpose()?;
+        .transpose()?; // Extract and report the error for failed parsing
 
     let config = SimpleExperimentConfig {
         experiment_name: args.experiment_name.clone(),

--- a/packages/engine/bin/cli/src/manifest.rs
+++ b/packages/engine/bin/cli/src/manifest.rs
@@ -561,15 +561,15 @@ fn get_simple_experiment_config(
     let plan = create_experiment_plan(&parsed, &args.experiment_name)
         .wrap_err("Could not read experiment plan")?;
 
-    let max_sims_in_parallel = match parsed.get("max_sims_in_parallel") {
-        Some(val) => {
-            let num = val.as_u64().ok_or_else(|| {
-                report!("max_sims_in_parallel in globals.json must be set to a valid integer")
-            })?;
-            Some(num as usize)
-        }
-        None => None,
-    };
+    let max_sims_in_parallel = parsed
+        .get("max_sims_in_parallel")
+        .map(|val| {
+            val.as_u64().ok_or_else(|| {
+                report!("max_sims_in_parallel in globals.json was set, but wasn't a valid integer")
+            })
+        })
+        // Report error if not a valid integer, ignore if key is not set
+        .transpose()?;
 
     let config = SimpleExperimentConfig {
         experiment_name: args.experiment_name.clone(),

--- a/packages/engine/src/experiment/package/simple.rs
+++ b/packages/engine/src/experiment/package/simple.rs
@@ -26,7 +26,7 @@ struct SimQueue<'a> {
     finished: HashMap<SimulationShortId, SimProgress>,
 }
 
-impl<'i> SimQueue<'i> {
+impl<'a> SimQueue<'a> {
     async fn start_sim_if_available(&mut self) -> Result<()> {
         if let Some((sim_idx, changed_props)) = self.pending_iter.next() {
             self.active

--- a/packages/engine/src/experiment/package/simple.rs
+++ b/packages/engine/src/experiment/package/simple.rs
@@ -13,16 +13,37 @@ pub struct SimpleExperiment {
     config: SimpleExperimentConfig,
 }
 
-// Returns whether to stop experiment.
-fn finish_run(n_remaining: &mut isize) -> bool {
-    assert!(*n_remaining > 0, "n_remaining {} <= 0", *n_remaining);
-    *n_remaining -= 1;
-    *n_remaining == 0
-}
-
-struct StepProgress {
+struct SimProgress {
     n_steps: usize,
     stopped: bool,
+}
+
+struct SimQueue<'a> {
+    max_num_steps: usize,
+    pkg_to_exp: &'a mut ExpPkgCtlSend,
+    pending_iter: &'a mut (dyn Iterator<Item = (usize, &'a serde_json::Value)> + Send),
+    active: HashMap<SimulationShortId, SimProgress>,
+    finished: HashMap<SimulationShortId, SimProgress>,
+}
+
+impl<'i> SimQueue<'i> {
+    async fn start_sim_if_available(&mut self) -> Result<()> {
+        if let Some((sim_idx, changed_props)) = self.pending_iter.next() {
+            self.active
+                .insert(sim_idx as SimulationShortId, SimProgress {
+                    n_steps: 0,
+                    stopped: false,
+                });
+            let msg = ExperimentControl::StartSim {
+                sim_id: sim_idx as SimulationShortId,
+                changed_properties: changed_props.clone(),
+                max_num_steps: self.max_num_steps,
+            };
+            self.pkg_to_exp.send(msg).await?;
+        }
+
+        Ok(())
+    }
 }
 
 impl SimpleExperiment {
@@ -42,24 +63,33 @@ impl SimpleExperiment {
         mut exp_pkg_update_recv: ExpPkgUpdateRecv,
     ) -> Result<()> {
         let max_num_steps = self.config.num_steps;
-        let mut n_sims_steps = HashMap::new();
         let num_sims = self.config.changed_properties.len();
-        for (sim_index, changed_properties) in self.config.changed_properties.iter().enumerate() {
-            let sim_id = sim_index + 1; // We sometimes use 0 as a default/null value, therefore it's not a valid SimulationShortId
-            n_sims_steps.insert(sim_id as SimulationShortId, StepProgress {
-                n_steps: 0,
-                stopped: false,
-            });
-            let msg = ExperimentControl::StartSim {
-                sim_id: sim_id as SimulationShortId,
-                changed_properties: changed_properties.clone(),
-                max_num_steps,
-            };
-            pkg_to_exp.send(msg).await?;
+        let max_sims_in_parallel = self.config.max_sims_in_parallel.unwrap_or(num_sims);
+
+        let mut queued_iter =
+            self.config
+                .changed_properties
+                .iter()
+                .enumerate()
+                .map(|(sim_idx, props)| {
+                    // We sometimes use 0 as a default/null value, therefore it's not a valid
+                    // SimulationShortId
+                    (sim_idx + 1, props)
+                });
+
+        let mut sim_queue = SimQueue {
+            pending_iter: &mut queued_iter,
+            max_num_steps,
+            pkg_to_exp: &mut pkg_to_exp,
+            active: HashMap::new(),
+            finished: HashMap::new(),
+        };
+
+        log::trace!("Starting {max_sims_in_parallel} sims in parallel");
+        for _ in 0..max_sims_in_parallel {
+            sim_queue.start_sim_if_available().await?;
         }
 
-        // Use `isize` to avoid issues with decrementing zero.
-        let mut n_remaining = num_sims as isize;
         loop {
             let response = exp_pkg_update_recv.recv().await.ok_or_else(|| {
                 Error::ExperimentRecv(
@@ -67,37 +97,35 @@ impl SimpleExperiment {
                 )
             })?;
 
-            let mut maybe_step_progress = n_sims_steps.get_mut(&response.sim_id);
-
             if response.was_error || response.stop_signal {
-                if let Some(step_progress) = &mut maybe_step_progress {
-                    step_progress.stopped = true;
-                } else {
-                    log::warn!("Stopped sim run with unknown id {}", &response.sim_id);
-                }
+                let mut sim_progress =
+                    sim_queue.active.remove(&response.sim_id).ok_or_else(|| {
+                        log::warn!("Sim run with unknown id {} stopped", &response.sim_id);
+                        Error::MissingSimulationRun(response.sim_id)
+                    })?;
 
-                if finish_run(&mut n_remaining) {
+                sim_progress.stopped = true;
+                sim_queue.finished.insert(response.sim_id, sim_progress);
+
+                sim_queue.start_sim_if_available().await?;
+
+                if sim_queue.active.is_empty() {
                     break;
                 }
-            }
+            } else {
+                let mut sim_progress = sim_queue
+                    .active
+                    .get_mut(&response.sim_id)
+                    .ok_or(Error::MissingSimulationRun(response.sim_id))?;
 
-            let step_progress =
-                maybe_step_progress.ok_or(Error::MissingSimulationRun(response.sim_id))?;
+                sim_progress.n_steps += 1;
 
-            if !step_progress.stopped {
-                step_progress.n_steps += 1;
-            }
-
-            let n_steps = step_progress.n_steps;
-            assert!(
-                n_steps <= max_num_steps,
-                "{} > max_num_steps {}",
-                n_steps,
-                max_num_steps
-            );
-
-            if n_steps == max_num_steps && finish_run(&mut n_remaining) {
-                break;
+                assert!(
+                    sim_progress.n_steps <= max_num_steps,
+                    "{} > max_num_steps {}",
+                    sim_progress.n_steps,
+                    max_num_steps
+                );
             }
         }
         Ok(())

--- a/packages/engine/src/proto.rs
+++ b/packages/engine/src/proto.rs
@@ -219,6 +219,7 @@ impl<'de> Deserialize<'de> for MetricObjective {
     }
 }
 
+// TODO: investigate if the renames are still needed
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Clone)]
 pub struct SimpleExperimentConfig {
     /// The experiment name
@@ -229,6 +230,8 @@ pub struct SimpleExperimentConfig {
     /// Number of steps each run should go for
     #[serde(rename = "numSteps")]
     pub num_steps: usize,
+    /// Maximum amount of simulations that can be ran in parallel - None is unlimited
+    pub max_sims_in_parallel: Option<usize>,
 }
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Clone)]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Sometimes it may be beneficial to limit how many simulations can run in parallel in an experiment. For example, it may have simulations that use a lot of resources and running them sequentially allows it to fit within RAM, or for benchmarking reasons.

## 🔗 Related links

<!-- Add links to Asana, Slack, Notion or whatever originated this PR -->
<!-- This will be _super_ handy 6 months from now.  -->

- [Asana task description](https://app.asana.com/0/1199550852792314/1201614340097579/f)

## 🔍 What does this change?

- Creates a new optional field in `experiments.json` called `max_sims_in_parallel` 
- Reworks the SimpleExperiment package execution logic to work around a queue of simulations, with a sized-batch of active ones according to the `max_sims_in_parallel` parameter (defaulting to an 'infinite (in reality := number_of_sims) number in parallel)

## 🛡 Tests

- ✅ Manual Tests

## ❓ How to test this?

Run a simple experiment with and without the parameter and check for correct differing behavior (RUST_LOG=trace will help) in terms of how many sims run at once.

