### PR TITLE
Always run all Rust jobs if toolchain changed

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,7 @@ jobs:
 
           while read -r file; do
             while read -r crate; do
-              if [[ $file =~ $crate ]] || [[ $file =~ .github ]]; then
+              if [[ $file =~ $crate ]] || [[ $file =~ .github ]] || [[ $file =~ rust-toolchain.toml ]]; then
                 changed_crates=$(echo -e "${crate}\n$changed_crates")
               fi
             done <<< "$available_crates"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

As seen in https://github.com/hashintel/hash/pull/550 only a few crates are run when changing the toolchain. To avoid surprises, let the CI run **all** Rust jobs when the toolchain changes.