### PR TITLE
Use Builders for `array_data_from_js`

### DIFF
--- a/packages/engine/src/worker/runner/javascript/mod.rs
+++ b/packages/engine/src/worker/runner/javascript/mod.rs
@@ -625,12 +625,10 @@ impl<'m> RunnerImpl<'m> {
                 //   [0]: The offset buffer (i32)
                 //   [1]: The value buffer (u8)
 
-                // TODO: Use `data.len` or target_len?
-                //   (In practice, target_len has worked for a long time, though that's not an ideal
-                //   reason to use it. Maybe `data.len` would also work.)
                 // The offsets are in the first buffer. For each value in the second buffer, we have
                 // a start offset and an end offset. The start offset is equal to the end offset of
                 // the previous value, thus we need `num_values + 1` offset values.
+
                 // SAFETY: `data.buffer_ptrs[0]` is provided by arrow as offsets, the type is `i32`,
                 //   and `target_len + 1` is carefully chosen.
                 let offsets = unsafe {
@@ -698,9 +696,9 @@ impl<'m> RunnerImpl<'m> {
                 // the size is known
 
                 // SAFETY: `data.buffer_ptrs[0]` is provided by arrow, the type is `u8`, and
-                //   `data.len * *size as usize` corresponds for the `size` of *each* value.
+                //   `target_len * *size as usize` corresponds for the `size` of *each* value.
                 let values = unsafe {
-                    slice::from_raw_parts(data.buffer_ptrs[0], data.len * *size as usize)
+                    slice::from_raw_parts(data.buffer_ptrs[0], target_len * *size as usize)
                 };
                 builder = builder.add_buffer(Buffer::from_slice_ref(&values));
             }

--- a/packages/engine/src/worker/runner/javascript/mod.rs
+++ b/packages/engine/src/worker/runner/javascript/mod.rs
@@ -2,13 +2,14 @@ mod error;
 mod mini_v8;
 
 use std::{
-    collections::HashMap, fs, future::Future, pin::Pin, result::Result as StdResult, sync::Arc,
+    collections::HashMap, fs, future::Future, pin::Pin, result::Result as StdResult, slice,
+    sync::Arc,
 };
 
 use arrow::{
-    array::ArrayData,
-    buffer::{Buffer, MutableBuffer},
-    datatypes::{DataType, Schema},
+    array::{ArrayData, BooleanBufferBuilder},
+    buffer::Buffer,
+    datatypes::{DataType, Field, Schema},
     ipc::writer::{IpcDataGenerator, IpcWriteOptions},
 };
 use futures::FutureExt;
@@ -538,162 +539,118 @@ impl<'m> RunnerImpl<'m> {
         })
     }
 
