### PR TITLE
Add a blocked-by section to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,13 @@
 
 <!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->
 
+## 🚫 Blocked by
+
+<!-- If the pull request is blocked by anything, list the blockers here. -->
+<!-- If applicable, link to them. -->
+
+- [ ] ...
+
 ## 🐾 Next steps
 
 <!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In some cases, a Pull request is blocked by another PR or other things like missing information. It's useful to point those information out.

## ⚠️ Known issues

- For PR without blockers, this section has to be removed manually

## 📹 Demo

#181 
