### PR TITLE
Fail CI if diff not empty during tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -257,7 +257,7 @@ jobs:
       # Non-empty diff could be a Cargo.lock that wasn't committed.
       - name: Ensure empty git diff
         run: |
-          echo "${{ env.ORIGINAL_CARGO_TOML }}" > ${{ matrix.directory }}/Cargo.toml
+          echo '${{ env.ORIGINAL_CARGO_TOML }}' > ${{ matrix.directory }}/Cargo.toml
           git --no-pager diff --exit-code --color
 
   bench:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -206,7 +206,8 @@ jobs:
       - name: Remove and store default members
         id: default_members
         run: |
-          echo "CARGO_TOML=$(cat ${{ matrix.directory }}/Cargo.toml)" >> $GITHUB_ENV
+          cargo_toml=`cat ${{ matrix.directory }}/Cargo.toml`
+          echo "CARGO_TOML=$($cargo_toml)" >> $GITHUB_ENV
           sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
 
       - name: Install Rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -201,6 +201,8 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Remove default members
         run: sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -180,10 +180,10 @@ jobs:
 
       - name: Check diff is empty after compilation
         uses: actions/github-script@v3
-        if: ${{ env.GIT_DIFF }}
+        if: ${{ env.GIT_DIFF }} && ${{ env.GIT_DIFF }} != ""
         with:
           script: |
