### PR TITLE
Update root LICENSE.md to reflect new products

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,15 +1,18 @@
-Source code in this repository is variously licensed under the Apache License
-Version 2.0, an Apache compatible license, or the [Server Side Public License](packages/engine/LICENSE).
+Source code in this repository is variously licensed under the MIT License,
+the GNU Affero General Public License, or the [Server Side Public License](packages/engine/LICENSE).
 
 All source code should have information at the beginning of its respective file
 which specifies its licensing information.
 
-* Outside of the `/packages/engine` directory, source code in a given file
-  is licensed under the Apache License Version 2.0, unless otherwise noted
-  (e.g. an Apache-compatible license).
-
 * Within the `/packages/engine` folder, source code in a given file is
   licensed under the Server Side Public License, unless otherwise noted.
+  
+* Within the `/packages/hash` folder, source code in a given file is
+  licensed under version 3 of the GNU Affero General Public License, unless
+  otherwise noted.
+  
+* Outside of these directories, source code in a given file is licensed
+  under the MIT License, unless otherwise noted.
 
 Written content, illustrations and graphics published under the `resources`
 folder within this repository are made available under the [Creative Commons

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -5,8 +5,9 @@ All source code should have information at the beginning of its respective file
 which specifies its licensing information.
 
 * Within the `/packages/engine` folder, source code in a given file is
-  dually-licensed under both the Server Side Public License and the Elastic
-  License 2.0, unless otherwise noted.
+  dually-licensed under either the Server Side Public License or the Elastic
+  License 2.0, unless otherwise noted, giving users the choice of which
+  license to apply.
   
 * Within the `/packages/hash` folder, source code in a given file is
   licensed under version 3 of the GNU Affero General Public License, unless

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -12,7 +12,9 @@ which specifies its licensing information.
   otherwise noted.
   
 * Outside of these directories, source code in a given file is licensed
-  under the MIT License, unless otherwise noted.
+  under the MIT License, unless otherwise noted (a) within the file, (b) in
+  the metadata of a package (e.g. its `package.json` file) or (c) within a
+  folder's `LICENSE.md` file (or that of its nearest parent).
 
 Written content, illustrations and graphics published under the `resources`
 folder within this repository are made available under the [Creative Commons

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -5,7 +5,8 @@ All source code should have information at the beginning of its respective file
 which specifies its licensing information.
 
 * Within the `/packages/engine` folder, source code in a given file is
-  licensed under the Server Side Public License, unless otherwise noted.
+  dually-licensed under both the Server Side Public License and the Elastic
+  License 2.0, unless otherwise noted.
   
 * Within the `/packages/hash` folder, source code in a given file is
   licensed under version 3 of the GNU Affero General Public License, unless

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -18,6 +18,8 @@ which specifies its licensing information.
   the metadata of a package (e.g. its `package.json` file) or (c) within a
   folder's `LICENSE.md` file (or that of its nearest parent).
 
+If you have any questions please [contact us](https://hash.ai/contact].
+
 Written content, illustrations and graphics published under the `resources`
 folder within this repository are made available under the [Creative Commons
 Attribution-ShareAlike 4.0 International](resources/LICENSE.md) license.

--- a/packages/engine/LICENSE.md
+++ b/packages/engine/LICENSE.md
@@ -1,3 +1,8 @@
+Source code in this repository is made available under both the Server
+Side Public License v1  and the Elastic License 2.0.
+
+---
+
                      Server Side Public License
                      VERSION 1, OCTOBER 16, 2018
 
@@ -555,3 +560,99 @@
   return for a fee.
   
                         END OF TERMS AND CONDITIONS
+                        
+---
+
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor’s trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.

--- a/packages/engine/LICENSE.md
+++ b/packages/engine/LICENSE.md
@@ -1,5 +1,5 @@
 Source code in this repository is made available under both the Server
-Side Public License v1  and the Elastic License 2.0.
+Side Public License v1 and the Elastic License 2.0.
 
 ---
 

--- a/packages/engine/LICENSE.md
+++ b/packages/engine/LICENSE.md
@@ -3,15 +3,16 @@ Side Public License v1  and the Elastic License 2.0.
 
 ---
 
-                     Server Side Public License
-                     VERSION 1, OCTOBER 16, 2018
+# Server Side Public License
 
-                    Copyright © 2018 MongoDB, Inc.
+VERSION 1, OCTOBER 16, 2018
 
-  Everyone is permitted to copy and distribute verbatim copies of this
-  license document, but changing it is not allowed.
+Copyright © 2018 MongoDB, Inc.
 
-                       TERMS AND CONDITIONS
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+**TERMS AND CONDITIONS**
 
   0. Definitions.
   
@@ -559,11 +560,11 @@ Side Public License v1  and the Elastic License 2.0.
   warranty or assumption of liability accompanies a copy of the Program in
   return for a fee.
   
-                        END OF TERMS AND CONDITIONS
+**END OF TERMS AND CONDITIONS**
                         
 ---
 
-Elastic License 2.0
+# Elastic License 2.0
 
 URL: https://www.elastic.co/licensing/elastic-license
 


### PR DESCRIPTION
This PR improves clarity around our licensing:

- it outlines that hEngine is in fact dual-licensed (available under Elastic License 2.0 as well as v1 of the Server Side Public License)
- it outlines the license under which the HASH workspace will be made available (GNU Affero General Public License 3.0)
- it outlines that source code outside of the above projects is by default now available under the **MIT** license (but exceptions may apply)
- appends a copy of the Elastic License 2.0 to our hEngine package `LICENSE.md` file, accompanying the SSPL text already there