### PR TITLE
Disable cancel messages

### DIFF
--- a/packages/engine/src/simulation/task/active.rs
+++ b/packages/engine/src/simulation/task/active.rs
@@ -65,32 +65,35 @@ impl ActiveTask {
         }
     }
 
-    // TODO: UNUSED: Needs triage
-    pub async fn cancel(mut self) -> Result<()> {
-        if self.running && !self.cancel_sent {
-            let cancel_send = self
-                .comms
-                .cancel_send
-                .take()
-                .ok_or_else(|| Error::from("Couldn't take cancel send"))?;
-            cancel_send
-                .send(CancelTask::new())
-                .map_err(|_| Error::from("Failed to send Cancel Task"))?;
-            self.cancel_sent = true;
-            let recv = self
-                .comms
-                .result_recv
-                .take()
-                .ok_or_else(|| Error::from("Couldn't take result recv"))?;
-            let res = recv.await?;
-            if matches!(res, TaskResultOrCancelled::Cancelled) {
-                tracing::warn!("Task was cancelled, but completed in the meanwhile");
-            }
-            self.running = false;
-        } else if !self.running {
-            tracing::warn!("Tried to cancel task which was not running");
-        }
-        Ok(())
+    #[allow(dead_code)]
+    pub async fn cancel(self) -> Result<()> {
+        todo!("Cancel messages are not implemented yet");
+        // see https://app.asana.com/0/1199548034582004/1202011714603653/f
+
+        // if self.running && !self.cancel_sent {
+        //     let cancel_send = self
+        //         .comms
+        //         .cancel_send
+        //         .take()
+        //         .ok_or_else(|| Error::from("Couldn't take cancel send"))?;
+        //     cancel_send
+        //         .send(CancelTask::new())
+        //         .map_err(|_| Error::from("Failed to send Cancel Task"))?;
+        //     self.cancel_sent = true;
+        //     let recv = self
+        //         .comms
+        //         .result_recv
+        //         .take()
+        //         .ok_or_else(|| Error::from("Couldn't take result recv"))?;
+        //     let res = recv.await?;
+        //     if matches!(res, TaskResultOrCancelled::Cancelled) {
+        //         tracing::warn!("Task was cancelled, but completed in the meanwhile");
+        //     }
+        //     self.running = false;
+        // } else if !self.running {
+        //     tracing::warn!("Tried to cancel task which was not running");
+        // }
+        // Ok(())
     }
 }
 

--- a/packages/engine/src/simulation/task/active.rs
+++ b/packages/engine/src/simulation/task/active.rs
@@ -65,35 +65,35 @@ impl ActiveTask {
         }
     }
 
-    #[allow(dead_code)]
-    pub async fn cancel(self) -> Result<()> {
+    #[allow(dead_code, unused_mut, unreachable_code)]
+    pub async fn cancel(mut self) -> Result<()> {
         todo!("Cancel messages are not implemented yet");
         // see https://app.asana.com/0/1199548034582004/1202011714603653/f
 
-        // if self.running && !self.cancel_sent {
-        //     let cancel_send = self
-        //         .comms
-        //         .cancel_send
-        //         .take()
-        //         .ok_or_else(|| Error::from("Couldn't take cancel send"))?;
-        //     cancel_send
-        //         .send(CancelTask::new())
-        //         .map_err(|_| Error::from("Failed to send Cancel Task"))?;
-        //     self.cancel_sent = true;
-        //     let recv = self
-        //         .comms
-        //         .result_recv
-        //         .take()
-        //         .ok_or_else(|| Error::from("Couldn't take result recv"))?;
-        //     let res = recv.await?;
-        //     if matches!(res, TaskResultOrCancelled::Cancelled) {
-        //         tracing::warn!("Task was cancelled, but completed in the meanwhile");
-        //     }
-        //     self.running = false;
-        // } else if !self.running {
-        //     tracing::warn!("Tried to cancel task which was not running");
-        // }
-        // Ok(())
+        if self.running && !self.cancel_sent {
+            let cancel_send = self
+                .comms
+                .cancel_send
+                .take()
+                .ok_or_else(|| Error::from("Couldn't take cancel send"))?;
+            cancel_send
+                .send(CancelTask::new())
+                .map_err(|_| Error::from("Failed to send Cancel Task"))?;
+            self.cancel_sent = true;
+            let recv = self
+                .comms
+                .result_recv
+                .take()
+                .ok_or_else(|| Error::from("Couldn't take result recv"))?;
+            let res = recv.await?;
+            if matches!(res, TaskResultOrCancelled::Cancelled) {
+                tracing::warn!("Task was cancelled, but completed in the meanwhile");
+            }
+            self.running = false;
+        } else if !self.running {
+            tracing::warn!("Tried to cancel task which was not running");
+        }
+        Ok(())
     }
 }
 

