### PR TITLE
Enable examples in debug builds

### DIFF
--- a/packages/engine/tests/examples/mod.rs
+++ b/packages/engine/tests/examples/mod.rs
@@ -1,5 +1,3 @@
-#![cfg(not(debug_assertions))]
-
 use crate::run_test;
 
 // https://core.hash.ai/@hash/city-infection-model/6.4.2


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

As our CI is now (more or less) stable with #281 merged, we can now run our example simulations in debug builds

## 🔍 What does this change?

- Enable module `integration::examples` for debug builds