### PR TITLE
[FE] effectively override twind preflight styles

### DIFF
--- a/packages/hash/frontend/styles/globals.scss
+++ b/packages/hash/frontend/styles/globals.scss
@@ -30,3 +30,24 @@ a {
 #__next {
   height: 100%;
 }
+
+/**
+ * twind preflight overrides
+ * (using an additional selector increases specificity)
+ */
+html {
+  h1 {
+    font-size: 2rem;
+    font-weight: 400;
+  }
+  
+  h2 {
+    font-size: 1.6rem;
+    font-weight: 400;
+  }
+  
+  h3 {
+    font-size: 1.3rem;
+    font-weight: 400;
+  }
+}

--- a/packages/hash/frontend/twind.config.js
+++ b/packages/hash/frontend/twind.config.js
@@ -1,3 +1,10 @@
+/**
+ * overriding twind's preflight styles does not work as documented.
+ * please put your overrides in ./src/styles/globals.scss
+ *
+ * @see https://twind.dev/handbook/configuration.html#preflight
+ */
+
 /** @type {import('twind').Configuration} */
 module.exports = {
   theme: {
@@ -15,21 +22,6 @@ module.exports = {
       },
     },
   },
-  preflight: (preflight, { theme }) => ({
-    ...preflight,
-    h1: {
-      "font-size": "2rem",
-      "font-weight": "400",
-    },
-    h2: {
-      "font-size": "1.6rem",
-      "font-weight": "400",
-    },
-    h3: {
-      "font-size": "1.3rem",
-      "font-weight": "400",
-    },
-  }),
   variants: {
     extend: {
       borderTopLeftRadius: ["first"],


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
Overriding twind's preflight styles did not work as documented. this PR works around that.

## ⚠️ Known issues
Overriding twind's preflight styles does not work as documented

## 🚫 Blocked by
none.

## 🐾 Next steps
no follow-up.

## 🔍 What does this change?
Moves overrides from `twind.config.json` to `globals.scss`.

### Does this require a change to the docs?
no.

## 🔗 Related links
- [twind docs on preflight](https://twind.dev/handbook/configuration.html#preflight)
- [Asana task](https://app.asana.com/0/1201095311341924/1201454402248656/f) (_internal_)

## 🛡 What tests cover this?
none.

## ❓ How to test this?
1.  Checkout the branch / view the deployment
1.  Confirm that styles from the twind-override-section in `packages/hash/frontend/src/styles/globals.scss` overrule those provided by twind's preflight (contained by one of the first inline stylesheets)

## 📹 Demo
see tests.