### PR TITLE
Enable Rust backtrace on CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -198,6 +198,7 @@ jobs:
           - ""
     env:
       OUTPUT_DIRECTORY: test-results
+      RUST_BACKTRACE: 1
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2

--- a/packages/engine/tests/integration.rs
+++ b/packages/engine/tests/integration.rs
@@ -37,7 +37,6 @@ macro_rules! run_test {
         $(#[$attr])*
         #[tokio::test]
         async fn $project() {
-            panic!();
             let project_path = std::path::Path::new(file!())
                 .parent()
                 .unwrap()

--- a/packages/engine/tests/integration.rs
+++ b/packages/engine/tests/integration.rs
@@ -37,6 +37,7 @@ macro_rules! run_test {
         $(#[$attr])*
         #[tokio::test]
         async fn $project() {
+            panic!();
             let project_path = std::path::Path::new(file!())
                 .parent()
                 .unwrap()


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Enable backtrace for tests to better understand the error.

## 🔍 What does this change?

- Set the "RUST_BACKTRACE" environment variable to 1 when running tests.

### 📜 Does this require a change to the docs?

No

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1199548034582004/1202022593956537/f) _(internal)_

## ❓ How to test this?

In theory push a commit that makes a test panic and check the backtrace is displayed in the github action's log.
You can see it here https://github.com/hashintel/hash/runs/6130654178?check_suite_focus=true.

## 📹 Demo

![image](https://user-images.githubusercontent.com/45027362/164745203-d39e29fc-189b-417c-acad-ed733010fccd.png)
