### PR TITLE
Revert `FieldSource` being turned into a trait

### DIFF
--- a/packages/engine/lib/stateful/src/agent/schema.rs
+++ b/packages/engine/lib/stateful/src/agent/schema.rs
@@ -3,23 +3,20 @@ use std::sync::Arc;
 use arrow::datatypes::Schema;
 use memory::arrow::{meta, meta::conversion::HashStaticMeta};
 
-use crate::{
-    error::Result,
-    field::{FieldSource, FieldSpecMap},
-};
+use crate::{error::Result, field::FieldSpecMap};
 
 /// `AgentSchema` describes the layout of every agent-containing `SharedBatch` in a datastore.
 ///
 /// It contains the dual representation of both the [`FieldSpec`] and the Arrow schema.
 #[derive(Clone, Debug)]
-pub struct AgentSchema<S> {
+pub struct AgentSchema {
     pub arrow: Arc<Schema>,
     pub static_meta: Arc<meta::Static>,
-    pub field_spec_map: Arc<FieldSpecMap<S>>,
+    pub field_spec_map: Arc<FieldSpecMap>,
 }
 
-impl<S: FieldSource + Clone> AgentSchema<S> {
-    pub fn new(field_spec_map: FieldSpecMap<S>) -> Result<Self> {
+impl AgentSchema {
+    pub fn new(field_spec_map: FieldSpecMap) -> Result<Self> {
         let arrow_schema = Arc::new(field_spec_map.create_arrow_schema()?);
         let static_meta = arrow_schema.get_static_metadata();
 

--- a/packages/engine/lib/stateful/src/field/accessor.rs
+++ b/packages/engine/lib/stateful/src/field/accessor.rs
@@ -5,13 +5,13 @@ use crate::{
     field::{FieldScope, FieldSource, FieldSpecMap, RootFieldKey, RootFieldSpec},
 };
 
-pub struct FieldSpecMapAccessor<S> {
-    accessor_source: S,
-    field_spec_map: Arc<FieldSpecMap<S>>,
+pub struct FieldSpecMapAccessor {
+    accessor_source: FieldSource,
+    field_spec_map: Arc<FieldSpecMap>,
 }
 
-impl<S: FieldSource> FieldSpecMapAccessor<S> {
-    pub fn new(accessor_source: S, field_spec_map: Arc<FieldSpecMap<S>>) -> Self {
+impl FieldSpecMapAccessor {
+    pub fn new(accessor_source: FieldSource, field_spec_map: Arc<FieldSpecMap>) -> Self {
         Self {
             accessor_source,
             field_spec_map,
@@ -21,7 +21,7 @@ impl<S: FieldSource> FieldSpecMapAccessor<S> {
     /// Get a [`FieldSpec`] stored under a given field name with [`FieldScope::Agent`].
     ///
     /// [`FieldSpec`]: crate::field::FieldSpec
-    pub fn get_agent_scoped_field_spec(&self, field_name: &str) -> Result<&RootFieldSpec<S>> {
+    pub fn get_agent_scoped_field_spec(&self, field_name: &str) -> Result<&RootFieldSpec> {
         let key = RootFieldKey::new_agent_scoped(field_name)?;
         self.field_spec_map.get_field_spec(&key)
     }
@@ -33,8 +33,8 @@ impl<S: FieldSource> FieldSpecMapAccessor<S> {
     pub fn get_hidden_scoped_field_spec(
         &self,
         field_name: &str,
-        field_source: &S,
-    ) -> Result<&RootFieldSpec<S>> {
+        field_source: FieldSource,
+    ) -> Result<&RootFieldSpec> {
         let key = RootFieldKey::new_private_or_hidden_scoped(
             field_name,
             field_source,
@@ -47,13 +47,10 @@ impl<S: FieldSource> FieldSpecMapAccessor<S> {
     /// belongs to the [`FieldSource`] of the accessor.
     ///
     /// [`FieldSpec`]: crate::field::FieldSpec
-    pub fn get_local_private_scoped_field_spec(
-        &self,
-        field_name: &str,
-    ) -> Result<&RootFieldSpec<S>> {
+    pub fn get_local_private_scoped_field_spec(&self, field_name: &str) -> Result<&RootFieldSpec> {
         let key = RootFieldKey::new_private_or_hidden_scoped(
             field_name,
-            &self.accessor_source,
+            self.accessor_source,
             FieldScope::Private,
         )?;
         self.field_spec_map.get_field_spec(&key)
@@ -63,13 +60,10 @@ impl<S: FieldSource> FieldSpecMapAccessor<S> {
     /// to the [`FieldSource`] of the accessor.
     ///
     /// [`FieldSpec`]: crate::field::FieldSpec
-    pub fn get_local_hidden_scoped_field_spec(
-        &self,
-        field_name: &str,
-    ) -> Result<&RootFieldSpec<S>> {
+    pub fn get_local_hidden_scoped_field_spec(&self, field_name: &str) -> Result<&RootFieldSpec> {
         let key = RootFieldKey::new_private_or_hidden_scoped(
             field_name,
-            &self.accessor_source,
+            self.accessor_source,
             FieldScope::Hidden,
         )?;
         self.field_spec_map.get_field_spec(&key)
@@ -81,15 +75,15 @@ impl<S: FieldSource> FieldSpecMapAccessor<S> {
 /// This Accessor is **only** intended for use by the Engine, i.e. something with root access.
 ///
 /// [`FieldSpec`]: crate::field::FieldSpec
-pub struct RootFieldSpecMapAccessor<S> {
-    pub field_spec_map: Arc<FieldSpecMap<S>>,
+pub struct RootFieldSpecMapAccessor {
+    pub field_spec_map: Arc<FieldSpecMap>,
 }
 
-impl<S: FieldSource> RootFieldSpecMapAccessor<S> {
+impl RootFieldSpecMapAccessor {
     // TODO: We're allowing dead code on these during development, if the engine doesn't
     //   end up needing these it might be worth removing
     #[allow(dead_code)]
-    fn get_agent_scoped_field_spec(&self, field_name: &str) -> Result<&RootFieldSpec<S>> {
+    fn get_agent_scoped_field_spec(&self, field_name: &str) -> Result<&RootFieldSpec> {
         let key = RootFieldKey::new_agent_scoped(field_name)?;
         self.field_spec_map.get_field_spec(&key)
     }
@@ -98,9 +92,9 @@ impl<S: FieldSource> RootFieldSpecMapAccessor<S> {
     fn get_private_or_hidden_scoped_field_spec(
         &self,
         field_name: &str,
-        field_source: &S,
+        field_source: FieldSource,
         field_scope: FieldScope,
-    ) -> Result<&RootFieldSpec<S>> {
+    ) -> Result<&RootFieldSpec> {
         let key =
             RootFieldKey::new_private_or_hidden_scoped(field_name, field_source, field_scope)?;
 

--- a/packages/engine/lib/stateful/src/field/key.rs
+++ b/packages/engine/lib/stateful/src/field/key.rs
@@ -55,9 +55,9 @@ impl RootFieldKey {
     /// - Returns [`Error`] if `name` starts with a prefix pre-defined by [`FieldScope`], and
     /// - Returns [`Error`] if `scope` is [`FieldScope::Agent`].
     #[inline]
-    pub fn new_private_or_hidden_scoped<S: FieldSource>(
+    pub fn new_private_or_hidden_scoped(
         name: &str,
-        source: &S,
+        source: FieldSource,
         scope: FieldScope,
     ) -> Result<Self> {
         Self::verify_name(name)?;

--- a/packages/engine/lib/stateful/src/field/key.rs
+++ b/packages/engine/lib/stateful/src/field/key.rs
@@ -74,7 +74,7 @@ impl RootFieldKey {
         Ok(Self(format!(
             "{}{}_{}",
             scope_prefix,
-            source.unique_id()?,
+            source.unique_id(),
             name
         )))
     }

--- a/packages/engine/lib/stateful/src/field/mod.rs
+++ b/packages/engine/lib/stateful/src/field/mod.rs
@@ -28,7 +28,7 @@ pub use self::{
     field_type::{FieldType, FieldTypeVariant, PresetFieldType},
     key::RootFieldKey,
     scope::FieldScope,
-    source::FieldSource,
+    source::{EngineComponent, FieldSource, PackageId},
     spec::{FieldSpec, RootFieldSpec, RootFieldSpecCreator},
     spec_map::FieldSpecMap,
 };

--- a/packages/engine/lib/stateful/src/field/mod.rs
+++ b/packages/engine/lib/stateful/src/field/mod.rs
@@ -28,7 +28,7 @@ pub use self::{
     field_type::{FieldType, FieldTypeVariant, PresetFieldType},
     key::RootFieldKey,
     scope::FieldScope,
-    source::{EngineComponent, FieldSource, PackageId},
+    source::{FieldSource, PackageId},
     spec::{FieldSpec, RootFieldSpec, RootFieldSpecCreator},
     spec_map::FieldSpecMap,
 };

--- a/packages/engine/lib/stateful/src/field/source.rs
+++ b/packages/engine/lib/stateful/src/field/source.rs
@@ -1,8 +1,6 @@
-use crate::error::Result;
-
 pub trait FieldSource {
     /// A unique static identifier of the field source, used in building Keys for fields.
-    fn unique_id(&self) -> Result<usize>;
+    fn unique_id(&self) -> usize;
 
     /// Returns if the `FieldSource` can guarantee nullability.
     ///

--- a/packages/engine/lib/stateful/src/field/source.rs
+++ b/packages/engine/lib/stateful/src/field/source.rs
@@ -1,14 +1,14 @@
 use core::fmt;
-use std::cmp::Ordering;
+use std::{cmp::Ordering, num::NonZeroUsize};
 
 use serde::Serialize;
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Serialize)]
-pub struct PackageId(usize);
+pub struct PackageId(NonZeroUsize);
 
 impl PackageId {
     #[inline]
-    pub fn as_usize(&self) -> usize {
+    pub fn as_usize(&self) -> NonZeroUsize {
         self.0
     }
 }
@@ -21,7 +21,7 @@ impl fmt::Display for PackageId {
 
 impl From<usize> for PackageId {
     fn from(id: usize) -> Self {
-        Self(id)
+        Self(NonZeroUsize::new(id).expect("Package ids with id `0` are reserved"))
     }
 }
 
@@ -37,7 +37,7 @@ impl FieldSource {
     pub fn unique_id(&self) -> usize {
         match self {
             FieldSource::Engine => 0,
-            FieldSource::Package(package_id) => package_id.as_usize(),
+            FieldSource::Package(package_id) => package_id.as_usize().get(),
         }
     }
 

--- a/packages/engine/lib/stateful/src/field/source.rs
+++ b/packages/engine/lib/stateful/src/field/source.rs
@@ -1,3 +1,8 @@
+use core::fmt;
+use std::cmp::Ordering;
+
+use serde::Serialize;
+
 pub trait FieldSource {
     /// A unique static identifier of the field source, used in building Keys for fields.
     fn unique_id(&self) -> usize;
@@ -12,4 +17,59 @@ pub trait FieldSource {
     //   `FieldSpec` with `Engine` as source returns `true` here. We probably want to get around
     //   this.
     fn can_guarantee_null(&self) -> bool;
+}
+
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Serialize)]
+pub struct PackageId(usize);
+
+impl PackageId {
+    #[inline]
+    pub fn as_usize(&self) -> usize {
+        self.0
+    }
+}
+
+impl fmt::Display for PackageId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<usize> for PackageId {
+    fn from(id: usize) -> Self {
+        Self(id)
+    }
+}
+
+/// Defines the source from which a Field was specified, useful for resolving clashes
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum EngineComponent {
+    Engine,
+    Package(PackageId),
+}
+
+impl FieldSource for EngineComponent {
+    fn unique_id(&self) -> usize {
+        match self {
+            EngineComponent::Engine => 0,
+            EngineComponent::Package(package_id) => package_id.as_usize(),
+        }
+    }
+
+    fn can_guarantee_null(&self) -> bool {
+        *self == EngineComponent::Engine
+    }
+}
+
+impl PartialOrd for EngineComponent {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        // TODO: We only do a partial ordering as we currently don't have a defined precedence of
+        //   packages. When `PartialOrd` for `PackageName` is implemented, derive it instead.
+        match (self, other) {
+            (Self::Engine, Self::Engine) => Some(Ordering::Equal),
+            (Self::Engine, Self::Package(_)) => Some(Ordering::Greater),
+            (Self::Package(_), Self::Engine) => Some(Ordering::Less),
+            (Self::Package(_), Self::Package(_)) => None,
+        }
+    }
 }

--- a/packages/engine/lib/stateful/src/field/source.rs
+++ b/packages/engine/lib/stateful/src/field/source.rs
@@ -33,7 +33,10 @@ pub enum FieldSource {
 }
 
 impl FieldSource {
-    /// A unique static identifier of the field source, used in building Keys for fields.
+    /// A unique static identifier of the field source, used in building [`RootFieldKey`]s for
+    /// fields.
+    ///
+    /// [`RootFieldKey`]: crate::field::RootFieldKey
     pub fn unique_id(&self) -> usize {
         match self {
             FieldSource::Engine => 0,

--- a/packages/engine/src/config/store.rs
+++ b/packages/engine/src/config/store.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use stateful::{agent::AgentSchema, field::EngineComponent, message::MessageSchema};
+use stateful::{agent::AgentSchema, message::MessageSchema};
 
 use crate::{
     config::{globals::Globals, Result},
@@ -9,7 +9,7 @@ use crate::{
 };
 
 pub struct Config {
-    pub agent_schema: Arc<AgentSchema<EngineComponent>>,
+    pub agent_schema: Arc<AgentSchema>,
     pub message_schema: Arc<MessageSchema>,
     pub context_schema: Arc<ContextSchema>,
 }

--- a/packages/engine/src/config/store.rs
+++ b/packages/engine/src/config/store.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use stateful::{agent::AgentSchema, message::MessageSchema};
+use stateful::{agent::AgentSchema, field::EngineComponent, message::MessageSchema};
 
 use crate::{
     config::{globals::Globals, Result},
-    datastore::schema::{context::ContextSchema, EngineComponent},
+    datastore::schema::context::ContextSchema,
     simulation::package::creator::PackageCreators,
 };
 

--- a/packages/engine/src/datastore/arrow/batch_conversion.rs
+++ b/packages/engine/src/datastore/arrow/batch_conversion.rs
@@ -20,7 +20,7 @@ use memory::arrow::{
 use serde_json::value::Value;
 use stateful::{
     agent::{Agent, AgentName, AgentSchema, AgentStateField, BUILTIN_FIELDS},
-    field::{EngineComponent, FieldScope, FieldTypeVariant, RootFieldKey},
+    field::{FieldScope, FieldTypeVariant, RootFieldKey},
     message::MESSAGE_BATCH_SCHEMA,
 };
 
@@ -42,7 +42,7 @@ pub trait IntoRecordBatch {
     fn into_message_batch(&self, schema: &Arc<Schema>) -> Result<RecordBatch>;
     fn into_empty_message_batch(&self, schema: &Arc<Schema>) -> Result<RecordBatch>;
     /// TODO: DOC describe, explain self is initialization data
-    fn into_agent_batch<S>(&self, schema: &Arc<AgentSchema<S>>) -> Result<RecordBatch>;
+    fn into_agent_batch(&self, schema: &Arc<AgentSchema>) -> Result<RecordBatch>;
 }
 
 fn builder_add_id(builder: &mut array::FixedSizeBinaryBuilder, id: &str) -> Result<()> {
@@ -163,7 +163,7 @@ impl IntoRecordBatch for &[Agent] {
             .into_empty_message_batch(schema)
     }
 
-    fn into_agent_batch<S>(&self, schema: &Arc<AgentSchema<S>>) -> Result<RecordBatch> {
+    fn into_agent_batch(&self, schema: &Arc<AgentSchema>) -> Result<RecordBatch> {
         self.iter()
             .collect::<Vec<_>>()
             .as_slice()
@@ -193,7 +193,7 @@ impl IntoRecordBatch for &[&Agent] {
         message::batch_from_json(schema, ids, None)
     }
 
-    fn into_agent_batch<S>(&self, schema: &Arc<AgentSchema<S>>) -> Result<RecordBatch> {
+    fn into_agent_batch(&self, schema: &Arc<AgentSchema>) -> Result<RecordBatch> {
         let mut cols = Vec::with_capacity(schema.arrow.fields().len());
 
         for field in schema.arrow.fields() {
@@ -258,17 +258,11 @@ impl IntoRecordBatch for &[&Agent] {
 
 /// Conversion into `Agent`, which can be converted to JSON
 pub trait IntoAgents {
-    fn into_agent_states(
-        &self,
-        agent_schema: Option<&Arc<AgentSchema<EngineComponent>>>,
-    ) -> Result<Vec<Agent>>;
+    fn into_agent_states(&self, agent_schema: Option<&Arc<AgentSchema>>) -> Result<Vec<Agent>>;
 
     // Conversion into `Agent` where certain built-in fields and
     // null values are selectively ignored
-    fn into_filtered_agent_states(
-        &self,
-        agent_schema: &Arc<AgentSchema<EngineComponent>>,
-    ) -> Result<Vec<Agent>>;
+    fn into_filtered_agent_states(&self, agent_schema: &Arc<AgentSchema>) -> Result<Vec<Agent>>;
 }
 
 // `array.null_count() > 0` can be moved out of loops by the compiler:
@@ -575,10 +569,7 @@ fn set_states_serialized(
 }
 
 impl IntoAgents for (&AgentBatch, &MessageBatch) {
-    fn into_agent_states(
-        &self,
-        agent_schema: Option<&Arc<AgentSchema<EngineComponent>>>,
-    ) -> Result<Vec<Agent>> {
+    fn into_agent_states(&self, agent_schema: Option<&Arc<AgentSchema>>) -> Result<Vec<Agent>> {
         let agents = self.0.batch.record_batch()?;
         let messages = self.1.batch.record_batch()?;
         let mut states = agents.into_agent_states(agent_schema)?;
@@ -586,10 +577,7 @@ impl IntoAgents for (&AgentBatch, &MessageBatch) {
         Ok(states)
     }
 
-    fn into_filtered_agent_states(
-        &self,
-        agent_schema: &Arc<AgentSchema<EngineComponent>>,
-    ) -> Result<Vec<Agent>> {
+    fn into_filtered_agent_states(&self, agent_schema: &Arc<AgentSchema>) -> Result<Vec<Agent>> {
         let agents = self.0.batch.record_batch()?;
         let messages = self.1.batch.record_batch()?;
         let mut states = agents.into_filtered_agent_states(agent_schema)?;
@@ -599,10 +587,7 @@ impl IntoAgents for (&AgentBatch, &MessageBatch) {
 }
 
 impl IntoAgents for (&RecordBatch, &RecordBatch) {
-    fn into_agent_states(
-        &self,
-        agent_schema: Option<&Arc<AgentSchema<EngineComponent>>>,
-    ) -> Result<Vec<Agent>> {
+    fn into_agent_states(&self, agent_schema: Option<&Arc<AgentSchema>>) -> Result<Vec<Agent>> {
         let agents = &self.0;
         let messages = &self.1;
         let mut states = agents.into_agent_states(agent_schema)?;
@@ -610,10 +595,7 @@ impl IntoAgents for (&RecordBatch, &RecordBatch) {
         Ok(states)
     }
 
-    fn into_filtered_agent_states(
-        &self,
-        agent_schema: &Arc<AgentSchema<EngineComponent>>,
-    ) -> Result<Vec<Agent>> {
+    fn into_filtered_agent_states(&self, agent_schema: &Arc<AgentSchema>) -> Result<Vec<Agent>> {
         let agents = &self.0;
         let messages = &self.1;
         let mut states = agents.into_filtered_agent_states(agent_schema)?;
@@ -623,10 +605,7 @@ impl IntoAgents for (&RecordBatch, &RecordBatch) {
 }
 
 impl IntoAgents for RecordBatch {
-    fn into_agent_states(
-        &self,
-        agent_schema: Option<&Arc<AgentSchema<EngineComponent>>>,
-    ) -> Result<Vec<Agent>> {
+    fn into_agent_states(&self, agent_schema: Option<&Arc<AgentSchema>>) -> Result<Vec<Agent>> {
         let agents = self;
 
         let mut states: Vec<Agent> = std::iter::repeat(Agent::empty())
@@ -676,10 +655,7 @@ impl IntoAgents for RecordBatch {
         Ok(states)
     }
 
-    fn into_filtered_agent_states(
-        &self,
-        agent_schema: &Arc<AgentSchema<EngineComponent>>,
-    ) -> Result<Vec<Agent>> {
+    fn into_filtered_agent_states(&self, agent_schema: &Arc<AgentSchema>) -> Result<Vec<Agent>> {
         let agent_states = self.into_agent_states(Some(agent_schema))?;
 
         let group_field_names = agent_schema

--- a/packages/engine/src/datastore/arrow/batch_conversion.rs
+++ b/packages/engine/src/datastore/arrow/batch_conversion.rs
@@ -20,7 +20,7 @@ use memory::arrow::{
 use serde_json::value::Value;
 use stateful::{
     agent::{Agent, AgentName, AgentSchema, AgentStateField, BUILTIN_FIELDS},
-    field::{FieldScope, FieldTypeVariant, RootFieldKey},
+    field::{EngineComponent, FieldScope, FieldTypeVariant, RootFieldKey},
     message::MESSAGE_BATCH_SCHEMA,
 };
 
@@ -29,7 +29,7 @@ use crate::{
         arrow::{message, message::messages_column_from_serde_values},
         batch::{AgentBatch, MessageBatch},
         error::{Error, Result},
-        schema::{EngineComponent, IsRequired},
+        schema::IsRequired,
         UUID_V4_LEN,
     },
     simulation::package::creator::PREVIOUS_INDEX_FIELD_KEY,

--- a/packages/engine/src/datastore/arrow/test.rs
+++ b/packages/engine/src/datastore/arrow/test.rs
@@ -3,12 +3,13 @@ use std::collections::HashMap;
 use arrow::datatypes::{DataType, Field, Schema};
 use stateful::{
     agent::AgentStateField,
-    field::{FieldScope, FieldSpecMap, FieldType, FieldTypeVariant, RootFieldSpecCreator},
+    field::{
+        EngineComponent, FieldScope, FieldSpecMap, FieldType, FieldTypeVariant,
+        RootFieldSpecCreator,
+    },
 };
 
-use crate::datastore::{
-    error::Result, schema::EngineComponent, test_utils::root_field_spec_from_agent_field,
-};
+use crate::datastore::{error::Result, test_utils::root_field_spec_from_agent_field};
 
 #[test]
 fn get_schema() -> Result<()> {

--- a/packages/engine/src/datastore/arrow/test.rs
+++ b/packages/engine/src/datastore/arrow/test.rs
@@ -4,8 +4,7 @@ use arrow::datatypes::{DataType, Field, Schema};
 use stateful::{
     agent::AgentStateField,
     field::{
-        EngineComponent, FieldScope, FieldSpecMap, FieldType, FieldTypeVariant,
-        RootFieldSpecCreator,
+        FieldScope, FieldSource, FieldSpecMap, FieldType, FieldTypeVariant, RootFieldSpecCreator,
     },
 };
 
@@ -13,7 +12,7 @@ use crate::datastore::{error::Result, test_utils::root_field_spec_from_agent_fie
 
 #[test]
 fn get_schema() -> Result<()> {
-    let field_spec_creator = RootFieldSpecCreator::new(EngineComponent::Engine);
+    let field_spec_creator = RootFieldSpecCreator::new(FieldSource::Engine);
     let mut field_spec_map = FieldSpecMap::empty();
 
     field_spec_map.try_extend([field_spec_creator.create(

--- a/packages/engine/src/datastore/batch/agent.rs
+++ b/packages/engine/src/datastore/batch/agent.rs
@@ -27,7 +27,7 @@ use memory::{
     },
     shared_memory::{BufferChange, MemoryId, Metaversion, Segment},
 };
-use stateful::{agent::AgentSchema, field::EngineComponent};
+use stateful::agent::AgentSchema;
 
 use crate::{
     datastore::{
@@ -54,7 +54,7 @@ impl AgentBatch {
     /// should be run on.
     pub fn from_agent_states<K: IntoRecordBatch>(
         agents: K,
-        schema: &Arc<AgentSchema<EngineComponent>>,
+        schema: &Arc<AgentSchema>,
         experiment_id: &ExperimentId,
     ) -> Result<Self> {
         let record_batch = agents.into_agent_batch(schema)?;
@@ -63,7 +63,7 @@ impl AgentBatch {
 
     pub fn duplicate_from(
         agent_batch: &Self,
-        schema: &AgentSchema<EngineComponent>,
+        schema: &AgentSchema,
         experiment_id: &ExperimentId,
     ) -> Result<Self> {
         if agent_batch.batch.loaded_metaversion().memory()
@@ -88,7 +88,7 @@ impl AgentBatch {
     /// Copy contents from RecordBatch and create a memory-backed Batch
     pub fn from_record_batch(
         record_batch: &RecordBatch,
-        schema: &AgentSchema<EngineComponent>,
+        schema: &AgentSchema,
         experiment_id: &ExperimentId,
     ) -> Result<Self> {
         let ipc_data_generator = IpcDataGenerator::default();
@@ -121,7 +121,7 @@ impl AgentBatch {
 
     pub fn from_segment(
         segment: Segment,
-        schema: Option<&AgentSchema<EngineComponent>>,
+        schema: Option<&AgentSchema>,
         worker_index: Option<usize>,
     ) -> Result<Self> {
         let persisted = segment.try_read_persisted_metaversion()?;
@@ -161,7 +161,7 @@ impl AgentBatch {
     }
 
     pub fn get_prepared_memory_for_data(
-        schema: &Arc<AgentSchema<EngineComponent>>,
+        schema: &Arc<AgentSchema>,
         dynamic_meta: &meta::Dynamic,
         experiment_id: &ExperimentId,
     ) -> Result<Segment> {

--- a/packages/engine/src/datastore/batch/agent.rs
+++ b/packages/engine/src/datastore/batch/agent.rs
@@ -27,13 +27,12 @@ use memory::{
     },
     shared_memory::{BufferChange, MemoryId, Metaversion, Segment},
 };
-use stateful::agent::AgentSchema;
+use stateful::{agent::AgentSchema, field::EngineComponent};
 
 use crate::{
     datastore::{
         arrow::batch_conversion::IntoRecordBatch,
         error::{Error, Result},
-        schema::EngineComponent,
     },
     proto::ExperimentId,
     simulation::package::creator::PREVIOUS_INDEX_FIELD_KEY,

--- a/packages/engine/src/datastore/batch/migration/mod.rs
+++ b/packages/engine/src/datastore/batch/migration/mod.rs
@@ -7,7 +7,7 @@ use memory::{
     arrow::meta::{self, Buffer, Node, NodeMapping},
     shared_memory::{padding, Segment},
 };
-use stateful::{agent::AgentSchema, field::EngineComponent, message::MessageSchema};
+use stateful::{agent::AgentSchema, message::MessageSchema};
 
 use crate::{
     datastore::{
@@ -149,7 +149,7 @@ struct NextState {
 impl<'a> BufferActions<'a> {
     pub fn new_batch(
         &self,
-        agent_schema: &Arc<AgentSchema<EngineComponent>>,
+        agent_schema: &Arc<AgentSchema>,
         message_schema: &Arc<MessageSchema>,
         experiment_id: &ExperimentId,
         worker_index: usize,

--- a/packages/engine/src/datastore/batch/migration/mod.rs
+++ b/packages/engine/src/datastore/batch/migration/mod.rs
@@ -7,13 +7,12 @@ use memory::{
     arrow::meta::{self, Buffer, Node, NodeMapping},
     shared_memory::{padding, Segment},
 };
-use stateful::{agent::AgentSchema, message::MessageSchema};
+use stateful::{agent::AgentSchema, field::EngineComponent, message::MessageSchema};
 
 use crate::{
     datastore::{
         batch::{AgentBatch, MessageBatch},
         error::{Error, Result},
-        schema::EngineComponent,
     },
     proto::ExperimentId,
 };

--- a/packages/engine/src/datastore/schema/context.rs
+++ b/packages/engine/src/datastore/schema/context.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
 use arrow::datatypes::Schema as ArrowSchema;
-use stateful::field::FieldSpecMap;
+use stateful::field::{EngineComponent, FieldSpecMap};
 
-use crate::datastore::{error::Result, schema::EngineComponent};
+use crate::datastore::error::Result;
 
 pub struct ContextSchema {
     pub arrow: Arc<ArrowSchema>,

--- a/packages/engine/src/datastore/schema/context.rs
+++ b/packages/engine/src/datastore/schema/context.rs
@@ -1,17 +1,17 @@
 use std::sync::Arc;
 
 use arrow::datatypes::Schema as ArrowSchema;
-use stateful::field::{EngineComponent, FieldSpecMap};
+use stateful::field::FieldSpecMap;
 
 use crate::datastore::error::Result;
 
 pub struct ContextSchema {
     pub arrow: Arc<ArrowSchema>,
-    pub field_spec_map: Arc<FieldSpecMap<EngineComponent>>,
+    pub field_spec_map: Arc<FieldSpecMap>,
 }
 
 impl ContextSchema {
-    pub fn new(field_spec_map: FieldSpecMap<EngineComponent>) -> Result<ContextSchema> {
+    pub fn new(field_spec_map: FieldSpecMap) -> Result<ContextSchema> {
         let arrow_schema = Arc::new(field_spec_map.create_arrow_schema()?);
 
         Ok(ContextSchema {

--- a/packages/engine/src/datastore/schema/field_spec/mod.rs
+++ b/packages/engine/src/datastore/schema/field_spec/mod.rs
@@ -1,11 +1,8 @@
 use std::cmp::Ordering;
 
-use stateful::{
-    field::{FieldSource, FieldSpec, FieldType, FieldTypeVariant, PresetFieldType},
-    Result,
-};
+use stateful::field::{FieldSource, FieldSpec, FieldType, FieldTypeVariant, PresetFieldType};
 
-use crate::simulation::package::name::PackageName;
+use crate::simulation::package::id::PackageId;
 
 pub mod built_in;
 
@@ -15,17 +12,14 @@ pub const PREVIOUS_INDEX_FIELD_NAME: &str = "previous_index";
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum EngineComponent {
     Engine,
-    Package(PackageName),
+    Package(PackageId),
 }
 
 impl FieldSource for EngineComponent {
-    fn unique_id(&self) -> Result<usize> {
+    fn unique_id(&self) -> usize {
         match self {
-            EngineComponent::Engine => Ok(0),
-            EngineComponent::Package(package_name) => Ok(package_name
-                .get_id()
-                .map_err(|err| stateful::Error::from(err.to_string()))?
-                .as_usize()),
+            EngineComponent::Engine => 0,
+            EngineComponent::Package(package_id) => package_id.as_usize(),
         }
     }
 
@@ -82,7 +76,7 @@ pub mod tests {
     use stateful::{
         agent::AgentStateField,
         field::{FieldScope, FieldSpecMap, RootFieldSpec, RootFieldSpecCreator},
-        Error,
+        Error, Result,
     };
 
     use super::*;

--- a/packages/engine/src/datastore/schema/field_spec/mod.rs
+++ b/packages/engine/src/datastore/schema/field_spec/mod.rs
@@ -38,7 +38,7 @@ pub fn last_state_index_key() -> FieldSpec {
 pub mod tests {
     use stateful::{
         agent::AgentStateField,
-        field::{EngineComponent, FieldScope, FieldSpecMap, RootFieldSpec, RootFieldSpecCreator},
+        field::{FieldScope, FieldSource, FieldSpecMap, RootFieldSpec, RootFieldSpecCreator},
         Error, Result,
     };
 
@@ -50,7 +50,7 @@ pub mod tests {
 
     #[test]
     fn name_collision_built_in() {
-        let field_spec_creator = RootFieldSpecCreator::new(EngineComponent::Engine);
+        let field_spec_creator = RootFieldSpecCreator::new(FieldSource::Engine);
         let mut field_spec_map = FieldSpecMap::empty();
 
         field_spec_map
@@ -69,7 +69,7 @@ pub mod tests {
 
     #[test]
     fn name_collision_custom() {
-        let field_spec_creator = RootFieldSpecCreator::new(EngineComponent::Engine);
+        let field_spec_creator = RootFieldSpecCreator::new(FieldSource::Engine);
         let mut field_spec_map = FieldSpecMap::empty();
 
         field_spec_map
@@ -96,7 +96,7 @@ pub mod tests {
 
     #[test]
     fn unchanged_size_built_in() {
-        let _field_spec_creator = RootFieldSpecCreator::new(EngineComponent::Engine);
+        let _field_spec_creator = RootFieldSpecCreator::new(FieldSource::Engine);
         let mut field_spec_map = FieldSpecMap::empty();
 
         field_spec_map
@@ -114,7 +114,7 @@ pub mod tests {
 
     #[test]
     fn unchanged_size_custom() {
-        let field_spec_creator = RootFieldSpecCreator::new(EngineComponent::Engine);
+        let field_spec_creator = RootFieldSpecCreator::new(FieldSource::Engine);
         let mut field_spec_map = FieldSpecMap::empty();
 
         field_spec_map
@@ -163,7 +163,7 @@ pub mod tests {
                 ),
             },
             scope: FieldScope::Private,
-            source: EngineComponent::Engine,
+            source: FieldSource::Engine,
         }])?;
 
         keys.create_arrow_schema()?;

--- a/packages/engine/src/datastore/schema/field_spec/mod.rs
+++ b/packages/engine/src/datastore/schema/field_spec/mod.rs
@@ -1,45 +1,8 @@
-use std::cmp::Ordering;
-
-use stateful::field::{FieldSource, FieldSpec, FieldType, FieldTypeVariant, PresetFieldType};
-
-use crate::simulation::package::id::PackageId;
+use stateful::field::{FieldSpec, FieldType, FieldTypeVariant, PresetFieldType};
 
 pub mod built_in;
 
 pub const PREVIOUS_INDEX_FIELD_NAME: &str = "previous_index";
-
-/// Defines the source from which a Field was specified, useful for resolving clashes
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum EngineComponent {
-    Engine,
-    Package(PackageId),
-}
-
-impl FieldSource for EngineComponent {
-    fn unique_id(&self) -> usize {
-        match self {
-            EngineComponent::Engine => 0,
-            EngineComponent::Package(package_id) => package_id.as_usize(),
-        }
-    }
-
-    fn can_guarantee_null(&self) -> bool {
-        *self == EngineComponent::Engine
-    }
-}
-
-impl PartialOrd for EngineComponent {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        // TODO: We only do a partial ordering as we currently don't have a defined precedence of
-        //   packages. When `PartialOrd` for `PackageName` is implemented, derive it instead.
-        match (self, other) {
-            (Self::Engine, Self::Engine) => Some(Ordering::Equal),
-            (Self::Engine, Self::Package(_)) => Some(Ordering::Greater),
-            (Self::Package(_), Self::Engine) => Some(Ordering::Less),
-            (Self::Package(_), Self::Package(_)) => None,
-        }
-    }
-}
 
 /// This key is required for accessing neighbors' outboxes (new inboxes).
 /// Since the neighbor agent state is always the previous step state of the
@@ -75,7 +38,7 @@ pub fn last_state_index_key() -> FieldSpec {
 pub mod tests {
     use stateful::{
         agent::AgentStateField,
-        field::{FieldScope, FieldSpecMap, RootFieldSpec, RootFieldSpecCreator},
+        field::{EngineComponent, FieldScope, FieldSpecMap, RootFieldSpec, RootFieldSpecCreator},
         Error, Result,
     };
 

--- a/packages/engine/src/datastore/schema/mod.rs
+++ b/packages/engine/src/datastore/schema/mod.rs
@@ -2,4 +2,4 @@ pub mod context;
 
 mod field_spec;
 
-pub use self::field_spec::{built_in::IsRequired, last_state_index_key, EngineComponent};
+pub use self::field_spec::{built_in::IsRequired, last_state_index_key};

--- a/packages/engine/src/datastore/table/context/mod.rs
+++ b/packages/engine/src/datastore/table/context/mod.rs
@@ -1,14 +1,13 @@
 use std::sync::Arc;
 
 use arrow::record_batch::RecordBatch;
-use stateful::agent::AgentSchema;
+use stateful::{agent::AgentSchema, field::EngineComponent};
 
 use crate::{
     config::StoreConfig,
     datastore::{
         batch::{context::ContextBatch, AgentBatch},
         error::{Error, Result},
-        schema::EngineComponent,
         table::{
             pool::{agent::AgentPool, message::MessagePool, BatchPool},
             state::{view::StatePools, State},

--- a/packages/engine/src/datastore/table/context/mod.rs
+++ b/packages/engine/src/datastore/table/context/mod.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use arrow::record_batch::RecordBatch;
-use stateful::{agent::AgentSchema, field::EngineComponent};
+use stateful::agent::AgentSchema;
 
 use crate::{
     config::StoreConfig,
@@ -111,7 +111,7 @@ impl Context {
     pub fn update_agent_snapshot(
         &mut self,
         state: &mut State,
-        agent_schema: &AgentSchema<EngineComponent>,
+        agent_schema: &AgentSchema,
         experiment_id: &ExperimentId,
     ) -> Result<()> {
         let mut previous_agent_batch_proxies = self.previous_state.agent_pool.write_proxies()?;

--- a/packages/engine/src/datastore/table/state/create_remove/command.rs
+++ b/packages/engine/src/datastore/table/state/create_remove/command.rs
@@ -1,12 +1,11 @@
 use std::{collections::HashSet, sync::Arc};
 
 use arrow::record_batch::RecordBatch;
-use stateful::agent::AgentSchema;
+use stateful::{agent::AgentSchema, field::EngineComponent};
 
 use crate::{
     datastore::{
         error::{Error, Result},
-        schema::EngineComponent,
         UUID_V4_LEN,
     },
     simulation::command::CreateRemoveCommands,

--- a/packages/engine/src/datastore/table/state/create_remove/command.rs
+++ b/packages/engine/src/datastore/table/state/create_remove/command.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashSet, sync::Arc};
 
 use arrow::record_batch::RecordBatch;
-use stateful::{agent::AgentSchema, field::EngineComponent};
+use stateful::agent::AgentSchema;
 
 use crate::{
     datastore::{
@@ -20,7 +20,7 @@ pub struct ProcessedCommands {
 impl ProcessedCommands {
     pub fn new(
         commands: CreateRemoveCommands,
-        schema: &Arc<AgentSchema<EngineComponent>>,
+        schema: &Arc<AgentSchema>,
     ) -> Result<ProcessedCommands> {
         commands
             .try_into_processed_commands(schema)

--- a/packages/engine/src/datastore/table/state/create_remove/planner.rs
+++ b/packages/engine/src/datastore/table/state/create_remove/planner.rs
@@ -2,7 +2,7 @@
 use std::sync::Arc;
 
 use arrow::record_batch::RecordBatch;
-use stateful::{agent::AgentSchema, field::EngineComponent, proxy::PoolReadProxy};
+use stateful::{agent::AgentSchema, proxy::PoolReadProxy};
 
 use crate::{
     config::SimRunConfig,
@@ -151,7 +151,7 @@ fn buffer_actions_from_pending_batch<'a>(
     state_proxy: &StateReadProxy,
     pending_batch: &PendingBatch,
     inbound_agents: &Option<&'a RecordBatch>,
-    schema: &Arc<AgentSchema<EngineComponent>>,
+    schema: &Arc<AgentSchema>,
     inbound_taken_count: &mut usize,
 ) -> Result<BufferActions<'a>> {
     let remove = RangeActions::collect_indices(pending_batch.get_remove_actions());

--- a/packages/engine/src/datastore/table/state/create_remove/planner.rs
+++ b/packages/engine/src/datastore/table/state/create_remove/planner.rs
@@ -2,7 +2,7 @@
 use std::sync::Arc;
 
 use arrow::record_batch::RecordBatch;
-use stateful::{agent::AgentSchema, proxy::PoolReadProxy};
+use stateful::{agent::AgentSchema, field::EngineComponent, proxy::PoolReadProxy};
 
 use crate::{
     config::SimRunConfig,
@@ -12,7 +12,6 @@ use crate::{
             AgentBatch,
         },
         error::Result,
-        schema::EngineComponent,
         table::{
             proxy::StateReadProxy,
             state::create_remove::{

--- a/packages/engine/src/datastore/test_utils.rs
+++ b/packages/engine/src/datastore/test_utils.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use stateful::{
     agent::{Agent, AgentSchema, AgentStateField},
     field::{
-        EngineComponent, FieldScope, FieldSpec, FieldSpecMap, FieldType, FieldTypeVariant,
+        FieldScope, FieldSource, FieldSpec, FieldSpecMap, FieldType, FieldTypeVariant,
         RootFieldSpec, RootFieldSpecCreator,
     },
 };
@@ -21,11 +21,11 @@ use crate::{
     simulation::package::creator::{get_base_agent_fields, PackageCreators},
 };
 
-fn test_field_specs() -> FieldSpecMap<EngineComponent> {
+fn test_field_specs() -> FieldSpecMap {
     let mut map = FieldSpecMap::default();
     map.try_extend([RootFieldSpec {
         inner: last_state_index_key(),
-        source: EngineComponent::Engine,
+        source: FieldSource::Engine,
         scope: FieldScope::Hidden,
     }])
     .unwrap();
@@ -47,7 +47,7 @@ fn test_field_specs() -> FieldSpecMap<EngineComponent> {
             ),
         },
         scope: FieldScope::Agent,
-        source: EngineComponent::Engine,
+        source: FieldSource::Engine,
     }])
     .unwrap();
     map.try_extend([RootFieldSpec {
@@ -56,7 +56,7 @@ fn test_field_specs() -> FieldSpecMap<EngineComponent> {
             field_type: FieldType::new(FieldTypeVariant::Number, false),
         },
         scope: FieldScope::Agent,
-        source: EngineComponent::Engine,
+        source: FieldSource::Engine,
     }])
     .unwrap();
     map.try_extend([RootFieldSpec {
@@ -144,22 +144,20 @@ fn test_field_specs() -> FieldSpecMap<EngineComponent> {
             ),
         },
         scope: FieldScope::Agent,
-        source: EngineComponent::Engine,
+        source: FieldSource::Engine,
     }])
     .unwrap();
     map
 }
 
-pub fn root_field_spec_from_agent_field(
-    field: AgentStateField,
-) -> Result<RootFieldSpec<EngineComponent>, Error> {
+pub fn root_field_spec_from_agent_field(field: AgentStateField) -> Result<RootFieldSpec, Error> {
     Ok(RootFieldSpec {
         inner: FieldSpec {
             name: field.name().into(),
             field_type: field.try_into()?,
         },
         scope: FieldScope::Agent,
-        source: EngineComponent::Engine,
+        source: FieldSource::Engine,
     })
 }
 
@@ -310,8 +308,8 @@ pub fn dummy_sim_run_config() -> SimRunConfig {
 pub fn gen_schema_and_test_agents(
     num_agents: usize,
     seed: u64,
-) -> Result<(Arc<AgentSchema<EngineComponent>>, Vec<Agent>), Error> {
-    let field_spec_creator = RootFieldSpecCreator::new(EngineComponent::Engine);
+) -> Result<(Arc<AgentSchema>, Vec<Agent>), Error> {
+    let field_spec_creator = RootFieldSpecCreator::new(FieldSource::Engine);
     let mut field_spec_map = FieldSpecMap::empty();
     field_spec_map.try_extend([field_spec_creator.create(
         "age".to_string(),

--- a/packages/engine/src/datastore/test_utils.rs
+++ b/packages/engine/src/datastore/test_utils.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 use stateful::{
     agent::{Agent, AgentSchema, AgentStateField},
     field::{
-        FieldScope, FieldSpec, FieldSpecMap, FieldType, FieldTypeVariant, RootFieldSpec,
-        RootFieldSpecCreator,
+        EngineComponent, FieldScope, FieldSpec, FieldSpecMap, FieldType, FieldTypeVariant,
+        RootFieldSpec, RootFieldSpecCreator,
     },
 };
 use uuid::Uuid;
@@ -16,10 +16,7 @@ use crate::{
         EngineConfig, ExperimentConfig, Globals, PackageConfig, PersistenceConfig, SimRunConfig,
         SimulationConfig, StoreConfig, WorkerPoolConfig,
     },
-    datastore::{
-        error::Error,
-        schema::{last_state_index_key, EngineComponent},
-    },
+    datastore::{error::Error, schema::last_state_index_key},
     proto::{ExperimentRunBase, InitialState, InitialStateName, ProjectBase},
     simulation::package::creator::{get_base_agent_fields, PackageCreators},
 };

--- a/packages/engine/src/simulation/command.rs
+++ b/packages/engine/src/simulation/command.rs
@@ -10,7 +10,7 @@ use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterato
 use serde::{Deserialize, Serialize};
 use stateful::{
     agent::{Agent, AgentSchema},
-    field::RootFieldKey,
+    field::{EngineComponent, RootFieldKey},
     message::payload::OutboundRemoveAgentData as RemoveAgentPayload,
     proxy::PoolReadProxy,
 };
@@ -20,7 +20,6 @@ use crate::{
     datastore::{
         arrow::batch_conversion::IntoRecordBatch,
         batch::MessageBatch,
-        schema::EngineComponent,
         table::{pool::message, references::MessageMap, state::create_remove::ProcessedCommands},
         UUID_V4_LEN,
     },

--- a/packages/engine/src/simulation/command.rs
+++ b/packages/engine/src/simulation/command.rs
@@ -10,7 +10,7 @@ use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterato
 use serde::{Deserialize, Serialize};
 use stateful::{
     agent::{Agent, AgentSchema},
-    field::{EngineComponent, RootFieldKey},
+    field::RootFieldKey,
     message::payload::OutboundRemoveAgentData as RemoveAgentPayload,
     proxy::PoolReadProxy,
 };
@@ -121,7 +121,7 @@ impl Commands {
     ///
     /// Returns an error if a creation command is for an agent that has a field that hasn't been
     /// defined in the schema
-    pub fn verify(&self, schema: &Arc<AgentSchema<EngineComponent>>) -> Result<()> {
+    pub fn verify(&self, schema: &Arc<AgentSchema>) -> Result<()> {
         let field_spec_map = &schema.field_spec_map; // Fields for entire simulation.
 
         // TODO[2](optimization): Convert `fields` HashMap to perfect hash set here if it makes
@@ -215,7 +215,7 @@ impl CreateRemoveCommands {
     /// that alongside a set of Agent UUIDs to be removed from state.
     pub fn try_into_processed_commands(
         mut self,
-        schema: &Arc<AgentSchema<EngineComponent>>,
+        schema: &Arc<AgentSchema>,
     ) -> Result<ProcessedCommands> {
         let new_agents = if !self.create.is_empty() {
             Some(

--- a/packages/engine/src/simulation/comms/message.rs
+++ b/packages/engine/src/simulation/comms/message.rs
@@ -1,9 +1,10 @@
+use stateful::field::PackageId;
 use tracing::Span;
 
 use crate::{
     datastore::table::{sync::SyncPayload, task_shared_store::TaskSharedStore},
     proto::SimulationShortId,
-    simulation::{comms::active::ActiveTaskExecutorComms, package::id::PackageId, task::Task},
+    simulation::{comms::active::ActiveTaskExecutorComms, task::Task},
     types::TaskId,
     worker::Result as WorkerResult,
 };

--- a/packages/engine/src/simulation/comms/mod.rs
+++ b/packages/engine/src/simulation/comms/mod.rs
@@ -26,13 +26,12 @@ pub mod package;
 
 use std::sync::{Arc, RwLock};
 
-use stateful::agent::Agent;
+use stateful::{agent::Agent, field::PackageId};
 use uuid::Uuid;
 
 use self::message::{EngineToWorkerPoolMsg, WrappedTask};
 use super::{
     command::Commands,
-    package::id::PackageId,
     task::{access::StoreAccessVerify, active::ActiveTask, Task},
     Error, Result,
 };

--- a/packages/engine/src/simulation/comms/package.rs
+++ b/packages/engine/src/simulation/comms/package.rs
@@ -1,4 +1,4 @@
-use stateful::agent::Agent;
+use stateful::{agent::Agent, field::PackageId};
 use tracing::Instrument;
 use uuid::Uuid;
 
@@ -6,7 +6,7 @@ use crate::{
     datastore::table::task_shared_store::TaskSharedStore,
     simulation::{
         comms::{Comms, Result},
-        package::{id::PackageId, PackageType},
+        package::PackageType,
         task::{active::ActiveTask, GetTaskName, Task},
     },
 };

--- a/packages/engine/src/simulation/package/context/mod.rs
+++ b/packages/engine/src/simulation/package/context/mod.rs
@@ -4,14 +4,16 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use memory::arrow::meta::ColumnDynamicMetadata;
-use stateful::field::{FieldSpecMapAccessor, RootFieldKey, RootFieldSpec, RootFieldSpecCreator};
+use stateful::field::{
+    EngineComponent, FieldSpecMapAccessor, RootFieldKey, RootFieldSpec, RootFieldSpecCreator,
+};
 use tracing::Span;
 
 pub use self::packages::{ContextTask, ContextTaskMessage, Name, PACKAGE_CREATORS};
 use crate::{
     config::{ExperimentConfig, Globals, SimRunConfig},
     datastore::{
-        schema::{context::ContextSchema, EngineComponent},
+        schema::context::ContextSchema,
         table::{proxy::StateReadProxy, state::view::StateSnapshot},
         Result as DatastoreResult,
     },

--- a/packages/engine/src/simulation/package/context/mod.rs
+++ b/packages/engine/src/simulation/package/context/mod.rs
@@ -4,9 +4,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use memory::arrow::meta::ColumnDynamicMetadata;
-use stateful::field::{
-    EngineComponent, FieldSpecMapAccessor, RootFieldKey, RootFieldSpec, RootFieldSpecCreator,
-};
+use stateful::field::{FieldSpecMapAccessor, RootFieldKey, RootFieldSpec, RootFieldSpecCreator};
 use tracing::Span;
 
 pub use self::packages::{ContextTask, ContextTaskMessage, Name, PACKAGE_CREATORS};
@@ -61,8 +59,8 @@ pub trait PackageCreator: GetWorkerExpStartMsg + Sync + Send {
         &self,
         config: &Arc<SimRunConfig>,
         system: PackageComms,
-        state_field_spec_accessor: FieldSpecMapAccessor<EngineComponent>,
-        context_field_spec_accessor: FieldSpecMapAccessor<EngineComponent>,
+        state_field_spec_accessor: FieldSpecMapAccessor,
+        context_field_spec_accessor: FieldSpecMapAccessor,
     ) -> Result<Box<dyn Package>>;
 
     fn dependencies() -> Dependencies
@@ -78,8 +76,8 @@ pub trait PackageCreator: GetWorkerExpStartMsg + Sync + Send {
         &self,
         _config: &ExperimentConfig,
         _globals: &Globals,
-        _field_spec_creator: &RootFieldSpecCreator<EngineComponent>,
-    ) -> Result<Vec<RootFieldSpec<EngineComponent>>> {
+        _field_spec_creator: &RootFieldSpecCreator,
+    ) -> Result<Vec<RootFieldSpec>> {
         Ok(vec![])
     }
 
@@ -87,8 +85,8 @@ pub trait PackageCreator: GetWorkerExpStartMsg + Sync + Send {
         &self,
         _config: &ExperimentConfig,
         _globals: &Globals,
-        _field_spec_creator: &RootFieldSpecCreator<EngineComponent>,
-    ) -> Result<Vec<RootFieldSpec<EngineComponent>>> {
+        _field_spec_creator: &RootFieldSpecCreator,
+    ) -> Result<Vec<RootFieldSpec>> {
         Ok(vec![])
     }
 }

--- a/packages/engine/src/simulation/package/context/packages/agent_messages/fields.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/fields.rs
@@ -1,6 +1,5 @@
 use stateful::field::{
-    EngineComponent, FieldScope, FieldType, FieldTypeVariant, PresetFieldType, RootFieldSpec,
-    RootFieldSpecCreator,
+    FieldScope, FieldType, FieldTypeVariant, PresetFieldType, RootFieldSpec, RootFieldSpecCreator,
 };
 
 use crate::simulation::package::context::packages::agent_messages::{Result, MESSAGE_INDEX_COUNT};
@@ -22,8 +21,8 @@ fn agent_messages() -> FieldType {
 }
 
 pub(super) fn get_messages_field_spec(
-    field_spec_creator: &RootFieldSpecCreator<EngineComponent>,
-) -> Result<RootFieldSpec<EngineComponent>> {
+    field_spec_creator: &RootFieldSpecCreator,
+) -> Result<RootFieldSpec> {
     let agent_messages = agent_messages();
     // The messages column can be agent-scoped because it
     // has custom getters in the language runners that

--- a/packages/engine/src/simulation/package/context/packages/agent_messages/fields.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/fields.rs
@@ -1,11 +1,9 @@
 use stateful::field::{
-    FieldScope, FieldType, FieldTypeVariant, PresetFieldType, RootFieldSpec, RootFieldSpecCreator,
+    EngineComponent, FieldScope, FieldType, FieldTypeVariant, PresetFieldType, RootFieldSpec,
+    RootFieldSpecCreator,
 };
 
-use crate::{
-    datastore::schema::EngineComponent,
-    simulation::package::context::packages::agent_messages::{Result, MESSAGE_INDEX_COUNT},
-};
+use crate::simulation::package::context::packages::agent_messages::{Result, MESSAGE_INDEX_COUNT};
 
 pub(super) const MESSAGES_FIELD_NAME: &str = "messages";
 

--- a/packages/engine/src/simulation/package/context/packages/agent_messages/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/mod.rs
@@ -6,13 +6,13 @@ mod writer;
 use arrow::array::{Array, FixedSizeListBuilder, ListBuilder};
 use async_trait::async_trait;
 use serde_json::Value;
-use stateful::field::{RootFieldKey, RootFieldSpec, RootFieldSpecCreator};
+use stateful::field::{EngineComponent, RootFieldKey, RootFieldSpec, RootFieldSpecCreator};
 use tracing::Span;
 
 use self::collected::Messages;
 use crate::{
     config::ExperimentConfig,
-    datastore::{batch::iterators, schema::EngineComponent},
+    datastore::batch::iterators,
     simulation::{
         comms::package::PackageComms,
         package::context::{

--- a/packages/engine/src/simulation/package/context/packages/agent_messages/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/agent_messages/mod.rs
@@ -6,7 +6,7 @@ mod writer;
 use arrow::array::{Array, FixedSizeListBuilder, ListBuilder};
 use async_trait::async_trait;
 use serde_json::Value;
-use stateful::field::{EngineComponent, RootFieldKey, RootFieldSpec, RootFieldSpecCreator};
+use stateful::field::{RootFieldKey, RootFieldSpec, RootFieldSpecCreator};
 use tracing::Span;
 
 use self::collected::Messages;
@@ -42,8 +42,8 @@ impl PackageCreator for Creator {
         &self,
         _config: &Arc<SimRunConfig>,
         _comms: PackageComms,
-        _state_field_spec_accessor: FieldSpecMapAccessor<EngineComponent>,
-        context_field_spec_accessor: FieldSpecMapAccessor<EngineComponent>,
+        _state_field_spec_accessor: FieldSpecMapAccessor,
+        context_field_spec_accessor: FieldSpecMapAccessor,
     ) -> Result<Box<dyn ContextPackage>> {
         Ok(Box::new(AgentMessages {
             context_field_spec_accessor,
@@ -54,8 +54,8 @@ impl PackageCreator for Creator {
         &self,
         _config: &ExperimentConfig,
         _globals: &Globals,
-        field_spec_creator: &RootFieldSpecCreator<EngineComponent>,
-    ) -> Result<Vec<RootFieldSpec<EngineComponent>>> {
+        field_spec_creator: &RootFieldSpecCreator,
+    ) -> Result<Vec<RootFieldSpec>> {
         Ok(vec![fields::get_messages_field_spec(field_spec_creator)?])
     }
 }
@@ -67,7 +67,7 @@ impl GetWorkerExpStartMsg for Creator {
 }
 
 struct AgentMessages {
-    context_field_spec_accessor: FieldSpecMapAccessor<EngineComponent>,
+    context_field_spec_accessor: FieldSpecMapAccessor,
 }
 
 impl MaybeCpuBound for AgentMessages {

--- a/packages/engine/src/simulation/package/context/packages/api_requests/fields.rs
+++ b/packages/engine/src/simulation/package/context/packages/api_requests/fields.rs
@@ -1,6 +1,5 @@
 use stateful::field::{
-    EngineComponent, FieldScope, FieldSpec, FieldType, FieldTypeVariant, RootFieldSpec,
-    RootFieldSpecCreator,
+    FieldScope, FieldSpec, FieldType, FieldTypeVariant, RootFieldSpec, RootFieldSpecCreator,
 };
 
 use crate::simulation::package::context::packages::api_requests::Result;
@@ -36,8 +35,8 @@ fn api_responses() -> FieldType {
 }
 
 pub(super) fn get_api_responses_field_spec(
-    field_spec_creator: &RootFieldSpecCreator<EngineComponent>,
-) -> Result<RootFieldSpec<EngineComponent>> {
+    field_spec_creator: &RootFieldSpecCreator,
+) -> Result<RootFieldSpec> {
     let api_responses = api_responses();
     Ok(field_spec_creator.create(
         API_RESPONSES_FIELD_NAME.into(),

--- a/packages/engine/src/simulation/package/context/packages/api_requests/fields.rs
+++ b/packages/engine/src/simulation/package/context/packages/api_requests/fields.rs
@@ -1,11 +1,9 @@
 use stateful::field::{
-    FieldScope, FieldSpec, FieldType, FieldTypeVariant, RootFieldSpec, RootFieldSpecCreator,
+    EngineComponent, FieldScope, FieldSpec, FieldType, FieldTypeVariant, RootFieldSpec,
+    RootFieldSpecCreator,
 };
 
-use crate::{
-    datastore::schema::EngineComponent,
-    simulation::package::context::packages::api_requests::Result,
-};
+use crate::simulation::package::context::packages::api_requests::Result;
 
 pub(super) const FROM_FIELD_NAME: &str = "from";
 pub(super) const TYPE_FIELD_NAME: &str = "type";

--- a/packages/engine/src/simulation/package/context/packages/api_requests/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/api_requests/mod.rs
@@ -7,7 +7,7 @@ use arrow::datatypes::DataType;
 use async_trait::async_trait;
 use futures::{stream::FuturesOrdered, StreamExt};
 use serde_json::Value;
-use stateful::field::{RootFieldKey, RootFieldSpec, RootFieldSpecCreator};
+use stateful::field::{EngineComponent, RootFieldKey, RootFieldSpec, RootFieldSpecCreator};
 use tracing::{Instrument, Span};
 
 pub use self::handlers::CustomApiMessageError;
@@ -16,7 +16,6 @@ use crate::{
     config::{ExperimentConfig, Globals},
     datastore::{
         batch::iterators,
-        schema::EngineComponent,
         table::pool::{message, BatchPool},
     },
     simulation::{

--- a/packages/engine/src/simulation/package/context/packages/api_requests/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/api_requests/mod.rs
@@ -7,7 +7,7 @@ use arrow::datatypes::DataType;
 use async_trait::async_trait;
 use futures::{stream::FuturesOrdered, StreamExt};
 use serde_json::Value;
-use stateful::field::{EngineComponent, RootFieldKey, RootFieldSpec, RootFieldSpecCreator};
+use stateful::field::{RootFieldKey, RootFieldSpec, RootFieldSpecCreator};
 use tracing::{Instrument, Span};
 
 pub use self::handlers::CustomApiMessageError;
@@ -43,8 +43,8 @@ impl PackageCreator for Creator {
         &self,
         config: &Arc<SimRunConfig>,
         _comms: PackageComms,
-        _state_field_spec_accessor: FieldSpecMapAccessor<EngineComponent>,
-        context_field_spec_accessor: FieldSpecMapAccessor<EngineComponent>,
+        _state_field_spec_accessor: FieldSpecMapAccessor,
+        context_field_spec_accessor: FieldSpecMapAccessor,
     ) -> Result<Box<dyn ContextPackage>> {
         let custom_message_handlers = custom_message_handlers_from_globals(&config.sim.globals)?;
         Ok(Box::new(ApiRequests {
@@ -57,8 +57,8 @@ impl PackageCreator for Creator {
         &self,
         _config: &ExperimentConfig,
         _globals: &Globals,
-        field_spec_creator: &RootFieldSpecCreator<EngineComponent>,
-    ) -> Result<Vec<RootFieldSpec<EngineComponent>>> {
+        field_spec_creator: &RootFieldSpecCreator,
+    ) -> Result<Vec<RootFieldSpec>> {
         Ok(vec![fields::get_api_responses_field_spec(
             field_spec_creator,
         )?])
@@ -73,7 +73,7 @@ impl GetWorkerExpStartMsg for Creator {
 
 struct ApiRequests {
     custom_message_handlers: Option<Vec<String>>,
-    context_field_spec_accessor: FieldSpecMapAccessor<EngineComponent>,
+    context_field_spec_accessor: FieldSpecMapAccessor,
 }
 
 impl MaybeCpuBound for ApiRequests {

--- a/packages/engine/src/simulation/package/context/packages/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/mod.rs
@@ -18,7 +18,11 @@ use crate::{
             enum_dispatch, GetTaskArgs, GetTaskName, RegisterWithoutTrait, StoreAccessVerify,
             TaskDistributionConfig, TaskSharedStore, WorkerHandler, WorkerPoolHandler,
         },
-        package::{context::PackageCreator, id::PackageIdGenerator, PackageMetadata, PackageType},
+        package::{
+            context::PackageCreator,
+            id::{PackageId, PackageIdGenerator},
+            PackageMetadata, PackageType,
+        },
         Error, Result,
     },
 };
@@ -30,6 +34,19 @@ pub enum Name {
     AgentMessages,
     ApiRequests,
     Neighbors,
+}
+
+impl Name {
+    pub fn id(self) -> Result<PackageId> {
+        Ok(METADATA
+            .get(&self)
+            .ok_or_else(|| {
+                Error::from(format!(
+                    "Package Metadata not registered for package: {self}"
+                ))
+            })?
+            .id)
+    }
 }
 
 // TODO: Reduce code duplication between Name enums of different package types.

--- a/packages/engine/src/simulation/package/context/packages/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/mod.rs
@@ -10,6 +10,7 @@ use std::{
 
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
+use stateful::field::PackageId;
 
 use crate::{
     config::ExperimentConfig,
@@ -18,11 +19,7 @@ use crate::{
             enum_dispatch, GetTaskArgs, GetTaskName, RegisterWithoutTrait, StoreAccessVerify,
             TaskDistributionConfig, TaskSharedStore, WorkerHandler, WorkerPoolHandler,
         },
-        package::{
-            context::PackageCreator,
-            id::{PackageId, PackageIdGenerator},
-            PackageMetadata, PackageType,
-        },
+        package::{context::PackageCreator, id::PackageIdGenerator, PackageMetadata, PackageType},
         Error, Result,
     },
 };

--- a/packages/engine/src/simulation/package/context/packages/neighbors/fields.rs
+++ b/packages/engine/src/simulation/package/context/packages/neighbors/fields.rs
@@ -1,12 +1,9 @@
 use stateful::field::{
-    FieldScope, FieldType, FieldTypeVariant, FieldTypeVariant::FixedLengthArray, PresetFieldType,
-    RootFieldSpec, RootFieldSpecCreator,
+    EngineComponent, FieldScope, FieldType, FieldTypeVariant, FieldTypeVariant::FixedLengthArray,
+    PresetFieldType, RootFieldSpec, RootFieldSpecCreator,
 };
 
-use crate::{
-    datastore::schema::EngineComponent,
-    simulation::package::context::packages::neighbors::{Result, NEIGHBOR_INDEX_COUNT},
-};
+use crate::simulation::package::context::packages::neighbors::{Result, NEIGHBOR_INDEX_COUNT};
 
 pub(super) const NEIGHBORS_FIELD_NAME: &str = "neighbors";
 pub(super) const SEARCH_RADIUS_FIELD_NAME: &str = "search_radius";

--- a/packages/engine/src/simulation/package/context/packages/neighbors/fields.rs
+++ b/packages/engine/src/simulation/package/context/packages/neighbors/fields.rs
@@ -1,6 +1,6 @@
 use stateful::field::{
-    EngineComponent, FieldScope, FieldType, FieldTypeVariant, FieldTypeVariant::FixedLengthArray,
-    PresetFieldType, RootFieldSpec, RootFieldSpecCreator,
+    FieldScope, FieldType, FieldTypeVariant, FieldTypeVariant::FixedLengthArray, PresetFieldType,
+    RootFieldSpec, RootFieldSpecCreator,
 };
 
 use crate::simulation::package::context::packages::neighbors::{Result, NEIGHBOR_INDEX_COUNT};
@@ -23,15 +23,15 @@ fn neighbors() -> FieldType {
 }
 
 pub(super) fn get_neighbors_field_spec(
-    field_spec_creator: &RootFieldSpecCreator<EngineComponent>,
-) -> Result<RootFieldSpec<EngineComponent>> {
+    field_spec_creator: &RootFieldSpecCreator,
+) -> Result<RootFieldSpec> {
     let neighbors = neighbors();
     Ok(field_spec_creator.create("neighbors".into(), neighbors, FieldScope::Agent))
 }
 
 pub(super) fn get_search_radius_field_spec(
-    field_spec_creator: &RootFieldSpecCreator<EngineComponent>,
-) -> Result<RootFieldSpec<EngineComponent>> {
+    field_spec_creator: &RootFieldSpecCreator,
+) -> Result<RootFieldSpec> {
     let search_radius = FieldType::new(FieldTypeVariant::Number, true);
     Ok(field_spec_creator.create(
         SEARCH_RADIUS_FIELD_NAME.to_string(),

--- a/packages/engine/src/simulation/package/context/packages/neighbors/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/neighbors/mod.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde_json::Value;
-use stateful::field::{FieldSpecMapAccessor, RootFieldKey, RootFieldSpec, RootFieldSpecCreator};
+use stateful::field::{
+    EngineComponent, FieldSpecMapAccessor, RootFieldKey, RootFieldSpec, RootFieldSpecCreator,
+};
 use tracing::Span;
 
 use self::map::{NeighborMap, NeighborRef};
@@ -10,7 +12,7 @@ use crate::{
     config::{ExperimentConfig, Globals, SimRunConfig, TopologyConfig},
     datastore::{
         batch::{iterators, AgentBatch},
-        schema::{context::ContextSchema, EngineComponent},
+        schema::context::ContextSchema,
         table::{proxy::StateReadProxy, state::view::StateSnapshot},
     },
     simulation::{

--- a/packages/engine/src/simulation/package/context/packages/neighbors/mod.rs
+++ b/packages/engine/src/simulation/package/context/packages/neighbors/mod.rs
@@ -2,9 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde_json::Value;
-use stateful::field::{
-    EngineComponent, FieldSpecMapAccessor, RootFieldKey, RootFieldSpec, RootFieldSpecCreator,
-};
+use stateful::field::{FieldSpecMapAccessor, RootFieldKey, RootFieldSpec, RootFieldSpecCreator};
 use tracing::Span;
 
 use self::map::{NeighborMap, NeighborRef};
@@ -50,8 +48,8 @@ impl PackageCreator for Creator {
         &self,
         config: &Arc<SimRunConfig>,
         _comms: PackageComms,
-        _state_field_spec_accessor: FieldSpecMapAccessor<EngineComponent>,
-        context_field_spec_accessor: FieldSpecMapAccessor<EngineComponent>,
+        _state_field_spec_accessor: FieldSpecMapAccessor,
+        context_field_spec_accessor: FieldSpecMapAccessor,
     ) -> Result<Box<dyn ContextPackage>> {
         let neighbors = Neighbors {
             topology: Arc::new(TopologyConfig::from_globals(&config.sim.globals)?),
@@ -64,8 +62,8 @@ impl PackageCreator for Creator {
         &self,
         _config: &ExperimentConfig,
         _globals: &Globals,
-        field_spec_creator: &RootFieldSpecCreator<EngineComponent>,
-    ) -> Result<Vec<RootFieldSpec<EngineComponent>>> {
+        field_spec_creator: &RootFieldSpecCreator,
+    ) -> Result<Vec<RootFieldSpec>> {
         Ok(vec![fields::get_neighbors_field_spec(field_spec_creator)?])
     }
 
@@ -73,8 +71,8 @@ impl PackageCreator for Creator {
         &self,
         _config: &ExperimentConfig,
         _globals: &Globals,
-        field_spec_creator: &RootFieldSpecCreator<EngineComponent>,
-    ) -> Result<Vec<RootFieldSpec<EngineComponent>>> {
+        field_spec_creator: &RootFieldSpecCreator,
+    ) -> Result<Vec<RootFieldSpec>> {
         Ok(vec![fields::get_search_radius_field_spec(
             field_spec_creator,
         )?])
@@ -89,7 +87,7 @@ impl GetWorkerExpStartMsg for Creator {
 
 struct Neighbors {
     topology: Arc<TopologyConfig>,
-    context_field_spec_accessor: FieldSpecMapAccessor<EngineComponent>,
+    context_field_spec_accessor: FieldSpecMapAccessor,
 }
 
 impl Neighbors {

--- a/packages/engine/src/simulation/package/creator.rs
+++ b/packages/engine/src/simulation/package/creator.rs
@@ -183,7 +183,7 @@ impl PackageCreators {
                     config,
                     PackageComms::new(comms.clone(), *package_id, PackageType::Init),
                     FieldSpecMapAccessor::new(
-                        EngineComponent::Package(*package_name),
+                        EngineComponent::Package(*package_id),
                         state_field_spec_map.clone(),
                     ),
                 )?;
@@ -206,11 +206,11 @@ impl PackageCreators {
                     config,
                     PackageComms::new(comms.clone(), *package_id, PackageType::Context),
                     FieldSpecMapAccessor::new(
-                        EngineComponent::Package(*package_name),
+                        EngineComponent::Package(*package_id),
                         Arc::clone(state_field_spec_map),
                     ),
                     FieldSpecMapAccessor::new(
-                        EngineComponent::Package(*package_name),
+                        EngineComponent::Package(*package_id),
                         Arc::clone(context_field_spec_map),
                     ),
                 )?;
@@ -233,7 +233,7 @@ impl PackageCreators {
                     config,
                     PackageComms::new(comms.clone(), *package_id, PackageType::State),
                     FieldSpecMapAccessor::new(
-                        EngineComponent::Package(*package_name),
+                        EngineComponent::Package(*package_id),
                         Arc::clone(state_field_spec_map),
                     ),
                 )?;
@@ -256,7 +256,7 @@ impl PackageCreators {
                     config,
                     PackageComms::new(comms.clone(), *package_id, PackageType::Output),
                     FieldSpecMapAccessor::new(
-                        EngineComponent::Package(*package_name),
+                        EngineComponent::Package(*package_id),
                         Arc::clone(state_field_spec_map),
                     ),
                 )?;
@@ -303,9 +303,9 @@ impl PackageCreators {
 
         // TODO: should we use enum_dispatch here to remove some duplication
         self.init.iter().try_for_each::<_, Result<()>>(
-            |(_package_id, package_name, creator)| {
+            |(package_id, _package_name, creator)| {
                 let field_spec_creator =
-                    RootFieldSpecCreator::new(EngineComponent::Package(*package_name));
+                    RootFieldSpecCreator::new(EngineComponent::Package(*package_id));
                 field_spec_map.try_extend(creator.get_state_field_specs(
                     exp_config,
                     globals,
@@ -316,9 +316,9 @@ impl PackageCreators {
         )?;
 
         self.context.iter().try_for_each::<_, Result<()>>(
-            |(_package_id, package_name, creator)| {
+            |(package_id, _package_name, creator)| {
                 let field_spec_creator =
-                    RootFieldSpecCreator::new(EngineComponent::Package(*package_name));
+                    RootFieldSpecCreator::new(EngineComponent::Package(*package_id));
                 field_spec_map.try_extend(creator.get_state_field_specs(
                     exp_config,
                     globals,
@@ -329,9 +329,9 @@ impl PackageCreators {
         )?;
 
         self.state.iter().try_for_each::<_, Result<()>>(
-            |(_package_id, package_name, creator)| {
+            |(package_id, _package_name, creator)| {
                 let field_spec_creator =
-                    RootFieldSpecCreator::new(EngineComponent::Package(*package_name));
+                    RootFieldSpecCreator::new(EngineComponent::Package(*package_id));
                 field_spec_map.try_extend(creator.get_state_field_specs(
                     exp_config,
                     globals,
@@ -342,9 +342,9 @@ impl PackageCreators {
         )?;
 
         self.output.iter().try_for_each::<_, Result<()>>(
-            |(_package_id, package_name, creator)| {
+            |(package_id, _package_name, creator)| {
                 let field_spec_creator =
-                    RootFieldSpecCreator::new(EngineComponent::Package(*package_name));
+                    RootFieldSpecCreator::new(EngineComponent::Package(*package_id));
                 field_spec_map.try_extend(creator.get_state_field_specs(
                     exp_config,
                     globals,
@@ -367,9 +367,9 @@ impl PackageCreators {
         let mut field_spec_map = FieldSpecMap::empty();
 
         self.context.iter().try_for_each::<_, Result<()>>(
-            |(_package_id, package_name, creator)| {
+            |(package_id, _package_name, creator)| {
                 let field_spec_creator =
-                    RootFieldSpecCreator::new(EngineComponent::Package(*package_name));
+                    RootFieldSpecCreator::new(EngineComponent::Package(*package_id));
                 field_spec_map.try_extend(creator.get_context_field_specs(
                     exp_config,
                     globals,

--- a/packages/engine/src/simulation/package/creator.rs
+++ b/packages/engine/src/simulation/package/creator.rs
@@ -3,20 +3,18 @@ use std::{collections::HashMap, sync::Arc};
 use stateful::{
     agent::AgentSchema,
     field::{
-        FieldScope, FieldSpecMap, FieldSpecMapAccessor, FieldType, RootFieldSpec,
-        RootFieldSpecCreator,
+        EngineComponent, FieldScope, FieldSpecMap, FieldSpecMapAccessor, FieldType, PackageId,
+        RootFieldSpec, RootFieldSpecCreator,
     },
 };
 
 use crate::{
     config::{ExperimentConfig, Globals, PackageConfig, SimRunConfig},
-    datastore::schema::{context::ContextSchema, last_state_index_key, EngineComponent},
+    datastore::schema::{context::ContextSchema, last_state_index_key},
     simulation::{
         comms::{package::PackageComms, Comms},
         package::{
-            context,
-            id::PackageId,
-            init,
+            context, init,
             name::PackageName,
             output,
             output::packages::OutputPackagesSimConfig,

--- a/packages/engine/src/simulation/package/creator.rs
+++ b/packages/engine/src/simulation/package/creator.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use stateful::{
     agent::AgentSchema,
     field::{
-        EngineComponent, FieldScope, FieldSpecMap, FieldSpecMapAccessor, FieldType, PackageId,
+        FieldScope, FieldSource, FieldSpecMap, FieldSpecMapAccessor, FieldType, PackageId,
         RootFieldSpec, RootFieldSpecCreator,
     },
 };
@@ -181,7 +181,7 @@ impl PackageCreators {
                     config,
                     PackageComms::new(comms.clone(), *package_id, PackageType::Init),
                     FieldSpecMapAccessor::new(
-                        EngineComponent::Package(*package_id),
+                        FieldSource::Package(*package_id),
                         state_field_spec_map.clone(),
                     ),
                 )?;
@@ -204,11 +204,11 @@ impl PackageCreators {
                     config,
                     PackageComms::new(comms.clone(), *package_id, PackageType::Context),
                     FieldSpecMapAccessor::new(
-                        EngineComponent::Package(*package_id),
+                        FieldSource::Package(*package_id),
                         Arc::clone(state_field_spec_map),
                     ),
                     FieldSpecMapAccessor::new(
-                        EngineComponent::Package(*package_id),
+                        FieldSource::Package(*package_id),
                         Arc::clone(context_field_spec_map),
                     ),
                 )?;
@@ -231,7 +231,7 @@ impl PackageCreators {
                     config,
                     PackageComms::new(comms.clone(), *package_id, PackageType::State),
                     FieldSpecMapAccessor::new(
-                        EngineComponent::Package(*package_id),
+                        FieldSource::Package(*package_id),
                         Arc::clone(state_field_spec_map),
                     ),
                 )?;
@@ -254,7 +254,7 @@ impl PackageCreators {
                     config,
                     PackageComms::new(comms.clone(), *package_id, PackageType::Output),
                     FieldSpecMapAccessor::new(
-                        EngineComponent::Package(*package_id),
+                        FieldSource::Package(*package_id),
                         Arc::clone(state_field_spec_map),
                     ),
                 )?;
@@ -296,14 +296,14 @@ impl PackageCreators {
         &self,
         exp_config: &ExperimentConfig,
         globals: &Globals,
-    ) -> Result<AgentSchema<EngineComponent>> {
+    ) -> Result<AgentSchema> {
         let mut field_spec_map = FieldSpecMap::empty();
 
         // TODO: should we use enum_dispatch here to remove some duplication
         self.init.iter().try_for_each::<_, Result<()>>(
             |(package_id, _package_name, creator)| {
                 let field_spec_creator =
-                    RootFieldSpecCreator::new(EngineComponent::Package(*package_id));
+                    RootFieldSpecCreator::new(FieldSource::Package(*package_id));
                 field_spec_map.try_extend(creator.get_state_field_specs(
                     exp_config,
                     globals,
@@ -316,7 +316,7 @@ impl PackageCreators {
         self.context.iter().try_for_each::<_, Result<()>>(
             |(package_id, _package_name, creator)| {
                 let field_spec_creator =
-                    RootFieldSpecCreator::new(EngineComponent::Package(*package_id));
+                    RootFieldSpecCreator::new(FieldSource::Package(*package_id));
                 field_spec_map.try_extend(creator.get_state_field_specs(
                     exp_config,
                     globals,
@@ -329,7 +329,7 @@ impl PackageCreators {
         self.state.iter().try_for_each::<_, Result<()>>(
             |(package_id, _package_name, creator)| {
                 let field_spec_creator =
-                    RootFieldSpecCreator::new(EngineComponent::Package(*package_id));
+                    RootFieldSpecCreator::new(FieldSource::Package(*package_id));
                 field_spec_map.try_extend(creator.get_state_field_specs(
                     exp_config,
                     globals,
@@ -342,7 +342,7 @@ impl PackageCreators {
         self.output.iter().try_for_each::<_, Result<()>>(
             |(package_id, _package_name, creator)| {
                 let field_spec_creator =
-                    RootFieldSpecCreator::new(EngineComponent::Package(*package_id));
+                    RootFieldSpecCreator::new(FieldSource::Package(*package_id));
                 field_spec_map.try_extend(creator.get_state_field_specs(
                     exp_config,
                     globals,
@@ -367,7 +367,7 @@ impl PackageCreators {
         self.context.iter().try_for_each::<_, Result<()>>(
             |(package_id, _package_name, creator)| {
                 let field_spec_creator =
-                    RootFieldSpecCreator::new(EngineComponent::Package(*package_id));
+                    RootFieldSpecCreator::new(FieldSource::Package(*package_id));
                 field_spec_map.try_extend(creator.get_context_field_specs(
                     exp_config,
                     globals,
@@ -420,9 +420,9 @@ impl PackageCreators {
 //      something like `get_hidden_column_name(PREVIOUS_INDEX_FIELD_NAME)`
 pub const PREVIOUS_INDEX_FIELD_KEY: &str = "_HIDDEN_0_previous_index";
 
-pub fn get_base_agent_fields() -> Result<Vec<RootFieldSpec<EngineComponent>>> {
+pub fn get_base_agent_fields() -> Result<Vec<RootFieldSpec>> {
     let mut field_specs = Vec::with_capacity(13);
-    let field_spec_creator = RootFieldSpecCreator::new(EngineComponent::Engine);
+    let field_spec_creator = RootFieldSpecCreator::new(FieldSource::Engine);
 
     use stateful::agent::AgentStateField::{
         AgentId, AgentName, Color, Direction, Height, Hidden, Position, Rgb, Scale, Shape, Velocity,
@@ -450,8 +450,8 @@ pub fn get_base_agent_fields() -> Result<Vec<RootFieldSpec<EngineComponent>>> {
     Ok(field_specs)
 }
 
-fn get_base_context_fields() -> Result<Vec<RootFieldSpec<EngineComponent>>> {
-    let _field_spec_creator = RootFieldSpecCreator::new(EngineComponent::Engine);
+fn get_base_context_fields() -> Result<Vec<RootFieldSpec>> {
+    let _field_spec_creator = RootFieldSpecCreator::new(FieldSource::Engine);
     // TODO: previous index and other fields that make sense
     // Doesn't do anything for now
     Ok(vec![])

--- a/packages/engine/src/simulation/package/id.rs
+++ b/packages/engine/src/simulation/package/id.rs
@@ -1,31 +1,6 @@
-use core::fmt;
-use std::fmt::Formatter;
-
-use serde::Serialize;
+use stateful::field::PackageId;
 
 use crate::simulation::package::PackageType;
-
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Serialize)]
-pub struct PackageId(usize);
-
-impl PackageId {
-    #[inline]
-    pub fn as_usize(&self) -> usize {
-        self.0
-    }
-}
-
-impl fmt::Display for PackageId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<usize> for PackageId {
-    fn from(id: usize) -> Self {
-        Self(id)
-    }
-}
 
 pub struct PackageIdGenerator {
     cur: usize,
@@ -45,7 +20,7 @@ impl PackageIdGenerator {
     }
 
     pub fn next(&mut self) -> PackageId {
-        let id = PackageId(self.multiplier * (2 ^ self.cur));
+        let id = PackageId::from(self.multiplier * (2 ^ self.cur));
         self.cur += 1;
         id
     }

--- a/packages/engine/src/simulation/package/init/mod.rs
+++ b/packages/engine/src/simulation/package/init/mod.rs
@@ -8,12 +8,11 @@ use async_trait::async_trait;
 pub use packages::{InitTask, InitTaskMessage, Name, PACKAGE_CREATORS};
 use stateful::{
     agent::Agent,
-    field::{FieldSpecMapAccessor, RootFieldSpec, RootFieldSpecCreator},
+    field::{EngineComponent, FieldSpecMapAccessor, RootFieldSpec, RootFieldSpecCreator},
 };
 
 use crate::{
     config::{ExperimentConfig, Globals, SimRunConfig},
-    datastore::schema::EngineComponent,
     simulation::{
         comms::package::PackageComms,
         package::{

--- a/packages/engine/src/simulation/package/init/mod.rs
+++ b/packages/engine/src/simulation/package/init/mod.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 pub use packages::{InitTask, InitTaskMessage, Name, PACKAGE_CREATORS};
 use stateful::{
     agent::Agent,
-    field::{EngineComponent, FieldSpecMapAccessor, RootFieldSpec, RootFieldSpecCreator},
+    field::{FieldSpecMapAccessor, RootFieldSpec, RootFieldSpecCreator},
 };
 
 use crate::{
@@ -40,7 +40,7 @@ pub trait PackageCreator: GetWorkerExpStartMsg + Sync + Send {
         &self,
         config: &Arc<SimRunConfig>,
         system: PackageComms,
-        accessor: FieldSpecMapAccessor<EngineComponent>,
+        accessor: FieldSpecMapAccessor,
     ) -> Result<Box<dyn Package>>;
 
     fn dependencies() -> Dependencies
@@ -54,8 +54,8 @@ pub trait PackageCreator: GetWorkerExpStartMsg + Sync + Send {
         &self,
         _config: &ExperimentConfig,
         _globals: &Globals,
-        _field_spec_map_builder: &RootFieldSpecCreator<EngineComponent>,
-    ) -> Result<Vec<RootFieldSpec<EngineComponent>>> {
+        _field_spec_map_builder: &RootFieldSpecCreator,
+    ) -> Result<Vec<RootFieldSpec>> {
         Ok(vec![])
     }
 }

--- a/packages/engine/src/simulation/package/init/packages/js_py/mod.rs
+++ b/packages/engine/src/simulation/package/init/packages/js_py/mod.rs
@@ -6,11 +6,10 @@ use std::{
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use stateful::agent::Agent;
+use stateful::{agent::Agent, field::EngineComponent};
 
 use crate::{
     config::ExperimentConfig,
-    datastore::schema::EngineComponent,
     proto::{ExperimentRunTrait, InitialState, InitialStateName},
     simulation::{
         enum_dispatch::{enum_dispatch, RegisterWithoutTrait, TaskSharedStore},

--- a/packages/engine/src/simulation/package/init/packages/js_py/mod.rs
+++ b/packages/engine/src/simulation/package/init/packages/js_py/mod.rs
@@ -6,7 +6,7 @@ use std::{
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use stateful::{agent::Agent, field::EngineComponent};
+use stateful::agent::Agent;
 
 use crate::{
     config::ExperimentConfig,
@@ -37,7 +37,7 @@ impl PackageCreator for Creator {
         &self,
         config: &Arc<SimRunConfig>,
         comms: PackageComms,
-        _accessor: FieldSpecMapAccessor<EngineComponent>,
+        _accessor: FieldSpecMapAccessor,
     ) -> Result<Box<dyn InitPackage>> {
         match &config.exp.run.base().project_base.initial_state.name {
             InitialStateName::InitPy | InitialStateName::InitJs => Ok(Box::new(Package {

--- a/packages/engine/src/simulation/package/init/packages/json/mod.rs
+++ b/packages/engine/src/simulation/package/init/packages/json/mod.rs
@@ -1,9 +1,8 @@
 use async_trait::async_trait;
 use serde_json::Value;
-use stateful::agent::Agent;
+use stateful::{agent::Agent, field::EngineComponent};
 
 use crate::{
-    datastore::schema::EngineComponent,
     proto::{ExperimentRunTrait, InitialStateName},
     simulation::{
         package::init::{

--- a/packages/engine/src/simulation/package/init/packages/json/mod.rs
+++ b/packages/engine/src/simulation/package/init/packages/json/mod.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use serde_json::Value;
-use stateful::{agent::Agent, field::EngineComponent};
+use stateful::agent::Agent;
 
 use crate::{
     proto::{ExperimentRunTrait, InitialStateName},
@@ -25,7 +25,7 @@ impl PackageCreator for Creator {
         &self,
         config: &Arc<SimRunConfig>,
         _comms: PackageComms,
-        _accessor: FieldSpecMapAccessor<EngineComponent>,
+        _accessor: FieldSpecMapAccessor,
     ) -> Result<Box<dyn InitPackage>> {
         match &config.exp.run.base().project_base.initial_state.name {
             InitialStateName::InitJson => Ok(Box::new(Package {
@@ -48,6 +48,7 @@ impl GetWorkerExpStartMsg for Creator {
         Ok(Value::Null)
     }
 }
+
 pub struct Package {
     initial_state_src: String,
 }

--- a/packages/engine/src/simulation/package/init/packages/mod.rs
+++ b/packages/engine/src/simulation/package/init/packages/mod.rs
@@ -10,6 +10,7 @@ use std::{
 use js_py::{js::JsInitTask, py::PyInitTask};
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
+use stateful::field::PackageId;
 
 use crate::{
     config::ExperimentConfig,
@@ -18,11 +19,7 @@ use crate::{
             enum_dispatch, JsPyInitTaskMessage, RegisterWithoutTrait, StoreAccessVerify,
             TaskSharedStore,
         },
-        package::{
-            id::{PackageId, PackageIdGenerator},
-            init::PackageCreator,
-            PackageMetadata, PackageType,
-        },
+        package::{id::PackageIdGenerator, init::PackageCreator, PackageMetadata, PackageType},
         Error, Result,
     },
 };

--- a/packages/engine/src/simulation/package/init/packages/mod.rs
+++ b/packages/engine/src/simulation/package/init/packages/mod.rs
@@ -18,7 +18,11 @@ use crate::{
             enum_dispatch, JsPyInitTaskMessage, RegisterWithoutTrait, StoreAccessVerify,
             TaskSharedStore,
         },
-        package::{id::PackageIdGenerator, init::PackageCreator, PackageMetadata, PackageType},
+        package::{
+            id::{PackageId, PackageIdGenerator},
+            init::PackageCreator,
+            PackageMetadata, PackageType,
+        },
         Error, Result,
     },
 };
@@ -29,6 +33,19 @@ use crate::{
 pub enum Name {
     Json,
     JsPy,
+}
+
+impl Name {
+    pub fn id(self) -> Result<PackageId> {
+        Ok(METADATA
+            .get(&self)
+            .ok_or_else(|| {
+                Error::from(format!(
+                    "Package Metadata not registered for package: {self}"
+                ))
+            })?
+            .id)
+    }
 }
 
 impl std::fmt::Display for Name {

--- a/packages/engine/src/simulation/package/mod.rs
+++ b/packages/engine/src/simulation/package/mod.rs
@@ -31,8 +31,9 @@ pub mod run;
 pub mod worker_init;
 
 use serde::Serialize;
+use stateful::field::PackageId;
 
-use crate::simulation::package::{deps::Dependencies, id::PackageId};
+use crate::simulation::package::deps::Dependencies;
 
 #[derive(Clone, Copy, Debug)]
 pub enum PackageType {

--- a/packages/engine/src/simulation/package/name.rs
+++ b/packages/engine/src/simulation/package/name.rs
@@ -1,9 +1,10 @@
 use std::fmt::Display;
 
 use serde::Serialize;
+use stateful::field::PackageId;
 
 use crate::simulation::{
-    package::{context, deps::Dependencies, id::PackageId, init, output, state, PackageMetadata},
+    package::{context, deps::Dependencies, init, output, state, PackageMetadata},
     Error, Result,
 };
 

--- a/packages/engine/src/simulation/package/output/mod.rs
+++ b/packages/engine/src/simulation/package/output/mod.rs
@@ -4,16 +4,13 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 pub use packages::{Name, OutputTask, OutputTaskMessage, PACKAGE_CREATORS};
-use stateful::field::{FieldSpecMapAccessor, RootFieldSpec, RootFieldSpecCreator};
+use stateful::field::{EngineComponent, FieldSpecMapAccessor, RootFieldSpec, RootFieldSpecCreator};
 use tracing::Span;
 
 use self::packages::Output;
 use crate::{
     config::{ExperimentConfig, Globals, SimRunConfig},
-    datastore::{
-        schema::EngineComponent,
-        table::{context::Context, state::State},
-    },
+    datastore::table::{context::Context, state::State},
     simulation::{
         comms::package::PackageComms,
         package::{

--- a/packages/engine/src/simulation/package/output/mod.rs
+++ b/packages/engine/src/simulation/package/output/mod.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 pub use packages::{Name, OutputTask, OutputTaskMessage, PACKAGE_CREATORS};
-use stateful::field::{EngineComponent, FieldSpecMapAccessor, RootFieldSpec, RootFieldSpecCreator};
+use stateful::field::{FieldSpecMapAccessor, RootFieldSpec, RootFieldSpecCreator};
 use tracing::Span;
 
 use self::packages::Output;
@@ -33,7 +33,7 @@ pub trait PackageCreator: GetWorkerExpStartMsg + Sync + Send {
         &self,
         config: &Arc<SimRunConfig>,
         system: PackageComms,
-        accessor: FieldSpecMapAccessor<EngineComponent>,
+        accessor: FieldSpecMapAccessor,
     ) -> Result<Box<dyn Package>>;
 
     fn dependencies() -> Dependencies
@@ -55,8 +55,8 @@ pub trait PackageCreator: GetWorkerExpStartMsg + Sync + Send {
         &self,
         _config: &ExperimentConfig,
         _globals: &Globals,
-        _field_spec_map_builder: &RootFieldSpecCreator<EngineComponent>,
-    ) -> Result<Vec<RootFieldSpec<EngineComponent>>> {
+        _field_spec_map_builder: &RootFieldSpecCreator,
+    ) -> Result<Vec<RootFieldSpec>> {
         Ok(vec![])
     }
 }

--- a/packages/engine/src/simulation/package/output/packages/analysis/analyzer.rs
+++ b/packages/engine/src/simulation/package/output/packages/analysis/analyzer.rs
@@ -1,10 +1,7 @@
 use std::{collections::HashMap, convert::TryFrom, sync::Arc};
 
 use serde::{Deserialize, Serialize};
-use stateful::{
-    agent::AgentSchema,
-    field::{EngineComponent, FieldSpecMapAccessor},
-};
+use stateful::{agent::AgentSchema, field::FieldSpecMapAccessor};
 
 use crate::{
     datastore::batch::AgentBatch,
@@ -43,8 +40,8 @@ pub struct Analyzer {
 impl Analyzer {
     pub fn from_analysis_source(
         analysis_source: &str,
-        _agent_schema: &AgentSchema<EngineComponent>,
-        accessor: &FieldSpecMapAccessor<EngineComponent>,
+        _agent_schema: &AgentSchema,
+        accessor: &FieldSpecMapAccessor,
     ) -> Result<Analyzer> {
         let repr = AnalysisSourceRepr::try_from(analysis_source)?;
         repr.validate_def()?;
@@ -131,7 +128,7 @@ pub struct OutputCreator {
 
 impl OutputCreator {
     fn new(
-        accessor: &FieldSpecMapAccessor<EngineComponent>,
+        accessor: &FieldSpecMapAccessor,
         operations: &[AnalysisOperationRepr],
     ) -> Result<OutputCreator> {
         let creator = Self::index_creator(operations, accessor)?;
@@ -144,7 +141,7 @@ impl OutputCreator {
 
     pub(super) fn index_creator(
         operations: &[AnalysisOperationRepr],
-        accessor: &FieldSpecMapAccessor<EngineComponent>,
+        accessor: &FieldSpecMapAccessor,
     ) -> Result<OutputRunnerCreator> {
         match &operations[0] {
             AnalysisOperationRepr::Filter {

--- a/packages/engine/src/simulation/package/output/packages/analysis/analyzer.rs
+++ b/packages/engine/src/simulation/package/output/packages/analysis/analyzer.rs
@@ -1,10 +1,13 @@
 use std::{collections::HashMap, convert::TryFrom, sync::Arc};
 
 use serde::{Deserialize, Serialize};
-use stateful::{agent::AgentSchema, field::FieldSpecMapAccessor};
+use stateful::{
+    agent::AgentSchema,
+    field::{EngineComponent, FieldSpecMapAccessor},
+};
 
 use crate::{
-    datastore::{batch::AgentBatch, schema::EngineComponent},
+    datastore::batch::AgentBatch,
     simulation::package::output::packages::analysis::{
         index_iter,
         output::{AnalysisFinalOutput, AnalysisSingleOutput},

--- a/packages/engine/src/simulation/package/output/packages/analysis/index_iter.rs
+++ b/packages/engine/src/simulation/package/output/packages/analysis/index_iter.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 
 use arrow::datatypes::DataType;
 use float_cmp::approx_eq;
-use stateful::field::{EngineComponent, FieldSpecMapAccessor, FieldTypeVariant};
+use stateful::field::{FieldSpecMapAccessor, FieldTypeVariant};
 
 use crate::{
     datastore::batch::iterators::agent::{
@@ -22,7 +22,7 @@ use crate::{
 
 fn index_iterator_f64_filter(
     operations: &[AnalysisOperationRepr],
-    accessor: &FieldSpecMapAccessor<EngineComponent>,
+    accessor: &FieldSpecMapAccessor,
     field: String,
     comparison: &ComparisonRepr,
     float: f64,
@@ -75,7 +75,7 @@ fn index_iterator_f64_filter(
 
 fn index_iterator_serialized_f64_filter(
     operations: &[AnalysisOperationRepr],
-    accessor: &FieldSpecMapAccessor<EngineComponent>,
+    accessor: &FieldSpecMapAccessor,
     field: String,
     comparison: &ComparisonRepr,
     float: f64,
@@ -182,7 +182,7 @@ fn index_iterator_serialized_f64_filter(
 
 fn index_iterator_null_filter(
     operations: &[AnalysisOperationRepr],
-    accessor: &FieldSpecMapAccessor<EngineComponent>,
+    accessor: &FieldSpecMapAccessor,
     field: String,
     comparison: &ComparisonRepr,
 ) -> Result<OutputRunnerCreator> {
@@ -201,7 +201,7 @@ fn index_iterator_null_filter(
 
 fn index_iterator_boolean_filter(
     operations: &[AnalysisOperationRepr],
-    accessor: &FieldSpecMapAccessor<EngineComponent>,
+    accessor: &FieldSpecMapAccessor,
     field: String,
     comparison: &ComparisonRepr,
     boolean: bool,
@@ -221,7 +221,7 @@ fn index_iterator_boolean_filter(
 
 fn index_iterator_serialized_null_filter(
     operations: &[AnalysisOperationRepr],
-    accessor: &FieldSpecMapAccessor<EngineComponent>,
+    accessor: &FieldSpecMapAccessor,
     field: String,
     comparison: &ComparisonRepr,
 ) -> Result<OutputRunnerCreator> {
@@ -248,7 +248,7 @@ fn index_iterator_serialized_null_filter(
 
 fn index_iterator_serialized_boolean_filter(
     operations: &[AnalysisOperationRepr],
-    accessor: &FieldSpecMapAccessor<EngineComponent>,
+    accessor: &FieldSpecMapAccessor,
     field: String,
     comparison: &ComparisonRepr,
     boolean: bool,
@@ -294,7 +294,7 @@ fn index_iterator_serialized_boolean_filter(
 
 fn index_iterator_string_filter(
     operations: &[AnalysisOperationRepr],
-    accessor: &FieldSpecMapAccessor<EngineComponent>,
+    accessor: &FieldSpecMapAccessor,
     field: String,
     comparison: &ComparisonRepr,
     string: String,
@@ -359,7 +359,7 @@ fn index_iterator_string_filter(
 
 fn index_iterator_serialized_string_filter(
     operations: &[AnalysisOperationRepr],
-    accessor: &FieldSpecMapAccessor<EngineComponent>,
+    accessor: &FieldSpecMapAccessor,
     field: String,
     comparison: &ComparisonRepr,
     string: String,
@@ -478,7 +478,7 @@ fn index_iterator_serialized_string_filter(
 
 fn index_iterator_serialized_filter(
     operations: &[AnalysisOperationRepr],
-    accessor: &FieldSpecMapAccessor<EngineComponent>,
+    accessor: &FieldSpecMapAccessor,
     field: String,
     comparison: &ComparisonRepr,
     value: &serde_json::Value,
@@ -605,7 +605,7 @@ fn f64_iter_aggregate(
 
 pub(super) fn index_iterator_filter_creator(
     operations: &[AnalysisOperationRepr],
-    accessor: &FieldSpecMapAccessor<EngineComponent>,
+    accessor: &FieldSpecMapAccessor,
     field: String,
     comparison: &ComparisonRepr,
     value: &serde_json::Value,
@@ -687,7 +687,7 @@ pub(super) fn index_iterator_filter_creator(
 }
 
 fn default_first_getter(
-    accessor: &FieldSpecMapAccessor<EngineComponent>,
+    accessor: &FieldSpecMapAccessor,
     first_field: &str,
 ) -> Result<ValueIteratorCreator> {
     let data_type = DataType::from(
@@ -709,7 +709,7 @@ fn default_first_getter(
 
 pub(super) fn index_iterator_mapper_creator(
     operations: &[AnalysisOperationRepr],
-    accessor: &FieldSpecMapAccessor<EngineComponent>,
+    accessor: &FieldSpecMapAccessor,
 ) -> Result<OutputRunnerCreator> {
     // Aggregator logic:
     // All NaNs, Infs and -Infs get mapped to null

--- a/packages/engine/src/simulation/package/output/packages/analysis/index_iter.rs
+++ b/packages/engine/src/simulation/package/output/packages/analysis/index_iter.rs
@@ -2,15 +2,12 @@ use std::cmp::Ordering;
 
 use arrow::datatypes::DataType;
 use float_cmp::approx_eq;
-use stateful::field::{FieldSpecMapAccessor, FieldTypeVariant};
+use stateful::field::{EngineComponent, FieldSpecMapAccessor, FieldTypeVariant};
 
 use crate::{
-    datastore::{
-        batch::iterators::agent::{
-            bool_iter, exists_iter, f64_iter, json_serialized_value_iter, json_value_iter_cols,
-            str_iter,
-        },
-        schema::EngineComponent,
+    datastore::batch::iterators::agent::{
+        bool_iter, exists_iter, f64_iter, json_serialized_value_iter, json_value_iter_cols,
+        str_iter,
     },
     simulation::package::output::packages::analysis::{
         analyzer::{

--- a/packages/engine/src/simulation/package/output/packages/analysis/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/analysis/mod.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use analyzer::Analyzer;
 use async_trait::async_trait;
 use serde_json::Value;
-use stateful::field::{EngineComponent, FieldSpecMapAccessor};
+use stateful::field::FieldSpecMapAccessor;
 use tracing::Span;
 
 pub use self::{
@@ -48,7 +48,7 @@ impl PackageCreator for Creator {
         &self,
         config: &Arc<SimRunConfig>,
         _comms: PackageComms,
-        accessor: FieldSpecMapAccessor<EngineComponent>,
+        accessor: FieldSpecMapAccessor,
     ) -> Result<Box<dyn Package>> {
         // TODO, look at reworking signatures and package creation to make ownership clearer and
         // make this unnecessary

--- a/packages/engine/src/simulation/package/output/packages/analysis/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/analysis/mod.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use analyzer::Analyzer;
 use async_trait::async_trait;
 use serde_json::Value;
-use stateful::field::FieldSpecMapAccessor;
+use stateful::field::{EngineComponent, FieldSpecMapAccessor};
 use tracing::Span;
 
 pub use self::{
@@ -21,10 +21,7 @@ pub use self::{
 };
 use crate::{
     config::{ExperimentConfig, Globals, SimRunConfig},
-    datastore::{
-        schema::EngineComponent,
-        table::{context::Context, pool::BatchPool, state::State},
-    },
+    datastore::table::{context::Context, pool::BatchPool, state::State},
     experiment::SimPackageArgs,
     proto::ExperimentRunTrait,
     simulation::{

--- a/packages/engine/src/simulation/package/output/packages/json_state/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/json_state/mod.rs
@@ -2,11 +2,14 @@ mod config;
 
 use async_trait::async_trait;
 use serde_json::Value;
-use stateful::{agent::Agent, field::FieldScope};
+use stateful::{
+    agent::Agent,
+    field::{EngineComponent, FieldScope},
+};
 
 pub use self::config::JsonStateOutputConfig;
 use crate::{
-    datastore::{arrow::batch_conversion::IntoAgents, schema::EngineComponent},
+    datastore::arrow::batch_conversion::IntoAgents,
     simulation::package::{
         name::PackageName,
         output,

--- a/packages/engine/src/simulation/package/output/packages/json_state/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/json_state/mod.rs
@@ -2,10 +2,7 @@ mod config;
 
 use async_trait::async_trait;
 use serde_json::Value;
-use stateful::{
-    agent::Agent,
-    field::{EngineComponent, FieldScope},
-};
+use stateful::{agent::Agent, field::FieldScope};
 
 pub use self::config::JsonStateOutputConfig;
 use crate::{
@@ -35,7 +32,7 @@ impl PackageCreator for Creator {
         &self,
         config: &Arc<SimRunConfig>,
         _comms: PackageComms,
-        _accessor: FieldSpecMapAccessor<EngineComponent>,
+        _accessor: FieldSpecMapAccessor,
     ) -> Result<Box<dyn Package>> {
         let value = config
             .sim

--- a/packages/engine/src/simulation/package/output/packages/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/mod.rs
@@ -9,6 +9,7 @@ use std::{
 
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
+use stateful::field::PackageId;
 
 use self::{analysis::AnalysisOutput, json_state::JsonStateOutput};
 use crate::{
@@ -19,10 +20,8 @@ use crate::{
             TaskSharedStore, WorkerHandler, WorkerPoolHandler,
         },
         package::{
-            id::{PackageId, PackageIdGenerator},
-            name::PackageName,
-            output::PackageCreator,
-            PackageMetadata, PackageType,
+            id::PackageIdGenerator, name::PackageName, output::PackageCreator, PackageMetadata,
+            PackageType,
         },
         Error, Result,
     },

--- a/packages/engine/src/simulation/package/output/packages/mod.rs
+++ b/packages/engine/src/simulation/package/output/packages/mod.rs
@@ -19,8 +19,10 @@ use crate::{
             TaskSharedStore, WorkerHandler, WorkerPoolHandler,
         },
         package::{
-            id::PackageIdGenerator, name::PackageName, output::PackageCreator, PackageMetadata,
-            PackageType,
+            id::{PackageId, PackageIdGenerator},
+            name::PackageName,
+            output::PackageCreator,
+            PackageMetadata, PackageType,
         },
         Error, Result,
     },
@@ -32,6 +34,19 @@ use crate::{
 pub enum Name {
     Analysis,
     JsonState,
+}
+
+impl Name {
+    pub fn id(self) -> Result<PackageId> {
+        Ok(METADATA
+            .get(&self)
+            .ok_or_else(|| {
+                Error::from(format!(
+                    "Package Metadata not registered for package: {self}"
+                ))
+            })?
+            .id)
+    }
 }
 
 impl std::fmt::Display for Name {

--- a/packages/engine/src/simulation/package/state/mod.rs
+++ b/packages/engine/src/simulation/package/state/mod.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use memory::arrow::ColumnChange;
 pub use packages::{Name, StateTask, StateTaskMessage, PACKAGE_CREATORS};
-use stateful::field::{EngineComponent, FieldSpecMapAccessor, RootFieldSpec, RootFieldSpecCreator};
+use stateful::field::{FieldSpecMapAccessor, RootFieldSpec, RootFieldSpecCreator};
 use tracing::Span;
 
 use crate::{
@@ -43,7 +43,7 @@ pub trait PackageCreator: GetWorkerExpStartMsg + Send + Sync {
         &self,
         config: &Arc<SimRunConfig>,
         comms: PackageComms,
-        accessor: FieldSpecMapAccessor<EngineComponent>,
+        accessor: FieldSpecMapAccessor,
     ) -> Result<Box<dyn Package>>;
 
     /// Get the package names that this package depends on.
@@ -58,8 +58,8 @@ pub trait PackageCreator: GetWorkerExpStartMsg + Send + Sync {
         &self,
         _config: &ExperimentConfig,
         _globals: &Globals,
-        _field_spec_map_builder: &RootFieldSpecCreator<EngineComponent>,
-    ) -> Result<Vec<RootFieldSpec<EngineComponent>>> {
+        _field_spec_map_builder: &RootFieldSpecCreator,
+    ) -> Result<Vec<RootFieldSpec>> {
         Ok(vec![])
     }
 }

--- a/packages/engine/src/simulation/package/state/mod.rs
+++ b/packages/engine/src/simulation/package/state/mod.rs
@@ -5,13 +5,12 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use memory::arrow::ColumnChange;
 pub use packages::{Name, StateTask, StateTaskMessage, PACKAGE_CREATORS};
-use stateful::field::{FieldSpecMapAccessor, RootFieldSpec, RootFieldSpecCreator};
+use stateful::field::{EngineComponent, FieldSpecMapAccessor, RootFieldSpec, RootFieldSpecCreator};
 use tracing::Span;
 
 use crate::{
     config::{ExperimentConfig, Globals, SimRunConfig},
     datastore::{
-        schema::EngineComponent,
         table::{context::Context, state::State},
         Result as DatastoreResult,
     },

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/fields/behavior.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/fields/behavior.rs
@@ -3,15 +3,15 @@ use std::{collections::HashMap, convert::TryFrom};
 use stateful::{
     agent::AgentStateField,
     field::{
-        FieldScope, FieldSpec, FieldSpecMap, FieldType, FieldTypeVariant, RootFieldSpec,
-        RootFieldSpecCreator,
+        EngineComponent, FieldScope, FieldSpec, FieldSpecMap, FieldType, FieldTypeVariant,
+        RootFieldSpec, RootFieldSpecCreator,
     },
 };
 
 // use crate::worker::runner::rust;
 use crate::{
     config::ExperimentConfig,
-    datastore::{schema::EngineComponent, Error, Result},
+    datastore::{Error, Result},
     experiment::SharedBehavior,
     proto::ExperimentRunTrait,
 };

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/fields/behavior.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/fields/behavior.rs
@@ -3,8 +3,8 @@ use std::{collections::HashMap, convert::TryFrom};
 use stateful::{
     agent::AgentStateField,
     field::{
-        EngineComponent, FieldScope, FieldSpec, FieldSpecMap, FieldType, FieldTypeVariant,
-        RootFieldSpec, RootFieldSpecCreator,
+        FieldScope, FieldSpec, FieldSpecMap, FieldType, FieldTypeVariant, RootFieldSpec,
+        RootFieldSpecCreator,
     },
 };
 
@@ -18,7 +18,7 @@ use crate::{
 
 #[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct BehaviorKeys {
-    pub inner: FieldSpecMap<EngineComponent>,
+    pub inner: FieldSpecMap,
     pub built_in_key_use: Option<Vec<String>>,
     pub dyn_access: bool,
 }
@@ -26,14 +26,14 @@ pub struct BehaviorKeys {
 impl BehaviorKeys {
     pub fn from_json_str<K: AsRef<str>>(
         json_str: K,
-        field_spec_creator: &RootFieldSpecCreator<EngineComponent>,
+        field_spec_creator: &RootFieldSpecCreator,
     ) -> Result<BehaviorKeys> {
         Self::_from_json_str(json_str.as_ref(), field_spec_creator)
     }
 
     pub fn _from_json_str(
         json_str: &str,
-        field_spec_creator: &RootFieldSpecCreator<EngineComponent>,
+        field_spec_creator: &RootFieldSpecCreator,
     ) -> Result<BehaviorKeys> {
         let json: serde_json::Value = serde_json::from_str(json_str)?;
         let map = match json {
@@ -130,7 +130,7 @@ impl BehaviorKeys {
     }
 
     // add all of the fields within self into builder
-    fn get_field_specs(&self) -> impl Iterator<Item = &RootFieldSpec<EngineComponent>> {
+    fn get_field_specs(&self) -> impl Iterator<Item = &RootFieldSpec> {
         self.inner.field_specs()
     }
 }
@@ -154,17 +154,14 @@ impl Behavior {
 #[derive(Clone)]
 pub struct BehaviorMap {
     pub(in super::super) inner: HashMap<String, Behavior>,
-    pub(in super::super) all_field_specs: FieldSpecMap<EngineComponent>,
+    pub(in super::super) all_field_specs: FieldSpecMap,
 }
 
-impl TryFrom<(&ExperimentConfig, &RootFieldSpecCreator<EngineComponent>)> for BehaviorMap {
+impl TryFrom<(&ExperimentConfig, &RootFieldSpecCreator)> for BehaviorMap {
     type Error = Error;
 
     fn try_from(
-        (experiment_config, field_spec_creator): (
-            &ExperimentConfig,
-            &RootFieldSpecCreator<EngineComponent>,
-        ),
+        (experiment_config, field_spec_creator): (&ExperimentConfig, &RootFieldSpecCreator),
     ) -> Result<Self> {
         let mut meta = HashMap::new();
         let mut field_spec_map = FieldSpecMap::empty();
@@ -206,7 +203,7 @@ impl TryFrom<(&ExperimentConfig, &RootFieldSpecCreator<EngineComponent>)> for Be
                 field_spec_map.try_extend(
                     keys.get_field_specs()
                         .cloned()
-                        .collect::<Vec<RootFieldSpec<EngineComponent>>>(),
+                        .collect::<Vec<RootFieldSpec>>(),
                 )?;
                 let behavior = Behavior {
                     shared: b.clone(),

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/fields/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/fields/mod.rs
@@ -2,8 +2,7 @@ pub mod behavior;
 
 use arrow::datatypes::DataType;
 use stateful::field::{
-    EngineComponent, FieldScope, FieldType, FieldTypeVariant, PresetFieldType, RootFieldSpec,
-    RootFieldSpecCreator,
+    FieldScope, FieldType, FieldTypeVariant, PresetFieldType, RootFieldSpec, RootFieldSpecCreator,
 };
 
 use self::behavior::BehaviorMap;
@@ -18,9 +17,7 @@ pub(super) const BEHAVIORS_FIELD_NAME: &str = "behaviors";
 pub(super) const BEHAVIOR_INDEX_FIELD_NAME: &str = "behavior_index";
 pub(super) const BEHAVIOR_IDS_FIELD_NAME: &str = "behavior_ids";
 
-fn get_behaviors_field_spec(
-    field_spec_creator: &RootFieldSpecCreator<EngineComponent>,
-) -> Result<RootFieldSpec<EngineComponent>> {
+fn get_behaviors_field_spec(field_spec_creator: &RootFieldSpecCreator) -> Result<RootFieldSpec> {
     let field_type = FieldType::new(
         FieldTypeVariant::VariableLengthArray(Box::new(FieldType::new(
             FieldTypeVariant::String,
@@ -32,8 +29,8 @@ fn get_behaviors_field_spec(
 }
 
 fn get_behavior_index_field_spec(
-    field_spec_creator: &RootFieldSpecCreator<EngineComponent>,
-) -> Result<RootFieldSpec<EngineComponent>> {
+    field_spec_creator: &RootFieldSpecCreator,
+) -> Result<RootFieldSpec> {
     let field_type = FieldType::new(FieldTypeVariant::Number, false);
     Ok(field_spec_creator.create(
         BEHAVIOR_INDEX_FIELD_NAME.into(),
@@ -61,9 +58,7 @@ fn behavior_ids_field_type() -> FieldType {
     FieldType::new(variant, false)
 }
 
-fn get_behavior_ids_field_spec(
-    field_spec_creator: &RootFieldSpecCreator<EngineComponent>,
-) -> Result<RootFieldSpec<EngineComponent>> {
+fn get_behavior_ids_field_spec(field_spec_creator: &RootFieldSpecCreator) -> Result<RootFieldSpec> {
     let field_type = behavior_ids_field_type();
     Ok(field_spec_creator.create(
         BEHAVIOR_IDS_FIELD_NAME.into(),
@@ -74,8 +69,8 @@ fn get_behavior_ids_field_spec(
 
 pub(super) fn get_state_field_specs(
     config: &ExperimentConfig,
-    field_spec_creator: &RootFieldSpecCreator<EngineComponent>,
-) -> Result<Vec<RootFieldSpec<EngineComponent>>> {
+    field_spec_creator: &RootFieldSpecCreator,
+) -> Result<Vec<RootFieldSpec>> {
     let behavior_map: BehaviorMap = (config, field_spec_creator).try_into()?;
     let mut field_specs = vec![
         // "behaviors" field that agents can modify

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/fields/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/fields/mod.rs
@@ -2,13 +2,13 @@ pub mod behavior;
 
 use arrow::datatypes::DataType;
 use stateful::field::{
-    FieldScope, FieldType, FieldTypeVariant, PresetFieldType, RootFieldSpec, RootFieldSpecCreator,
+    EngineComponent, FieldScope, FieldType, FieldTypeVariant, PresetFieldType, RootFieldSpec,
+    RootFieldSpecCreator,
 };
 
 use self::behavior::BehaviorMap;
 use crate::{
     config::ExperimentConfig,
-    datastore::schema::EngineComponent,
     simulation::{
         package::state::packages::behavior_execution::BEHAVIOR_INDEX_INNER_COUNT, Result,
     },

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/mod.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use serde_json::Value;
 use stateful::{
-    field::{RootFieldSpec, RootFieldSpecCreator},
+    field::{EngineComponent, RootFieldSpec, RootFieldSpecCreator},
     proxy::PoolWriteProxy,
 };
 
@@ -11,7 +11,6 @@ use self::{
 use crate::{
     datastore::{
         batch::AgentBatch,
-        schema::EngineComponent,
         table::{
             context::Context, pool::agent, proxy::StateWriteProxy,
             task_shared_store::TaskSharedStoreBuilder,

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/mod.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use serde_json::Value;
 use stateful::{
-    field::{EngineComponent, RootFieldSpec, RootFieldSpecCreator},
+    field::{FieldSource, RootFieldSpec, RootFieldSpecCreator},
     proxy::PoolWriteProxy,
 };
 
@@ -81,7 +81,7 @@ impl PackageCreator for Creator {
     fn new(experiment_config: &Arc<ExperimentConfig>) -> Result<Box<dyn PackageCreator>> {
         // TODO: Packages shouldn't have to set the source
         let field_spec_creator =
-            RootFieldSpecCreator::new(EngineComponent::Package(Name::BehaviorExecution.id()?));
+            RootFieldSpecCreator::new(FieldSource::Package(Name::BehaviorExecution.id()?));
         let behavior_map =
             BehaviorMap::try_from((experiment_config.as_ref(), &field_spec_creator))?;
         let behavior_ids = BehaviorIds::from_behaviors(&behavior_map)?;
@@ -96,7 +96,7 @@ impl PackageCreator for Creator {
         &self,
         config: &Arc<SimRunConfig>,
         comms: PackageComms,
-        accessor: FieldSpecMapAccessor<EngineComponent>,
+        accessor: FieldSpecMapAccessor,
     ) -> Result<Box<dyn Package>> {
         let behavior_ids_col_data_types = fields::id_column_data_types();
         let behavior_ids_col = accessor
@@ -133,8 +133,8 @@ impl PackageCreator for Creator {
         &self,
         config: &ExperimentConfig,
         _globals: &Globals,
-        field_spec_creator: &RootFieldSpecCreator<EngineComponent>,
-    ) -> Result<Vec<RootFieldSpec<EngineComponent>>> {
+        field_spec_creator: &RootFieldSpecCreator,
+    ) -> Result<Vec<RootFieldSpec>> {
         fields::get_state_field_specs(config, field_spec_creator)
     }
 }

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/mod.rs
@@ -19,19 +19,16 @@ use crate::{
     },
     language::Language,
     simulation::{
-        package::{
-            name::PackageName,
-            state::{
-                packages::behavior_execution::{
-                    config::BehaviorIds,
-                    fields::{BEHAVIOR_IDS_FIELD_NAME, BEHAVIOR_INDEX_FIELD_NAME},
-                    tasks::ExecuteBehaviorsTask,
-                },
-                Arc, DatastoreResult, Error, ExperimentConfig, FieldSpecMapAccessor,
-                GetWorkerExpStartMsg, GetWorkerSimStartMsg, Globals, IntoArrowChange, Name,
-                Package, PackageComms, PackageCreator, Result, SimRunConfig, Span, State,
-                StateColumn, StateTask,
+        package::state::{
+            packages::behavior_execution::{
+                config::BehaviorIds,
+                fields::{BEHAVIOR_IDS_FIELD_NAME, BEHAVIOR_INDEX_FIELD_NAME},
+                tasks::ExecuteBehaviorsTask,
             },
+            Arc, DatastoreResult, Error, ExperimentConfig, FieldSpecMapAccessor,
+            GetWorkerExpStartMsg, GetWorkerSimStartMsg, Globals, IntoArrowChange, Name, Package,
+            PackageComms, PackageCreator, Result, SimRunConfig, Span, State, StateColumn,
+            StateTask,
         },
         task::{active::ActiveTask, Task},
     },
@@ -84,9 +81,8 @@ impl GetWorkerExpStartMsg for Creator {
 impl PackageCreator for Creator {
     fn new(experiment_config: &Arc<ExperimentConfig>) -> Result<Box<dyn PackageCreator>> {
         // TODO: Packages shouldn't have to set the source
-        let field_spec_creator = RootFieldSpecCreator::new(EngineComponent::Package(
-            PackageName::State(Name::BehaviorExecution),
-        ));
+        let field_spec_creator =
+            RootFieldSpecCreator::new(EngineComponent::Package(Name::BehaviorExecution.id()?));
         let behavior_map =
             BehaviorMap::try_from((experiment_config.as_ref(), &field_spec_creator))?;
         let behavior_ids = BehaviorIds::from_behaviors(&behavior_map)?;

--- a/packages/engine/src/simulation/package/state/packages/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/mod.rs
@@ -15,7 +15,11 @@ use crate::{
     config::ExperimentConfig,
     simulation::{
         enum_dispatch::{enum_dispatch, RegisterWithoutTrait, StoreAccessVerify, TaskSharedStore},
-        package::{id::PackageIdGenerator, state::PackageCreator, PackageMetadata, PackageType},
+        package::{
+            id::{PackageId, PackageIdGenerator},
+            state::PackageCreator,
+            PackageMetadata, PackageType,
+        },
         Error, Result,
     },
 };
@@ -26,6 +30,19 @@ use crate::{
 pub enum Name {
     BehaviorExecution,
     Topology,
+}
+
+impl Name {
+    pub fn id(self) -> Result<PackageId> {
+        Ok(METADATA
+            .get(&self)
+            .ok_or_else(|| {
+                Error::from(format!(
+                    "Package Metadata not registered for package: {self}"
+                ))
+            })?
+            .id)
+    }
 }
 
 impl std::fmt::Display for Name {

--- a/packages/engine/src/simulation/package/state/packages/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/mod.rs
@@ -9,17 +9,14 @@ use std::{
 
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
+use stateful::field::PackageId;
 
 use self::behavior_execution::tasks::{ExecuteBehaviorsTask, ExecuteBehaviorsTaskMessage};
 use crate::{
     config::ExperimentConfig,
     simulation::{
         enum_dispatch::{enum_dispatch, RegisterWithoutTrait, StoreAccessVerify, TaskSharedStore},
-        package::{
-            id::{PackageId, PackageIdGenerator},
-            state::PackageCreator,
-            PackageMetadata, PackageType,
-        },
+        package::{id::PackageIdGenerator, state::PackageCreator, PackageMetadata, PackageType},
         Error, Result,
     },
 };

--- a/packages/engine/src/simulation/package/state/packages/topology/fields.rs
+++ b/packages/engine/src/simulation/package/state/packages/topology/fields.rs
@@ -1,12 +1,12 @@
 use stateful::field::{
-    EngineComponent, FieldScope, FieldType, FieldTypeVariant, RootFieldSpec, RootFieldSpecCreator,
+    FieldScope, FieldType, FieldTypeVariant, RootFieldSpec, RootFieldSpecCreator,
 };
 
 use crate::simulation::Result;
 
 pub(super) fn get_pos_corrected_field_spec(
-    field_spec_creator: &RootFieldSpecCreator<EngineComponent>,
-) -> Result<RootFieldSpec<EngineComponent>> {
+    field_spec_creator: &RootFieldSpecCreator,
+) -> Result<RootFieldSpec> {
     let field_type = FieldType::new(FieldTypeVariant::Boolean, false);
     Ok(field_spec_creator.create(
         "position_was_corrected".into(),

--- a/packages/engine/src/simulation/package/state/packages/topology/fields.rs
+++ b/packages/engine/src/simulation/package/state/packages/topology/fields.rs
@@ -1,8 +1,8 @@
 use stateful::field::{
-    FieldScope, FieldType, FieldTypeVariant, RootFieldSpec, RootFieldSpecCreator,
+    EngineComponent, FieldScope, FieldType, FieldTypeVariant, RootFieldSpec, RootFieldSpecCreator,
 };
 
-use crate::{datastore::schema::EngineComponent, simulation::Result};
+use crate::simulation::Result;
 
 pub(super) fn get_pos_corrected_field_spec(
     field_spec_creator: &RootFieldSpecCreator<EngineComponent>,

--- a/packages/engine/src/simulation/package/state/packages/topology/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/topology/mod.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use serde_json::Value;
-use stateful::field::{EngineComponent, RootFieldSpec, RootFieldSpecCreator};
+use stateful::field::{RootFieldSpec, RootFieldSpecCreator};
 
 use crate::{
     config::{ExperimentConfig, TopologyConfig},
@@ -37,7 +37,7 @@ impl PackageCreator for Creator {
         &self,
         config: &Arc<SimRunConfig>,
         _comms: PackageComms,
-        _accessor: FieldSpecMapAccessor<EngineComponent>,
+        _accessor: FieldSpecMapAccessor,
     ) -> Result<Box<dyn Package>> {
         let topology = Topology {
             config: Arc::new(TopologyConfig::from_globals(&config.sim.globals)?),
@@ -49,8 +49,8 @@ impl PackageCreator for Creator {
         &self,
         _config: &ExperimentConfig,
         _globals: &Globals,
-        field_spec_creator: &RootFieldSpecCreator<EngineComponent>,
-    ) -> Result<Vec<RootFieldSpec<EngineComponent>>> {
+        field_spec_creator: &RootFieldSpecCreator,
+    ) -> Result<Vec<RootFieldSpec>> {
         Ok(vec![fields::get_pos_corrected_field_spec(
             field_spec_creator,
         )?])

--- a/packages/engine/src/simulation/package/state/packages/topology/mod.rs
+++ b/packages/engine/src/simulation/package/state/packages/topology/mod.rs
@@ -1,12 +1,11 @@
 use async_trait::async_trait;
 use serde_json::Value;
-use stateful::field::{RootFieldSpec, RootFieldSpecCreator};
+use stateful::field::{EngineComponent, RootFieldSpec, RootFieldSpecCreator};
 
 use crate::{
     config::{ExperimentConfig, TopologyConfig},
     datastore::{
         batch::{iterators::record_batch::topology_mut_iter, AgentBatch},
-        schema::EngineComponent,
         table::{context::Context, pool::BatchPool, state::State},
     },
     simulation::{

--- a/packages/engine/src/simulation/package/worker_init.rs
+++ b/packages/engine/src/simulation/package/worker_init.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
+use stateful::field::PackageId;
 
-use crate::simulation::package::{id::PackageId, name::PackageName, PackageType};
+use crate::simulation::package::{name::PackageName, PackageType};
 
 /// Initialization message for language runners
 /// These can be sent out for experiment and simulation

--- a/packages/engine/src/worker/runner/comms/mod.rs
+++ b/packages/engine/src/worker/runner/comms/mod.rs
@@ -6,17 +6,19 @@ use std::{
 };
 
 use arrow::datatypes::Schema;
-use stateful::agent::AgentSchema;
+use stateful::{
+    agent::AgentSchema,
+    field::{EngineComponent, PackageId},
+};
 use tracing::Span;
 
 use crate::{
     config::{EngineConfig, Globals},
-    datastore::{schema::EngineComponent, shared_store::SharedStore},
+    datastore::shared_store::SharedStore,
     language::Language,
     proto::{ExperimentId, SimulationShortId},
     simulation::{
-        enum_dispatch::TaskSharedStore,
-        package::{id::PackageId, worker_init::PackageInitMsgForWorker},
+        enum_dispatch::TaskSharedStore, package::worker_init::PackageInitMsgForWorker,
         task::msg::TaskMessage,
     },
     types::{TaskId, WorkerIndex},

--- a/packages/engine/src/worker/runner/comms/mod.rs
+++ b/packages/engine/src/worker/runner/comms/mod.rs
@@ -6,10 +6,7 @@ use std::{
 };
 
 use arrow::datatypes::Schema;
-use stateful::{
-    agent::AgentSchema,
-    field::{EngineComponent, PackageId},
-};
+use stateful::{agent::AgentSchema, field::PackageId};
 use tracing::Span;
 
 use crate::{
@@ -194,7 +191,7 @@ pub struct NewSimulationRun {
 
 #[derive(derive_new::new, Clone)]
 pub struct DatastoreSimulationPayload {
-    pub agent_batch_schema: Arc<AgentSchema<EngineComponent>>,
+    pub agent_batch_schema: Arc<AgentSchema>,
     pub message_batch_schema: Arc<Schema>,
     pub context_batch_schema: Arc<Schema>,
     pub shared_store: Arc<SharedStore>,

--- a/packages/engine/src/worker/runner/javascript/error.rs
+++ b/packages/engine/src/worker/runner/javascript/error.rs
@@ -1,11 +1,11 @@
 use arrow::{datatypes::DataType, error::ArrowError};
+use stateful::field::PackageId;
 use thiserror::Error as ThisError;
 use tokio::sync::mpsc::error::SendError;
 use tracing::Span;
 
 use crate::{
     proto::SimulationShortId,
-    simulation::package::id::PackageId,
     worker::runner::comms::{
         inbound::InboundToRunnerMsgPayload,
         outbound::{OutboundFromRunnerMsg, PackageError, UserError},

--- a/packages/engine/src/worker/runner/javascript/mod.rs
+++ b/packages/engine/src/worker/runner/javascript/mod.rs
@@ -26,6 +26,7 @@ use memory::{
     arrow::{ArrowBatch, ColumnChange},
     shared_memory::{arrow_continuation, Metaversion, Segment},
 };
+use stateful::field::PackageId;
 use tokio::{
     sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
     task::JoinError,
@@ -46,10 +47,7 @@ use crate::{
     },
     language::Language,
     proto::SimulationShortId,
-    simulation::{
-        package::{id::PackageId, PackageType},
-        task::msg::TaskMessage,
-    },
+    simulation::{package::PackageType, task::msg::TaskMessage},
     types::TaskId,
     worker::{
         runner::comms::{

--- a/packages/engine/src/worker/runner/javascript/mod.rs
+++ b/packages/engine/src/worker/runner/javascript/mod.rs
@@ -416,7 +416,7 @@ fn sim_id_to_js<'s>(scope: &mut v8::HandleScope<'s>, sim_id: SimulationShortId) 
 }
 
 fn pkg_id_to_js<'s>(scope: &mut v8::HandleScope<'s>, pkg_id: PackageId) -> Value<'s> {
-    v8::Number::new(scope, pkg_id.as_usize() as f64).into()
+    v8::Number::new(scope, pkg_id.as_usize().get() as f64).into()
 }
 
 fn new_js_array_from_usizes<'s>(

--- a/packages/engine/src/worker/runner/python/fbs.rs
+++ b/packages/engine/src/worker/runner/python/fbs.rs
@@ -30,7 +30,7 @@ pub fn pkgs_to_fbs<'f>(
                 &flatbuffers_gen::package_config_generated::PackageArgs {
                     type_: init_msg.r#type.into(),
                     name: Some(package_name),
-                    sid: package_id.as_usize() as u64,
+                    sid: package_id.as_usize().get() as u64,
                     init_payload: Some(payload),
                 },
             ))

--- a/packages/engine/src/worker/runner/python/sender.rs
+++ b/packages/engine/src/worker/runner/python/sender.rs
@@ -150,7 +150,7 @@ fn inbound_to_nng(
             let msg = flatbuffers_gen::task_msg_generated::TaskMsg::create(
                 fbb,
                 &flatbuffers_gen::task_msg_generated::TaskMsgArgs {
-                    package_sid: msg.package_id.as_usize() as u64,
+                    package_sid: msg.package_id.as_usize().get() as u64,
                     task_id: Some(&task_id),
                     target: MessageTarget::Python.into(),
                     group_index: group_index.as_ref(),

--- a/packages/engine/src/worker/task.rs
+++ b/packages/engine/src/worker/task.rs
@@ -1,9 +1,8 @@
+use stateful::field::PackageId;
+
 use crate::{
     datastore::table::task_shared_store::TaskSharedStore,
-    simulation::{
-        package::id::PackageId,
-        task::{msg::TaskResultOrCancelled, Task},
-    },
+    simulation::task::{msg::TaskResultOrCancelled, Task},
     types::TaskId,
 };
 

--- a/packages/engine/src/workerpool/mod.rs
+++ b/packages/engine/src/workerpool/mod.rs
@@ -11,6 +11,7 @@ use futures::{
     stream::{FuturesUnordered, StreamExt},
 };
 use rand::prelude::SliceRandom;
+use stateful::field::PackageId;
 use tokio::{pin, task::JoinHandle};
 use tracing::{Instrument, Span};
 
@@ -31,7 +32,6 @@ use crate::{
     proto::SimulationShortId,
     simulation::{
         comms::message::{EngineToWorkerPoolMsg, EngineToWorkerPoolMsgPayload},
-        package::id::PackageId,
         task::{args::GetTaskArgs, handler::WorkerPoolHandler, Task},
     },
     types::{TaskId, WorkerIndex},


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Converting `FieldSource` to be a trait added a lot of generics to be used all over the code. This

## ⚠️ Known issues

The term `FieldSource::Engine` and `FieldSource::Package` is not really known at the `stateful` crate, we might come up with a better name.

## 🚫 Blocked by

- #457 
- #469 
- #474

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- [Add function to get the `PackageId` from `package::Name`](https://github.com/hashintel/hash/commit/ec480f166de8d44a148f95a26f2a19a2d121bc3c)
- [Change `EngineComponent` to use `PackageId`](https://github.com/hashintel/hash/commit/052c6673284ab48fe674a2f06bde6ee0ad86b433)
- [Move `EngineComponent` and `PackageId` to `stateful::field`](https://github.com/hashintel/hash/commit/3b38ecfa664e445fa63a3af3879a79c005510dac)
- [Make `FieldSource` a `struct` again](https://github.com/hashintel/hash/commit/bc809fdbf158ff1aa6fe1d124487b191cadf4b63)

## 🔗 Related links

- introduced in #457
- identified in #469

Note: this is a separate PR based on those two as the merge conflicts would be far more work than simply adding a follow-up PR.