### PR TITLE
Upgrade `check-dependency-version-consistency` to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "node-fetch": "^2.6.7"
   },
   "devDependencies": {
-    "check-dependency-version-consistency": "1.6.0",
+    "check-dependency-version-consistency": "2.0.0",
     "concurrently": "7.0.0",
     "cross-env": "7.0.3",
     "husky": "7.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5985,11 +5985,6 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
-array-union@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/array-union/-/array-union-3.0.1.tgz#da52630d327f8b88cfbfb57728e2af5cd9b6b975"
-  integrity sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==
-
 array-uniq@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
@@ -6946,15 +6941,15 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-check-dependency-version-consistency@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/check-dependency-version-consistency/-/check-dependency-version-consistency-1.6.0.tgz#213a3c53d5976c46b63383c725b1fa0cb0b471fc"
-  integrity sha512-7SlDVyoSnIf5BnPzIYxxLLTqK3nfXETBdXSHu72RK3utxYvFanKGa3YRmiHeh9h3l32JrYrzpcLcLHs7WJ29hA==
+check-dependency-version-consistency@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/check-dependency-version-consistency/-/check-dependency-version-consistency-2.0.0.tgz#06eaa6faee2d0fc50eef8c0666b6ab0ec3b0bb12"
+  integrity sha512-FT3f13Nxvez9qXcvH5UJyrHZKGwQh+nTCWD5DhI/W/qvhU4zyX2IPS5XLgnGwpb/PQqCU3JLDSrkO0kRbJp47A==
   dependencies:
     chalk "^4.1.2"
     commander "^8.1.0"
     edit-json-file "^1.7.0"
-    globby "^12.0.2"
+    globby "^13.1.1"
     semver "^7.3.5"
     table "^6.7.1"
     type-fest "^2.1.0"
@@ -8962,7 +8957,7 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.0.3, fast-glob@^3.1.1, fast-glob@^3.2.7:
+fast-glob@^3.0.3, fast-glob@^3.1.1, fast-glob@^3.2.11:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
   integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
@@ -9629,15 +9624,14 @@ globby@^11.0.4:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-globby@^12.0.2:
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-12.2.0.tgz#2ab8046b4fba4ff6eede835b29f678f90e3d3c22"
-  integrity sha512-wiSuFQLZ+urS9x2gGPl1H5drc5twabmm4m2gTR27XDFyjUHJUNsS8o/2aKyIF6IoBaR630atdher0XJ5g6OMmA==
+globby@^13.1.1:
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-13.1.1.tgz#7c44a93869b0b7612e38f22ed532bfe37b25ea6f"
+  integrity sha512-XMzoDZbGZ37tufiv7g0N4F/zp3zkwdFtVbV3EHsVl1KQr4RPLfNoT068/97RPshz2J5xYNEjLKKBKaGHifBd3Q==
   dependencies:
-    array-union "^3.0.1"
     dir-glob "^3.0.1"
-    fast-glob "^3.2.7"
-    ignore "^5.1.9"
+    fast-glob "^3.2.11"
+    ignore "^5.2.0"
     merge2 "^1.4.1"
     slash "^4.0.0"
 
@@ -10228,7 +10222,7 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.1, ignore@^5.1.4, ignore@^5.1.8, ignore@^5.1.9, ignore@^5.2.0, ignore@~5.2.0:
+ignore@^5.1.1, ignore@^5.1.4, ignore@^5.1.8, ignore@^5.2.0, ignore@~5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Author of `check-dependency-version-consistency` [implemented](https://github.com/bmish/check-dependency-version-consistency/pull/343) my [feature request](https://github.com/bmish/check-dependency-version-consistency/issues/332) 🎉 This PR hardens our checks by upgrading the dependency.

## 🔍 What does this change?

We are now protected against wrong version numbers for our own packages, a mistake I have made before.

### 📜 Does this require a change to the docs?

No

## 🔗 Related links

Same change in the Block Protocol repo: https://github.com/blockprotocol/blockprotocol/pull/221

## 🛡 What tests cover this?

CI

## ❓ How to test this?

1. Change package version of any app inside `packages/hash/*`.

1. Run `yarn lint:dependency-version-consistency`

1. Observe the error

1. Revert and run the same command again, observe no error.

## 📹 Demo

 Here is what happens if I change `@hashintel/hash-shared` version to `0.4.2` in `packages/hash/frontend/package.json`:
 
<img width="910" alt="Screenshot 2022-02-15 at 17 16 54" src="https://user-images.githubusercontent.com/608862/154114455-6567d1db-abd9-4dbe-a0c4-4ae747af9ca1.png">

