### PR TITLE
Block Configuration Menu Updates

### DIFF
--- a/packages/hash/frontend/src/blocks/page/BlockConfigMenu/BlockConfigMenu.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockConfigMenu/BlockConfigMenu.tsx
@@ -63,7 +63,12 @@ const ConfigurationInput: VoidFunctionComponent<{
   ) => {
     const { value: newValue } = event.target;
     // If a type is a number or an array that accepts a number, convert to a number
-    if (type === "number" || (Array.isArray(type) && type.includes("number"))) {
+    if (
+      type === "number" ||
+      (Array.isArray(type) &&
+        type.includes("string") &&
+        type.includes("number"))
+    ) {
       onChange(Number.isNaN(+newValue) ? newValue : Number(newValue));
     } else {
       onChange(newValue);

--- a/packages/hash/frontend/src/blocks/page/BlockConfigMenu/BlockConfigMenu.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockConfigMenu/BlockConfigMenu.tsx
@@ -60,7 +60,15 @@ const ConfigurationInput: VoidFunctionComponent<{
 
   const updateProperty = (
     event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-  ) => onChange(event.target.value);
+  ) => {
+    const { value: newValue } = event.target;
+    // If a type is a number or an array that accepts a number, convert to a number
+    if (type === "number" || (Array.isArray(type) && type.includes("number"))) {
+      onChange(Number.isNaN(+newValue) ? newValue : Number(newValue));
+    } else {
+      onChange(newValue);
+    }
+  };
 
   const [draftValue, setDraftValue] = useState(value);
 
@@ -76,60 +84,87 @@ const ConfigurationInput: VoidFunctionComponent<{
     setDraftValue(value);
   }
 
-  switch (type) {
-    case "boolean":
-      return (
-        <FormControlLabel
-          control={
-            <Checkbox
-              onChange={(event) => onChange(event.target.checked)}
-              checked={typeof value === "boolean" ? value : value === "true"}
-            />
-          }
-          label={name}
-        />
-      );
-
-    case "string":
-      if (format) {
-        // @todo validate string format - should have a reusable input that does this
-      }
-      return (
-        <TextField
-          label={name}
-          onBlur={enumList ? undefined : updateProperty}
-          onChange={(event) => {
-            setDraftValue(event.target.value);
-            if (enumList) {
-              updateProperty(event);
-            }
-          }}
-          select={!!enumList}
-          value={draftValue}
-        >
-          {(enumList ?? []).map((option: string) => (
-            <MenuItem key={option} value={option}>
-              {option}
-            </MenuItem>
-          ))}
-        </TextField>
-      );
-
-    case "number":
-      return (
-        <TextField
-          defaultValue={value ?? ""}
-          onBlur={(event) => onChange(event.target.value)}
-          onChange={(event) => setDraftValue(event.target.value)}
-          type="number"
-          value={draftValue}
-          variant="outlined"
-        />
-      );
-
-    default:
-      throw new Error(`Property type ${type} config input not implemented`);
+  if (type === "boolean") {
+    return (
+      <FormControlLabel
+        control={
+          <Checkbox
+            onChange={(event) => onChange(event.target.checked)}
+            checked={typeof value === "boolean" ? value : value === "true"}
+          />
+        }
+        label={name}
+      />
+    );
   }
+
+  if (type === "string") {
+    if (format) {
+      // @todo validate string format - should have a reusable input that does this
+    }
+    return (
+      <TextField
+        label={name}
+        onBlur={enumList ? undefined : updateProperty}
+        onChange={(event) => {
+          setDraftValue(event.target.value);
+          if (enumList) {
+            updateProperty(event);
+          }
+        }}
+        select={!!enumList}
+        value={draftValue}
+      >
+        {(enumList ?? []).map((option: string) => (
+          <MenuItem key={option} value={option}>
+            {option}
+          </MenuItem>
+        ))}
+      </TextField>
+    );
+  }
+
+  if (type === "number") {
+    return (
+      <TextField
+        defaultValue={value ?? ""}
+        onBlur={(event) => onChange(event.target.value)}
+        onChange={(event) => setDraftValue(event.target.value)}
+        type="number"
+        value={draftValue}
+        variant="outlined"
+      />
+    );
+  }
+
+  if (
+    Array.isArray(type) &&
+    type.includes("string") &&
+    type.includes("number")
+  ) {
+    return (
+      <TextField
+        label={name}
+        onBlur={enumList ? undefined : updateProperty}
+        onChange={(event) => {
+          setDraftValue(event.target.value);
+          if (enumList) {
+            updateProperty(event);
+          }
+        }}
+        select={!!enumList}
+        value={draftValue}
+      >
+        {(enumList ?? []).map((option: string) => (
+          <MenuItem key={option} value={option}>
+            {option}
+          </MenuItem>
+        ))}
+      </TextField>
+    );
+  }
+
+  throw new Error(`Property type ${type} config input not implemented`);
 };
 
 type BlockConfigMenuProps = {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
Currently the Block Config Menu doesn't
1. properly handle changes to properties of type "number". changes to properties get saved as a string even though the property type is a number
1. handle displaying input for properties that can either be a number or string. i.e properties with type ["number", "string"]

I noticed this when working on #515 . This PR fixes both issues 

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](link) _(internal)_

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

- [ ] ...

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Update `updateProperty` to properly handle changes when the property type is "number" or ["number", "string"]
- Render an input when the property type is an array that contains "number"

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

- No