### PR TITLE
Improve checking for array type in JS state tests

### DIFF
--- a/packages/engine/tests/units/state/edit/dot/bool_array/src/behaviors/test.js
+++ b/packages/engine/tests/units/state/edit/dot/bool_array/src/behaviors/test.js
@@ -2,12 +2,12 @@
  * Gets and sets a boolean array using dot notation
  */
 const behavior = (state, context) => {
-  state.b1_is_list = typeof state.b1 === "object";
+  state.b1_is_list = Array.isArray(state.b1);
   state.b1_0_is_boolean = typeof state.b1[0] === "boolean";
 
   state.b2 = state.b1.concat(true);
   state.b1.unshift(false);
 
-  state.b2_is_list = typeof state.b2 === "object";
+  state.b2_is_list = Array.isArray(state.b2);
   state.b2_0_is_boolean = typeof state.b2[0] === "boolean";
 };

--- a/packages/engine/tests/units/state/edit/dot/number_array/src/behaviors/test.js
+++ b/packages/engine/tests/units/state/edit/dot/number_array/src/behaviors/test.js
@@ -2,12 +2,12 @@
  * Gets and sets a number array using dot notation
  */
 const behavior = (state, context) => {
-  state.n1_is_list = typeof state.n1 === "object";
+  state.n1_is_list = Array.isArray(state.n1);
   state.n1_0_is_number = typeof state.n1[0] === "number";
 
   state.n2 = state.n1.concat(4);
   state.n1.unshift(0);
 
-  state.n2_is_list = typeof state.n2 === "object";
+  state.n2_is_list = Array.isArray(state.n2);
   state.n2_0_is_number = typeof state.n2[0] === "number";
 };

--- a/packages/engine/tests/units/state/edit/dot/object_array/src/behaviors/test.js
+++ b/packages/engine/tests/units/state/edit/dot/object_array/src/behaviors/test.js
@@ -2,7 +2,7 @@
  * Gets and sets a struct array using dot notation
  */
 const behavior = (state, context) => {
-  state.o1_is_list = typeof state.o1 === "object";
+  state.o1_is_list = Array.isArray(state.o1);
   state.o1_0_is_struct = typeof state.o1[0] === "object";
   state.o1_0_n1_is_number = typeof state.o1[0].n1 === "number";
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

JavaScript does not have a built-in type for lists like Python's `list`, so `typeof ["a"]` will return "object". To improve testing stability, we want to check for lists with `Array.isArray` instead.

## 🔍 What does this change?

Replaces `typeof <list>` checks with `Array.isArray` checks.