### PR TITLE
Provide BP functions and entity properties to HTML blocks

### DIFF
--- a/packages/blocks/html-para/block-schema.json
+++ b/packages/blocks/html-para/block-schema.json
@@ -1,5 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "properties": {},
+  "properties": {
+    "text": {
+      "type": "string"
+    }
+  },
   "type": "object"
 }

--- a/packages/blocks/html-para/index.html
+++ b/packages/blocks/html-para/index.html
@@ -1,10 +1,46 @@
-<p id="para-block" style="font-family: var(--font-family, 'Courier')">
-  Hello, world!
-  <script>
-    (() => {
-      const para = document.getElementById("para-block");
-      para.addEventListener("mouseover", () => (para.style.color = "red"));
-      para.addEventListener("mouseout", () => (para.style.color = "black"));
-    })();
-  </script>
+<script>
+  // Prevent declarations bleeding into the global scope by wrapping in an IIFE
+  // we'll have to repeat some code in the onsubmit handler as it can't reach this code
+  (() => {
+    // HTMLBlock attaches the entityId as an `data-entity-id` attribute
+    function getBlockEntityId(element) {
+      return element.parentElement.dataset.entityId;
+    }
+
+    function getBlockProperties(element) {
+      const entityId = getBlockEntityId(element);
+
+      // HTMLBlock assigns entity properties to the window when loading an HTML block
+      return window[entityId];
+    }
+
+    const parent = document.currentScript.parentElement;
+    const properties = getBlockProperties(document.currentScript);
+    if (properties) {
+      const paragraph = parent.querySelector("p");
+      paragraph.innerText = properties.text || "[No text entered]";
+    }
+  })();
+</script>
+
+<p>
+  Loading...
 </p>
+
+<form onsubmit="event.preventDefault(); const properties = window[this.parentElement.dataset.entityId]; window.updateEntities([
+      {
+        accountId: properties.accountId,
+        entityId: properties.entityId,
+        entityTypeId: properties.entityTypeId,
+        data: { text: this.querySelector('input').value }
+      }
+    ]); return false;"
+  >
+  <label>
+    Set new text
+    <input type="text" placeholder="New text for the paragraph" />
+  </label>
+  <button type="submit">
+    Update text
+  </button>
+</form>

--- a/packages/hash/frontend/src/components/BlockLoader/BlockLoader.tsx
+++ b/packages/hash/frontend/src/components/BlockLoader/BlockLoader.tsx
@@ -126,11 +126,15 @@ export const BlockLoader: VoidFunctionComponent<BlockLoaderProps> = ({
 
   return (
     <RemoteBlock
-      {...blockProperties}
-      {...functions}
-      linkedAggregations={
-        blockProperties.linkedAggregations as BlockProtocolLinkedAggregation[]
-      }
+      blockProperties={{
+        ...blockProperties,
+        entityId: blockProperties.entityId ?? null,
+        entityTypeId: blockProperties.entityTypeId ?? null,
+        entityTypeVersionId: blockProperties.entityTypeVersionId ?? null,
+        linkedAggregations:
+          blockProperties.linkedAggregations as BlockProtocolLinkedAggregation[],
+      }}
+      blockFunctions={functions}
       editableRef={editableRef}
       onBlockLoaded={onRemoteBlockLoaded}
       sourceUrl={sourceUrl}

--- a/packages/hash/frontend/src/components/HtmlBlock/HtmlBlock.tsx
+++ b/packages/hash/frontend/src/components/HtmlBlock/HtmlBlock.tsx
@@ -1,26 +1,59 @@
 import React, { useEffect, useRef, VoidFunctionComponent } from "react";
+import { BlockProtocolFunctions, BlockProtocolProps } from "blockprotocol";
 
 type HtmlBlockProps = {
+  blockFunctions: BlockProtocolFunctions;
+  blockProperties: Omit<BlockProtocolProps, keyof BlockProtocolFunctions>;
   html: string;
-  [key: string]: any;
 };
 
+declare global {
+  interface Window {
+    [key: string]: any;
+  }
+}
+
+/**
+ * Renders a block from a HTML string. Re-renders it when properties change.
+ * The entityId is attached to the parent element and the properties to the window, so that the block can pick it up.
+ * Without sandboxing, rendering a HTML block risks the block polluting the global scope, and is not advised.
+ * @see /packages/blocks/html-para/index.html for an example
+ * @todo add this 'attach to the window' approach to the spec or come up with a better one
+ */
 export const HtmlBlock: VoidFunctionComponent<HtmlBlockProps> = ({
+  blockFunctions,
+  blockProperties,
   html,
-  ...props
 }) => {
   const divRef = useRef<HTMLDivElement>(null);
+  const previousPropertiesString = useRef<string | null>(null);
 
   useEffect(() => {
     if (!divRef.current) {
       return;
     }
 
+    if (previousPropertiesString.current === JSON.stringify(blockProperties)) {
+      return;
+    }
+    previousPropertiesString.current = JSON.stringify(blockProperties);
+
     const docFragment = document.createRange().createContextualFragment(html);
 
     divRef.current.innerHTML = "";
     divRef.current.appendChild(docFragment);
-  }, [html]);
+  }, [blockProperties, html]);
 
-  return <div ref={divRef} {...props} />;
+  // attach the BP functions to the global scope if we haven't already
+  for (const [fnName, fn] of Object.entries(blockFunctions)) {
+    if (!window[fnName]) {
+      window[fnName] = fn;
+    }
+  }
+
+  // attach the block's own properties to the window under its entityId
+  window[blockProperties.entityId] = blockProperties;
+
+  // make the entityId available on `[div].dataset.entityId` so that the block can look it up
+  return <div ref={divRef} data-entity-id={blockProperties.entityId} />;
 };

--- a/packages/hash/frontend/src/components/RemoteBlock/RemoteBlock.tsx
+++ b/packages/hash/frontend/src/components/RemoteBlock/RemoteBlock.tsx
@@ -1,25 +1,30 @@
-import { BlockProtocolProps } from "blockprotocol";
+import { BlockProtocolFunctions, BlockProtocolProps } from "blockprotocol";
 import React from "react";
 
 import { HtmlBlock } from "../HtmlBlock/HtmlBlock";
 import { useRemoteBlock } from "./useRemoteBlock";
 
 type RemoteBlockProps = {
+  blockFunctions: BlockProtocolFunctions;
+  blockProperties: Omit<BlockProtocolProps, keyof BlockProtocolFunctions>;
   crossFrame?: boolean;
-  sourceUrl: string;
+  editableRef?: unknown;
   onBlockLoaded?: () => void;
-} & BlockProtocolProps;
+  sourceUrl: string;
+};
 
 export const BlockLoadingIndicator: React.VFC = () => <div>Loading...</div>;
 
 /**
  * @see https://github.com/Paciolan/remote-component/blob/2b2cfbb5b6006117c56f3aa7daa2292d3823bb83/src/createRemoteComponent.tsx
  */
