### PR TITLE
Resolve entire inheritance chain of an EntityType

### DIFF
--- a/packages/hash/api/src/db/adapter.ts
+++ b/packages/hash/api/src/db/adapter.ts
@@ -12,6 +12,7 @@ import {
   OrgSize,
   Visibility,
   WayToUseHash,
+  JsonSchemaMeta,
 } from "../graphql/apiTypes.gen";
 
 /**
@@ -255,6 +256,14 @@ export interface DBClient {
     accountId: string;
     entityId: string;
   }): Promise<DbEntity | undefined>;
+
+  /**
+   * Get deconstructed JSONSchema inheritance tree for a given Entity Type
+   * @param params.entityTypeId the fixed entityTypeId
+   */
+  getEntityTypeJsonSchemaMeta(params: {
+    entityTypeId: string;
+  }): Promise<JsonSchemaMeta>;
 
   /**
    * Get an entityType by its fixed id.

--- a/packages/hash/api/src/db/adapter.ts
+++ b/packages/hash/api/src/db/adapter.ts
@@ -12,7 +12,7 @@ import {
   OrgSize,
   Visibility,
   WayToUseHash,
-  JsonSchemaMeta,
+  DestructuredSchema,
 } from "../graphql/apiTypes.gen";
 
 /**
@@ -261,9 +261,9 @@ export interface DBClient {
    * Get deconstructed JSONSchema inheritance tree for a given Entity Type
    * @param params.entityTypeId the fixed entityTypeId
    */
