### PR TITLE
Add links to our open roles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,3 +9,7 @@ We have a community [Discord server](https://hash.ai/discord) and [support forum
 This repository is HASH's public monorepo. It contains [several different](README.md) projects, some of which are open-source. Each project has its own [license](LICENSE.md) and contribution policies which may vary slightly.
 
 To ascertain the license and contributor policy for a given project, check out the `LICENSE.md` and `CONTRIBUTOR.md` files in its root.
+
+## Paid Roles
+
+We're recruiting for a number of full-time roles. If you've already contributed to the open-source `hash` repo, mention this in your application. View our open roles at [hash.ai/careers](https://hash.ai/careers) and drop your name in the _General Pool_ even if you'd be happy to work on HASH, but can't see a good fit right now.

--- a/README.md
+++ b/README.md
@@ -10,30 +10,22 @@ This repository contains HASH's open-source and public code, documentation, and 
 - `resources/docs`: A user guide to the whole HASH platform ([hash.ai/docs](https://hash.ai/docs))
 - `resources/glossary`: A glossary of terms explaining common concepts relevant to the use of HASH ([hash.ai/glossary](https://hash.ai/glossary))
 
-<p align="right">(<a href="#top">back to top</a>)</p>
-
 ## Contributing
 
-Please see [CONTRIBUTING.md](CONTRIBUTING.md) if you're interested in getting involved in the design or development of HASH
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) if you're interested in getting involved in the design or development of HASH.
 
-<p align="right">(<a href="#top">back to top</a>)</p>
+We're also [hiring](https://hash.ai/careers) for a number of key roles. If you contribute to HASH's public monorepo be sure to mention this in your application.
 
 ## License
 
 Please see [LICENSE.md](LICENSE.md) for more information about the terms under which the various parts of this repository are made available
 
-<p align="right">(<a href="#top">back to top</a>)</p>
-
 ## Security
 
 Please see [SECURITY.md](SECURITY.md) for instructions around reporting issues, and details of which package versions we actively support
-
-<p align="right">(<a href="#top">back to top</a>)</p>
 
 ## Contact
 
 Find us on Twitter at [@hashintel](https://twitter.com/hashintel), join our [Discord server](https://hash.ai/discord) for quick help and support, or post in our [community forum](https://hash.community/).
 
-Project Link: [https://github.com/hashintel/hash](https://github.com/hashintel/hash)
-
-<p align="right">(<a href="#top">back to top</a>)</p>
+Project permalink: `https://github.com/hashintel/hash`

--- a/packages/engine/CONTRIBUTING.md
+++ b/packages/engine/CONTRIBUTING.md
@@ -34,11 +34,7 @@ to contribute to and benefit from HASH. Please follow these when interacting wit
 
 ## I have a question, where do I go?
 
-> **Note:** Please don't use GitHub issues for help, we have a friendly community on...
-
-* [Discord](https://discord.com/invite/BPMrGAhjPh)
-* [Our Forum](https://community.hash.ai/)
-* And any other methods outlined on [our site](https://hash.ai/contact)
+If you have a question, you can ask it on our [community forum](https://hash.community/) or join our public [Discord server](https://hash.ai/discord) (requires a HASH account). Please don't use GitHub issues for general help or discussions. You can also get in touch with us directly via any of the methods outlined on [our site](https://hash.ai/contact).
 
 ## Getting started, what do I need to know?
 
@@ -150,3 +146,7 @@ Then simply run them with:
 ### Issue and Pull Request Labels
 
 > TODO
+
+### Hiring
+
+**We're growing the team behind HASH.** If you like what we've built, have contributed to the repo, or are otherwise interested in a full-time role, check out our [open opportunities](hash.ai/careers).


### PR DESCRIPTION
We're recruiting for a handful of key roles and would like to encourage our open-source contributors to apply. To date some of our best applicants (and hires) have been active users of our platform.