### PR TITLE
[FE] [BE] [COLLAB] Rewrite entity store plugin to be based on discrete actions

### DIFF
--- a/packages/hash/api/src/collab/Instance.ts
+++ b/packages/hash/api/src/collab/Instance.ts
@@ -211,7 +211,7 @@ export class Instance {
   private updateSavedContents(nextSavedContents: BlockEntity[]) {
     const { tr } = this.state;
     addEntityStoreAction(this.state, tr, {
-      type: "contents",
+      type: "mergeNewPageContents",
       payload: nextSavedContents,
     });
     this.state = this.state.apply(tr);

--- a/packages/hash/api/src/collab/Instance.ts
+++ b/packages/hash/api/src/collab/Instance.ts
@@ -210,7 +210,10 @@ export class Instance {
 
   private updateSavedContents(nextSavedContents: BlockEntity[]) {
     const { tr } = this.state;
-    addEntityStoreAction(tr, { type: "contents", payload: nextSavedContents });
+    addEntityStoreAction(this.state, tr, {
+      type: "contents",
+      payload: nextSavedContents,
+    });
     this.state = this.state.apply(tr);
     this.savedContents = nextSavedContents;
     this.recordStoreUpdate();

--- a/packages/hash/frontend/src/blocks/page/collab/EditorConnection.ts
+++ b/packages/hash/frontend/src/blocks/page/collab/EditorConnection.ts
@@ -99,7 +99,7 @@ export class EditorConnection {
         // @todo clear history?
         const { tr } = editorState;
 
-        addEntityStoreAction(tr, {
+        addEntityStoreAction(editorState, tr, {
           type: "store",
           payload: action.store,
         });
@@ -232,7 +232,10 @@ export class EditorConnection {
 
         if (data.store && this.state.edit) {
           const tr = this.state.edit.tr;
-          addEntityStoreAction(tr, { type: "store", payload: data.store });
+          addEntityStoreAction(this.state.edit, tr, {
+            type: "store",
+            payload: data.store,
+          });
           // @todo remove need to dispatch here, combine with below dispatch
           this.dispatch({
             type: "update",

--- a/packages/hash/shared/src/ProsemirrorSchemaManager.ts
+++ b/packages/hash/shared/src/ProsemirrorSchemaManager.ts
@@ -383,7 +383,7 @@ export class ProsemirrorSchemaManager {
 
     const { tr } = state;
 
-    addEntityStoreAction(tr, { type: "store", payload: store });
+    addEntityStoreAction(state, tr, { type: "store", payload: store });
 
     tr.replaceWith(0, state.doc.content.size, newNodes);
 

--- a/packages/hash/shared/src/entityStorePlugin.ts
+++ b/packages/hash/shared/src/entityStorePlugin.ts
@@ -33,9 +33,21 @@ type EntityStorePluginState = {
 };
 
 type EntityStorePluginAction =
-  | {
-      // @todo remove this
-      type: "contents";
+  | /**
+   * This is an action that merges in a new set of blocks from a Page
+   * entity's contents property, usually post save while attempting to
+   * remember draft data which has not yet been saved. This is not a
+   * fool-proof solution, and is only necessary because we don't yet
+   * convert the changes made during a save into discrete actions. Once
+   * we do that, we should remove this as its a source of complexity and
+   * bugs. It also results in needing to send the entire store to the
+   * other clients, as it is not sync-able.
+   *
+   * @deprecated
+   * @todo remove this once we better handle saves
+   */
+  {
+      type: "mergeNewPageContents";
       payload: BlockEntity[];
     }
   | { type: "store"; payload: EntityStore }
@@ -94,7 +106,7 @@ const entityStoreReducer = (
   action: EntityStorePluginAction,
 ): EntityStorePluginState => {
   switch (action.type) {
-    case "contents":
+    case "mergeNewPageContents":
       return {
         ...state,
         store: createEntityStore(action.payload, state.store.draft),

--- a/packages/hash/shared/src/entityStorePlugin.ts
+++ b/packages/hash/shared/src/entityStorePlugin.ts
@@ -220,7 +220,7 @@ class ProsemirrorStateChangeHandler {
      * @todo address this
      * @see https://immerjs.github.io/immer/pitfalls#immer-only-supports-unidirectional-trees
      */
-    this.state.doc.descendants((node, pos) => {
+    this.tr.doc.descendants((node, pos) => {
       this.handleNode(node, pos);
     });
 

--- a/packages/hash/shared/src/entityStorePlugin.ts
+++ b/packages/hash/shared/src/entityStorePlugin.ts
@@ -135,63 +135,43 @@ const entityStoreReducer = (
         throw new Error("Entity missing to merge entity properties");
       }
 
-      const nextDraft = produce(
-        state.store.draft,
-        (draftedDraftEntityStore) => {
-          const entities: Draft<DraftEntity>[] = [
-            draftedDraftEntityStore[action.payload.draftId],
-          ];
+      return produce(state, (draftState) => {
+        const entities: Draft<DraftEntity>[] = [
+          draftState.store.draft[action.payload.draftId],
+        ];
 
-          for (const entity of Object.values(draftedDraftEntityStore)) {
-            if (
-              isDraftBlockEntity(entity) &&
-              entity.properties.entity.draftId === action.payload.draftId
-            ) {
-              entities.push(entity.properties.entity);
-            }
+        for (const entity of Object.values(draftState.store.draft)) {
+          if (
+            isDraftBlockEntity(entity) &&
+            entity.properties.entity.draftId === action.payload.draftId
+          ) {
+            entities.push(entity.properties.entity);
           }
+        }
 
-          if (action.payload.merge) {
-            for (const entity of entities) {
-              Object.assign(entity.properties, action.payload.properties);
-            }
-          } else {
-            for (const entity of entities) {
-              entity.properties = action.payload.properties;
-            }
+        if (action.payload.merge) {
+          for (const entity of entities) {
+            Object.assign(entity.properties, action.payload.properties);
           }
-        },
-      );
-
-      return {
-        ...state,
-        store: {
-          ...state.store,
-          draft: nextDraft,
-        },
-      };
+        } else {
+          for (const entity of entities) {
+            entity.properties = action.payload.properties;
+          }
+        }
+      });
     }
-    case "newDraftEntity": {
+    case "newDraftEntity":
       if (state.store.draft[action.payload.draftId]) {
         throw new Error("Draft entity already exists");
       }
 
-      const nextDraft = produce(state.store.draft, (draft) => {
-        draft[action.payload.draftId] = {
+      return produce(state, (draftState) => {
+        draftState.store.draft[action.payload.draftId] = {
           entityId: action.payload.entityId,
           draftId: action.payload.draftId,
           properties: {},
         };
       });
-
-      return {
-        ...state,
-        store: {
-          ...state.store,
-          draft: nextDraft,
-        },
-      };
-    }
   }
 
   return state;

--- a/packages/hash/shared/src/entityStorePlugin.ts
+++ b/packages/hash/shared/src/entityStorePlugin.ts
@@ -51,6 +51,20 @@ const entityStorePluginKey = new PluginKey<EntityStorePluginState, Schema>(
 );
 
 /**
+ * @use {@link subscribeToEntityStore} if you need a live subscription
+ */
+export const entityStorePluginState = (state: EditorState<Schema>) => {
+  const pluginState = entityStorePluginKey.getState(state);
+
+  if (!pluginState) {
+    throw new Error(
+      "Cannot get entity store when state does not have entity store plugin",
+    );
+  }
+  return pluginState;
+};
+
+/**
  * We current violate Immer's rules, as properties inside entities can be
  * other entities themselves, and we expect `entity.property.entity` to be
  * the same object as the other entity. We either need to change that, or
@@ -191,20 +205,6 @@ const updateEntityStoreListeners = collect<
     view.dispatch(transaction);
   }
 });
-
-/**
- * @use {@link subscribeToEntityStore} if you need a live subscription
- */
-export const entityStorePluginState = (state: EditorState<Schema>) => {
-  const pluginState = entityStorePluginKey.getState(state);
-
-  if (!pluginState) {
-    throw new Error(
-      "Cannot get entity store when state does not have entity store plugin",
-    );
-  }
-  return pluginState;
-};
 
 export const subscribeToEntityStore = (
   view: EditorView<Schema>,

--- a/packages/hash/shared/src/entityStorePlugin.ts
+++ b/packages/hash/shared/src/entityStorePlugin.ts
@@ -123,14 +123,14 @@ const updateEntityStoreListeners = collect<
 });
 
 /**
- * @use subscribeToEntityStore if you need a live subscription
+ * @use {@link subscribeToEntityStore} if you need a live subscription
  */
 export const entityStorePluginState = (state: EditorState<Schema>) => {
   const pluginState = entityStorePluginKey.getState(state);
 
   if (!pluginState) {
     throw new Error(
-      "Cannot process transaction when state does not have entity store plugin",
+      "Cannot get entity store when state does not have entity store plugin",
     );
   }
   return pluginState;
@@ -192,48 +192,6 @@ const draftIdForNode = (
   }
 
   return draftId;
-};
-
-const entityStoreReducer = (
-  state: EntityStorePluginState,
-  action: EntityStorePluginAction,
-): EntityStorePluginState => {
-  switch (action.type) {
-    case "contents":
-      return {
-        ...state,
-        store: createEntityStore(action.payload, state.store.draft),
-      };
-
-    case "draft":
-      return {
-        ...state,
-        store: {
-          ...state.store,
-          draft: action.payload,
-        },
-      };
-
-    case "store": {
-      return { ...state, store: action.payload };
-    }
-
-    case "subscribe":
-      return {
-        ...state,
-        listeners: Array.from(new Set([...state.listeners, action.payload])),
-      };
-
-    case "unsubscribe":
-      return {
-        ...state,
-        listeners: state.listeners.filter(
-          (listener) => listener !== action.payload,
-        ),
-      };
-  }
-
-  return state;
 };
 
 class ProsemirrorStateChangeHandler {
@@ -374,6 +332,48 @@ class ProsemirrorStateChangeHandler {
     });
   }
 }
+
+const entityStoreReducer = (
+  state: EntityStorePluginState,
+  action: EntityStorePluginAction,
+): EntityStorePluginState => {
+  switch (action.type) {
+    case "contents":
+      return {
+        ...state,
+        store: createEntityStore(action.payload, state.store.draft),
+      };
+
+    case "draft":
+      return {
+        ...state,
+        store: {
+          ...state.store,
+          draft: action.payload,
+        },
+      };
+
+    case "store": {
+      return { ...state, store: action.payload };
+    }
+
+    case "subscribe":
+      return {
+        ...state,
+        listeners: Array.from(new Set([...state.listeners, action.payload])),
+      };
+
+    case "unsubscribe":
+      return {
+        ...state,
+        listeners: state.listeners.filter(
+          (listener) => listener !== action.payload,
+        ),
+      };
+  }
+
+  return state;
+};
 
 export const entityStorePlugin = new Plugin<EntityStorePluginState, Schema>({
   key: entityStorePluginKey,

--- a/packages/hash/shared/src/entityStorePlugin.ts
+++ b/packages/hash/shared/src/entityStorePlugin.ts
@@ -306,11 +306,15 @@ class ProsemirrorStateChangeHandler {
         );
       }
 
-      this.setDraftEntityStoreToTransaction(
-        updateEntityProperties(draftEntityStore, entity.draftId, true, {
-          componentId: componentNodeToId(node),
-        }),
-      );
+      const componentId = componentNodeToId(node);
+
+      if (entity.properties.componentId !== componentId) {
+        this.setDraftEntityStoreToTransaction(
+          updateEntityProperties(draftEntityStore, entity.draftId, true, {
+            componentId,
+          }),
+        );
+      }
     }
   }
 

--- a/packages/hash/shared/src/entityStorePlugin.ts
+++ b/packages/hash/shared/src/entityStorePlugin.ts
@@ -271,7 +271,7 @@ class ProsemirrorStateChangeHandler {
     return this.tr;
   }
 
-  handleNode(node: ProsemirrorNode<Schema>, pos: number) {
+  private handleNode(node: ProsemirrorNode<Schema>, pos: number) {
     if (isComponentNode(node)) {
       this.componentNode(node, pos);
     }
@@ -305,7 +305,6 @@ class ProsemirrorStateChangeHandler {
         );
       }
 
-      // eslint-disable-next-line no-param-reassign
       this.draft = updateEntityProperties(
         this.draft,
         blockEntityNode.attrs.draftId,
@@ -318,11 +317,15 @@ class ProsemirrorStateChangeHandler {
   }
 
   private entityNode(node: EntityNode, pos: number) {
+    // @todo clean this up
     const res = produce({ draftId: "", draft: this.draft }, (draftRes) => {
       draftRes.draftId = draftIdForNode(this.tr, node, pos, draftRes.draft);
     });
+
     this.draft = res.draft;
     const draftId = res.draftId;
+
+    // @todo remove mutation
     this.draft = produce(this.draft, (draftDraftEntityStore) => {
       const draftEntity = draftDraftEntityStore[draftId];
 

--- a/packages/hash/shared/src/entityStorePlugin.ts
+++ b/packages/hash/shared/src/entityStorePlugin.ts
@@ -1,5 +1,6 @@
 import { ProsemirrorNode } from "@hashintel/hash-shared/node";
 import { Draft, produce } from "immer";
+import { isEqual } from "lodash";
 import { Schema } from "prosemirror-model";
 import { EditorState, Plugin, PluginKey, Transaction } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
@@ -378,14 +379,17 @@ class ProsemirrorStateChangeHandler {
       node.firstChild.isTextblock
     ) {
       const nextProps = textBlockNodeToEntityProperties(node.firstChild);
-      this.setDraftEntityStoreToTransaction(
-        updateEntityProperties(
-          draftEntityStore,
-          draftEntity.draftId,
-          false,
-          nextProps,
-        ),
-      );
+
+      if (!isEqual(draftEntity.properties, nextProps)) {
+        this.setDraftEntityStoreToTransaction(
+          updateEntityProperties(
+            draftEntityStore,
+            draftEntity.draftId,
+            false,
+            nextProps,
+          ),
+        );
+      }
     }
   }
 

--- a/packages/hash/shared/src/entityStorePlugin.ts
+++ b/packages/hash/shared/src/entityStorePlugin.ts
@@ -34,12 +34,9 @@ type EntityStorePluginState = {
 
 type EntityStorePluginAction =
   | {
+      // @todo remove this
       type: "contents";
       payload: BlockEntity[];
-    }
-  | {
-      type: "draft";
-      payload: EntityStore["draft"];
     }
   | { type: "store"; payload: EntityStore }
   | { type: "subscribe"; payload: EntityStorePluginStateListener }
@@ -101,15 +98,6 @@ const entityStoreReducer = (
       return {
         ...state,
         store: createEntityStore(action.payload, state.store.draft),
-      };
-
-    case "draft":
-      return {
-        ...state,
-        store: {
-          ...state.store,
-          draft: action.payload,
-        },
       };
 
     case "store": {

--- a/packages/hash/shared/src/entityStorePlugin.ts
+++ b/packages/hash/shared/src/entityStorePlugin.ts
@@ -81,7 +81,7 @@ export const pluginStateFromTransaction = (
   tr.getMeta(entityStorePluginKey) ?? entityStorePluginState(state);
 
 /**
- * We current violate Immer's rules, as properties inside entities can be
+ * We currently violate Immer's rules, as properties inside entities can be
  * other entities themselves, and we expect `entity.property.entity` to be
  * the same object as the other entity. We either need to change that, or
  * remove immer, or both.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR rewrites the entity store plugin to generate changes via a set of discrete actions that describe the change being made, instead of those just overwriting the full draft entity store whenever anything changes. This will allow a future PR to sync those actions between clients, to allow clients to push updates to the entity store that are not connected to changes in the Prosemirror tree, which are the only changes clients can make right now.

This will be necessary for variant switching.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

N/A

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

- [x] Depends on https://github.com/hashintel/hash/pull/192

## 🐾 Next steps

- [**\[ASANA\]** Rewrite entityStorePlugin to be based on discrete actions which can be synced with collab](https://app.asana.com/0/1201095311341924/1201662619366268/f) (_internal_)
- [**\[ASANA\]** Fix switching variant ](https://app.asana.com/0/1200211978612931/1200972693311572/f) (_internal_)

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- The entity store plugin now uses its transaction meta slot to store the result of actions applied within this transaction, instead of each individual action. There's a chance this will be reverted in the future, but this allows one part of the code to read the results of actions applied within any given transaction, and build on them, in the same transaction, which can be useful for code separation purposes. It's probably a less ideal way of doing things than before, but does make certain refactors easier which were necessary in order to split changes into individual actions, and we can look at changing back within that constraint later. 
	- 	This means `addEntityStoreAction` now takes the state as well as a transaction, as we need to the state to get the previous entity plugin state in the event you're adding an action to a transaction which has not yet had an action applied to it
- Removed the `draft` action in the entity store plugin, which had previously been used to replace the entirety of the draft entity store. This is because we want discrete actions that describe the change being made, which can be synced to reproduce the change on the collab server / other clients, which makes interoperability easier and reduces the size of network payloads
- Introduced new `updateEntityProperties` and `newDraftEntity` actions, which can fully describe the changes previously described using the `draft` action
- New `pluginStateFromTransaction` function will allows you to access the entity store plugin state based on actions applied thus far on any transaction. This allows code to build up on other code applying actions to the entity store
-  New `ProsemirrorStateChangeHandler` class which houses methods for interpreting a prosemirror state to find the entity store changes necessary to sync the entity store with the prosemirror state (and vice versa). This is primarily refactoring / abstracting existing code to be more modular / extensible, and to depend less on object mutation / immer. 

### Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

N/A

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as (_internal_) -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [**\[ASANA\]** Rewrite entity store plugin to be based on actions, which can later by synced between clients](https://app.asana.com/0/1201095311341924/1201681091845019/f) (_internal_)

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Behavior should not have visibly changed. Ensure collab works as expected.

## 📹 Demo

N/A