### PR TITLE
Simplify error macros

### DIFF
--- a/packages/engine/lib/error/src/frame.rs
+++ b/packages/engine/lib/error/src/frame.rs
@@ -278,8 +278,6 @@ impl Frame {
         let downcasted = downcasted.or_else(|| {
             // Fallback for `T: Error` as `Error` is wrapped inside of `ErrorRepr`
             // TODO: Remove fallback when `Provider` is implemented for `Error` upstream
-            // SAFETY: Dereferencing is safe as T has the same lifetimes as Self and casting
-            //   `ErrorRepr<T>` to `T` is safe as `ErrorRepr` is `#[repr(transparent)]`
             self.inner.downcast::<ErrorRepr<T>>().map(|addr| {
                 // SAFETY: Dereferencing is safe as T has the same lifetimes as Self and casting
                 //   `ErrorRepr<T>` to `T` is safe as `ErrorRepr` is `#[repr(transparent)]`

--- a/packages/engine/lib/error/src/frame.rs
+++ b/packages/engine/lib/error/src/frame.rs
@@ -3,13 +3,15 @@
 
 use alloc::boxed::Box;
 use core::{
-    any::TypeId,
+    any::{Any, TypeId},
     fmt,
     fmt::Formatter,
     mem::ManuallyDrop,
     panic::Location,
     ptr::{self, addr_of, NonNull},
 };
+#[cfg(feature = "std")]
+use std::error::Error;
 
 use provider::{self, Demand, Provider};
 
@@ -26,49 +28,55 @@ struct VTable {
     object_downcast: unsafe fn(&FrameRepr, target: TypeId) -> Option<NonNull<()>>,
 }
 
-// Contextual messages don't necessarily implement `Provider`, `Message` adds an empty
-// implementation.
-struct MessageRepr<E>(E);
+/// Wrapper around [`Message`].
+///
+/// As [`Message`] does not necessarily implement [`Provider`], an empty implementation is provided.
+/// If a [`Provider`] is required use it directly instead of [`Message`].
+struct MessageRepr<M: Message>(M);
 
-impl<E: fmt::Display> fmt::Display for MessageRepr<E> {
+impl<C: Message> fmt::Display for MessageRepr<C> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, fmt)
     }
 }
 
-impl<E: fmt::Debug> fmt::Debug for MessageRepr<E> {
+impl<C: Message> fmt::Debug for MessageRepr<C> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&self.0, fmt)
     }
 }
 
-impl<E> Provider for MessageRepr<E> {
-    // An empty impl is fine as it's not possible to safely create a Requisition outside of the
-    // provider API, so this won't cause silent problems
-    fn provide<'a>(&'a self, _demand: &mut Demand<'a>) {}
+impl<C: Message> Provider for MessageRepr<C> {
+    fn provide<'a>(&'a self, _: &mut Demand<'a>) {
+        // Empty definition as `Message` does not convey provider information
+    }
 }
 
-// std errors don't necessarily implement `Provider`, `std::error::Error` adds an implementation
-// providing the backtrace if any.
+/// Wrapper around [`Error`].
+///
+/// As [`Error`] does not necessarily implement [`Provider`], an implementation is provided. As soon
+/// as [`Provider`] is implemented on [`Error`], this struct will be removed and used directly
+/// instead.
 #[cfg(feature = "std")]
+#[repr(transparent)]
 struct ErrorRepr<E>(E);
 
 #[cfg(feature = "std")]
-impl<E: fmt::Display> fmt::Display for ErrorRepr<E> {
+impl<E: Error> fmt::Display for ErrorRepr<E> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, fmt)
     }
 }
 
 #[cfg(feature = "std")]
-impl<E: fmt::Debug> fmt::Debug for ErrorRepr<E> {
+impl<E: Error> fmt::Debug for ErrorRepr<E> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&self.0, fmt)
     }
 }
 
 #[cfg(feature = "std")]
