### PR TITLE
Fix `state.behaviorIndex()` return the right behavior index

### DIFF
--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/package.js
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/package.js
@@ -193,11 +193,11 @@ const run_task = (
     const behavior_ids = agent_state[behavior_ids_field_key];
     const n_behaviors = behavior_ids.length;
     for (
-      var i_behavior = agent_state.behavior_index;
+      var i_behavior = agent_state.__i_behavior;
       i_behavior < n_behaviors;
       ++i_behavior
     ) {
-      agent_state.behavior_index = i_behavior;
+      agent_state.__i_behavior = i_behavior;
 
       const key = behavior_ids.get(i_behavior);
       // We do this because it's shallow-loaded and the key is an Arrow Vec rather than a clean array

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/package.js
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/package.js
@@ -193,7 +193,7 @@ const run_task = (
     const behavior_ids = agent_state[behavior_ids_field_key];
     const n_behaviors = behavior_ids.length;
     for (
-      var i_behavior = agent_state.__i_behavior;
+      var i_behavior = agent_state.behavior_index;
       i_behavior < n_behaviors;
       ++i_behavior
     ) {

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/package.js
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/package.js
@@ -197,6 +197,10 @@ const run_task = (
       i_behavior < n_behaviors;
       ++i_behavior
     ) {
+      // TODO: reevaluate when other runners are implemented: If there are failing tests,
+      //   - either this has to be changed to `agent_state.behavior_index = i_behavior` and `AgentState.behaviorIndex()`
+      //     has to be adjusted to use `behavior_index` instead of `__i_behavior`, or
+      //   - `agent_state.behavior_index = i_behavior;` has to be added.
       agent_state.__i_behavior = i_behavior;
 
       const key = behavior_ids.get(i_behavior);

--- a/packages/engine/tests/units/state/mod.rs
+++ b/packages/engine/tests/units/state/mod.rs
@@ -1,5 +1,3 @@
 mod edit;
 
-// TODO: Fix behaviorIndex() returns `undefined`
-//   see https://app.asana.com/0/1201481007343159/1201671951990162/f
-crate::run_test!(behavior_index, #[ignore]);
+crate::run_test!(behavior_index);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fix `state.behaviorIndex()` return the right behavior index instead of `undefined`

## 🔍 What does this change?

`AgentState.behaviorIndex()` is using the internal field `__i_behavior` instead of `behavior_index`. `__i_behavior` is never set, so this PR fixes this.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201481007343159/1201671951990162/f) (_internal_)

## 🛡 What tests cover this?

- ✅ The integration test for testing `state.behaviorIndex()` turns green. The integration test is designed so that the expected behavior is the same as in hCloud.
