### PR TITLE
Update Apache-Arrow bundler README

### DIFF
--- a/packages/engine/apache-arrow-js-bundle/README.md
+++ b/packages/engine/apache-arrow-js-bundle/README.md
@@ -13,7 +13,8 @@ The bundle should appear as `./dist/apache-arrow-bundle.js`
 
 ### Modifying for use in the Engine
 
-- Manually modify the bundle, adding `return arrow` underneath `arrow = __webpack_exports__;` at the very bottom of the file [1]
+- Manually modify the bundle, adding `export` to `var arrow;` at the very top of the file [1]
+- Manually modify the bundle, adding `return arrow` underneath `arrow = __webpack_exports__;` at the very bottom of the file
 - Manually modify `class MessageReader` to re-export the `VectorLoader` as follows [2]:
 
   ```javascript
@@ -42,9 +43,8 @@ The bundle should appear as `./dist/apache-arrow-bundle.js`
 - From the `./packages/engine` folder run:
   `cp apache-arrow-js-bundle/dist/apache-arrow-bundle.js lib/execution/src/runner/javascript/apache-arrow-bundle.js`
 
-> [1] Unfortunately at this time we haven't figured out how to generate the exact format we need for the way we load scripts into V8 (through `eval`ing).
+> [1] Unfortunately at this time we haven't figured out how to generate the exact format we need for the way we load modules into V8.
 > This is why we require the bundle to be manually modified.
-> Due to using `eval` we need the module to be the return result of the file, rather than a normal module that you can import.
 >
 > If anyone has ideas on how to resolve this, suggestions are welcome.
 >


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Since #493 the arrow bundle needs to be modified a bit more but this change wasn't reflected in the bundler's README.
We also no longer `eval` the bundle.
This PR updates it.

## 🔍 What does this change?

- Add the new modification that needs to happen for the bundle to work with the engine
- Remove mention of `eval` as this is no longer how we import most files including this bundle

## 📜 Does this require a change to the docs?

- Update the bundler's README