-            core.setFailed('Diff was not empty after compilation')
+            core.setFailed('Diff was not empty after compilation: ${{ env.GIT_DIFF }}')
 
       - name: Annotate
         if: ${{ failure() }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -249,8 +249,8 @@ jobs:
         if: matrix.directory == 'packages/engine' && ${{ env.DIFF_BEFORE_TESTS }} != ""
         with:
           script: |
-          echo ${{ env.DIFF_BEFORE_TESTS }}
-          core.setFailed('Diff was not empty before tests')
+            echo ${{ env.DIFF_BEFORE_TESTS }}
+            core.setFailed('Diff was not empty before tests')
 
       - name: Setup Python environment
         if: matrix.directory == 'packages/engine'
@@ -272,8 +272,8 @@ jobs:
         if: matrix.directory == 'packages/engine' && ${{ env.DIFF_AFTER_TESTS }} != ""
         with:
           script: |
-          echo ${{ env.DIFF_AFTER_TESTS }}
-          core.setFailed('Diff was not empty after tests')
+            echo ${{ env.DIFF_AFTER_TESTS }}
+            core.setFailed('Diff was not empty after tests')
 
   bench:
     name: bench

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -173,6 +173,9 @@ jobs:
       - name: Run clippy
         run: cargo clippy --manifest-path ${{ matrix.directory }}/Cargo.toml --no-deps --tests ${{ matrix.flags }} -- -D warnings
 
+      - name: Ensure empty git diff
+        run: git --no-pager diff --exit-code --color
+
       - name: Generate diff after compilation
         run: |
           changed_files="$(git diff --name-only HEAD)"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -251,6 +251,7 @@ jobs:
         if: matrix.directory == 'packages/engine' && ${{ steps.diff_before_tests.DIFF_BEFORE_TESTS }}
         with:
           script: |
+            console.log("${{ steps.diff_before_tests.DIFF_BEFORE_TESTS }}")
             core.setFailed('Diff was not empty before tests')
 
       - name: Setup Python environment

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -241,7 +241,7 @@ jobs:
       - name: Generate diff before tests
         if: matrix.directory == 'packages/engine'
         run: |
-          echo git --no-pager diff ${{ matrix.directory }}
+          git --no-pager diff ${{ matrix.directory }}
           echo "DIFF=$(git --no-pager diff ${{ matrix.directory }})"
 
       - name: Check diff is empty before tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Remove and store default members
         id: default_members
         run: |
-          echo "::set-output Cargo=$(cat ${{ matrix.directory }}/Cargo.toml)"
+          echo "::set-output name=Cargo::$(cat ${{ matrix.directory }}/Cargo.toml)"
           sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
 
       - name: Install Rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -252,17 +252,8 @@ jobs:
         if: matrix.directory == 'packages/engine'
         run: cargo test --manifest-path ${{ matrix.directory }}/Cargo.toml --no-run ${{ matrix.flags }}
 
-      - name: Generate diff after compilation
-        run: |
-          changed_files="$(git diff --name-only HEAD)"
-          echo "GIT_DIFF=$(echo $changed_files)"
-
-      - name: Check diff is empty after compilation
-        uses: actions/github-script@v3
-        if: ${{ env.GIT_DIFF }} && ${{ env.GIT_DIFF }} != ""
-        with:
-          script: |
-            core.setFailed('Diff was not empty after compilation')
+      - name: Ensure empty git diff
+        run: git --no-pager diff --exit-code --color
 
       - name: Setup Python environment
         if: matrix.directory == 'packages/engine'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -254,7 +254,7 @@ jobs:
       # Non-empty diff could be a Cargo.lock that wasn't committed.
       - name: Ensure empty git diff
         run: |
-          echo ${{ steps.default_members.${{ matrix.directory }}_Cargo }} > ${{ matrix.directory }}/Cargo.toml
+          echo ${{ steps.default_members.outputs.${{ matrix.directory }}_Cargo }} > ${{ matrix.directory }}/Cargo.toml
           git --no-pager diff --exit-code --color
 
   bench:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -181,7 +181,7 @@ jobs:
 
       - name: Check diff is empty after compilation
         uses: actions/github-script@v3
-        if: ${{ env.GIT_DIFF }} != ""
+        if: ${{ env.GIT_DIFF }}
         with:
           script: |
             core.setFailed('Diff was not empty after compilation')

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -249,7 +249,7 @@ jobs:
         if: matrix.directory == 'packages/engine' && ${{ env.DIFF_BEFORE_TESTS }} != ""
         with:
           script: |
-            console.log(`${env.DIFF_BEFORE_TESTS}`)
+            console.log(`${process.env.DIFF_BEFORE_TESTS}`)
             core.setFailed('Diff was not empty before tests')
 
       - name: Setup Python environment
@@ -272,7 +272,7 @@ jobs:
         if: matrix.directory == 'packages/engine' && ${{ env.DIFF_AFTER_TESTS }} != ""
         with:
           script: |
-            console.log(`${env.DIFF_AFTER_TESTS}`)
+            console.log(`${process.env.DIFF_AFTER_TESTS}`)
             core.setFailed('Diff was not empty after tests')
 
   bench:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -207,9 +207,7 @@ jobs:
         id: default_members
         run: |
           cargo_toml=$(< ${{ matrix.directory }}/Cargo.toml)
-          echo "ORIGINAL_CARGO_TOML<<'EOF'" >> $GITHUB_ENV
-          echo "$cargo_toml" >> $GITHUB_ENV
-          echo "'EOF'" >> $GITHUB_ENV
+          echo "ORIGINAL_CARGO_TOML=$cargo_toml" >> $GITHUB_ENV
           sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
 
       - name: Install Rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -239,9 +239,8 @@ jobs:
         run: cargo test --manifest-path ${{ matrix.directory }}/Cargo.toml --no-run ${{ matrix.flags }}
 
       - name: Generate diff before tests
-        if: matrix.directory == 'packages/engine'
         run: |
-          git --no-pager diff ${{ matrix.directory }}
+          git --no-pager diff packages/engine
           echo "GIT_DIFF=$(git --no-pager diff ${{ matrix.directory }})"
 
       - name: Check diff is empty before tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Remove and store default members
         id: default_members
         run: |
-          echo "::set-output ${{ matrix.directory }}_Cargo=$(cat ${{ matrix.directory }}/Cargo.toml)"
+          echo "::set-output Cargo=$(cat ${{ matrix.directory }}/Cargo.toml)"
           sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
 
       - name: Install Rust
@@ -254,7 +254,7 @@ jobs:
       # Non-empty diff could be a Cargo.lock that wasn't committed.
       - name: Ensure empty git diff
         run: |
-          echo "${{ steps.default_members.outputs.${{ matrix.directory }}_Cargo }}" > ${{ matrix.directory }}/Cargo.toml
+          echo "${{ steps.default_members.outputs.Cargo }}" > ${{ matrix.directory }}/Cargo.toml
           git --no-pager diff --exit-code --color
 
   bench:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -202,10 +202,10 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v2
 
-      # Store `Cargo.toml` before modifying it to not affect the diff.
-      - name: Remove and store default members
+      - name: Remove default members
         run: |
-          cp "${{ matrix.directory }}/Cargo.toml" "${{ matrix.directory }}/Cargo.toml.orig"
+          # Backup `Config.toml` to restore it later so that `git diff` does not report any changes
+          cp -v "${{ matrix.directory }}/Cargo.toml" "${{ matrix.directory }}/Cargo.toml.orig"
           sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
 
       - name: Install Rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -267,6 +267,9 @@ jobs:
       - name: Run tests
         run: cargo test --manifest-path ${{ matrix.directory }}/Cargo.toml --no-fail-fast ${{ matrix.flags }}
 
+      - name: Ensure empty git diff
+        run: git --no-pager diff --exit-code --color
+
   bench:
     name: bench
     needs: setup

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -173,6 +173,21 @@ jobs:
       - name: Run clippy
         run: cargo clippy --manifest-path ${{ matrix.directory }}/Cargo.toml --no-deps --tests ${{ matrix.flags }} -- -D warnings
 
+      - name: Generate diff before tests
+        run: |
+          changed_files="$(git diff --name-only HEAD)"
+          echo $changed_files
+          git --no-pager diff packages/engine
+          echo "GIT_DIFF=$(git --no-pager diff packages/engine)"
+
+      - name: Check diff is empty before tests
+        uses: actions/github-script@v3
+        if: matrix.directory == 'packages/engine' && ${{ env.GIT_DIFF }} != ""
+        with:
+          script: |
+            console.log(${{ env.GIT_DIFF }})
+            core.setFailed('Diff was not empty before tests')
+
       - name: Annotate
         if: ${{ failure() }}
         # use `actions-rs/clippy-check@v1` when https://github.com/actions-rs/clippy-check/pull/158 is merged

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -239,13 +239,12 @@ jobs:
         run: cargo test --manifest-path ${{ matrix.directory }}/Cargo.toml --no-run ${{ matrix.flags }}
 
       - name: Check diff is empty before tests
-        uses: actions/github-script@v3
         uses: technote-space/get-diff-action@v6
         if: matrix.directory == 'packages/engine' && ${{ env.GIT_DIFF }}
         with:
           script: |
             console.log("${{ env.GIT_DIFF }}")
-            core.setFailed('Diff was not empty before tests')
+            exit 1
 
       - name: Setup Python environment
         if: matrix.directory == 'packages/engine'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -242,13 +242,13 @@ jobs:
         id: diff_before_tests
         if: matrix.directory == 'packages/engine'
         run: |
-          diff = git diff ${{ matrix.directory }}
+          diff = git --no-pager diff ${{ matrix.directory }}
           echo "::$diff::"
           echo "::set-output name=DIFF_BEFORE_TESTS::$(diff)"
 
       - name: Check diff is empty before tests
         uses: actions/github-script@v3
-        if: matrix.directory == 'packages/engine' && ${{ steps.diff_before_tests.DIFF_BEFORE_TESTS }}
+        if: matrix.directory == 'packages/engine' && ${{ steps.diff_before_tests.DIFF_BEFORE_TESTS }} && ${{ steps.diff_before_tests.DIFF_BEFORE_TESTS }} != ""
         with:
           script: |
             console.log("${{ steps.diff_before_tests.DIFF_BEFORE_TESTS }}")

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Store original Cargo.toml
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.toolchain }}/Cargo.toml
+          name: ${{ matrix.directory }}-Cargo.toml
           path: ${{ matrix.directory }}/Cargo.toml
 
       - name: Remove default members
