### PR TITLE
Bump arrow version to 9.1.0

### DIFF
--- a/packages/engine/Cargo.lock
+++ b/packages/engine/Cargo.lock
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "arrow"
-version = "9.0.2"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374ec8e5f39015ab754cfc63398a897423c877b66aecbfd036903b2c9c07f244"
+checksum = "9864ca2fdcd3d4883259495b4517879877c5991d9928cc9713794d8076d3e78b"
 dependencies = [
  "bitflags",
  "chrono",

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -11,7 +11,7 @@ default-members = [".", "bin/*", "lib/*"]
 flatbuffers_gen = { path = "lib/flatbuffers_gen" }
 
 arr_macro = "0.1.3"
-arrow = { version = "9.0.2", default-features = false, features = ["ipc"] }
+arrow = { version = "9.1.0", default-features = false, features = ["ipc"] }
 async-trait = "0.1.48"
 clap = { version = "3.0.0", features = ["cargo", "derive", "env"] }
 csv = "1.1.5"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We want to use the latest version of arrow-rs

## ⚠️ Known issues

None

## 🐾 Next steps

Fix the last issue to merge the dev-branch into main

## 🔍 What does this change?

- Bumps the arrow version from 9.0.2 to 9.1.0

### 📜 Does this require a change to the docs?

No