### PR TITLE
Fix no-std issues in error library

### DIFF
--- a/packages/engine/lib/error/src/frame.rs
+++ b/packages/engine/lib/error/src/frame.rs
@@ -8,9 +8,8 @@ use core::{
     fmt::Formatter,
     mem::ManuallyDrop,
     panic::Location,
-    ptr::{self, NonNull},
+    ptr::{self, addr_of, NonNull},
 };
-use std::ptr::addr_of;
 
 use provider::{self, Demand, Provider};
 

--- a/packages/engine/lib/error/src/macros.rs
+++ b/packages/engine/lib/error/src/macros.rs
@@ -44,7 +44,7 @@ pub mod __private {
     }
 
     pub fn report(args: fmt::Arguments) -> Report {
-        Report::new(args.to_string())
+        Report::new(alloc::string::ToString::to_string(&args))
     }
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The error library is supposed to support `#[no_std]`, but there are two errors, which has to be fixed