### PR TITLE
Only use one test threads when benchmarking

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -322,7 +322,7 @@ jobs:
       - name: Run tests
         env:
           SAMPLES: ${{ needs.setup.outputs.samples }}
-        run: cargo test --test ${{ matrix.tests }} --manifest-path ${{ matrix.directory }}/Cargo.toml --no-fail-fast ${{ matrix.flags }}
+        run: cargo test --test ${{ matrix.tests }} --manifest-path ${{ matrix.directory }}/Cargo.toml --no-fail-fast ${{ matrix.flags }} -- --test-threads=1
 
       - name: Upload to DataDog
         if: always()


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Running multiple benchmarks at once isn't very smart

## 🔍 What does this change?

- Limits the number of parallel tests