### PR TITLE
Apply clippy.toml to other library crates

### DIFF
--- a/packages/engine/lib/clippy.toml
+++ b/packages/engine/lib/clippy.toml
@@ -8,4 +8,4 @@ single-char-binding-names-threshold = 0
 
 # Names should be expressive, avoid throw-away variable names, abbrevations, and redundant names
 # defaults to ["foo", "baz", "quux"]
-blacklisted-names = ["foo", "baz", "quux", "toto", "tutu", "tata", "rb", "res", "yes", "no"]
+blacklisted-names = ["foo", "baz", "quux", "toto", "tutu", "tata", "rb", "yes", "no"]

--- a/packages/engine/lib/error/src/ext.rs
+++ b/packages/engine/lib/error/src/ext.rs
@@ -14,22 +14,16 @@ where
     where
         M: Message,
     {
-        match self {
-            Ok(t) => Ok(t),
-            Err(error) => Err(Report::from(error).wrap(message)),
-        }
+        self.map_err(|error| Report::from(error).wrap(message))
     }
 
     #[track_caller]
-    fn wrap_err_lazy<M, F>(self, op: F) -> Result<T, Self::Context>
+    fn wrap_err_lazy<M, F>(self, message: F) -> Result<T, Self::Context>
     where
         M: Message,
         F: FnOnce() -> M,
     {
-        match self {
-            Ok(t) => Ok(t),
-            Err(error) => Err(Report::from(error).wrap(op())),
-        }
+        self.map_err(|error| Report::from(error).wrap(message()))
     }
 
     #[track_caller]
@@ -37,22 +31,16 @@ where
     where
         C: Context,
     {
-        match self {
-            Ok(t) => Ok(t),
-            Err(error) => Err(Report::from(error).provide_context(context)),
-        }
+        self.map_err(|error| Report::from(error).provide_context(context))
     }
 
     #[track_caller]
-    fn provide_context_lazy<C, F>(self, op: F) -> Result<T, C>
+    fn provide_context_lazy<C, F>(self, context: F) -> Result<T, C>
     where
         C: Context,
         F: FnOnce() -> C,
     {
-        match self {
-            Ok(t) => Ok(t),
-            Err(error) => Err(Report::from(error).provide_context(op())),
-        }
+        self.map_err(|error| Report::from(error).provide_context(context()))
     }
 }
 
@@ -64,22 +52,16 @@ impl<T, C> ResultExt<T> for Result<T, C> {
     where
         M: Message,
     {
-        match self {
-            Ok(t) => Ok(t),
-            Err(report) => Err(report.wrap(message)),
-        }
+        self.map_err(|report| report.wrap(message))
     }
 
     #[track_caller]
-    fn wrap_err_lazy<M, F>(self, op: F) -> Result<T, Self::Context>
+    fn wrap_err_lazy<M, F>(self, message: F) -> Result<T, Self::Context>
     where
         M: Message,
         F: FnOnce() -> M,
     {
-        match self {
-            Ok(t) => Ok(t),
-            Err(report) => Err(report.wrap(op())),
-        }
+        self.map_err(|report| report.wrap(message()))
     }
 
     #[track_caller]
@@ -87,21 +69,15 @@ impl<T, C> ResultExt<T> for Result<T, C> {
     where
         C2: Context,
     {
-        match self {
-            Ok(t) => Ok(t),
-            Err(report) => Err(report.provide_context(context)),
-        }
+        self.map_err(|report| report.provide_context(context))
     }
 
     #[track_caller]
-    fn provide_context_lazy<C2, F>(self, op: F) -> Result<T, C2>
+    fn provide_context_lazy<C2, F>(self, context: F) -> Result<T, C2>
     where
         C2: Context,
         F: FnOnce() -> C2,
     {
-        match self {
-            Ok(t) => Ok(t),
-            Err(report) => Err(report.provide_context(op())),
-        }
+        self.map_err(|report| report.provide_context(context()))
     }
 }

--- a/packages/engine/lib/error/src/macros.rs
+++ b/packages/engine/lib/error/src/macros.rs
@@ -44,7 +44,7 @@ pub mod __private {
     }
 
     pub fn report(args: fmt::Arguments) -> Report {
-        Report::new(alloc::format!("{}", args))
+        Report::new(args.to_string())
     }
 }
 

--- a/packages/engine/lib/provider/src/lib.rs
+++ b/packages/engine/lib/provider/src/lib.rs
@@ -166,11 +166,13 @@ pub(crate) mod tests {
     use crate::{tags, Provider, Requisition, TypeTag};
 
     struct CustomTagA;
+
     impl<'p> TypeTag<'p> for CustomTagA {
         type Type = usize;
     }
 
     struct CustomTagB;
+
     impl<'p> TypeTag<'p> for CustomTagB {
         type Type = usize;
     }

--- a/packages/engine/lib/provider/src/requisition.rs
+++ b/packages/engine/lib/provider/src/requisition.rs
@@ -8,21 +8,21 @@ impl<'p> Requisition<'p, '_> {
     where
         I: TypeTag<'p>,
     {
-        if let Some(res @ TagValue(Option::None)) =
+        if let Some(tag_value @ TagValue(Option::None)) =
             self.0.tagged.downcast_mut::<tags::OptionTag<I>>()
         {
-            res.0 = Some(value);
+            tag_value.0 = Some(value);
         }
         self
     }
 
     /// Provide a value or other type with only static lifetimes.
-    pub fn provide_value<T, F>(&mut self, f: F) -> &mut Self
+    pub fn provide_value<T, F>(&mut self, value: F) -> &mut Self
     where
         T: 'static,
         F: FnOnce() -> T,
     {
-        self.provide_with::<tags::Value<T>, F>(f)
+        self.provide_with::<tags::Value<T>, F>(value)
     }
 
     /// Provide a reference, note that `T` must be bounded by `'static`, but may be unsized.
@@ -31,15 +31,15 @@ impl<'p> Requisition<'p, '_> {
     }
 
     /// Provide a value with the given [`TypeTag`], using a closure to prevent unnecessary work.
-    pub fn provide_with<I, F>(&mut self, f: F) -> &mut Self
+    pub fn provide_with<I, F>(&mut self, op: F) -> &mut Self
     where
         I: TypeTag<'p>,
         F: FnOnce() -> I::Type,
     {
-        if let Some(res @ TagValue(Option::None)) =
+        if let Some(tag_value @ TagValue(Option::None)) =
             self.0.tagged.downcast_mut::<tags::OptionTag<I>>()
         {
-            res.0 = Some(f());
+            tag_value.0 = Some(op());
         }
         self
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#426 added a `clippy.toml`. This also applies that config to other library files to let newly moved-out crates directly pick it up.

## ⚠️ Known issues

`res` is used in `format!()`, thus it can't be blacklisted.

## 🔍 What does this change?

- Move `clippy.toml` from `lib/nano/` to `lib/`
- Apply lints to other crates in that directory