### PR TITLE
Skip Arrow validation for ArrayData

### DIFF
--- a/packages/engine/lib/execution/src/runner/javascript/mod.rs
+++ b/packages/engine/lib/execution/src/runner/javascript/mod.rs
@@ -1217,8 +1217,12 @@ impl<'s> ThreadLocalRunner<'s> {
                 .null_count(data.null_count + target_len - data.len);
         }
 
-        // TODO: OPTIM: skip validation within `build()` for non-debug builds
-        Ok(builder.build()?)
+        // TODO: Either move to Arrow2 or fix the validation error
+        //
+        // Arrow's null checking fails for a couple of tests when trying to validate the
+        // conversion from JS to Rust. This is likely a false-positive and will be fixed by moving
+        // to Arrow2. In the meantime we bypass the validation.
+        Ok(unsafe { builder.build_unchecked() })
     }
 
     fn flush_batch(

--- a/packages/engine/lib/execution/src/runner/javascript/mod.rs
+++ b/packages/engine/lib/execution/src/runner/javascript/mod.rs
@@ -1218,6 +1218,7 @@ impl<'s> ThreadLocalRunner<'s> {
         }
 
         // TODO: Either move to Arrow2 or fix the validation error
+        // Arrow2 task: https://app.asana.com/0/1199548034582004/1201999214936733/f
         //
         // Arrow's null checking fails for a couple of tests when trying to validate the
         // conversion from JS to Rust. This is likely a false-positive and will be fixed by moving


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In order to replace a few Rust behaviors with Javascript ones we need to get rid of an Arrow validation error when converting Javascript arrays to Rust.
An actual fix for this error would be to switch to Arrow2 but this would take quite some time.
As this validation error is likely a false-positive, we are going to ignore it for now.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1199548034582004/1201927209654757/f) _(internal)_

- [Move to Arrow2 Asana task](https://app.asana.com/0/1199548034582004/1201999214936733/f) _(internal)_

## 🔍 What does this change?

- Switch [`ArrayDataBuilder::build`](https://docs.rs/arrow/latest/arrow/array/struct.ArrayDataBuilder.html#method.build) with [`ArrayDataBuilder::build_unchecked`](https://docs.rs/arrow/latest/arrow/array/struct.ArrayDataBuilder.html#method.build_unchecked)

## 📜 Does this require a change to the docs?

No

## 🐾 Next steps

- [Move to Arrow2](https://app.asana.com/0/1199548034582004/1201999214936733/f) or fix the validation error

## 🛡 What tests cover this?

Test with Javascript behaviors

## ❓ How to test this?

1.  Checkout the branch / view the deployment
2.  Try `cargo test`
3.  Confirm that all tests pass
