### PR TITLE
[ENGINE] Adding more Spans

### DIFF
--- a/packages/engine/src/experiment/controller/controller.rs
+++ b/packages/engine/src/experiment/controller/controller.rs
@@ -79,9 +79,8 @@ impl<P: OutputPersistenceCreatorRepr> ExperimentController<P> {
                 changed_properties,
                 max_num_steps,
             } => {
-                let sim_span = utils::texray::examine(tracing::span!(
+                let sim_span = utils::texray::examine(tracing::info_span!(
                     parent: span_id,
-                    tracing::Level::INFO,
                     "sim",
                     id = &sim_id
                 ));

--- a/packages/engine/src/simulation/comms/package.rs
+++ b/packages/engine/src/simulation/comms/package.rs
@@ -39,7 +39,7 @@ impl PackageComms {
 
         self.inner
             .new_task(self.package_id, task, shared_store)
-            .instrument(tracing::info_span!("Task", name = task_name))
+            .instrument(tracing::debug_span!("Task", name = task_name))
             .await
     }
 }

--- a/packages/engine/src/simulation/comms/package.rs
+++ b/packages/engine/src/simulation/comms/package.rs
@@ -39,7 +39,7 @@ impl PackageComms {
 
         self.inner
             .new_task(self.package_id, task, shared_store)
-            .instrument(tracing::trace_span!("Task", name = task_name))
+            .instrument(tracing::info_span!("Task", name = task_name))
             .await
     }
 }

--- a/packages/engine/src/simulation/engine.rs
+++ b/packages/engine/src/simulation/engine.rs
@@ -124,7 +124,7 @@ impl Engine {
         // Synchronize snapshot with workers
         self.comms
             .state_snapshot_sync(&snapshot)
-            .instrument(tracing::trace_span!("snapshot_sync"))
+            .instrument(tracing::info_span!("snapshot_sync"))
             .await?;
 
         // After this point, we'll only need read access to state until
@@ -143,7 +143,7 @@ impl Engine {
 
             Result::Ok(())
         }
-        .instrument(tracing::trace_span!("state_sync"))
+        .instrument(tracing::info_span!("state_sync"))
         .await?;
 
         let pre_context = context.into_pre_context();
@@ -151,7 +151,7 @@ impl Engine {
             .packages
             .step
             .run_context(state.clone(), snapshot, pre_context)
-            .instrument(tracing::trace_span!("run_context_packages"))
+            .instrument(tracing::info_span!("run_context_packages"))
             .await?
             .into_shared();
 
@@ -159,7 +159,7 @@ impl Engine {
         // again until the next step.
         self.comms
             .context_batch_sync(&context, current_step, state.group_start_indices())
-            .instrument(tracing::trace_span!("context_sync"))
+            .instrument(tracing::info_span!("context_sync"))
             .await?;
 
         // Note: the comment below is mostly invalid until state sync is fixed

--- a/packages/engine/src/simulation/engine.rs
+++ b/packages/engine/src/simulation/engine.rs
@@ -127,7 +127,7 @@ impl Engine {
         let (mut state, mut context) = self.store.take_upgraded()?;
 
         let snapshot = {
-            let _span = tracing::trace_span!("prepare_context_packages").entered();
+            let _span = tracing::debug_span!("prepare_context_packages").entered();
             self.prepare_for_context_packages(&mut state, &mut context)?
         };
 

--- a/packages/engine/src/simulation/package/context/mod.rs
+++ b/packages/engine/src/simulation/package/context/mod.rs
@@ -38,7 +38,7 @@ pub trait Package: MaybeCpuBound + GetWorkerSimStartMsg + Send + Sync {
         context_schema: &ContextSchema,
     ) -> Result<Vec<(FieldKey, Arc<dyn arrow::array::Array>)>>;
 
-    fn get_span(&self) -> Span;
+    fn span(&self) -> Span;
 }
 
 pub trait PackageCreator: GetWorkerExpStartMsg + Sync + Send {

--- a/packages/engine/src/simulation/package/context/packages/agent_messages/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/mod.rs
@@ -125,7 +125,7 @@ impl Package for AgentMessages {
         Ok(vec![(field_key, Arc::new(messages_builder.finish()))])
     }
 
-    fn get_span(&self) -> Span {
+    fn span(&self) -> Span {
         tracing::debug_span!("agent_messages")
     }
 }

--- a/packages/engine/src/simulation/package/context/packages/agent_messages/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/mod.rs
@@ -5,6 +5,7 @@ mod writer;
 
 use arrow::array::{FixedSizeListBuilder, ListBuilder};
 use serde_json::Value;
+use tracing::Span;
 
 use self::collected::Messages;
 use super::super::*;
@@ -16,7 +17,7 @@ use crate::{
     },
     simulation::{
         comms::package::PackageComms,
-        package::context::packages::agent_messages::fields::MESSAGES_FIELD_NAME,
+        package::context::{packages::agent_messages::fields::MESSAGES_FIELD_NAME, Package},
     },
 };
 
@@ -83,6 +84,10 @@ impl Package for AgentMessages {
         state: Arc<State>,
         snapshot: Arc<StateSnapshot>,
     ) -> Result<Vec<ContextColumn>> {
+        // We want to pass the span for the package to the writer, so that the write() call isn't
+        // nested under the run span
+        let pkg_span = Span::current();
+        let _run_entered = tracing::trace_span!("run").entered();
         let agent_pool = state.agent_pool();
         let batches = agent_pool.try_read_batches()?;
         let id_name_iter = iterators::agent::agent_id_iter(&batches)?
@@ -97,6 +102,7 @@ impl Package for AgentMessages {
         Ok(vec![ContextColumn {
             field_key,
             inner: Box::new(messages),
+            span: pkg_span,
         }])
     }
 
@@ -117,5 +123,9 @@ impl Package for AgentMessages {
             .to_key()?;
 
         Ok(vec![(field_key, Arc::new(messages_builder.finish()))])
+    }
+
+    fn get_span(&self) -> Span {
+        tracing::debug_span!("agent_messages")
     }
 }

--- a/packages/engine/src/simulation/package/context/packages/api_requests/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/api_requests/mod.rs
@@ -195,7 +195,6 @@ async fn build_api_response_maps(
     snapshot: &StateSnapshot,
     handlers: &[String],
 ) -> Result<Vec<ApiResponseMap>> {
-    tracing::warn!("BUILDIN API RESPONSE");
     let mut futs = FuturesOrdered::new();
     {
         let message_pool = snapshot.message_pool();

--- a/packages/engine/src/simulation/package/context/packages/api_requests/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/api_requests/mod.rs
@@ -168,7 +168,7 @@ impl Package for ApiRequests {
         )])
     }
 
-    fn get_span(&self) -> Span {
+    fn span(&self) -> Span {
         tracing::debug_span!("api_requests")
     }
 }

--- a/packages/engine/src/simulation/package/context/packages/neighbors/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/neighbors/mod.rs
@@ -170,7 +170,7 @@ impl Package for Neighbors {
         Ok(vec![(field_key, Arc::new(neighbors_builder.finish()))])
     }
 
-    fn get_span(&self) -> Span {
+    fn span(&self) -> Span {
         tracing::debug_span!("neighbors")
     }
 }

--- a/packages/engine/src/simulation/package/context/packages/neighbors/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/neighbors/mod.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use parking_lot::RwLockReadGuard;
 use serde_json::Value;
+use tracing::Span;
 
 use self::map::{NeighborMap, NeighborRef};
 use crate::{
@@ -125,6 +126,11 @@ impl Package for Neighbors {
         state: Arc<State>,
         _snapshot: Arc<StateSnapshot>,
     ) -> Result<Vec<ContextColumn>> {
+        // We want to pass the span for the package to the writer, so that the write() call isn't
+        // nested under the run span
+        let pkg_span = Span::current();
+        let _run_entered = tracing::trace_span!("run").entered();
+
         let agent_pool = state.agent_pool();
         let batches = agent_pool.try_read_batches()?;
         let states = Self::neighbor_vec(&batches)?;
@@ -138,6 +144,7 @@ impl Package for Neighbors {
         Ok(vec![ContextColumn {
             field_key,
             inner: Box::new(map),
+            span: pkg_span,
         }])
     }
 
@@ -161,5 +168,9 @@ impl Package for Neighbors {
             .to_key()?;
 
         Ok(vec![(field_key, Arc::new(neighbors_builder.finish()))])
+    }
+
+    fn get_span(&self) -> Span {
+        tracing::debug_span!("neighbors")
     }
 }

--- a/packages/engine/src/simulation/package/init/packages/js_py/mod.rs
+++ b/packages/engine/src/simulation/package/init/packages/js_py/mod.rs
@@ -1,4 +1,7 @@
-use std::convert::TryInto;
+use std::{
+    convert::TryInto,
+    fmt::{Debug, Formatter},
+};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -119,9 +122,23 @@ pub struct StartMessage {
     initial_state_source: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct SuccessMessage {
     agents: Vec<Agent>,
+}
+
+impl Debug for SuccessMessage {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SuccessMessage")
+            .field("agents", &{
+                if !self.agents.is_empty() {
+                    format_args!("[...]") // The Agents JSON can result in huge log lines otherwise
+                } else {
+                    format_args!("[]")
+                }
+            })
+            .finish()
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/packages/engine/src/simulation/package/output/mod.rs
+++ b/packages/engine/src/simulation/package/output/mod.rs
@@ -62,5 +62,5 @@ pub trait PackageCreator: GetWorkerExpStartMsg + Sync + Send {
 pub trait Package: MaybeCpuBound + GetWorkerSimStartMsg + Send + Sync {
     async fn run(&mut self, state: Arc<State>, context: Arc<Context>) -> Result<Output>;
 
-    fn get_span(&self) -> Span;
+    fn span(&self) -> Span;
 }

--- a/packages/engine/src/simulation/package/output/mod.rs
+++ b/packages/engine/src/simulation/package/output/mod.rs
@@ -3,6 +3,7 @@ pub mod packages;
 use std::sync::Arc;
 
 pub use packages::{Name, OutputTask, OutputTaskMessage, PACKAGE_CREATORS};
+use tracing::Span;
 
 use self::packages::Output;
 use super::{
@@ -60,4 +61,6 @@ pub trait PackageCreator: GetWorkerExpStartMsg + Sync + Send {
 #[async_trait]
 pub trait Package: MaybeCpuBound + GetWorkerSimStartMsg + Send + Sync {
     async fn run(&mut self, state: Arc<State>, context: Arc<Context>) -> Result<Output>;
+
+    fn get_span(&self) -> Span;
 }

--- a/packages/engine/src/simulation/package/output/packages/analysis/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/analysis/mod.rs
@@ -89,7 +89,7 @@ impl Package for Analysis {
         ))
     }
 
-    fn get_span(&self) -> Span {
+    fn span(&self) -> Span {
         tracing::debug_span!("analysis")
     }
 }

--- a/packages/engine/src/simulation/package/output/packages/analysis/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/analysis/mod.rs
@@ -8,6 +8,7 @@ pub use self::config::AnalysisOutputConfig;
 pub use super::super::*;
 use crate::{
     datastore::table::state::ReadState, experiment::SimPackageArgs, proto::ExperimentRunTrait,
+    simulation::package::output::Package,
 };
 
 #[macro_use]
@@ -86,6 +87,10 @@ impl Package for Analysis {
         Ok(Output::AnalysisOutput(
             self.analyzer.get_latest_output_set(),
         ))
+    }
+
+    fn get_span(&self) -> Span {
+        tracing::debug_span!("analysis")
     }
 }
 

--- a/packages/engine/src/simulation/package/output/packages/json_state/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/json_state/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         table::state::ReadState,
     },
     hash_types::Agent,
-    simulation::package::{name::PackageName, output},
+    simulation::package::{name::PackageName, output, output::Package},
 };
 
 mod config;
@@ -106,6 +106,10 @@ impl Package for JsonState {
         Ok(Output::JsonStateOutput(JsonStateOutput {
             inner: agent_states,
         }))
+    }
+
+    fn get_span(&self) -> Span {
+        tracing::debug_span!("json_state")
     }
 }
 

--- a/packages/engine/src/simulation/package/output/packages/json_state/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/json_state/mod.rs
@@ -108,7 +108,7 @@ impl Package for JsonState {
         }))
     }
 
