### PR TITLE
Apply Prettier to style files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,11 +8,13 @@
 
 # Allow certain file types
 !*.cjs
+!*.css
 !*.js
 !*.json
 !*.md
 !*.mdx
 !*.mjs
+!*.scss
 !*.ts
 !*.tsx
 !*.yml

--- a/packages/blocks/drawing-canvas/src/base.css
+++ b/packages/blocks/drawing-canvas/src/base.css
@@ -1,87 +1,87 @@
 .drawing-canvas-container {
-    width: 100%;
-    position: relative;
+  width: 100%;
+  position: relative;
 }
 
 #TD-MenuItem-File-Export-PNG,
 #TD-MenuItem-File-Export-JPG,
 #TD-MenuItem-File-Export-WEBP {
-    display: none;
+  display: none;
 }
 
-#TD-MenuItem-Edit + div[role="separator"] { 
-    display: none
+#TD-MenuItem-Edit + div[role="separator"] {
+  display: none;
 }
 
 #TD-MenuItem-Preferences ~ * {
-    display: none;
+  display: none;
 }
 
 /* React Resizable Styles */
 
 .react-resizable {
-    position: relative;
-  }
-  .react-resizable-handle {
-    position: absolute;
-    width: 20px;
-    height: 20px;
-    background-repeat: no-repeat;
-    background-origin: content-box;
-    box-sizing: border-box;
-    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2IDYiIHN0eWxlPSJiYWNrZ3JvdW5kLWNvbG9yOiNmZmZmZmYwMCIgeD0iMHB4IiB5PSIwcHgiIHdpZHRoPSI2cHgiIGhlaWdodD0iNnB4Ij48ZyBvcGFjaXR5PSIwLjMwMiI+PHBhdGggZD0iTSA2IDYgTCAwIDYgTCAwIDQuMiBMIDQgNC4yIEwgNC4yIDQuMiBMIDQuMiAwIEwgNiAwIEwgNiA2IEwgNiA2IFoiIGZpbGw9IiMwMDAwMDAiLz48L2c+PC9zdmc+');
-    background-position: bottom right;
-    padding: 0 3px 3px 0;
-    z-index: 10;
-  }
-  .react-resizable-handle-sw {
-    bottom: 0;
-    left: 0;
-    cursor: sw-resize;
-    transform: rotate(90deg);
-  }
-  .react-resizable-handle-se {
-    bottom: 0;
-    right: 0;
-    cursor: se-resize;
-  }
-  .react-resizable-handle-nw {
-    top: 0;
-    left: 0;
-    cursor: nw-resize;
-    transform: rotate(180deg);
-  }
-  .react-resizable-handle-ne {
-    top: 0;
-    right: 0;
-    cursor: ne-resize;
-    transform: rotate(270deg);
-  }
-  .react-resizable-handle-w,
-  .react-resizable-handle-e {
-    top: 50%;
-    margin-top: -10px;
-    cursor: ew-resize;
-  }
-  .react-resizable-handle-w {
-    left: 0;
-    transform: rotate(135deg);
-  }
-  .react-resizable-handle-e {
-    right: 0;
-    transform: rotate(315deg);
-  }
-  .react-resizable-handle-n,
-  .react-resizable-handle-s {
-    left: 50%;
-    margin-left: -10px;
-    cursor: ns-resize;
-  }
-  .react-resizable-handle-n {
-    top: 0;
-    transform: rotate(225deg);
-  }
-  .react-resizable-handle-s {
-    bottom: 0;
-    transform: rotate(45deg);
-  }
+  position: relative;
+}
+.react-resizable-handle {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  background-repeat: no-repeat;
+  background-origin: content-box;
+  box-sizing: border-box;
+  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2IDYiIHN0eWxlPSJiYWNrZ3JvdW5kLWNvbG9yOiNmZmZmZmYwMCIgeD0iMHB4IiB5PSIwcHgiIHdpZHRoPSI2cHgiIGhlaWdodD0iNnB4Ij48ZyBvcGFjaXR5PSIwLjMwMiI+PHBhdGggZD0iTSA2IDYgTCAwIDYgTCAwIDQuMiBMIDQgNC4yIEwgNC4yIDQuMiBMIDQuMiAwIEwgNiAwIEwgNiA2IEwgNiA2IFoiIGZpbGw9IiMwMDAwMDAiLz48L2c+PC9zdmc+");
+  background-position: bottom right;
+  padding: 0 3px 3px 0;
+  z-index: 10;
+}
+.react-resizable-handle-sw {
+  bottom: 0;
+  left: 0;
+  cursor: sw-resize;
+  transform: rotate(90deg);
+}
+.react-resizable-handle-se {
+  bottom: 0;
+  right: 0;
+  cursor: se-resize;
+}
+.react-resizable-handle-nw {
+  top: 0;
+  left: 0;
+  cursor: nw-resize;
+  transform: rotate(180deg);
+}
+.react-resizable-handle-ne {
+  top: 0;
+  right: 0;
+  cursor: ne-resize;
+  transform: rotate(270deg);
+}
+.react-resizable-handle-w,
+.react-resizable-handle-e {
+  top: 50%;
+  margin-top: -10px;
+  cursor: ew-resize;
+}
+.react-resizable-handle-w {
+  left: 0;
+  transform: rotate(135deg);
+}
+.react-resizable-handle-e {
+  right: 0;
+  transform: rotate(315deg);
+}
+.react-resizable-handle-n,
+.react-resizable-handle-s {
+  left: 50%;
+  margin-left: -10px;
+  cursor: ns-resize;
+}
+.react-resizable-handle-n {
+  top: 0;
+  transform: rotate(225deg);
+}
+.react-resizable-handle-s {
+  bottom: 0;
+  transform: rotate(45deg);
+}