--- a/packages/engine/src/worker/mod.rs
+++ b/packages/engine/src/worker/mod.rs
@@ -736,62 +736,62 @@ impl WorkerController {
     }
 
     /// Sends a message to all spawned runners to cancel the current task.
-    #[allow(dead_code)]
-    async fn cancel_task(&mut self, _task_id: TaskId) -> Result<()> {
+    #[allow(dead_code, unused_variables, unreachable_code)]
+    async fn cancel_task(&mut self, task_id: TaskId) -> Result<()> {
         todo!("Cancel messages are not implemented yet");
         // see https://app.asana.com/0/1199548034582004/1202011714603653/f
 
-        // tracing::trace!("Cancelling task");
-        // if let Some(_task) = self.tasks.inner.get_mut(&task_id) {
-        //     // TODO: Or `CancelState::None`?
-        //     // task.cancelling = CancelState::Active(vec![task.active_runner]);
-        // }
-        // tokio::try_join!(
-        //     self.py
-        //         .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id)),
-        //     self.js
-        //         .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id)),
-        //     self.rs
-        //         .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
-        // )?;
-        // Ok(())
+        tracing::trace!("Cancelling task");
+        if let Some(_task) = self.tasks.inner.get_mut(&task_id) {
+            // TODO: Or `CancelState::None`?
+            // task.cancelling = CancelState::Active(vec![task.active_runner]);
+        }
+        tokio::try_join!(
+            self.py
+                .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id)),
+            self.js
+                .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id)),
+            self.rs
+                .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
+        )?;
+        Ok(())
     }
 
     /// Sends a message to cancel the current task to any runner except for `runner_language`.
-    #[allow(dead_code)]
+    #[allow(dead_code, unused_variables, unreachable_code)]
     async fn cancel_task_except_for_runner(
         &self,
-        _task_id: TaskId,
-        _runner_language: Language,
+        task_id: TaskId,
+        runner_language: Language,
     ) -> Result<()> {
         todo!("Cancel messages are not implemented yet");
         // see https://app.asana.com/0/1199548034582004/1202011714603653/f
 
-        // if matches!(runner_language, Language::Python) {
-        //     self.js
-        //         .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
-        //         .await?;
-        //     self.rs
-        //         .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
-        //         .await?;
-        // }
-        // if matches!(runner_language, Language::JavaScript) {
-        //     self.py
-        //         .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
-        //         .await?;
-        //     self.rs
-        //         .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
-        //         .await?;
-        // }
-        // if matches!(runner_language, Language::Rust) {
-        //     self.py
-        //         .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
-        //         .await?;
-        //     self.js
-        //         .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
-        //         .await?;
-        // }
-        // Ok(())
+        if matches!(runner_language, Language::Python) {
+            self.js
+                .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
+                .await?;
+            self.rs
+                .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
+                .await?;
+        }
+        if matches!(runner_language, Language::JavaScript) {
+            self.py
+                .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
+                .await?;
+            self.rs
+                .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
+                .await?;
+        }
+        if matches!(runner_language, Language::Rust) {
+            self.py
+                .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
+                .await?;
+            self.js
+                .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
+                .await?;
+        }
+        Ok(())
     }
 
     /// Forwards `new_simulation_run` to all spawned workers.

