### PR TITLE
Update branch for block repository fields to main

### DIFF
--- a/packages/blocks/code/package.json
+++ b/packages/blocks/code/package.json
@@ -5,7 +5,7 @@
   "description": "Capture a code snippet",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hashintel/hash.git",
+    "url": "https://github.com/hashintel/hash.git#main",
     "directory": "packages/blocks/code"
   },
   "license": "MIT",

--- a/packages/blocks/divider/package.json
+++ b/packages/blocks/divider/package.json
@@ -5,7 +5,7 @@
   "description": "Visually break up content on a page with dividing lines",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hashintel/hash.git",
+    "url": "https://github.com/hashintel/hash.git#main",
     "directory": "packages/blocks/divider"
   },
   "license": "MIT",

--- a/packages/blocks/embed/package.json
+++ b/packages/blocks/embed/package.json
@@ -5,7 +5,7 @@
   "description": "Embed external content",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hashintel/hash.git",
+    "url": "https://github.com/hashintel/hash.git#main",
     "directory": "packages/blocks/embed"
   },
   "license": "MIT",

--- a/packages/blocks/header/package.json
+++ b/packages/blocks/header/package.json
@@ -5,7 +5,7 @@
   "description": "Section headings of varying size",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hashintel/hash.git",
+    "url": "https://github.com/hashintel/hash.git#main",
     "directory": "packages/blocks/header"
   },
   "license": "MIT",

--- a/packages/blocks/html-para/block-metadata.json
+++ b/packages/blocks/html-para/block-metadata.json
@@ -11,7 +11,7 @@
   "schema": "block-schema.json",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hashintel/hash.git",
+    "url": "https://github.com/hashintel/hash.git#main",
     "directory": "packages/blocks/html-para"
   }
 }

--- a/packages/blocks/html-para/package.json
+++ b/packages/blocks/html-para/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hashintel/hash.git",
+    "url": "https://github.com/hashintel/hash.git#main",
     "directory": "packages/blocks/html-para"
   },
   "license": "MIT",

--- a/packages/blocks/image/package.json
+++ b/packages/blocks/image/package.json
@@ -5,7 +5,7 @@
   "description": "Insert an image",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hashintel/hash.git",
+    "url": "https://github.com/hashintel/hash.git#main",
     "directory": "packages/blocks/image"
   },
   "license": "MIT",

--- a/packages/blocks/paragraph/package.json
+++ b/packages/blocks/paragraph/package.json
@@ -5,7 +5,7 @@
   "description": "Just start writing",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hashintel/hash.git",
+    "url": "https://github.com/hashintel/hash.git#main",
     "directory": "packages/blocks/paragraph"
   },
   "license": "MIT",

--- a/packages/blocks/person/package.json
+++ b/packages/blocks/person/package.json
@@ -5,7 +5,7 @@
   "description": "person block component",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hashintel/hash.git",
+    "url": "https://github.com/hashintel/hash.git#main",
     "directory": "packages/blocks/person"
   },
   "license": "MIT",

--- a/packages/blocks/table/package.json
+++ b/packages/blocks/table/package.json
@@ -5,7 +5,7 @@
   "description": "Create a table for storing information in rows and columns",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hashintel/hash.git",
+    "url": "https://github.com/hashintel/hash.git#main",
     "directory": "packages/blocks/table"
   },
   "license": "MIT",

--- a/packages/blocks/video/package.json
+++ b/packages/blocks/video/package.json
@@ -5,7 +5,7 @@
   "description": "video block component",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hashintel/hash.git",
+    "url": "https://github.com/hashintel/hash.git#main",
     "directory": "packages/blocks/video"
   },
   "license": "MIT",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR is a follow-up to https://github.com/blockprotocol/blockprotocol/pull/198, updating the `repository` fields in `package.json` to include the `main` branch, as described in the npm [`package.json` spec](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository).

Without this update, the above-mentioned PR would link to `master` as the default branch, which is not the link we desire.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as (_internal_) -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Add #main to package.json:repository for blocks in hashintel/hash/packages/blocks](https://app.asana.com/0/1201707629991380/1201785439041126/f)
