### PR TITLE
Add Agent UUID to stop message

### DIFF
--- a/packages/engine/lib/orchestrator/src/experiment.rs
+++ b/packages/engine/lib/orchestrator/src/experiment.rs
@@ -158,22 +158,29 @@ impl Experiment {
                 }
                 proto::EngineStatus::SimStatus(status) => {
                     debug!("Got simulation run status: {status:?}");
-                    for stop_message in status.stop_msg {
-                        let reason = if let Some(reason) = stop_message.reason.as_ref() {
+                    for stop_command in status.stop_msg {
+                        let reason = if let Some(reason) = stop_command.message.reason.as_ref() {
                             format!(": {reason}")
                         } else {
                             String::new()
                         };
-                        match stop_message.status {
+                        let agent = &stop_command.agent;
+                        match stop_command.message.status {
                             StopStatus::Success => {
-                                tracing::info!("Simulation stopped sucessfully{reason}");
+                                tracing::info!(
+                                    "Simulation stopped by agent `{agent}` successfully{reason}"
+                                );
                             }
                             StopStatus::Warning => {
-                                tracing::warn!("Simulation stopped with a warning{reason}");
+                                tracing::warn!(
+                                    "Simulation stopped by agent `{agent}` with a warning{reason}"
+                                );
                             }
                             StopStatus::Error => {
                                 errored = true;
-                                tracing::error!("Simulation stopped with an error{reason}");
+                                tracing::error!(
+                                    "Simulation stopped by agent `{agent}` with an error{reason}"
+                                );
                             }
                         }
                     }

--- a/packages/engine/src/simulation/agent_control.rs
+++ b/packages/engine/src/simulation/agent_control.rs
@@ -1,8 +1,8 @@
-use crate::simulation::command::StopMessage;
+use crate::simulation::command::StopCommand;
 #[derive(Debug)]
 pub enum AgentControl {
     Continue,
-    Stop(Vec<StopMessage>),
+    Stop(Vec<StopCommand>),
 }
 
 impl Default for AgentControl {

--- a/packages/engine/src/simulation/command.rs
+++ b/packages/engine/src/simulation/command.rs
@@ -50,7 +50,7 @@ struct RemoveCommand {
     uuid: Uuid,
 }
 
-/// Status of the stop message occurred.
+/// Status of the stop message that occurred.
 ///
 /// See the [HASH-documentation] for more information.
 ///
@@ -67,6 +67,15 @@ impl Default for StopStatus {
     fn default() -> Self {
         Self::Warning
     }
+}
+
+/// Command to stop the simulation.
+///
+/// Stores the [`StopMessage`] and the agent's UUID.
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct StopCommand {
+    pub message: StopMessage,
+    pub agent: Uuid,
 }
 
 /// Stop message sent from an agent.
@@ -91,7 +100,7 @@ pub struct CreateRemoveCommands {
 #[derive(Debug, Default)]
 pub struct Commands {
     pub create_remove: CreateRemoveCommands,
-    pub stop: Vec<StopMessage>,
+    pub stop: Vec<StopCommand>,
 }
 
 impl Commands {
@@ -245,7 +254,10 @@ fn handle_hash_message(
             handle_remove_data(cmds, data, from)?;
         }
         HashMessageType::Stop => {
-            cmds.stop.push(serde_json::from_str(data)?);
+            cmds.stop.push(StopCommand {
+                message: serde_json::from_str(data)?,
+                agent: uuid::Uuid::from_bytes(*from),
+            });
         }
     }
     Ok(())

--- a/packages/engine/src/simulation/engine.rs
+++ b/packages/engine/src/simulation/engine.rs
@@ -20,7 +20,7 @@ use crate::{
     proto::ExperimentRunTrait,
     simulation::{
         agent_control::AgentControl,
-        command::{Commands, StopMessage},
+        command::{Commands, StopCommand},
     },
 };
 
@@ -30,7 +30,7 @@ pub struct Engine {
     store: Store,
     comms: Arc<Comms>,
     config: Arc<SimRunConfig>,
-    stop_messages: Vec<StopMessage>,
+    stop_messages: Vec<StopCommand>,
 }
 
 impl Engine {

--- a/packages/engine/src/simulation/status.rs
+++ b/packages/engine/src/simulation/status.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use super::Result;
 use crate::{
     hash_types::worker::RunnerError, output::OutputPersistenceResultRepr, proto::SimulationShortId,
-    simulation::command::StopMessage,
+    simulation::command::StopCommand,
 };
 
 // Sent from sim runs to experiment main loop.
@@ -12,7 +12,7 @@ pub struct SimStatus {
     pub sim_id: SimulationShortId,
     pub steps_taken: isize,
     pub early_stop: bool,
-    pub stop_msg: Vec<StopMessage>,
+    pub stop_msg: Vec<StopCommand>,
     pub stop_signal: bool,
     pub persistence_result: Option<(String, serde_json::Value)>,
     // TODO: OS do we need these within SimStatus or should they be handled elsewhere, such as
@@ -46,7 +46,7 @@ impl SimStatus {
         sim_id: SimulationShortId,
         steps_taken: isize,
         early_stop: bool,
-        stop_msg: Vec<StopMessage>,
+        stop_msg: Vec<StopCommand>,
         persistence_result: P,
     ) -> Result<SimStatus> {
         let persistence_result = OutputPersistenceResultRepr::into_value(persistence_result)


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds the agent's UUID to the stop message

## 🔗 Related links

- #235 

## 📹 Demo

```
     0.303205213s  INFO orchestrator::experiment: Simulation stopped by agent `366f9a12-a629-400b-ba7d-c0feb527a606` successfully: test
    at lib/orchestrator/src/experiment.rs:170
    in orchestrator::experiment::run with project_name="stop_simulation" experiment_id=57bd184c-c3aa-4076-b5dc-22f4f8d3f2d6
```
