### PR TITLE
Fix handling of relative icon urls

### DIFF
--- a/packages/hash/frontend/src/blocks/page/createSuggester/BlockSuggester.tsx
+++ b/packages/hash/frontend/src/blocks/page/createSuggester/BlockSuggester.tsx
@@ -21,7 +21,7 @@ export const getVariantIcon = (option: {
   const iconPath = option.variant.icon;
 
   const regex = /^(?:[a-z]+:)?\/\//i;
-  if (regex.test(iconPath)) {
+  if (!iconPath || regex.test(iconPath)) {
     return iconPath;
   }
 

--- a/packages/hash/frontend/src/blocks/page/createSuggester/BlockSuggester.tsx
+++ b/packages/hash/frontend/src/blocks/page/createSuggester/BlockSuggester.tsx
@@ -14,22 +14,18 @@ export interface BlockSuggesterProps {
   sx?: SxProps<Theme>;
 }
 
-// @todo remove this when API returns actual icon URL
 export const getVariantIcon = (option: {
   variant: BlockVariant;
   meta: RemoteBlockMetadata;
 }): string | undefined => {
-  if (option.variant.icon?.startsWith("/")) {
-    return `https://blockprotocol.org${option.variant.icon}`;
+  const iconPath = option.variant.icon;
+
+  const regex = /^(?:[a-z]+:)?\/\//i;
+  if (regex.test(iconPath)) {
+    return iconPath;
   }
 
-  if (option.variant.icon?.startsWith("public/")) {
-    return `https://blockprotocol.org${
-      option.meta.icon!.split("public/")[0]
-    }public/${option.variant.icon.split("public/")[1]}`;
-  }
-
-  return option.variant.icon;
+  return `${option.meta.componentId}/${iconPath.replace(/^\//, "")}`;
 };
 
 /**


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
The code to load block icons was not properly handling relative URLs: it was trying to construct an absolute URL by prepending `blockprotocol.org`, which won't be where all blocks come from. For some reason it also handled relative URLs with `public/` differently

The immediate benefit of this is when loading blocks locally.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201959586244685/1202085228123347/f) _(internal)_

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Serve a block locally with a relative URL
2. Check its icon loads