### PR TITLE
Run Rust CI on push

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,8 +3,6 @@ name: Rust
 on:
   pull_request:
   push:
-    branches:
-      - main
 
 defaults:
   run:
@@ -86,7 +84,7 @@ jobs:
   rustfmt:
     name: rustfmt
     needs: setup
-    if: needs.setup.outputs.rustfmt != '[]' && github.event_name == 'pull_request'
+    if: needs.setup.outputs.rustfmt != '[]'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -131,7 +129,7 @@ jobs:
   clippy:
     name: clippy
     needs: setup
-    if: needs.setup.outputs.clippy != '[]' && github.event_name == 'pull_request'
+    if: needs.setup.outputs.clippy != '[]'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -200,7 +198,7 @@ jobs:
   test:
     name: test
     needs: setup
-    if: needs.setup.outputs.test != '[]' && github.event_name == 'pull_request'
+    if: needs.setup.outputs.test != '[]'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -264,7 +262,7 @@ jobs:
   bench:
     name: bench
     needs: setup
-    if: needs.setup.outputs.bench != '[]'
+    if: needs.setup.outputs.bench != '[]' && (github.event_name == 'pull_request' || github.ref_name == 'main')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, we only run Rust CI on pull requests (and the `bench` job when pushing to main). In order to rely on CI when pushing to a branch like `td/my-wip-branch`, CI can simply be run on every push.

## ⚠️ Known issues

None:

- Secrets are not exposed
- [CI for Open Source repositories is free](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration):
    > GitHub Actions usage is free for both public repositories and self-hosted runners

## 🔍 What does this change?

- Removes the limitation on `push`-branches
- Removes check to only run tests on `pull_request`s
- As `bench` runs pretty long on push (10 samples), it's limited to pull requests and `main`
- **This does not change the behavior when the CI is running in regards to changed files, so it will still only run if `A-Engine` changes** (And when CI changes)
