### PR TITLE
Change the log output to `stderr` instead of `stdout`

### DIFF
--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -42,7 +42,7 @@ pub struct Args {
     output: PathBuf,
 
     /// Output format emitted to the terminal.
-    #[clap(long, default_value = "pretty", arg_enum, env = "HASH_EMIT")]
+    #[clap(long, default_value = "full", arg_enum, env = "HASH_EMIT")]
     emit: OutputFormat,
 
     /// Experiment type to be run.

--- a/packages/engine/src/args.rs
+++ b/packages/engine/src/args.rs
@@ -26,7 +26,7 @@ pub struct Args {
     pub max_workers: Option<usize>,
 
     /// Output format emitted to the terminal.
-    #[clap(long, default_value = "pretty", arg_enum, env = "HASH_EMIT")]
+    #[clap(long, default_value = "full", arg_enum, env = "HASH_EMIT")]
     pub emit: OutputFormat,
 }
 

--- a/packages/engine/src/utils.rs
+++ b/packages/engine/src/utils.rs
@@ -94,11 +94,13 @@ pub fn init_logger(output_format: OutputFormat) {
         OutputFormat::Compact => OutputFormatter::Compact(formatter.compact()),
     };
 
-    let stdout_layer = fmt::layer().event_format(formatter);
+    let stderr_layer = fmt::layer()
+        .event_format(formatter)
+        .with_writer(std::io::stderr);
 
     let error_layer = tracing_error::ErrorLayer::default();
     tracing_subscriber::registry()
-        .with(filter.and_then(stdout_layer))
+        .with(filter.and_then(stderr_layer))
         .with(error_layer)
         .init();
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

- Change the log output to `stderr` instead of `stdout`
- Change default log format to `full` instead of `pretty` (see #145 for demos)

## 🛡 Tests
- ✅ Manual Tests