### PR TITLE
[ENGINE] Handle stop messages from agents

### DIFF
--- a/packages/engine/lib/orchestrator/src/experiment.rs
+++ b/packages/engine/lib/orchestrator/src/experiment.rs
@@ -158,7 +158,7 @@ impl Experiment {
                 }
                 proto::EngineStatus::SimStatus(status) => {
                     debug!("Got simulation run status: {status:?}");
-                    if let Some(stop_message) = &status.stop_msg {
+                    for stop_message in status.stop_msg {
                         let reason = if let Some(reason) = stop_message.reason.as_ref() {
                             format!(": {reason}")
                         } else {

--- a/packages/engine/lib/orchestrator/src/experiment.rs
+++ b/packages/engine/lib/orchestrator/src/experiment.rs
@@ -9,6 +9,7 @@ use hash_engine::{
         ExecutionEnvironment, ExperimentId, ExperimentName, ExperimentPackageConfig,
         ExperimentRunBase, SimpleExperimentConfig, SingleRunExperimentConfig,
     },
+    simulation::command::StopStatus,
     utils::OutputFormat,
 };
 use rand::{distributions::Distribution, Rng, RngCore};
@@ -157,7 +158,26 @@ impl Experiment {
                 }
                 proto::EngineStatus::SimStatus(status) => {
                     debug!("Got simulation run status: {status:?}");
-                    // TODO: OS - handle status fields
+                    if let Some(stop_message) = &status.stop_msg {
+                        let reason = if let Some(reason) = stop_message.reason.as_ref() {
+                            format!(": {reason}")
+                        } else {
+                            String::new()
+                        };
+                        match stop_message.status {
+                            StopStatus::Success => {
+                                tracing::info!("Simulation stopped sucessfully{reason}");
+                            }
+                            StopStatus::Warning => {
+                                tracing::warn!("Simulation stopped with a warning{reason}");
+                            }
+                            StopStatus::Error => {
+                                errored = true;
+                                tracing::error!("Simulation stopped with an error{reason}");
+                            }
+                        }
+                    }
+                    // TODO: OS - handle more status fields
                 }
                 proto::EngineStatus::SimStop(sim_id) => {
                     debug!("Simulation stopped: {sim_id}");

--- a/packages/engine/src/simulation/agent_control.rs
+++ b/packages/engine/src/simulation/agent_control.rs
@@ -1,7 +1,8 @@
+use crate::simulation::command::StopMessage;
 #[derive(Debug)]
 pub enum AgentControl {
     Continue,
-    Stop(serde_json::Value),
+    Stop(StopMessage),
 }
 
 impl Default for AgentControl {

--- a/packages/engine/src/simulation/agent_control.rs
+++ b/packages/engine/src/simulation/agent_control.rs
@@ -2,7 +2,7 @@ use crate::simulation::command::StopMessage;
 #[derive(Debug)]
 pub enum AgentControl {
     Continue,
-    Stop(StopMessage),
+    Stop(Vec<StopMessage>),
 }
 
 impl Default for AgentControl {

--- a/packages/engine/src/simulation/command.rs
+++ b/packages/engine/src/simulation/command.rs
@@ -245,7 +245,7 @@ fn handle_hash_message(
             handle_remove_data(cmds, data, from)?;
         }
         HashMessageType::Stop => {
-            cmds.stop = vec![serde_json::from_str(data)?];
+            cmds.stop.push(serde_json::from_str(data)?);
         }
     }
     Ok(())

--- a/packages/engine/src/simulation/command.rs
+++ b/packages/engine/src/simulation/command.rs
@@ -6,6 +6,7 @@
 use std::{collections::HashSet, sync::Arc};
 
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use super::{Error, Result};
@@ -34,32 +35,73 @@ enum HashMessageType {
     Create,
     /// Remove an Agent
     Remove,
+    /// Stop the simulation
+    Stop,
 }
 
+#[derive(Debug)]
 struct CreateCommand {
     agent: Agent,
 }
 
+#[derive(Debug)]
 struct RemoveCommand {
     uuid: Uuid,
 }
 
+/// Status of the stop message occurred.
+///
+/// See the [HASH-documentation] for more information.
+///
+/// [HASH-documentation]: https://hash.ai/docs/simulation/creating-simulations/agent-messages/built-in-message-handlers#Stopping-a-simulation
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StopStatus {
+    Success,
+    Warning,
+    Error,
+}
+
+impl Default for StopStatus {
+    fn default() -> Self {
+        Self::Warning
+    }
+}
+
+/// Stop message sent from an agent.
+///
+/// See the [HASH-documentation] for more information.
+///
+/// [HASH-documentation]: https://hash.ai/docs/simulation/creating-simulations/agent-messages/built-in-message-handlers#Stopping-a-simulation
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct StopMessage {
+    pub status: StopStatus,
+    pub reason: Option<String>,
+}
+
 /// Collection of queued commands for the creation and deletion of agents.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct CreateRemoveCommands {
     create: Vec<CreateCommand>,
     remove: Vec<RemoveCommand>,
 }
 
-impl CreateRemoveCommands {
+/// Commands queued by agents
+#[derive(Debug, Default)]
+pub struct Commands {
+    pub create_remove: CreateRemoveCommands,
+    pub stop: Option<StopMessage>,
+}
+
+impl Commands {
     /// Push a command for the request of the creation of an agent
     pub fn add_create(&mut self, agent: Agent) {
-        self.create.push(CreateCommand { agent });
+        self.create_remove.create.push(CreateCommand { agent });
     }
 
     /// Push a command for the request of the deletion of the agent associated with the given UUID
     pub fn add_remove(&mut self, uuid: Uuid) {
-        self.remove.push(RemoveCommand { uuid });
+        self.create_remove.remove.push(RemoveCommand { uuid });
     }
 
     /// Ensures that all agent-creation commands contain valid agent fields.
@@ -71,7 +113,7 @@ impl CreateRemoveCommands {
 
         // TODO[2](optimization): Convert `fields` HashMap to perfect hash set here if it makes
         //   lookups faster.
-        for create in &self.create {
+        for create in &self.create_remove.create {
             for field in create.agent.custom.keys() {
                 // Hopefully branch prediction will make this not as slow as it looks.
                 if !field_spec_map.contains_key(&FieldKey::new_agent_scoped(field)?) {
@@ -82,9 +124,16 @@ impl CreateRemoveCommands {
         Ok(())
     }
 
-    pub fn merge(&mut self, mut other: CreateRemoveCommands) {
-        self.create.append(&mut other.create);
-        self.remove.append(&mut other.remove);
+    pub fn merge(&mut self, mut other: Commands) {
+        self.create_remove
+            .create
+            .append(&mut other.create_remove.create);
+        self.create_remove
+            .remove
+            .append(&mut other.create_remove.remove);
+        if self.stop.is_none() {
+            self.stop = other.stop;
+        }
     }
 
     /// Reads the messages of a simulation step, and identifies, transforms, and collects the
@@ -92,7 +141,7 @@ impl CreateRemoveCommands {
     pub fn from_hash_messages(
         message_map: &MessageMap,
         message_pool: MessagePoolRead<'_>,
-    ) -> Result<CreateRemoveCommands> {
+    ) -> Result<Commands> {
         let message_reader = message_pool.get_reader();
 
         let mut refs = Vec::with_capacity(HASH.len());
@@ -100,7 +149,7 @@ impl CreateRemoveCommands {
             refs.push(message_map.get_msg_refs(*hash_recipient))
         }
 
-        let res: CreateRemoveCommands = refs
+        let res: Commands = refs
             .into_par_iter()
             .map(|refs| {
                 // TODO[5](optimization) see if collecting type information before (to avoid cache
@@ -111,35 +160,39 @@ impl CreateRemoveCommands {
                         .map(|type_str| match type_str {
                             "create_agent" => Ok(HashMessageType::Create),
                             "remove_agent" => Ok(HashMessageType::Remove),
+                            "mapbox" => todo!(),
+                            "stop" => Ok(HashMessageType::Stop),
                             _ => Err(Error::UnexpectedSystemMessage {
                                 message_type: type_str.into(),
                             }),
                         });
 
-                let res: Result<CreateRemoveCommands> = message_reader
+                let res: Result<Commands> = message_reader
                     .data_iter(refs)
                     .zip_eq(message_reader.from_iter(refs))
                     .zip_eq(hash_message_types)
                     .try_fold(
-                        CreateRemoveCommands::default,
+                        Commands::default,
                         |mut cmds, ((data, from), message_type)| {
                             handle_hash_message(&mut cmds, message_type?, data, from)?;
                             Ok(cmds)
                         },
                     )
-                    .try_reduce(CreateRemoveCommands::default, |mut a, b| {
+                    .try_reduce(Commands::default, |mut a, b| {
                         a.merge(b);
                         Ok(a)
                     });
                 res
             })
-            .try_reduce(CreateRemoveCommands::default, |mut a, b| {
+            .try_reduce(Commands::default, |mut a, b| {
                 a.merge(b);
                 Ok(a)
             })?;
         Ok(res)
     }
+}
 
+impl CreateRemoveCommands {
     /// Processes the commands by creating a new AgentBatch from the create commands, and returning
     /// that alongside a set of Agent UUIDs to be removed from state.
     pub fn try_into_processed_commands(
@@ -175,13 +228,13 @@ impl CreateRemoveCommands {
 /// Extends a given [`CreateRemoveCommands`] with a new command created and parsed depending on the
 /// given HashMessageType
 fn handle_hash_message(
-    cmds: &mut CreateRemoveCommands,
+    cmds: &mut Commands,
     message_type: HashMessageType,
     data: &str,
     from: &[u8; UUID_V4_LEN],
 ) -> Result<()> {
     match message_type {
-        // See https://docs.hash.ai/core/agent-messages/built-in-message-handlers
+        // See https://hash.ai/docs/simulation/creating-simulations/agent-messages/built-in-message-handlers
         HashMessageType::Create => {
             cmds.add_create(
                 serde_json::from_str(data)
@@ -191,17 +244,16 @@ fn handle_hash_message(
         HashMessageType::Remove => {
             handle_remove_data(cmds, data, from)?;
         }
+        HashMessageType::Stop => {
+            cmds.stop = Some(serde_json::from_str(data)?);
+        }
     }
     Ok(())
 }
 
 /// Adds a [`RemoveCommand`], reading the UUID either from the payload, or using the from field on
 /// the message if the payload is missing.
-fn handle_remove_data(
-    cmds: &mut CreateRemoveCommands,
-    data: &str,
-    from: &[u8; UUID_V4_LEN],
-) -> Result<()> {
+fn handle_remove_data(cmds: &mut Commands, data: &str, from: &[u8; UUID_V4_LEN]) -> Result<()> {
     let uuid = if data == "null" {
         Ok(uuid::Uuid::from_bytes(*from))
     } else {

--- a/packages/engine/src/simulation/comms/mod.rs
+++ b/packages/engine/src/simulation/comms/mod.rs
@@ -30,7 +30,7 @@ use uuid::Uuid;
 
 use self::message::{EngineToWorkerPoolMsg, WrappedTask};
 use super::{
-    command::CreateRemoveCommands,
+    command::Commands,
     package::id::PackageId,
     task::{access::StoreAccessVerify, active::ActiveTask, Task},
 };
@@ -56,7 +56,7 @@ use crate::{
 /// All relevant to communication between the Loop and the Language Runtime(s)
 pub struct Comms {
     sim_id: SimulationShortId,
-    cmds: Arc<RwLock<CreateRemoveCommands>>,
+    cmds: Arc<RwLock<Commands>>,
     worker_pool_sender: MainMsgSend,
 }
 
@@ -64,12 +64,12 @@ impl Comms {
     pub fn new(sim_id: SimulationShortId, worker_pool_sender: MainMsgSend) -> Result<Comms> {
         Ok(Comms {
             sim_id,
-            cmds: Arc::new(RwLock::new(CreateRemoveCommands::default())),
+            cmds: Arc::new(RwLock::new(Commands::default())),
             worker_pool_sender,
         })
     }
 
-    pub fn take_create_remove_commands(&self) -> Result<CreateRemoveCommands> {
+    pub fn take_commands(&self) -> Result<Commands> {
         let mut cmds = self.cmds.try_write()?;
         let taken = std::mem::take(&mut *cmds);
         Ok(taken)

--- a/packages/engine/src/simulation/controller/run.rs
+++ b/packages/engine/src/simulation/controller/run.rs
@@ -71,7 +71,7 @@ pub async fn sim_run<P: SimulationOutputPersistenceRepr>(
     let now = std::time::Instant::now();
     let mut steps_taken = 0;
     let mut early_stop = false;
-    let mut stop_msg = None;
+    let mut stop_msg = Vec::new();
     'sim_main: loop {
         // Behaviors expect context.step() to give the current step rather than steps_taken
         let current_step = steps_taken + 1;
@@ -128,7 +128,7 @@ pub async fn sim_run<P: SimulationOutputPersistenceRepr>(
             .await?;
         if let AgentControl::Stop(msg) = step_result.agent_control {
             early_stop = true;
-            stop_msg = Some(msg);
+            stop_msg = msg;
             // Break before `send`, because stop messages (like other messages) are handled at the
             // start of a step, before running behaviors, so the stop message was already sent on
             // the previous step.

--- a/packages/engine/src/simulation/engine.rs
+++ b/packages/engine/src/simulation/engine.rs
@@ -91,7 +91,6 @@ impl Engine {
             errors: vec![],
             warnings: vec![],
             agent_control,
-            stop_signal: self.stop.is_some(),
         };
         Ok(result)
     }

--- a/packages/engine/src/simulation/status.rs
+++ b/packages/engine/src/simulation/status.rs
@@ -12,7 +12,7 @@ pub struct SimStatus {
     pub sim_id: SimulationShortId,
     pub steps_taken: isize,
     pub early_stop: bool,
-    pub stop_msg: Option<StopMessage>,
+    pub stop_msg: Vec<StopMessage>,
     pub stop_signal: bool,
     pub persistence_result: Option<(String, serde_json::Value)>,
     // TODO: OS do we need these within SimStatus or should they be handled elsewhere, such as
@@ -46,7 +46,7 @@ impl SimStatus {
         sim_id: SimulationShortId,
         steps_taken: isize,
         early_stop: bool,
-        stop_msg: Option<StopMessage>,
+        stop_msg: Vec<StopMessage>,
         persistence_result: P,
     ) -> Result<SimStatus> {
         let persistence_result = OutputPersistenceResultRepr::into_value(persistence_result)

--- a/packages/engine/src/simulation/status.rs
+++ b/packages/engine/src/simulation/status.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use super::Result;
 use crate::{
     hash_types::worker::RunnerError, output::OutputPersistenceResultRepr, proto::SimulationShortId,
+    simulation::command::StopMessage,
 };
 
 // Sent from sim runs to experiment main loop.
@@ -11,7 +12,7 @@ pub struct SimStatus {
     pub sim_id: SimulationShortId,
     pub steps_taken: isize,
     pub early_stop: bool,
-    pub stop_msg: Option<serde_json::Value>,
+    pub stop_msg: Option<StopMessage>,
     pub stop_signal: bool,
     pub persistence_result: Option<(String, serde_json::Value)>,
     // TODO: OS do we need these within SimStatus or should they be handled elsewhere, such as
@@ -45,7 +46,7 @@ impl SimStatus {
         sim_id: SimulationShortId,
         steps_taken: isize,
         early_stop: bool,
-        stop_msg: Option<serde_json::Value>,
+        stop_msg: Option<StopMessage>,
         persistence_result: P,
     ) -> Result<SimStatus> {
         let persistence_result = OutputPersistenceResultRepr::into_value(persistence_result)

--- a/packages/engine/src/simulation/step_result.rs
+++ b/packages/engine/src/simulation/step_result.rs
@@ -7,8 +7,4 @@ pub struct SimulationStepResult {
     pub errors: Vec<RunnerError>,
     pub warnings: Vec<RunnerError>,
     pub agent_control: AgentControl,
-    // True if this output signals the stopping of a simulation.
-    // Can be False even if a stop signal was sent out before
-    // for this simulation run.
-    pub stop_signal: bool,
 }

--- a/packages/engine/tests/units/message/mod.rs
+++ b/packages/engine/tests/units/message/mod.rs
@@ -14,9 +14,7 @@ mod js {
     run_test!(create_agent, JavaScript);
     run_test!(remove_agent, JavaScript);
     run_test!(remove_self, JavaScript);
-    // TODO: Handle stop messages
-    //   see https://app.asana.com/0/1199550852792314/1201630005867419/f
-    run_test!(stop_simulation, JavaScript, #[ignore]);
+    run_test!(stop_simulation, JavaScript);
 }
 
 mod py {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds support for stop-messages

## 🔍 What does this change?

- Renames `CreateRemoveCommands` to `Commands` and include `StopMessage`
- Handle `"stop"` messages from agents and forwards it to the orchestrator
- Logs the stop message and fail if the status is `"error"`

## 🔗 Related links

- [Messages documentation](https://hash.ai/docs/simulation/creating-simulations/agent-messages/built-in-message-handlers#Stopping-a-simulation)
- [Asana task](https://app.asana.com/0/1199550852792314/1201630005867419/f) (_internal_)

## 🛡 What tests cover this?

- This PR enables the integration test covering this exact case

![image](https://user-images.githubusercontent.com/21277928/151354047-b4b0ebba-6620-4395-b86e-5c91d766a196.png)


## ❓ How to test this?

- Run `cargo test`

or

- Run a simulation sending the `"stop"` message to `"hash"`

## 📹 Demo

Sending a message with `"data": { "status": "success", "reason": "<stop message provided by a behavior>" }`
```
     0.276331810s INFO orchestrator::experiment: Simulation stopped sucessfully: <stop message provided by a behavior>
    at lib/orchestrator/src/experiment.rs:176
    in orchestrator::experiment::run with project_name="stop_simulation" experiment_id=6be4f1af-f48f-4a63-95bd-fe0e5d1ee9f2
```
Sending a message with `"data": { "status": "warning", "reason": "<stop message provided by a behavior>" }`
```
     0.276331810s WARN orchestrator::experiment: Simulation stopped with a warning: <stop message provided by a behavior>
    at lib/orchestrator/src/experiment.rs:176
    in orchestrator::experiment::run with project_name="stop_simulation" experiment_id=6be4f1af-f48f-4a63-95bd-fe0e5d1ee9f2
```
Sending a message with `"data": { "status": "error", "reason": "<stop message provided by a behavior>" }`
```
     0.276331810s ERROR orchestrator::experiment: Simulation stopped with an error: <stop message provided by a behavior>
    at lib/orchestrator/src/experiment.rs:176
    in orchestrator::experiment::run with project_name="stop_simulation" experiment_id=6be4f1af-f48f-4a63-95bd-fe0e5d1ee9f2
```

