### PR TITLE
Make Logging output configurable for tests

### DIFF
--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -8,7 +8,10 @@ use std::{
 
 use clap::{AppSettings, Parser};
 use error::{report, Result, ResultExt};
-use hash_engine::{proto::ExperimentName, utils::OutputFormat};
+use hash_engine::{
+    proto::ExperimentName,
+    utils::{OutputFormat, OutputLocation},
+};
 use orchestrator::{create_server, Experiment, ExperimentConfig, Manifest};
 
 /// Arguments passed to the CLI
@@ -107,6 +110,8 @@ async fn main() -> Result<()> {
 
     let _guard = hash_engine::init_logger(
         args.emit,
+        OutputLocation::default(),
+        "./log",
         &format!("cli-{now}"),
         &format!("cli-{now}-texray"),
     );
@@ -130,6 +135,8 @@ async fn main() -> Result<()> {
         num_workers: args.num_workers.unwrap_or_else(num_cpus::get),
         emit: args.emit,
         output_folder: args.output,
+        output_location: OutputLocation::default(),
+        log_folder: PathBuf::from("./log"),
         engine_start_timeout: Duration::from_secs(args.start_timeout),
         engine_wait_timeout: Duration::from_secs(args.wait_timeout),
     });

--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -40,6 +40,17 @@ pub struct Args {
     #[clap(long, default_value = "pretty", arg_enum, env = "HASH_EMIT")]
     emit: OutputFormat,
 
+    /// Output location where to emit logs.
+    ///
+    /// Can be `stdout`, `stderr` or any file name. Relative to `--log-folder` if a file is
+    /// specified.
+    #[clap(long, default_value = "stderr")]
+    output_location: OutputLocation,
+
+    /// Logging output folder.
+    #[clap(long, default_value = "./log")]
+    log_folder: PathBuf,
+
     /// Engine start timeout in seconds
     #[clap(long, default_value = "2", env = "ENGINE_START_TIMEOUT")]
     start_timeout: u64,
@@ -110,8 +121,8 @@ async fn main() -> Result<()> {
 
     let _guard = hash_engine::init_logger(
         args.emit,
-        OutputLocation::default(),
-        "./log",
+        &args.output_location,
+        args.log_folder.clone(),
         &format!("cli-{now}"),
         &format!("cli-{now}-texray"),
     );
@@ -135,8 +146,8 @@ async fn main() -> Result<()> {
         num_workers: args.num_workers.unwrap_or_else(num_cpus::get),
         emit: args.emit,
         output_folder: args.output,
-        output_location: OutputLocation::default(),
-        log_folder: PathBuf::from("./log"),
+        output_location: args.output_location,
+        log_folder: args.log_folder,
         engine_start_timeout: Duration::from_secs(args.start_timeout),
         engine_wait_timeout: Duration::from_secs(args.wait_timeout),
     });

--- a/packages/engine/bin/server/src/main.rs
+++ b/packages/engine/bin/server/src/main.rs
@@ -10,8 +10,8 @@ async fn main() -> Result<()> {
     let args = hash_engine::args();
     let _guard = hash_engine::init_logger(
         args.emit,
-        args.output.clone(),
-        args.log_folder.clone(),
+        &args.output,
+        &args.log_folder,
         &format!("experiment-{}", args.experiment_id),
         &format!("experiment-{}-texray", args.experiment_id),
     );

--- a/packages/engine/bin/server/src/main.rs
+++ b/packages/engine/bin/server/src/main.rs
@@ -10,6 +10,8 @@ async fn main() -> Result<()> {
     let args = hash_engine::args();
     let _guard = hash_engine::init_logger(
         args.emit,
+        args.output.clone(),
+        args.log_folder.clone(),
         &format!("experiment-{}", args.experiment_id),
         &format!("experiment-{}-texray", args.experiment_id),
     );

--- a/packages/engine/lib/orchestrator/src/experiment.rs
+++ b/packages/engine/lib/orchestrator/src/experiment.rs
@@ -10,7 +10,7 @@ use hash_engine::{
         ExperimentRunBase, SimpleExperimentConfig, SingleRunExperimentConfig,
     },
     simulation::command::StopStatus,
-    utils::OutputFormat,
+    utils::{OutputFormat, OutputLocation},
 };
 use rand::{distributions::Distribution, Rng, RngCore};
 use rand_distr::{Beta, LogNormal, Normal, Poisson};
@@ -25,6 +25,8 @@ pub struct ExperimentConfig {
     pub num_workers: usize,
     pub emit: OutputFormat,
     pub output_folder: PathBuf,
+    pub output_location: OutputLocation,
+    pub log_folder: PathBuf,
     pub engine_start_timeout: Duration,
     pub engine_wait_timeout: Duration,
 }
@@ -68,6 +70,8 @@ impl Experiment {
             self.config.num_workers,
             controller_url,
             self.config.emit,
+            self.config.output_location.clone(),
+            self.config.log_folder.clone(),
         )?))
     }
 

