### PR TITLE
[FE] persist block urls

### DIFF
--- a/packages/hash/frontend/src/blocks/blocksMeta.tsx
+++ b/packages/hash/frontend/src/blocks/blocksMeta.tsx
@@ -1,5 +1,5 @@
 import { BlockMeta } from "@hashintel/hash-shared/blockMeta";
-import { createContext, useContext, useMemo, useState } from "react";
+import { useLocalstorageState } from "rooks";
 
 type BlocksMetaMap = Map<string, BlockMeta>;
 
@@ -17,7 +17,7 @@ export const BlocksMetaProvider: React.FC<{ value: BlocksMetaMap }> = ({
   value: initialValue,
   children,
 }) => {
-  const [value, setValue] = useState(initialValue);
+  const [value, setValue] = useLocalstorageState("blocks-meta", initialValue);
 
   const state = useMemo(() => ({ value, setValue }), [value, setValue]);
 

--- a/packages/hash/frontend/src/blocks/blocksMeta.tsx
+++ b/packages/hash/frontend/src/blocks/blocksMeta.tsx
@@ -1,7 +1,8 @@
 import { BlockMeta } from "@hashintel/hash-shared/blockMeta";
+import { createContext, useContext, useMemo } from "react";
 import { useLocalstorageState } from "rooks";
 
-type BlocksMetaMap = Map<string, BlockMeta>;
+export type BlocksMetaMap = Record<string, BlockMeta>;
 
 interface BlocksMetaContextState {
   value: BlocksMetaMap;
@@ -9,7 +10,7 @@ interface BlocksMetaContextState {
 }
 
 const BlocksMetaContext = createContext<BlocksMetaContextState>({
-  value: new Map(),
+  value: {},
   setValue(_) {},
 });
 

--- a/packages/hash/frontend/src/blocks/page/PageBlock.tsx
+++ b/packages/hash/frontend/src/blocks/page/PageBlock.tsx
@@ -1,19 +1,18 @@
-import { BlockMeta } from "@hashintel/hash-shared/blockMeta";
 import { ProsemirrorSchemaManager } from "@hashintel/hash-shared/ProsemirrorSchemaManager";
 import { Schema } from "prosemirror-model";
 import { EditorView } from "prosemirror-view";
 import "prosemirror-view/style/prosemirror.css";
 import React, { useLayoutEffect, useRef, VoidFunctionComponent } from "react";
-
 import { tw } from "twind";
+
 import { Button } from "../../components/forms/Button";
-import { BlocksMetaProvider } from "../blocksMeta";
+import { BlocksMetaMap, BlocksMetaProvider } from "../blocksMeta";
 import { EditorConnection } from "./collab/EditorConnection";
 import { createEditorView } from "./createEditorView";
 import { usePortals } from "./usePortals";
 
 type PageBlockProps = {
-  blocksMeta: Map<string, BlockMeta>;
+  blocksMeta: BlocksMetaMap;
   accountId: string;
   entityId: string;
 };
@@ -56,7 +55,7 @@ export const PageBlock: VoidFunctionComponent<PageBlockProps> = ({
       renderPortal,
       accountId,
       entityId,
-      Array.from(blocksMeta.values()),
+      blocksMeta,
     );
 
     prosemirrorSetup.current = {

--- a/packages/hash/frontend/src/blocks/page/createEditorView.ts
+++ b/packages/hash/frontend/src/blocks/page/createEditorView.ts
@@ -1,4 +1,3 @@
-import { BlockMeta } from "@hashintel/hash-shared/blockMeta";
 import { createProseMirrorState } from "@hashintel/hash-shared/createProseMirrorState";
 import { apiOrigin } from "@hashintel/hash-shared/environment";
 import { ProsemirrorNode } from "@hashintel/hash-shared/node";
@@ -7,6 +6,7 @@ import { ProsemirrorSchemaManager } from "@hashintel/hash-shared/ProsemirrorSche
 import { Schema } from "prosemirror-model";
 import { Plugin } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
+import type { BlocksMetaMap } from "../blocksMeta";
 import { BlockView } from "./BlockView";
 import { EditorConnection } from "./collab/EditorConnection";
 import { Reporter } from "./collab/Reporter";
@@ -22,7 +22,7 @@ export const createEditorView = (
   renderPortal: RenderPortal,
   accountId: string,
   pageEntityId: string,
-  preloadedBlocks: BlockMeta[],
+  blocksMeta: BlocksMetaMap,
 ) => {
   let manager: ProsemirrorSchemaManager;
 
@@ -123,9 +123,13 @@ export const createEditorView = (
 
   view.dom.classList.add(styles.ProseMirror);
 
-  for (const meta of preloadedBlocks) {
-    manager.defineNewBlock(meta);
-  }
+  // prosemirror will use the first node type (per group) for auto-creation.
+  // we want this to be the paragraph node type.
+  Object.values(blocksMeta)
+    .sort((blockMeta) =>
+      blockMeta.componentMetadata.name === "paragraph" ? -1 : 0,
+    )
+    .forEach(manager.defineNewBlock, manager);
 
   // @todo figure out how to use dev tools without it breaking fast refresh
   // applyDevTools(view);

--- a/packages/hash/frontend/src/blocks/page/createSuggester/BlockSuggester.tsx
+++ b/packages/hash/frontend/src/blocks/page/createSuggester/BlockSuggester.tsx
@@ -26,7 +26,7 @@ export const BlockSuggester: VFC<BlockSuggesterProps> = ({
   const { value: blocksMeta } = useBlocksMeta();
 
   const options = useMemo(() => {
-    const allOptions = Array.from(blocksMeta.values()).flatMap((blockMeta) =>
+    const allOptions = Object.values(blocksMeta).flatMap((blockMeta) =>
       blockMeta.componentMetadata.variants.map((variant) => ({
         variant,
         meta: blockMeta,

--- a/packages/hash/frontend/src/components/BlockContextMenu/BlockContextMenu.tsx
+++ b/packages/hash/frontend/src/components/BlockContextMenu/BlockContextMenu.tsx
@@ -86,7 +86,7 @@ export const BlockContextMenu: React.VFC<BlockContextMenuProps> = ({
   const { value: blocksMeta } = useBlocksMeta();
 
   const blockOptions = useMemo(() => {
-    return Array.from(blocksMeta.values()).flatMap((blockMeta) =>
+    return Object.values(blocksMeta).flatMap((blockMeta) =>
       blockMeta.componentMetadata.variants.map((variant) => ({
         variant,
         meta: blockMeta,

--- a/packages/hash/frontend/src/components/BlockContextMenu/BlockLoaderInput.tsx
+++ b/packages/hash/frontend/src/components/BlockContextMenu/BlockLoaderInput.tsx
@@ -4,10 +4,6 @@ import { Button } from "../forms/Button";
 import { useBlocksMeta } from "../../blocks/blocksMeta";
 import { useBlockView } from "../../blocks/page/BlockViewContext";
 
-/** immutable version of {@link Map#set} */
-const setEntry = <K, V>(map: Map<K, V>, entry: [K, V]) =>
-  new Map(Array.from(map.entries()).concat([entry]));
-
 export const BlockLoaderInput: React.VFC = () => {
   const blockView = useBlockView();
   const { value: blocksMeta, setValue: setBlocksMeta } = useBlocksMeta();
@@ -16,7 +12,7 @@ export const BlockLoaderInput: React.VFC = () => {
   const [blockUrl, setBlockUrl] = useState("");
   const blockUrlRef = useRef<HTMLInputElement | null>(null);
 
-  const isDefinedBlock = blocksMeta.has(blockUrl);
+  const isDefinedBlock = blockUrl in blocksMeta;
   const isValidBlockUrl = Boolean(blockUrlRef.current?.validity.valid);
 
   const loadBlockFromUrl = () => {
@@ -27,7 +23,7 @@ export const BlockLoaderInput: React.VFC = () => {
       .fetchAndDefineBlock(blockUrl)
       .then((blockMeta) => {
         setError(null);
-        setBlocksMeta(setEntry(blocksMeta, [blockUrl, blockMeta]));
+        setBlocksMeta({ ...blocksMeta, [blockUrl]: blockMeta });
         return blockView.manager.createRemoteBlock(blockUrl);
       })
       .then((block) => {

--- a/packages/hash/frontend/src/pages/[accountId]/[pageEntityId].page.tsx
+++ b/packages/hash/frontend/src/pages/[accountId]/[pageEntityId].page.tsx
@@ -1,12 +1,13 @@
 import { useQuery } from "@apollo/client";
-import { BlockMeta, fetchBlockMeta } from "@hashintel/hash-shared/blockMeta";
+import { fetchBlockMeta } from "@hashintel/hash-shared/blockMeta";
 import { blockPaths } from "@hashintel/hash-shared/paths";
 import { getPageQuery } from "@hashintel/hash-shared/queries/page.queries";
+import { keyBy } from "lodash";
 import { GetStaticPaths, GetStaticProps } from "next";
 import { Router, useRouter } from "next/router";
 import { tw } from "twind";
 
-import { useEffect, useMemo, useState, VoidFunctionComponent } from "react";
+import React, { useEffect, useState } from "react";
 import {
   GetPageQuery,
   GetPageQueryVariables,
@@ -22,6 +23,7 @@ import styles from "../index.module.scss";
 import { CollabPositionProvider } from "../../contexts/CollabPositionContext";
 import { PageTransferDropdown } from "../../components/Dropdowns/PageTransferDropdown";
 import { MainContentWrapper } from "../../components/layout/MainContentWrapper";
+import type { BlocksMetaMap } from "../../blocks/blocksMeta";
 
 /**
  * preload all configured blocks for now. in the future these will be loaded
@@ -42,17 +44,23 @@ export const getStaticPaths: GetStaticPaths<{ slug: string }> = () => ({
  * @todo Include blocks present in the document in this
  */
 export const getStaticProps: GetStaticProps = async () => {
-  const preloadedBlockMeta = await Promise.all(
-    preloadedComponentIds?.map((componentId) => fetchBlockMeta(componentId)) ??
-      [],
+  const fetchedBlocksMeta = await Promise.all(
+    preloadedComponentIds.map(fetchBlockMeta),
   );
 
-  return { props: { preloadedBlockMeta } };
+  return {
+    props: {
+      blocksMeta: keyBy(
+        fetchedBlocksMeta,
+        (blockMeta) => blockMeta.componentMetadata.componentId,
+      ),
+    },
+  };
 };
 
-export const Page: VoidFunctionComponent<{
-  preloadedBlockMeta: BlockMeta[];
-}> = ({ preloadedBlockMeta }) => {
+export const Page: React.VFC<{ blocksMeta: BlocksMetaMap }> = ({
+  blocksMeta,
+}) => {
   const router = useRouter();
 
   // entityId is the consistent identifier for pages (across all versions)
@@ -71,41 +79,6 @@ export const Page: VoidFunctionComponent<{
   >(getPageQuery, {
     variables: { entityId: pageEntityId, accountId, versionId },
   });
-
-  /**
-   * This is to ensure that certain blocks are always contained within the
-   * "select type" dropdown even if the document does not yet contain those
-   * blocks. This is important for paragraphs especially, as the first text
-   * block in the schema is what prosemirror defaults to when creating a new
-   * paragraph. We need to change it so the order of blocks in the dropdown
-   * is not determinned by the order in the prosemirror schema, and also so
-   * that items can be in that dropdown without having be loaded into the
-   * schema.
-   *
-   * @todo this doesn't need to be a map.
-   */
-  const preloadedBlocks = useMemo(
-    () =>
-      new Map(
-        preloadedBlockMeta
-          /**
-           * Paragraph must be first for now, as it'll bw the first loaded
-           * into prosemirror and therefore the block chosen when you
-           * press enter.
-           *
-           * @todo remove need for this
-           */
-          .sort((a, b) =>
-            a.componentMetadata.name === "paragraph"
-              ? -1
-              : b.componentMetadata.name === "paragraph"
-              ? 1
-              : 0,
-          )
-          .map((node) => [node.componentMetadata.componentId, node] as const),
-      ),
-    [preloadedBlockMeta],
-  );
 
   const collabPositions = useCollabPositions(accountId, pageEntityId);
   const reportPosition = useCollabPositionReporter(accountId, pageEntityId);
@@ -201,7 +174,7 @@ export const Page: VoidFunctionComponent<{
         <CollabPositionProvider value={collabPositions}>
           <PageBlock
             accountId={data.page.accountId}
-            blocksMeta={preloadedBlocks}
+            blocksMeta={blocksMeta}
             entityId={data.page.entityId}
           />
         </CollabPositionProvider>

--- a/packages/hash/frontend/src/pages/[accountId]/[pageEntityId].page.tsx
+++ b/packages/hash/frontend/src/pages/[accountId]/[pageEntityId].page.tsx
@@ -30,12 +30,10 @@ import { MainContentWrapper } from "../../components/layout/MainContentWrapper";
 const preloadedComponentIds = Object.keys(blockPaths);
 
 // Apparently defining this is necessary in order to get server rendered props?
-export const getStaticPaths: GetStaticPaths<{ slug: string }> = async () => {
-  return {
-    paths: [], // indicates that no page needs be created at build time
-    fallback: "blocking", // indicates the type of fallback
-  };
-};
+export const getStaticPaths: GetStaticPaths<{ slug: string }> = () => ({
+  paths: [], // indicates that no page needs be created at build time
+  fallback: "blocking", // indicates the type of fallback
+});
 
 /**
  * This is used to fetch the metadata associated with blocks that're preloaded

--- a/packages/hash/shared/src/ProsemirrorSchemaManager.ts
+++ b/packages/hash/shared/src/ProsemirrorSchemaManager.ts
@@ -217,8 +217,8 @@ export class ProsemirrorSchemaManager {
   }
 
   /**
-   * used to ensure all blocks
-   * @todo type this
+   * used to ensure all blocks used by a given document are loaded before
+   * PM tries to instanciate them.
    */
   async ensureBlocksDefined(data: any) {
     return Promise.all(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
This is a follow-up PR for the recent introduction of "load from URL" functionality in the HASH product. Currently, additions to the list of loaded blocks (aka `blockPaths.json`) are not persisted across reloads. This PR uses `localStorage` to fix that.

## ⚠️ Known issues
none

## 🐾 Next steps
n/a

## 🔍 What does this change?
- converts blocksMeta Map to simple object
- push down sorting logic where needed (PM requires paragraph to be defined first)
- use `localStorage` to persist loaded block metadata

### Does this require a change to the docs?
n/a

## 🔗 Related links
- [Asana task](https://app.asana.com/0/0/1201678218839990/f) (_internal_)

## 🛡 What tests cover this?
n/a

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch / view the deployment
1.  Try to load a block from url, then reload the browser-tag
1.  Confirm that it's still available in the context submenu "turn into"

## 📹 Demo
see tests