### PR TITLE
Workaround: Create inner null fields for expected fixed-size-lists

### DIFF
--- a/packages/engine/src/worker/runner/javascript/batch.js
+++ b/packages/engine/src/worker/runner/javascript/batch.js
@@ -173,11 +173,9 @@
     // TODO: Is there a way to add the whole column all at once to `builder`?
     try {
       for (var i_agent = 0; i_agent < col.length; ++i_agent) {
-        if (col[i_agent] === null && field_type.listSize) {
-          // null fixed-size-list
-          // TODO: child-data must contain `field_type.listSize` elements
-          //   see https://app.asana.com/0/0/1201893568192898/f
-        }
+        // TODO: If `field_type` is a fixed-size-list and `col[i_agent === null]` child-data must contain
+        //   `field_type.listSize` elements
+        //   see https://app.asana.com/0/0/1201893568192898/f
         builder.append(col[i_agent]);
       }
     } catch (e) {

--- a/packages/engine/src/worker/runner/javascript/batch.js
+++ b/packages/engine/src/worker/runner/javascript/batch.js
@@ -173,6 +173,11 @@
     // TODO: Is there a way to add the whole column all at once to `builder`?
     try {
       for (var i_agent = 0; i_agent < col.length; ++i_agent) {
+        if (col[i_agent] === null && field_type.listSize) {
+          // null fixed-size-list
+          // TODO: child-data must contain `field_type.listSize` elements
+          //   see https://app.asana.com/0/0/1201893568192898/f
+        }
         builder.append(col[i_agent]);
       }
     } catch (e) {

--- a/packages/engine/src/worker/runner/javascript/hash_util.js
+++ b/packages/engine/src/worker/runner/javascript/hash_util.js
@@ -73,7 +73,6 @@
       return vector;
     }
 
-    // `vector` is not a fixed-size-list
     const size = field_type.listSize;
 
     if (vector === null) {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This is a workaround for https://github.com/hashintel/hash/pull/356

## ⚠️ Known issues

A fixed-size list requires a continuous list of data as child data to calculate the offset from the index and the type size. Thus, a child data for 
```json
[null, [0, 1, 2], null]
```
needs values for the first and second `null`. This PR implements a workaround only to set `null` to `[null, null, null]` to ensure the correct offsets, but this is a wrong behavior which is only working for now as we don't rely on null checks for fixed-size lists.

## 🐾 Next steps

Fix this properly by picking up the [follow-up task](https://app.asana.com/0/0/1201893568192898/f) (_internal_)

## 🔍 What does this change?

- Picks up `null` values for fixed-size lists and replaces them with `Array.new(listSize)`.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201793759102797/1201829883247748/f) (_internal_)

## 🛡 What tests cover this?

The integration test suite covers the workaround. https://github.com/hashintel/hash/pull/356 will cover the proper fix.