### PR TITLE
Use proxies or messages and don't store the state at the JS Runners

### DIFF
--- a/packages/engine/src/datastore/table/pool/proxy.rs
+++ b/packages/engine/src/datastore/table/pool/proxy.rs
@@ -13,7 +13,8 @@ use crate::datastore::{
 /// Collects [`BatchReadProxy`] for all the batches within the pool.
 #[derive(Default)]
 pub struct PoolReadProxy<K: Batch> {
-    batches: Vec<BatchReadProxy<K>>,
+    // TODO: Remove `pub(super)` by providing parallel iterator
+    pub(super) batches: Vec<BatchReadProxy<K>>,
 }
 
 impl<K: Batch> PoolReadProxy<K> {
@@ -25,8 +26,16 @@ impl<K: Batch> PoolReadProxy<K> {
         self.batches.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub fn batch(&self, index: usize) -> Option<&K> {
         self.batches.get(index).map(Deref::deref)
+    }
+
+    pub fn batch_proxies(&self) -> impl Iterator<Item = &BatchReadProxy<K>> {
+        self.batches.iter()
     }
 
     // TODO: Use a concrete type, e.g.
@@ -89,6 +98,10 @@ impl<K: Batch> PoolWriteProxy<K> {
 
     pub fn len(&self) -> usize {
         self.batches.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     pub fn batch(&self, index: usize) -> Option<&K> {

--- a/packages/engine/src/datastore/table/references.rs
+++ b/packages/engine/src/datastore/table/references.rs
@@ -5,11 +5,8 @@ use std::{
 
 use rayon::iter::ParallelIterator;
 
-use super::{
-    super::prelude::*,
-    pool::message::{MessagePoolRead, MessageReader},
-};
-use crate::datastore::UUID_V4_LEN;
+use super::{super::prelude::*, pool::message::MessageReader};
+use crate::datastore::{table::pool::proxy::PoolReadProxy, UUID_V4_LEN};
 
 #[derive(Clone, Debug)]
 pub struct AgentMessageReference {
@@ -39,7 +36,7 @@ pub struct MessageMap {
 }
 
 impl MessageMap {
-    pub fn new(pool: &MessagePoolRead<'_>) -> Result<MessageMap> {
+    pub fn new(pool: &PoolReadProxy<MessageBatch>) -> Result<MessageMap> {
         let iter = pool.recipient_iter_all();
         let inner = iter
             .fold(

--- a/packages/engine/src/datastore/table/state/mod.rs
+++ b/packages/engine/src/datastore/table/state/mod.rs
@@ -144,8 +144,7 @@ impl State {
     }
 
     pub fn message_map(&self) -> Result<MessageMap> {
-        let read = self.message_pool().read()?;
-        MessageMap::new(&read)
+        MessageMap::new(&self.message_pool().read_proxy()?)
     }
 
     pub fn agent_pool(&self) -> &AgentPool {

--- a/packages/engine/src/datastore/table/sync.rs
+++ b/packages/engine/src/datastore/table/sync.rs
@@ -4,12 +4,8 @@ use futures::future::join_all;
 
 use crate::{
     datastore::{
-        batch::{AgentBatch, MessageBatch},
         prelude::ContextBatch,
-        table::{
-            pool::proxy::PoolReadProxy,
-            proxy::{BatchReadProxy, StateReadProxy},
-        },
+        table::proxy::{BatchReadProxy, StateReadProxy},
     },
     simulation::comms::message::{SyncCompletionReceiver, SyncCompletionSender},
     worker::{
@@ -34,8 +30,7 @@ use crate::{
 #[derive(derive_new::new)]
 pub struct WaitableStateSync {
     pub completion_sender: SyncCompletionSender,
-    pub agent_pool: PoolReadProxy<AgentBatch>,
-    pub message_pool: PoolReadProxy<MessageBatch>,
+    pub state: StateReadProxy,
 }
 
 impl fmt::Debug for WaitableStateSync {
@@ -55,8 +50,7 @@ impl WaitableStateSync {
             child_receivers.push(receiver);
             child_msgs.push(Self {
                 completion_sender: sender,
-                agent_pool: self.agent_pool.clone(),
-                message_pool: self.message_pool.clone(),
+                state: self.state.clone(),
             });
         }
         (child_msgs, child_receivers)

--- a/packages/engine/src/simulation/command.rs
+++ b/packages/engine/src/simulation/command.rs
@@ -14,9 +14,10 @@ use super::{Error, Result};
 use crate::{
     datastore::{
         arrow::batch_conversion::IntoRecordBatch,
+        batch::MessageBatch,
         schema::{state::AgentSchema, FieldKey},
         table::{
-            pool::message::MessagePoolRead, references::MessageMap,
+            pool::proxy::PoolReadProxy, references::MessageMap,
             state::create_remove::ProcessedCommands,
         },
         UUID_V4_LEN,
@@ -148,7 +149,7 @@ impl Commands {
     /// commands.
     pub fn from_hash_messages(
         message_map: &MessageMap,
-        message_pool: MessagePoolRead<'_>,
+        message_pool: PoolReadProxy<MessageBatch>,
     ) -> Result<Commands> {
         let message_reader = message_pool.get_reader();
 

--- a/packages/engine/src/simulation/comms/mod.rs
+++ b/packages/engine/src/simulation/comms/mod.rs
@@ -107,8 +107,10 @@ impl Comms {
         let (completion_sender, completion_receiver) = tokio::sync::oneshot::channel();
 
         // Synchronize the state batches
-        let sync_msg =
-            WaitableStateSync::new(completion_sender, state.agent_pool, state.message_pool);
+        let sync_msg = WaitableStateSync {
+            completion_sender,
+            state,
+        };
         self.worker_pool_sender
             .send(EngineToWorkerPoolMsg::sync(
                 self.sim_id,

--- a/packages/engine/src/simulation/engine.rs
+++ b/packages/engine/src/simulation/engine.rs
@@ -12,7 +12,7 @@ use crate::{
         prelude::Store,
         table::{
             context::Context,
-            pool::{agent::AgentPool, message::MessagePool},
+            pool::{agent::AgentPool, message::MessagePool, BatchPool},
             references::MessageMap,
             state::{
                 view::{StatePools, StateSnapshot},
@@ -265,7 +265,7 @@ impl Engine {
     /// through agent inboxes. Also creates and removes agents that have been requested by State
     /// packages.
     fn handle_messages(&mut self, state: &mut State, message_map: &MessageMap) -> Result<()> {
-        let read = state.message_pool().read()?;
+        let read = state.message_pool().read_proxy()?;
         let mut commands = Commands::from_hash_messages(message_map, read)?;
         commands.merge(self.comms.take_commands()?);
         commands.verify(&self.config.sim.store.agent_schema)?;

--- a/packages/engine/src/simulation/package/context/packages/api_requests/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/api_requests/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     datastore::{
         batch::iterators,
         schema::{accessor::GetFieldSpec, FieldKey},
+        table::pool::BatchPool,
     },
     simulation::{
         comms::package::PackageComms,
@@ -196,11 +197,8 @@ async fn build_api_response_maps(
 ) -> Result<Vec<ApiResponseMap>> {
     let mut futs = FuturesOrdered::new();
     {
-        let message_pool = &snapshot.state.message_pool;
-        let message_pool_read = message_pool
-            .read()
-            .map_err(|e| Error::from(e.to_string()))?;
-        let reader = message_pool_read.get_reader();
+        let message_pool = &snapshot.state.message_pool.read_proxy()?;
+        let reader = message_pool.get_reader();
 
         handlers.iter().try_for_each::<_, Result<()>>(|handler| {
             let messages = snapshot.message_map.get_msg_refs(handler);

--- a/packages/engine/src/simulation/package/state/packages/topology/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/topology/mod.rs
@@ -80,8 +80,8 @@ impl Package for Topology {
     async fn run(&mut self, state: &mut State, _context: &Context) -> Result<()> {
         tracing::trace!("Running Topology package");
         if self.config.move_wrapped_agents {
-            for mut batch in state.agent_pool_mut().write_proxy()?.batches_iter_mut() {
-                if self.topology_correction(&mut batch)? {
+            for batch in state.agent_pool_mut().write_proxy()?.batches_iter_mut() {
+                if self.topology_correction(batch)? {
                     // TODO: inplace changes and metaversioning should happen at a deeper level.
                     batch.metaversion.increment_batch();
                 }

--- a/packages/engine/src/worker/runner/python/sender.rs
+++ b/packages/engine/src/worker/runner/python/sender.rs
@@ -14,7 +14,7 @@ use crate::{
         batch::{ContextBatch, MessageBatch},
         prelude::AgentBatch,
         table::{
-            pool::proxy::PoolReadProxy,
+            proxy::StateReadProxy,
             task_shared_store::{PartialSharedState, SharedState},
         },
     },
@@ -160,8 +160,7 @@ fn inbound_to_nng(
         }
         InboundToRunnerMsgPayload::CancelTask(_) => todo!(), // Unused for now
         InboundToRunnerMsgPayload::StateSync(msg) => {
-            let (agent_pool, message_pool) =
-                state_sync_to_fbs(fbb, &msg.agent_pool, &msg.message_pool)?;
+            let (agent_pool, message_pool) = state_sync_to_fbs(fbb, &msg.state)?;
             let msg = flatbuffers_gen::sync_state_generated::StateSync::create(
                 fbb,
                 &flatbuffers_gen::sync_state_generated::StateSyncArgs {
@@ -176,8 +175,7 @@ fn inbound_to_nng(
             )
         }
         InboundToRunnerMsgPayload::StateSnapshotSync(msg) => {
-            let (agent_pool, message_pool) =
-                state_sync_to_fbs(fbb, &msg.state.agent_pool, &msg.state.message_pool)?;
+            let (agent_pool, message_pool) = state_sync_to_fbs(fbb, &msg.state)?;
             let msg = flatbuffers_gen::sync_state_snapshot_generated::StateSnapshotSync::create(
                 fbb,
                 &flatbuffers_gen::sync_state_snapshot_generated::StateSnapshotSyncArgs {
@@ -295,25 +293,26 @@ fn inbound_to_nng(
 
 fn state_sync_to_fbs<'f>(
     fbb: &mut FlatBufferBuilder<'f>,
-    agent_pool: &PoolReadProxy<AgentBatch>,
-    msg_pool: &PoolReadProxy<MessageBatch>,
+    state: &StateReadProxy,
 ) -> Result<(
     WIPOffset<Vector<'f, ForwardsUOffset<flatbuffers_gen::batch_generated::Batch<'f>>>>,
     WIPOffset<Vector<'f, ForwardsUOffset<flatbuffers_gen::batch_generated::Batch<'f>>>>,
 )> {
-    let agent_pool: Vec<_> = agent_pool
+    let agent_pool: Vec<_> = state
+        .agent_pool
         .batches_iter()
         .map(|batch| batch_to_fbs(fbb, batch))
         .collect();
     let agent_pool = fbb.create_vector(&agent_pool);
 
-    let msg_pool: Vec<_> = msg_pool
+    let message_pool: Vec<_> = state
+        .message_pool
         .batches_iter()
         .map(|batch| batch_to_fbs(fbb, batch))
         .collect();
-    let msg_pool = fbb.create_vector(&msg_pool);
+    let message_pool = fbb.create_vector(&message_pool);
 
-    Ok((agent_pool, msg_pool))
+    Ok((agent_pool, message_pool))
 }
 
 // TODO: Reduce code duplication between enum variants.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds proxy access to messages and don't store the state in the JavaScript runner anymore.

## 🐾 Next steps

Merge proxies into main

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201481007343159/1201545519802517/f) (_internal_)

## 🛡 What tests cover this?

- Integration test suite