### PR TITLE
Don't wait for `bench` to complete before merging is enabled

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -317,7 +317,7 @@ jobs:
 
   merging-enabled:
     name: merging enabled
-    needs: [rustfmt, clippy, test, bench]
+    needs: [rustfmt, clippy, test]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Changes the Rust CI to not wait for `bench` to be able to merge