### PR TITLE
Always run Rust CI when a workflow file has changed

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,9 +43,8 @@ jobs:
 
           while read -r file; do
             while read -r crate; do
-              if [[ $file =~ $crate ]]; then
+              if [[ $file =~ $crate ]] || [[ $file =~ .github ]]; then
                 changed_crates=$(echo -e "${crate}\n$changed_crates")
-                break
               fi
             done <<< "$available_crates"
           done <<< "$changed_files"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, the Rust CI only runs, if a crate was changed. As we require the CI to pass, it should run when changing it.

## 🔍 What does this change?

- Checks for _.github/_ folder to run tests
- Remove the `break` statement from loop, otherwise, only the first crate will be tested. This has no implications for the tests as duplications will be removed later.
