### PR TITLE
Remove `Proxy` for `ContextBatch` access

### DIFF
--- a/packages/engine/src/datastore/table/sync.rs
+++ b/packages/engine/src/datastore/table/sync.rs
@@ -3,10 +3,7 @@ use std::{fmt, sync::Arc};
 use futures::future::join_all;
 
 use crate::{
-    datastore::{
-        prelude::ContextBatch,
-        table::proxy::{BatchReadProxy, StateReadProxy},
-    },
+    datastore::{prelude::ContextBatch, table::proxy::StateReadProxy},
     simulation::comms::message::{SyncCompletionReceiver, SyncCompletionSender},
     worker::{
         error::{Error as WorkerError, Result as WorkerResult},
@@ -97,7 +94,7 @@ impl fmt::Debug for StateSync {
 
 #[derive(derive_new::new, Clone)]
 pub struct ContextBatchSync {
-    pub context_batch: BatchReadProxy<ContextBatch>,
+    pub context_batch: Arc<ContextBatch>,
     pub current_step: usize,
     pub state_group_start_indices: Arc<Vec<usize>>,
 }

--- a/packages/engine/src/simulation/comms/mod.rs
+++ b/packages/engine/src/simulation/comms/mod.rs
@@ -143,7 +143,8 @@ impl Comms {
         tracing::trace!("Synchronizing context batch");
         // Synchronize the context batch
         let indices = Arc::clone(state_group_start_indices);
-        let sync_msg = ContextBatchSync::new(context.batch(), current_step, indices);
+        let sync_msg =
+            ContextBatchSync::new(Arc::clone(context.global_batch()), current_step, indices);
         self.worker_pool_sender
             .send(EngineToWorkerPoolMsg::sync(
                 self.sim_id,

--- a/packages/engine/src/simulation/comms/mod.rs
+++ b/packages/engine/src/simulation/comms/mod.rs
@@ -142,9 +142,8 @@ impl Comms {
     ) -> Result<()> {
         tracing::trace!("Synchronizing context batch");
         // Synchronize the context batch
-        let context_batch_reader = context.read_proxy()?;
         let indices = Arc::clone(state_group_start_indices);
-        let sync_msg = ContextBatchSync::new(context_batch_reader, current_step, indices);
+        let sync_msg = ContextBatchSync::new(context.batch(), current_step, indices);
         self.worker_pool_sender
             .send(EngineToWorkerPoolMsg::sync(
                 self.sim_id,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In order to access the `Context`, it's not required to use a Proxy

## 🐾 Next steps

Do this for the rest of `Batch`es

## 🔍 What does this change?

Removes the `RwLock` inside of `Context`

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201707629991362/1201822309177039/f) (_internal_)
