### PR TITLE
Allow removing parent page links from the setParentPage mutation

### DIFF
--- a/packages/hash/api/src/db/adapter.ts
+++ b/packages/hash/api/src/db/adapter.ts
@@ -404,17 +404,6 @@ export interface DBClient {
     systemTypeName: SystemType;
   }): Promise<DbEntity[]>;
 
-  getEntitiesByTypeWithOutgoingEntityIds(params: {
-    accountId: string;
-    entityTypeId?: string;
-    systemTypeName?: SystemType;
-  }): Promise<EntityWithOutgoingEntityIds[]>;
-
-  getEntityWithOutgoingEntityIds(params: {
-    accountId: string;
-    entityId: string;
-  }): Promise<EntityWithOutgoingEntityIds | null>;
-
   /**
    * Get all account type entities (User or Account).
    */

--- a/packages/hash/api/src/db/postgres/client.ts
+++ b/packages/hash/api/src/db/postgres/client.ts
@@ -51,11 +51,7 @@ import {
   updateEntityAccountId,
   getAccountEntities,
 } from "./entity";
-import {
-  getEntitiesByTypeWithOutgoingEntityIds,
-  getEntityOutgoingLinks,
-  getEntityWithOutgoingEntityIds,
-} from "./link/getEntityOutgoingLinks";
+import { getEntityOutgoingLinks } from "./link/getEntityOutgoingLinks";
 import { getLink, getLinkByEntityId } from "./link/getLink";
 import { createLink } from "./link/createLink";
 import { deleteLink } from "./link/deleteLink";
@@ -438,41 +434,6 @@ export class PostgresClient implements DBClient {
     return params.latestOnly
       ? await getEntitiesByTypeLatestVersion(this.conn, queryParams)
       : await getEntitiesByTypeAllVersions(this.conn, queryParams);
-  }
-
-  async getEntitiesByTypeWithOutgoingEntityIds(
-    params: Parameters<DBClient["getEntitiesByTypeWithOutgoingEntityIds"]>[0],
-  ): ReturnType<DBClient["getEntitiesByTypeWithOutgoingEntityIds"]> {
-    let entityTypeId: string = "";
-
-    if (params.entityTypeId) {
-      entityTypeId = params.entityTypeId;
-    } else if (params.systemTypeName) {
-      const { entity_type_id } = await this.conn.one<{
-        entity_type_id: string;
-      }>(selectSystemEntityTypeIds({ systemTypeName: params.systemTypeName }));
-
-      entityTypeId = entity_type_id ?? "";
-    }
-
-    if (!entityTypeId) {
-      throw new Error(
-        `Did not receive valid entityTypeId or systemTypeName for fetching outgoing entity ids for entity by entityTypeId. entityTypeId = '${params.entityTypeId}' systemTypeName = '${params.systemTypeName}'`,
-      );
-    }
-
-    const queryParams = {
-      entityTypeId,
-      accountId: params.accountId,
-    };
-
-    return await getEntitiesByTypeWithOutgoingEntityIds(this.conn, queryParams);
-  }
-
-  async getEntityWithOutgoingEntityIds(
-    params: Parameters<DBClient["getEntityWithOutgoingEntityIds"]>[0],
-  ): ReturnType<DBClient["getEntityWithOutgoingEntityIds"]> {
-    return getEntityWithOutgoingEntityIds(this.conn, params);
   }
 
   /** Get all entities of a given type in a given account. */

--- a/packages/hash/api/src/db/postgres/index.ts
+++ b/packages/hash/api/src/db/postgres/index.ts
@@ -215,22 +215,6 @@ export class PostgresAdapter extends DataSource implements DBAdapter {
     return this.query((adapter) => adapter.getEntitiesBySystemType(params));
   }
 
-  getEntitiesByTypeWithOutgoingEntityIds(
-    params: Parameters<DBClient["getEntitiesByTypeWithOutgoingEntityIds"]>[0],
-  ): ReturnType<DBClient["getEntitiesByTypeWithOutgoingEntityIds"]> {
-    return this.query((adapter) =>
-      adapter.getEntitiesByTypeWithOutgoingEntityIds(params),
-    );
-  }
-
-  getEntityWithOutgoingEntityIds(
-    params: Parameters<DBClient["getEntityWithOutgoingEntityIds"]>[0],
-  ): ReturnType<DBClient["getEntityWithOutgoingEntityIds"]> {
-    return this.query((adapter) =>
-      adapter.getEntityWithOutgoingEntityIds(params),
-    );
-  }
-
   accountExists(params: { accountId: string }): Promise<boolean> {
     return this.query((adapter) => adapter.accountExists(params));
   }