--- a/packages/engine/lib/orchestrator/src/process/local.rs
+++ b/packages/engine/lib/orchestrator/src/process/local.rs
@@ -1,9 +1,11 @@
+use std::path::PathBuf;
+
 use async_trait::async_trait;
 use error::{Report, Result, ResultExt};
 use hash_engine::{
     nano,
     proto::{EngineMsg, ExperimentId},
-    utils::OutputFormat,
+    utils::{OutputFormat, OutputLocation},
 };
 
 use crate::process;
@@ -56,6 +58,8 @@ pub struct LocalCommand {
     controller_url: String,
     max_num_workers: usize,
     output_format: OutputFormat,
+    output_location: OutputLocation,
+    log_folder: PathBuf,
 }
 
 impl LocalCommand {
@@ -64,6 +68,8 @@ impl LocalCommand {
         max_num_workers: usize,
         controller_url: &str,
         output_format: OutputFormat,
+        output_location: OutputLocation,
+        log_folder: PathBuf,
     ) -> Result<Self> {
         // The NNG URL that the engine process will listen on
         let engine_url = format!("ipc://run-{experiment_id}");
@@ -74,6 +80,8 @@ impl LocalCommand {
             controller_url: controller_url.to_string(),
             max_num_workers,
             output_format,
+            output_location,
+            log_folder,
         })
     }
 }
