### PR TITLE
Fix Image block state stability

### DIFF
--- a/packages/blocks/image/src/Image.tsx
+++ b/packages/blocks/image/src/Image.tsx
@@ -1,20 +1,19 @@
+import {
+  BlockProtocolEntity,
+  BlockProtocolLinkGroup,
+  BlockProtocolUpdateEntitiesAction,
+  BlockProtocolUploadFileFunction,
+} from "blockprotocol";
+import { BlockComponent } from "blockprotocol/react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { unstable_batchedUpdates } from "react-dom";
 
 import { tw } from "twind";
-import { BlockComponent } from "blockprotocol/react";
-import {
-  BlockProtocolLinkGroup,
-  BlockProtocolEntity,
-  BlockProtocolUploadFileFunction,
-  BlockProtocolUpdateEntitiesAction,
-} from "blockprotocol";
 
 import { ResizeImageBlock } from "./components/ResizeImageBlock";
-
-import Loader from "./svgs/Loader";
-import Pencil from "./svgs/Pencil";
 import Cross from "./svgs/Cross";
+import { UploadImageForm } from "./components/UploadImageForm";
+import Pencil from "./svgs/Pencil";
 
 // https://www.typescriptlang.org/docs/handbook/release-notes/overview.html#recursive-conditional-types
 type Awaited<T> = T extends PromiseLike<infer U> ? Awaited<U> : T;
@@ -33,12 +32,6 @@ type BlockProtocolUpdateEntitiesActionData = Pick<
 > & {
   file?: FileType;
 };
-
-const placeholderText = "Enter Image URL";
-const buttonText = "Embed Image";
-const bottomText = "Works with web-supported image formats";
-
-const IMG_MIME_TYPE = "image/*";
 
 function getLinkGroup(params: {
   linkGroups: BlockProtocolLinkGroup[];
@@ -296,8 +289,7 @@ export const Image: BlockComponent<AppProps> = (props) => {
     ],
   );
 
-  const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+  const onUrlConfirm = () => {
     const { loading } = stateObject;
 
     if (loading) {
@@ -308,14 +300,6 @@ export const Image: BlockComponent<AppProps> = (props) => {
       handleImageUpload({ url: inputText });
     } else {
       displayError("Please enter a valid image URL or select a file below");
-    }
-  };
-
-  const onFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const { files } = event.target;
-
-    if (files?.[0]) {
-      handleImageUpload({ file: files[0] });
     }
   };
 
@@ -387,65 +371,14 @@ export const Image: BlockComponent<AppProps> = (props) => {
         </div>
       )}
 
-      <div
-        className={tw`w-96 mx-auto bg-white rounded-sm shadow-md overflow-hidden text-center p-4 border-2 border-gray-200`}
-        onDragOver={(event) => {
-          event.stopPropagation();
-          event.preventDefault();
-        }}
-        onDrop={(event) => {
-          event.preventDefault();
-          event.stopPropagation();
-
-          const dT = event.dataTransfer;
-          const files = dT.files;
-
-          if (files && files.length) {
-            // we set our input's 'files' property
-
-            if (files[0].type.search("image") > -1) {
-              handleImageUpload({ file: files[0] });
-            }
-          }
-        }}
-      >
-        <form className={tw`mb-0`} onSubmit={onSubmit}>
-          <div>
-            <input
-              className={tw`px-1.5 py-1 rounded-sm border-2 border-gray-200 bg-gray-50 focus:outline-none focus:ring focus:border-blue-300 w-full`}
-              onChange={(event) => setInputText(event.target.value)}
-              type="url"
-              placeholder={placeholderText}
-            />
-          </div>
-          <div>
-            <label>
-              <div
-                className={tw`my-4 bg-gray-50 border-2 border-dashed border-gray-200 py-4 text-sm text-gray-400 cursor-pointer`}
-              >
-                Choose a File. <br /> (or Drop it Here)
-              </div>
-
-              <input
-                className={tw`hidden`}
-                type="file"
-                accept={IMG_MIME_TYPE}
-                onChange={onFileSelect}
-              />
-            </label>
-          </div>
-          <div className={tw`mt-4`}>
-            <button
-              className={tw`bg-blue-400 rounded-sm hover:bg-blue-500 focus:bg-blue-600 py-1 text-white w-full flex items-center justify-center`}
-              type="submit"
-            >
-              {stateObject.loading && <Loader />}
-              {buttonText}
-            </button>
-          </div>
-          <div className={tw`text-sm text-gray-400 mt-4`}>{bottomText}</div>
-        </form>
-      </div>
+      <UploadImageForm
+        onUrlConfirm={onUrlConfirm}
+        onFileChoose={(file) => handleImageUpload({ file })}
+        onUrlChange={(url) => setInputText(url)}
+        src={stateObject.src}
+        width={stateObject.width}
+        loading={stateObject.loading}
+      />
     </>
   );
 };

