### PR TITLE
Remove redundant `getAggregation` pg utility method

### DIFF
--- a/packages/hash/api/src/db/errors.ts
+++ b/packages/hash/api/src/db/errors.ts
@@ -54,14 +54,34 @@ export class DbEntityTypeNotFoundError extends Error {
 }
 
 export class DbLinkNotFoundError extends Error {
-  accountId?: string;
+  sourceAccountId?: string;
   linkId: string;
 
-  constructor(params: { accountId?: string; linkId: string }) {
-    const { accountId, linkId } = params;
-    super(`Link ${linkId} not found in account ${accountId}`);
-    this.accountId = accountId;
+  constructor(params: { sourceAccountId?: string; linkId: string }) {
+    const { sourceAccountId, linkId } = params;
+    super(`Link ${linkId} not found in account ${sourceAccountId}`);
+    this.sourceAccountId = sourceAccountId;
     this.linkId = linkId;
+  }
+}
+
+export class DbAggregationNotFoundError extends Error {
+  sourceAccountId?: string;
+  sourceEntityId?: string;
+  path: string;
+
+  constructor(params: {
+    sourceAccountId?: string;
+    sourceEntityId?: string;
+    path: string;
+  }) {
+    const { sourceAccountId, sourceEntityId, path } = params;
+    super(
+      `Aggregation with path ${path} for source entity with id ${sourceEntityId} in account ${sourceAccountId} not found`,
+    );
+    this.sourceAccountId = sourceAccountId;
+    this.sourceEntityId = sourceEntityId;
+    this.path = path;
   }
 }
 

--- a/packages/hash/api/src/db/index.ts
+++ b/packages/hash/api/src/db/index.ts
@@ -1,8 +1,4 @@
 export type { DBAdapter, DBClient } from "./adapter";
 export { PostgresAdapter } from "./postgres";
 export { setupCronJobs } from "./cron";
-export {
-  DbInvalidLinksError,
-  DbEntityNotFoundError,
-  DbLinkNotFoundError,
-} from "./errors";
+export * from "./errors";

--- a/packages/hash/api/src/db/postgres/aggregation/updateAggregationOperation.ts
+++ b/packages/hash/api/src/db/postgres/aggregation/updateAggregationOperation.ts
@@ -5,13 +5,11 @@ import {
   updateVersionedEntity,
 } from "../entity";
 import { DbEntityNotFoundError } from "../..";
-import {
-  getAggregation,
-  insertAggregation,
-  updateAggregationRowOperation,
-} from "./util";
+import { insertAggregation, updateAggregationRowOperation } from "./util";
+import { getEntityAggregation } from "./getEntityAggregation";
 import { DBAggregation } from "../../adapter";
 import { requireTransaction } from "../util";
+import { DbAggregationNotFoundError } from "../../errors";
 
 export const updateAggregationOperation = (
   existingConnection: Connection,
@@ -27,11 +25,17 @@ export const updateAggregationOperation = (
 
     const now = new Date();
 
+    const dbAggregation = await getEntityAggregation(conn, params);
+
+    if (!dbAggregation) {
+      throw new DbAggregationNotFoundError(params);
+    }
+
     const {
       createdByAccountId,
       createdAt,
       sourceEntityVersionIds: prevSourceEntityVersionIds,
-    } = await getAggregation(conn, params);
+    } = dbAggregation;
 
     let sourceEntityVersionIds: Set<string> = prevSourceEntityVersionIds;
 

--- a/packages/hash/api/src/db/postgres/aggregation/util.ts
+++ b/packages/hash/api/src/db/postgres/aggregation/util.ts
@@ -68,27 +68,6 @@ export const insertAggregation = async (
 };
 
 /**
- * Get an aggregation from the aggregations table
- */
-export const getAggregation = async (
-  conn: Connection,
-  params: { sourceAccountId: string; sourceEntityId: string; path: string },
-): Promise<DBAggregation> => {
-  const row = await conn.one(sql<DBAggregationRow>`
-    select ${aggregationsColumnNamesSQL}
-    from aggregations
-    where
-      source_account_id = ${params.sourceAccountId}
-      and source_entity_id = ${params.sourceEntityId}
-      and path = ${params.path}
-    order by created_at desc  
-    limit 1
-  `);
-
-  return mapRowToDBAggregation(row);
-};
-
-/**
  * Update the operation of an aggregation.
  *
  * Note: this shouldn't be called on an aggregation where the source entity


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This task removes the `getAggregation` postgres utility method, as it implements the same functionality of the existing `getEntityAggregation` db adapter method (which can be used instead).

Note: This indirectly addresses [this task](https://app.asana.com/0/1201825402400452/1201820398013202/f)

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->


## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- removes `getAggregation` pg utility method
- adds `DbAggregationNotFoundError` error class, to be thrown when `getEntityAggregation` unexpectedly returns null

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

No

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as (_internal_) -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201825402400452/1201820398013202/f) (_internal_)

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- existing aggregation tests

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->


## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
