### PR TITLE
Fallback to `run_id` when running Rust CI on push

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ defaults:
     shell: bash
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fix the Rust CI when pushing to main

## 🔍 What does this change?

- `github.head_ref` is only defined for pull requests
- Fallback to `github.run_id` to ensure the CI will run on push
