### PR TITLE
Implement BP hooks for creating/updating/deleting linked aggregations

### DIFF
--- a/packages/blocks/image/src/components/media.tsx
+++ b/packages/blocks/image/src/components/media.tsx
@@ -274,7 +274,6 @@ export const Media: BlockComponent<
                   .filter(isSingleTargetLink)
                   .map((link) => ({
                     sourceAccountId: accountId,
-                    sourceEntityId: link.sourceEntityId,
                     linkId: link.linkId,
                   })),
               );

--- a/packages/blocks/image/src/components/media.tsx
+++ b/packages/blocks/image/src/components/media.tsx
@@ -12,7 +12,6 @@ import {
   BlockProtocolLinkGroup,
   BlockProtocolUpdateEntitiesAction,
   BlockProtocolUploadFileFunction,
-  SingleTargetLinkFields,
 } from "blockprotocol";
 import { BlockComponent } from "blockprotocol/react";
 import React, {
@@ -119,7 +118,7 @@ function getLinkedEntities(params: {
 
 const isSingleTargetLink = (
   link: BlockProtocolLink,
-): link is BlockProtocolLink & SingleTargetLinkFields => "linkId" in link;
+): link is BlockProtocolLink => "linkId" in link;
 
 /**
  * @todo Rewrite the state here to use a reducer, instead of batched updates

--- a/packages/blocks/table/src/table.tsx
+++ b/packages/blocks/table/src/table.tsx
@@ -301,7 +301,6 @@ export const Table: BlockComponent<AppProps> = ({
       void updateLinkedAggregations([
         cleanUpdateLinkedAggregationAction({
           sourceAccountId: matchingLinkedAggregation.sourceAccountId,
-          sourceEntityId: matchingLinkedAggregation.sourceEntityId,
           aggregationId: matchingLinkedAggregation.aggregationId,
           data: newLinkedData.operation,
         }),
@@ -458,7 +457,6 @@ export const Table: BlockComponent<AppProps> = ({
           void updateLinkedAggregations([
             cleanUpdateLinkedAggregationAction({
               sourceAccountId: accountId,
-              sourceEntityId: entityId,
               aggregationId: tableData.linkedAggregation.aggregationId,
               data: {
                 entityTypeId: updatedEntityTypeId,

--- a/packages/blocks/table/src/table.tsx
+++ b/packages/blocks/table/src/table.tsx
@@ -112,7 +112,6 @@ export const Table: BlockComponent<AppProps> = ({
   accountId,
   aggregateEntities,
   aggregateEntityTypes,
-  createLinks,
   entityId,
   entityTypeId,
   entityTypes: schemas,
@@ -120,7 +119,8 @@ export const Table: BlockComponent<AppProps> = ({
   initialState,
   linkedAggregations,
   updateEntities,
-  updateLinks,
+  updateLinkedAggregations,
+  createLinkedAggregations,
 }) => {
   const matchingLinkedAggregation = useMemo(() => {
     if (!entityId) {
@@ -245,7 +245,7 @@ export const Table: BlockComponent<AppProps> = ({
       if (
         !entityId ||
         !updateEntities ||
-        !updateLinks ||
+        !updateLinkedAggregations ||
         !matchingLinkedAggregation ||
         !tableData.linkedAggregation
       ) {
@@ -298,11 +298,11 @@ export const Table: BlockComponent<AppProps> = ({
         },
       ]);
 
-      void updateLinks([
+      void updateLinkedAggregations([
         cleanUpdateLinkedAggregationAction({
           sourceAccountId: matchingLinkedAggregation.sourceAccountId,
           sourceEntityId: matchingLinkedAggregation.sourceEntityId,
-          path,
+          aggregationId: matchingLinkedAggregation.aggregationId,
           data: newLinkedData.operation,
         }),
       ]);
@@ -315,7 +315,7 @@ export const Table: BlockComponent<AppProps> = ({
       initialState,
       matchingLinkedAggregation,
       updateEntities,
-      updateLinks,
+      updateLinkedAggregations,
       tableData.linkedAggregation,
     ],
   );
@@ -442,19 +442,24 @@ export const Table: BlockComponent<AppProps> = ({
 
   const handleEntityTypeChange = useCallback(
     (updatedEntityTypeId: string | undefined) => {
-      if (!entityId || !updateLinks || !createLinks) {
+      if (
+        !accountId ||
+        !entityId ||
+        !updateLinkedAggregations ||
+        !createLinkedAggregations
+      ) {
         throw new Error(
-          "All of entityId, createLinks and updateLinks must be passed to the block to update data linked from it",
+          "All of accountId, entityId, createLinkedAggregations and updateLinkedAggregations must be passed to the block to update data linked from it",
         );
       }
 
-      if (updatedEntityTypeId) {
+      if (updatedEntityTypeId && tableData.linkedAggregation) {
         if (tableData?.linkedAggregation) {
-          void updateLinks?.([
+          void updateLinkedAggregations([
             cleanUpdateLinkedAggregationAction({
               sourceAccountId: accountId,
               sourceEntityId: entityId,
-              path,
+              aggregationId: tableData.linkedAggregation.aggregationId,
               data: {
                 entityTypeId: updatedEntityTypeId,
                 // There is scope to include other options if entity properties overlap
@@ -464,7 +469,7 @@ export const Table: BlockComponent<AppProps> = ({
             }),
           ]);
         } else {
-          void createLinks?.([
+          void createLinkedAggregations([
             {
               operation: {
                 entityTypeId: updatedEntityTypeId,
@@ -479,10 +484,10 @@ export const Table: BlockComponent<AppProps> = ({
     },
     [
       accountId,
-      createLinks,
       entityId,
       tableData.linkedAggregation,
-      updateLinks,
+      updateLinkedAggregations,
+      createLinkedAggregations,
     ],
   );
 

--- a/packages/blocks/table/src/table.tsx
+++ b/packages/blocks/table/src/table.tsx
@@ -112,6 +112,7 @@ export const Table: BlockComponent<AppProps> = ({
   accountId,
   aggregateEntities,
   aggregateEntityTypes,
+  createLinkedAggregations,
   entityId,
   entityTypeId,
   entityTypes: schemas,
@@ -120,7 +121,6 @@ export const Table: BlockComponent<AppProps> = ({
   linkedAggregations,
   updateEntities,
   updateLinkedAggregations,
-  createLinkedAggregations,
 }) => {
   const matchingLinkedAggregation = useMemo(() => {
     if (!entityId) {

--- a/packages/blocks/video/src/components/media.tsx
+++ b/packages/blocks/video/src/components/media.tsx
@@ -274,7 +274,6 @@ export const Media: BlockComponent<
                   .filter(isSingleTargetLink)
                   .map((link) => ({
                     sourceAccountId: accountId,
-                    sourceEntityId: link.sourceEntityId,
                     linkId: link.linkId,
                   })),
               );

--- a/packages/blocks/video/src/components/media.tsx
+++ b/packages/blocks/video/src/components/media.tsx
@@ -12,7 +12,6 @@ import {
   BlockProtocolLinkGroup,
   BlockProtocolUpdateEntitiesAction,
   BlockProtocolUploadFileFunction,
-  SingleTargetLinkFields,
 } from "blockprotocol";
 import { BlockComponent } from "blockprotocol/react";
 import React, {
@@ -119,7 +118,7 @@ function getLinkedEntities(params: {
 
 const isSingleTargetLink = (
   link: BlockProtocolLink,
-): link is BlockProtocolLink & SingleTargetLinkFields => "linkId" in link;
+): link is BlockProtocolLink => "linkId" in link;
 
 /**
  * @todo Rewrite the state here to use a reducer, instead of batched updates

--- a/packages/hash/api/src/graphql/resolvers/link/deleteLink.ts
+++ b/packages/hash/api/src/graphql/resolvers/link/deleteLink.ts
@@ -1,6 +1,6 @@
 import { ApolloError } from "apollo-server-errors";
 import { MutationDeleteLinkArgs, Resolver } from "../../apiTypes.gen";
-import { Entity } from "../../../model";
+import { Link } from "../../../model";
 import { LoggedInGraphQLContext } from "../../context";
 
 export const deleteLink: Resolver<
@@ -8,22 +8,18 @@ export const deleteLink: Resolver<
   {},
   LoggedInGraphQLContext,
   MutationDeleteLinkArgs
-> = (_, { sourceAccountId, sourceEntityId, linkId }, { dataSources, user }) =>
+> = (_, { sourceAccountId, linkId }, { dataSources, user }) =>
   dataSources.db.transaction(async (client) => {
-    const source = await Entity.getEntityLatestVersion(client, {
-      accountId: sourceAccountId,
-      entityId: sourceEntityId,
-    });
+    const link = await Link.get(client, { sourceAccountId, linkId });
 
-    if (!source) {
+    if (!link) {
       throw new ApolloError(
-        `Link source entity with accountId ${sourceAccountId} and entityId ${sourceEntityId} not found`,
+        `Link with sourceAccountId ${sourceAccountId} and linkId ${linkId} not found`,
         "NOT_FOUND",
       );
     }
 
-    await source.deleteOutgoingLink(client, {
-      linkId,
+    await link.delete(client, {
       deletedByAccountId: user.accountId,
     });
 

--- a/packages/hash/api/src/graphql/resolvers/linkedAggregation/deleteLinkedAggregation.ts
+++ b/packages/hash/api/src/graphql/resolvers/linkedAggregation/deleteLinkedAggregation.ts
@@ -3,7 +3,7 @@ import {
   MutationDeleteLinkedAggregationArgs,
   Resolver,
 } from "../../apiTypes.gen";
-import { Entity } from "../../../model";
+import { Aggregation, Entity } from "../../../model";
 import { LoggedInGraphQLContext } from "../../context";
 
 export const deleteLinkedAggregation: Resolver<
@@ -13,7 +13,7 @@ export const deleteLinkedAggregation: Resolver<
   MutationDeleteLinkedAggregationArgs
 > = async (
   _,
-  { sourceAccountId, sourceEntityId, path },
+  { sourceAccountId, sourceEntityId, aggregationId },
   { dataSources, user },
 ) =>
   dataSources.db.transaction(async (client) => {
@@ -27,12 +27,13 @@ export const deleteLinkedAggregation: Resolver<
       throw new ApolloError(msg, "NOT_FOUND");
     }
 
-    const aggregation = await source.getAggregationByPath(client, {
-      stringifiedPath: path,
+    const aggregation = await Aggregation.getAggregationById(client, {
+      sourceAccountId,
+      aggregationId,
     });
 
     if (!aggregation) {
-      const msg = `aggregation with path '${path}' not found on entity with fixed ID ${source.entityId}`;
+      const msg = `aggregation with aggregation ID '${aggregationId}' not found`;
       throw new ApolloError(msg, "NOT_FOUND");
     }
 

--- a/packages/hash/api/src/graphql/resolvers/linkedAggregation/deleteLinkedAggregation.ts
+++ b/packages/hash/api/src/graphql/resolvers/linkedAggregation/deleteLinkedAggregation.ts
@@ -3,7 +3,7 @@ import {
   MutationDeleteLinkedAggregationArgs,
   Resolver,
 } from "../../apiTypes.gen";
-import { Aggregation, Entity } from "../../../model";
+import { Aggregation } from "../../../model";
 import { LoggedInGraphQLContext } from "../../context";
 
 export const deleteLinkedAggregation: Resolver<
@@ -11,22 +11,8 @@ export const deleteLinkedAggregation: Resolver<
   {},
   LoggedInGraphQLContext,
   MutationDeleteLinkedAggregationArgs
-> = async (
-  _,
-  { sourceAccountId, sourceEntityId, aggregationId },
-  { dataSources, user },
-) =>
+> = async (_, { sourceAccountId, aggregationId }, { dataSources, user }) =>
   dataSources.db.transaction(async (client) => {
-    const source = await Entity.getEntityLatestVersion(client, {
-      accountId: sourceAccountId,
-      entityId: sourceEntityId,
-    });
-
-    if (!source) {
-      const msg = `entity with fixed ID ${sourceEntityId} not found in account ${sourceAccountId}`;
-      throw new ApolloError(msg, "NOT_FOUND");
-    }
-
     const aggregation = await Aggregation.getAggregationById(client, {
       sourceAccountId,
       aggregationId,

--- a/packages/hash/api/src/graphql/resolvers/linkedAggregation/linkedAggregationResults.ts
+++ b/packages/hash/api/src/graphql/resolvers/linkedAggregation/linkedAggregationResults.ts
@@ -1,6 +1,7 @@
 import { ApolloError } from "apollo-server-express";
 import { GraphQLContext } from "../../context";
 import {
+  Aggregation,
   Entity,
   UnresolvedGQLLinkedAggregation,
   UnresolvedGQLUnknownEntity,
@@ -11,7 +12,11 @@ export const linkedAggregationResults: Resolver<
   UnresolvedGQLUnknownEntity[],
   UnresolvedGQLLinkedAggregation,
   GraphQLContext
-> = async ({ sourceAccountId, sourceEntityId, path }, _, { dataSources }) => {
+> = async (
+  { sourceAccountId, sourceEntityId, aggregationId },
+  _,
+  { dataSources },
+) => {
   const source = await Entity.getEntityLatestVersion(dataSources.db, {
     accountId: sourceAccountId,
     entityId: sourceEntityId,
@@ -22,12 +27,13 @@ export const linkedAggregationResults: Resolver<
     throw new ApolloError(msg, "NOT_FOUND");
   }
 
-  const aggregation = await source.getAggregationByPath(dataSources.db, {
-    stringifiedPath: path,
+  const aggregation = await Aggregation.getAggregationById(dataSources.db, {
+    sourceAccountId,
+    aggregationId,
   });
 
   if (!aggregation) {
-    const msg = `aggregation with path ${path} not on entity with fixed ID ${sourceEntityId}`;
+    const msg = `aggregation with aggregation ID ${aggregationId} not on entity with fixed ID ${sourceEntityId}`;
     throw new ApolloError(msg, "NOT_FOUND");
   }
 

--- a/packages/hash/api/src/graphql/resolvers/linkedAggregation/updateLinkedAggregationOperation.ts
+++ b/packages/hash/api/src/graphql/resolvers/linkedAggregation/updateLinkedAggregationOperation.ts
@@ -3,11 +3,7 @@ import {
   MutationUpdateLinkedAggregationOperationArgs,
   Resolver,
 } from "../../apiTypes.gen";
-import {
-  Aggregation,
-  Entity,
-  UnresolvedGQLLinkedAggregation,
-} from "../../../model";
+import { Aggregation, UnresolvedGQLLinkedAggregation } from "../../../model";
 import { LoggedInGraphQLContext } from "../../context";
 
 export const updateLinkedAggregationOperation: Resolver<
@@ -17,20 +13,10 @@ export const updateLinkedAggregationOperation: Resolver<
   MutationUpdateLinkedAggregationOperationArgs
 > = async (
   _,
-  { sourceAccountId, sourceEntityId, aggregationId, updatedOperation },
+  { sourceAccountId, aggregationId, updatedOperation },
   { dataSources, user },
 ) =>
   dataSources.db.transaction(async (client) => {
-    const source = await Entity.getEntityLatestVersion(client, {
-      accountId: sourceAccountId,
-      entityId: sourceEntityId,
-    });
-
-    if (!source) {
-      const msg = `entity with fixed ID ${sourceEntityId} not found in account ${sourceAccountId}`;
-      throw new ApolloError(msg, "NOT_FOUND");
-    }
-
     const aggregation = await Aggregation.getAggregationById(client, {
       sourceAccountId,
       aggregationId,

--- a/packages/hash/api/src/graphql/resolvers/linkedAggregation/updateLinkedAggregationOperation.ts
+++ b/packages/hash/api/src/graphql/resolvers/linkedAggregation/updateLinkedAggregationOperation.ts
@@ -3,7 +3,11 @@ import {
   MutationUpdateLinkedAggregationOperationArgs,
   Resolver,
 } from "../../apiTypes.gen";
-import { Entity, UnresolvedGQLLinkedAggregation } from "../../../model";
+import {
+  Aggregation,
+  Entity,
+  UnresolvedGQLLinkedAggregation,
+} from "../../../model";
 import { LoggedInGraphQLContext } from "../../context";
 
 export const updateLinkedAggregationOperation: Resolver<
@@ -13,7 +17,7 @@ export const updateLinkedAggregationOperation: Resolver<
   MutationUpdateLinkedAggregationOperationArgs
 > = async (
   _,
-  { sourceAccountId, sourceEntityId, path, updatedOperation },
+  { sourceAccountId, sourceEntityId, aggregationId, updatedOperation },
   { dataSources, user },
 ) =>
   dataSources.db.transaction(async (client) => {
@@ -27,14 +31,15 @@ export const updateLinkedAggregationOperation: Resolver<
       throw new ApolloError(msg, "NOT_FOUND");
     }
 
-    const aggregation = await source.getAggregationByPath(client, {
-      stringifiedPath: path,
+    const aggregation = await Aggregation.getAggregationById(client, {
+      sourceAccountId,
+      aggregationId,
     });
 
     /** @todo: lock aggregation on retrieval? */
 
     if (!aggregation) {
-      const msg = `aggregation with path '${path}' not found on entity with fixed ID ${source.entityId}`;
+      const msg = `aggregation with aggregation ID '${aggregationId}' not found`;
       throw new ApolloError(msg, "NOT_FOUND");
     }
 

--- a/packages/hash/api/src/graphql/typeDefs/aggregation.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/aggregation.typedef.ts
@@ -100,7 +100,7 @@ export const aggregationTypedef = gql`
     updateLinkedAggregationOperation(
       sourceAccountId: ID!
       sourceEntityId: ID!
-      path: String!
+      aggregationId: ID!
       updatedOperation: AggregateOperationInput!
     ): LinkedAggregation!
     """
@@ -109,7 +109,7 @@ export const aggregationTypedef = gql`
     deleteLinkedAggregation(
       sourceAccountId: ID!
       sourceEntityId: ID!
-      path: String!
+      aggregationId: ID!
     ): Boolean!
   }
 `;

--- a/packages/hash/api/src/graphql/typeDefs/aggregation.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/aggregation.typedef.ts
@@ -99,17 +99,12 @@ export const aggregationTypedef = gql`
     """
     updateLinkedAggregationOperation(
       sourceAccountId: ID!
-      sourceEntityId: ID!
       aggregationId: ID!
       updatedOperation: AggregateOperationInput!
     ): LinkedAggregation!
     """
     Delete an entity's linked aggregation
     """
-    deleteLinkedAggregation(
-      sourceAccountId: ID!
-      sourceEntityId: ID!
-      aggregationId: ID!
-    ): Boolean!
+    deleteLinkedAggregation(sourceAccountId: ID!, aggregationId: ID!): Boolean!
   }
 `;

--- a/packages/hash/api/src/graphql/typeDefs/link.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/link.typedef.ts
@@ -63,6 +63,6 @@ export const linkTypedef = gql`
     """
     Delete a link using its id
     """
-    deleteLink(sourceAccountId: ID!, sourceEntityId: ID!, linkId: ID!): Boolean!
+    deleteLink(sourceAccountId: ID!, linkId: ID!): Boolean!
   }
 `;

--- a/packages/hash/api/src/model/aggregation.model.ts
+++ b/packages/hash/api/src/model/aggregation.model.ts
@@ -334,6 +334,21 @@ class __Aggregation {
     return this;
   }
 
+  async getSourceEntity(client: DbClient): Promise<Entity> {
+    const sourceEntity = await Entity.getEntityLatestVersion(client, {
+      accountId: this.sourceAccountId,
+      entityId: this.sourceEntityId,
+    });
+
+    if (!sourceEntity) {
+      throw new Error(
+        `Critical: source entity of aggregation with aggregationId ${this.aggregationId} not found`,
+      );
+    }
+
+    return sourceEntity;
+  }
+
   async getResults(
     client: DbClient,
     params?: {

--- a/packages/hash/api/src/model/entity.model.ts
+++ b/packages/hash/api/src/model/entity.model.ts
@@ -394,21 +394,6 @@ class __Entity {
     return aggregations;
   }
 
-  async getAggregationByPath(
-    client: DbClient,
-    params: {
-      stringifiedPath: string;
-    },
-  ) {
-    const { stringifiedPath } = params;
-    const aggregation = await Aggregation.getEntityAggregationByPath(client, {
-      source: this,
-      stringifiedPath,
-    });
-
-    return aggregation;
-  }
-
   async getOutgoingLinks(
     client: DbClient,
     params?: {

--- a/packages/hash/frontend/src/components/BlockLoader/BlockLoader.tsx
+++ b/packages/hash/frontend/src/components/BlockLoader/BlockLoader.tsx
@@ -19,6 +19,9 @@ import { useBlockProtocolCreateLinks } from "../hooks/blockProtocolFunctions/use
 import { useBlockProtocolDeleteLinks } from "../hooks/blockProtocolFunctions/useBlockProtocolDeleteLinks";
 import { useBlockProtocolUpdateLinks } from "../hooks/blockProtocolFunctions/useBlockProtocolUpdateLinks";
 import { useBlockLoaded } from "../../blocks/onBlockLoaded";
+import { useBlockProtocolCreateLinkedAggregations } from "../hooks/blockProtocolFunctions/useBlockProtocolCreateLinkedAggregations";
+import { useBlockProtocolUpdateLinkedAggregations } from "../hooks/blockProtocolFunctions/useBlockProtocolUpdateLinkedAggregations";
+import { useBlockProtocolDeleteLinkedAggregations } from "../hooks/blockProtocolFunctions/useBlockProtocolDeleteLinkedAggregations";
 
 type BlockLoaderProps = {
   accountId: string;
@@ -53,11 +56,17 @@ export const BlockLoader: VoidFunctionComponent<BlockLoaderProps> = ({
 }) => {
   const { aggregateEntityTypes } = useBlockProtocolAggregateEntityTypes();
   const { aggregateEntities } = useBlockProtocolAggregateEntities();
-  const { createLinks } = useBlockProtocolCreateLinks();
-  const { deleteLinks } = useBlockProtocolDeleteLinks();
   const { updateEntities } = useBlockProtocolUpdateEntities();
   const { uploadFile } = useFileUpload();
+  const { createLinks } = useBlockProtocolCreateLinks();
   const { updateLinks } = useBlockProtocolUpdateLinks();
+  const { deleteLinks } = useBlockProtocolDeleteLinks();
+  const { createLinkedAggregations } =
+    useBlockProtocolCreateLinkedAggregations();
+  const { updateLinkedAggregations } =
+    useBlockProtocolUpdateLinkedAggregations();
+  const { deleteLinkedAggregations } =
+    useBlockProtocolDeleteLinkedAggregations();
 
   const flattenedProperties = useMemo(() => {
     let flattenedLinkedEntities: UnknownEntity[] = [];
@@ -93,13 +102,16 @@ export const BlockLoader: VoidFunctionComponent<BlockLoaderProps> = ({
   const functions = {
     aggregateEntityTypes,
     aggregateEntities,
-    createLinks,
-    deleteLinks,
     /** @todo pick one of getEmbedBlock or fetchEmbedCode */
     getEmbedBlock: fetchEmbedCode,
     updateEntities,
-    updateLinks,
     uploadFile,
+    createLinks,
+    updateLinks,
+    deleteLinks,
+    createLinkedAggregations,
+    updateLinkedAggregations,
+    deleteLinkedAggregations,
   };
 
   const onBlockLoaded = useBlockLoaded();

--- a/packages/hash/frontend/src/components/BlockLoader/BlockLoader.tsx
+++ b/packages/hash/frontend/src/components/BlockLoader/BlockLoader.tsx
@@ -56,17 +56,17 @@ export const BlockLoader: VoidFunctionComponent<BlockLoaderProps> = ({
 }) => {
   const { aggregateEntityTypes } = useBlockProtocolAggregateEntityTypes();
   const { aggregateEntities } = useBlockProtocolAggregateEntities();
-  const { updateEntities } = useBlockProtocolUpdateEntities();
-  const { uploadFile } = useFileUpload();
-  const { createLinks } = useBlockProtocolCreateLinks();
-  const { updateLinks } = useBlockProtocolUpdateLinks();
-  const { deleteLinks } = useBlockProtocolDeleteLinks();
   const { createLinkedAggregations } =
     useBlockProtocolCreateLinkedAggregations();
-  const { updateLinkedAggregations } =
-    useBlockProtocolUpdateLinkedAggregations();
+  const { createLinks } = useBlockProtocolCreateLinks();
   const { deleteLinkedAggregations } =
     useBlockProtocolDeleteLinkedAggregations();
+  const { deleteLinks } = useBlockProtocolDeleteLinks();
+  const { updateEntities } = useBlockProtocolUpdateEntities();
+  const { uploadFile } = useFileUpload();
+  const { updateLinkedAggregations } =
+    useBlockProtocolUpdateLinkedAggregations();
+  const { updateLinks } = useBlockProtocolUpdateLinks();
 
   const flattenedProperties = useMemo(() => {
     let flattenedLinkedEntities: UnknownEntity[] = [];
@@ -102,16 +102,16 @@ export const BlockLoader: VoidFunctionComponent<BlockLoaderProps> = ({
   const functions = {
     aggregateEntityTypes,
     aggregateEntities,
+    createLinkedAggregations,
+    createLinks,
+    deleteLinkedAggregations,
+    deleteLinks,
     /** @todo pick one of getEmbedBlock or fetchEmbedCode */
     getEmbedBlock: fetchEmbedCode,
     updateEntities,
     uploadFile,
-    createLinks,
     updateLinks,
-    deleteLinks,
-    createLinkedAggregations,
     updateLinkedAggregations,
-    deleteLinkedAggregations,
   };
 
   const onBlockLoaded = useBlockLoaded();

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolCreateLinkedAggregations.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolCreateLinkedAggregations.ts
@@ -1,0 +1,78 @@
+import { useMutation } from "@apollo/client";
+
+import {
+  BlockProtocolCreateLinkedAggregationsFunction,
+  BlockProtocolLinkedAggregation,
+} from "blockprotocol";
+import { createLinkedAggregationMutation } from "@hashintel/hash-shared/queries/link.queries";
+import { useCallback } from "react";
+import {
+  CreateLinkedAggregationOperationMutation,
+  CreateLinkedAggregationOperationMutationVariables,
+} from "@hashintel/hash-shared/graphql/apiTypes.gen";
+
+export const useBlockProtocolCreateLinkedAggregations = (): {
+  createLinkedAggregations: BlockProtocolCreateLinkedAggregationsFunction;
+  createLinkedAggregationsLoading: boolean;
+  createLinkedAggregationsError: any;
+} => {
+  const [
+    runCreateLinkedAggregationMutation,
+    {
+      loading: createLinkedAggregationsLoading,
+      error: createLinkedAggregationsError,
+    },
+  ] = useMutation<
+    CreateLinkedAggregationOperationMutation,
+    CreateLinkedAggregationOperationMutationVariables
+  >(createLinkedAggregationMutation);
+
+  const createLinkedAggregations: BlockProtocolCreateLinkedAggregationsFunction =
+    useCallback(
+      async (actions) => {
+        const results: BlockProtocolLinkedAggregation[] = [];
+        // TODO: Support multiple actions in one GraphQL mutation for transaction integrity and better status reporting
+        for (const action of actions) {
+          if (!action.sourceAccountId) {
+            throw new Error(
+              "createLinkedAggregations needs to be passed a sourceAccountId",
+            );
+          }
+
+          if (!action.operation.entityTypeId) {
+            throw new Error(
+              "entityTypeId is compulsory on operation while trying to create a linkedAggregation",
+            );
+          }
+
+          const { data, errors } = await runCreateLinkedAggregationMutation({
+            variables: {
+              ...action,
+              operation: {
+                // @todo this shouldn't be necessary
+                ...action.operation,
+                entityTypeId: action.operation.entityTypeId,
+              },
+              sourceAccountId: action.sourceAccountId,
+            },
+          });
+          if (!data) {
+            throw new Error(`Could not create link: ${errors?.[0]!.message}`);
+          }
+
+          // @todo, add a proper typecheck. The GraphQL query for multiFilter { operator } returns String, but BlockProtocolLinkedAggregationUpdateMutationResults defines the exact type for operator. This typecast is used to typecast string to the one the query expects.
+          results.push(
+            data.createLinkedAggregation as BlockProtocolLinkedAggregation,
+          );
+        }
+        return results;
+      },
+      [runCreateLinkedAggregationMutation],
+    );
+
+  return {
+    createLinkedAggregations,
+    createLinkedAggregationsLoading,
+    createLinkedAggregationsError,
+  };
+};

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolCreateLinks.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolCreateLinks.ts
@@ -4,15 +4,8 @@ import {
   BlockProtocolCreateLinksFunction,
   BlockProtocolLink,
 } from "blockprotocol";
-import {
-  createLinkedAggregationMutation,
-  createLinkMutation,
-} from "@hashintel/hash-shared/queries/link.queries";
+import { createLinkMutation } from "@hashintel/hash-shared/queries/link.queries";
 import { useCallback } from "react";
-import {
-  CreateLinkedAggregationOperationMutation,
-  CreateLinkedAggregationOperationMutationVariables,
-} from "@hashintel/hash-shared/graphql/apiTypes.gen";
 
 import {
   CreateLinkMutation,
@@ -31,11 +24,6 @@ export const useBlockProtocolCreateLinks = (): {
     createLinkMutation,
   );
 
-  const [runCreateLinkedAggregationMutation] = useMutation<
-    CreateLinkedAggregationOperationMutation,
-    CreateLinkedAggregationOperationMutationVariables
-  >(createLinkedAggregationMutation);
-
   const createLinks: BlockProtocolCreateLinksFunction = useCallback(
     async (actions) => {
       const results: BlockProtocolLink[] = [];
@@ -45,66 +33,35 @@ export const useBlockProtocolCreateLinks = (): {
           throw new Error("createLinks needs to be passed a sourceAccountId");
         }
 
-        const baseFields = {
-          path: action.path,
-          sourceEntityId: action.sourceEntityId,
-          sourceAccountId: action.sourceAccountId,
-        };
-
-        if ("operation" in action) {
-          if (!action.operation.entityTypeId) {
-            throw new Error(
-              "entityTypeId is compulsory on operation while trying to create a linkedAggregation",
-            );
-          }
-
-          const { data, errors } = await runCreateLinkedAggregationMutation({
-            variables: {
-              ...action,
-              operation: {
-                // @todo this shouldn't be necessary
-                ...action.operation,
-                entityTypeId: action.operation.entityTypeId,
-              },
-              sourceAccountId: action.sourceAccountId,
-            },
-          });
-          if (!data) {
-            throw new Error(`Could not create link: ${errors?.[0]!.message}`);
-          }
-
-          // @todo, add a proper typecheck. The GraphQL query for multiFilter { operator } returns String, but BlockProtocolLinkedAggregationUpdateMutationResults defines the exact type for operator. This typecast is used to typecast string to the one the query expects.
-          results.push(
-            data.createLinkedAggregation as unknown as BlockProtocolLink,
-          );
-        } else if (!("destinationAccountId" in action)) {
+        if (!("destinationAccountId" in action)) {
           throw new Error(
             "One of operation or destinationEntityId must be provided",
           );
-        } else {
-          const newLink = {
-            ...baseFields,
-            destinationEntityId: action.destinationEntityId,
-            destinationAccountId: action.destinationAccountId
-              ? action.destinationAccountId
-              : action.sourceAccountId,
-          };
-
-          const { data, errors } = await runCreateLinksMutation({
-            variables: {
-              link: newLink,
-            },
-          });
-          if (!data) {
-            throw new Error(`Could not create link: ${errors?.[0]!.message}`);
-          }
-
-          results.push(data.createLink);
         }
+
+        const { data, errors } = await runCreateLinksMutation({
+          variables: {
+            link: {
+              path: action.path,
+              sourceEntityId: action.sourceEntityId,
+              sourceAccountId: action.sourceAccountId,
+              destinationEntityId: action.destinationEntityId,
+              destinationAccountId: action.destinationAccountId
+                ? action.destinationAccountId
+                : action.sourceAccountId,
+            },
+          },
+        });
+
+        if (!data) {
+          throw new Error(`Could not create link: ${errors?.[0]!.message}`);
+        }
+
+        results.push(data.createLink);
       }
       return results;
     },
-    [runCreateLinksMutation, runCreateLinkedAggregationMutation],
+    [runCreateLinksMutation],
   );
 
   return {

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolCreateLinks.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolCreateLinks.ts
@@ -33,12 +33,6 @@ export const useBlockProtocolCreateLinks = (): {
           throw new Error("createLinks needs to be passed a sourceAccountId");
         }
 
-        if (!("destinationAccountId" in action)) {
-          throw new Error(
-            "One of operation or destinationEntityId must be provided",
-          );
-        }
-
         const { data, errors } = await runCreateLinksMutation({
           variables: {
             link: {

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolDeleteLinkedAggregations.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolDeleteLinkedAggregations.ts
@@ -1,0 +1,67 @@
+import { useMutation } from "@apollo/client";
+
+import { BlockProtocolDeleteLinkedAggregationsFunction } from "blockprotocol";
+import { deleteLinkedAggregationMutation } from "@hashintel/hash-shared/queries/link.queries";
+import { useCallback } from "react";
+import {
+  DeleteLinkedAggregationMutation,
+  DeleteLinkedAggregationMutationVariables,
+} from "../../../graphql/apiTypes.gen";
+
+export const useBlockProtocolDeleteLinkedAggregations = (): {
+  deleteLinkedAggregations: BlockProtocolDeleteLinkedAggregationsFunction;
+  deleteLinkedAggregationsLoading: boolean;
+  deleteLinkedAggregationsError: any;
+} => {
+  const [
+    runDeleteLinkedAggregationsMutation,
+    {
+      loading: deleteLinkedAggregationsLoading,
+      error: deleteLinkedAggregationsError,
+    },
+  ] = useMutation<
+    DeleteLinkedAggregationMutation,
+    DeleteLinkedAggregationMutationVariables
+  >(deleteLinkedAggregationMutation);
+
+  const deleteLinkedAggregations: BlockProtocolDeleteLinkedAggregationsFunction =
+    useCallback(
+      async (actions) => {
+        const results: boolean[] = [];
+        // TODO: Support multiple actions in one GraphQL mutation for transaction integrity and better status reporting
+        for (const action of actions) {
+          if (!action.sourceAccountId) {
+            throw new Error("deleteLinks needs to be passed a sourceAccountId");
+          }
+
+          if (!action.sourceEntityId) {
+            throw new Error("deleteLinks needs to be passed a sourceEntityId");
+          }
+
+          const { data, errors } = await runDeleteLinkedAggregationsMutation({
+            variables: {
+              aggregationId: action.aggregationId,
+              sourceAccountId: action.sourceAccountId,
+              sourceEntityId: action.sourceEntityId,
+            },
+          });
+
+          if (!data) {
+            throw new Error(
+              `Could not delete linked aggregation: ${errors?.[0]!.message}`,
+            );
+          }
+
+          results.push(data.deleteLinkedAggregation);
+        }
+        return results;
+      },
+      [runDeleteLinkedAggregationsMutation],
+    );
+
+  return {
+    deleteLinkedAggregations,
+    deleteLinkedAggregationsLoading,
+    deleteLinkedAggregationsError,
+  };
+};

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolDeleteLinkedAggregations.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolDeleteLinkedAggregations.ts
@@ -31,11 +31,15 @@ export const useBlockProtocolDeleteLinkedAggregations = (): {
         // TODO: Support multiple actions in one GraphQL mutation for transaction integrity and better status reporting
         for (const action of actions) {
           if (!action.sourceAccountId) {
-            throw new Error("deleteLinks needs to be passed a sourceAccountId");
+            throw new Error(
+              "deleteLinkedAggregations needs to be passed a sourceAccountId",
+            );
           }
 
           if (!action.sourceEntityId) {
-            throw new Error("deleteLinks needs to be passed a sourceEntityId");
+            throw new Error(
+              "deleteLinkedAggregations needs to be passed a sourceEntityId",
+            );
           }
 
           const { data, errors } = await runDeleteLinkedAggregationsMutation({

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolDeleteLinkedAggregations.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolDeleteLinkedAggregations.ts
@@ -36,17 +36,10 @@ export const useBlockProtocolDeleteLinkedAggregations = (): {
             );
           }
 
-          if (!action.sourceEntityId) {
-            throw new Error(
-              "deleteLinkedAggregations needs to be passed a sourceEntityId",
-            );
-          }
-
           const { data, errors } = await runDeleteLinkedAggregationsMutation({
             variables: {
               aggregationId: action.aggregationId,
               sourceAccountId: action.sourceAccountId,
-              sourceEntityId: action.sourceEntityId,
             },
           });
 

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolDeleteLinks.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolDeleteLinks.ts
@@ -33,14 +33,19 @@ export const useBlockProtocolDeleteLinks = (): {
           throw new Error("deleteLinks needs to be passed a sourceEntityId");
         }
 
-        const { data } = await runDeleteLinkMutation({
+        const { data, errors } = await runDeleteLinkMutation({
           variables: {
             linkId: action.linkId,
             sourceAccountId: action.sourceAccountId,
             sourceEntityId: action.sourceEntityId,
           },
         });
-        results.push(!!data?.deleteLink);
+
+        if (!data) {
+          throw new Error(`Could not delete link: ${errors?.[0]!.message}`);
+        }
+
+        results.push(data.deleteLink);
       }
       return results;
     },

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolDeleteLinks.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolDeleteLinks.ts
@@ -29,15 +29,10 @@ export const useBlockProtocolDeleteLinks = (): {
           throw new Error("deleteLinks needs to be passed a sourceAccountId");
         }
 
-        if (!action.sourceEntityId) {
-          throw new Error("deleteLinks needs to be passed a sourceEntityId");
-        }
-
         const { data, errors } = await runDeleteLinkMutation({
           variables: {
             linkId: action.linkId,
             sourceAccountId: action.sourceAccountId,
-            sourceEntityId: action.sourceEntityId,
           },
         });
 

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolUpdateLinkedAggregations.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolUpdateLinkedAggregations.ts
@@ -1,0 +1,65 @@
+import { useMutation } from "@apollo/client";
+
+import {
+  BlockProtocolUpdateLinkedAggregationsFunction,
+  BlockProtocolLinkedAggregation,
+} from "blockprotocol";
+
+import { updateLinkedAggregationMutation } from "@hashintel/hash-shared/queries/link.queries";
+import { useCallback } from "react";
+import {
+  UpdateLinkedAggregationOperationMutation,
+  UpdateLinkedAggregationOperationMutationVariables,
+} from "../../../graphql/apiTypes.gen";
+
+export const useBlockProtocolUpdateLinkedAggregations = (): {
+  updateLinkedAggregations: BlockProtocolUpdateLinkedAggregationsFunction;
+} => {
+  const [runUpdateLinkedAggregationMutation] = useMutation<
+    UpdateLinkedAggregationOperationMutation,
+    UpdateLinkedAggregationOperationMutationVariables
+  >(updateLinkedAggregationMutation);
+
+  const updateLinkedAggregations: BlockProtocolUpdateLinkedAggregationsFunction =
+    useCallback(
+      async (actions) => {
+        const results: BlockProtocolLinkedAggregation[] = [];
+        // TODO: Support multiple actions in one GraphQL mutation for transaction integrity and better status reporting
+        for (const action of actions) {
+          if (action.data.entityTypeId == null) {
+            // @todo we should allow aggregating without narrowing the type
+            throw new Error(
+              "An aggregation operation must have an entityTypeId",
+            );
+          }
+
+          const { data, errors } = await runUpdateLinkedAggregationMutation({
+            variables: {
+              ...action,
+              updatedOperation: {
+                // @todo this shouldn't be necessary
+                ...action.data,
+                entityTypeId: action.data.entityTypeId,
+              },
+              sourceAccountId: action.sourceAccountId,
+            },
+          });
+
+          if (!data) {
+            throw new Error(`Could not update link: ${errors?.[0]!.message}`);
+          }
+
+          // @todo, add a proper typecheck. The GraphQL query for multiFilter { operator } returns String, but BlockProtocolLinkedAggregationUpdateMutationResults defines the exact type for operator. This typecast is used to typecast string to the one the query expects.
+          results.push(
+            data.updateLinkedAggregationOperation as BlockProtocolLinkedAggregation,
+          );
+        }
+        return results;
+      },
+      [runUpdateLinkedAggregationMutation],
+    );
+
+  return {
+    updateLinkedAggregations,
+  };
+};

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolUpdateLinkedAggregations.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolUpdateLinkedAggregations.ts
@@ -33,6 +33,12 @@ export const useBlockProtocolUpdateLinkedAggregations = (): {
             );
           }
 
+          if (!action.sourceAccountId) {
+            throw new Error(
+              "updateLinkedAggregations needs to be passed a sourceAccountId",
+            );
+          }
+
           const { data, errors } = await runUpdateLinkedAggregationMutation({
             variables: {
               ...action,

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolUpdateLinks.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolUpdateLinks.ts
@@ -1,88 +1,15 @@
-import { useMutation } from "@apollo/client";
+import { BlockProtocolUpdateLinksFunction } from "blockprotocol";
 
-import {
-  BlockProtocolUpdateLinksFunction,
-  BlockProtocolUpdateLinksAction,
-  BlockProtocolLink,
-} from "blockprotocol";
-
-import { updateLinkedAggregationMutation } from "@hashintel/hash-shared/queries/link.queries";
 import { useCallback } from "react";
-import {
-  UpdateLinkedAggregationOperationMutation,
-  UpdateLinkedAggregationOperationMutationVariables,
-} from "../../../graphql/apiTypes.gen";
 
 export const useBlockProtocolUpdateLinks = (): {
   updateLinks: BlockProtocolUpdateLinksFunction;
 } => {
-  const [runUpdateLinkedAggregationMutation] = useMutation<
-    UpdateLinkedAggregationOperationMutation,
-    UpdateLinkedAggregationOperationMutationVariables
-  >(updateLinkedAggregationMutation);
-
-  const getUpdatedLinksData = useCallback(
-    async (action: BlockProtocolUpdateLinksAction) => {
-      // @todo implement updating linkgroups and linkedentities
-      if ("linkId" in action) {
-        throw new Error(
-          "Updating single links via linkId not yet implemented.",
-        );
-      }
-      if (action.data && action.sourceAccountId) {
-        if (action.data.entityTypeId == null) {
-          // @todo we should allow aggregating without narrowing the type
-          throw new Error("An aggregation operation must have an entityTypeId");
-        }
-        const { data, errors } = await runUpdateLinkedAggregationMutation({
-          variables: {
-            ...action,
-            updatedOperation: {
-              // @todo this shouldn't be necessary
-              ...action.data,
-              entityTypeId: action.data.entityTypeId,
-            },
-            sourceAccountId: action.sourceAccountId,
-          },
-        });
-
-        return {
-          data,
-          errors,
-        };
-      }
-
-      return {
-        errors: [
-          {
-            message:
-              "Action has updated operation missing. If you were trying to update linked entity, the implementation for that is currently missing",
-          },
-        ],
-      };
-    },
-    [runUpdateLinkedAggregationMutation],
-  );
-
   const updateLinks: BlockProtocolUpdateLinksFunction = useCallback(
-    async (actions) => {
-      const results: BlockProtocolLink[] = [];
-      // TODO: Support multiple actions in one GraphQL mutation for transaction integrity and better status reporting
-      for (const action of actions) {
-        const { data, errors } = await getUpdatedLinksData(action);
-
-        if (!data) {
-          throw new Error(`Could not update link: ${errors?.[0]!.message}`);
-        }
-
-        // @todo, add a proper typecheck. The GraphQL query for multiFilter { operator } returns String, but BlockProtocolLinkedAggregationUpdateMutationResults defines the exact type for operator. This typecast is used to typecast string to the one the query expects.
-        results.push(
-          data.updateLinkedAggregationOperation as unknown as BlockProtocolLink,
-        );
-      }
-      return results;
+    async (_actions) => {
+      throw new Error("Updating single links via linkId not yet implemented.");
     },
-    [getUpdatedLinksData],
+    [],
   );
 
   return {

--- a/packages/hash/frontend/src/components/util/typeUtils.tsx
+++ b/packages/hash/frontend/src/components/util/typeUtils.tsx
@@ -1,5 +1,5 @@
-import { BlockProtocolLink, SingleTargetLinkFields } from "blockprotocol";
+import { BlockProtocolLink } from "blockprotocol";
 
 export const isSingleTargetLink = (
   link: BlockProtocolLink,
-): link is BlockProtocolLink & SingleTargetLinkFields => "linkId" in link;
+): link is BlockProtocolLink => "linkId" in link;

--- a/packages/hash/frontend/src/pages/[account-slug]/entities/shared/simple-entity-editor.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/entities/shared/simple-entity-editor.tsx
@@ -228,7 +228,6 @@ export const SimpleEntityEditor: VoidFunctionComponent<
             {
               ...action,
               sourceAccountId: accountId,
-              sourceEntityId: entityId,
             },
           ]).then((res) => {
             refetchEntity?.();

--- a/packages/hash/frontend/src/pages/[account-slug]/entities/shared/simple-entity-editor/entity-field-link-editor.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/entities/shared/simple-entity-editor/entity-field-link-editor.tsx
@@ -11,7 +11,6 @@ import {
   BlockProtocolEntity,
   BlockProtocolLink,
   JSONObject,
-  SingleTargetLinkFields,
 } from "blockprotocol";
 import { tw } from "twind";
 
@@ -180,7 +179,7 @@ export const EntityFieldLinkEditor: VoidFunctionComponent<
               (
                 linkOnField,
               ): linkOnField is {
-                link: BlockProtocolLink & SingleTargetLinkFields;
+                link: BlockProtocolLink;
                 linkedEntity: BlockProtocolEntity;
               } => {
                 return isSingleTargetLink(linkOnField.link);

--- a/packages/hash/integration/src/graphql/queries/aggregation.queries.ts
+++ b/packages/hash/integration/src/graphql/queries/aggregation.queries.ts
@@ -34,13 +34,11 @@ export const createLinkedAggregation = gql`
 export const updateLinkedAggregationOperation = gql`
   mutation updateLinkedAggregationOperation(
     $sourceAccountId: ID!
-    $sourceEntityId: ID!
     $aggregationId: ID!
     $updatedOperation: AggregateOperationInput!
   ) {
     updateLinkedAggregationOperation(
       sourceAccountId: $sourceAccountId
-      sourceEntityId: $sourceEntityId
       aggregationId: $aggregationId
       updatedOperation: $updatedOperation
     ) {
@@ -59,14 +57,9 @@ export const updateLinkedAggregationOperation = gql`
 `;
 
 export const deleteLinkedAggregation = gql`
-  mutation deleteLinkedAggregation(
-    $sourceAccountId: ID!
-    $sourceEntityId: ID!
-    $aggregationId: ID!
-  ) {
+  mutation deleteLinkedAggregation($sourceAccountId: ID!, $aggregationId: ID!) {
     deleteLinkedAggregation(
       sourceAccountId: $sourceAccountId
-      sourceEntityId: $sourceEntityId
       aggregationId: $aggregationId
     )
   }

--- a/packages/hash/integration/src/graphql/queries/aggregation.queries.ts
+++ b/packages/hash/integration/src/graphql/queries/aggregation.queries.ts
@@ -13,6 +13,7 @@ export const createLinkedAggregation = gql`
       path: $path
       operation: $operation
     ) {
+      aggregationId
       sourceAccountId
       sourceEntityId
       path
@@ -34,15 +35,16 @@ export const updateLinkedAggregationOperation = gql`
   mutation updateLinkedAggregationOperation(
     $sourceAccountId: ID!
     $sourceEntityId: ID!
-    $path: String!
+    $aggregationId: ID!
     $updatedOperation: AggregateOperationInput!
   ) {
     updateLinkedAggregationOperation(
       sourceAccountId: $sourceAccountId
       sourceEntityId: $sourceEntityId
-      path: $path
+      aggregationId: $aggregationId
       updatedOperation: $updatedOperation
     ) {
+      aggregationId
       sourceAccountId
       sourceEntityId
       path
@@ -60,12 +62,12 @@ export const deleteLinkedAggregation = gql`
   mutation deleteLinkedAggregation(
     $sourceAccountId: ID!
     $sourceEntityId: ID!
-    $path: String!
+    $aggregationId: ID!
   ) {
     deleteLinkedAggregation(
       sourceAccountId: $sourceAccountId
       sourceEntityId: $sourceEntityId
-      path: $path
+      aggregationId: $aggregationId
     )
   }
 `;

--- a/packages/hash/integration/src/tests/integration.test.ts
+++ b/packages/hash/integration/src/tests/integration.test.ts
@@ -1,5 +1,6 @@
 import "./loadTestEnv";
 import {
+  Aggregation,
   Entity,
   EntityType,
   Org,
@@ -1641,8 +1642,11 @@ describe("logged in user ", () => {
     });
     expect(gqlAggregation.results).toHaveLength(numberOfAggregateEntities);
 
-    const aggregation = (await sourceEntity.getAggregationByPath(db, {
-      stringifiedPath: variables.path,
+    const { aggregationId } = gqlAggregation;
+
+    const aggregation = (await Aggregation.getAggregationById(db, {
+      ...variables,
+      aggregationId,
     }))!;
 
     expect(aggregation).not.toBeNull();
@@ -1693,7 +1697,7 @@ describe("logged in user ", () => {
 
     const stringifiedPath = "$.test";
 
-    await sourceEntity.createAggregation(db, {
+    const { aggregationId } = await sourceEntity.createAggregation(db, {
       stringifiedPath,
       createdBy: existingUser,
       operation: {
@@ -1715,7 +1719,7 @@ describe("logged in user ", () => {
       {
         sourceAccountId: sourceEntity.accountId,
         sourceEntityId: sourceEntity.entityId,
-        path: stringifiedPath,
+        aggregationId,
         updatedOperation,
       },
     );
@@ -1725,8 +1729,9 @@ describe("logged in user ", () => {
       pageCount: 0,
     });
 
-    const aggregation = (await sourceEntity.getAggregationByPath(db, {
-      stringifiedPath,
+    const aggregation = (await Aggregation.getAggregationById(db, {
+      sourceAccountId: existingUser.accountId,
+      aggregationId,
     }))!;
 
     expect(aggregation).not.toBeNull();
@@ -1744,7 +1749,7 @@ describe("logged in user ", () => {
 
     const stringifiedPath = "$.test";
 
-    await sourceEntity.createAggregation(db, {
+    const { aggregationId } = await sourceEntity.createAggregation(db, {
       stringifiedPath,
       createdBy: existingUser,
       operation: {
@@ -1757,11 +1762,12 @@ describe("logged in user ", () => {
     await client.deleteLinkedAggregation({
       sourceAccountId: sourceEntity.accountId,
       sourceEntityId: sourceEntity.entityId,
-      path: stringifiedPath,
+      aggregationId,
     });
 
-    const aggregation = await sourceEntity.getAggregationByPath(db, {
-      stringifiedPath,
+    const aggregation = await Aggregation.getAggregationById(db, {
+      sourceAccountId: sourceEntity.accountId,
+      aggregationId,
     });
 
     expect(aggregation).toBeNull();

--- a/packages/hash/integration/src/tests/integration.test.ts
+++ b/packages/hash/integration/src/tests/integration.test.ts
@@ -1718,7 +1718,6 @@ describe("logged in user ", () => {
     const updatedGQLAggregation = await client.updateLinkedAggregationOperation(
       {
         sourceAccountId: sourceEntity.accountId,
-        sourceEntityId: sourceEntity.entityId,
         aggregationId,
         updatedOperation,
       },
@@ -1761,7 +1760,6 @@ describe("logged in user ", () => {
 
     await client.deleteLinkedAggregation({
       sourceAccountId: sourceEntity.accountId,
-      sourceEntityId: sourceEntity.entityId,
       aggregationId,
     });
 

--- a/packages/hash/shared/src/queries/entity.queries.ts
+++ b/packages/hash/shared/src/queries/entity.queries.ts
@@ -3,6 +3,7 @@ import { linkFieldsFragment } from "./link.queries";
 
 export const linkedAggregationsFragment = gql`
   fragment LinkedAggregationsFields on LinkedAggregation {
+    aggregationId
     sourceAccountId
     sourceEntityId
     path

--- a/packages/hash/shared/src/queries/link.queries.ts
+++ b/packages/hash/shared/src/queries/link.queries.ts
@@ -111,6 +111,7 @@ export const createLinkedAggregationMutation = gql`
       path: $path
       operation: $operation
     ) {
+      aggregationId
       sourceAccountId
       sourceEntityId
       path
@@ -141,15 +142,16 @@ export const updateLinkedAggregationMutation = gql`
   mutation updateLinkedAggregationOperation(
     $sourceAccountId: ID!
     $sourceEntityId: ID!
-    $path: String!
+    $aggregationId: ID!
     $updatedOperation: AggregateOperationInput!
   ) {
     updateLinkedAggregationOperation(
       sourceAccountId: $sourceAccountId
       sourceEntityId: $sourceEntityId
-      path: $path
+      aggregationId: $aggregationId
       updatedOperation: $updatedOperation
     ) {
+      aggregationId
       sourceAccountId
       sourceEntityId
       path

--- a/packages/hash/shared/src/queries/link.queries.ts
+++ b/packages/hash/shared/src/queries/link.queries.ts
@@ -85,16 +85,8 @@ export const createLinkMutation = gql`
 `;
 
 export const deleteLinkMutation = gql`
-  mutation deleteLink(
-    $sourceAccountId: ID!
-    $sourceEntityId: ID!
-    $linkId: ID!
-  ) {
-    deleteLink(
-      sourceAccountId: $sourceAccountId
-      sourceEntityId: $sourceEntityId
-      linkId: $linkId
-    )
+  mutation deleteLink($sourceAccountId: ID!, $linkId: ID!) {
+    deleteLink(sourceAccountId: $sourceAccountId, linkId: $linkId)
   }
 `;
 
@@ -141,13 +133,11 @@ export const createLinkedAggregationMutation = gql`
 export const updateLinkedAggregationMutation = gql`
   mutation updateLinkedAggregationOperation(
     $sourceAccountId: ID!
-    $sourceEntityId: ID!
     $aggregationId: ID!
     $updatedOperation: AggregateOperationInput!
   ) {
     updateLinkedAggregationOperation(
       sourceAccountId: $sourceAccountId
-      sourceEntityId: $sourceEntityId
       aggregationId: $aggregationId
       updatedOperation: $updatedOperation
     ) {
@@ -179,14 +169,9 @@ export const updateLinkedAggregationMutation = gql`
 `;
 
 export const deleteLinkedAggregationMutation = gql`
-  mutation deleteLinkedAggregation(
-    $sourceAccountId: ID!
-    $sourceEntityId: ID!
-    $aggregationId: ID!
-  ) {
+  mutation deleteLinkedAggregation($sourceAccountId: ID!, $aggregationId: ID!) {
     deleteLinkedAggregation(
       sourceAccountId: $sourceAccountId
-      sourceEntityId: $sourceEntityId
       aggregationId: $aggregationId
     )
   }

--- a/packages/hash/shared/src/queries/link.queries.ts
+++ b/packages/hash/shared/src/queries/link.queries.ts
@@ -177,3 +177,17 @@ export const updateLinkedAggregationMutation = gql`
     }
   }
 `;
+
+export const deleteLinkedAggregationMutation = gql`
+  mutation deleteLinkedAggregation(
+    $sourceAccountId: ID!
+    $sourceEntityId: ID!
+    $aggregationId: ID!
+  ) {
+    deleteLinkedAggregation(
+      sourceAccountId: $sourceAccountId
+      sourceEntityId: $sourceEntityId
+      aggregationId: $aggregationId
+    )
+  }
+`;

--- a/patches/blockprotocol+0.0.7.patch
+++ b/patches/blockprotocol+0.0.7.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/blockprotocol/core.d.ts b/node_modules/blockprotocol/core.d.ts
-index 20a9bbd..a849fa3 100644
+index 20a9bbd..3691f72 100644
 --- a/node_modules/blockprotocol/core.d.ts
 +++ b/node_modules/blockprotocol/core.d.ts
 @@ -1,3 +1,6 @@
@@ -33,49 +33,160 @@ index 20a9bbd..a849fa3 100644
  
  export type BlockProtocolAggregateOperationInput = {
    entityTypeId?: string | null;
-@@ -249,7 +254,8 @@ export type BlockProtocolUploadFileFunction = {
+@@ -249,16 +254,6 @@ export type BlockProtocolUploadFileFunction = {
  
  // ----------------------------- LINKS -------------------------------- //
  
 -type SingleTargetLinkFields = {
-+export type SingleTargetLinkFields = {
-+  linkId: string;
-   destinationEntityId: string;
-   destinationEntityTypeId?: string | null;
-   destinationEntityVersionId?: string | null;
-@@ -260,7 +266,6 @@ type AggregationTargetLinkFields = {
+-  destinationEntityId: string;
+-  destinationEntityTypeId?: string | null;
+-  destinationEntityVersionId?: string | null;
+-};
+-
+-type AggregationTargetLinkFields = {
+-  operation: BlockProtocolAggregateOperationInput;
+-};
+-
+ export type BlockProtocolLink = {
+   linkId: string;
+   sourceAccountId?: string | null;
+@@ -266,9 +261,12 @@ export type BlockProtocolLink = {
+   sourceEntityTypeId?: string | null;
+   sourceEntityVersionId?: string | null;
+   destinationAccountId?: string | null;
++  destinationEntityId: string;
++  destinationEntityTypeId?: string | null;
++  destinationEntityVersionId?: string | null;
+   index?: number | null;
+   path: string;
+-} & (SingleTargetLinkFields | AggregationTargetLinkFields);
++};
+ 
+ export type BlockProtocolLinkGroup = {
+   sourceAccountId?: string | null;
+@@ -279,14 +277,6 @@ export type BlockProtocolLinkGroup = {
+   links: BlockProtocolLink[];
  };
  
- export type BlockProtocolLink = {
--  linkId: string;
-   sourceAccountId?: string | null;
-   sourceEntityId: string;
-   sourceEntityTypeId?: string | null;
-@@ -304,14 +309,16 @@ export type BlockProtocolCreateLinksFunction = {
+-export type BlockProtocolLinkedAggregation = {
+-  sourceAccountId?: string | null;
+-  sourceEntityId: string;
+-  sourceEntityVersionId?: string | null;
+-  sourceEntityTypeId?: string | null;
+-  path: string;
+-} & BlockProtocolAggregateEntitiesResult<BlockProtocolEntity>;
+-
+ export type BlockProtocolGetLinkAction = {
+   linkId: string;
+ };
+@@ -304,14 +294,7 @@ export type BlockProtocolCreateLinksFunction = {
    (actions: BlockProtocolCreateLinksAction[]): Promise<BlockProtocolLink[]>;
  };
  
-+export type BlockProtocolUpdateLinkedAggregationActionFragment = {
-+  // temporary identifiers for LinkedAggregations - to be replaced with a single id
-+  sourceAccountId?: string | null;
-+  sourceEntityId: string;
-+  path: string;
-+}
-+
- export type BlockProtocolUpdateLinksAction =
-   | { linkId: string; data: Pick<BlockProtocolLink, "index"> }
+-export type BlockProtocolUpdateLinksAction =
+-  | { linkId: string; data: Pick<BlockProtocolLink, "index"> }
 -  | ({
 -      // temporary identifiers for LinkedAggregations - to be replaced with a single id
 -      sourceAccountId?: string | null;
 -      sourceEntityId: string;
 -      path: string;
 -    } & { data: BlockProtocolAggregateOperationInput });
-+  | (BlockProtocolUpdateLinkedAggregationActionFragment & { data: BlockProtocolAggregateOperationInput });
++export type BlockProtocolUpdateLinksAction = { linkId: string; data: Pick<BlockProtocolLink, "index"> }
  
  export type BlockProtocolUpdateLinksFunction = {
    (actions: BlockProtocolUpdateLinksAction[]): Promise<BlockProtocolLink[]>;
-@@ -452,4 +459,4 @@ export type BlockProtocolProps = {
-   linkedAggregations?: BlockProtocolLinkedAggregation[];
+@@ -327,6 +310,73 @@ export type BlockProtocolDeleteLinksFunction = {
+   (actions: BlockProtocolDeleteLinksAction[]): Promise<boolean[]>;
+ };
+ 
++// ---------------------- LINKED AGGREGATIONS ------------------------- //
++
++export type SingleTargetLinkFields = {
++  destinationEntityId: string;
++  destinationEntityTypeId?: string | null;
++  destinationEntityVersionId?: string | null;
++};
++
++export type BlockProtocolLinkedAggregationInput = {
++  aggregationId: string;
++  sourceAccountId?: string | null;
++  sourceEntityId: string;
++  sourceEntityTypeId?: string | null;
++  sourceEntityVersionId?: string | null;
++  path: string;
++  operation: BlockProtocolAggregateOperationInput;
++};
++
++export type BlockProtocolLinkedAggregation = 
++  Omit<BlockProtocolLinkedAggregation, "operation">
++  & BlockProtocolAggregateEntitiesResult<BlockProtocolEntity>;
++
++export type BlockProtocolGetLinkedAggregationAction = {
++  sourceAccountId: string;
++  aggregationId: string;
++};
++
++export type BlockProtocolGetLinkedAggregationsFunction = {
++  (actions: BlockProtocolGetLinkedAggregationAction[]): Promise<BlockProtocolLinkedAggregation[]>;
++};
++
++export type BlockProtocolCreateLinkedAggregationAction = DistributedOmit<
++  BlockProtocolLinkedAggregationInput,
++  "aggregationId"
++>;
++
++export type BlockProtocolCreateLinkedAggregationsFunction = {
++  (actions: BlockProtocolCreateLinkedAggregationAction[]): Promise<BlockProtocolLinkedAggregation[]>;
++};
++
++export type BlockProtocolUpdateLinkedAggregationActionFragment = {
++  sourceAccountId: string;
++  sourceEntityId: string;
++  aggregationId: string;
++}
++
++export type BlockProtocolUpdateLinkedAggregationAction =  {
++  sourceAccountId: string;
++  sourceEntityId: string;
++  aggregationId: string;
++  data: BlockProtocolAggregateOperationInput
++};
++
++export type BlockProtocolUpdateLinkedAggregationsFunction = {
++  (actions: BlockProtocolUpdateLinkedAggregationAction[]): Promise<BlockProtocolLinkedAggregation[]>;
++};
++
++export type BlockProtocolDeleteLinkedAggregationAction = {
++  sourceAccountId?: string | null;
++  sourceEntityId?: string | null;
++  aggregationId: string;
++};
++
++export type BlockProtocolDeleteLinkedAggregationsFunction = {
++  (actions: BlockProtocolDeleteLinkedAggregationAction[]): Promise<boolean[]>;
++};
++
+ // ------------------------- ENTITY TYPES ----------------------------- //
+ 
+ export type BlockProtocolEntityType = {
+@@ -436,6 +486,11 @@ export type BlockProtocolFunctions = {
+   deleteLinks?: BlockProtocolDeleteLinksFunction | undefined;
+   updateLinks?: BlockProtocolUpdateLinksFunction | undefined;
+ 
++  getLinkedAggregations?: BlockProtocolGetLinkedAggregationsFunction | undefined;
++  createLinkedAggregations?: BlockProtocolCreateLinkedAggregationsFunction | undefined;
++  deleteLinkedAggregations?: BlockProtocolDeleteLinkedAggregationsFunction | undefined;
++  updateLinkedAggregations?: BlockProtocolUpdateLinkedAggregationsFunction | undefined;
++
+   uploadFile?: BlockProtocolUploadFileFunction | undefined;
+ };
+ 
+@@ -449,7 +504,7 @@ export type BlockProtocolProps = {
+   entityTypeId?: string | null;
+   entityTypeVersionId?: string | null;
+   entityTypes?: BlockProtocolEntityType[];
+-  linkedAggregations?: BlockProtocolLinkedAggregation[];
++  linkedAggregations?: BlockProtocolLinkedAggregationWithResult[];
    linkedEntities?: BlockProtocolEntity[];
    linkGroups?: BlockProtocolLinkGroup[];
 -} & BlockProtocolFunctions;

--- a/patches/blockprotocol+0.0.7.patch
+++ b/patches/blockprotocol+0.0.7.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/blockprotocol/core.d.ts b/node_modules/blockprotocol/core.d.ts
-index 20a9bbd..f89c9be 100644
+index 20a9bbd..dda5c76 100644
 --- a/node_modules/blockprotocol/core.d.ts
 +++ b/node_modules/blockprotocol/core.d.ts
 @@ -1,3 +1,6 @@
@@ -124,7 +124,7 @@ index 20a9bbd..f89c9be 100644
 +  & BlockProtocolAggregateEntitiesResult<BlockProtocolEntity>;
 +
 +export type BlockProtocolGetLinkedAggregationAction = {
-+  sourceAccountId: string;
++  sourceAccountId?: string | null;
 +  aggregationId: string;
 +};
 +
@@ -142,12 +142,12 @@ index 20a9bbd..f89c9be 100644
 +};
 +
 +export type BlockProtocolUpdateLinkedAggregationActionFragment = {
-+  sourceAccountId: string;
++  sourceAccountId?: string | null;
 +  aggregationId: string;
 +}
 +
 +export type BlockProtocolUpdateLinkedAggregationAction =  {
-+  sourceAccountId: string;
++  sourceAccountId?: string | null;
 +  aggregationId: string;
 +  data: BlockProtocolAggregateOperationInput
 +};
@@ -180,12 +180,8 @@ index 20a9bbd..f89c9be 100644
    uploadFile?: BlockProtocolUploadFileFunction | undefined;
  };
  
-@@ -449,7 +494,7 @@ export type BlockProtocolProps = {
-   entityTypeId?: string | null;
-   entityTypeVersionId?: string | null;
-   entityTypes?: BlockProtocolEntityType[];
--  linkedAggregations?: BlockProtocolLinkedAggregation[];
-+  linkedAggregations?: BlockProtocolLinkedAggregationWithResult[];
+@@ -452,4 +497,4 @@ export type BlockProtocolProps = {
+   linkedAggregations?: BlockProtocolLinkedAggregation[];
    linkedEntities?: BlockProtocolEntity[];
    linkGroups?: BlockProtocolLinkGroup[];
 -} & BlockProtocolFunctions;

--- a/patches/blockprotocol+0.0.7.patch
+++ b/patches/blockprotocol+0.0.7.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/blockprotocol/core.d.ts b/node_modules/blockprotocol/core.d.ts
-index 20a9bbd..3691f72 100644
+index 20a9bbd..579b0b3 100644
 --- a/node_modules/blockprotocol/core.d.ts
 +++ b/node_modules/blockprotocol/core.d.ts
 @@ -1,3 +1,6 @@
@@ -95,17 +95,11 @@ index 20a9bbd..3691f72 100644
  
  export type BlockProtocolUpdateLinksFunction = {
    (actions: BlockProtocolUpdateLinksAction[]): Promise<BlockProtocolLink[]>;
-@@ -327,6 +310,73 @@ export type BlockProtocolDeleteLinksFunction = {
+@@ -327,6 +310,67 @@ export type BlockProtocolDeleteLinksFunction = {
    (actions: BlockProtocolDeleteLinksAction[]): Promise<boolean[]>;
  };
  
 +// ---------------------- LINKED AGGREGATIONS ------------------------- //
-+
-+export type SingleTargetLinkFields = {
-+  destinationEntityId: string;
-+  destinationEntityTypeId?: string | null;
-+  destinationEntityVersionId?: string | null;
-+};
 +
 +export type BlockProtocolLinkedAggregationInput = {
 +  aggregationId: string;
@@ -169,7 +163,7 @@ index 20a9bbd..3691f72 100644
  // ------------------------- ENTITY TYPES ----------------------------- //
  
  export type BlockProtocolEntityType = {
-@@ -436,6 +486,11 @@ export type BlockProtocolFunctions = {
+@@ -436,6 +480,11 @@ export type BlockProtocolFunctions = {
    deleteLinks?: BlockProtocolDeleteLinksFunction | undefined;
    updateLinks?: BlockProtocolUpdateLinksFunction | undefined;
  
@@ -181,7 +175,7 @@ index 20a9bbd..3691f72 100644
    uploadFile?: BlockProtocolUploadFileFunction | undefined;
  };
  
-@@ -449,7 +504,7 @@ export type BlockProtocolProps = {
+@@ -449,7 +498,7 @@ export type BlockProtocolProps = {
    entityTypeId?: string | null;
    entityTypeVersionId?: string | null;
    entityTypes?: BlockProtocolEntityType[];

--- a/patches/blockprotocol+0.0.7.patch
+++ b/patches/blockprotocol+0.0.7.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/blockprotocol/core.d.ts b/node_modules/blockprotocol/core.d.ts
-index 20a9bbd..ddcda7a 100644
+index 20a9bbd..f89c9be 100644
 --- a/node_modules/blockprotocol/core.d.ts
 +++ b/node_modules/blockprotocol/core.d.ts
 @@ -1,3 +1,6 @@
@@ -120,7 +120,7 @@ index 20a9bbd..ddcda7a 100644
 +};
 +
 +export type BlockProtocolLinkedAggregation = 
-+  Omit<BlockProtocolLinkedAggregation, "operation">
++  Omit<BlockProtocolLinkedAggregationInput, "operation">
 +  & BlockProtocolAggregateEntitiesResult<BlockProtocolEntity>;
 +
 +export type BlockProtocolGetLinkedAggregationAction = {

--- a/patches/blockprotocol+0.0.7.patch
+++ b/patches/blockprotocol+0.0.7.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/blockprotocol/core.d.ts b/node_modules/blockprotocol/core.d.ts
-index 20a9bbd..579b0b3 100644
+index 20a9bbd..ddcda7a 100644
 --- a/node_modules/blockprotocol/core.d.ts
 +++ b/node_modules/blockprotocol/core.d.ts
 @@ -1,3 +1,6 @@
@@ -95,7 +95,15 @@ index 20a9bbd..579b0b3 100644
  
  export type BlockProtocolUpdateLinksFunction = {
    (actions: BlockProtocolUpdateLinksAction[]): Promise<BlockProtocolLink[]>;
-@@ -327,6 +310,67 @@ export type BlockProtocolDeleteLinksFunction = {
+@@ -319,7 +302,6 @@ export type BlockProtocolUpdateLinksFunction = {
+ 
+ export type BlockProtocolDeleteLinksAction = {
+   sourceAccountId?: string | null;
+-  sourceEntityId?: string | null;
+   linkId: string;
+ };
+ 
+@@ -327,6 +309,64 @@ export type BlockProtocolDeleteLinksFunction = {
    (actions: BlockProtocolDeleteLinksAction[]): Promise<boolean[]>;
  };
  
@@ -135,13 +143,11 @@ index 20a9bbd..579b0b3 100644
 +
 +export type BlockProtocolUpdateLinkedAggregationActionFragment = {
 +  sourceAccountId: string;
-+  sourceEntityId: string;
 +  aggregationId: string;
 +}
 +
 +export type BlockProtocolUpdateLinkedAggregationAction =  {
 +  sourceAccountId: string;
-+  sourceEntityId: string;
 +  aggregationId: string;
 +  data: BlockProtocolAggregateOperationInput
 +};
@@ -152,7 +158,6 @@ index 20a9bbd..579b0b3 100644
 +
 +export type BlockProtocolDeleteLinkedAggregationAction = {
 +  sourceAccountId?: string | null;
-+  sourceEntityId?: string | null;
 +  aggregationId: string;
 +};
 +
@@ -163,7 +168,7 @@ index 20a9bbd..579b0b3 100644
  // ------------------------- ENTITY TYPES ----------------------------- //
  
  export type BlockProtocolEntityType = {
-@@ -436,6 +480,11 @@ export type BlockProtocolFunctions = {
+@@ -436,6 +476,11 @@ export type BlockProtocolFunctions = {
    deleteLinks?: BlockProtocolDeleteLinksFunction | undefined;
    updateLinks?: BlockProtocolUpdateLinksFunction | undefined;
  
@@ -175,7 +180,7 @@ index 20a9bbd..579b0b3 100644
    uploadFile?: BlockProtocolUploadFileFunction | undefined;
  };
  
-@@ -449,7 +498,7 @@ export type BlockProtocolProps = {
+@@ -449,7 +494,7 @@ export type BlockProtocolProps = {
    entityTypeId?: string | null;
    entityTypeVersionId?: string | null;
    entityTypes?: BlockProtocolEntityType[];


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR implements three new BP methods for creating/updating/deleting the linked aggregations of an entity.

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

- There is a bug presumed to be related to the entity store where updates to linked aggregations are no longer reflected in the entity store. This means updating an aggregation (when toggling the entity type displayed in the table block for example) does not get reflected in the block, although the update was saved in the datastore.

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

- [ ] ...

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

- [update the `blockprotocol` package to include the updated BP method types](https://app.asana.com/0/1201095311341924/1202216335609392/f)
- [update the BP spec to include the introduced BP aggregation methods](https://app.asana.com/0/1201095311341924/1202216335609402/f)
- [implement the `useBlockProtocolUpdateLinks` hook to update links using their `linkId`](https://app.asana.com/0/1201095311341924/1202216335609406/f)

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->


#### GQL API

- updates the `deleteLinkedAggregation` and `updateLinkedAggregationOperation` GQL mutations to use `aggregationId` as an identifier

#### Blockprotocol

- patches the `blockprotocol` NPM package to include `BlockProtocolCreateLinkedAggregationsFunction`, `BlockProtocolUpdateLinkedAggregationsFunction` and `BlockProtocolDeleteLinkedAggregationsFunction` type definitions

#### Frontend

- implements `useBlockProtocolCreateLinkedAggregations`, `useBlockProtocolUpdateLinkedAggregations` and `useBlockProtocolDeleteLinkedAggregations` hooks
- updates the Table block to make use of the new BP methods

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

No (updating the BP spec will be handled in a separate task)

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201095311341924/1201866327702956/f) _(internal)_

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- integration tests cover create/update/delete linked aggregation GQL mutations

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Build & serve the table block locally
2. Login to the workspace, load the locally hosted table block
3. Modify the entity type displayed in the table to update the aggregation. Note that nothing changes because of am existing bug in the entity store.
4. Edit another block in the page, to refresh the entity store. The block will now be updated with the new linked aggregation, and display the entity type you previously selected.

## 📹 Demo

https://user-images.githubusercontent.com/42802102/164500974-c95fff65-bbc2-4545-974a-70122027df7e.mov
