### PR TITLE
Fix collab polling timeout

### DIFF
--- a/packages/hash/api/src/collab/Waiting.ts
+++ b/packages/hash/api/src/collab/Waiting.ts
@@ -16,7 +16,9 @@ export class Waiting {
     this.inst = inst;
     this.userId = userId;
     this.finish = finish;
-    resp.setTimeout(1000 * 60 * 5, () => {
+
+    // Force pollers to restart polling after 5 seconds.
+    resp.setTimeout(1000 * 5, () => {
       this.abort();
       this.send({});
     });

--- a/packages/hash/frontend/src/blocks/page/collab/EditorConnection.ts
+++ b/packages/hash/frontend/src/blocks/page/collab/EditorConnection.ts
@@ -234,6 +234,8 @@ export class EditorConnection {
 
         if (this.state.edit) {
           const tr = this.state.edit.tr;
+          // This also allows an empty object response to act
+          // like a polling checkpoint
           let shouldDispatch = false;
 
           if (data.store) {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
This is a fix for the collab polling requests timing out different load balancers in the hosted instance.

Simply reducing the waiting timeout will put in natural ending points for the collab polling connections, allowing the frontend to restart polling.

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->
- This is not moving to socket.io, as it introduced a whole range of issues which were quite out-of-scope to fix

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->
This is a middle-ground PR to get collab working in the hosted instance. Next steps:
- Move to websocket based transport
- Perhaps use Yjs for its wire protocol and CRDT which would allow automatic conflict resolution

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- The collab polling timeout on the server side

### 📜 Does this require a change to the docs?


## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1200211978612931/1202047422882134/f) _(internal)_

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->
Doesn't change functionality


## How to test this
1. Spin up the front- and backend
1. Open any document and open dev tools on network tab
1. Every 5 seconds, the event request should be recreated, allowing the collab polling to be split up and not keep a single request alive for 5 hours.
