### PR TITLE
Disable twind preflight

### DIFF
--- a/packages/hash/frontend/twind.config.js
+++ b/packages/hash/frontend/twind.config.js
@@ -7,6 +7,7 @@
 
 /** @type {import('twind').Configuration} */
 module.exports = {
+  preflight: false,
   theme: {
     extend: {
       colors: {},


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Disables the Tailwind [preflight](https://tailwindcss.com/docs/preflight) CSS. We already had `preflight: false` in `tailwind.config.js` but we also need it in `twind.config.js` to properly turn it off, which this does.

Tailwind is not sticking around in the app long term, because we're using MUI for component styling instead. We'll remove it incrementally as we redesign existing components which are currently using Tailwind.

## ⚠️ Known issues

Some elements now appear differently, e.g. link colour in sidebar, button text background.

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

- Check and fix styles which are now broken in the sidebar.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
<img width="1366" alt="Screenshot 2022-04-26 at 08 43 31" src="https://user-images.githubusercontent.com/37743469/165266218-421f2bc1-ef45-4c35-b640-96e16da36f60.png">

