### PR TITLE
Fix `yarn install` in Algolia CI

### DIFF
--- a/.github/workflows/algolia-upload-index.yml
+++ b/.github/workflows/algolia-upload-index.yml
@@ -19,10 +19,6 @@ jobs:
           node-version: 16
           cache: yarn
 
-      - name: Reduce the number of dependencies to install by hiding workspaces
-        run: |
-          npx replace '"workspaces":' '"ignored-workspaces":' package.json
-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR fixes https://github.com/hashintel/hash/actions/workflows/algolia-upload-index.yml. This is done by removing a [broken optimization](https://github.com/hashintel/hash/pull/324/files#r809292163) added in #324.

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🔍 What does this change?

[Error example](https://github.com/hashintel/hash/runs/5301110474?check_suite_focus=true):

```txt
[4/4] Building fresh packages...
error /home/runner/work/hash/hash/node_modules/postinstall-postinstall: Command failed.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Exit code: 1
Command: node ./run.js
Arguments: 
Directory: /home/runner/work/hash/hash/node_modules/postinstall-postinstall
Output:
Error: Patch file found for package prosemirror-model which is not present at node_modules/@types/prosemirror-model
Error: Patch file found for package blockprotocol which is not present at node_modules/blockprotocol
```

CI was failing because `patch-package` was trying to patch packages that were not installed. Alternatively, I could delete `patches` folder in the yaml — it would keep `yarn install` fast, but the CI code would look a bit more cryptic.

Algolia CI should work again after this PR.

## ⚠️ Known issues

By running `yarn install` in CI, all dependencies from all workspace will be downloaded. This is what my optimization was trying to avoid. We can bring it back when we upgrade to Yarn Berry (which supports focus mode when installing stuff and has built-in support for patching packages).

### 📜 Does this require a change to the docs?

No