-    unsafe fn new_buffer(&self, ptr: *const u8, len: usize, _capacity: usize) -> Buffer {
-        let s = std::slice::from_raw_parts(ptr, len);
-        s.into()
-    }
-
     /// TODO: DOC, flushing from a single column
     fn array_data_from_js(
         &mut self,
         mv8: &'m MiniV8,
         data: &mv8::Value<'m>,
-        dt: &DataType,
+        field: &Field,
         len: Option<usize>,
     ) -> Result<ArrayData> {
         // `data` must not be dropped until flush is over, because
         // pointers returned from FFI point inside `data`'s ArrayBuffers' memory.
-        let obj = data
-            .as_object()
-            .ok_or_else(|| Error::Embedded("Flush data not object".into()))?;
-        let child_data: mv8::Array<'_> = obj.get("child_data")?;
+        let obj = data.as_object().ok_or_else(|| {
+            Error::Embedded(format!("Flush data not object for field {:?}", field))
+        })?;
 
         // `data_node_from_js` isn't recursive -- doesn't convert children.
         let data: mv8::DataFfi = mv8.data_node_from_js(data);
 
-        let n_children = child_data.len();
-        let child_data: Vec<ArrayData> = match dt.clone() {
-            DataType::List(field) => {
-                let child: mv8::Value<'_> = child_data.get(0)?;
-                Ok(vec![self.array_data_from_js(
-                    mv8,
-                    &child,
-                    field.data_type(),
-                    None,
-                )?])
-            }
-            DataType::FixedSizeList(field, multiplier) => {
-                let child: mv8::Value<'_> = child_data.get(0)?;
-                Ok(vec![self.array_data_from_js(
-                    mv8,
-                    &child,
-                    field.data_type(),
-                    Some(data.len * multiplier as usize),
-                )?])
-            }
-            DataType::Struct(fields) => {
-                let mut v = Vec::new();
-                for (i, field) in fields.iter().enumerate() {
-                    let child = child_data.get(i as u32)?;
-                    v.push(self.array_data_from_js(
-                        mv8,
-                        &child,
-                        field.data_type(),
-                        Some(data.len),
-                    )?);
-                }
-                Ok(v)
-            }
-            t => {
-                if n_children == 0 {
-                    Ok(vec![])
-                } else {
-                    Err(Error::FlushType(t))
-                }
-            }
-        }?; // TODO: More types?
-
-        // TODO: Extra copies (in `new_buffer`) of buffers here,
-        //       because JS Arrow doesn't align things properly.
-        //       (Due to which buffer capacities are currently unused.)
-
-        // This target length is used because the JS repr does not mirror
-        // buffer building as Rust Arrow and pyarrow.
+        // This target length is used because the JS repr does not mirror buffer building as Rust
+        // Arrow and pyarrow.
         let target_len = len.unwrap_or(data.len);
 
-        let null_bit_buffer = if data.null_bits_ptr.is_null() {
-            None // Can't match on `std::ptr::null()`, because not compile-time const.
-        } else {
-            let capacity = data.null_bits_capacity;
-            // Ceil division.
-            let n_bytes = (target_len / 8) + (if target_len % 8 == 0 { 0 } else { 1 });
-            Some(unsafe { self.new_buffer(data.null_bits_ptr, n_bytes, capacity) })
-            // Some(unsafe { Buffer::from_unowned(data.null_bits_ptr, n_bytes, capacity) })
-        };
+        // TODO: Extra copies when generating buffers, because JS Arrow doesn't align things
+        //   properly. (Due to which buffer capacities are currently unused.)
+        let mut builder = ArrayData::builder(field.data_type().clone());
 
-        let mut buffer_lens = Vec::with_capacity(2);
+        match field.data_type() {
+            DataType::Boolean => unsafe {
+                let mut boolean_builder = BooleanBufferBuilder::new(target_len);
+                let values = slice::from_raw_parts(data.buffer_ptrs[0], target_len);
+                boolean_builder.append_packed_range(0..target_len, values);
 
-        match dt.clone() {
-            DataType::Float64 => {
-                buffer_lens.push(target_len * 8); // 8 bytes per f64
-                Ok(())
-            }
-            DataType::UInt32 => {
-                buffer_lens.push(target_len * 4); // 4 bytes per u32
-                Ok(())
-            }
-            DataType::UInt16 => {
-                buffer_lens.push(target_len * 2); // 2 bytes per u16
-                Ok(())
-            }
-            DataType::Utf8 => {
+                builder = builder.add_buffer(boolean_builder.finish());
+            },
+            DataType::UInt16 => unsafe {
+                let values = slice::from_raw_parts(data.buffer_ptrs[0] as *const u16, target_len);
+                builder = builder.add_buffer(Buffer::from_slice_ref(&values));
+            },
+            DataType::UInt32 => unsafe {
+                let values = slice::from_raw_parts(data.buffer_ptrs[0] as *const u32, target_len);
+                builder = builder.add_buffer(Buffer::from_slice_ref(&values));
+            },
+            DataType::Float64 => unsafe {
+                let values = slice::from_raw_parts(data.buffer_ptrs[0] as *const f64, target_len);
+                builder = builder.add_buffer(Buffer::from_slice_ref(&values));
+            },
+            DataType::Utf8 => unsafe {
                 // TODO: Use `data.len` or target_len?
                 //       (In practice, target_len has worked for a long time,
                 //       though that's not an ideal reason to use it. Maybe
                 //       `data.len` would also work.)
-                let offsets = unsafe {
-                    std::slice::from_raw_parts(data.buffer_ptrs[0] as *const i32, target_len + 1)
+                let offsets =
+                    slice::from_raw_parts(data.buffer_ptrs[0] as *const i32, target_len + 1);
+                builder = builder.add_buffer(Buffer::from_slice_ref(&offsets));
+                let values = if let Some(size) = offsets.last() {
+                    slice::from_raw_parts(data.buffer_ptrs[1], *size as usize)
+                } else {
+                    &[]
                 };
-                debug_assert_eq!(offsets[0], 0);
-                let last = offsets[target_len];
-                // offsets
-                buffer_lens.push((target_len + 1) * 4);
-                buffer_lens.push(last as usize);
-                Ok(())
+                builder = builder.add_buffer(values.into());
+            },
+            DataType::List(inner_field) => unsafe {
+                let offsets =
+                    slice::from_raw_parts(data.buffer_ptrs[0] as *const i32, target_len + 1);
+                builder = builder.add_buffer(Buffer::from_slice_ref(&offsets));
+
+                let child_data: mv8::Array<'_> = obj.get("child_data")?;
+                let child = child_data.get(0)?;
+                builder = builder.add_child_data(self.array_data_from_js(
+                    mv8,
+                    &child,
+                    inner_field,
+                    None,
+                )?);
+            },
+            DataType::FixedSizeList(inner_field, size) => {
+                let child_data: mv8::Array<'_> = obj.get("child_data")?;
+                let child = child_data.get(0)?;
+                builder = builder.add_child_data(self.array_data_from_js(
+                    mv8,
+                    &child,
+                    inner_field,
+                    Some(data.len * *size as usize),
+                )?);
             }
-            DataType::List(_) => {
-                // offsets
-                buffer_lens.push((target_len + 1) * 4);
-                Ok(())
-            } // Just offsets
-            DataType::Struct(_) => Ok(()), // No non-child buffers
-            DataType::FixedSizeList(..) => Ok(()),
-            DataType::FixedSizeBinary(sz) => {
-                buffer_lens.push(data.len * sz as usize);
-                Ok(())
-            } // Just values
-            DataType::Boolean => {
-                buffer_lens.push((data.len / 8) + (if data.len % 8 == 0 { 0 } else { 1 }));
-                Ok(())
-            } // Just values
-            t => Err(Error::FlushType(t)), // TODO: More types?
-        }?;
+            DataType::Struct(inner_fields) => {
+                let child_data: mv8::Array<'_> = obj.get("child_data")?;
+                for (i, inner_field) in inner_fields.iter().enumerate() {
+                    let child = child_data.get(i as u32)?;
+                    builder = builder.add_child_data(self.array_data_from_js(
+                        mv8,
+                        &child,
+                        inner_field,
+                        Some(data.len),
+                    )?);
+                }
+            }
+            DataType::FixedSizeBinary(size) => unsafe {
+                let values = slice::from_raw_parts(data.buffer_ptrs[0], data.len * *size as usize);
+                builder = builder.add_buffer(Buffer::from_slice_ref(&values));
+            },
+            data_type => return Err(Error::FlushType(data_type.clone())), // TODO: More types?
+        };
 
-        debug_assert_eq!(data.n_buffers, buffer_lens.len());
-        let mut buffers = Vec::new();
-        for (i, &len) in buffer_lens.iter().enumerate().take(data.n_buffers) {
-            let ptr = data.buffer_ptrs[i];
-            debug_assert_ne!(ptr, std::ptr::null());
-            let capacity = data.buffer_capacities[i];
-            let buffer = if len <= capacity {
-                unsafe { self.new_buffer(ptr, len, capacity) }
-            } else {
-                // This happens when we have fixed size buffers, but the inner nodes are null
-                let mut mut_buffer = MutableBuffer::new(len);
-                mut_buffer.resize(len, 0);
-                mut_buffer.into()
-            };
-            // let buffer = unsafe { Buffer::from_unowned(ptr, len, capacity) };
-            buffers.push(buffer);
-        }
+        builder = builder.len(target_len);
+        if !data.null_bits_ptr.is_null() {
+            let mut boolean_builder = BooleanBufferBuilder::new(target_len);
+            let values = unsafe { slice::from_raw_parts(data.null_bits_ptr, target_len) };
+            boolean_builder.append_packed_range(0..target_len, values);
 
-        let mut builder = ArrayData::builder(dt.clone())
-            .len(len.unwrap_or(data.len))
-            .null_count(data.null_count)
-            .buffers(buffers)
-            .child_data(child_data);
-        if let Some(null_bit_buffer) = null_bit_buffer {
-            builder = builder.null_bit_buffer(null_bit_buffer);
+            builder = builder
+                .null_bit_buffer(boolean_builder.finish())
+                .null_count(data.null_count);
         }
 
         Ok(builder.build()?)
@@ -714,7 +671,7 @@ impl<'m> RunnerImpl<'m> {
             let field = schema.field(i_field);
 
             let data: mv8::Value<'_> = change.get("data")?;
-            let data = self.array_data_from_js(mv8, &data, field.data_type(), None)?;
+            let data = self.array_data_from_js(mv8, &data, field, None)?;
             batch.push_change(ArrayChange {
                 array: data,
                 index: i_field,

--- a/packages/engine/src/worker/runner/javascript/mod.rs
+++ b/packages/engine/src/worker/runner/javascript/mod.rs
@@ -696,7 +696,7 @@ impl<'m> RunnerImpl<'m> {
                 // the size is known
 
                 // SAFETY: `data.buffer_ptrs[0]` is provided by arrow, the type is `u8`, and
-                //   `target_len * *size as usize` corresponds for the `size` of *each* value.
+                //   `*size as usize * target_len` corresponds for the `size` of *each* value.
                 let values = unsafe {
                     slice::from_raw_parts(data.buffer_ptrs[0], target_len * *size as usize)
                 };

--- a/packages/engine/src/worker/runner/javascript/mod.rs
+++ b/packages/engine/src/worker/runner/javascript/mod.rs
@@ -674,7 +674,7 @@ impl<'m> RunnerImpl<'m> {
                     mv8,
                     &child,
                     inner_field,
-                    Some(target_len * *size as usize),
+                    Some(*size as usize * target_len),
                 )?);
             }
             DataType::Struct(inner_fields) => {

--- a/packages/engine/src/worker/runner/javascript/mod.rs
+++ b/packages/engine/src/worker/runner/javascript/mod.rs
@@ -579,8 +579,9 @@ impl<'m> RunnerImpl<'m> {
         // Arrow and pyarrow.
         let target_len = len.unwrap_or(data.len);
 
-        // TODO: We currently copy the buffers because the JavaScript representation of arrays does
-        //   not match the Rust implementation. Try to reduce copies where possible.
+        // TODO: We currently copy the buffers by calling `Buffer::from_slice_ref` because the
+        //   JavaScript representation of arrays does   not match the Rust implementation. Try to
+        //   reduce copies where possible.
         let mut builder = ArrayData::builder(field.data_type().clone());
 
         match field.data_type() {

--- a/packages/engine/src/worker/runner/javascript/mod.rs
+++ b/packages/engine/src/worker/runner/javascript/mod.rs
@@ -675,7 +675,7 @@ impl<'m> RunnerImpl<'m> {
                     mv8,
                     &child,
                     inner_field,
-                    Some(data.len * *size as usize),
+                    Some(target_len * *size as usize),
                 )?);
             }
             DataType::Struct(inner_fields) => {
@@ -688,7 +688,7 @@ impl<'m> RunnerImpl<'m> {
                         mv8,
                         &child,
                         inner_field,
-                        Some(data.len),
+                        Some(target_len),
                     )?);
                 }
             }

--- a/packages/engine/src/worker/runner/javascript/mod.rs
+++ b/packages/engine/src/worker/runner/javascript/mod.rs
@@ -580,7 +580,7 @@ impl<'m> RunnerImpl<'m> {
         let target_len = len.unwrap_or(data.len);
 
         // TODO: We currently copy the buffers by calling `Buffer::from_slice_ref` because the
-        //   JavaScript representation of arrays does   not match the Rust implementation. Try to
+        //   JavaScript representation of arrays does not match the Rust implementation. Try to
         //   reduce copies where possible.
         let mut builder = ArrayData::builder(field.data_type().clone());
 
@@ -698,7 +698,7 @@ impl<'m> RunnerImpl<'m> {
                 // SAFETY: `data.buffer_ptrs[0]` is provided by arrow, the type is `u8`, and
                 //   `*size as usize * target_len` corresponds for the `size` of *each* value.
                 let values = unsafe {
-                    slice::from_raw_parts(data.buffer_ptrs[0], target_len * *size as usize)
+                    slice::from_raw_parts(data.buffer_ptrs[0], *size as usize * target_len)
                 };
                 builder = builder.add_buffer(Buffer::from_slice_ref(&values));
             }

--- a/packages/engine/src/worker/runner/javascript/mod.rs
+++ b/packages/engine/src/worker/runner/javascript/mod.rs
@@ -579,7 +579,7 @@ impl<'m> RunnerImpl<'m> {
         // Arrow and pyarrow.
         let target_len = len.unwrap_or(data.len);
 
-        // TODO: We currently copy the buffers because the JavsScript representation of arrays does
+        // TODO: We currently copy the buffers because the JavaScript representation of arrays does
         //   not match the Rust implementation. Try to reduce copies where possible.
         let mut builder = ArrayData::builder(field.data_type().clone());
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

For loading the arrow data from JavaScript, we previously did some real low level stuff, which is not needed anymore.

## 🐾 Next steps

Use more builders in the rest of the code

## 🔍 What does this change?

- Changes `array_data_from_js` to use an `ArrayDataBuilder` instead of building int by hand
- Use builders for data where possible

It's not possible (or not a good idea) to use non-buffer builders, as the data already exists (behind pointers). Otherwise the data would need to be parsed and recreated from scratch, which would hit the performance badly.

### 📜 Does this require a change to the docs?

No

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201793759102797/1201877648275953/f) (_internal_)

## 🛡 What tests cover this?

None directly, this function is indirectly tested by integration tests.