### PR TITLE
Fix caption visibility in the code block

### DIFF
--- a/packages/blocks/code/src/App.tsx
+++ b/packages/blocks/code/src/App.tsx
@@ -105,10 +105,7 @@ export const App: BlockComponent<AppProps> = ({
   }, [localData.caption]);
 
   const handleCaptionInputBlur = () => {
-    setCaptionVisibility(true);
-    if (!captionRef.current?.value.length) {
-      setCaptionVisibility(false);
-    }
+    setCaptionVisibility(!!captionRef.current?.value.length);
     updateRemoteData();
   };
 

--- a/packages/blocks/code/src/App.tsx
+++ b/packages/blocks/code/src/App.tsx
@@ -29,6 +29,7 @@ export const App: BlockComponent<AppProps> = ({
     language,
   }));
   const [copied, setCopied] = useState(false);
+  const [captionIsVisible, setCaptionVisibility] = useState(caption.length > 0);
   const editorRef = useRef<HTMLTextAreaElement>(null);
   const captionRef = useRef<HTMLInputElement>(null);
 
@@ -86,12 +87,29 @@ export const App: BlockComponent<AppProps> = ({
     }
   };
 
-  const handleCaptionBtnClick = () => {
-    if (!captionRef.current) return;
-    if (captionRef.current.classList.contains("invisible")) {
-      captionRef.current.classList.remove("invisible");
+  const handleCaptionButtonClick = () => {
+    setCaptionVisibility(true);
+    setTimeout(() => {
+      captionRef.current?.focus();
+      captionRef.current?.setSelectionRange(
+        0,
+        captionRef.current?.value.length,
+      );
+    }, 0);
+  };
+
+  useEffect(() => {
+    if (captionRef.current !== document.activeElement) {
+      setCaptionVisibility(localData.caption.length > 0);
     }
-    captionRef.current.focus();
+  }, [localData.caption]);
+
+  const handleCaptionInputBlur = () => {
+    setCaptionVisibility(true);
+    if (!captionRef.current?.value.length) {
+      setCaptionVisibility(false);
+    }
+    updateRemoteData();
   };
 
   return (
@@ -128,7 +146,7 @@ export const App: BlockComponent<AppProps> = ({
             <button
               type="button"
               className={tw`bg-black bg-opacity-10 hover:bg-opacity-20 px-2 py-1 rounded-md`}
-              onClick={handleCaptionBtnClick}
+              onClick={handleCaptionButtonClick}
             >
               Caption
             </button>
@@ -144,11 +162,13 @@ export const App: BlockComponent<AppProps> = ({
       </div>
       <input
         ref={captionRef}
-        className={tw`text-sm text-gray-400 outline-none w-full invisible`}
+        className={tw`text-sm text-gray-400 outline-none w-full ${
+          captionIsVisible ? "" : "invisible"
+        }`}
         placeholder="Write a caption..."
         value={localData.caption}
         onChange={(evt) => updateLocalData({ caption: evt.target.value })}
-        onBlur={updateRemoteData}
+        onBlur={handleCaptionInputBlur}
       />
     </div>
   );


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## ⚠️ Known issues

State management in the block is still based on `useEffect`. We should switch to `setState` in the render phase in most blocks.


## 🐾 Next steps

- Update commit has in https://github.com/blockprotocol/blockprotocol/pull/258 and merge.

## 🔍 What does this change?

- If initial value of `caption ` is not empty, the caption is rendered
- Clicking on the caption button selects caption text for convenience
- Removing focus from an empty caption hides the input.

### 📜 Does this require a change to the docs?

No

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as (_internal_) -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1200211978612931/1201858561350502/f) _(internal)_

## 🛡 What tests cover this?

- Manual
- https://github.com/blockprotocol/blockprotocol/pull/258 (see Preview Release on Vercel)

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch / view the deployment
1.  Run `yarn workspace @hashintel/block-code dev`
1. Open `localhost:9000` and click around.
1. Try changing `initialData` → `caption` in `packages/blocks/code/src/webpack-dev-server.js` and repeat the previous step.

1) Open Preview Release for https://github.com/blockprotocol/blockprotocol/pull/258

## 📹 Demo

![Kapture 2022-03-11 at 15 16 55](https://user-images.githubusercontent.com/608862/157895526-f7523f1a-ccd7-47f5-b64c-7710f5c9829f.gif)