--- a/packages/hash/api/src/db/postgres/link/getEntityOutgoingLinks.ts
+++ b/packages/hash/api/src/db/postgres/link/getEntityOutgoingLinks.ts
@@ -4,12 +4,7 @@ import {
   TaggedTemplateLiteralInvocationType,
 } from "slonik";
 import { EntityWithOutgoingEntityIds } from "../../adapter";
-import {
-  EntityPGRow,
-  mapPGRowToEntity,
-  selectEntities,
-  selectEntitiesByType,
-} from "../entity";
+import { EntityPGRow, mapPGRowToEntity, selectEntities } from "../entity";
 
 import { Connection } from "../types";
 import { mapColumnNamesToSQL } from "../util";
@@ -77,26 +72,6 @@ const entitiesOutgoingLinksQuery = (
     select * from distinct_entitites as a
     left join lateral (${outgoingLinkAggregationQuery}) as l on true
   `;
-
-/**
- * Get the latest version of all entities of a given type and their outgoing link ids with a matching entity type.
- * @param params.entityTypeId the entity type id to return entities of
- * @param params.entityTypeVersionId optionally limit to entities of a specific version of a type
- * @param params.accountId the account to retrieve entities from
- */
-export const getEntitiesByTypeWithOutgoingEntityIds = async (
-  conn: Connection,
-  params: {
-    entityTypeId: string;
-    entityTypeVersionId?: string;
-    accountId: string;
-  },
-): Promise<EntityWithOutgoingEntityIds[]> => {
-  const rows = await conn.any<EntityWithOutgoingEntityIdsPGRow>(
-    entitiesOutgoingLinksQuery(selectEntitiesByType(params)),
-  );
-  return rows.map(mapEntityWithOutgoingEntityIdsPGRowToEntity);
-};
 
 /**
  * Get the latest version of a given entity and all outgoing link ids with a matching entity type.

--- a/packages/hash/api/src/graphql/resolvers/pages/accountPages.ts
+++ b/packages/hash/api/src/graphql/resolvers/pages/accountPages.ts
@@ -1,36 +1,16 @@
-import {
-  PageStructure,
-  QueryAccountPagesArgs,
-  Resolver,
-} from "../../apiTypes.gen";
+import { QueryAccountPagesArgs, Resolver } from "../../apiTypes.gen";
 import { GraphQLContext } from "../../context";
-import { Entity, Page, UnresolvedGQLEntity } from "../../../model";
+import { Page, UnresolvedGQLEntity } from "../../../model";
 
 export const accountPages: Resolver<
   Promise<UnresolvedGQLEntity[]>,
   {},
   GraphQLContext,
   QueryAccountPagesArgs
-> = async (_, { accountId, structure }, { dataSources }) => {
-  let pages: UnresolvedGQLEntity[] = [];
-  if (structure === PageStructure.Flat) {
-    pages = (
-      await Entity.getEntitiesBySystemType(dataSources.db, {
-        accountId,
-        systemTypeName: "Page",
-        latestOnly: true,
-      })
-    ).map((page) => page.toGQLUnknownEntity());
-  } else if (structure === PageStructure.Tree) {
-    pages = (
-      await Page.getAccountPagesWithParents(dataSources.db, {
-        accountId,
-        systemTypeName: "Page",
-      })
-    ).map((page) => ({
-      ...page.toGQLUnknownEntity(),
-      parentPageId: page.parentEntityId,
-    }));
-  }
-  return pages;
+> = async (_, { accountId }, { dataSources }) => {
+  const pages = await Page.getAllPagesInAccount(dataSources.db, {
+    accountId,
+  });
+
+  return pages.map((page) => page.toGQLUnknownEntity());
 };

--- a/packages/hash/api/src/graphql/resolvers/pages/setParentPage.ts
+++ b/packages/hash/api/src/graphql/resolvers/pages/setParentPage.ts
@@ -10,37 +10,37 @@ export const setParentPage: Resolver<
   MutationSetParentPageArgs
 > = async (
   _,
-  { accountId, pageId, parentPageId },
+  { accountId, pageEntityId, parentPageEntityId },
   { dataSources: { db }, user },
 ) => {
-  if (pageId === parentPageId) {
+  if (pageEntityId === parentPageEntityId) {
     throw new ApolloError("A page cannot be the parent of itself");
   }
 
   return await db.transaction(async (client) => {
     const pageEntity = await Page.getPageById(client, {
       accountId,
-      entityId: pageId,
+      entityId: pageEntityId,
     });
 
     if (!pageEntity) {
       throw new ApolloError(
-        `Could not find page entity with entityId = ${pageId} on account with id = ${accountId}.`,
+        `Could not find page entity with entityId = ${pageEntityId} on account with id = ${accountId}.`,
         "NOT_FOUND",
       );
     }
 
     let parentPage: Page | null = null;
 
-    if (parentPageId) {
+    if (parentPageEntityId) {
       parentPage = await Page.getPageById(client, {
         accountId,
-        entityId: parentPageId,
+        entityId: parentPageEntityId,
       });
 
       if (!parentPage) {
         throw new ApolloError(
-          `Could not find parent page entity with entityId = ${parentPageId} on account with id = ${accountId}.`,
+          `Could not find parent page entity with entityId = ${parentPageEntityId} on account with id = ${accountId}.`,
           "NOT_FOUND",
         );
       }

--- a/packages/hash/api/src/graphql/resolvers/pages/setParentPage.ts
+++ b/packages/hash/api/src/graphql/resolvers/pages/setParentPage.ts
@@ -1,83 +1,7 @@
 import { ApolloError } from "apollo-server-express";
 import { MutationSetParentPageArgs, Resolver } from "../../apiTypes.gen";
 import { LoggedInGraphQLContext } from "../../context";
-import { DBClient } from "../../../db";
-import { Entity, Page, UnresolvedGQLEntity, User } from "../../../model";
-import { topologicalSort } from "../../../util";
-
-async function deleteParentPage(
-  client: DBClient,
-  user: User,
-  pageEntity: Page,
-): Promise<void> {
-  if (pageEntity.parentEntityId) {
-    const link = await pageEntity.getOutgoingLinkByEntityId(client, {
-      destinationEntityId: pageEntity.parentEntityId,
-    });
-
-    if (!link) {
-      throw new Error(
-        `Could not find existing link to parent page = '${pageEntity.parentEntityId}'.`,
-      );
-    }
-
-    await pageEntity.deleteOutgoingLink(client, {
-      linkId: link.linkId,
-      deletedByAccountId: user.accountId,
-    });
-  }
-}
-
-async function replaceParentPage(
-  client: DBClient,
-  user: User,
-  accountId: string,
-  pageEntity: Page,
-  parentPageId: string,
-): Promise<void> {
-  const parentPageEntity = await Entity.getEntityLatestVersion(client, {
-    accountId,
-    entityId: parentPageId,
-  });
-
-  if (!parentPageEntity) {
-    throw new ApolloError(
-      `Could not find (parent) page entity with entityId = ${parentPageId}  on account with id = ${accountId}.`,
-      "NOT_FOUND",
-    );
-  }
-
-  const pages = await Page.getAccountPagesWithParents(client, {
-    accountId,
-    systemTypeName: "Page",
-  });
-
-  const pageId = pageEntity.entityId;
-
-  // Check for cyclic dependencies.
-  try {
-    const directedPages = pages
-      .filter((page) => page.parentEntityId != null)
-      .map((page) => [page.entityId, page.parentEntityId] as [string, string]);
-    // add the new parent relation to the existing relations
-    directedPages.push([pageId, parentPageId]);
-    topologicalSort(directedPages);
-  } catch (_error) {
-    throw new ApolloError(
-      `Could not set '${parentPageId}' as parent to '${pageId}' as this would create a cyclic dependency.`,
-      "CYCLIC_TREE",
-    );
-  }
-
-  await deleteParentPage(client, user, pageEntity);
-
-  // @todo: lock entity to prevent potential race-condition when updating entity's properties
-  await pageEntity.createOutgoingLink(client, {
-    createdByAccountId: user.accountId,
-    stringifiedPath: "$.parent",
-    destination: parentPageEntity,
-  });
-}
+import { Page, UnresolvedGQLEntity } from "../../../model";
 
 export const setParentPage: Resolver<
   Promise<UnresolvedGQLEntity>,
@@ -89,8 +13,12 @@ export const setParentPage: Resolver<
   { accountId, pageId, parentPageId },
   { dataSources: { db }, user },
 ) => {
+  if (pageId === parentPageId) {
+    throw new ApolloError("A page cannot be the parent of itself");
+  }
+
   return await db.transaction(async (client) => {
-    const pageEntity = await Page.getAccountPageWithParents(client, {
+    const pageEntity = await Page.getPageById(client, {
       accountId,
       entityId: pageId,
     });
@@ -101,21 +29,28 @@ export const setParentPage: Resolver<
         "NOT_FOUND",
       );
     }
-    // Either replace a parent page link, or delete it depending on whether or not `parentPageId` is set.
+
+    let parentPage: Page | null = null;
+
     if (parentPageId) {
-      await replaceParentPage(db, user, accountId, pageEntity, parentPageId);
-    } else {
-      await deleteParentPage(db, user, pageEntity);
+      parentPage = await Page.getPageById(client, {
+        accountId,
+        entityId: parentPageId,
+      });
+
+      if (!parentPage) {
+        throw new ApolloError(
+          `Could not find parent page entity with entityId = ${parentPageId} on account with id = ${accountId}.`,
+          "NOT_FOUND",
+        );
+      }
     }
 
-    // @todo: allow to refetch account page with parents
-    // Refetched page exists here, but it could fail (return null) if the entity were to be removed before this point.
-    // A Page model method to refetch would be ideal here.
-    const refetchedPage = await Page.getAccountPageWithParents(client, {
-      accountId,
-      entityId: pageId,
+    await pageEntity.setParentPage(client, {
+      parentPage,
+      setByAccountId: user.accountId,
     });
 
-    return refetchedPage!.toGQLPageEntity();
+    return pageEntity.toGQLUnknownEntity();
   });
 };

--- a/packages/hash/api/src/graphql/resolvers/pages/setParentPage.ts
+++ b/packages/hash/api/src/graphql/resolvers/pages/setParentPage.ts
@@ -1,87 +1,121 @@
 import { ApolloError } from "apollo-server-express";
 import { MutationSetParentPageArgs, Resolver } from "../../apiTypes.gen";
 import { LoggedInGraphQLContext } from "../../context";
-import { Entity, Page, UnresolvedGQLEntity } from "../../../model";
+import { DBClient } from "../../../db";
+import { Entity, Page, UnresolvedGQLEntity, User } from "../../../model";
 import { topologicalSort } from "../../../util";
+
+async function deleteParentPage(
+  client: DBClient,
+  user: User,
+  pageEntity: Page,
+): Promise<void> {
+  if (pageEntity.parentEntityId) {
+    const link = await pageEntity.getOutgoingLinkByEntityId(client, {
+      destinationEntityId: pageEntity.parentEntityId,
+    });
+
+    if (!link) {
+      throw new Error(
+        `Could not find existing link to parent page = '${pageEntity.parentEntityId}'.`,
+      );
+    }
+
+    await pageEntity.deleteOutgoingLink(client, {
+      linkId: link.linkId,
+      deletedByAccountId: user.accountId,
+    });
+  }
+}
+
+async function replaceParentPage(
+  client: DBClient,
+  user: User,
+  accountId: string,
+  pageEntity: Page,
+  parentPageId: string,
+): Promise<void> {
+  const parentPageEntity = await Entity.getEntityLatestVersion(client, {
+    accountId,
+    entityId: parentPageId,
+  });
+
+  if (!parentPageEntity) {
+    throw new ApolloError(
+      `Could not find (parent) page entity with entityId = ${parentPageId}  on account with id = ${accountId}.`,
+      "NOT_FOUND",
+    );
+  }
+
+  const pages = await Page.getAccountPagesWithParents(client, {
+    accountId,
+    systemTypeName: "Page",
+  });
+
+  const pageId = pageEntity.entityId;
+
+  // Check for cyclic dependencies.
+  try {
+    const directedPages = pages
+      .filter((page) => page.parentEntityId != null)
+      .map((page) => [page.entityId, page.parentEntityId] as [string, string]);
+    // add the new parent relation to the existing relations
+    directedPages.push([pageId, parentPageId]);
+    topologicalSort(directedPages);
+  } catch (_error) {
+    throw new ApolloError(
+      `Could not set '${parentPageId}' as parent to '${pageId}' as this would create a cyclic dependency.`,
+      "CYCLIC_TREE",
+    );
+  }
+
+  await deleteParentPage(client, user, pageEntity);
+
+  // @todo: lock entity to prevent potential race-condition when updating entity's properties
+  await pageEntity.createOutgoingLink(client, {
+    createdByAccountId: user.accountId,
+    stringifiedPath: "$.parent",
+    destination: parentPageEntity,
+  });
+}
 
 export const setParentPage: Resolver<
   Promise<UnresolvedGQLEntity>,
   {},
   LoggedInGraphQLContext,
   MutationSetParentPageArgs
-> = async (_, { accountId, pageId, parentPageId }, { dataSources, user }) => {
-  return await dataSources.db.transaction(async (client) => {
-    const [pageEntity, parentPageEntity] = await Promise.all([
-      Page.getAccountPageWithParents(client, {
-        accountId,
-        entityId: pageId,
-      }),
+> = async (
+  _,
+  { accountId, pageId, parentPageId },
+  { dataSources: { db }, user },
+) => {
+  return await db.transaction(async (client) => {
+    const pageEntity = await Page.getAccountPageWithParents(client, {
+      accountId,
+      entityId: pageId,
+    });
 
-      Entity.getEntityLatestVersion(client, {
-        accountId,
-        entityId: parentPageId,
-      }),
-    ]);
-
-    if (!pageEntity || !parentPageEntity) {
-      const notFoundId = pageEntity?.entityId
-        ? `'${parentPageId}'`
-        : `'${pageId}'${
-            parentPageEntity?.entityId
-              ? ""
-              : ` nor parent page with entityId = '${parentPageId}'`
-          }`;
+    if (!pageEntity) {
       throw new ApolloError(
-        `Could not find entity with entityId = ${notFoundId}.`,
+        `Could not find page entity with entityId = ${pageId} on account with id = ${accountId}.`,
         "NOT_FOUND",
       );
     }
+    // Either replace a parent page link, or delete it depending on whether or not `parentPageId` is set.
+    if (parentPageId) {
+      await replaceParentPage(db, user, accountId, pageEntity, parentPageId);
+    } else {
+      await deleteParentPage(db, user, pageEntity);
+    }
 
-    const pages = await Page.getAccountPagesWithParents(dataSources.db, {
+    // @todo: allow to refetch account page with parents
+    // Refetched page exists here, but it could fail (return null) if the entity were to be removed before this point.
+    // A Page model method to refetch would be ideal here.
+    const refetchedPage = await Page.getAccountPageWithParents(client, {
       accountId,
-      systemTypeName: "Page",
+      entityId: pageId,
     });
 
-    // Check for cyclic dependencies.
-    try {
-      const directedPages = pages
-        .filter((page) => page.parentEntityId != null)
-        .map(
-          (page) => [page.entityId, page.parentEntityId] as [string, string],
-        );
-      // add the new parent relation to the existing relations
-      directedPages.push([pageId, parentPageId]);
-      topologicalSort(directedPages);
-    } catch (_error) {
-      throw new ApolloError(
-        `Could not set '${parentPageId}' as parent to '${pageId}' as this would create a cyclic dependency.`,
-        "CYCLIC_TREE",
-      );
-    }
-
-    if (pageEntity.parentEntityId) {
-      const link = await pageEntity.getOutgoingLinkByEntityId(client, {
-        destinationEntityId: pageEntity.parentEntityId,
-      });
-      if (!link) {
-        throw new Error(
-          `Could not find existing link to parent page = '${pageEntity.parentEntityId}'.`,
-        );
-      }
-
-      await pageEntity.deleteOutgoingLink(client, {
-        linkId: link.linkId,
-        deletedByAccountId: user.accountId,
-      });
-    }
-
-    // @todo: lock entity to prevent potential race-condition when updating entity's properties
-    await pageEntity.createOutgoingLink(client, {
-      createdByAccountId: user.accountId,
-      stringifiedPath: "$.parent",
-      destination: parentPageEntity,
-    });
-
-    return pageEntity.toGQLUnknownEntity();
+    return refetchedPage!.toGQLPageEntity();
   });
 };

--- a/packages/hash/api/src/graphql/typeDefs/page.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/page.typedef.ts
@@ -131,11 +131,6 @@ export const pageTypedef = gql`
     content: String!
   }
 
