### PR TITLE
Update BlockProtocolUpdateLinkedAggregationAction data -> operation

### DIFF
--- a/packages/blocks/table/src/table.tsx
+++ b/packages/blocks/table/src/table.tsx
@@ -90,7 +90,7 @@ const getLinkedAggregation = (params: {
 
 const cleanUpdateLinkedAggregationAction = (
   action: BlockProtocolUpdateLinkedAggregationActionFragment & {
-    data: Omit<BlockProtocolAggregateOperationInput, "multiSort"> & {
+    operation: Omit<BlockProtocolAggregateOperationInput, "multiSort"> & {
       __typename?: string;
       pageCount?: number | null;
       multiSort?: (BlockProtocolSort & { __typename?: string })[] | null;
@@ -98,9 +98,9 @@ const cleanUpdateLinkedAggregationAction = (
   },
 ) => {
   return produce(action, (draftAction) => {
-    delete draftAction.data.pageCount;
-    delete draftAction.data.__typename;
-    for (const sort of draftAction.data.multiSort ?? []) {
+    delete draftAction.operation.pageCount;
+    delete draftAction.operation.__typename;
+    for (const sort of draftAction.operation.multiSort ?? []) {
       delete sort?.__typename;
     }
   });
@@ -303,7 +303,7 @@ export const Table: BlockComponent<AppProps> = ({
         cleanUpdateLinkedAggregationAction({
           sourceAccountId: matchingLinkedAggregation.sourceAccountId,
           aggregationId: matchingLinkedAggregation.aggregationId,
-          data: newLinkedData.operation,
+          operation: newLinkedData.operation,
         }),
       ]);
     },
@@ -459,7 +459,7 @@ export const Table: BlockComponent<AppProps> = ({
             cleanUpdateLinkedAggregationAction({
               sourceAccountId: accountId,
               aggregationId: tableData.linkedAggregation.aggregationId,
-              data: {
+              operation: {
                 entityTypeId: updatedEntityTypeId,
                 // There is scope to include other options if entity properties overlap
                 itemsPerPage:

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolUpdateLinkedAggregations.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolUpdateLinkedAggregations.ts
@@ -26,7 +26,7 @@ export const useBlockProtocolUpdateLinkedAggregations = (): {
         const results: BlockProtocolLinkedAggregation[] = [];
         // TODO: Support multiple actions in one GraphQL mutation for transaction integrity and better status reporting
         for (const action of actions) {
-          if (action.data.entityTypeId == null) {
+          if (action.operation.entityTypeId == null) {
             // @todo we should allow aggregating without narrowing the type
             throw new Error(
               "An aggregation operation must have an entityTypeId",
@@ -44,8 +44,8 @@ export const useBlockProtocolUpdateLinkedAggregations = (): {
               ...action,
               updatedOperation: {
                 // @todo this shouldn't be necessary
-                ...action.data,
-                entityTypeId: action.data.entityTypeId,
+                ...action.operation,
+                entityTypeId: action.operation.entityTypeId,
               },
               sourceAccountId: action.sourceAccountId,
             },

--- a/patches/blockprotocol+0.0.7.patch
+++ b/patches/blockprotocol+0.0.7.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/blockprotocol/core.d.ts b/node_modules/blockprotocol/core.d.ts
-index 20a9bbd..dda5c76 100644
+index 20a9bbd..c1dd91d 100644
 --- a/node_modules/blockprotocol/core.d.ts
 +++ b/node_modules/blockprotocol/core.d.ts
 @@ -1,3 +1,6 @@
@@ -149,7 +149,7 @@ index 20a9bbd..dda5c76 100644
 +export type BlockProtocolUpdateLinkedAggregationAction =  {
 +  sourceAccountId?: string | null;
 +  aggregationId: string;
-+  data: BlockProtocolAggregateOperationInput
++  operation: BlockProtocolAggregateOperationInput
 +};
 +
 +export type BlockProtocolUpdateLinkedAggregationsFunction = {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Updates the key under which the updated `LinkedAggregation` should be passed to be called "operation" instead of "data" - suggested [here](https://github.com/blockprotocol/blockprotocol/pull/302#discussion_r865776607).

Updating here so that the counterpart PR can be merged without breaking the table block in the Block Hub. 

To follow: update `blockprotocol` version in this repo once https://github.com/blockprotocol/blockprotocol/pull/302 is merged, and reduce patch here.