### PR TITLE
Consolidate block metadata manipulation. Handle 'default' properties

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -211,6 +211,8 @@
       { "checksVoidReturn": { "attributes": false, "properties": false } }
     ],
     "@typescript-eslint/no-use-before-define": ["error"],
+    "no-redeclare": "off",
+    "@typescript-eslint/no-redeclare": ["error"],
 
     // Part of @typescript-eslint/recommended-requiring-type-checking
     // TODO: re-enable

--- a/packages/blocks/callout/webpack-block-meta-plugin.js
+++ b/packages/blocks/callout/webpack-block-meta-plugin.js
@@ -23,8 +23,8 @@ const variants = fs.existsSync("./variants.json")
 class StatsPlugin {
   apply(compiler) {
     compiler.hooks.done.tap(this.constructor.name, (stats) => {
-      const main = Object.keys(stats.compilation.assets).find((asset) =>
-        asset.startsWith("main"),
+      const main = Object.keys(stats.compilation.assets).find(
+        (asset) => asset.startsWith("main") && asset.endsWith(".js"),
       );
 
       const blockMetadata = {

--- a/packages/blocks/code/webpack-block-meta-plugin.js
+++ b/packages/blocks/code/webpack-block-meta-plugin.js
@@ -23,8 +23,8 @@ const variants = fs.existsSync("./variants.json")
 class StatsPlugin {
   apply(compiler) {
     compiler.hooks.done.tap(this.constructor.name, (stats) => {
-      const main = Object.keys(stats.compilation.assets).find((asset) =>
-        asset.startsWith("main"),
+      const main = Object.keys(stats.compilation.assets).find(
+        (asset) => asset.startsWith("main") && asset.endsWith(".js"),
       );
 
       const blockMetadata = {

--- a/packages/blocks/divider/webpack-block-meta-plugin.js
+++ b/packages/blocks/divider/webpack-block-meta-plugin.js
@@ -23,8 +23,8 @@ const variants = fs.existsSync("./variants.json")
 class StatsPlugin {
   apply(compiler) {
     compiler.hooks.done.tap(this.constructor.name, (stats) => {
-      const main = Object.keys(stats.compilation.assets).find((asset) =>
-        asset.startsWith("main"),
+      const main = Object.keys(stats.compilation.assets).find(
+        (asset) => asset.startsWith("main") && asset.endsWith(".js"),
       );
 
       const blockMetadata = {

--- a/packages/blocks/embed/webpack-block-meta-plugin.js
+++ b/packages/blocks/embed/webpack-block-meta-plugin.js
@@ -23,8 +23,8 @@ const variants = fs.existsSync("./variants.json")
 class StatsPlugin {
   apply(compiler) {
     compiler.hooks.done.tap(this.constructor.name, (stats) => {
-      const main = Object.keys(stats.compilation.assets).find((asset) =>
-        asset.startsWith("main"),
+      const main = Object.keys(stats.compilation.assets).find(
+        (asset) => asset.startsWith("main") && asset.endsWith(".js"),
       );
 
       const blockMetadata = {

--- a/packages/blocks/header/webpack-block-meta-plugin.js
+++ b/packages/blocks/header/webpack-block-meta-plugin.js
@@ -23,8 +23,8 @@ const variants = fs.existsSync("./variants.json")
 class StatsPlugin {
   apply(compiler) {
     compiler.hooks.done.tap(this.constructor.name, (stats) => {
-      const main = Object.keys(stats.compilation.assets).find((asset) =>
-        asset.startsWith("main"),
+      const main = Object.keys(stats.compilation.assets).find(
+        (asset) => asset.startsWith("main") && asset.endsWith(".js"),
       );
 
       const blockMetadata = {

--- a/packages/blocks/image/webpack-block-meta-plugin.js
+++ b/packages/blocks/image/webpack-block-meta-plugin.js
@@ -23,8 +23,8 @@ const variants = fs.existsSync("./variants.json")
 class StatsPlugin {
   apply(compiler) {
     compiler.hooks.done.tap(this.constructor.name, (stats) => {
-      const main = Object.keys(stats.compilation.assets).find((asset) =>
-        asset.startsWith("main"),
+      const main = Object.keys(stats.compilation.assets).find(
+        (asset) => asset.startsWith("main") && asset.endsWith(".js"),
       );
 
       const blockMetadata = {

--- a/packages/blocks/paragraph/webpack-block-meta-plugin.js
+++ b/packages/blocks/paragraph/webpack-block-meta-plugin.js
@@ -23,8 +23,8 @@ const variants = fs.existsSync("./variants.json")
 class StatsPlugin {
   apply(compiler) {
     compiler.hooks.done.tap(this.constructor.name, (stats) => {
-      const main = Object.keys(stats.compilation.assets).find((asset) =>
-        asset.startsWith("main"),
+      const main = Object.keys(stats.compilation.assets).find(
+        (asset) => asset.startsWith("main") && asset.endsWith(".js"),
       );
 
       const blockMetadata = {

--- a/packages/blocks/person/webpack-block-meta-plugin.js
+++ b/packages/blocks/person/webpack-block-meta-plugin.js
@@ -23,8 +23,8 @@ const variants = fs.existsSync("./variants.json")
 class StatsPlugin {
   apply(compiler) {
     compiler.hooks.done.tap(this.constructor.name, (stats) => {
-      const main = Object.keys(stats.compilation.assets).find((asset) =>
-        asset.startsWith("main"),
+      const main = Object.keys(stats.compilation.assets).find(
+        (asset) => asset.startsWith("main") && asset.endsWith(".js"),
       );
 
       const blockMetadata = {

--- a/packages/blocks/table/webpack-block-meta-plugin.js
+++ b/packages/blocks/table/webpack-block-meta-plugin.js
@@ -23,8 +23,8 @@ const variants = fs.existsSync("./variants.json")
 class StatsPlugin {
   apply(compiler) {
     compiler.hooks.done.tap(this.constructor.name, (stats) => {
-      const main = Object.keys(stats.compilation.assets).find((asset) =>
-        asset.startsWith("main"),
+      const main = Object.keys(stats.compilation.assets).find(
+        (asset) => asset.startsWith("main") && asset.endsWith(".js"),
       );
 
       const blockMetadata = {

--- a/packages/blocks/video/webpack-block-meta-plugin.js
+++ b/packages/blocks/video/webpack-block-meta-plugin.js
@@ -23,8 +23,8 @@ const variants = fs.existsSync("./variants.json")
 class StatsPlugin {
   apply(compiler) {
     compiler.hooks.done.tap(this.constructor.name, (stats) => {
-      const main = Object.keys(stats.compilation.assets).find((asset) =>
-        asset.startsWith("main"),
+      const main = Object.keys(stats.compilation.assets).find(
+        (asset) => asset.startsWith("main") && asset.endsWith(".js"),
       );
 
       const blockMetadata = {

--- a/packages/hash/frontend/src/blocks/page/ComponentView.tsx
+++ b/packages/hash/frontend/src/blocks/page/ComponentView.tsx
@@ -1,7 +1,6 @@
 import {
   blockComponentRequiresText,
   BlockMeta,
-  componentIdToUrl,
 } from "@hashintel/hash-shared/blockMeta";
 import { BlockEntity } from "@hashintel/hash-shared/entity";
 import {
@@ -125,7 +124,6 @@ export class ComponentView implements NodeView<Schema> {
         .resolve(this.getPos())
         .node(2).attrs.draftId;
 
-      const mappedUrl = componentIdToUrl(this.componentId);
       const entity = this.store.draft[blockDraftId]!;
 
       // @todo handle entity id not being defined
@@ -151,7 +149,7 @@ export class ComponentView implements NodeView<Schema> {
           fallback={(props) => <ErrorBlock {...props} onRetry={onRetry} />}
         >
           <BlockLoader
-            sourceUrl={`${mappedUrl}/${this.sourceName}`}
+            sourceUrl={this.sourceName}
             blockEntityId={entityId}
             shouldSandbox={!this.editable}
             editableRef={this.editable ? this.editableRef : undefined}

--- a/packages/hash/frontend/src/blocks/page/createSuggester/BlockSuggester.tsx
+++ b/packages/hash/frontend/src/blocks/page/createSuggester/BlockSuggester.tsx
@@ -14,20 +14,6 @@ export interface BlockSuggesterProps {
   sx?: SxProps<Theme>;
 }
 
-export const getVariantIcon = (option: {
-  variant: BlockVariant;
-  meta: RemoteBlockMetadata;
-}): string | undefined => {
-  const iconPath = option.variant.icon;
-
-  const regex = /^(?:[a-z]+:)?\/\//i;
-  if (!iconPath || regex.test(iconPath)) {
-    return iconPath;
-  }
-
-  return `${option.meta.componentId}/${iconPath.replace(/^\//, "")}`;
-};
-
 /**
  * used to present list of blocks to choose from to the user
  *
@@ -52,7 +38,7 @@ export const BlockSuggester: VFC<BlockSuggesterProps> = ({
               <img
                 className={tw`w-6 h-6`}
                 alt={option.variant.name}
-                src={getVariantIcon(option)}
+                src={option.variant.icon}
               />
             )}
           </div>

--- a/packages/hash/frontend/src/blocks/page/createSuggester/useFilteredBlocks.tsx
+++ b/packages/hash/frontend/src/blocks/page/createSuggester/useFilteredBlocks.tsx
@@ -15,30 +15,13 @@ export const useFilteredBlocks = (
 ) => {
   return useMemo(() => {
     const allOptions: Option[] = Object.values(userBlocks).flatMap(
-      (blockMeta) => {
-        if (blockMeta.variants?.length) {
-          return blockMeta.variants.map((variant) => ({
-            variant: {
-              ...variant,
-              name: variant.name ?? variant.displayName,
-            },
-            meta: blockMeta,
-          }));
-        }
-
-        return {
-          variant: {
-            description:
-              blockMeta.description ?? blockMeta.displayName ?? blockMeta.name,
-            displayName: blockMeta.displayName ?? blockMeta.name,
-            // @todo add a fallback icon
-            icon: blockMeta.icon ?? "",
-            name: blockMeta.displayName ?? blockMeta.name,
-            properties: blockMeta.default ?? {},
-          },
+      (blockMeta) =>
+        // Assumes that variants have been built for all blocks in toBlockConfig
+        // any required changes to block metadata should happen there
+        (blockMeta.variants ?? []).map((variant) => ({
+          variant,
           meta: blockMeta,
-        };
-      },
+        })),
     );
 
     return fuzzySearchBy(allOptions, searchText, (option) =>

--- a/packages/hash/frontend/src/blocks/userBlocks.tsx
+++ b/packages/hash/frontend/src/blocks/userBlocks.tsx
@@ -16,20 +16,6 @@ import { useCachedDefaultState } from "../components/hooks/useDefaultState";
 
 export type RemoteBlockMetadata = BlockMetadata & {
   componentId: string;
-  packagePath?: string;
-};
-
-// @todo - remove this and packagePath once componentId starts being generated on the backend
-const getComponentId = (meta: RemoteBlockMetadata) => {
-  if (meta.componentId) {
-    return meta.componentId;
-  }
-
-  if (meta.packagePath) {
-    return `https://blockprotocol.org/blocks/${meta.packagePath}`;
-  }
-
-  throw new Error("Added a block without packagePath or componentId");
 };
 
 type UserBlocks = RemoteBlockMetadata[];
@@ -112,15 +98,8 @@ export const UserBlocksProvider: FC<{ value: UserBlocks }> = ({
             return response.json();
           })
           .then((responseData) => {
-            const userBlocks = (responseData.results as UserBlocks).map(
-              (userBlock) => ({
-                ...userBlock,
-                componentId: getComponentId(userBlock),
-              }),
-            );
-
             setValue((prevValue) => {
-              return mergeBlocksData(prevValue, userBlocks);
+              return mergeBlocksData(prevValue, responseData);
             });
           })
           .catch((error) => {

--- a/packages/hash/frontend/src/components/BlockContextMenu/SearchView.tsx
+++ b/packages/hash/frontend/src/components/BlockContextMenu/SearchView.tsx
@@ -1,9 +1,6 @@
 import { VoidFunctionComponent } from "react";
 import { tw } from "twind";
-import {
-  BlockSuggesterProps,
-  getVariantIcon,
-} from "../../blocks/page/createSuggester/BlockSuggester";
+import { BlockSuggesterProps } from "../../blocks/page/createSuggester/BlockSuggester";
 import { BlockContextMenuItem } from "./BlockContextMenuItem";
 import {
   FilteredMenuItems,
@@ -62,8 +59,6 @@ export const SearchView: VoidFunctionComponent<SearchViewProps> = ({
             {filteredMenuItems.blocks.map((option, index) => {
               const { name } = option.variant;
 
-              const icon = getVariantIcon(option);
-
               return (
                 <BlockContextMenuItem
                   key={`${option.meta.name}-${option.variant.name}`}
@@ -75,8 +70,11 @@ export const SearchView: VoidFunctionComponent<SearchViewProps> = ({
                   }
                   onSelect={() => updateMenuState({ selectedIndex: index })}
                   icon={
-                    // @todo add a fallback icon
-                    <img src={icon ?? ""} alt={name} className={iconStyles} />
+                    <img
+                      src={option.variant.icon ?? "/format-font.svg"}
+                      alt={name}
+                      className={iconStyles}
+                    />
                   }
                   title={name}
                 />

--- a/packages/hash/frontend/src/components/entityTypes/SchemaEditor/SchemaEditor.tsx
+++ b/packages/hash/frontend/src/components/entityTypes/SchemaEditor/SchemaEditor.tsx
@@ -17,8 +17,8 @@ import React, {
 import { tw } from "twind";
 import { debounce, get } from "lodash";
 
+import { JsonSchema } from "@hashintel/hash-shared/json-utils";
 import { SchemaPropertiesTable } from "./SchemaPropertiesTable";
-import { JsonSchema } from "../../../lib/json-utils";
 import { TextInputOrDisplay } from "./Inputs";
 import {
   schemaEditorReducer,

--- a/packages/hash/frontend/src/components/entityTypes/SchemaEditor/SchemaPropertiesTable.tsx
+++ b/packages/hash/frontend/src/components/entityTypes/SchemaEditor/SchemaPropertiesTable.tsx
@@ -1,8 +1,8 @@
 import React, { FormEvent, useState, VoidFunctionComponent } from "react";
 import { tw } from "twind";
+import { JsonSchema } from "@hashintel/hash-shared/json-utils";
 import { SchemaSelectElementType } from "./SchemaEditor";
 import { SchemaPropertyRow } from "./SchemaPropertyRow";
-import { JsonSchema } from "../../../lib/json-utils";
 import { TextInputOrDisplay } from "./Inputs";
 import { SchemaEditorDispatcher } from "./schemaEditorReducer";
 import { Button } from "../../../shared/ui";

--- a/packages/hash/frontend/src/components/entityTypes/SchemaEditor/SchemaPropertyRow.tsx
+++ b/packages/hash/frontend/src/components/entityTypes/SchemaEditor/SchemaPropertyRow.tsx
@@ -1,11 +1,11 @@
 import { VoidFunctionComponent } from "react";
 import { tw } from "twind";
 
+import { JsonSchema } from "@hashintel/hash-shared/json-utils";
 import { tdClasses, trClasses } from "./SchemaPropertiesTable";
 import { SchemaPropertyTypeList } from "./SchemaPropertyTypeList";
 import { SchemaSelectElementType } from "./SchemaEditor";
 import { ToggleInputOrDisplay, TextInputOrDisplay } from "./Inputs";
-import { JsonSchema } from "../../../lib/json-utils";
 import { SchemaEditorDispatcher } from "./schemaEditorReducer";
 import { Button } from "../../../shared/ui";
 

--- a/packages/hash/frontend/src/components/entityTypes/SchemaEditor/SchemaPropertyTypeList.tsx
+++ b/packages/hash/frontend/src/components/entityTypes/SchemaEditor/SchemaPropertyTypeList.tsx
@@ -8,9 +8,9 @@ import {
 import { Schema } from "jsonschema";
 
 import { tw } from "twind";
+import { primitiveJsonTypes } from "@hashintel/hash-shared/json-utils";
 import { SchemaOptionsContext, SchemaSelectElementType } from "./SchemaEditor";
 import { SelectInput } from "../../forms/SelectInput";
-import { primitiveJsonTypes } from "../../../lib/json-utils";
 
 type SchemaPropertyTypeListProps = {
   hasSubSchema: boolean;

--- a/packages/hash/frontend/src/components/entityTypes/SchemaEditor/SubSchemaItem.tsx
+++ b/packages/hash/frontend/src/components/entityTypes/SchemaEditor/SubSchemaItem.tsx
@@ -2,7 +2,7 @@ import { useRouter } from "next/router";
 import { useState, VoidFunctionComponent } from "react";
 import { tw } from "twind";
 
-import { JsonSchema } from "../../../lib/json-utils";
+import { JsonSchema } from "@hashintel/hash-shared/json-utils";
 import { Button } from "../../../shared/ui";
 import { ConfirmationAlert } from "../../ConfirmationAlert";
 import { SchemaSelectElementType } from "./SchemaEditor";

--- a/packages/hash/frontend/src/components/entityTypes/SchemaEditor/schemaEditorReducer.ts
+++ b/packages/hash/frontend/src/components/entityTypes/SchemaEditor/schemaEditorReducer.ts
@@ -2,7 +2,7 @@ import produce from "immer";
 import { Schema } from "jsonschema";
 import { get } from "lodash";
 import { Reducer } from "react";
-import { JsonSchema } from "../../../lib/json-utils";
+import { JsonSchema } from "@hashintel/hash-shared/json-utils";
 
 type Action<S, T> = {
   type: S;
@@ -161,6 +161,8 @@ export const schemaEditorReducer: Reducer<
         return schemaState;
       }
       return produce(schemaState, (draftRootSchema) => {
+        // @ts-expect-error TS warns `Type instantiation is excessively deep`
+        // @todo figure out why here and not below, which uses the same code
         const schemaToEdit = selectSubSchema(draftRootSchema, pathToSubSchema);
         schemaToEdit.properties ??= {};
         schemaToEdit.properties[action.payload.newPropertyName] = {

--- a/packages/hash/frontend/src/components/entityTypes/SchemaEditor/schemaEditorReducer.ts
+++ b/packages/hash/frontend/src/components/entityTypes/SchemaEditor/schemaEditorReducer.ts
@@ -40,8 +40,8 @@ const selectSubSchema = <T extends JsonSchema | Draft<JsonSchema>>(
   pathToSubSchema: string | undefined,
 ): T => (pathToSubSchema ? get(schema, pathToSubSchema) : schema);
 
-const updatePropertyType = (
-  schemaToEdit: JsonSchema,
+const updatePropertyType = <T extends JsonSchema | Draft<JsonSchema>>(
+  schemaToEdit: T,
   propertyName: string,
   newType: string,
 ): Schema => {

--- a/packages/hash/frontend/src/lib/entities.ts
+++ b/packages/hash/frontend/src/lib/entities.ts
@@ -1,8 +1,11 @@
 import { cloneDeep } from "lodash";
 import { JSONObject } from "blockprotocol";
 
+import {
+  isParsedJsonObject,
+  isParsedJsonObjectOrArray,
+} from "@hashintel/hash-shared/json-utils";
 import { UnknownEntity } from "../graphql/apiTypes.gen";
-import { isParsedJsonObject, isParsedJsonObjectOrArray } from "./json-utils";
 
 /* eslint-disable no-param-reassign */
 

--- a/packages/hash/shared/src/blockMeta.ts
+++ b/packages/hash/shared/src/blockMeta.ts
@@ -1,5 +1,5 @@
 import { BlockMetadata, BlockVariant } from "blockprotocol";
-import { Schema as JSONSchema } from "jsonschema";
+import { JsonSchema } from "@hashintel/hash-shared/json-utils";
 
 /** @todo: might need refactor: https://github.com/hashintel/dev/pull/206#discussion_r723210329 */
 // eslint-disable-next-line global-require
@@ -24,7 +24,7 @@ export type Block = {
   entity: Record<any, any>;
   componentId: string;
   componentMetadata: BlockConfig;
-  componentSchema: JSONSchema;
+  componentSchema: JsonSchema;
 };
 
 /**
@@ -47,52 +47,97 @@ export const componentIdToUrl = (componentId: string) =>
   componentId.replace(/\/$/, "");
 
 /**
- * transform mere options into a useable block configuration
+ * Get an absolute url if the path is not already one.
  */
-const toBlockConfig = (
-  options: BlockMetadata,
-  componentId: string,
-): BlockConfig => {
+function getAbsoluteUrl(args: { baseUrl: string; path: string }): string;
+function getAbsoluteUrl(args: {
+  baseUrl: string;
+  path?: string | null | undefined;
+}): string | null | undefined;
+function getAbsoluteUrl({
+  baseUrl,
+  path,
+}: {
+  baseUrl: string;
+  path?: string | null;
+}): string | null | undefined {
+  const regex = /^(?:[a-z]+:)?\/\//i;
+  if (!path || regex.test(path)) {
+    return path;
+  }
+
+  return `${baseUrl}/${path.replace(/^\//, "")}`;
+}
+
+/**
+ * Transform a block metadata and schema file into fully-defined block variants.
+ * This would ideally be the one place we manipulate block metadata.
+ */
+const toBlockConfig = ({
+  componentId,
+  metadata,
+  schema,
+}: {
+  componentId: string;
+  metadata: BlockMetadata;
+  schema: BlockMeta["componentSchema"];
+}): BlockConfig => {
+  const defaultProperties =
+    schema.default &&
+    typeof schema.default === "object" &&
+    !Array.isArray(schema.default)
+      ? schema.default
+      : {};
+
   const defaultVariant: BlockVariant = {
-    description: options.description ?? "",
-    name: options.displayName ?? options.name,
-    icon: options.icon ?? "",
-    properties: {},
+    description: metadata.description ?? metadata.displayName ?? metadata.name,
+    name: metadata.displayName ?? metadata.name,
+    icon: metadata.icon ?? "",
+    properties: defaultProperties,
   };
 
   const baseUrl = componentIdToUrl(componentId);
 
-  const variants = (options.variants ?? [{}])
+  const variants = (metadata.variants?.length ? metadata.variants : [{}])
     .map((variant) => ({ ...defaultVariant, ...variant }))
     .map((variant) => ({
       ...variant,
-      // make the icon url absolute or use a relative fallback
       icon: variant.icon
-        ? [baseUrl, variant.icon].join("/")
+        ? // the Block Protocol API is returning absolute URLs for icons, but this might be from elsewhere
+          getAbsoluteUrl({ baseUrl, path: variant.icon })
         : "/format-font.svg",
+      name: variant.name ?? variant.displayName, // fallback to handle deprecated 'variant[].displayName' field
     }));
 
-  return { ...options, componentId, variants };
+  return {
+    ...metadata,
+    componentId,
+    variants,
+    icon: getAbsoluteUrl({ baseUrl, path: metadata.image }),
+    image: getAbsoluteUrl({ baseUrl, path: metadata.icon }),
+    schema: getAbsoluteUrl({ baseUrl, path: metadata.schema }),
+    source: getAbsoluteUrl({ baseUrl, path: metadata.source }),
+  };
 };
 
 // @todo deal with errors, loading, abort etc.
 export const fetchBlockMeta = async (
   componentId: string,
 ): Promise<BlockMeta> => {
-  const url = componentIdToUrl(componentId);
+  const baseUrl = componentIdToUrl(componentId);
 
-  if (blockCache.has(url)) {
-    return blockCache.get(url)!;
+  if (blockCache.has(baseUrl)) {
+    return blockCache.get(baseUrl)!;
   }
 
   const promise = (async () => {
     // the spec requires a metadata file called `block-metadata.json`
-    const metadataUrl = `${url}/block-metadata.json`;
+    const metadataUrl = `${baseUrl}/block-metadata.json`;
     let metadata: BlockMetadata;
     try {
       metadata = await (await fetch(metadataUrl)).json();
     } catch (err) {
-      blockCache.delete(url);
+      blockCache.delete(baseUrl);
       throw new Error(
         `Could not fetch and parse block metadata at url ${metadataUrl}: ${
           (err as Error).message
@@ -106,13 +151,10 @@ export const fetchBlockMeta = async (
     let schema: BlockMeta["componentSchema"];
     let schemaUrl;
     try {
-      schemaUrl =
-        schemaPath && schemaPath.match(/^(?:[a-z]+:)?\/\//)
-          ? schemaPath
-          : `${url}/${schemaPath.replace(/^\//, "")}`;
+      schemaUrl = getAbsoluteUrl({ baseUrl, path: schemaPath });
       schema = schemaUrl ? await (await fetch(schemaUrl)).json() : {};
     } catch (err) {
-      blockCache.delete(url);
+      blockCache.delete(baseUrl);
       throw new Error(
         `Could not fetch and parse block schema at url ${schemaUrl}: ${
           (err as Error).message
@@ -121,7 +163,11 @@ export const fetchBlockMeta = async (
     }
 
     const result: BlockMeta = {
-      componentMetadata: toBlockConfig(metadata, url),
+      componentMetadata: toBlockConfig({
+        metadata,
+        schema,
+        componentId: baseUrl,
+      }),
       componentSchema: schema,
     };
 
@@ -129,7 +175,7 @@ export const fetchBlockMeta = async (
   })();
 
   if (typeof window !== "undefined") {
-    blockCache.set(url, promise);
+    blockCache.set(baseUrl, promise);
   }
 
   return await promise;

--- a/packages/hash/shared/src/blockMeta.ts
+++ b/packages/hash/shared/src/blockMeta.ts
@@ -102,10 +102,8 @@ const toBlockConfig = ({
     .map((variant) => ({ ...defaultVariant, ...variant }))
     .map((variant) => ({
       ...variant,
-      icon: variant.icon
-        ? // the Block Protocol API is returning absolute URLs for icons, but this might be from elsewhere
-          getAbsoluteUrl({ baseUrl, path: variant.icon })
-        : "/format-font.svg",
+      // the Block Protocol API is returning absolute URLs for icons, but this might be from elsewhere
+      icon: getAbsoluteUrl({ baseUrl, path: variant.icon }),
       name: variant.name ?? variant.displayName, // fallback to handle deprecated 'variant[].displayName' field
     }));
 

--- a/packages/hash/shared/src/blockMeta.ts
+++ b/packages/hash/shared/src/blockMeta.ts
@@ -49,12 +49,12 @@ export const componentIdToUrl = (componentId: string) =>
 /**
  * Get an absolute url if the path is not already one.
  */
-function getAbsoluteUrl(args: { baseUrl: string; path: string }): string;
-function getAbsoluteUrl(args: {
+function deriveAbsoluteUrl(args: { baseUrl: string; path: string }): string;
+function deriveAbsoluteUrl(args: {
   baseUrl: string;
   path?: string | null | undefined;
 }): string | null | undefined;
-function getAbsoluteUrl({
+function deriveAbsoluteUrl({
   baseUrl,
   path,
 }: {
@@ -73,7 +73,7 @@ function getAbsoluteUrl({
  * Transform a block metadata and schema file into fully-defined block variants.
  * This would ideally be the one place we manipulate block metadata.
  */
-const toBlockConfig = ({
+const transformBlockConfig = ({
   componentId,
   metadata,
   schema,
@@ -103,7 +103,7 @@ const toBlockConfig = ({
     .map((variant) => ({
       ...variant,
       // the Block Protocol API is returning absolute URLs for icons, but this might be from elsewhere
-      icon: getAbsoluteUrl({ baseUrl, path: variant.icon }),
+      icon: deriveAbsoluteUrl({ baseUrl, path: variant.icon }),
       name: variant.name ?? variant.displayName, // fallback to handle deprecated 'variant[].displayName' field
     }));
 
@@ -111,10 +111,10 @@ const toBlockConfig = ({
     ...metadata,
     componentId,
     variants,
-    icon: getAbsoluteUrl({ baseUrl, path: metadata.image }),
-    image: getAbsoluteUrl({ baseUrl, path: metadata.icon }),
-    schema: getAbsoluteUrl({ baseUrl, path: metadata.schema }),
-    source: getAbsoluteUrl({ baseUrl, path: metadata.source }),
+    icon: deriveAbsoluteUrl({ baseUrl, path: metadata.image }),
+    image: deriveAbsoluteUrl({ baseUrl, path: metadata.icon }),
+    schema: deriveAbsoluteUrl({ baseUrl, path: metadata.schema }),
+    source: deriveAbsoluteUrl({ baseUrl, path: metadata.source }),
   };
 };
 
@@ -149,7 +149,7 @@ export const fetchBlockMeta = async (
     let schema: BlockMeta["componentSchema"];
     let schemaUrl;
     try {
-      schemaUrl = getAbsoluteUrl({ baseUrl, path: schemaPath });
+      schemaUrl = deriveAbsoluteUrl({ baseUrl, path: schemaPath });
       schema = schemaUrl ? await (await fetch(schemaUrl)).json() : {};
     } catch (err) {
       blockCache.delete(baseUrl);
@@ -161,7 +161,7 @@ export const fetchBlockMeta = async (
     }
 
     const result: BlockMeta = {
-      componentMetadata: toBlockConfig({
+      componentMetadata: transformBlockConfig({
         metadata,
         schema,
         componentId: baseUrl,

--- a/packages/hash/shared/src/json-utils.ts
+++ b/packages/hash/shared/src/json-utils.ts
@@ -17,6 +17,7 @@ export const parseJson = <T extends JSONObject | JSONArray>(
 
 export type JsonSchema = Schema & {
   $defs?: Record<string, JsonSchema>;
+  default?: JSONValue;
 };
 
 export const primitiveJsonTypes = [


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
The primary purpose of this PR is to introduce the ability to read a `default` object from a block schema to set as its starting properties (e.g. as we do for `variants`, but on the assumption that a block has no variants).

Figuring this out took longer than it should have because we were doing things to the block's metadata in several places, so I've also taken the opportunity to consolidate all the fallbacks and string manipulation we were doing to one place.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## ⚠️ Known issues

There are a lot of deprecation warnings in the `blockMeta` file and a hint that how we're handling metadata through context is not the intended final solution, which we could usefully expand with more detail.

## 🐾 Next steps

- We should have some way of users setting the `default` on the block schema for the autogenerated type, in `block-template`, rather than having to add it manually on each build. [Task](https://app.asana.com/0/1200211978612931/1202112150698024/f) _(internal)_.

## 🔍 What does this change?

- Gather together all metadata fallbacks and absolute URL creation into `blockMeta`
- Read `metadata.default` for default properties, if it exists and is of the correct type
- move `json-utils` to the `shared` package
- Remove an obsolete `getComponentId` now that the block API returns it
- Fix source file identification in block webpack plugins (previously had false positives on `main.[hash].LICENSE.txt`)
- Use `@typescript-eslint/no-redeclare` so we can do function overloads

### 📜 Does this require a change to the docs?

- No.

## 🔗 Related links

- [Asana task for default properties](https://app.asana.com/0/1200211978612931/1201472293975887/f) _(internal)_
- [Asana task for cleaning up hacks related to componentId, icon URLs](https://app.asana.com/0/1200211978612931/1202047419669872/f) _(internal)_

## 🛡 What tests cover this?
- Existing CI.

## ❓ How to test this?

1. To check **metadata changes**:
  - remove the `hash-workspace-user-blocks` from `localhost:3000` localStorage and refresh the app
  - Check that the metadata in LS contains correct absolute URLs etc and that the app loads, and that block suggester icons, names etc load
2. To check **use of schema default**:
  - pick some block, e.g. `code`
  - in its folder, run `yarn build && yarn dist`
  - in `dist/block-schema.json`, add a `default` object, e.g. `"default": { "content": "This should appear in the code block" } }` (there's a task under Next Steps to avoid having to do this manual edit)
  - run `yarn serve`, then paste the URL to the code block into the block picker. it should load with the default content. **Note**: the default content may then immediately unload - this is an unrelated bug tracked [here](https://app.asana.com/0/1200211978612931/1202106892392942/f) _(internal)_
