### PR TITLE
Rename `Pool` to `BatchPool`

### DIFF
--- a/packages/engine/lib/stateful/src/agent/arrow/mod.rs
+++ b/packages/engine/lib/stateful/src/agent/arrow/mod.rs
@@ -16,7 +16,7 @@ pub use self::{
         json_serialized_value_iter, json_value_iter_cols, position_iter, search_radius_iter,
         str_iter,
     },
-    pool::AgentPool,
+    pool::AgentBatchPool,
 };
 
 // TODO: this should be deleted, i.e. if this value is required use

--- a/packages/engine/lib/stateful/src/agent/arrow/pool.rs
+++ b/packages/engine/lib/stateful/src/agent/arrow/pool.rs
@@ -12,11 +12,11 @@ use crate::{
 ///
 /// All fields (except for messages) that agents' have are persisted in the Agent Pool.
 #[derive(Clone)]
-pub struct AgentPool {
+pub struct AgentBatchPool {
     batches: Vec<Arc<RwLock<AgentBatch>>>,
 }
 
-impl AgentPool {
+impl AgentBatchPool {
     /// Creates a new pool from [`AgentBatch`]es.
     ///
     /// Because of the way `BatchPools` are organized it's required that the [`AgentBatch`]es are
@@ -42,7 +42,7 @@ impl AgentPool {
     }
 }
 
-impl BatchPool for AgentPool {
+impl BatchPool for AgentBatchPool {
     type Batch = AgentBatch;
 
     fn len(&self) -> usize {

--- a/packages/engine/lib/stateful/src/agent/mod.rs
+++ b/packages/engine/lib/stateful/src/agent/mod.rs
@@ -5,8 +5,8 @@
 //! The main struct in this module is [`Agent`]. It contains all agent fields as an accessible
 //! struct. Its fields are represented by [`AgentStateField`], which is based on the [`field`] API.
 //! A group of [`Agent`]s has an in-memory representation defined by [`AgentSchema`] and can be used
-//! by [`AgentBatch`] or, in case of multiple groups of [`Agent`]s, [`AgentPool`]. To convert an
-//! [`AgentBatch`] to [`Vec`]`<`[`Agent`]`>`, the [`IntoAgents`] trait is used.
+//! by [`AgentBatch`] or, in case of multiple groups of [`Agent`]s, [`AgentBatchPool`]. To convert
+//! an [`AgentBatch`] to [`Vec`]`<`[`Agent`]`>`, the [`IntoAgents`] trait is used.
 //!
 //! [HASH documentation]: https://hash.ai/docs/simulation/creating-simulations/anatomy-of-an-agent
 //! [`field`]: crate::field
@@ -21,7 +21,7 @@ mod schema;
 pub mod arrow;
 
 pub use self::{
-    arrow::{AgentBatch, AgentPool},
+    arrow::{AgentBatch, AgentBatchPool},
     field::{Agent, AgentStateField},
     into_agent::IntoAgents,
     name::AgentName,

--- a/packages/engine/lib/stateful/src/context/batch.rs
+++ b/packages/engine/lib/stateful/src/context/batch.rs
@@ -27,12 +27,13 @@ const UPPER_BOUND_DATA_SIZE_MULTIPLIER: usize = 3;
 /// Contains the information required to build the context, which is accessible in the language
 /// runners.
 ///
-/// Data within the `ContextBatch` can rely on the contents of the [`AgentPool`] and [`MessagePool`]
-/// within the [`Context`] object. For example, the list of neighbors in the [`ContextBatch`]
-/// is a collection of indices pointing to different agents within the [`AgentPool`].
+/// Data within the `ContextBatch` can rely on the contents of the [`AgentBatchPool`] and
+/// [`MessageBatchPool`] within the [`Context`] object. For example, the list of neighbors in the
+/// [`ContextBatch`] is a collection of indices pointing to different agents within the
+/// [`AgentBatchPool`].
 ///
-/// [`AgentPool`]: crate::agent::AgentPool
-/// [`MessagePool`]: crate::message::MessagePool
+/// [`AgentBatchPool`]: crate::agent::AgentBatchPool
+/// [`MessageBatchPool`]: crate::message::MessageBatchPool
 /// [`Context`]: crate::context::Context
 pub struct ContextBatch {
     segment: Segment,

--- a/packages/engine/lib/stateful/src/message/mod.rs
+++ b/packages/engine/lib/stateful/src/message/mod.rs
@@ -7,8 +7,9 @@
 //! provides different variants, please see its documentation for more information.
 //!
 //! [`Message`]s are laid out in-memory in [`MessageBatch`]es according to the representation
-//! defined by [`MessageSchema`]. Multiple [`MessageBatch`]es are collected in a [`MessagePool`]
-//! which is interacted with through the [`MessageLoader`] and [`MessageReader`].
+//! defined by [`MessageSchema`]. Multiple [`MessageBatch`]es are collected in a
+//! [`MessageBatchPool`] which is interacted with through the [`MessageLoader`] and
+//! [`MessageReader`].
 //!
 //! [HASH documentation]: https://hash.ai/docs/simulation/creating-simulations/agent-messages
 //! [`Agent`]: crate::agent::Agent
@@ -30,7 +31,7 @@ pub use self::{
     loader::{MessageLoader, RawMessage},
     map::MessageMap,
     outbound::Message,
-    pool::{MessagePool, MessageReader},
+    pool::{MessageBatchPool, MessageReader},
     schema::MessageSchema,
 };
 pub(in crate) use self::{

--- a/packages/engine/lib/stateful/src/message/pool.rs
+++ b/packages/engine/lib/stateful/src/message/pool.rs
@@ -19,17 +19,17 @@ use crate::{
 
 /// A collection of [`MessageBatch`]es which contain the current (outbound) messages of agents.
 ///
-/// This is kept separate to the [`AgentPool`], because while agents can be removed between steps,
-/// messages are still sent out in the next step (including the ones by deleted agents) — this
-/// removes the need for making copies of the pool.
+/// This is kept separate to the [`AgentBatchPool`], because while agents can be removed between
+/// steps, messages are still sent out in the next step (including the ones by deleted agents) —
+/// this removes the need for making copies of the pool.
 ///
-/// [`AgentPool`]: crate::agent::AgentPool
+/// [`AgentBatchPool`]: crate::agent::AgentBatchPool
 #[derive(Clone)]
-pub struct MessagePool {
+pub struct MessageBatchPool {
     batches: Vec<Arc<RwLock<MessageBatch>>>,
 }
 
-impl MessagePool {
+impl MessageBatchPool {
     /// Creates a new pool from [`MessageBatch`]es.
     ///
     /// Because of the way `BatchPools` are organized it's required that the [`MessageBatch`]es are
@@ -101,7 +101,7 @@ impl MessagePool {
     }
 }
 
-impl BatchPool for MessagePool {
+impl BatchPool for MessageBatchPool {
     type Batch = MessageBatch;
 
     fn len(&self) -> usize {

--- a/packages/engine/lib/stateful/src/state/column.rs
+++ b/packages/engine/lib/stateful/src/state/column.rs
@@ -5,9 +5,9 @@ use crate::{agent::AgentBatch, proxy::PoolWriteProxy, Result};
 /// Encapsulates the functionality of writing a specific column within the state batches.
 ///
 /// Wrapping the logic within this struct allows any type implementing [`IntoArrowChange`] to
-/// write the [`ColumnChange`] to an [`AgentPool`].
+/// write the [`ColumnChange`] to an [`AgentBatchPool`].
 ///
-/// [`AgentPool`]: crate::agent::AgentPool
+/// [`AgentBatchPool`]: crate::agent::AgentBatchPool
 pub struct StateColumn {
     inner: Box<dyn IntoArrowChange + Send + Sync>,
 }

--- a/packages/engine/lib/stateful/src/state/proxy.rs
+++ b/packages/engine/lib/stateful/src/state/proxy.rs
@@ -4,7 +4,7 @@ use crate::{
     agent::AgentBatch,
     message::MessageBatch,
     proxy::{BatchPool, BatchReadProxy, BatchWriteProxy, PoolReadProxy, PoolWriteProxy},
-    state::StatePools,
+    state::StateBatchPools,
     Result,
 };
 
@@ -41,7 +41,7 @@ impl Debug for StateReadProxy {
 }
 
 impl StateReadProxy {
-    pub(crate) fn new(state: &StatePools) -> Result<Self> {
+    pub(crate) fn new(state: &StateBatchPools) -> Result<Self> {
         Ok(StateReadProxy {
             agent_proxies: state.agent_pool.read_proxies()?,
             message_proxies: state.message_pool.read_proxies()?,
@@ -50,7 +50,7 @@ impl StateReadProxy {
 
     // TODO: UNUSED: Needs triage
     #[allow(dead_code)]
-    pub(crate) fn new_partial(state: &StatePools, group_indices: &[usize]) -> Result<Self> {
+    pub(crate) fn new_partial(state: &StateBatchPools, group_indices: &[usize]) -> Result<Self> {
         Ok(StateReadProxy {
             agent_proxies: state.agent_pool.partial_read_proxies(group_indices)?,
             message_proxies: state.message_pool.partial_read_proxies(group_indices)?,
@@ -118,7 +118,7 @@ impl
 }
 
 impl StateWriteProxy {
-    pub(crate) fn new(state: &mut StatePools) -> Result<Self> {
+    pub(crate) fn new(state: &mut StateBatchPools) -> Result<Self> {
         Ok(StateWriteProxy {
             agent_proxies: state.agent_pool.write_proxies()?,
             message_proxies: state.message_pool.write_proxies()?,
@@ -127,7 +127,10 @@ impl StateWriteProxy {
 
     // TODO: UNUSED: Needs triage
     #[allow(dead_code)]
-    pub(crate) fn new_partial(state: &mut StatePools, group_indices: &[usize]) -> Result<Self> {
+    pub(crate) fn new_partial(
+        state: &mut StateBatchPools,
+        group_indices: &[usize],
+    ) -> Result<Self> {
         Ok(StateWriteProxy {
             agent_proxies: state.agent_pool.partial_write_proxies(group_indices)?,
             message_proxies: state.message_pool.partial_write_proxies(group_indices)?,

--- a/packages/engine/lib/stateful/src/state/references.rs
+++ b/packages/engine/lib/stateful/src/state/references.rs
@@ -1,12 +1,12 @@
-/// A record pointing to a specific agent inside of an [`AgentPool`].
+/// A record pointing to a specific agent inside of an [`AgentBatchPool`].
 ///
-/// [`AgentPool`]: crate::agent::AgentPool
+/// [`AgentBatchPool`]: crate::agent::AgentBatchPool
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AgentIndex {
-    /// Index of the [`AgentBatch`] inside of a [`AgentPool`]
+    /// Index of the [`AgentBatch`] inside of a [`AgentBatchPool`]
     ///
     /// [`AgentBatch`]: crate::agent::AgentBatch
-    /// [`AgentPool`]: crate::agent::AgentPool
+    /// [`AgentBatchPool`]: crate::agent::AgentBatchPool
     pub group_index: u32,
     /// Index of the agent inside of an [`AgentBatch`]
     ///
@@ -15,12 +15,12 @@ pub struct AgentIndex {
 }
 
 /// A reference to a [`Message`] by an [`Agent`] and the [`MessageBatch`] inside of a
-/// [`MessagePool`].
+/// [`MessageBatchPool`].
 ///
 /// [`Agent`]: crate::agent::Agent
 /// [`Message`]: crate::message::Message
 /// [`MessageBatch`]: crate::message::MessageBatch
-/// [`MessagePool`]: crate::message::MessagePool
+/// [`MessageBatchPool`]: crate::message::MessageBatchPool
 #[derive(Clone, Debug)]
 pub struct MessageReference {
     pub batch_index: usize,

--- a/packages/engine/lib/stateful/src/state/view.rs
+++ b/packages/engine/lib/stateful/src/state/view.rs
@@ -1,18 +1,18 @@
 use crate::{
-    agent::{AgentBatch, AgentPool},
-    message::{MessageBatch, MessageMap, MessagePool},
+    agent::{AgentBatch, AgentBatchPool},
+    message::{MessageBatch, MessageBatchPool, MessageMap},
     state::{StateReadProxy, StateWriteProxy},
     Result,
 };
 
-/// Unification of [`AgentPool`]s and [`MessagePool`]s for simultaneous access.
+/// Unification of [`AgentBatchPool`]s and [`MessageBatchPool`]s for simultaneous access.
 #[derive(Clone)]
-pub struct StatePools {
-    pub agent_pool: AgentPool,
-    pub message_pool: MessagePool,
+pub struct StateBatchPools {
+    pub agent_pool: AgentBatchPool,
+    pub message_pool: MessageBatchPool,
 }
 
-impl StatePools {
+impl StateBatchPools {
     pub fn read(&self) -> Result<StateReadProxy> {
         StateReadProxy::new(self)
     }
@@ -22,7 +22,7 @@ impl StatePools {
     }
 }
 
-impl Extend<(AgentBatch, MessageBatch)> for StatePools {
+impl Extend<(AgentBatch, MessageBatch)> for StateBatchPools {
     fn extend<T: IntoIterator<Item = (AgentBatch, MessageBatch)>>(&mut self, iter: T) {
         let iter = iter.into_iter();
         let n = iter.size_hint().0;
@@ -37,8 +37,8 @@ impl Extend<(AgentBatch, MessageBatch)> for StatePools {
     }
 }
 
-/// Associates the [`StatePools`] with a [`MessageMap`].
+/// Associates the [`StateBatchPools`] with a [`MessageMap`].
 pub struct StateSnapshot {
-    pub state: StatePools,
+    pub state: StateBatchPools,
     pub message_map: MessageMap,
 }

--- a/packages/engine/src/datastore/table/create_remove/plan.rs
+++ b/packages/engine/src/datastore/table/create_remove/plan.rs
@@ -1,6 +1,6 @@
 use memory::shared_memory::MemoryId;
 use rayon::prelude::*;
-use stateful::{proxy::BatchPool, state::StatePools};
+use stateful::{proxy::BatchPool, state::StateBatchPools};
 
 use crate::{
     config::SimRunConfig,
@@ -20,7 +20,11 @@ pub struct MigrationPlan<'a> {
 }
 
 impl<'a> MigrationPlan<'a> {
-    pub fn execute(self, state: &mut StatePools, config: &SimRunConfig) -> Result<Vec<String>> {
+    pub fn execute(
+        self,
+        state: &mut StateBatchPools,
+        config: &SimRunConfig,
+    ) -> Result<Vec<String>> {
         // tracing::debug!("Updating");
         self.existing_mutations
             .par_iter()

--- a/packages/engine/src/simulation/engine.rs
+++ b/packages/engine/src/simulation/engine.rs
@@ -2,11 +2,11 @@ use std::{mem, sync::Arc};
 
 use memory::shared_memory::MemoryId;
 use stateful::{
-    agent::AgentPool,
+    agent::AgentBatchPool,
     context::Context,
-    message::{MessageMap, MessagePool},
+    message::{MessageBatchPool, MessageMap},
     proxy::BatchPool,
-    state::{State, StatePools, StateSnapshot},
+    state::{State, StateBatchPools, StateSnapshot},
 };
 use tracing::Instrument;
 
@@ -255,7 +255,7 @@ impl Engine {
         self.handle_messages(state, &message_map)?;
         let message_pool = self.finalize_agent_messages(state, context)?;
         let agent_pool = self.finalize_agent_state(state, context)?;
-        let mut state_view = StatePools {
+        let mut state_view = StateBatchPools {
             agent_pool,
             message_pool,
         };
@@ -296,7 +296,7 @@ impl Engine {
         &mut self,
         state: &mut State,
         context: &mut Context,
-    ) -> Result<MessagePool> {
+    ) -> Result<MessageBatchPool> {
         let message_pool = context.take_message_pool();
         let finalized_message_pool = state.reset_messages(message_pool)?;
         Ok(finalized_message_pool)
@@ -308,7 +308,7 @@ impl Engine {
         &mut self,
         state: &mut State,
         context: &mut Context,
-    ) -> Result<AgentPool> {
+    ) -> Result<AgentBatchPool> {
         context.update_agent_snapshot(
             state,
             &self.config.sim.store.agent_schema,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The term `AgentPool`, `MessagePool`, and `StatePools` are confusing. This PR renames the structs to `AgentBatchPool`, `MessageBatchPool`, and `StateBatchPool`.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201893074552404/1201800853370429/f) _(internal)_