### PR TITLE
Fix `@opensearch-project/opensearch` compatibility with Node 18

### DIFF
--- a/.github/actions/warm-up-repo/action.yml
+++ b/.github/actions/warm-up-repo/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: actions/setup-node@v2
       with:
-        node-version: 16
+        node-version: 18
         cache: yarn
 
     - run: yarn install

--- a/.github/workflows/algolia-upload-index.yml
+++ b/.github/workflows/algolia-upload-index.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
           cache: yarn
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
         if: ${{ success() || failure() }}
         run: |
           yarn dev:backend 2>&1 | tee var/logs/backend.log & ## ampersand enables background mode
-          yarn wait-on --timeout 30000 http://localhost:5001
+          yarn wait-on --timeout 30000 http://0.0.0.0:5001
         env:
           NODE_ENV: test
 
@@ -204,14 +204,14 @@ jobs:
         if: ${{ success() || failure() }}
         run: |
           yarn dev:backend 2>&1 | tee var/logs/backend.log & ## ampersand enables background mode
-          yarn wait-on --timeout 30000 http://localhost:5001
+          yarn wait-on --timeout 30000 http://0.0.0.0:5001
 
       - name: Build and launch frontend
         if: ${{ success() || failure() }}
         run: |
           yarn workspace @hashintel/hash-frontend next build
           yarn workspace @hashintel/hash-frontend start 2>&1 | tee var/logs/frontend.log & ## ampersand enables background mode
-          yarn wait-on --timeout 30000 http://localhost:3000
+          yarn wait-on --timeout 30000 http://0.0.0.0:3000
 
       - run: yarn playwright install-deps chrome firefox
         if: ${{ success() || failure() }}

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "serve": "13.0.2",
     "suppress-exit-code": "1.0.0",
     "ts-node": "10.4.0",
-    "wait-on": "6.0.0",
+    "wait-on": "6.0.1",
     "yarn-deduplicate": "3.1.0"
   }
 }

--- a/packages/hash/README.md
+++ b/packages/hash/README.md
@@ -26,7 +26,7 @@ To run HASH locally, please follow these steps:
     ## ≥ 2.17
     
     node --version
-    ## ≥ 16.13 and < 17.00 (`@opensearch-project/opensearch` currently does not support node 17)
+    ## ≥ 16.13, < 17 or ≥ 18.0, < 19
     
     yarn --version
     ## ≥ 1.16

--- a/packages/hash/README.md
+++ b/packages/hash/README.md
@@ -26,7 +26,7 @@ To run HASH locally, please follow these steps:
     ## ≥ 2.17
     
     node --version
-    ## ≥ 16.13, < 17 or ≥ 18.0, < 19
+    ## ≥ 16.13
     
     yarn --version
     ## ≥ 1.16

--- a/packages/hash/backend-utils/package.json
+++ b/packages/hash/backend-utils/package.json
@@ -21,7 +21,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@opensearch-project/opensearch": "1.0.0",
+    "@opensearch-project/opensearch": "1.1.0",
     "apollo-datasource": "3.3.0",
     "blockprotocol": "0.0.7",
     "dotenv-flow": "3.2.0",

--- a/packages/hash/backend-utils/package.json
+++ b/packages/hash/backend-utils/package.json
@@ -27,7 +27,7 @@
     "dotenv-flow": "3.2.0",
     "redis": "3.1.2",
     "slonik": "24.1.2",
