### PR TITLE
Only match first crate when determining crates to test in Rust Action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,19 +30,20 @@ jobs:
           fetch-depth: 2
       - name: Find changed crates
         id: crates
-        run: |
-          changed_crates=""
-          
-          available_crates="$(find . -name Cargo.toml -printf '%h\n' | sed 's:./::')"
+        run: |          
+          available_crates="$(find . -name Cargo.toml -printf '%h\n' | sed 's:./::' | sort | tac)"
           changed_files="$(git diff --name-only HEAD^ HEAD)"
           
-          while read -r crate; do
-            while read -r file; do
+          changed_crates=""
+          
+          while read -r file; do
+            while read -r crate; do
               if [[ $file =~ $crate ]]; then
                 changed_crates=$(echo -e "${crate}\n$changed_crates")
+                break
               fi
-            done <<< "$changed_files"
-          done <<< "$available_crates"
+            done <<< "$available_crates"
+          done <<< "$changed_files"
           
           changed_crates=$(echo "$changed_crates" | uniq | jq -R | jq -sc '[ .[] | select(length > 0) ]')
           


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Let changed files in Rust crates only affect the corresponding module

## 🔍 What does this change?

When a Rust file of a submodule (e.g. `packages/engine/lib/error`) is changed, this is also matched by `packages/engine`. This small fix sorts the available crates, so the longest name will be matched first. As soon as it's matching the changed file, the next file is searched.

## 🛡 Tests

- ✅ Manual Tests