### PR TITLE
Add bench Action to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,6 +47,7 @@ jobs:
 
           # We always run "packages/engine" tests when a nested crate was changed
           test_crates="$changed_crates"
+          bench_crates=""
           if echo "$test_crates" | grep -qe "^packages/engine"; then
             test_crates=$(echo -e "${changed_crates}\npackages/engine")
           fi
@@ -194,6 +195,7 @@ jobs:
         toolchain: ${{ fromJSON(needs.setup.outputs.toolchains) }}
         flags:
           - --all-features
+          - ""
     env:
       V8_PATH: ${{ github.workspace }}/.v8
     steps:
@@ -239,15 +241,86 @@ jobs:
 
       - name: Build test dependencies
         if: matrix.directory == 'packages/engine'
-        run: cargo build -p server --manifest-path ${{ matrix.directory }}/Cargo.toml
+        run: cargo build -p server --manifest-path ${{ matrix.directory }}/Cargo.toml ${{ matrix.flags }}
 
       - name: Run tests
-        id: test-parallel
-        run: cargo test --manifest-path ${{ matrix.directory }}/Cargo.toml ${{ matrix.flags }} --no-fail-fast
+        run: cargo test --manifest-path ${{ matrix.directory }}/Cargo.toml --no-fail-fast ${{ matrix.flags }}
+
+  bench:
+    name: bench
+    needs: setup
+    if: needs.setup.outputs.bench != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        directory: ${{ fromJSON(needs.setup.outputs.test) }}
+        toolchain: ${{ fromJSON(needs.setup.outputs.toolchains) }}
+        tests:
+          - integration
+        flags:
+          - --release
+    env:
+      V8_PATH: ${{ github.workspace }}/.v8
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Install Rust
+        id: toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            **/target/
+          key: ${{ runner.os }}-bench-${{ matrix.directory }}-${{ matrix.toolchain }}-${{ matrix.flags }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bench-${{ matrix.directory }}-${{ matrix.toolchain }}-${{ matrix.flags }}
+            ${{ runner.os }}-bench-${{ matrix.directory }}-${{ matrix.toolchain }}
+
+      - name: Install v8
+        run: |
+          mkdir -p ${V8_PATH}/tmp
+          cd ${V8_PATH}/tmp
+          curl -L -o libv8.tar.gz https://github.com/rubyjs/libv8/releases/download/v8.4.255.0/libv8-8.4.255.0-x86_64-linux.gem
+          tar xf libv8.tar.gz # Extract the gem
+          tar xf data.tar.gz # Extract the data folder
+          mv -v vendor/v8/* .. # Move out the wanted files
+          cd ..
+          rm -rf tmp # Delete the tmp folder
+
+      - name: Build test dependencies
+        run: cargo build -p server --manifest-path ${{ matrix.directory }}/Cargo.toml ${{ matrix.flags }}
+
+      - name: Run tests
+        run: |
+          mkdir bench-results
+          cargo test \
+              --test ${{ matrix.tests }} \
+              --manifest-path ${{ matrix.directory }}/Cargo.toml \
+              --no-fail-fast \
+              ${{ matrix.flags }} \
+              -- \
+              -Z unstable-options \
+              --report-time \
+              --format json \
+            | jq 'select(.type == "test" and .event != "started") | del(.type)' \
+            | tee bench-results/${{ matrix.tests }}.json
 
   merging-enabled:
     name: merging enabled
-    needs: [rustfmt, clippy, test]
+    needs: [rustfmt, clippy, test, bench]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -260,3 +333,6 @@ jobs:
       - name: check test
         run: |
           [[ ${{ needs.test.result }} =~ success|skipped ]]
+      - name: check bench
+        run: |
+          [[ ${{ needs.bench.result }} =~ success|skipped ]]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -312,7 +312,7 @@ jobs:
 
       - name: Read results
         run: |
-          find ${{ OUTPUT_DIRECTORY }} -name timing.json -exec cat {} + | jq '{(.test_path): . | del(.test_path)}' | jq -s add
+          find ${{ env.OUTPUT_DIRECTORY }} -name timing.json -exec cat {} + | jq '{(.test_path): . | del(.test_path)}' | jq -s add
 
   merging-enabled:
     name: merging enabled

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,7 @@ jobs:
       rustfmt: ${{ steps.crates.outputs.rustfmt }}
       clippy: ${{ steps.crates.outputs.clippy }}
       test: ${{ steps.crates.outputs.test }}
+      bench: ${{ steps.crates.outputs.bench }}
       toolchains: ${{ steps.toolchains.outputs.toolchains }}
     steps:
       - name: Checkout source code

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -336,6 +336,7 @@ jobs:
       - name: check test
         run: |
           [[ ${{ needs.test.result }} =~ success|skipped ]]
-      - name: check bench
-        run: |
-          [[ ${{ needs.bench.result }} =~ success|skipped ]]
+      # TODO: Require bench to pass after https://app.asana.com/0/1201481007343159/1201545519802517/f
+      # - name: check bench
+      #   run: |
+      #     [[ ${{ needs.bench.result }} =~ success|skipped ]]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -312,7 +312,7 @@ jobs:
 
       - name: Read results
         run: |
-          find ${{ env.OUTPUT_DIRECTORY }} -name timing.json -exec cat {} + | jq '{(.test_path): . | del(.test_path)}' | jq -s add
+          find ${{ matrix.directory }}/${{ env.OUTPUT_DIRECTORY }} -name timing.json -exec cat {} + | jq '{(.test_path): . | del(.test_path)}' | jq -s add
 
   merging-enabled:
     name: merging enabled

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -256,7 +256,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        directory: ${{ fromJSON(needs.setup.outputs.test) }}
+        directory: ${{ fromJSON(needs.setup.outputs.bench) }}
         toolchain: ${{ fromJSON(needs.setup.outputs.toolchains) }}
         tests:
           - integration

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,7 +52,7 @@ jobs:
           fi
 
           changed_crates=$(echo "$changed_crates" | sort | uniq | jq -R | jq -sc '[ .[] | select(length > 0) ]')
-          bench_crates=$(echo "$test_crates" | sort | uniq | jq -R | jq -sc '[ .[] | select(. == "packages/engine") ]')
+          bench_crates=$(echo "$test_crates" | sort | uniq | jq -R | jq -sc '[ .[] | select(length > 0 and . == "packages/engine") ]')
           test_crates=$(echo "$test_crates" | sort | uniq | jq -R | jq -sc '[ .[] | select(length > 0) ]')
 
           echo "::set-output name=rustfmt::$changed_crates"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,21 +47,23 @@ jobs:
 
           # We always run "packages/engine" tests when a nested crate was changed
           test_crates="$changed_crates"
-          bench_crates=""
           if echo "$test_crates" | grep -qe "^packages/engine"; then
             test_crates=$(echo -e "${changed_crates}\npackages/engine")
           fi
 
           changed_crates=$(echo "$changed_crates" | sort | uniq | jq -R | jq -sc '[ .[] | select(length > 0) ]')
+          bench_crates=$(echo "$test_crates" | sort | uniq | jq -R | jq -sc '[ .[] | select(. == "packages/engine") ]')
           test_crates=$(echo "$test_crates" | sort | uniq | jq -R | jq -sc '[ .[] | select(length > 0) ]')
 
           echo "::set-output name=rustfmt::$changed_crates"
           echo "::set-output name=clippy::$changed_crates"
           echo "::set-output name=test::$test_crates"
+          echo "::set-output name=bench::$bench_crates"
 
-          echo "run \`cargo fmt\` for: $(echo $changed_crates | jq -r)"
-          echo "run \`cargo clippy\` for: $(echo $changed_crates | jq -r)"
-          echo "run \`cargo test\` for: $(echo $test_crates | jq -r)"
+          echo "run \`cargo fmt\` for: $(echo "$changed_crates" | jq -r)"
+          echo "run \`cargo clippy\` for: $(echo "$changed_crates" | jq -r)"
+          echo "run \`cargo test\` for: $(echo "$test_crates" | jq -r)"
+          echo "run \`cargo test --release\` for: $(echo "$bench_crates" | jq -r)"
       - name: Find toolchain
         id: toolchains
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -311,6 +311,7 @@ jobs:
         run: cargo test --test ${{ matrix.tests }} --manifest-path ${{ matrix.directory }}/Cargo.toml --no-fail-fast ${{ matrix.flags }}
 
       - name: Read results
+        if: always()
         run: |
           find ${{ matrix.directory }}/${{ env.OUTPUT_DIRECTORY }} -name timing.json -exec cat {} + | jq '{(.test_path): . | del(.test_path)}' | jq -s add
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -265,6 +265,7 @@ jobs:
           - --release
     env:
       V8_PATH: ${{ github.workspace }}/.v8
+      OUTPUT_DIRECTORY: test-results
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -307,19 +308,11 @@ jobs:
         run: cargo build -p server --manifest-path ${{ matrix.directory }}/Cargo.toml ${{ matrix.flags }}
 
       - name: Run tests
+        run: cargo test --test ${{ matrix.tests }} --manifest-path ${{ matrix.directory }}/Cargo.toml --no-fail-fast ${{ matrix.flags }}
+
+      - name: Read results
         run: |
-          mkdir bench-results
-          cargo test \
-              --test ${{ matrix.tests }} \
-              --manifest-path ${{ matrix.directory }}/Cargo.toml \
-              --no-fail-fast \
-              ${{ matrix.flags }} \
-              -- \
-              -Z unstable-options \
-              --report-time \
-              --format json \
-            | jq 'select(.type == "test" and .event != "started") | del(.type)' \
-            | tee bench-results/${{ matrix.tests }}.json
+          find ${{ OUTPUT_DIRECTORY }} -name timing.json -exec cat {} + | jq '{(.test_path): . | del(.test_path)}' | jq -s add
 
   merging-enabled:
     name: merging enabled

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,7 @@ jobs:
           fi
 
           changed_crates=$(echo "$changed_crates" | sort | uniq | jq -R | jq -sc '[ .[] | select(length > 0) ]')
-          bench_crates=$(echo "$test_crates" | sort | uniq | jq -R | jq -sc '[ .[] | select(length > 0 and . == "packages/engine") ]')
+          bench_crates=$(echo "$test_crates" | sort | uniq | jq -R | jq -sc '[ .[] | select(. == "packages/engine") ]')
           test_crates=$(echo "$test_crates" | sort | uniq | jq -R | jq -sc '[ .[] | select(length > 0) ]')
 
           echo "::set-output name=rustfmt::$changed_crates"

--- a/packages/engine/tests/integration.rs
+++ b/packages/engine/tests/integration.rs
@@ -40,7 +40,7 @@ macro_rules! run_test {
                 .canonicalize()
                 .unwrap();
 
-            $crate::units::experiment::run_test_suite(project_path, module_path!(), None, None).await
+            $crate::units::experiment::run_test_suite(project_path, concat!(module_path!(), "::", stringify!($project)), None, None).await
         }
     };
     ($project:ident, $language:ident $(,)? $(#[$attr:meta])* ) => {
@@ -58,7 +58,7 @@ macro_rules! run_test {
                 .canonicalize()
                 .unwrap();
 
-            $crate::units::experiment::run_test_suite(project_path, module_path!(), Some(hash_engine::Language::$language), None).await
+            $crate::units::experiment::run_test_suite(project_path, concat!(module_path!(), "::", stringify!($project)), Some(hash_engine::Language::$language), None).await
         }
     };
     ($project:ident, experiment: $experiment:ident $(,)? $(#[$attr:meta])* ) => {
@@ -72,7 +72,7 @@ macro_rules! run_test {
                 .canonicalize()
                 .unwrap();
 
-            $crate::units::experiment::run_test_suite(project_path, module_path!(), None, Some(stringify!($experiment))).await
+            $crate::units::experiment::run_test_suite(project_path, concat!(module_path!(), "::", stringify!($experiment)), None, Some(stringify!($experiment))).await
         }
     };
     ($project:ident, $language:ident, experiment: $experiment:ident $(,)? $(#[$attr:meta])* ) => {
@@ -90,7 +90,7 @@ macro_rules! run_test {
                 .canonicalize()
                 .unwrap();
 
-            $crate::units::experiment::run_test_suite(project_path, module_path!(), Some(hash_engine::Language::$language), Some(stringify!($experiment))).await
+            $crate::units::experiment::run_test_suite(project_path, concat!(module_path!(), "::", stringify!($experiment)), Some(hash_engine::Language::$language), Some(stringify!($experiment))).await
         }
     };
 }

--- a/packages/engine/tests/units/experiment.rs
+++ b/packages/engine/tests/units/experiment.rs
@@ -158,10 +158,6 @@ pub async fn run_test_suite(
             .join("output.log");
 
         let log_output = fs::read_to_string(&log_file_path);
-        // Remove the output directory if it was not set manually
-        if std::env::var("OUTPUT_DIRECTORY").is_err() {
-            let _ = fs::remove_dir_all(&output_folder);
-        }
 
         let test_result = match outputs.unwrap() {
             Ok(outputs) => outputs,
@@ -211,6 +207,11 @@ pub async fn run_test_suite(
             serde_json::to_string_pretty(&timings).unwrap(),
         )
         .expect("Could not write test timings");
+
+        // Remove the output directory if it was not set manually
+        if std::env::var("OUTPUT_DIRECTORY").is_err() {
+            let _ = fs::remove_dir_all(&output_folder);
+        }
     }
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Runs the integration test suite as release build and captures timings to be uploaded

## 🐾 Next steps

Log the timings and compare them between PR and `main`

## 🔍 What does this change?

- Adds a new job  `bench` to the Rust CI
- Adjust `setup` job to run `bench` when "packages/engine" tests has to run
- Print timing information from tests

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201707629991362/1201762844341058/f) (_internal_)
