### PR TITLE
[DOCS] Add missing closing quotes

### DIFF
--- a/resources/docs/simulation/creating-simulations/libraries/hash/random.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/random.md
@@ -41,7 +41,7 @@ def behavior(state, context):
 Sets a seed for the random number generator used in hash_stdlib.random\(\) and in any stochastic function in [hash_stdlib.stats](/docs/simulation/creating-simulations/libraries/hash/javascript-libraries#jstat-distributions). The seed will apply across all behaviors and agents within a simulation run.
 
 <Tabs>
-<Tab title="JavaScript>
+<Tab title="JavaScript">
 
 ```javascript
 function behavior(state, context) {

--- a/resources/docs/simulation/creating-simulations/libraries/hash/spatial.md
+++ b/resources/docs/simulation/creating-simulations/libraries/hash/spatial.md
@@ -81,7 +81,7 @@ function behavior(state, context) {
 ```
 
 </Tab>
-<Tab title="Python>
+<Tab title="Python">
 
 ```python
 import hstd


### PR DESCRIPTION
There are a couple of MDX tags missing closing quotes on their `title` property. This PR fixes that.