@@ -257,7 +257,7 @@ jobs:
       - name: Restore Cargo.toml
         uses: actions/download-artifact@v3
         with:
-          name: ${{ matrix.toolchain }}/Cargo.toml
+          name: ${{ matrix.directory }}-Cargo.toml
 
       # Non-empty diff could be a Cargo.lock that wasn't committed.
       - name: Ensure empty git diff

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Remove and store default members
         id: default_members
         run: |
-          cargo_toml=$(cat ${{ matrix.directory }}/Cargo.toml)
+          cargo_toml=$(< cat ${{ matrix.directory }}/Cargo.toml)
           echo "ORIGINAL_CARGO_TOML<<'EOF'" >> $GITHUB_ENV
           echo "$cargo_toml" >> $GITHUB_ENV
           echo "'EOF'" >> $GITHUB_ENV

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -204,8 +204,9 @@ jobs:
 
       # Store `Cargo.toml` before modifying it to not affect the diff.
       - name: Remove and store default members
+        id: default_members
         run: |
-          echo "ORIGINAL_CARGO_TOML=$(cat ${{ matrix.directory }}/Cargo.toml)"
+          echo "::set-output ${{ matrix.directory }}_Cargo=$(cat ${{ matrix.directory }}/Cargo.toml)"
           sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
 
       - name: Install Rust
@@ -253,7 +254,7 @@ jobs:
       # Non-empty diff could be a Cargo.lock that wasn't committed.
       - name: Ensure empty git diff
         run: |
-          echo $ORIGINAL_CARGO_TOML > ${{ matrix.directory }}/Cargo.toml
+          echo ${{ steps.default_members.${{ matrix.directory }}_Cargo }} > ${{ matrix.directory }}/Cargo.toml
           git --no-pager diff --exit-code --color
 
   bench:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -183,7 +183,7 @@ jobs:
         if: ${{ env.GIT_DIFF }} && ${{ env.GIT_DIFF }} != ""
         with:
           script: |
