### PR TITLE
Renaming affinity to worker_index

### DIFF
--- a/packages/engine/src/datastore/batch/migration/mod.rs
+++ b/packages/engine/src/datastore/batch/migration/mod.rs
@@ -168,7 +168,7 @@ impl<'a> BufferActions<'a> {
         &self,
         schema: &Arc<AgentSchema>,
         experiment_id: &ExperimentId,
-        affinity: usize,
+        worker_index: usize,
     ) -> Result<AgentBatch> {
         let mut memory = AgentBatch::get_prepared_memory_for_data(
             schema,
@@ -177,7 +177,7 @@ impl<'a> BufferActions<'a> {
         )?;
         self.flush_memory(&mut memory)?;
 
-        AgentBatch::from_memory(memory, Some(schema.as_ref()), Some(affinity))
+        AgentBatch::from_memory(memory, Some(schema.as_ref()), Some(worker_index))
     }
 
     #[allow(clippy::too_many_lines)]

--- a/packages/engine/src/datastore/table/state/create_remove/action.rs
+++ b/packages/engine/src/datastore/table/state/create_remove/action.rs
@@ -2,12 +2,12 @@ use crate::datastore::batch::migration::BufferActions;
 
 pub enum ExistingGroupBufferActions<'a> {
     Persist {
-        affinity: usize,
+        worker_index: usize,
     },
     Remove,
     Update {
         actions: BufferActions<'a>,
-        affinity: usize,
+        worker_index: usize,
     },
     Undefined,
 }
@@ -15,23 +15,23 @@ pub enum ExistingGroupBufferActions<'a> {
 #[derive(Debug)]
 pub struct CreateActions<'a> {
     pub actions: BufferActions<'a>,
-    pub affinity: usize,
+    pub worker_index: usize,
 }
 
 impl std::fmt::Debug for ExistingGroupBufferActions<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ExistingGroupBufferActions::Persist { affinity } => f
+            ExistingGroupBufferActions::Persist { worker_index } => f
                 .debug_struct("Persist")
-                .field("affinity", affinity)
+                .field("worker_index", worker_index)
                 .finish(),
             ExistingGroupBufferActions::Remove => f.debug_struct("Remove").finish(),
             ExistingGroupBufferActions::Update {
                 actions: _,
-                affinity,
+                worker_index,
             } => f
                 .debug_struct("Update")
-                .field("affinity", affinity)
+                .field("worker_index", worker_index)
                 .finish(),
             ExistingGroupBufferActions::Undefined => f.debug_struct("Undefined").finish(),
         }

--- a/packages/engine/src/datastore/table/state/create_remove/batch.rs
+++ b/packages/engine/src/datastore/table/state/create_remove/batch.rs
@@ -54,7 +54,7 @@ impl PendingBatch {
         let remove_indices_len = remove_indices.len();
         let old_batch = BaseBatch {
             index: batch_index,
-            worker: batch.affinity,
+            worker: batch.worker_index,
             remove_indices,
             _num_agents: batch.num_agents(),
         };

--- a/packages/engine/src/datastore/table/state/create_remove/plan.rs
+++ b/packages/engine/src/datastore/table/state/create_remove/plan.rs
@@ -46,15 +46,18 @@ impl<'a> MigrationPlan<'a> {
             )
             .try_for_each::<_, Result<()>>(|(action, batch)| {
                 match action {
-                    ExistingGroupBufferActions::Persist { affinity } => {
-                        batch.set_affinity(*affinity);
+                    ExistingGroupBufferActions::Persist { worker_index } => {
+                        batch.set_worker_index(*worker_index);
                     }
                     ExistingGroupBufferActions::Remove => {
                         // Do nothing yet
                     }
-                    ExistingGroupBufferActions::Update { actions, affinity } => {
+                    ExistingGroupBufferActions::Update {
+                        actions,
+                        worker_index,
+                    } => {
                         actions.flush(batch)?;
-                        batch.set_affinity(*affinity);
+                        batch.set_worker_index(*worker_index);
                     }
                     ExistingGroupBufferActions::Undefined => {
                         return Err(Error::UnexpectedUndefinedCommand);
@@ -82,7 +85,7 @@ impl<'a> MigrationPlan<'a> {
                     .new_batch(
                         &config.sim.store.agent_schema,
                         &config.exp.run.base().id,
-                        action.affinity,
+                        action.worker_index,
                     )
                     .map_err(Error::from)?;
                 Ok(new_batch)

--- a/packages/engine/src/datastore/table/state/create_remove/planner.rs
+++ b/packages/engine/src/datastore/table/state/create_remove/planner.rs
@@ -92,7 +92,6 @@ impl PendingPlan {
         let mut num_inbound_agents_allocated = 0;
         let mut num_agents_after_execution = 0;
         for (worker_index, batch) in self.distribution.iter() {
-            let affinity = worker_index;
             let planned_num_agents = batch.num_agents();
             num_agents_after_execution += planned_num_agents;
             if batch.wraps_batch() {
@@ -103,7 +102,7 @@ impl PendingPlan {
                     ExistingGroupBufferActions::Remove
                 } else if batch.num_delete_unchecked() == 0 && batch.num_inbound() == 0 {
                     // No outbound nor inbound agents
-                    ExistingGroupBufferActions::Persist { affinity }
+                    ExistingGroupBufferActions::Persist { worker_index }
                 } else {
                     let actions = buffer_actions_from_pending_batch(
                         state_proxy,
@@ -112,7 +111,10 @@ impl PendingPlan {
                         &config.sim.store.agent_schema,
                         &mut num_inbound_agents_allocated,
                     )?;
-                    ExistingGroupBufferActions::Update { actions, affinity }
+                    ExistingGroupBufferActions::Update {
+                        actions,
+                        worker_index,
+                    }
                 }
             } else {
                 let actions = buffer_actions_from_pending_batch(
@@ -122,7 +124,10 @@ impl PendingPlan {
                     &config.sim.store.agent_schema,
                     &mut num_inbound_agents_allocated,
                 )?;
-                let create_command = CreateActions { actions, affinity };
+                let create_command = CreateActions {
+                    actions,
+                    worker_index,
+                };
 
                 create_commands.push(create_command)
             }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We had a variable called affinity in a lot of places which was confusing and not self descriptive. This renames it to a clearer `worker_index`

## 🛡 What tests cover this?

- CI should pass, this is just a refactor/rename
