### PR TITLE
Improve documentation for important datastore types

### DIFF
--- a/packages/engine/src/datastore/batch/agent.rs
+++ b/packages/engine/src/datastore/batch/agent.rs
@@ -31,9 +31,8 @@ use crate::{
     simulation::package::creator::PREVIOUS_INDEX_FIELD_KEY,
 };
 
-/// A Shared Batch. Contains a shared memory
-/// segment and the Arrow `RecordBatch` view
-/// into that data.
+/// A Shared Batch containing a shared memory segment and the Arrow [`RecordBatch`] view into that
+/// data.
 #[allow(clippy::module_name_repetitions)]
 pub struct Batch {
     pub memory: Memory,

--- a/packages/engine/src/datastore/batch/context.rs
+++ b/packages/engine/src/datastore/batch/context.rs
@@ -26,6 +26,12 @@ const UPPER_BOUND_DATA_SIZE_MULTIPLIER: usize = 3;
 pub type AgentIndex = (u32, u32);
 pub type MessageIndex = (u32, u32, u32);
 
+/// Contains the information required to build the `context` object accessible in the language
+/// runners.
+///
+/// The `ContextBatch` can refer to the **Agent** and **Message Pool** within the **Context**
+/// object. For example, neighbor list is a collection of indices pointing to different agents
+/// within the **Agent Pool**.
 pub struct Batch {
     pub(crate) memory: Memory,
     pub(crate) metaversion: Metaversion,

--- a/packages/engine/src/datastore/table/pool/agent.rs
+++ b/packages/engine/src/datastore/table/pool/agent.rs
@@ -12,6 +12,8 @@ use crate::{
 };
 
 /// An ordered collection of similar [`AgentBatch`]es for each group within a simulation run.
+///
+/// All fields (except for messages) that agents' have are persisted in the Agent Pool.
 #[derive(Clone)]
 pub struct AgentPool {
     batches: Vec<Arc<RwLock<AgentBatch>>>,
@@ -39,6 +41,7 @@ impl Extend<AgentBatch> for AgentPool {
 }
 
 impl PoolWriteProxy<AgentBatch> {
+    /// TODO: DOC
     pub fn set_pending_column(&mut self, column: StateColumn) -> Result<()> {
         let mut index = 0;
         for batch in self.batches_iter_mut() {
@@ -51,6 +54,7 @@ impl PoolWriteProxy<AgentBatch> {
         Ok(())
     }
 
+    /// Calls [`Batch::flush_changes()`] all all batches in this proxy.
     pub fn flush_pending_columns(&mut self) -> Result<()> {
         for batch in self.batches_iter_mut() {
             batch.flush_changes()?;

--- a/packages/engine/src/datastore/table/pool/message.rs
+++ b/packages/engine/src/datastore/table/pool/message.rs
@@ -19,7 +19,11 @@ use crate::{
     SimRunConfig,
 };
 
-/// TODO: DOC
+/// A collection of [`Batch`]es which contain the current (outbound) messages of agents.
+///
+/// This is kept separate to the [`AgentPool`], because while agents can be removed between steps,
+/// messages are still sent out in the next step (including the ones by deleted agents) — this
+/// removes the need for making copies of the pool.
 #[derive(Clone)]
 pub struct MessagePool {
     batches: Vec<Arc<RwLock<MessageBatch>>>,

--- a/packages/engine/src/datastore/table/pool/mod.rs
+++ b/packages/engine/src/datastore/table/pool/mod.rs
@@ -20,11 +20,25 @@ trait Pool<B> {
     fn get_batches_mut(&mut self) -> &mut Vec<Arc<RwLock<B>>>;
 }
 
-/// A pool is an ordered collection of batches, where each group of agents within a simulation run
-/// is associated to a batch in the pool.
+/// A pool is an ordered collection of batches.
+///
+/// Each group of agents within a simulation run is associated to a [`Batch`] in the pool. Each
+/// [`Batch`] in a pool can either be borrowed as shared ([`read_proxies()`] and
+/// [`partial_read_proxies()`] returning [`PoolReadProxy`]) or mutable reference
+/// ([`write_proxies()`] and [`partial_write_proxies()`] returning [`PoolReadProxy`]).
+///
+/// [`read_proxies()`]: Self::read_proxies
+/// [`partial_read_proxies()`]: Self::partial_read_proxies
+/// [`write_proxies()`]: Self::write_proxies
+/// [`partial_write_proxies()`]: Self::partial_write_proxies
 pub trait BatchPool<B: Batch>: Send + Sync {
+    /// Creates a new pool from [`Batches`].
+    ///
+    /// Because of the way, `BatchPools` are organized, it's required, that the [`Batch`]es are
+    /// stored inside an [`RwLock`] behind an [`Arc`]. This is subject to change.
     fn new(batches: Vec<Arc<RwLock<B>>>) -> Self;
 
+    /// Creates a new empty pool.
     fn empty() -> Self
     where
         Self: Sized,
@@ -32,32 +46,95 @@ pub trait BatchPool<B: Batch>: Send + Sync {
         Self::new(Vec::new())
     }
 
+    /// Returns the number of [`Batch`]es inside this pool.
     fn len(&self) -> usize;
 
+    /// Returns if there are no [`Batch`]es in this pool.
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
+    /// Adds a [`Batch`] at the end of this pool.
+    ///
+    /// Note, that unless in [`new()`](Self::new) this does not require the [`Batch`] to be wrapped
+    /// inside of [`Arc`]`<RwLock<B>>`.
     fn push(&mut self, batch: B);
 
+    /// Removes and returns the `element` at position `index` within the pool, shifting all
+    /// elements after it to the left and returns it as [`BatchReadProxy`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if index is out of bounds.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProxySharedLock`] if the [`Batch`] is currently borrowed as
+    /// [`BatchWriteProxy`].
+    ///
+    /// [`ProxySharedLock`]: crate::datastore::error::Error::ProxySharedLock
     fn remove(&mut self, index: usize) -> Result<BatchReadProxy<B>>;
 
+    /// Removes a [`Batch`] from the pool and returns it as [`BatchReadProxy`].
+    ///
+    /// The removed [`Batch`] is replaced by the last [`Batch`] of the pool. This does not preserve
+    /// ordering, but is `O(1)`. If you need to preserve the element order, use
+    /// [`remove()`](Self::remove) instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if index is out of bounds.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProxySharedLock`] if the [`Batch`] is currently borrowed as
+    /// [`BatchWriteProxy`].
+    ///
+    /// [`ProxySharedLock`]: crate::datastore::error::Error::ProxySharedLock
     fn swap_remove(&mut self, index: usize) -> Result<BatchReadProxy<B>>;
 
     /// Creates a [`PoolReadProxy`] for _all_ batches within the pool.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProxySharedLock`] if any of the [`Batch`]es is currently borrowed as
+    /// [`BatchWriteProxy`].
+    ///
+    /// [`ProxySharedLock`]: crate::datastore::error::Error::ProxySharedLock
     fn read_proxies(&self) -> Result<PoolReadProxy<B>>;
 
     /// Creates a [`PoolReadProxy`] for a _selection_ of the batches within the pool, selected by
     /// the given `indices`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProxySharedLock`] if any of the [`Batch`]es at one of the specified
+    /// `indices` is currently borrowed as [`BatchWriteProxy`].
+    ///
+    /// [`ProxySharedLock`]: crate::datastore::error::Error::ProxySharedLock
     fn partial_read_proxies(&self, indices: &[usize]) -> Result<PoolReadProxy<B>>;
 
     /// Creates a [`PoolWriteProxy`] for _all_ batches within the pool.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProxyExclusiveLock`] if any of the [`Batch`]es at one of the specified
+    /// `indices` is currently borrowed either as [`BatchReadProxy`] or as [`BatchWriteProxy`].
+    ///
+    /// [`ProxyExclusiveLock`]: crate::datastore::error::Error::ProxyExclusiveLock
     fn write_proxies(&mut self) -> Result<PoolWriteProxy<B>>;
 
     /// Creates a [`PoolWriteProxy`] for a _selection_ of the batches within the pool, selected by
     /// the given `indices`.
     ///
     /// This can be used to create multiple mutable disjoint partitions of the pool.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProxyExclusiveLock`] if any of the [`Batch`]es at one of the specified
+    /// `indices` is currently borrowed either as [`BatchReadProxy`] or as [`BatchWriteProxy`].
+    ///
+    /// [`ProxyExclusiveLock`]: crate::datastore::error::Error::ProxyExclusiveLock
     fn partial_write_proxies(&mut self, indices: &[usize]) -> Result<PoolWriteProxy<B>>;
 }
 
@@ -87,11 +164,10 @@ impl<P: Pool<B> + Send + Sync, B: Batch> BatchPool<B> for P {
     }
 
     fn partial_read_proxies(&self, indices: &[usize]) -> Result<PoolReadProxy<B>> {
-        self.get_batches()
-            .iter()
-            .enumerate()
-            .filter(|(index, _)| indices.contains(index))
-            .map(|(_, b)| BatchReadProxy::new(b))
+        let batches = self.get_batches();
+        indices
+            .into_iter()
+            .map(|i| BatchReadProxy::new(&batches[*i]))
             .collect()
     }
 
@@ -103,11 +179,10 @@ impl<P: Pool<B> + Send + Sync, B: Batch> BatchPool<B> for P {
     }
 
     fn partial_write_proxies(&mut self, indices: &[usize]) -> Result<PoolWriteProxy<B>> {
-        self.get_batches()
-            .iter()
-            .enumerate()
-            .filter(|(index, _)| indices.contains(index))
-            .map(|(_, b)| BatchWriteProxy::new(b))
+        let batches = self.get_batches_mut();
+        indices
+            .into_iter()
+            .map(|i| BatchWriteProxy::new(&batches[*i]))
             .collect()
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The datastore is one of the core concepts in hEngine, so it should be reasonably documented.

## ⚠️ Known issues

`Proxy` and related types should also have better documentation, but as they get removed or reworked in the near future, this PR does not affect them.

## 🔍 What does this change?

See the commit history

### Does this require a change to the docs?

This PR is improving the documentation

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201707629991362/1201779453266387/f) (_internal_)

## 🛡 What tests cover this?

We are currently not checking links in documentation

## ❓ How to test this?

Run `cargo doc` and navigate to the changed pages