-            core.setFailed(`Diff was not empty after compilation: ${ process.env.GIT_DIFF }`)
+            core.setFailed('Diff was not empty after compilation')
 
       - name: Annotate
         if: ${{ failure() }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Remove and store default members
         id: default_members
         run: |
-          echo "::set-output name=Cargo::$(cat ${{ matrix.directory }}/Cargo.toml)"
+          echo "CARGO_TOML=$(cat ${{ matrix.directory }}/Cargo.toml)" >> $GITHUB_ENV
           sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
 
       - name: Install Rust
@@ -254,7 +254,7 @@ jobs:
       # Non-empty diff could be a Cargo.lock that wasn't committed.
       - name: Ensure empty git diff
         run: |
-          echo "${{ steps.default_members.outputs.Cargo }}" > ${{ matrix.directory }}/Cargo.toml
+          echo $CARGO_TOML > ${{ matrix.directory }}/Cargo.toml
           git --no-pager diff --exit-code --color
 
   bench:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -249,6 +249,7 @@ jobs:
         if: matrix.directory == 'packages/engine' && ${{ env.DIFF_BEFORE_TESTS }} != ""
         with:
           script: |
+            console.log(`${env.DIFF_BEFORE_TESTS}`)
             core.setFailed('Diff was not empty before tests')
 
       - name: Setup Python environment
@@ -271,6 +272,7 @@ jobs:
         if: matrix.directory == 'packages/engine' && ${{ env.DIFF_AFTER_TESTS }} != ""
         with:
           script: |
+            console.log(`${env.DIFF_AFTER_TESTS}`)
             core.setFailed('Diff was not empty after tests')
 
   bench:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -238,10 +238,17 @@ jobs:
         if: matrix.directory == 'packages/engine'
         run: cargo test --manifest-path ${{ matrix.directory }}/Cargo.toml --no-run ${{ matrix.flags }}
 
+      - name: Generate diff before tests
+        id: diff_before_tests
+        if: matrix.directory == 'packages/engine'
+        run: |
+          echo "DIFF_BEFORE_TESTS=$(git diff ${{ matrix.directory }})" >> $GITHUB_ENV
+
       - name: Check diff is empty before tests
         uses: actions/github-script@v3
-        if: matrix.directory == 'packages/engine' && git diff ${{ matrix.directory }} != ""
+        if: matrix.directory == 'packages/engine' && ${{ env.DIFF_BEFORE_TESTS }} != ""
         run: |
+          echo ${{ env.DIFF_BEFORE_TESTS }}
           core.setFailed('Diff was not empty before tests')
 
       - name: Setup Python environment
@@ -253,10 +260,17 @@ jobs:
       - name: Run tests
         run: cargo test --manifest-path ${{ matrix.directory }}/Cargo.toml --no-fail-fast ${{ matrix.flags }}
 
-      - name: Check diff is empty before tests
-        uses: actions/github-script@v3
-        if: matrix.directory == 'packages/engine' && git diff ${{ matrix.directory }} != ""
+      - name: Generate diff after tests
+        id: diff_after_tests
+        if: matrix.directory == 'packages/engine'
         run: |
+          echo "DIFF_AFTER_TESTS=$(git diff ${{ matrix.directory }})" >> $GITHUB_ENV
+
+      - name: Check diff is empty after tests
+        uses: actions/github-script@v3
+        if: matrix.directory == 'packages/engine' && ${{ env.DIFF_AFTER_TESTS }} != ""
+        run: |
+          echo ${{ env.DIFF_AFTER_TESTS }}
           core.setFailed('Diff was not empty after tests')
 
   bench:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -242,12 +242,14 @@ jobs:
 
       - name: Generate diff before tests
         run: |
+          changed_files="$(git diff --name-only HEAD)"
+          echo $changed_files
           git --no-pager diff packages/engine
           echo "GIT_DIFF=$(git --no-pager diff packages/engine)"
 
       - name: Check diff is empty before tests
         uses: actions/github-script@v3
-        if: matrix.directory == 'packages/engine' && ${{ env.GIT_DIFF }}
+        if: matrix.directory == 'packages/engine' && ${{ env.GIT_DIFF }} != ""
         with:
           script: |
             console.log(${{ env.GIT_DIFF }})

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -183,7 +183,7 @@ jobs:
         if: ${{ env.GIT_DIFF }} && ${{ env.GIT_DIFF }} != ""
         with:
           script: |
-            core.setFailed('Diff was not empty after compilation: ${{ env.GIT_DIFF }}')
+            core.setFailed(`Diff was not empty after compilation: ${ env.GIT_DIFF }`)
 
       - name: Annotate
         if: ${{ failure() }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -247,7 +247,8 @@ jobs:
       - name: Check diff is empty before tests
         uses: actions/github-script@v3
         if: matrix.directory == 'packages/engine' && ${{ env.DIFF_BEFORE_TESTS }} != ""
-        run: |
+        with:
+          script: |
           echo ${{ env.DIFF_BEFORE_TESTS }}
           core.setFailed('Diff was not empty before tests')
 
@@ -269,7 +270,8 @@ jobs:
       - name: Check diff is empty after tests
         uses: actions/github-script@v3
         if: matrix.directory == 'packages/engine' && ${{ env.DIFF_AFTER_TESTS }} != ""
-        run: |
+        with:
+          script: |
           echo ${{ env.DIFF_AFTER_TESTS }}
           core.setFailed('Diff was not empty after tests')
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -249,7 +249,6 @@ jobs:
         if: matrix.directory == 'packages/engine' && ${{ env.DIFF_BEFORE_TESTS }} != ""
         with:
           script: |
-            echo ${{ env.DIFF_BEFORE_TESTS }}
             core.setFailed('Diff was not empty before tests')
 
       - name: Setup Python environment
@@ -272,7 +271,6 @@ jobs:
         if: matrix.directory == 'packages/engine' && ${{ env.DIFF_AFTER_TESTS }} != ""
         with:
           script: |
-            echo ${{ env.DIFF_AFTER_TESTS }}
             core.setFailed('Diff was not empty after tests')
 
   bench:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -242,7 +242,7 @@ jobs:
         if: matrix.directory == 'packages/engine'
         run: |
           git --no-pager diff ${{ matrix.directory }}
-          echo "DIFF=$(git --no-pager diff ${{ matrix.directory }})"
+          echo "GIT_DIFF=$(git --no-pager diff ${{ matrix.directory }})"
 
       - name: Check diff is empty before tests
         uses: actions/github-script@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -183,7 +183,7 @@ jobs:
         if: ${{ env.GIT_DIFF }} && ${{ env.GIT_DIFF }} != ""
         with:
           script: |
-            core.setFailed(`Diff was not empty after compilation: ${ env.GIT_DIFF }`)
+            core.setFailed(`Diff was not empty after compilation: ${ process.env.GIT_DIFF }`)
 
       - name: Annotate
         if: ${{ failure() }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -201,8 +201,6 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Remove default members
         run: sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -250,7 +250,7 @@ jobs:
       - name: Run tests
         run: cargo test --manifest-path ${{ matrix.directory }}/Cargo.toml --no-fail-fast ${{ matrix.flags }}
 
-      # Non empty diff can be a Cargo.lock that wasn't pushed.
+      # Non-empty diff could be a Cargo.lock that wasn't committed.
       - name: Ensure empty git diff
         run: |
           echo $ORIGINAL_CARGO_TOML > ${{ matrix.directory }}/Cargo.toml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -238,20 +238,13 @@ jobs:
         if: matrix.directory == 'packages/engine'
         run: cargo test --manifest-path ${{ matrix.directory }}/Cargo.toml --no-run ${{ matrix.flags }}
 
-      - name: Generate diff before tests
-        id: diff_before_tests
-        if: matrix.directory == 'packages/engine'
-        run: |
-          diff = git --no-pager diff ${{ matrix.directory }}
-          echo "::$diff::"
-          echo "::set-output name=DIFF_BEFORE_TESTS::$(diff)"
-
       - name: Check diff is empty before tests
         uses: actions/github-script@v3
-        if: matrix.directory == 'packages/engine' && ${{ steps.diff_before_tests.DIFF_BEFORE_TESTS }} && ${{ steps.diff_before_tests.DIFF_BEFORE_TESTS }} != ""
+        uses: technote-space/get-diff-action@v6
+        if: matrix.directory == 'packages/engine' && ${{ env.GIT_DIFF }}
         with:
           script: |
-            console.log("${{ steps.diff_before_tests.DIFF_BEFORE_TESTS }}")
+            console.log("${{ env.GIT_DIFF }}")
             core.setFailed('Diff was not empty before tests')
 
       - name: Setup Python environment

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -176,8 +176,7 @@ jobs:
       - name: Generate diff after compilation
         run: |
           changed_files="$(git diff --name-only HEAD)"
-          echo $changed_files
-          echo "GIT_DIFF=$($changed_files)"
+          echo "GIT_DIFF=$(echo $changed_files)"
 
       - name: Check diff is empty after compilation
         uses: actions/github-script@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -203,14 +203,11 @@ jobs:
         uses: actions/checkout@v2
 
       # Store `Cargo.toml` before modifying it to not affect the diff.
-      - name: Store original Cargo.toml
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ matrix.directory }}-Cargo.toml
-          path: ${{ matrix.directory }}/Cargo.toml
-
-      - name: Remove default members
-        run: sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
+      - name: Remove and store default members
+        id: default_members
+        run: |
+          echo "::set-output name=Cargo::$(cat ${{ matrix.directory }}/Cargo.toml)"
+          sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
 
       - name: Install Rust
         id: toolchain
@@ -254,14 +251,11 @@ jobs:
       - name: Run tests
         run: cargo test --manifest-path ${{ matrix.directory }}/Cargo.toml --no-fail-fast ${{ matrix.flags }}
 
-      - name: Restore Cargo.toml
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ matrix.directory }}-Cargo.toml
-
       # Non-empty diff could be a Cargo.lock that wasn't committed.
       - name: Ensure empty git diff
