### PR TITLE
Fix failing test on header-sidebar branch

### DIFF
--- a/packages/hash/frontend/src/components/layout/MainContentWrapper.tsx
+++ b/packages/hash/frontend/src/components/layout/MainContentWrapper.tsx
@@ -1,9 +1,11 @@
 import { IconButton, Fade, Box, Tooltip, styled } from "@mui/material";
 import { FunctionComponent } from "react";
-import { SIDEBAR_WIDTH } from "../../theme/components/navigation/MuiDrawerThemeOptions";
+import {
+  HEADER_HEIGHT,
+  SIDEBAR_WIDTH,
+} from "../../theme/components/navigation/MuiDrawerThemeOptions";
 
 import { SidebarToggleIcon } from "../icons";
-import { HEADER_HEIGHT } from "./PageHeader/PageHeader";
 import { PageSidebar } from "./PageSidebar/PageSidebar";
 import { useSidebarContext } from "./SidebarContext";
 

--- a/packages/hash/frontend/src/components/layout/PageHeader/PageHeader.tsx
+++ b/packages/hash/frontend/src/components/layout/PageHeader/PageHeader.tsx
@@ -12,6 +12,7 @@ import { HashNavIcon } from "../../icons";
 import { Link } from "../../Link";
 import { ActionsDropdown } from "./ActionsDropdown";
 import { NotificationsDropdown } from "./NotificationsDropdown";
+import { HEADER_HEIGHT } from "../../../theme/components/navigation/MuiDrawerThemeOptions";
 
 const Nav: React.FC = ({ children }) => (
   <Box
@@ -26,8 +27,6 @@ const Nav: React.FC = ({ children }) => (
     {children}
   </Box>
 );
-
-export const HEADER_HEIGHT = 64;
 
 export const PageHeader: React.VFC<{
   accountId: string;

--- a/packages/hash/frontend/src/theme/components/navigation/MuiDrawerThemeOptions.ts
+++ b/packages/hash/frontend/src/theme/components/navigation/MuiDrawerThemeOptions.ts
@@ -1,7 +1,7 @@
 import { Components, Theme } from "@mui/material";
-import { HEADER_HEIGHT } from "../../../components/layout/PageHeader/PageHeader";
 
 export const SIDEBAR_WIDTH = 260;
+export const HEADER_HEIGHT = 64;
 
 export const MuiDrawerThemeOptions: Components<Theme>["MuiDrawer"] = {
   defaultProps: {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This is a tiny PR for fixing the failing unit test on #379, which moves the `SIDEBAR_WIDTH` export to the Mui theme. This was done because the original tests were failing due to an incorrect dependency on `BlockView`. Since this PR moves the export to the theme directly, the `PageHeader` component is never triggered, preventing the dependency error.