### PR TITLE
[FE] Accept fallback URL for media blocks and add example

### DIFF
--- a/packages/blocks/image/package.json
+++ b/packages/blocks/image/package.json
@@ -69,6 +69,12 @@
   "blockprotocol": {
     "displayName": "Image",
     "icon": "public/image.svg",
-    "image": "public/preview.svg"
+    "image": "public/preview.svg",
+    "examples": [
+      {
+        "initialCaption": "Image of a Dog",
+        "url": "https://placedog.net/450/300"
+      }
+    ]
   }
 }

--- a/packages/blocks/image/src/Image.tsx
+++ b/packages/blocks/image/src/Image.tsx
@@ -24,6 +24,7 @@ type FileType = Awaited<ReturnType<BlockProtocolUploadFileFunction>>;
 type AppProps = {
   initialCaption?: string;
   initialWidth?: number;
+  url?: string;
 };
 
 type BlockProtocolUpdateEntitiesActionData = Pick<
@@ -98,6 +99,7 @@ export const Image: BlockComponent<AppProps> = (props) => {
     linkedEntities,
     uploadFile,
     updateEntities,
+    url,
   } = props;
 
   // TODO: Consider replacing multiple states with useReducer()
@@ -329,12 +331,12 @@ export const Image: BlockComponent<AppProps> = (props) => {
     });
   };
 
-  if (stateObject.src?.trim()) {
+  if (stateObject.src?.trim() || url) {
     return (
       <div className={tw`flex justify-center text-center w-full`}>
         <div className={tw`flex flex-col`}>
           <ResizeImageBlock
-            imageSrc={stateObject.src}
+            imageSrc={stateObject.src ? stateObject.src : url!}
             width={stateObject.width}
             updateWidth={updateWidth}
           />

--- a/packages/blocks/image/src/webpack-dev-server.tsx
+++ b/packages/blocks/image/src/webpack-dev-server.tsx
@@ -79,8 +79,9 @@ const App = () => {
         createLinks={createLinks}
         deleteLinks={deleteLinks}
         entityId="entity-asdasd"
-        initialCaption="ASDASDASDSAD"
+        initialCaption="Image of a Dog"
         uploadFile={uploadFile}
+        url={"https://placedog.net/450/300"}
       />
     </div>
   );

--- a/packages/blocks/video/package.json
+++ b/packages/blocks/video/package.json
@@ -64,6 +64,12 @@
   "blockprotocol": {
     "displayName": "Video",
     "icon": "public/play-box-outline.svg",
-    "image": "public/preview.svg"
+    "image": "public/preview.svg",
+    "examples": [
+      {
+        "initialCaption": "A blooming flower",
+        "url": "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
+      }
+    ]
   }
 }

--- a/packages/blocks/video/src/Video.tsx
+++ b/packages/blocks/video/src/Video.tsx
@@ -20,6 +20,7 @@ type FileType = Awaited<ReturnType<BlockProtocolUploadFileFunction>>;
 
 type AppProps = {
   initialCaption?: string;
+  url?: string;
 };
 
 type BlockProtocolUpdateEntitiesActionData = Pick<
@@ -93,6 +94,7 @@ export const Video: BlockComponent<AppProps> = (props) => {
     linkedEntities,
     uploadFile,
     updateEntities,
+    url,
   } = props;
 
   // TODO: Consider replacing multiple states with useReducer()
@@ -288,7 +290,7 @@ export const Video: BlockComponent<AppProps> = (props) => {
     });
   };
 
-  if (stateObject.src?.trim()) {
+  if (stateObject.src?.trim() || url) {
     return (
       <div className={tw`flex justify-center text-center w-full`}>
         <div className={tw`max-w-full`}>
@@ -298,7 +300,7 @@ export const Video: BlockComponent<AppProps> = (props) => {
             style={{
               maxWidth: "100%",
             }}
-            src={stateObject.src}
+            src={stateObject.src ? stateObject.src : url}
           />
 
           <input

--- a/packages/blocks/video/src/webpack-dev-server.tsx
+++ b/packages/blocks/video/src/webpack-dev-server.tsx
@@ -77,9 +77,12 @@ const App = () => {
         accountId="account-asdasd"
         createLinks={createLinks}
         deleteLinks={deleteLinks}
-        initialCaption="ASDASDASDSAD"
+        initialCaption="A blooming flower"
         entityId="entity-asdasd"
         uploadFile={uploadFile}
+        url={
+          "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm"
+        }
       />
     </div>
   );


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR works in congruence with the other example-related PRs, and is responsible for 2 things:
1. Add a fallback URL prop to the media blocks, allowing the users, and us, to add a fallback URL to the blocks. In our case, it helps us demo the blocks in the hub better.
2. Add examples to each block's `package.json`. This, working together with 1, helps us to demo our blocks in the app.

Related Asana Task: https://app.asana.com/0/1201668052739245/1201697302996564/f