-        run: git --no-pager diff --exit-code --color
+        run: |
+          echo "${{ steps.default_members.outputs.Cargo }}" > ${{ matrix.directory }}/Cargo.toml
+          git --no-pager diff --exit-code --color
 
   bench:
     name: bench

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -202,8 +202,11 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v2
 
-      - name: Remove default members
-        run: sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
+      # Store `Cargo.toml` before modifying it to not affect the diff.
+      - name: Remove and store default members
+        run: |
+          echo "ORIGINAL_CARGO_TOML=$(cat ${{ matrix.directory }}/Cargo.toml)"
+          sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
 
       - name: Install Rust
         id: toolchain
@@ -249,7 +252,9 @@ jobs:
 
       # Non empty diff can be a Cargo.lock that wasn't pushed.
       - name: Ensure empty git diff
-        run: git --no-pager diff --exit-code --color
+        run: |
+          echo $ORIGINAL_CARGO_TOML > ${{ matrix.directory }}/Cargo.toml
+          git --no-pager diff --exit-code --color
 
   bench:
     name: bench

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Remove and store default members
         id: default_members
         run: |
-          cargo_toml=$(cat ${{ matrix.directory }}/Cargo.toml
+          cargo_toml=$(cat ${{ matrix.directory }}/Cargo.toml)
           echo "ORIGINAL_CARGO_TOML<<EOF" >> $GITHUB_ENV
           echo "$cargo_toml" >> $GITHUB_ENV
           sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -241,13 +241,15 @@ jobs:
       - name: Generate diff before tests
         uses: technote-space/get-diff-action@v6
         if: matrix.directory == 'packages/engine'
+        with:
+          RELATIVE: ${{ matrix.directory }}
 
       - name: Check diff is empty before tests
         uses: actions/github-script@v3
         if: matrix.directory == 'packages/engine' && ${{ env.GIT_DIFF }}
         with:
           script: |
-            console.log("${{ env.GIT_DIFF }}")
+            console.log(${{ env.GIT_DIFF }})
             core.setFailed('Diff was not empty before tests')
 
       - name: Setup Python environment

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Remove and store default members
         id: default_members
         run: |
-          cargo_toml=$(< cat ${{ matrix.directory }}/Cargo.toml)
+          cargo_toml=$(< ${{ matrix.directory }}/Cargo.toml)
           echo "ORIGINAL_CARGO_TOML<<'EOF'" >> $GITHUB_ENV
           echo "$cargo_toml" >> $GITHUB_ENV
           echo "'EOF'" >> $GITHUB_ENV

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -243,7 +243,7 @@ jobs:
       - name: Generate diff before tests
         run: |
           git --no-pager diff packages/engine
-          echo "GIT_DIFF=$(git --no-pager diff ${{ matrix.directory }})"
+          echo "GIT_DIFF=$(git --no-pager diff packages/engine)"
 
       - name: Check diff is empty before tests
         uses: actions/github-script@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -204,7 +204,6 @@ jobs:
 
       # Store `Cargo.toml` before modifying it to not affect the diff.
       - name: Remove and store default members
-        id: default_members
         run: |
           cp "${{ matrix.directory }}/Cargo.toml" "${{ matrix.directory }}/Cargo.toml.orig"
           sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -251,7 +251,6 @@ jobs:
         if: matrix.directory == 'packages/engine' && ${{ steps.diff_before_tests.DIFF_BEFORE_TESTS }}
         with:
           script: |
-            console.log(`${steps.diff_before_tests.DIFF_BEFORE_TESTS}`)
             core.setFailed('Diff was not empty before tests')
 
       - name: Setup Python environment

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -239,10 +239,10 @@ jobs:
         run: cargo test --manifest-path ${{ matrix.directory }}/Cargo.toml --no-run ${{ matrix.flags }}
 
       - name: Generate diff before tests
-        uses: technote-space/get-diff-action@v6
         if: matrix.directory == 'packages/engine'
-        with:
-          RELATIVE: ${{ matrix.directory }}
+        run: |
+          echo git --no-pager diff ${{ matrix.directory }}
+          echo "DIFF=$(git --no-pager diff ${{ matrix.directory }})"
 
       - name: Check diff is empty before tests
         uses: actions/github-script@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -206,10 +206,7 @@ jobs:
       - name: Remove and store default members
         id: default_members
         run: |
-          cargo_toml=$(< ${{ matrix.directory }}/Cargo.toml)
-          echo "ORIGINAL_CARGO_TOML<<EOF" >> $GITHUB_ENV
-          echo "$cargo_toml" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          cp "${{ matrix.directory }}/Cargo.toml" "${{ matrix.directory }}/Cargo.toml.orig"
           sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
 
       - name: Install Rust
@@ -257,7 +254,7 @@ jobs:
       # Non-empty diff could be a Cargo.lock that wasn't committed.
       - name: Ensure empty git diff
         run: |
-          echo '${{ env.ORIGINAL_CARGO_TOML }}' > ${{ matrix.directory }}/Cargo.toml
+          mv "${{ matrix.directory }}/Cargo.toml.orig" "${{ matrix.directory }}/Cargo.toml"
           git --no-pager diff --exit-code --color
 
   bench:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -254,7 +254,7 @@ jobs:
       # Non-empty diff could be a Cargo.lock that wasn't committed.
       - name: Ensure empty git diff
         run: |
-          echo ${{ steps.default_members.outputs.${{ matrix.directory }}_Cargo }} > ${{ matrix.directory }}/Cargo.toml
+          echo "${{ steps.default_members.outputs.${{ matrix.directory }}_Cargo }}" > ${{ matrix.directory }}/Cargo.toml
           git --no-pager diff --exit-code --color
 
   bench:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -252,6 +252,18 @@ jobs:
         if: matrix.directory == 'packages/engine'
         run: cargo test --manifest-path ${{ matrix.directory }}/Cargo.toml --no-run ${{ matrix.flags }}
 
+      - name: Generate diff after compilation
+        run: |
+          changed_files="$(git diff --name-only HEAD)"
+          echo "GIT_DIFF=$(echo $changed_files)"
+
+      - name: Check diff is empty after compilation
+        uses: actions/github-script@v3
+        if: ${{ env.GIT_DIFF }} && ${{ env.GIT_DIFF }} != ""
+        with:
+          script: |
+            core.setFailed('Diff was not empty after compilation')
+
       - name: Setup Python environment
         if: matrix.directory == 'packages/engine'
         working-directory: ${{ matrix.directory }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -206,7 +206,9 @@ jobs:
       - name: Remove and store default members
         id: default_members
         run: |
-          echo "::set-output name=Cargo::$(cat ${{ matrix.directory }}/Cargo.toml)"
+          cargo_toml=$(cat ${{ matrix.directory }}/Cargo.toml
+          echo "ORIGINAL_CARGO_TOML<<EOF" >> $GITHUB_ENV
+          echo "$cargo_toml" >> $GITHUB_ENV
           sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
 
       - name: Install Rust
@@ -254,7 +256,7 @@ jobs:
       # Non-empty diff could be a Cargo.lock that wasn't committed.
       - name: Ensure empty git diff
         run: |
-          echo "${{ steps.default_members.outputs.Cargo }}" > ${{ matrix.directory }}/Cargo.toml
+          echo "${{ env.ORIGINAL_CARGO_TOML }}" > ${{ matrix.directory }}/Cargo.toml
           git --no-pager diff --exit-code --color
 
   bench:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -209,6 +209,7 @@ jobs:
           cargo_toml=$(cat ${{ matrix.directory }}/Cargo.toml)
           echo "ORIGINAL_CARGO_TOML<<EOF" >> $GITHUB_ENV
           echo "$cargo_toml" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
           sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
 
       - name: Install Rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -207,7 +207,9 @@ jobs:
         id: default_members
         run: |
           cargo_toml=$(< ${{ matrix.directory }}/Cargo.toml)
-          echo "ORIGINAL_CARGO_TOML=$cargo_toml" >> $GITHUB_ENV
+          echo "ORIGINAL_CARGO_TOML<<EOF" >> $GITHUB_ENV
+          echo "$cargo_toml" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
           sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
 
       - name: Install Rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -238,13 +238,17 @@ jobs:
         if: matrix.directory == 'packages/engine'
         run: cargo test --manifest-path ${{ matrix.directory }}/Cargo.toml --no-run ${{ matrix.flags }}
 
-      - name: Check diff is empty before tests
+      - name: Generate diff before tests
         uses: technote-space/get-diff-action@v6
+        if: matrix.directory == 'packages/engine'
+
+      - name: Check diff is empty before tests
+        uses: actions/github-script@v3
         if: matrix.directory == 'packages/engine' && ${{ env.GIT_DIFF }}
         with:
           script: |
             console.log("${{ env.GIT_DIFF }}")
-            exit 1
+            core.setFailed('Diff was not empty before tests')
 
       - name: Setup Python environment
         if: matrix.directory == 'packages/engine'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -253,7 +253,7 @@ jobs:
       # Non-empty diff could be a Cargo.lock that wasn't committed.
       - name: Ensure empty git diff
         run: |
-          mv "${{ matrix.directory }}/Cargo.toml.orig" "${{ matrix.directory }}/Cargo.toml"
+          mv -v "${{ matrix.directory }}/Cargo.toml.orig" "${{ matrix.directory }}/Cargo.toml"
           git --no-pager diff --exit-code --color
 
   bench:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -173,20 +173,18 @@ jobs:
       - name: Run clippy
         run: cargo clippy --manifest-path ${{ matrix.directory }}/Cargo.toml --no-deps --tests ${{ matrix.flags }} -- -D warnings
 
-      - name: Generate diff before tests
+      - name: Generate diff after compilation
         run: |
           changed_files="$(git diff --name-only HEAD)"
           echo $changed_files
-          git --no-pager diff packages/engine
-          echo "GIT_DIFF=$(git --no-pager diff packages/engine)"
+          echo "GIT_DIFF=$($changed_files)"
 
-      - name: Check diff is empty before tests
+      - name: Check diff is empty after compilation
         uses: actions/github-script@v3
-        if: matrix.directory == 'packages/engine' && ${{ env.GIT_DIFF }} != ""
+        if: ${{ env.GIT_DIFF }} != ""
         with:
           script: |
-            console.log(${{ env.GIT_DIFF }})
-            core.setFailed('Diff was not empty before tests')
+            core.setFailed('Diff was not empty after compilation')
 
       - name: Annotate
         if: ${{ failure() }}
@@ -255,21 +253,6 @@ jobs:
         if: matrix.directory == 'packages/engine'
         run: cargo test --manifest-path ${{ matrix.directory }}/Cargo.toml --no-run ${{ matrix.flags }}
 
-      - name: Generate diff before tests
-        run: |
-          changed_files="$(git diff --name-only HEAD)"
-          echo $changed_files
-          git --no-pager diff packages/engine
-          echo "GIT_DIFF=$(git --no-pager diff packages/engine)"
-
-      - name: Check diff is empty before tests
-        uses: actions/github-script@v3
-        if: matrix.directory == 'packages/engine' && ${{ env.GIT_DIFF }} != ""
-        with:
-          script: |
-            console.log(${{ env.GIT_DIFF }})
-            core.setFailed('Diff was not empty before tests')
-
       - name: Setup Python environment
         if: matrix.directory == 'packages/engine'
         working-directory: ${{ matrix.directory }}
@@ -278,20 +261,6 @@ jobs:
 
       - name: Run tests
         run: cargo test --manifest-path ${{ matrix.directory }}/Cargo.toml --no-fail-fast ${{ matrix.flags }}
-
-      - name: Generate diff after tests
-        id: diff_after_tests
-        if: matrix.directory == 'packages/engine'
-        run: |
-          echo "DIFF_AFTER_TESTS=$(git diff ${{ matrix.directory }})" >> $GITHUB_ENV
-
-      - name: Check diff is empty after tests
-        uses: actions/github-script@v3
-        if: matrix.directory == 'packages/engine' && ${{ env.DIFF_AFTER_TESTS }}
-        with:
-          script: |
-            console.log(`${process.env.DIFF_AFTER_TESTS}`)
-            core.setFailed('Diff was not empty after tests')
 
   bench:
     name: bench

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -203,12 +203,14 @@ jobs:
         uses: actions/checkout@v2
 
       # Store `Cargo.toml` before modifying it to not affect the diff.
-      - name: Remove and store default members
-        id: default_members
-        run: |
-          cargo_toml=`cat ${{ matrix.directory }}/Cargo.toml`
-          echo "CARGO_TOML=$($cargo_toml)" >> $GITHUB_ENV
-          sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
+      - name: Store original Cargo.toml
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.toolchain }}/Cargo.toml
+          path: ${{ matrix.directory }}/Cargo.toml
+
+      - name: Remove default members
+        run: sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
 
       - name: Install Rust
         id: toolchain
@@ -252,11 +254,14 @@ jobs:
       - name: Run tests
         run: cargo test --manifest-path ${{ matrix.directory }}/Cargo.toml --no-fail-fast ${{ matrix.flags }}
 
+      - name: Restore Cargo.toml
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ matrix.toolchain }}/Cargo.toml
+
       # Non-empty diff could be a Cargo.lock that wasn't committed.
       - name: Ensure empty git diff
