### PR TITLE
Rerun integration test with `LogLevel::Trace` if `RUST_LOG` is not set manually

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,9 +43,8 @@ jobs:
 
           while read -r file; do
             while read -r crate; do
-              if [[ $file =~ $crate ]]; then
+              if [[ $file =~ $crate ]] || [[ $file =~ .github ]]; then
                 changed_crates=$(echo -e "${crate}\n$changed_crates")
-                break
               fi
             done <<< "$available_crates"
           done <<< "$changed_files"

--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -84,6 +84,7 @@ async fn main() -> Result<()> {
         args.experiment_config.log_format,
         &args.experiment_config.output_location,
         args.experiment_config.log_folder.clone(),
+        args.experiment_config.log_level,
         &format!("cli-{now}"),
         &format!("cli-{now}-texray"),
     );

--- a/packages/engine/bin/hash_engine/src/main.rs
+++ b/packages/engine/bin/hash_engine/src/main.rs
@@ -12,6 +12,7 @@ async fn main() -> Result<()> {
         args.log_format,
         &args.output,
         &args.log_folder,
+        args.log_level,
         &format!("experiment-{}", args.experiment_id),
         &format!("experiment-{}-texray", args.experiment_id),
     );

--- a/packages/engine/lib/orchestrator/src/experiment.rs
+++ b/packages/engine/lib/orchestrator/src/experiment.rs
@@ -59,7 +59,7 @@ pub struct ExperimentConfig {
     pub log_format: LogFormat,
 
     /// Logging verbosity to use. If not set `RUST_LOG` will be used
-    #[clap(global = true, long, arg_enum)]
+    #[cfg_attr(feature = "clap", clap(global = true, long, arg_enum))]
     pub log_level: Option<LogLevel>,
 
     /// Output location where logs are emitted to.

--- a/packages/engine/lib/orchestrator/src/experiment.rs
+++ b/packages/engine/lib/orchestrator/src/experiment.rs
@@ -181,7 +181,7 @@ impl Experiment {
     /// returns once the experiment has finished.
     ///
     /// [`Process`]: crate::process::Process
-    #[instrument(skip_all, fields(experiment_name = %experiment_run.base.name, experiment_id = % experiment_run.base.id))]
+    #[instrument(skip_all, fields(experiment_name = %experiment_run.base.name, experiment_id = %experiment_run.base.id))]
     pub async fn run(
         &self,
         experiment_run: proto::ExperimentRun,

--- a/packages/engine/lib/orchestrator/src/experiment.rs
+++ b/packages/engine/lib/orchestrator/src/experiment.rs
@@ -181,7 +181,7 @@ impl Experiment {
     /// returns once the experiment has finished.
     ///
     /// [`Process`]: crate::process::Process
-    #[instrument(skip_all, fields(experiment_name = % experiment_run.base.name, experiment_id = % experiment_run.base.id))]
+    #[instrument(skip_all, fields(experiment_name = %experiment_run.base.name, experiment_id = % experiment_run.base.id))]
     pub async fn run(
         &self,
         experiment_run: proto::ExperimentRun,

--- a/packages/engine/lib/orchestrator/src/experiment.rs
+++ b/packages/engine/lib/orchestrator/src/experiment.rs
@@ -14,7 +14,7 @@ use hash_engine_lib::{
         ExperimentRunBase, SimpleExperimentConfig, SingleRunExperimentConfig,
     },
     simulation::command::StopStatus,
-    utils::{LogFormat, OutputLocation},
+    utils::{LogFormat, LogLevel, OutputLocation},
 };
 use rand::{distributions::Distribution, Rng, RngCore};
 use rand_distr::{Beta, LogNormal, Normal, Poisson};
@@ -58,6 +58,10 @@ pub struct ExperimentConfig {
     )]
     pub log_format: LogFormat,
 
+    /// Logging verbosity to use. If not set `RUST_LOG` will be used
+    #[clap(long, arg_enum)]
+    pub log_level: Option<LogLevel>,
+
     /// Output location where logs are emitted to.
     ///
     /// Can be `stdout`, `stderr` or any file name. Relative to `--log-folder` if a file is
@@ -87,8 +91,8 @@ pub struct ExperimentConfig {
     ///
     /// Defaults to the number of logical CPUs available in order to maximize performance.
     #[cfg_attr(
-        feature = "clap",
-        clap(global = true, short = 'w', long, default_value_t = num_cpus::get(), validator = at_least_one, env = "HASH_WORKERS")
+    feature = "clap",
+    clap(global = true, short = 'w', long, default_value_t = num_cpus::get(), validator = at_least_one, env = "HASH_WORKERS")
     )]
     pub num_workers: usize,
 }
@@ -164,6 +168,7 @@ impl Experiment {
             self.config.num_workers,
             controller_url,
             self.config.log_format,
+            self.config.log_level,
             self.config.output_location.clone(),
             self.config.log_folder.clone(),
         ))
