### PR TITLE
Rename `Report::generalise` to `generalize`

### DIFF
--- a/packages/engine/lib/error/src/report.rs
+++ b/packages/engine/lib/error/src/report.rs
@@ -133,7 +133,7 @@ impl<C> Report<C> {
 
     /// Converts the `Report<Context>` to `Report<()>` without modifying the frame stack.
     #[allow(clippy::missing_const_for_fn)] // False positive
-    pub fn generalise(self) -> Report {
+    pub fn generalize(self) -> Report {
         Report {
             inner: self.inner,
             _context: PhantomData,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We are using American English