### PR TITLE
Exit orchestrator if engine process exits abnormally

### DIFF
--- a/packages/engine/lib/orchestrator/src/experiment.rs
+++ b/packages/engine/lib/orchestrator/src/experiment.rs
@@ -262,6 +262,15 @@ impl Experiment {
                     graceful_finish = false;
                     break;
                 }
+                exit_code = engine_process.wait() => {
+                    match exit_code {
+                        Ok(exit_code) if exit_code.success() => warn!("Engine process ended"),
+                        Ok(exit_code) => error!("Engine process errored with exit code {exit_code}"),
+                        Err(err) => error!("Engine process errored: {err}"),
+                    }
+                    graceful_finish = false;
+                    break;
+                }
                 m = engine_handle.recv() => { msg = Some(m) },
             }
             let msg = msg.unwrap();

--- a/packages/engine/lib/orchestrator/src/process/mod.rs
+++ b/packages/engine/lib/orchestrator/src/process/mod.rs
@@ -2,6 +2,8 @@
 
 mod local;
 
+use std::process::ExitStatus;
+
 use async_trait::async_trait;
 use error::Result;
 use hash_engine_lib::proto::EngineMsg;
@@ -21,6 +23,9 @@ pub trait Process {
     ///
     /// Returns an error if the message could not be sent.
     async fn send(&mut self, msg: &EngineMsg) -> Result<()>;
+
+    /// Waits for the process to exit completely, returning the status that it exited with.
+    async fn wait(&mut self) -> Result<ExitStatus>;
 }
 
 /// A command for creating an engine-subprocess represented by [`Process`].


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We currently don't check if the `hash_engine` process has actually finished, instead, we wait for responses and also wait on a timeout.

## 🔍 What does this change?

- Change the `orchestrator` to use `tokio::process` rather than `std::process
- Add `async fn wait()` to the `Process` trait
- Add a `select!` arm to `wait()` on the engine process

### 📜 Does this require a change to the docs?

No.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201893074552404/1201837823804295/f) (_internal_)

## 🛡 What tests cover this?

We don't have tests for abnormally exiting the engine process.

## ❓ How to test this?

1. Set the `ENGINE_WAIT_TIMEOUT` to a high value
3. Run a simulation, which is 
4. Kill the engine subprocess
5. Verify that the orchestrator is exiting

## 📹 Demo

```
   3.529230193s ERROR run: orchestrator::experiment: Engine process errored with exit code signal: 15
```