-  getEntityTypeJsonSchemaMeta(params: {
+  getEntityTypeDestructuredSchema(params: {
     entityTypeId: string;
-  }): Promise<JsonSchemaMeta>;
+  }): Promise<DestructuredSchema>;
 
   /**
    * Get an entityType by its fixed id.

--- a/packages/hash/api/src/db/postgres/client.ts
+++ b/packages/hash/api/src/db/postgres/client.ts
@@ -273,9 +273,9 @@ export class PostgresClient implements DBClient {
     return (await getEntityLatestVersion(this.conn, params)) || undefined;
   }
 
-  async getEntityTypeJsonSchemaMeta(
-    params: Parameters<DBClient["getEntityTypeJsonSchemaMeta"]>[0],
-  ): ReturnType<DBClient["getEntityTypeJsonSchemaMeta"]> {
+  async getEntityTypeDestructuredSchema(
+    params: Parameters<DBClient["getEntityTypeDestructuredSchema"]>[0],
+  ): ReturnType<DBClient["getEntityTypeDestructuredSchema"]> {
     const jsonSchemaCompiler = this.jsonSchemaCompiler(this.conn);
     const entityType = await this.getEntityTypeLatestVersion(params);
     if (!entityType) {

--- a/packages/hash/api/src/db/postgres/index.ts
+++ b/packages/hash/api/src/db/postgres/index.ts
@@ -116,6 +116,12 @@ export class PostgresAdapter extends DataSource implements DBAdapter {
     return this.query((adapter) => adapter.getEntityLatestVersion(params));
   }
 
+  getEntityTypeJsonSchemaMeta(
+    params: Parameters<DBClient["getEntityTypeJsonSchemaMeta"]>[0],
+  ): ReturnType<DBClient["getEntityTypeJsonSchemaMeta"]> {
+    return this.query((adapter) => adapter.getEntityTypeJsonSchemaMeta(params));
+  }
+
   getEntityTypeLatestVersion(params: {
     entityTypeId: string;
   }): Promise<EntityType | null> {

--- a/packages/hash/api/src/db/postgres/index.ts
+++ b/packages/hash/api/src/db/postgres/index.ts
@@ -116,10 +116,12 @@ export class PostgresAdapter extends DataSource implements DBAdapter {
     return this.query((adapter) => adapter.getEntityLatestVersion(params));
   }
 
-  getEntityTypeJsonSchemaMeta(
-    params: Parameters<DBClient["getEntityTypeJsonSchemaMeta"]>[0],
-  ): ReturnType<DBClient["getEntityTypeJsonSchemaMeta"]> {
-    return this.query((adapter) => adapter.getEntityTypeJsonSchemaMeta(params));
+  getEntityTypeDestructuredSchema(
+    params: Parameters<DBClient["getEntityTypeDestructuredSchema"]>[0],
+  ): ReturnType<DBClient["getEntityTypeDestructuredSchema"]> {
+    return this.query((adapter) =>
+      adapter.getEntityTypeDestructuredSchema(params),
+    );
   }
 
   getEntityTypeLatestVersion(params: {

--- a/packages/hash/api/src/graphql/resolvers/entityType/entityTypeInheritance.ts
+++ b/packages/hash/api/src/graphql/resolvers/entityType/entityTypeInheritance.ts
@@ -1,4 +1,8 @@
-import { Resolver, EntityType as GQLEntityType } from "../../apiTypes.gen";
+import {
+  Resolver,
+  EntityType as GQLEntityType,
+  JsonSchemaMeta,
+} from "../../apiTypes.gen";
 import { GraphQLContext } from "../../context";
 import { EntityType, UnresolvedGQLEntityType } from "../../../model";
 import {
@@ -34,7 +38,20 @@ const entityTypeParentsResolver: Resolver<
   return entityTypes.map((ent) => ent.toGQLEntityType());
 };
 
+const entityTypeDestructuredSchemaResolver: Resolver<
+  Promise<JsonSchemaMeta>,
+  GQLEntityType,
+  GraphQLContext
+> = async (params, _, { dataSources: { db } }) => {
+  const { entityId: entityTypeId } = params;
+
+  const jsonSchemaMeta = await db.getEntityTypeJsonSchemaMeta({ entityTypeId });
+
+  return jsonSchemaMeta;
+};
+
 export const entityTypeInheritance = {
   entityTypeChildren: entityTypeChildrenResolver,
   entityTypeParents: entityTypeParentsResolver,
+  entityTypeDestructuredSchema: entityTypeDestructuredSchemaResolver,
 };

--- a/packages/hash/api/src/graphql/resolvers/entityType/entityTypeInheritance.ts
+++ b/packages/hash/api/src/graphql/resolvers/entityType/entityTypeInheritance.ts
@@ -1,7 +1,7 @@
 import {
   Resolver,
   EntityType as GQLEntityType,
-  JsonSchemaMeta,
+  DestructuredSchema,
 } from "../../apiTypes.gen";
 import { GraphQLContext } from "../../context";
 import { EntityType, UnresolvedGQLEntityType } from "../../../model";
@@ -39,15 +39,17 @@ const entityTypeParentsResolver: Resolver<
 };
 
 const entityTypeDestructuredSchemaResolver: Resolver<
-  Promise<JsonSchemaMeta>,
+  Promise<DestructuredSchema>,
   GQLEntityType,
   GraphQLContext
 > = async (params, _, { dataSources: { db } }) => {
   const { entityId: entityTypeId } = params;
 
-  const jsonSchemaMeta = await db.getEntityTypeJsonSchemaMeta({ entityTypeId });
+  const destructuredSchema = await db.getEntityTypeDestructuredSchema({
+    entityTypeId,
+  });
 
-  return jsonSchemaMeta;
+  return destructuredSchema;
 };
 
 export const entityTypeInheritance = {

--- a/packages/hash/api/src/graphql/resolvers/index.ts
+++ b/packages/hash/api/src/graphql/resolvers/index.ts
@@ -203,6 +203,7 @@ export const resolvers = {
     entityTypeVersionId: entityTypeTypeFields.entityTypeVersionId,
     children: entityTypeInheritance.entityTypeChildren,
     parents: entityTypeInheritance.entityTypeParents,
+    destructuredSchema: entityTypeInheritance.entityTypeDestructuredSchema,
   },
 
   Account: {

--- a/packages/hash/api/src/graphql/typeDefs/entityType.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/entityType.typedef.ts
@@ -67,6 +67,23 @@ export const entityTypeTypedef = gql`
     OrgEmailInvitation
   }
 
+  type JsonSchemaMetaProperty {
+    name: String!
+    content: JSONObject!
+  }
+
+  type JsonSchemaMetaParent {
+    id: String!
+    parents: [String!]!
+    properties: [JsonSchemaMetaProperty!]!
+  }
+
+  type JsonSchemaMeta {
+    id: String!
+    parentSchemas: [JsonSchemaMetaParent!]!
+    properties: [JsonSchemaMetaProperty!]!
+  }
+
   """
   A schema describing and validating a specific type of entity
   """
@@ -154,5 +171,6 @@ export const entityTypeTypedef = gql`
     # ENTITY INTERFACE FIELDS END #
     children: [EntityType!]
     parents: [EntityType!]
+    destructuredSchema: JsonSchemaMeta
   }
 `;

--- a/packages/hash/api/src/graphql/typeDefs/entityType.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/entityType.typedef.ts
@@ -67,21 +67,21 @@ export const entityTypeTypedef = gql`
     OrgEmailInvitation
   }
 
-  type JsonSchemaMetaProperty {
+  type DestructuredSchemaProperty {
     name: String!
     content: JSONObject!
   }
 
-  type JsonSchemaMetaParent {
+  type DestructuredSchemaParent {
     id: String!
     parents: [String!]!
-    properties: [JsonSchemaMetaProperty!]!
+    properties: [DestructuredSchemaProperty!]!
   }
 
-  type JsonSchemaMeta {
+  type DestructuredSchema {
     id: String!
-    parentSchemas: [JsonSchemaMetaParent!]!
-    properties: [JsonSchemaMetaProperty!]!
+    parentSchemas: [DestructuredSchemaParent!]!
+    properties: [DestructuredSchemaProperty!]!
   }
 
   """
@@ -171,6 +171,6 @@ export const entityTypeTypedef = gql`
     # ENTITY INTERFACE FIELDS END #
     children: [EntityType!]
     parents: [EntityType!]
-    destructuredSchema: JsonSchemaMeta
+    destructuredSchema: DestructuredSchema
   }
 `;

--- a/packages/hash/api/src/lib/schemas/jsonSchema.test.ts
+++ b/packages/hash/api/src/lib/schemas/jsonSchema.test.ts
@@ -320,27 +320,35 @@ describe("destructing json schemas", () => {
 
   it("disallows recursive deconstruction/duplicate names", async () => {
     const schema = {
-      $id: "$doctor",
-      type: "object",
-      allOf: [
-        {
-          $id: "$medicalProfessional",
+      $id: "schema",
+      definitions: {
+        person: {
           type: "object",
-          allOf: [
-            {
-              $id: "$doctor",
-              type: "object",
-              properties: {},
-            },
-          ],
           properties: {},
         },
-      ],
+        medicalProfessional: {
+          type: "object",
+          allOf: [{ $ref: "#/definitions/person" }],
+          properties: {},
+        },
+        doctor: {
+          type: "object",
+          allOf: [
+            { $ref: "#/definitions/medicalProfessional" },
+            { $ref: "#/definitions/doctor" },
+          ],
+
+          properties: {},
+        },
+      },
+
+      type: "object",
+      allOf: [{ $ref: "#/definitions/doctor" }],
       properties: {},
     };
 
     await expect(
       jsonSchemaCompiler.deconstructedJsonSchema(schema),
-    ).rejects.toThrowError(/Detected cyclic reference for parent "\$doctor"/i);
+    ).rejects.toThrowError(/circular \$ref pointer found/i);
   });
 });

--- a/packages/hash/api/src/lib/schemas/jsonSchema.test.ts
+++ b/packages/hash/api/src/lib/schemas/jsonSchema.test.ts
@@ -216,8 +216,8 @@ describe("destructing json schemas", () => {
 
     expect(result.id).toEqual("$person");
     expect(result.properties).toEqual([
-      ["name", { type: "string" }],
-      ["age", { type: "string" }],
+      { name: "name", content: { type: "string" } },
+      { name: "age", content: { type: "string" } },
     ]);
     expect(result.parentSchemas).toHaveLength(0);
   });
@@ -247,8 +247,8 @@ describe("destructing json schemas", () => {
 
     expect(result.id).toEqual("$doctor");
     expect(result.properties).toEqual([
-      ["licenseId", { type: "string" }],
-      ["age", { type: "string" }],
+      { name: "licenseId", content: { type: "string" } },
+      { name: "age", content: { type: "string" } },
     ]);
 
     expect(result.parentSchemas).toHaveLength(1);
@@ -256,9 +256,9 @@ describe("destructing json schemas", () => {
     expect(result.parentSchemas).toContainEqual({
       id: "$medicalProfessional",
       properties: [
-        ["name", { type: "string" }],
-        ["age", { type: "string" }],
-        ["field", { type: "string" }],
+        { name: "name", content: { type: "string" } },
+        { name: "age", content: { type: "string" } },
+        { name: "field", content: { type: "string" } },
       ],
       parents: [],
     });
@@ -297,22 +297,22 @@ describe("destructing json schemas", () => {
 
     expect(result.id).toEqual("$doctor");
     expect(result.properties).toEqual([
-      ["licenseId", { type: "string" }],
-      ["age", { type: "string" }],
+      { name: "licenseId", content: { type: "string" } },
+      { name: "age", content: { type: "string" } },
     ]);
 
     expect(result.parentSchemas).toHaveLength(2);
     expect(result.parentSchemas).toContainEqual({
       id: "$medicalProfessional",
-      properties: [["field", { type: "string" }]],
+      properties: [{ name: "field", content: { type: "string" } }],
       parents: ["$person"],
     });
 
     expect(result.parentSchemas).toContainEqual({
       id: "$person",
       properties: [
-        ["name", { type: "string" }],
-        ["age", { type: "string" }],
+        { name: "name", content: { type: "string" } },
+        { name: "age", content: { type: "string" } },
       ],
       parents: [],
     });

--- a/packages/hash/api/src/lib/schemas/jsonSchema.ts
+++ b/packages/hash/api/src/lib/schemas/jsonSchema.ts
@@ -239,6 +239,7 @@ export class JsonSchemaCompiler {
             return self.resolver(file.url);
           },
         },
+        file: false,
       },
     });
     if (dereferences.properties && dereferences.allOf) {

--- a/packages/hash/api/src/lib/schemas/jsonSchema.ts
+++ b/packages/hash/api/src/lib/schemas/jsonSchema.ts
@@ -105,14 +105,14 @@ export class TypeMismatch extends Error {
   }
 }
 
-type Prop = [_: string, __: any];
-type Schema = {
+export type Prop = [_: string, __: any];
+export type Schema = {
   id: string;
   parents: string[];
   properties: Prop[];
 };
 
-type SchemaExt = {
+export type SchemaExt = {
   id: string;
   parentSchemas: Schema[];
   properties: Prop[];
@@ -123,7 +123,7 @@ export const deconstructSchemaParentsFlat = (
   seen: Set<string>,
 ): Schema[] => {
   if (seen.has(schema.$id)) {
-    throw new Error(`Detected cyclic reference for parent ${schema.$id}`);
+    throw new Error(`Detected cyclic reference for parent "${schema.$id}"`);
   }
 
   seen.add(schema.$id);
@@ -302,7 +302,7 @@ export class JsonSchemaCompiler {
         ? JSON.parse(maybeStringifiedSchema)
         : maybeStringifiedSchema;
 
-    const bundledSchema = this.prevalidateProperties(schema);
+    const bundledSchema = await this.prevalidateProperties(schema);
 
     return deconstructSchemaParents(bundledSchema);
   }

--- a/packages/hash/integration/src/graphql/queries/entity.queries.ts
+++ b/packages/hash/integration/src/graphql/queries/entity.queries.ts
@@ -51,6 +51,21 @@ export const getEntityType = gql`
         entityId
         properties
       }
+
+      destructuredSchema {
+        parentSchemas {
+          id
+          parents
+          properties {
+            name
+            content
+          }
+        }
+        properties {
+          name
+          content
+        }
+      }
       __typename
     }
   }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
This PR is a follow up to https://github.com/hashintel/hash/pull/204
A new property has been added to `EntityType` that allows for fetching full inheritance information.
Inspired by the page-tree feature, the type for the property is `DestructuredSchema` given by the types below. A `DestructuredSchemaParent` only contains a list of IDs of their parents, such that we do not need to query recursively.
```graphql
type DestructuredSchemaProperty {
  name: String!
  content: JSONObject!
}

type DestructuredSchemaParent {
  id: String!
  parents: [String!]!
  properties: [DestructuredSchemaProperty!]!
}

type DestructuredSchema {
  id: String!
  parentSchemas: [DestructuredSchemaParent!]!
  properties: [DestructuredSchemaProperty!]!
}
```
such that we do not have to have nested GraphQL queries.

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->
Next step is to implement UI for assigning parent EntityTypes as well as one for viewing these inheritance relations.

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Adds new resolver for `destructuredSchema`
- Makes use of existing JsonSchemaCompiler features

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as (_internal_) -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201095311341924/1201715431493439/f) (_internal_)

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- Unit tests
- Integration tests

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->
This can be tested through the GraphQL endpoint.

To do this, it is assumed that entity types exist that have some level of inheritance. 
Example `EntityType`s can be seen in the describe block here https://github.com/hashintel/hash/blob/9cb9936cf3dbc642c28a11230503fd6e77f29cd3/packages/hash/integration/src/tests/integration.test.ts#L782

<details><summary>destructuredSchema GQL query + data</summary>

**Query**:

```graphql
query getEntityType($entTypeId: ID!) {
  getEntityType(entityTypeId: $entTypeId) {
    properties
    entityId
    destructuredSchema {
      parentSchemas {
        id
        parents
        properties {
          name
          content
        }
      }
      properties {
        name
        content
      }
    }
  
  }
}

```

**Data**:
```json
{
  "entTypeId":"--some type that has inheritance--"
}
```
</details>

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
The below example output is more or less the same as the type given by the integration tests, but without multiple parent at the first level.
<details><summary>destructuredSchema example </summary>

```json
{
  "data": {
    "getEntityType": {
      "properties": {
        "$id": "http://localhost:3000/dcff2485-2cb3-47a9-9178-192456a614d8/types/2bbc47a3-7822-4787-aa8d-4b04ea3f26b8",
        "type": "object",
        "allOf": [
          {
            "$ref": "http://localhost:3000/dcff2485-2cb3-47a9-9178-192456a614d8/types/8a7a9244-fcef-4dce-9b57-0b9f5212ead2"
          }
        ],
        "title": "Doctor",
        "$schema": "https://json-schema.org/draft/2019-09/schema",
        "properties": {
          "licenseId": {
            "type": "string"
          }
        },
        "description": ""
      },
      "entityId": "2bbc47a3-7822-4787-aa8d-4b04ea3f26b8",
      "destructuredSchema": {
        "parentSchemas": [
          {
            "id": "http://localhost:3000/dcff2485-2cb3-47a9-9178-192456a614d8/types/8a7a9244-fcef-4dce-9b57-0b9f5212ead2",
            "parents": [
              "http://localhost:3000/dcff2485-2cb3-47a9-9178-192456a614d8/types/8624a974-dae7-4741-a88b-a9bc3956546b"
            ],
            "properties": [
              {
                "name": "field",
                "content": {
                  "type": "string"
                }
              }
            ]
          },
          {
            "id": "http://localhost:3000/dcff2485-2cb3-47a9-9178-192456a614d8/types/8624a974-dae7-4741-a88b-a9bc3956546b",
            "parents": [],
            "properties": [
              {
                "name": "age",
                "content": {
                  "type": "number"
                }
              },
              {
                "name": "name",
                "content": {
                  "type": "string"
                }
              }
            ]
          }
        ],
        "properties": [
          {
            "name": "licenseId",
            "content": {
              "type": "string"
            }
          }
        ]
      }
    }
  }
}
```
</details>