### PR TITLE
[ENGINE] Hotfixing the integration tests

### DIFF
--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -50,7 +50,7 @@ uuid = { version = "0.8.1", features = ["v4", "serde"] }
 [dev-dependencies]
 provider = { path = "lib/provider" }
 error = { path = "lib/error" }
-orchestrator = { path = "lib/orchestrator" }
+orchestrator = { path = "lib/orchestrator", default-features = false }
 num_cpus = "1.13.1"
 
 [features]

--- a/packages/engine/tests/units/experiment.rs
+++ b/packages/engine/tests/units/experiment.rs
@@ -166,7 +166,7 @@ pub async fn run_test<P: AsRef<Path>>(
         num_workers: num_cpus::get(),
         emit: OutputFormat::Full,
         output_folder: std::env::var("OUT_DIR")
-            .wrap_err("$OUT_DIR is not set")?
+            .unwrap_or_else(|_| "./output".to_string())
             .into(),
         engine_start_timeout: Duration::from_secs(10),
         engine_wait_timeout: Duration::from_secs(10 * 60),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The integration tests didn't work on ARM macOS because you couldn't disable default features.
We also shouldn't need to require the `OUT_DIR` env-var to be set so this adds a default.