### PR TITLE
Fix table block updating / deleting linked aggregation

### DIFF
--- a/packages/blocks/table/src/table.tsx
+++ b/packages/blocks/table/src/table.tsx
@@ -113,6 +113,7 @@ export const Table: BlockComponent<AppProps> = ({
   aggregateEntities,
   aggregateEntityTypes,
   createLinkedAggregations,
+  deleteLinkedAggregations,
   entityId,
   entityTypeId,
   entityTypes: schemas,
@@ -452,8 +453,8 @@ export const Table: BlockComponent<AppProps> = ({
         );
       }
 
-      if (updatedEntityTypeId && tableData.linkedAggregation) {
-        if (tableData?.linkedAggregation) {
+      if (updatedEntityTypeId) {
+        if (tableData.linkedAggregation) {
           void updateLinkedAggregations([
             cleanUpdateLinkedAggregationAction({
               sourceAccountId: accountId,
@@ -478,14 +479,22 @@ export const Table: BlockComponent<AppProps> = ({
             },
           ]);
         }
+      } else if (tableData.linkedAggregation) {
+        void deleteLinkedAggregations?.([
+          {
+            sourceAccountId: accountId,
+            aggregationId: tableData.linkedAggregation.aggregationId,
+          },
+        ]);
       }
     },
     [
       accountId,
+      createLinkedAggregations,
+      deleteLinkedAggregations,
       entityId,
       tableData.linkedAggregation,
       updateLinkedAggregations,
-      createLinkedAggregations,
     ],
   );
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
Fix the table block for two bugs:

1. It was checking for the presence of a `linkedAggregation` on the table before allowing creating one, meaning that it was impossible to create one if one didn't already exist
2. There was no provision to delete a `linkedAggregation` if the entity type selector was set to None/`undefined`

## 🔍 What does this change?

- remove check for existing `linkedAggregation` before allowing one to be created
- add `deleteLinkedAggregation` when switching back to none

## 🐾 Next steps

I will be releasing a PR on `blockprotocol` which updates the version number there, once this is merged (it seems to be a recent breakage as the version on the hub is working).

## ❓ How to test this?

Try a table block in HASH.


