### PR TITLE
GitHub action to build services, push to ECR and (re)deploy ECS Fargate instances

### DIFF
--- a/.github/actions/docker-ecr-login/action.yml
+++ b/.github/actions/docker-ecr-login/action.yml
@@ -1,5 +1,5 @@
-name: Warm-up repo
-description: Prepares Node and Yarn dependencies
+name: Docker ECR login
+description: Authenticate with AWS, sigh Docker into ECR
 
 inputs:
   AWS_ACCESS_KEY_ID:

--- a/.github/actions/docker-ecr-login/action.yml
+++ b/.github/actions/docker-ecr-login/action.yml
@@ -1,0 +1,38 @@
+name: Warm-up repo
+description: Prepares Node and Yarn dependencies
+
+inputs:
+  AWS_ACCESS_KEY_ID:
+    description: AWS access key id
+    required: true
+  AWS_SECRET_ACCESS_KEY:
+    description: AWS secret access key
+    required: true
+  AWS_REGION:
+    description: AWS region
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # Set up AWS ECR login
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ inputs.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ inputs.AWS_REGION }}
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    # Configure Docker with Buildx and caching
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    # Docker images use Yarn cache which is shared with the rest of the repo, use that.
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 16
+        cache: yarn

--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -1,0 +1,139 @@
+on:
+  push:
+    branches: [main]
+
+env:
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+  AWS_ECR_URL: ${{ secrets.AWS_ECR_URL }}
+
+  # Format "user:pass"
+  HASH_POSTGRES_MIGRATE_USER_PASS: ${{ secrets.HASH_POSTGRES_MIGRATE_USER_PASS }}
+  # Format: "env.id.region.rds.amazonaws.com/database"
+  HASH_POSTGRES_HOST_DB: ${{ secrets.HASH_POSTGRES_HOST_DB }}
+
+  HASH_API_RESOURCE_NAME: ${{ secrets.HASH_API_RESOURCE_NAME }}
+  HASH_REALTIME_RESOURCE_NAME: ${{ secrets.HASH_REALTIME_RESOURCE_NAME }}
+  HASH_SEARCHLOADER_RESOURCE_NAME: ${{ secrets.HASH_SEARCHLOADER_RESOURCE_NAME }}
+
+  HASH_ECS_CLUSTER_NAME: ${{ secrets.HASH_ECS_CLUSTER_NAME }}
+
+name: HASH backend deployment
+jobs:
+  build-api:
+    name: Build and push HASH api image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: ./.github/actions/docker-ecr-login
+        with:
+          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+
+      # Build images and push to ECR
+      - name: Build and push api
+        uses: docker/build-push-action@v2
+        env:
+          HASH_API_IMAGE_NAME: ${{ env.HASH_API_RESOURCE_NAME }}ecr
+        with:
+          # The Dockerfile is in a leaf-folder without access to what it needs.
+          # Thus the context is within the root, while the dockerfile is deeply nested.
+          context: ${{ github.workspace }}
+          push: true
+          file: ${{ github.workspace }}/packages/hash/docker/api/prod/Dockerfile
+          tags: ${{ env.AWS_ECR_URL }}/${{ env.HASH_API_IMAGE_NAME }}:latest
+
+  build-realtime:
+    name: Build and push HASH realtime image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: ./.github/actions/docker-ecr-login
+        with:
+          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+
+      - name: Build and push realtime
+        uses: docker/build-push-action@v2
+        env:
+          HASH_REALTIME_IMAGE_NAME: ${{ env.HASH_REALTIME_RESOURCE_NAME }}ecr
+        with:
+          context: ${{ github.workspace }}
+          push: true
+          file: ${{ github.workspace }}/packages/hash/docker/realtime/prod/Dockerfile
+          tags: ${{ env.AWS_ECR_URL }}/${{ env.HASH_REALTIME_IMAGE_NAME }}:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+  build-searchloader:
+    name: Build and push HASH searchloader image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: ./.github/actions/docker-ecr-login
+        with:
+          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+
+      - name: Build and push search-loader
+        uses: docker/build-push-action@v2
+        env:
+          HASH_SEARCHLOADER_IMAGE_NAME: ${{ env.HASH_SEARCHLOADER_RESOURCE_NAME }}ecr
+        with:
+          context: ${{ github.workspace }}
+          push: true
+          file: ${{ github.workspace }}/packages/hash/docker/search-loader/prod/Dockerfile
+          tags: ${{ env.AWS_ECR_URL }}/${{ env.HASH_SEARCHLOADER_IMAGE_NAME }}:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+  deploy:
+    name: Deploy HASH images
+    runs-on: ubuntu-latest
+    needs:
+      - build-api
+      - build-realtime
+      - build-searchloader
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: ./.github/actions/docker-ecr-login
+        with:
+          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+
+      - name: Prepare dev tools for DB migration
+        run: yarn install
+        shell: bash
+
+      # TODO: should we stop the services before migrating the db?
+      - name: Migrate database
+        run: |
+          HASH_MIGRATION_PG_URL=postgres://${{ env.HASH_POSTGRES_MIGRATE_USER_PASS }}@${{ env.HASH_POSTGRES_HOST_DB }} \
+            yarn workspace @hashintel/hash-datastore pg:migrate up
+
+      - name: Redeploy api service
+        env:
+          HASH_API_SERVICE_NAME: ${{ env.HASH_API_RESOURCE_NAME }}svc
+        run: |
+          aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_API_SERVICE_NAME }} --force-new-deployment 1> /dev/null
+
+      - name: Redeploy realtime service
+        env:
+          HASH_REALTIME_SERVICE_NAME: ${{ env.HASH_REALTIME_RESOURCE_NAME }}svc
+        run: |
+          aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_REALTIME_SERVICE_NAME }} --force-new-deployment 1> /dev/null
+
+      - name: Redeploy serach-loader service
+        env:
+          HASH_SEARCHLOADER_SERVICE_NAME: ${{ env.HASH_SEARCHLOADER_RESOURCE_NAME }}svc
+        run: |
+          aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_SEARCHLOADER_SERVICE_NAME }} --force-new-deployment 1> /dev/null

