### PR TITLE
Fix `--num-workers` panicking when passing an invalid digit

### DIFF
--- a/packages/engine/lib/orchestrator/src/experiment.rs
+++ b/packages/engine/lib/orchestrator/src/experiment.rs
@@ -81,18 +81,18 @@ pub struct ExperimentConfig {
     /// Defaults to the number of logical CPUs available in order to maximize performance.
     #[cfg_attr(
         feature = "clap",
-        clap(short = 'w', long, default_value_t = num_cpus::get(), validator = at_least_one,
-             env = "HASH_WORKERS")
+        clap(short = 'w', long, default_value_t = num_cpus::get(), validator = at_least_one, env = "HASH_WORKERS")
     )]
     pub num_workers: usize,
 }
 
-fn at_least_one(v: &str) -> core::result::Result<(), &'static str> {
-    let num: usize = v.parse().unwrap();
-    if num > 0 {
-        Ok(())
+#[cfg(feature = "clap")]
+fn at_least_one(v: &str) -> core::result::Result<(), String> {
+    let num = v.parse::<usize>().map_err(|e| e.to_string())?;
+    if num == 0 {
+        Err("must be at least 1".to_string())
     } else {
-        Err("Must be at least 1")
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The CLI panicked when providing an invalid number to `--num-workers` as `validator = ` replaces the default validator.

## 🐾 Next steps

Make CLI arguments global so one can pass things like `--num-workers` after the subcommand

## 🔍 What does this change?

- Forwards the error returned from `parse`
- Add conditional compilation for the otherwise unused function `at_least_one`

## ❓ How to test this?

Run the CLI with different arguments to `--num-workers`