@@ -98,6 +106,10 @@ impl process::Command for LocalCommand {
             .arg(self.max_num_workers.to_string())
             .arg("--emit")
             .arg(self.output_format.to_string())
+            .arg("--output")
+            .arg(self.output_location.to_string())
+            .arg("--log-folder")
+            .arg(self.log_folder)
             .stdout(std::process::Stdio::inherit())
             .stderr(std::process::Stdio::inherit());
         debug!("Running `{cmd:?}`");

--- a/packages/engine/src/args.rs
+++ b/packages/engine/src/args.rs
@@ -1,6 +1,11 @@
+use std::path::PathBuf;
+
 use clap::{AppSettings, Parser};
 
-use crate::{proto::ExperimentId, utils::OutputFormat};
+use crate::{
+    proto::ExperimentId,
+    utils::{OutputFormat, OutputLocation},
+};
 
 /// Arguments passed to hEngine
 #[derive(Debug, Parser)]
@@ -25,9 +30,20 @@ pub struct Args {
     #[clap(short, long)]
     pub max_workers: Option<usize>,
 
-    /// Output format emitted to the terminal.
+    /// Output format emitted to the output location.
     #[clap(long, default_value = "pretty", arg_enum, env = "HASH_EMIT")]
     pub emit: OutputFormat,
+
+    /// Output location where to emit logs.
+    ///
+    /// Can be `stdout`, `stderr` or any file name. Relative to `--log-folder` if a file is
+    /// specified.
+    #[clap(long, default_value = "stderr")]
+    pub output: OutputLocation,
+
+    /// Logging output folder.
+    #[clap(long, default_value = "./log")]
+    pub log_folder: PathBuf,
 }
 
 pub fn args() -> Args {

--- a/packages/engine/src/utils.rs
+++ b/packages/engine/src/utils.rs
@@ -261,7 +261,8 @@ pub fn parse_env_duration(name: &str, default: u64) -> Duration {
 #[cfg(feature = "texray")]
 pub mod texray {
     use tracing_appender::non_blocking::WorkerGuard;
-    use tracing_texray::{examine, TeXRayLayer};
+    pub use tracing_texray::examine;
+    use tracing_texray::TeXRayLayer;
 
     pub fn create_texray_layer(output_name: &str) -> (Option<TeXRayLayer>, WorkerGuard) {
         let texray_file_appender =

--- a/packages/engine/tests/integration.rs
+++ b/packages/engine/tests/integration.rs
@@ -40,7 +40,7 @@ macro_rules! run_test {
                 .canonicalize()
                 .unwrap();
 
-            $crate::units::experiment::run_test_suite(project_path, None, None).await
+            $crate::units::experiment::run_test_suite(project_path, module_path!(), None, None).await
         }
     };
     ($project:ident, $language:ident $(,)? $(#[$attr:meta])* ) => {
@@ -58,7 +58,7 @@ macro_rules! run_test {
                 .canonicalize()
                 .unwrap();
 
-            $crate::units::experiment::run_test_suite(project_path, Some(hash_engine::Language::$language), None).await
+            $crate::units::experiment::run_test_suite(project_path, module_path!(), Some(hash_engine::Language::$language), None).await
         }
     };
     ($project:ident, experiment: $experiment:ident $(,)? $(#[$attr:meta])* ) => {
@@ -72,7 +72,7 @@ macro_rules! run_test {
                 .canonicalize()
                 .unwrap();
 
-            $crate::units::experiment::run_test_suite(project_path, None, Some(stringify!($experiment))).await
+            $crate::units::experiment::run_test_suite(project_path, module_path!(), None, Some(stringify!($experiment))).await
         }
     };
     ($project:ident, $language:ident, experiment: $experiment:ident $(,)? $(#[$attr:meta])* ) => {
@@ -90,7 +90,7 @@ macro_rules! run_test {
                 .canonicalize()
                 .unwrap();
 
-            $crate::units::experiment::run_test_suite(project_path, Some(hash_engine::Language::$language), Some(stringify!($experiment))).await
+            $crate::units::experiment::run_test_suite(project_path, module_path!(), Some(hash_engine::Language::$language), Some(stringify!($experiment))).await
         }
     };
 }

--- a/packages/engine/tests/units/experiment.rs
+++ b/packages/engine/tests/units/experiment.rs
@@ -3,12 +3,16 @@ use std::{
     fs::{self, File},
     io::BufReader,
     iter,
-    path::Path,
+    path::{Path, PathBuf},
     time::Duration,
 };
 
 use error::{bail, ensure, report, Result, ResultExt};
-use hash_engine::{proto::ExperimentName, utils::OutputFormat, Language};
+use hash_engine::{
+    proto::ExperimentName,
+    utils::{OutputFormat, OutputLocation},
+    Language,
+};
 use orchestrator::{create_server, ExperimentConfig, ExperimentType, Manifest};
 use serde::{de::DeserializeOwned, Deserialize};
 use serde_json::Value;
@@ -65,12 +69,20 @@ fn load_manifest<P: AsRef<Path>>(project_path: P, language: Option<Language>) ->
 
 pub async fn run_test_suite<P: AsRef<Path>>(
     project_path: P,
+    project_module: &str,
     language: Option<Language>,
     experiment: Option<&str>,
 ) {
-    std::env::set_var("RUST_LOG", "info");
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "trace");
+    }
 
     let project_path = project_path.as_ref();
+    let project_name = project_path
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
 
     let experiments = read_config(project_path.join("integration-test.json"))
         .expect("Could not read experiments")
@@ -86,29 +98,63 @@ pub async fn run_test_suite<P: AsRef<Path>>(
         // TODO: Remove attempting strategy
         let mut outputs = None;
         let attempts = 10;
+        // Will be initialized in the loop
+        let mut output_folder = PathBuf::new();
+
         for attempt in 1..=attempts {
             if attempt > 1 {
                 std::env::set_var("RUST_LOG", "trace");
             }
-            println!(
-                "\n\n\nRunning test {:?} attempt {attempt}/{attempts}:\n",
-                project_path.file_name().unwrap()
+
+            // Use `OUTPUT_DIRECTORY` as output directory. If it's not set, cargo's `OUT_DIR` is
+            // used. If, for whatever reason, this is not set, default to `./output`.
+            output_folder = PathBuf::from(
+                std::env::var("OUTPUT_DIRECTORY")
+                    .or_else(|_| std::env::var("OUT_DIR"))
+                    .unwrap_or_else(|_| "./output".to_string()),
             );
+            for module in project_module.split("::") {
+                output_folder.push(module);
+            }
+            output_folder.push(&project_name);
+
             let test_result = run_test(
                 experiment_type.clone(),
                 &project_path,
+                project_name.clone(),
+                output_folder.join(format!("attempt-{attempt}")),
                 language,
                 expected_outputs.len(),
             );
-            match test_result.await {
-                Ok(out) => {
-                    outputs.replace(out);
-                    break;
-                }
-                Err(err) => eprintln!("\n\n{err:?}\n\n"),
+            let output = test_result.await;
+            let success = output.is_ok();
+            outputs.replace(output);
+            if success {
+                break;
             }
         }
-        let outputs = outputs.expect(&format!("Could not run experiment"));
+
+        let log_file_path = output_folder
+            .join(format!("attempt-{attempts}"))
+            .join("log")
+            .join("output.log");
+
+        let log_output = fs::read_to_string(&log_file_path);
+        // Remove the output directory if it was not set manually
+        if std::env::var("OUTPUT_DIRECTORY").is_err() {
+            let _ = fs::remove_dir_all(&output_folder);
+        }
+
+        let outputs = match outputs.unwrap() {
+            Ok(outputs) => outputs,
+            Err(err) => {
+                match log_output {
+                    Ok(log) => eprintln!("{log}"),
+                    Err(err) => eprintln!("Could not read {log_file_path:?}: {err}"),
+                }
+                panic!("{:?}", err.wrap("Could not run experiment"));
+            }
+        };
 
         assert_eq!(
             expected_outputs.len(),
@@ -135,15 +181,12 @@ pub async fn run_test_suite<P: AsRef<Path>>(
 pub async fn run_test<P: AsRef<Path>>(
     experiment_type: ExperimentType,
     project_path: P,
+    project_name: String,
+    output_folder: PathBuf,
     language: Option<Language>,
     num_outputs_expected: usize,
 ) -> Result<Vec<(AgentStates, Globals, Analysis)>> {
     let project_path = project_path.as_ref();
-    let project_name = project_path
-        .file_name()
-        .unwrap()
-        .to_string_lossy()
-        .to_string();
 
     let nng_listen_url = {
         use std::time::{SystemTime, UNIX_EPOCH};
@@ -169,10 +212,10 @@ pub async fn run_test<P: AsRef<Path>>(
 
     let experiment = orchestrator::Experiment::new(ExperimentConfig {
         num_workers: num_cpus::get(),
-        emit: OutputFormat::Full,
-        output_folder: std::env::var("OUT_DIR")
-            .unwrap_or_else(|_| "./output".to_string())
-            .into(),
+        emit: OutputFormat::Pretty,
+        log_folder: output_folder.join("log"),
+        output_folder,
+        output_location: OutputLocation::File("output.log".into()),
         engine_start_timeout: Duration::from_secs(10),
         engine_wait_timeout: Duration::from_secs(10 * 60),
     });
@@ -200,8 +243,6 @@ pub async fn run_test<P: AsRef<Path>>(
                 .wrap_err("Could not read globals")?;
             let analysis_outputs = parse_file(Path::new(&output_dir).join("analysis_outputs.json"))
                 .wrap_err("Could not read analysis outputs`")?;
-
-            let _ = fs::remove_dir_all(&output_dir);
 
             Ok((json_state, globals, analysis_outputs))
         })
@@ -259,7 +300,7 @@ fn assert_subset_value(subset: &Value, superset: &Value, path: String) -> Result
         (Value::Number(a), Value::Number(b)) if a.is_f64() && b.is_f64() => {
             ensure!(
                 (a.as_f64().unwrap() - b.as_f64().unwrap()).abs() < f64::EPSILON,
-                "{path:?}: Expected `{a} == {b}`"
+                "Expected `{path} == {a}` but it was `{b}`"
             );
         }
         (Value::Array(a), Value::Array(b)) => {
@@ -287,7 +328,7 @@ fn assert_subset_value(subset: &Value, superset: &Value, path: String) -> Result
         _ => {
             ensure!(
                 subset == superset,
-                "{path:?}: Expected `{} == {}`",
+                "Expected `{path} == {}` but it was `{}`",
                 serde_json::to_string_pretty(subset).unwrap(),
                 serde_json::to_string_pretty(superset).unwrap()
             );

--- a/packages/engine/tests/units/experiment.rs
+++ b/packages/engine/tests/units/experiment.rs
@@ -74,7 +74,7 @@ pub async fn run_test_suite<P: AsRef<Path>>(
     experiment: Option<&str>,
 ) {
     if std::env::var("RUST_LOG").is_err() {
-        std::env::set_var("RUST_LOG", "trace");
+        std::env::set_var("RUST_LOG", "info");
     }
 
     let project_path = project_path.as_ref();

--- a/packages/engine/tests/units/message/stop_simulation/src/behaviors/test.js
+++ b/packages/engine/tests/units/message/stop_simulation/src/behaviors/test.js
@@ -8,7 +8,7 @@ const behavior = (state, context) => {
         to: "hash",
         type: "stop",
         data: {
-          status: "success",
+          status: "error",
           reason: "test",
         },
       },

--- a/packages/engine/tests/units/message/stop_simulation/src/behaviors/test.js
+++ b/packages/engine/tests/units/message/stop_simulation/src/behaviors/test.js
@@ -8,7 +8,7 @@ const behavior = (state, context) => {
         to: "hash",
         type: "stop",
         data: {
-          status: "error",
+          status: "success",
           reason: "test",
         },
       },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We are going to measure performance in integration tests. In order to do this, the output should be stored for each test separately. This PR makes logging output configurable ~~(not from the CLI but when using the orchestrator)~~ and changes the testing output strategy.

This also speed ups our testing suite as we are not outputting every simulation to the terminal.

## 🔍 What does this change?

- Add command line arguments for server-binary (logic mainly in _packages/engine/src/utils.rs_)
  - `--output`: Output location, either `stderr`, `stdout` or a file name. File is relative to `--log-folder`
  - `--log-folder`: Logs are stored in this directory
- ~~Default to `RUST_LOG=trace` in tests (will not overwrite user-defined environment)~~
- Make `RUST_LOG` be over-writable by environment variables
- Use "pretty" for output format in tests
- Only write latest failed test to terminal
- Write test outputs relative to output location (uses `OUTPUT_DIRECTORY`, defaults to cargo's `OUT_DIR`, falls back to `./output`
- Test outputs will only be removed, when output is not specified by `OUTPUT_DIRECTORY`

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201481007343159/1201734781593095/f) (_internal_)

### Does this require a change to the docs?

- No, as there is no public change

## 📹 Demo

- Comparison of CI outputs:
  - [Now (success)](https://github.com/hashintel/hash/runs/4980841395?check_suite_focus=true#step:8:138)
  - [Now (failed)](https://github.com/hashintel/hash/runs/4981416158?check_suite_focus=true#step:8:244)
  - [Then (success)](https://github.com/hashintel/hash/runs/4979103054?check_suite_focus=true#step:8:138) (#240)
  - [Then (failed)](https://github.com/hashintel/hash/runs/4978995475?check_suite_focus=true#step:8:138) (#240)
- Example output structure:
```
 output/integration/units/message/js/stop_simulation
├──  attempt-1
│  ├──  log
│  │  ├──  experiment-eb1ba57f-30a5-454d-9962-7e657680620e.json
│  │  └──  output.log
│  └──  single_run
│     └──  eb1ba57f-30a5-454d-9962-7e657680620e
│        └──  1
│           ├──  analysis_outputs.json
│           ├──  globals.json
│           └──  json_state.json
├──  attempt-...
└──  attempt-10
    ├──  log
    │  ├──  experiment-b0d10146-7d34-4ec5-ad0b-e1323f86c582.json
    │  └──  output.log
    └──  single_run
       └──  b0d10146-7d34-4ec5-ad0b-e1323f86c582
          └──  1
             ├──  analysis_outputs.json
             ├──  globals.json
             └──  json_state.json
```
