### PR TITLE
Renaming the lib component of hash_engine to hash_engine_lib

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -257,7 +257,7 @@ jobs:
 
       - name: Build test dependencies
         if: matrix.directory == 'packages/engine'
-        run: cargo build -p server --manifest-path ${{ matrix.directory }}/Cargo.toml ${{ matrix.flags }}
+        run: cargo build -p hash_engine --manifest-path ${{ matrix.directory }}/Cargo.toml ${{ matrix.flags }}
 
       - name: Run tests
         run: cargo test --manifest-path ${{ matrix.directory }}/Cargo.toml --no-fail-fast ${{ matrix.flags }}
@@ -320,7 +320,7 @@ jobs:
           rm -rf tmp # Delete the tmp folder
 
       - name: Build test dependencies
-        run: cargo build -p server --manifest-path ${{ matrix.directory }}/Cargo.toml ${{ matrix.flags }}
+        run: cargo build -p hash_engine --manifest-path ${{ matrix.directory }}/Cargo.toml ${{ matrix.flags }}
 
       - name: Run tests
         run: cargo test --test ${{ matrix.tests }} --manifest-path ${{ matrix.directory }}/Cargo.toml --no-fail-fast ${{ matrix.flags }} -- --test-threads=1

--- a/packages/engine/Cargo.lock
+++ b/packages/engine/Cargo.lock
@@ -413,7 +413,7 @@ version = "0.0.0"
 dependencies = [
  "clap",
  "error",
- "hash_engine",
+ "hash_engine_lib",
  "orchestrator",
  "serde",
  "tokio",
@@ -929,6 +929,16 @@ dependencies = [
 
 [[package]]
 name = "hash_engine"
+version = "0.0.0"
+dependencies = [
+ "error",
+ "hash_engine_lib",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hash_engine_lib"
 version = "0.0.0"
 dependencies = [
  "arr_macro",
@@ -1472,7 +1482,7 @@ dependencies = [
  "async-trait",
  "clap",
  "error",
- "hash_engine",
+ "hash_engine_lib",
  "num_cpus",
  "rand 0.8.4",
  "rand_distr",
@@ -1917,16 +1927,6 @@ dependencies = [
  "itoa 0.4.8",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "server"
-version = "0.0.0"
-dependencies = [
- "error",
- "hash_engine",
- "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "hash_engine"
+name = "hash_engine_lib"
 version = "0.0.0"
 edition = "2021"
 
@@ -59,6 +59,7 @@ build-nng = ["nng/build-nng"]
 texray = ["tracing-texray"]
 
 [lib]
+name = "hash_engine_lib"
 crate-type = ["lib", "cdylib"]
 
 [build-dependencies.cc]

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -134,7 +134,7 @@ Due to ARM-Based Macs, the `macos` `target_os` has some added complications for 
 
 Due to limitations in Cargo at the moment we can't properly check if it's being built _on_ an ARM Mac (rather than _for_ an ARM Mac). Due to this it's necessary to:
 
-- _Disable_ the `hash_engine/build-nng` feature by passing `--no-default-features` to any cargo commands such as `cargo build`
+- _Disable_ the `hash_engine_lib/build-nng` feature by passing `--no-default-features` to any cargo commands such as `cargo build`
 
   At the moment the project only seems to be compiling if you use the `x86_64-apple-darwin` target. This has some added complexity, especially due to the fact that rustc fails to link 'fat-binaries' in certain scenarios.
 

--- a/packages/engine/bin/cli/Cargo.toml
+++ b/packages/engine/bin/cli/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 description = "The hEngine Command line interface"
 
 [dependencies]
-hash_engine = { path = "../..", default-features = false }
+hash_engine_lib = { path = "../..", default-features = false }
 error = { path = "../../lib/error", features = ["spantrace"] }
 orchestrator = { path = "../../lib/orchestrator", default-features = false, features = ["clap"] }
 
@@ -20,5 +20,5 @@ uuid = { version = "0.8.1", features = ["v4", "serde"] }
 
 [features]
 default = ["build-nng"]
-texray = ["hash_engine/texray"]
-build-nng = ["hash_engine/build-nng", "orchestrator/build-nng"]
+texray = ["hash_engine_lib/texray"]
+build-nng = ["hash_engine_lib/build-nng", "orchestrator/build-nng"]

--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -8,7 +8,7 @@ use std::{
 
 use clap::{AppSettings, Parser};
 use error::{Result, ResultExt};
-use hash_engine::proto::ExperimentName;
+use hash_engine_lib::proto::ExperimentName;
 use orchestrator::{Experiment, ExperimentConfig, Manifest, Server};
 
 /// Arguments passed to the CLI
@@ -80,7 +80,7 @@ async fn main() -> Result<()> {
         .unwrap()
         .as_millis();
 
-    let _guard = hash_engine::init_logger(
+    let _guard = hash_engine_lib::init_logger(
         args.experiment_config.log_format,
         &args.experiment_config.output_location,
         args.experiment_config.log_folder.clone(),

--- a/packages/engine/bin/hash_engine/Cargo.toml
+++ b/packages/engine/bin/hash_engine/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "server"
+name = "hash_engine"
 version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-hash_engine = { path = "../..", default-features = false }
+hash_engine_lib = { path = "../..", default-features = false }
 error = { path = "../../lib/error", features = ["spantrace"] }
 
 tokio = "1.5.0"
@@ -16,5 +16,5 @@ path = "src/main.rs"
 
 [features]
 default = ["build-nng"]
-texray = ["hash_engine/texray"]
-build-nng = ["hash_engine/build-nng"]
+texray = ["hash_engine_lib/texray"]
+build-nng = ["hash_engine_lib/build-nng"]

--- a/packages/engine/bin/hash_engine/src/main.rs
+++ b/packages/engine/bin/hash_engine/src/main.rs
@@ -1,5 +1,5 @@
 use error::{Result, ResultExt};
-use hash_engine::{
+use hash_engine_lib::{
     experiment::controller::run::run_experiment,
     fetch::FetchDependencies,
     proto::{ExperimentRun, ExperimentRunTrait},
@@ -7,8 +7,8 @@ use hash_engine::{
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let args = hash_engine::args();
-    let _guard = hash_engine::init_logger(
+    let args = hash_engine_lib::args();
+    let _guard = hash_engine_lib::init_logger(
         args.log_format,
         &args.output,
         &args.log_folder,
@@ -16,7 +16,7 @@ async fn main() -> Result<()> {
         &format!("experiment-{}-texray", args.experiment_id),
     );
 
-    let mut env = hash_engine::env::<ExperimentRun>(&args)
+    let mut env = hash_engine_lib::env::<ExperimentRun>(&args)
         .await
         .wrap_err("Could not create environment for experiment")?;
     // Fetch all dependencies of the experiment run such as datasets
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
         .await
         .wrap_err("Could not fetch dependencies for experiment")?;
     // Generate the configuration for packages from the environment
-    let config = hash_engine::experiment_config(&args, &env).await?;
+    let config = hash_engine_lib::experiment_config(&args, &env).await?;
 
     tracing::info!(
         "HASH Engine process started for experiment {}",

--- a/packages/engine/lib/orchestrator/Cargo.toml
+++ b/packages/engine/lib/orchestrator/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 error = { path = "../../lib/error", features = ["spantrace"] }
-hash_engine = { path = "../..", default-features = false }
+hash_engine_lib = { path = "../..", default-features = false }
 
 async-trait = "0.1.48"
 clap = { version = "3.0.13", optional = true }
@@ -20,4 +20,4 @@ uuid = { version = "0.8.1", features = ["v4", "serde"] }
 
 [features]
 default = ["build-nng"]
-build-nng = ["hash_engine/build-nng"]
+build-nng = ["hash_engine_lib/build-nng"]

--- a/packages/engine/lib/orchestrator/src/experiment.rs
+++ b/packages/engine/lib/orchestrator/src/experiment.rs
@@ -5,7 +5,7 @@
 use std::{collections::HashMap, path::PathBuf, time::Duration};
 
 use error::{bail, ensure, report, Result, ResultExt};
-use hash_engine::{
+use hash_engine_lib::{
     experiment::controller::config::{OutputPersistenceConfig, OUTPUT_PERSISTENCE_KEY},
     output::local::config::LocalPersistenceConfig,
     proto,

--- a/packages/engine/lib/orchestrator/src/experiment_server.rs
+++ b/packages/engine/lib/orchestrator/src/experiment_server.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashMap, fmt::Display};
 
 use error::{bail, report, Result, ResultExt};
-use hash_engine::{nano, proto, proto::ExperimentId};
+use hash_engine_lib::{nano, proto, proto::ExperimentId};
 use tokio::sync::{mpsc, oneshot};
 
 type ResultSender = oneshot::Sender<Result<()>>;

--- a/packages/engine/lib/orchestrator/src/manifest.rs
+++ b/packages/engine/lib/orchestrator/src/manifest.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use error::{bail, ensure, report, Result, ResultExt};
-use hash_engine::{
+use hash_engine_lib::{
     fetch::parse_raw_csv_into_json,
     proto::{
         ExperimentRun, ExperimentRunBase, InitialState, InitialStateName, ProjectBase,
@@ -39,10 +39,11 @@ pub struct Manifest {
     pub behaviors: Vec<SharedBehavior>,
     /// A list of all datasets in the project.
     pub datasets: Vec<SharedDataset>,
-    /// JSON string describing the [`Globals`](hash_engine::config::Globals) object.
+    /// JSON string describing the [`Globals`](hash_engine_lib::config::Globals) object.
     pub globals_json: Option<String>,
     /// JSON string describing the analysis that's calculated by the
-    /// [analysis output package](hash_engine::simulation::package::output::packages::analysis).
+    /// [analysis output
+    /// package](hash_engine_lib::simulation::package::output::packages::analysis).
     pub analysis_json: Option<String>,
     /// JSON string describing the structure of available experiments for this project.
     pub experiments_json: Option<String>,
@@ -123,7 +124,7 @@ impl Manifest {
     }
 
     /// Reads the content from the file at the provided `path` describing the
-    /// [`Globals`](hash_engine::config::Globals).
+    /// [`Globals`](hash_engine_lib::config::Globals).
     ///
     /// # Errors
     ///
@@ -135,7 +136,7 @@ impl Manifest {
 
     /// Reads the content from the file at the provided `path` describing the analysis of the
     /// experiment, calculated by the
-    /// [analysis output package](hash_engine::simulation::package::output::packages::analysis).
+    /// [analysis output package](hash_engine_lib::simulation::package::output::packages::analysis).
     ///
     /// # Errors
     ///

--- a/packages/engine/lib/orchestrator/src/process/local.rs
+++ b/packages/engine/lib/orchestrator/src/process/local.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use error::{Report, Result, ResultExt};
-use hash_engine::{
+use hash_engine_lib::{
     nano,
     proto::{EngineMsg, ExperimentId},
     utils::{LogFormat, OutputLocation},

--- a/packages/engine/lib/orchestrator/src/process/mod.rs
+++ b/packages/engine/lib/orchestrator/src/process/mod.rs
@@ -4,7 +4,7 @@ mod local;
 
 use async_trait::async_trait;
 use error::Result;
-use hash_engine::proto::EngineMsg;
+use hash_engine_lib::proto::EngineMsg;
 pub use local::{LocalCommand, LocalProcess};
 
 /// The engine-subprocess running in the background.

--- a/packages/engine/src/datastore/schema/field_spec/creator.rs
+++ b/packages/engine/src/datastore/schema/field_spec/creator.rs
@@ -11,7 +11,7 @@ use crate::datastore::schema::field_spec::{
 /// # Example
 ///
 /// ```
-/// use hash_engine::{
+/// use hash_engine_lib::{
 ///     datastore::schema::{FieldSource, RootFieldSpecCreator},
 ///     simulation::package::{name::PackageName, output::Name as OutputName},
 /// };
@@ -32,7 +32,7 @@ impl RootFieldSpecCreator {
     /// # Example
     ///
     /// ```
-    /// use hash_engine::datastore::schema::{FieldSource, RootFieldSpecCreator};
+    /// use hash_engine_lib::datastore::schema::{FieldSource, RootFieldSpecCreator};
     ///
     /// # #[allow(unused_variables)]
     /// let rfs_creator = RootFieldSpecCreator::new(FieldSource::Engine);
@@ -47,7 +47,7 @@ impl RootFieldSpecCreator {
     /// # Example
     ///
     /// ```
-    /// use hash_engine::datastore::schema::{
+    /// use hash_engine_lib::datastore::schema::{
     ///     FieldScope, FieldSource, FieldType, FieldTypeVariant, RootFieldSpecCreator,
     /// };
     ///

--- a/packages/engine/src/worker/runner/python/main.py
+++ b/packages/engine/src/worker/runner/python/main.py
@@ -28,7 +28,7 @@ def logging_setup():
             pair = kv.replace(" ", "").split("=")
             if len(pair) != 2:
                 continue
-            if pair[0] == "hash_engine":
+            if pair[0] in ["hash_engine", "hash_engine_lib"]:
                 possible_level = get_logging_level(pair[1])
                 if possible_level is not None:
                     level = possible_level

--- a/packages/engine/src/worker/runner/python/setup.py
+++ b/packages/engine/src/worker/runner/python/setup.py
@@ -18,7 +18,7 @@ setup(
         Extension(prefix + "wrappers",
                   [script_path + "/wrappers.pyx"],
                   include_dirs=[numpy.get_include()],
-                  libraries=["hash_engine"],
+                  libraries=["hash_engine_lib"],
                   library_dirs=[  # Process directory should be packages/engine.
                       # TODO, should we just add all possibilities for targets here, we might need to do a
                       #  programmatic directory search

--- a/packages/engine/tests/experiment/mod.rs
+++ b/packages/engine/tests/experiment/mod.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use error::{bail, ensure, report, Result, ResultExt};
-use hash_engine::{
+use hash_engine_lib::{
     proto::ExperimentName,
     utils::{LogFormat, OutputLocation},
     Language,

--- a/packages/engine/tests/integration.rs
+++ b/packages/engine/tests/integration.rs
@@ -50,7 +50,7 @@ macro_rules! run_test {
     ($project:ident, $language:ident $(,)? $(#[$attr:meta])* ) => {
         // Enable syntax highlighting and code completion
         #[allow(unused)]
-        use hash_engine::Language::$language as _;
+        use hash_engine_lib::Language::$language as _;
 
         $(#[$attr])*
         #[tokio::test]
@@ -62,7 +62,7 @@ macro_rules! run_test {
                 .canonicalize()
                 .unwrap();
 
-            $crate::experiment::run_test_suite(project_path, concat!(module_path!(), "::", stringify!($project)), Some(hash_engine::Language::$language), None).await
+            $crate::experiment::run_test_suite(project_path, concat!(module_path!(), "::", stringify!($project)), Some(hash_engine_lib::Language::$language), None).await
         }
     };
     ($project:ident, experiment: $experiment:ident $(,)? $(#[$attr:meta])* ) => {
@@ -82,7 +82,7 @@ macro_rules! run_test {
     ($project:ident, $language:ident, experiment: $experiment:ident $(,)? $(#[$attr:meta])* ) => {
         // Enable syntax highlighting and code completion
         #[allow(unused)]
-        use hash_engine::Language::$language as _;
+        use hash_engine_lib::Language::$language as _;
 
         $(#[$attr])*
         #[tokio::test]
@@ -94,7 +94,7 @@ macro_rules! run_test {
                 .canonicalize()
                 .unwrap();
 
-            $crate::experiment::run_test_suite(project_path, concat!(module_path!(), "::", stringify!($experiment)), Some(hash_engine::Language::$language), Some(stringify!($experiment))).await
+            $crate::experiment::run_test_suite(project_path, concat!(module_path!(), "::", stringify!($experiment)), Some(hash_engine_lib::Language::$language), Some(stringify!($experiment))).await
         }
     };
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The engine itself is composed of a lib crate and a binary crate. We had them both called `hash_engine` which was causing problems with things like generating docs.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201707629991362/1201660430639978/f) (_internal_)

## 🛡 What tests cover this?

- Integration and unit tests
