### PR TITLE
Permit swapping the first block in a page to another type

### DIFF
--- a/packages/hash/api/src/graphql/resolvers/pages/updatePageContents.ts
+++ b/packages/hash/api/src/graphql/resolvers/pages/updatePageContents.ts
@@ -120,6 +120,9 @@ export const updatePageContents: Resolver<
           await page.removeBlock(client, {
             ...action.removeBlock,
             removedByAccountId: user.accountId,
+            allowRemovingFinal: actions
+              .slice(i + 1)
+              .some((actionToFollow) => actionToFollow.insertNewBlock),
           });
         }
       } catch (err) {

--- a/packages/hash/api/src/model/page.model.ts
+++ b/packages/hash/api/src/model/page.model.ts
@@ -387,9 +387,13 @@ class __Page extends Entity {
 
   async removeBlock(
     client: DbClient,
-    params: { position: number; removedByAccountId: string },
+    params: {
+      position: number;
+      removedByAccountId: string;
+      allowRemovingFinal: boolean;
+    },
   ) {
-    const { position } = params;
+    const { allowRemovingFinal, position } = params;
 
     const contentLinks = await this.getOutgoingLinks(client, {
       path: ["contents"],
@@ -407,7 +411,7 @@ class __Page extends Entity {
       );
     }
 
-    if (contentLinks.length === 1) {
+    if (!allowRemovingFinal && contentLinks.length === 1) {
       throw new Error("Cannot remove final block from page");
     }
 

--- a/packages/hash/api/src/model/page.model.ts
+++ b/packages/hash/api/src/model/page.model.ts
@@ -390,7 +390,7 @@ class __Page extends Entity {
     params: {
       position: number;
       removedByAccountId: string;
-      allowRemovingFinal: boolean;
+      allowRemovingFinal?: boolean;
     },
   ) {
     const { allowRemovingFinal, position } = params;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes a bug whereby it was impossible to change the type of the first block in a page.

This was caused by a check preventing the removal of the only block in a page. We need to remove the block in order to insert a new one. 

This PR fixes it by allowing the removal of the final block if another one will be inserted in the same set of actions. 

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Load a new page
2. Change the type of the first block in the page

