### PR TITLE
Fixing logging in integration tests

### DIFF
--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -87,7 +87,8 @@ async fn main() -> Result<()> {
         args.experiment_config.log_level,
         &format!("cli-{now}"),
         &format!("cli-{now}-texray"),
-    );
+    )
+    .wrap_err("Failed to initialise the logger")?;
 
     let nng_listen_url = format!("ipc://hash-orchestrator-{now}");
 

--- a/packages/engine/bin/hash_engine/src/main.rs
+++ b/packages/engine/bin/hash_engine/src/main.rs
@@ -15,7 +15,8 @@ async fn main() -> Result<()> {
         args.log_level,
         &format!("experiment-{}", args.experiment_id),
         &format!("experiment-{}-texray", args.experiment_id),
-    );
+    )
+    .wrap_err("Failed to initialise the logger")?;
 
     let mut env = hash_engine_lib::env::<ExperimentRun>(&args)
         .await

--- a/packages/engine/src/utils.rs
+++ b/packages/engine/src/utils.rs
@@ -21,6 +21,7 @@ use tracing_subscriber::{
     },
     prelude::*,
     registry::LookupSpan,
+    util::TryInitError,
     EnvFilter,
 };
 
@@ -198,9 +199,9 @@ pub fn init_logger<P: AsRef<Path>>(
     output_location: &OutputLocation,
     log_folder: P,
     log_level: Option<LogLevel>,
-    log_file_output_name: &str,
-    texray_output_name: &str,
-) -> impl Drop {
+    log_file_name: &str,
+    texray_log_file_name: &str,
+) -> Result<impl Drop, TryInitError> {
     let log_folder = log_folder.as_ref();
 
     let filter = if let Some(log_level) = log_level {
@@ -255,7 +256,7 @@ pub fn init_logger<P: AsRef<Path>>(
     };
 
     let json_file_appender =
-        tracing_appender::rolling::never(log_folder, format!("{log_file_output_name}.json"));
+        tracing_appender::rolling::never(log_folder, format!("{log_file_name}.json"));
     let (non_blocking, _json_file_guard) = tracing_appender::non_blocking(json_file_appender);
 
     let json_file_layer = fmt::layer()
@@ -264,7 +265,7 @@ pub fn init_logger<P: AsRef<Path>>(
         .with_writer(non_blocking);
 
     let (texray_layer, _texray_guard) =
-        texray::create_texray_layer(&log_folder, texray_output_name);
+        texray::create_texray_layer(&log_folder, texray_log_file_name);
 
     tracing_subscriber::registry()
         .with(filter)
@@ -273,13 +274,13 @@ pub fn init_logger<P: AsRef<Path>>(
         .with(json_file_layer)
         .with(error_layer)
         .with(texray_layer)
-        .init();
+        .try_init()?;
 
-    LogGuard {
+    Ok(LogGuard {
         _output_guard,
         _json_file_guard,
         _texray_guard,
-    }
+    })
 }
 
 pub fn parse_env_duration(name: &str, default: u64) -> Duration {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We use RUST_LOG in the integration tests to encapsulate information about how to run the engine subprocesses (this also makes it difficult to use crates like [tracing_test](https://docs.rs/tracing-test/latest/tracing_test/)). 

Because of this we actually had broken logging coming from the testing suite itself. This PR fixes that

## 🔍 What does this change?

- Initialises the Logger from the testing suite
- Changes some variable names to be clearer

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as (_internal_) -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201707629991362/1201823931582526/f) (_internal_)

## 🛡 What tests cover this?

- CI integration tests