### PR TITLE
Improve checking for struct and arrays in JS tests

### DIFF
--- a/packages/engine/tests/units/state/edit/dot/object/src/behaviors/test.js
+++ b/packages/engine/tests/units/state/edit/dot/object/src/behaviors/test.js
@@ -2,7 +2,7 @@
  * Gets and sets an object value using dot notation
  */
 const behavior = (state, context) => {
-  state.o1_is_struct = typeof state.o1 === "object";
+  state.o1_is_struct = typeof state.o1 === "object" && !Array.isArray(state.o1);
   state.o1_n1_is_number = typeof state.o1.n1 === "number";
 
   state.o1.n2 = state.o1.n1 + 1;

--- a/packages/engine/tests/units/state/edit/dot/object_array/src/behaviors/test.js
+++ b/packages/engine/tests/units/state/edit/dot/object_array/src/behaviors/test.js
@@ -3,13 +3,15 @@
  */
 const behavior = (state, context) => {
   state.o1_is_list = Array.isArray(state.o1);
-  state.o1_0_is_struct = typeof state.o1[0] === "object";
+  state.o1_0_is_struct =
+    typeof state.o1[0] === "object" && !Array.isArray(state.o1[0]);
   state.o1_0_n1_is_number = typeof state.o1[0].n1 === "number";
 
   state.o1[0].n2 = state.o1[0].n1 + 1;
   state.o1.push({ n3: 3 });
 
   state.o1_0_n2_is_number = typeof state.o1[0].n2 === "number";
-  state.o1_1_is_struct = typeof state.o1[0] === "object";
+  state.o1_1_is_struct =
+    typeof state.o1[1] === "object" && !Array.isArray(state.o1[1]);
   state.o1_1_n3_is_number = typeof state.o1[1].n3 === "number";
 };

--- a/packages/engine/tests/units/state/edit/index/bool_array/src/behaviors/test.js
+++ b/packages/engine/tests/units/state/edit/index/bool_array/src/behaviors/test.js
@@ -2,12 +2,12 @@
  * Gets and sets a boolean array using index notation
  */
 const behavior = (state, context) => {
-  state["b1_is_list"] = typeof state["b1"] === "object";
+  state["b1_is_list"] = Array.isArray(state["b1"]);
   state["b1_0_is_boolean"] = typeof state["b1"][0] === "boolean";
 
   state["b2"] = state["b1"].concat(true);
   state["b1"].unshift(false);
 
-  state["b2_is_list"] = typeof state["b2"] === "object";
+  state["b2_is_list"] = Array.isArray(state["b2"]);
   state["b2_0_is_boolean"] = typeof state["b2"][0] === "boolean";
 };

--- a/packages/engine/tests/units/state/edit/index/number_array/src/behaviors/test.js
+++ b/packages/engine/tests/units/state/edit/index/number_array/src/behaviors/test.js
@@ -2,12 +2,12 @@
  * Gets and sets a number array using index notation
  */
 const behavior = (state, context) => {
-  state["n1_is_list"] = typeof state["n1"] === "object";
+  state["n1_is_list"] = Array.isArray(state["n1"]);
   state["n1_0_is_number"] = typeof state["n1"][0] === "number";
 
   state["n2"] = state["n1"].concat(4);
   state["n1"].unshift(0);
 
-  state["n2_is_list"] = typeof state["n2"] === "object";
+  state["n2_is_list"] = Array.isArray(state["n2"]);
   state["n2_0_is_number"] = typeof state["n2"][0] === "number";
 };

--- a/packages/engine/tests/units/state/edit/index/object/src/behaviors/test.js
+++ b/packages/engine/tests/units/state/edit/index/object/src/behaviors/test.js
@@ -2,7 +2,8 @@
  * Gets and sets an object value using index notation
  */
 const behavior = (state, context) => {
-  state["o1_is_struct"] = typeof state["o1"] === "object";
+  state["o1_is_struct"] =
+    typeof state["o1"] === "object" && !Array.isArray(state["o1"]);
   state["o1_n1_is_number"] = typeof state["o1"]["n1"] === "number";
 
   state["o1"]["n2"] = state["o1"]["n1"] + 1;

--- a/packages/engine/tests/units/state/edit/index/object_array/src/behaviors/test.js
+++ b/packages/engine/tests/units/state/edit/index/object_array/src/behaviors/test.js
@@ -2,14 +2,16 @@
  * Gets and sets a struct array using index notation
  */
 const behavior = (state, context) => {
-  state["o1_is_list"] = typeof state["o1"] === "object";
-  state["o1_0_is_struct"] = typeof state["o1"][0] === "object";
+  state["o1_is_list"] = Array.isArray(state["o1"]);
+  state["o1_0_is_struct"] =
+    typeof state["o1"][0] === "object" && !Array.isArray(state["o1"][0]);
   state["o1_0_n1_is_number"] = typeof state["o1"][0]["n1"] === "number";
 
   state["o1"][0]["n2"] = state["o1"][0]["n1"] + 1;
   state["o1"].push({ n3: 3 });
 
   state["o1_0_n2_is_number"] = typeof state["o1"][0]["n2"] === "number";
-  state["o1_1_is_struct"] = typeof state["o1"][0] === "object";
+  state["o1_1_is_struct"] =
+    typeof state["o1"][1] === "object" && !Array.isArray(state["o1"][0]);
   state["o1_1_n3_is_number"] = typeof state["o1"][1]["n3"] === "number";
 };

--- a/packages/engine/tests/units/state/edit/set_get/bool_array/src/behaviors/test.js
+++ b/packages/engine/tests/units/state/edit/set_get/bool_array/src/behaviors/test.js
@@ -2,7 +2,7 @@
  * Gets and sets a boolean array using set/get notation
  */
 const behavior = (state, context) => {
-  state.set("b1_is_list", typeof state.get("b1") === "object");
+  state.set("b1_is_list", Array.isArray(state.get("b1")));
   state.set("b1_0_is_boolean", typeof state.get("b1")[0] === "boolean");
 
   const b1 = state.get("b1");
@@ -12,6 +12,6 @@ const behavior = (state, context) => {
 
   state.set("b1", b1);
 
-  state.set("b2_is_list", typeof state.get("b2") === "object");
+  state.set("b2_is_list", Array.isArray(state.get("b2")));
   state.set("b2_0_is_boolean", typeof state.get("b2")[0] === "boolean");
 };

--- a/packages/engine/tests/units/state/edit/set_get/number_array/src/behaviors/test.js
+++ b/packages/engine/tests/units/state/edit/set_get/number_array/src/behaviors/test.js
@@ -2,7 +2,7 @@
  * Gets and sets a number array using set/get notation
  */
 const behavior = (state, context) => {
-  state.set("n1_is_list", typeof state.get("n1") === "object");
+  state.set("n1_is_list", Array.isArray(state.get("n1")));
   state.set("n1_0_is_number", typeof state.get("n1")[0] === "number");
 
   const n1 = state.get("n1");
@@ -12,6 +12,6 @@ const behavior = (state, context) => {
 
   state.set("n1", n1);
 
-  state.set("n2_is_list", typeof state.get("n2") === "object");
+  state.set("n2_is_list", Array.isArray(state.get("n2")));
   state.set("n2_0_is_number", typeof state.get("n2")[0] === "number");
 };

--- a/packages/engine/tests/units/state/edit/set_get/object/src/behaviors/test.js
+++ b/packages/engine/tests/units/state/edit/set_get/object/src/behaviors/test.js
@@ -2,7 +2,10 @@
  * Gets and sets an object value using set/get notation
  */
 const behavior = (state, context) => {
-  state.set("o1_is_struct", typeof state.get("o1") === "object");
+  state.set(
+    "o1_is_struct",
+    typeof state.get("o1") === "object" && !Array.isArray(state.get("o1")),
+  );
   state.set("o1_n1_is_number", typeof state.get("o1").n1 === "number");
 
   const o1 = state.get("o1");

--- a/packages/engine/tests/units/state/edit/set_get/object_array/src/behaviors/test.js
+++ b/packages/engine/tests/units/state/edit/set_get/object_array/src/behaviors/test.js
@@ -2,8 +2,12 @@
  * Gets and sets a struct array using set/get notation
  */
 const behavior = (state, context) => {
-  state.set("o1_is_list", typeof state.get("o1") === "object");
-  state.set("o1_0_is_struct", typeof state.get("o1")[0] === "object");
+  state.set("o1_is_list", Array.isArray(state.get("o1")));
+  state.set(
+    "o1_0_is_struct",
+    typeof state.get("o1")[0] === "object" &&
+      !Array.isArray(state.get("o1")[0]),
+  );
   state.set("o1_0_n1_is_number", typeof state.get("o1")[0].n1 === "number");
 
   const o1 = state.get("o1");
@@ -14,6 +18,10 @@ const behavior = (state, context) => {
   state.set("o1", o1);
 
   state.set("o1_0_n2_is_number", typeof state.get("o1")[0].n2 === "number");
-  state.set("o1_1_is_struct", typeof state.get("o1")[0] === "object");
+  state.set(
+    "o1_1_is_struct",
+    typeof state.get("o1")[1] === "object" &&
+      !Array.isArray(state.get("o1")[0]),
+  );
   state.set("o1_1_n3_is_number", typeof state.get("o1")[1].n3 === "number");
 };

--- a/packages/engine/tests/units/state/empty/object/src/behaviors/test.js
+++ b/packages/engine/tests/units/state/empty/object/src/behaviors/test.js
@@ -2,5 +2,5 @@
  * Verifies the type of the object
  */
 const behavior = (state, context) => {
-  state.o1_is_struct = typeof state.o1 === "object";
+  state.o1_is_struct = typeof state.o1 === "object" && !Array.isArray(state.o1);
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

JavaScript does not have a built-in type for lists like Python's `list`, so `typeof ["a"]` will return "object". To improve testing stability, we want to check for lists with `Array.isArray` instead. For actual structs, this also adds checks, if the type is **not** an array.

## 🔍 What does this change?

- Replaces more `typeof <list>` checks with `Array.isArray` checks.
- Adds `!Array.isArray` for struct fields

## Next steps

Also, apply it to #301

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201793759102797/1201816386539221/f) (_internal_)

## 🛡 What tests cover this?

This is to improve the stability of the touched tests