--- a/packages/engine/src/worker/mod.rs
+++ b/packages/engine/src/worker/mod.rs
@@ -410,7 +410,7 @@ impl WorkerController {
         task_id: TaskId,
         sim_id: SimulationShortId,
         group_index: Option<usize>,
-        source: Language,
+        _source: Language,
         message: TaskMessage,
         shared_store: TaskSharedStore,
     ) -> Result<()> {
@@ -445,7 +445,11 @@ impl WorkerController {
                     "No more pending groups on task [{task_id}], cancelling task on the other \
                      runners"
                 );
-                self.cancel_task_except_for_runner(task_id, source).await?;
+
+                // TODO: Cancel messages are not implemented yet");
+                //   see https://app.asana.com/0/1199548034582004/1202011714603653/f
+                // self.cancel_task_except_for_runner(task_id, source).await?;
+
                 self.worker_pool_comms.send(
                     sim_id,
                     WorkerToWorkerPoolMsg::TaskResultOrCancelled(WorkerTaskResultOrCancelled {
@@ -731,58 +735,63 @@ impl WorkerController {
         Ok(())
     }
 
-    // TODO: We don't currently use Task cancelling, and to be able use it we would need
-    //  to change how and when cancel messages are sent
     /// Sends a message to all spawned runners to cancel the current task.
     #[allow(dead_code)]
-    async fn cancel_task(&mut self, task_id: TaskId) -> Result<()> {
-        tracing::trace!("Cancelling task");
-        if let Some(_task) = self.tasks.inner.get_mut(&task_id) {
-            // TODO: Or `CancelState::None`?
-            // task.cancelling = CancelState::Active(vec![task.active_runner]);
-        }
-        tokio::try_join!(
-            self.py
-                .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id)),
-            self.js
-                .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id)),
-            self.rs
-                .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
-        )?;
-        Ok(())
+    async fn cancel_task(&mut self, _task_id: TaskId) -> Result<()> {
+        todo!("Cancel messages are not implemented yet");
+        // see https://app.asana.com/0/1199548034582004/1202011714603653/f
+
+        // tracing::trace!("Cancelling task");
+        // if let Some(_task) = self.tasks.inner.get_mut(&task_id) {
+        //     // TODO: Or `CancelState::None`?
+        //     // task.cancelling = CancelState::Active(vec![task.active_runner]);
+        // }
+        // tokio::try_join!(
+        //     self.py
+        //         .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id)),
+        //     self.js
+        //         .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id)),
+        //     self.rs
+        //         .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
+        // )?;
+        // Ok(())
     }
 
     /// Sends a message to cancel the current task to any runner except for `runner_language`.
+    #[allow(dead_code)]
     async fn cancel_task_except_for_runner(
         &self,
-        task_id: TaskId,
-        runner_language: Language,
+        _task_id: TaskId,
+        _runner_language: Language,
     ) -> Result<()> {
-        if matches!(runner_language, Language::Python) {
-            self.js
-                .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
-                .await?;
-            self.rs
-                .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
-                .await?;
-        }
-        if matches!(runner_language, Language::JavaScript) {
-            self.py
-                .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
-                .await?;
-            self.rs
-                .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
-                .await?;
-        }
-        if matches!(runner_language, Language::Rust) {
-            self.py
-                .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
-                .await?;
-            self.js
-                .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
-                .await?;
-        }
-        Ok(())
+        todo!("Cancel messages are not implemented yet");
+        // see https://app.asana.com/0/1199548034582004/1202011714603653/f
+
+        // if matches!(runner_language, Language::Python) {
+        //     self.js
+        //         .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
+        //         .await?;
+        //     self.rs
+        //         .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
+        //         .await?;
+        // }
+        // if matches!(runner_language, Language::JavaScript) {
+        //     self.py
+        //         .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
+        //         .await?;
+        //     self.rs
+        //         .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
+        //         .await?;
+        // }
+        // if matches!(runner_language, Language::Rust) {
+        //     self.py
+        //         .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
+        //         .await?;
+        //     self.js
+        //         .send_if_spawned(None, InboundToRunnerMsgPayload::CancelTask(task_id))
+        //         .await?;
+        // }
+        // Ok(())
     }
 
     /// Forwards `new_simulation_run` to all spawned workers.

--- a/packages/engine/src/worker/runner/javascript/mod.rs
+++ b/packages/engine/src/worker/runner/javascript/mod.rs
@@ -1397,7 +1397,10 @@ impl<'m> RunnerImpl<'m> {
                 let sim_id = sim_id.ok_or(Error::SimulationIdRequired("run task"))?;
                 self.handle_task_msg(mv8, sim_id, msg, outbound_sender)?;
             }
-            InboundToRunnerMsgPayload::CancelTask(_) => {} // TODO
+            InboundToRunnerMsgPayload::CancelTask(_) => {
+                todo!("Cancel messages are not implemented yet");
+                // see https://app.asana.com/0/1199548034582004/1202011714603653/f
+            }
         }
         Ok(true) // Continue running.
     }

--- a/packages/engine/src/worker/runner/python/mod.rs
+++ b/packages/engine/src/worker/runner/python/mod.rs
@@ -168,10 +168,8 @@ async fn _run(
                         (Some(payload), Some(wrapper))
                     }
                     InboundToRunnerMsgPayload::CancelTask(_) => {
-                        // Don't send to Python process -- unused for now.
-                        // TODO: Remove `continue` when/if a package uses `CancelTask`
-                        //       and it's implemented in Python.
-                        continue
+                        todo!("Cancel messages are not implemented yet");
+                        // see https://app.asana.com/0/1199548034582004/1202011714603653/f
                     }
                     _ => (None, None)
                 };

