### PR TITLE
Fix memory issues with new arrow version

### DIFF
--- a/packages/engine/src/worker/runner/javascript/mod.rs
+++ b/packages/engine/src/worker/runner/javascript/mod.rs
@@ -2,16 +2,14 @@ mod error;
 mod mini_v8;
 
 use std::{
-    collections::HashMap, fs, future::Future, pin::Pin, result::Result as StdResult, slice,
-    sync::Arc,
+    collections::HashMap, fs, future::Future, pin::Pin, result::Result as StdResult, sync::Arc,
 };
 
 use arrow::{
-    array::{ArrayData, BooleanBufferBuilder},
-    buffer::Buffer,
-    datatypes::{DataType, Field, Schema},
+    array::ArrayData,
+    buffer::{Buffer, MutableBuffer},
+    datatypes::{DataType, Schema},
     ipc::writer::{IpcDataGenerator, IpcWriteOptions},
-    util::bit_util,
 };
 use futures::FutureExt;
 use mv8::MiniV8;
@@ -559,174 +557,167 @@ impl<'m> RunnerImpl<'m> {
         })
     }
 
+    unsafe fn new_buffer(&self, ptr: *const u8, len: usize, _capacity: usize) -> Buffer {
+        let s = std::slice::from_raw_parts(ptr, len);
+        s.into()
+    }
+
     /// TODO: DOC, flushing from a single column
     fn array_data_from_js(
         &mut self,
         mv8: &'m MiniV8,
         data: &mv8::Value<'m>,
-        field: &Field,
+        dt: &DataType,
         len: Option<usize>,
     ) -> Result<ArrayData> {
         // `data` must not be dropped until flush is over, because
         // pointers returned from FFI point inside `data`'s ArrayBuffers' memory.
-        let obj = data.as_object().ok_or_else(|| {
-            Error::Embedded(format!("Flush data not object for field {:?}", field))
-        })?;
+        let obj = data
+            .as_object()
+            .ok_or_else(|| Error::Embedded("Flush data not object".into()))?;
+        let child_data: mv8::Array<'_> = obj.get("child_data")?;
 
         // `data_node_from_js` isn't recursive -- doesn't convert children.
         let data: mv8::DataFfi = mv8.data_node_from_js(data);
 
-        // This target length is used because the JS repr does not mirror buffer building as Rust
-        // Arrow and pyarrow.
-        let target_len = len.unwrap_or(data.len);
-
-        // TODO: We currently copy the buffers by calling `Buffer::from_slice_ref` because the
-        //   JavaScript representation of arrays does not match the Rust implementation. Try to
-        //   reduce copies where possible.
-        let mut builder = ArrayData::builder(field.data_type().clone());
-
-        match field.data_type() {
-            DataType::Boolean => {
-                // SAFETY: `data.buffer_ptrs[0]` is provided by arrow, the type is `u8`, and
-                //   `target_len` is carefully chosen
-                let values = unsafe { slice::from_raw_parts(data.buffer_ptrs[0], target_len) };
-
-                // Booleans are packed in arrow, `values` are already packed, so use them directly
-                let mut boolean_builder = BooleanBufferBuilder::new(target_len);
-                boolean_builder.append_packed_range(0..target_len, values);
-
-                builder = builder.add_buffer(boolean_builder.finish());
-            }
-            DataType::UInt16 => {
-                // SAFETY: `data.buffer_ptrs[0]` is provided by arrow, the type is `u16`, and
-                //   `target_len` is carefully chosen
-                let values =
-                    unsafe { slice::from_raw_parts(data.buffer_ptrs[0] as *const u16, target_len) };
-
-                builder = builder.add_buffer(Buffer::from_slice_ref(&values));
-            }
-            DataType::UInt32 => {
-                // SAFETY: `data.buffer_ptrs[0]` is provided by arrow, the type is `u32`, and
-                //   `target_len` is carefully chosen
-                let values =
-                    unsafe { slice::from_raw_parts(data.buffer_ptrs[0] as *const u32, target_len) };
-
-                builder = builder.add_buffer(Buffer::from_slice_ref(&values));
-            }
-            DataType::Float64 => {
-                // SAFETY: `data.buffer_ptrs[0]` is provided by arrow, the type is `f64`, and
-                //   `target_len` is carefully chosen
-                let values =
-                    unsafe { slice::from_raw_parts(data.buffer_ptrs[0] as *const f64, target_len) };
-
-                builder = builder.add_buffer(Buffer::from_slice_ref(&values));
-            }
-            DataType::Utf8 => {
-                // Utf8 is stored in two buffers:
-                //   [0]: The offset buffer (i32)
-                //   [1]: The value buffer (u8)
-
-                // The offsets are in the first buffer. For each value in the second buffer, we have
-                // a start offset and an end offset. The start offset is equal to the end offset of
-                // the previous value, thus we need `num_values + 1` offset values.
-
-                // SAFETY: `data.buffer_ptrs[0]` is provided by arrow as offsets, the type is `i32`,
-                //   and `target_len + 1` is carefully chosen.
-                let offsets = unsafe {
-                    slice::from_raw_parts(data.buffer_ptrs[0] as *const i32, target_len + 1)
-                };
-                builder = builder.add_buffer(Buffer::from_slice_ref(&offsets));
-
-                // SAFETY: `data.buffer_ptrs[1]` is provided by arrow as values, the type is
-                //   `u8`, and the length is provided by the offsets
-                let values = unsafe {
-                    slice::from_raw_parts(data.buffer_ptrs[1], offsets[target_len] as usize)
-                };
-                builder = builder.add_buffer(Buffer::from_slice_ref(&values));
-            }
-            DataType::List(inner_field) => {
-                // List is stored in one buffer and child data containing the indexed values:
-                //   buffer: The offset buffer (i32)
-                //   child_data: The value data
-
-                // See `DataType::Utf8` above for reasoning on `target_len + 1`
-                // SAFETY: `data.buffer_ptrs[0]` is provided by arrow, the type is `i32`, and
-                //   `target_len + 1` is carefully chosen.
-                let offsets = unsafe {
-                    slice::from_raw_parts(data.buffer_ptrs[0] as *const i32, target_len + 1)
-                };
-                builder = builder.add_buffer(Buffer::from_slice_ref(&offsets));
-
-                let child_data: mv8::Array<'_> = obj.get("child_data")?;
-                let child = child_data.get(0)?;
-                builder = builder.add_child_data(self.array_data_from_js(
+        let n_children = child_data.len();
+        let child_data: Vec<ArrayData> = match dt.clone() {
+            DataType::List(t) => {
+                let child: mv8::Value<'_> = child_data.get(0)?;
+                Ok(vec![self.array_data_from_js(
                     mv8,
                     &child,
-                    inner_field,
+                    &t.data_type(),
                     None,
-                )?);
+                )?])
             }
-            DataType::FixedSizeList(inner_field, size) => {
-                // FixedSizeListList is only stored by child data, as offsets are not required
-                // because the size is known.
-                let child_data: mv8::Array<'_> = obj.get("child_data")?;
-                let child = child_data.get(0)?;
-                builder = builder.add_child_data(self.array_data_from_js(
+            DataType::FixedSizeList(t, multiplier) => {
+                let child: mv8::Value<'_> = child_data.get(0)?;
+                Ok(vec![self.array_data_from_js(
                     mv8,
                     &child,
-                    inner_field,
-                    Some(*size as usize * target_len),
-                )?);
+                    t.data_type(),
+                    Some(data.len * multiplier as usize),
+                )?])
             }
-            DataType::Struct(inner_fields) => {
-                // Structs are only defined by child data
-
-                let child_data: mv8::Array<'_> = obj.get("child_data")?;
-                for (i, inner_field) in inner_fields.iter().enumerate() {
+            DataType::Struct(fields) => {
+                let mut v = Vec::new();
+                for (i, field) in fields.iter().enumerate() {
                     let child = child_data.get(i as u32)?;
-                    builder = builder.add_child_data(self.array_data_from_js(
+                    v.push(self.array_data_from_js(
                         mv8,
                         &child,
-                        inner_field,
-                        Some(target_len),
+                        field.data_type(),
+                        Some(data.len),
                     )?);
                 }
+                Ok(v)
             }
-            DataType::FixedSizeBinary(size) => {
-                // FixedSizeBinary is only stored as a buffer (u8), offsets are not required because
-                // the size is known
+            t => {
+                if n_children == 0 {
+                    Ok(vec![])
+                } else {
+                    Err(Error::FlushType(t))
+                }
+            }
+        }?; // TODO: More types?
 
-                // SAFETY: `data.buffer_ptrs[0]` is provided by arrow, the type is `u8`, and
-                //   `*size as usize * target_len` corresponds for the `size` of *each* value.
-                let values = unsafe {
-                    slice::from_raw_parts(data.buffer_ptrs[0], *size as usize * target_len)
-                };
-                builder = builder.add_buffer(Buffer::from_slice_ref(&values));
-            }
-            data_type => return Err(Error::FlushType(data_type.clone())), // TODO: More types?
+        // TODO: Extra copies (in `new_buffer`) of buffers here,
+        //       because JS Arrow doesn't align things properly.
+        //       (Due to which buffer capacities are currently unused.)
+
+        // This target length is used because the JS repr does not mirror
+        // buffer building as Rust Arrow and pyarrow.
+        let target_len = len.unwrap_or(data.len);
+
+        let null_bit_buffer = if data.null_bits_ptr.is_null() {
+            None // Can't match on `std::ptr::null()`, because not compile-time const.
+        } else {
+            let capacity = data.null_bits_capacity;
+            // Ceil division.
+            let n_bytes = (target_len / 8) + (if target_len % 8 == 0 { 0 } else { 1 });
+            Some(unsafe { self.new_buffer(data.null_bits_ptr, n_bytes, capacity) })
+            // Some(unsafe { Buffer::from_unowned(data.null_bits_ptr, n_bytes, capacity) })
         };
 
-        builder = builder.len(target_len);
-        if !data.null_bits_ptr.is_null() {
-            // Create a validity map with the provided data, but reserve for `target_len` bits
-            let mut boolean_builder = BooleanBufferBuilder::new(target_len);
-            // Read bits from JS
-            let values =
-                unsafe { slice::from_raw_parts(data.null_bits_ptr, bit_util::ceil(data.len, 8)) };
-            boolean_builder.append_packed_range(0..data.len, values);
-            // Resize the validity map to match the size of the resulting array. This won't resize
-            // the underlying buffer because we reserved with `target_len`. `resize` sets all new
-            // bits to `0`
-            boolean_builder.resize(target_len);
+        let mut buffer_lens = Vec::with_capacity(2);
 
-            // The `data.null_count` provided is only valid for `data.len`, as the buffer is
-            // resized, the `null_count` has to be adjusted.
-            builder = builder
-                .null_bit_buffer(boolean_builder.finish())
-                .null_count(data.null_count + target_len - data.len);
+        match dt.clone() {
+            DataType::Float64 => {
+                buffer_lens.push(target_len * 8); // 8 bytes per f64
+                Ok(())
+            }
+            DataType::UInt32 => {
+                buffer_lens.push(target_len * 4); // 4 bytes per u32
+                Ok(())
+            }
+            DataType::UInt16 => {
+                buffer_lens.push(target_len * 2); // 2 bytes per u16
+                Ok(())
+            }
+            DataType::Utf8 => {
+                // TODO: Use `data.len` or target_len?
+                //       (In practice, target_len has worked for a long time,
+                //       though that's not an ideal reason to use it. Maybe
+                //       `data.len` would also work.)
+                let offsets = unsafe {
+                    std::slice::from_raw_parts(data.buffer_ptrs[0] as *const i32, target_len + 1)
+                };
+                debug_assert_eq!(offsets[0], 0);
+                let last = offsets[target_len];
+                // offsets
+                buffer_lens.push((target_len + 1) * 4);
+                buffer_lens.push(last as usize);
+                Ok(())
+            }
+            DataType::List(_) => {
+                // offsets
+                buffer_lens.push((target_len + 1) * 4);
+                Ok(())
+            } // Just offsets
+            DataType::Struct(_) => Ok(()), // No non-child buffers
+            DataType::FixedSizeList(..) => Ok(()),
+            DataType::FixedSizeBinary(sz) => {
+                buffer_lens.push(data.len * sz as usize);
+                Ok(())
+            } // Just values
+            DataType::Boolean => {
+                buffer_lens.push((data.len / 8) + (if data.len % 8 == 0 { 0 } else { 1 }));
+                Ok(())
+            } // Just values
+            t => Err(Error::FlushType(t)), // TODO: More types?
+        }?;
+
+        debug_assert_eq!(data.n_buffers, buffer_lens.len());
+        let mut buffers = Vec::new();
+        for (i, &len) in buffer_lens.iter().enumerate().take(data.n_buffers) {
+            let ptr = data.buffer_ptrs[i];
+            debug_assert_ne!(ptr, std::ptr::null());
+            let capacity = data.buffer_capacities[i];
+            let buffer = if len <= capacity {
+                unsafe { self.new_buffer(ptr, len, capacity) }
+            } else {
+                // This happens when we have fixed size buffers, but the inner nodes are null
+                let mut mut_buffer = MutableBuffer::new(len);
+                mut_buffer.resize(len, 0);
+                mut_buffer.into()
+            };
+            // let buffer = unsafe { Buffer::from_unowned(ptr, len, capacity) };
+            buffers.push(buffer);
         }
 
-        Ok(builder.build()?)
+        let data = unsafe {
+            ArrayData::new_unchecked(
+                dt.clone(),
+                len.unwrap_or(data.len),
+                Some(data.null_count),
+                null_bit_buffer,
+                0,
+                buffers,
+                child_data,
+            )
+        };
+        Ok(data)
     }
 
     fn flush_batch<B: DynamicBatch>(
@@ -744,7 +735,7 @@ impl<'m> RunnerImpl<'m> {
             let field = schema.field(i_field);
 
             let data: mv8::Value<'_> = change.get("data")?;
-            let data = self.array_data_from_js(mv8, &data, field, None)?;
+            let data = self.array_data_from_js(mv8, &data, field.data_type(), None)?;
             batch.push_change(ArrayChange {
                 array: data,
                 index: i_field,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Since we upgraded Arrow to version 9.1.0 in #362, we observed a higher memory consumption, especially with many agents.

## 🔍 What does this change?

- Reverts #342 
- Re-applies #360 
- A few drive-by improvements to make the code more readable

### 📜 Does this require a change to the docs?

No

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1199548034582004/1201908585432582/f) (_internal_)

## 🛡 What tests cover this?

The integration test suite

## ❓ How to test this?

Compare memory consumption with a long-running simulation with many agents before and after this PR