### PR TITLE
Use UUID for generating the NNG url in tests

### DIFF
--- a/packages/engine/tests/experiment/mod.rs
+++ b/packages/engine/tests/experiment/mod.rs
@@ -243,15 +243,11 @@ pub async fn run_test<P: AsRef<Path>>(
     let project_path = project_path.as_ref();
 
     let nng_listen_url = {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis();
+        let uuid = uuid::Uuid::new_v4();
         if let Some(language) = language {
-            format!("ipc://integration-test-suite-{project_name}-{language}-{now}")
+            format!("ipc://integration-test-suite-{project_name}-{language}-{uuid}")
         } else {
-            format!("ipc://integration-test-suite-{project_name}-{now}")
+            format!("ipc://integration-test-suite-{project_name}-{uuid}")
         }
     };
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

If two tests start at the same time, they may use the same NNG URL. To avoid this, we should use a UUID instead.