### PR TITLE
Use `--no-deps` on clippy in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -163,7 +163,7 @@ jobs:
           rm -rf tmp # Delete the tmp folder
 
       - name: Run clippy
-        run: cargo clippy --manifest-path ${{ matrix.directory }}/Cargo.toml ${{ matrix.flags }} -- -D warnings
+        run: cargo clippy --manifest-path ${{ matrix.directory }}/Cargo.toml --no-deps ${{ matrix.flags }} -- -D warnings
 
       - name: Annotate
         if: ${{ failure() }}
@@ -173,7 +173,7 @@ jobs:
           name: clippy (${{ matrix.directory }})
           token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: ${{ matrix.directory }}
-          args: ${{ matrix.flags }}
+          args: --no-deps ${{ matrix.flags }}
 
   test:
     name: test


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds the `--no-deps` flag for clippy in GH Actions to only run clippy on the corresponding crate