### PR TITLE
Stick rusty_v8 version

### DIFF
--- a/packages/engine/Cargo.lock
+++ b/packages/engine/Cargo.lock
@@ -2645,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "v8"
 version = "0.41.0"
-source = "git+https://github.com/hashdeps/rusty_v8#ed5a6ba31d6ecb91eb564b8f848241baf0e33a79"
+source = "git+https://github.com/hashdeps/rusty_v8?rev=0bf4d26961697591baf54bc4ceb0d15d3f195f86#0bf4d26961697591baf54bc4ceb0d15d3f195f86"
 dependencies = [
  "bitflags",
  "fslock",

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -48,7 +48,7 @@ tracing-subscriber = { version = "0.3.7", features = ["env-filter", "json"] }
 tracing-texray = { version = "0.1.2", optional = true }
 # Only temporary, use the crates.io release when ArrayBuffer::new_backing_store_from_ptr is available
 # https://github.com/denoland/rusty_v8/pull/926
-v8 = { git = "https://github.com/hashdeps/rusty_v8" }
+v8 = { git = "https://github.com/hashdeps/rusty_v8", rev = "0bf4d26961697591baf54bc4ceb0d15d3f195f86" }
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 
 [dev-dependencies]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Instead of relying on a random commit, this sticks the commit of `rusty_v8`, which has a well defined submodule commit for `v8`. This will hopefully be more reliable than the random commit-poking we did before.

## 🔍 What does this change?

- Stick `v8` version in https://github.com/hashdeps/rusty_v8/commit/0bf4d26961697591baf54bc4ceb0d15d3f195f86
- Stick `rusty_v8` version in 552f2602052368c2357e04ca10d859b5d7c2409f