### PR TITLE
Cache cargo checkouts in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -163,6 +163,7 @@ jobs:
             ~/.cargo/bin
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
+            ~/.cargo/git/checkouts
             **/target/
           key: ${{ runner.os }}-clippy-${{ matrix.directory }}-${{ matrix.toolchain }}-${{ matrix.flags }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
@@ -226,6 +227,7 @@ jobs:
             ~/.cargo/bin
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
+            ~/.cargo/git/checkouts
             **/target/
           key: ${{ runner.os }}-test-${{ matrix.directory }}-${{ matrix.toolchain }}-${{ matrix.flags }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
@@ -288,6 +290,7 @@ jobs:
             ~/.cargo/bin
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
+            ~/.cargo/git/checkouts
             **/target/
           key: ${{ runner.os }}-bench-${{ matrix.directory }}-${{ matrix.toolchain }}-${{ matrix.flags }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Resolving deltas on large git repositories takes a lot of time, which is a flat overhead for all CI runs.

## 🔍 What does this change?

- Cache the git checkouts cargo does

## 🛡 What tests cover this?

This does not affect any code, only CI

## ❓ How to test this?

Let the CI run