### PR TITLE
Make euclidean the default distance function

### DIFF
--- a/packages/engine/src/config/topology.rs
+++ b/packages/engine/src/config/topology.rs
@@ -304,7 +304,7 @@ pub enum DistanceFunction {
 
 impl Default for DistanceFunction {
     fn default() -> Self {
-        Self::Conway
+        Self::Euclidean
     }
 }
 

--- a/packages/engine/tests/units/neighbors/search_radius/mod.rs
+++ b/packages/engine/tests/units/neighbors/search_radius/mod.rs
@@ -1,6 +1,4 @@
 use crate::run_test;
 
 run_test!(global);
-// TODO: Change default distance function to "euclidean"
-//   see https://app.asana.com/0/1201481007343159/1201674703280810
-run_test!(local, #[ignore]);
+run_test!(local);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Changes the default distance function from `conway` to `euclidean`

### Does this require a change to the docs?

- No, as this is to behave as hCloud

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as (_internal_) -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201481007343159/1201674703280810/f) (_internal_)

## 🛡 What tests cover this?

- ✅ Integration tests for search radius turned green
