### PR TITLE
[BE] [FE] [COLLAB] Sync entity store actions through collab

### DIFF
--- a/packages/hash/api/src/collab/Instance.ts
+++ b/packages/hash/api/src/collab/Instance.ts
@@ -10,6 +10,7 @@ import {
 } from "@hashintel/hash-shared/entityStore";
 import {
   addEntityStoreAction,
+  disableEntityStoreTransactionInterpretation,
   EntityStorePluginAction,
   entityStorePluginState,
 } from "@hashintel/hash-shared/entityStorePlugin";
@@ -247,10 +248,15 @@ export class Instance {
       steps: Step[],
       clientID: string,
       actions: EntityStorePluginAction[] = [],
+      fromClient = true,
     ) => {
       this.checkVersion(version);
       if (this.version !== version) return false;
       const tr = this.state.tr;
+
+      if (fromClient) {
+        disableEntityStoreTransactionInterpretation(tr);
+      }
 
       for (let i = 0; i < steps.length; i++) {
         this.clientIds.set(steps[i], clientID);
@@ -341,6 +347,8 @@ export class Instance {
               this.version,
               transform.steps,
               `${clientID}-server`,
+              [],
+              false,
             );
           }
 

--- a/packages/hash/api/src/collab/collabApp.ts
+++ b/packages/hash/api/src/collab/collabApp.ts
@@ -37,6 +37,7 @@ const formatGetEventsResponse = (
   clientIDs: data.clientIDs,
   users: data.users,
   store: data.store,
+  actions: data.actions,
 });
 
 interface UserInfo {
@@ -233,6 +234,8 @@ export const createCollabApp = async (queue: QueueExclusiveConsumer) => {
           data.steps,
           data.clientID,
           data.blockIds,
+          // @todo these need to be validated
+          data.actions,
         );
         if (!result) {
           response.status(409).send("Version not current");

--- a/packages/hash/frontend/src/blocks/page/collab/EditorConnection.ts
+++ b/packages/hash/frontend/src/blocks/page/collab/EditorConnection.ts
@@ -2,7 +2,7 @@ import { createProseMirrorState } from "@hashintel/hash-shared/createProseMirror
 import { EntityStore } from "@hashintel/hash-shared/entityStore";
 import {
   addEntityStoreAction,
-  EntityStorePluginAction,
+  disableEntityStoreTransactionInterpretation,
   entityStorePluginState,
 } from "@hashintel/hash-shared/entityStorePlugin";
 import { ProsemirrorNode } from "@hashintel/hash-shared/node";
@@ -263,6 +263,7 @@ export class EditorConnection {
           }
 
           if (shouldDispatch) {
+            disableEntityStoreTransactionInterpretation(tr);
             this.dispatch({
               type: "update",
               transaction: tr,
@@ -282,6 +283,7 @@ export class EditorConnection {
             data.steps.map((json: any) => Step.fromJSON(this.schema, json)),
             data.clientIDs,
           );
+          disableEntityStoreTransactionInterpretation(tr);
         }
 
         if (

--- a/packages/hash/frontend/src/blocks/page/collab/EditorConnection.ts
+++ b/packages/hash/frontend/src/blocks/page/collab/EditorConnection.ts
@@ -342,7 +342,14 @@ export class EditorConnection {
       ),
       actions: actions.map((action) => action.action),
     });
-    this.run(POST(`${this.url}/events`, json, "application/json")).then(
+    const removeActions = () => {
+      for (const action of actions) {
+        this.sentActions.delete(action.id);
+      }
+    };
+    this.run(
+      POST(`${this.url}/events`, json, "application/json", removeActions),
+    ).then(
       (data) => {
         this.report.success();
         this.backOff = 0;
@@ -365,9 +372,7 @@ export class EditorConnection {
         });
       },
       (err) => {
-        for (const action of actions) {
-          this.sentActions.delete(action.id);
-        }
+        removeActions();
         if (err.status === 409) {
           // The client's document conflicts with the server's version.
           // Poll for changes and then try again.

--- a/packages/hash/shared/src/entityStorePlugin.ts
+++ b/packages/hash/shared/src/entityStorePlugin.ts
@@ -127,7 +127,11 @@ const entityStoreReducer = (
       };
 
     case "store": {
-      return { ...state, store: action.payload };
+      return {
+        ...state,
+        store: action.payload,
+        trackedActions: [],
+      };
     }
 
     case "subscribe":


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This builds on previous work of making the entity store plugin work based on discrete actions, by syncing those actions with the collab instance, and then with other clients. This will allow clients to make and sync changes to the entity store that are not linked to a change in the prosemirror document, which was previously their only way to describe changes to the server. This will come in a future PR and is necessary for variant switching. 

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

Collab already has issues where high frequency updates cause 409 Conflict issues which is to be expected. This will be fixed by moving to a websocket transport.

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

- [x] https://github.com/hashintel/hash/pull/193

## 🐾 Next steps

- [**\[ASANA\]** Fix switching variant ](https://app.asana.com/0/1200211978612931/1200972693311572/f) (_internal_)

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- New type of update in collab update list for entity store actions
- New ability to disable document interpretation for a transaction – this prevents the plugin comparing the document from the transaction against the entity store to generate a list of changes to the entity store. This is necessary for collab to turn off document interpretation when receiving steps from clients, as actions are now sent alongside those steps
	- New `fromClient` option for `Instance#addEvents` to use this functionality
- New `received` option when adding actions to the entity store – this prevents them being tracked for distribution
- When scanning a document post-save, we now generate a list of changes necessary to update the entity store with the new entity id for new blocks. This is in addition to existing functionality which is used to update the prosemirror document  with the new entity ids
	- This requires a new `updateEntityId` action in the entity store plugin
- Allow clients to post action updates to the collab instance, which are applied to the collab instance, and redistributed to other clients
- Actions which require syncing are now added to a `trackedActions` array, alongside a unique id which can be used by other parts of the app to track if they've been synced with other clients or not
- `EditorConnection` now syncs tracked actions from the entity store plugin to the collab instance, and applies actions received from the collab instance back to the entity store plugin
- The HTTP layer in `EditorConnection` has been enhanced to ensure the error handler is more reliably called, and to add an on abort handler. This is used to ensure actions marked as sent are then marked as unsent if the request fails
- `pluginStateFromTransaction` has been renamed to `entityStorePluginStateFromTransaction`

### Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

N/A

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as (_internal_) -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [**\[ASANA\]** Rewrite entityStorePlugin to be based on discrete actions which can be synced with collab](https://app.asana.com/0/1201519755227635/1201662619366268/f) (_internal_)
- [**\[GITHUB\]**](https://github.com/hashintel/dev/pull/450) (_internal_) – Migrated from here

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

While there is no visible functionality change for this, it is vital that actions posted from one client end up in another.  You should make changes and check the network traffic to see actions posted in one client, end up in another. You should also see `updateEntityId` actions coming back from the server for new blocks shortly after they're created.

## 📹 Demo

N/A