### PR TITLE
Enable `empty::array` Python test

### DIFF
--- a/packages/engine/tests/units/state/empty/mod.rs
+++ b/packages/engine/tests/units/state/empty/mod.rs
@@ -6,6 +6,8 @@ mod js {
 }
 
 mod py {
-    crate::run_test!(array, Python, #[ignore]);
+    crate::run_test!(array, Python);
+    // TODO: Empty structs fails with `'index out of bounds: the len is 0 but the index is 0`
+    //   see https://app.asana.com/0/1199548034582004/1201826554813225/f
     crate::run_test!(object, Python, #[ignore]);
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This test was missed in #229, so we enable it *now*. The error for `empty::object` is the same as in JS.
