### PR TITLE
Make delete block button functional. Hide non-functional buttons

### DIFF
--- a/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockContextMenu.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockContextMenu.tsx
@@ -32,10 +32,11 @@ import { BlockListMenuContent } from "./BlockListMenuContent";
 
 type BlockContextMenuProps = {
   blockEntity: BlockEntity | null;
-  popupState: PopupState;
   blockSuggesterProps: BlockSuggesterProps;
+  deleteBlock: () => void;
   entityId: string | null;
   openConfigMenu: () => void;
+  popupState: PopupState;
 };
 
 const LOAD_BLOCK_ENTITY_UI = "hash-load-entity-ui";
@@ -45,7 +46,14 @@ export const BlockContextMenu = forwardRef<
   BlockContextMenuProps
 >(
   (
-    { blockEntity, popupState, blockSuggesterProps, entityId, openConfigMenu },
+    {
+      blockEntity,
+      blockSuggesterProps,
+      deleteBlock,
+      entityId,
+      openConfigMenu,
+      popupState,
+    },
     ref,
   ) => {
     const { data: users } = useUsers();
@@ -87,11 +95,13 @@ export const BlockContextMenu = forwardRef<
           key: "duplicate",
           title: "Duplicate",
           icon: <FontAwesomeIcon icon={faCopy} />,
+          isNotYetImplemented: true,
         },
         {
           key: "delete",
           title: "Delete",
           icon: <FontAwesomeIcon icon={faTrashCan} />,
+          onClick: deleteBlock,
         },
         {
           key: "swap-block",
@@ -106,11 +116,13 @@ export const BlockContextMenu = forwardRef<
           key: "move-to-page",
           title: "Move to page",
           icon: <FontAwesomeIcon icon={faArrowRight} />,
+          isNotYetImplemented: true,
         },
         {
           key: "comment",
           title: "Comment",
           icon: <FontAwesomeIcon icon={faMessage} />,
+          isNotYetImplemented: true,
         },
       ];
 
@@ -123,8 +135,9 @@ export const BlockContextMenu = forwardRef<
       return items;
     }, [
       blockEntity,
-      entityId,
       blockSuggesterProps,
+      entityId,
+      deleteBlock,
       openConfigMenu,
       popupState,
     ]);
@@ -169,7 +182,15 @@ export const BlockContextMenu = forwardRef<
         </Box>
 
         {menuItems.map(
-          ({ key, title, icon, onClick, subMenu, subMenuWidth }) => {
+          ({
+            icon,
+            isNotYetImplemented,
+            key,
+            onClick,
+            subMenu,
+            subMenuWidth,
+            title,
+          }) => {
             if (key === "copy-link" && !entityId) {
               return null;
             }
@@ -180,6 +201,10 @@ export const BlockContextMenu = forwardRef<
             }
             if (key === "swap-block") {
               menuItemRef = swapBlocksMenuItemRef;
+            }
+
+            if (isNotYetImplemented) {
+              return null;
             }
 
             return (

--- a/packages/hash/frontend/src/blocks/page/BlockView.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockView.tsx
@@ -29,13 +29,14 @@ import { BlockConfigMenu } from "./BlockConfigMenu/BlockConfigMenu";
 import { useUserBlocks } from "../userBlocks";
 
 type BlockHandleProps = {
+  deleteBlock: () => void;
   entityId: string | null;
-  onTypeChange: BlockSuggesterProps["onChange"];
   entityStore: EntityStore;
+  onTypeChange: BlockSuggesterProps["onChange"];
 };
 
 export const BlockHandle = forwardRef<HTMLDivElement, BlockHandleProps>(
-  ({ entityId, onTypeChange, entityStore }, ref) => {
+  ({ deleteBlock, entityId, entityStore, onTypeChange }, ref) => {
     const blockMenuRef = useRef(null);
     const contextMenuPopupState = usePopupState({
       variant: "popover",
@@ -106,8 +107,9 @@ export const BlockHandle = forwardRef<HTMLDivElement, BlockHandleProps>(
 
         <BlockContextMenu
           blockEntity={blockEntity}
-          entityId={entityId}
           blockSuggesterProps={blockSuggesterProps}
+          deleteBlock={deleteBlock}
+          entityId={entityId}
           openConfigMenu={configMenuPopupState.open}
           popupState={contextMenuPopupState}
           ref={blockMenuRef}
@@ -333,10 +335,11 @@ export class BlockView implements NodeView<Schema> {
           onClick={this.onDragEnd}
         />
         <BlockHandle
-          ref={this.blockHandleRef}
+          deleteBlock={this.deleteBlock}
           entityId={blockEntityId}
-          onTypeChange={this.onBlockChange}
           entityStore={this.store}
+          onTypeChange={this.onBlockChange}
+          ref={this.blockHandleRef}
         />
       </BlockViewContext.Provider>,
       this.selectContainer,
@@ -351,6 +354,16 @@ export class BlockView implements NodeView<Schema> {
     this.dom.remove();
     document.removeEventListener("dragend", this.onDragEnd);
   }
+
+  deleteBlock = () => {
+    const { node, getPos } = this;
+    this.manager.deleteNode(node, getPos()).catch((err: Error) => {
+      // eslint-disable-next-line no-console -- TODO: consider using logger
+      console.error(
+        `Error deleting node at position ${getPos()}: ${err.message}`,
+      );
+    });
+  };
 
   onBlockChange = (variant: BlockVariant, meta: BlockConfig) => {
     const { node, editorView, getPos } = this;

--- a/packages/hash/shared/src/ProsemirrorSchemaManager.ts
+++ b/packages/hash/shared/src/ProsemirrorSchemaManager.ts
@@ -436,6 +436,23 @@ export class ProsemirrorSchemaManager {
     view.dispatch(tr);
   }
 
+  /**
+   * @todo consider removing the old block from the entity store
+   * @todo need to support variants here (copied from {@link replaceNodeWithRemoteBlock} - is this still relevant?
+   */
+  async deleteNode(node: ProsemirrorNode<Schema>, pos: number) {
+    const { view } = this;
+
+    if (!view) {
+      throw new Error("Cannot trigger replaceNodeWithRemoteBlock without view");
+    }
+
+    const { tr } = view.state;
+
+    tr.delete(pos, pos + node.nodeSize);
+    view.dispatch(tr);
+  }
+
   // @todo handle empty variant properties
   // @todo handle saving the results of this
   // @todo handle non-intermediary entities


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Makes the 'delete' button in the context menu delete a block. This makes it nicer to add a bunch of testing blocks and clean them up without abandoning the page.

I've also hidden the context menu items which do nothing, so that people aren't wondering if they're broken or unimplemented.

Also ordered some props to be alphabetical which were almost-but-not-quite.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202055186269233/1202189029159327/f) _(internal)_

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Click 'delete' in the block context menu
2. Refresh to check persistence