### PR TITLE
Fix getting batch at maybe existing index

### DIFF
--- a/packages/engine/src/datastore/table/pool/agent.rs
+++ b/packages/engine/src/datastore/table/pool/agent.rs
@@ -58,18 +58,19 @@ impl AgentPool {
     pub fn get_batch_at_index(
         &self,
         index: usize,
-    ) -> Result<Option<RwLockWriteGuard<'_, AgentBatch>>> {
-        let batch = self
-            .batches
-            .get(index)
-            .map(|batch| batch.try_write())
-            .ok_or_else(|| {
-                Error::from(format!(
-                    "failed to get write lock for batch at index: {}",
-                    index
-                ))
-            })?;
-        Ok(batch)
+    ) -> Result<Option<RwLockReadGuard<'_, AgentBatch>>> {
+        let batch = match self.batches.get(index) {
+            Some(batch) => batch,
+            None => return Ok(None),
+        };
+
+        let batch = batch
+            .try_read()
+            .ok_or_else(|| Error::from(format!(
+                "Failed to get read lock for agent batch at index {}",
+                index
+            )))?;
+        Ok(Some(batch))
     }
 
     pub fn set_pending_column(&mut self, column: StateColumn) -> Result<()> {

--- a/packages/engine/src/datastore/table/pool/agent.rs
+++ b/packages/engine/src/datastore/table/pool/agent.rs
@@ -66,8 +66,7 @@ impl AgentPool {
 
         let batch = batch.try_read().ok_or_else(|| {
             Error::from(format!(
-                "Failed to get read lock for agent batch at index {}",
-                index
+                "Failed to get read lock for agent batch at index {index}"
             ))
         })?;
         Ok(Some(batch))

--- a/packages/engine/src/datastore/table/pool/agent.rs
+++ b/packages/engine/src/datastore/table/pool/agent.rs
@@ -64,12 +64,12 @@ impl AgentPool {
             None => return Ok(None),
         };
 
-        let batch = batch
-            .try_read()
-            .ok_or_else(|| Error::from(format!(
+        let batch = batch.try_read().ok_or_else(|| {
+            Error::from(format!(
                 "Failed to get read lock for agent batch at index {}",
                 index
-            )))?;
+            ))
+        })?;
         Ok(Some(batch))
     }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR fixes the function `get_batch_at_index` to return `Some(batch)` if there is a batch at that index and `None` otherwise. Previously when there wasn't a batch at the index, it returned a misleading error about acquiring a write lock.

## 🔍 What does this change?

* `get_batch_at_index` returns `None` when there is no batch at the index.
* `get_batch_at_index` acquires a read lock, not a write lock, because a write lock isn't necessary.

### Does this require a change to the docs?

No

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201481007343159/1201545519802517/f) (_internal_)

## 🛡 What tests cover this?

Integration tests

## ❓ How to test this?

1.  Run JavaScript integration tests.
2. No errors like "failed to acquire batch lock" should occur.
