### PR TITLE
Fix checkbox in block config menu

### DIFF
--- a/packages/hash/frontend/src/blocks/page/BlockConfigMenu/BlockConfigMenu.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockConfigMenu/BlockConfigMenu.tsx
@@ -82,8 +82,8 @@ const ConfigurationInput: VoidFunctionComponent<{
         <FormControlLabel
           control={
             <Checkbox
-              onChange={updateProperty}
-              checked={typeof value === "boolean" ? value : false}
+              onChange={(event) => onChange(event.target.checked)}
+              checked={typeof value === "boolean" ? value : value === "true"}
             />
           }
           label={name}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes a bug whereby the checkbox for dealing with boolean values in the block config menu did not become checked.

This is because it was sending a string as a property value, rather than a boolean, and so it was never receiving a boolean back.

I've also added a fallback to become checked if it is given a string value "true".

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Add `"configProperties": ["myBooleanProperty"]` to your block-schema.json, where `myBooleanProperty` is a boolean property listed in `"properties"` in your schema.
2. Check that clicking the checkbox makes a check appear, and the property update properly.