### PR TITLE
Remove explicit `backtrace` feature and infer it from release channel

### DIFF
--- a/packages/engine/Cargo.lock
+++ b/packages/engine/Cargo.lock
@@ -667,6 +667,7 @@ name = "error"
 version = "0.0.0"
 dependencies = [
  "provider",
+ "rustc_version",
  "tracing-error",
 ]
 

--- a/packages/engine/lib/error/Cargo.toml
+++ b/packages/engine/lib/error/Cargo.toml
@@ -8,8 +8,10 @@ provider = { path = "../provider" }
 
 tracing-error = { version = "0.2.0", optional = true }
 
+[build-dependencies]
+rustc_version = "0.2.3"
+
 [features]
-default = ["backtrace"]
-backtrace = ["std"]
-spantrace = ["tracing-error"]
+default = ["std"]
 std = []
+spantrace = ["tracing-error"]

--- a/packages/engine/lib/error/build.rs
+++ b/packages/engine/lib/error/build.rs
@@ -1,0 +1,7 @@
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+    if version_meta().unwrap().channel == Channel::Nightly {
+        println!("cargo:rustc-cfg=nightly")
+    }
+}

--- a/packages/engine/lib/error/src/frame.rs
+++ b/packages/engine/lib/error/src/frame.rs
@@ -70,7 +70,7 @@ impl<E: fmt::Debug> fmt::Debug for ErrorRepr<E> {
 #[cfg(feature = "std")]
 impl<E: std::error::Error> Provider for ErrorRepr<E> {
     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
-        #[cfg(feature = "backtrace")]
+        #[cfg(all(nightly, feature = "std"))]
         if let Some(backtrace) = self.0.backtrace() {
             demand.provide_ref(backtrace);
         }

--- a/packages/engine/lib/error/src/lib.rs
+++ b/packages/engine/lib/error/src/lib.rs
@@ -134,13 +134,18 @@
 //!
 //! # Feature flags
 //!
-//! - `std`: Enables support for [`Error`], **enabled** by default
-//! - `backtrace`: Enables the capturing of [`Backtrace`]s, implies `std`, **enabled** by default
+//! - `std`: Enables support for [`Error`] and, on nightly, [`Backtrace`], **enabled** by default
 //! - `spantrace`: Enables the capturing of [`SpanTrace`]s, **disabled** by default
+//!
+//! Using the `backtrace` crate instead of `std::backtrace` is a considered feature to support
+//! backtraces on non-nightly channels and can be prioritized depending on demand.
+//!
+//! [`display_hook`]: Report::display_hook
+//! [`debug_hook`]: Report::debug_hook
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(doc, feature(doc_auto_cfg))]
-#![cfg_attr(feature = "backtrace", feature(backtrace))]
+#![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
+#![cfg_attr(all(nightly, feature = "std"), feature(backtrace))]
 #![warn(missing_docs, clippy::pedantic, clippy::nursery)]
 #![allow(clippy::missing_errors_doc)] // This is an error handling library producing Results, not Errors
 #![cfg_attr(

--- a/packages/engine/lib/error/src/report.rs
+++ b/packages/engine/lib/error/src/report.rs
@@ -1,6 +1,6 @@
 use alloc::boxed::Box;
 use core::{fmt, fmt::Formatter, marker::PhantomData, panic::Location};
-#[cfg(feature = "backtrace")]
+#[cfg(all(nightly, feature = "std"))]
 use std::backtrace::{Backtrace, BacktraceStatus};
 #[cfg(feature = "std")]
 use std::error::Error as StdError;
@@ -14,7 +14,7 @@ use crate::{Context, Frames, Message, Report, RequestRef, RequestValue};
 #[allow(clippy::module_name_repetitions)]
 pub struct ReportImpl {
     pub(super) frame: Frame,
-    #[cfg(feature = "backtrace")]
+    #[cfg(all(nightly, feature = "std"))]
     backtrace: Option<Backtrace>,
     #[cfg(feature = "spantrace")]
     span_trace: Option<SpanTrace>,
@@ -30,7 +30,7 @@ impl Report<()> {
         // SAFETY: `FrameRepr` is wrapped in `ManuallyDrop`
         Self::from_frame(
             Frame::from_message(message, Location::caller(), None),
-            #[cfg(feature = "backtrace")]
+            #[cfg(all(nightly, feature = "std"))]
             Some(Backtrace::capture()),
             #[cfg(feature = "spantrace")]
             Some(SpanTrace::capture()),
@@ -41,13 +41,13 @@ impl Report<()> {
 impl<C> Report<C> {
     fn from_frame(
         frame: Frame,
-        #[cfg(feature = "backtrace")] backtrace: Option<Backtrace>,
+        #[cfg(all(nightly, feature = "std"))] backtrace: Option<Backtrace>,
         #[cfg(feature = "spantrace")] span_trace: Option<SpanTrace>,
     ) -> Self {
         Self {
             inner: Box::new(ReportImpl {
                 frame,
-                #[cfg(feature = "backtrace")]
+                #[cfg(all(nightly, feature = "std"))]
                 backtrace,
                 #[cfg(feature = "spantrace")]
                 span_trace,
@@ -71,7 +71,7 @@ impl<C> Report<C> {
             Location::caller()
         };
 
-        #[cfg(feature = "backtrace")]
+        #[cfg(all(nightly, feature = "std"))]
         let backtrace = if provider::request_ref::<Backtrace, _>(&context).is_some() {
             None
         } else {
@@ -87,7 +87,7 @@ impl<C> Report<C> {
 
         Self::from_frame(
             Frame::from_context(context, location, None),
-            #[cfg(feature = "backtrace")]
+            #[cfg(all(nightly, feature = "std"))]
             backtrace,
             #[cfg(feature = "spantrace")]
             span_trace,
@@ -106,7 +106,7 @@ impl<C> Report<C> {
                 Location::caller(),
                 Some(Box::new(self.inner.frame)),
             ),
-            #[cfg(feature = "backtrace")]
+            #[cfg(all(nightly, feature = "std"))]
             self.inner.backtrace,
             #[cfg(feature = "spantrace")]
             self.inner.span_trace,
@@ -125,7 +125,7 @@ impl<C> Report<C> {
                 Location::caller(),
                 Some(Box::new(self.inner.frame)),
             ),
-            #[cfg(feature = "backtrace")]
+            #[cfg(all(nightly, feature = "std"))]
             self.inner.backtrace,
             #[cfg(feature = "spantrace")]
             self.inner.span_trace,
@@ -147,7 +147,7 @@ impl<C> Report<C> {
     ///
     /// [`ReportBackTrace`]: crate::tags::ReportBackTrace
     #[must_use]
-    #[cfg(feature = "backtrace")]
+    #[cfg(all(nightly, feature = "std"))]
     pub fn backtrace(&self) -> Option<&Backtrace> {
         let backtrace = self.inner.backtrace.as_ref().unwrap_or_else(|| {
             // Should never panic as it's either stored inside of `Report` or is provided by a frame
@@ -238,7 +238,7 @@ impl<Context> fmt::Debug for Report<Context> {
         if fmt.alternate() {
             let mut debug = fmt.debug_struct("Report");
             debug.field("frames", &self.frames());
-            #[cfg(feature = "backtrace")]
+            #[cfg(all(nightly, feature = "std"))]
             debug.field("backtrace", &self.backtrace());
             debug.finish()
         } else {
@@ -255,7 +255,7 @@ impl<Context> fmt::Debug for Report<Context> {
                 write!(fmt, "\n             at {}", frame.location())?;
             }
 
-            #[cfg(feature = "backtrace")]
+            #[cfg(all(nightly, feature = "std"))]
             if let Some(backtrace) = self.backtrace() {
                 write!(fmt, "\n\nStack backtrace:\n{backtrace}")?;
             }
@@ -277,7 +277,7 @@ where
 {
     #[track_caller]
     fn from(error: E) -> Self {
-        #[cfg(feature = "backtrace")]
+        #[cfg(all(nightly, feature = "std"))]
         let backtrace = if error.backtrace().is_some() {
             None
         } else {
@@ -286,7 +286,7 @@ where
 
         Self::from_frame(
             Frame::from_std(error, Location::caller(), None),
-            #[cfg(feature = "backtrace")]
+            #[cfg(all(nightly, feature = "std"))]
             backtrace,
             #[cfg(feature = "spantrace")]
             Some(SpanTrace::capture()),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, we only support backtraces on the nightly release channel. It's possible to add the [`backtrace` crate](https://crates.io/crates/backtrace) as optional dependency to enable backtraces on stable release channel as well (similar to the [`anyhow` crate](https://crates.io/crates/anyhow)). We chose not to do that currently but we will prioritize that depending on demand. To support this eventually, this PR removes the `backtrace` feature, as adding the optional `backtrace` dependency will introduce the same feature flag as well (which is forbidden).

## 🔍 What does this change?

- Changes `#[cfg(feature = "backtrace")]` attribute to `#[cfg(all(nightly, feature = "std"))]]`
- Adjust documentation to reflect this

Only the user-facing method `Report::backtrace()` is changed publicly.

## 📜 Does this require a change to the docs?

Documentation as adjusted
