### PR TITLE
Fix selecting the type on table block when none is selected

### DIFF
--- a/packages/blocks/table/src/Table.tsx
+++ b/packages/blocks/table/src/Table.tsx
@@ -471,34 +471,15 @@ export const Table: BlockComponent<AppProps> = ({
 
   const handleEntityTypeChange = useCallback(
     (updatedEntityTypeId: string | undefined) => {
-      if (
-        !entityId ||
-        !updateEntities ||
-        !updateLinks ||
-        !matchingLinkedAggregation
-      ) {
+      if (!entityId || !updateLinks) {
         return;
       }
-
-      void updateEntities<{
-        initialState?: Record<string, any>;
-      }>([
-        {
-          accountId,
-          entityId,
-          data: {
-            initialState,
-          },
-          entityTypeId,
-          entityTypeVersionId,
-        },
-      ]);
 
       if (updatedEntityTypeId) {
         void updateLinks?.([
           cleanUpdateLinkedAggregationAction({
-            sourceAccountId: matchingLinkedAggregation.sourceAccountId,
-            sourceEntityId: matchingLinkedAggregation.sourceEntityId,
+            sourceAccountId: accountId,
+            sourceEntityId: entityId,
             path,
             updatedOperation: {
               entityTypeId: updatedEntityTypeId,
@@ -513,12 +494,7 @@ export const Table: BlockComponent<AppProps> = ({
     [
       accountId,
       entityId,
-      entityTypeId,
-      entityTypeVersionId,
-      initialState,
       tableData.linkedAggregation?.operation?.itemsPerPage,
-      matchingLinkedAggregation,
-      updateEntities,
       updateLinks,
     ],
   );

--- a/packages/blocks/table/src/Table.tsx
+++ b/packages/blocks/table/src/Table.tsx
@@ -118,6 +118,7 @@ export const Table: BlockComponent<AppProps> = ({
   accountId,
   aggregateEntities,
   aggregateEntityTypes,
+  createLinks,
   entityId,
   entityTypeId,
   entityTypeVersionId,
@@ -471,30 +472,46 @@ export const Table: BlockComponent<AppProps> = ({
 
   const handleEntityTypeChange = useCallback(
     (updatedEntityTypeId: string | undefined) => {
-      if (!entityId || !updateLinks) {
-        return;
+      if (!entityId || !updateLinks || !createLinks) {
+        throw new Error(
+          "All of entityId, createLinks and updateLinks must be passed to the block to update data linke from it",
+        );
       }
 
       if (updatedEntityTypeId) {
-        void updateLinks?.([
-          cleanUpdateLinkedAggregationAction({
-            sourceAccountId: accountId,
-            sourceEntityId: entityId,
-            path,
-            updatedOperation: {
-              entityTypeId: updatedEntityTypeId,
-              // There is scope to include other options if entity properties overlap
-              itemsPerPage:
-                tableData.linkedAggregation?.operation?.itemsPerPage,
+        if (tableData?.linkedAggregation) {
+          void updateLinks?.([
+            cleanUpdateLinkedAggregationAction({
+              sourceAccountId: accountId,
+              sourceEntityId: entityId,
+              path,
+              updatedOperation: {
+                entityTypeId: updatedEntityTypeId,
+                // There is scope to include other options if entity properties overlap
+                itemsPerPage:
+                  tableData.linkedAggregation?.operation?.itemsPerPage,
+              },
+            }),
+          ]);
+        } else {
+          void createLinks?.([
+            {
+              operation: {
+                entityTypeId: updatedEntityTypeId,
+              },
+              path,
+              sourceAccountId: accountId,
+              sourceEntityId: entityId,
             },
-          }),
-        ]);
+          ]);
+        }
       }
     },
     [
       accountId,
+      createLinks,
       entityId,
-      tableData.linkedAggregation?.operation?.itemsPerPage,
+      tableData.linkedAggregation,
       updateLinks,
     ],
   );

--- a/packages/blocks/table/src/Table.tsx
+++ b/packages/blocks/table/src/Table.tsx
@@ -10,8 +10,6 @@ import {
   BlockProtocolLinkedAggregation,
   BlockProtocolEntityType,
   BlockProtocolUpdateLinksAction,
-  BlockProtocolLinkedDataDefinition,
-  BlockProtocolMultiSort,
 } from "blockprotocol";
 import { BlockComponent } from "blockprotocol/react";
 import { tw } from "twind";
@@ -34,10 +32,6 @@ type TableData = {
 };
 
 type AppProps = {
-  data: {
-    data?: Record<string, any>[];
-    __linkedData?: BlockProtocolLinkedDataDefinition;
-  };
   initialState?: TableOptions<{}>["initialState"] & {
     columns?: { Header: string; accessor: string }[];
   };
@@ -95,14 +89,6 @@ const cleanUpdateLinkedAggregationAction = (
   },
 ) => {
   return produce(action, (draftAction) => {
-    draftAction.data.multiSort = draftAction.data.multiSort?.map((sort) => {
-      const newSort = sort as BlockProtocolMultiSort[number] & {
-        __typename?: string;
-      };
-      delete newSort.__typename;
-      return newSort;
-    });
-
     delete draftAction.data.pageCount;
   });
 };

--- a/packages/blocks/table/src/Table.tsx
+++ b/packages/blocks/table/src/Table.tsx
@@ -91,24 +91,19 @@ const getLinkedAggregation = (params: {
 
 const cleanUpdateLinkedAggregationAction = (
   action: BlockProtocolUpdateLinksAction & {
-    updatedOperation: Partial<BlockProtocolLinkedAggregation> & {
-      __typename?: string;
-    };
+    data: Partial<BlockProtocolLinkedAggregation>;
   },
 ) => {
   return produce(action, (draftAction) => {
-    draftAction.updatedOperation.multiSort =
-      draftAction.updatedOperation.multiSort?.map((sort) => {
-        const newSort = sort as BlockProtocolMultiSort[number] & {
-          __typename?: string;
-        };
-        delete newSort.__typename;
-        return newSort;
-      });
+    draftAction.data.multiSort = draftAction.data.multiSort?.map((sort) => {
+      const newSort = sort as BlockProtocolMultiSort[number] & {
+        __typename?: string;
+      };
+      delete newSort.__typename;
+      return newSort;
+    });
 
-    delete draftAction.updatedOperation.pageCount;
-
-    delete draftAction.updatedOperation.__typename;
+    delete draftAction.data.pageCount;
   });
 };
 
@@ -320,7 +315,7 @@ export const Table: BlockComponent<AppProps> = ({
           sourceAccountId: matchingLinkedAggregation.sourceAccountId,
           sourceEntityId: matchingLinkedAggregation.sourceEntityId,
           path,
-          updatedOperation: newLinkedData.operation,
+          data: newLinkedData.operation,
         }),
       ]);
     },
@@ -378,7 +373,7 @@ export const Table: BlockComponent<AppProps> = ({
           sourceAccountId: matchingLinkedAggregation.sourceAccountId,
           sourceEntityId: matchingLinkedAggregation.sourceEntityId,
           path,
-          updatedOperation: { ...tableData.linkedAggregation.operation },
+          data: { ...tableData.linkedAggregation.operation },
         }),
       ]);
     }
@@ -487,7 +482,7 @@ export const Table: BlockComponent<AppProps> = ({
               sourceAccountId: accountId,
               sourceEntityId: entityId,
               path,
-              updatedOperation: {
+              data: {
                 entityTypeId: updatedEntityTypeId,
                 // There is scope to include other options if entity properties overlap
                 itemsPerPage:

--- a/packages/blocks/table/src/Table.tsx
+++ b/packages/blocks/table/src/Table.tsx
@@ -137,8 +137,6 @@ export const Table: BlockComponent<AppProps> = ({
 
   const [tableData, setTableData] = useTableData(matchingLinkedAggregation);
 
-  console.log({ matchingLinkedAggregation, tableData });
-
   const columns = useMemo(
     () => makeColumns(tableData.data?.[0] || {}),
     [tableData.data],

--- a/packages/blocks/table/src/Table.tsx
+++ b/packages/blocks/table/src/Table.tsx
@@ -142,6 +142,8 @@ export const Table: BlockComponent<AppProps> = ({
 
   const [tableData, setTableData] = useTableData(matchingLinkedAggregation);
 
+  console.log({ matchingLinkedAggregation, tableData });
+
   const columns = useMemo(
     () => makeColumns(tableData.data?.[0] || {}),
     [tableData.data],

--- a/packages/blocks/table/src/devRenderer.tsx
+++ b/packages/blocks/table/src/devRenderer.tsx
@@ -13,12 +13,10 @@ import { initialTableData } from "./mockData/mockData";
 const node = document.getElementById("app");
 
 const App = () => {
-  // @todo recreate useMockData hook when needed
-
   return (
+    // @todo wrap in MockBlockDock once https://github.com/blockprotocol/blockprotocol/pull/249 is merged
     <div className={tw`flex justify-center py-8 mx-2`}>
       <Component
-        data={initialTableData.data}
         initialState={initialTableData.initialState}
         entityId="table-1"
       />

--- a/packages/hash/frontend/src/blocks/page/ComponentView.tsx
+++ b/packages/hash/frontend/src/blocks/page/ComponentView.tsx
@@ -156,6 +156,7 @@ export class ComponentView implements NodeView<Schema> {
             blockEntityId={entityId}
             shouldSandbox={!this.editable}
             editableRef={this.editable ? this.editableRef : undefined}
+            // @todo these asserted non-null fields do not definitely exist when the block is first loaded
             accountId={childEntity?.accountId!}
             entityId={childEntity?.entityId!}
             entityTypeId={childEntity?.entityTypeId!}

--- a/packages/hash/frontend/src/components/EntityEditor/types.ts
+++ b/packages/hash/frontend/src/components/EntityEditor/types.ts
@@ -1,3 +1,4 @@
+import { DistributiveOmit } from "@hashintel/hash-shared/util";
 import {
   BlockProtocolCreateLinksFunction,
   BlockProtocolDeleteLinksFunction,
@@ -11,7 +12,7 @@ export type EntityLinkDefinition = {
 
 export type CreateLinkFnWithFixedSource = {
   (
-    payload: Omit<
+    payload: DistributiveOmit<
       Parameters<BlockProtocolCreateLinksFunction>[0][0],
       "sourceAccountId" | "sourceEntityId"
     >,

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolCreateLinks.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolCreateLinks.ts
@@ -32,17 +32,33 @@ export const useBlockProtocolCreateLinks = (): {
           throw new Error("createLinks needs to be passed a sourceAccountId");
         }
 
+        const baseFields = {
+          path: action.path,
+          sourceEntityId: action.sourceEntityId,
+          sourceAccountId: action.sourceAccountId,
+        };
+
+        if ("operation" in action) {
+          throw new Error(
+            "Creating new linkedAggregations not yet implemented.",
+          );
+        } else if (!("destinationAccountId" in action)) {
+          throw new Error(
+            "One of operation or destinationEntityId must be provided",
+          );
+        }
+
+        const newLink = {
+          ...baseFields,
+          destinationEntityId: action.destinationEntityId,
+          destinationAccountId: action.destinationAccountId
+            ? action.destinationAccountId
+            : action.sourceAccountId,
+        };
+
         const { data, errors } = await runCreateLinksMutation({
           variables: {
-            link: {
-              destinationEntityId: action.destinationEntityId,
-              destinationAccountId: action.destinationAccountId
-                ? action.destinationAccountId
-                : action.sourceAccountId,
-              path: action.path,
-              sourceEntityId: action.sourceEntityId,
-              sourceAccountId: action.sourceAccountId,
-            },
+            link: newLink,
           },
         });
         if (!data) {

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolUpdateLinks.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolUpdateLinks.ts
@@ -24,10 +24,11 @@ export const useBlockProtocolUpdateLinks = (): {
   // @todo implement updating linkgroups and linkedentities
   const getUpdatedLinksData = useCallback(
     async (action: BlockProtocolUpdateLinksAction) => {
-      if (action.updatedOperation && action.sourceAccountId) {
+      if (action.data && action.sourceAccountId) {
         const { data, errors } = await runUpdateLinkedAggregationMutation({
           variables: {
             ...action,
+            updatedOperation: action.data,
             sourceAccountId: action.sourceAccountId,
           },
         });

--- a/patches/blockprotocol+0.0.1.patch
+++ b/patches/blockprotocol+0.0.1.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/blockprotocol/core.d.ts b/node_modules/blockprotocol/core.d.ts
-index 205630a..6ab9516 100644
+index 205630a..a9e292a 100644
 --- a/node_modules/blockprotocol/core.d.ts
 +++ b/node_modules/blockprotocol/core.d.ts
 @@ -66,6 +66,7 @@ export type BlockProtocolMultiSort = {
@@ -69,7 +69,7 @@ index 205630a..6ab9516 100644
 +  sourceEntityTypeVersionId?: string;
 +  index?: number | null;
 +  path: string;
-+} & { 
++} & ({ 
 +  operation?: BlockProtocolAggregateOperationInput; 
 +} | {  
    destinationAccountId?: string | null;
@@ -77,7 +77,8 @@ index 205630a..6ab9516 100644
    destinationEntityVersionId?: string | null; 
 -  index?: number | null;
 -  path: string;
- };
+-};
++});
  
  export type BlockProtocolCreateLinksFunction = {
    (actions: BlockProtocolCreateLinksAction[]): Promise<BlockProtocolLink[]>;

--- a/patches/blockprotocol+0.0.1.patch
+++ b/patches/blockprotocol+0.0.1.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/blockprotocol/core.d.ts b/node_modules/blockprotocol/core.d.ts
-index 205630a..9dd787c 100644
+index 205630a..eb9a888 100644
 --- a/node_modules/blockprotocol/core.d.ts
 +++ b/node_modules/blockprotocol/core.d.ts
 @@ -66,6 +66,7 @@ export type BlockProtocolMultiSort = {
@@ -39,7 +39,7 @@ index 205630a..9dd787c 100644
    sourceEntityId: string;
    destinationEntityId: string;
    destinationEntityVersionId?: string | null;
-@@ -153,9 +158,30 @@ export type BlockProtocolLinkGroup = {
+@@ -153,25 +158,60 @@ export type BlockProtocolLinkGroup = {
    links: BlockProtocolLink[];
  };
  
@@ -67,10 +67,19 @@ index 205630a..9dd787c 100644
    sourceEntityId: string;
 +  sourceEntityTypeId?: string;
 +  sourceEntityTypeVersionId?: string;
++  index?: number | null;
++  path: string;
++} & { 
++  operation?: BlockProtocolAggregateOperationInput; 
++} | {  
    destinationAccountId?: string | null;
    destinationEntityId: string;
-   destinationEntityVersionId?: string | null;
-@@ -167,11 +193,22 @@ export type BlockProtocolCreateLinksFunction = {
+   destinationEntityVersionId?: string | null; 
+-  index?: number | null;
+-  path: string;
+ };
+ 
+ export type BlockProtocolCreateLinksFunction = {
    (actions: BlockProtocolCreateLinksAction[]): Promise<BlockProtocolLink[]>;
  };
  
@@ -94,7 +103,7 @@ index 205630a..9dd787c 100644
  };
  
  export type BlockProtocolDeleteLinksFunction = {
-@@ -185,6 +222,7 @@ export type BlockProtocolAggregateEntityTypesFunction = {
+@@ -185,6 +225,7 @@ export type BlockProtocolAggregateEntityTypesFunction = {
  };
  
  type BlockProtocolUpdateEntityTypesAction = {
@@ -102,7 +111,7 @@ index 205630a..9dd787c 100644
    entityId: string;
    schema: JSONObject;
  };
-@@ -219,6 +257,7 @@ export interface JSONArray extends Array<JSONValue> {}
+@@ -219,6 +260,7 @@ export interface JSONArray extends Array<JSONValue> {}
   * which the embedding application should provide.
   */
  export type BlockProtocolProps = {
@@ -110,7 +119,7 @@ index 205630a..9dd787c 100644
    aggregateEntities?: BlockProtocolAggregateEntitiesFunction;
    aggregateEntitiesLoading?: boolean;
    aggregateEntitiesError?: Error;
-@@ -234,8 +273,10 @@ export type BlockProtocolProps = {
+@@ -234,8 +276,10 @@ export type BlockProtocolProps = {
    deleteLinksError?: Error;
    entityId?: string;
    entityTypeId?: string;
@@ -121,7 +130,7 @@ index 205630a..9dd787c 100644
    id?: string;
    schemas?: Record<string, JSONObject>;
    type?: string;
-@@ -245,4 +286,6 @@ export type BlockProtocolProps = {
+@@ -245,4 +289,6 @@ export type BlockProtocolProps = {
    updateEntityTypes?: BlockProtocolUpdateEntityTypesFunction;
    updateEntityTypesLoading?: boolean;
    updateEntityTypesError?: Error;

--- a/patches/blockprotocol+0.0.1.patch
+++ b/patches/blockprotocol+0.0.1.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/blockprotocol/core.d.ts b/node_modules/blockprotocol/core.d.ts
-index 205630a..eb9a888 100644
+index 205630a..6ab9516 100644
 --- a/node_modules/blockprotocol/core.d.ts
 +++ b/node_modules/blockprotocol/core.d.ts
 @@ -66,6 +66,7 @@ export type BlockProtocolMultiSort = {
@@ -87,7 +87,7 @@ index 205630a..eb9a888 100644
 +  sourceAccountId?: string;
 +  sourceEntityId: string;
 +  path: string;
-+  updatedOperation: BlockProtocolLinkedAggregationOperationInput;
++  data: BlockProtocolLinkedAggregationOperationInput;
 +};
 +
 +export type BlockProtocolUpdateLinksFunction = {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
Fixes the table block so that users can select a type when a type is not yet selected.

In conjunction with https://github.com/blockprotocol/blockprotocol/pull/249, this fixes the [table block in the Block Hub](https://blockprotocol.org/@hash/blocks/table).

## 🔍 What does this change?
In the order they appear in the diff:
- remove some redundant code passing `data` to the table block
- remove some code that was just removing `__typename` in arguments passed out of the Table block - this is a GraphQL-specific thing that should be handled by the embedding application instead
- change `updatedOperation` argument on `BlockProtocolUpdateLinksFunction` to `data`, to match the spec (we can sort this out properly when we split out CRUD operations for links and linkedAggregations)
- create a link if none already exist, i.e. fix setting the type when none is yet selected

## 🔗 Related links
- [Asana task](https://app.asana.com/0/1201837296904616/1201921145862576/f) (_internal_)

## ❓ How to test this?
Load preview deployment in https://github.com/blockprotocol/blockprotocol/pull/249, which is using table built off this branch, and check it.

## 📹 Demo

See demo in https://github.com/blockprotocol/blockprotocol/pull/249