### PR TITLE
Fix Rust CI to always run "merging-enabled"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -347,7 +347,7 @@ jobs:
   merging-enabled:
     name: merging enabled
     needs: [rustfmt, clippy, test]
-    if: github.event_name == 'pull_request'
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: check rustfmt

--- a/packages/engine/src/output/local/mod.rs
+++ b/packages/engine/src/output/local/mod.rs
@@ -26,7 +26,11 @@ impl OutputPersistenceCreatorRepr for LocalOutputPersistence {
         sim_id: SimulationShortId,
         persistence_config: &PersistenceConfig,
     ) -> Result<Self::SimulationOutputPersistence> {
-        let buffers = Buffers::new(&self.experiment_id, sim_id, &persistence_config.output_config)?;
+        let buffers = Buffers::new(
+            &self.experiment_id,
+            sim_id,
+            &persistence_config.output_config,
+        )?;
         Ok(LocalSimulationOutputPersistence::new(
             self.project_name.clone(),
             self.experiment_name.clone(),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The Rust CI has a "merging-enabled" job. This was changed to run only on PRs, but now it's skipped if the previous steps are failing. Running it always isn't a big deal for pushes as it's almost a no-op, but for Pull Requests it's much clearer when it's failing instead of being skipped.