### PR TITLE
Deprecate legacy `outgoing_links` lookup table

### DIFF
--- a/packages/hash/api/datastore/postgres/schema/0000_base.sql
+++ b/packages/hash/api/datastore/postgres/schema/0000_base.sql
@@ -168,19 +168,6 @@ create table if not exists links (
 
 /** @todo: create link table index */
 
-/** Stores parent --> child link references for looking up the outgoing links for a given entity */
-create table if not exists outgoing_links (
-    source_account_id           uuid not null,
-    source_entity_id            uuid not null,
-    link_id                     uuid not null,
-
-    constraint outgoing_links_pk primary key (
-      source_account_id, -- included in the primary key so it can be used as a sharding key
-      source_entity_id,
-      link_id
-    )
-);
-
 /** Stores reverse child --> parent link references for looking up the incoming links for a given entity */
 create table if not exists incoming_links (
     destination_account_id      uuid not null,

--- a/packages/hash/api/datastore/postgres/schema/0002_citus_setup.sql
+++ b/packages/hash/api/datastore/postgres/schema/0002_citus_setup.sql
@@ -30,10 +30,6 @@ begin
       perform create_distributed_table('links', 'source_account_id');
     end if;
 
-    if not is_citus_distributed_table('outgoing_links') then
-      perform create_distributed_table('outgoing_links', 'source_account_id');
-    end if;
-
     if not is_citus_distributed_table('incoming_links') then
       perform create_distributed_table('incoming_links', 'destination_account_id');
     end if;

--- a/packages/hash/api/datastore/postgres/schema/0003_foreign_keys.sql
+++ b/packages/hash/api/datastore/postgres/schema/0003_foreign_keys.sql
@@ -7,29 +7,6 @@ select create_fk_if_not_exists(
   '(account_id, entity_id)'                    --to_columns
 );
 
--- FK from outgoing_links --> entity_versions
-select create_fk_if_not_exists(
-  'outgoing_links_source_account_id_source_entity_id_fk',   --constraint_name
-  'outgoing_links',                                         --from_table
-  '(source_account_id, source_entity_id)',                  --from_columns
-  'entities',                                               --to_table
-  '(account_id, entity_id)'                                 --to_columns
-);
-
--- FK from outgoing_links --> links on the parent entity. We cannot create this
--- if Citus is enabled because child_account_id is not a distribution column.
-do $$ begin
-  if not is_citus_enabled() then
-    perform create_fk_if_not_exists(
-      'outgoing_links_source_account_id_link_id_fk',    --constraint_name
-      'outgoing_links',                                 --from_table
-      '(source_account_id, link_id)',                   --from_columns
-      'links',                                          --to_table
-      '(source_account_id, link_id)'                    --to_columns
-    );
-  end if;
-end; $$;
-
 -- FK from incoming_links --> entity_versions
 select create_fk_if_not_exists(
   'incoming_links_destination_account_id_destination_entity_id_fk',   --constraint_name

--- a/packages/hash/api/src/db/postgres/client.ts
+++ b/packages/hash/api/src/db/postgres/client.ts
@@ -218,8 +218,6 @@ export class PostgresClient implements DBClient {
         set constraints
           entity_versions_account_id_entity_id_fk,
           entity_account_account_id_entity_version_id_fk,
-          outgoing_links_source_account_id_source_entity_id_fk,
-          outgoing_links_source_account_id_link_id_fk,
           incoming_links_destination_account_id_destination_entity_id_fk,
           incoming_links_source_account_id_link_id_fk
         deferred

--- a/packages/hash/api/src/db/postgres/entity.ts
+++ b/packages/hash/api/src/db/postgres/entity.ts
@@ -414,8 +414,6 @@ export const updateEntityAccountId = async (
         set constraints
           entity_versions_account_id_entity_id_fk,
           entity_account_account_id_entity_version_id_fk,
-          outgoing_links_source_account_id_source_entity_id_fk,
-          outgoing_links_source_account_id_link_id_fk,
           incoming_links_destination_account_id_destination_entity_id_fk,
           incoming_links_source_account_id_link_id_fk
         deferred
@@ -444,7 +442,7 @@ export const updateEntityAccountId = async (
           account_id = ${originalAccountId}
           and entity_id = ${entityId}
       `),
-      /** Update links, incoming_links and outgoing_links account ids */
+      /** Update links and incoming_links account ids */
       transaction.query(sql`
         update links set
           source_account_id = ${newAccountId}
@@ -477,13 +475,6 @@ export const updateEntityAccountId = async (
         where
           destination_account_id = ${originalAccountId}
           and destination_entity_id = ${entityId}
-      `),
-      transaction.query(sql`
-        update outgoing_links set
-          source_account_id = ${newAccountId}
-        where
-          source_account_id = ${originalAccountId}
-          and source_entity_id = ${entityId}
       `),
     ]);
   });
@@ -803,8 +794,6 @@ export const updateVersionedEntity = async (
   await conn.query(sql`
     set constraints
       entity_account_account_id_entity_version_id_fk,
-      outgoing_links_source_account_id_source_entity_id_fk,
-      outgoing_links_source_account_id_link_id_fk,
       incoming_links_destination_account_id_destination_entity_id_fk,
       incoming_links_source_account_id_link_id_fk
     deferred

--- a/packages/hash/api/src/db/postgres/link/createLink.ts
+++ b/packages/hash/api/src/db/postgres/link/createLink.ts
@@ -36,7 +36,6 @@ export const createLink = async (
     // Defer FKs until end of transaction so we can insert concurrently
     await conn.query(sql`
       set constraints
-        outgoing_links_source_account_id_link_id_fk,
         incoming_links_source_account_id_link_id_fk
       deferred
     `);

--- a/packages/hash/api/src/db/postgres/link/getEntityOutgoingLinks.ts
+++ b/packages/hash/api/src/db/postgres/link/getEntityOutgoingLinks.ts
@@ -22,11 +22,10 @@ export type EntityWithOutgoingEntityIdsPGRow = EntityPGRow & {
 /** maps a postgres row with parent to its corresponding EntityWithOutgoingEntityIds object */
 export const mapEntityWithOutgoingEntityIdsPGRowToEntity = (
   row: EntityWithOutgoingEntityIdsPGRow,
-): EntityWithOutgoingEntityIds =>
-  ({
-    ...mapPGRowToEntity(row),
-    outgoingEntityIds: row.outgoing_entity_ids,
-  } as EntityWithOutgoingEntityIds);
+): EntityWithOutgoingEntityIds => ({
+  ...mapPGRowToEntity(row),
+  outgoingEntityIds: row.outgoing_entity_ids,
+});
 
 export const getEntityOutgoingLinks = async (
   conn: Connection,
@@ -38,18 +37,15 @@ export const getEntityOutgoingLinks = async (
   },
 ) => {
   const rows = await conn.any(sql<DBLinkRow>`
-    select ${mapColumnNamesToSQL(linksColumnNames, "links")}
-    from links inner join outgoing_links on (
-      links.source_account_id = outgoing_links.source_account_id
-      and links.link_id = outgoing_links.link_id
-    )
+    select ${mapColumnNamesToSQL(linksColumnNames)}
+    from links
     where
     ${sql.join(
       [
-        sql`outgoing_links.source_account_id = ${params.accountId}`,
-        sql`outgoing_links.source_entity_id = ${params.entityId}`,
+        sql`source_account_id = ${params.accountId}`,
+        sql`source_entity_id = ${params.entityId}`,
         params.entityVersionId !== undefined
-          ? sql`${params.entityVersionId} = ANY(links.source_entity_version_ids)`
+          ? sql`${params.entityVersionId} = ANY(source_entity_version_ids)`
           : [],
         params.path !== undefined ? sql`path = ${params.path}` : [],
       ].flat(),

--- a/packages/hash/api/src/db/postgres/link/util.ts
+++ b/packages/hash/api/src/db/postgres/link/util.ts
@@ -4,33 +4,6 @@ import { Connection } from "../types";
 import { DBLink } from "../../adapter";
 import { mapColumnNamesToSQL } from "../util";
 
-const outgoingLinksColumnNames = [
-  "source_account_id",
-  "source_entity_id",
-  "link_id",
-];
-
-const outgoingLinksColumnNamesSQL = mapColumnNamesToSQL(
-  outgoingLinksColumnNames,
-);
-
-export const insertOutgoingLink = async (
-  conn: Connection,
-  params: {
-    sourceAccountId: string;
-    sourceEntityId: string;
-    linkId: string;
-  },
-): Promise<void> => {
-  await conn.query(sql`
-    insert into outgoing_links (${outgoingLinksColumnNamesSQL})
-    values (${sql.join(
-      [params.sourceAccountId, params.sourceEntityId, params.linkId],
-      sql`, `,
-    )})
-  `);
-};
-
 const incomingLinksColumnNames = [
   "destination_account_id",
   "destination_entity_id",
@@ -145,9 +118,6 @@ export const insertLink = async (
         sql`, `,
       )})
     `),
-    insertOutgoingLink(conn, {
-      ...params,
-    }),
     insertIncomingLink(conn, {
       ...params,
     }),

--- a/packages/hash/api/src/db/postgres/link/util.ts
+++ b/packages/hash/api/src/db/postgres/link/util.ts
@@ -180,9 +180,6 @@ export const deleteLinkRow = async (
 
   await Promise.all([
     conn.query(sql`
-    delete from outgoing_links where source_account_id = ${params.sourceAccountId} and link_id = ${params.linkId};
-  `),
-    conn.query(sql`
     delete from incoming_links where source_account_id = ${params.sourceAccountId} and link_id = ${params.linkId};
   `),
     conn.query(sql`


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR deprecates a legacy `outgoing_links` lookup table, whose functionality has been replaced by the dedicated `links` table (introduced as part of https://github.com/hashintel/dev/pull/293).

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- removes all references to the `outgoing_links` table
- refractors postgres query for getting outgoing links of an entity to uniquely use `links` table


## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as (_internal_) -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201095311341924/1201610239258382/f) (_internal_)

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- various integration tests make use of the the `getOutgoingLinks` db adapter method, which (to my knowledge) is the only place the `outgoing_links` table was used prior to this PR