### PR TITLE
[ENGINE] Make language in integration test macro optional (again)

### DIFF
--- a/packages/engine/tests/integration.rs
+++ b/packages/engine/tests/integration.rs
@@ -29,6 +29,20 @@ mod units;
 /// specified, the test fails. When no language is specified, it omits the language suffix.
 #[macro_export]
 macro_rules! run_test {
+    ($project:ident $(,)? $(#[$attr:meta])* ) => {
+        $(#[$attr])*
+        #[tokio::test]
+        async fn $project() {
+            let project_path = std::path::Path::new(file!())
+                .parent()
+                .unwrap()
+                .join(stringify!($project))
+                .canonicalize()
+                .unwrap();
+
+            $crate::units::experiment::run_test_suite(project_path, None, None).await
+        }
+    };
     ($project:ident, $language:ident $(,)? $(#[$attr:meta])* ) => {
         // Enable syntax highlighting and code completion
         #[allow(unused)]
@@ -44,7 +58,21 @@ macro_rules! run_test {
                 .canonicalize()
                 .unwrap();
 
-            $crate::units::experiment::run_test_suite(project_path, hash_engine::Language::$language, None).await
+            $crate::units::experiment::run_test_suite(project_path, Some(hash_engine::Language::$language), None).await
+        }
+    };
+    ($project:ident, experiment: $experiment:ident $(,)? $(#[$attr:meta])* ) => {
+        $(#[$attr])*
+        #[tokio::test]
+        async fn $experiment() {
+            let project_path = std::path::Path::new(file!())
+                .parent()
+                .unwrap()
+                .join(stringify!($project))
+                .canonicalize()
+                .unwrap();
+
+            $crate::units::experiment::run_test_suite(project_path, None, Some(stringify!($experiment))).await
         }
     };
     ($project:ident, $language:ident, experiment: $experiment:ident $(,)? $(#[$attr:meta])* ) => {
@@ -62,7 +90,7 @@ macro_rules! run_test {
                 .canonicalize()
                 .unwrap();
 
-            $crate::units::experiment::run_test_suite(project_path, hash_engine::Language::$language, Some(stringify!($experiment))).await
+            $crate::units::experiment::run_test_suite(project_path, Some(hash_engine::Language::$language), Some(stringify!($experiment))).await
         }
     };
 }

--- a/packages/engine/tests/units/experiment.rs
+++ b/packages/engine/tests/units/experiment.rs
@@ -34,7 +34,7 @@ pub struct ExpectedOutput {
 /// example when [`Python`](Language::Python) is passed, it searches for the files `init-py.js`,
 /// `init-py.py`, and `init-py.json`. If more than one initial state is specified, the function
 /// fails.
-fn load_manifest<P: AsRef<Path>>(project_path: P, language: Language) -> Result<Manifest> {
+fn load_manifest<P: AsRef<Path>>(project_path: P, language: Option<Language>) -> Result<Manifest> {
     let project_path = project_path.as_ref();
 
     // We read the manifest without initial state ...
@@ -44,9 +44,10 @@ fn load_manifest<P: AsRef<Path>>(project_path: P, language: Language) -> Result<
     // ... so we provide it ourself
     // If `language` is specified, use a `-lang` suffix
     let suffix = match language {
-        Language::JavaScript => "-js",
-        Language::Python => "-py",
-        Language::Rust => "-rs",
+        Some(Language::JavaScript) => "-js",
+        Some(Language::Python) => "-py",
+        Some(Language::Rust) => "-rs",
+        None => "",
     };
     let initial_states: Vec<_> = ["js", "py", "json"]
         .into_iter()
@@ -64,7 +65,7 @@ fn load_manifest<P: AsRef<Path>>(project_path: P, language: Language) -> Result<
 
 pub async fn run_test_suite<P: AsRef<Path>>(
     project_path: P,
-    language: Language,
+    language: Option<Language>,
     experiment: Option<&str>,
 ) {
     std::env::set_var("RUST_LOG", "info");
@@ -134,7 +135,7 @@ pub async fn run_test_suite<P: AsRef<Path>>(
 pub async fn run_test<P: AsRef<Path>>(
     experiment_type: ExperimentType,
     project_path: P,
-    language: Language,
+    language: Option<Language>,
     num_outputs_expected: usize,
 ) -> Result<Vec<(AgentStates, Globals, Analysis)>> {
     let project_path = project_path.as_ref();
@@ -150,7 +151,11 @@ pub async fn run_test<P: AsRef<Path>>(
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_millis();
-        format!("ipc://integration-test-suite-{project_name}-{language}-{now}")
+        if let Some(language) = language {
+            format!("ipc://integration-test-suite-{project_name}-{language}-{now}")
+        } else {
+            format!("ipc://integration-test-suite-{project_name}-{now}")
+        }
     };
 
     let (mut experiment_server, handler) = create_server(nng_listen_url)?;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#218 made passing the `Language` to `run_test!` required, this PR reverts the change because we also want to test multiple language runners at once and run more complex simulations. When specifying a language here could be confusing.

## 🐾 Next steps

- Add integration tests with multiple languages
- Add more complex integration tests

## 🔍 What does this change?

Reverts the macro change from #218

### Does this require a change to the docs?

#218 forgot to update the documentation, the docs are now correct again

## 🔗 Related links

- #218