### PR TITLE
Propagating the project name and using in output

### DIFF
--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -339,7 +339,10 @@ If you haven't created and exported a project from [hCore], it's also possible t
 
 At the end of each simulation run, various outputs appear within the `./<OUTPUT FOLDER>/<PROJECT NAME>/<EXPERIMENT NAME>/<EXPERIMENT ID>/<SIMULATION ID>` directories.
 
-Where `<PROJECT NAME>` is the name of the folder containing your experiments, and, `<EXPERIMENT ID>` and `<SIMULATION ID>` are unique identifiers created for each run of an experiment or simulation.
+Where:
+
+- `<PROJECT NAME>` is the name of the folder containing your experiments
+- `<EXPERIMENT ID>` and `<SIMULATION ID>` are unique identifiers created for each run of an experiment or simulation.
 
 There is an override ([CLI Arguments and Options](#cli-arguments-and-options)) for the default of the output folder.
 

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -339,9 +339,9 @@ If you haven't created and exported a project from [hCore], it's also possible t
 
 At the end of each simulation run, various outputs appear within the `./<OUTPUT FOLDER>/<PROJECT NAME>/<EXPERIMENT NAME>/<EXPERIMENT ID>/<SIMULATION ID>` directories.
 
-Where `<EXPERIMENT ID>` and `<SIMULATION ID>` are unique identifiers created for each run of an experiment or simulation.
+Where `<PROJECT NAME>` is the name of the folder containing your experiments, and, `<EXPERIMENT ID>` and `<SIMULATION ID>` are unique identifiers created for each run of an experiment or simulation.
 
-There are overrides ([CLI Arguments and Options](#cli-arguments-and-options)) for the defaults of the output folder and project name.
+There is an override ([CLI Arguments and Options](#cli-arguments-and-options)) for the default of the output folder.
 
 #### JSON-State [`json_state.json`]
 

--- a/packages/engine/lib/orchestrator/src/manifest.rs
+++ b/packages/engine/lib/orchestrator/src/manifest.rs
@@ -32,7 +32,7 @@ const DATASET_FILE_EXTENSIONS: [&str; 2] = ["csv", "json"];
 #[derive(Debug, Default, Clone)]
 pub struct Manifest {
     /// The name of the project
-    pub name: String,
+    pub project_name: String,
     /// The initial state for the simulation.
     pub initial_state: Option<InitialState>,
     /// A list of all behaviors in the project.
@@ -423,7 +423,7 @@ impl Manifest {
         let mut project = Manifest::new();
 
         if !is_dependency {
-            project.name = project_name;
+            project.project_name = project_name;
 
             project
                 .set_initial_state_from_directory(src_folder)
@@ -484,7 +484,7 @@ impl Manifest {
     /// - if the manifest does not provide an initial state
     pub fn read(self, experiment_type: ExperimentType) -> Result<ExperimentRun> {
         let project_base = ProjectBase {
-            name: self.name,
+            name: self.project_name,
             initial_state: self
                 .initial_state
                 .ok_or_else(|| report!("Project must specify an initial state file."))?,

--- a/packages/engine/lib/orchestrator/src/manifest.rs
+++ b/packages/engine/lib/orchestrator/src/manifest.rs
@@ -31,6 +31,8 @@ const DATASET_FILE_EXTENSIONS: [&str; 2] = ["csv", "json"];
 /// to parse the project structure easily.
 #[derive(Debug, Default, Clone)]
 pub struct Manifest {
+    /// The name of the project
+    pub name: String,
     /// The initial state for the simulation.
     pub initial_state: Option<InitialState>,
     /// A list of all behaviors in the project.
@@ -403,6 +405,11 @@ impl Manifest {
             project_path.to_string_lossy()
         );
 
+        let project_name = project_path.file_name()
+            // Shouldn't be able to fail as it should have been validated by now
+            .ok_or_else(|| report!("Project path didn't point to a directory: {project_path:?}"))? 
+            .to_string_lossy()
+            .to_string();
         let experiments_json = project_path.join("experiments.json");
         let dependencies_json = project_path.join("dependencies.json");
         let src_folder = project_path.join("src");
@@ -416,24 +423,28 @@ impl Manifest {
         let mut project = Manifest::new();
 
         if !is_dependency {
+            project.name = project_name;
+
             project
                 .set_initial_state_from_directory(src_folder)
                 .wrap_err("Could not read initial state")?;
-        }
-        if !is_dependency && globals_json.exists() {
-            project
-                .set_globals_from_file(globals_json)
-                .wrap_err("Could not read globals")?;
-        }
-        if !is_dependency && analysis_json.exists() {
-            project
-                .set_analysis_from_file(analysis_json)
-                .wrap_err("Could not read analysis view")?;
-        }
-        if !is_dependency && experiments_json.exists() {
-            project
-                .set_experiments_from_file(experiments_json)
-                .wrap_err("Could not read experiments")?;
+
+            if globals_json.exists() {
+                project
+                    .set_globals_from_file(globals_json)
+                    .wrap_err("Could not read globals")?;
+            }
+            if analysis_json.exists() {
+                project
+                    .set_analysis_from_file(analysis_json)
+                    .wrap_err("Could not read analysis view")?;
+            }
+
+            if experiments_json.exists() {
+                project
+                    .set_experiments_from_file(experiments_json)
+                    .wrap_err("Could not read experiments")?;
+            }
         }
         if dependencies_json.exists() {
             project
@@ -473,6 +484,7 @@ impl Manifest {
     /// - if the manifest does not provide an initial state
     pub fn read(self, experiment_type: ExperimentType) -> Result<ExperimentRun> {
         let project_base = ProjectBase {
+            name: self.name,
             initial_state: self
                 .initial_state
                 .ok_or_else(|| report!("Project must specify an initial state file."))?,

--- a/packages/engine/src/experiment/controller/run.rs
+++ b/packages/engine/src/experiment/controller/run.rs
@@ -73,6 +73,7 @@ pub async fn run_local_experiment(exp_config: ExperimentConfig, env: Environment
         OutputPersistenceConfig::Local(local) => {
             tracing::debug!("Running experiment with local persistence");
             let persistence = LocalOutputPersistence::new(
+                exp_config.run.base().project_base.name.clone(),
                 exp_config.name().clone(),
                 exp_config.run.base().id,
                 local.clone(),

--- a/packages/engine/src/output/local/mod.rs
+++ b/packages/engine/src/output/local/mod.rs
@@ -12,8 +12,9 @@ use crate::{
 
 #[derive(derive_new::new)]
 pub struct LocalOutputPersistence {
-    exp_name: ExperimentName,
-    exp_id: ExperimentId,
+    project_name: String,
+    experiment_name: ExperimentName,
+    experiment_id: ExperimentId,
     config: LocalPersistenceConfig,
 }
 
@@ -25,10 +26,11 @@ impl OutputPersistenceCreatorRepr for LocalOutputPersistence {
         sim_id: SimulationShortId,
         persistence_config: &PersistenceConfig,
     ) -> Result<Self::SimulationOutputPersistence> {
-        let buffers = Buffers::new(&self.exp_id, sim_id, &persistence_config.output_config)?;
+        let buffers = Buffers::new(&self.experiment_id, sim_id, &persistence_config.output_config)?;
         Ok(LocalSimulationOutputPersistence::new(
-            self.exp_name.clone(),
-            self.exp_id,
+            self.project_name.clone(),
+            self.experiment_name.clone(),
+            self.experiment_id,
             sim_id,
             buffers,
             self.config.clone(),

--- a/packages/engine/src/output/local/sim.rs
+++ b/packages/engine/src/output/local/sim.rs
@@ -10,8 +10,9 @@ use crate::{
 
 #[derive(derive_new::new)]
 pub struct LocalSimulationOutputPersistence {
-    exp_name: ExperimentName,
-    exp_id: ExperimentId,
+    project_name: String,
+    experiment_name: ExperimentName,
+    experiment_id: ExperimentId,
     sim_id: SimulationShortId,
     // TODO: Should this be unused? If so remove
     buffers: Buffers,
@@ -44,8 +45,9 @@ impl SimulationOutputPersistenceRepr for LocalSimulationOutputPersistence {
         let path = self
             .config
             .output_folder
-            .join(self.exp_name.as_str())
-            .join(self.exp_id.to_string())
+            .join(&self.project_name)
+            .join(self.experiment_name.as_str())
+            .join(self.experiment_id.to_string())
             .join(self.sim_id.to_string());
 
         tracing::info!("Making new output directory: {:?}", path);

--- a/packages/engine/src/proto.rs
+++ b/packages/engine/src/proto.rs
@@ -219,6 +219,7 @@ pub struct InitialState {
 /// dependencies source and the source for all running behaviors
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct ProjectBase {
+    pub name: String,
     pub initial_state: InitialState,
     pub globals_src: String,
     pub experiments_src: Option<String>,

--- a/packages/engine/src/simulation/package/deps.rs
+++ b/packages/engine/src/simulation/package/deps.rs
@@ -138,11 +138,12 @@ pub mod tests {
                     name: String::new().into(),
                     id: Uuid::new_v4(),
                     project_base: ProjectBase {
+                        name: String::new(),
                         initial_state: InitialState {
                             name: InitialStateName::InitJson,
-                            src: "".to_string(),
+                            src: String::new(),
                         },
-                        globals_src: "".to_string(),
+                        globals_src: String::new(),
                         experiments_src: None,
                         behaviors: vec![],
                         datasets: vec![],


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
We previously allowed users to set a project_name and this was used in output structure.
This was accidentally removed in a previous PR.

This PR re-adds the project name and structure albeit in a different implementation to before. It's also no longer overrideable from the CLI

## 🔍 What does this change?

- Modifies `ProjectBase` to include a `name` field
- Modifies the output directory to once again have the project name as a top-level folder
- A few tiny driveby clean-ups

### Does this require a change to the docs?

- A small clarification to the README was included

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201707629991362/1201778502679423/f) (_internal_)

## 🛡 What tests cover this?

- None

## ❓ How to test this?

1.  Run any simulation or experiment, check the output folder

## 📹 Demo

![image](https://user-images.githubusercontent.com/25749103/152779150-a8cc4f1f-71b4-4615-9056-f174bbe9ee1a.png)