-impl<E: std::error::Error> Provider for ErrorRepr<E> {
+impl<E: Error> Provider for ErrorRepr<E> {
     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
         #[cfg(all(nightly, feature = "std"))]
         if let Some(backtrace) = self.0.backtrace() {
@@ -169,10 +177,7 @@ impl FrameRepr {
         unsafe { (self.vtable.object_ref)(self) }
     }
 
-    fn downcast<C>(&self) -> Option<NonNull<C>>
-    where
-        C: Context,
-    {
+    fn downcast<C: Any>(&self) -> Option<NonNull<C>> {
         let target = TypeId::of::<C>();
         // Use vtable to attach C's native vtable for the right original type C.
         let addr = unsafe { (self.vtable.object_downcast)(self, target) };
@@ -220,7 +225,7 @@ impl Frame {
         source: Option<Box<Self>>,
     ) -> Self
     where
-        E: std::error::Error + Send + Sync + 'static,
+        E: Error + Send + Sync + 'static,
     {
         // SAFETY: `inner` is wrapped in `ManuallyDrop`
         Self {
@@ -254,22 +259,29 @@ impl Frame {
         provider::request_value(self)
     }
 
-    /// Returns if `E` is the type held by this frame.
+    /// Returns if `T` is the type held by this frame.
     #[must_use]
-    pub fn is<C>(&self) -> bool
-    where
-        C: Context,
-    {
-        self.inner.downcast::<C>().is_some()
+    pub fn is<T: Any>(&self) -> bool {
+        self.downcast_ref::<T>().is_some()
     }
 
-    /// Downcasts this frame if the held provider object is the same as `C`.
+    /// Downcasts this frame if the held provider object is the same as `T`.
     #[must_use]
-    pub fn downcast_ref<C>(&self) -> Option<&C>
-    where
-        C: Context,
-    {
-        self.inner.downcast().map(|addr| unsafe { &*addr.as_ptr() })
+    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
+        #[cfg_attr(not(feature = "std"), allow(clippy::let_and_return))]
+        let downcasted = self.inner.downcast().map(|addr| unsafe { addr.as_ref() });
+
+        #[cfg(feature = "std")]
+        let downcasted = downcasted.or_else(|| {
+            // Fallback for `T: Error` as `Error` is wrapped inside of `ErrorRepr`
+            // TODO: Remove fallback when `Provider` is implemented for `Error` upstream
+            // SAFETY: `ErrorRepr` is `#[repr(transparent)]`
+            self.inner
+                .downcast::<ErrorRepr<T>>()
+                .map(|addr| unsafe { addr.cast().as_ref() })
+        });
+
+        downcasted
     }
 }
 

--- a/packages/engine/lib/error/src/lib.rs
+++ b/packages/engine/lib/error/src/lib.rs
@@ -293,7 +293,7 @@ pub use self::{
 /// # #[allow(unused_variables)]
 /// fn read_config(path: impl AsRef<Path>) -> Result<String, Report<ConfigError>> {
 ///     # #[cfg(any(miri, not(feature = "std")))]
-///     # error::bail!(context: ConfigError::IoError, "No such file");
+///     # return Err(error::report!("No such file").provide_context(ConfigError::IoError));
 ///     # #[cfg(all(not(miri), feature = "std"))]
 ///     std::fs::read_to_string(path.as_ref()).provide_context(ConfigError::IoError)
 /// }

--- a/packages/engine/lib/error/src/lib.rs
+++ b/packages/engine/lib/error/src/lib.rs
@@ -146,7 +146,12 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
 #![cfg_attr(all(nightly, feature = "std"), feature(backtrace))]
-#![warn(missing_docs, clippy::pedantic, clippy::nursery)]
+#![warn(
+    missing_docs,
+    clippy::pedantic,
+    clippy::nursery,
+    clippy::undocumented_unsafe_blocks
+)]
 #![allow(clippy::missing_errors_doc)] // This is an error handling library producing Results, not Errors
 #![allow(clippy::module_name_repetitions)]
 #![cfg_attr(

--- a/packages/engine/lib/error/src/report.rs
+++ b/packages/engine/lib/error/src/report.rs
@@ -1,5 +1,5 @@
 use alloc::boxed::Box;
-use core::{fmt, fmt::Formatter, marker::PhantomData, panic::Location};
+use core::{any::Any, fmt, fmt::Formatter, marker::PhantomData, panic::Location};
 #[cfg(all(nightly, feature = "std"))]
 use std::backtrace::{Backtrace, BacktraceStatus};
 #[cfg(feature = "std")]
@@ -205,23 +205,19 @@ impl<C> Report<C> {
         RequestValue::new(self)
     }
 
-    /// Returns if `C` is the type held by any frame inside of the report.
+    /// Returns if `T` is the type held by any frame inside of the report.
+    // TODO: Provide example
     #[must_use]
-    pub fn contains<C2>(&self) -> bool
-    where
-        C2: Context,
-    {
-        self.frames().any(Frame::is::<C2>)
+    pub fn contains<T: Any>(&self) -> bool {
+        self.frames().any(Frame::is::<T>)
     }
 
-    /// Searches the frame stack for a context provider `C` and returns the most recent context
+    /// Searches the frame stack for a context provider `T` and returns the most recent context
     /// found.
+    // TODO: Provide example
     #[must_use]
-    pub fn downcast_ref<C2>(&self) -> Option<&C2>
-    where
-        C2: Context,
-    {
-        self.frames().find_map(Frame::downcast_ref::<C2>)
+    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
+        self.frames().find_map(Frame::downcast_ref::<T>)
     }
 }
 

--- a/packages/engine/lib/nano/src/client.rs
+++ b/packages/engine/lib/nano/src/client.rs
@@ -105,7 +105,7 @@ impl Worker {
         if let Err(report) = self
             .ctx
             .send(&self.aio, msg)
-            .map_err(|(_, error)| report!(context: ErrorKind::Send, error))
+            .map_err(|(_, error)| report!(error).provide_context(ErrorKind::Send))
         {
             sender.send(Err(report)).expect(SEND_EXPECT_MESSAGE);
             return;

--- a/packages/engine/lib/nano/src/spmc.rs
+++ b/packages/engine/lib/nano/src/spmc.rs
@@ -40,7 +40,7 @@ impl<T: Send> Sender<T> {
         self.sender
             .send(value)
             .await
-            .map_err(|e| report!(context: ErrorKind::Send, "{e}"))
+            .map_err(|e| report!("{e}").provide_context(ErrorKind::Send))
     }
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Error macros are too complicated, passing `context: ` is not required. This PR adjusts this

## 🚫 Blocked by

- ~#590~

## 🎥  Demo

**Before**:
```rust
report!(context: std::io::Error { .. }, "Some error message");
```

**After** (Will be forbidden in a follow up PR as string literals will be removed from macros):
```rust
report!("Some error message").provide_context(std::io::Error { .. });
```
---

**Before**:
```rust
let report = report!(context: std::io::Error { .. });
assert!(report.contains::<std::io::Error>);

let report = report!(std::io::Error { .. });
assert!(report.contains::<std::io::Error>); // Fails
```

**After**:
```rust
let report = report!(std::io::Error { .. });
assert!(report.contains::<std::io::Error>); // Succeeds
```
