### PR TITLE
Bump Rust toolchain to 2202-02-10

### DIFF
--- a/packages/engine/rust-toolchain.toml
+++ b/packages/engine/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2022-02-07"
+channel = "nightly-2022-02-10"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We currently encounter an error in CI, this PR attempts to fix this by bumping the toolchain.

## 🔗 Related links
- rust-lang/rust#93633
