### PR TITLE
Update hash README.md supported node version

### DIFF
--- a/packages/hash/README.md
+++ b/packages/hash/README.md
@@ -26,7 +26,7 @@ To run HASH locally, please follow these steps:
     ## ≥ 2.17
     
     node --version
-    ## ≥ 16.13
+    ## ≥ 16.13 and < 17.00 (`@opensearch-project/opensearch` currently does not support node 17)
     
     yarn --version
     ## ≥ 1.16


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

Currently the `@opensearch-project/opensearch` package does not support node version 17. This PR updates the hash `README.md` to specify that the local developer environment cannot run using node 17.

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- the readme at `packages/hash/README.md`

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

This is an update to the docs :)