--- a/packages/blocks/image/src/Image.tsx
+++ b/packages/blocks/image/src/Image.tsx
@@ -11,7 +11,7 @@ import { unstable_batchedUpdates } from "react-dom";
 import { tw } from "twind";
 
 import { ResizeImageBlock } from "./components/ResizeImageBlock";
-import Cross from "./svgs/Cross";
+import { ImageErrorAlert } from "./components/ImageErrorAlert";
 import { UploadImageForm } from "./components/UploadImageForm";
 import Pencil from "./svgs/Pencil";
 
@@ -350,25 +350,10 @@ export const Image: BlockComponent<AppProps> = (props) => {
   return (
     <>
       {stateObject.errorString && (
-        <div
-          className={tw`w-96 mx-auto mb-4 bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative`}
-          role="alert"
-        >
-          <div className={tw`mr-5`}>
-            <strong className={tw`font-bold`}>Error</strong>
-            <span className={tw`block sm:inline ml-2 `}>
-              {stateObject.errorString}
-            </span>
-          </div>
-
-          <button
-            type="button"
-            onClick={() => updateStateObject({ errorString: null })}
-            className={tw`absolute top-0 bottom-0 right-0 px-4 py-3`}
-          >
-            <Cross />
-          </button>
-        </div>
+        <ImageErrorAlert
+          error={stateObject.errorString}
+          onClearError={() => updateStateObject({ errorString: null })}
+        />
       )}
 
       <UploadImageForm

--- a/packages/blocks/image/src/Image.tsx
+++ b/packages/blocks/image/src/Image.tsx
@@ -183,7 +183,6 @@ export const Image: BlockComponent<AppProps> = (props) => {
     };
   }, []);
 
