### PR TITLE
Fix `PackageId` generation

### DIFF
--- a/packages/engine/src/simulation/package/id.rs
+++ b/packages/engine/src/simulation/package/id.rs
@@ -28,7 +28,7 @@ impl From<usize> for PackageId {
 }
 
 pub struct PackageIdGenerator {
-    cur: usize,
+    cur: u32,
     multiplier: usize,
 }
 
@@ -45,7 +45,7 @@ impl PackageIdGenerator {
     }
 
     pub fn next(&mut self) -> PackageId {
-        let id = PackageId(self.multiplier * (2 ^ self.cur));
+        let id = PackageId(self.multiplier * usize::pow(2, self.cur));
         self.cur += 1;
         id
     }

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/package.js
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/package.js
@@ -1,6 +1,6 @@
 // TODO: Propagate field specs to runners and use in state and context objects
-const BEHAVIOR_INDEX_FIELD_KEY = "_PRIVATE_14_behavior_index";
-const BEHAVIOR_IDS_FIELD_KEY = "_PRIVATE_14_behavior_ids";
+const BEHAVIOR_INDEX_FIELD_KEY = "_PRIVATE_7_behavior_index";
+const BEHAVIOR_IDS_FIELD_KEY = "_PRIVATE_7_behavior_ids";
 
 // The `BEHAVIOR_INDEX_FIELD_KEY` column is reset to zero and the private `behavior_ids`
 // column is written to

--- a/packages/engine/src/simulation/package/state/packages/behavior_execution/package.py
+++ b/packages/engine/src/simulation/package/state/packages/behavior_execution/package.py
@@ -2,8 +2,8 @@ import sys
 import traceback
 
 # TODO: Propagate field specs to runners and use in state and context objects
-BEHAVIOR_INDEX_FIELD_KEY = '_PRIVATE_14_behavior_index'
-BEHAVIOR_IDS_FIELD_KEY = '_PRIVATE_14_behavior_ids'
+BEHAVIOR_INDEX_FIELD_KEY = '_PRIVATE_7_behavior_index'
+BEHAVIOR_IDS_FIELD_KEY = '_PRIVATE_7_behavior_ids'
 
 
 def _hash_behavior_id(lang_index, id_within_lang):

--- a/packages/engine/src/worker/runner/javascript/state.js
+++ b/packages/engine/src/worker/runner/javascript/state.js
@@ -1,6 +1,6 @@
 (hash_util) => {
   // TODO: Propagate field specs to runners and use in state and context objects
-  const BEHAVIOR_INDEX_FIELD_KEY = "_PRIVATE_14_behavior_index";
+  const BEHAVIOR_INDEX_FIELD_KEY = "_PRIVATE_7_behavior_index";
 
   const throw_missing_field = (field) => {
     throw new ReferenceError("Missing field (behavior keys?): " + field);

--- a/packages/engine/src/worker/runner/python/state.py
+++ b/packages/engine/src/worker/runner/python/state.py
@@ -9,7 +9,7 @@ def raise_missing_field(field_name):
 
 
 # TODO: Propagate field specs to runners and use in state and context objects
-BEHAVIOR_INDEX_FIELD_KEY = "_PRIVATE_14_behavior_index"
+BEHAVIOR_INDEX_FIELD_KEY = "_PRIVATE_7_behavior_index"
 
 
 class AgentState:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We wrongly generate the `PackageId`, instead of `pow(2, package_number)` we are doing `2 ^ package_number` (= `2 XOR package_number`). This implies, that the third package for each package type (package number `2`) would become `PackageId(0)` as `2 XOR 2 == 0`, which is reserved for the engine.
Also, the `PackageId` generation was supposed to generate unique ids based on prime numbers. This was "simply" a bug.

## 🔍 What does this change?

- Change the `PackageId` generation to use `pow`
- Adjust hardcoded field keys to use the corrected value
