### PR TITLE
Fix checking for primitive and lists arrow types in JS

### DIFF
--- a/packages/engine/src/worker/runner/javascript/hash_util.js
+++ b/packages/engine/src/worker/runner/javascript/hash_util.js
@@ -63,7 +63,9 @@
   };
 
   const _is_primitive_or_list = (children) => {
-    // TODO: Change this to test by types
+    // TODO: This is currently a flakey form of duck-typing, that only works because the only nested field we support
+    // are structs (we do not support Union or Map types). We should be testing by the type of the object here,
+    // if we move to TypeScript this will become a lot easier to do
     return children.length === 1 && children[0].name === "item";
   };
 

--- a/packages/engine/src/worker/runner/javascript/hash_util.js
+++ b/packages/engine/src/worker/runner/javascript/hash_util.js
@@ -63,7 +63,8 @@
   };
 
   const _is_primitive_or_list = (children) => {
-    return children.length === 1 && children[0].name === null;
+    // TODO: Change this to test by types
+    return children.length === 1 && children[0].name === "item";
   };
 
   const _struct_vec_to_obj = (struct, children) => {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Since arrow-rs version 3.0.0, the inner types of `List`s and `FixedSizeList`s are named. This change adjusts the JS side.

## ⚠️ Known issues

- The check for a primitive/list relies on duck-typing. This is very bad considering we should have known the actual type. This will be fixed, when we switch to TS.

## 🔍 What does this change?

- Change the checks for primitive/list in JS find the field `"item"`, which is now the default name for `List`'s and `FixedSizeList`'s inner type

### 📜 Does this require a change to the docs?

No