### PR TITLE
Don't process entities twice when creating entity store

### DIFF
--- a/packages/hash/api/src/collab/Instance.ts
+++ b/packages/hash/api/src/collab/Instance.ts
@@ -6,10 +6,7 @@ import {
   BlockEntity,
   isTextContainingEntityProperties,
 } from "@hashintel/hash-shared/entity";
-import {
-  EntityStore,
-  walkValueForEntity,
-} from "@hashintel/hash-shared/entityStore";
+import { EntityStore } from "@hashintel/hash-shared/entityStore";
 import {
   addEntityStoreAction,
   disableEntityStoreTransactionInterpretation,
@@ -43,6 +40,7 @@ import { logger } from "../logger";
 import { EntityWatcher } from "./EntityWatcher";
 import { InvalidVersionError } from "./errors";
 import { CollabPositionPoller, TimedCollabPosition } from "./types";
+import { walkValueForEntity } from "./util";
 import { Waiting } from "./Waiting";
 
 const MAX_STEP_HISTORY = 10000;

--- a/packages/hash/api/src/collab/util.ts
+++ b/packages/hash/api/src/collab/util.ts
@@ -1,3 +1,61 @@
+import { EntityStoreType, isEntity } from "@hashintel/hash-shared/entityStore";
 import { getRequiredEnv } from "../util";
 
 export const COLLAB_QUEUE_NAME = getRequiredEnv("HASH_COLLAB_QUEUE_NAME");
+
+type Entries<T> = {
+  [K in keyof T]: [K, T[K]];
+}[keyof T][];
+
+/**
+ * @see https://stackoverflow.com/a/60142095
+ */
+const typeSafeEntries = <T>(obj: T): Entries<T> => Object.entries(obj) as any;
+
+const walkObjectValueForEntity = <T extends {}>(
+  value: T,
+  entityHandler: <E extends EntityStoreType>(entity: E) => E,
+): T => {
+  let changed = false;
+  let result = value;
+
+  for (const [key, innerValue] of typeSafeEntries(value)) {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    const nextValue = walkValueForEntity(innerValue, entityHandler);
+
+    if (nextValue !== innerValue) {
+      if (!changed) {
+        result = (Array.isArray(value) ? [...value] : { ...value }) as T;
+      }
+
+      changed = true;
+      result[key] = nextValue;
+    }
+  }
+
+  if (isEntity(value)) {
+    const nextValue = entityHandler(value);
+
+    if (nextValue !== value) {
+      changed = true;
+      result = nextValue;
+    }
+  }
+
+  return changed ? result : value;
+};
+
+/**
+ * @deprecated
+ * @todo remove this when we have a flat entity store
+ */
+export const walkValueForEntity = <T>(
+  value: T,
+  entityHandler: <E extends EntityStoreType>(entity: E) => E,
+): T => {
+  if (typeof value !== "object" || value === null) {
+    return value;
+  }
+
+  return walkObjectValueForEntity(value, entityHandler);
+};

--- a/packages/hash/shared/src/entityStore.ts
+++ b/packages/hash/shared/src/entityStore.ts
@@ -128,7 +128,7 @@ const findEntities = (contents: EntityStoreType[]) => {
       if (
         isTextContainingEntityProperties(entity.properties.entity.properties)
       ) {
-        entities.push(entity, entity.properties.entity.properties.text.data);
+        entities.push(entity.properties.entity.properties.text.data);
       }
     }
     return entity;

--- a/packages/hash/shared/src/entityStore.ts
+++ b/packages/hash/shared/src/entityStore.ts
@@ -1,6 +1,6 @@
 import { Draft, produce } from "immer";
 import { BlockEntity, isTextContainingEntityProperties } from "./entity";
-import { DistributiveOmit, typeSafeEntries } from "./util";
+import { DistributiveOmit } from "./util";
 
 export type EntityStoreType = BlockEntity | BlockEntity["properties"]["entity"];
 
@@ -69,54 +69,6 @@ export const draftEntityForEntityId = (
   draft: EntityStore["draft"],
   entityId: string,
 ) => Object.values(draft).find((entity) => entity.entityId === entityId);
-
-export const walkObjectValueForEntity = <T extends {}>(
-  value: T,
-  entityHandler: <E extends EntityStoreType>(entity: E) => E,
-): T => {
-  let changed = false;
-  let result = value;
-
-  for (const [key, innerValue] of typeSafeEntries(value)) {
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    const nextValue = walkValueForEntity(innerValue, entityHandler);
-
-    if (nextValue !== innerValue) {
-      if (!changed) {
-        result = (Array.isArray(value) ? [...value] : { ...value }) as T;
-      }
-
-      changed = true;
-      result[key] = nextValue;
-    }
-  }
-
-  if (isEntity(value)) {
-    const nextValue = entityHandler(value);
-
-    if (nextValue !== value) {
-      changed = true;
-      result = nextValue;
-    }
-  }
-
-  return changed ? result : value;
-};
-
-/**
- * @deprecated
- * @todo remove this when we have a flat entity store
- */
-export const walkValueForEntity = <T>(
-  value: T,
-  entityHandler: <E extends EntityStoreType>(entity: E) => E,
-): T => {
-  if (typeof value !== "object" || value === null) {
-    return value;
-  }
-
-  return walkObjectValueForEntity(value, entityHandler);
-};
 
 const findEntities = (contents: BlockEntity[]): EntityStoreType[] => {
   const entities: EntityStoreType[] = [];

--- a/packages/hash/shared/src/entityStore.ts
+++ b/packages/hash/shared/src/entityStore.ts
@@ -118,21 +118,16 @@ export const walkValueForEntity = <T>(
   return walkObjectValueForEntity(value, entityHandler);
 };
 
-const findEntities = (contents: EntityStoreType[]) => {
+const findEntities = (contents: BlockEntity[]): EntityStoreType[] => {
   const entities: EntityStoreType[] = [];
 
-  walkValueForEntity(contents, (entity) => {
-    if (isBlockEntity(entity)) {
-      entities.push(entity, entity.properties.entity);
+  for (const entity of contents) {
+    entities.push(entity, entity.properties.entity);
 
-      if (
-        isTextContainingEntityProperties(entity.properties.entity.properties)
-      ) {
-        entities.push(entity.properties.entity.properties.text.data);
-      }
+    if (isTextContainingEntityProperties(entity.properties.entity.properties)) {
+      entities.push(entity.properties.entity.properties.text.data);
     }
-    return entity;
-  });
+  }
 
   return entities;
 };
@@ -158,7 +153,7 @@ const restoreDraftId = (
  * @todo clean up
  */
 export const createEntityStore = (
-  contents: EntityStoreType[],
+  contents: BlockEntity[],
   draftData: Record<string, DraftEntity>,
 ): EntityStore => {
   const saved: EntityStore["saved"] = {};

--- a/packages/hash/shared/src/util.ts
+++ b/packages/hash/shared/src/util.ts
@@ -43,16 +43,6 @@ export const collect = <P extends Array<any>>(
   };
 };
 
-type Entries<T> = {
-  [K in keyof T]: [K, T[K]];
-}[keyof T][];
-
-/**
- * @see https://stackoverflow.com/a/60142095
- */
-export const typeSafeEntries = <T>(obj: T): Entries<T> =>
-  Object.entries(obj) as any;
-
 export const isFileProperties = (props: {}): props is FileProperties => {
   return (
     "key" in props &&


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

In order to create an entity store from a given entity or set of entities, we walk the value looking for values that look like block entities, and then insert the block entity and any important "subentities" (i.e, `block.properties.entity` and also any text entities if this is a text block). 

This process currently returns multiple copies of the block entity when working on text variants. This is a bug, but probably harmless. This PR fixes that bug. 

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

N/A

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

N/A

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

This bug/simplification was discovered when updating collab's change detection/processing mechanism – a PR depending on this PR will follow. 

- https://github.com/hashintel/hash/pull/260

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- `findEntities` won't now return duplicates when building an entity store from a text block with a variant entity. 
- `findEntities` doesn't need to use `walkValueForEntity` as we know we're working directly on block entities in `createEntityStore` – therefore `walkValueForEntity` can be moved out of shared 

### Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

No 

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as (_internal_) -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task Remove duplicate block entity processing when building an entity store](https://app.asana.com/0/1201095311341924/1201759257251081/f) (_internal_)

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Log entities processed in `createEntityStore` (returned by `findEntities`) and ensure you don't see any duplicate blocks entities 