### PR TITLE
Td/fix ci

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -264,7 +264,7 @@ jobs:
   bench:
     name: bench
     needs: setup
-    if: needs.setup.outputs.bench != '[]' && (github.event_name == 'pull_request' || github.ref_name == 'main')
+    if: needs.setup.outputs.bench != '[]'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,6 +3,8 @@ name: Rust
 on:
   pull_request:
   push:
+    branches:
+      - main
 
 defaults:
   run:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

If we are pushing a commit to a branch inside of hashintel/hash, the push-CI is triggered. This means, that the `merge-enabled` job is executed and may pass even if no test ran.

## 🔍 What does this change?

- Limit push-runs to `main` branch (main branch can't be pushed to directly)

### 📜 Does this require a change to the docs?

No

## 🛡 What tests cover this?

The CI itself