--- a/packages/blocks/github-pr-overview/src/index.css
+++ b/packages/blocks/github-pr-overview/src/index.css
@@ -1,10 +1,10 @@
-.prOverviewContainer>div {
-    display: flex;
-    flex-direction: column;
+.prOverviewContainer > div {
+  display: flex;
+  flex-direction: column;
 }
 
 .timeline {
-    flex-basis: 0px;
-    flex-grow: 1;
-    overflow-y: auto;
+  flex-basis: 0px;
+  flex-grow: 1;
+  overflow-y: auto;
 }

--- a/packages/blocks/toggle-item/src/index.css
+++ b/packages/blocks/toggle-item/src/index.css
@@ -1,7 +1,7 @@
 .toggle-item-base-paragraph {
-    font-size: var(--font-size-3);
-    line-height: var(--line-height-base);
-    margin-bottom: var(--space-4);
-    font-family: var(--font-family);
-    color: var(--primary-text-base);
+  font-size: var(--font-size-3);
+  line-height: var(--line-height-base);
+  margin-bottom: var(--space-4);
+  font-family: var(--font-family);
+  color: var(--primary-text-base);
 }

--- a/packages/hash/frontend/styles/globals.scss
+++ b/packages/hash/frontend/styles/globals.scss
@@ -1,7 +1,5 @@
 // @todo remove these styles when main components are converted to mui
 main {
-
-
   h1 {
     font-size: 2rem;
     font-weight: 400;

--- a/sites/hashdev/styles/globals.css
+++ b/sites/hashdev/styles/globals.css
@@ -1,11 +1,11 @@
 code {
-    padding: 0.25rem 0.5rem;
-    margin: 0 0.15rem;
-    background-color: #F7FAFC;
-    border-radius: 0.25rem;
-    border: 1px solid #DDE7F0;
+  padding: 0.25rem 0.5rem;
+  margin: 0 0.15rem;
+  background-color: #f7fafc;
+  border-radius: 0.25rem;
+  border: 1px solid #dde7f0;
 }
 
 pre code {
-    border: none;
+  border: none;
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When working on https://github.com/hashintel/hash/pull/576, I noticed that my new `app.scss` files was not fixed by Prettier. I added `!*.css` and `!*.scss` to `.prettierignore`, but it broke CI. This PR applies formatting to all pre-existing style files to reduce the diff in #576.

## 🛡 What tests cover this?

- CI