-    fn get_span(&self) -> Span {
+    fn span(&self) -> Span {
         tracing::debug_span!("json_state")
     }
 }

--- a/packages/engine/src/simulation/package/run.rs
+++ b/packages/engine/src/simulation/package/run.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use futures::{executor::block_on, stream::FuturesOrdered, StreamExt};
-use tracing::Instrument;
+use tracing::{Instrument, Span};
 
 use crate::{
     datastore::{
@@ -168,14 +168,21 @@ impl StepPackages {
 
             let cpu_bound = package.cpu_bound();
             futs.push(if cpu_bound {
+                let current_span = Span::current();
                 tokio::task::spawn_blocking(move || {
-                    let res = block_on(package.run(state, snapshot_clone).in_current_span());
+                    let package_span = {
+                        // We want to create the package span within the scope of the current one
+                        let _entered = current_span.entered();
+                        package.get_span()
+                    };
+                    let res = block_on(package.run(state, snapshot_clone).instrument(package_span));
                     (package, res)
                 })
             } else {
+                let span = package.get_span();
                 tokio::task::spawn(
                     async {
-                        let res = package.run(state, snapshot_clone).await;
+                        let res = package.run(state, snapshot_clone).instrument(span).await;
                         (package, res)
                     }
                     .in_current_span(),

--- a/packages/engine/src/simulation/package/run.rs
+++ b/packages/engine/src/simulation/package/run.rs
@@ -241,7 +241,8 @@ impl StepPackages {
         // Traits are tricky anyway for working with iterators
         // Will instead use state.upgrade() and exstate.downgrade() and respectively for context
         for pkg in self.state.iter_mut() {
-            pkg.run(&mut state, context).await?;
+            let span = pkg.get_span();
+            pkg.run(&mut state, context).instrument(span).await?;
         }
 
         Ok(state)

--- a/packages/engine/src/simulation/package/run.rs
+++ b/packages/engine/src/simulation/package/run.rs
@@ -173,13 +173,13 @@ impl StepPackages {
                     let package_span = {
                         // We want to create the package span within the scope of the current one
                         let _entered = current_span.entered();
-                        package.get_span()
+                        package.span()
                     };
                     let res = block_on(package.run(state, snapshot_clone).instrument(package_span));
                     (package, res)
                 })
             } else {
-                let span = package.get_span();
+                let span = package.span();
                 tokio::task::spawn(
                     async {
                         let res = package.run(state, snapshot_clone).instrument(span).await;
@@ -248,7 +248,7 @@ impl StepPackages {
         // Traits are tricky anyway for working with iterators
         // Will instead use state.upgrade() and exstate.downgrade() and respectively for context
         for pkg in self.state.iter_mut() {
-            let span = pkg.get_span();
+            let span = pkg.span();
             pkg.run(&mut state, context).instrument(span).await?;
         }
 
@@ -276,13 +276,13 @@ impl StepPackages {
                     let package_span = {
                         // We want to create the package span within the scope of the current one
                         let _entered = current_span.entered();
-                        pkg.get_span()
+                        pkg.span()
                     };
                     let res = block_on(pkg.run(state, context).instrument(package_span));
                     (pkg, res)
                 })
             } else {
-                let span = pkg.get_span();
+                let span = pkg.span();
                 tokio::task::spawn(
                     async {
                         let res = pkg.run(state, context).instrument(span).await;

--- a/packages/engine/src/simulation/package/state/mod.rs
+++ b/packages/engine/src/simulation/package/state/mod.rs
@@ -25,7 +25,7 @@ use crate::{
 pub trait Package: GetWorkerSimStartMsg + Send + Sync {
     async fn run(&mut self, state: &mut StateMut, context: &Context) -> Result<()>;
 
-    fn get_span(&self) -> Span;
+    fn span(&self) -> Span;
 }
 
 pub trait PackageCreator: GetWorkerExpStartMsg + Send + Sync {

--- a/packages/engine/src/simulation/package/state/mod.rs
+++ b/packages/engine/src/simulation/package/state/mod.rs
@@ -3,6 +3,7 @@ pub mod packages;
 use std::sync::Arc;
 
 pub use packages::{Name, StateTask, StateTaskMessage, PACKAGE_CREATORS};
+use tracing::Span;
 
 use super::{deps::Dependencies, ext_traits::GetWorkerSimStartMsg, prelude::*};
 pub use crate::config::Globals;
@@ -23,6 +24,8 @@ use crate::{
 #[async_trait]
 pub trait Package: GetWorkerSimStartMsg + Send + Sync {
     async fn run(&mut self, state: &mut StateMut, context: &Context) -> Result<()>;
+
+    fn get_span(&self) -> Span;
 }
 
 pub trait PackageCreator: GetWorkerExpStartMsg + Send + Sync {

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/mod.rs
@@ -238,7 +238,7 @@ impl Package for BehaviorExecution {
         Ok(())
     }
 
-    fn get_span(&self) -> Span {
+    fn span(&self) -> Span {
         tracing::debug_span!("behavior_execution")
     }
 }

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/mod.rs
@@ -18,10 +18,13 @@ use crate::{
     simulation::{
         package::{
             name::PackageName,
-            state::packages::behavior_execution::{
-                config::BehaviorIds,
-                fields::{BEHAVIOR_IDS_FIELD_NAME, BEHAVIOR_INDEX_FIELD_NAME},
-                tasks::ExecuteBehaviorsTask,
+            state::{
+                packages::behavior_execution::{
+                    config::BehaviorIds,
+                    fields::{BEHAVIOR_IDS_FIELD_NAME, BEHAVIOR_INDEX_FIELD_NAME},
+                    tasks::ExecuteBehaviorsTask,
+                },
+                Package,
             },
         },
         task::{active::ActiveTask, Task},

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/mod.rs
@@ -234,4 +234,8 @@ impl Package for BehaviorExecution {
         tracing::trace!("BehaviorExecution task finished: {:?}", &msg);
         Ok(())
     }
+
+    fn get_span(&self) -> Span {
+        tracing::debug_span!("behavior_execution")
+    }
 }

--- a/packages/engine/src/simulation/package/state/packages/topology/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/topology/mod.rs
@@ -90,7 +90,7 @@ impl Package for Topology {
         Ok(())
     }
 
-    fn get_span(&self) -> Span {
+    fn span(&self) -> Span {
         tracing::debug_span!("topology")
     }
 }

--- a/packages/engine/src/simulation/package/state/packages/topology/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/topology/mod.rs
@@ -89,4 +89,8 @@ impl Package for Topology {
         }
         Ok(())
     }
+
+    fn get_span(&self) -> Span {
+        tracing::debug_span!("topology")
+    }
 }

--- a/packages/engine/src/worker/runner/javascript/mod.rs
+++ b/packages/engine/src/worker/runner/javascript/mod.rs
@@ -953,11 +953,6 @@ impl<'m> RunnerImpl<'m> {
         let (next_target, next_task_payload) = get_next_task(mv8, &r)?;
 
         let next_inner_task_msg: serde_json::Value = serde_json::from_str(&next_task_payload)?;
-        tracing::trace!(
-            "Wrapper: {:?}, next_inner: {:?}",
-            &wrapper,
-            &next_inner_task_msg
-        );
         let next_task_payload =
             TaskMessage::try_from_inner_msg_and_wrapper(next_inner_task_msg, wrapper).map_err(
                 |err| {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

Expands upon the work done in #228 by adding more spans around key parts of code execution. 
This greatly improves the timings produced by TeXRay, and adds additional information to general logging.

It also cleans up some of the logging in general, where we have messages that are far too large to be printed.

## 🔍 What does this change?
- Overrides the Debug impl for the `SuccessMessage` in the JsPy init package, as we shouldn't be printing the full Agent JSON, that can be far too large
- Removes a trace log in the Javascript runner where we log every message (including init messages like above) which can be far too large and pollutes the logs.
- Adds Spans for the following
  - Running Init Packages 
  - Preparing for Context Packages
  - Running Context Packages
    - A span for each package
      - A span for the run method
      - A span for the write method
  - Running State Packages
    - A span for each package 
  - Running Output Packages
    - A span for each package 

To do this it adds a `get_span` method on most Packages so they can provide the span they want wrapped around their execution (this is necessary as we have trait objects for Packages so we can't set it manually)

### Does this require a change to the docs?

Nope

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as (_internal_) -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201481007343159/1201734259001872/f) (_internal_)

## 🛡 What tests cover this?

- This shouldn't affect functionalities, so the normal integration tests passing is sufficient

## ❓ How to test this?

1. Checkout the branch / view the deployment
2. Run a simulation with `RUST_LOG=info` and look for spans on events happening in the situations mentioned above, then run with `RUST_LOG=trace` and note the additional span information that's provided
3. Optionally run with `--features "texray"` for both cases above and look at the output in the log folder.

## 📹 Demo

### Logs in Debug
![image](https://user-images.githubusercontent.com/25749103/151608632-6994d168-d9fa-46c4-bb5b-d8deb765ee35.png)

### Logs in Trace
![image](https://user-images.githubusercontent.com/25749103/151607835-b234a0c7-be52-4d49-ad38-d1fb5701f59f.png)

### TeXRay in Info
![image](https://user-images.githubusercontent.com/25749103/151608781-65d424fc-193d-4734-aef1-e34938853e77.png)

### TeXRay in Debug
![image](https://user-images.githubusercontent.com/25749103/151608535-51de5085-393f-4b36-8f82-b73b3634baf3.png)

### TeXRay in Trace
![image](https://user-images.githubusercontent.com/25749103/151608447-04684b33-2f33-49ad-9ae1-1b1386a10a3e.png)