--- a/packages/engine/src/worker/runner/python/sender.rs
+++ b/packages/engine/src/worker/runner/python/sender.rs
@@ -163,7 +163,10 @@ fn inbound_to_nng(
                 flatbuffers_gen::runner_inbound_msg_generated::RunnerInboundMsgPayload::TaskMsg,
             )
         }
-        InboundToRunnerMsgPayload::CancelTask(_) => todo!(), // Unused for now
+        InboundToRunnerMsgPayload::CancelTask(_) => {
+            todo!("Cancel messages are not implemented yet");
+            // see https://app.asana.com/0/1199548034582004/1202011714603653/f
+        }
         InboundToRunnerMsgPayload::StateSync(msg) => {
             let (agent_pool, message_pool) = state_sync_to_fbs(fbb, &msg.state_proxy)?;
             let msg = flatbuffers_gen::sync_state_generated::StateSync::create(

--- a/packages/engine/src/workerpool/comms/mod.rs
+++ b/packages/engine/src/workerpool/comms/mod.rs
@@ -84,16 +84,16 @@ impl WorkerPoolToWorkerMsg {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn cancel_task(_task_id: TaskId) -> WorkerPoolToWorkerMsg {
+    #[allow(dead_code, unused_variables, unreachable_code)]
+    pub fn cancel_task(task_id: TaskId) -> WorkerPoolToWorkerMsg {
         todo!("Cancel messages are not implemented yet");
         // see https://app.asana.com/0/1199548034582004/1202011714603653/f
 
-        // WorkerPoolToWorkerMsg {
-        //     span: Span::current(),
-        //     sim_id: None,
-        //     payload: WorkerPoolToWorkerMsgPayload::CancelTask(task_id),
-        // }
+        WorkerPoolToWorkerMsg {
+            span: Span::current(),
+            sim_id: None,
+            payload: WorkerPoolToWorkerMsgPayload::CancelTask(task_id),
+        }
     }
 
     pub fn new_simulation_run(new_simulation_run: NewSimulationRun) -> WorkerPoolToWorkerMsg {

--- a/packages/engine/src/workerpool/comms/mod.rs
+++ b/packages/engine/src/workerpool/comms/mod.rs
@@ -84,12 +84,16 @@ impl WorkerPoolToWorkerMsg {
         }
     }
 
-    pub fn cancel_task(task_id: TaskId) -> WorkerPoolToWorkerMsg {
-        WorkerPoolToWorkerMsg {
-            span: Span::current(),
-            sim_id: None,
-            payload: WorkerPoolToWorkerMsgPayload::CancelTask(task_id),
-        }
+    #[allow(dead_code)]
+    pub fn cancel_task(_task_id: TaskId) -> WorkerPoolToWorkerMsg {
+        todo!("Cancel messages are not implemented yet");
+        // see https://app.asana.com/0/1199548034582004/1202011714603653/f
+
+        // WorkerPoolToWorkerMsg {
+        //     span: Span::current(),
+        //     sim_id: None,
+        //     payload: WorkerPoolToWorkerMsgPayload::CancelTask(task_id),
+        // }
     }
 
     pub fn new_simulation_run(new_simulation_run: NewSimulationRun) -> WorkerPoolToWorkerMsg {

--- a/packages/engine/src/workerpool/mod.rs
+++ b/packages/engine/src/workerpool/mod.rs
@@ -336,38 +336,38 @@ impl WorkerPoolController {
     }
 
     // TODO: delete or use when cancel is revisited
-    #[allow(dead_code)]
-    async fn handle_cancel_msgs(&mut self, _cancel_msgs: Vec<TaskId>) -> Result<()> {
+    #[allow(dead_code, unused_variables, unreachable_code)]
+    async fn handle_cancel_msgs(&mut self, cancel_msgs: Vec<TaskId>) -> Result<()> {
         todo!("Cancel messages are not implemented yet");
         // see https://app.asana.com/0/1199548034582004/1202011714603653/f
 
-        // for id in cancel_msgs {
-        //     tracing::trace!("Handling cancel msg for task with id: {}", id);
-        //     if let Some(task) = self.pending_tasks.inner.get(&id) {
-        //         match &task.distribution_controller {
-        //             DistributionController::Distributed {
-        //                 active_workers,
-        //                 received_results: _,
-        //                 reference_task: _,
-        //             } => {
-        //                 for worker in active_workers {
-        //                     self.send_to_worker(
-        //                         worker.index(),
-        //                         WorkerPoolToWorkerMsg::cancel_task(task.task_id),
-        //                     )?;
-        //                 }
-        //             }
-        //             DistributionController::Single { active_worker } => {
-        //                 self.send_to_worker(
-        //                     active_worker.index(),
-        //                     WorkerPoolToWorkerMsg::cancel_task(task.task_id),
-        //                 )?;
-        //             }
-        //         }
-        //     }
-        // }
-        //
-        // Ok(())
+        for id in cancel_msgs {
+            tracing::trace!("Handling cancel msg for task with id: {}", id);
+            if let Some(task) = self.pending_tasks.inner.get(&id) {
+                match &task.distribution_controller {
+                    DistributionController::Distributed {
+                        active_workers,
+                        received_results: _,
+                        reference_task: _,
+                    } => {
+                        for worker in active_workers {
+                            self.send_to_worker(
+                                worker.index(),
+                                WorkerPoolToWorkerMsg::cancel_task(task.task_id),
+                            )?;
+                        }
+                    }
+                    DistributionController::Single { active_worker } => {
+                        self.send_to_worker(
+                            active_worker.index(),
+                            WorkerPoolToWorkerMsg::cancel_task(task.task_id),
+                        )?;
+                    }
+                }
+            }
+        }
+
+        Ok(())
     }
 
     fn send_to_worker(&self, index: WorkerIndex, msg: WorkerPoolToWorkerMsg) -> Result<()> {

--- a/packages/engine/src/workerpool/mod.rs
+++ b/packages/engine/src/workerpool/mod.rs
@@ -249,7 +249,8 @@ impl WorkerPoolController {
                     })?;
                 }
                 let fut = async move {
-                    let sync = sync; // Capture `sync` in lambda.
+                    let sync = sync;
+                    // Capture `sync` in lambda.
                     // TODO: these types of logs are better suited as a span
                     tracing::trace!("Waiting for worker synchronization");
                     sync.forward_children(worker_completion_receivers).await;
@@ -337,34 +338,37 @@ impl WorkerPoolController {
 
     // TODO: delete or use when cancel is revisited
     #[allow(dead_code)]
-    async fn handle_cancel_msgs(&mut self, cancel_msgs: Vec<TaskId>) -> Result<()> {
-        for id in cancel_msgs {
-            tracing::trace!("Handling cancel msg for task with id: {}", id);
-            if let Some(task) = self.pending_tasks.inner.get(&id) {
-                match &task.distribution_controller {
-                    DistributionController::Distributed {
-                        active_workers,
-                        received_results: _,
-                        reference_task: _,
-                    } => {
-                        for worker in active_workers {
-                            self.send_to_worker(
-                                worker.index(),
-                                WorkerPoolToWorkerMsg::cancel_task(task.task_id),
-                            )?;
-                        }
-                    }
-                    DistributionController::Single { active_worker } => {
-                        self.send_to_worker(
-                            active_worker.index(),
-                            WorkerPoolToWorkerMsg::cancel_task(task.task_id),
-                        )?;
-                    }
-                }
-            }
-        }
+    async fn handle_cancel_msgs(&mut self, _cancel_msgs: Vec<TaskId>) -> Result<()> {
+        todo!("Cancel messages are not implemented yet");
+        // see https://app.asana.com/0/1199548034582004/1202011714603653/f
 
-        Ok(())
+        // for id in cancel_msgs {
+        //     tracing::trace!("Handling cancel msg for task with id: {}", id);
+        //     if let Some(task) = self.pending_tasks.inner.get(&id) {
+        //         match &task.distribution_controller {
+        //             DistributionController::Distributed {
+        //                 active_workers,
+        //                 received_results: _,
+        //                 reference_task: _,
+        //             } => {
+        //                 for worker in active_workers {
+        //                     self.send_to_worker(
+        //                         worker.index(),
+        //                         WorkerPoolToWorkerMsg::cancel_task(task.task_id),
+        //                     )?;
+        //                 }
+        //             }
+        //             DistributionController::Single { active_worker } => {
+        //                 self.send_to_worker(
+        //                     active_worker.index(),
+        //                     WorkerPoolToWorkerMsg::cancel_task(task.task_id),
+        //                 )?;
+        //             }
+        //         }
+        //     }
+        // }
+        //
+        // Ok(())
     }
 
     fn send_to_worker(&self, index: WorkerIndex, msg: WorkerPoolToWorkerMsg) -> Result<()> {

--- a/packages/engine/src/workerpool/mod.rs
+++ b/packages/engine/src/workerpool/mod.rs
@@ -249,8 +249,7 @@ impl WorkerPoolController {
                     })?;
                 }
                 let fut = async move {
-                    let sync = sync;
-                    // Capture `sync` in lambda.
+                    let sync = sync; // Capture `sync` in lambda.
                     // TODO: these types of logs are better suited as a span
                     tracing::trace!("Waiting for worker synchronization");
                     sync.forward_children(worker_completion_receivers).await;

--- a/packages/engine/src/workerpool/pending.rs
+++ b/packages/engine/src/workerpool/pending.rs
@@ -85,7 +85,7 @@ impl PendingWorkerPoolTask {
     }
 
     /// TODO: DOC
-    #[allow(dead_code, unused_variables, unreachable_code)]
+    #[allow(unused_variables, unreachable_code)]
     fn handle_cancel_state(&mut self, worker: Worker, _task_id: TaskId) -> Result<HasTerminated> {
         todo!("Cancel messages are not implemented yet");
         // see https://app.asana.com/0/1199548034582004/1202011714603653/f
@@ -121,6 +121,7 @@ impl PendingWorkerPoolTask {
     }
 
     /// TODO: DOC
+    #[allow(unreachable_code)]
     pub fn handle_result_or_cancel(
         &mut self,
         worker: Worker,
@@ -132,7 +133,7 @@ impl PendingWorkerPoolTask {
                 &TaskResultOrCancelled::Cancelled
             )
         {
-            todo!("Cancel messages are not implemented yet")
+            todo!("Cancel messages are not implemented yet");
             // see https://app.asana.com/0/1199548034582004/1202011714603653/f
             self.handle_cancel_state(worker, result_or_cancelled.task_id)
         } else if let TaskResultOrCancelled::Result(result) = result_or_cancelled.payload {

--- a/packages/engine/src/workerpool/pending.rs
+++ b/packages/engine/src/workerpool/pending.rs
@@ -134,7 +134,7 @@ impl PendingWorkerPoolTask {
         {
             todo!("Cancel messages are not implemented yet")
             // see https://app.asana.com/0/1199548034582004/1202011714603653/f
-            // self.handle_cancel_state(worker, result_or_cancelled.task_id)
+            self.handle_cancel_state(worker, result_or_cancelled.task_id)
         } else if let TaskResultOrCancelled::Result(result) = result_or_cancelled.payload {
             self.handle_result_state(worker, result_or_cancelled.task_id, result)
         } else {

--- a/packages/engine/src/workerpool/pending.rs
+++ b/packages/engine/src/workerpool/pending.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use tokio::sync::oneshot;
+
 use super::error::{Error, Result};
 use crate::{
     config::Worker,
@@ -83,39 +85,39 @@ impl PendingWorkerPoolTask {
     }
 
     /// TODO: DOC
-    #[allow(dead_code)]
-    fn handle_cancel_state(&mut self, _worker: Worker, _task_id: TaskId) -> Result<HasTerminated> {
+    #[allow(dead_code, unused_variables, unreachable_code)]
+    fn handle_cancel_state(&mut self, worker: Worker, _task_id: TaskId) -> Result<HasTerminated> {
         todo!("Cancel messages are not implemented yet");
         // see https://app.asana.com/0/1199548034582004/1202011714603653/f
 
-        // if let DistributionController::Distributed {
-        //     active_workers: active_workers_comms,
-        //     received_results: _,
-        //     reference_task: _,
-        // } = &mut self.distribution_controller
-        // {
-        //     active_workers_comms.remove(worker.index());
-        //     if active_workers_comms.is_empty() {
-        //         let combined_result = TaskResultOrCancelled::Cancelled;
-        //         self.comms
-        //             .result_send
-        //             .take()
-        //             .ok_or(Error::NoResultSender)?
-        //             .send(combined_result)
-        //             .map_err(|_| Error::from("Couldn't send cancelled task result"))?;
-        //         Ok(true)
-        //     } else {
-        //         Ok(false)
-        //     }
-        // } else {
-        //     self.comms
-        //         .result_send
-        //         .take()
-        //         .ok_or(Error::NoResultSender)?
-        //         .send(TaskResultOrCancelled::Cancelled)
-        //         .map_err(|_| Error::from("Couldn't send cancelled task result"))?;
-        //     Ok(true)
-        // }
+        if let DistributionController::Distributed {
+            active_workers: active_workers_comms,
+            received_results: _,
+            reference_task: _,
+        } = &mut self.distribution_controller
+        {
+            active_workers_comms.remove(worker.index());
+            if active_workers_comms.is_empty() {
+                let combined_result = TaskResultOrCancelled::Cancelled;
+                self.comms
+                    .result_send
+                    .take()
+                    .ok_or(Error::NoResultSender)?
+                    .send(combined_result)
+                    .map_err(|_| Error::from("Couldn't send cancelled task result"))?;
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        } else {
+            self.comms
+                .result_send
+                .take()
+                .ok_or(Error::NoResultSender)?
+                .send(TaskResultOrCancelled::Cancelled)
+                .map_err(|_| Error::from("Couldn't send cancelled task result"))?;
+            Ok(true)
+        }
     }
 
     /// TODO: DOC
@@ -142,24 +144,24 @@ impl PendingWorkerPoolTask {
         }
     }
 
-    #[allow(dead_code)]
+    #[allow(dead_code, unreachable_code)]
     pub fn recv_cancel(&mut self) -> Result<Option<CancelTask>> {
         todo!("Cancel messages are not implemented yet");
         // see https://app.asana.com/0/1199548034582004/1202011714603653/f
 
-        // use oneshot::error::TryRecvError;
-        // if !self.cancelling {
-        //     return match self.comms.cancel_recv.try_recv() {
-        //         Ok(res) => Ok(Some(res)),
-        //         Err(err) => match err {
-        //             TryRecvError::Empty => Ok(None),
-        //             TryRecvError::Closed => Err(Error::CancelClosed),
-        //         },
-        //     };
-        // }
-        // // Don't send anything because we've already received a cancel
-        // // message.
-        // Ok(None)
+        use oneshot::error::TryRecvError;
+        if !self.cancelling {
+            return match self.comms.cancel_recv.try_recv() {
+                Ok(res) => Ok(Some(res)),
+                Err(err) => match err {
+                    TryRecvError::Empty => Ok(None),
+                    TryRecvError::Closed => Err(Error::CancelClosed),
+                },
+            };
+        }
+        // Don't send anything because we've already received a cancel
+        // message.
+        Ok(None)
     }
 }
 
@@ -170,21 +172,21 @@ pub struct PendingWorkerPoolTasks {
 }
 
 impl PendingWorkerPoolTasks {
-    #[allow(dead_code)]
+    #[allow(dead_code, unreachable_code)]
     pub async fn run_cancel_check(&mut self) -> Vec<TaskId> {
         todo!("Cancel messages are not implemented yet");
         // see https://app.asana.com/0/1199548034582004/1202011714603653/f
 
-        // self.inner
-        //     .iter_mut()
-        //     .filter_map(|(id, task)| {
-        //         // Ignore if closed
-        //         if let Ok(Some(_)) = task.recv_cancel() {
-        //             Some(*id)
-        //         } else {
-        //             None
-        //         }
-        //     })
-        //     .collect::<Vec<_>>()
+        self.inner
+            .iter_mut()
+            .filter_map(|(id, task)| {
+                // Ignore if closed
+                if let Ok(Some(_)) = task.recv_cancel() {
+                    Some(*id)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>()
     }
 }

--- a/packages/engine/src/workerpool/pending.rs
+++ b/packages/engine/src/workerpool/pending.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 
-use tokio::sync::oneshot;
-
 use super::error::{Error, Result};
 use crate::{
     config::Worker,
@@ -85,35 +83,39 @@ impl PendingWorkerPoolTask {
     }
 
     /// TODO: DOC
-    fn handle_cancel_state(&mut self, worker: Worker, _task_id: TaskId) -> Result<HasTerminated> {
-        if let DistributionController::Distributed {
-            active_workers: active_workers_comms,
-            received_results: _,
-            reference_task: _,
-        } = &mut self.distribution_controller
-        {
-            active_workers_comms.remove(worker.index());
-            if active_workers_comms.is_empty() {
-                let combined_result = TaskResultOrCancelled::Cancelled;
-                self.comms
-                    .result_send
-                    .take()
-                    .ok_or(Error::NoResultSender)?
-                    .send(combined_result)
-                    .map_err(|_| Error::from("Couldn't send cancelled task result"))?;
-                Ok(true)
-            } else {
-                Ok(false)
-            }
-        } else {
-            self.comms
-                .result_send
-                .take()
-                .ok_or(Error::NoResultSender)?
-                .send(TaskResultOrCancelled::Cancelled)
-                .map_err(|_| Error::from("Couldn't send cancelled task result"))?;
-            Ok(true)
-        }
+    #[allow(dead_code)]
+    fn handle_cancel_state(&mut self, _worker: Worker, _task_id: TaskId) -> Result<HasTerminated> {
+        todo!("Cancel messages are not implemented yet");
+        // see https://app.asana.com/0/1199548034582004/1202011714603653/f
+
+        // if let DistributionController::Distributed {
+        //     active_workers: active_workers_comms,
+        //     received_results: _,
+        //     reference_task: _,
+        // } = &mut self.distribution_controller
+        // {
+        //     active_workers_comms.remove(worker.index());
+        //     if active_workers_comms.is_empty() {
+        //         let combined_result = TaskResultOrCancelled::Cancelled;
+        //         self.comms
+        //             .result_send
+        //             .take()
+        //             .ok_or(Error::NoResultSender)?
+        //             .send(combined_result)
+        //             .map_err(|_| Error::from("Couldn't send cancelled task result"))?;
+        //         Ok(true)
+        //     } else {
+        //         Ok(false)
+        //     }
+        // } else {
+        //     self.comms
+        //         .result_send
+        //         .take()
+        //         .ok_or(Error::NoResultSender)?
+        //         .send(TaskResultOrCancelled::Cancelled)
+        //         .map_err(|_| Error::from("Couldn't send cancelled task result"))?;
+        //     Ok(true)
+        // }
     }
 
     /// TODO: DOC
@@ -128,7 +130,9 @@ impl PendingWorkerPoolTask {
                 &TaskResultOrCancelled::Cancelled
             )
         {
-            self.handle_cancel_state(worker, result_or_cancelled.task_id)
+            todo!("Cancel messages are not implemented yet")
+            // see https://app.asana.com/0/1199548034582004/1202011714603653/f
+            // self.handle_cancel_state(worker, result_or_cancelled.task_id)
         } else if let TaskResultOrCancelled::Result(result) = result_or_cancelled.payload {
             self.handle_result_state(worker, result_or_cancelled.task_id, result)
         } else {
@@ -138,22 +142,24 @@ impl PendingWorkerPoolTask {
         }
     }
 
-    // TODO: delete or use when cancel is revisited
     #[allow(dead_code)]
     pub fn recv_cancel(&mut self) -> Result<Option<CancelTask>> {
-        use oneshot::error::TryRecvError;
-        if !self.cancelling {
-            return match self.comms.cancel_recv.try_recv() {
-                Ok(res) => Ok(Some(res)),
-                Err(err) => match err {
-                    TryRecvError::Empty => Ok(None),
-                    TryRecvError::Closed => Err(Error::CancelClosed),
-                },
-            };
-        }
-        // Don't send anything because we've already received a cancel
-        // message.
-        Ok(None)
+        todo!("Cancel messages are not implemented yet");
+        // see https://app.asana.com/0/1199548034582004/1202011714603653/f
+
+        // use oneshot::error::TryRecvError;
+        // if !self.cancelling {
+        //     return match self.comms.cancel_recv.try_recv() {
+        //         Ok(res) => Ok(Some(res)),
+        //         Err(err) => match err {
+        //             TryRecvError::Empty => Ok(None),
+        //             TryRecvError::Closed => Err(Error::CancelClosed),
+        //         },
+        //     };
+        // }
+        // // Don't send anything because we've already received a cancel
+        // // message.
+        // Ok(None)
     }
 }
 
@@ -164,19 +170,21 @@ pub struct PendingWorkerPoolTasks {
 }
 
 impl PendingWorkerPoolTasks {
-    // TODO: delete or use when cancel is revisited
     #[allow(dead_code)]
     pub async fn run_cancel_check(&mut self) -> Vec<TaskId> {
-        self.inner
-            .iter_mut()
-            .filter_map(|(id, task)| {
-                // Ignore if closed
-                if let Ok(Some(_)) = task.recv_cancel() {
-                    Some(*id)
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>()
+        todo!("Cancel messages are not implemented yet");
+        // see https://app.asana.com/0/1199548034582004/1202011714603653/f
+
+        // self.inner
+        //     .iter_mut()
+        //     .filter_map(|(id, task)| {
+        //         // Ignore if closed
+        //         if let Ok(Some(_)) = task.recv_cancel() {
+        //             Some(*id)
+        //         } else {
+        //             None
+        //         }
+        //     })
+        //     .collect::<Vec<_>>()
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Cancel-events are currently not handled. Instead of silently ignoring them, we should not even send them to the runners and `panic!` if they appear instead.

## 🐾 Next steps

- [Handle cancel messages](https://app.asana.com/0/1199548034582004/1202011714603653/f) (_internal_, low priority)

## 🔍 What does this change?

- Panic, as soon as a cancel-method is called or a cancel message occurred at a runner
- Annotate every change with the link to the corresponding task above for easier picking it up

### 📜 Does this require a change to the docs?

No

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201893074552404/1202011714603665/f) _(internal)_

## 🛡 What tests cover this?

The integration test suite would `panic!`, if there are still cancel-messages around
