### PR TITLE
[ENGINE] Make CLI arguments global

### DIFF
--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use clap::{AppSettings, Parser};
-use error::{report, Result, ResultExt};
+use error::{Result, ResultExt};
 use hash_engine::proto::ExperimentName;
 use orchestrator::{Experiment, ExperimentConfig, Manifest, Server};
 

--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -21,12 +21,6 @@ pub struct Args {
     #[clap(short, long, env = "HASH_PROJECT")]
     project: PathBuf,
 
-    /// The Project Name.
-    ///
-    /// If not provided, the name of the project directory will be used.
-    #[clap(short = 'n', long)]
-    project_name: Option<String>,
-
     #[clap(flatten)]
     experiment_config: ExperimentConfig,
 
@@ -111,13 +105,5 @@ async fn main() -> Result<()> {
 
     let experiment = Experiment::new(args.experiment_config);
 
-    let project_name = args.project_name.clone().unwrap_or(
-        absolute_project_path
-            .file_name()
-            .ok_or_else(|| report!("Project path didn't point to a directory: {absolute_project_path:?}"))? // Shouldn't be able to fail as we canonicalize above
-            .to_string_lossy()
-            .to_string(),
-    );
-
-    experiment.run(experiment_run, project_name, handler).await
+    experiment.run(experiment_run, handler).await
 }

--- a/packages/engine/lib/orchestrator/src/experiment.rs
+++ b/packages/engine/lib/orchestrator/src/experiment.rs
@@ -176,11 +176,10 @@ impl Experiment {
     /// returns once the experiment has finished.
     ///
     /// [`Process`]: crate::process::Process
-    #[instrument(skip_all, fields(project_name = project_name.as_str(), experiment_id = % experiment_run.base.id))]
+    #[instrument(skip_all, fields(experiment_name = %experiment_run.base.name, experiment_id = %experiment_run.base.id))]
     pub async fn run(
         &self,
         experiment_run: proto::ExperimentRun,
-        project_name: String,
         mut handler: Handler,
     ) -> Result<()> {
         let experiment_name = experiment_run.base.name.clone();

--- a/packages/engine/lib/orchestrator/src/experiment.rs
+++ b/packages/engine/lib/orchestrator/src/experiment.rs
@@ -36,6 +36,7 @@ pub struct ExperimentConfig {
     #[cfg_attr(
         feature = "clap",
         clap(
+            global = true,
             short,
             long = "output",
             default_value = "./output",
@@ -47,7 +48,13 @@ pub struct ExperimentConfig {
     /// Logging output format to be emitted
     #[cfg_attr(
         feature = "clap",
-        clap(long, default_value = "pretty", arg_enum, env = "HASH_LOG_FORMAT")
+        clap(
+            global = true,
+            long,
+            default_value = "pretty",
+            arg_enum,
+            env = "HASH_LOG_FORMAT"
+        )
     )]
     pub log_format: LogFormat,
 
@@ -55,24 +62,24 @@ pub struct ExperimentConfig {
     ///
     /// Can be `stdout`, `stderr` or any file name. Relative to `--log-folder` if a file is
     /// specified.
-    #[cfg_attr(feature = "clap", clap(long, default_value = "stderr"))]
+    #[cfg_attr(feature = "clap", clap(global = true, long, default_value = "stderr"))]
     pub output_location: OutputLocation,
 
     /// Logging output folder.
-    #[cfg_attr(feature = "clap", clap(long, default_value = "./log"))]
+    #[cfg_attr(feature = "clap", clap(global = true, long, default_value = "./log"))]
     pub log_folder: PathBuf,
 
     /// Timeout, in seconds, for how long to wait for a response when the Engine starts
     #[cfg_attr(
         feature = "clap",
-        clap(long, default_value = "2", env = "ENGINE_START_TIMEOUT")
+        clap(global = true, long, default_value = "2", env = "ENGINE_START_TIMEOUT")
     )]
     pub start_timeout: u64,
 
     /// Timeout, in seconds, for how long to wait for updates when the Engine is executing
     #[cfg_attr(
         feature = "clap",
-        clap(long, default_value = "60", env = "ENGINE_WAIT_TIMEOUT")
+        clap(global = true, long, default_value = "60", env = "ENGINE_WAIT_TIMEOUT")
     )]
     pub wait_timeout: u64,
 
@@ -81,7 +88,7 @@ pub struct ExperimentConfig {
     /// Defaults to the number of logical CPUs available in order to maximize performance.
     #[cfg_attr(
         feature = "clap",
-        clap(short = 'w', long, default_value_t = num_cpus::get(), validator = at_least_one, env = "HASH_WORKERS")
+        clap(global = true, short = 'w', long, default_value_t = num_cpus::get(), validator = at_least_one, env = "HASH_WORKERS")
     )]
     pub num_workers: usize,
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Mark a lot of the CLI arguments as global if they are not required (limited behavior by clap). We do this so it doesn't matter if the parameters are passed before or after the subcommand (`single-run` or `simple`). Without doing this, the error message was very unclear when a user put, for example, `--num-workers` after `single-run`.

## 🔍 What does this change?

- Remove unused CLI arguments, left over from previous changes
- Add `global = true` to clap arguments