### PR TITLE
Fix unit tests

### DIFF
--- a/packages/engine/src/datastore/arrow/batch_conversion.rs
+++ b/packages/engine/src/datastore/arrow/batch_conversion.rs
@@ -1122,8 +1122,8 @@ impl IntoAgentStates for RecordBatch {
             .unwrap_or_else(|| {
                 self.schema()
                     .metadata()
-                    .get("serialized")
-                    .expect("Should always contain `serialized` in metadata")
+                    .get("any_type_fields")
+                    .expect("Should always contain `any_type_fields` in metadata")
                     .split(',')
                     .map(|v| v.to_string())
                     .collect()

--- a/packages/engine/src/datastore/arrow/field_conversion.rs
+++ b/packages/engine/src/datastore/arrow/field_conversion.rs
@@ -197,7 +197,6 @@ pub mod tests {
     };
 
     #[test]
-    #[ignore] // TODO: reenable test
     fn get_schema() -> Result<()> {
         let field_spec_creator = RootFieldSpecCreator::new(FieldSource::Engine);
         let mut field_spec_map = FieldSpecMap::empty();
@@ -235,7 +234,7 @@ pub mod tests {
         field_spec_map.add(AgentStateField::AgentId.try_into()?)?;
 
         let mut meta = HashMap::new();
-        meta.insert("serialized".into(), "".into());
+        meta.insert("any_type_fields".into(), "".into());
         meta.insert("nullable".into(), "1,1,0,1".into());
         let target = ArrowSchema::new_with_metadata(
             vec![

--- a/packages/engine/src/worker/runner/javascript/mini_v8/ffi.rs
+++ b/packages/engine/src/worker/runner/javascript/mini_v8/ffi.rs
@@ -21,6 +21,7 @@ extern "C" {
         line_offset: i32,
         column_offset: i32,
     ) -> TryCatchDesc;
+    #[allow(dead_code)]
     pub(super) fn mv8_interface_terminate_execution(_: Interface);
     pub(super) fn mv8_interface_global(_: Interface) -> ValuePtr;
     pub(super) fn mv8_interface_set_data(_: Interface, slot: u32, data: *mut c_void);

--- a/packages/engine/src/worker/runner/javascript/mini_v8/mini_v8.rs
+++ b/packages/engine/src/worker/runner/javascript/mini_v8/mini_v8.rs
@@ -67,21 +67,8 @@ impl MiniV8 {
         R: FromValue<'mv8>,
     {
         let script = script.into();
-        match (self.is_top, script.timeout) {
-            (true, Some(timeout)) => {
-                let interface = self.interface;
-                execute_with_timeout(
-                    timeout,
-                    || self.eval_inner(script),
-                    move || unsafe {
-                        mv8_interface_terminate_execution(interface);
-                    },
-                )?
-                .into(self)
-            }
-            (false, Some(_)) => Err(Error::invalid_timeout()),
-            (_, None) => self.eval_inner(script)?.into(self),
-        }
+        // Change: we've removed logic based on timeouts as it wasn't working and we don't need it
+        self.eval_inner(script)?.into(self)
     }
 
     fn eval_inner(&self, script: Script) -> Result<'_, Value<'_>> {
@@ -295,7 +282,8 @@ pub struct Script {
     /// V8 can only cancel script evaluation while running actual JavaScript code. If Rust code is
     /// being executed when the timeout is triggered, the execution will continue until the
     /// evaluation has returned to running JavaScript code.
-    pub timeout: Option<Duration>,
+    // Change: this seems broken so we've made it private, as we don't need to use it anyway
+    // _timeout: Option<Duration>,
     /// The script's origin.
     pub origin: Option<ScriptOrigin>,
 }

--- a/packages/engine/src/worker/runner/javascript/mini_v8/mini_v8.rs
+++ b/packages/engine/src/worker/runner/javascript/mini_v8/mini_v8.rs
@@ -314,6 +314,7 @@ impl<'a> From<&'a str> for Script {
     }
 }
 
+#[allow(dead_code)]
 fn execute_with_timeout<T>(
     timeout: Duration,
     execute_fn: impl FnOnce() -> T,

--- a/packages/engine/src/worker/runner/javascript/mini_v8/tests/function.rs
+++ b/packages/engine/src/worker/runner/javascript/mini_v8/tests/function.rs
@@ -100,7 +100,6 @@ fn return_unit() {
 }
 
 #[test]
-#[ignore] // TODO: reenable test
 fn rust_closure_mut_callback_error() {
     let mv8 = MiniV8::new();
 

--- a/packages/engine/src/worker/runner/javascript/mini_v8/tests/mini_v8.rs
+++ b/packages/engine/src/worker/runner/javascript/mini_v8/tests/mini_v8.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, rc::Rc, string::String as StdString, time::Duration};
+use std::{cell::RefCell, rc::Rc, string::String as StdString};
 
 use super::super::*;
 
@@ -13,7 +13,6 @@ fn eval_origin() {
                 line_offset: 123,
                 column_offset: 456,
             }),
-            ..Default::default()
         })
         .unwrap();
     let result = result.split_whitespace().collect::<Vec<_>>().join(" ");
@@ -21,28 +20,6 @@ fn eval_origin() {
         "ReferenceError: MISSING_VAR is not defined at eval_origin:124:463",
         result
     );
-}
-
-#[test]
-#[ignore] // TODO: reenable test
-fn eval_timeout() {
-    let mv8 = MiniV8::new();
-    let result = mv8.eval::<_, Value<'_>>(Script {
-        source: "a = 0; while (true) { a++; }".to_owned(),
-        timeout: Some(Duration::from_millis(50)),
-        ..Default::default()
-    });
-
-    let expected = "execution timed out";
-    match result {
-        Err(Error::Value(Value::Object(o)))
-            if o.get::<_, StdString>("message").unwrap() == expected => {}
-        _ => panic!("unexpected result: {:?}", result),
-    }
-
-    // Make sure we can still evaluate again:
-    let a: f64 = mv8.eval("a").unwrap();
-    assert!(a > 0.0);
 }
 
 #[test]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes and re-enables unit-tests that were ignored.

## ⚠️ Known issues

There are some more ignored unit-tests within the datastore. 

## 🐾 Next steps

We'll fix and re-enable the unit tests within Datastore after some imminent work is completed on restructuring read/write access to state and context objects. 

## 🔍 What does this change?

- Fixes remnants of a rename of `serialized` to `any_type_fields` in schema metadata and re-enables field_conversion tests that were mistakenly ignored because of it.
- Re-enables unit-tests in batch migration that were broken for the same reason
- Removes an additional unnecessary test module within the test module in batch migration (**the git diff is big because of this, no code changes were made outside of removing the nesting and commented imports**) 
- Removes the `timeout` field from the mv8 `Script` object as it was broken, and we do not use it. We're also planning on swapping to rustyV8 at some point in the near-term future so this is not a concern

### Does this require a change to the docs?

No

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201707629991362/1201780889982503/f) (_internal_)
- [Asana task](https://app.asana.com/0/0/1201780889982505/f) (_internal_)
- [Asana task](https://app.asana.com/0/1201707629991362/1201780889982506/f) (_internal_)

## 🛡 What tests cover this?

- These are tests
