### PR TITLE
Make entityTypeId optional in aggregateEntities

### DIFF
--- a/packages/hash/api/src/graphql/resolvers/entity/aggregateEntity.ts
+++ b/packages/hash/api/src/graphql/resolvers/entity/aggregateEntity.ts
@@ -18,13 +18,14 @@ export const dbAggregateEntity =
     const multiSort = operation?.multiSort ?? [{ field: "updatedAt" }];
     const multiFilter = operation?.multiFilter;
 
-    // TODO: this returns an array of all entities of the given type in the account.
+    // TODO: this returns an array of all entities matching the type filter (if any) in the account.
     // We should perform the sorting & filtering in the database for better performance.
     // For pagination, using a database cursor may be an option.
-    const entities = await Entity.getEntitiesByType(db, {
+    const entities = await Entity.getAccountEntities(db, {
       accountId,
-      entityTypeId,
-      latestOnly: true,
+      entityTypeFilter: {
+        entityTypeId,
+      },
     });
 
     const startIndex = pageNumber === 1 ? 0 : (pageNumber - 1) * itemsPerPage;

--- a/packages/hash/api/src/graphql/typeDefs/aggregation.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/aggregation.typedef.ts
@@ -16,7 +16,7 @@ export const aggregationTypedef = gql`
   }
 
   type AggregateOperation {
-    entityTypeId: ID!
+    entityTypeId: ID
     entityTypeVersionId: ID
     multiFilter: MultiFilterOperation
     multiSort: [SortOperation!]
@@ -42,7 +42,7 @@ export const aggregationTypedef = gql`
   }
 
   input AggregateOperationInput {
-    entityTypeId: ID!
+    entityTypeId: ID
     entityTypeVersionId: ID
     multiFilter: MultiFilterOperationInput
     multiSort: [SortOperationInput!]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This makes the `entityTypeId` optional in the `aggregateEntities` query, so that blocks can look for entities containing particular values, without knowing their `entityTypeId.

## ⚠️ Known issues

There are some overlapping queries and db methods related to aggregation which we intend to consolidate as part of a wider refactor of the graph methods.

## ❓ How to test this?

1. Make a request to `aggregateEntities` with / without an `entityTypeId`, check both work
```graphql
{
  aggregateEntity(
    accountId: "ACCOUNT_ID_FROM_YOUR_LOCAL_DB"
    operation: { multiSort: [] }
  ) {
    results {
      accountId
      entityTypeId
    }
    operation {
      entityTypeId
    }
  }
}
```