-export const RemoteBlock: React.VFC<RemoteBlockProps & Record<string, any>> = ({
+export const RemoteBlock: React.VFC<RemoteBlockProps> = ({
+  blockFunctions,
+  blockProperties,
   crossFrame,
+  editableRef,
   sourceUrl,
   onBlockLoaded,
-  ...props
 }) => {
   const [loading, err, Component] = useRemoteBlock(
     sourceUrl,
@@ -45,8 +50,20 @@ export const RemoteBlock: React.VFC<RemoteBlockProps & Record<string, any>> = ({
      * @todo do something about this. throw if not in an iframe?
      *    or check for iframe status and assign props to window here, not FramedBlock?
      */
-    return <HtmlBlock html={Component} />;
+    return (
+      <HtmlBlock
+        html={Component}
+        blockFunctions={blockFunctions}
+        blockProperties={blockProperties}
+      />
+    );
   }
 
-  return <Component {...props} />;
+  return (
+    <Component
+      {...blockFunctions}
+      {...blockProperties}
+      editableRef={editableRef}
+    />
+  );
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
Provides slightly better support for blocks which have an HTML file as their entry point, rather than encapsulated JavaScript components.

This involves attaching an `entityId` to the `div` where the HTML is inserted, and attaching the block's properties to the window, keyed by the `entityId`. The HTML block can look up the entityId from its immediate `parentElement` and retrieve the properties from the window.

HTML blocks are still a terrible idea outside of sandboxes (more so than all blocks are because of security, given their lack of guaranteed scoping) but this allows people to play around with them in any case.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1200211978612931/1202177196101462/f) _(internal)_

## 🔍 What does this change?

- Expands `HtmlBlock` (the block loader) to take the 'attach things to window' approach described above
- Update `html-para` block to provide an example which doesn't pollute the global scope of the app (although we should never load an HTML block unsandboxed in any case)
- Update the interface for block loading components to split out functions from properties.

## 📜 Does this require a change to the docs?

- We could formalize this in the spec, although it's not clear that we should encourage these sorts of blocks.

## ⚠️ Known issues

- The demo html-para block displays weirdly in the app, something is up with flex. Out of scope for this PR.

## 🐾 Next steps

- Update `HTMLBlock` in https://github.com/blockprotocol/blockprotocol/pull/289 with this tweaked approach.
- Consider formalizing this in the spec, or thinking of a better solution.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  `yarn build && yarn serve` `html-para`
2. Load it into HASH
3. Change the text input, hit the button. After a couple of seconds the text above should change
4. Refresh to check persistence
5. Can also check the presence of the functions and entity properties on the window
