### PR TITLE
Update `block-scripts` to 0.0.5

### DIFF
--- a/packages/blocks/callout/package.json
+++ b/packages/blocks/callout/package.json
@@ -22,7 +22,7 @@
     "blockprotocol": "0.0.7"
   },
   "devDependencies": {
-    "block-scripts": "0.0.2",
+    "block-scripts": "0.0.5",
     "eslint": "8.13.0",
     "mock-block-dock": "0.0.7",
     "react": "17.0.2",

--- a/packages/blocks/code/package.json
+++ b/packages/blocks/code/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/prismjs": "1.26.0",
     "@types/styled-components": "5.1.25",
-    "block-scripts": "0.0.2",
+    "block-scripts": "0.0.5",
     "mock-block-dock": "0.0.7",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/packages/blocks/divider/package.json
+++ b/packages/blocks/divider/package.json
@@ -22,7 +22,7 @@
     "blockprotocol": "0.0.7"
   },
   "devDependencies": {
-    "block-scripts": "0.0.2",
+    "block-scripts": "0.0.5",
     "eslint": "8.13.0",
     "mock-block-dock": "0.0.7",
     "react": "17.0.2",

--- a/packages/blocks/embed/package.json
+++ b/packages/blocks/embed/package.json
@@ -23,7 +23,7 @@
     "lodash": "4.17.21"
   },
   "devDependencies": {
-    "block-scripts": "0.0.2",
+    "block-scripts": "0.0.5",
     "eslint": "8.13.0",
     "mock-block-dock": "0.0.7",
     "react": "17.0.2",

--- a/packages/blocks/header/package.json
+++ b/packages/blocks/header/package.json
@@ -22,7 +22,7 @@
     "blockprotocol": "0.0.7"
   },
   "devDependencies": {
-    "block-scripts": "0.0.2",
+    "block-scripts": "0.0.5",
     "eslint": "8.13.0",
     "mock-block-dock": "0.0.7",
     "react": "17.0.2",

--- a/packages/blocks/image/package.json
+++ b/packages/blocks/image/package.json
@@ -22,7 +22,7 @@
     "blockprotocol": "0.0.7"
   },
   "devDependencies": {
-    "block-scripts": "0.0.2",
+    "block-scripts": "0.0.5",
     "eslint": "8.13.0",
     "mock-block-dock": "0.0.7",
     "react": "17.0.2",

--- a/packages/blocks/paragraph/package.json
+++ b/packages/blocks/paragraph/package.json
@@ -22,7 +22,7 @@
     "blockprotocol": "0.0.7"
   },
   "devDependencies": {
-    "block-scripts": "0.0.2",
+    "block-scripts": "0.0.5",
     "eslint": "8.13.0",
     "mock-block-dock": "0.0.7",
     "react": "17.0.2",

--- a/packages/blocks/person/package.json
+++ b/packages/blocks/person/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/dompurify": "2.3.3",
-    "block-scripts": "0.0.2",
+    "block-scripts": "0.0.5",
     "eslint": "8.13.0",
     "mock-block-dock": "0.0.7",
     "react": "17.0.2",

--- a/packages/blocks/table/package.json
+++ b/packages/blocks/table/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@types/react-table": "7.7.1",
-    "block-scripts": "0.0.2",
+    "block-scripts": "0.0.5",
     "eslint": "8.13.0",
     "mock-block-dock": "0.0.7",
     "react": "17.0.2",

--- a/packages/blocks/video/package.json
+++ b/packages/blocks/video/package.json
@@ -22,7 +22,7 @@
     "blockprotocol": "0.0.7"
   },
   "devDependencies": {
-    "block-scripts": "0.0.2",
+    "block-scripts": "0.0.5",
     "eslint": "8.13.0",
     "mock-block-dock": "0.0.7",
     "react": "17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8535,10 +8535,10 @@ bl@^4.0.3:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-block-scripts@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/block-scripts/-/block-scripts-0.0.2.tgz#d881f131ef7214f2552102f22bd2fd61ad3414bb"
-  integrity sha512-18kXOcnJb6q1RdN/fbVAkxPFqcq9R1Vilh7GHwYVgJz4/wq7gaVZv4Rbebpe5Fp8CsTfpd+HGC9XfSNLRM8yQQ==
+block-scripts@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/block-scripts/-/block-scripts-0.0.5.tgz#66c5e1fcf6ff78c3c6b97165dd809611d1f6c5c9"
+  integrity sha512-zJohgZTRviWiKhsh8JTnfoFPuusttdv+sJDbG1MgIyiwvMFSkzwfgO9K5lGQ925R9FbFvVArmeRY/oCra+EWUg==
   dependencies:
     "@babel/cli" "^7.17.6"
     "@babel/core" "^7.17.9"
@@ -8557,9 +8557,6 @@ block-scripts@0.0.2:
     fs-extra "^10.0.1"
     html-webpack-plugin "^5.5.0"
     lodash "^4.17.21"
-    mock-block-dock "0.0.6"
-    react "^17.0.2"
-    react-dom "^17.0.2"
     regenerator-runtime "^0.13.9"
     sass-loader "^12.6.0"
     serve-handler "^6.1.3"
@@ -8574,7 +8571,7 @@ block-scripts@0.0.2:
     webpack-dev-server "^4.8.1"
     yargs-parser "21.0.1"
 
-blockprotocol@0.0.6, blockprotocol@0.0.7, blockprotocol@0.0.8:
+blockprotocol@0.0.7, blockprotocol@0.0.8:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/blockprotocol/-/blockprotocol-0.0.7.tgz#e9f36e6e9c468a8611075a1f6d93b9af22711f19"
   integrity sha512-8Hapdz1jaBoTYZqd2m9MY/+NAYCOGhMq0zR5t7Q3F8LjpKTP1DmAj6LayOIJFYVzQCYAbFouI45GhHyWmtRRnA==
@@ -15974,15 +15971,6 @@ mkdirp@^1.0.3, mkdirp@^1.0.4, mkdirp@~1.0.0:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mock-block-dock@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/mock-block-dock/-/mock-block-dock-0.0.6.tgz#86dbc984fffb67e0ae4d442bf716288350d9bf61"
-  integrity sha512-bJNMflnr0wFSzMsV135wRFhkVyFLm76Su267EAl4R+oqb4MbtHnypP8Z/zOOhF3N1+op7COAZhWwk/nsRw4nIQ==
-  dependencies:
-    blockprotocol "0.0.6"
-    lodash "^4.17.21"
-    uuid "^8.3.2"
-
 mock-block-dock@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mock-block-dock/-/mock-block-dock-0.0.7.tgz#f8504c80fd1942b6aa6fbb441f6a89f93627f0de"
@@ -17976,7 +17964,7 @@ react-dock@^0.2.4:
     lodash.debounce "^3.1.1"
     prop-types "^15.5.8"
 
-react-dom@17.0.2, react-dom@^17.0.2:
+react-dom@17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
   integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
@@ -18067,7 +18055,7 @@ react-transition-group@4.4.2, react-transition-group@^4.4.2:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@17.0.2, react@^17.0.2:
+react@17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Updates block-scripts for the whole repo, or new PRs with new versions of block scripts will fail CI due to mismatched versions.