### PR TITLE
Propagating the UserErrors, UserWarnings, and PackageError variants

### DIFF
--- a/packages/engine/format/package_error.fbs
+++ b/packages/engine/format/package_error.fbs
@@ -7,7 +7,7 @@
 // fields:
 //    `msg` : the error message
 table PackageError {
-  msg:string;
+  msg:string (required);
 }
 
 root_type PackageError;

--- a/packages/engine/format/user_error.fbs
+++ b/packages/engine/format/user_error.fbs
@@ -7,7 +7,7 @@
 // fields:
 //    `msg` : the error message
 table UserError {
-  msg:string;
+  msg:string (required);
 }
 
 root_type UserError;

--- a/packages/engine/lib/flatbuffers_gen/src/package_error_generated.rs
+++ b/packages/engine/lib/flatbuffers_gen/src/package_error_generated.rs
@@ -54,9 +54,10 @@ impl<'a> PackageError<'a> {
     }
 
     #[inline]
-    pub fn msg(&self) -> Option<&'a str> {
+    pub fn msg(&self) -> &'a str {
         self._tab
             .get::<flatbuffers::ForwardsUOffset<&str>>(PackageError::VT_MSG, None)
+            .unwrap()
     }
 }
 
@@ -68,7 +69,7 @@ impl flatbuffers::Verifiable for PackageError<'_> {
     ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
         use self::flatbuffers::Verifiable;
         v.visit_table(pos)?
-            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(&"msg", Self::VT_MSG, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(&"msg", Self::VT_MSG, true)?
             .finish();
         Ok(())
     }
@@ -79,7 +80,9 @@ pub struct PackageErrorArgs<'a> {
 impl<'a> Default for PackageErrorArgs<'a> {
     #[inline]
     fn default() -> Self {
-        PackageErrorArgs { msg: None }
+        PackageErrorArgs {
+            msg: None, // required field
+        }
     }
 }
 pub struct PackageErrorBuilder<'a: 'b, 'b> {
@@ -105,6 +108,7 @@ impl<'a: 'b, 'b> PackageErrorBuilder<'a, 'b> {
     #[inline]
     pub fn finish(self) -> flatbuffers::WIPOffset<PackageError<'a>> {
         let o = self.fbb_.end_table(self.start_);
+        self.fbb_.required(o, PackageError::VT_MSG, "msg");
         flatbuffers::WIPOffset::new(o.value())
     }
 }

--- a/packages/engine/lib/flatbuffers_gen/src/user_error_generated.rs
+++ b/packages/engine/lib/flatbuffers_gen/src/user_error_generated.rs
@@ -54,9 +54,10 @@ impl<'a> UserError<'a> {
     }
 
     #[inline]
-    pub fn msg(&self) -> Option<&'a str> {
+    pub fn msg(&self) -> &'a str {
         self._tab
             .get::<flatbuffers::ForwardsUOffset<&str>>(UserError::VT_MSG, None)
+            .unwrap()
     }
 }
 
@@ -68,7 +69,7 @@ impl flatbuffers::Verifiable for UserError<'_> {
     ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
         use self::flatbuffers::Verifiable;
         v.visit_table(pos)?
-            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(&"msg", Self::VT_MSG, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(&"msg", Self::VT_MSG, true)?
             .finish();
         Ok(())
     }
@@ -79,7 +80,9 @@ pub struct UserErrorArgs<'a> {
 impl<'a> Default for UserErrorArgs<'a> {
     #[inline]
     fn default() -> Self {
-        UserErrorArgs { msg: None }
+        UserErrorArgs {
+            msg: None, // required field
+        }
     }
 }
 pub struct UserErrorBuilder<'a: 'b, 'b> {
@@ -105,6 +108,7 @@ impl<'a: 'b, 'b> UserErrorBuilder<'a, 'b> {
     #[inline]
     pub fn finish(self) -> flatbuffers::WIPOffset<UserError<'a>> {
         let o = self.fbb_.end_table(self.start_);
