### PR TITLE
Fix resolving metadata for blocks loaded from the bp api

### DIFF
--- a/packages/hash/frontend/src/blocks/userBlocks.tsx
+++ b/packages/hash/frontend/src/blocks/userBlocks.tsx
@@ -44,9 +44,7 @@ const mergeBlocksData = (
       if (matchingUserBlockIndex === -1) {
         // @ts-expect-error TS warns `Type instantiation is excessively deep` but this isn't a problem here
         draftUserBlocks.push(latestUserBlock);
-      }
-
-      if (
+      } else if (
         // in development, overwrite the locally cached block if the source has changed
         (!isProduction &&
           draftUserBlocks[matchingUserBlockIndex]?.source !==

--- a/packages/hash/frontend/src/blocks/userBlocks.tsx
+++ b/packages/hash/frontend/src/blocks/userBlocks.tsx
@@ -1,5 +1,6 @@
 import { BlockMetadata } from "blockprotocol";
 import produce from "immer";
+import { BlockConfig, fetchBlockMeta } from "@hashintel/hash-shared/blockMeta";
 import {
   createContext,
   Dispatch,
@@ -97,9 +98,17 @@ export const UserBlocksProvider: FC<{ value: UserBlocks }> = ({
             }
             return response.json();
           })
-          .then((responseData) => {
+          .then(async ({ results: responseData }) => {
+            const resolvedMetadata = await Promise.all(
+              (responseData as BlockConfig[]).map(
+                async (metadata) =>
+                  (
+                    await fetchBlockMeta(metadata.componentId)
+                  ).componentMetadata,
+              ),
+            );
             setValue((prevValue) => {
-              return mergeBlocksData(prevValue, responseData);
+              return mergeBlocksData(prevValue, resolvedMetadata);
             });
           })
           .catch((error) => {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
This fixes a bug introduced in #481, which didn't properly handle blocks loaded from the blockprotocol.org API. This meant that blocks from the API weren't appearing in the block suggester.

Fixes:
1. The results from the block API are in an object with a 'results' key, now used
2. We then need to run block metadata through `fetchBlockMeta` so that these fetched blocks also get their fallbacks and variants generated properly
3. (pre-existing bug revealed after fixing the above) If the block didn't exist, it was pushed into the user blocks array, but then also possibly added again immediately afterwards.

## Next steps
I'm improving the blocks context and removing the need to manually clear local storage as part of introducing a block config panel.

## ❓ How to test this?
1. Remove local storage -> `hash-workspace-user-blocks` 
2. Generate a blocks API key and put in `frontend/.env.local` under `NEXT_PUBLIC_BLOCK_PROTOCOL_API_KEY=`
4. Load block suggester, check non-HASH blocks appear at end

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
<img width="600" alt="Screenshot 2022-04-13 at 16 16 05" src="https://user-images.githubusercontent.com/37743469/163213397-7835bfbb-3042-4d35-a4ed-433cc132722e.png">

