### PR TITLE
Deduplicate Rust Actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,7 +45,7 @@ jobs:
             done <<< "$available_crates"
           done <<< "$changed_files"
 
-          changed_crates=$(echo "$changed_crates" | uniq | jq -R | jq -sc '[ .[] | select(length > 0) ]')
+          changed_crates=$(echo "$changed_crates" | sort | uniq | jq -R | jq -sc '[ .[] | select(length > 0) ]')
 
           echo "::set-output name=rustfmt::$changed_crates"
           echo "::set-output name=clippy::$changed_crates"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Deduplicates crate executions in Rust CI

## 🔍 What does this change?

I expected that `git diff` already sorts the outputs. Without sorted outputs, `uniq` does not work for full deduplications, this PR sorts the output of `git diff`.

## 🔗 Related links

- PR with duplicated actions: #195