### PR TITLE
Run miri for all lib-crates

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,8 +43,8 @@ jobs:
           # All jobs for all crates will run if any of those paths changes
           always_run_on=(".github" "rust-toolchain.toml")
 
-          # We ensure, that `miri` will run for these crates
-          run_miri_for=("packages/engine/lib/error" "packages/engine/lib/provider")
+          # Miri can't run the following crates
+          dont_run_miri_for=("packages/engine")
 
           changed_crates=""
           while read -r file; do
@@ -67,10 +67,10 @@ jobs:
           fi
 
           miri_crates=""
-          for crate in "${run_miri_for[@]}"; do
+          for avoid_crate in "${dont_run_miri_for[@]}"; do
             while read -r changed_crate; do
-              if [[ $changed_crate =~ $crate ]]; then
-                miri_crates=$(echo -e "${crate}\n$miri_crates")
+              if [[ $changed_crate != $avoid_crate ]]; then
+                miri_crates=$(echo -e "$changed_crate\n$miri_crates")
               fi
             done <<< "$changed_crates"
           done

--- a/packages/engine/lib/memory/src/shared_memory/segment.rs
+++ b/packages/engine/lib/memory/src/shared_memory/segment.rs
@@ -542,7 +542,7 @@ impl Segment {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(miri)))]
 pub mod tests {
     use super::*;
 

--- a/packages/engine/lib/stateful/src/vec.rs
+++ b/packages/engine/lib/stateful/src/vec.rs
@@ -85,24 +85,12 @@ impl Vec3 {
         self / self.magnitude()
     }
 
-    #[must_use]
-    pub fn as_slice(&self) -> &[f64] {
-        let f: *const f64 = &self.0;
-        unsafe { std::slice::from_raw_parts(f, 3) }
-    }
-
     // TODO: I'm not sure if we want truncation vs rounding, so I'm marking this as allowed.
     // TODO: UNUSED: Needs triage
     #[allow(clippy::cast_possible_truncation)]
     #[must_use]
     pub fn as_grid(&self) -> [i64; 3] {
         [self.0 as i64, self.1 as i64, self.2 as i64]
-    }
-}
-
-impl AsRef<[f64]> for Vec3 {
-    fn as_ref(&self) -> &[f64] {
-        self.as_slice()
     }
 }
 
@@ -313,12 +301,6 @@ mod tests {
         assert_eq!(pos.0, 3.0);
         assert_eq!(pos.1, 4.0);
         assert_eq!(pos.2, 5.0);
-
-        let slice = pos.as_slice();
-
-        assert_eq!(slice[0], 3.0);
-        assert_eq!(slice[1], 4.0);
-        assert_eq!(slice[2], 5.0);
 
         let mut pos: Vec3 = Vec3::origin();
         pos[0] = 5.0;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

As introduced in #557, miri is running for `provider` and `error`. With only small adjustments to the tests, it could run almost everywhere and actually found a soundness hole.

## 🚫 

- #557 