### PR TITLE
Add `FutureExt` adaptor trait

### DIFF
--- a/packages/engine/Cargo.lock
+++ b/packages/engine/Cargo.lock
@@ -666,10 +666,13 @@ dependencies = [
 name = "error"
 version = "0.0.0"
 dependencies = [
+ "futures-core",
  "once_cell",
+ "pin-project",
  "provider",
  "rustc_version",
  "serde_json",
+ "tokio",
  "tracing-error",
 ]
 
@@ -807,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-executor"
@@ -1680,18 +1683,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/packages/engine/Cargo.lock
+++ b/packages/engine/Cargo.lock
@@ -666,13 +666,13 @@ dependencies = [
 name = "error"
 version = "0.0.0"
 dependencies = [
+ "futures",
  "futures-core",
  "once_cell",
  "pin-project",
  "provider",
  "rustc_version",
  "serde_json",
- "tokio",
  "tracing-error",
 ]
 
@@ -785,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -800,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -816,9 +816,9 @@ checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -827,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-lite"
@@ -848,12 +848,10 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -861,23 +859,22 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
- "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -887,8 +884,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -1778,12 +1773,6 @@ name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"

--- a/packages/engine/lib/error/Cargo.toml
+++ b/packages/engine/lib/error/Cargo.toml
@@ -8,9 +8,12 @@ provider = { path = "../provider" }
 
 tracing-error = { version = "0.2.0", optional = true }
 once_cell = { version = "1.10.0", optional = true }
+pin-project = { version = "1.0.10", optional = true }
+futures-core = { version = "0.3.21", optional = true, default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0.81"
+tokio = { version = "1.18.2", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 rustc_version = "0.2.3"
@@ -20,6 +23,7 @@ default = ["std", "hooks"]
 std = []
 hooks = ["dep:once_cell"]
 spantrace = ["dep:tracing-error"]
+futures = ["dep:pin-project"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/packages/engine/lib/error/Cargo.toml
+++ b/packages/engine/lib/error/Cargo.toml
@@ -13,7 +13,7 @@ futures-core = { version = "0.3.21", optional = true, default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0.81"
-tokio = { version = "1.18.2", features = ["macros", "rt-multi-thread"] }
+futures = { version = "0.3.21", default-features = false, features = ["executor"] }
 
 [build-dependencies]
 rustc_version = "0.2.3"

--- a/packages/engine/lib/error/src/future_ext.rs
+++ b/packages/engine/lib/error/src/future_ext.rs
@@ -174,6 +174,8 @@ pub trait FutureExt: Future + Sized {
     ///     # }; error::bail!("unknown error")
     /// }
     ///
+    /// # #[cfg(miri)] fn main() {} // Miri can't run `tokio::main`
+    /// # #[cfg(not(miri))]
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
     ///     # async fn fake_main() -> Result<()> { // We want to assert on the result
@@ -217,6 +219,8 @@ pub trait FutureExt: Future + Sized {
     ///     # }; error::bail!("unknown error")
     /// }
     ///
+    /// # #[cfg(miri)] fn main() {} // Miri can't run `tokio::main`
+    /// # #[cfg(not(miri))]
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
     ///     # async fn fake_main() -> Result<()> { // We want to assert on the result

--- a/packages/engine/lib/error/src/future_ext.rs
+++ b/packages/engine/lib/error/src/future_ext.rs
@@ -1,0 +1,315 @@
+use core::{
+    future::Future,
+    pin::Pin,
+    task::{Context as TaskContext, Poll},
+};
+
+use pin_project::pin_project;
+
+use crate::{Context, Message, Result, ResultExt};
+
+/// Adaptor returned by [`FutureExt::wrap_err`].
+#[pin_project]
+#[cfg(feature = "futures")]
+pub struct WrappedFuture<Fut, M> {
+    #[pin]
+    inner: Fut,
+    message: Option<M>,
+}
+
+impl<Fut, M> Future for WrappedFuture<Fut, M>
+where
+    Fut: Future,
+    Fut::Output: ResultExt,
+    M: Message,
+{
+    type Output = Result<<Fut::Output as ResultExt>::Ok, <Fut::Output as ResultExt>::Context>;
+
+    #[track_caller]
+    fn poll(self: Pin<&mut Self>, cx: &mut TaskContext) -> Poll<Self::Output> {
+        let projection = self.project();
+        let inner = projection.inner;
+        let message = projection.message;
+
+        // Can't use `map` as `#[track_caller]` is unstable on closures
+        match inner.poll(cx) {
+            Poll::Ready(value) => Poll::Ready(value.wrap_err({
+                message
+                    .take()
+                    .expect("Cannot poll context after it resolves")
+            })),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// Adaptor returned by [`FutureExt::wrap_err_lazy`].
+#[pin_project]
+#[cfg(feature = "futures")]
+pub struct LazyWrappedFuture<Fut, F> {
+    #[pin]
+    inner: Fut,
+    op: Option<F>,
+}
+
+impl<Fut, F, M> Future for LazyWrappedFuture<Fut, F>
+where
+    Fut: Future,
+    Fut::Output: ResultExt,
+    F: FnOnce() -> M,
+    M: Message,
+{
+    type Output = Result<<Fut::Output as ResultExt>::Ok, <Fut::Output as ResultExt>::Context>;
+
+    #[track_caller]
+    fn poll(self: Pin<&mut Self>, cx: &mut TaskContext) -> Poll<Self::Output> {
+        let projection = self.project();
+        let inner = projection.inner;
+        let op = projection.op;
+
+        // Can't use `map` as `#[track_caller]` is unstable on closures
+        match inner.poll(cx) {
+            Poll::Ready(value) => Poll::Ready(
+                value.wrap_err_lazy(op.take().expect("Cannot poll context after it resolves")),
+            ),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// Adaptor returned by [`FutureExt::provide_context`].
+#[pin_project]
+#[cfg(feature = "futures")]
+pub struct ProviderFuture<Fut, C> {
+    #[pin]
+    inner: Fut,
+    context: Option<C>,
+}
+
+impl<Fut, C> Future for ProviderFuture<Fut, C>
+where
+    Fut: Future,
+    Fut::Output: ResultExt,
+    C: Context,
+{
+    type Output = Result<<Fut::Output as ResultExt>::Ok, C>;
+
+    #[track_caller]
+    fn poll(self: Pin<&mut Self>, cx: &mut TaskContext) -> Poll<Self::Output> {
+        let projection = self.project();
+        let inner = projection.inner;
+        let context = projection.context;
+
+        // Can't use `map` as `#[track_caller]` is unstable on closures
+        match inner.poll(cx) {
+            Poll::Ready(value) => Poll::Ready(value.provide_context({
+                context
+                    .take()
+                    .expect("Cannot poll context after it resolves")
+            })),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// Adaptor returned by [`FutureExt::provide_context_lazy`].
+#[pin_project]
+#[cfg(feature = "futures")]
+pub struct LazyProviderFuture<Fut, F> {
+    #[pin]
+    inner: Fut,
+    op: Option<F>,
+}
+
+impl<Fut, F, C> Future for LazyProviderFuture<Fut, F>
+where
+    Fut: Future,
+    Fut::Output: ResultExt,
+    F: FnOnce() -> C,
+    C: Context,
+{
+    type Output = Result<<Fut::Output as ResultExt>::Ok, C>;
+
+    #[track_caller]
+    fn poll(self: Pin<&mut Self>, cx: &mut TaskContext) -> Poll<Self::Output> {
+        let projection = self.project();
+        let inner = projection.inner;
+        let op = projection.op;
+
+        // Can't use `map` as `#[track_caller]` is unstable on closures
+        match inner.poll(cx) {
+            Poll::Ready(value) => {
+                Poll::Ready(value.provide_context_lazy(
+                    op.take().expect("Cannot poll context after it resolves"),
+                ))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// Extension trait for [`Future`] to provide contextual information on [`Report`]s.
+///
+/// [`Report`]: crate::Report
+#[cfg(feature = "futures")]
+pub trait FutureExt: Future + Sized {
+    /// Adds new contextual message to the [`Frame`] stack of a [`Report`] when [`poll`]ing the
+    /// [`Future`].
+    ///
+    /// [`Frame`]: crate::Frame
+    /// [`Report`]: crate::Report
+    /// [`poll`]: Future::poll
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # struct User;
+    /// # struct Resource;
+    /// use error::{FutureExt, Result};
+    ///
+    /// # #[allow(unused_variables)]
+    /// async fn load_resource(user: &User, resource: &Resource) -> Result<()> {
+    ///     # const _: &str = stringify! {
+    ///     ...
+    ///     # }; error::bail!("unknown error")
+    /// }
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     # async fn fake_main() -> Result<()> { // We want to assert on the result
+    ///     # let user = User;
+    ///     # let resource = Resource;
+    ///     // A contextual message can be provided before polling the `Future`
+    ///     load_resource(&user, &resource)
+    ///         .wrap_err("Could not load resource").await?;
+    ///     # Ok(()) }
+    ///     # assert_eq!(fake_main().await.unwrap_err().frames().count(), 2);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[track_caller]
+    fn wrap_err<M>(self, message: M) -> WrappedFuture<Self, M>
+    where
+        M: Message;
+
+    /// Lazily adds new contextual message to the [`Frame`] stack of a [`Report`] when [`poll`]ing
+    /// the [`Future`].
+    ///
+    /// The function is only executed in the `Err` arm.
+    ///
+    /// [`Frame`]: crate::Frame
+    /// [`Report`]: crate::Report
+    /// [`poll`]: Future::poll
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use core::fmt;
+    /// # struct User;
+    /// # struct Resource;
+    /// # impl fmt::Display for Resource { fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result { Ok(()) }}
+    /// use error::{FutureExt, Result};
+    ///
+    /// # #[allow(unused_variables)]
+    /// async fn load_resource(user: &User, resource: &Resource) -> Result<()> {
+    ///     # const _: &str = stringify! {
+    ///     ...
+    ///     # }; error::bail!("unknown error")
+    /// }
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     # async fn fake_main() -> Result<()> { // We want to assert on the result
+    ///     # let user = User;
+    ///     # let resource = Resource;
+    ///     // A contextual message can be provided before polling the `Future`
+    ///     load_resource(&user, &resource)
+    ///         .wrap_err_lazy(|| format!("Could not load resource {resource}")).await?;
+    ///     # Ok(()) }
+    ///     # assert_eq!(fake_main().await.unwrap_err().frames().count(), 2);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[track_caller]
+    fn wrap_err_lazy<M, F>(self, op: F) -> LazyWrappedFuture<Self, F>
+    where
+        M: Message,
+        F: FnOnce() -> M;
+
+    /// Adds a context provider to the [`Frame`] stack of a [`Report`] when [`poll`]ing the
+    /// [`Future`] returning [`Result<T, C>`].
+    ///
+    /// [`Frame`]: crate::Frame
+    /// [`Report`]: crate::Report
+    /// [`poll`]: Future::poll
+    // TODO: come up with a decent example
+    #[track_caller]
+    fn provide_context<C>(self, context: C) -> ProviderFuture<Self, C>
+    where
+        C: Context;
+
+    /// Lazily adds a context provider to the [`Frame`] stack of a [`Report`] when [`poll`]ing the
+    /// [`Future`] returning [`Result<T, C>`].
+    ///
+    /// The function is only executed in the `Err` arm.
+    ///
+    /// [`Frame`]: crate::Frame
+    /// [`Report`]: crate::Report
+    /// [`poll`]: Future::poll
+    // TODO: come up with a decent example
+    #[track_caller]
+    fn provide_context_lazy<C, F>(self, context: F) -> LazyProviderFuture<Self, F>
+    where
+        C: Context,
+        F: FnOnce() -> C;
+}
+
+impl<Fut: Future> FutureExt for Fut
+where
+    Fut::Output: ResultExt,
+{
+    fn wrap_err<M>(self, message: M) -> WrappedFuture<Self, M>
+    where
+        M: Message,
+    {
+        WrappedFuture {
+            inner: self,
+            message: Some(message),
+        }
+    }
+
+    #[track_caller]
+    fn wrap_err_lazy<M, F>(self, op: F) -> LazyWrappedFuture<Self, F>
+    where
+        M: Message,
+        F: FnOnce() -> M,
+    {
+        LazyWrappedFuture {
+            inner: self,
+            op: Some(op),
+        }
+    }
+
+    #[track_caller]
+    fn provide_context<C>(self, context: C) -> ProviderFuture<Self, C>
+    where
+        C: Context,
+    {
+        ProviderFuture {
+            inner: self,
+            context: Some(context),
+        }
+    }
+
+    #[track_caller]
+    fn provide_context_lazy<C, F>(self, context: F) -> LazyProviderFuture<Self, F>
+    where
+        C: Context,
+        F: FnOnce() -> C,
+    {
+        LazyProviderFuture {
+            inner: self,
+            op: Some(context),
+        }
+    }
+}

--- a/packages/engine/lib/error/src/future_ext.rs
+++ b/packages/engine/lib/error/src/future_ext.rs
@@ -174,20 +174,15 @@ pub trait FutureExt: Future + Sized {
     ///     # }; error::bail!("unknown error")
     /// }
     ///
-    /// # #[cfg(miri)] fn main() {} // Miri can't run `tokio::main`
-    /// # #[cfg(not(miri))]
-    /// #[tokio::main]
-    /// async fn main() -> Result<()> {
-    ///     # async fn fake_main() -> Result<()> { // We want to assert on the result
+    /// # let fut = async {
     ///     # let user = User;
     ///     # let resource = Resource;
     ///     // A contextual message can be provided before polling the `Future`
-    ///     load_resource(&user, &resource)
-    ///         .wrap_err("Could not load resource").await?;
-    ///     # Ok(()) }
-    ///     # assert_eq!(fake_main().await.unwrap_err().frames().count(), 2);
-    ///     Ok(())
-    /// }
+    ///     load_resource(&user, &resource).wrap_err("Could not load resource").await
+    /// # };
+    /// # #[cfg(not(miri))] // miri can't `block_on`
+    /// # assert_eq!(futures::executor::block_on(fut).unwrap_err().frames().count(), 2);
+    /// # Result::<_>::Ok(())
     /// ```
     #[track_caller]
     fn wrap_err<M>(self, message: M) -> WrappedFuture<Self, M>
@@ -219,20 +214,15 @@ pub trait FutureExt: Future + Sized {
     ///     # }; error::bail!("unknown error")
     /// }
     ///
-    /// # #[cfg(miri)] fn main() {} // Miri can't run `tokio::main`
-    /// # #[cfg(not(miri))]
-    /// #[tokio::main]
-    /// async fn main() -> Result<()> {
-    ///     # async fn fake_main() -> Result<()> { // We want to assert on the result
+    /// # let fut = async {
     ///     # let user = User;
     ///     # let resource = Resource;
     ///     // A contextual message can be provided before polling the `Future`
-    ///     load_resource(&user, &resource)
-    ///         .wrap_err_lazy(|| format!("Could not load resource {resource}")).await?;
-    ///     # Ok(()) }
-    ///     # assert_eq!(fake_main().await.unwrap_err().frames().count(), 2);
-    ///     Ok(())
-    /// }
+    ///     load_resource(&user, &resource).wrap_err_lazy(|| format!("Could not load resource {resource}")).await
+    /// # };
+    /// # #[cfg(not(miri))]
+    /// # assert_eq!(futures::executor::block_on(fut).unwrap_err().frames().count(), 2);
+    /// # Result::<_>::Ok(())
     /// ```
     #[track_caller]
     fn wrap_err_lazy<M, F>(self, op: F) -> LazyWrappedFuture<Self, F>

--- a/packages/engine/lib/error/src/future_ext.rs
+++ b/packages/engine/lib/error/src/future_ext.rs
@@ -11,13 +11,13 @@ use crate::{Context, Message, Result, ResultExt};
 /// Adaptor returned by [`FutureExt::wrap_err`].
 #[pin_project]
 #[cfg(feature = "futures")]
-pub struct WrappedFuture<Fut, M> {
+pub struct FutureWithErr<Fut, M> {
     #[pin]
     inner: Fut,
     message: Option<M>,
 }
 
-impl<Fut, M> Future for WrappedFuture<Fut, M>
+impl<Fut, M> Future for FutureWithErr<Fut, M>
 where
     Fut: Future,
     Fut::Output: ResultExt,
@@ -46,13 +46,13 @@ where
 /// Adaptor returned by [`FutureExt::wrap_err_lazy`].
 #[pin_project]
 #[cfg(feature = "futures")]
-pub struct LazyWrappedFuture<Fut, F> {
+pub struct FutureWithLazyErr<Fut, F> {
     #[pin]
     inner: Fut,
     op: Option<F>,
 }
 
-impl<Fut, F, M> Future for LazyWrappedFuture<Fut, F>
+impl<Fut, F, M> Future for FutureWithLazyErr<Fut, F>
 where
     Fut: Future,
     Fut::Output: ResultExt,
@@ -80,13 +80,13 @@ where
 /// Adaptor returned by [`FutureExt::provide_context`].
 #[pin_project]
 #[cfg(feature = "futures")]
-pub struct ProviderFuture<Fut, C> {
+pub struct FutureWithContext<Fut, C> {
     #[pin]
     inner: Fut,
     context: Option<C>,
 }
 
-impl<Fut, C> Future for ProviderFuture<Fut, C>
+impl<Fut, C> Future for FutureWithContext<Fut, C>
 where
     Fut: Future,
     Fut::Output: ResultExt,
@@ -115,13 +115,13 @@ where
 /// Adaptor returned by [`FutureExt::provide_context_lazy`].
 #[pin_project]
 #[cfg(feature = "futures")]
-pub struct LazyProviderFuture<Fut, F> {
+pub struct FutureWithLazyContext<Fut, F> {
     #[pin]
     inner: Fut,
     op: Option<F>,
 }
 
-impl<Fut, F, C> Future for LazyProviderFuture<Fut, F>
+impl<Fut, F, C> Future for FutureWithLazyContext<Fut, F>
 where
     Fut: Future,
     Fut::Output: ResultExt,
@@ -185,7 +185,7 @@ pub trait FutureExt: Future + Sized {
     /// # Result::<_>::Ok(())
     /// ```
     #[track_caller]
-    fn wrap_err<M>(self, message: M) -> WrappedFuture<Self, M>
+    fn wrap_err<M>(self, message: M) -> FutureWithErr<Self, M>
     where
         M: Message;
 
@@ -225,7 +225,7 @@ pub trait FutureExt: Future + Sized {
     /// # Result::<_>::Ok(())
     /// ```
     #[track_caller]
-    fn wrap_err_lazy<M, F>(self, op: F) -> LazyWrappedFuture<Self, F>
+    fn wrap_err_lazy<M, F>(self, op: F) -> FutureWithLazyErr<Self, F>
     where
         M: Message,
         F: FnOnce() -> M;
@@ -238,7 +238,7 @@ pub trait FutureExt: Future + Sized {
     /// [`poll`]: Future::poll
     // TODO: come up with a decent example
     #[track_caller]
-    fn provide_context<C>(self, context: C) -> ProviderFuture<Self, C>
+    fn provide_context<C>(self, context: C) -> FutureWithContext<Self, C>
     where
         C: Context;
 
@@ -252,7 +252,7 @@ pub trait FutureExt: Future + Sized {
     /// [`poll`]: Future::poll
     // TODO: come up with a decent example
     #[track_caller]
-    fn provide_context_lazy<C, F>(self, context: F) -> LazyProviderFuture<Self, F>
+    fn provide_context_lazy<C, F>(self, context: F) -> FutureWithLazyContext<Self, F>
     where
         C: Context,
         F: FnOnce() -> C;
@@ -262,46 +262,46 @@ impl<Fut: Future> FutureExt for Fut
 where
     Fut::Output: ResultExt,
 {
-    fn wrap_err<M>(self, message: M) -> WrappedFuture<Self, M>
+    fn wrap_err<M>(self, message: M) -> FutureWithErr<Self, M>
     where
         M: Message,
     {
-        WrappedFuture {
+        FutureWithErr {
             inner: self,
             message: Some(message),
         }
     }
 
     #[track_caller]
-    fn wrap_err_lazy<M, F>(self, op: F) -> LazyWrappedFuture<Self, F>
+    fn wrap_err_lazy<M, F>(self, op: F) -> FutureWithLazyErr<Self, F>
     where
         M: Message,
         F: FnOnce() -> M,
     {
-        LazyWrappedFuture {
+        FutureWithLazyErr {
             inner: self,
             op: Some(op),
         }
     }
 
     #[track_caller]
-    fn provide_context<C>(self, context: C) -> ProviderFuture<Self, C>
+    fn provide_context<C>(self, context: C) -> FutureWithContext<Self, C>
     where
         C: Context,
     {
-        ProviderFuture {
+        FutureWithContext {
             inner: self,
             context: Some(context),
         }
     }
 
     #[track_caller]
-    fn provide_context_lazy<C, F>(self, context: F) -> LazyProviderFuture<Self, F>
+    fn provide_context_lazy<C, F>(self, context: F) -> FutureWithLazyContext<Self, F>
     where
         C: Context,
         F: FnOnce() -> C,
     {
-        LazyProviderFuture {
+        FutureWithLazyContext {
             inner: self,
             op: Some(context),
         }

--- a/packages/engine/lib/error/src/hook.rs
+++ b/packages/engine/lib/error/src/hook.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "hooks")]
-
 use core::fmt;
 
 use once_cell::sync::OnceCell;

--- a/packages/engine/lib/error/src/lib.rs
+++ b/packages/engine/lib/error/src/lib.rs
@@ -135,7 +135,6 @@
 //! # Feature flags
 //!
 //! - `std`: Enables support for [`Error`] and, on nightly, [`Backtrace`], **enabled** by default
-//! - `hooks`: Enables setting of [`display_hook`] and [`debug_hook`], **enabled** by default
 //! - `spantrace`: Enables the capturing of [`SpanTrace`]s, **disabled** by default
 //!
 //! Using the `backtrace` crate instead of `std::backtrace` is a considered feature to support
@@ -158,11 +157,14 @@
 extern crate alloc;
 
 mod frame;
+#[cfg(feature = "futures")]
+mod future_ext;
+#[cfg(feature = "hooks")]
 mod hook;
 mod iter;
 mod macros;
 mod report;
-mod result;
+mod result_ext;
 // pub mod tags;
 
 use alloc::boxed::Box;
@@ -170,10 +172,14 @@ use core::{fmt, marker::PhantomData, mem::ManuallyDrop, panic::Location};
 
 use provider::Provider;
 
+#[cfg(feature = "futures")]
+pub use self::future_ext::{
+    FutureExt, LazyProviderFuture, LazyWrappedFuture, ProviderFuture, WrappedFuture,
+};
 use self::{frame::FrameRepr, report::ReportImpl};
 pub use self::{
     macros::*,
-    result::{Result, ResultExt},
+    result_ext::{Result, ResultExt},
 };
 
 /// Contains a [`Frame`] stack consisting of an original error, context information, and optionally

--- a/packages/engine/lib/error/src/lib.rs
+++ b/packages/engine/lib/error/src/lib.rs
@@ -174,7 +174,7 @@ use provider::Provider;
 
 #[cfg(feature = "futures")]
 pub use self::future_ext::{
-    FutureExt, LazyProviderFuture, LazyWrappedFuture, ProviderFuture, WrappedFuture,
+    FutureExt, FutureWithContext, FutureWithErr, FutureWithLazyContext, FutureWithLazyErr,
 };
 use self::{frame::FrameRepr, report::ReportImpl};
 pub use self::{

--- a/packages/engine/lib/error/src/result_ext.rs
+++ b/packages/engine/lib/error/src/result_ext.rs
@@ -93,8 +93,7 @@ pub trait ResultExt {
         M: Message,
         F: FnOnce() -> M;
 
-    /// Adds a context provider to the [`Frame`] stack of a [`Report`] returning
-    /// [`Result<T, Context>`]).
+    /// Adds a context provider to the [`Frame`] stack of a [`Report`] returning [`Result<T, C>`].
     ///
     /// [`Frame`]: crate::Frame
     // TODO: come up with a decent example
@@ -103,7 +102,9 @@ pub trait ResultExt {
         C: Context;
 
     /// Lazily adds a context provider to the [`Frame`] stack of a [`Report`] returning
-    /// [`Result<T, C>`]).
+    /// [`Result<T, C>`].
+    ///
+    /// The function is only executed in the `Err` arm.
     ///
     /// [`Frame`]: crate::Frame
     // TODO: come up with a decent example


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

It's useful to add contextual information on futures without calling `map` but call `wrap_err` directly (without polling the future). This PR adds `FutureExt` to wrap a `Future` with contextual information.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/0/1201908585432589) _(internal)_

## 🔍 What does this change?

- Adds the `FutureExt` Adaptor
- Slightly adjust documentation for `ResultExt`

## 📜 Does this require a change to the docs?

The documentation were adjusted and is tested on CI

## 📹 Demo

![image](https://user-images.githubusercontent.com/21277928/170262949-6a1b0ab3-b229-4e36-b289-c0ee9431c333.png)
![image](https://user-images.githubusercontent.com/21277928/170263002-c6ee0c81-d953-4e6c-a9ba-d8108c206f37.png)
![image](https://user-images.githubusercontent.com/21277928/170263047-6d9bbb88-c877-4acc-b74a-77145d7ca281.png)
![image](https://user-images.githubusercontent.com/21277928/170263080-18bc595f-cdf4-447e-adac-63318d30f516.png)

