### PR TITLE
Use `tracing` instead of `log`

### DIFF
--- a/packages/engine/Cargo.lock
+++ b/packages/engine/Cargo.lock
@@ -66,6 +66,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,13 +416,12 @@ dependencies = [
  "error",
  "hash_engine",
  "lazy_static",
- "log",
- "pretty_env_logger",
  "rand 0.8.4",
  "rand_distr",
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -665,19 +673,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -957,11 +952,9 @@ dependencies = [
  "http-types",
  "kdtree",
  "lazy_static",
- "log",
  "nng",
  "num_cpus",
  "parking_lot",
- "pretty_env_logger",
  "rand 0.8.4",
  "rayon",
  "regex",
@@ -973,6 +966,9 @@ dependencies = [
  "surf",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-error",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -1072,15 +1068,6 @@ dependencies = [
  "serde_qs",
  "serde_urlencoded",
  "url",
-]
-
-[[package]]
-name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
 ]
 
 [[package]]
@@ -1232,6 +1219,15 @@ checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
  "value-bag",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -1568,16 +1564,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
-name = "pretty_env_logger"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
-dependencies = [
- "env_logger",
- "log",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,12 +1611,6 @@ dependencies = [
 [[package]]
 name = "provider"
 version = "0.0.0"
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1782,6 +1762,9 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-syntax"
@@ -1908,8 +1891,8 @@ version = "0.0.0"
 dependencies = [
  "error",
  "hash_engine",
- "log",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2326,14 +2309,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d81bfa81424cc98cb034b837c985b7a290f592e5b4322f353f94a0ab0f9f594"
 dependencies = [
+ "ansi_term",
+ "lazy_static",
+ "matchers",
+ "regex",
  "sharded-slab",
+ "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -26,11 +26,10 @@ glob = "0.3.0"
 http-types = "2.6.0"
 kdtree = "0.6.0"
 lazy_static = "1.4.0"
-log = "0.4.11"
+log = { package = "tracing", version = "0.1.29" }
 num_cpus = "1.13.0"
 nng = { version = "1.0.1", default-features = false }
 parking_lot = "0.11.1"
-pretty_env_logger = "0.4.0"
 rand = "0.8.3"
 rayon = "1.4.1"
 regex = "1.5.4"
@@ -42,6 +41,8 @@ strum_macros = "0.19.4"
 surf = "2.0.0"
 thiserror = "1.0.21"
 tokio = { version = "1.5.0", features = ["macros", "rt-multi-thread", "sync", "process", "io-util", "net", "rt", "fs", "time"] }
+tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
+tracing-error = "0.2.0"
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 
 [features]

--- a/packages/engine/bin/cli/Cargo.toml
+++ b/packages/engine/bin/cli/Cargo.toml
@@ -10,19 +10,18 @@ description = "The hEngine Command line interface"
 
 [dependencies]
 hash_engine = { path = "../..", default-features = false }
-error = { path = "../../lib/error" }
+error = { path = "../../lib/error", features = ["spantrace"] }
 #server = { path = "../server", artifact = "bin" }
 
 async-trait = "0.1.48"
 clap = { version = "3.0.0", features = ["cargo", "derive", "env"] }
 lazy_static = "1.4.0"
-log = "0.4.11"
-pretty_env_logger = "0.4.0"
 rand = "0.8.3"
 rand_distr = "0.4.2"
 serde = { version = "1.0.111", features = ["derive"] }
 serde_json = "1.0.59"
 tokio = { version = "1.5.0", features = ["macros", "rt-multi-thread", "sync", "process", "io-util", "net", "rt", "fs"] }
+tracing = "0.1.29"
 
 [features]
 default = ["build-nng"]

--- a/packages/engine/bin/cli/src/experiment.rs
+++ b/packages/engine/bin/cli/src/experiment.rs
@@ -52,6 +52,7 @@ fn create_engine_command(
     )?))
 }
 
+#[instrument(skip_all, fields(project_name = project_name.as_str(), experiment_id = experiment_run.base.id.as_str()))]
 async fn run_experiment_with_manifest(
     args: Args,
     experiment_run: proto::ExperimentRun,

--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -3,8 +3,7 @@
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
-extern crate log;
-extern crate pretty_env_logger;
+extern crate tracing;
 
 pub mod experiment;
 pub mod exsrv;
@@ -80,7 +79,7 @@ pub struct SimpleExperimentArgs {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    pretty_env_logger::init();
+    hash_engine::init_logger();
     let args = Args::parse();
 
     let nng_listen_url = {

--- a/packages/engine/bin/server/Cargo.toml
+++ b/packages/engine/bin/server/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 
 [dependencies]
 hash_engine = { path = "../..", default-features = false }
-error = { path = "../../lib/error" }
+error = { path = "../../lib/error", features = ["spantrace"] }
 
-log = "0.4.11"
 tokio = { version = "1.5.0", features = ["macros", "rt-multi-thread", "sync", "process", "io-util", "net", "rt", "fs"] }
+tracing = "0.1.29"
 
 [[bin]]
 name = "hash_engine"

--- a/packages/engine/bin/server/src/main.rs
+++ b/packages/engine/bin/server/src/main.rs
@@ -8,7 +8,7 @@ async fn main() -> Result<()> {
     hash_engine::init_logger();
     let args = hash_engine::args();
 
-    log::info!(
+    tracing::info!(
         "HASH Engine process started for experiment {}",
         &args.experiment_id
     );

--- a/packages/engine/src/utils.rs
+++ b/packages/engine/src/utils.rs
@@ -1,6 +1,8 @@
 use std::{env::VarError, time::Duration};
 
 pub fn init_logger() {
+    use tracing_subscriber::{fmt::time, prelude::*, EnvFilter};
+
     if cfg!(debug_assertions) && std::env::var("RUST_LOG").is_err() {
         std::env::set_var(
             "RUST_LOG",
@@ -8,7 +10,16 @@ pub fn init_logger() {
              apiclient=debug",
         );
     }
-    pretty_env_logger::init();
+
+    let stdout_layer = tracing_subscriber::fmt::layer()
+        .with_timer(time::Uptime::default())
+        .pretty();
+
+    let error_layer = tracing_error::ErrorLayer::default();
+    tracing_subscriber::registry()
+        .with(EnvFilter::from_default_env().and_then(stdout_layer))
+        .with(error_layer)
+        .init();
 }
 
 pub fn parse_env_duration(name: &str, default: u64) -> Duration {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Replace `log` with a structured logging library `tracing`

## 🔗 Related links

- [Asana task description](https://app.asana.com/0/1199550852792314/1201612388082320/f)

## 🔍 What does this change?

Replaces the `log` crate with `tracing` crate. The macros are backwards compatible (even though `tracing`s are more powerful). They inspect the current span and add it to the log entry: https://github.com/hashintel/hash/blob/fc161e9fb6bf64ba31aa91b9d5f792c460136834/packages/engine/bin/cli/src/experiment.rs#L55-L61
Spans also enables us to print `SpanTraces`.

## 🛡 Tests

<!-- Delete as appropriate -->

- ✅ Manual Tests

## 📹 Demo

```
     0.013644156s  INFO hash_engine::utils: Setting `ENGINE_START_TIMEOUT=2`
    at src/utils.rs:35
    in cli::experiment::run_experiment_with_manifest with , project_name: "sugarscape", experiment_id: "single_run-85adf6"

     0.056424725s  INFO hash_engine: HASH Engine process started for experiment single_run-85adf6
    at bin/server/src/main.rs:11

     0.154515008s  INFO hash_engine::utils: Setting `ENGINE_WAIT_TIMEOUT=60`
    at src/utils.rs:35
    in cli::experiment::run_experiment_with_manifest with , project_name: "sugarscape", experiment_id: "single_run-85adf6"

     0.509995201s ERROR cli::experiment: Got error: "Worker error: JavaScript runner error: Datastore: Shared memory error: `/dev/shm`is out of memory"
    at bin/cli/src/experiment.rs:160
    in cli::experiment::run_experiment_with_manifest with , project_name: "sugarscape", experiment_id: "single_run-85adf6"
```
