### PR TITLE
Refactor `State`, `StateMut` and `Inner` into `State`

### DIFF
--- a/packages/engine/src/datastore/store.rs
+++ b/packages/engine/src/datastore/store.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
-use super::{prelude::*, table::state::StateMut};
+use super::prelude::*;
 use crate::{
     config::{ExperimentConfig, SimulationConfig},
-    datastore::table::context::Context,
+    datastore::table::{context::Context, state::State},
     SimRunConfig,
 };
 
@@ -37,11 +37,6 @@ impl Store {
                 .take()
                 .ok_or_else(|| Error::from("Expected context"))?,
         ))
-    }
-
-    pub fn take_upgraded(&mut self) -> Result<(StateMut, Context)> {
-        let (state, context) = self.take()?;
-        Ok((state.into_mut(), context))
     }
 
     pub fn set(&mut self, state: State, context: Context) {

--- a/packages/engine/src/datastore/table/proxy.rs
+++ b/packages/engine/src/datastore/table/proxy.rs
@@ -24,14 +24,11 @@ use std::{
 
 use parking_lot::{lock_api::RawRwLock, RwLock};
 
-use super::{
-    pool::proxy::{PoolReadProxy, PoolWriteProxy},
-    state::{ReadState, WriteState},
-};
+use super::pool::proxy::{PoolReadProxy, PoolWriteProxy};
 use crate::datastore::{
     batch::Batch,
     prelude::{AgentBatch, Error, MessageBatch, Result},
-    table::pool::BatchPool,
+    table::{pool::BatchPool, state::State},
 };
 
 /// A thread-sendable guard for reading a batch, see module-level documentation for more reasoning.
@@ -163,14 +160,14 @@ impl Debug for StateReadProxy {
 }
 
 impl StateReadProxy {
-    pub fn new<K: ReadState>(state: &K) -> Result<Self> {
+    pub fn new(state: &State) -> Result<Self> {
         Ok(StateReadProxy {
             agent_pool_proxy: state.agent_pool().read_proxy()?,
             message_pool_proxy: state.message_pool().read_proxy()?,
         })
     }
 
-    pub fn new_partial<K: ReadState>(state: &K, indices: &[usize]) -> Result<Self> {
+    pub fn new_partial(state: &State, indices: &[usize]) -> Result<Self> {
         Ok(StateReadProxy {
             agent_pool_proxy: state.agent_pool().partial_read_proxy(indices)?,
             message_pool_proxy: state.message_pool().partial_read_proxy(indices)?,
@@ -237,17 +234,17 @@ impl
 }
 
 impl StateWriteProxy {
-    pub fn new<K: WriteState>(state: &mut K) -> Result<Self> {
+    pub fn new(state: &mut State) -> Result<Self> {
         Ok(StateWriteProxy {
             agent_pool_proxy: state.agent_pool_mut().write_proxy()?,
             message_pool_proxy: state.message_pool_mut().write_proxy()?,
         })
     }
 
-    pub fn new_partial<K: WriteState>(state: &K, indices: &[usize]) -> Result<Self> {
+    pub fn new_partial(state: &mut State, indices: &[usize]) -> Result<Self> {
         Ok(StateWriteProxy {
-            agent_pool_proxy: state.agent_pool().partial_write_proxy(indices)?,
-            message_pool_proxy: state.message_pool().partial_write_proxy(indices)?,
+            agent_pool_proxy: state.agent_pool_mut().partial_write_proxy(indices)?,
+            message_pool_proxy: state.message_pool_mut().partial_write_proxy(indices)?,
         })
     }
 

--- a/packages/engine/src/datastore/table/state/create_remove/planner.rs
+++ b/packages/engine/src/datastore/table/state/create_remove/planner.rs
@@ -14,10 +14,7 @@ use crate::{
         batch::migration::{BufferActions, IndexRange, RangeActions},
         error::Result,
         prelude::*,
-        table::{
-            pool::{agent::AgentPool, BatchPool},
-            state::ReadState,
-        },
+        table::pool::{agent::AgentPool, BatchPool},
     },
     simulation::command::CreateRemoveCommands,
     SimRunConfig,
@@ -39,7 +36,7 @@ impl CreateRemovePlanner {
         })
     }
 
-    pub fn run(&mut self, state: &impl ReadState) -> Result<MigrationPlan<'_>> {
+    pub fn run(&mut self, state: &State) -> Result<MigrationPlan<'_>> {
         let mut pending = self.pending_plan(state.agent_pool())?;
 
         let number_inbound = self.commands.get_number_inbound();
@@ -88,7 +85,7 @@ impl PendingPlan {
 
     fn complete<'b>(
         &mut self,
-        state: &impl ReadState,
+        state: &State,
         new_agents: Option<&'b RecordBatch>,
         config: &Arc<SimRunConfig>,
     ) -> Result<MigrationPlan<'b>> {
@@ -148,7 +145,7 @@ impl PendingPlan {
 }
 
 fn buffer_actions_from_pending_batch<'a>(
-    state: &impl ReadState,
+    state: &State,
     batch: &PendingBatch,
     inbound_agents: &Option<&'a RecordBatch>,
     schema: &Arc<AgentSchema>,

--- a/packages/engine/src/datastore/table/state/mod.rs
+++ b/packages/engine/src/datastore/table/state/mod.rs
@@ -47,10 +47,10 @@ impl State {
     ///
     /// Uses the schemas in the provided `sim_config` to validate the provided state, and to create
     /// the agent and message batches. The agent batches use the data provided in
-    /// `agent_state_batches`, where each element is a group, and the total elements (i.e.
+    /// `agent_state_groups`, where each element is a group, and the total elements (i.e.
     /// [`AgentState`]s) within those groups is `num_agents`.
     ///
-    /// Effectively converts the `agent_state_batches` from Array-of-Structs into a
+    /// Effectively converts the `agent_state_groups` from Array-of-Structs into a
     /// Struct-of-Arrays.
     pub fn from_agent_groups(
         agent_state_groups: &[&[AgentState]],
@@ -67,7 +67,7 @@ impl State {
         let mut group_start_indices = Vec::new();
         let mut start = 0;
 
-        // converts the `agent_state_batches` from Array-of-Structs into a Struct-of-Arrays.
+        // converts the `agent_state_groups` from Array-of-Structs into a Struct-of-Arrays.
         for agent_state_group in agent_state_groups {
             group_start_indices.push(start);
             start += agent_state_group.len();

--- a/packages/engine/src/datastore/table/state/mod.rs
+++ b/packages/engine/src/datastore/table/state/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     SimRunConfig,
 };
 
-pub struct Inner {
+pub struct State {
     /// Pool which contains all batches for the current step's Agent state.
     agent_pool: AgentPool,
 
@@ -38,23 +38,35 @@ pub struct Inner {
     local_meta: Meta,
 
     num_agents: usize,
+
+    sim_config: Arc<SimRunConfig>,
 }
 
-impl Inner {
-    /// Creates a new State object from a collection of groups of `AgentState`.
+impl State {
+    /// Creates a new State object from a provided array of `AgentState`.
     ///
     /// Uses the schemas in the provided `sim_config` to validate the provided state, and to create
-    /// the agent and message batches. The agent batches use the data provided in
-    /// `agent_state_batches`, where each element is a group, and the total elements (i.e.
-    /// `AgentState`s) within those groups is `num_agents`.
-    ///
-    /// Effectively converts the `agent_state_batches` from Array-of-Structs into a
-    /// Struct-of-Arrays.
-    fn from_agent_states(
-        agent_state_batches: &[&[AgentState]],
-        num_agents: usize,
-        sim_config: &SimRunConfig,
-    ) -> Result<Inner> {
+    /// the agent and message batches. The agent batches are created by splitting up the
+    /// `agent_states` into groups based on the number of workers specified in `sim_config`.
+    pub fn from_agent_states(
+        agent_states: &[AgentState],
+        sim_config: Arc<SimRunConfig>,
+    ) -> Result<State> {
+        let num_workers = sim_config.sim.engine.num_workers;
+        let num_agents = agent_states.len();
+
+        // Distribute agents across workers
+        const MIN_PER_WORKER: usize = 10;
+        let num_agents_per_worker =
+            ((num_agents as f64 / num_workers as f64).ceil() as usize).max(MIN_PER_WORKER);
+        let mut agent_state_batches = vec![];
+        let mut next_index = 0;
+        while next_index != num_agents {
+            let this_index = next_index;
+            next_index = (next_index + num_agents_per_worker).min(num_agents);
+            agent_state_batches.push(&agent_states[this_index..next_index]);
+        }
+
         let mut agent_batches = Vec::with_capacity(agent_state_batches.len());
         let mut message_batches = Vec::with_capacity(agent_state_batches.len());
 
@@ -65,101 +77,33 @@ impl Inner {
         let mut group_start_indices = Vec::new();
         let mut start = 0;
 
+        // converts the `agent_state_batches` from Array-of-Structs into a Struct-of-Arrays.
         for agent_state_batch in agent_state_batches {
             group_start_indices.push(start);
             start += agent_state_batch.len();
 
             agent_batches.push(Arc::new(parking_lot::RwLock::new(
-                AgentBatch::from_agent_states(*agent_state_batch, agent_schema, experiment_id)?,
+                AgentBatch::from_agent_states(agent_state_batch, agent_schema, experiment_id)?,
             )));
             message_batches.push(Arc::new(parking_lot::RwLock::new(
-                MessageBatch::from_agent_states(*agent_state_batch, message_schema, experiment_id)?,
+                MessageBatch::from_agent_states(agent_state_batch, message_schema, experiment_id)?,
             )));
         }
         let agent_pool = AgentPool::new(agent_batches);
         let message_pool = MessagePool::new(message_batches);
 
-        let inner = Inner {
+        Ok(Self {
             agent_pool,
             message_pool,
             local_meta: Meta::default(),
             num_agents,
             group_start_indices: Arc::new(group_start_indices),
-        };
-        Ok(inner)
-    }
-}
-
-pub struct State {
-    inner: Inner,
-    sim_config: Arc<SimRunConfig>,
-}
-
-impl State {
-    /// Creates a new State object from a provided collection of `AgentState`.
-    ///
-    /// Uses the schemas in the provided `sim_config` to validate the provided state, and to create
-    /// the agent and message batches. The agent batches are created by splitting up the
-    /// `agent_states` into groups based on the number of workers specified in `sim_config`.
-    pub fn from_agent_states(
-        agent_states: Vec<AgentState>,
-        sim_config: Arc<SimRunConfig>,
-    ) -> Result<State> {
-        let num_workers = sim_config.sim.engine.num_workers;
-        let num_agents = agent_states.len();
-
-        // Distribute agents across workers
-        const MIN_PER_WORKER: usize = 10;
-        let num_agents_per_worker =
-            ((num_agents as f64 / num_workers as f64).ceil() as usize).max(MIN_PER_WORKER);
-        let mut split_agent_states = vec![];
-        let mut next_index = 0;
-        while next_index != num_agents {
-            let this_index = next_index;
-            next_index = (next_index + num_agents_per_worker).min(num_agents);
-            split_agent_states.push(&agent_states[this_index..next_index]);
-        }
-        let inner = Inner::from_agent_states(&split_agent_states, num_agents, &sim_config)?;
-        Ok(State { inner, sim_config })
-    }
-
-    /// Get mutable access to the State.
-    pub fn into_mut(self) -> StateMut {
-        StateMut {
-            inner: self.inner,
-            global_meta: self.sim_config,
-        }
-    }
-}
-
-impl ReadState for State {
-    fn inner(&self) -> &Inner {
-        &self.inner
-    }
-
-    fn sim_config(&self) -> &Arc<SimRunConfig> {
-        &self.sim_config
-    }
-}
-
-// TODO can we just wrap the State instead of needing another layer called Inner
-/// Exclusive (write) access to `State`.
-pub struct StateMut {
-    inner: Inner,
-    global_meta: Arc<SimRunConfig>,
-}
-
-impl StateMut {
-    /// Give up mutable access and allow for it to be read in multiple places.
-    pub fn into_shared(self) -> State {
-        State {
-            inner: self.inner,
-            sim_config: self.global_meta,
-        }
+            sim_config,
+        })
     }
 
     pub fn local_meta(&mut self) -> &mut Meta {
-        &mut self.inner.local_meta
+        &mut self.local_meta
     }
 
     // TODO can this be moved into Context
@@ -241,7 +185,7 @@ impl StateMut {
                 .collect(),
         );
         drop(dynamic_pool);
-        self.inner.group_start_indices = group_start_indices;
+        self.group_start_indices = group_start_indices;
         Ok(())
     }
 
@@ -264,39 +208,48 @@ impl StateMut {
 
     // TODO: enable writing into the message batch too
     pub fn set_pending_column(&mut self, column: StateColumn) -> Result<()> {
-        self.inner.agent_pool.set_pending_column(column)
+        self.agent_pool_mut().set_pending_column(column)
     }
 
     pub fn flush_pending_columns(&mut self) -> Result<()> {
-        self.inner.agent_pool.flush_pending_columns()
-    }
-}
-
-impl ReadState for StateMut {
-    fn inner(&self) -> &Inner {
-        &self.inner
+        self.agent_pool_mut().flush_pending_columns()
     }
 
-    fn sim_config(&self) -> &Arc<SimRunConfig> {
-        &self.global_meta
-    }
-}
-
-impl WriteState for StateMut {
-    fn inner_mut(&mut self) -> &mut Inner {
-        &mut self.inner
-    }
-}
-
-pub trait WriteState: ReadState {
-    fn inner_mut(&mut self) -> &mut Inner;
-
-    fn agent_pool_mut(&mut self) -> &mut AgentPool {
-        &mut self.inner_mut().agent_pool
+    pub fn sim_config(&self) -> &Arc<SimRunConfig> {
+        &self.sim_config
     }
 
-    fn message_pool_mut(&mut self) -> &mut MessagePool {
-        &mut self.inner_mut().message_pool
+    pub fn message_pool(&self) -> &MessagePool {
+        &self.message_pool
+    }
+
+    pub fn message_pool_mut(&mut self) -> &mut MessagePool {
+        &mut self.message_pool
+    }
+
+    pub fn message_map(&self) -> Result<MessageMap> {
+        let read = self.message_pool().read()?;
+        MessageMap::new(&read)
+    }
+
+    pub fn agent_pool(&self) -> &AgentPool {
+        &self.agent_pool
+    }
+
+    pub fn agent_pool_mut(&mut self) -> &mut AgentPool {
+        &mut self.agent_pool
+    }
+
+    pub fn num_agents(&self) -> usize {
+        self.num_agents
+    }
+
+    pub fn num_agents_mut(&mut self) -> &mut usize {
+        &mut self.num_agents
+    }
+
+    pub fn group_start_indices(&self) -> &Arc<Vec<usize>> {
+        &self.group_start_indices
     }
 
     /// Reset the messages of the State
@@ -307,52 +260,20 @@ pub trait WriteState: ReadState {
     /// Returns the old messages so they can be used later for reference.
     ///
     /// ### Performance
+    ///
     /// This creates a new empty messages column for each old column to replace, which
     /// requires creating a null bit buffer with all bits set to 1 (i.e. all valid), i.e. one bit
     /// per each agent in each group. Everything else is O(m), where `m` is the number of batches,
     /// so this function shouldn't take very long to run.
-    fn reset_messages(
+    pub fn reset_messages(
         &mut self,
         mut old_context_message_pool: MessagePool,
         sim_config: &SimRunConfig,
     ) -> Result<MessagePool> {
-        let inner = self.inner_mut();
-        let agent_pool = &inner.agent_pool;
-        old_context_message_pool.reset(agent_pool, sim_config)?;
+        old_context_message_pool.reset(&self.agent_pool, sim_config)?;
         Ok(std::mem::replace(
-            &mut inner.message_pool,
+            &mut self.message_pool,
             old_context_message_pool,
         ))
-    }
-
-    fn num_agents_mut(&mut self) -> &mut usize {
-        &mut self.inner_mut().num_agents
-    }
-}
-
-pub trait ReadState {
-    fn inner(&self) -> &Inner;
-
-    fn sim_config(&self) -> &Arc<SimRunConfig>;
-
-    fn message_pool(&self) -> &MessagePool {
-        &self.inner().message_pool
-    }
-
-    fn message_map(&self) -> Result<MessageMap> {
-        let read = self.message_pool().read()?;
-        MessageMap::new(&read)
-    }
-
-    fn agent_pool(&self) -> &AgentPool {
-        &self.inner().agent_pool
-    }
-
-    fn num_agents(&self) -> usize {
-        self.inner().num_agents
-    }
-
-    fn group_start_indices(&self) -> &Arc<Vec<usize>> {
-        &self.inner().group_start_indices
     }
 }

--- a/packages/engine/src/datastore/table/task_shared_store.rs
+++ b/packages/engine/src/datastore/table/task_shared_store.rs
@@ -1,13 +1,14 @@
 //! TODO: DOC
 use std::fmt::Debug;
 
-use super::{
-    proxy::{StateReadProxy, StateWriteProxy},
-    state::{ReadState, WriteState},
-};
+use super::proxy::{StateReadProxy, StateWriteProxy};
 use crate::{
     config::{Distribution, Worker, WorkerAllocation},
-    datastore::{prelude::Result, table::context::Context, Error},
+    datastore::{
+        prelude::Result,
+        table::{context::Context, state::State},
+        Error,
+    },
     simulation::task::handler::worker_pool::SplitConfig,
 };
 
@@ -83,9 +84,9 @@ impl TaskSharedStoreBuilder {
         self.inner
     }
 
-    pub fn partial_write_state<K: WriteState>(
+    pub fn partial_write_state(
         mut self,
-        state: &K,
+        state: &mut State,
         batch_indices: Vec<usize>,
     ) -> Result<Self> {
         self.inner.state =
@@ -94,25 +95,21 @@ impl TaskSharedStoreBuilder {
         Ok(self)
     }
 
-    pub fn partial_read_state<K: ReadState>(
-        mut self,
-        state: &K,
-        batch_indices: Vec<usize>,
-    ) -> Result<Self> {
+    pub fn partial_read_state(mut self, state: &State, batch_indices: Vec<usize>) -> Result<Self> {
         self.inner.state =
             SharedState::Partial(PartialSharedState::new_read(state, batch_indices)?);
         Ok(self)
     }
 
-    /// Allow the task runners to have write access to all of agent state
-    pub fn write_state<K: WriteState>(mut self, state: &mut K) -> Result<Self> {
-        self.inner.state = SharedState::Write(StateWriteProxy::new(state)?);
+    /// Allow the task runners to have read access to all of agent state
+    pub fn read_state(mut self, state: &State) -> Result<Self> {
+        self.inner.state = SharedState::Read(StateReadProxy::new(state)?);
         Ok(self)
     }
 
-    /// Allow the task runners to have read access to all of agent state
-    pub fn read_state<K: ReadState>(mut self, state: &K) -> Result<Self> {
-        self.inner.state = SharedState::Read(StateReadProxy::new(state)?);
+    /// Allow the task runners to have write access to all of agent state
+    pub fn write_state(mut self, state: &mut State) -> Result<Self> {
+        self.inner.state = SharedState::Write(StateWriteProxy::new(state)?);
         Ok(self)
     }
 
@@ -135,20 +132,17 @@ pub enum PartialSharedState {
 }
 
 impl PartialSharedState {
-    fn new_write<K: WriteState>(
-        state: &K,
-        group_indices: Vec<usize>,
-    ) -> Result<PartialSharedState> {
-        let inner = StateWriteProxy::new_partial(state, &group_indices)?;
-        Ok(PartialSharedState::Write(PartialStateWriteProxy {
+    fn new_read(state: &State, group_indices: Vec<usize>) -> Result<PartialSharedState> {
+        let inner = StateReadProxy::new_partial(state, &group_indices)?;
+        Ok(PartialSharedState::Read(PartialStateReadProxy {
             group_indices,
             inner,
         }))
     }
 
-    fn new_read<K: ReadState>(state: &K, group_indices: Vec<usize>) -> Result<PartialSharedState> {
-        let inner = StateReadProxy::new_partial(state, &group_indices)?;
-        Ok(PartialSharedState::Read(PartialStateReadProxy {
+    fn new_write(state: &mut State, group_indices: Vec<usize>) -> Result<PartialSharedState> {
+        let inner = StateWriteProxy::new_partial(state, &group_indices)?;
+        Ok(PartialSharedState::Write(PartialStateWriteProxy {
             group_indices,
             inner,
         }))
@@ -302,7 +296,7 @@ impl TaskSharedStore {
             };
             let group_sizes = agent_batches
                 .iter()
-                .map(|batch| batch.batch().num_agents())
+                .map(|proxy| proxy.batch().num_agents())
                 .collect();
             let (stores, split_config) = distribute_batches(
                 worker_list,
@@ -345,7 +339,7 @@ impl TaskSharedStore {
             };
             let group_sizes = agent_batches
                 .iter()
-                .map(|batch_reader| batch_reader.batch().num_agents())
+                .map(|proxy| proxy.batch().num_agents())
                 .collect();
             let (stores, split_config) = distribute_batches(
                 worker_list,

--- a/packages/engine/src/output/local/mod.rs
+++ b/packages/engine/src/output/local/mod.rs
@@ -26,7 +26,11 @@ impl OutputPersistenceCreatorRepr for LocalOutputPersistence {
         sim_id: SimulationShortId,
         persistence_config: &PersistenceConfig,
     ) -> Result<Self::SimulationOutputPersistence> {
-        let buffers = Buffers::new(&self.experiment_id, sim_id, &persistence_config.output_config)?;
+        let buffers = Buffers::new(
+            &self.experiment_id,
+            sim_id,
+            &persistence_config.output_config,
+        )?;
         Ok(LocalSimulationOutputPersistence::new(
             self.project_name.clone(),
             self.experiment_name.clone(),

--- a/packages/engine/src/simulation/comms/mod.rs
+++ b/packages/engine/src/simulation/comms/mod.rs
@@ -36,14 +36,11 @@ use super::{
 };
 pub use super::{Error, Result};
 use crate::{
-    datastore::{
-        prelude::State,
-        table::{
-            context::Context,
-            state::{view::StateSnapshot, ReadState},
-            sync::{ContextBatchSync, StateSync, SyncPayload, WaitableStateSync},
-            task_shared_store::TaskSharedStore,
-        },
+    datastore::table::{
+        context::Context,
+        state::{view::StateSnapshot, State},
+        sync::{ContextBatchSync, StateSync, SyncPayload, WaitableStateSync},
+        task_shared_store::TaskSharedStore,
     },
     hash_types::Agent,
     proto::SimulationShortId,

--- a/packages/engine/src/simulation/package/context/packages/agent_messages/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/mod.rs
@@ -13,7 +13,6 @@ use crate::{
     datastore::{
         batch::iterators,
         schema::{accessor::GetFieldSpec, RootFieldSpec},
-        table::state::ReadState,
     },
     simulation::{
         comms::package::PackageComms,

--- a/packages/engine/src/simulation/package/context/packages/api_requests/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/api_requests/mod.rs
@@ -16,7 +16,6 @@ use crate::{
     datastore::{
         batch::iterators,
         schema::{accessor::GetFieldSpec, FieldKey},
-        table::state::ReadState,
     },
     simulation::{
         comms::package::PackageComms,

--- a/packages/engine/src/simulation/package/context/packages/neighbors/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/neighbors/mod.rs
@@ -15,7 +15,7 @@ use crate::{
             context::ContextSchema,
             FieldKey, RootFieldSpec, RootFieldSpecCreator,
         },
-        table::state::{view::StateSnapshot, ReadState, State},
+        table::state::{view::StateSnapshot, State},
     },
     simulation::{
         comms::package::PackageComms,

--- a/packages/engine/src/simulation/package/mod.rs
+++ b/packages/engine/src/simulation/package/mod.rs
@@ -41,10 +41,7 @@ pub mod prelude {
         config::{ExperimentConfig, SimulationConfig},
         datastore::{
             prelude::*,
-            table::{
-                context::Context,
-                state::{State, StateMut},
-            },
+            table::{context::Context, state::State},
         },
         simulation::{Error, Result},
     };

--- a/packages/engine/src/simulation/package/output/packages/analysis/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/analysis/mod.rs
@@ -7,8 +7,7 @@ use serde_json::Value;
 pub use self::config::AnalysisOutputConfig;
 pub use super::super::*;
 use crate::{
-    datastore::table::state::ReadState, experiment::SimPackageArgs, proto::ExperimentRunTrait,
-    simulation::package::output::Package,
+    experiment::SimPackageArgs, proto::ExperimentRunTrait, simulation::package::output::Package,
 };
 
 #[macro_use]

--- a/packages/engine/src/simulation/package/output/packages/json_state/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/json_state/mod.rs
@@ -6,7 +6,6 @@ use crate::{
     datastore::{
         batch::ArrowBatch,
         schema::{HIDDEN_PREFIX, PRIVATE_PREFIX},
-        table::state::ReadState,
     },
     hash_types::Agent,
     simulation::package::{name::PackageName, output, output::Package},

--- a/packages/engine/src/simulation/package/run.rs
+++ b/packages/engine/src/simulation/package/run.rs
@@ -4,12 +4,9 @@ use futures::{executor::block_on, stream::FuturesOrdered, StreamExt};
 use tracing::{Instrument, Span};
 
 use crate::{
-    datastore::{
-        prelude::State,
-        table::{
-            context::{Context, PreContext},
-            state::{view::StateSnapshot, ReadState},
-        },
+    datastore::table::{
+        context::{Context, PreContext},
+        state::{view::StateSnapshot, State},
     },
     proto::ExperimentRunTrait,
     simulation::{
@@ -17,7 +14,7 @@ use crate::{
             context,
             context::ContextColumn,
             init, output,
-            prelude::{Error, Result, StateMut},
+            prelude::{Error, Result},
             state,
         },
         step_output::SimulationStepOutput,
@@ -74,7 +71,7 @@ impl InitPackages {
         }
 
         tracing::trace!("Init packages finished, building state");
-        let state = State::from_agent_states(agents, sim_config)?;
+        let state = State::from_agent_states(&agents, sim_config)?;
         Ok(state)
     }
 }
@@ -242,7 +239,7 @@ impl StepPackages {
         Ok(context)
     }
 
-    pub async fn run_state(&mut self, mut state: StateMut, context: &Context) -> Result<StateMut> {
+    pub async fn run_state(&mut self, mut state: State, context: &Context) -> Result<State> {
         tracing::debug!("Running state packages");
         // Design-choices:
         // Cannot use trait bounds as dyn Package won't be object-safe

--- a/packages/engine/src/simulation/package/state/mod.rs
+++ b/packages/engine/src/simulation/package/state/mod.rs
@@ -13,7 +13,7 @@ use crate::{
         batch::change::ArrayChange,
         error::Result as DatastoreResult,
         schema::{accessor::FieldSpecMapAccessor, RootFieldSpec, RootFieldSpecCreator},
-        table::state::StateMut,
+        table::state::State,
     },
     simulation::{
         comms::package::PackageComms, package::ext_traits::GetWorkerExpStartMsg, Error, Result,
@@ -23,7 +23,7 @@ use crate::{
 
 #[async_trait]
 pub trait Package: GetWorkerSimStartMsg + Send + Sync {
-    async fn run(&mut self, state: &mut StateMut, context: &Context) -> Result<()>;
+    async fn run(&mut self, state: &mut State, context: &Context) -> Result<()>;
 
     fn span(&self) -> Span;
 }

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/chain.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/chain.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 pub fn gather_behavior_chains(
-    state: &StateMut,
+    state: &State,
     behavior_ids: &BehaviorIds,
     data_types: [arrow::datatypes::DataType; 3],
     behavior_ids_col_index: usize,

--- a/packages/engine/src/simulation/package/state/packages/topology/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/topology/mod.rs
@@ -1,10 +1,7 @@
 use serde_json::Value;
 
 use super::super::*;
-use crate::{
-    config::{ExperimentConfig, TopologyConfig},
-    datastore::table::state::WriteState,
-};
+use crate::config::{ExperimentConfig, TopologyConfig};
 
 mod adjacency;
 mod fields;
@@ -77,7 +74,7 @@ impl GetWorkerSimStartMsg for Topology {
 
 #[async_trait]
 impl Package for Topology {
-    async fn run(&mut self, state: &mut StateMut, _context: &Context) -> Result<()> {
+    async fn run(&mut self, state: &mut State, _context: &Context) -> Result<()> {
         tracing::trace!("Running Topology package");
         if self.config.move_wrapped_agents {
             for mut mut_table in state.agent_pool_mut().try_write_batches()? {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`State` and `StateMut` can be merged into a single struct, instead `&mut` and `mut` should be used properly. 

## 🐾 Next steps

- Use the Proxy API for states

## 🔍 What does this change?

- Move `state::Inner` into `state::State`
- Move `state::StateMut` into `state::State`
- Removes `ReadState` and `WriteState` as they are not needed anymore

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201707629991362/1201778198730315/f) (_internal_)
