### PR TITLE
Add missing Cargo.lock

### DIFF
--- a/packages/engine/Cargo.lock
+++ b/packages/engine/Cargo.lock
@@ -2645,8 +2645,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.41.0"
-source = "git+https://github.com/hashdeps/rusty_v8?rev=0bf4d26961697591baf54bc4ceb0d15d3f195f86#0bf4d26961697591baf54bc4ceb0d15d3f195f86"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d743ec43aa5297faec64715b85411340495cac129e34e9cce1a0e879557d32c"
 dependencies = [
  "bitflags",
  "fslock",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Merge a `Cargo.lock` forgotten in https://github.com/hashintel/hash/pull/487.

## 🔍 What does this change?

- Add the missing `Cargo.lock`.

### 📜 Does this require a change to the docs?

No