### PR TITLE
Clarifying orchestrator experiment error logic

### DIFF
--- a/packages/engine/lib/orchestrator/src/experiment.rs
+++ b/packages/engine/lib/orchestrator/src/experiment.rs
@@ -288,7 +288,7 @@ impl Experiment {
                                 );
                             }
                             StopStatus::Error => {
-                                graceful_finish = true;
+                                graceful_finish = false;
                                 tracing::error!(
                                     "Simulation stopped by agent `{agent}` with an error{reason}"
                                 );

--- a/packages/engine/lib/orchestrator/src/process/local.rs
+++ b/packages/engine/lib/orchestrator/src/process/local.rs
@@ -29,6 +29,8 @@ impl process::Process for LocalProcess {
         self.child
             .kill()
             .or_else(|e| match e.kind() {
+                // From `Child::kill` docs: Forces the child process to exit. If the child has
+                // already exited, an InvalidInput error is returned
                 std::io::ErrorKind::InvalidInput => Ok(()),
                 _ => Err(Report::new(e)),
             })


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

If the orchestrator timed out while waiting for an Engine response, we still gave an Ok(()) return. This PR fixes that and clarifies the messages.