### PR TITLE
Bust in-memory block cache when loading block from url

### DIFF
--- a/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockLoaderInput.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockLoaderInput.tsx
@@ -35,7 +35,7 @@ export const BlockLoaderInput: React.VFC = () => {
     const normalizedUrl = createNormalizedBlockUrl(blockUrl);
 
     blockView.manager
-      .fetchAndDefineBlock(normalizedUrl)
+      .fetchAndDefineBlock(normalizedUrl, true)
       .then((blockMeta) => {
         unstable_batchedUpdates(() => {
           setError(null);

--- a/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockLoaderInput.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockLoaderInput.tsx
@@ -35,7 +35,7 @@ export const BlockLoaderInput: React.VFC = () => {
     const normalizedUrl = createNormalizedBlockUrl(blockUrl);
 
     blockView.manager
-      .fetchAndDefineBlock(normalizedUrl, true)
+      .fetchAndDefineBlock(normalizedUrl, { bustCache: true })
       .then((blockMeta) => {
         unstable_batchedUpdates(() => {
           setError(null);

--- a/packages/hash/shared/src/ProsemirrorSchemaManager.ts
+++ b/packages/hash/shared/src/ProsemirrorSchemaManager.ts
@@ -211,8 +211,11 @@ export class ProsemirrorSchemaManager {
    *
    * @todo support taking a signal
    */
-  async fetchAndDefineBlock(componentId: string): Promise<BlockMeta> {
-    const meta = await fetchBlockMeta(componentId);
+  async fetchAndDefineBlock(
+    componentId: string,
+    bustCache: boolean = false,
+  ): Promise<BlockMeta> {
+    const meta = await fetchBlockMeta(componentId, bustCache);
 
     await this.defineRemoteBlock(componentId);
 
@@ -245,7 +248,7 @@ export class ProsemirrorSchemaManager {
       Object.values(data.store.saved)
         .map((entity: any) => entity.properties?.componentId)
         .filter(isString)
-        .map(this.fetchAndDefineBlock, this),
+        .map((componentId) => this.fetchAndDefineBlock(componentId), this),
     );
   }
 

--- a/packages/hash/shared/src/ProsemirrorSchemaManager.ts
+++ b/packages/hash/shared/src/ProsemirrorSchemaManager.ts
@@ -213,9 +213,11 @@ export class ProsemirrorSchemaManager {
    */
   async fetchAndDefineBlock(
     componentId: string,
-    bustCache: boolean = false,
+    options?: { bustCache: boolean },
   ): Promise<BlockMeta> {
-    const meta = await fetchBlockMeta(componentId, bustCache);
+    const meta = await fetchBlockMeta(componentId, {
+      bustCache: !!options?.bustCache,
+    });
 
     await this.defineRemoteBlock(componentId);
 

--- a/packages/hash/shared/src/blockMeta.ts
+++ b/packages/hash/shared/src/blockMeta.ts
@@ -121,10 +121,13 @@ const transformBlockConfig = ({
 // @todo deal with errors, loading, abort etc.
 export const fetchBlockMeta = async (
   componentId: string,
+  bustCache: boolean = false,
 ): Promise<BlockMeta> => {
   const baseUrl = componentIdToUrl(componentId);
 
-  if (blockCache.has(baseUrl)) {
+  if (bustCache) {
+    blockCache.delete(baseUrl);
+  } else if (blockCache.has(baseUrl)) {
     return blockCache.get(baseUrl)!;
   }
 

--- a/packages/hash/shared/src/blockMeta.ts
+++ b/packages/hash/shared/src/blockMeta.ts
@@ -121,11 +121,11 @@ const transformBlockConfig = ({
 // @todo deal with errors, loading, abort etc.
 export const fetchBlockMeta = async (
   componentId: string,
-  bustCache: boolean = false,
+  options?: { bustCache: boolean },
 ): Promise<BlockMeta> => {
   const baseUrl = componentIdToUrl(componentId);
 
-  if (bustCache) {
+  if (options?.bustCache) {
     blockCache.delete(baseUrl);
   } else if (blockCache.has(baseUrl)) {
     return blockCache.get(baseUrl)!;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We have an input field to paste a URL to load a block from, for development purposes.

Re-loading a block is supposed to refresh its source from the URL, but an in-memory cache wasn't being busted when doing so.

This PR fixes that.

## ❓ How to test this?

1.  Serve a block locally, load it in the app
2. Change something, re-load it via the URL input
3. Check the change has taken effect