### PR TITLE
Avoid copying data when converting ArrayData from JS to Rust

### DIFF
--- a/packages/engine/Cargo.lock
+++ b/packages/engine/Cargo.lock
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "arrow"
-version = "10.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1328dbc6d5d76a08b13df3ac630f61a6a31276d9e9d08eb813e98efa624c2382"
+checksum = "5c6bee230122beb516ead31935a61f683715f987c6f003eff44ad6986624105a"
 dependencies = [
  "bitflags",
  "chrono",
@@ -715,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "flatbuffers"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea97b4fe4b84e2f2765449bcea21cbdb3ee28cecb88afbf38a0c2e1639f5eb5"
+checksum = "86b428b715fdbdd1c364b84573b5fdc0f84f8e423661b9f398735278bc7f2b6a"
 dependencies = [
  "bitflags",
  "smallvec",

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -17,7 +17,7 @@ simulation_structure = { path = "lib/simulation_structure" }
 execution = { path = "lib/execution", default-features = false }
 
 arr_macro = "0.1.3"
-arrow = { version = "10.0.0", default-features = false, features = ["ipc"] }
+arrow = { version = "13.0.0", default-features = false, features = ["ipc"] }
 async-trait = "0.1.48"
 clap = { version = "3.0.0", features = ["cargo", "derive", "env"] }
 csv = "1.1.5"

--- a/packages/engine/lib/execution/Cargo.toml
+++ b/packages/engine/lib/execution/Cargo.toml
@@ -9,7 +9,7 @@ memory = { path = "../memory" }
 stateful = { path = "../stateful" }
 simulation_structure = { path = "../simulation_structure" }
 
-arrow = { version = "10.0.0", default-features = false }
+arrow = { version = "13.0.0", default-features = false }
 async-trait = "0.1.48"
 flatbuffers = "2.1.1"
 float-cmp = "0.8.0"

--- a/packages/engine/lib/execution/src/runner/javascript/mod.rs
+++ b/packages/engine/lib/execution/src/runner/javascript/mod.rs
@@ -891,6 +891,7 @@ impl<'s> ThreadLocalRunner<'s> {
             return Buffer::from_custom_allocation(
                 data_ptr.cast::<u8>(),
                 data_len * std::mem::size_of::<T>(),
+                // JS is taking care of freeing the buffer and Rust should just do nothing
                 Arc::new(()),
             );
         }
@@ -941,6 +942,7 @@ impl<'s> ThreadLocalRunner<'s> {
                 Buffer::from_custom_allocation(
                     data_ptr.cast::<u8>(),
                     (data_len + 1) * std::mem::size_of::<i32>(),
+                    // JS is taking care of freeing the buffer and Rust should just do nothing
                     Arc::new(()),
                 ),
                 last as usize,
@@ -982,6 +984,7 @@ impl<'s> ThreadLocalRunner<'s> {
             return Buffer::from_custom_allocation(
                 data_ptr,
                 bit_util::ceil(data_len, 8),
+                // JS is taking care of freeing the buffer and Rust should just do nothing
                 Arc::new(()),
             );
         }

--- a/packages/engine/lib/memory/Cargo.toml
+++ b/packages/engine/lib/memory/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 flatbuffers_gen = { path = "../flatbuffers_gen" }
 
-arrow = { version = "10.0.0", default-features = false, features = ["ipc"] }
+arrow = { version = "13.0.0", default-features = false, features = ["ipc"] }
 flatbuffers = "2.1.1"
 glob = "0.3.0"
 rand = "0.8.3"

--- a/packages/engine/lib/memory/src/arrow/load.rs
+++ b/packages/engine/lib/memory/src/arrow/load.rs
@@ -26,5 +26,6 @@ pub fn record_batch(
         record_batch_message,
         schema,
         &[],
+        None,
     )?)
 }

--- a/packages/engine/lib/stateful/Cargo.toml
+++ b/packages/engine/lib/stateful/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 memory = { path = "../memory" }
 
-arrow = { version = "10.0.0", default-features = false }
+arrow = { version = "13.0.0", default-features = false }
 flatbuffers = "2.1.1"
 lazy_static = "1.4.0"
 parking_lot = "0.11.1"

--- a/packages/engine/lib/stateful/src/agent/arrow/batch.rs
+++ b/packages/engine/lib/stateful/src/agent/arrow/batch.rs
@@ -144,7 +144,7 @@ impl AgentBatch {
 
         let dynamic_meta = batch_message.into_meta(buffers.data().len())?;
 
-        let record_batch = read_record_batch(buffers.data(), batch_message, schema, &[])?;
+        let record_batch = read_record_batch(buffers.data(), batch_message, schema, &[], None)?;
 
         Ok(Self {
             batch: ArrowBatch::new(

--- a/packages/engine/lib/stateful/src/context/batch.rs
+++ b/packages/engine/lib/stateful/src/context/batch.rs
@@ -78,7 +78,7 @@ impl ContextBatch {
         let rb_msg = ipc::root_as_message(buffers.meta())?
             .header_as_record_batch()
             .ok_or(Error::InvalidRecordBatchIpcMessage)?;
-        let batch = read_record_batch(buffers.data(), rb_msg, schema, &[])?;
+        let batch = read_record_batch(buffers.data(), rb_msg, schema, &[], None)?;
 
         Ok(Self {
             segment,
@@ -171,7 +171,7 @@ impl ContextBatch {
         let rb_msg = &ipc::root_as_message(buffers.meta())?
             .header_as_record_batch()
             .ok_or(Error::InvalidRecordBatchIpcMessage)?;
-        self.batch = read_record_batch(buffers.data(), *rb_msg, self.batch.schema(), &[])?;
+        self.batch = read_record_batch(buffers.data(), *rb_msg, self.batch.schema(), &[], None)?;
         self.loaded = persisted;
 
         Ok(())

--- a/packages/engine/lib/stateful/src/message/batch.rs
+++ b/packages/engine/lib/stateful/src/message/batch.rs
@@ -228,9 +228,13 @@ impl MessageBatch {
         let data_length = buffers.data().len();
         let dynamic_meta = batch_message.into_meta(data_length)?;
 
-        let record_batch =
-            read_record_batch(buffers.data(), batch_message, Arc::clone(&schema.arrow), &[
-            ])?;
+        let record_batch = read_record_batch(
+            buffers.data(),
+            batch_message,
+            Arc::clone(&schema.arrow),
+            &[],
+            None,
+        )?;
 
         let persisted = segment.try_read_persisted_metaversion()?;
         Ok(Self {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When building `ArrayData` on the Rust side we copy all data from Javascript.
Rust and Javascript don't have the same expectation regarding what the array contains.
But sometimes they line up and we can skip the copy and just map the array.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1199548034582004/1201927209654755/f) _(internal)_

## 🚫 Blocked by

- [ ] [Investigate memory leak](https://app.asana.com/0/1199548034582004/1202479511750422/f) (_internal_)

## 🔍 What does this change?

- Update the arrow Rust library from v10 to v13
- Map array data when possible to avoid copying the data from Javascript to Rust

## 📜 Does this require a change to the docs?

No

## 🐾 Next steps

- [Move to Arrow2](https://app.asana.com/0/1199548034582004/1201999214936733/f) _(internal)_

## 🛡 What tests cover this?

- All tests involving Arrow and the Javascript runner

## ❓ How to test this?

1.  Checkout the branch / view the deployment
2.  Try `cargo test`
3.  Confirm that all tests pass
