### PR TITLE
Rename `Batch`es to `AgentBatch`, `MessageBatch` etc.

### DIFF
--- a/packages/engine/src/datastore/batch/agent.rs
+++ b/packages/engine/src/datastore/batch/agent.rs
@@ -35,7 +35,7 @@ use crate::{
 /// segment and the Arrow `RecordBatch` view
 /// into that data.
 #[allow(clippy::module_name_repetitions)]
-pub struct Batch {
+pub struct AgentBatch {
     pub memory: Memory,
     /// Arrow `RecordBatch` with references to `self.memory`
     pub batch: RecordBatch,
@@ -56,7 +56,7 @@ pub struct Batch {
     pub affinity: usize,
 }
 
-impl BatchRepr for Batch {
+impl BatchRepr for AgentBatch {
     fn memory(&self) -> &Memory {
         &self.memory
     }
@@ -91,7 +91,7 @@ impl BatchRepr for Batch {
     }
 }
 
-impl ArrowBatch for Batch {
+impl ArrowBatch for AgentBatch {
     fn record_batch(&self) -> &RecordBatch {
         &self.batch
     }
@@ -101,7 +101,7 @@ impl ArrowBatch for Batch {
     }
 }
 
-impl DynamicBatch for Batch {
+impl DynamicBatch for AgentBatch {
     fn dynamic_meta(&self) -> &DynamicMeta {
         &self.dynamic_meta
     }
@@ -135,7 +135,7 @@ impl DynamicBatch for Batch {
 }
 
 /// Constructors for `Batch`
-impl Batch {
+impl AgentBatch {
     /// Get a shared batch from the `AgentState` format.
     /// Need to specify which behaviors the shared batch
     /// should be run on.
@@ -143,9 +143,9 @@ impl Batch {
         agents: K,
         schema: &Arc<AgentSchema>,
         experiment_id: &ExperimentId,
-    ) -> Result<Batch> {
+    ) -> Result<Self> {
         let rb = agents.into_agent_batch(schema)?;
-        Batch::from_record_batch(&rb, schema, experiment_id)
+        Self::from_record_batch(&rb, schema, experiment_id)
     }
 
     pub fn set_dynamic_meta(&mut self, dynamic_meta: &DynamicMeta) -> Result<()> {
@@ -157,10 +157,10 @@ impl Batch {
     }
 
     pub fn duplicate_from(
-        batch: &Batch,
+        batch: &Self,
         schema: &AgentSchema,
         experiment_id: &ExperimentId,
-    ) -> Result<Batch> {
+    ) -> Result<Self> {
         let memory = Memory::duplicate_from(&batch.memory, experiment_id)?;
         Self::from_memory(memory, Some(schema), Some(batch.affinity))
     }
@@ -170,7 +170,7 @@ impl Batch {
         record_batch: &RecordBatch,
         schema: &AgentSchema,
         experiment_id: &ExperimentId,
-    ) -> Result<Batch> {
+    ) -> Result<Self> {
         let schema_buffer = schema_to_bytes(&schema.arrow);
 
         let header_buffer = vec![]; // Nothing here
@@ -201,7 +201,7 @@ impl Batch {
         memory: Memory,
         schema: Option<&AgentSchema>,
         affinity: Option<usize>,
-    ) -> Result<Batch> {
+    ) -> Result<Self> {
         let (schema_buffer, _header_buffer, meta_buffer, data_buffer) =
             memory.get_batch_buffers()?;
         let (schema, static_meta) = if let Some(s) = schema {
@@ -228,7 +228,7 @@ impl Batch {
             Err(e) => return Err(Error::from(e)),
         };
 
-        Ok(Batch {
+        Ok(Self {
             memory,
             batch,
             dynamic_meta,
@@ -277,7 +277,7 @@ impl Batch {
     }
 }
 
-impl GrowableBatch<ArrayChange, Arc<array::ArrayData>> for Batch {
+impl GrowableBatch<ArrayChange, Arc<array::ArrayData>> for AgentBatch {
     fn take_changes(&mut self) -> Vec<ArrayChange> {
         std::mem::take(&mut self.changes)
     }
@@ -303,7 +303,7 @@ impl GrowableBatch<ArrayChange, Arc<array::ArrayData>> for Batch {
     }
 }
 
-impl Batch {
+impl AgentBatch {
     /// This agent index column contains the indices of the agents *before* agent migration
     /// was performed. This is important so an agent can access its neighbor's outbox
     pub fn write_agent_indices(&mut self, batch_index: usize) -> Result<()> {
@@ -333,10 +333,10 @@ impl Batch {
     }
 }
 
-impl Batch {
+impl AgentBatch {
     pub fn from_shmem_os_id(os_id: &str) -> Result<Box<Self>> {
         let memory = Memory::shmem_os_id(os_id, true, true)?;
-        Ok(Box::new(Batch::from_memory(memory, None, None)?))
+        Ok(Box::new(Self::from_memory(memory, None, None)?))
     }
 
     pub fn set_affinity(&mut self, affinity: usize) {
@@ -358,7 +358,7 @@ impl Batch {
 }
 
 // Special-case columns getter and setters
-impl Batch {
+impl AgentBatch {
     pub fn get_arrow_column_ref(&self, key: &FieldKey) -> Result<&ArrayRef> {
         self.get_arrow_column(key.value())
     }
@@ -724,14 +724,14 @@ impl AgentList for RecordBatch {
     }
 }
 
-impl AgentList for Batch {
+impl AgentList for AgentBatch {
     fn record_batch(&self) -> &RecordBatch {
         &self.batch
     }
 }
 
-impl AsRef<Batch> for Batch {
-    fn as_ref(&self) -> &Batch {
+impl AsRef<AgentBatch> for AgentBatch {
+    fn as_ref(&self) -> &Self {
         self
     }
 }

--- a/packages/engine/src/datastore/batch/context.rs
+++ b/packages/engine/src/datastore/batch/context.rs
@@ -26,13 +26,13 @@ const UPPER_BOUND_DATA_SIZE_MULTIPLIER: usize = 3;
 pub type AgentIndex = (u32, u32);
 pub type MessageIndex = (u32, u32, u32);
 
-pub struct Batch {
+pub struct ContextBatch {
     pub(crate) memory: Memory,
     pub(crate) metaversion: Metaversion,
     pub(crate) batch: RecordBatch,
 }
 
-impl BatchRepr for Batch {
+impl BatchRepr for ContextBatch {
     fn memory(&self) -> &Memory {
         &self.memory
     }
@@ -58,12 +58,12 @@ impl BatchRepr for Batch {
     }
 }
 
-impl Batch {
+impl ContextBatch {
     pub fn from_record_batch(
         record_batch: &RecordBatch,
         schema: Option<&Arc<ArrowSchema>>,
         experiment_id: &ExperimentId,
-    ) -> Result<Batch> {
+    ) -> Result<Self> {
         let (meta_buffer, data_buffer) = static_record_batch_to_bytes(record_batch);
 
         let memory = Memory::from_batch_buffers(
@@ -77,7 +77,7 @@ impl Batch {
         Self::from_memory(memory, schema)
     }
 
-    pub fn from_memory(memory: Memory, schema: Option<&Arc<ArrowSchema>>) -> Result<Batch> {
+    pub fn from_memory(memory: Memory, schema: Option<&Arc<ArrowSchema>>) -> Result<Self> {
         let (schema_buffer, _, meta_buffer, data_buffer) = memory.get_batch_buffers()?;
         let schema = if let Some(s) = schema {
             s.clone()
@@ -97,7 +97,7 @@ impl Batch {
             Err(e) => return Err(Error::from(e)),
         };
 
-        Ok(Batch {
+        Ok(Self {
             memory,
             metaversion: Metaversion::default(),
             batch,

--- a/packages/engine/src/datastore/batch/dataset.rs
+++ b/packages/engine/src/datastore/batch/dataset.rs
@@ -3,12 +3,12 @@ use crate::{
     proto::{ExperimentId, SharedDataset},
 };
 
-pub struct Batch {
+pub struct Dataset {
     pub(crate) memory: Memory,
     pub(crate) reload_state: Metaversion,
 }
 
-impl super::Batch for Batch {
+impl Batch for Dataset {
     fn memory(&self) -> &Memory {
         &self.memory
     }
@@ -40,11 +40,8 @@ impl super::Batch for Batch {
     }
 }
 
-impl Batch {
-    pub fn new_from_dataset(
-        dataset: &SharedDataset,
-        experiment_id: &ExperimentId,
-    ) -> Result<Batch> {
+impl Dataset {
+    pub fn new_from_dataset(dataset: &SharedDataset, experiment_id: &ExperimentId) -> Result<Self> {
         let dataset_name = dataset.shortname.clone();
         let dataset_size = dataset
             .data
@@ -63,7 +60,7 @@ impl Batch {
                 .map(|data| data.as_bytes())
                 .unwrap_or_default(),
         );
-        Ok(Batch {
+        Ok(Self {
             memory,
             reload_state,
         })

--- a/packages/engine/src/datastore/batch/mod.rs
+++ b/packages/engine/src/datastore/batch/mod.rs
@@ -9,10 +9,10 @@ pub mod message;
 pub mod metaversion;
 pub mod migration;
 
-pub use agent::Batch as AgentBatch;
-pub use context::{AgentIndex, Batch as ContextBatch, MessageIndex};
-pub use dataset::Batch as Dataset;
-pub use message::Batch as MessageBatch;
+pub use agent::AgentBatch;
+pub use context::{AgentIndex, ContextBatch, MessageIndex};
+pub use dataset::Dataset;
+pub use message::MessageBatch;
 pub use metaversion::Metaversion;
 
 use super::{

--- a/packages/engine/src/datastore/table/state/create_remove/batch.rs
+++ b/packages/engine/src/datastore/table/state/create_remove/batch.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashSet, ops::Deref};
 
 use super::{AgentIndex, BatchIndex, Result, WorkerIndex};
-use crate::datastore::{batch::agent::Batch as AgentBatch, UUID_V4_LEN};
+use crate::datastore::{batch::agent::AgentBatch, UUID_V4_LEN};
 
 #[derive(Debug, Clone)]
 pub struct BaseBatch {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, we have multiple types called `Batch` in different files and reimporting them as `AgentBatch`, `MessageBatch` etc.. For IDE it's (currently?) not possible to find reimported aliases, so renaming will improve maintainability and readability.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201793759102797/1201819939567707/f) (_internal_)
