### PR TITLE
[FE] Hide restart collab instance button

### DIFF
--- a/packages/hash/frontend/src/blocks/page/PageBlock.tsx
+++ b/packages/hash/frontend/src/blocks/page/PageBlock.tsx
@@ -4,6 +4,7 @@ import { Schema } from "prosemirror-model";
 import { EditorView } from "prosemirror-view";
 import "prosemirror-view/style/prosemirror.css";
 import React, { useLayoutEffect, useRef, VoidFunctionComponent } from "react";
+import { useLocalstorageState } from "rooks";
 
 import { tw } from "twind";
 import { Button } from "../../components/forms/Button";
@@ -31,6 +32,9 @@ export const PageBlock: VoidFunctionComponent<PageBlockProps> = ({
 }) => {
   const root = useRef<HTMLDivElement>(null);
   const [portals, renderPortal] = usePortals();
+  const [debugging] = useLocalstorageState<
+    { restartCollabButton?: boolean } | boolean
+  >("hash.internal.debugging", false);
 
   const prosemirrorSetup = useRef<null | {
     view: EditorView<Schema>;
@@ -80,14 +84,20 @@ export const PageBlock: VoidFunctionComponent<PageBlockProps> = ({
       {/**
        * @todo position this better
        */}
-      <Button
-        className={tw`fixed bottom-5 right-5 opacity-30 hover:(opacity-100) transition-all`}
-        onClick={() => {
-          prosemirrorSetup.current?.connection?.restart();
-        }}
-      >
-        Restart Collab Instance
-      </Button>
+      {(
+        typeof debugging === "boolean"
+          ? debugging
+          : debugging.restartCollabButton
+      ) ? (
+        <Button
+          className={tw`fixed bottom-5 right-5 opacity-30 hover:(opacity-100) transition-all`}
+          onClick={() => {
+            prosemirrorSetup.current?.connection?.restart();
+          }}
+        >
+          Restart Collab Instance
+        </Button>
+      ) : null}
     </BlocksMetaProvider>
   );
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

Hides the "restart collab instance" button which is useful for testing but possibly confusing, unless local storage value is present.

## ⚠️ Known issues

N/A

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

N/A

## 🐾 Next steps

N/A

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Hides the "restart collab" button, unless there's a localStorage value for `hash.internal.debugging` set to either `true` or an object containing a key of `restartCollabButton` with a value of true (with the view that we can expand our debugging tools, and you might want a way to show them all or just some)

### Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

It might be worth following up in the README that this is available, but no immediate need.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as (_internal_) -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [**\[ASANA\]** Hide restart collab instance button by default](https://app.asana.com/0/1201095311341924/1201701347014981/f) (_internal_)
- [Slack discussion](https://hashintel.slack.com/archives/C022217GAHF/p1642178037020100) (_internal_)

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Confirm the button is hidden by default, and shown if `localStorage["hash.internal.debugging"]` is set either to `true` or `{ restartCollabButton: true }`