-        run: |
-          echo $CARGO_TOML > ${{ matrix.directory }}/Cargo.toml
-          git --no-pager diff --exit-code --color
+        run: git --no-pager diff --exit-code --color
 
   bench:
     name: bench

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -242,14 +242,16 @@ jobs:
         id: diff_before_tests
         if: matrix.directory == 'packages/engine'
         run: |
-          echo "DIFF_BEFORE_TESTS=$(git diff ${{ matrix.directory }})" >> $GITHUB_ENV
+          diff = git diff ${{ matrix.directory }}
+          echo "::$diff::"
+          echo "::set-output name=DIFF_BEFORE_TESTS::$(diff)"
 
       - name: Check diff is empty before tests
         uses: actions/github-script@v3
-        if: matrix.directory == 'packages/engine' && ${{ env.DIFF_BEFORE_TESTS }} != ""
+        if: matrix.directory == 'packages/engine' && ${{ steps.diff_before_tests.DIFF_BEFORE_TESTS }}
         with:
           script: |
-            console.log(`${process.env.DIFF_BEFORE_TESTS}`)
+            console.log(`${steps.diff_before_tests.DIFF_BEFORE_TESTS}`)
             core.setFailed('Diff was not empty before tests')
 
       - name: Setup Python environment
@@ -269,7 +271,7 @@ jobs:
 
       - name: Check diff is empty after tests
         uses: actions/github-script@v3
