### PR TITLE
Require bench CI to pass before merging is enabled

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -346,7 +346,7 @@ jobs:
 
   merging-enabled:
     name: merging enabled
-    needs: [rustfmt, clippy, test]
+    needs: [rustfmt, clippy, test, bench]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -359,7 +359,6 @@ jobs:
       - name: check test
         run: |
           [[ ${{ needs.test.result }} =~ success|skipped ]]
-      # TODO: Require bench to pass after https://app.asana.com/0/1201481007343159/1201545519802517/f
-      # - name: check bench
-      #   run: |
-      #     [[ ${{ needs.bench.result }} =~ success|skipped ]]
+      - name: check bench
+        run: |
+          [[ ${{ needs.bench.result }} =~ success|skipped ]]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

As our CI is now (more or less) stable with #281 merged, we can require the bench CI to pass before merging is enabled.

## 🔍 What does this change?

- Require `bench` Action to pass