### PR TITLE
Fix code block when caption is undefined

### DIFF
--- a/packages/blocks/code/src/App.tsx
+++ b/packages/blocks/code/src/App.tsx
@@ -29,7 +29,9 @@ export const App: BlockComponent<AppProps> = ({
     language,
   }));
   const [copied, setCopied] = useState(false);
-  const [captionIsVisible, setCaptionVisibility] = useState(caption.length > 0);
+  const [captionIsVisible, setCaptionVisibility] = useState(
+    caption && caption.length > 0,
+  );
   const editorRef = useRef<HTMLTextAreaElement>(null);
   const captionRef = useRef<HTMLInputElement>(null);
 
@@ -100,7 +102,7 @@ export const App: BlockComponent<AppProps> = ({
 
   useEffect(() => {
     if (captionRef.current !== document.activeElement) {
-      setCaptionVisibility(localData.caption.length > 0);
+      setCaptionVisibility(localData.caption?.length > 0);
     }
   }, [localData.caption]);
 
@@ -163,7 +165,7 @@ export const App: BlockComponent<AppProps> = ({
           captionIsVisible ? "" : "invisible"
         }`}
         placeholder="Write a caption..."
-        value={localData.caption}
+        value={localData.caption ?? ""}
         onChange={(evt) => updateLocalData({ caption: evt.target.value })}
         onBlur={handleCaptionInputBlur}
       />

--- a/packages/blocks/code/src/App.tsx
+++ b/packages/blocks/code/src/App.tsx
@@ -8,7 +8,7 @@ import { languages, LanguageType } from "./utils";
 import { Editor } from "./components/Editor";
 
 type AppProps = {
-  caption: string;
+  caption?: string;
   language: LanguageType;
   content: string;
 };

--- a/packages/blocks/code/src/App.tsx
+++ b/packages/blocks/code/src/App.tsx
@@ -102,7 +102,7 @@ export const App: BlockComponent<AppProps> = ({
 
   useEffect(() => {
     if (captionRef.current !== document.activeElement) {
-      setCaptionVisibility(localData.caption?.length > 0);
+      setCaptionVisibility(localData.caption && localData.caption?.length > 0);
     }
   }, [localData.caption]);
 

--- a/packages/blocks/code/src/webpack-dev-server.js
+++ b/packages/blocks/code/src/webpack-dev-server.js
@@ -13,7 +13,6 @@ const node = document.getElementById("app");
 const initialData = {
   content: 'var foo = "bar";',
   language: "javascript",
-  caption: "",
 };
 
 const App = () => {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
Fixes the code block when the caption is undefined (currently broken, see [here](https://blockprotocol.org/@hash/blocks/code)). We shouldn't rely on users passing an empty string when there is no caption.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201927504137297/1201966863964862/f) _(internal)_

## ❓ How to test this?

1. Try passing undefined, an empty string, and a non-empty string to the code block in the dev renderer to check all work correctly
