### PR TITLE
Changing the remove methods on BatchPools to return the ID

### DIFF
--- a/packages/engine/src/datastore/table/context/mod.rs
+++ b/packages/engine/src/datastore/table/context/mod.rs
@@ -149,14 +149,11 @@ impl Context {
             }
         } else if dynamic_pool.len() < static_pool.len() {
             // Remove unneeded static batches
-            let mut removed_ids = Vec::with_capacity(static_pool.len() - dynamic_pool.len());
-            for remove_index in (dynamic_pool.len()..static_pool.len()).rev() {
-                let removed_agent_proxy = static_pool.remove(remove_index)?;
-                removed_ids.push(removed_agent_proxy.get_batch_id().to_string());
-            }
-            removed_ids
-                .into_iter()
-                .for_each(|id| self.removed_batches.push(id));
+            let removed_ids = (dynamic_pool.len()..static_pool.len())
+                .rev()
+                .map(|remove_index| static_pool.remove(remove_index))
+                .collect::<Result<Vec<_>>>()?;
+            self.removed_batches.extend(removed_ids);
         }
 
         // State group start indices need to be updated, because we

--- a/packages/engine/src/datastore/table/context/mod.rs
+++ b/packages/engine/src/datastore/table/context/mod.rs
@@ -152,7 +152,7 @@ impl Context {
             let removed_ids = (dynamic_pool.len()..static_pool.len())
                 .rev()
                 .map(|remove_index| static_pool.remove(remove_index))
-                .collect::<Result<Vec<_>>>()?;
+                .collect::<Vec<_>>();
             self.removed_batches.extend(removed_ids);
         }
 

