### PR TITLE
Fixing dynamic groups

### DIFF
--- a/packages/engine/src/datastore/table/task_shared_store.rs
+++ b/packages/engine/src/datastore/table/task_shared_store.rs
@@ -173,7 +173,7 @@ fn distribute_batches<A, M>(
         .enumerate();
     for (i_group, (agent_batch, msg_batch)) in iter {
         let i_worker = i_group % num_workers;
-        agent_distribution[i_group] += group_sizes[i_worker];
+        agent_distribution[i_worker] += group_sizes[i_group];
 
         let store = &mut stores[i_worker];
         store.1.push(agent_batch);

--- a/packages/engine/src/datastore/table/task_shared_store.rs
+++ b/packages/engine/src/datastore/table/task_shared_store.rs
@@ -28,14 +28,14 @@ impl TaskSharedStore {
 /// TODO: DOC
 #[derive(Debug)]
 pub struct PartialStateWriteProxy {
-    pub indices: Vec<usize>,
+    pub group_indices: Vec<usize>,
     pub inner: StateWriteProxy,
 }
 
 /// TODO: DOC
 #[derive(Debug, Clone)]
 pub struct PartialStateReadProxy {
-    pub indices: Vec<usize>,
+    pub group_indices: Vec<usize>,
     pub inner: StateReadProxy,
 }
 
@@ -135,7 +135,7 @@ impl PartialSharedState {
     fn new_write<K: WriteState>(state: &K, indices: Vec<usize>) -> Result<PartialSharedState> {
         let inner = StateWriteProxy::new_partial(state, &indices)?;
         Ok(PartialSharedState::Write(PartialStateWriteProxy {
-            indices,
+            group_indices: indices,
             inner,
         }))
     }
@@ -143,7 +143,7 @@ impl PartialSharedState {
     fn new_read<K: ReadState>(state: &K, indices: Vec<usize>) -> Result<PartialSharedState> {
         let inner = StateReadProxy::new_partial(state, &indices)?;
         Ok(PartialSharedState::Read(PartialStateReadProxy {
-            indices,
+            group_indices: indices,
             inner,
         }))
     }
@@ -241,7 +241,7 @@ impl TaskSharedStore {
                     (state.deconstruct(), indices)
                 }
                 SharedState::Partial(PartialSharedState::Write(partial)) => {
-                    let (state, indices) = (partial.inner, partial.indices);
+                    let (state, indices) = (partial.inner, partial.group_indices);
                     (state.deconstruct(), indices)
                 }
                 _ => unreachable!(),
@@ -263,7 +263,7 @@ impl TaskSharedStore {
                     let store = Self {
                         state: SharedState::Partial(PartialSharedState::Write(
                             PartialStateWriteProxy {
-                                indices,
+                                group_indices: indices,
                                 inner: StateWriteProxy::from((agent_batches, msg_batches)),
                             },
                         )),
@@ -284,7 +284,7 @@ impl TaskSharedStore {
                     (state.deconstruct(), indices)
                 }
                 SharedState::Partial(PartialSharedState::Read(partial)) => {
-                    let (state, indices) = (partial.inner, partial.indices);
+                    let (state, indices) = (partial.inner, partial.group_indices);
                     (state.deconstruct(), indices)
                 }
                 _ => unreachable!(),
@@ -306,7 +306,7 @@ impl TaskSharedStore {
                     let store = Self {
                         state: SharedState::Partial(PartialSharedState::Read(
                             PartialStateReadProxy {
-                                indices,
+                                group_indices: indices,
                                 inner: StateReadProxy::from((agent_batches, msg_batches)),
                             },
                         )),

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/tasks.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/tasks.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use super::Result;
+use super::{Error, Result};
 use crate::{
     config::{Distribution, TaskDistributionConfig},
     simulation::{

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/tasks.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/tasks.rs
@@ -60,11 +60,11 @@ impl WorkerPoolHandler for ExecuteBehaviorsTask {
 
     fn combine_messages(&self, split_tasks: Vec<TaskMessage>) -> Result<TaskMessage> {
         for task in split_tasks {
-            match task {
-                // TODO: could be cleaner, if not matches
-                TaskMessage::StateTaskMessage(StateTaskMessage::ExecuteBehaviorsTaskMessage(_)) => {
-                }
-                _ => return Err(Error::InvalidBehaviorTaskMessage(task)),
+            if !matches!(
+                task,
+                TaskMessage::StateTaskMessage(StateTaskMessage::ExecuteBehaviorsTaskMessage(_))
+            ) {
+                return Err(Error::InvalidBehaviorTaskMessage(task));
             }
         }
         let task: StateTaskMessage = ExecuteBehaviorsTaskMessage {}.into();

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/tasks.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/tasks.rs
@@ -59,16 +59,13 @@ impl WorkerPoolHandler for ExecuteBehaviorsTask {
     }
 
     fn combine_messages(&self, split_tasks: Vec<TaskMessage>) -> Result<TaskMessage> {
-        for _task in split_tasks {
-            // TODO: How can we match an enum_dispatch nested enum?
-            // match task {
-            //     TaskMessage::StateTaskMessage(
-            //         StateTaskMessage::ExecuteBehaviorsTaskMessage(
-            //             ExecuteBehaviorsTaskMessage
-            //         )
-            //     ) => {},
-            //     _ => return Err(Error::InvalidBehaviorTaskMessage(task))
-            // }
+        for task in split_tasks {
+            match task {
+                // TODO: could be cleaner, if not matches
+                TaskMessage::StateTaskMessage(StateTaskMessage::ExecuteBehaviorsTaskMessage(_)) => {
+                }
+                _ => return Err(Error::InvalidBehaviorTaskMessage(task)),
+            }
         }
         let task: StateTaskMessage = ExecuteBehaviorsTaskMessage {}.into();
         let task: TaskMessage = task.into();

--- a/packages/engine/src/worker/runner/javascript/mod.rs
+++ b/packages/engine/src/worker/runner/javascript/mod.rs
@@ -977,6 +977,7 @@ impl<'m> RunnerImpl<'m> {
     /// - a value from Javascript could not be parsed,
     /// - the task errored, or
     /// - the state could not be flushed to the datastore.
+    #[allow(clippy::too_many_arguments)]
     fn run_task(
         &mut self,
         mv8: &'m MiniV8,

--- a/packages/engine/src/worker/runner/python/sender.rs
+++ b/packages/engine/src/worker/runner/python/sender.rs
@@ -371,7 +371,7 @@ fn shared_store_to_fbs<'f>(
                     .iter()
                     .map(|b| batch_to_fbs(fbb, b))
                     .collect();
-                (a, m, partial.indices.clone())
+                (a, m, partial.group_indices.clone())
             }
             PartialSharedState::Write(partial) => {
                 let state = &partial.inner;
@@ -387,7 +387,7 @@ fn shared_store_to_fbs<'f>(
                     .iter()
                     .map(|b| batch_to_fbs(fbb, b))
                     .collect();
-                (a, m, partial.indices.clone())
+                (a, m, partial.group_indices.clone())
             }
         },
     };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Large simple simulations were breaking (500,000+ agents) due to some odd errors about group indices.
This PR fixes that error, and a following error to do with task distribution across groups of agents.

## ⚠️ Known issues

We know about shared write-access issues, that occasionally appear within CI runs, etc.
> failed to acquire write locks on batches in pool

This is now happening every time on a simple simulation with 500,000 agents.

We've also identified that Tasks that are split by group are ended prematurely, we need to wait for all individual messages _within_ a task. 

## 🐾 Next steps

- Follow Up PR to handle write access with distributed tasks

## 🔍 What does this change?

- Renames some fields to be more self-explanatory
- Adds a function to take a TaskSharedStore and safely partition it into many TaskSharedStores for each group within it.
- Re-enables message combination in BehaviorExecution
- Fixes a bug where the group index was wrongly swapped with the worker index

### Does this require a change to the docs?

- No

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201707629991362/1201745286267280/f) (_internal_)

## 🛡 What tests cover this?

- None really at this stage