-        if: matrix.directory == 'packages/engine' && ${{ env.DIFF_AFTER_TESTS }} != ""
+        if: matrix.directory == 'packages/engine' && ${{ env.DIFF_AFTER_TESTS }}
         with:
           script: |
             console.log(`${process.env.DIFF_AFTER_TESTS}`)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -207,9 +207,9 @@ jobs:
         id: default_members
         run: |
           cargo_toml=$(cat ${{ matrix.directory }}/Cargo.toml)
-          echo "ORIGINAL_CARGO_TOML<<EOF" >> $GITHUB_ENV
+          echo "ORIGINAL_CARGO_TOML<<'EOF'" >> $GITHUB_ENV
           echo "$cargo_toml" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          echo "'EOF'" >> $GITHUB_ENV
           sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
 
       - name: Install Rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -239,8 +239,10 @@ jobs:
         run: cargo test --manifest-path ${{ matrix.directory }}/Cargo.toml --no-run ${{ matrix.flags }}
 
       - name: Check diff is empty before tests
-        if: matrix.directory == 'packages/engine' && git diff ${{ matrix.directory }} != 1
-        run: exit 1
+        uses: actions/github-script@v3
+        if: matrix.directory == 'packages/engine' && git diff ${{ matrix.directory }} != ""
+        run: |
+          core.setFailed('Diff was not empty before tests')
 
       - name: Setup Python environment
         if: matrix.directory == 'packages/engine'
