### PR TITLE
[FE] Fix media blocks updates in hub

### DIFF
--- a/packages/blocks/image/src/Image.tsx
+++ b/packages/blocks/image/src/Image.tsx
@@ -109,11 +109,13 @@ export const Image: BlockComponent<AppProps> = (props) => {
     loading: boolean;
     width: number | undefined;
     errorString: string | null;
+    userIsEditing: boolean;
   }>({
     src: "",
     width: initialWidth,
     loading: false,
     errorString: null,
+    userIsEditing: !url,
   });
 
   const [inputText, setInputText] = useState("");
@@ -270,8 +272,8 @@ export const Image: BlockComponent<AppProps> = (props) => {
             ]);
 
             if (isMounted.current) {
-              updateStateObject({ loading: false });
               updateData({ src: file.url, file });
+              updateStateObject({ loading: false, userIsEditing: false });
             }
           })
           .catch((error: Error) =>
@@ -324,6 +326,7 @@ export const Image: BlockComponent<AppProps> = (props) => {
         errorString: null,
         src: "",
         width: undefined,
+        userIsEditing: true,
       });
 
       setInputText("");
@@ -331,7 +334,7 @@ export const Image: BlockComponent<AppProps> = (props) => {
     });
   };
 
-  if (stateObject.src?.trim() || url) {
+  if (stateObject.src?.trim() || (url && !stateObject.userIsEditing)) {
     return (
       <div className={tw`flex justify-center text-center w-full`}>
         <div className={tw`flex flex-col`}>

--- a/packages/blocks/video/src/Video.tsx
+++ b/packages/blocks/video/src/Video.tsx
@@ -103,10 +103,12 @@ export const Video: BlockComponent<AppProps> = (props) => {
     src: string;
     loading: boolean;
     errorString: string | null;
+    userIsEditing: boolean;
   }>({
     src: "",
     loading: false,
     errorString: null,
+    userIsEditing: !url,
   });
 
   const isMounted = useRef(false);
@@ -229,8 +231,8 @@ export const Video: BlockComponent<AppProps> = (props) => {
             ]);
 
             if (isMounted.current) {
-              updateStateObject({ loading: false });
               updateData({ file, src: file.url });
+              updateStateObject({ loading: false, userIsEditing: false });
             }
           })
           .catch((error: Error) =>
@@ -283,6 +285,7 @@ export const Video: BlockComponent<AppProps> = (props) => {
         loading: false,
         errorString: null,
         src: "",
+        userIsEditing: true,
       });
 
       setInputText("");
@@ -290,7 +293,7 @@ export const Video: BlockComponent<AppProps> = (props) => {
     });
   };
 
-  if (stateObject.src?.trim() || url) {
+  if (stateObject.src?.trim() || (url && !stateObject.userIsEditing)) {
     return (
       <div className={tw`flex justify-center text-center w-full`}>
         <div className={tw`max-w-full`}>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

In the present demo for media blocks in the [blocks hub](https://blockprotocol.org/hub), the media blocks appear to be working fine on first render. However, on clicking the editing pencil, one quickly realizes the blocks update don't work, which I have traced back to the UI rendering condition I've updated in this PR.

As a part of this PR, users will be able to update the media blocks as easily as they do so in the HASH app.

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- [Add `userIsEditing` key to handle edit state](https://github.com/hashintel/hash/pull/244/files#diff-6885e28abf53ee8f6e0799552660e0d4e4e9a00bdb59ad43b19c7d091bca4f0cR112)
- [Decide which state to render based on the previous state](https://github.com/hashintel/hash/pull/244/files#diff-e0b0728aab1c50ff39ee7d7178fc58c8369c8585841d34962443bfc463cb72a7R296)

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as (_internal_) -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Fix media blocks updates for Hub](https://app.asana.com/0/1201668052739245/1201741313328393/f)

## ❓ How to test this?

- Pass a default URL to either video or image blocks in local dev
- Try clicking on edit icon, the upload form should pop up.

