### PR TITLE
Refresh entire block when an entity within it changes in postgres

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "seed-data": "concurrently \"yarn:seed-data:*\"",
     "test:backend-integration": "yarn workspace @hashintel/hash-integration test",
     "test:playwright": "yarn workspace @hashintel/hash-playwright playwright test",
-    "test:unit": "yarn workspace @hashintel/hash-api test && yarn workspace @hashintel/hash-frontend test"
+    "test:unit": "yarn workspace @hashintel/hash-api test && yarn workspace @hashintel/hash-shared test && yarn workspace @hashintel/hash-frontend test"
   },
   "lint-staged": {
     "**/*": [

--- a/packages/hash/api/src/collab/Instance.ts
+++ b/packages/hash/api/src/collab/Instance.ts
@@ -172,10 +172,12 @@ export class Instance {
   private async processEntityVersion(entityVersion: EntityVersion) {
     const entityVersionTime = new Date(entityVersion.updatedAt).getTime();
     const blocksToRefresh = new Set<BlockFilter>();
+    const versionFilter = blockFilter(entityVersion);
 
     walkValueForEntity(this.savedContents, (entity, blockEntity) => {
+      const filter = blockFilter(entity);
       if (
-        entity.entityId === entityVersion.entityId &&
+        filter === versionFilter &&
         entityVersionTime > new Date(entity.updatedAt).getTime()
       ) {
         blocksToRefresh.add(blockFilter(blockEntity));

--- a/packages/hash/api/src/collab/Instance.ts
+++ b/packages/hash/api/src/collab/Instance.ts
@@ -204,7 +204,7 @@ export class Instance {
       const refreshedPageBlocks = new Map<LatestEntityRef, BlockEntity>(
         refreshedBlocksQuery.data.blocks.map(
           (block) => [getEntityRef(block), block] as const,
-        ) ?? [],
+        ),
       );
 
       const nextSavedContents = this.savedContents.map((block) => {

--- a/packages/hash/api/src/collab/util.ts
+++ b/packages/hash/api/src/collab/util.ts
@@ -1,3 +1,4 @@
+import { BlockEntity } from "@hashintel/hash-shared/entity";
 import {
   EntityStoreType,
   isBlockEntity,
@@ -9,26 +10,26 @@ export const COLLAB_QUEUE_NAME = getRequiredEnv("HASH_COLLAB_QUEUE_NAME");
 
 export const walkValueForEntity = (
   value: unknown,
-  entityHandler: (entity: EntityStoreType, blockId: string) => void,
-  blockId: string | null = null,
+  entityHandler: (entity: EntityStoreType, block: BlockEntity) => void,
+  parentBlock: BlockEntity | null = null,
 ) => {
   if (typeof value === "object" && value !== null) {
-    let blockEntityId = blockId;
+    let blockEntity = parentBlock;
 
     if (isBlockEntity(value)) {
-      blockEntityId = value.entityId;
+      blockEntity = value;
     }
 
     for (const innerValue of Object.values(value)) {
-      walkValueForEntity(innerValue, entityHandler, blockEntityId);
+      walkValueForEntity(innerValue, entityHandler, blockEntity);
     }
 
     if (isEntity(value)) {
-      if (!blockEntityId) {
-        throw new Error("Missing block entity id");
+      if (!blockEntity) {
+        throw new Error("Missing block entity");
       }
 
-      entityHandler(value, blockEntityId);
+      entityHandler(value, blockEntity);
     }
   }
 };

--- a/packages/hash/api/src/collab/util.ts
+++ b/packages/hash/api/src/collab/util.ts
@@ -1,35 +1,3 @@
-import { BlockEntity } from "@hashintel/hash-shared/entity";
-import {
-  EntityStoreType,
-  isBlockEntity,
-  isEntity,
-} from "@hashintel/hash-shared/entityStore";
 import { getRequiredEnv } from "../util";
 
 export const COLLAB_QUEUE_NAME = getRequiredEnv("HASH_COLLAB_QUEUE_NAME");
-
-export const walkValueForEntity = (
-  value: unknown,
-  entityHandler: (entity: EntityStoreType, block: BlockEntity) => void,
-  parentBlock: BlockEntity | null = null,
-) => {
-  if (typeof value === "object" && value !== null) {
-    let blockEntity = parentBlock;
-
-    if (isBlockEntity(value)) {
-      blockEntity = value;
-    }
-
-    for (const innerValue of Object.values(value)) {
-      walkValueForEntity(innerValue, entityHandler, blockEntity);
-    }
-
-    if (isEntity(value)) {
-      if (!blockEntity) {
-        throw new Error("Missing block entity");
-      }
-
-      entityHandler(value, blockEntity);
-    }
-  }
-};

--- a/packages/hash/api/src/graphql/resolvers/block/blocks.ts
+++ b/packages/hash/api/src/graphql/resolvers/block/blocks.ts
@@ -1,0 +1,16 @@
+import { UnresolvedGQLEntity } from "../../../model";
+
+import { QueryBlocksArgs, Resolver } from "../../apiTypes.gen";
+import { GraphQLContext } from "../../context";
+import { getBlocks } from "../pages/contents";
+
+export const blocks: Resolver<
+  Promise<UnresolvedGQLEntity[]>,
+  {},
+  GraphQLContext,
+  QueryBlocksArgs
+> = async (_, args, ctx) => {
+  const { dataSources } = ctx;
+
+  return args.blocks ? await getBlocks(dataSources.db, args.blocks) : [];
+};

--- a/packages/hash/api/src/graphql/resolvers/block/blocks.ts
+++ b/packages/hash/api/src/graphql/resolvers/block/blocks.ts
@@ -12,5 +12,5 @@ export const blocks: Resolver<
 > = async (_, args, ctx) => {
   const { dataSources } = ctx;
 
-  return args.blocks ? await getBlocks(dataSources.db, args.blocks) : [];
+  return await getBlocks(dataSources.db, args.blocks);
 };

--- a/packages/hash/api/src/graphql/resolvers/block/index.ts
+++ b/packages/hash/api/src/graphql/resolvers/block/index.ts
@@ -1,5 +1,7 @@
 import { blockEntity } from "./blockEntity";
 
+export { blocks } from "./blocks";
+
 export const blockFields = {
   entity: blockEntity,
 };

--- a/packages/hash/api/src/graphql/resolvers/index.ts
+++ b/packages/hash/api/src/graphql/resolvers/index.ts
@@ -13,7 +13,7 @@ import {
 } from "./entity";
 import { createLink } from "./link/createLink";
 import { deleteLink } from "./link/deleteLink";
-import { blockFields } from "./block";
+import { blockFields, blocks } from "./block";
 import {
   createPage,
   accountPages,
@@ -78,6 +78,7 @@ export const resolvers = {
         accounts,
       ) /** @todo: make accessible to admins only (or deprecate) */,
     aggregateEntity: loggedInAndSignedUp(aggregateEntity),
+    blocks: loggedInAndSignedUp(blocks),
     getAccountEntityTypes: loggedInAndSignedUp(getAccountEntityTypes),
     entity: loggedInAndSignedUp(entity),
     entities: loggedInAndSignedUp(canAccessAccount(entities)),

--- a/packages/hash/api/src/graphql/typeDefs/block.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/block.typedef.ts
@@ -87,4 +87,16 @@ export const blockTypedef = gql`
     entity: UnknownEntity!
     componentId: ID!
   }
+
+  input BlockFilter {
+    accountId: ID!
+    entityId: ID!
+  }
+
+  extend type Query {
+    """
+    Get a specified list of blocks by accountId and entityId
+    """
+    blocks(blocks: [BlockFilter!]): [Block!]!
+  }
 `;

--- a/packages/hash/api/src/graphql/typeDefs/block.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/block.typedef.ts
@@ -97,6 +97,6 @@ export const blockTypedef = gql`
     """
     Get a specified list of blocks by accountId and entityId
     """
-    blocks(blocks: [BlockFilter!]): [Block!]!
+    blocks(blocks: [BlockFilter!]!): [Block!]!
   }
 `;

--- a/packages/hash/api/src/graphql/typeDefs/block.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/block.typedef.ts
@@ -88,7 +88,8 @@ export const blockTypedef = gql`
     componentId: ID!
   }
 
-  input BlockFilter {
+  # Similar to EntityRef, except not linked to a specific version of the Entity
+  input LatestEntityRef {
     accountId: ID!
     entityId: ID!
   }
@@ -97,6 +98,6 @@ export const blockTypedef = gql`
     """
     Get a specified list of blocks by accountId and entityId
     """
-    blocks(blocks: [BlockFilter!]!): [Block!]!
+    blocks(blocks: [LatestEntityRef!]!): [Block!]!
   }
 `;

--- a/packages/hash/shared/package.json
+++ b/packages/hash/shared/package.json
@@ -19,7 +19,8 @@
     "fix:eslint": "eslint --ext .js,.ts,.tsx --fix ./src/",
     "postinstall": "yarn codegen",
     "lint:eslint": "eslint --ext .js,.ts,.tsx ./src/",
-    "lint:tsc": "tsc --noEmit"
+    "lint:tsc": "tsc --noEmit",
+    "test": "jest"
   },
   "dependencies": {
     "@apollo/client": "3.3.21",

--- a/packages/hash/shared/src/entity.test.ts
+++ b/packages/hash/shared/src/entity.test.ts
@@ -1,0 +1,141 @@
+import { flatMapTree } from "./util";
+
+describe("flatMapTree", () => {
+  it("can flatmap simple properties", () => {
+    const test1 = [
+      {
+        rootId: "1",
+        children: {
+          relatesTo: { entityId: "id2" },
+        },
+      },
+      {
+        rootId: "2",
+        children: {
+          entityId: "xid1",
+        },
+      },
+    ];
+
+    const result = [];
+    for (const block of test1) {
+      result.push(
+        ...flatMapTree(block, (node: any) => {
+          return [node];
+        }),
+      );
+    }
+
+    expect(result).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "children": Object {
+      "relatesTo": Object {
+        "entityId": "id2",
+      },
+    },
+    "rootId": "1",
+  },
+  "1",
+  Object {
+    "relatesTo": Object {
+      "entityId": "id2",
+    },
+  },
+  Object {
+    "entityId": "id2",
+  },
+  "id2",
+  Object {
+    "children": Object {
+      "entityId": "xid1",
+    },
+    "rootId": "2",
+  },
+  "2",
+  Object {
+    "entityId": "xid1",
+  },
+  "xid1",
+]
+`);
+  });
+
+  it("can flatmap simple properties", () => {
+    const test1 = [
+      {
+        rootId: "1",
+        children: ["one", "two"],
+      },
+      {
+        rootId: "2",
+        children: {
+          entityId: "xid1",
+          relatesTo: { entityId: "xid2", relatesTo: { entityId: "xid3" } },
+        },
+      },
+    ];
+
+    const result = [];
+    for (const block of test1) {
+      result.push(
+        ...flatMapTree(block, (node: any) => {
+          return [node];
+        }),
+      );
+    }
+
+    expect(result).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "children": Array [
+      "one",
+      "two",
+    ],
+    "rootId": "1",
+  },
+  "1",
+  Array [
+    "one",
+    "two",
+  ],
+  "one",
+  "two",
+  Object {
+    "children": Object {
+      "entityId": "xid1",
+      "relatesTo": Object {
+        "entityId": "xid2",
+        "relatesTo": Object {
+          "entityId": "xid3",
+        },
+      },
+    },
+    "rootId": "2",
+  },
+  "2",
+  Object {
+    "entityId": "xid1",
+    "relatesTo": Object {
+      "entityId": "xid2",
+      "relatesTo": Object {
+        "entityId": "xid3",
+      },
+    },
+  },
+  "xid1",
+  Object {
+    "entityId": "xid2",
+    "relatesTo": Object {
+      "entityId": "xid3",
+    },
+  },
+  "xid2",
+  Object {
+    "entityId": "xid3",
+  },
+  "xid3",
+]
+`);
+  });
+});

--- a/packages/hash/shared/src/entity.ts
+++ b/packages/hash/shared/src/entity.ts
@@ -8,7 +8,12 @@ import {
   isEntity,
 } from "./entityStore";
 import { PageFieldsFragment, Text } from "./graphql/apiTypes.gen";
-import { DistributiveOmit, DistributivePick, isUnknownObject } from "./util";
+import {
+  DistributiveOmit,
+  DistributivePick,
+  flatMapTree,
+  isUnknownObject,
+} from "./util";
 
 type ContentsEntity = PageFieldsFragment["properties"]["contents"][number];
 
@@ -156,4 +161,31 @@ export const blockEntityIdExists = (entities: BlockEntity[]) => {
 
   return (blockEntityId: string | null): blockEntityId is string =>
     !!blockEntityId && ids.has(blockEntityId);
+};
+
+/**
+ * Flatmap a list of BlockEntities
+ * @param blockEntities blocks to traverse
+ * @param mapFn function to match each entity
+ * @returns a list of mapped values
+ */
+export const flatMapBlocks = <T>(
+  blockEntities: BlockEntity[],
+  mapFn: (entity: EntityStoreType, block: BlockEntity) => T[],
+) => {
+  const result = [];
+
+  for (const block of blockEntities) {
+    result.push(
+      ...flatMapTree(block, (node) => {
+        if (isEntity(node)) {
+          return mapFn(node, block);
+        }
+
+        return [];
+      }),
+    );
+  }
+
+  return result;
 };

--- a/packages/hash/shared/src/queries/page.queries.ts
+++ b/packages/hash/shared/src/queries/page.queries.ts
@@ -13,6 +13,54 @@ const linkFieldsFragment = gql`
   }
 `;
 
+const blockFieldsFragment = gql`
+  fragment BlockFields on Block {
+    __typename
+    id
+    entityVersionId
+    entityId
+    accountId
+    updatedAt
+    createdAt
+    entityVersionCreatedAt
+    createdByAccountId
+    entityTypeId
+    properties {
+      __typename
+      componentId
+      entity {
+        __typename
+        id
+        entityVersionId
+        entityId
+        accountId
+        updatedAt
+        createdAt
+        entityVersionCreatedAt
+        createdByAccountId
+        entityTypeId
+        properties
+        linkGroups {
+          links {
+            ...LinkFields
+          }
+          sourceEntityId
+          sourceEntityVersionId
+          path
+        }
+        linkedEntities {
+          accountId
+          entityId
+          entityTypeId
+          properties
+        }
+      }
+    }
+  }
+
+  ${linkFieldsFragment}
+`;
+
 const pageFieldsFragment = gql`
   fragment PageFields on Page {
     __typename
@@ -30,51 +78,11 @@ const pageFieldsFragment = gql`
       summary
       title
       contents {
-        __typename
-        id
-        entityVersionId
-        entityId
-        accountId
-        updatedAt
-        createdAt
-        entityVersionCreatedAt
-        createdByAccountId
-        entityTypeId
-        properties {
-          __typename
-          componentId
-          entity {
-            __typename
-            id
-            entityVersionId
-            entityId
-            accountId
-            updatedAt
-            createdAt
-            entityVersionCreatedAt
-            createdByAccountId
-            entityTypeId
-            properties
-            linkGroups {
-              links {
-                ...LinkFields
-              }
-              sourceEntityId
-              sourceEntityVersionId
-              path
-            }
-            linkedEntities {
-              accountId
-              entityId
-              entityTypeId
-              properties
-            }
-          }
-        }
+        ...BlockFields
       }
     }
   }
-  ${linkFieldsFragment}
+  ${blockFieldsFragment}
 `;
 
 export const getPageQuery = gql`
@@ -88,6 +96,16 @@ export const getPageQuery = gql`
     }
   }
   ${pageFieldsFragment}
+`;
+
+export const getBlocksQuery = gql`
+  query getBlocks($blocks: [BlockFilter!]!) {
+    blocks(blocks: $blocks) {
+      ...BlockFields
+    }
+  }
+
+  ${blockFieldsFragment}
 `;
 
 export const createPage = gql`

--- a/packages/hash/shared/src/queries/page.queries.ts
+++ b/packages/hash/shared/src/queries/page.queries.ts
@@ -99,7 +99,7 @@ export const getPageQuery = gql`
 `;
 
 export const getBlocksQuery = gql`
-  query getBlocks($blocks: [BlockFilter!]!) {
+  query getBlocks($blocks: [LatestEntityRef!]!) {
     blocks(blocks: $blocks) {
       ...BlockFields
     }

--- a/packages/hash/shared/src/util.ts
+++ b/packages/hash/shared/src/util.ts
@@ -193,3 +193,31 @@ export const treeFromParentReferences = <
     (element) => element[reference] == null,
   );
 };
+
+/**
+ * Try to traverse a Graph and flatMap each node.
+ * @param graph any object which may contain object values
+ * @param fn mapping function for each node
+ * @returns List of mapped nodes
+ */
+export const flatMapTree = <T>(graph: object, fn: (a: unknown) => T[]) => {
+  const queue = [graph];
+  const result: T[] = [];
+
+  // BFS traversal using FIFO queue
+  while (queue.length !== 0) {
+    const currentNode = queue.shift();
+
+    // Add current nodes to result array
+    result.push(...fn(currentNode));
+
+    // Traverse direct descendants of all nodes in the current depth
+    if (typeof currentNode === "object" && currentNode !== null) {
+      for (const current of Object.values(currentNode)) {
+        queue.push(current);
+      }
+    }
+  }
+
+  return result;
+};


### PR DESCRIPTION

## 🌟 What is the purpose of this PR?

This PR updates collab so that it refreshes updated entities by refreshing the block(s) these entities belongs to, instead of the entities themselves. This ensures new links are refreshed properly when updates are made to them in postgres.

Helped by @thehabbos007 on changes to tree iteration. 

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

N/A

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

- [x] https://github.com/hashintel/hash/pull/259

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

- https://github.com/hashintel/hash/pull/188

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- New `blocks` query in GraphQL to fetch a specified set of blocks, by `accountId` and `entityId`. 
	- Abstracted the implementation of the `Page` `properties.contents` field resolver to use in the new `blocks` query
	- New `LatestEntityRef` type which is similar to the existing `EntityRef` type, but not linked to a specific version of the entity. This is used to reference blocks in the new `blocks` query
	- Abstracted `blockFieldsFragment` out of `pageFieldsFragment` so it can be shared with a new query
- New  `getBlocks` query in shared to get a specified list of blocks – this will be used by collab
- `walkValueForEntity` has been removed, and replaced with a non-recursive `flatMapBlocks` function (based on an abstract `flatMapTree` function) 
	- Thanks to @thehabbos007 for suggesting and writing this, and for testing it 
	- This returns a flattened combination of the result from the function called with each visited node, which makes its usage simpler than `walkValueForEntity`
- When processing a change notification from postgres, we now detect the block which that entity belongs to in order to make a request to get the latest version of that entire block, which we can then swap out in the entity store
	- This is instead of the previous approach, where we would request the updated entity itself, and then try to update the entity store where ever that entity appeared. However, because links are now requested at a higher level, this means links weren't properly being updated
	- We could have fixed this by requesting links on any updated entities, and then applying those updated links to the entity store too, but that would have been orders of magnitude more complicated and fragile, for very minor performance improvements. This is simpler.
	- The process of applying refreshed entities to the entity store is much simpler now, as we just need to swap out the blocks that have been refreshed and recreate entity store, instead of walking the entire entity tree and applying the updates to any matching entities. 
- When matching change notifications against entities on the page, we now compare by `accountId` and `entityId` instead of just `entityId`. 
- Shared package is now setup to have unit tests, which we can start expanding on. 

### Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

No 

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as (_internal_) -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task Extend collab so that it understands changes to entities that are linked to by other entities already in the entity store, using the new links](https://app.asana.com/0/1201095311341924/1201701182511253/f) (_internal_)
- [Slack thread](https://hashintel.slack.com/archives/C022217GAHF/p1643824807820839) (_internal_)

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

N/A

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

I verified this by combining it with https://github.com/hashintel/hash/pull/188 and seeing if the table block entity type updates worked, and they did. This has also been confirmed by @akash-joshi. 

Other than this, you should confirm that syncing changes made outside of prosemirror works – i.e, you can update a row in a table and this should sync as expected.