### PR TITLE
Remove preludes from `hash_engine_lib`

### DIFF
--- a/packages/engine/src/datastore/arrow/message.rs
+++ b/packages/engine/src/datastore/arrow/message.rs
@@ -3,14 +3,21 @@ use std::sync::Arc;
 use arrow::{
     array::{self, Array},
     datatypes::{DataType, Field, Schema},
+    record_batch::RecordBatch,
 };
 use lazy_static::lazy_static;
 
 use crate::{
-    datastore::{prelude::*, schema::PresetFieldType},
-    hash_types::message::{
-        GenericPayload, Outbound, OutboundCreateAgentPayload, OutboundRemoveAgentPayload,
-        OutboundStopSimPayload,
+    datastore::{
+        error::{Error, Result},
+        schema::PresetFieldType,
+    },
+    hash_types::{
+        message::{
+            GenericPayload, Outbound, OutboundCreateAgentPayload, OutboundRemoveAgentPayload,
+            OutboundStopSimPayload,
+        },
+        Agent,
     },
 };
 
@@ -280,11 +287,7 @@ pub fn get_column_from_list_array(array: &array::ListArray) -> Result<Vec<Vec<Ou
     Ok(result)
 }
 
-pub fn column_into_state(
-    states: &mut [AgentState],
-    batch: &RecordBatch,
-    index: usize,
-) -> Result<()> {
+pub fn column_into_state(states: &mut [Agent], batch: &RecordBatch, index: usize) -> Result<()> {
     let reference = batch
         .column(index)
         .as_any()

--- a/packages/engine/src/datastore/arrow/message.rs
+++ b/packages/engine/src/datastore/arrow/message.rs
@@ -1,8 +1,11 @@
 use std::sync::Arc;
 
+use arrow::{
+    array::{self, Array},
+    datatypes::{DataType, Field, Schema},
+};
 use lazy_static::lazy_static;
 
-use super::prelude::*;
 use crate::{
     datastore::{prelude::*, schema::PresetFieldType},
     hash_types::message::{
@@ -31,30 +34,30 @@ pub enum FieldIndex {
 }
 
 lazy_static! {
-    pub static ref SENDER_ARROW_FIELD: ArrowField = ArrowField::new(
+    pub static ref SENDER_ARROW_FIELD: Field = Field::new(
         "from",
         PresetFieldType::Id.get_arrow_data_type(),
         false
     );
-    pub static ref MESSAGE_ARROW_FIELDS: Vec<ArrowField> = vec![
-        ArrowField::new(
+    pub static ref MESSAGE_ARROW_FIELDS: Vec<Field> = vec![
+        Field::new(
             "to",
-            ArrowDataType::List(Box::new(ArrowField::new("item", ArrowDataType::Utf8, true))),
+            DataType::List(Box::new(Field::new("item", DataType::Utf8, true))),
             false
         ),
-        ArrowField::new("type", ArrowDataType::Utf8, false),
-        ArrowField::new("data", ArrowDataType::Utf8, true),
+        Field::new("type", DataType::Utf8, false),
+        Field::new("data", DataType::Utf8, true),
     ];
-    pub static ref MESSAGE_ARROW_TYPE: ArrowDataType =
-        ArrowDataType::Struct(MESSAGE_ARROW_FIELDS.clone());
-    pub static ref MESSAGE_LIST_ARROW_FIELD: ArrowField = ArrowField::new(
+    pub static ref MESSAGE_ARROW_TYPE: DataType =
+        DataType::Struct(MESSAGE_ARROW_FIELDS.clone());
+    pub static ref MESSAGE_LIST_ARROW_FIELD: Field = Field::new(
         MESSAGE_COLUMN_NAME,
-        ArrowDataType::List(Box::new(ArrowField::new("item", MESSAGE_ARROW_TYPE.clone(), true))),
+        DataType::List(Box::new(Field::new("item", MESSAGE_ARROW_TYPE.clone(), true))),
         false
     );
     // It is important to keep this order unchanged. If changed
     // then the consts above must be updated
-    pub static ref MESSAGE_BATCH_SCHEMA: ArrowSchema = ArrowSchema::new(vec![
+    pub static ref MESSAGE_BATCH_SCHEMA: Schema = Schema::new(vec![
         SENDER_ARROW_FIELD.clone(),
         MESSAGE_LIST_ARROW_FIELD.clone()
     ]);
@@ -299,14 +302,14 @@ pub fn column_into_state(
 }
 
 pub fn batch_from_json(
-    schema: &Arc<ArrowSchema>,
+    schema: &Arc<Schema>,
     ids: Vec<&str>,
     messages: Option<Vec<serde_json::Value>>,
 ) -> Result<RecordBatch> {
     let agent_count = ids.len();
     let ids = Arc::new(super::batch_conversion::get_agent_id_array(ids)?);
 
-    let messages: Arc<dyn ArrowArray> = messages.map_or_else(
+    let messages: Arc<dyn Array> = messages.map_or_else(
         || empty_messages_column(agent_count).map(Arc::new),
         |values| messages_column_from_serde_values(values).map(Arc::new),
     )?;

--- a/packages/engine/src/datastore/arrow/mod.rs
+++ b/packages/engine/src/datastore/arrow/mod.rs
@@ -5,14 +5,3 @@ pub mod message;
 pub mod meta_conversion;
 pub mod padding;
 pub mod util;
-
-mod prelude {
-    pub use arrow::{
-        array::{self, Array as ArrowArray, ArrayBuilder as ArrowArrayBuilder},
-        buffer::{Buffer as ArrowBuffer, MutableBuffer as ArrowMutableBuffer},
-        datatypes::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema},
-        util::bit_util as arrow_bit_util,
-    };
-
-    pub use super::message;
-}

--- a/packages/engine/src/datastore/arrow/util.rs
+++ b/packages/engine/src/datastore/arrow/util.rs
@@ -1,6 +1,5 @@
+use arrow::util::bit_util;
 use flatbuffers::FlatBufferBuilder;
-
-use super::prelude::*;
 
 pub const CONTINUATION: usize = 8;
 
@@ -51,7 +50,7 @@ impl AsRef<[u8]> for FlatBufferWrapper<'_> {
 
 // TODO: UNUSED: Needs triage
 pub fn get_bit(buffer: &[u8], i: usize) -> bool {
-    arrow_bit_util::get_bit(buffer, i)
+    bit_util::get_bit(buffer, i)
 }
 
 pub trait DataSliceUtils<'a> {

--- a/packages/engine/src/datastore/batch/dataset.rs
+++ b/packages/engine/src/datastore/batch/dataset.rs
@@ -1,5 +1,9 @@
 use crate::{
-    datastore::{batch::Segment, prelude::*},
+    datastore::{
+        batch::{metaversion::Metaversion, Segment},
+        error::Result,
+        storage::memory::Memory,
+    },
     proto::{ExperimentId, SharedDataset},
 };
 

--- a/packages/engine/src/datastore/batch/iterators.rs
+++ b/packages/engine/src/datastore/batch/iterators.rs
@@ -5,7 +5,11 @@ use crate::datastore::{Error, Result};
 pub mod agent {
     use arrow::datatypes::DataType;
 
-    use crate::datastore::{batch::iterators::record_batch, prelude::*, POSITION_DIM, UUID_V4_LEN};
+    use crate::datastore::{
+        batch::{iterators::record_batch, AgentBatch, AgentIndex},
+        error::Result,
+        POSITION_DIM, UUID_V4_LEN,
+    };
 
     pub fn agent_id_iter<'b: 'a, 'a>(
         agent_pool: &'a [&'b AgentBatch],
@@ -204,7 +208,7 @@ pub fn column_with_name<'a>(record_batch: &'a RecordBatch, name: &str) -> Result
 pub mod record_batch {
     use std::borrow::Cow;
 
-    use arrow::{array::Array, datatypes::DataType, record_batch::RecordBatch};
+    use arrow::{array::Array, datatypes::DataType, record_batch::RecordBatch, util::bit_util};
 
     use crate::{
         datastore::{
@@ -212,7 +216,6 @@ pub mod record_batch {
             batch::{
                 boolean::Column as BooleanColumn, change::ColumnChange, iterators::column_with_name,
             },
-            prelude::arrow_bit_util,
             Error, Result, POSITION_DIM, UUID_V4_LEN,
         },
         hash_types::state::AgentStateField,
@@ -244,7 +247,7 @@ pub mod record_batch {
         if let Some(nulls) = nulls {
             // This column is nullable.
             let nulls = nulls.as_slice();
-            if arrow_bit_util::get_bit(nulls, row_index) {
+            if bit_util::get_bit(nulls, row_index) {
                 // The null buffer contains a 1 for this row, so this row isn't null.
                 Ok(Some(old_message_location))
             } else {

--- a/packages/engine/src/datastore/batch/migration/mod.rs
+++ b/packages/engine/src/datastore/batch/migration/mod.rs
@@ -1357,7 +1357,10 @@ pub(super) mod test {
 
     use super::*;
     use crate::{
-        datastore::{schema::state::MessageSchema, test_utils::gen_schema_and_test_agents},
+        datastore::{
+            arrow::batch_conversion::IntoAgents, schema::state::MessageSchema,
+            test_utils::gen_schema_and_test_agents,
+        },
         simulation::package::creator::PREVIOUS_INDEX_FIELD_KEY,
     };
 

--- a/packages/engine/src/datastore/error.rs
+++ b/packages/engine/src/datastore/error.rs
@@ -3,7 +3,6 @@ use std::fmt;
 use arrow::{datatypes::DataType, error::ArrowError};
 use thiserror::Error as ThisError;
 
-use super::prelude::*;
 use crate::{
     datastore::schema::{FieldKey, FieldType, RootFieldSpec},
     hash_types,
@@ -94,7 +93,7 @@ pub enum Error {
     UnexpectedVectorLength { len: usize, expected: usize },
 
     #[error("Unsupported Arrow datatype: {d_type:?}")]
-    UnsupportedArrowDataType { d_type: ArrowDataType },
+    UnsupportedArrowDataType { d_type: DataType },
 
     #[error("Did not expect to resize Shared Memory")]
     UnexpectedAgentBatchMemoryResize,

--- a/packages/engine/src/datastore/ffi/flush.rs
+++ b/packages/engine/src/datastore/ffi/flush.rs
@@ -5,10 +5,14 @@
     clippy::missing_safety_doc
 )]
 
+use arrow::util::bit_util;
+
 use super::{memory::CMemory, ArrowArray};
 use crate::datastore::{
     batch::flush::{GrowableArrayData, GrowableBatch, GrowableColumn},
-    prelude::*,
+    error::{Error, Result},
+    meta,
+    storage::memory::Memory,
 };
 
 type Flag = usize;
@@ -28,8 +32,8 @@ pub struct Changes {
 #[no_mangle]
 unsafe extern "C" fn flush_changes(
     c_memory: *mut CMemory,
-    dynamic_meta: *mut DynamicMeta,
-    static_meta: *const StaticMeta,
+    dynamic_meta: *mut meta::Dynamic,
+    static_meta: *const meta::Static,
     changes: *const Changes,
 ) -> Flag {
     let changes = &*changes;
@@ -117,7 +121,7 @@ unsafe extern "C" fn flush_changes(
 // Assumes all buffers are properly aligned
 unsafe fn node_into_prepared_array_data(
     arrow_array: *const ArrowArray,
-    static_meta: &StaticMeta,
+    static_meta: &meta::Static,
     node_index: usize,
 ) -> Result<(PreparedArrayData<'_>, usize)> {
     let arrow_array_ref = &*arrow_array;
@@ -162,7 +166,7 @@ unsafe fn node_into_prepared_array_data(
             None
         } else {
             let ptr = (*arrow_array_ref.buffers) as *const u8;
-            let byte_length = arrow_bit_util::ceil(num_elem, 8);
+            let byte_length = bit_util::ceil(num_elem, 8);
             let slice = std::slice::from_raw_parts(ptr, byte_length);
             Some(slice)
         }
@@ -187,7 +191,7 @@ unsafe fn node_into_prepared_array_data(
                             "The null buffer is null but the null count is non-zero",
                         ));
                     }
-                    let byte_length = arrow_bit_util::ceil(num_elem, 8);
+                    let byte_length = bit_util::ceil(num_elem, 8);
                     std::slice::from_raw_parts(ptr, byte_length)
                 }
                 crate::datastore::meta::BufferType::Offset => {
@@ -274,21 +278,21 @@ impl<'a> GrowableColumn<PreparedArrayData<'a>> for PreparedColumn<'a> {
 
 /// Batch used by Python FFI.
 pub struct PreparedBatch<'a> {
-    static_meta: *const StaticMeta,
-    dynamic_meta: &'a mut DynamicMeta,
+    static_meta: *const meta::Static,
+    dynamic_meta: &'a mut meta::Dynamic,
     memory: &'a mut Memory,
 }
 
 impl<'a> GrowableBatch<PreparedArrayData<'a>, PreparedColumn<'a>> for PreparedBatch<'a> {
-    fn static_meta(&self) -> &StaticMeta {
+    fn static_meta(&self) -> &meta::Static {
         unsafe { &*self.static_meta }
     }
 
-    fn dynamic_meta(&self) -> &DynamicMeta {
+    fn dynamic_meta(&self) -> &meta::Dynamic {
         self.dynamic_meta
     }
 
-    fn dynamic_meta_mut(&mut self) -> &mut DynamicMeta {
+    fn dynamic_meta_mut(&mut self) -> &mut meta::Dynamic {
         self.dynamic_meta
     }
 

--- a/packages/engine/src/datastore/meta.rs
+++ b/packages/engine/src/datastore/meta.rs
@@ -1,4 +1,4 @@
-use super::prelude::*;
+use crate::datastore::arrow::padding;
 
 /// Internal representation of Arrow `FieldNode` Message
 #[derive(Debug, Clone)]

--- a/packages/engine/src/datastore/mod.rs
+++ b/packages/engine/src/datastore/mod.rs
@@ -25,46 +25,6 @@ pub const POSITION_DIM: usize = 3;
 
 pub use self::error::{Error, Result};
 
-pub mod prelude {
-    pub use arrow::{
-        array::Array as ArrowArray,
-        buffer::{Buffer as ArrowBuffer, MutableBuffer as ArrowMutableBuffer},
-        datatypes::{
-            DataType as ArrowDataType, Field as ArrowField, IntervalUnit as ArrowIntervalUnit,
-            Schema as ArrowSchema, TimeUnit as ArrowTimeUnit,
-        },
-        error::ArrowError,
-        ipc as arrow_ipc,
-        ipc::gen::Message::RecordBatch as RecordBatchMessage,
-        record_batch::RecordBatch,
-        util::bit_util as arrow_bit_util,
-    };
-
-    pub use super::{
-        arrow::{
-            batch_conversion::{IntoAgentStates, IntoRecordBatch},
-            field_conversion,
-            meta_conversion::{HashDynamicMeta, HashStaticMeta},
-            padding,
-        },
-        batch::{
-            metaversion::Metaversion,
-            migration::{CopyAction, CreateAction, RemoveAction, RowActions},
-            AgentBatch, AgentIndex, Dataset, MessageBatch, MessageIndex,
-        },
-        error::{Error, Result, SupportedType},
-        meta::{
-            Buffer, BufferAction, Column as ColumnMeta, Dynamic as DynamicMeta, Node, NodeMapping,
-            NodeStatic as NodeStaticMeta, Static as StaticMeta,
-        },
-        shared_store::SharedStore,
-        storage::memory::Memory,
-        store::Store,
-        table::state::State,
-    };
-    pub use crate::hash_types::{message::Outbound as OutboundMessage, Agent as AgentState};
-}
-
 #[cfg(test)]
 pub mod tests {
     use std::{borrow::Cow, sync::Arc};

--- a/packages/engine/src/datastore/mod.rs
+++ b/packages/engine/src/datastore/mod.rs
@@ -29,11 +29,15 @@ pub use self::error::{Error, Result};
 pub mod tests {
     use std::{borrow::Cow, sync::Arc};
 
+    use ::arrow::array::{Array, BooleanBuilder, FixedSizeListBuilder};
     use rand::Rng;
 
-    use super::{prelude::*, test_utils::gen_schema_and_test_agents};
+    use super::{test_utils::gen_schema_and_test_agents, *};
     use crate::datastore::{
-        batch::iterators, table::state::State, test_utils::dummy_sim_run_config,
+        arrow::batch_conversion::IntoAgents,
+        batch::{iterators, AgentBatch},
+        table::state::State,
+        test_utils::dummy_sim_run_config,
     };
 
     #[test]
@@ -132,14 +136,13 @@ pub mod tests {
     pub fn uuid_v4_len() {
         let uuid = uuid::Uuid::new_v4();
         let bytes = uuid.as_bytes();
-        assert_eq!(bytes.len(), super::UUID_V4_LEN);
+        assert_eq!(bytes.len(), UUID_V4_LEN);
     }
 
     #[test]
     fn test_print_boolean_array() -> Result<()> {
-        let boolean_builder = arrow::array::BooleanBuilder::new(100);
-        let mut fixed_size_list_builder =
-            arrow::array::FixedSizeListBuilder::new(boolean_builder, 3);
+        let boolean_builder = BooleanBuilder::new(100);
+        let mut fixed_size_list_builder = FixedSizeListBuilder::new(boolean_builder, 3);
 
         for _ in 0..10 {
             fixed_size_list_builder

--- a/packages/engine/src/datastore/schema/context.rs
+++ b/packages/engine/src/datastore/schema/context.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use crate::datastore::{prelude::*, schema::field_spec::FieldSpecMap};
+use arrow::datatypes::Schema as ArrowSchema;
+
+use crate::datastore::{error::Result, schema::field_spec::FieldSpecMap};
 
 pub struct ContextSchema {
     pub arrow: Arc<ArrowSchema>,

--- a/packages/engine/src/datastore/schema/state/message.rs
+++ b/packages/engine/src/datastore/schema/state/message.rs
@@ -1,6 +1,11 @@
 use std::sync::Arc;
 
-use crate::datastore::{arrow::message::MESSAGE_BATCH_SCHEMA, prelude::*};
+use arrow::datatypes::Schema as ArrowSchema;
+
+use crate::datastore::{
+    arrow::{message::MESSAGE_BATCH_SCHEMA, meta_conversion::HashStaticMeta},
+    meta::Static as StaticMeta,
+};
 
 pub struct MessageSchema {
     pub arrow: Arc<ArrowSchema>,

--- a/packages/engine/src/datastore/schema/state/mod.rs
+++ b/packages/engine/src/datastore/schema/state/mod.rs
@@ -2,10 +2,13 @@ mod message;
 
 use std::sync::Arc;
 
+use arrow::datatypes::Schema as ArrowSchema;
 pub use message::MessageSchema;
 
 use super::FieldSpecMap;
-use crate::datastore::prelude::*;
+use crate::datastore::{
+    arrow::meta_conversion::HashStaticMeta, error::Result, meta::Static as StaticMeta,
+};
 
 /// `AgentSchema` describes the layout of every
 /// agent-containing `SharedBatch` in a datastore. It contains

--- a/packages/engine/src/datastore/storage/markers.rs
+++ b/packages/engine/src/datastore/storage/markers.rs
@@ -27,7 +27,7 @@ use std::{
 };
 
 use super::ptr::MemoryPtr;
-use crate::datastore::prelude::*;
+use crate::datastore::arrow::padding;
 
 #[repr(usize)]
 pub enum Val {

--- a/packages/engine/src/datastore/storage/memory.rs
+++ b/packages/engine/src/datastore/storage/memory.rs
@@ -9,7 +9,14 @@ use super::{
     visitor::{Visit, Visitor, VisitorMut},
     BufferChange,
 };
-use crate::{datastore::prelude::*, proto::ExperimentId};
+use crate::{
+    datastore::{
+        arrow::padding,
+        batch::Metaversion,
+        error::{Error, Result},
+    },
+    proto::ExperimentId,
+};
 
 pub type Buffers<'a> = (&'a [u8], &'a [u8], &'a [u8], &'a [u8]);
 

--- a/packages/engine/src/datastore/storage/visitor.rs
+++ b/packages/engine/src/datastore/storage/visitor.rs
@@ -10,7 +10,11 @@ use super::{
     ptr::MemoryPtr,
     BufferChange,
 };
-use crate::datastore::{arrow::util, prelude::*};
+use crate::datastore::{
+    arrow::util,
+    error::{Error, Result},
+    storage::memory::Memory,
+};
 
 pub(in crate::datastore) trait Visit<'mem: 'v, 'v> {
     fn ptr(&self) -> &MemoryPtr;

--- a/packages/engine/src/datastore/store.rs
+++ b/packages/engine/src/datastore/store.rs
@@ -1,5 +1,7 @@
-use super::prelude::*;
-use crate::datastore::table::{context::Context, state::State};
+use crate::datastore::{
+    error::{Error, Result},
+    table::{context::Context, state::State},
+};
 
 /// The underlying state of a simulation run.
 pub struct Store {

--- a/packages/engine/src/datastore/table/context/mod.rs
+++ b/packages/engine/src/datastore/table/context/mod.rs
@@ -1,14 +1,16 @@
 use std::sync::Arc;
 
+use arrow::record_batch::RecordBatch;
+
 use crate::{
     config::StoreConfig,
     datastore::{
-        batch::context::ContextBatch,
-        prelude::*,
+        batch::{context::ContextBatch, AgentBatch},
+        error::{Error, Result},
         schema::state::AgentSchema,
         table::{
             pool::{agent::AgentPool, message::MessagePool, BatchPool},
-            state::view::StatePools,
+            state::{view::StatePools, State},
         },
     },
     proto::ExperimentId,

--- a/packages/engine/src/datastore/table/pool/mod.rs
+++ b/packages/engine/src/datastore/table/pool/mod.rs
@@ -8,7 +8,7 @@ use parking_lot::RwLock;
 
 use self::proxy::{PoolReadProxy, PoolWriteProxy};
 use crate::datastore::{
-    prelude::Result,
+    error::Result,
     table::proxy::{BatchReadProxy, BatchWriteProxy},
 };
 

--- a/packages/engine/src/datastore/table/proxy.rs
+++ b/packages/engine/src/datastore/table/proxy.rs
@@ -32,7 +32,8 @@ use parking_lot::{
 
 use super::pool::proxy::{PoolReadProxy, PoolWriteProxy};
 use crate::datastore::{
-    prelude::{AgentBatch, Error, MessageBatch, Result},
+    batch::{AgentBatch, MessageBatch},
+    error::{Error, Result},
     table::{pool::BatchPool, state::view::StatePools},
 };
 

--- a/packages/engine/src/datastore/table/references.rs
+++ b/packages/engine/src/datastore/table/references.rs
@@ -5,8 +5,7 @@ use std::{
 
 use rayon::iter::ParallelIterator;
 
-use super::super::prelude::*;
-use crate::datastore::table::pool::proxy::PoolReadProxy;
+use crate::datastore::{batch::MessageBatch, error::Result, table::pool::proxy::PoolReadProxy};
 
 #[derive(Clone, Debug)]
 pub struct AgentMessageReference {

--- a/packages/engine/src/datastore/table/state/create_remove/batch.rs
+++ b/packages/engine/src/datastore/table/state/create_remove/batch.rs
@@ -1,8 +1,9 @@
 use std::{collections::HashSet, ops::Deref};
 
-use super::{AgentIndex, BatchIndex, Result, WorkerIndex};
+use super::{AgentIndex, BatchIndex, WorkerIndex};
 use crate::datastore::{
     batch::{agent::AgentBatch, iterators::record_batch},
+    error::Result,
     UUID_V4_LEN,
 };
 

--- a/packages/engine/src/datastore/table/state/create_remove/command.rs
+++ b/packages/engine/src/datastore/table/state/create_remove/command.rs
@@ -3,7 +3,11 @@ use std::{collections::HashSet, sync::Arc};
 use arrow::record_batch::RecordBatch;
 
 use crate::{
-    datastore::{prelude::*, schema::state::AgentSchema, UUID_V4_LEN},
+    datastore::{
+        error::{Error, Result},
+        schema::state::AgentSchema,
+        UUID_V4_LEN,
+    },
     simulation::command::CreateRemoveCommands,
 };
 

--- a/packages/engine/src/datastore/table/state/create_remove/distribution.rs
+++ b/packages/engine/src/datastore/table/state/create_remove/distribution.rs
@@ -1,4 +1,8 @@
-use super::{super::*, batch::PendingBatch, WorkerIndex};
+use super::{
+    super::{Error, Result},
+    batch::PendingBatch,
+    WorkerIndex,
+};
 
 /// Represents the distribution of agents per worker.
 /// Each worker has its own collection of batches (usually one for smaller simulations).

--- a/packages/engine/src/datastore/table/state/create_remove/mod.rs
+++ b/packages/engine/src/datastore/table/state/create_remove/mod.rs
@@ -9,8 +9,6 @@ pub use command::ProcessedCommands;
 pub use plan::MigrationPlan;
 pub use planner::CreateRemovePlanner;
 
-use crate::datastore::prelude::*;
-
 type AgentIndex = crate::datastore::batch::migration::IndexAction;
 type BatchIndex = usize;
 type WorkerIndex = usize;

--- a/packages/engine/src/datastore/table/state/create_remove/planner.rs
+++ b/packages/engine/src/datastore/table/state/create_remove/planner.rs
@@ -1,8 +1,10 @@
 //! TODO: DOC
 use std::sync::Arc;
 
+use arrow::record_batch::RecordBatch;
+
 use super::{
-    super::*,
+    super::AgentSchema,
     action::{CreateActions, ExistingGroupBufferActions},
     batch::PendingBatch,
     command::ProcessedCommands,
@@ -11,9 +13,11 @@ use super::{
 };
 use crate::{
     datastore::{
-        batch::migration::{BufferActions, IndexRange, RangeActions},
+        batch::{
+            migration::{BufferActions, IndexRange, RangeActions},
+            AgentBatch,
+        },
         error::Result,
-        prelude::*,
         table::{pool::proxy::PoolReadProxy, proxy::StateReadProxy},
     },
     simulation::command::CreateRemoveCommands,

--- a/packages/engine/src/datastore/table/state/mod.rs
+++ b/packages/engine/src/datastore/table/state/mod.rs
@@ -10,7 +10,8 @@ use super::{
 };
 use crate::{
     datastore::{
-        prelude::*,
+        batch::{AgentBatch, MessageBatch},
+        error::{Error, Result},
         schema::state::AgentSchema,
         table::{
             pool::BatchPool,
@@ -18,6 +19,7 @@ use crate::{
             state::view::StatePools,
         },
     },
+    hash_types::Agent as AgentState,
     proto::ExperimentRunTrait,
     simulation::command::CreateRemoveCommands,
     SimRunConfig,

--- a/packages/engine/src/datastore/table/task_shared_store.rs
+++ b/packages/engine/src/datastore/table/task_shared_store.rs
@@ -4,7 +4,10 @@ use std::fmt::Debug;
 use super::proxy::{StateReadProxy, StateWriteProxy};
 use crate::{
     config::{StateBatchDistribution, Worker, WorkerAllocation},
-    datastore::{prelude::Result, table::context::Context, Error},
+    datastore::{
+        error::{Error, Result},
+        table::context::Context,
+    },
     simulation::task::handler::worker_pool::SplitConfig,
 };
 

--- a/packages/engine/src/experiment/controller/comms.rs
+++ b/packages/engine/src/experiment/controller/comms.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use super::Result;
 
 pub mod simulation {
-    use super::*;
+    use super::{unbounded_channel, Result, UnboundedReceiver, UnboundedSender};
     use crate::simulation::controller::SimControl;
 
     pub struct SimCtlSend {
@@ -33,7 +33,7 @@ pub mod simulation {
 }
 
 pub mod sim_status {
-    use super::*;
+    use super::{unbounded_channel, Result, UnboundedReceiver, UnboundedSender};
     use crate::simulation::status::SimStatus;
 
     #[derive(Clone)]
@@ -64,7 +64,7 @@ pub mod sim_status {
 }
 
 pub mod exp_pkg_ctl {
-    use super::*;
+    use super::{unbounded_channel, Result, UnboundedReceiver, UnboundedSender};
     use crate::experiment::ExperimentControl;
 
     pub struct ExpPkgCtlSend {
@@ -96,7 +96,7 @@ pub mod exp_pkg_ctl {
 /// Handles communication between the Experiment Controller and the Experiment Packages for updates
 /// at each simulation step
 pub mod exp_pkg_update {
-    use super::*;
+    use super::{unbounded_channel, Result, UnboundedReceiver, UnboundedSender};
     use crate::experiment::package::StepUpdate;
 
     #[derive(Clone)]

--- a/packages/engine/src/experiment/controller/controller.rs
+++ b/packages/engine/src/experiment/controller/controller.rs
@@ -12,7 +12,7 @@ use super::{
 };
 use crate::{
     config::{PersistenceConfig, StoreConfig},
-    datastore::prelude::SharedStore,
+    datastore::shared_store::SharedStore,
     env::OrchClient,
     experiment::{
         apply_globals_changes,

--- a/packages/engine/src/experiment/controller/run.rs
+++ b/packages/engine/src/experiment/controller/run.rs
@@ -4,7 +4,7 @@ use tracing::Instrument;
 
 use super::{config, controller::ExperimentController, Error, Result};
 use crate::{
-    datastore::prelude::SharedStore,
+    datastore::shared_store::SharedStore,
     experiment::{
         controller::{config::OutputPersistenceConfig, sim_configurer::SimConfigurer},
         package::ExperimentPackage,

--- a/packages/engine/src/hash_types/state.rs
+++ b/packages/engine/src/hash_types/state.rs
@@ -356,10 +356,7 @@ impl<'de> Deserialize<'de> for Agent {
     }
 }
 
-fn to_vec3_default(
-    val: serde_json::Value,
-    default: f64,
-) -> std::result::Result<Option<Vec3>, String> {
+fn to_vec3_default(val: serde_json::Value, default: f64) -> Result<Option<Vec3>, String> {
     match val {
         serde_json::Value::Null => Ok(None),
         serde_json::Value::Array(arr) => {

--- a/packages/engine/src/proto.rs
+++ b/packages/engine/src/proto.rs
@@ -49,13 +49,13 @@ impl From<String> for ExperimentName {
 impl FromStr for ExperimentName {
     type Err = Infallible;
 
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self(s.to_string()))
     }
 }
 
 use crate::{
-    simulation::enum_dispatch::*,
+    simulation::enum_dispatch::enum_dispatch,
     worker::runner::comms::outbound::{PackageError, UserError, UserWarning},
 };
 
@@ -256,7 +256,7 @@ pub enum MetricObjective {
 }
 
 impl Serialize for MetricObjective {
-    fn serialize<S: serde::Serializer>(&self, ser: S) -> std::result::Result<S::Ok, S::Error> {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
         ser.serialize_str(match self {
             MetricObjective::Max => "max",
             MetricObjective::Min => "min",
@@ -266,9 +266,7 @@ impl Serialize for MetricObjective {
 }
 
 impl<'de> Deserialize<'de> for MetricObjective {
-    fn deserialize<D: ::serde::Deserializer<'de>>(
-        deserializer: D,
-    ) -> std::result::Result<Self, D::Error> {
+    fn deserialize<D: ::serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let s = <String>::deserialize(deserializer)?;
         match s.as_str() {
             "max" => Ok(MetricObjective::Max),

--- a/packages/engine/src/simulation/controller/run.rs
+++ b/packages/engine/src/simulation/controller/run.rs
@@ -5,7 +5,7 @@ use tokio::time::Duration;
 
 use super::{Error, Result};
 use crate::{
-    datastore::prelude::Store,
+    datastore::store::Store,
     experiment::controller::comms::{sim_status::SimStatusSend, simulation::SimCtlRecv},
     hash_types::worker::RunnerError,
     output::SimulationOutputPersistenceRepr,

--- a/packages/engine/src/simulation/engine.rs
+++ b/packages/engine/src/simulation/engine.rs
@@ -9,7 +9,7 @@ use super::{
 use crate::{
     config::SimRunConfig,
     datastore::{
-        prelude::Store,
+        store::Store,
         table::{
             context::Context,
             pool::{agent::AgentPool, message::MessagePool, BatchPool},
@@ -158,7 +158,7 @@ impl Engine {
             active_sync.await?.map_err(Error::state_sync)?;
             tracing::trace!("State sync finished");
 
-            Result::Ok(())
+            Result::<_>::Ok(())
         }
         .instrument(tracing::info_span!("state_sync"))
         .await?;

--- a/packages/engine/src/simulation/error.rs
+++ b/packages/engine/src/simulation/error.rs
@@ -5,7 +5,7 @@ use crate::{
     hash_types::Agent,
 };
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(ThisError, Debug)]
 pub enum Error {
@@ -101,10 +101,7 @@ pub enum Error {
     InvalidBehaviorTaskMessage(crate::simulation::enum_dispatch::TaskMessage),
 
     #[error("Invalid behavior bytes: {0:?} ({1:?})")]
-    InvalidBehaviorBytes(
-        Vec<u8>,
-        std::result::Result<String, std::string::FromUtf8Error>,
-    ),
+    InvalidBehaviorBytes(Vec<u8>, Result<String, std::string::FromUtf8Error>),
 
     #[error("Invalid behavior name: \"{0}\"")]
     InvalidBehaviorName(String),

--- a/packages/engine/src/simulation/package/context/mod.rs
+++ b/packages/engine/src/simulation/package/context/mod.rs
@@ -1,15 +1,15 @@
 use std::sync::Arc;
 
+use async_trait::async_trait;
 pub use packages::{ContextTask, ContextTaskMessage, Name, PACKAGE_CREATORS};
 use tracing::Span;
 
 use super::{
     deps::Dependencies,
     ext_traits::{GetWorkerSimStartMsg, MaybeCpuBound},
-    prelude::*,
 };
-pub use crate::config::Globals;
 use crate::{
+    config::{ExperimentConfig, Globals},
     datastore::{
         error::Result as DatastoreResult,
         meta::ColumnDynamicMetadata,
@@ -19,7 +19,11 @@ use crate::{
         },
         table::{proxy::StateReadProxy, state::view::StateSnapshot},
     },
-    simulation::{comms::package::PackageComms, package::ext_traits::GetWorkerExpStartMsg, Result},
+    simulation::{
+        comms::package::PackageComms,
+        package::{context::Package as ContextPackage, ext_traits::GetWorkerExpStartMsg},
+        Error, Result,
+    },
     SimRunConfig,
 };
 

--- a/packages/engine/src/simulation/package/context/mod.rs
+++ b/packages/engine/src/simulation/package/context/mod.rs
@@ -11,8 +11,8 @@ use super::{
 pub use crate::config::Globals;
 use crate::{
     datastore::{
+        error::Result as DatastoreResult,
         meta::ColumnDynamicMetadata,
-        prelude::Result as DatastoreResult,
         schema::{
             accessor::FieldSpecMapAccessor, context::ContextSchema, FieldKey, FieldSpec,
             RootFieldSpec, RootFieldSpecCreator,

--- a/packages/engine/src/simulation/package/context/packages/agent_messages/collected.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/collected.rs
@@ -1,4 +1,4 @@
-use super::{indices::AgentMessageIndices, *};
+use super::{indices::AgentMessageIndices, Result};
 use crate::datastore::{table::references::MessageMap, UUID_V4_LEN};
 
 /// Columnar native representation of indices to messages

--- a/packages/engine/src/simulation/package/context/packages/agent_messages/fields.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/fields.rs
@@ -1,6 +1,8 @@
-use super::*;
+use super::{Result, RootFieldSpecCreator, MESSAGE_INDEX_COUNT};
 use crate::datastore::schema::{
-    FieldScope, FieldType, FieldTypeVariant::*, PresetFieldType, RootFieldSpec,
+    FieldScope, FieldType,
+    FieldTypeVariant::{FixedLengthArray, Preset, VariableLengthArray},
+    PresetFieldType, RootFieldSpec,
 };
 
 pub(super) const MESSAGES_FIELD_NAME: &str = "messages";

--- a/packages/engine/src/simulation/package/context/packages/agent_messages/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/mod.rs
@@ -4,14 +4,27 @@ mod indices;
 mod writer;
 
 use arrow::array::{Array, FixedSizeListBuilder, ListBuilder};
+pub use async_trait::async_trait;
 use serde_json::Value;
 use tracing::Span;
 
 use self::collected::Messages;
 use super::super::{
-    async_trait, Arc, ContextColumn, ContextPackage, ContextSchema, ExperimentConfig, FieldKey,
-    FieldSpecMapAccessor, GetWorkerExpStartMsg, GetWorkerSimStartMsg, Globals, MaybeCpuBound,
-    PackageCreator, Result, RootFieldSpecCreator, SimRunConfig, StateReadProxy, StateSnapshot,
+    Arc, ContextColumn, ContextSchema, FieldKey, FieldSpecMapAccessor, GetWorkerExpStartMsg,
+    GetWorkerSimStartMsg, Globals, MaybeCpuBound, PackageCreator, RootFieldSpecCreator,
+    SimRunConfig, StateReadProxy, StateSnapshot,
+};
+pub use crate::{
+    config::{ExperimentConfig, SimulationConfig},
+    datastore::table::{context::Context, state::State},
+    simulation::{
+        comms::Comms,
+        package::{
+            context::Package as ContextPackage, init::Package as InitPackage,
+            output::Package as OutputPackage, state::Package as StatePackage,
+        },
+        Error, Result,
+    },
 };
 use crate::{
     datastore::{

--- a/packages/engine/src/simulation/package/context/packages/agent_messages/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/mod.rs
@@ -3,12 +3,16 @@ mod fields;
 mod indices;
 mod writer;
 
-use arrow::array::{FixedSizeListBuilder, ListBuilder};
+use arrow::array::{Array, FixedSizeListBuilder, ListBuilder};
 use serde_json::Value;
 use tracing::Span;
 
 use self::collected::Messages;
-use super::super::*;
+use super::super::{
+    async_trait, Arc, ContextColumn, ContextPackage, ContextSchema, ExperimentConfig, FieldKey,
+    FieldSpecMapAccessor, GetWorkerExpStartMsg, GetWorkerSimStartMsg, Globals, MaybeCpuBound,
+    PackageCreator, Result, RootFieldSpecCreator, SimRunConfig, StateReadProxy, StateSnapshot,
+};
 use crate::{
     datastore::{
         batch::iterators,
@@ -109,7 +113,7 @@ impl Package for AgentMessages {
         &self,
         num_agents: usize,
         _schema: &ContextSchema,
-    ) -> Result<Vec<(FieldKey, Arc<dyn ArrowArray>)>> {
+    ) -> Result<Vec<(FieldKey, Arc<dyn Array>)>> {
         let index_builder = ArrowIndexBuilder::new(1024);
         let loc_builder = FixedSizeListBuilder::new(index_builder, 3);
         let mut messages_builder = ListBuilder::new(loc_builder);

--- a/packages/engine/src/simulation/package/context/packages/agent_messages/writer.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/writer.rs
@@ -2,8 +2,8 @@ use super::collected::Messages;
 use crate::{
     datastore::{
         arrow::util::DataSliceUtils,
+        error::Result as DatastoreResult,
         meta::{ColumnDynamicMetadata, ColumnDynamicMetadataBuilder},
-        prelude::Result as DatastoreResult,
     },
     simulation::package::context::ContextColumnWriter,
 };

--- a/packages/engine/src/simulation/package/context/packages/api_requests/fields.rs
+++ b/packages/engine/src/simulation/package/context/packages/api_requests/fields.rs
@@ -1,5 +1,8 @@
-use super::*;
-use crate::datastore::schema::{FieldScope, FieldType, FieldTypeVariant::*};
+use super::{FieldSpec, Result, RootFieldSpec, RootFieldSpecCreator};
+use crate::datastore::schema::{
+    FieldScope, FieldType,
+    FieldTypeVariant::{String, Struct, VariableLengthArray},
+};
 
 pub(super) const FROM_FIELD_NAME: &str = "from";
 pub(super) const TYPE_FIELD_NAME: &str = "type";

--- a/packages/engine/src/simulation/package/context/packages/api_requests/handlers.rs
+++ b/packages/engine/src/simulation/package/context/packages/api_requests/handlers.rs
@@ -3,7 +3,7 @@ use std::collections::hash_map;
 use serde_json::Value;
 use thiserror::Error as ThisError;
 
-use super::*;
+use super::{handlers, ApiResponseMap, Error, Result};
 use crate::datastore::{
     table::{pool::message::MessageReader, references::AgentMessageReference},
     UUID_V4_LEN,
@@ -63,7 +63,10 @@ pub mod mapbox {
 
     use futures::StreamExt;
 
-    use super::*;
+    use super::{
+        hash_map, ApiResponseMap, CustomError, Request, Requests, Result, ThisError, Value,
+        ACTIVE_REQUESTS,
+    };
     use crate::datastore::UUID_V4_LEN;
 
     #[derive(ThisError, Debug)]

--- a/packages/engine/src/simulation/package/context/packages/api_requests/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/api_requests/mod.rs
@@ -4,6 +4,7 @@ mod response;
 mod writer;
 
 use arrow::datatypes::DataType;
+pub use async_trait::async_trait;
 use futures::{stream::FuturesOrdered, StreamExt};
 pub use handlers::CustomApiMessageError;
 use response::{ApiResponseMap, ApiResponses};
@@ -11,10 +12,9 @@ use serde_json::Value;
 use tracing::{Instrument, Span};
 
 use super::super::{
-    async_trait, Arc, ContextColumn, ContextPackage, ContextSchema, Error, ExperimentConfig,
-    FieldSpec, FieldSpecMapAccessor, GetWorkerExpStartMsg, GetWorkerSimStartMsg, MaybeCpuBound,
-    PackageCreator, Result, RootFieldSpec, RootFieldSpecCreator, SimRunConfig, StateReadProxy,
-    StateSnapshot,
+    Arc, ContextColumn, ContextSchema, Error, FieldSpec, FieldSpecMapAccessor,
+    GetWorkerExpStartMsg, GetWorkerSimStartMsg, MaybeCpuBound, PackageCreator, RootFieldSpec,
+    RootFieldSpecCreator, SimRunConfig, StateReadProxy, StateSnapshot,
 };
 use crate::{
     config::Globals,
@@ -26,6 +26,18 @@ use crate::{
     simulation::{
         comms::package::PackageComms,
         package::context::{packages::api_requests::fields::API_RESPONSES_FIELD_NAME, Package},
+    },
+};
+pub use crate::{
+    config::{ExperimentConfig, SimulationConfig},
+    datastore::table::{context::Context, state::State},
+    simulation::{
+        comms::Comms,
+        package::{
+            context::Package as ContextPackage, init::Package as InitPackage,
+            output::Package as OutputPackage, state::Package as StatePackage,
+        },
+        Result,
     },
 };
 

--- a/packages/engine/src/simulation/package/context/packages/api_requests/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/api_requests/mod.rs
@@ -10,7 +10,12 @@ use response::{ApiResponseMap, ApiResponses};
 use serde_json::Value;
 use tracing::{Instrument, Span};
 
-use super::super::*;
+use super::super::{
+    async_trait, Arc, ContextColumn, ContextPackage, ContextSchema, Error, ExperimentConfig,
+    FieldSpec, FieldSpecMapAccessor, GetWorkerExpStartMsg, GetWorkerSimStartMsg, MaybeCpuBound,
+    PackageCreator, Result, RootFieldSpec, RootFieldSpecCreator, SimRunConfig, StateReadProxy,
+    StateSnapshot,
+};
 use crate::{
     config::Globals,
     datastore::{

--- a/packages/engine/src/simulation/package/context/packages/api_requests/writer.rs
+++ b/packages/engine/src/simulation/package/context/packages/api_requests/writer.rs
@@ -2,8 +2,8 @@ use super::response::ApiResponses;
 use crate::{
     datastore::{
         arrow::util::DataSliceUtils,
+        error::Result as DatastoreResult,
         meta::{Buffer, ColumnDynamicMetadata, ColumnDynamicMetadataBuilder},
-        prelude::Result as DatastoreResult,
     },
     simulation::package::context::ContextColumnWriter,
 };

--- a/packages/engine/src/simulation/package/context/packages/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/mod.rs
@@ -14,7 +14,10 @@ use serde::{Deserialize, Serialize};
 use super::PackageCreator;
 use crate::{
     simulation::{
-        enum_dispatch::*,
+        enum_dispatch::{
+            enum_dispatch, GetTaskArgs, GetTaskName, RegisterWithoutTrait, StoreAccessVerify,
+            TaskDistributionConfig, TaskSharedStore, WorkerHandler, WorkerPoolHandler,
+        },
         package::{id::PackageIdGenerator, PackageMetadata, PackageType},
         Error, Result,
     },
@@ -90,7 +93,7 @@ impl PackageCreators {
         experiment_config: &Arc<ExperimentConfig>,
     ) -> Result<()> {
         tracing::debug!("Initializing Context Package Creators");
-        use Name::*;
+        use Name::{AgentMessages, ApiRequests, Neighbors};
         let mut m = HashMap::new();
         m.insert(
             AgentMessages,
@@ -129,7 +132,7 @@ impl PackageCreators {
 lazy_static! {
     /// All context package creators are registered in this hashmap
     pub static ref METADATA: HashMap<Name, PackageMetadata> = {
-        use Name::*;
+        use Name::{AgentMessages, ApiRequests, Neighbors};
         let mut id_creator = PackageIdGenerator::new(PackageType::Context);
         let mut m = HashMap::new();
         m.insert(AgentMessages, PackageMetadata{

--- a/packages/engine/src/simulation/package/context/packages/neighbors/fields.rs
+++ b/packages/engine/src/simulation/package/context/packages/neighbors/fields.rs
@@ -1,6 +1,8 @@
-use super::*;
+use super::{Result, RootFieldSpecCreator, NEIGHBOR_INDEX_COUNT};
 use crate::datastore::schema::{
-    FieldScope, FieldType, FieldTypeVariant::*, PresetFieldType, RootFieldSpec,
+    FieldScope, FieldType,
+    FieldTypeVariant::{FixedLengthArray, Number, Preset, VariableLengthArray},
+    PresetFieldType, RootFieldSpec,
 };
 
 pub(super) const NEIGHBORS_FIELD_NAME: &str = "neighbors";

--- a/packages/engine/src/simulation/package/context/packages/neighbors/map.rs
+++ b/packages/engine/src/simulation/package/context/packages/neighbors/map.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
-use super::*;
+use super::{Result, TopologyConfig};
 use crate::{datastore::batch::AgentIndex, simulation::Error};
 
 pub(super) type PositionSubType = f64;

--- a/packages/engine/src/simulation/package/context/packages/neighbors/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/neighbors/mod.rs
@@ -20,11 +20,10 @@ use crate::{
         comms::package::PackageComms,
         package::{
             context::{
-                packages::neighbors::fields::NEIGHBORS_FIELD_NAME, ContextColumn, Package,
-                PackageCreator,
+                packages::neighbors::fields::NEIGHBORS_FIELD_NAME, ContextColumn, ContextPackage,
+                Package, PackageCreator,
             },
             ext_traits::{GetWorkerExpStartMsg, GetWorkerSimStartMsg, MaybeCpuBound},
-            prelude::ContextPackage,
         },
         Result,
     },

--- a/packages/engine/src/simulation/package/context/packages/neighbors/writer.rs
+++ b/packages/engine/src/simulation/package/context/packages/neighbors/writer.rs
@@ -2,8 +2,8 @@ use super::map::NeighborMap;
 use crate::{
     datastore::{
         arrow::util::DataSliceUtils,
+        error::Result as DatastoreResult,
         meta::{ColumnDynamicMetadata, ColumnDynamicMetadataBuilder},
-        prelude::Result as DatastoreResult,
     },
     simulation::package::context::ContextColumnWriter,
 };

--- a/packages/engine/src/simulation/package/creator.rs
+++ b/packages/engine/src/simulation/package/creator.rs
@@ -5,7 +5,6 @@ use super::{
     id::PackageId,
     init, output,
     output::packages::OutputPackagesSimConfig,
-    prelude::Comms,
     run::{InitPackages, Packages, StepPackages},
     state, PackageType,
 };
@@ -16,7 +15,7 @@ use crate::{
         FieldSource, FieldSpec, FieldSpecMap, FieldType, RootFieldSpec, RootFieldSpecCreator,
     },
     simulation::{
-        comms::package::PackageComms,
+        comms::{package::PackageComms, Comms},
         package::{name::PackageName, worker_init::PackageInitMsgForWorker},
         Error, Result,
     },

--- a/packages/engine/src/simulation/package/creator.rs
+++ b/packages/engine/src/simulation/package/creator.rs
@@ -357,7 +357,7 @@ impl PackageCreators {
         &self,
         exp_config: &ExperimentConfig,
         globals: &Globals,
-    ) -> std::result::Result<ContextSchema, Error> {
+    ) -> Result<ContextSchema, Error> {
         let mut field_spec_map = FieldSpecMap::empty();
 
         self.context.iter().try_for_each::<_, Result<()>>(
@@ -420,7 +420,9 @@ pub fn get_base_agent_fields() -> Result<Vec<RootFieldSpec>> {
     let mut field_specs = Vec::with_capacity(13);
     let field_spec_creator = RootFieldSpecCreator::new(FieldSource::Engine);
 
-    use crate::hash_types::state::AgentStateField::*;
+    use crate::hash_types::state::AgentStateField::{
+        AgentId, AgentName, Color, Direction, Height, Hidden, Position, Scale, Shape, Velocity, RGB,
+    };
     let used = [
         AgentId, AgentName, Position, Direction, Velocity, Shape, Height, Scale, Color, RGB, Hidden,
     ];

--- a/packages/engine/src/simulation/package/ext_traits.rs
+++ b/packages/engine/src/simulation/package/ext_traits.rs
@@ -1,4 +1,4 @@
-use super::prelude::Result;
+use crate::simulation::error::Result;
 
 pub trait GetWorkerExpStartMsg {
     // TODO: maybe the Ok(Null) return should be impl by default

--- a/packages/engine/src/simulation/package/init/mod.rs
+++ b/packages/engine/src/simulation/package/init/mod.rs
@@ -2,17 +2,18 @@
 
 use std::sync::Arc;
 
+use async_trait::async_trait;
 pub use packages::{InitTask, InitTaskMessage, Name, PACKAGE_CREATORS};
 
 use super::{
     deps::Dependencies,
     ext_traits::{GetWorkerSimStartMsg, MaybeCpuBound},
-    prelude::*,
 };
-pub use crate::{config::Globals, hash_types::Agent};
 use crate::{
+    config::{ExperimentConfig, Globals},
     datastore::schema::{accessor::FieldSpecMapAccessor, RootFieldSpec, RootFieldSpecCreator},
-    simulation::{comms::package::PackageComms, package::ext_traits::GetWorkerExpStartMsg},
+    hash_types::Agent,
+    simulation::{comms::package::PackageComms, package::ext_traits::GetWorkerExpStartMsg, Result},
     SimRunConfig,
 };
 

--- a/packages/engine/src/simulation/package/init/packages/js_py/mod.rs
+++ b/packages/engine/src/simulation/package/init/packages/js_py/mod.rs
@@ -3,19 +3,23 @@ use std::{
     fmt::{Debug, Formatter},
 };
 
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use super::super::{
-    async_trait, Agent, Arc, ExperimentConfig, FieldSpecMapAccessor, GetWorkerExpStartMsg,
-    GetWorkerSimStartMsg, InitPackage, InitTask, InitTaskMessage, MaybeCpuBound, PackageComms,
-    PackageCreator, SimRunConfig,
+    Agent, Arc, FieldSpecMapAccessor, GetWorkerExpStartMsg, GetWorkerSimStartMsg, InitTask,
+    InitTaskMessage, MaybeCpuBound, PackageComms, PackageCreator, SimRunConfig,
 };
 use crate::{
+    config::ExperimentConfig,
     proto::{ExperimentRunTrait, InitialState, InitialStateName},
     simulation::{
         enum_dispatch::{enum_dispatch, RegisterWithoutTrait, TaskSharedStore},
-        package::init::packages::js_py::{js::JsInitTask, py::PyInitTask},
+        package::init::{
+            packages::js_py::{js::JsInitTask, py::PyInitTask},
+            Package as InitPackage,
+        },
         Error, Result,
     },
 };

--- a/packages/engine/src/simulation/package/init/packages/js_py/mod.rs
+++ b/packages/engine/src/simulation/package/init/packages/js_py/mod.rs
@@ -6,11 +6,15 @@ use std::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::super::*;
+use super::super::{
+    async_trait, Agent, Arc, ExperimentConfig, FieldSpecMapAccessor, GetWorkerExpStartMsg,
+    GetWorkerSimStartMsg, InitPackage, InitTask, InitTaskMessage, MaybeCpuBound, PackageComms,
+    PackageCreator, SimRunConfig,
+};
 use crate::{
     proto::{ExperimentRunTrait, InitialState, InitialStateName},
     simulation::{
-        enum_dispatch::*,
+        enum_dispatch::{enum_dispatch, RegisterWithoutTrait, TaskSharedStore},
         package::init::packages::js_py::{js::JsInitTask, py::PyInitTask},
         Error, Result,
     },

--- a/packages/engine/src/simulation/package/init/packages/json/mod.rs
+++ b/packages/engine/src/simulation/package/init/packages/json/mod.rs
@@ -1,6 +1,9 @@
 use serde_json::Value;
 
-use super::super::*;
+use super::super::{
+    async_trait, Agent, Arc, ExperimentConfig, FieldSpecMapAccessor, GetWorkerExpStartMsg,
+    GetWorkerSimStartMsg, InitPackage, MaybeCpuBound, PackageComms, PackageCreator, SimRunConfig,
+};
 use crate::{
     proto::{ExperimentRunTrait, InitialStateName},
     simulation::{Error, Result},

--- a/packages/engine/src/simulation/package/init/packages/json/mod.rs
+++ b/packages/engine/src/simulation/package/init/packages/json/mod.rs
@@ -1,12 +1,13 @@
+use async_trait::async_trait;
 use serde_json::Value;
 
 use super::super::{
-    async_trait, Agent, Arc, ExperimentConfig, FieldSpecMapAccessor, GetWorkerExpStartMsg,
-    GetWorkerSimStartMsg, InitPackage, MaybeCpuBound, PackageComms, PackageCreator, SimRunConfig,
+    Agent, Arc, ExperimentConfig, FieldSpecMapAccessor, GetWorkerExpStartMsg, GetWorkerSimStartMsg,
+    MaybeCpuBound, PackageComms, PackageCreator, SimRunConfig,
 };
 use crate::{
     proto::{ExperimentRunTrait, InitialStateName},
-    simulation::{Error, Result},
+    simulation::{package::init::Package as InitPackage, Error, Result},
 };
 
 pub struct Creator {}

--- a/packages/engine/src/simulation/package/init/packages/mod.rs
+++ b/packages/engine/src/simulation/package/init/packages/mod.rs
@@ -11,7 +11,10 @@ use serde::{Deserialize, Serialize};
 use super::PackageCreator;
 use crate::{
     simulation::{
-        enum_dispatch::*,
+        enum_dispatch::{
+            enum_dispatch, JsPyInitTaskMessage, RegisterWithoutTrait, StoreAccessVerify,
+            TaskSharedStore,
+        },
         package::{id::PackageIdGenerator, PackageMetadata, PackageType},
         Error, Result,
     },
@@ -75,7 +78,7 @@ impl PackageCreators {
         experiment_config: &Arc<ExperimentConfig>,
     ) -> Result<()> {
         tracing::debug!("Initializing Init Package Creators");
-        use Name::*;
+        use Name::{JsPy, Json};
         let mut m = HashMap::new();
         m.insert(Json, json::Creator::new(experiment_config)?);
         m.insert(JsPy, js_py::Creator::new(experiment_config)?);
@@ -110,7 +113,7 @@ impl PackageCreators {
 
 lazy_static! {
     pub static ref METADATA: HashMap<Name, PackageMetadata> = {
-        use Name::*;
+        use Name::{JsPy, Json};
         let mut id_creator = PackageIdGenerator::new(PackageType::Init);
         let mut m = HashMap::new();
         m.insert(Json, PackageMetadata {

--- a/packages/engine/src/simulation/package/mod.rs
+++ b/packages/engine/src/simulation/package/mod.rs
@@ -30,20 +30,6 @@ pub mod package;
 pub mod run;
 pub mod worker_init;
 
-pub mod prelude {
-    pub use async_trait::async_trait;
-
-    pub use super::{
-        super::comms::Comms, context::Package as ContextPackage, init::Package as InitPackage,
-        output::Package as OutputPackage, state::Package as StatePackage,
-    };
-    pub use crate::{
-        config::{ExperimentConfig, SimulationConfig},
-        datastore::table::{context::Context, state::State},
-        simulation::{Error, Result},
-    };
-}
-
 use serde::Serialize;
 
 use crate::simulation::package::{deps::Dependencies, id::PackageId};

--- a/packages/engine/src/simulation/package/mod.rs
+++ b/packages/engine/src/simulation/package/mod.rs
@@ -39,10 +39,7 @@ pub mod prelude {
     };
     pub use crate::{
         config::{ExperimentConfig, SimulationConfig},
-        datastore::{
-            prelude::*,
-            table::{context::Context, state::State},
-        },
+        datastore::table::{context::Context, state::State},
         simulation::{Error, Result},
     };
 }

--- a/packages/engine/src/simulation/package/name.rs
+++ b/packages/engine/src/simulation/package/name.rs
@@ -30,7 +30,7 @@ impl Display for PackageName {
 }
 
 impl Serialize for PackageName {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {

--- a/packages/engine/src/simulation/package/output/mod.rs
+++ b/packages/engine/src/simulation/package/output/mod.rs
@@ -2,6 +2,7 @@ pub mod packages;
 
 use std::sync::Arc;
 
+use async_trait::async_trait;
 pub use packages::{Name, OutputTask, OutputTaskMessage, PACKAGE_CREATORS};
 use tracing::Span;
 
@@ -9,12 +10,16 @@ use self::packages::Output;
 use super::{
     deps::Dependencies,
     ext_traits::{GetWorkerSimStartMsg, MaybeCpuBound},
-    prelude::*,
 };
-pub use crate::config::Globals;
 use crate::{
-    datastore::schema::{accessor::FieldSpecMapAccessor, RootFieldSpec, RootFieldSpecCreator},
-    simulation::{comms::package::PackageComms, package::ext_traits::GetWorkerExpStartMsg},
+    config::{ExperimentConfig, Globals},
+    datastore::{
+        schema::{accessor::FieldSpecMapAccessor, RootFieldSpec, RootFieldSpecCreator},
+        table::{context::Context, state::State},
+    },
+    simulation::{
+        comms::package::PackageComms, package::ext_traits::GetWorkerExpStartMsg, Error, Result,
+    },
     SimRunConfig,
 };
 

--- a/packages/engine/src/simulation/package/output/packages/analysis/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/analysis/mod.rs
@@ -1,12 +1,29 @@
+use std::sync::Arc;
+
 use analyzer::Analyzer;
+use async_trait::async_trait;
 pub use output::{AnalysisOutput, AnalysisSingleOutput};
 use serde_json::Value;
+use tracing::Span;
 
 pub use self::config::AnalysisOutputConfig;
-pub use super::super::*;
 use crate::{
-    datastore::table::pool::BatchPool, experiment::SimPackageArgs, proto::ExperimentRunTrait,
-    simulation::package::output::Package,
+    config::{ExperimentConfig, Globals},
+    datastore::{
+        schema::accessor::FieldSpecMapAccessor,
+        table::{context::Context, pool::BatchPool, state::State},
+    },
+    experiment::SimPackageArgs,
+    proto::ExperimentRunTrait,
+    simulation::{
+        comms::package::PackageComms,
+        package::{
+            ext_traits::{GetWorkerExpStartMsg, GetWorkerSimStartMsg, MaybeCpuBound},
+            output::{packages::Output, Package, PackageCreator},
+        },
+        Error, Result,
+    },
+    SimRunConfig,
 };
 
 #[macro_use]

--- a/packages/engine/src/simulation/package/output/packages/json_state/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/json_state/mod.rs
@@ -1,9 +1,16 @@
 use serde_json::Value;
 
 pub use self::config::JsonStateOutputConfig;
-use super::super::*;
+use super::super::{
+    async_trait, Arc, Context, Error, ExperimentConfig, FieldSpecMapAccessor, GetWorkerExpStartMsg,
+    GetWorkerSimStartMsg, Globals, MaybeCpuBound, Output, PackageComms, PackageCreator, Result,
+    SimRunConfig, Span, State,
+};
 use crate::{
-    datastore::schema::{HIDDEN_PREFIX, PRIVATE_PREFIX},
+    datastore::{
+        arrow::batch_conversion::IntoAgents,
+        schema::{HIDDEN_PREFIX, PRIVATE_PREFIX},
+    },
     hash_types::Agent,
     simulation::package::{name::PackageName, output, output::Package},
 };

--- a/packages/engine/src/simulation/package/output/packages/json_state/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/json_state/mod.rs
@@ -1,8 +1,9 @@
+use async_trait::async_trait;
 use serde_json::Value;
 
 pub use self::config::JsonStateOutputConfig;
 use super::super::{
-    async_trait, Arc, Context, Error, ExperimentConfig, FieldSpecMapAccessor, GetWorkerExpStartMsg,
+    Arc, Context, Error, ExperimentConfig, FieldSpecMapAccessor, GetWorkerExpStartMsg,
     GetWorkerSimStartMsg, Globals, MaybeCpuBound, Output, PackageComms, PackageCreator, Result,
     SimRunConfig, Span, State,
 };

--- a/packages/engine/src/simulation/package/output/packages/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/mod.rs
@@ -14,7 +14,10 @@ use self::{analysis::AnalysisOutput, json_state::JsonStateOutput};
 use super::PackageCreator;
 use crate::{
     simulation::{
-        enum_dispatch::*,
+        enum_dispatch::{
+            enum_dispatch, GetTaskArgs, GetTaskName, StoreAccessVerify, TaskDistributionConfig,
+            TaskSharedStore, WorkerHandler, WorkerPoolHandler,
+        },
         package::{id::PackageIdGenerator, name::PackageName, PackageMetadata, PackageType},
         Error, Result,
     },
@@ -106,7 +109,7 @@ impl PackageCreators {
         experiment_config: &Arc<ExperimentConfig>,
     ) -> Result<()> {
         tracing::debug!("Initializing Output Package Creators");
-        use Name::*;
+        use Name::{Analysis, JsonState};
         let mut m = HashMap::new();
         m.insert(Analysis, analysis::Creator::new(experiment_config)?);
         m.insert(JsonState, json_state::Creator::new(experiment_config)?);
@@ -141,7 +144,7 @@ impl PackageCreators {
 
 lazy_static! {
     pub static ref METADATA: HashMap<Name, PackageMetadata> = {
-        use Name::*;
+        use Name::{Analysis, JsonState};
         let mut id_creator = PackageIdGenerator::new(PackageType::Output);
         let mut m = HashMap::new();
         m.insert(Analysis, PackageMetadata {

--- a/packages/engine/src/simulation/package/run.rs
+++ b/packages/engine/src/simulation/package/run.rs
@@ -11,13 +11,8 @@ use crate::{
     },
     proto::ExperimentRunTrait,
     simulation::{
-        package::{
-            context,
-            context::ContextColumn,
-            init, output,
-            prelude::{Error, Result},
-            state,
-        },
+        error::{Error, Result},
+        package::{context, context::ContextColumn, init, output, state},
         step_output::SimulationStepOutput,
     },
     SimRunConfig,

--- a/packages/engine/src/simulation/package/state/mod.rs
+++ b/packages/engine/src/simulation/package/state/mod.rs
@@ -2,10 +2,11 @@ pub mod packages;
 
 use std::sync::Arc;
 
+use async_trait::async_trait;
 pub use packages::{Name, StateTask, StateTaskMessage, PACKAGE_CREATORS};
 use tracing::Span;
 
-use super::{deps::Dependencies, ext_traits::GetWorkerSimStartMsg, prelude::*};
+use super::{deps::Dependencies, ext_traits::GetWorkerSimStartMsg};
 pub use crate::config::Globals;
 use crate::{
     config::ExperimentConfig,
@@ -13,13 +14,13 @@ use crate::{
         batch::change::ColumnChange,
         error::Result as DatastoreResult,
         schema::{accessor::FieldSpecMapAccessor, RootFieldSpec, RootFieldSpecCreator},
+        table::{context::Context, state::State},
     },
     simulation::{
         comms::package::PackageComms, package::ext_traits::GetWorkerExpStartMsg, Error, Result,
     },
     SimRunConfig,
 };
-
 #[async_trait]
 pub trait Package: GetWorkerSimStartMsg + Send + Sync {
     async fn run(&mut self, state: &mut State, context: &Context) -> Result<()>;

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/chain.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/chain.rs
@@ -1,8 +1,14 @@
-use arrow::array::ArrayData;
+use arrow::{array::ArrayData, record_batch::RecordBatch};
 
-use super::*;
+use super::{
+    BehaviorIdInnerDataType, BehaviorIds, ColumnChange, DatastoreResult, Error, IntoArrowChange,
+    Result, StateColumn, BEHAVIOR_INDEX_INNER_COUNT,
+};
 use crate::{
-    datastore::arrow::batch_conversion::{new_buffer, new_offsets_buffer},
+    datastore::{
+        arrow::batch_conversion::{new_buffer, new_offsets_buffer},
+        batch::AgentBatch,
+    },
     simulation::package::state::packages::behavior_execution::config::BehaviorId,
 };
 

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/mod.rs
@@ -1,19 +1,20 @@
+pub use async_trait::async_trait;
 use reset_index_col::reset_index_col;
 use serde_json::Value;
 
 use self::{config::exp_init_message, fields::behavior::BehaviorMap};
 use super::super::{
-    async_trait, Arc, ColumnChange, Context, DatastoreResult, Error, ExperimentConfig,
-    FieldSpecMapAccessor, GetWorkerExpStartMsg, GetWorkerSimStartMsg, Globals, IntoArrowChange,
-    PackageComms, PackageCreator, Result, RootFieldSpec, RootFieldSpecCreator, SimRunConfig, Span,
-    State, StateColumn, StateTask,
+    Arc, ColumnChange, DatastoreResult, Error, ExperimentConfig, FieldSpecMapAccessor,
+    GetWorkerExpStartMsg, GetWorkerSimStartMsg, Globals, IntoArrowChange, PackageComms,
+    PackageCreator, Result, RootFieldSpec, RootFieldSpecCreator, SimRunConfig, Span, State,
+    StateColumn, StateTask,
 };
 use crate::{
     datastore::{
         batch::AgentBatch,
         schema::{accessor::GetFieldSpec, FieldSource},
         table::{
-            pool::proxy::PoolWriteProxy, proxy::StateWriteProxy,
+            context::Context, pool::proxy::PoolWriteProxy, proxy::StateWriteProxy,
             task_shared_store::TaskSharedStoreBuilder,
         },
     },

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/mod.rs
@@ -2,9 +2,15 @@ use reset_index_col::reset_index_col;
 use serde_json::Value;
 
 use self::{config::exp_init_message, fields::behavior::BehaviorMap};
-use super::super::*;
+use super::super::{
+    async_trait, Arc, ColumnChange, Context, DatastoreResult, Error, ExperimentConfig,
+    FieldSpecMapAccessor, GetWorkerExpStartMsg, GetWorkerSimStartMsg, Globals, IntoArrowChange,
+    PackageComms, PackageCreator, Result, RootFieldSpec, RootFieldSpecCreator, SimRunConfig, Span,
+    State, StateColumn, StateTask,
+};
 use crate::{
     datastore::{
+        batch::AgentBatch,
         schema::{accessor::GetFieldSpec, FieldSource},
         table::{
             pool::proxy::PoolWriteProxy, proxy::StateWriteProxy,

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/reset_index_col.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/reset_index_col.rs
@@ -1,6 +1,8 @@
 use arrow::{array::ArrayData, datatypes::DataType};
 
-use super::*;
+use super::{
+    BehaviorIndexInnerDataType, ColumnChange, DatastoreResult, IntoArrowChange, Result, StateColumn,
+};
 use crate::datastore::arrow::batch_conversion::new_buffer;
 
 pub fn reset_index_col(behavior_index_col_index: usize) -> Result<StateColumn> {

--- a/packages/engine/src/simulation/package/state/packages/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/mod.rs
@@ -14,7 +14,7 @@ use self::behavior_execution::tasks::{ExecuteBehaviorsTask, ExecuteBehaviorsTask
 use super::PackageCreator;
 use crate::{
     simulation::{
-        enum_dispatch::*,
+        enum_dispatch::{enum_dispatch, RegisterWithoutTrait, StoreAccessVerify, TaskSharedStore},
         package::{id::PackageIdGenerator, PackageMetadata, PackageType},
         Error, Result,
     },
@@ -78,7 +78,7 @@ impl PackageCreators {
         experiment_config: &Arc<ExperimentConfig>,
     ) -> Result<()> {
         tracing::debug!("Initializing State Package Creators");
-        use Name::*;
+        use Name::{BehaviorExecution, Topology};
         let mut m = HashMap::new();
         m.insert(
             BehaviorExecution,
@@ -116,7 +116,7 @@ impl PackageCreators {
 
 lazy_static! {
     pub static ref METADATA: HashMap<Name, PackageMetadata> = {
-        use Name::*;
+        use Name::{BehaviorExecution, Topology};
         let mut id_creator = PackageIdGenerator::new(PackageType::State);
         let mut m = HashMap::new();
         m.insert(BehaviorExecution, PackageMetadata {

--- a/packages/engine/src/simulation/package/state/packages/topology/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/topology/mod.rs
@@ -1,16 +1,17 @@
+use async_trait::async_trait;
 use serde_json::Value;
 
 use super::super::{
-    async_trait, Arc, Context, FieldSpecMapAccessor, GetWorkerExpStartMsg, GetWorkerSimStartMsg,
-    Globals, Package, PackageComms, PackageCreator, Result, RootFieldSpec, RootFieldSpecCreator,
-    SimRunConfig, Span, State,
+    Arc, FieldSpecMapAccessor, GetWorkerExpStartMsg, GetWorkerSimStartMsg, Globals, Package,
+    PackageComms, PackageCreator, RootFieldSpec, RootFieldSpecCreator, SimRunConfig, Span,
 };
 use crate::{
     config::{ExperimentConfig, TopologyConfig},
     datastore::{
         batch::{iterators::record_batch::topology_mut_iter, AgentBatch},
-        table::pool::BatchPool,
+        table::{context::Context, pool::BatchPool, state::State},
     },
+    simulation::Result,
 };
 
 mod adjacency;

--- a/packages/engine/src/simulation/package/state/packages/topology/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/topology/mod.rs
@@ -1,9 +1,16 @@
 use serde_json::Value;
 
-use super::super::*;
+use super::super::{
+    async_trait, Arc, Context, FieldSpecMapAccessor, GetWorkerExpStartMsg, GetWorkerSimStartMsg,
+    Globals, Package, PackageComms, PackageCreator, Result, RootFieldSpec, RootFieldSpecCreator,
+    SimRunConfig, Span, State,
+};
 use crate::{
     config::{ExperimentConfig, TopologyConfig},
-    datastore::{batch::iterators::record_batch::topology_mut_iter, table::pool::BatchPool},
+    datastore::{
+        batch::{iterators::record_batch::topology_mut_iter, AgentBatch},
+        table::pool::BatchPool,
+    },
 };
 
 mod adjacency;

--- a/packages/engine/src/simulation/task/access.rs
+++ b/packages/engine/src/simulation/task/access.rs
@@ -1,6 +1,6 @@
 use crate::{
     datastore::table::task_shared_store::TaskSharedStore,
-    simulation::{enum_dispatch::*, Result},
+    simulation::{enum_dispatch::enum_dispatch, Result},
 };
 
 #[enum_dispatch]

--- a/packages/engine/src/simulation/task/args.rs
+++ b/packages/engine/src/simulation/task/args.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::TaskDistributionConfig,
     simulation::{
-        enum_dispatch::*,
+        enum_dispatch::{enum_dispatch, ExecuteBehaviorsTask, InitTask, StateTask},
         package::init::packages::js_py::{js::JsInitTask, py::PyInitTask},
     },
 };

--- a/packages/engine/src/simulation/task/handler/worker.rs
+++ b/packages/engine/src/simulation/task/handler/worker.rs
@@ -1,5 +1,5 @@
 use crate::simulation::{
-    enum_dispatch::*,
+    enum_dispatch::{enum_dispatch, InitTask, StateTask},
     task::msg::{TargetedTaskMessage, TaskMessage},
     Error, Result,
 };

--- a/packages/engine/src/simulation/task/handler/worker_pool.rs
+++ b/packages/engine/src/simulation/task/handler/worker_pool.rs
@@ -1,4 +1,8 @@
-use crate::simulation::{enum_dispatch::*, task::Task, Error, Result};
+use crate::simulation::{
+    enum_dispatch::{enum_dispatch, InitTask, StateTask, TaskMessage},
+    task::Task,
+    Error, Result,
+};
 
 /// Describes how agent groups are split between workers.
 /// If the task uses distributed execution, `agent_distribution`

--- a/packages/engine/src/simulation/task/mod.rs
+++ b/packages/engine/src/simulation/task/mod.rs
@@ -81,7 +81,11 @@ pub mod cancel;
 pub mod handler;
 pub mod msg;
 
-use crate::simulation::enum_dispatch::*;
+use crate::simulation::enum_dispatch::{
+    enum_dispatch, ContextTask, GetTaskArgs, InitTask, OutputTask, Result, SplitConfig, StateTask,
+    StoreAccessVerify, TargetedTaskMessage, TaskDistributionConfig, TaskMessage, TaskSharedStore,
+    WorkerHandler, WorkerPoolHandler,
+};
 
 // All traits applied here apply to the enum.
 // Also we have automatically derived all

--- a/packages/engine/src/simulation/task/msg.rs
+++ b/packages/engine/src/simulation/task/msg.rs
@@ -2,7 +2,13 @@ use std::hint::unreachable_unchecked;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{simulation::enum_dispatch::*, worker::runner::comms::MessageTarget};
+use crate::{
+    simulation::enum_dispatch::{
+        enum_dispatch, ContextTaskMessage, InitTaskMessage, OutputTaskMessage,
+        RegisterWithoutTrait, Result, StateTaskMessage,
+    },
+    worker::runner::comms::MessageTarget,
+};
 
 // TODO: Possibly come up with a better interface for distinguishing between types of TaskMessages
 /// The possible variants of messages passed as part of a [`Task`]'s execution.

--- a/packages/engine/src/worker/mod.rs
+++ b/packages/engine/src/worker/mod.rs
@@ -302,7 +302,10 @@ impl WorkerController {
     /// [`Dynamic`]: MessageTarget::Dynamic
     /// [`Main`]: MessageTarget::Main
     async fn handle_runner_msg(&mut self, msg: OutboundFromRunnerMsg) -> Result<()> {
-        use OutboundFromRunnerMsgPayload::*;
+        use OutboundFromRunnerMsgPayload::{
+            PackageError, RunnerError, RunnerErrors, RunnerLog, RunnerLogs, RunnerWarning,
+            RunnerWarnings, SyncCompletion, TaskCancelled, TaskMsg, UserErrors, UserWarnings,
+        };
         let sim_id = msg.sim_id;
         match msg.payload {
             TaskMsg(task) => match task.target {

--- a/packages/engine/src/worker/runner/comms/mod.rs
+++ b/packages/engine/src/worker/runner/comms/mod.rs
@@ -5,11 +5,12 @@ use std::{
     sync::Arc,
 };
 
+use arrow::datatypes::Schema;
 use tracing::Span;
 
 use crate::{
     config::{EngineConfig, Globals},
-    datastore::{prelude::ArrowSchema, schema::state::AgentSchema, shared_store::SharedStore},
+    datastore::{schema::state::AgentSchema, shared_store::SharedStore},
     proto::{ExperimentId, SimulationShortId},
     simulation::{
         enum_dispatch::TaskSharedStore,
@@ -191,8 +192,8 @@ pub struct NewSimulationRun {
 #[derive(derive_new::new, Clone)]
 pub struct DatastoreSimulationPayload {
     pub agent_batch_schema: Arc<AgentSchema>,
-    pub message_batch_schema: Arc<ArrowSchema>,
-    pub context_batch_schema: Arc<ArrowSchema>,
+    pub message_batch_schema: Arc<Schema>,
+    pub context_batch_schema: Arc<Schema>,
     pub shared_store: Arc<SharedStore>,
 }
 

--- a/packages/engine/src/worker/runner/javascript/mini_v8/array.rs
+++ b/packages/engine/src/worker/runner/javascript/mini_v8/array.rs
@@ -1,6 +1,9 @@
 use std::{fmt, marker::PhantomData};
 
-use super::*;
+use super::{
+    desc_to_result, desc_to_result_noval, mv8_array_get, mv8_array_len, mv8_array_set,
+    value_to_desc, FromValue, Object, Ref, Result, ToValue, Value,
+};
 
 /// Reference to a JavaScript array.
 #[derive(Clone)]

--- a/packages/engine/src/worker/runner/javascript/mini_v8/conversion.rs
+++ b/packages/engine/src/worker/runner/javascript/mini_v8/conversion.rs
@@ -5,7 +5,10 @@ use std::{
     time::Duration,
 };
 
-use super::*;
+use super::{
+    Array, Error, FromValue, FromValues, Function, MiniV8, Object, Result, String, ToValue,
+    ToValues, Value, Values, Variadic,
+};
 
 impl<'mv8> ToValue<'mv8> for Value<'mv8> {
     fn to_value(self, _mv8: &'mv8 MiniV8) -> Result<'mv8, Value<'mv8>> {

--- a/packages/engine/src/worker/runner/javascript/mini_v8/error.rs
+++ b/packages/engine/src/worker/runner/javascript/mini_v8/error.rs
@@ -1,6 +1,6 @@
 use std::{error::Error as StdError, fmt, result::Result as StdResult};
 
-use super::*;
+use super::{MiniV8, Value};
 
 /// `std::result::Result` specialized for this mini_v8's `Error` type.
 pub type Result<'mv8, T> = StdResult<T, Error<'mv8>>;
@@ -97,7 +97,7 @@ impl fmt::Display for Error<'_> {
     }
 }
 
-impl From<Error<'_>> for std::string::String {
+impl From<Error<'_>> for String {
     fn from(e: Error<'_>) -> Self {
         format!("{}", e)
     }

--- a/packages/engine/src/worker/runner/javascript/mini_v8/ffi.rs
+++ b/packages/engine/src/worker/runner/javascript/mini_v8/ffi.rs
@@ -6,7 +6,9 @@ use std::{
     sync::Once,
 };
 
-use super::*;
+use super::{
+    Array, Callback, DataFfi, Error, Function, MiniV8, Object, Result, String, Value, Values,
+};
 
 extern "C" {
     pub(super) fn mv8_init(wrapper_func: *const c_void, drop_func: *const c_void);

--- a/packages/engine/src/worker/runner/javascript/mini_v8/function.rs
+++ b/packages/engine/src/worker/runner/javascript/mini_v8/function.rs
@@ -1,6 +1,9 @@
 use std::{cmp, fmt, mem};
 
-use super::*;
+use super::{
+    desc_to_result, mv8_function_call, mv8_function_call_new, mv8_function_create, value_to_desc,
+    FromValue, MiniV8, Object, Ref, Result, ToValue, ToValues, Value, ValueDesc, Values,
+};
 
 /// Reference to a JavaScript function.
 #[derive(Clone)]

--- a/packages/engine/src/worker/runner/javascript/mini_v8/mini_v8.rs
+++ b/packages/engine/src/worker/runner/javascript/mini_v8/mini_v8.rs
@@ -9,7 +9,14 @@ use std::{
     time::Duration,
 };
 
-use super::*;
+use super::{
+    desc_to_result, desc_to_result_val, ffi_init, mv8_array_new, mv8_arraybuffer_new,
+    mv8_coerce_boolean, mv8_coerce_number, mv8_coerce_string, mv8_data_node_from_js,
+    mv8_interface_drop, mv8_interface_eval, mv8_interface_get_data, mv8_interface_global,
+    mv8_interface_new, mv8_interface_set_data, mv8_object_new, mv8_string_new, value_to_desc,
+    Array, Error, FromValue, Function, Interface, Invocation, Object, Ref, Result, String, ToValue,
+    Value,
+};
 
 /// The entry point into the JavaScript execution environment.
 pub struct MiniV8 {

--- a/packages/engine/src/worker/runner/javascript/mini_v8/mod.rs
+++ b/packages/engine/src/worker/runner/javascript/mini_v8/mod.rs
@@ -13,5 +13,14 @@ mod tests;
 mod value;
 
 //#[ignore(unused_imports)]
-use self::ffi::*;
+use self::ffi::{
+    desc_to_result, desc_to_result_noval, desc_to_result_val, ffi_init, mv8_array_get,
+    mv8_array_len, mv8_array_new, mv8_array_set, mv8_arraybuffer_new, mv8_coerce_boolean,
+    mv8_coerce_number, mv8_coerce_string, mv8_data_node_from_js, mv8_function_call,
+    mv8_function_call_new, mv8_function_create, mv8_interface_drop, mv8_interface_eval,
+    mv8_interface_get_data, mv8_interface_global, mv8_interface_new, mv8_interface_set_data,
+    mv8_object_get, mv8_object_has, mv8_object_keys, mv8_object_new, mv8_object_remove,
+    mv8_object_set, mv8_string_new, mv8_string_to_utf8_value, mv8_utf8_value_drop, value_to_desc,
+    Interface, Ref, ValueDesc,
+};
 pub use self::{array::*, error::*, function::*, mini_v8::*, object::*, string::*, value::*};

--- a/packages/engine/src/worker/runner/javascript/mini_v8/object.rs
+++ b/packages/engine/src/worker/runner/javascript/mini_v8/object.rs
@@ -1,6 +1,10 @@
 use std::{fmt, marker::PhantomData};
 
-use super::*;
+use super::{
+    desc_to_result, desc_to_result_noval, desc_to_result_val, mv8_object_get, mv8_object_has,
+    mv8_object_keys, mv8_object_remove, mv8_object_set, value_to_desc, Array, FromValue, Function,
+    Ref, Result, ToValue, ToValues, Value,
+};
 
 /// Reference to a JavaScript object.
 #[derive(Clone)]

--- a/packages/engine/src/worker/runner/javascript/mini_v8/string.rs
+++ b/packages/engine/src/worker/runner/javascript/mini_v8/string.rs
@@ -1,6 +1,6 @@
 use std::{fmt, slice, string::String as StdString};
 
-use super::*;
+use super::{mv8_string_to_utf8_value, mv8_utf8_value_drop, Ref};
 
 /// Reference to an immutable JavaScript string.
 #[derive(Clone)]

--- a/packages/engine/src/worker/runner/javascript/mini_v8/value.rs
+++ b/packages/engine/src/worker/runner/javascript/mini_v8/value.rs
@@ -4,7 +4,7 @@ use std::{
     slice, vec,
 };
 
-use super::*;
+use super::{Array, Function, MiniV8, Object, Ref, Result, String};
 
 /// A JavaScript value.
 ///

--- a/packages/engine/src/worker/runner/javascript/mod.rs
+++ b/packages/engine/src/worker/runner/javascript/mod.rs
@@ -32,8 +32,8 @@ use crate::{
     config::Globals,
     datastore::{
         arrow::util::arrow_continuation,
-        batch::{change::ColumnChange, ArrowBatch, Metaversion},
-        prelude::{AgentBatch, MessageBatch, SharedStore},
+        batch::{change::ColumnChange, AgentBatch, ArrowBatch, MessageBatch, Metaversion},
+        shared_store::SharedStore,
         storage::memory::Memory,
         table::{
             proxy::StateWriteProxy,

--- a/packages/engine/src/worker/runner/python/fbs.rs
+++ b/packages/engine/src/worker/runner/python/fbs.rs
@@ -2,7 +2,7 @@ use flatbuffers::{FlatBufferBuilder, WIPOffset};
 
 use super::error::Result;
 use crate::{
-    datastore::{batch::Segment, prelude::SharedStore},
+    datastore::{batch::Segment, shared_store::SharedStore},
     worker::runner::comms::PackageMsgs,
 };
 

--- a/packages/engine/src/worker/runner/rust/behaviors/accessors.rs
+++ b/packages/engine/src/worker/runner/rust/behaviors/accessors.rs
@@ -618,19 +618,19 @@ pub enum OptionNativeColumnExtError {
 
 pub trait OptionNativeColumnExt {
     type Value;
-    fn u_ref(&self) -> std::result::Result<&Self::Value, OptionNativeColumnExtError>;
-    fn u_mut(&mut self) -> std::result::Result<&mut Self::Value, OptionNativeColumnExtError>;
+    fn u_ref(&self) -> Result<&Self::Value, OptionNativeColumnExtError>;
+    fn u_mut(&mut self) -> Result<&mut Self::Value, OptionNativeColumnExtError>;
 }
 
 impl<T> OptionNativeColumnExt for Option<NativeColumn<T>> {
     type Value = NativeColumn<T>;
 
-    fn u_ref(&self) -> std::result::Result<&Self::Value, OptionNativeColumnExtError> {
+    fn u_ref(&self) -> Result<&Self::Value, OptionNativeColumnExtError> {
         self.as_ref()
             .ok_or_else(|| OptionNativeColumnExtError::UnwrapRefFailed(std::any::type_name::<T>()))
     }
 
-    fn u_mut(&mut self) -> std::result::Result<&mut Self::Value, OptionNativeColumnExtError> {
+    fn u_mut(&mut self) -> Result<&mut Self::Value, OptionNativeColumnExtError> {
         self.as_mut()
             .ok_or_else(|| OptionNativeColumnExtError::UnwrapMutFailed(std::any::type_name::<T>()))
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We have three preludes for importing common types in the engine. Over time, the prelude was scattered with more uncommon symbols and by now they are even nested in each other, which makes it really hard to track, where one symbol is coming from. In order to properly split modules into crates, those preludes should be removed, and instead, direct imports should be used.

## 🔍 What does this change?

- Remove preludes from `datastore`, `datastore::arrow`, and `simulation`
- Add clippy lints to forbid globbing imports (applied by `clippy --fix`)
- Aliases from preludes were not kept, so e.g. `arrow::Array as ArrowArray` was changed to `arrow::Array`.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/0/1201499989227952/f) _(internal)_