### PR TITLE
Watch links & aggregations via realtime, and respond in collab

### DIFF
--- a/packages/hash/api/src/collab/EntityWatcher.ts
+++ b/packages/hash/api/src/collab/EntityWatcher.ts
@@ -60,11 +60,14 @@ export class EntityWatcher {
      */
     if (msg.action !== "D") {
       const message: RealtimeMessage =
-        table === "entity_versions"
-          ? { table, record: EntityVersion.parseWal2JsonMsg(msg) }
-          : table === "link_versions"
-          ? { table, record: LinkVersion.parseWal2JsonMsg(msg) }
-          : { table, record: AggregationVersion.parseWal2JsonMsg(msg) };
+        msg.table === "entity_versions"
+          ? { table: msg.table, record: EntityVersion.parseWal2JsonMsg(msg) }
+          : msg.table === "link_versions"
+          ? { table: msg.table, record: LinkVersion.parseWal2JsonMsg(msg) }
+          : {
+              table: msg.table,
+              record: AggregationVersion.parseWal2JsonMsg(msg),
+            };
 
       for (const subscriber of this.subscriptions) {
         try {

--- a/packages/hash/api/src/collab/EntityWatcher.ts
+++ b/packages/hash/api/src/collab/EntityWatcher.ts
@@ -59,31 +59,12 @@ export class EntityWatcher {
      * @todo address this
      */
     if (msg.action !== "D") {
-      let message: RealtimeMessage;
-      switch (msg.table) {
-        case "entity_versions":
-          message = {
-            table: msg.table,
-            record: EntityVersion.parseWal2JsonMsg(msg),
-          };
-          break;
-        case "link_versions":
-          message = {
-            table: msg.table,
-            record: LinkVersion.parseWal2JsonMsg(msg),
-          };
-          break;
-        case "aggregation_versions":
-          message = {
-            table: msg.table,
-            record: AggregationVersion.parseWal2JsonMsg(msg),
-          };
-          break;
-        default:
-          throw new Error(
-            `Unexpected record from table '${msg.table}' when processing message.`,
-          );
-      }
+      const message: RealtimeMessage =
+        table === "entity_versions"
+          ? { table, record: EntityVersion.parseWal2JsonMsg(msg) }
+          : table === "link_versions"
+          ? { table, record: LinkVersion.parseWal2JsonMsg(msg) }
+          : { table, record: AggregationVersion.parseWal2JsonMsg(msg) };
 
       for (const subscriber of this.subscriptions) {
         try {

--- a/packages/hash/api/src/collab/Instance.ts
+++ b/packages/hash/api/src/collab/Instance.ts
@@ -283,7 +283,7 @@ export class Instance {
       const affectedEntityRefs: LatestEntityRef[] =
         table === "entity_versions"
           ? [getEntityRef(record)] // an entity itself has been updated - get its ref
-          : await getEntityRefsFromLinkOrAggregation(record); // a link has been updated - get the linked entities
+          : await getEntityRefsFromLinkOrAggregation(record); // a link or linked aggregation has been updated - get the affected entities
 
       /**
        * Determine which blocks to refresh by checking if any of the entities within it are affected

--- a/packages/hash/api/src/collab/Instance.ts
+++ b/packages/hash/api/src/collab/Instance.ts
@@ -1,5 +1,5 @@
 import { ApolloClient } from "@apollo/client";
-import { EntityVersion } from "@hashintel/hash-backend-utils/pgTables";
+import { RealtimeMessage } from "@hashintel/hash-backend-utils/realtime";
 import { CollabPosition } from "@hashintel/hash-shared/collab";
 import { createProseMirrorState } from "@hashintel/hash-shared/createProseMirrorState";
 import {
@@ -17,6 +17,10 @@ import {
 import {
   GetBlocksQuery,
   GetBlocksQueryVariables,
+  GetLinkedAggregationQuery,
+  GetLinkedAggregationQueryVariables,
+  GetLinkQuery,
+  GetLinkQueryVariables,
   GetPageQuery,
   GetPageQueryVariables,
   LatestEntityRef,
@@ -28,6 +32,10 @@ import {
   getPageQuery,
 } from "@hashintel/hash-shared/queries/page.queries";
 import {
+  getLinkedAggregationIdentifierFieldsQuery,
+  getLinkQuery,
+} from "@hashintel/hash-shared/queries/link.queries";
+import {
   createNecessaryEntities,
   updatePageMutation,
 } from "@hashintel/hash-shared/save";
@@ -36,6 +44,10 @@ import { isEqual, memoize, pick } from "lodash";
 import { Schema } from "prosemirror-model";
 import { EditorState } from "prosemirror-state";
 import { Step } from "prosemirror-transform";
+import {
+  AggregationVersion,
+  LinkVersion,
+} from "@hashintel/hash-backend-utils/pgTables";
 import { logger } from "../logger";
 import { EntityWatcher } from "./EntityWatcher";
 import { InvalidVersionError } from "./errors";
@@ -116,7 +128,7 @@ export class Instance {
     }, POSITION_CLEANUP_INTERVAL);
 
     this.unsubscribeFromEntityWatcher = this.entityWatcher.subscribe(
-      (entityVersion) => this.processEntityVersion(entityVersion),
+      (message) => this.processWatcherMessage(message),
     );
   }
 
@@ -170,7 +182,7 @@ export class Instance {
    * talk to the GraphQL server to resolve links on the incoming entity, and
    * walkValueForEntity cannot handle async operations
    */
-  private async processEntityVersion(entityVersion: EntityVersion) {
+  private async processWatcherMessage({ table, record }: RealtimeMessage) {
     if (this.errored) {
       return;
     }
@@ -203,16 +215,107 @@ export class Instance {
         ({ accountId, entityId }) => `${accountId}/${entityId}`,
       );
 
-      const entityVersionTime = new Date(entityVersion.updatedAt).getTime();
-      const entityVersionRef = getEntityRef(entityVersion);
+      /**
+       * This fetches entity references relevant to the provided LinkVersion or AggregationVersion.
+       * Multiple entity refs may be returned, as a LinkVersion has both a source and a destination.
+       * The LinkedEntities for a destination can change if any of its properties are resolved via incoming links.
+       * This uses {@link getEntityRef} to memoize the refs, so they can be checked against refs
+       * acquired through that function directly.
+       */
+      const getEntityRefsFromLinkOrAggregation = (
+        recordToGetIdsFrom: LinkVersion | AggregationVersion,
+      ): Promise<LatestEntityRef[]> => {
+        const variables =
+          "linkId" in recordToGetIdsFrom
+            ? {
+                sourceAccountId: recordToGetIdsFrom.sourceAccountId,
+                linkId: recordToGetIdsFrom.linkId,
+              }
+            : {
+                sourceAccountId: recordToGetIdsFrom.sourceAccountId,
+                aggregationId: recordToGetIdsFrom.aggregationId,
+              };
+        return this.fallbackClient
+          .query<
+            GetLinkQuery | GetLinkedAggregationQuery,
+            GetLinkQueryVariables | GetLinkedAggregationQueryVariables
+          >({
+            query:
+              "linkId" in recordToGetIdsFrom
+                ? getLinkQuery
+                : getLinkedAggregationIdentifierFieldsQuery,
+            variables,
+            fetchPolicy: "network-only",
+          })
+          .then(({ data }) => {
+            if ("getLink" in data) {
+              const {
+                sourceAccountId,
+                sourceEntityId,
+                destinationAccountId,
+                destinationEntityId,
+              } = data.getLink;
+              return [
+                getEntityRef({
+                  accountId: sourceAccountId,
+                  entityId: sourceEntityId,
+                }),
+                getEntityRef({
+                  accountId: destinationAccountId,
+                  entityId: destinationEntityId,
+                }),
+              ];
+            } else {
+              const { sourceAccountId, sourceEntityId } =
+                data.getLinkedAggregation;
+              return [
+                getEntityRef({
+                  accountId: sourceAccountId,
+                  entityId: sourceEntityId,
+                }),
+              ];
+            }
+          });
+      };
 
+      const recordUpdatedAt = new Date(record.updatedAt).getTime();
+
+      const affectedEntityRefs: LatestEntityRef[] =
+        table === "entity_versions"
+          ? [getEntityRef(record)] // an entity itself has been updated - get its ref
+          : await getEntityRefsFromLinkOrAggregation(record); // a link has been updated - get the linked entities
+
+      /**
+       * Determine which blocks to refresh by checking if any of the entities within it are affected
+       */
       const blocksToRefresh = new Set(
         flatMapBlocks(this.savedContents, (entity, blockEntity) => {
           const entityRef = getEntityRef(entity);
 
+          // check if the entity itself is affected
+          let affected = affectedEntityRefs.includes(entityRef);
+
+          if ("linkedEntities" in entity) {
+            // this is the entity within the block, i.e. the 'child' entity
+            // check if any of its linked entities or linked aggregations are affected
+            affected =
+              entity.linkedEntities.some((linkedEntity) =>
+                affectedEntityRefs.includes(getEntityRef(linkedEntity)),
+              ) ||
+              entity.linkedAggregations.some(
+                ({ sourceAccountId, sourceEntityId }) =>
+                  affectedEntityRefs.includes(
+                    getEntityRef({
+                      accountId: sourceAccountId,
+                      entityId: sourceEntityId,
+                    }),
+                  ),
+              );
+          }
+
           if (
-            entityRef === entityVersionRef &&
-            entityVersionTime > new Date(entity.updatedAt).getTime()
+            affected &&
+            recordUpdatedAt > new Date(entity.updatedAt).getTime()
           ) {
             return [getEntityRef(blockEntity)];
           }

--- a/packages/hash/api/src/graphql/resolvers/index.ts
+++ b/packages/hash/api/src/graphql/resolvers/index.ts
@@ -71,6 +71,8 @@ import { orgEmailInvitationLinkedEntities } from "./orgEmailInvitation/linkedEnt
 import { orgInvitationLinkLinkedEntities } from "./orgInvitationLink/linkedEntities";
 import { pageSearchResultConnection } from "./paginationConnection/pageSearchResultConnection";
 import { executeDemoTask } from "./taskExecutor";
+import { getLink } from "./link/getLink";
+import { getLinkedAggregation } from "./linkedAggregation/getLinkedAggregation";
 
 export const resolvers = {
   Query: {
@@ -86,6 +88,8 @@ export const resolvers = {
     entity: loggedInAndSignedUp(entity),
     entities: loggedInAndSignedUp(canAccessAccount(entities)),
     getEntityType: loggedInAndSignedUp(getEntityType),
+    getLink: loggedInAndSignedUp(getLink),
+    getLinkedAggregation: loggedInAndSignedUp(getLinkedAggregation),
     page: canAccessAccount(page),
     getImpliedEntityHistory: loggedInAndSignedUp(getImpliedEntityHistory),
     getImpliedEntityVersion: loggedInAndSignedUp(getImpliedEntityVersion),

--- a/packages/hash/api/src/graphql/resolvers/link/getLink.ts
+++ b/packages/hash/api/src/graphql/resolvers/link/getLink.ts
@@ -1,0 +1,28 @@
+import { ApolloError } from "apollo-server-express";
+
+import { QueryGetLinkArgs, Resolver } from "../../apiTypes.gen";
+import { GraphQLContext } from "../../context";
+import { UnresolvedGQLLink, Link } from "../../../model";
+
+export const getLink: Resolver<
+  Promise<UnresolvedGQLLink>,
+  {},
+  GraphQLContext,
+  QueryGetLinkArgs
+> = async (_, { sourceAccountId, linkId }, { dataSources }) => {
+  return dataSources.db.transaction(async (client) => {
+    const link = await Link.get(client, {
+      sourceAccountId,
+      linkId,
+    });
+
+    if (!link) {
+      throw new ApolloError(
+        `Link with linkId '${linkId}' and sourceAccountId '${sourceAccountId}' not found`,
+        "NOT_FOUND",
+      );
+    }
+
+    return link.toUnresolvedGQLLink();
+  });
+};

--- a/packages/hash/api/src/graphql/resolvers/linkedAggregation/getLinkedAggregation.ts
+++ b/packages/hash/api/src/graphql/resolvers/linkedAggregation/getLinkedAggregation.ts
@@ -1,0 +1,28 @@
+import { ApolloError } from "apollo-server-express";
+
+import { QueryGetLinkedAggregationArgs, Resolver } from "../../apiTypes.gen";
+import { GraphQLContext } from "../../context";
+import { UnresolvedGQLLinkedAggregation, Aggregation } from "../../../model";
+
+export const getLinkedAggregation: Resolver<
+  Promise<UnresolvedGQLLinkedAggregation>,
+  {},
+  GraphQLContext,
+  QueryGetLinkedAggregationArgs
+> = async (_, { sourceAccountId, aggregationId }, { dataSources }) => {
+  return dataSources.db.transaction(async (client) => {
+    const linkedAggregation = await Aggregation.getAggregationById(client, {
+      sourceAccountId,
+      aggregationId,
+    });
+
+    if (!linkedAggregation) {
+      throw new ApolloError(
+        `LinkedAggregation with aggregationId '${aggregationId}' and sourceAccountId '${sourceAccountId}' not found`,
+        "NOT_FOUND",
+      );
+    }
+
+    return linkedAggregation.toGQLLinkedAggregation(client);
+  });
+};

--- a/packages/hash/api/src/graphql/typeDefs/aggregation.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/aggregation.typedef.ts
@@ -74,6 +74,14 @@ export const aggregationTypedef = gql`
       accountId: ID!
       operation: AggregateOperationInput!
     ): AggregationResponse!
+
+    """
+    Retrieve a linked aggregation
+    """
+    getLinkedAggregation(
+      sourceAccountId: ID!
+      aggregationId: ID!
+    ): LinkedAggregation!
   }
 
   extend type Mutation {

--- a/packages/hash/api/src/graphql/typeDefs/link.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/link.typedef.ts
@@ -48,6 +48,13 @@ export const linkTypedef = gql`
     destinationEntityVersionId: ID
   }
 
+  extend type Query {
+    """
+    Retrieve a link
+    """
+    getLink(sourceAccountId: ID!, linkId: ID!): Link!
+  }
+
   extend type Mutation {
     """
     Create a link

--- a/packages/hash/backend-utils/src/pgTables.ts
+++ b/packages/hash/backend-utils/src/pgTables.ts
@@ -37,6 +37,108 @@ export class EntityVersion {
     const obj = Object.fromEntries(
       msg.columns.map(({ name, value }) => [name, value]),
     );
-    return EntityVersion.parseFromRow(obj);
+    return this.parseFromRow(obj);
+  }
+}
+
+export class AggregationVersion {
+  constructor(
+    public aggregationId: string,
+    public aggregationVersionId: string,
+    public sourceAccountId: string,
+    public sourceEntityId: string,
+    public appliedToSourceAt: Date,
+    public appliedToSourceByAccountId: string,
+    public removedFromSourceAt: Date | undefined,
+    public removedFromSourceByAccountId: string | undefined,
+    public operation: any,
+    public updatedAt: Date,
+    public updatedByAccountId: string,
+  ) {}
+
+  private static parseFromRow(
+    row: Record<string, unknown>,
+  ): AggregationVersion {
+    return {
+      aggregationId: row.aggregation_id as string,
+      aggregationVersionId: row.aggregation_version_id as string,
+      sourceAccountId: row.source_account_id as string,
+      sourceEntityId: row.source_entity_id as string,
+      appliedToSourceAt: new Date(row.applied_to_source_at as string),
+      appliedToSourceByAccountId: row.applied_to_source_by_account_id as string,
+      removedFromSourceAt: row.removed_from_source_at
+        ? new Date(row.removed_from_source_at as string)
+        : undefined,
+      removedFromSourceByAccountId:
+        (row.removed_from_source_by_account_id as string | undefined) ??
+        undefined,
+      operation: row.operation,
+      updatedAt: new Date(row.updated_at as string),
+      updatedByAccountId: row.updated_by_account_id as string,
+    };
+  }
+
+  static parseWal2JsonMsg(msg: Wal2JsonMsg): AggregationVersion {
+    if (msg.table !== "aggregation_versions") {
+      throw new Error(
+        `invalid table "${msg.table}" for AggregationVersion type`,
+      );
+    }
+    const obj = Object.fromEntries(
+      msg.columns.map(({ name, value }) => [name, value]),
+    );
+    return this.parseFromRow(obj);
+  }
+}
+
+export class LinkVersion {
+  constructor(
+    public linkId: string,
+    public linkVersionId: string,
+    public index: number | undefined,
+    public sourceAccountId: string,
+    public sourceEntityId: string,
+    public appliedToSourceAt: Date,
+    public appliedToSourceByAccountId: string,
+    public removedFromSourceAt: Date | undefined,
+    public removedFromSourceByAccountId: string | undefined,
+    public destinationAccountId: string,
+    public destinationEntityId: string,
+    public destinationEntityVersionId: string | undefined,
+    public updatedAt: Date,
+    public updatedByAccountId: string,
+  ) {}
+
+  private static parseFromRow(row: Record<string, unknown>): LinkVersion {
+    return {
+      linkId: row.link_id as string,
+      linkVersionId: row.link_version_id as string,
+      index: row.index === null ? undefined : (row.index as number),
+      sourceAccountId: row.source_account_id as string,
+      sourceEntityId: row.source_entity_id as string,
+      appliedToSourceAt: new Date(row.applied_to_source_at as string),
+      appliedToSourceByAccountId: row.applied_to_source_by_account_id as string,
+      removedFromSourceAt: row.removed_from_source_at
+        ? new Date(row.removed_from_source_at as string)
+        : undefined,
+      removedFromSourceByAccountId:
+        (row.removed_from_source_by_account_id as string) ?? undefined,
+      destinationAccountId: row.destination_account_id as string,
+      destinationEntityId: row.destination_entity_id as string,
+      destinationEntityVersionId:
+        (row.destination_entity_version_id as string | undefined) ?? undefined,
+      updatedAt: new Date(row.updated_at as string),
+      updatedByAccountId: row.updated_by_account_id as string,
+    };
+  }
+
+  static parseWal2JsonMsg(msg: Wal2JsonMsg): LinkVersion {
+    if (msg.table !== "link_versions") {
+      throw new Error(`invalid table "${msg.table}" for LinkVersion type`);
+    }
+    const obj = Object.fromEntries(
+      msg.columns.map(({ name, value }) => [name, value]),
+    );
+    return this.parseFromRow(obj);
   }
 }

--- a/packages/hash/backend-utils/src/realtime.ts
+++ b/packages/hash/backend-utils/src/realtime.ts
@@ -1,0 +1,26 @@
+import {
+  EntityVersion,
+  AggregationVersion,
+  LinkVersion,
+} from "@hashintel/hash-backend-utils/pgTables";
+
+export const supportedRealtimeTables = [
+  "entity_versions",
+  "aggregation_versions",
+  "link_versions",
+] as const;
+
+export type SupportedRealtimeTable = typeof supportedRealtimeTables[number];
+
+export const isSupportedRealtimeTable = (
+  table: string,
+): table is SupportedRealtimeTable =>
+  supportedRealtimeTables.includes(table as SupportedRealtimeTable);
+
+export type RealtimeMessage =
+  | {
+      table: "entity_versions";
+      record: EntityVersion;
+    }
+  | { table: "aggregation_versions"; record: AggregationVersion }
+  | { table: "link_versions"; record: LinkVersion };

--- a/packages/hash/realtime/src/config.ts
+++ b/packages/hash/realtime/src/config.ts
@@ -3,9 +3,12 @@ import { RedisQueueProducer } from "@hashintel/hash-backend-utils/queue/redis";
 import { QueueProducer } from "@hashintel/hash-backend-utils/queue/adapter";
 import { AsyncRedisClient } from "@hashintel/hash-backend-utils/redis";
 import { Logger } from "@hashintel/hash-backend-utils/logger";
+import { supportedRealtimeTables } from "@hashintel/hash-backend-utils/realtime";
 
 // The tables to monitor for changes
-export const MONITOR_TABLES = ["public.entity_versions"];
+export const MONITOR_TABLES = supportedRealtimeTables.map(
+  (table) => `public.${table}`,
+);
 
 // The realtime service will push all updates from the Postgres changestream to the
 // following queues.

--- a/packages/hash/shared/src/queries/link.queries.ts
+++ b/packages/hash/shared/src/queries/link.queries.ts
@@ -13,6 +13,68 @@ export const linkFieldsFragment = gql`
   }
 `;
 
+export const linkedAggregationsWithoutResultsFragment = gql`
+  fragment LinkedAggregationsWithoutResultsFields on LinkedAggregation {
+    sourceAccountId
+    sourceEntityId
+    path
+    operation {
+      entityTypeId
+      entityTypeVersionId
+      multiFilter {
+        filters {
+          field
+          value
+          operator
+        }
+        operator
+      }
+      multiSort {
+        field
+        desc
+      }
+      itemsPerPage
+      pageNumber
+      pageCount
+    }
+  }
+`;
+
+export const linkedAggregationIdentifierFieldsFragment = gql`
+  fragment LinkedAggregationIdentifierFields on LinkedAggregation {
+    aggregationId
+    sourceAccountId
+    sourceEntityId
+  }
+`;
+
+export const getLinkQuery = gql`
+  query getLink($linkId: ID!, $sourceAccountId: ID!) {
+    getLink(linkId: $linkId, sourceAccountId: $sourceAccountId) {
+      ...LinkFields
+    }
+  }
+  ${linkFieldsFragment}
+`;
+
+/**
+ * doesn't include the results of a linked aggregation, which is an expensive operation
+ * @todo should do this with a @skip directive on the existing {@link linkedAggregationsFragment}
+ *    but linting warns about unused variable on the query (e.g. $skipResults: Boolean=true) if you do this
+ *    @see https://stackoverflow.com/a/58251208/17217717 for how to do a fragment with skip/include directive
+ */
+export const getLinkedAggregationIdentifierFieldsQuery = gql`
+  query getLinkedAggregation($aggregationId: ID!, $sourceAccountId: ID!) {
+    getLinkedAggregation(
+      aggregationId: $aggregationId
+      sourceAccountId: $sourceAccountId
+    ) {
+      ...LinkedAggregationsWithoutResultsFields
+    }
+  }
+  ${linkedAggregationsWithoutResultsFragment}
+`;
+
 export const createLinkMutation = gql`
   mutation createLink($link: CreateLinkInput!) {
     createLink(link: $link) {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
Our collab service, which the frontend relies on for the document state, is subscribed to realtime updates from the db for records which are updated via some other means than collab. When receiving these updates, it checks if they affect the document, and refreshes it if so.

Previously, it was only receiving updates on the `entity_versions` table. Since #364 meant that new `entity_versions` are **not** created when a link from an entity is created/updated, and #484 took the same approach for linked aggregations, there are updates which should lead to a change in the document which (a) collab is not set up to check for, and (b) realtime is not notifying subscribers about anyway.

This PR fixes that by (a) making the realtime service send out notifications of changes to links/aggregations, and (b) updates collab to process those notifications and refresh the document accordingly.

This fixes the bug mentioned in #497 where changing the table block's linked aggregation is not reflected in the document.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1200211978612931/1202165937631283/f) _(internal)_

## 🔍 What does this change?

- See commits.

## 🐾 Next steps

- There are a couple of other places that need updating in collab and the frontend to take account of the latest links/linked aggregation system (various tasks exist for this).

## 🛡 What tests cover this?

- None.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  See if the table block updates when changing the dropdown (it will take a couple seconds for the roundtrip to the db and back via collab)
2. Check the document otherwise updates as expected.