-    "wait-on": "6.0.0",
+    "wait-on": "6.0.1",
     "winston": "3.3.3"
   },
   "devDependencies": {

--- a/packages/hash/backend-utils/src/search/opensearch.ts
+++ b/packages/hash/backend-utils/src/search/opensearch.ts
@@ -1,6 +1,5 @@
 import { JSONObject } from "blockprotocol";
-import { Client, ClientOptions } from "@opensearch-project/opensearch";
-import { ResponseError } from "@opensearch-project/opensearch/lib/errors";
+import { Client, ClientOptions, errors } from "@opensearch-project/opensearch";
 import { DataSource } from "apollo-datasource";
 
 import { sleep } from "@hashintel/hash-shared/sleep";
@@ -369,7 +368,7 @@ export class OpenSearch extends DataSource implements SearchAdapter {
         scroll_id: openSearchCursor,
       });
     } catch (ex) {
-      if (ex instanceof ResponseError && ex.statusCode === 404) {
+      if (ex instanceof errors.ResponseError && ex.statusCode === 404) {
         throw new Error(
           "OpenSearch could not execute query. Perhaps the cursor is closed or the query is malformed?",
         );

--- a/packages/hash/search-loader/package.json
+++ b/packages/hash/search-loader/package.json
@@ -16,7 +16,7 @@
     "@hashintel/hash-api": "0.0.0",
     "@hashintel/hash-backend-utils": "0.0.0",
     "@hashintel/hash-shared": "0.0.0",
-    "@opensearch-project/opensearch": "1.0.0",
+    "@opensearch-project/opensearch": "1.1.0",
     "hot-shots": "8.5.0",
     "slonik": "24.1.2",
     "ts-node": "10.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4547,10 +4547,10 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@opensearch-project/opensearch@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@opensearch-project/opensearch/-/opensearch-1.0.0.tgz#0b3fd369bcb3ff3425baf7e42deb06fa75808b04"
-  integrity sha512-vLZTwQtUtDhtSVMfqV1DsfC8u0DKtwKtUvBXvCGeUY2/gdu/FyiQQr/nucdGGPnXLTT6SRWQmeiIVhhbx+Ocwg==
+"@opensearch-project/opensearch@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@opensearch-project/opensearch/-/opensearch-1.1.0.tgz#8b3c8b4cbcea01755ba092d2997bf0b4ca7f22f7"
+  integrity sha512-1TDw92JL8rD1b2QGluqBsIBLIiD5SGciIpz4qkrGAe9tcdfQ1ptub5e677rhWl35UULSjr6hP8M6HmISZ/M5HQ==
   dependencies:
     debug "^4.3.1"
     hpagent "^0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8181,12 +8181,12 @@ axios@0.26.1:
   dependencies:
     follow-redirects "^1.14.8"
 
-axios@^0.21.1:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+axios@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.25.0.tgz#349cfbb31331a9b4453190791760a8d35b093e0a"
+  integrity sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==
   dependencies:
-    follow-redirects "^1.14.0"
+    follow-redirects "^1.14.7"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -11639,7 +11639,7 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.8:
+follow-redirects@^1.0.0, follow-redirects@^1.14.7, follow-redirects@^1.14.8:
   version "1.14.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
   integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
@@ -14181,10 +14181,10 @@ jest@27.1.1:
     import-local "^3.0.2"
     jest-cli "^27.1.1"
 
-joi@^17.4.0:
-  version "17.5.0"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-17.5.0.tgz#7e66d0004b5045d971cf416a55fb61d33ac6e011"
-  integrity sha512-R7hR50COp7StzLnDi4ywOXHrBrgNXuUUfJWIR5lPY5Bm/pOD3jZaTwpluUXVLRWcoWZxkrHBBJ5hLxgnlehbdw==
+joi@^17.6.0:
+  version "17.6.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.6.0.tgz#0bb54f2f006c09a96e75ce687957bd04290054b2"
+  integrity sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==
   dependencies:
     "@hapi/hoek" "^9.0.0"
     "@hapi/topo" "^5.0.0"
@@ -18739,10 +18739,10 @@ rxjs@^6.3.3, rxjs@^6.6.0, rxjs@^6.6.3:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^7.1.0, rxjs@^7.5.2:
-  version "7.5.3"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.3.tgz#1359f8a4704797bee74357d65a125dbc7d8f4a91"
-  integrity sha512-6162iC/N7L7K8q3UvdOMWix1ju+esADGrDaPrTu5XJmCv69YNdYoUaop/iatN8GHK+YHOdszPP+qygA0yi04zQ==
+rxjs@^7.5.2, rxjs@^7.5.4:
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.5.tgz#2ebad89af0f560f460ad5cc4213219e1f7dd4e9f"
+  integrity sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==
   dependencies:
     tslib "^2.1.0"
 
@@ -21218,16 +21218,16 @@ w3c-xmlserializer@^2.0.0:
   dependencies:
     xml-name-validator "^3.0.0"
 
-wait-on@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-6.0.0.tgz#7e9bf8e3d7fe2daecbb7a570ac8ca41e9311c7e7"
-  integrity sha512-tnUJr9p5r+bEYXPUdRseolmz5XqJTTj98JgOsfBn7Oz2dxfE2g3zw1jE+Mo8lopM3j3et/Mq1yW7kKX6qw7RVw==
+wait-on@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-6.0.1.tgz#16bbc4d1e4ebdd41c5b4e63a2e16dbd1f4e5601e"
+  integrity sha512-zht+KASY3usTY5u2LgaNqn/Cd8MukxLGjdcZxT2ns5QzDmTFc4XoWBgC+C/na+sMRZTuVygQoMYwdcVjHnYIVw==
   dependencies:
-    axios "^0.21.1"
-    joi "^17.4.0"
+    axios "^0.25.0"
+    joi "^17.6.0"
     lodash "^4.17.21"
     minimist "^1.2.5"
-    rxjs "^7.1.0"
+    rxjs "^7.5.4"
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.8"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The goal of this PR is to unlock the usage of Node 18. This used to be blocked by `@opensearch-project/opensearch` in which we had this problem with imports:

```
[seed-data:*opensearch] Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/errors' is not defined by "exports" in /Users/alfie/Documents/code/hash_2/node_modules/@opensearch-project/opensearch/package.json
[seed-data:*opensearch]     at new NodeError (node:internal/errors:377:5)
[seed-data:*opensearch]     at throwExportsNotFound (node:internal/modules/esm/resolve:440:9)
[seed-data:*opensearch]     at packageExportsResolve (node:internal/modules/esm/resolve:719:3)
[seed-data:*opensearch]     at resolveExports (node:internal/modules/cjs/loader:483:36)
[seed-data:*opensearch]     at Function.Module._findPath (node:internal/modules/cjs/loader:523:31)
[seed-data:*opensearch]     at Function.Module._resolveFilename (node:internal/modules/cjs/loader:925:27)
[seed-data:*opensearch]     at Function.Module._resolveFilename.sharedData.moduleResolveFilenameHook.installedValue [as _resolveFilename] (/Users/alfie/Documents/code/hash_2/node_modules/@cspotcode/source-map-support/source-map-support.js:679:30)
[seed-data:*opensearch]     at Function.Module._load (node:internal/modules/cjs/loader:780:27)
[seed-data:*opensearch]     at Module.require (node:internal/modules/cjs/loader:1005:19)
[seed-data:*opensearch]     at require (node:internal/modules/cjs/helpers:102:18) {
[seed-data:*opensearch]   code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
```

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
Node 18 (and 17) are stricter on what’s allowed to import from a package. Opensearch says ‘[you can only import from index](https://github.com/opensearch-project/opensearch-js/blob/f587b2946776efe175cac28dc48626e793e3b6a3/package.json#L6-L12)’ but Node 16 and below are OK with us using `@opensearch-project/opensearch/lib/errors` despite that. Replacing this import with `@opensearch-project/opensearch` fixed the problem.

There was also a small issue with `wait-on`, details here: https://github.com/hashintel/hash/pull/528#discussion_r864268460

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202055186269233/1202210072243228/f) _(internal)_
- [Slack thread](https://hashintel.slack.com/archives/C022217GAHF/p1651596822649619) _(internal)_

## 📜 Does this require a change to the docs?

Yes. An update to README is included.

## 🛡 What tests cover this?

CI

## 📹 Demo

See PR commits and corresponding CI results.