### PR TITLE
Use timestamps instead of an array of `entityVersionId`s to store the source versions of links

### DIFF
--- a/packages/hash/api/datastore/postgres/schema/0000_base.sql
+++ b/packages/hash/api/datastore/postgres/schema/0000_base.sql
@@ -146,9 +146,16 @@ create table if not exists links (
     source_account_id             uuid not null,
     -- The entity id of the source entity.
     source_entity_id              uuid not null,
-    -- The entity version ids of the source entity's versions where
-    -- the link exists.
-    source_entity_version_ids     uuid[] not null,
+    -- The timestamp when the link was applied to the source entity (i.e. when
+    -- it was created)
+    applied_to_source_at          timestamp with time zone not null,
+    -- the account_id of the account which created the link
+    applied_to_source_by          uuid not null,
+    -- The timestamp when the link was removed from the source entity, if at
+    -- all (i.e. when it was deleted)
+    removed_from_source_at        timestamp with time zone,
+    -- the account_id of the account which deleted the link
+    removed_from_source_by        uuid,
     -- The account id of the destination entity
     destination_account_id        uuid not null,
     -- The entity id of the destination entity
@@ -158,7 +165,6 @@ create table if not exists links (
     -- of the destination entity. When set to null, the link is to the latest
     -- version of the destination entity.
     destination_entity_version_id  uuid,
-    created_at                     timestamp with time zone not null,
 
     constraint links_pk primary key (
       source_account_id, -- included in the primary key so it can be used as a sharding key

--- a/packages/hash/api/src/db/adapter.ts
+++ b/packages/hash/api/src/db/adapter.ts
@@ -65,11 +65,13 @@ export type DBLink = {
   index?: number;
   sourceAccountId: string;
   sourceEntityId: string;
-  sourceEntityVersionIds: Set<string>;
+  appliedToSourceAt: Date;
+  appliedToSourceBy: string;
+  removedFromSourceAt?: Date;
+  removedFromSourceBy?: string;
   destinationAccountId: string;
   destinationEntityId: string;
   destinationEntityVersionId?: string;
-  createdAt: Date;
 };
 
 export type DBAggregation = {
@@ -456,10 +458,22 @@ export interface DBClient {
     linkId: string;
   }): Promise<void>;
 
+  /**
+   * Gets all the outgoing links of an entity.
+   *
+   * Note: when the entity is versioned, the currently active links are returned by default. To get
+   * the outgoing links of the versioned entity at a particular point in time in its history, a
+   * timestamp can be specified using the `params.activeAt` parameter.
+   *
+   * @param params.accountId the account ID of the source entity
+   * @param params.entityId the entity ID of the source entity
+   * @param params.activeAt the timestamp at which the outgoing links were active, when the source entity is versioned (optional)
+   * @param params.path the path of the outgoing links (optional)
+   */
   getEntityOutgoingLinks(params: {
     accountId: string;
     entityId: string;
-    entityVersionId?: string;
+    activeAt?: Date;
     path?: string;
   }): Promise<DBLink[]>;
 

--- a/packages/hash/api/src/db/adapter.ts
+++ b/packages/hash/api/src/db/adapter.ts
@@ -445,13 +445,6 @@ export interface DBClient {
     linkId: string;
   }): Promise<DBLink | null>;
 
-  getLinkByEntityId(params: {
-    sourceAccountId: string;
-    sourceEntityId: string;
-    sourceEntityVersionId: string;
-    destinationEntityId: string;
-  }): Promise<DBLink | null>;
-
   deleteLink(params: {
     deletedByAccountId: string;
     sourceAccountId: string;

--- a/packages/hash/api/src/db/postgres/client.ts
+++ b/packages/hash/api/src/db/postgres/client.ts
@@ -52,7 +52,7 @@ import {
   getAccountEntities,
 } from "./entity";
 import { getEntityOutgoingLinks } from "./link/getEntityOutgoingLinks";
-import { getLink, getLinkByEntityId } from "./link/getLink";
+import { getLink } from "./link/getLink";
 import { createLink } from "./link/createLink";
 import { deleteLink } from "./link/deleteLink";
 import { getUserByEmail, getUserByShortname } from "./user";
@@ -484,12 +484,6 @@ export class PostgresClient implements DBClient {
     linkId: string;
   }): Promise<DBLink | null> {
     return await getLink(this.conn, params);
-  }
-
-  async getLinkByEntityId(
-    params: Parameters<DBClient["getLinkByEntityId"]>[0],
-  ): ReturnType<DBClient["getLinkByEntityId"]> {
-    return await getLinkByEntityId(this.conn, params);
   }
 
   async deleteLink(params: {

--- a/packages/hash/api/src/db/postgres/client.ts
+++ b/packages/hash/api/src/db/postgres/client.ts
@@ -530,12 +530,9 @@ export class PostgresClient implements DBClient {
     return await deleteAggregation(this.conn, params);
   }
 
-  async getEntityOutgoingLinks(params: {
-    accountId: string;
-    entityId: string;
-    entityVersionId?: string;
-    path?: string;
-  }): Promise<DBLink[]> {
+  async getEntityOutgoingLinks(
+    params: Parameters<DBClient["getEntityOutgoingLinks"]>[0],
+  ): Promise<DBLink[]> {
     return await getEntityOutgoingLinks(this.conn, params);
   }
 

--- a/packages/hash/api/src/db/postgres/entity.ts
+++ b/packages/hash/api/src/db/postgres/entity.ts
@@ -15,7 +15,6 @@ import { genId } from "../../util";
 import { insertEntityAccount } from "./account";
 import { DbEntityNotFoundError } from "../errors";
 import { getEntityOutgoingLinks } from "./link/getEntityOutgoingLinks";
-import { addSourceEntityVersionIdToLink } from "./link/util";
 import { getEntityIncomingLinks } from "./link/getEntityIncomingLinks";
 import { getEntityAggregations } from "./aggregation/getEntityAggregations";
 import { addSourceEntityVersionIdToAggregation } from "./aggregation/util";
@@ -144,7 +143,8 @@ export const selectEntityAllVersions = (params: {
   entityId: string;
 }) => sql`
   with entities as (${selectEntities})
-  select * from entities
+  select *
+  from entities
   where
     account_id = ${params.accountId} and entity_id = ${params.entityId}
 `;
@@ -718,42 +718,6 @@ const addSourceEntityVersionIdToAggregations = async (
   );
 };
 
-const addSourceEntityVersionIdToOutgoingLinks = async (
-  conn: Connection,
-  params: {
-    entity: DbEntity;
-    omittedOutgoingLinks?: { sourceAccountId: string; linkId: string }[];
-    newSourceEntityVersionId: string;
-  },
-) => {
-  const { entity } = params;
-
-  const outgoingLinks = await getEntityOutgoingLinks(conn, {
-    accountId: entity.accountId,
-    entityId: entity.entityId,
-    entityVersionId: entity.entityVersionId,
-  });
-
-  const isDbLinkInNextVersion = (link: DBLink): boolean =>
-    params.omittedOutgoingLinks?.find(
-      ({ linkId }) => link.linkId === linkId,
-    ) === undefined;
-
-  const { newSourceEntityVersionId } = params;
-
-  await Promise.all(
-    outgoingLinks
-      .filter(isDbLinkInNextVersion)
-      .map(({ sourceAccountId, linkId }) =>
-        addSourceEntityVersionIdToLink(conn, {
-          sourceAccountId,
-          linkId,
-          newSourceEntityVersionId,
-        }),
-      ),
-  );
-};
-
 /** Update the properties of the provided entity by creating a new version.
  * @throws `DbEntityNotFoundError` if the entity does not exist.
  * @throws `DbInvalidLinksError` if the entity's new properties link to an entity which
@@ -765,7 +729,6 @@ export const updateVersionedEntity = async (
     entity: DbEntity;
     properties: any;
     updatedByAccountId: string;
-    omittedOutgoingLinks?: { sourceAccountId: string; linkId: string }[];
     omittedAggregations?: {
       sourceAccountId: string;
       sourceEntityId: string;
@@ -801,16 +764,11 @@ export const updateVersionedEntity = async (
     deferred
   `);
 
-  const { omittedOutgoingLinks, omittedAggregations } = params;
+  const { omittedAggregations } = params;
 
   await Promise.all([
     insertEntityVersion(conn, newEntityVersion),
 
-    addSourceEntityVersionIdToOutgoingLinks(conn, {
-      entity,
-      omittedOutgoingLinks,
-      newSourceEntityVersionId: newEntityVersion.entityVersionId,
-    }),
     addSourceEntityVersionIdToAggregations(conn, {
       entity,
       omittedAggregations,

--- a/packages/hash/api/src/db/postgres/history.ts
+++ b/packages/hash/api/src/db/postgres/history.ts
@@ -167,7 +167,9 @@ export const getImpliedEntityHistory = async (
             accountId: link.sourceAccountId,
             entityId: link.sourceEntityId,
             entityVersionId: link.destinationEntityVersionId,
-            validForSourceEntityVersionIds: link.sourceEntityVersionIds,
+            /** @todo: fix this type when fixing implied history resolver */
+            validForSourceEntityVersionIds: (link as any)
+              .sourceEntityVersionIds,
           }),
         ),
       ),

--- a/packages/hash/api/src/db/postgres/index.ts
+++ b/packages/hash/api/src/db/postgres/index.ts
@@ -268,12 +268,9 @@ export class PostgresAdapter extends DataSource implements DBAdapter {
     return this.query((adapter) => adapter.deleteLink(params));
   }
 
-  getEntityOutgoingLinks(params: {
-    accountId: string;
-    entityId: string;
-    entityVersionId?: string;
-    path?: string;
-  }): Promise<DBLink[]> {
+  getEntityOutgoingLinks(
+    params: Parameters<DBClient["getEntityOutgoingLinks"]>[0],
+  ): ReturnType<DBClient["getEntityOutgoingLinks"]> {
     return this.query((adapter) => adapter.getEntityOutgoingLinks(params));
   }
 

--- a/packages/hash/api/src/db/postgres/index.ts
+++ b/packages/hash/api/src/db/postgres/index.ts
@@ -254,12 +254,6 @@ export class PostgresAdapter extends DataSource implements DBAdapter {
     return this.query((adapter) => adapter.getLink(params));
   }
 
-  getLinkByEntityId(
-    params: Parameters<DBClient["getLinkByEntityId"]>[0],
-  ): ReturnType<DBClient["getLinkByEntityId"]> {
-    return this.query((adapter) => adapter.getLinkByEntityId(params));
-  }
-
   deleteLink(params: {
     deletedByAccountId: string;
     sourceAccountId: string;

--- a/packages/hash/api/src/db/postgres/link/getEntityOutgoingLinks.ts
+++ b/packages/hash/api/src/db/postgres/link/getEntityOutgoingLinks.ts
@@ -7,15 +7,6 @@ import {
   DBLinkRow,
 } from "./util";
 
-/**
- * Get all outgoing links for a versioned or non-versioned source entity
- * that are "active" (i.e. have not been removed), or were "active" at a
- * particular timestamp.
- * @param params.sourceAccountId the account id of the source entity
- * @param params.sourceEntityId the entityId of the source entity
- * @param params.activeAt the timestamp where the links were "active" (optional)
- * @param params.path the path of the link (optional)
- */
 export const getEntityOutgoingLinks = async (
   conn: Connection,
   params: {

--- a/packages/hash/api/src/db/postgres/link/getLink.ts
+++ b/packages/hash/api/src/db/postgres/link/getLink.ts
@@ -2,14 +2,14 @@ import { sql } from "slonik";
 import { DBLink } from "../../adapter";
 
 import { Connection } from "../types";
-import { selectLinks, DBLinkRow, mapDBLinkRowToDBLink } from "./util";
+import { selectAllLinks, DBLinkRow, mapDBLinkRowToDBLink } from "./util";
 
 export const getLink = async (
   conn: Connection,
   params: { sourceAccountId: string; linkId: string },
 ): Promise<DBLink | null> => {
   const row = await conn.maybeOne(sql<DBLinkRow>`
-    ${selectLinks}
+    ${selectAllLinks}
     where
       source_account_id = ${params.sourceAccountId}
       and link_id = ${params.linkId}
@@ -28,7 +28,7 @@ export const getLinkByEntityId = async (
   },
 ): Promise<DBLink | null> => {
   const row = await conn.maybeOne(sql<DBLinkRow>`
-    ${selectLinks}
+    ${selectAllLinks}
     where
       source_account_id = ${params.sourceAccountId}
       and source_entity_id = ${params.sourceEntityId}

--- a/packages/hash/api/src/db/postgres/link/getLink.ts
+++ b/packages/hash/api/src/db/postgres/link/getLink.ts
@@ -17,24 +17,3 @@ export const getLink = async (
 
   return row ? mapDBLinkRowToDBLink(row) : null;
 };
-
-export const getLinkByEntityId = async (
-  conn: Connection,
-  params: {
-    sourceAccountId: string;
-    sourceEntityId: string;
-    sourceEntityVersionId: string;
-    destinationEntityId: string;
-  },
-): Promise<DBLink | null> => {
-  const row = await conn.maybeOne(sql<DBLinkRow>`
-    ${selectAllLinks}
-    where
-      source_account_id = ${params.sourceAccountId}
-      and source_entity_id = ${params.sourceEntityId}
-      and destination_entity_id = ${params.destinationEntityId}
-      and ${params.sourceEntityVersionId} = ANY(source_entity_version_ids)
-  `);
-
-  return row ? mapDBLinkRowToDBLink(row) : null;
-};

--- a/packages/hash/api/src/db/postgres/link/util.ts
+++ b/packages/hash/api/src/db/postgres/link/util.ts
@@ -1,4 +1,4 @@
-import { sql } from "slonik";
+import { sql, ValueExpressionType } from "slonik";
 
 import { Connection } from "../types";
 import { DBLink } from "../../adapter";
@@ -44,11 +44,13 @@ export const linksColumnNames = [
   "index",
   "source_account_id",
   "source_entity_id",
-  "source_entity_version_ids",
+  "applied_to_source_at",
+  "applied_to_source_by",
+  "removed_from_source_at",
+  "removed_from_source_by",
   "destination_account_id",
   "destination_entity_id",
   "destination_entity_version_id",
-  "created_at",
 ];
 
 export const linksColumnNamesSQL = mapColumnNamesToSQL(linksColumnNames);
@@ -59,11 +61,13 @@ export type DBLinkRow = {
   index: number | null;
   source_account_id: string;
   source_entity_id: string;
-  source_entity_version_ids: string[];
+  applied_to_source_at: string;
+  applied_to_source_by: string;
+  removed_from_source_at: string | null;
+  removed_from_source_by: string | null;
   destination_account_id: string;
   destination_entity_id: string;
   destination_entity_version_id: string | null;
-  created_at: string;
 };
 
 export const mapDBLinkRowToDBLink = (row: DBLinkRow): DBLink => ({
@@ -72,18 +76,61 @@ export const mapDBLinkRowToDBLink = (row: DBLinkRow): DBLink => ({
   index: row.index === null ? undefined : row.index,
   sourceAccountId: row.source_account_id,
   sourceEntityId: row.source_entity_id,
-  sourceEntityVersionIds: new Set(row.source_entity_version_ids),
+  appliedToSourceAt: new Date(row.applied_to_source_at),
+  appliedToSourceBy: row.applied_to_source_by,
+  removedFromSourceAt: row.removed_from_source_at
+    ? new Date(row.removed_from_source_at)
+    : undefined,
+  removedFromSourceBy: row.removed_from_source_by ?? undefined,
   destinationAccountId: row.destination_account_id,
   destinationEntityId: row.destination_entity_id,
-  destinationEntityVersionId: row.destination_entity_version_id || undefined,
-  createdAt: new Date(row.created_at),
+  destinationEntityVersionId: row.destination_entity_version_id ?? undefined,
 });
 
-export const selectLinks = sql<DBLinkRow>`
+export const selectAllLinks = sql<DBLinkRow>`
   select ${linksColumnNamesSQL}
   from links
 `;
 
+const selectAllLinksWithSourceEntity = (params: {
+  sourceAccountId: string;
+  sourceEntityId: string;
+  activeAt?: Date;
+  path?: string;
+  additionalClauses?: ValueExpressionType[];
+}) => sql<DBLinkRow>`
+    ${selectAllLinks}
+    where
+      ${sql.join(
+        [
+          sql`source_account_id = ${params.sourceAccountId}`,
+          sql`source_entity_id = ${params.sourceEntityId}`,
+          params.activeAt
+            ? [
+                // the link was applied before the timestamp
+                sql`applied_to_source_at <= ${params.activeAt.toISOString()}`,
+                // either the link was removed after the timestamp, or the link hasn't been removed yet
+                sql`(
+                    removed_from_source_at >= ${params.activeAt.toISOString()}
+                  or
+                    removed_from_source_at is null 
+                )`,
+              ]
+            : [
+                // the link hasn't been removed yet (so can be considered as "active" right now)
+                sql`removed_from_source_at is null`,
+              ],
+          params.path !== undefined ? sql`path = ${params.path}` : [],
+          ...(params.additionalClauses ?? []),
+        ].flat(),
+        sql` and `,
+      )}
+`;
+
+/**
+ * Inserts a new link into the `links` table, and into the `incoming_links`
+ * lookup table.
+ */
 export const insertLink = async (
   conn: Connection,
   params: {
@@ -92,11 +139,11 @@ export const insertLink = async (
     index?: number;
     sourceAccountId: string;
     sourceEntityId: string;
-    sourceEntityVersionIds: Set<string>;
+    appliedToSourceAt: Date;
+    appliedToSourceBy: string;
     destinationAccountId: string;
     destinationEntityId: string;
     destinationEntityVersionId?: string;
-    createdAt: Date;
   },
 ): Promise<void> => {
   await Promise.all([
@@ -109,18 +156,18 @@ export const insertLink = async (
           params.index === undefined ? null : params.index,
           params.sourceAccountId,
           params.sourceEntityId,
-          sql.array(Array.from(params.sourceEntityVersionIds), "uuid"),
+          params.appliedToSourceAt.toISOString(),
+          params.appliedToSourceBy,
+          null,
+          null,
           params.destinationAccountId,
           params.destinationEntityId,
-          params.destinationEntityVersionId || null,
-          params.createdAt.toISOString(),
+          params.destinationEntityVersionId ?? null,
         ],
         sql`, `,
       )})
     `),
-    insertIncomingLink(conn, {
-      ...params,
-    }),
+    insertIncomingLink(conn, params),
   ]);
 };
 
@@ -148,28 +195,79 @@ export const updateLinkIndices = async (
   `);
 };
 
+/**
+ * Get all outgoing links for a versioned or non-versioned source entity
+ * that are "active" (i.e. have not been removed), or were "active" at a
+ * particular timestamp.
+ * @param params.sourceAccountId the account id of the source entity
+ * @param params.sourceEntityId the entityId of the source entity
+ * @param params.activeAt the timestamp where the links were "active" (optional)
+ * @param params.path the path of the link (optional)
+ */
+export const getLinks = async (
+  conn: Connection,
+  params: {
+    sourceAccountId: string;
+    sourceEntityId: string;
+    activeAt?: Date;
+    path?: string;
+  },
+): Promise<DBLink[]> => {
+  const dbLinks = await conn.any(sql<DBLinkRow>`
+    ${selectAllLinksWithSourceEntity(params)}
+    ${
+      params.path !== undefined
+        ? /** if a link path was specified, we can order them by their index */
+          sql`order by index`
+        : sql``
+    }
+  `);
+
+  return dbLinks.map(mapDBLinkRowToDBLink);
+};
+
 export const getLinksWithMinimumIndex = async (
   conn: Connection,
   params: {
     sourceAccountId: string;
     sourceEntityId: string;
-    sourceEntityVersionId: string;
+    activeAt?: Date;
     path: string;
     minimumIndex: number;
   },
 ): Promise<DBLink[]> => {
-  const linkRows = await conn.any(sql<DBLinkRow>`
-      ${selectLinks}
-      where
-        source_account_id = ${params.sourceAccountId}
-        and source_entity_id = ${params.sourceEntityId}
-        and ${params.sourceEntityVersionId} = ANY(source_entity_version_ids)
-        and path = ${params.path}
-        and index is not null
-        and index >= ${params.minimumIndex}
-  `);
+  const linkRows = await conn.any(
+    selectAllLinksWithSourceEntity({
+      ...params,
+      additionalClauses: [
+        sql`index is not null`,
+        sql`index >= ${params.minimumIndex}`,
+      ],
+    }),
+  );
 
   return linkRows.map(mapDBLinkRowToDBLink);
+};
+
+export const removeLinkFromSource = async (
+  conn: Connection,
+  params: {
+    sourceAccountId: string;
+    linkId: string;
+    removedFromSourceAt: Date;
+    removedFromSourceBy: string;
+  },
+): Promise<void> => {
+  await conn.query(sql`
+    update links
+    set
+      removed_from_source_at = ${params.removedFromSourceAt.toISOString()},
+      removed_from_source_by = ${params.removedFromSourceBy}
+    where (
+      source_account_id = ${params.sourceAccountId}
+      and link_id = ${params.linkId}
+    );
+  `);
 };
 
 export const deleteLinkRow = async (
@@ -180,31 +278,16 @@ export const deleteLinkRow = async (
 
   await Promise.all([
     conn.query(sql`
-    delete from incoming_links where source_account_id = ${params.sourceAccountId} and link_id = ${params.linkId};
+      delete from incoming_links
+      where source_account_id = ${params.sourceAccountId}
+      and link_id = ${params.linkId};
   `),
     conn.query(sql`
-    delete from links where source_account_id = ${params.sourceAccountId} and link_id = ${params.linkId};
+      delete from links
+      where
+          source_account_id = ${params.sourceAccountId}
+        and
+          link_id = ${params.linkId};
   `),
   ]);
-};
-
-export const addSourceEntityVersionIdToLink = async (
-  conn: Connection,
-  params: {
-    sourceAccountId: string;
-    linkId: string;
-    newSourceEntityVersionId: string;
-  },
-) => {
-  await conn.many(
-    sql`
-      update links
-      set source_entity_version_ids = array_append(links.source_entity_version_ids, ${params.newSourceEntityVersionId})
-      where
-        source_account_id = ${params.sourceAccountId}
-        and link_id = ${params.linkId}
-        and not ${params.newSourceEntityVersionId} = ANY(links.source_entity_version_ids)
-      returning link_id
-    `,
-  );
 };

--- a/packages/hash/api/src/db/postgres/link/util.ts
+++ b/packages/hash/api/src/db/postgres/link/util.ts
@@ -92,7 +92,7 @@ export const selectAllLinks = sql<DBLinkRow>`
   from links
 `;
 
-const selectAllLinksWithSourceEntity = (params: {
+export const selectAllLinksWithSourceEntity = (params: {
   sourceAccountId: string;
   sourceEntityId: string;
   activeAt?: Date;
@@ -193,37 +193,6 @@ export const updateLinkIndices = async (
       and index >= ${params.minimumIndex}
     );
   `);
-};
-
-/**
- * Get all outgoing links for a versioned or non-versioned source entity
- * that are "active" (i.e. have not been removed), or were "active" at a
- * particular timestamp.
- * @param params.sourceAccountId the account id of the source entity
- * @param params.sourceEntityId the entityId of the source entity
- * @param params.activeAt the timestamp where the links were "active" (optional)
- * @param params.path the path of the link (optional)
- */
-export const getLinks = async (
-  conn: Connection,
-  params: {
-    sourceAccountId: string;
-    sourceEntityId: string;
-    activeAt?: Date;
-    path?: string;
-  },
-): Promise<DBLink[]> => {
-  const dbLinks = await conn.any(sql<DBLinkRow>`
-    ${selectAllLinksWithSourceEntity(params)}
-    ${
-      params.path !== undefined
-        ? /** if a link path was specified, we can order them by their index */
-          sql`order by index`
-        : sql``
-    }
-  `);
-
-  return dbLinks.map(mapDBLinkRowToDBLink);
 };
 
 export const getLinksWithMinimumIndex = async (

--- a/packages/hash/api/src/model/entity.model.ts
+++ b/packages/hash/api/src/model/entity.model.ts
@@ -441,22 +441,6 @@ class __Entity {
     return link;
   }
 
-  async getOutgoingLinkByEntityId(
-    client: DBClient,
-    params: {
-      destinationEntityId: string;
-    },
-  ) {
-    const link = await Link.getByEntityId(client, {
-      ...params,
-      sourceAccountId: this.accountId,
-      sourceEntityId: this.entityId,
-      sourceEntityVersionId: this.entityVersionId,
-    });
-
-    return link;
-  }
-
   async createOutgoingLink(
     client: DBClient,
     params: Omit<CreateLinkArgs, "source">,

--- a/packages/hash/api/src/model/entity.model.ts
+++ b/packages/hash/api/src/model/entity.model.ts
@@ -452,11 +452,6 @@ class __Entity {
       source: this,
     });
 
-    // If this is a versioned entity, fetch the updated entityVersionId
-    if (this.metadata.versioned) {
-      await this.refetchLatestVersion(client);
-    }
-
     return link;
   }
 
@@ -478,10 +473,6 @@ class __Entity {
     await link.delete(client, {
       deletedByAccountId: params.deletedByAccountId,
     });
-
-    if (this.metadata.versioned) {
-      await this.refetchLatestVersion(client);
-    }
   }
 
   private static async getOrCreate(

--- a/packages/hash/api/src/model/entity.model.ts
+++ b/packages/hash/api/src/model/entity.model.ts
@@ -410,20 +410,20 @@ class __Entity {
   async getOutgoingLinks(
     client: DBClient,
     params?: {
+      activeAt?: Date;
       stringifiedPath?: string;
       path?: PathComponent[];
     },
   ) {
-    const { stringifiedPath, path } = params || {};
+    const { activeAt, stringifiedPath, path } = params || {};
 
     const outgoingDBLinks = await client.getEntityOutgoingLinks({
       accountId: this.accountId,
       entityId: this.entityId,
-      entityVersionId: this.metadata.versioned
-        ? this.entityVersionId
-        : undefined,
+      activeAt,
       path: stringifiedPath ?? (path ? Link.stringifyPath(path) : undefined),
     });
+
     return outgoingDBLinks.map((dbLink) => new Link(dbLink));
   }
 

--- a/packages/hash/api/src/model/link.model.ts
+++ b/packages/hash/api/src/model/link.model.ts
@@ -56,11 +56,13 @@ type LinkConstructorArgs = {
   index?: number;
   sourceAccountId: string;
   sourceEntityId: string;
-  sourceEntityVersionIds: Set<string>;
+  appliedToSourceAt: Date;
+  appliedToSourceBy: string;
+  removedFromSourceAt?: Date;
+  removedFromSourceBy?: string;
   destinationAccountId: string;
   destinationEntityId: string;
   destinationEntityVersionId?: string;
-  createdAt: Date;
 };
 
 class __Link {
@@ -71,13 +73,15 @@ class __Link {
 
   sourceAccountId: string;
   sourceEntityId: string;
-  sourceEntityVersionIds: Set<string>;
+
+  appliedToSourceAt: Date;
+  appliedToSourceBy: string;
+  removedFromSourceAt?: Date;
+  removedFromSourceBy?: string;
 
   destinationAccountId: string;
   destinationEntityId: string;
   destinationEntityVersionId?: string;
-
-  createdAt: Date;
 
   constructor({
     linkId,
@@ -85,11 +89,13 @@ class __Link {
     index,
     sourceAccountId,
     sourceEntityId,
-    sourceEntityVersionIds,
+    appliedToSourceAt,
+    appliedToSourceBy,
+    removedFromSourceAt,
+    removedFromSourceBy,
     destinationAccountId,
     destinationEntityId,
     destinationEntityVersionId,
-    createdAt,
   }: LinkConstructorArgs) {
     this.linkId = linkId;
     this.stringifiedPath = path;
@@ -97,11 +103,13 @@ class __Link {
     this.index = index;
     this.sourceAccountId = sourceAccountId;
     this.sourceEntityId = sourceEntityId;
-    this.sourceEntityVersionIds = sourceEntityVersionIds;
+    this.appliedToSourceAt = appliedToSourceAt;
+    this.appliedToSourceBy = appliedToSourceBy;
+    this.removedFromSourceAt = removedFromSourceAt;
+    this.removedFromSourceBy = removedFromSourceBy;
     this.destinationAccountId = destinationAccountId;
     this.destinationEntityId = destinationEntityId;
     this.destinationEntityVersionId = destinationEntityVersionId;
-    this.createdAt = createdAt;
   }
 
   static isPathValid(path: string): boolean {
@@ -185,7 +193,7 @@ class __Link {
     },
   ): Promise<Link | null> {
     const dbLink = await client.getLink(params);
-    return dbLink ? new Link({ ...dbLink }) : null;
+    return dbLink ? new Link(dbLink) : null;
   }
 
   static async getByEntityId(

--- a/packages/hash/api/src/model/link.model.ts
+++ b/packages/hash/api/src/model/link.model.ts
@@ -196,19 +196,6 @@ class __Link {
     return dbLink ? new Link(dbLink) : null;
   }
 
-  static async getByEntityId(
-    client: DBClient,
-    params: {
-      sourceAccountId: string;
-      sourceEntityId: string;
-      sourceEntityVersionId: string;
-      destinationEntityId: string;
-    },
-  ): Promise<Link | null> {
-    const dbLink = await client.getLinkByEntityId(params);
-    return dbLink ? new Link({ ...dbLink }) : null;
-  }
-
   async delete(client: DBClient, params: { deletedByAccountId: string }) {
     await client.deleteLink({
       deletedByAccountId: params.deletedByAccountId,

--- a/packages/hash/api/src/model/page.model.ts
+++ b/packages/hash/api/src/model/page.model.ts
@@ -341,9 +341,6 @@ class __Page extends Entity {
       createdByAccountId: insertedByAccountId,
       index: specifiedPosition ?? contentLinks.length,
     });
-
-    /** @todo: remove when modifying links no longer creates new versions of the source entity */
-    await this.refetchLatestVersion(client);
   }
 
   async moveBlock(
@@ -383,9 +380,6 @@ class __Page extends Entity {
       updatedIndex: newPosition,
       updatedByAccountId: movedByAccountId,
     });
-
-    /** @todo: remove when modifying links no longer creates new versions of the source entity */
-    await this.refetchLatestVersion(client);
   }
 
   async removeBlock(
@@ -417,9 +411,6 @@ class __Page extends Entity {
     const { removedByAccountId } = params;
 
     await link.delete(client, { deletedByAccountId: removedByAccountId });
-
-    /** @todo: remove when modifying links no longer creates new versions of the source entity */
-    await this.refetchLatestVersion(client);
   }
 }
 

--- a/packages/hash/integration/src/graphql/queries/page.queries.ts
+++ b/packages/hash/integration/src/graphql/queries/page.queries.ts
@@ -65,54 +65,54 @@ const pageFieldsFragment = gql`
       createdAt
       entityVersionId
     }
-    properties {
+    contents {
       __typename
-      archived
-      summary
-      title
-      contents {
+      entityVersionId
+      entityId
+      accountId
+      updatedAt
+      createdAt
+      entityVersionCreatedAt
+      createdByAccountId
+      data {
         __typename
         entityVersionId
         entityId
         accountId
         updatedAt
         createdAt
+        entityTypeId
+        entityTypeVersionId
         entityVersionCreatedAt
         createdByAccountId
-        properties {
-          componentId
-          entity {
-            __typename
-            entityVersionId
-            entityId
-            accountId
-            updatedAt
-            createdAt
-            entityTypeId
-            entityTypeVersionId
-            entityVersionCreatedAt
-            createdByAccountId
-            properties
-            linkGroups {
-              links {
-                ...LinkFields
-              }
-              sourceEntityId
-              sourceEntityVersionId
-              path
-            }
-            linkedEntities {
-              accountId
-              entityId
-              entityTypeId
-              properties
-            }
-            linkedAggregations {
-              ...LinkedAggregationsFields
-            }
+        properties
+        linkGroups {
+          links {
+            ...LinkFields
           }
+          sourceEntityId
+          sourceEntityVersionId
+          path
+        }
+        linkedEntities {
+          accountId
+          entityId
+          entityTypeId
+          properties
+        }
+        linkedAggregations {
+          ...LinkedAggregationsFields
         }
       }
+      properties {
+        componentId
+      }
+    }
+    properties {
+      __typename
+      archived
+      summary
+      title
     }
   }
   ${linkFieldsFragment}

--- a/packages/hash/integration/src/tests/integration.test.ts
+++ b/packages/hash/integration/src/tests/integration.test.ts
@@ -577,30 +577,25 @@ describe("logged in user ", () => {
       });
 
       expect(updatedPage.entityId).toEqual(page.entityId);
-      expect(updatedPage.entityVersionId).not.toEqual(page.entityVersionId); // new version
+      // creating a link shouldn't create a new version of the source entity
+      expect(updatedPage.entityVersionId).toEqual(page.entityVersionId);
       // expect(updatedPage.history).toHaveLength(2);
       // expect(updatedPage.history).toEqual(pageHistory);
       expect(updatedPage.properties.title).toEqual("My first page");
 
       // We inserted a block at the beginning of the page. The remaining blocks should
       // be the same.
-      expect(updatedPage.properties.contents.length).toEqual(
-        page.properties.contents.length + 1,
-      );
-      expect(updatedPage.properties.contents.slice(1)).toEqual(
-        page.properties.contents,
-      );
+      expect(updatedPage.contents.length).toEqual(page.contents.length + 1);
+      expect(updatedPage.contents.slice(1)).toEqual(page.contents);
 
       // Get the text entity we just inserted and make sure it matches
-      const newBlock = updatedPage.properties.contents[0];
-      textEntityId = newBlock.properties.entity.entityId;
+      const newBlock = updatedPage.contents[0];
+      textEntityId = newBlock.data.entityId;
       const textEntity = await client.getUnknownEntity({
         entityId: textEntityId,
         accountId: existingUser.accountId,
       });
-      expect(textEntity.entityVersionId).toEqual(
-        newBlock.properties.entity.entityVersionId,
-      );
+      expect(textEntity.entityVersionId).toEqual(newBlock.data.entityVersionId);
       expect(textEntity.properties).toEqual(textProperties);
     });
 
@@ -630,19 +625,19 @@ describe("logged in user ", () => {
         entityId: page.entityId,
       });
 
-      expect(
-        updatedPage.properties.contents[0].properties.entity.entityVersionId,
-      ).toEqual(newTextEntity.entityVersionId);
+      expect(updatedPage.contents[0].data.entityVersionId).toEqual(
+        newTextEntity.entityVersionId,
+      );
 
       // Update the header block text entity (2nd block)
       const newHeaderTextProperties = {
         tokens: [{ tokenType: "text", text: "Header Text" }],
       };
 
-      const headerBlock = updatedPage.properties.contents[1];
+      const headerBlock = updatedPage.contents[1];
       const headerUpdate = await client.updateEntity({
         accountId: existingUser.accountId,
-        entityId: headerBlock.properties.entity.entityId,
+        entityId: headerBlock.data.entityId,
         properties: newHeaderTextProperties,
       });
 
@@ -651,9 +646,9 @@ describe("logged in user ", () => {
         accountId: existingUser.accountId,
         entityId: page.entityId,
       });
-      expect(
-        updatedPage.properties.contents[1].properties.entity.entityVersionId,
-      ).toEqual(headerUpdate.entityVersionId);
+      expect(updatedPage.contents[1].data.entityVersionId).toEqual(
+        headerUpdate.entityVersionId,
+      );
     });
 
     // ComponentId doesn't exist in the database
@@ -687,15 +682,16 @@ describe("logged in user ", () => {
       });
 
       expect(updatedPage.entityId).toEqual(page.entityId);
-      expect(updatedPage.entityVersionId).not.toEqual(page.entityVersionId); // new version
+      // creating links shouldn't create a new version of the source entity
+      expect(updatedPage.entityVersionId).toEqual(page.entityVersionId);
       // expect(updatedPage.history).toHaveLength(3);
       // expect(updatedPage.history).toEqual(pageHistory);
       expect(updatedPage.properties.title).toEqual("My first page");
 
       // Get the new entity we just inserted and make sure it matches
-      const newBlock = updatedPage.properties.contents[0];
-      const entityId = newBlock.properties.entity.entityId;
-      entityTypeComponentId = newBlock.properties.entity.entityTypeId;
+      const newBlock = updatedPage.contents[0];
+      const entityId = newBlock.data.entityId;
+      entityTypeComponentId = newBlock.data.entityTypeId;
 
       // Get the EntitType that has been created because of the ComponentId
       const componentIdType = await client.getEntityType({
@@ -708,7 +704,7 @@ describe("logged in user ", () => {
       });
 
       expect(entityWithComponentIdType.entityVersionId).toEqual(
-        newBlock.properties.entity.entityVersionId,
+        newBlock.data.entityVersionId,
       );
       expect(entityWithComponentIdType.properties).toEqual({});
       expect(entityWithComponentIdType.entityTypeId).toEqual(
@@ -748,7 +744,8 @@ describe("logged in user ", () => {
       });
 
       expect(updatedPage.entityId).toEqual(page.entityId);
-      expect(updatedPage.entityVersionId).not.toEqual(page.entityVersionId); // new version
+      // updating links shouldn't create a new version of the source entity
+      expect(updatedPage.entityVersionId).toEqual(page.entityVersionId);
 
       // expect(updatedPage.history).toHaveLength(4);
       // expect(updatedPage.history).toEqual(pageHistory);
@@ -756,8 +753,8 @@ describe("logged in user ", () => {
       expect(updatedPage.properties.title).toEqual("My first page");
 
       // Get the new entity we just inserted and make sure it matches
-      const newBlock = updatedPage.properties.contents[0];
-      const entityId = newBlock.properties.entity.entityId;
+      const newBlock = updatedPage.contents[0];
+      const entityId = newBlock.data.entityId;
 
       // Get the EntitType that has been created _previously_ because of the ComponentId
       const componentIdType = await client.getEntityType({
@@ -770,7 +767,7 @@ describe("logged in user ", () => {
       });
 
       expect(entityWithComponentIdType.entityVersionId).toEqual(
-        newBlock.properties.entity.entityVersionId,
+        newBlock.data.entityVersionId,
       );
       expect(entityWithComponentIdType.properties).toEqual({});
       expect(entityWithComponentIdType.entityTypeId).toEqual(
@@ -849,7 +846,7 @@ describe("logged in user ", () => {
       },
     });
     // The page currently has 1 block: an empty paragraph block
-    expect(page.properties.contents).toHaveLength(1);
+    expect(page.contents).toHaveLength(1);
 
     const textPropertiesA = { tokens: [{ tokenType: "text", text: "A" }] };
     const textPropertiesB = { tokens: [{ tokenType: "text", text: "B" }] };
@@ -887,8 +884,8 @@ describe("logged in user ", () => {
         },
         {
           updateEntity: {
-            accountId: page.properties.contents[0].properties.entity.accountId,
-            entityId: page.properties.contents[0].properties.entity.entityId,
+            accountId: page.contents[0].data.accountId,
+            entityId: page.contents[0].data.entityId,
             properties: textPropertiesC,
           },
         },
@@ -901,9 +898,7 @@ describe("logged in user ", () => {
       ],
     });
 
-    const pageEntities = updatedPage.properties.contents.map(
-      (block) => block.properties.entity,
-    );
+    const pageEntities = updatedPage.contents.map((block) => block.data);
 
     expect(pageEntities[2].properties).toMatchObject(textPropertiesA);
     expect(pageEntities[1].properties).toMatchObject(textPropertiesB);
@@ -1115,47 +1110,55 @@ describe("logged in user ", () => {
       ],
     });
 
-    expect(updatedPage.properties.contents).toHaveLength(2);
+    expect(updatedPage.contents).toHaveLength(2);
 
-    const pageEntities = updatedPage.properties.contents.map(
-      (block) => block.properties.entity,
-    );
+    const pageEntities = updatedPage.contents.map((block) => block.data);
 
     // The page will have an empty paragraph and a text paragraph with textPropertiesA
     expect(pageEntities[0].properties).toMatchObject({ tokens: [] });
     expect(pageEntities[1].properties).toMatchObject(textPropertiesA);
 
-    // getEntities gives back entities orderes by updated_at
-    const { entities } = await client.getEntities({
-      accountId: page.accountId,
-    });
+    // Check text entity A was created with the correct properties & outgoing links
 
-    expect(
-      entities
-        .slice(0, 5)
-        .map((entity) => ({
-          type: entity.entityTypeName,
-          props:
-            entity.entityTypeName === "Text" ? entity.properties : undefined,
-        }))
-        .sort((a, b) =>
-          // lexical sorting to circumvent concurrency of linked entity ordering when they are inserted
-          // Non-text blocks are first, page and block are not inserted concurrently and will be stable.
-          a.props === undefined || b.props === undefined
-            ? (a.props === undefined) !== (b.props === undefined)
-            : (a.props as any).tokens![0].text.localeCompare(
-                (b.props as any).tokens![0].text,
-              ),
-        ),
-    ).toEqual([
-      { type: "Page", props: undefined },
-      { type: "Block", props: undefined },
-      // The following 3 Text elements should be the concurrently inserted, nested entities
-      // sorting beforehand ensures reproducibility.
-      { type: "Text", props: textPropertiesA },
-      { type: "Text", props: textPropertiesB },
-      { type: "Text", props: textPropertiesC },
-    ]);
+    const textEntityA = (await Entity.getEntityLatestVersion(db, {
+      accountId: pageEntities[1].accountId,
+      entityId: pageEntities[1].entityId,
+    }))!;
+
+    expect(textEntityA).not.toBeNull();
+    expect(textEntityA.properties).toMatchObject(textPropertiesA);
+
+    const textEntityAOutgoingLinks = await textEntityA.getOutgoingLinks(db);
+
+    expect(textEntityAOutgoingLinks).toHaveLength(1);
+
+    const [textEntityAOutgoingLink] = textEntityAOutgoingLinks;
+
+    expect(textEntityAOutgoingLink.stringifiedPath).toBe("$.textB");
+
+    // Check text entity B was created with the correct properties & outgoing links
+
+    const textEntityB = await textEntityAOutgoingLink.getDestination(db);
+
+    expect(textEntityB.properties).toMatchObject(textPropertiesB);
+
+    const textEntityBOutgoingLinks = await textEntityB.getOutgoingLinks(db);
+
+    expect(textEntityBOutgoingLinks).toHaveLength(1);
+
+    const [textEntityBOutgoingLink] = textEntityBOutgoingLinks;
+
+    expect(textEntityBOutgoingLink.stringifiedPath).toBe("$.textC");
+
+    // Check text entity C was created with the correct properties & outgoing links
+
+    const textEntityC = await textEntityBOutgoingLink.getDestination(db);
+
+    expect(textEntityC.properties).toMatchObject(textPropertiesC);
+
+    const textEntityCOutgoingLinks = await textEntityC.getOutgoingLinks(db);
+
+    expect(textEntityCOutgoingLinks).toHaveLength(0);
   });
 
   describe("can create entity types", () => {

--- a/packages/hash/integration/src/tests/model/page.model.test.ts
+++ b/packages/hash/integration/src/tests/model/page.model.test.ts
@@ -120,8 +120,6 @@ describe("Page model class ", () => {
       movedByAccountId: existingUser.accountId,
     });
 
-    await page.refetchLatestVersion(db);
-
     const newBlocks = await page.getBlocks(db);
 
     expect(newBlocks).toHaveLength(2);
@@ -137,8 +135,6 @@ describe("Page model class ", () => {
       position: 0,
       removedByAccountId: existingUser.accountId,
     });
-
-    await page.refetchLatestVersion(db);
 
     const blocks = await page.getBlocks(db);
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR refactors how outgoing links of versioned entities are stored in the datastore. Previously all `entityVersionId`s of a source entity that a link was valid for was stored in an `sourceEntityVersionIds` array. This had the drawbacks that:
- a new version of the source entity had to be created when its outgoing links changed
- the `sourceEntityVersionIds` array would scale significantly for links that exist for a long time

This PR replaces the `sourceEntityVersionIds` array with `appliedToSourceAt` and `removedFromSourceAt` timestamps, that indicate for which period a link was "active" in the history of its source entity.

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

- [Improve how versions of links are stored in the db](https://app.asana.com/0/1201095311341924/1201817757879406/f)
- [Implement way of updating a link's index without creating two new versions of the source entity](https://app.asana.com/0/1201095311341924/1201817757879408/f)

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

### Datastore

- updates db schema to replace `source_entity_version_ids` (and `created_at`) with `applied_to_source_at`, `applied_to_source_by`, `removed_from_source_at` and `removed_from_source_by` columns
- removes unused `getLinkByEntityId` db adapter method
- refactors `getEntityOutgoingLinks` db adapter method to accept an `activeAt` timestamp as a parameter (instead of a `entityVersionId`)
- update `createLink` and `deleteLink` db methods to stop creating new versions of their source entity

### Models

- removes calls to `this.refetchLatestVersion` in model classes where they are no longer necessary (because creating/deleting outgoing links no longer creates a new version of the source entity)

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

No

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as (_internal_) -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201095311341924/1201836485518642/f) (_internal_)

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- The integration tests and link/entity model class tests check outgoing links of versioned/non-versioned entities can be created/removed

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->


## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
