### PR TITLE
Fixes: aggregate sorting; collab change detection; block handle alignment

### DIFF
--- a/packages/hash/api/src/collab/Instance.ts
+++ b/packages/hash/api/src/collab/Instance.ts
@@ -295,9 +295,10 @@ export class Instance {
           // check if the entity itself is affected
           let affected = affectedEntityRefs.includes(entityRef);
 
-          if ("linkedEntities" in entity) {
+          if (!affected && "linkedEntities" in entity) {
             // this is the entity within the block, i.e. the 'child' entity
             // check if any of its linked entities or linked aggregations are affected
+            // we don't need to check this if we already know it's affected
             affected =
               entity.linkedEntities.some((linkedEntity) =>
                 affectedEntityRefs.includes(getEntityRef(linkedEntity)),

--- a/packages/hash/api/src/model/aggregation.model.ts
+++ b/packages/hash/api/src/model/aggregation.model.ts
@@ -212,7 +212,7 @@ class __Aggregation {
           return field;
         }
 
-        return (entity) => entity.properties[field];
+        return (entity) => get(entity.properties, field);
       }),
       multiSort.map(({ desc }) => (desc ? "desc" : "asc")),
     );

--- a/packages/hash/frontend/src/blocks/page/BlockView.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockView.tsx
@@ -98,6 +98,7 @@ export const BlockHandle = forwardRef<HTMLDivElement, BlockHandleProps>(
         sx={{
           position: "relative",
           cursor: "pointer",
+          height: 24,
         }}
         data-testid="block-changer"
       >

--- a/packages/hash/frontend/src/blocks/page/style.module.css
+++ b/packages/hash/frontend/src/blocks/page/style.module.css
@@ -17,7 +17,7 @@
 
 .Block {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   word-break: break-all;
   margin: 30px 0;
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
Fixes the following
1. Collab change detection: previously re-calculated based on linkedEntities when affected status was already true (possibly setting it to false again) ([Internal thread](https://hashintel.slack.com/archives/C022217GAHF/p1650989640608069))
2. Enable sorting by nested properties (use lodash `get`) ([Internal thread](https://hashintel.slack.com/archives/C02LG39FJAU/p1650969257542389))
3. Vertically align block handle to top, not centre ([Internal thread](https://hashintel.slack.com/archives/C022217GAHF/p1650896905203879))