--- a/packages/engine/src/datastore/table/pool/message.rs
+++ b/packages/engine/src/datastore/table/pool/message.rs
@@ -138,7 +138,7 @@ impl PoolWriteProxy<MessageBatch> {
             if let Some(dynamic_batch) = agent_proxies.batch(batch_index) {
                 self[batch_index].reset(dynamic_batch)?;
             } else {
-                removed.push(message_pool.remove(batch_index)?);
+                removed.push(message_pool.remove(batch_index));
             }
         }
         if agent_proxies.len() > self.len() {

--- a/packages/engine/src/datastore/table/pool/message.rs
+++ b/packages/engine/src/datastore/table/pool/message.rs
@@ -8,7 +8,7 @@ use rayon::iter::{
 use super::BatchPool;
 use crate::{
     datastore::{
-        batch::{self, AgentBatch, Batch, MessageBatch},
+        batch::{self, AgentBatch, MessageBatch},
         table::{
             pool::proxy::{PoolReadProxy, PoolWriteProxy},
             references::AgentMessageReference,
@@ -138,8 +138,7 @@ impl PoolWriteProxy<MessageBatch> {
             if let Some(dynamic_batch) = agent_proxies.batch(batch_index) {
                 self[batch_index].reset(dynamic_batch)?;
             } else {
-                let message_proxy = message_pool.remove(batch_index)?;
-                removed.push(message_proxy.get_batch_id().to_string());
+                removed.push(message_pool.remove(batch_index)?);
             }
         }
         if agent_proxies.len() > self.len() {

--- a/packages/engine/src/datastore/table/pool/mod.rs
+++ b/packages/engine/src/datastore/table/pool/mod.rs
@@ -40,9 +40,9 @@ pub trait BatchPool<B: Batch>: Send + Sync {
 
     fn push(&mut self, batch: B);
 
-    fn remove(&mut self, index: usize) -> Result<String>;
+    fn remove(&mut self, index: usize) -> String;
 
-    fn swap_remove(&mut self, index: usize) -> Result<String>;
+    fn swap_remove(&mut self, index: usize) -> String;
 
     /// Creates a [`PoolReadProxy`] for _all_ batches within the pool.
     fn read_proxies(&self) -> Result<PoolReadProxy<B>>;
@@ -74,31 +74,25 @@ impl<P: Pool<B> + Send + Sync, B: Batch> BatchPool<B> for P {
         self.get_batches_mut().push(Arc::new(RwLock::new(batch)))
     }
 
-    fn remove(&mut self, index: usize) -> Result<String> {
+    fn remove(&mut self, index: usize) -> String {
         let mut batch_arc = self.get_batches_mut().remove(index);
         if let Some(rw_lock) = Arc::get_mut(&mut batch_arc) {
             // This can't deadlock as we just checked that the Arc owning this RwLock is unique
             let batch = rw_lock.write();
-            Ok(batch.get_batch_id().to_string())
+            batch.get_batch_id().to_string()
         } else {
-            Err(
-                format!("Failed to remove Batch at index {index}, other Arcs to the Batch existed")
-                    .into(),
-            )
+            panic!("Failed to remove Batch at index {index}, other Arcs to the Batch existed")
         }
     }
 
-    fn swap_remove(&mut self, index: usize) -> Result<String> {
+    fn swap_remove(&mut self, index: usize) -> String {
         let mut batch_arc = self.get_batches_mut().swap_remove(index);
         if let Some(rw_lock) = Arc::get_mut(&mut batch_arc) {
             // This can't deadlock as we just checked that the Arc owning this RwLock is unique
             let batch = rw_lock.write();
-            Ok(batch.get_batch_id().to_string())
+            batch.get_batch_id().to_string()
         } else {
-            Err(format!(
-                "Failed to swap remove Batch at index {index}, other Arcs to the Batch existed"
-            )
-            .into())
+            panic!("Failed to swap remove Batch at index {index}, other Arcs to the Batch existed")
         }
     }
 

--- a/packages/engine/src/datastore/table/pool/mod.rs
+++ b/packages/engine/src/datastore/table/pool/mod.rs
@@ -40,9 +40,9 @@ pub trait BatchPool<B: Batch>: Send + Sync {
 
     fn push(&mut self, batch: B);
 
-    fn remove(&mut self, index: usize) -> Result<BatchReadProxy<B>>;
+    fn remove(&mut self, index: usize) -> Result<String>;
 
-    fn swap_remove(&mut self, index: usize) -> Result<BatchReadProxy<B>>;
+    fn swap_remove(&mut self, index: usize) -> Result<String>;
 
     /// Creates a [`PoolReadProxy`] for _all_ batches within the pool.
     fn read_proxies(&self) -> Result<PoolReadProxy<B>>;
@@ -74,12 +74,32 @@ impl<P: Pool<B> + Send + Sync, B: Batch> BatchPool<B> for P {
         self.get_batches_mut().push(Arc::new(RwLock::new(batch)))
     }
 
-    fn remove(&mut self, index: usize) -> Result<BatchReadProxy<B>> {
-        BatchReadProxy::new(&self.get_batches_mut().remove(index))
+    fn remove(&mut self, index: usize) -> Result<String> {
+        let mut batch_arc = self.get_batches_mut().remove(index);
+        if let Some(rw_lock) = Arc::get_mut(&mut batch_arc) {
+            // This can't deadlock as we just checked that the Arc owning this RwLock is unique
+            let batch = rw_lock.write();
+            Ok(batch.get_batch_id().to_string())
+        } else {
+            Err(
+                format!("Failed to remove Batch at index {index}, other Arcs to the Batch existed")
+                    .into(),
+            )
+        }
     }
 
-    fn swap_remove(&mut self, index: usize) -> Result<BatchReadProxy<B>> {
-        BatchReadProxy::new(&self.get_batches_mut().swap_remove(index))
+    fn swap_remove(&mut self, index: usize) -> Result<String> {
+        let mut batch_arc = self.get_batches_mut().swap_remove(index);
+        if let Some(rw_lock) = Arc::get_mut(&mut batch_arc) {
+            // This can't deadlock as we just checked that the Arc owning this RwLock is unique
+            let batch = rw_lock.write();
+            Ok(batch.get_batch_id().to_string())
+        } else {
+            Err(format!(
+                "Failed to swap remove Batch at index {index}, other Arcs to the Batch existed"
+            )
+            .into())
+        }
     }
 
     fn read_proxies(&self) -> Result<PoolReadProxy<B>> {

--- a/packages/engine/src/datastore/table/pool/mod.rs
+++ b/packages/engine/src/datastore/table/pool/mod.rs
@@ -78,8 +78,7 @@ impl<P: Pool<B> + Send + Sync, B: Batch> BatchPool<B> for P {
         let mut batch_arc = self.get_batches_mut().remove(index);
         if let Some(rw_lock) = Arc::get_mut(&mut batch_arc) {
             // This can't deadlock as we just checked that the Arc owning this RwLock is unique
-            let batch = rw_lock.write();
-            batch.get_batch_id().to_string()
+            rw_lock.write().get_batch_id().to_string()
         } else {
             panic!("Failed to remove Batch at index {index}, other Arcs to the Batch existed")
         }
@@ -89,8 +88,7 @@ impl<P: Pool<B> + Send + Sync, B: Batch> BatchPool<B> for P {
         let mut batch_arc = self.get_batches_mut().swap_remove(index);
         if let Some(rw_lock) = Arc::get_mut(&mut batch_arc) {
             // This can't deadlock as we just checked that the Arc owning this RwLock is unique
-            let batch = rw_lock.write();
-            batch.get_batch_id().to_string()
+            rw_lock.write().get_batch_id().to_string()
         } else {
             panic!("Failed to swap remove Batch at index {index}, other Arcs to the Batch existed")
         }

--- a/packages/engine/src/datastore/table/state/create_remove/plan.rs
+++ b/packages/engine/src/datastore/table/state/create_remove/plan.rs
@@ -67,7 +67,7 @@ impl<'a> MigrationPlan<'a> {
         for (batch_index, action) in self.existing_mutations.iter().enumerate().rev() {
             if let ExistingGroupBufferActions::Remove = action {
                 // Removing in tandem to keep similarly sized batches together
-                removed_ids.push(state_agent_pool.swap_remove(batch_index)?);
+                removed_ids.push(state_agent_pool.swap_remove(batch_index));
             }
         }
 

--- a/packages/engine/src/datastore/table/state/create_remove/plan.rs
+++ b/packages/engine/src/datastore/table/state/create_remove/plan.rs
@@ -4,7 +4,6 @@ use super::action::{CreateActions, ExistingGroupBufferActions};
 use crate::{
     datastore::{
         error::{Error, Result},
-        prelude::*,
         table::pool::{agent::AgentPool, BatchPool},
     },
     proto::ExperimentRunTrait,
@@ -68,12 +67,7 @@ impl<'a> MigrationPlan<'a> {
         for (batch_index, action) in self.existing_mutations.iter().enumerate().rev() {
             if let ExistingGroupBufferActions::Remove = action {
                 // Removing in tandem to keep similarly sized batches together
-                removed_ids.push(
-                    state_agent_pool
-                        .swap_remove(batch_index)?
-                        .get_batch_id()
-                        .to_string(),
-                );
+                removed_ids.push(state_agent_pool.swap_remove(batch_index)?);
             }
         }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When removing batches from a Pool, we previously returned a proxy. This was misleading as it didn't clearly explain we were dropping the Batch in the method (a proxy sort of implied we were viewing the batch and dropping the view).

Those methods were only used when tracking IDs of Batches we removed, so the methods have been changed to return Batch IDs instead of proxies/batches.

## 🔍 What does this change?

- Changes `remove` and `swap_remove` on the Pool traits to return a `String`
- Updates the areas of the code that called them, cleaning up the iters

### 📜 Does this require a change to the docs?

No

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as (_internal_) -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201793759102797/1201819939567711/f) (_internal_)

## 🛡 What tests cover this?

- Standard integration tests, maybe
