### PR TITLE
[ENGINE] Adding tracing

### DIFF
--- a/packages/engine/.gitignore
+++ b/packages/engine/.gitignore
@@ -10,6 +10,6 @@ src/worker/runner/python/wrappers.c*
 *-topy*
 *-frompy*
 *hash-orchestrator-*
-./parts/
-./output/
-./log/
+/parts
+/output
+/log

--- a/packages/engine/Cargo.lock
+++ b/packages/engine/Cargo.lock
@@ -970,6 +970,7 @@ dependencies = [
  "tracing-appender",
  "tracing-error",
  "tracing-subscriber",
+ "tracing-texray",
  "uuid",
 ]
 
@@ -2151,6 +2152,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "term_size"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2401,6 +2412,19 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-texray"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0df064f167ff07b179fb6fc2a095c5e04ce2c13c26271fa239d80d14128d60d"
+dependencies = [
+ "lazy_static",
+ "parking_lot",
+ "term_size",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -44,7 +44,7 @@ tracing = "0.1.29"
 tracing-appender = "0.2.0"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.7", features = ["env-filter", "json"] }
-tracing-texray = "0.1.2"
+tracing-texray = { version = "0.1.2", optional = true }
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 
 [dev-dependencies]
@@ -56,6 +56,7 @@ num_cpus = "1.13.1"
 [features]
 default = ["build-nng"]
 build-nng = ["nng/build-nng"]
+texray = ["tracing-texray"]
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -26,7 +26,6 @@ glob = "0.3.0"
 http-types = "2.6.0"
 kdtree = "0.6.0"
 lazy_static = "1.4.0"
-log = { package = "tracing", version = "0.1.29" }
 num_cpus = "1.13.0"
 nng = { version = "1.0.1", default-features = false }
 parking_lot = "0.11.1"
@@ -40,6 +39,7 @@ serde-aux = "0.6.1"
 strum_macros = "0.19.4"
 surf = "2.0.0"
 thiserror = "1.0.21"
+tracing = "0.1.29"
 tokio = { version = "1.5.0", features = ["macros", "rt-multi-thread", "sync", "process", "time"] }
 tracing-subscriber = { version = "0.3.7", features = ["env-filter", "json"] }
 tracing-appender = "0.2.0"

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -39,11 +39,12 @@ serde-aux = "0.6.1"
 strum_macros = "0.19.4"
 surf = "2.0.0"
 thiserror = "1.0.21"
-tracing = "0.1.29"
 tokio = { version = "1.5.0", features = ["macros", "rt-multi-thread", "sync", "process", "time"] }
-tracing-subscriber = { version = "0.3.7", features = ["env-filter", "json"] }
+tracing = "0.1.29"
 tracing-appender = "0.2.0"
 tracing-error = "0.2.0"
+tracing-subscriber = { version = "0.3.7", features = ["env-filter", "json"] }
+tracing-texray = "0.1.2"
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 
 [dev-dependencies]

--- a/packages/engine/bin/cli/Cargo.toml
+++ b/packages/engine/bin/cli/Cargo.toml
@@ -21,4 +21,5 @@ uuid = { version = "0.8.1", features = ["v4", "serde"] }
 
 [features]
 default = ["build-nng"]
+texray = ["hash_engine/texray"]
 build-nng = ["hash_engine/build-nng", "orchestrator/build-nng"]

--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -34,7 +34,7 @@ pub struct Args {
     output: PathBuf,
 
     /// Output format emitted to the terminal.
-    #[clap(long, default_value = "full", arg_enum, env = "HASH_EMIT")]
+    #[clap(long, default_value = "pretty", arg_enum, env = "HASH_EMIT")]
     emit: OutputFormat,
 
     /// Engine start timeout in seconds

--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -105,7 +105,11 @@ async fn main() -> Result<()> {
         .unwrap()
         .as_millis();
 
-    let _guard = hash_engine::init_logger(args.emit, &format!("cli-{now}"));
+    let _guard = hash_engine::init_logger(
+        args.emit,
+        &format!("cli-{now}"),
+        &format!("cli-{now}-texray"),
+    );
 
     let nng_listen_url = format!("ipc://hash-orchestrator-{now}");
 

--- a/packages/engine/bin/server/Cargo.toml
+++ b/packages/engine/bin/server/Cargo.toml
@@ -16,4 +16,5 @@ path = "src/main.rs"
 
 [features]
 default = ["build-nng"]
+texray = ["hash_engine/texray"]
 build-nng = ["hash_engine/build-nng"]

--- a/packages/engine/bin/server/src/main.rs
+++ b/packages/engine/bin/server/src/main.rs
@@ -8,7 +8,11 @@ use hash_engine::{
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = hash_engine::args();
-    let _guard = hash_engine::init_logger(args.emit, &format!("experiment-{}", args.experiment_id));
+    let _guard = hash_engine::init_logger(
+        args.emit,
+        &format!("experiment-{}", args.experiment_id),
+        &format!("experiment-{}-texray", args.experiment_id),
+    );
 
     let mut env = hash_engine::env::<ExperimentRun>(&args)
         .await

--- a/packages/engine/src/args.rs
+++ b/packages/engine/src/args.rs
@@ -26,7 +26,7 @@ pub struct Args {
     pub max_workers: Option<usize>,
 
     /// Output format emitted to the terminal.
-    #[clap(long, default_value = "full", arg_enum, env = "HASH_EMIT")]
+    #[clap(long, default_value = "pretty", arg_enum, env = "HASH_EMIT")]
     pub emit: OutputFormat,
 }
 

--- a/packages/engine/src/config/topology.rs
+++ b/packages/engine/src/config/topology.rs
@@ -469,7 +469,7 @@ impl Config {
             };
             // All keys from the topology object are consumed to check for remaining keys
             for (key, _) in topology_props {
-                log::warn!("Unused key in topology: \"{key}\"")
+                tracing::warn!("Unused key in topology: \"{key}\"")
             }
             Ok(config)
         } else {

--- a/packages/engine/src/datastore/batch/agent.rs
+++ b/packages/engine/src/datastore/batch/agent.rs
@@ -688,7 +688,7 @@ impl Batch {
             a.map(|v| match serde_json::from_str(v) {
                 Ok(v) => v,
                 Err(_) => {
-                    log::warn!("Cannot deserialize value {}", v);
+                    tracing::warn!("Cannot deserialize value {}", v);
                     serde_json::Value::Null
                 }
             })

--- a/packages/engine/src/datastore/batch/dataset.rs
+++ b/packages/engine/src/datastore/batch/dataset.rs
@@ -28,14 +28,14 @@ impl super::Batch for Batch {
     fn maybe_reload(&mut self, _reload_state: Metaversion) -> Result<()> {
         // TODO: ret these errors
         // Error::from("Datasets are not updated");
-        log::error!("Datasets are not updated");
+        tracing::error!("Datasets are not updated");
         Ok(())
     }
 
     fn reload(&mut self) -> Result<()> {
         // TODO: ret these errors
         // Error::from("Datasets are not updated");
-        log::error!("Datasets are not updated");
+        tracing::error!("Datasets are not updated");
         Ok(())
     }
 }

--- a/packages/engine/src/datastore/batch/message.rs
+++ b/packages/engine/src/datastore/batch/message.rs
@@ -153,7 +153,7 @@ impl GrowableBatch<ArrayChange, Arc<array::ArrayData>> for Batch {
 
 impl Batch {
     pub fn reset(&mut self, agents: &AgentBatch) -> Result<()> {
-        log::trace!("Resetting batch");
+        tracing::trace!("Resetting batch");
         let agent_count = agents.batch.num_rows();
         let column_name = AgentStateField::AgentId.name();
         let id_column = agents.get_arrow_column(column_name)?;
@@ -191,7 +191,7 @@ impl Batch {
         if cur_len < data_len && self.memory.set_data_length(data_len)?.resized() {
             // This shouldn't happen very often unless the bounds above are very inaccurate
             self.metaversion.increment();
-            log::info!(
+            tracing::info!(
                 "Unexpected message batch memory resize. Was {}, should have been at least {}",
                 cur_len,
                 data_len

--- a/packages/engine/src/datastore/batch/migration/mod.rs
+++ b/packages/engine/src/datastore/batch/migration/mod.rs
@@ -1111,7 +1111,7 @@ impl RowActions {
         let mut last_i = 0;
         for action in &self.remove {
             if action.val < last_i {
-                log::error!(
+                tracing::error!(
                     "Remove row actions are not ordered correctly: {} < {}",
                     action.val,
                     last_i
@@ -1221,7 +1221,7 @@ impl RangeActions {
         let mut last_i = 0;
         for action in self.remove() {
             if action.index < last_i {
-                log::error!(
+                tracing::error!(
                     "Remove range actions are not ordered correctly: {} < {}",
                     action.index,
                     last_i

--- a/packages/engine/src/datastore/ffi/flush.rs
+++ b/packages/engine/src/datastore/ffi/flush.rs
@@ -71,11 +71,11 @@ unsafe extern "C" fn flush_changes(
     let resized = match prepared.flush_changes() {
         Ok(resized) => resized,
         Err(Error::SharedMemory(shared_memory::ShmemError::DevShmOutOfMemory)) => {
-            log::error!("Out of memory in `flush_changes`");
+            tracing::error!("Out of memory in `flush_changes`");
             return OUT_OF_MEMORY;
         }
         Err(err) => {
-            log::error!("Error in `flush_changes`: {err}");
+            tracing::error!("Error in `flush_changes`: {err}");
             return ERROR_FLAG;
         }
     };

--- a/packages/engine/src/datastore/ffi/mod.rs
+++ b/packages/engine/src/datastore/ffi/mod.rs
@@ -66,7 +66,7 @@ unsafe extern "C" fn get_static_metadata(schema: usize) -> *const StaticMeta {
             Box::into_raw(boxed)
         }
         Err(why) => {
-            log::error!("Error in `get_static_metadata`: {:?}", &why);
+            tracing::error!("Error in `get_static_metadata`: {:?}", &why);
             std::ptr::null()
         }
     }
@@ -105,7 +105,7 @@ unsafe extern "C" fn get_dynamic_metadata(memory_ptr: *const CMemory) -> *const 
             {
                 Ok(ret) => ret,
                 Err(why) => {
-                    log::error!("Error in `get_dynamic_metadata`: {:?}", &why);
+                    tracing::error!("Error in `get_dynamic_metadata`: {:?}", &why);
                     return std::ptr::null();
                 }
             };
@@ -114,7 +114,7 @@ unsafe extern "C" fn get_dynamic_metadata(memory_ptr: *const CMemory) -> *const 
             let dynamic_meta = match batch_message.into_meta(data_buffer_len) {
                 Ok(ret) => ret,
                 Err(why) => {
-                    log::error!("Error in `get_dynamic_metadata`: {:?}", &why);
+                    tracing::error!("Error in `get_dynamic_metadata`: {:?}", &why);
                     return std::ptr::null();
                 }
             };
@@ -122,7 +122,7 @@ unsafe extern "C" fn get_dynamic_metadata(memory_ptr: *const CMemory) -> *const 
             Box::into_raw(boxed)
         }
         Err(why) => {
-            log::error!("Error in `get_dynamic_metadata`: {:?}", &why);
+            tracing::error!("Error in `get_dynamic_metadata`: {:?}", &why);
             std::ptr::null()
         }
     }

--- a/packages/engine/src/datastore/meta.rs
+++ b/packages/engine/src/datastore/meta.rs
@@ -289,7 +289,7 @@ impl Static {
         for (i, col) in self.column_meta.iter().enumerate() {
             let node = &dynamic.nodes[col.node_start];
             if node.length != base_length {
-                log::warn!(
+                tracing::warn!(
                     "Column {} base node does not have required length, is {}, should be {}",
                     i,
                     node.length,

--- a/packages/engine/src/datastore/schema/field_spec/mod.rs
+++ b/packages/engine/src/datastore/schema/field_spec/mod.rs
@@ -283,7 +283,7 @@ impl FieldSpecMap {
                     ));
                 } else if let FieldSource::Package(_package_src) = &new_field.source {
                     if existing_field.source == FieldSource::Engine {
-                        log::warn!(
+                        tracing::warn!(
                             "Key clash when a package attempted to insert a new agent-scoped \
                              field with key: {:?}, the existing field was created by the engine, \
                              the new field will be ignored",

--- a/packages/engine/src/datastore/storage/memory.rs
+++ b/packages/engine/src/datastore/storage/memory.rs
@@ -75,7 +75,7 @@ impl Memory {
     /// reloading
     pub fn resize(&mut self, mut new_size: usize) -> Result<()> {
         new_size = Self::calculate_total_size(new_size, self.include_terminal_padding)?;
-        log::trace!("Trying to resize memory to: {}", new_size);
+        tracing::trace!("Trying to resize memory to: {}", new_size);
         self.data.resize(new_size)?;
         self.size = new_size;
         Ok(())
@@ -321,7 +321,9 @@ impl Memory {
                 size = val.parse().expect(&format!(
                     "OS_MEMORY_ALLOC_OVERRIDE was an invalid value: {val}"
                 ));
-                log::debug!("Memory size was overridden by value set in envvar, set to: {size}");
+                tracing::debug!(
+                    "Memory size was overridden by value set in envvar, set to: {size}"
+                );
             }
         }
 
@@ -360,7 +362,9 @@ impl Memory {
                 size = val.parse().expect(&format!(
                     "OS_MEMORY_ALLOC_OVERRIDE was an invalid value: {val}"
                 ));
-                log::debug!("Memory size was overridden by value set in envvar, set to: {size}");
+                tracing::debug!(
+                    "Memory size was overridden by value set in envvar, set to: {size}"
+                );
             }
         }
 

--- a/packages/engine/src/datastore/storage/visitor.rs
+++ b/packages/engine/src/datastore/storage/visitor.rs
@@ -94,7 +94,7 @@ pub(in crate::datastore) trait Visit<'mem: 'v, 'v> {
             && markers.data_offset() + markers.data_size() <= size;
 
         if !res {
-            log::warn!(
+            tracing::warn!(
                 "Invalid markers in shared buffer with id {}. Markers: {:?}, Shared buffer size: \
                  {}",
                 message,

--- a/packages/engine/src/datastore/table/state/create_remove/plan.rs
+++ b/packages/engine/src/datastore/table/state/create_remove/plan.rs
@@ -34,7 +34,7 @@ impl<'a> MigrationPlan<'a> {
     }
 
     pub fn execute(self, state: &mut AgentPool, config: &SimRunConfig) -> Result<Vec<String>> {
-        // log::debug!("Updating");
+        // tracing::debug!("Updating");
         let mut_batches = state.mut_batches();
         self.existing_mutations
             .par_iter()
@@ -62,7 +62,7 @@ impl<'a> MigrationPlan<'a> {
             })?;
 
         let mut removed_ids = vec![];
-        // log::debug!("Deleting");
+        // tracing::debug!("Deleting");
         self.existing_mutations
             .iter()
             .enumerate()
@@ -82,7 +82,7 @@ impl<'a> MigrationPlan<'a> {
                 Ok(())
             })?;
 
-        // log::debug!("Creating {} ", self.create_commands.len());
+        // tracing::debug!("Creating {} ", self.create_commands.len());
         let mut created_dynamic_batches = self
             .create_commands
             .into_par_iter()
@@ -100,7 +100,7 @@ impl<'a> MigrationPlan<'a> {
             .collect::<Result<_>>()?;
         mut_batches.append(&mut created_dynamic_batches);
 
-        // log::debug!("Finished");
+        // tracing::debug!("Finished");
         Ok(removed_ids)
     }
 }

--- a/packages/engine/src/datastore/table/sync.rs
+++ b/packages/engine/src/datastore/table/sync.rs
@@ -70,9 +70,9 @@ impl WaitableStateSync {
     /// // Send `child_msgs` to appropriate message handlers.
     /// self.forward_children(child_receivers).await;
     pub async fn forward_children(self, child_receivers: Vec<SyncCompletionReceiver>) {
-        log::trace!("Getting state sync completions");
+        tracing::trace!("Getting state sync completions");
         let child_results: Vec<_> = join_all(child_receivers).await;
-        log::trace!("Got all state sync completions");
+        tracing::trace!("Got all state sync completions");
         let result = child_results
             .into_iter()
             .map(|recv_result| {
@@ -83,7 +83,7 @@ impl WaitableStateSync {
         self.completion_sender
             .send(result)
             .expect("Couldn't send waitable sync result to engine");
-        log::trace!("Sent main state sync completion");
+        tracing::trace!("Sent main state sync completion");
     }
 }
 

--- a/packages/engine/src/env.rs
+++ b/packages/engine/src/env.rs
@@ -86,15 +86,15 @@ where
     E: ExperimentRunTrait + for<'de> Deserialize<'de>,
 {
     let mut orch_client = OrchClient::new(&args.orchestrator_url, args.experiment_id)?;
-    log::debug!("Connected to orchestrator at {}", &args.orchestrator_url);
+    tracing::debug!("Connected to orchestrator at {}", &args.orchestrator_url);
 
     let mut orch_listener = nano::Server::new(&args.listen_url)?;
-    log::debug!("Listening on NNG socket at {}", &args.listen_url);
+    tracing::debug!("Listening on NNG socket at {}", &args.listen_url);
 
     // Before it will send the init message, we must tell the orchestrator that the
     // engine has started
     orch_client.send(EngineStatus::Started).await?;
-    log::debug!("Sent started message");
+    tracing::debug!("Sent started message");
 
     // Wait for the init message from the orchestrator
     let InitMessage {
@@ -102,7 +102,7 @@ where
         env: execution_env,
         dyn_payloads,
     } = recv_init_msg(&mut orch_listener).await?;
-    log::debug!("Received initialization message from the orchestrator");
+    tracing::debug!("Received initialization message from the orchestrator");
 
     Ok(Environment {
         orch_client,

--- a/packages/engine/src/experiment/controller/controller.rs
+++ b/packages/engine/src/experiment/controller/controller.rs
@@ -78,8 +78,12 @@ impl<P: OutputPersistenceCreatorRepr> ExperimentController<P> {
                 changed_properties,
                 max_num_steps,
             } => {
-                let sim_span =
-                    tracing::span!(parent: span_id, tracing::Level::INFO, "sim", id = &sim_id);
+                let sim_span = tracing_texray::examine(tracing::span!(
+                    parent: span_id,
+                    tracing::Level::INFO,
+                    "sim",
+                    id = &sim_id
+                ));
                 self.start_new_sim_run(sim_id, changed_properties, max_num_steps)
                     .instrument(sim_span)
                     .await?;

--- a/packages/engine/src/experiment/controller/controller.rs
+++ b/packages/engine/src/experiment/controller/controller.rs
@@ -106,7 +106,7 @@ impl<P: OutputPersistenceCreatorRepr> ExperimentController<P> {
         if let Err(err) = send_step_update {
             if !status.running || status.stop_signal {
                 // non-fatal error if the sim is stopping
-                log::debug!(
+                tracing::debug!(
                     "Failed to send the step update to the experiment package, logging rather \
                      than error as simulation has been marked as ending this step: {}",
                     err.to_string()
@@ -134,12 +134,12 @@ impl<P: OutputPersistenceCreatorRepr> ExperimentController<P> {
     ) -> Result<()> {
         let engine_status = match msg {
             WorkerPoolToExpCtlMsg::Errors(errors) => {
-                log::debug!("Received Errors Experiment Control Message from Worker Pool");
+                tracing::debug!("Received Errors Experiment Control Message from Worker Pool");
                 let runner_errors = errors.into_iter().map(|w| w.into_sendable(false)).collect();
                 EngineStatus::Errors(id, runner_errors)
             }
             WorkerPoolToExpCtlMsg::Warnings(warnings) => {
-                log::debug!("Received Warnings Experiment Control Message from Worker Pool");
+                tracing::debug!("Received Warnings Experiment Control Message from Worker Pool");
                 let runner_warnings = warnings
                     .into_iter()
                     .map(|w| w.into_sendable(true))
@@ -147,7 +147,7 @@ impl<P: OutputPersistenceCreatorRepr> ExperimentController<P> {
                 EngineStatus::Warnings(id, runner_warnings)
             }
             WorkerPoolToExpCtlMsg::Logs(logs) => {
-                log::debug!("Received Logs Experiment Control Message from Worker Pool");
+                tracing::debug!("Received Logs Experiment Control Message from Worker Pool");
                 EngineStatus::Logs(id, logs)
             }
         };
@@ -285,7 +285,7 @@ impl<P: OutputPersistenceCreatorRepr> ExperimentController<P> {
     ) -> Result<()> {
         if self.sim_senders.contains_key(&sim_short_id) {
             let msg = "Cannot mutate a simulation control msg sender";
-            log::error!("{}, sim short id: {}", msg, sim_short_id);
+            tracing::error!("{}, sim short id: {}", msg, sim_short_id);
             return Err(Error::from(msg));
         }
         self.sim_senders.insert(sim_short_id, sender);
@@ -308,7 +308,7 @@ impl<P: OutputPersistenceCreatorRepr> ExperimentController<P> {
         loop {
             tokio::select! {
                 Some(msg) = self.experiment_package_comms.ctl_recv.recv() => {
-                    log::debug!("Handling experiment control message: {:?}", &msg);
+                    tracing::debug!("Handling experiment control message: {:?}", &msg);
                     self.handle_experiment_control_msg(msg).await?;
                 }
                 result = self.sim_run_tasks.next() => {
@@ -316,11 +316,11 @@ impl<P: OutputPersistenceCreatorRepr> ExperimentController<P> {
                         self.handle_sim_run_stop(result?).await?;
 
                         if self.sim_run_tasks.is_empty() && waiting_for_completion.is_some() {
-                            log::debug!("Stopping experiment controller");
+                            tracing::debug!("Stopping experiment controller");
                             return Ok(())
                         }
 
-                        log::trace!("There was a result from a sim run but: self.sim_run_tasks.is_empty(): {}, waiting_for_completion.is_some(): {} so continuing", self.sim_run_tasks.is_empty(), waiting_for_completion.is_some());
+                        tracing::trace!("There was a result from a sim run but: self.sim_run_tasks.is_empty(): {}, waiting_for_completion.is_some(): {} so continuing", self.sim_run_tasks.is_empty(), waiting_for_completion.is_some());
                     }
                 }
                 Some(msg) = self.sim_status_recv.recv() => {
@@ -336,19 +336,19 @@ impl<P: OutputPersistenceCreatorRepr> ExperimentController<P> {
                 }
                 terminate_res = &mut terminate_recv, if waiting_for_completion.is_none() => {
                     terminate_res.map_err(|err| Error::from(format!("Couldn't receive terminate: {:?}", err)))?;
-                    log::trace!("Received terminate message");
+                    tracing::trace!("Received terminate message");
 
                     if self.sim_run_tasks.is_empty() {
-                        log::debug!("Stopping experiment controller");
+                        tracing::debug!("Stopping experiment controller");
                         return Ok(())
                     } else {
-                        log::trace!("sim_run_tasks wasn't empty, starting a wait and warn loop");
+                        tracing::trace!("sim_run_tasks wasn't empty, starting a wait and warn loop");
                         waiting_for_completion = Some(Box::pin(tokio::time::sleep(Duration::from_secs(time_to_wait))));
                     }
                 }
                 _ = async { waiting_for_completion.as_mut().expect("must be some").await }, if waiting_for_completion.is_some() => {
                     time_to_wait *= WAITING_MULTIPLIER;
-                    log::warn!("Experiment Controller received a termination message, but simulation runs haven't finished, waiting {} seconds", time_to_wait);
+                    tracing::warn!("Experiment Controller received a termination message, but simulation runs haven't finished, waiting {} seconds", time_to_wait);
                     waiting_for_completion = Some(Box::pin(tokio::time::sleep(Duration::from_secs(time_to_wait))));
                 }
             }

--- a/packages/engine/src/experiment/controller/controller.rs
+++ b/packages/engine/src/experiment/controller/controller.rs
@@ -28,6 +28,7 @@ use crate::{
         status::SimStatus,
         Error as SimulationError,
     },
+    utils,
     worker::runner::comms::{
         DatastoreSimulationPayload, ExperimentInitRunnerMsgBase, NewSimulationRun,
     },
@@ -78,7 +79,7 @@ impl<P: OutputPersistenceCreatorRepr> ExperimentController<P> {
                 changed_properties,
                 max_num_steps,
             } => {
-                let sim_span = tracing_texray::examine(tracing::span!(
+                let sim_span = utils::texray::examine(tracing::span!(
                     parent: span_id,
                     tracing::Level::INFO,
                     "sim",

--- a/packages/engine/src/experiment/controller/run.rs
+++ b/packages/engine/src/experiment/controller/run.rs
@@ -22,7 +22,7 @@ use crate::{
 pub async fn run_experiment(exp_config: ExperimentConfig, env: Environment) -> Result<()> {
     let experiment_name = exp_config.name().to_string();
     let experiment_id = exp_config.run.base().id;
-    log::info!("Running experiment \"{experiment_name}\"");
+    tracing::info!("Running experiment \"{experiment_name}\"");
     // TODO: Get cloud-specific configuration from `env`
     let _output_persistence_config = config::output_persistence(&env)?;
 
@@ -32,19 +32,21 @@ pub async fn run_experiment(exp_config: ExperimentConfig, env: Environment) -> R
         Ok(result) => {
             let final_result = match result {
                 Ok(()) => {
-                    log::debug!("Successful termination of experiment \"{experiment_name}\"");
+                    tracing::debug!("Successful termination of experiment \"{experiment_name}\"");
                     EngineStatus::Exit
                 }
                 Err(err) => {
                     let err = CrateError::from(ExperimentError::from(err)).user_facing_string();
-                    log::debug!("Terminating experiment \"{experiment_name}\" with error: {err}");
+                    tracing::debug!(
+                        "Terminating experiment \"{experiment_name}\" with error: {err}"
+                    );
                     EngineStatus::ProcessError(err)
                 }
             };
             orch_client.send(final_result).await?;
         }
         Err(join_err) => {
-            log::error!("Experiment run \"{experiment_name}\" task join error: {join_err:?}");
+            tracing::error!("Experiment run \"{experiment_name}\" task join error: {join_err:?}");
             return if join_err.is_panic() {
                 Err(Error::from(
                     "Error in the experiment runner, please contact support",
@@ -59,14 +61,14 @@ pub async fn run_experiment(exp_config: ExperimentConfig, env: Environment) -> R
 
     // Allow messages to be picked up.
     std::thread::sleep(std::time::Duration::from_millis(100));
-    log::info!("Exiting \"{experiment_name}\"");
+    tracing::info!("Exiting \"{experiment_name}\"");
     Ok(())
 }
 
 pub async fn run_local_experiment(exp_config: ExperimentConfig, env: Environment) -> Result<()> {
     match config::output_persistence(&env)? {
         OutputPersistenceConfig::Local(local) => {
-            log::debug!("Running experiment with local persistence");
+            tracing::debug!("Running experiment with local persistence");
             let persistence = LocalOutputPersistence::new(
                 exp_config.name().clone(),
                 exp_config.run.base().id,
@@ -75,7 +77,7 @@ pub async fn run_local_experiment(exp_config: ExperimentConfig, env: Environment
             run_experiment_with_persistence(exp_config, env, persistence).await?;
         }
         OutputPersistenceConfig::None => {
-            log::debug!("Running experiment without output persistence");
+            tracing::debug!("Running experiment without output persistence");
             let persistence = NoOutputPersistence::new();
             run_experiment_with_persistence(exp_config, env, persistence).await?;
         }
@@ -169,7 +171,7 @@ async fn run_experiment_with_persistence<P: OutputPersistenceCreatorRepr>(
     loop {
         tokio::select! {
             _ = async { exit_timeout.take().expect("must be some").await }, if exit_timeout.is_some() => {
-                log::warn!("Exit timed out");
+                tracing::warn!("Exit timed out");
                 successful_exit = false;
                 // TODO: should we have an additional timeout and send terminate signals to all 3
 
@@ -183,7 +185,7 @@ async fn run_experiment_with_persistence<P: OutputPersistenceCreatorRepr>(
             }
             Ok(res) = &mut experiment_package_handle, if experiment_package_result.is_none() => {
                 if let Err(ref inner_err) = res {
-                    log::error!("Error from experiment package: {}", inner_err);
+                    tracing::error!("Error from experiment package: {}", inner_err);
                     successful_exit = false;
                     if err.is_empty() {
                         err = inner_err.to_string();
@@ -203,7 +205,7 @@ async fn run_experiment_with_persistence<P: OutputPersistenceCreatorRepr>(
             }
             Ok(res) = &mut experiment_controller_handle, if experiment_controller_result.is_none() => {
                 if let Err(ref inner_err) = res {
-                    log::error!("Error from experiment controller: {}", inner_err);
+                    tracing::error!("Error from experiment controller: {}", inner_err);
                     successful_exit = false;
                     if err.is_empty() {
                         err = inner_err.to_string();
@@ -224,7 +226,7 @@ async fn run_experiment_with_persistence<P: OutputPersistenceCreatorRepr>(
             }
             Ok(res) = &mut worker_pool_controller_handle, if worker_pool_result.is_none() => {
                 if let Err(ref inner_err) = res {
-                    log::error!("Error from worker pool: {}", inner_err);
+                    tracing::error!("Error from worker pool: {}", inner_err);
                     successful_exit = false;
                     if err.is_empty() {
                         err = inner_err.to_string();
@@ -240,7 +242,7 @@ async fn run_experiment_with_persistence<P: OutputPersistenceCreatorRepr>(
             else => {
                 successful_exit = false;
                 err = "Unexpected tokio select exit".into();
-                log::error!("Unexpected tokio select exit");
+                tracing::error!("Unexpected tokio select exit");
                 break;
             }
         }
@@ -263,16 +265,16 @@ fn experiment_package_exit_logic(
     experiment_controller_terminate_send: &mut TerminateSend,
     exit_timeout: &mut Option<Pin<Box<tokio::time::Sleep>>>,
 ) -> Result<bool> {
-    log::debug!("Result from experiment package");
+    tracing::debug!("Result from experiment package");
 
     // The experiment package should finish before the controller and worker pool
     if experiment_controller_result.is_some() {
-        log::warn!("Experiment controller finished before experiment package");
+        tracing::warn!("Experiment controller finished before experiment package");
     } else {
         experiment_controller_terminate_send.send()?;
     }
     if worker_pool_result.is_some() {
-        log::warn!("Worker pool finished before experiment package");
+        tracing::warn!("Worker pool finished before experiment package");
     }
 
     // If both have finished something has gone wrong but loop should break
@@ -281,7 +283,7 @@ fn experiment_package_exit_logic(
     }
 
     if exit_timeout.is_none() {
-        log::debug!("Starting timeout");
+        tracing::debug!("Starting timeout");
         *exit_timeout = Some(Box::pin(tokio::time::sleep(Duration::from_secs(20))));
     };
 
@@ -295,11 +297,11 @@ fn experiment_controller_exit_logic(
     worker_pool_terminate_send: &mut TerminateSend,
     exit_timeout: &mut Option<Pin<Box<tokio::time::Sleep>>>,
 ) -> Result<bool> {
-    log::debug!("Result from experiment controller");
+    tracing::debug!("Result from experiment controller");
 
     // Controller should finish before the Worker Pool
     if worker_pool_result.is_some() {
-        log::warn!("Worker pool finished before experiment controller");
+        tracing::warn!("Worker pool finished before experiment controller");
     }
 
     // If both have finished something has gone wrong but loop should break
@@ -310,7 +312,7 @@ fn experiment_controller_exit_logic(
     }
 
     if exit_timeout.is_none() {
-        log::debug!("Starting timeout");
+        tracing::debug!("Starting timeout");
         *exit_timeout = Some(Box::pin(tokio::time::sleep(Duration::from_secs(20))));
     };
 
@@ -323,14 +325,14 @@ fn worker_pool_exit_logic(
     experiment_controller_result: &ExperimentControllerResult,
     exit_timeout: &mut Option<Pin<Box<tokio::time::Sleep>>>,
 ) -> bool {
-    log::debug!("Result from worker pool");
+    tracing::debug!("Result from worker pool");
 
     if experiment_package_result.is_some() && experiment_controller_result.is_some() {
         return true;
     }
 
     if exit_timeout.is_none() {
-        log::debug!("Starting timeout");
+        tracing::debug!("Starting timeout");
         *exit_timeout = Some(Box::pin(tokio::time::sleep(Duration::from_secs(3600))));
     };
 

--- a/packages/engine/src/experiment/package/simple.rs
+++ b/packages/engine/src/experiment/package/simple.rs
@@ -84,7 +84,7 @@ impl SimpleExperiment {
             finished: HashMap::new(),
         };
 
-        log::trace!("Starting {max_sims_in_parallel} sims in parallel");
+        tracing::trace!("Starting {max_sims_in_parallel} sims in parallel");
         for _ in 0..max_sims_in_parallel {
             sim_queue.start_sim_if_available().await?;
         }
@@ -99,7 +99,7 @@ impl SimpleExperiment {
             if response.was_error || response.stop_signal {
                 let mut sim_progress =
                     sim_queue.active.remove(&response.sim_id).ok_or_else(|| {
-                        log::warn!("Sim run with unknown id {} stopped", &response.sim_id);
+                        tracing::warn!("Sim run with unknown id {} stopped", &response.sim_id);
                         Error::MissingSimulationRun(response.sim_id)
                     })?;
 

--- a/packages/engine/src/experiment/package/simple.rs
+++ b/packages/engine/src/experiment/package/simple.rs
@@ -34,6 +34,7 @@ impl<'a> SimQueue<'a> {
                 stopped: false,
             });
             let msg = ExperimentControl::StartSim {
+                span_id: tracing::Span::current().id(),
                 sim_id,
                 changed_properties: changed_props.clone(),
                 max_num_steps: self.max_num_steps,

--- a/packages/engine/src/experiment/package/single.rs
+++ b/packages/engine/src/experiment/package/single.rs
@@ -28,7 +28,9 @@ impl SingleRunExperiment {
         mut pkg_to_exp: ExpPkgCtlSend,
         mut pkg_from_exp: ExpPkgUpdateRecv,
     ) -> Result<()> {
+        tracing::debug!("Calling run on single package");
         let msg = ExperimentControl::StartSim {
+            span_id: tracing::Span::current().id(),
             sim_id: 1 as SimulationShortId,
             changed_properties: serde_json::Map::new().into(), // Don't change properties
             max_num_steps: self.config.num_steps,

--- a/packages/engine/src/experiment/package/single.rs
+++ b/packages/engine/src/experiment/package/single.rs
@@ -46,7 +46,7 @@ impl SingleRunExperiment {
                 break;
             }
         }
-        log::debug!("Experiment package exiting");
+        tracing::debug!("Experiment package exiting");
         Ok(())
     }
 }

--- a/packages/engine/src/fetch.rs
+++ b/packages/engine/src/fetch.rs
@@ -32,7 +32,7 @@ impl FetchDependencies for SharedDataset {
         // mean losing access to datasets which only exist in production.
         if contents.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>") {
             // TODO: changes so erroring is explict
-            log::error!(
+            tracing::error!(
                 "Possible error with dataset fetching. Returned message starts with: {}. Dataset \
                  metadata: {:?}",
                 &contents[0..100.min(contents.len())],

--- a/packages/engine/src/nano/server.rs
+++ b/packages/engine/src/nano/server.rs
@@ -30,7 +30,7 @@ impl Worker {
         let ctx = ctx_orig.clone();
 
         let socket_url = url.to_string();
-        log::debug!("Creating nng worker listening on socket: {}", socket_url);
+        tracing::debug!("Creating nng worker listening on socket: {}", socket_url);
         // The unwraps in the Aio callback here are fine. If they panic, then it's a logic
         // error, and not something which can be recovered from.
         let aio = nng::Aio::new(move |aio, res| match res {
@@ -44,10 +44,10 @@ impl Worker {
                 sender.send(msg).unwrap();
             }
             nng::AioResult::Recv(Err(nng::Error::Closed)) => {
-                log::debug!("aio context closed for socket listening on: {socket_url}");
+                tracing::debug!("aio context closed for socket listening on: {socket_url}");
             }
             nng::AioResult::Recv(Err(err)) => {
-                log::error!("aio receive error: {err}");
+                tracing::error!("aio receive error: {err}");
             }
             nng::AioResult::Sleep(_) => {
                 panic!("unexpected sleep");

--- a/packages/engine/src/output/buffer/part.rs
+++ b/packages/engine/src/output/buffer/part.rs
@@ -58,7 +58,7 @@ impl OutputPartBuffer {
     }
 
     pub fn persist_current_on_disk(&mut self) -> Result<()> {
-        log::trace!("Persisting current output to disk");
+        tracing::trace!("Persisting current output to disk");
         let mut next_i = self.parts.len();
 
         let current = std::mem::replace(

--- a/packages/engine/src/output/buffer/util.rs
+++ b/packages/engine/src/output/buffer/util.rs
@@ -11,7 +11,7 @@ use crate::{
 /// Shared memory cleanup in the process hard crash case.
 /// Not required for pod instances.
 pub fn cleanup_experiment(experiment_id: &ExperimentId) -> Result<()> {
-    log::trace!("Cleaning up experiment: {}", experiment_id);
+    tracing::trace!("Cleaning up experiment: {}", experiment_id);
     // TODO: Mac differences in shared_memory
     let shm_files = glob::glob(&format!("/dev/shm/{}_*", shmem_id_prefix(experiment_id)))
         .map_err(|e| Error::Unique(format!("cleanup glob error: {}", e)))?;
@@ -43,7 +43,7 @@ fn remove_experiment_parts(experiment_id: &ExperimentId) -> Result<()> {
     //  differently, we should update the design to store the paths and use them here when we use
     //  the clean up code again
     base_path.push(experiment_id.to_string());
-    log::trace!("Removing all parts files in: {base_path:?}");
+    tracing::trace!("Removing all parts files in: {base_path:?}");
     std::fs::remove_dir_all(base_path)?;
     Ok(())
 }

--- a/packages/engine/src/output/local/sim.rs
+++ b/packages/engine/src/output/local/sim.rs
@@ -38,7 +38,7 @@ impl SimulationOutputPersistenceRepr for LocalSimulationOutputPersistence {
     }
 
     async fn finalize(mut self, config: &SimRunConfig) -> Result<Self::OutputPersistenceResult> {
-        log::trace!("Finalizing output");
+        tracing::trace!("Finalizing output");
         // JSON state
         let (_, parts) = self.buffers.json_state.finalize()?;
         let path = self
@@ -48,7 +48,7 @@ impl SimulationOutputPersistenceRepr for LocalSimulationOutputPersistence {
             .join(self.exp_id.to_string())
             .join(self.sim_id.to_string());
 
-        log::info!("Making new output directory: {:?}", path);
+        tracing::info!("Making new output directory: {:?}", path);
         std::fs::create_dir_all(&path)?;
 
         let json_state_path = path.join("json_state.json");

--- a/packages/engine/src/simulation/comms/message.rs
+++ b/packages/engine/src/simulation/comms/message.rs
@@ -1,3 +1,5 @@
+use tracing::Span;
+
 use super::active::ActiveTaskExecutorComms;
 use crate::{
     datastore::table::{sync::SyncPayload, task_shared_store::TaskSharedStore},
@@ -21,6 +23,7 @@ pub struct WrappedTask {
 
 #[derive(Debug)]
 pub struct EngineToWorkerPoolMsg {
+    pub span: Span,
     pub sim_id: SimulationShortId,
     pub payload: EngineToWorkerPoolMsgPayload,
 }
@@ -28,6 +31,7 @@ pub struct EngineToWorkerPoolMsg {
 impl EngineToWorkerPoolMsg {
     pub fn task(sim_id: SimulationShortId, task: WrappedTask) -> Self {
         Self {
+            span: Span::current(),
             sim_id,
             payload: EngineToWorkerPoolMsgPayload::Task(task),
         }
@@ -35,6 +39,7 @@ impl EngineToWorkerPoolMsg {
 
     pub fn sync(sim_id: SimulationShortId, sync_msg: SyncPayload) -> Self {
         Self {
+            span: Span::current(),
             sim_id,
             payload: EngineToWorkerPoolMsgPayload::Sync(sync_msg),
         }

--- a/packages/engine/src/simulation/comms/mod.rs
+++ b/packages/engine/src/simulation/comms/mod.rs
@@ -160,10 +160,10 @@ impl Comms {
 }
 
 impl Comms {
-    pub async fn new_task<T: Into<Task>>(
+    pub async fn new_task(
         &self,
         package_id: PackageId,
-        task: T,
+        task: Task,
         shared_store: TaskSharedStore,
     ) -> Result<ActiveTask> {
         let task_id = uuid::Uuid::new_v4().as_u128();
@@ -176,13 +176,12 @@ impl Comms {
 }
 
 /// TODO: DOC
-fn wrap_task<T: Into<Task>>(
+fn wrap_task(
     task_id: TaskId,
     package_id: PackageId,
-    task: T,
+    task: Task,
     shared_store: TaskSharedStore,
 ) -> Result<(WrappedTask, ActiveTask)> {
-    let task: Task = task.into();
     task.verify_store_access(&shared_store)?;
     let (owner_channels, executor_channels) = active::comms();
     let wrapped = WrappedTask::new(task_id, package_id, task, executor_channels, shared_store);

--- a/packages/engine/src/simulation/comms/mod.rs
+++ b/packages/engine/src/simulation/comms/mod.rs
@@ -105,7 +105,7 @@ impl Comms {
     /// Errors: tokio failed to send the message to the worker pool for some reason;
     ///         e.g. the worker pool already stopped due to some other error.
     pub async fn state_sync(&self, state: &State) -> Result<SyncCompletionReceiver> {
-        log::trace!("Synchronizing state");
+        tracing::trace!("Synchronizing state");
         let (completion_sender, completion_receiver) = tokio::sync::oneshot::channel();
 
         // Synchronize the state batches
@@ -123,7 +123,7 @@ impl Comms {
 
     /// TODO: DOC
     pub async fn state_snapshot_sync(&self, state: &StateSnapshot) -> Result<()> {
-        log::trace!("Synchronizing state snapshot");
+        tracing::trace!("Synchronizing state snapshot");
         // Synchronize the state snapshot batches
         let agents = state.agent_pool().clone();
         let agent_messages = state.message_pool().clone();
@@ -144,7 +144,7 @@ impl Comms {
         current_step: usize,
         state_group_start_indices: &Arc<Vec<usize>>,
     ) -> Result<()> {
-        log::trace!("Synchronizing context batch");
+        tracing::trace!("Synchronizing context batch");
         // Synchronize the context batch
         let batch = context.batch();
         let indices = Arc::clone(state_group_start_indices);

--- a/packages/engine/src/simulation/comms/package.rs
+++ b/packages/engine/src/simulation/comms/package.rs
@@ -1,3 +1,4 @@
+use tracing::Instrument;
 use uuid::Uuid;
 
 use super::{Comms, Result};
@@ -6,7 +7,7 @@ use crate::{
     hash_types::Agent,
     simulation::{
         package::{id::PackageId, PackageType},
-        task::{active::ActiveTask, Task},
+        task::{active::ActiveTask, GetTaskName, Task},
     },
 };
 
@@ -33,8 +34,11 @@ impl PackageComms {
         task: T,
         shared_store: TaskSharedStore,
     ) -> Result<ActiveTask> {
+        let task = task.into();
+        let task_name = task.get_task_name();
         self.inner
             .new_task(self.package_id, task, shared_store)
+            .instrument(tracing::trace_span!("Task", name = task_name))
             .await
     }
 }

--- a/packages/engine/src/simulation/comms/package.rs
+++ b/packages/engine/src/simulation/comms/package.rs
@@ -36,6 +36,7 @@ impl PackageComms {
     ) -> Result<ActiveTask> {
         let task = task.into();
         let task_name = task.get_task_name();
+
         self.inner
             .new_task(self.package_id, task, shared_store)
             .instrument(tracing::trace_span!("Task", name = task_name))

--- a/packages/engine/src/simulation/controller/mod.rs
+++ b/packages/engine/src/simulation/controller/mod.rs
@@ -6,6 +6,7 @@ pub mod sim_control;
 use std::sync::Arc;
 
 use tokio::task::JoinHandle;
+use tracing::Instrument;
 
 pub use self::{
     error::{Error, Result},
@@ -73,7 +74,8 @@ fn new_task_handle<P: SimulationOutputPersistenceRepr>(
         receiver,
         sender,
         persistence_service,
-    ));
+    ))
+    .in_current_span();
 
     Ok(tokio::task::spawn_blocking(move || {
         tokio::runtime::Handle::current().block_on(task)

--- a/packages/engine/src/simulation/controller/run.rs
+++ b/packages/engine/src/simulation/controller/run.rs
@@ -54,11 +54,7 @@ pub async fn sim_run<P: SimulationOutputPersistenceRepr>(
 ) -> Result<SimulationShortId> {
     let sim_run_id = config.sim.id;
     let max_num_steps = config.sim.max_num_steps;
-    tracing::info!(
-        "Beginning simulation run with id {} for a maximum of {} steps",
-        &sim_run_id,
-        max_num_steps,
-    );
+    tracing::info!(steps = &max_num_steps, "Beginning simulation run");
 
     let uninitialized_store = Store::new_uninitialized(shared_store, &config);
 

--- a/packages/engine/src/simulation/engine.rs
+++ b/packages/engine/src/simulation/engine.rs
@@ -69,7 +69,7 @@ impl Engine {
     /// output packages are run only once, context and state packages
     /// can technically be run any number of times.
     pub async fn next(&mut self, current_step: usize) -> Result<SimulationStepResult> {
-        log::debug!("Running next step");
+        tracing::debug!("Running next step");
         self.run_context_packages(current_step).await?;
         self.run_state_packages().await?;
         let output = self.run_output_packages().await?;
@@ -99,7 +99,7 @@ impl Engine {
     /// dependent on each other, then all context packages are run in parallel
     /// and their outputs are merged into one Context object.
     async fn run_context_packages(&mut self, current_step: usize) -> Result<()> {
-        log::trace!("Starting run context packages stage");
+        tracing::trace!("Starting run context packages stage");
         // Need write access to state to prepare for context packages,
         // so can't start state sync (with workers) yet.
         let (mut state, mut context) = self.store.take_upgraded()?;
@@ -121,9 +121,9 @@ impl Engine {
         let active_sync = self.comms.state_sync(&state).await?;
         // TODO: fix issues with getting write access to the message batch while state sync runs in
         //  parallel with context packages
-        log::trace!("Waiting for active state sync");
+        tracing::trace!("Waiting for active state sync");
         active_sync.await?.map_err(Error::state_sync)?;
-        log::trace!("State sync finished");
+        tracing::trace!("State sync finished");
 
         let pre_context = context.into_pre_context();
         let context = self
@@ -209,7 +209,7 @@ impl Engine {
         state: &mut ExState,
         context: &mut ExContext,
     ) -> Result<StateSnapshot> {
-        log::trace!("Preparing for context packages");
+        tracing::trace!("Preparing for context packages");
         let message_map = state.message_map()?;
         self.add_remove_agents(state, &message_map)?;
         let message_pool = self.finalize_agent_messages(state, context)?;

--- a/packages/engine/src/simulation/enum_dispatch.rs
+++ b/packages/engine/src/simulation/enum_dispatch.rs
@@ -97,6 +97,7 @@ pub use crate::{
             args::GetTaskArgs,
             handler::{SplitConfig, WorkerHandler, WorkerPoolHandler},
             msg::{TargetedTaskMessage, TaskMessage},
+            GetTaskName,
         },
         Result,
     },

--- a/packages/engine/src/simulation/package/context/packages/agent_messages/writer.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/writer.rs
@@ -36,7 +36,7 @@ impl ContextColumnWriter for Messages {
     }
 
     fn write(&self, mut data: &mut [u8], meta: &ColumnDynamicMetadata) -> DatastoreResult<()> {
-        log::debug!("Writing context message locs");
+        tracing::debug!("Writing context message locs");
         // TODO[6](optimization)
         // we can leave these null buffers out (length = 0) if Rust does not need to read them.
 

--- a/packages/engine/src/simulation/package/context/packages/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/mod.rs
@@ -71,7 +71,7 @@ impl PackageCreators {
         &self,
         experiment_config: &Arc<ExperimentConfig>,
     ) -> Result<()> {
-        log::debug!("Initializing Context Package Creators");
+        tracing::debug!("Initializing Context Package Creators");
         use Name::*;
         let mut m = HashMap::new();
         m.insert(

--- a/packages/engine/src/simulation/package/context/packages/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/mod.rs
@@ -42,11 +42,17 @@ impl std::fmt::Display for Name {
 }
 
 /// All context package tasks are registered in this enum
-// #[enum_dispatch(WorkerHandler, WorkerPoolHandler, GetTaskArgs)]
+// #[enum_dispatch(GetTaskName, WorkerHandler, WorkerPoolHandler, GetTaskArgs)]
 #[derive(Clone, Debug)]
 pub struct ContextTask {}
 
 // Empty impls to satisfy constraints from enum_dispatch while there are no task variants
+impl GetTaskName for ContextTask {
+    fn get_task_name(&self) -> &'static str {
+        unimplemented!()
+    }
+}
+
 impl WorkerHandler for ContextTask {}
 
 impl WorkerPoolHandler for ContextTask {}

--- a/packages/engine/src/simulation/package/init/packages/js_py/js/mod.rs
+++ b/packages/engine/src/simulation/package/init/packages/js_py/js/mod.rs
@@ -9,6 +9,7 @@ use crate::{
             args::GetTaskArgs,
             handler::{WorkerHandler, WorkerPoolHandler},
             msg::TargetedTaskMessage,
+            GetTaskName,
         },
         Result as SimulationResult,
     },
@@ -18,6 +19,12 @@ use crate::{
 #[derive(Clone, Debug)]
 pub struct JsInitTask {
     pub initial_state_source: String,
+}
+
+impl GetTaskName for JsInitTask {
+    fn get_task_name(&self) -> &'static str {
+        "JsInit"
+    }
 }
 
 impl GetTaskArgs for JsInitTask {

--- a/packages/engine/src/simulation/package/init/packages/js_py/py/mod.rs
+++ b/packages/engine/src/simulation/package/init/packages/js_py/py/mod.rs
@@ -7,6 +7,7 @@ use crate::{
             args::GetTaskArgs,
             handler::{WorkerHandler, WorkerPoolHandler},
             msg::TargetedTaskMessage,
+            GetTaskName,
         },
         Result as SimulationResult,
     },
@@ -16,6 +17,12 @@ use crate::{
 #[derive(Clone, Debug)]
 pub struct PyInitTask {
     pub initial_state_source: String,
+}
+
+impl GetTaskName for PyInitTask {
+    fn get_task_name(&self) -> &'static str {
+        "PyInit"
+    }
 }
 
 impl GetTaskArgs for PyInitTask {

--- a/packages/engine/src/simulation/package/init/packages/mod.rs
+++ b/packages/engine/src/simulation/package/init/packages/mod.rs
@@ -40,7 +40,7 @@ impl std::fmt::Display for Name {
 }
 
 /// All init package tasks are registered in this enum
-#[enum_dispatch(WorkerHandler, WorkerPoolHandler, GetTaskArgs)]
+#[enum_dispatch(GetTaskName, WorkerHandler, WorkerPoolHandler, GetTaskArgs)]
 #[derive(Clone, Debug)]
 pub enum InitTask {
     JsInitTask,

--- a/packages/engine/src/simulation/package/init/packages/mod.rs
+++ b/packages/engine/src/simulation/package/init/packages/mod.rs
@@ -63,7 +63,7 @@ impl PackageCreators {
         &self,
         experiment_config: &Arc<ExperimentConfig>,
     ) -> Result<()> {
-        log::debug!("Initializing Init Package Creators");
+        tracing::debug!("Initializing Init Package Creators");
         use Name::*;
         let mut m = HashMap::new();
         m.insert(Json, json::Creator::new(experiment_config)?);

--- a/packages/engine/src/simulation/package/output/packages/analysis/analyzer.rs
+++ b/packages/engine/src/simulation/package/output/packages/analysis/analyzer.rs
@@ -74,7 +74,7 @@ impl Analyzer {
                     ))
                 })?;
                 outputs.push(output);
-                // log::debug!("Ran analysis. Output ({}): {:?}", _output_name, v);
+                // tracing::debug!("Ran analysis. Output ({}): {:?}", _output_name, v);
                 Ok(())
             })
     }

--- a/packages/engine/src/simulation/package/output/packages/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/mod.rs
@@ -80,7 +80,7 @@ impl PackageCreators {
         &self,
         experiment_config: &Arc<ExperimentConfig>,
     ) -> Result<()> {
-        log::debug!("Initializing Output Package Creators");
+        tracing::debug!("Initializing Output Package Creators");
         use Name::*;
         let mut m = HashMap::new();
         m.insert(Analysis, analysis::Creator::new(experiment_config)?);

--- a/packages/engine/src/simulation/package/output/packages/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/mod.rs
@@ -52,11 +52,17 @@ pub enum Output {
 }
 
 /// All output package tasks are registered in this enum
-// #[enum_dispatch(WorkerHandler, WorkerPoolHandler, GetTaskArgs)]
+// #[enum_dispatch(GetTaskName, WorkerHandler, WorkerPoolHandler, GetTaskArgs)]
 #[derive(Clone, Debug)]
 pub enum OutputTask {}
 
 // Empty impls to satisfy constraints enum_dispatch while there are no task variants
+impl GetTaskName for OutputTask {
+    fn get_task_name(&self) -> &'static str {
+        unimplemented!()
+    }
+}
+
 impl WorkerHandler for OutputTask {}
 
 impl WorkerPoolHandler for OutputTask {}

--- a/packages/engine/src/simulation/package/run.rs
+++ b/packages/engine/src/simulation/package/run.rs
@@ -152,7 +152,7 @@ impl StepPackages {
         snapshot: StateSnapshot,
         pre_context: PreContext,
     ) -> Result<ExContext> {
-        log::debug!("Running context packages");
+        tracing::debug!("Running context packages");
         // Execute packages in parallel and collect the data
         let mut futs = FuturesOrdered::new();
 
@@ -231,7 +231,7 @@ impl StepPackages {
     }
 
     pub async fn run_state(&mut self, mut state: ExState, context: &Context) -> Result<ExState> {
-        log::debug!("Running state packages");
+        tracing::debug!("Running state packages");
         // Design-choices:
         // Cannot use trait bounds as dyn Package won't be object-safe
         // Traits are tricky anyway for working with iterators

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/mod.rs
@@ -214,7 +214,7 @@ impl BehaviorExecution {
 #[async_trait]
 impl Package for BehaviorExecution {
     async fn run(&mut self, state: &mut ExState, context: &Context) -> Result<()> {
-        log::trace!("Running BehaviorExecution");
+        tracing::trace!("Running BehaviorExecution");
         self.fix_behavior_chains(state)?;
         self.reset_behavior_index_col(state)?;
         state.flush_pending_columns()?;
@@ -222,16 +222,16 @@ impl Package for BehaviorExecution {
         let lang = match self.get_first_lang(state)? {
             Some(lang) => lang,
             None => {
-                log::warn!("No behaviors were found to execute");
+                tracing::warn!("No behaviors were found to execute");
                 return Ok(());
             } // No behaviors to execute
         };
-        log::trace!("Beginning BehaviorExecution task");
+        tracing::trace!("Beginning BehaviorExecution task");
         let active_task = self.begin_execution(state, context, lang).await?;
         let msg = active_task.drive_to_completion().await?;
         // Wait for results
         // TODO: Get latest metaversions from message and reload state if necessary.
-        log::trace!("BehaviorExecution task finished: {:?}", &msg);
+        tracing::trace!("BehaviorExecution task finished: {:?}", &msg);
         Ok(())
     }
 }

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/tasks.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/tasks.rs
@@ -9,7 +9,7 @@ use crate::{
             args::GetTaskArgs,
             handler::{SplitConfig, WorkerPoolHandler},
             msg::{TargetedTaskMessage, TaskMessage},
-            Task,
+            GetTaskName, Task,
         },
         Result as SimulationResult,
     },
@@ -19,6 +19,12 @@ use crate::{
 #[derive(Clone, Debug)]
 pub struct ExecuteBehaviorsTask {
     pub target: MessageTarget,
+}
+
+impl GetTaskName for ExecuteBehaviorsTask {
+    fn get_task_name(&self) -> &'static str {
+        "BehaviorExecution"
+    }
 }
 
 impl GetTaskArgs for ExecuteBehaviorsTask {

--- a/packages/engine/src/simulation/package/state/packages/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/mod.rs
@@ -62,7 +62,7 @@ impl PackageCreators {
         &self,
         experiment_config: &Arc<ExperimentConfig>,
     ) -> Result<()> {
-        log::debug!("Initializing State Package Creators");
+        tracing::debug!("Initializing State Package Creators");
         use Name::*;
         let mut m = HashMap::new();
         m.insert(

--- a/packages/engine/src/simulation/package/state/packages/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/mod.rs
@@ -40,7 +40,7 @@ impl std::fmt::Display for Name {
 }
 
 /// All state package tasks are registered in this enum
-#[enum_dispatch(WorkerHandler, WorkerPoolHandler, GetTaskArgs)]
+#[enum_dispatch(GetTaskName, WorkerHandler, WorkerPoolHandler, GetTaskArgs)]
 #[derive(Clone, Debug)]
 pub enum StateTask {
     ExecuteBehaviorsTask,

--- a/packages/engine/src/simulation/package/state/packages/topology/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/topology/mod.rs
@@ -78,7 +78,7 @@ impl GetWorkerSimStartMsg for Topology {
 #[async_trait]
 impl Package for Topology {
     async fn run(&mut self, state: &mut ExState, _context: &Context) -> Result<()> {
-        log::trace!("Running Topology package");
+        tracing::trace!("Running Topology package");
         if self.config.move_wrapped_agents {
             for mut mut_table in state.agent_pool_mut().write_batches()? {
                 if self.topology_correction(&mut mut_table)? {

--- a/packages/engine/src/simulation/task/mod.rs
+++ b/packages/engine/src/simulation/task/mod.rs
@@ -12,13 +12,24 @@ use crate::simulation::enum_dispatch::*;
 // From<init::Task>, ..., From<output::Task> for this enum.
 // Additionally we have TryInto<init::Task>, (and others)
 // implemented for this enum.
-#[enum_dispatch(WorkerHandler, WorkerPoolHandler, GetTaskArgs, StoreAccessVerify)]
+#[enum_dispatch(
+    GetTaskName,
+    WorkerHandler,
+    WorkerPoolHandler,
+    GetTaskArgs,
+    StoreAccessVerify
+)]
 #[derive(Clone, Debug)]
 pub enum Task {
     InitTask,
     ContextTask,
     StateTask,
     OutputTask,
+}
+
+#[enum_dispatch]
+pub trait GetTaskName {
+    fn get_task_name(&self) -> &'static str;
 }
 
 // TODO: Is there an important differentiation between Task and TaskMessage

--- a/packages/engine/src/types.rs
+++ b/packages/engine/src/types.rs
@@ -3,3 +3,4 @@ pub type BatchId = [u8; BATCH_ID_LENGTH];
 
 pub type WorkerIndex = usize;
 pub type TaskId = u128;
+pub type SpanId = Option<tracing::span::Id>;

--- a/packages/engine/src/utils.rs
+++ b/packages/engine/src/utils.rs
@@ -1,6 +1,6 @@
 use std::{env::VarError, fmt::Display, time::Duration};
 
-use log::{Event, Subscriber};
+use tracing::{Event, Subscriber};
 use tracing_subscriber::{
     filter::{Directive, LevelFilter},
     fmt::{
@@ -143,12 +143,12 @@ pub fn parse_env_duration(name: &str, default: u64) -> Duration {
         std::env::var(name)
             .and_then(|timeout| {
                 timeout.parse().map_err(|e| {
-                    log::error!("Could not parse `{}` as integral: {}", name, e);
+                    tracing::error!("Could not parse `{}` as integral: {}", name, e);
                     VarError::NotPresent
                 })
             })
             .unwrap_or_else(|_| {
-                log::info!("Setting `{}={}`", name, default);
+                tracing::info!("Setting `{}={}`", name, default);
                 default
             }),
     )

--- a/packages/engine/src/utils.rs
+++ b/packages/engine/src/utils.rs
@@ -76,7 +76,8 @@ impl Default for OutputFormat {
 
 pub fn init_logger(
     std_err_output_format: OutputFormat,
-    file_output_name: &str,
+    log_file_output_name: &str,
+    texray_output_name: &str,
 ) -> (impl Drop, impl Drop) {
     let filter = match std::env::var("RUST_LOG") {
         Ok(env) => EnvFilter::new(env),
@@ -123,7 +124,7 @@ pub fn init_logger(
     };
 
     let json_file_appender =
-        tracing_appender::rolling::never("./log", format!("{file_output_name}.log"));
+        tracing_appender::rolling::never("./log", format!("{log_file_output_name}.log"));
     let (non_blocking, _json_file_guard) = tracing_appender::non_blocking(json_file_appender);
 
     let json_file_layer = fmt::layer()
@@ -131,7 +132,8 @@ pub fn init_logger(
         .fmt_fields(JsonFields::new())
         .with_writer(non_blocking);
 
-    let texray_file_appender = tracing_appender::rolling::never("./log", format!("texray.txt"));
+    let texray_file_appender =
+        tracing_appender::rolling::never("./log", format!("{texray_output_name}.txt"));
     let (non_blocking, _tex_ray_guard) = tracing_appender::non_blocking(texray_file_appender);
 
     // we clone update_settings to satisfy move rules as writer takes a `Fn` rather than `FnOnce`

--- a/packages/engine/src/worker/mod.rs
+++ b/packages/engine/src/worker/mod.rs
@@ -660,7 +660,8 @@ impl WorkerController {
         let fut = async move {
             let sync = sync; // Capture `sync` in lambda.
             sync.forward_children(runner_receivers).await
-        };
+        }
+        .in_current_span();
         pending_syncs.push(Box::pin(fut) as _);
         Ok(())
     }

--- a/packages/engine/src/worker/runner/comms/mod.rs
+++ b/packages/engine/src/worker/runner/comms/mod.rs
@@ -5,6 +5,8 @@ use std::{
     sync::Arc,
 };
 
+use tracing::Span;
+
 use crate::{
     config::{EngineConfig, Globals},
     datastore::{prelude::ArrowSchema, schema::state::AgentSchema, shared_store::SharedStore},
@@ -140,6 +142,7 @@ pub struct PackageMsgs(pub HashMap<PackageId, PackageInitMsgForWorker>);
 
 #[derive(Debug, Clone)]
 pub struct NewSimulationRun {
+    pub span: Span,
     pub short_id: SimulationShortId,
     pub engine_config: Arc<EngineConfig>,
     pub packages: PackageMsgs,

--- a/packages/engine/src/worker/runner/comms/outbound.rs
+++ b/packages/engine/src/worker/runner/comms/outbound.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use flatbuffers_gen::runner_outbound_msg_generated::root_as_runner_outbound_msg;
+use tracing::Span;
 
 use super::TargetedRunnerTaskMsg;
 use crate::{
@@ -190,6 +191,7 @@ impl OutboundFromRunnerMsgPayload {
 
 #[derive(Debug)]
 pub struct OutboundFromRunnerMsg {
+    pub span: Span,
     pub source: Language,
     pub sim_id: SimulationShortId,
     pub payload: OutboundFromRunnerMsgPayload,
@@ -211,6 +213,7 @@ impl OutboundFromRunnerMsg {
         })?;
         let payload = OutboundFromRunnerMsgPayload::try_from_fbs(msg, sent_tasks)?;
         Ok(Self {
+            span: Span::current(),
             source,
             sim_id: msg.sim_sid(),
             payload,

--- a/packages/engine/src/worker/runner/javascript/error.rs
+++ b/packages/engine/src/worker/runner/javascript/error.rs
@@ -1,6 +1,7 @@
 use arrow::{datatypes::DataType, error::ArrowError};
 use thiserror::Error as ThisError;
 use tokio::sync::mpsc::error::SendError;
+use tracing::Span;
 
 use super::mini_v8 as mv8;
 use crate::{
@@ -73,7 +74,7 @@ pub enum Error {
     UnknownTarget(String),
 
     #[error("Couldn't send inbound message to runner: {0}")]
-    InboundSend(#[from] SendError<(Option<SimulationShortId>, InboundToRunnerMsgPayload)>),
+    InboundSend(#[from] SendError<(Span, Option<SimulationShortId>, InboundToRunnerMsgPayload)>),
 
     #[error("Couldn't send outbound message from runner: {0}")]
     OutboundSend(#[from] SendError<OutboundFromRunnerMsg>),

--- a/packages/engine/src/worker/runner/python/mod.rs
+++ b/packages/engine/src/worker/runner/python/mod.rs
@@ -56,7 +56,7 @@ impl PythonRunner {
         sim_id: Option<SimulationShortId>,
         msg: InboundToRunnerMsgPayload,
     ) -> WorkerResult<()> {
-        log::trace!("Sending message to Python: {:?}", &msg);
+        tracing::trace!("Sending message to Python: {:?}", &msg);
         self.inbound_sender
             .send((sim_id, msg))
             .map_err(|e| WorkerError::Python(Error::InboundSend(e)))
@@ -97,7 +97,7 @@ impl PythonRunner {
     ) -> WorkerResult<Pin<Box<dyn Future<Output = StdResult<WorkerResult<()>, JoinError>> + Send>>>
     {
         // TODO: Duplication with other runners (move into worker?)
-        log::debug!("Running Python runner");
+        tracing::debug!("Running Python runner");
         if !self.spawn {
             return Ok(Box::pin(async move { Ok(Ok(())) }));
         }
@@ -126,7 +126,7 @@ async fn _run(
         .arg(&init_msg.experiment_id.to_string())
         .arg(&init_msg.worker_index.to_string());
     let _process = cmd.spawn().map_err(Error::Spawn)?;
-    log::debug!("Started Python process {}", init_msg.worker_index);
+    tracing::debug!("Started Python process {}", init_msg.worker_index);
 
     // Send init message to Python process.
     nng_receiver.init(&init_msg)?;
@@ -134,7 +134,7 @@ async fn _run(
     // so we know that sender init can be done now.
     nng_sender.init()?;
 
-    log::debug!("Waiting for messages to Python runner");
+    tracing::debug!("Waiting for messages to Python runner");
     let mut sent_tasks: HashMap<TaskId, SentTask> = HashMap::new();
     'select_loop: loop {
         // TODO: Send errors instead of immediately stopping?
@@ -204,11 +204,11 @@ async fn _run(
     // // TODO: Drop nng_sender/nng_receiver before killing process?
     // match tokio::time::timeout(std::time::Duration::from_secs(10), process.wait()).await? {
     //     None => {
-    //         log::info!("Python process has failed to exit; killing.");
+    //         tracing::info!("Python process has failed to exit; killing.");
     //         process.kill().await?;
     //     }
     //     Some(status) => {
-    //         log::info!(
+    //         tracing::info!(
     //             "Python runner has successfully exited with status: {:?}.",
     //             status.code().unwrap_or(-1)
     //         );

--- a/packages/engine/src/worker/runner/python/receiver.rs
+++ b/packages/engine/src/worker/runner/python/receiver.rs
@@ -65,7 +65,7 @@ impl NngReceiver {
             }
             nng::AioResult::Sleep(Ok(_)) => {}
             nng::AioResult::Send(_) => {
-                log::warn!("Unexpected send result");
+                tracing::warn!("Unexpected send result");
             }
             nng::AioResult::Recv(Err(nng::Error::Canceled)) => {}
             nng::AioResult::Recv(Err(nng::Error::Closed)) => {}

--- a/packages/engine/src/worker/runner/python/sender.rs
+++ b/packages/engine/src/worker/runner/python/sender.rs
@@ -50,14 +50,14 @@ impl NngSender {
                     aio_result_sender.send(Ok(())).unwrap();
                 }
                 Err((msg, err)) => {
-                    log::warn!(
+                    tracing::warn!(
                         "External worker receiving socket tried to send but failed w/ error: {}",
                         err
                     );
                     match aio_result_sender.send(Err(Error::NngSend(msg, err))) {
                         Ok(_) => {}
                         Err(err) => {
-                            log::warn!(
+                            tracing::warn!(
                                 "Failed to pass send error back to message handler thread {}",
                                 err
                             );
@@ -67,7 +67,7 @@ impl NngSender {
             },
             nng::AioResult::Sleep(res) => {
                 if let Err(err) = res {
-                    log::error!("AIO sleep error: {}", err);
+                    tracing::error!("AIO sleep error: {}", err);
                     aio_result_sender.send(Err(Error::Nng(err))).unwrap();
                 }
             }
@@ -102,7 +102,7 @@ impl NngSender {
         self.to_py
             .send_async(&self.aio, msg)
             .map_err(|(msg, err)| {
-                log::warn!("Send failed: {:?}", (&msg, &err));
+                tracing::warn!("Send failed: {:?}", (&msg, &err));
                 Error::NngSend(msg, err)
             })?;
         Ok(())

--- a/packages/engine/src/worker/runner/rust/mod.rs
+++ b/packages/engine/src/worker/runner/rust/mod.rs
@@ -45,7 +45,7 @@ impl RustRunner {
         _sim_id: Option<SimulationShortId>,
         _msg: InboundToRunnerMsgPayload,
     ) -> WorkerResult<()> {
-        log::trace!("Received message to send to Rust Runner: {:?}", &_msg);
+        tracing::trace!("Received message to send to Rust Runner: {:?}", &_msg);
         Ok(())
     }
 

--- a/packages/engine/src/workerpool/comms/experiment.rs
+++ b/packages/engine/src/workerpool/comms/experiment.rs
@@ -1,4 +1,5 @@
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use tracing::Span;
 
 use super::Result;
 use crate::worker::runner::comms::NewSimulationRun;
@@ -9,22 +10,22 @@ pub enum ExperimentToWorkerPoolMsg {
 }
 
 pub struct ExpMsgSend {
-    inner: UnboundedSender<ExperimentToWorkerPoolMsg>,
+    inner: UnboundedSender<(Span, ExperimentToWorkerPoolMsg)>,
 }
 
 impl ExpMsgSend {
     pub(crate) async fn send(&mut self, msg: ExperimentToWorkerPoolMsg) -> Result<()> {
-        self.inner.send(msg)?;
+        self.inner.send((Span::current(), msg))?;
         Ok(())
     }
 }
 
 pub struct ExpMsgRecv {
-    inner: UnboundedReceiver<ExperimentToWorkerPoolMsg>,
+    inner: UnboundedReceiver<(Span, ExperimentToWorkerPoolMsg)>,
 }
 
 impl ExpMsgRecv {
-    pub(crate) async fn recv(&mut self) -> Option<ExperimentToWorkerPoolMsg> {
+    pub(crate) async fn recv(&mut self) -> Option<(Span, ExperimentToWorkerPoolMsg)> {
         self.inner.recv().await
     }
 }

--- a/packages/engine/src/workerpool/comms/main.rs
+++ b/packages/engine/src/workerpool/comms/main.rs
@@ -3,6 +3,7 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use super::Result;
 use crate::{proto::SimulationShortId, simulation::comms::message::EngineToWorkerPoolMsg};
 
+// TODO: move span out of msg?
 pub struct MainMsgRecv {
     inner: UnboundedReceiver<EngineToWorkerPoolMsg>,
 }

--- a/packages/engine/src/workerpool/comms/main.rs
+++ b/packages/engine/src/workerpool/comms/main.rs
@@ -24,7 +24,7 @@ pub fn new_no_sim() -> (MainMsgSendBase, MainMsgRecv) {
 
 impl MainMsgSend {
     pub(crate) fn send(&self, msg: EngineToWorkerPoolMsg) -> Result<()> {
-        log::trace!("Sending msg to worker pool: {:?}", &msg);
+        tracing::trace!("Sending msg to worker pool: {:?}", &msg);
         self.inner.send(msg)?;
         Ok(())
     }

--- a/packages/engine/src/workerpool/comms/mod.rs
+++ b/packages/engine/src/workerpool/comms/mod.rs
@@ -10,6 +10,7 @@ use tokio::sync::{
     mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
     oneshot::Receiver,
 };
+use tracing::Span;
 
 pub use super::{Error, Result};
 use crate::{
@@ -33,6 +34,7 @@ pub enum WorkerPoolToWorkerMsgPayload {
 
 #[derive(Debug)]
 pub struct WorkerPoolToWorkerMsg {
+    pub span: Span,
     pub sim_id: Option<SimulationShortId>,
     pub payload: WorkerPoolToWorkerMsgPayload,
 }
@@ -55,6 +57,7 @@ impl WorkerPoolToWorkerMsg {
         }?;
 
         Ok(WorkerPoolToWorkerMsg {
+            span: self.span.clone(),
             sim_id: self.sim_id,
             payload,
         })
@@ -64,6 +67,7 @@ impl WorkerPoolToWorkerMsg {
 impl WorkerPoolToWorkerMsg {
     pub fn sync(sim_id: SimulationShortId, sync_payload: SyncPayload) -> WorkerPoolToWorkerMsg {
         WorkerPoolToWorkerMsg {
+            span: Span::current(),
             sim_id: Some(sim_id),
             payload: WorkerPoolToWorkerMsgPayload::Sync(sync_payload),
         }
@@ -71,6 +75,7 @@ impl WorkerPoolToWorkerMsg {
 
     pub fn task(sim_id: SimulationShortId, task_payload: WorkerTask) -> WorkerPoolToWorkerMsg {
         WorkerPoolToWorkerMsg {
+            span: Span::current(),
             sim_id: Some(sim_id),
             payload: WorkerPoolToWorkerMsgPayload::Task(task_payload),
         }
@@ -78,6 +83,7 @@ impl WorkerPoolToWorkerMsg {
 
     pub fn cancel_task(task_id: TaskId) -> WorkerPoolToWorkerMsg {
         WorkerPoolToWorkerMsg {
+            span: Span::current(),
             sim_id: None,
             payload: WorkerPoolToWorkerMsgPayload::CancelTask(task_id),
         }
@@ -85,6 +91,7 @@ impl WorkerPoolToWorkerMsg {
 
     pub fn new_simulation_run(new_simulation_run: NewSimulationRun) -> WorkerPoolToWorkerMsg {
         WorkerPoolToWorkerMsg {
+            span: Span::current(),
             sim_id: Some(new_simulation_run.short_id),
             payload: WorkerPoolToWorkerMsgPayload::NewSimulationRun(new_simulation_run),
         }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
This PR expands our use of the [tokio-rs/tracing](https://github.com/tokio-rs/tracing) that was already being used for logging within the engine and CLI. It's purpose is to introduce a convention for how we track execution flow across threads and processes. It implements this methodology in a number of places, but it is not comprehensive, and we should look at expanding it as we go where it makes sense to do so. 

### The problem
The hEngine is an asynchronous, multithreaded, multi-language and multi-process application. This results in a number of difficulties when using traditional observation techniques, such as logging, profiling, error reporting, etc. 

### Solutions
These problems often occur within distributed systems when trying to track requests across services. This is most often solved through using some variation of a tracing method (See descriptions from [OpenTracing](https://opentracing.io/docs/overview/what-is-tracing/), [Dynatrace](https://www.dynatrace.com/news/blog/what-is-distributed-tracing/), and [Splunk](https://www.splunk.com/en_us/data-insider/what-is-distributed-tracing.html)). The method basically boils down to adding a unique identifier to each request (and subsequent request), to allow each service to know the ID of the original request. Some system then joining up the observability mechanisms of each system and 'trace' the request through the systems.

In terms of how this applies to the engine, being asynchronous and multi-threaded means that a lot of our execution doesn't happen linearly within a stackframe. This means that for both error-handling, and logging, it's easy to see what module the event is happening in, but not the context within the actual execution flow (i.e. this is happening within experiment X and simulation Y). We can use a tracing library to attach contextual information to our code execution, and propagate that information with the messages between threads.

### Some key vocabulary

* **Span** [[alternative explanation in the tracing docs.rs](https://docs.rs/tracing/latest/tracing/#spans)] - A span conceptually is a stretch of time (i.e. it _spans_ time). It's a way of describing a part of the execution of your application. For example, the whole execution of your application might be a span. Thus, anything that happens within that time, _is within that span_. It's also possible to be in multiple spans at once, so if your application is a web-server, the code to handle an HTTP request might be within the span of the lifetime of the application, and then in a smaller span of serving that request. (Nesting of such spans is often referred to as a span-tree)
* **Event** [[alternative explanation in the tracing docs.rs](https://docs.rs/tracing/latest/tracing/#events)]  - An event is something that happens _within_ a span, these are therefore _points_ in time. An event might be something like a log, throwing an error, a result being returned, etc.

### What's introduced in this PR
#### Logging
All logs that happen within a span, automatically have that information attached, for example:
```rust
     6.115936584s DEBUG hash_engine::worker::runner::javascript: JS runner got sim `Some(1)` inbound ContextBatchSync
    at src/worker/runner/javascript/mod.rs:1285
    in hash_engine::simulation::engine::context_sync
    in hash_engine::experiment::controller::controller::sim with id=1
    in hash_engine::experiment::controller::run::run_experiment with experiment_id=1edae304-593f-4673-8c84-53d5047d1633
```
**We also change our default logging output to be `pretty` (as shown above) due to the possible quantity of additional information attached to each log**

#### Spans
This PR creates spans to track events happening within the following contexts:
- An Experiment run
- A Simulation run
- Snapshot Sync
- State Sync
- The running of Context Packages
- Context Sync
- The execution of a Task

These spans can happen within one another, for example if one were to see an event happening:
`Experiment Run: 1 { Simulation Run: 3 { State Sync } } }: Some event`
The event would have happened during state sync, during simulation 3's run, during experiment 1's run

#### Texray
Having information about the spans also allows us to track time spent within a span. This PR adds a library, [tracing-texray](https://github.com/rcoh/tracing-texray), which is designed to be a lightweight and simple implementation which generates text output showing the time spent in each span.

Below is a simplified example of the graphical results produced by texray (although the actual file contains timings):
If the program execution is a timeline from left to right, one might see the following spans for one step of the simulation
```
{Experiment Run}                  |-------------------------|
{Simulation Run}                        |--------------|
{Snapshot Sync}                          |-|
{State Sync}                               |-|
{Context Packages}                            |-|
{Context Sync}                                  |-|
{A Behavior Execution Task}                       |--|
```

Actual example, which is too wide to fit in a screenshot:
![image](https://user-images.githubusercontent.com/25749103/151190808-9b215222-d171-4a93-993a-fec76d072416.png)


## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🚫 Blocked by

- [x] #224 

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

- Adding further spans for various package executions, etc.

## 🔍 What does this change?

### How we handle distributed Spans 
By default, the spans generated in the tracing library are dependent on the thread. This means that when our code moves in a distributed flow, the span is lost. This can happen in two cases, which we solve as following:

#### Directly moving Threads and/or Async code
Async poses a problem for span tracking. The [tracing docs explains ways around this](https://docs.rs/tracing/0.1.29/tracing/span/struct.Span.html#in-asynchronous-code), and for the most part the implementation in this PR aims to use either `.instrument` on futures, or `in_current_span`. This needed whenever we move to a new thread, for example, `tokio::spawn`.

#### Message Passing
We also move between threads and contexts through message passing. This poses the same problems as above, but we can't rely on tracing's async handling. To address this, there are two possibilities:
1. The new context will immediately start a new span for the entirety of its execution
2. The new context might not need a new span, or creates a new span that only spans its execution partially

In the case of 1., we can simply pass the `Id` of the span in the message, and when receiving that message we create a new span using that id as the parent. This ensures that anything within the new span is correctly placed within the span tree. (This is done in `handle_experiment_control_msg` when creating a new simulation run, as we make a new sim span for the entirety of its execution).

In the case of 2. we can't pass the id, but instead we have to pass the entire span in the message, and enter it within the new context. This is what we do everywhere else.


### Changes
- Stops aliases the `tracing` crate as `log` in the project 
- Changes the default [log format to `pretty`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/index.html#formatters) to make the larger logs readable
- Adds a span for execution within the following:
  - Experiment Run
  - Simulation Run
  - Snapshot Sync
  - State Sync
  - Context Packages run()
  - Context Sync
  - Tasks
- Makes it so that spans can be tracked across threads by:
  - Adding the span_id to the `ExperimentControl::StartSim` message so that a new span (the sim span) can be created with it as the parent
  - Propagates the current span in the `NewSimulationRun` struct
  - Propagates the current span in the `EngineToWorkerPoolMsg` struct
  - Propagates the current span in the `OutboundFromRunnerMsg` struct
  - Propagates the current span in the `WorkerPoolToWorkerMsg` struct
- Adds a method to the Task enum to associate a task implementation with its name, to attach as a field on the span (e.g. BehaviorExecution)
- Adds the texray layer to the logger
  - Adds a new file to the log output for texray
  - `examine`s the sim spans to track timings for all spans within a simulation run

### Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

This needs to be figured out. Perhaps we do not need to describe tracing strategy, but we will need to describe texray at least.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as (_internal_) -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201481007343159/1201699134949648/f) (_internal_)

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Checkout the branch / view the deployment
2. Run a simulation with `RUST_LOG=trace`
3. Confirm that the logs contain span information for experiments and sims
4. Confirm that the log directory has a `-texray.log` file that contains a texray output as shown above

## 📹 Demo

![image](https://user-images.githubusercontent.com/25749103/151193543-c52b73f5-b75a-4227-addf-3bf97b6715e5.png)
![image](https://user-images.githubusercontent.com/25749103/151193584-8d01beae-06e0-4931-b254-1f3e59efd7ad.png)


## ❓ Open Questions before Merging
- [x] Do we want to include tracing-texray, it is Alpha. And we do not know the performance overhead. Perhaps an acceptable solution is to flag it
  - [x] If we do want to add it, how do we want to configure it (file names, etc.)
- [x] Do we want to change the level of the spans? The EnvFilter can stop them being added if we're not in TRACE for example, same with texray not producing results if we're not in TRACE.
- [x] Do we want to add a span for the current step?
