### PR TITLE
Fix line numbers for JavaScript runner

### DIFF
--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/package.js
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/package.js
@@ -86,7 +86,7 @@ const load_behaviors = (experiment, behavior_descs) => {
       )(hash_stdlib, hash_stdlib, console);
     } catch (e) {
       // Catch behavior code syntax errors and rethrow.
-      // Error.prepareStackTrace = prepare_user_trace; // TODO
+      Error.prepareStackTrace = prepare_user_trace;
       const trace = e.stack;
       trace.msg =
         "Couldn't load behavior (NAME " +
@@ -220,8 +220,9 @@ const run_task = (
       try {
         behavior.fn(agent_state, agent_ctx);
       } catch (e) {
-        // TODO expose/return user error properly
-        throw Error(behavior.name + "\n" + e.stack);
+        Error.prepareStackTrace = prepare_user_trace;
+        const trace = e.stack;
+        throw Error(JSON.stringify(trace));
       }
       postprocess(agent_state);
     }

--- a/packages/engine/src/worker/runner/javascript/runner.js
+++ b/packages/engine/src/worker/runner/javascript/runner.js
@@ -200,7 +200,7 @@
       }
     } catch (e) {
       return {
-        pkg_error: String(e.stack), // `.stack` is V8 built-in; TODO: `e.toString()`?
+        pkg_error: e.toString(),
       };
     }
     return ret;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

JavaScript behaviors are off by 2. This PR changes the stack trace generation for JS Code to return the right line numbers.

## 🐾 Next steps

- When improving error handling, the stack trace can be used to display a pretty trace to the user.

## 🔍 What does this change?

- Use `prepare_user_trace` as `Error.prepareStackTrace`
- This produces not a string as trace but a dictionary, which can be parsed

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201481007343159/1201674006952090/f) (_internal_)

## ❓ How to test this?

Use any JS simulation, add an error (e.g. `throw new Error("JavaScript error handling is stupid");`) and watch the output.

## 📹 Demo

Before:
```
   0.144500954s ERROR orchestrator::experiment: Got error: "Worker error: JavaScript runner error: Error in package: Error: \"Error: JavaScript error handling is stupid\\n    at Object.behavior [as fn] (eval at load_behaviors (unknown source), <anonymous>:8:1)\\n    at run_task (<anonymous>:222:18)\\n    at Object.run_task (<anonymous>:192:11)\""
Error: experiment had errors
```

After:
```
   0.202180992s ERROR orchestrator::experiment: Got error: "Worker error: JavaScript runner error: Error in package: Error: {\"msg\":\"Error: JavaScript error handling is stupid\",\"frames\":[{\"line\":7,\"fn\":\"behavior\"}]}"
Error: experiment had errors
```
