### PR TITLE
Fix wrong memory access in JavaScript Arrow conversion

### DIFF
--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(backtrace, box_patterns, map_try_insert, once_cell, test)]
+#![feature(backtrace, box_patterns, map_try_insert, once_cell, test, is_sorted)]
 #![warn(
     rust_2018_compatibility,
     rust_2018_idioms,

--- a/packages/engine/src/worker/runner/javascript/mod.rs
+++ b/packages/engine/src/worker/runner/javascript/mod.rs
@@ -569,7 +569,7 @@ impl<'m> RunnerImpl<'m> {
         &self,
         ptr: NonNull<T>,
         len: usize,
-        _capacity: usize,
+        _capacity: usize, // for future use to create a `Buffer::from_raw_parts`
         target_len: usize,
     ) -> Buffer {
         // TODO: OPTIM: We currently copy the buffers because the JavaScript representation of
@@ -605,7 +605,7 @@ impl<'m> RunnerImpl<'m> {
         &self,
         ptr: NonNull<i32>,
         len: usize,
-        _capacity: usize,
+        _capacity: usize, // for future use to create a `Buffer::from_raw_parts`
         target_len: usize,
     ) -> (Buffer, usize) {
         // TODO: OPTIM: We currently copy the buffers because the JavaScript representation of
@@ -653,7 +653,7 @@ impl<'m> RunnerImpl<'m> {
         &self,
         ptr: NonNull<u8>,
         len: usize,
-        _capacity: usize,
+        _capacity: usize, // for future use to create a `Buffer::from_raw_parts`
         target_len: usize,
     ) -> Buffer {
         // TODO: OPTIM: We currently copy the buffers because the JavaScript representation of

--- a/packages/engine/src/worker/runner/javascript/mod.rs
+++ b/packages/engine/src/worker/runner/javascript/mod.rs
@@ -771,7 +771,7 @@ impl<'m> RunnerImpl<'m> {
                 //   type for strings is `u8`
                 unsafe {
                     debug_assert!(
-                        !data.buffer_ptrs[0].is_null(),
+                        !data.buffer_ptrs[1].is_null(),
                         "Required pointer for `Utf8` (`buffers[1]`) is null"
                     );
                     builder = builder.add_buffer(self.read_primitive_buffer(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When converting JavaScript Arrow data, we use the wrong length to read the data. JavaScript is writing only the required amount of values when writing null-values for child-data, so for example writing a fixed-size-list with 2 elements, each element containing 5 values: `[[1, 2, 3, 4, 5], null]`, JavaScript will only write `[1, 2, 3, 4, 5]` for the child data. Our current implementation would read `10` elements, regardless of the number of elements provided by JavaScript. This is likely to result in undefined behavior, thus we have seen segmentation fault errors. As Arrow allocates more memory than needed (for example memory for 64 elements), our current test suite didn't catch this error and for smaller simulations, this UB never happened in practice.

## ⚠️ Known issues

- We currently copy the data from JavaScript, this could be optimized (see TODOs).
- Because of the provided API by arrow-rs, it's not possible to set the length for primitive builders (see TODOs).
- Since arrow-rs 6, `ArrayDataBuilder::build` runs validation, which is likely to slow down the conversion (see TODO).

## 🐾 Next steps

See *Known Issues*

## 🔍 What does this change?

- Move out buffer creation to be reusable
- Use `data.len` to read the buffer from JS and resize it to `target_len`

### 📜 Does this require a change to the docs?

No

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201893074552404/1201908585432582/f) (_internal_)
- [Compare array implementation for different runners](https://app.asana.com/0/1199548034582004/1201927209654753/f) (_internal_)
- [Avoid copying of Data when converting Array Data from JS->RS](https://app.asana.com/0/1199548034582004/1201927209654755/f) (_internal_)
- [Don't validate Arrow array data when converting JS->RS](https://app.asana.com/0/1199548034582004/1201927209654757/f) (_internal_)
- [Unit tests for testing batch conversion between languages](https://app.asana.com/0/1199548034582004/1201893568192899/f) (_internal_)

## 🛡 What tests cover this?

None so far, we want additional unit tests for arrow code, especially when converting between JS and RS. See *Related links*