--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -13,6 +13,8 @@ env:
   # Format: "env.id.region.rds.amazonaws.com/database"
   HASH_POSTGRES_HOST_DB: ${{ secrets.HASH_POSTGRES_HOST_DB }}
 
+  GH_RUN_ID: ${{ github.run_id }}
+
   HASH_API_RESOURCE_NAME: ${{ secrets.HASH_API_RESOURCE_NAME }}
   HASH_REALTIME_RESOURCE_NAME: ${{ secrets.HASH_REALTIME_RESOURCE_NAME }}
   HASH_SEARCHLOADER_RESOURCE_NAME: ${{ secrets.HASH_SEARCHLOADER_RESOURCE_NAME }}
@@ -44,7 +46,7 @@ jobs:
           context: ${{ github.workspace }}
           push: true
           file: ${{ github.workspace }}/packages/hash/docker/api/prod/Dockerfile
-          tags: ${{ env.AWS_ECR_URL }}/${{ env.HASH_API_IMAGE_NAME }}:latest
+          tags: ${{ env.AWS_ECR_URL }}/${{ env.HASH_API_IMAGE_NAME }}:latest , ${{ env.AWS_ECR_URL }}/${{ env.HASH_API_IMAGE_NAME }}:run-${{ env.GH_RUN_ID }}
 
   build-realtime:
     name: Build and push HASH realtime image
@@ -66,7 +68,7 @@ jobs:
           context: ${{ github.workspace }}
           push: true
           file: ${{ github.workspace }}/packages/hash/docker/realtime/prod/Dockerfile
-          tags: ${{ env.AWS_ECR_URL }}/${{ env.HASH_REALTIME_IMAGE_NAME }}:latest
+          tags: ${{ env.AWS_ECR_URL }}/${{ env.HASH_REALTIME_IMAGE_NAME }}:latest , ${{ env.AWS_ECR_URL }}/${{ env.HASH_REALTIME_IMAGE_NAME }}:run-${{ env.GH_RUN_ID }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 
@@ -90,7 +92,7 @@ jobs:
           context: ${{ github.workspace }}
           push: true
           file: ${{ github.workspace }}/packages/hash/docker/search-loader/prod/Dockerfile
-          tags: ${{ env.AWS_ECR_URL }}/${{ env.HASH_SEARCHLOADER_IMAGE_NAME }}:latest
+          tags: ${{ env.AWS_ECR_URL }}/${{ env.HASH_SEARCHLOADER_IMAGE_NAME }}:latest , ${{ env.AWS_ECR_URL }}/${{ env.HASH_SEARCHLOADER_IMAGE_NAME }}:run-${{ env.GH_RUN_ID }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
This PR adds a pipeline to publish the HASH backend every time the `main` branch is merged into.
Because of prior work in #438, we are able to continuously apply changes without needing to consider a lot of edge cases in regards to the DB.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1200211978612931/1202142633000396/f) _(internal)_

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Add new GitHub Action for building, pushing and deploying HASH images
- Adds composite action that allows connecting to AWS and exposes the AWS CLI for our pipelines when needed
- Makes health checks more quickly available for the `api` service, as we would previously be blocked by a redis connection that would never succeed without terminating existing instances of the `api`.

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->


## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->
- It takes around 2 minutes from the final step of the pipeline to the new services being fully available
  This is because of the AWS load balancer making sure that the services are healthy and drained for connections before moving on. This total time is 3 x health checks with 30 second intervals between plus a 30 second `deregistration_delay`.
  
![image](https://user-images.githubusercontent.com/6988668/166486393-bf602f8a-f54c-4d87-92fb-2ab7f0912034.png)


## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->
- We must add the following secrets to this repository, which will connect to our AWS deployment instance.
``` 
AWS_ACCESS_KEY_ID
AWS_SECRET_ACCESS_KEY
AWS_REGION
AWS_ECR_URL
HASH_POSTGRES_HOST_DB
HASH_POSTGRES_MIGRATE_USER_PASS
HASH_ECS_CLUSTER_NAME
HASH_API_RESOURCE_NAME
HASH_REALTIME_RESOURCE_NAME
HASH_SEARCHLOADER_RESOURCE_NAME
```
I'm aware that some of these values are not to be considered secrets, but we don't really need to expose them publicly either.

- We could also consider introducing caching to the Docker layers. AWS ECR does not support cache manifests, though. And GitHub Actions have a 10gb cache limit.
## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

This isn't too easy to test, but i have successful runs available here https://github.com/thehabbos007/hash/actions
The latest one should show the current latest state of the pipelines.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
https://github.com/thehabbos007/hash/actions/runs/2264711570