### PR TITLE
Add option to chose output format

### DIFF
--- a/packages/engine/bin/cli/src/experiment.rs
+++ b/packages/engine/bin/cli/src/experiment.rs
@@ -49,6 +49,7 @@ fn create_engine_command(
         experiment_id,
         args.num_workers as usize,
         controller_url,
+        args.emit,
     )?))
 }
 

--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -15,6 +15,7 @@ use std::path::PathBuf;
 use clap::{AppSettings, Parser};
 use error::Result;
 use experiment::run_experiment;
+use hash_engine::utils::OutputFormat;
 
 use crate::exsrv::create_server;
 
@@ -39,6 +40,10 @@ pub struct Args {
     /// The folder will be created if it's missing.
     #[clap(short, long, default_value = "./output", env = "HASH_OUTPUT")]
     output: PathBuf,
+
+    /// Output format emitted to the terminal.
+    #[clap(long, default_value = "pretty", arg_enum, env = "HASH_EMIT")]
+    emit: OutputFormat,
 
     /// Experiment type to be run.
     #[clap(subcommand)]
@@ -79,8 +84,8 @@ pub struct SimpleExperimentArgs {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    hash_engine::init_logger();
     let args = Args::parse();
+    hash_engine::init_logger(args.emit);
 
     let nng_listen_url = {
         use std::time::{SystemTime, UNIX_EPOCH};

--- a/packages/engine/bin/cli/src/process/local.rs
+++ b/packages/engine/bin/cli/src/process/local.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use error::{Report, Result, ResultExt};
-use hash_engine::{nano, proto::EngineMsg};
+use hash_engine::{nano, proto::EngineMsg, utils::OutputFormat};
 
 use super::process;
 
@@ -55,10 +55,16 @@ pub struct LocalCommand {
     experiment_id: String,
     controller_url: String,
     max_num_workers: usize,
+    output_format: OutputFormat,
 }
 
 impl LocalCommand {
-    pub fn new(experiment_id: &str, max_num_workers: usize, controller_url: &str) -> Result<Self> {
+    pub fn new(
+        experiment_id: &str,
+        max_num_workers: usize,
+        controller_url: &str,
+        output_format: OutputFormat,
+    ) -> Result<Self> {
         // The NNG URL that the engine process will listen on
         let engine_url = format!("ipc://run-{experiment_id}");
 
@@ -67,6 +73,7 @@ impl LocalCommand {
             experiment_id: experiment_id.to_string(),
             controller_url: controller_url.to_string(),
             max_num_workers,
+            output_format,
         })
     }
 }
@@ -90,6 +97,8 @@ impl process::Command for LocalCommand {
             .arg(&self.engine_url)
             .arg("--max-workers")
             .arg(self.max_num_workers.to_string())
+            .arg("--emit")
+            .arg(self.output_format.to_string())
             .stdout(std::process::Stdio::inherit())
             .stderr(std::process::Stdio::inherit());
         debug!("Running `{cmd:?}`");

--- a/packages/engine/bin/server/src/main.rs
+++ b/packages/engine/bin/server/src/main.rs
@@ -5,8 +5,8 @@ use hash_engine::{
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    hash_engine::init_logger();
     let args = hash_engine::args();
+    hash_engine::init_logger(args.emit);
 
     tracing::info!(
         "HASH Engine process started for experiment {}",

--- a/packages/engine/src/args.rs
+++ b/packages/engine/src/args.rs
@@ -1,5 +1,7 @@
 use clap::{AppSettings, Parser};
 
+use crate::utils::OutputFormat;
+
 /// Arguments passed to hEngine
 #[derive(Debug, Parser)]
 #[clap(about, version, author)]
@@ -22,6 +24,10 @@ pub struct Args {
     /// max number of workers per simulation run (optional).
     #[clap(short, long)]
     pub max_workers: Option<usize>,
+
+    /// Output format emitted to the terminal.
+    #[clap(long, default_value = "pretty", arg_enum, env = "HASH_EMIT")]
+    pub emit: OutputFormat,
 }
 
 pub fn args() -> Args {

--- a/packages/engine/src/utils.rs
+++ b/packages/engine/src/utils.rs
@@ -22,6 +22,8 @@ pub enum OutputFormat {
     Full,
     /// excessively pretty, multi-line logs, optimized for human readability.
     Pretty,
+    // TODO: Readd JSON output. Currently it's failing when adding spans, we probably need to add
+    //   it ourself
     // /// Newline-delimited JSON logs.
     // Json,
     /// Only includes the fields from the most recently entered span.

--- a/packages/engine/src/utils.rs
+++ b/packages/engine/src/utils.rs
@@ -22,7 +22,7 @@ pub enum OutputFormat {
     Full,
     /// excessively pretty, multi-line logs, optimized for human readability.
     Pretty,
-    // TODO: Readd JSON output. Currently it's failing when adding spans, we probably need to add
+    // TODO: Add JSON output. Currently it's failing when adding spans, we probably need to add
     //   it ourself
     // /// Newline-delimited JSON logs.
     // Json,

--- a/packages/engine/src/utils.rs
+++ b/packages/engine/src/utils.rs
@@ -1,23 +1,102 @@
-use std::{env::VarError, time::Duration};
+use std::{env::VarError, fmt::Display, time::Duration};
 
-pub fn init_logger() {
-    use tracing_subscriber::{fmt::time, prelude::*, EnvFilter};
+use log::{Event, Subscriber};
+use tracing_subscriber::{
+    filter::{Directive, LevelFilter},
+    fmt::{
+        self,
+        format::{Format, Writer},
+        time::FormatTime,
+        FmtContext, FormatEvent, FormatFields,
+    },
+    prelude::*,
+    registry::LookupSpan,
+    EnvFilter,
+};
 
-    if cfg!(debug_assertions) && std::env::var("RUST_LOG").is_err() {
-        std::env::set_var(
-            "RUST_LOG",
-            "hash_cloud=debug,hash_engine=debug,cli=debug,server=debug,proto=debug,nano=debug,\
-             apiclient=debug",
-        );
+/// Output format emitted to the terminal
+#[derive(Debug, Copy, Clone, PartialEq, Eq, clap::ArgEnum)]
+pub enum OutputFormat {
+    /// Human-readable, single-line logs for each event that occurs, with the current span context
+    /// displayed before the formatted representation of the event.
+    Full,
+    /// excessively pretty, multi-line logs, optimized for human readability.
+    Pretty,
+    // /// Newline-delimited JSON logs.
+    // Json,
+    /// Only includes the fields from the most recently entered span.
+    Compact,
+}
+
+impl Display for OutputFormat {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            OutputFormat::Full => f.write_str("full"),
+            OutputFormat::Pretty => f.write_str("pretty"),
+            // OutputFormat::Json => f.write_str("json"),
+            OutputFormat::Compact => f.write_str("compact"),
+        }
     }
+}
 
-    let stdout_layer = tracing_subscriber::fmt::layer()
-        .with_timer(time::Uptime::default())
-        .pretty();
+enum OutputFormatter<T> {
+    Full(Format<fmt::format::Full, T>),
+    Pretty(Format<fmt::format::Pretty, T>),
+    // Json(Format<fmt::format::Json, T>),
+    Compact(Format<fmt::format::Compact, T>),
+}
+
+impl<S, N, T> FormatEvent<S, N> for OutputFormatter<T>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+    T: FormatTime,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> std::fmt::Result {
+        match self {
+            OutputFormatter::Full(fmt) => fmt.format_event(ctx, writer, event),
+            OutputFormatter::Pretty(fmt) => fmt.format_event(ctx, writer, event),
+            // OutputFormatter::Json(fmt) => fmt.format_event(ctx, writer, event),
+            OutputFormatter::Compact(fmt) => fmt.format_event(ctx, writer, event),
+        }
+    }
+}
+
+impl Default for OutputFormat {
+    fn default() -> Self {
+        Self::Pretty
+    }
+}
+
+pub fn init_logger(output_format: OutputFormat) {
+    let filter = match std::env::var("RUST_LOG") {
+        Ok(env) => EnvFilter::new(env),
+        #[cfg(debug_assertions)]
+        _ => EnvFilter::default().add_directive(Directive::from(LevelFilter::DEBUG)),
+        #[cfg(not(debug_assertions))]
+        _ => EnvFilter::default().add_directive(Directive::from(LevelFilter::WARN)),
+    };
+
+    let formatter = fmt::format()
+        .with_timer(fmt::time::Uptime::default())
+        .with_target(true);
+    let formatter = match output_format {
+        OutputFormat::Full => OutputFormatter::Full(formatter),
+        OutputFormat::Pretty => OutputFormatter::Pretty(formatter.pretty()),
+        // OutputFormat::Json => OutputFormatter::Json(formatter.json()),
+        OutputFormat::Compact => OutputFormatter::Compact(formatter.compact()),
+    };
+
+    let stdout_layer = fmt::layer().event_format(formatter);
 
     let error_layer = tracing_error::ErrorLayer::default();
     tracing_subscriber::registry()
-        .with(EnvFilter::from_default_env().and_then(stdout_layer))
+        .with(filter.and_then(stdout_layer))
         .with(error_layer)
         .init();
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

For easier parsing in integration tests, this adds an optional argument `--emit` to chose from different formats (`pretty` (default), `full`, `compact`, and `json` (disabled) )

## 🔗 Related links

- [Asana task description](https://app.asana.com/0/1199550852792314/1201643790165293/f)

## 🛡 Tests

- ✅ Manual Tests

## ❓ How to test this?

- Run simulation with different `--emit` arguments

## 📹 Demo

`cargo run -p cli -- -p sugarscape --emit compact single-run -n2`
![image](https://user-images.githubusercontent.com/21277928/148936115-3986d3c9-d9ec-4dfd-97fa-fc0c37fae928.png)

`cargo run -p cli -- -p sugarscape --emit full single-run -n2` (We currently don't have nested spans)
![image](https://user-images.githubusercontent.com/21277928/148936115-3986d3c9-d9ec-4dfd-97fa-fc0c37fae928.png)

`cargo run -p cli -- -p sugarscape --emit pretty single-run -n2`
![image](https://user-images.githubusercontent.com/21277928/148936335-0cb0ae41-a103-4a9a-9f66-34663ce814a5.png)