+        self.fbb_.required(o, UserError::VT_MSG, "msg");
         flatbuffers::WIPOffset::new(o.value())
     }
 }

--- a/packages/engine/lib/orchestrator/src/experiment.rs
+++ b/packages/engine/lib/orchestrator/src/experiment.rs
@@ -300,12 +300,18 @@ impl Experiment {
                 proto::EngineStatus::SimStop(sim_id) => {
                     debug!("Simulation stopped: {sim_id}");
                 }
-                proto::EngineStatus::Errors(sim_id, errs) => {
-                    error!("There were errors when running simulation [{sim_id}]: {errs:?}");
+                proto::EngineStatus::RunnerErrors(sim_id, errs) => {
+                    error!(
+                        "There were errors from the runner when running simulation [{sim_id}]: \
+                         {errs:?}"
+                    );
                     graceful_finish = false;
                 }
-                proto::EngineStatus::Warnings(sim_id, warnings) => {
-                    warn!("There were warnings when running simulation [{sim_id}]: {warnings:?}");
+                proto::EngineStatus::RunnerWarnings(sim_id, warnings) => {
+                    warn!(
+                        "There were warnings from the runner when running simulation [{sim_id}]: \
+                         {warnings:?}"
+                    );
                 }
                 proto::EngineStatus::Logs(sim_id, logs) => {
                     for log in logs {
@@ -314,8 +320,26 @@ impl Experiment {
                         }
                     }
                 }
+                proto::EngineStatus::UserErrors(sim_id, errs) => {
+                    error!(
+                        "There were user-facing errors when running simulation [{sim_id}]: \
+                         {errs:?}"
+                    );
+                }
+                proto::EngineStatus::UserWarnings(sim_id, warnings) => {
+                    warn!(
+                        "There were user-facing warnings when running simulation [{sim_id}]: \
+                         {warnings:?}"
+                    );
+                }
+                proto::EngineStatus::PackageError(sim_id, error) => {
+                    warn!(
+                        "There was an error from a package running simulation [{sim_id}]: \
+                         {error:?}"
+                    );
+                }
                 proto::EngineStatus::Exit => {
-                    debug!("Process exited successfully for experiment run \"{experiment_name}\"",);
+                    debug!("Process exited successfully for experiment run \"{experiment_name}\"");
                     break;
                 }
                 proto::EngineStatus::ProcessError(error) => {

--- a/packages/engine/src/experiment/controller/controller.rs
+++ b/packages/engine/src/experiment/controller/controller.rs
@@ -143,22 +143,42 @@ impl<P: OutputPersistenceCreatorRepr> ExperimentController<P> {
         msg: WorkerPoolToExpCtlMsg,
     ) -> Result<()> {
         let engine_status = match msg {
-            WorkerPoolToExpCtlMsg::Errors(errors) => {
-                tracing::debug!("Received Errors Experiment Control Message from Worker Pool");
+            WorkerPoolToExpCtlMsg::RunnerErrors(errors) => {
+                tracing::debug!(
+                    "Received RunnerErrors Experiment Control Message from Worker Pool"
+                );
                 let runner_errors = errors.into_iter().map(|w| w.into_sendable(false)).collect();
-                EngineStatus::Errors(id, runner_errors)
+                EngineStatus::RunnerErrors(id, runner_errors)
             }
-            WorkerPoolToExpCtlMsg::Warnings(warnings) => {
-                tracing::debug!("Received Warnings Experiment Control Message from Worker Pool");
+            WorkerPoolToExpCtlMsg::RunnerWarnings(warnings) => {
+                tracing::debug!(
+                    "Received RunnerWarnings Experiment Control Message from Worker Pool"
+                );
                 let runner_warnings = warnings
                     .into_iter()
                     .map(|w| w.into_sendable(true))
                     .collect();
-                EngineStatus::Warnings(id, runner_warnings)
+                EngineStatus::RunnerWarnings(id, runner_warnings)
             }
             WorkerPoolToExpCtlMsg::Logs(logs) => {
                 tracing::debug!("Received Logs Experiment Control Message from Worker Pool");
                 EngineStatus::Logs(id, logs)
+            }
+            WorkerPoolToExpCtlMsg::UserErrors(errors) => {
+                tracing::debug!("Received UserErrors Experiment Control Message from Worker Pool");
+                EngineStatus::UserErrors(id, errors)
+            }
+            WorkerPoolToExpCtlMsg::UserWarnings(warnings) => {
+                tracing::debug!(
+                    "Received UserWarnings Experiment Control Message from Worker Pool"
+                );
+                EngineStatus::UserWarnings(id, warnings)
+            }
+            WorkerPoolToExpCtlMsg::PackageError(error) => {
+                tracing::debug!(
+                    "Received PackageError Experiment Control Message from Worker Pool"
+                );
+                EngineStatus::PackageError(id, error)
             }
         };
         self.orch_client().send(engine_status).await?;

--- a/packages/engine/src/proto.rs
+++ b/packages/engine/src/proto.rs
@@ -53,7 +53,10 @@ impl FromStr for ExperimentName {
     }
 }
 
-use crate::simulation::enum_dispatch::*;
+use crate::{
+    simulation::enum_dispatch::*,
+    worker::runner::comms::outbound::{PackageError, UserError, UserWarning},
+};
 
 /// The message type sent from the engine to the orchestrator.
 #[derive(Serialize, Deserialize, Debug)]
@@ -75,8 +78,11 @@ pub enum EngineStatus {
     },
     SimStop(SimulationShortId),
     // TODO: OS - Confirm are these only Runner/Simulation errors, if so rename
-    Errors(SimulationShortId, Vec<RunnerError>),
-    Warnings(SimulationShortId, Vec<RunnerError>),
+    RunnerErrors(SimulationShortId, Vec<RunnerError>),
+    RunnerWarnings(SimulationShortId, Vec<RunnerError>),
+    UserErrors(SimulationShortId, Vec<UserError>),
+    UserWarnings(SimulationShortId, Vec<UserWarning>),
+    PackageError(SimulationShortId, PackageError),
     Logs(SimulationShortId, Vec<String>),
 }
 
@@ -126,9 +132,12 @@ impl EngineStatus {
                 globals: _,
             } => "SimStart",
             EngineStatus::SimStop(_) => "SimStop",
-            EngineStatus::Errors(..) => "Errors",
-            EngineStatus::Warnings(..) => "Warnings",
+            EngineStatus::RunnerErrors(..) => "RunnerErrors",
+            EngineStatus::RunnerWarnings(..) => "RunnerWarnings",
             EngineStatus::Logs(..) => "Logs",
+            EngineStatus::UserErrors(..) => "UserErrors",
+            EngineStatus::UserWarnings(..) => "UserWarnings",
+            EngineStatus::PackageError(..) => "PackageError",
         }
     }
 }

--- a/packages/engine/src/worker/mod.rs
+++ b/packages/engine/src/worker/mod.rs
@@ -24,7 +24,7 @@ use self::{
     pending::PendingWorkerTasks,
     runner::{
         comms::{
-            outbound::{OutboundFromRunnerMsg, OutboundFromRunnerMsgPayload, RunnerError},
+            outbound::{OutboundFromRunnerMsg, OutboundFromRunnerMsgPayload},
             ExperimentInitRunnerMsg, NewSimulationRun, RunnerTaskMsg,
         },
         javascript::JavaScriptRunner,
@@ -348,28 +348,33 @@ impl WorkerController {
                 //     .in_current_span()
                 //     .await?;
             }
-            RunnerError(err) => {
-                self.handle_errors(sim_id, vec![err])
-                    .in_current_span()
-                    .await?
-            }
-            RunnerErrors(errs) => self.handle_errors(sim_id, errs).in_current_span().await?,
-            RunnerWarning(warning) => {
-                self.handle_warnings(sim_id, vec![warning])
-                    .in_current_span()
-                    .await?
-            }
-            RunnerWarnings(warnings) => {
-                self.handle_warnings(sim_id, warnings)
-                    .in_current_span()
-                    .await?
-            }
-            RunnerLog(log) => {
-                self.handle_logs(sim_id, vec![log])
-                    .in_current_span()
-                    .await?
-            }
-            RunnerLogs(logs) => self.handle_logs(sim_id, logs).in_current_span().await?,
+            RunnerError(error) => self
+                .worker_pool_comms
+                .send(sim_id, WorkerToWorkerPoolMsg::RunnerErrors(vec![error]))?,
+            RunnerErrors(errors) => self
+                .worker_pool_comms
+                .send(sim_id, WorkerToWorkerPoolMsg::RunnerErrors(errors))?,
+            RunnerWarning(warning) => self
+                .worker_pool_comms
+                .send(sim_id, WorkerToWorkerPoolMsg::RunnerWarnings(vec![warning]))?,
+            RunnerWarnings(warnings) => self
+                .worker_pool_comms
+                .send(sim_id, WorkerToWorkerPoolMsg::RunnerWarnings(warnings))?,
+            RunnerLog(log) => self
+                .worker_pool_comms
+                .send(sim_id, WorkerToWorkerPoolMsg::RunnerLogs(vec![log]))?,
+            RunnerLogs(logs) => self
+                .worker_pool_comms
+                .send(sim_id, WorkerToWorkerPoolMsg::RunnerLogs(logs))?,
+            UserErrors(errors) => self
+                .worker_pool_comms
+                .send(sim_id, WorkerToWorkerPoolMsg::UserErrors(errors))?,
+            UserWarnings(warnings) => self
+                .worker_pool_comms
+                .send(sim_id, WorkerToWorkerPoolMsg::UserWarnings(warnings))?,
+            PackageError(package_error) => self
+                .worker_pool_comms
+                .send(sim_id, WorkerToWorkerPoolMsg::PackageError(package_error))?,
         }
         Ok(())
     }
@@ -592,35 +597,6 @@ impl WorkerController {
         // }
         // else ignore, since it must be that either the active runner cancelled or completed
         // Ok(())
-    }
-
-    /// Forwards the errors to the worker pool.
-    async fn handle_errors(
-        &mut self,
-        sim_id: SimulationShortId,
-        errors: Vec<RunnerError>,
-    ) -> Result<()> {
-        self.worker_pool_comms
-            .send(sim_id, WorkerToWorkerPoolMsg::RunnerErrors(errors))?;
-        Ok(())
-    }
-
-    /// Forwards the warnings to the worker pool.
-    async fn handle_warnings(
-        &mut self,
-        sim_id: SimulationShortId,
-        warnings: Vec<RunnerError>,
-    ) -> Result<()> {
-        self.worker_pool_comms
-            .send(sim_id, WorkerToWorkerPoolMsg::RunnerWarnings(warnings))?;
-        Ok(())
-    }
-
-    /// Forwards the log entries to the worker pool.
-    async fn handle_logs(&mut self, sim_id: SimulationShortId, logs: Vec<String>) -> Result<()> {
-        self.worker_pool_comms
-            .send(sim_id, WorkerToWorkerPoolMsg::RunnerLogs(logs))?;
-        Ok(())
     }
 
     /// Sends a message containing the `task` to the appropriate language runner.

--- a/packages/engine/src/worker/runner/comms/outbound.rs
+++ b/packages/engine/src/worker/runner/comms/outbound.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use flatbuffers_gen::runner_outbound_msg_generated::root_as_runner_outbound_msg;
+use serde::{Deserialize, Serialize};
 use tracing::Span;
 
 use super::TargetedRunnerTaskMsg;
@@ -57,6 +58,60 @@ impl From<flatbuffers_gen::runner_warning_generated::RunnerWarning<'_>> for Runn
         }
     }
 }
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UserError(pub String);
+
+impl From<flatbuffers_gen::user_error_generated::UserError<'_>> for UserError {
+    fn from(user_error: flatbuffers_gen::user_error_generated::UserError<'_>) -> Self {
+        Self(user_error.msg().to_string())
+    }
+}
+
+impl std::fmt::Display for UserError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UserWarning {
+    pub message: String,
+    pub details: Option<String>,
+}
+
+impl From<flatbuffers_gen::user_warning_generated::UserWarning<'_>> for UserWarning {
+    fn from(user_warning: flatbuffers_gen::user_warning_generated::UserWarning<'_>) -> Self {
+        Self {
+            message: user_warning.msg().to_string(),
+            details: user_warning.details().map(|warning| warning.to_string()),
+        }
+    }
+}
+
+impl std::fmt::Display for UserWarning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(details) = &self.details {
+            write!(f, "Message: {}\nDetails: {}", self.message, details)
+        } else {
+            write!(f, "Message: {}", self.message)
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PackageError(pub String);
+
+impl From<flatbuffers_gen::package_error_generated::PackageError<'_>> for PackageError {
+    fn from(package_error: flatbuffers_gen::package_error_generated::PackageError<'_>) -> Self {
+        Self(package_error.msg().to_string())
+    }
+}
+
+impl std::fmt::Display for PackageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 #[derive(Debug)]
 pub enum OutboundFromRunnerMsgPayload {
@@ -68,10 +123,9 @@ pub enum OutboundFromRunnerMsgPayload {
     RunnerWarnings(Vec<RunnerError>),
     RunnerLog(String),
     RunnerLogs(Vec<String>),
-    /* TODO: add
-     * PackageError
-     * UserErrors
-     * UserWarnings */
+    PackageError(PackageError),
+    UserErrors(Vec<UserError>),
+    UserWarnings(Vec<UserWarning>),
 }
 
 impl OutboundFromRunnerMsgPayload {
@@ -155,34 +209,44 @@ impl OutboundFromRunnerMsgPayload {
                 Self::RunnerWarnings(runner_warnings)
             }
             flatbuffers_gen::runner_outbound_msg_generated::RunnerOutboundMsgPayload::PackageError => {
-                let _payload = parsed_msg.payload_as_package_error().ok_or_else(|| {
+                let payload = parsed_msg.payload_as_package_error().ok_or_else(|| {
                     Error::from(
                         "Message from runner should have had a PackageError payload but it was \
                          missing",
                     )
                 })?;
 
-                todo!() // TODO: there is no Self::PackageError
+                Self::PackageError(payload.into())
             }
             flatbuffers_gen::runner_outbound_msg_generated::RunnerOutboundMsgPayload::UserErrors => {
-                let _payload = parsed_msg.payload_as_user_errors().ok_or_else(|| {
+                let payload = parsed_msg.payload_as_user_errors().ok_or_else(|| {
                     Error::from(
                         "Message from runner should have had a UserErrors payload but it was \
                          missing",
                     )
                 })?;
 
-                todo!() // TODO: there is no Self::UserErrors
+                let user_errors = payload
+                    .inner()
+                    .iter()
+                    .map(|user_error| user_error.into())
+                    .collect();
+                Self::UserErrors(user_errors)
             }
             flatbuffers_gen::runner_outbound_msg_generated::RunnerOutboundMsgPayload::UserWarnings => {
-                let _payload = parsed_msg.payload_as_user_warnings().ok_or_else(|| {
+                let payload = parsed_msg.payload_as_user_warnings().ok_or_else(|| {
                     Error::from(
                         "Message from runner should have had a UserWarnings payload but it was \
                          missing",
                     )
                 })?;
 
-                todo!() // TODO: there is no Self::UserWarnings
+                let user_warnings = payload
+                    .inner()
+                    .iter()
+                    .map(|user_warning| user_warning.into())
+                    .collect();
+                Self::UserWarnings(user_warnings)
             }
             _ => return Err(Error::from("Invalid outbound flatbuffers message payload")),
         })

--- a/packages/engine/src/worker/runner/javascript/error.rs
+++ b/packages/engine/src/worker/runner/javascript/error.rs
@@ -9,7 +9,7 @@ use crate::{
     simulation::package::id::PackageId,
     worker::runner::comms::{
         inbound::InboundToRunnerMsgPayload,
-        outbound::{OutboundFromRunnerMsg, RunnerError},
+        outbound::{OutboundFromRunnerMsg, PackageError, UserError},
     },
 };
 
@@ -41,7 +41,7 @@ pub enum Error {
     Eval(String, String), // First element is path/name.
 
     #[error("Error in package: {0}")]
-    Package(String),
+    Package(PackageError),
 
     #[error("Couldn't import package {0}: {1}")]
     PackageImport(String, String), // First element is path/name.
@@ -59,7 +59,7 @@ pub enum Error {
     TerminateMissingSimulationRun(SimulationShortId),
 
     #[error("User JavaScript errors: {0:?}")]
-    User(Vec<RunnerError>),
+    User(Vec<UserError>),
 
     #[error("Duplicate package (id, name): {0:?}, {1:?}")]
     DuplicatePackage(PackageId, String),

--- a/packages/engine/src/worker/runner/javascript/mod.rs
+++ b/packages/engine/src/worker/runner/javascript/mod.rs
@@ -928,7 +928,7 @@ impl<'m> RunnerImpl<'m> {
             payload_str.clone(),
         ]);
 
-        match self.run_task(
+        let run_task_result = self.run_task(
             mv8,
             args,
             sim_id,
@@ -937,7 +937,9 @@ impl<'m> RunnerImpl<'m> {
             msg.task_id,
             &wrapper,
             msg.shared_store,
-        ) {
+        );
+
+        match run_task_result {
             Ok((next_task_msg, warnings, logs)) => {
                 // TODO: `send` fn to reduce code duplication.
                 outbound_sender.send(OutboundFromRunnerMsg {

--- a/packages/engine/src/workerpool/comms/mod.rs
+++ b/packages/engine/src/workerpool/comms/mod.rs
@@ -18,7 +18,10 @@ use crate::{
     proto::SimulationShortId,
     types::{TaskId, WorkerIndex},
     worker::{
-        runner::comms::{outbound::RunnerError, NewSimulationRun},
+        runner::comms::{
+            outbound::{PackageError, RunnerError, UserError, UserWarning},
+            NewSimulationRun,
+        },
         task::{WorkerTask, WorkerTaskResultOrCancelled},
     },
     workerpool::comms::terminate::TerminateMessage,
@@ -104,6 +107,9 @@ pub enum WorkerToWorkerPoolMsg {
     RunnerErrors(Vec<RunnerError>),
     RunnerWarnings(Vec<RunnerError>),
     RunnerLogs(Vec<String>),
+    UserErrors(Vec<UserError>),
+    UserWarnings(Vec<UserWarning>),
+    PackageError(PackageError),
 }
 
 pub struct WorkerCommsWithWorkerPool {

--- a/packages/engine/src/workerpool/comms/top.rs
+++ b/packages/engine/src/workerpool/comms/top.rs
@@ -1,6 +1,9 @@
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
-use crate::{proto::SimulationShortId, worker::runner::comms::outbound::RunnerError};
+use crate::{
+    proto::SimulationShortId,
+    worker::runner::comms::outbound::{PackageError, RunnerError, UserError, UserWarning},
+};
 // This is for communications between the worker pool and the simulation top-level controller.
 // Mainly used only for passing errors and warnings.
 
@@ -20,9 +23,12 @@ pub struct WorkerPoolMsgSend {
 
 #[derive(Debug)]
 pub enum WorkerPoolToExpCtlMsg {
-    Errors(Vec<RunnerError>),
-    Warnings(Vec<RunnerError>),
+    RunnerErrors(Vec<RunnerError>),
+    RunnerWarnings(Vec<RunnerError>),
     Logs(Vec<String>),
+    UserErrors(Vec<UserError>),
+    UserWarnings(Vec<UserWarning>),
+    PackageError(PackageError),
 }
 
 pub fn new_pair() -> (WorkerPoolMsgSend, WorkerPoolMsgRecv) {

--- a/packages/engine/src/workerpool/mod.rs
+++ b/packages/engine/src/workerpool/mod.rs
@@ -296,19 +296,37 @@ impl WorkerPoolController {
                 tracing::debug!("Received RunnerErrors Message from Worker");
                 self.top_send
                     .inner
-                    .send((sim_id, WorkerPoolToExpCtlMsg::Errors(errors)))?;
+                    .send((sim_id, WorkerPoolToExpCtlMsg::RunnerErrors(errors)))?;
             }
             WorkerToWorkerPoolMsg::RunnerWarnings(warnings) => {
                 tracing::debug!("Received RunnerWarnings Message from Worker");
                 self.top_send
                     .inner
-                    .send((sim_id, WorkerPoolToExpCtlMsg::Warnings(warnings)))?;
+                    .send((sim_id, WorkerPoolToExpCtlMsg::RunnerWarnings(warnings)))?;
             }
             WorkerToWorkerPoolMsg::RunnerLogs(logs) => {
                 tracing::debug!("Received RunnerLogs Message from Worker");
                 self.top_send
                     .inner
                     .send((sim_id, WorkerPoolToExpCtlMsg::Logs(logs)))?;
+            }
+            WorkerToWorkerPoolMsg::UserErrors(errors) => {
+                tracing::debug!("Received UserErrors message from Worker");
+                self.top_send
+                    .inner
+                    .send((sim_id, WorkerPoolToExpCtlMsg::UserErrors(errors)))?
+            }
+            WorkerToWorkerPoolMsg::UserWarnings(warnings) => {
+                tracing::debug!("Received UserWarnings message from Worker");
+                self.top_send
+                    .inner
+                    .send((sim_id, WorkerPoolToExpCtlMsg::UserWarnings(warnings)))?
+            }
+            WorkerToWorkerPoolMsg::PackageError(error) => {
+                tracing::debug!("Received PackageError message from Worker");
+                self.top_send
+                    .inner
+                    .send((sim_id, WorkerPoolToExpCtlMsg::PackageError(error)))?
             }
         }
         Ok(())


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We distinguish between errors/warnings that come from the Runner and those that come from user-code. There was a TODO about implementing these variants and properly propagating them. This PR does that.

It also fixes a mistake where certain classifications of errors were marked as fatal for the runners (thus killing an experiment rather than just a simulation), when they shouldn't have been. (User errors and Package errors are non-fatal).

## 🔍 What does this change?

- Makes the msg strings on `PackageError` and `UserError` required in the FlatBuffers schemas. It doesn't make sense to propagate these without any associated error information
- Creates the `UserError`, `UserWarning`, and `PackageError` variants on all the relevant enums within the Rust code, propagating it up to the orchestrator for display.
- `UserError`s and `PackageError`s are matched against and no longer cause fatal exits of the Runners

### 📜 Does this require a change to the docs?

- No

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201707629991362/1201770186881429/f) (_internal_)

## 🛡 What tests cover this?

- None at the moment, we don't really test our reporting setup and/or failure conditions