@@ -251,9 +253,11 @@ jobs:
       - name: Run tests
         run: cargo test --manifest-path ${{ matrix.directory }}/Cargo.toml --no-fail-fast ${{ matrix.flags }}
 
-      - name: Check diff is empty after tests
-        if: matrix.directory == 'packages/engine' && git diff ${{ matrix.directory }} != 1
-        run: exit 1
+      - name: Check diff is empty before tests
+        uses: actions/github-script@v3
+        if: matrix.directory == 'packages/engine' && git diff ${{ matrix.directory }} != ""
+        run: |
+          core.setFailed('Diff was not empty after tests')
 
   bench:
     name: bench

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -173,21 +173,6 @@ jobs:
       - name: Run clippy
         run: cargo clippy --manifest-path ${{ matrix.directory }}/Cargo.toml --no-deps --tests ${{ matrix.flags }} -- -D warnings
 
-      - name: Ensure empty git diff
-        run: git --no-pager diff --exit-code --color
-
-      - name: Generate diff after compilation
-        run: |
-          changed_files="$(git diff --name-only HEAD)"
-          echo "GIT_DIFF=$(echo $changed_files)"
-
-      - name: Check diff is empty after compilation
-        uses: actions/github-script@v3
-        if: ${{ env.GIT_DIFF }} && ${{ env.GIT_DIFF }} != ""
-        with:
-          script: |
-            core.setFailed('Diff was not empty after compilation')
-
       - name: Annotate
         if: ${{ failure() }}
         # use `actions-rs/clippy-check@v1` when https://github.com/actions-rs/clippy-check/pull/158 is merged
@@ -255,9 +240,6 @@ jobs:
         if: matrix.directory == 'packages/engine'
         run: cargo test --manifest-path ${{ matrix.directory }}/Cargo.toml --no-run ${{ matrix.flags }}
 
-      - name: Ensure empty git diff
-        run: git --no-pager diff --exit-code --color
-
       - name: Setup Python environment
         if: matrix.directory == 'packages/engine'
         working-directory: ${{ matrix.directory }}
@@ -267,6 +249,7 @@ jobs:
       - name: Run tests
         run: cargo test --manifest-path ${{ matrix.directory }}/Cargo.toml --no-fail-fast ${{ matrix.flags }}
 
+      # Non empty diff can be a Cargo.lock that wasn't pushed.
       - name: Ensure empty git diff
         run: git --no-pager diff --exit-code --color
 

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -20,7 +20,7 @@ clap = { version = "3.0.0", features = ["cargo", "derive", "env"] }
 csv = "1.1.5"
 derive-new = "0.5"
 flatbuffers = "2.1.1"
-float-cmp = "0.8.0"
+float-cmp = "0.9.0"
 futures = { version = "0.3.6", features = ["std"] }
 glob = "0.3.0"
 http-types = "2.6.0"

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -20,7 +20,7 @@ clap = { version = "3.0.0", features = ["cargo", "derive", "env"] }
 csv = "1.1.5"
 derive-new = "0.5"
 flatbuffers = "2.1.1"
-float-cmp = "0.9.0"
+float-cmp = "0.8.0"
 futures = { version = "0.3.6", features = ["std"] }
 glob = "0.3.0"
 http-types = "2.6.0"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Making sure no generated file were forgotten when opening a PR.
This can happen with `Cargo.lock` for example.

## 🔍 What does this change?

- Add a check to make sure that the `git diff` is empty after tests.

### 📜 Does this require a change to the docs?

No

## ❓ How to test this?

In theory push a commit with an outdated `Cargo.lock`.
You can see it on this commit https://github.com/hashintel/hash/runs/6120802375?check_suite_focus=true.
As opposed to the same code but with the `Cargo.lock` https://github.com/hashintel/hash/pull/498/checks?sha=3516ca3216780945ad2c8140b4b18ff2af4f8a4d.