### PR TITLE
Add regression test for current arrow error

### DIFF
--- a/packages/engine/tests/units/state/mod.rs
+++ b/packages/engine/tests/units/state/mod.rs
@@ -3,8 +3,10 @@ mod empty;
 
 mod js {
     crate::run_test!(behavior_index, JavaScript);
+    crate::run_test!(nullable_fixed_size_list, JavaScript);
 }
 
 mod py {
     crate::run_test!(behavior_index, Python, #[ignore]);
+    crate::run_test!(nullable_fixed_size_list, Python, #[ignore]);
 }

--- a/packages/engine/tests/units/state/nullable_fixed_size_list/integration-test.json
+++ b/packages/engine/tests/units/state/nullable_fixed_size_list/integration-test.json
@@ -1,0 +1,6 @@
+[
+  {
+    "steps": 2,
+    "expected-output": {}
+  }
+]

--- a/packages/engine/tests/units/state/nullable_fixed_size_list/src/behaviors/empty.js
+++ b/packages/engine/tests/units/state/nullable_fixed_size_list/src/behaviors/empty.js
@@ -1,0 +1,7 @@
+/**
+ * Regression test with at least three agents, where one agent has a fixed-size list as field, but one agent before and
+ * one agent after does not have this field.
+ *
+ * Empty behavior (we need a behavior to execute)
+ */
+const behavior = (state, context) => {};

--- a/packages/engine/tests/units/state/nullable_fixed_size_list/src/behaviors/empty.js.json
+++ b/packages/engine/tests/units/state/nullable_fixed_size_list/src/behaviors/empty.js.json
@@ -1,0 +1,13 @@
+{
+  "keys": {
+    "list": {
+      "type": "fixed_size_list",
+      "length": 3,
+      "nullable": true,
+      "child": {
+        "type": "number",
+        "nullable": false
+      }
+    }
+  }
+}

--- a/packages/engine/tests/units/state/nullable_fixed_size_list/src/behaviors/empty.py
+++ b/packages/engine/tests/units/state/nullable_fixed_size_list/src/behaviors/empty.py
@@ -1,0 +1,8 @@
+def behavior(state, context):
+ """
+ Regression test with at least three agents, where one agent has a fixed-size list as field, but one agent before and
+ one agent after does not have this field.
+
+ Empty behavior (we need a behavior to execute)
+ """
+ pass

--- a/packages/engine/tests/units/state/nullable_fixed_size_list/src/behaviors/empty.py.json
+++ b/packages/engine/tests/units/state/nullable_fixed_size_list/src/behaviors/empty.py.json
@@ -1,0 +1,13 @@
+{
+  "keys": {
+    "list": {
+      "type": "fixed_size_list",
+      "length": 3,
+      "nullable": true,
+      "child": {
+        "type": "number",
+        "nullable": false
+      }
+    }
+  }
+}

--- a/packages/engine/tests/units/state/nullable_fixed_size_list/src/init-js.json
+++ b/packages/engine/tests/units/state/nullable_fixed_size_list/src/init-js.json
@@ -1,0 +1,12 @@
+[
+  {
+    "behaviors": ["empty.js"]
+  },
+  {
+    "behaviors": ["empty.js"],
+    "list": [0, 0, 0]
+  },
+  {
+    "behaviors": ["empty.js"]
+  }
+]

--- a/packages/engine/tests/units/state/nullable_fixed_size_list/src/init-py.json
+++ b/packages/engine/tests/units/state/nullable_fixed_size_list/src/init-py.json
@@ -1,0 +1,12 @@
+[
+  {
+    "behaviors": ["empty.js"]
+  },
+  {
+    "behaviors": ["empty.js"],
+    "list": [0, 0, 0]
+  },
+  {
+    "behaviors": ["empty.js"]
+  }
+]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The dev branch is currently failing because the size of the inner fields for fixed-size-length lists is not properly calculated. This only happens, if we have a nullable list and one agent is setting it to a non-null value, but two other agents (one before, one after - index wise) have set this field to `null` (i.e. don't set it).

### Example

Three agents:
```json
{
  "behaviors": ["empty.js"]
},
{
  "behaviors": ["empty.js"],
  "list": [0, 0, 0]
},
{
  "behaviors": ["empty.js"]
}
```

JavaScript creates the following vector to be converted to an arrow array:
```json
[null, [0, 0, 0], null]
```

This is supposed to be
```js
[[<UNSPECIFIED>, <UNSPECIFIED>, <UNSPECIFIED>], [0, 0, 0], [<UNSPECIFIED>, <UNSPECIFIED>, <UNSPECIFIED>]]
```
or at least 
```js
[<UNSPECIFIED>, [0, 0, 0], <UNSPECIFIED>]
```
where the size of `<UNSPECIFIED>` is the same as the size of `[0, 0, 0]`.

This PR adds a test to catch this error.

## 🐾 Next steps

Fix this error
