### PR TITLE
Bump tokio to `1.18.2`

### DIFF
--- a/packages/engine/Cargo.lock
+++ b/packages/engine/Cargo.lock
@@ -1278,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.114"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0005d08a8f7b65fb8073cb697aa0b12b631ed251ce73d862ce50eeb52ce3b50"
+checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
 name = "libm"
@@ -1394,24 +1394,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.14"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
 dependencies = [
  "libc",
  "log",
- "miow",
- "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2459,11 +2449,10 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.13.0"
+version = "1.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
+checksum = "4903bf0427cf68dddd5aa6a93220756f8be0c34fcfa9f5e6191e103e15a31395"
 dependencies = [
- "autocfg",
  "bytes 1.1.0",
  "libc",
  "mio",
@@ -2734,6 +2723,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2859,3 +2854,46 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -39,7 +39,7 @@ serde-aux = "0.6.1"
 strum_macros = "0.19.4"
 surf = "2.0.0"
 thiserror = "1.0.21"
-tokio = { version = "1.5.0", features = ["macros", "rt-multi-thread", "sync", "process", "time"] }
+tokio = { version = "1.18.2", features = ["macros", "rt-multi-thread", "sync", "process", "time"] }
 tracing = "0.1.29"
 tracing-appender = "0.2.0"
 tracing-error = "0.2.0"

--- a/packages/engine/bin/cli/Cargo.toml
+++ b/packages/engine/bin/cli/Cargo.toml
@@ -13,7 +13,7 @@ orchestrator = { path = "../../lib/orchestrator", default-features = false, feat
 
 clap = { version = "3.0.0", features = ["cargo", "derive", "env"] }
 serde = { version = "1.0.111", features = ["derive"] }
-tokio = "1.5.0"
+tokio = "1.18.2"
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 
 [features]

--- a/packages/engine/bin/hash_engine/Cargo.toml
+++ b/packages/engine/bin/hash_engine/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 hash_engine_lib = { path = "../..", default-features = false }
 error = { path = "../../lib/error", features = ["spantrace"] }
 
-tokio = "1.5.0"
+tokio = "1.18.2"
 tracing = "0.1.29"
 
 [[bin]]

--- a/packages/engine/lib/execution/Cargo.toml
+++ b/packages/engine/lib/execution/Cargo.toml
@@ -23,7 +23,7 @@ rayon = "1.4.1"
 serde = { version = "1.0.111", features = ["derive"] }
 serde_json = "1.0.59"
 thiserror = "1.0.21"
-tokio = { version = "1.5.0", features = ["macros", "rt", "sync", "process", "time"] }
+tokio = { version = "1.18.2", features = ["macros", "rt", "sync", "process", "time"] }
 tracing = "0.1.29"
 uuid = { version = "0.8.1" }
 v8 = "0.42.0"

--- a/packages/engine/lib/nano/Cargo.toml
+++ b/packages/engine/lib/nano/Cargo.toml
@@ -8,7 +8,7 @@ nng = { version = "1.0.1", default-features = false }
 serde = { version = "1.0.111", features = ["derive"] }
 serde_json = "1.0.59"
 thiserror = "1.0.21"
-tokio = { version = "1.5.0", features = ["sync", "macros", "rt"] }
+tokio = { version = "1.18.2", features = ["sync", "macros", "rt"] }
 tracing = "0.1.29"
 
 [features]

--- a/packages/engine/lib/orchestrator/Cargo.toml
+++ b/packages/engine/lib/orchestrator/Cargo.toml
@@ -20,7 +20,7 @@ rand_distr = "0.4.2"
 serde = "1.0.133"
 serde_json = "1.0.74"
 tracing = "0.1.29"
-tokio = { version = "1.5.0" }
+tokio = { version = "1.18.2" }
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 
 [features]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Our current tokio version (`1.5.0`) does not implement `Error` on it's error types like `SendError`, in later versions this is fixed.

This also fixes [Data race when sending and receiving after closing a oneshot channel](https://rustsec.org/advisories/RUSTSEC-2021-0124).