### PR TITLE
Add support to request from `Report` by value

### DIFF
--- a/packages/engine/lib/error/src/iter.rs
+++ b/packages/engine/lib/error/src/iter.rs
@@ -1,7 +1,7 @@
 use core::{fmt, fmt::Formatter, iter::FusedIterator, marker::PhantomData};
 
 use super::Frame;
-use crate::{Frames, Report, Requests};
+use crate::{Frames, Report, RequestRef, RequestValue};
 
 impl<'r> Frames<'r> {
     pub(super) const fn new<C>(report: &'r Report<C>) -> Self {
@@ -30,7 +30,7 @@ impl fmt::Debug for Frames<'_> {
     }
 }
 
-impl<'r, T: ?Sized> Requests<'r, T> {
+impl<'r, T: ?Sized> RequestRef<'r, T> {
     pub(super) const fn new<Context>(report: &'r Report<Context>) -> Self {
         Self {
             frames: report.frames(),
@@ -39,7 +39,7 @@ impl<'r, T: ?Sized> Requests<'r, T> {
     }
 }
 
-impl<'r, T> Iterator for Requests<'r, T>
+impl<'r, T> Iterator for RequestRef<'r, T>
 where
     T: ?Sized + 'static,
 {
@@ -50,9 +50,9 @@ where
     }
 }
 
-impl<'r, T> FusedIterator for Requests<'r, T> where T: ?Sized + 'static {}
+impl<'r, T> FusedIterator for RequestRef<'r, T> where T: ?Sized + 'static {}
 
-impl<T: ?Sized> Clone for Requests<'_, T> {
+impl<T: ?Sized> Clone for RequestRef<'_, T> {
     fn clone(&self) -> Self {
         Self {
             frames: self.frames.clone(),
@@ -61,9 +61,49 @@ impl<T: ?Sized> Clone for Requests<'_, T> {
     }
 }
 
-impl<'r, T> fmt::Debug for Requests<'r, T>
+impl<'r, T> fmt::Debug for RequestRef<'r, T>
 where
     T: ?Sized + fmt::Debug + 'static,
+{
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+        fmt.debug_list().entries(self.clone()).finish()
+    }
+}
+
+impl<'r, T> RequestValue<'r, T> {
+    pub(super) const fn new<Context>(report: &'r Report<Context>) -> Self {
+        Self {
+            frames: report.frames(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'r, T> Iterator for RequestValue<'r, T>
+where
+    T: 'static,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.frames.by_ref().find_map(Frame::request_value)
+    }
+}
+
+impl<'r, T> FusedIterator for RequestValue<'r, T> where T: 'static {}
+
+impl<T> Clone for RequestValue<'_, T> {
+    fn clone(&self) -> Self {
+        Self {
+            frames: self.frames.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'r, T> fmt::Debug for RequestValue<'r, T>
+where
+    T: fmt::Debug + 'static,
 {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         fmt.debug_list().entries(self.clone()).finish()

--- a/packages/engine/lib/error/src/macros.rs
+++ b/packages/engine/lib/error/src/macros.rs
@@ -397,29 +397,29 @@ mod tests {
     fn error() {
         let err = capture_error(|| Err(report!(context: ContextA(10))));
         assert_eq!(err.frames().count(), 1);
-        assert_eq!(err.request_ref().collect::<Vec<&u32>>(), [&10]);
+        assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
         assert_eq!(request_messages(&err), ["Context A"]);
 
         let err = capture_error(|| Err(report!(context: ContextA(10), "Literal")));
         assert_eq!(err.frames().count(), 2);
-        assert_eq!(err.request_ref().collect::<Vec<&u32>>(), [&10]);
+        assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
         assert_eq!(request_messages(&err), ["Context A", "Literal"]);
 
         let err = capture_error(|| Err(report!(context: ContextA(10), MESSAGE_A)));
         assert_eq!(err.frames().count(), 2);
-        assert_eq!(err.request_ref().collect::<Vec<&u32>>(), [&10]);
+        assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
         assert_eq!(request_messages(&err), ["Context A", "Message A"]);
 
         let var = "foo";
         let err = capture_error(|| Err(report!(context: ContextA(10), "Format String: {}", var)));
         assert_eq!(err.frames().count(), 2);
-        assert_eq!(err.request_ref().collect::<Vec<&u32>>(), [&10]);
+        assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
         assert_eq!(request_messages(&err), ["Context A", "Format String: foo"]);
 
         let var = "foo";
         let err = capture_error(|| Err(report!(context: ContextA(10), "Format String: {var}")));
         assert_eq!(err.frames().count(), 2);
-        assert_eq!(err.request_ref().collect::<Vec<&u32>>(), [&10]);
+        assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
         assert_eq!(request_messages(&err), ["Context A", "Format String: foo"]);
 
         let err = capture_error(|| Err(report!("Literal")));
@@ -445,29 +445,29 @@ mod tests {
     fn bail() {
         let err = capture_error(|| bail!(context: ContextA(10)));
         assert_eq!(err.frames().count(), 1);
-        assert_eq!(err.request_ref().collect::<Vec<&u32>>(), [&10]);
+        assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
         assert_eq!(request_messages(&err), ["Context A"]);
 
         let err = capture_error(|| bail!(context: ContextA(10), "Literal"));
         assert_eq!(err.frames().count(), 2);
-        assert_eq!(err.request_ref().collect::<Vec<&u32>>(), [&10]);
+        assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
         assert_eq!(request_messages(&err), ["Context A", "Literal"]);
 
         let err = capture_error(|| bail!(context: ContextA(10), MESSAGE_A));
         assert_eq!(err.frames().count(), 2);
-        assert_eq!(err.request_ref().collect::<Vec<&u32>>(), [&10]);
+        assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
         assert_eq!(request_messages(&err), ["Context A", "Message A"]);
 
         let var = "foo";
         let err = capture_error(|| bail!(context: ContextA(10), "Format String: {}", var));
         assert_eq!(err.frames().count(), 2);
-        assert_eq!(err.request_ref().collect::<Vec<&u32>>(), [&10]);
+        assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
         assert_eq!(request_messages(&err), ["Context A", "Format String: foo"]);
 
         let var = "foo";
         let err = capture_error(|| bail!(context: ContextA(10), "Format String: {var}"));
         assert_eq!(err.frames().count(), 2);
-        assert_eq!(err.request_ref().collect::<Vec<&u32>>(), [&10]);
+        assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
         assert_eq!(request_messages(&err), ["Context A", "Format String: foo"]);
 
         let err = capture_error(|| bail!("Literal"));
@@ -496,7 +496,7 @@ mod tests {
             Ok(())
         });
         assert_eq!(err.frames().count(), 1);
-        assert_eq!(err.request_ref().collect::<Vec<&u32>>(), [&10]);
+        assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
         assert_eq!(request_messages(&err), ["Context A"]);
 
         let err = capture_error(|| {
@@ -504,7 +504,7 @@ mod tests {
             Ok(())
         });
         assert_eq!(err.frames().count(), 2);
-        assert_eq!(err.request_ref().collect::<Vec<&u32>>(), [&10]);
+        assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
         assert_eq!(request_messages(&err), ["Context A", "Literal"]);
 
         let err = capture_error(|| {
@@ -512,7 +512,7 @@ mod tests {
             Ok(())
         });
         assert_eq!(err.frames().count(), 2);
-        assert_eq!(err.request_ref().collect::<Vec<&u32>>(), [&10]);
+        assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
         assert_eq!(request_messages(&err), ["Context A", "Message A"]);
 
         let var = "foo";
@@ -521,7 +521,7 @@ mod tests {
             Ok(())
         });
         assert_eq!(err.frames().count(), 2);
-        assert_eq!(err.request_ref().collect::<Vec<&u32>>(), [&10]);
+        assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
         assert_eq!(request_messages(&err), ["Context A", "Format String: foo"]);
 
         let var = "foo";
@@ -530,7 +530,7 @@ mod tests {
             Ok(())
         });
         assert_eq!(err.frames().count(), 2);
-        assert_eq!(err.request_ref().collect::<Vec<&u32>>(), [&10]);
+        assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
         assert_eq!(request_messages(&err), ["Context A", "Format String: foo"]);
 
         let err = capture_error(|| {

--- a/packages/engine/lib/error/src/report.rs
+++ b/packages/engine/lib/error/src/report.rs
@@ -9,7 +9,7 @@ use std::error::Error as StdError;
 use tracing_error::{SpanTrace, SpanTraceStatus};
 
 use super::Frame;
-use crate::{Context, Frames, Message, Report, Requests};
+use crate::{Context, Frames, Message, Report, RequestRef, RequestValue};
 
 #[allow(clippy::module_name_repetitions)]
 pub struct ReportImpl {
@@ -189,9 +189,14 @@ impl<C> Report<C> {
         Frames::new(self)
     }
 
-    /// Creates an iterator over the [`Frame`] stack requesting a reference of type `T`.
-    pub const fn request_ref<T: ?Sized + 'static>(&self) -> Requests<'_, T> {
-        Requests::new(self)
+    /// Creates an iterator over the [`Frame`] stack requesting references of type `T`.
+    pub const fn request_ref<T: ?Sized + 'static>(&self) -> RequestRef<'_, T> {
+        RequestRef::new(self)
+    }
+
+    /// Creates an iterator over the [`Frame`] stack requesting values of type `T`.
+    pub const fn request_value<T: 'static>(&self) -> RequestValue<'_, T> {
+        RequestValue::new(self)
     }
 
     /// Returns if `C` is the type held by any frame inside of the report.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Re-add `Report::request_value`, which was removed while vendoring in the upstream provider RFC.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201893074552404/1201481007343178/f) _(internal)_

## 🔍 What does this change?

- Rename `Requests` to `RequestRef` and add `RequestValue`
- Add `Report::request_value`
- Fix documentation

## 🐾 Next steps

- Check documentation in CI to ensure doc-links are generated properly