### PR TITLE
Sort test outputs

### DIFF
--- a/packages/engine/tests/units/experiment.rs
+++ b/packages/engine/tests/units/experiment.rs
@@ -314,7 +314,7 @@ impl ExpectedOutput {
         analysis: &Analysis,
     ) -> Result<()> {
         let mut json_state = self.json_state.iter().collect::<Vec<_>>();
-        json_state.sort_unstable();
+        json_state.sort_unstable_by(|(lhs, _), (rhs, _)| Ord::cmp(lhs, rhs));
         for (step, expected_states) in json_state {
             let step = step
                 .parse::<usize>()

--- a/packages/engine/tests/units/experiment.rs
+++ b/packages/engine/tests/units/experiment.rs
@@ -313,7 +313,9 @@ impl ExpectedOutput {
         globals: &Globals,
         analysis: &Analysis,
     ) -> Result<()> {
-        for (step, expected_states) in &self.json_state {
+        let mut json_state = self.json_state.iter().collect::<Vec<_>>();
+        json_state.sort_unstable();
+        for (step, expected_states) in json_state {
             let step = step
                 .parse::<usize>()
                 .wrap_err_lazy(|| format!("Could not parse {step:?} as number of a step"))?;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In integration tests we have a config file with the expected test outputs. We specify a specific step and compare the results to the actual outputs. The steps are stored as `HashMap` with the step as key. If a test fails with the output at step Y, we don't know, if the test would already fail on step X (with step X < step Y) as `HashMaps` are unsorted. This PR sorts the map before comparing to the outputs to compare expected outputs to actual outputs chronologically. If now step Y fails, we now, that step X was successful.