-  // @todo remove this
   const updateData = useCallback(
     ({
       width,

--- a/packages/blocks/image/src/Image.tsx
+++ b/packages/blocks/image/src/Image.tsx
@@ -332,9 +332,6 @@ export const Image: BlockComponent<AppProps> = (props) => {
         onWidthChange={updateWidth}
         caption={draftCaption}
         onCaptionChange={(caption) => setDraftCaption(caption)}
-        /**
-         * @todo this makes no sense
-         */
         onCaptionConfirm={() => updateData({ src: draftSrc })}
         onReset={resetComponent}
         width={draftWidth}

--- a/packages/blocks/image/src/Image.tsx
+++ b/packages/blocks/image/src/Image.tsx
@@ -10,6 +10,7 @@ import React, {
   SetStateAction,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -132,19 +133,20 @@ export const Image: BlockComponent<AppProps> = (props) => {
     url,
   } = props;
 
-  let matchingLinkedEntities: (BlockProtocolEntity & { url: string })[] | null =
-    null;
+  const matchingLinkedEntities = useMemo(() => {
+    if (linkGroups && linkedEntities && entityId) {
+      return getLinkedEntities<{
+        url: string;
+      }>({
+        sourceEntityId: entityId,
+        path: "$.file",
+        linkGroups,
+        linkedEntities,
+      });
+    }
 
-  if (linkGroups && linkedEntities && entityId) {
-    matchingLinkedEntities = getLinkedEntities<{
-      url: string;
-    }>({
-      sourceEntityId: entityId,
-      path: "$.file",
-      linkGroups,
-      linkedEntities,
-    });
-  }
+    return null;
+  }, [entityId, linkGroups, linkedEntities]);
 
   const [draftSrc, setDraftSrc] = useDefaultState(
     url ?? matchingLinkedEntities?.[0]?.url ?? "",

--- a/packages/blocks/image/src/Image.tsx
+++ b/packages/blocks/image/src/Image.tsx
@@ -158,7 +158,6 @@ export const Image: BlockComponent<AppProps> = (props) => {
     });
   }
 
-  // @todo which should be the default
   const [draftSrc, setDraftSrc] = useDefaultState(
     url ?? matchingLinkedEntities?.[0]?.url ?? "",
   );

--- a/packages/blocks/image/src/Image.tsx
+++ b/packages/blocks/image/src/Image.tsx
@@ -53,7 +53,8 @@ const useDefaultState = <T extends any>(
   const setState = useCallback((value: SetStateAction<T>) => {
     setNextValue((prevValue) => {
       const nextValue =
-        // @ts-expect-error figure this out
+        // @ts-expect-error We know this is callable, but TS thinks value
+        // could be another kind of function
         typeof value === "function" ? value(prevValue.currentValue) : value;
 
       return {

--- a/packages/blocks/image/src/Image.tsx
+++ b/packages/blocks/image/src/Image.tsx
@@ -160,7 +160,7 @@ export const Image: BlockComponent<AppProps> = (props) => {
 
   // @todo which should be the default
   const [draftSrc, setDraftSrc] = useDefaultState(
-    matchingLinkedEntities?.[0]?.url ?? url ?? "",
+    url ?? matchingLinkedEntities?.[0]?.url ?? "",
   );
 
   const [loading, setLoading] = useState(false);

--- a/packages/blocks/image/src/Image.tsx
+++ b/packages/blocks/image/src/Image.tsx
@@ -125,6 +125,9 @@ function getLinkedEntities<T>(params: {
 //   return state;
 // }
 
+/**
+ * @todo Rewrite the state here to use a reducer, instead of batched updates
+ */
 export const Image: BlockComponent<AppProps> = (props) => {
   const {
     accountId,
@@ -163,9 +166,13 @@ export const Image: BlockComponent<AppProps> = (props) => {
   const [loading, setLoading] = useState(false);
   const [errorString, setErrorString] = useState<null | string>(null);
 
-  const [draftUrl, setDraftUrl] = useState("");
   const [draftCaption, setDraftCaption] = useDefaultState(initialCaption ?? "");
   const [draftWidth, setDraftWidth] = useDefaultState(initialWidth);
+
+  /**
+   * Default for this input field is blank, not the URL passed
+   */
+  const [draftUrl, setDraftUrl] = useState("");
 
   const isMounted = useRef(false);
 

--- a/packages/blocks/image/src/Image.tsx
+++ b/packages/blocks/image/src/Image.tsx
@@ -113,19 +113,6 @@ function getLinkedEntities<T>(params: {
   return matchingLinkedEntities as (BlockProtocolEntity & T)[];
 }
 
-// type ImageState = {
-//   url: string;
-//   caption: string;
-// }
-//
-// type ImageAction = {
-//
-// }
-//
-// function imageStateReducer(state: ImageState, action: ImageAction): ImageState {
-//   return state;
-// }
-
 /**
  * @todo Rewrite the state here to use a reducer, instead of batched updates
  */

--- a/packages/blocks/image/src/Image.tsx
+++ b/packages/blocks/image/src/Image.tsx
@@ -7,13 +7,9 @@ import {
 import { BlockComponent } from "blockprotocol/react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { unstable_batchedUpdates } from "react-dom";
-
-import { tw } from "twind";
-
-import { ResizeImageBlock } from "./components/ResizeImageBlock";
 import { ImageErrorAlert } from "./components/ImageErrorAlert";
+import { ImageWithCaption } from "./components/ImageWithCaption";
 import { UploadImageForm } from "./components/UploadImageForm";
-import Pencil from "./svgs/Pencil";
 
 // https://www.typescriptlang.org/docs/handbook/release-notes/overview.html#recursive-conditional-types
 type Awaited<T> = T extends PromiseLike<infer U> ? Awaited<U> : T;
@@ -320,30 +316,15 @@ export const Image: BlockComponent<AppProps> = (props) => {
 
   if (stateObject.src?.trim() || (url && !stateObject.userIsEditing)) {
     return (
-      <div className={tw`flex justify-center text-center w-full`}>
-        <div className={tw`flex flex-col`}>
-          <ResizeImageBlock
-            imageSrc={stateObject.src ? stateObject.src : url!}
-            width={stateObject.width}
-            updateWidth={updateWidth}
-          />
-          <input
-            placeholder="Add a caption"
-            className={tw`focus:outline-none text-center mt-3`}
-            type="text"
-            value={captionText}
-            onChange={(event) => setCaptionText(event.target.value)}
-            onBlur={() => updateData({ src: stateObject.src })}
-          />
-        </div>
-        <button
-          type="button"
-          onClick={resetComponent}
-          className={tw`ml-2 bg-gray-100 p-1.5 border-1 border-gray-300 rounded-sm self-start`}
-        >
-          <Pencil />
-        </button>
-      </div>
+      <ImageWithCaption
+        image={stateObject.src ? stateObject.src : url!}
+        onWidthChange={updateWidth}
+        caption={captionText}
+        onCaptionChange={(caption) => setCaptionText(caption)}
+        onCaptionConfirm={() => updateData({ src: stateObject.src })}
+        onReset={resetComponent}
+        width={stateObject.width}
+      />
     );
   }
 

--- a/packages/blocks/image/src/components/ImageErrorAlert.tsx
+++ b/packages/blocks/image/src/components/ImageErrorAlert.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { tw } from "twind";
+import Cross from "../svgs/Cross";
+
+type ImageErrorAlertProps = { error: string | null; onClearError: () => void };
+export const ImageErrorAlert = (props: ImageErrorAlertProps) => (
+  <div
+    className={tw`w-96 mx-auto mb-4 bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative`}
+    role="alert"
+  >
+    <div className={tw`mr-5`}>
+      <strong className={tw`font-bold`}>Error</strong>
+      <span className={tw`block sm:inline ml-2 `}>{props.error}</span>
+    </div>
+
+    <button
+      type="button"
+      onClick={props.onClearError}
+      className={tw`absolute top-0 bottom-0 right-0 px-4 py-3`}
+    >
+      <Cross />
+    </button>
+  </div>
+);

--- a/packages/blocks/image/src/components/ImageErrorAlert.tsx
+++ b/packages/blocks/image/src/components/ImageErrorAlert.tsx
@@ -1,21 +1,25 @@
-import React from "react";
+import React, { VFC } from "react";
 import { tw } from "twind";
 import Cross from "../svgs/Cross";
 
 type ImageErrorAlertProps = { error: string | null; onClearError: () => void };
-export const ImageErrorAlert = (props: ImageErrorAlertProps) => (
+
+export const ImageErrorAlert: VFC<ImageErrorAlertProps> = ({
+  error,
+  onClearError,
+}) => (
   <div
     className={tw`w-96 mx-auto mb-4 bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative`}
     role="alert"
   >
     <div className={tw`mr-5`}>
       <strong className={tw`font-bold`}>Error</strong>
-      <span className={tw`block sm:inline ml-2 `}>{props.error}</span>
+      <span className={tw`block sm:inline ml-2 `}>{error}</span>
     </div>
 
     <button
       type="button"
-      onClick={props.onClearError}
+      onClick={onClearError}
       className={tw`absolute top-0 bottom-0 right-0 px-4 py-3`}
     >
       <Cross />

--- a/packages/blocks/image/src/components/ImageWithCaption.tsx
+++ b/packages/blocks/image/src/components/ImageWithCaption.tsx
@@ -13,26 +13,34 @@ type ImageWithCaptionProps = {
   onReset: () => void;
 };
 
-export const ImageWithCaption: VFC<ImageWithCaptionProps> = (props) => (
+export const ImageWithCaption: VFC<ImageWithCaptionProps> = ({
+  caption,
+  image,
+  onCaptionChange,
+  onCaptionConfirm,
+  onReset,
+  onWidthChange,
+  width,
+}) => (
   <div className={tw`flex justify-center text-center w-full`}>
     <div className={tw`flex flex-col`}>
       <ResizeImageBlock
-        imageSrc={props.image}
-        width={props.width}
-        updateWidth={props.onWidthChange}
+        imageSrc={image}
+        width={width}
+        updateWidth={onWidthChange}
       />
       <input
         placeholder="Add a caption"
         className={tw`focus:outline-none text-center mt-3`}
         type="text"
-        value={props.caption}
-        onChange={(event) => props.onCaptionChange(event.target.value)}
-        onBlur={props.onCaptionConfirm}
+        value={caption}
+        onChange={(event) => onCaptionChange(event.target.value)}
+        onBlur={onCaptionConfirm}
       />
     </div>
     <button
       type="button"
-      onClick={props.onReset}
+      onClick={onReset}
       className={tw`ml-2 bg-gray-100 p-1.5 border-1 border-gray-300 rounded-sm self-start`}
     >
       <Pencil />

--- a/packages/blocks/image/src/components/ImageWithCaption.tsx
+++ b/packages/blocks/image/src/components/ImageWithCaption.tsx
@@ -1,0 +1,41 @@
+import React, { VFC } from "react";
+import { tw } from "twind";
+import Pencil from "../svgs/Pencil";
+import { ResizeImageBlock } from "./ResizeImageBlock";
+
+type ImageWithCaptionProps = {
+  image: string;
+  width: number | undefined;
+  onWidthChange: (width: number) => void;
+  caption: string;
+  onCaptionChange: (caption: string) => void;
+  onCaptionConfirm: () => void;
+  onReset: () => void;
+};
+
+export const ImageWithCaption: VFC<ImageWithCaptionProps> = (props) => (
+  <div className={tw`flex justify-center text-center w-full`}>
+    <div className={tw`flex flex-col`}>
+      <ResizeImageBlock
+        imageSrc={props.image}
+        width={props.width}
+        updateWidth={props.onWidthChange}
+      />
+      <input
+        placeholder="Add a caption"
+        className={tw`focus:outline-none text-center mt-3`}
+        type="text"
+        value={props.caption}
+        onChange={(event) => props.onCaptionChange(event.target.value)}
+        onBlur={props.onCaptionConfirm}
+      />
+    </div>
+    <button
+      type="button"
+      onClick={props.onReset}
+      className={tw`ml-2 bg-gray-100 p-1.5 border-1 border-gray-300 rounded-sm self-start`}
+    >
+      <Pencil />
+    </button>
+  </div>
+);

--- a/packages/blocks/image/src/components/ResizeImageBlock.tsx
+++ b/packages/blocks/image/src/components/ResizeImageBlock.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useRef } from "react";
+import React, { useEffect, useLayoutEffect, useRef } from "react";
 import { tw } from "twind";
 
 type ResizeBlockProps = {
@@ -19,6 +19,12 @@ export const ResizeImageBlock: React.VFC<ResizeBlockProps> = ({
   updateWidth,
 }) => {
   const imageRef = useRef<HTMLImageElement>(null);
+
+  const updateWidthRef = useRef(updateWidth);
+
+  useLayoutEffect(() => {
+    updateWidthRef.current = updateWidth;
+  });
 
   useLayoutEffect(() => {
     if (!imageRef.current) return;
@@ -64,7 +70,7 @@ export const ResizeImageBlock: React.VFC<ResizeBlockProps> = ({
       setTimeout(() => {
         if (!imageRef.current) return;
         const { width: newWidth } = imageRef.current.getBoundingClientRect();
-        updateWidth(newWidth);
+        updateWidthRef.current(newWidth);
       }, 1000);
     }
 

--- a/packages/blocks/image/src/components/ResizeImageBlock.tsx
+++ b/packages/blocks/image/src/components/ResizeImageBlock.tsx
@@ -60,6 +60,7 @@ export const ResizeImageBlock: React.VFC<ResizeBlockProps> = ({
 
     function onMouseUp() {
       document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
       setTimeout(() => {
         if (!imageRef.current) return;
         const { width: newWidth } = imageRef.current.getBoundingClientRect();

--- a/packages/blocks/image/src/components/UploadImageForm.tsx
+++ b/packages/blocks/image/src/components/UploadImageForm.tsx
@@ -7,7 +7,6 @@ type UploadImageFormProps = {
   onUrlChange: (url: string) => void;
   onUrlConfirm: () => void;
   loading: boolean;
-  src: string;
   width: number | undefined;
 };
 

--- a/packages/blocks/image/src/components/UploadImageForm.tsx
+++ b/packages/blocks/image/src/components/UploadImageForm.tsx
@@ -10,13 +10,18 @@ type UploadImageFormProps = {
   width: number | undefined;
 };
 
-export const UploadImageForm: VFC<UploadImageFormProps> = (props) => {
+export const UploadImageForm: VFC<UploadImageFormProps> = ({
+  loading,
+  onFileChoose,
+  onUrlChange,
+  onUrlConfirm,
+}) => {
   /**
    * @todo This should throw some kind of error if an invalid image is passed
    */
   const onFilesChoose = (files: FileList | null) => {
     if (files?.[0] && files[0].type.search("image") > -1) {
-      props.onFileChoose(files[0]);
+      onFileChoose(files[0]);
     }
   };
 
@@ -39,14 +44,14 @@ export const UploadImageForm: VFC<UploadImageFormProps> = (props) => {
         onSubmit={(event) => {
           event.preventDefault();
 
-          props.onUrlConfirm();
+          onUrlConfirm();
         }}
       >
         <div>
           {/** @todo need to make this controlled */}
           <input
             className={tw`px-1.5 py-1 rounded-sm border-2 border-gray-200 bg-gray-50 focus:outline-none focus:ring focus:border-blue-300 w-full`}
-            onChange={(event) => props.onUrlChange(event.target.value)}
+            onChange={(event) => onUrlChange(event.target.value)}
             type="url"
             placeholder="Enter Image URL"
           />
@@ -74,7 +79,7 @@ export const UploadImageForm: VFC<UploadImageFormProps> = (props) => {
             className={tw`bg-blue-400 rounded-sm hover:bg-blue-500 focus:bg-blue-600 py-1 text-white w-full flex items-center justify-center`}
             type="submit"
           >
-            {props.loading && <Loader />}
+            {loading && <Loader />}
             Embed Image
           </button>
         </div>

--- a/packages/blocks/image/src/components/UploadImageForm.tsx
+++ b/packages/blocks/image/src/components/UploadImageForm.tsx
@@ -1,0 +1,88 @@
+import React, { VFC } from "react";
+import { tw } from "twind";
+import Loader from "../svgs/Loader";
+
+type UploadImageFormProps = {
+  onFileChoose: (file: File) => void;
+  onUrlChange: (url: string) => void;
+  onUrlConfirm: () => void;
+  loading: boolean;
+  src: string;
+  width: number | undefined;
+};
+
+export const UploadImageForm: VFC<UploadImageFormProps> = (props) => {
+  /**
+   * @todo This should throw some kind of error if an invalid image is passed
+   */
+  const onFilesChoose = (files: FileList | null) => {
+    if (files?.[0] && files[0].type.search("image") > -1) {
+      props.onFileChoose(files[0]);
+    }
+  };
+
+  return (
+    <div
+      className={tw`w-96 mx-auto bg-white rounded-sm shadow-md overflow-hidden text-center p-4 border-2 border-gray-200`}
+      onDragOver={(event) => {
+        event.stopPropagation();
+        event.preventDefault();
+      }}
+      onDrop={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        onFilesChoose(event.dataTransfer.files);
+      }}
+    >
+      <form
+        className={tw`mb-0`}
+        onSubmit={(event) => {
+          event.preventDefault();
+
+          props.onUrlConfirm();
+        }}
+      >
+        <div>
+          {/** @todo need to make this controlled */}
+          <input
+            className={tw`px-1.5 py-1 rounded-sm border-2 border-gray-200 bg-gray-50 focus:outline-none focus:ring focus:border-blue-300 w-full`}
+            onChange={(event) => props.onUrlChange(event.target.value)}
+            type="url"
+            placeholder="Enter Image URL"
+          />
+        </div>
+        <div>
+          <label>
+            <div
+              className={tw`my-4 bg-gray-50 border-2 border-dashed border-gray-200 py-4 text-sm text-gray-400 cursor-pointer`}
+            >
+              Choose a File. <br /> (or Drop it Here)
+            </div>
+
+            <input
+              className={tw`hidden`}
+              type="file"
+              accept="image/*"
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                onFilesChoose(event.target.files)
+              }
+            />
+          </label>
+        </div>
+        <div className={tw`mt-4`}>
+          <button
+            className={tw`bg-blue-400 rounded-sm hover:bg-blue-500 focus:bg-blue-600 py-1 text-white w-full flex items-center justify-center`}
+            type="submit"
+          >
+            {props.loading && <Loader />}
+            Embed Image
+          </button>
+        </div>
+        <div className={tw`text-sm text-gray-400 mt-4`}>
+          Works with web-supported image formats
+        </div>
+      </form>
+    </div>
+  );
+};


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This fixes at least three bugs in the image block, while improving code readability.

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

- Image block is using multiple pieces of state that need to be updated in tandem. To avoid multiple renders, I'm using an unofficial batch API. I'm doing this because:

 - A) Image block is already doing this
 - B) Doing this simplifies some of the "revert to initial state" logic
 - C) We want to move to a reducer here anyway
 - D) React 18 batches by default

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

N/A

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- All different pieces of state are now in individual states. This makes it easier read, but proliferates `unstable_batchedUpdates`. We already plan to move to a reducer to fix this
- New `useDefaultState` hook which makes it easy to have state-set-by-prop-as-default-but-reset-when-props-change
- UI parts of the image block have been compentized. This should ensure we react to props changes better.
- When you mouse up when changing width, ensure the event handler which sets the width is then removed, so it doesn't get called on every subsequent click
- Ensure the latest on width change function gets called when changing width, to prevent reverting to previous state

These changes should fix a symptom where changing blocks doesn't properly reset the state.

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

No

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as (_internal_) -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1200211978612931/1201882912244908/f) (_internal_)

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

No

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Most of the bugs are present in the hub but not when tested in isolation

1.  Change the width of the block
2. Change the caption using the UI
3. Change the props passed by the hub
4. Change caption again
5. Ensure everything updates as expected