-  enum PageStructure {
-    Flat
-    Tree
-  }
-
   extend type Query {
     """
     Return a page by its id
@@ -145,7 +140,7 @@ export const pageTypedef = gql`
     """
     Return a list of pages belonging to an account
     """
-    accountPages(accountId: ID!, structure: PageStructure = Flat): [Page!]!
+    accountPages(accountId: ID!): [Page!]!
 
     """
     Search for pages matching a query string.

--- a/packages/hash/api/src/graphql/typeDefs/page.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/page.typedef.ts
@@ -83,9 +83,15 @@ export const pageTypedef = gql`
     # ENTITY INTERFACE FIELDS END #
 
     """
-    The id of the page's parent. Used for nesting pages in a tree structure.
+    The entity id of the page's parent (equivalent to "parentPage.entityId").
+
+    Can be used for nesting pages in a tree structure.
     """
-    parentPageId: ID
+    parentPageEntityId: ID
+    """
+    The parent page of the page
+    """
+    parentPage: Page
   }
 
   type PageProperties {
@@ -256,9 +262,13 @@ export const pageTypedef = gql`
     """
     Set the parent of a page
 
-    If the parentPageId is not set, any existing page link is removed.
+    If the parentPageEntityId is not set, any existing page link is removed.
     """
-    setParentPage(accountId: ID!, pageId: ID!, parentPageId: ID): Page!
+    setParentPage(
+      accountId: ID!
+      pageEntityId: ID!
+      parentPageEntityId: ID
+    ): Page!
 
     """
     Atomically update the contents of a page.

--- a/packages/hash/api/src/graphql/typeDefs/page.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/page.typedef.ts
@@ -258,7 +258,12 @@ export const pageTypedef = gql`
       properties: PageUpdateData!
     ): Page!
 
-    setParentPage(accountId: ID!, pageId: ID!, parentPageId: ID!): Page!
+    """
+    Set the parent of a page
+
+    If the parentPageId is not set, any existing page link is removed.
+    """
+    setParentPage(accountId: ID!, pageId: ID!, parentPageId: ID): Page!
 
     """
     Atomically update the contents of a page.

--- a/packages/hash/api/src/model/page.model.ts
+++ b/packages/hash/api/src/model/page.model.ts
@@ -191,7 +191,7 @@ class __Page extends Entity {
 
   async getParentPage(client: DBClient): Promise<Page | null> {
     const parentPageLinks = await this.getOutgoingLinks(client, {
-      path: ["parent"],
+      path: ["parentPage"],
     });
 
     if (parentPageLinks.length > 1) {
@@ -241,7 +241,7 @@ class __Page extends Entity {
     },
   ): Promise<void> {
     const parentPageLinks = await this.getOutgoingLinks(client, {
-      path: ["parent"],
+      path: ["parentPage"],
     });
 
     if (parentPageLinks.length > 1) {
@@ -294,7 +294,7 @@ class __Page extends Entity {
 
       await this.createOutgoingLink(client, {
         createdByAccountId: setByAccountId,
-        stringifiedPath: "$.parent",
+        stringifiedPath: "$.parentPage",
         destination: parentPage,
       });
     }

--- a/packages/hash/api/src/model/page.model.ts
+++ b/packages/hash/api/src/model/page.model.ts
@@ -21,10 +21,7 @@ import {
   LinkedEntityDefinition,
 } from "../graphql/apiTypes.gen";
 
-export type PageExternalResolvers =
-  | EntityExternalResolvers
-  | "contents" // contents resolved in `src/graphql/resolvers/pages/linkedEntities.ts`
-  | "properties"; // properties.contents is deprecated, and resolved seperately.
+export type PageExternalResolvers = EntityExternalResolvers | "contents"; // contents resolved in `src/graphql/resolvers/pages/linkedEntities.ts`
 
 export type UnresolvedGQLPage = Omit<GQLPage, PageExternalResolvers> & {
   entityType: UnresolvedGQLEntityType;

--- a/packages/hash/api/src/model/page.model.ts
+++ b/packages/hash/api/src/model/page.model.ts
@@ -287,7 +287,7 @@ class __Page extends Entity {
       /** Check whether adding the parent page would create a cycle */
       if (await parentPage.hasParentPage(client, { page: this })) {
         throw new ApolloError(
-          `Could not set '${parentPage.entityId}' to '${this.entityId}' as this would create a cyclic dependency.`,
+          `Could not set '${parentPage.entityId}' as parent of '${this.entityId}', this would create a cyclic dependency.`,
           "CYCLIC_TREE",
         );
       }

--- a/packages/hash/integration/src/graphql/queries/page.queries.ts
+++ b/packages/hash/integration/src/graphql/queries/page.queries.ts
@@ -148,7 +148,7 @@ export const getAccountPagesTree = gql`
       properties {
         title
       }
-      parentPageId
+      parentPageEntityId
     }
   }
 `;
@@ -171,11 +171,15 @@ export const updatePageContents = gql`
 `;
 
 export const setPageParent = gql`
-  mutation setParentPage($accountId: ID!, $pageId: ID!, $parentPageId: ID) {
+  mutation setParentPage(
+    $accountId: ID!
+    $pageEntityId: ID!
+    $parentPageEntityId: ID
+  ) {
     setParentPage(
       accountId: $accountId
-      pageId: $pageId
-      parentPageId: $parentPageId
+      pageEntityId: $pageEntityId
+      parentPageEntityId: $parentPageEntityId
     ) {
       entityId
       properties {

--- a/packages/hash/integration/src/graphql/queries/page.queries.ts
+++ b/packages/hash/integration/src/graphql/queries/page.queries.ts
@@ -143,7 +143,7 @@ export const getPage = gql`
 
 export const getAccountPagesTree = gql`
   query getAccountPagesTree($accountId: ID!) {
-    accountPages(accountId: $accountId, structure: Tree) {
+    accountPages(accountId: $accountId) {
       entityId
       properties {
         title

--- a/packages/hash/integration/src/graphql/queries/page.queries.ts
+++ b/packages/hash/integration/src/graphql/queries/page.queries.ts
@@ -171,7 +171,7 @@ export const updatePageContents = gql`
 `;
 
 export const setPageParent = gql`
-  mutation setParentPage($accountId: ID!, $pageId: ID!, $parentPageId: ID!) {
+  mutation setParentPage($accountId: ID!, $pageId: ID!, $parentPageId: ID) {
     setParentPage(
       accountId: $accountId
       pageId: $pageId

--- a/packages/hash/integration/src/tests/integration.test.ts
+++ b/packages/hash/integration/src/tests/integration.test.ts
@@ -1374,8 +1374,8 @@ describe("logged in user ", () => {
 
       const result = await client.setParentPage({
         accountId: existingUser.accountId,
-        pageId: subPage.entityId,
-        parentPageId: superPage.entityId,
+        pageEntityId: subPage.entityId,
+        parentPageEntityId: superPage.entityId,
       });
 
       const pageTree = await client.getAccountPagesTree({
@@ -1386,7 +1386,7 @@ describe("logged in user ", () => {
       expect(pageTree).toContainEqual({
         entityId: subPage.entityId,
         properties: { title },
-        parentPageId: superPage.entityId,
+        parentPageEntityId: superPage.entityId,
       });
     });
 
@@ -1405,8 +1405,8 @@ describe("logged in user ", () => {
 
       const result = await client.setParentPage({
         accountId: existingUser.accountId,
-        pageId: subSubPage.entityId,
-        parentPageId: subPage.entityId,
+        pageEntityId: subSubPage.entityId,
+        parentPageEntityId: subPage.entityId,
       });
 
       const pageTree = await client.getAccountPagesTree({
@@ -1417,7 +1417,7 @@ describe("logged in user ", () => {
       expect(pageTree).toContainEqual({
         entityId: subSubPage.entityId,
         properties: { title },
-        parentPageId: subPage.entityId,
+        parentPageEntityId: subPage.entityId,
       });
     });
 
@@ -1429,8 +1429,8 @@ describe("logged in user ", () => {
       await expect(
         client.setParentPage({
           accountId: existingUser.accountId,
-          pageId: superPage.entityId,
-          parentPageId: subSubPage.entityId,
+          pageEntityId: superPage.entityId,
+          parentPageEntityId: subSubPage.entityId,
         }),
       ).rejects.toThrowError(
         /Could not set '.*' as parent to '.*' as this would create a cyclic dependency./i,
@@ -1445,8 +1445,8 @@ describe("logged in user ", () => {
       await expect(
         client.setParentPage({
           accountId: existingUser.accountId,
-          pageId: subPage.entityId,
-          parentPageId: subSubPage.entityId,
+          pageEntityId: subPage.entityId,
+          parentPageEntityId: subSubPage.entityId,
         }),
       ).rejects.toThrowError(
         /Could not set '.*' as parent to '.*' as this would create a cyclic dependency./i,
@@ -1456,7 +1456,7 @@ describe("logged in user ", () => {
     it("can reconstruct a tree based on the resulting pages", async () => {
       type TreeElement = {
         entityId: string;
-        parentPageId: string;
+        parentPageEntityId: string;
         properties: {
           title: string;
         };
@@ -1472,22 +1472,22 @@ describe("logged in user ", () => {
       const treePages = treeFromParentReferences(
         pages,
         "entityId",
-        "parentPageId",
+        "parentPageEntityId",
         "children",
       );
 
       expect(treePages).toContainEqual({
-        parentPageId: undefined,
+        parentPageEntityId: undefined,
         entityId: superPage.entityId,
         properties: { title: superTitle },
         children: [
           {
-            parentPageId: superPage.entityId,
+            parentPageEntityId: superPage.entityId,
             entityId: subPage.entityId,
             properties: { title: subPage.properties.title },
             children: [
               {
-                parentPageId: subPage.entityId,
+                parentPageEntityId: subPage.entityId,
                 entityId: subSubPage.entityId,
                 properties: { title: subSubPage.properties.title },
                 children: undefined,
@@ -1506,8 +1506,8 @@ describe("logged in user ", () => {
 
       const result = await client.setParentPage({
         accountId: existingUser.accountId,
-        pageId: subSubPage.entityId,
-        parentPageId: superPage.entityId,
+        pageEntityId: subSubPage.entityId,
+        parentPageEntityId: superPage.entityId,
       });
 
       const pageTree = await client.getAccountPagesTree({
@@ -1518,7 +1518,7 @@ describe("logged in user ", () => {
       expect(pageTree).toContainEqual({
         entityId: subSubPage.entityId,
         properties: { title },
-        parentPageId: superPage.entityId,
+        parentPageEntityId: superPage.entityId,
       });
     });
 
@@ -1530,8 +1530,8 @@ describe("logged in user ", () => {
 
       const result = await client.setParentPage({
         accountId: existingUser.accountId,
-        pageId: subSubPage.entityId,
-        parentPageId: null,
+        pageEntityId: subSubPage.entityId,
+        parentPageEntityId: null,
       });
 
       const pageTree = await client.getAccountPagesTree({
@@ -1542,7 +1542,7 @@ describe("logged in user ", () => {
       expect(pageTree).toContainEqual({
         entityId: subSubPage.entityId,
         properties: { title },
-        parentPageId: null,
+        parentPageEntityId: null,
       });
     });
   });

--- a/packages/hash/integration/src/tests/integration.test.ts
+++ b/packages/hash/integration/src/tests/integration.test.ts
@@ -1521,6 +1521,30 @@ describe("logged in user ", () => {
         parentPageId: superPage.entityId,
       });
     });
+
+    it("Allow removing parents", async () => {
+      // - Super page 1
+      //   - sub page 1
+      // - sub sub page 1 <- changed to be a top-level page
+      const title = "sub sub page 1";
+
+      const result = await client.setParentPage({
+        accountId: existingUser.accountId,
+        pageId: subSubPage.entityId,
+        parentPageId: null,
+      });
+
+      const pageTree = await client.getAccountPagesTree({
+        accountId: existingUser.accountId,
+      });
+
+      expect(result.entityId).toEqual(subSubPage.entityId);
+      expect(pageTree).toContainEqual({
+        entityId: subSubPage.entityId,
+        properties: { title },
+        parentPageId: null,
+      });
+    });
   });
 
   it("can only create 5 login codes before being rate limited", async () => {

--- a/packages/hash/integration/src/tests/integration.test.ts
+++ b/packages/hash/integration/src/tests/integration.test.ts
@@ -1433,7 +1433,7 @@ describe("logged in user ", () => {
           parentPageEntityId: subSubPage.entityId,
         }),
       ).rejects.toThrowError(
-        /Could not set '.*' as parent to '.*' as this would create a cyclic dependency./i,
+        /Could not set '.*' as parent of '.*', this would create a cyclic dependency./i,
       );
     });
 
@@ -1449,7 +1449,7 @@ describe("logged in user ", () => {
           parentPageEntityId: subSubPage.entityId,
         }),
       ).rejects.toThrowError(
-        /Could not set '.*' as parent to '.*' as this would create a cyclic dependency./i,
+        /Could not set '.*' as parent of '.*', this would create a cyclic dependency./i,
       );
     });
 
@@ -1544,6 +1544,19 @@ describe("logged in user ", () => {
         properties: { title },
         parentPageEntityId: null,
       });
+    });
+
+    it("Allow changing parent to itself", async () => {
+      // - Super page 1 <- try to set this as its own parent
+      //   - sub page 1
+      //   - sub sub page 1
+      await expect(
+        client.setParentPage({
+          accountId: existingUser.accountId,
+          pageEntityId: superPage.entityId,
+          parentPageEntityId: superPage.entityId,
+        }),
+      ).rejects.toThrowError(/A page cannot be the parent of itself/i);
     });
   });
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
This PR is a follow up to #230, which is also useful for implementing the sidebar design that @teenoh is implementing.
Instead of deleting links manually to remove a parent page, this change allows API users to set the `parentPageId` to `null` in order to specify that a page should have no parent - deleting any existing parent page link.

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->


## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Use the APIs in the new sidebar

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

- GQL documentation of the mutaiton (done)

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as (_internal_) -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201837296904616/1201906825107761/f) (_internal_)

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- Integration tests

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Follow test procedure of #230 and use `null`  as a `parentPageId`

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