@@ -176,7 +181,7 @@ impl Experiment {
     /// returns once the experiment has finished.
     ///
     /// [`Process`]: crate::process::Process
-    #[instrument(skip_all, fields(experiment_name = %experiment_run.base.name, experiment_id = %experiment_run.base.id))]
+    #[instrument(skip_all, fields(experiment_name = % experiment_run.base.name, experiment_id = % experiment_run.base.id))]
     pub async fn run(
         &self,
         experiment_run: proto::ExperimentRun,

--- a/packages/engine/lib/orchestrator/src/experiment.rs
+++ b/packages/engine/lib/orchestrator/src/experiment.rs
@@ -59,7 +59,7 @@ pub struct ExperimentConfig {
     pub log_format: LogFormat,
 
     /// Logging verbosity to use. If not set `RUST_LOG` will be used
-    #[clap(long, arg_enum)]
+    #[clap(global = true, long, arg_enum)]
     pub log_level: Option<LogLevel>,
 
     /// Output location where logs are emitted to.

--- a/packages/engine/lib/orchestrator/src/process/local.rs
+++ b/packages/engine/lib/orchestrator/src/process/local.rs
@@ -5,7 +5,7 @@ use error::{Report, Result, ResultExt};
 use hash_engine_lib::{
     nano,
     proto::{EngineMsg, ExperimentId},
-    utils::{LogFormat, OutputLocation},
+    utils::{LogFormat, LogLevel, OutputLocation},
 };
 
 use crate::process;
@@ -66,6 +66,7 @@ pub struct LocalCommand {
     controller_url: String,
     num_workers: usize,
     log_format: LogFormat,
+    log_level: Option<LogLevel>,
     output_location: OutputLocation,
     log_folder: PathBuf,
 }
@@ -77,6 +78,7 @@ impl LocalCommand {
         num_workers: usize,
         controller_url: &str,
         log_format: LogFormat,
+        log_level: Option<LogLevel>,
         output_location: OutputLocation,
         log_folder: PathBuf,
     ) -> Self {
@@ -89,6 +91,7 @@ impl LocalCommand {
             controller_url: controller_url.to_string(),
             num_workers,
             log_format,
+            log_level,
             output_location,
             log_folder,
         }
@@ -126,6 +129,9 @@ impl process::Command for LocalCommand {
             .arg(self.log_folder)
             .stdout(std::process::Stdio::inherit())
             .stderr(std::process::Stdio::inherit());
+        if let Some(log_level) = self.log_level {
+            cmd.arg("--log-level").arg(log_level.to_string());
+        }
         debug!("Running `{cmd:?}`");
 
         let child = cmd

--- a/packages/engine/src/args.rs
+++ b/packages/engine/src/args.rs
@@ -4,7 +4,7 @@ use clap::{AppSettings, Parser};
 
 use crate::{
     proto::ExperimentId,
-    utils::{LogFormat, OutputLocation},
+    utils::{LogFormat, LogLevel, OutputLocation},
 };
 
 /// Arguments passed to hEngine
@@ -35,6 +35,10 @@ pub struct Args {
     /// Output format emitted to the output location.
     #[clap(long, default_value = "pretty", arg_enum, env = "HASH_LOG_FORMAT")]
     pub log_format: LogFormat,
+
+    /// Logging verbosity to use. If not set `RUST_LOG` will be used
+    #[clap(long, arg_enum)]
+    pub log_level: Option<LogLevel>,
 
     /// Output location where to emit logs.
     ///

--- a/packages/engine/tests/experiment/mod.rs
+++ b/packages/engine/tests/experiment/mod.rs
@@ -165,6 +165,7 @@ pub async fn run_test_suite(
 
             let mut test_output = None;
             for rust_log_env in &rust_log_envs {
+                let environment = std::env::vars();
                 std::env::set_var("RUST_LOG", &rust_log_env);
                 eprint!("Running test with RUST_LOG={rust_log_env}... ");
 
@@ -177,6 +178,13 @@ pub async fn run_test_suite(
                     expected_outputs.len(),
                 )
                 .await;
+
+                std::env::remove_var("RUST_LOG");
+                for (key, var) in environment {
+                    if key == "RUST_LOG" {
+                        std::env::set_var(key, var);
+                    }
+                }
 
                 match test_result {
                     Ok(outputs) => {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

If our tests are failing, we want to know why. As always running them with `RUST_LOG=trace` affects performance, they should run with a lower severity unless it fails.

## 🔍 What does this change?

- Adds a command-line argument to specify the `LogLevel`
- Runs tests with `LogLevel::Warning` and rerun it with `LogLevel::Trace` if it failed
- If `RUST_LOG` is set manually, only one attempt is running