### PR TITLE
Change context type for errors to `Report<Error>`

### DIFF
--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -89,7 +89,8 @@ async fn main() -> Result<()> {
         &format!("cli-{now}"),
         &format!("cli-{now}-texray"),
     )
-    .wrap_err("Failed to initialise the logger")?;
+    .wrap_err("Failed to initialise the logger")
+    .generalize()?;
 
     let nng_listen_url = format!("ipc://hash-orchestrator-{now}");
 
@@ -99,7 +100,8 @@ async fn main() -> Result<()> {
     let absolute_project_path = args
         .project
         .canonicalize()
-        .wrap_err_lazy(|| format!("Could not canonicalize project path: {:?}", args.project))?;
+        .wrap_err_lazy(|| format!("Could not canonicalize project path: {:?}", args.project))
+        .generalize()?;
     let manifest = Manifest::from_local(&absolute_project_path)
         .wrap_err_lazy(|| format!("Could not read local project {absolute_project_path:?}"))?;
     let experiment_run = manifest

--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -89,7 +89,7 @@ async fn main() -> Result<()> {
         &format!("cli-{now}"),
         &format!("cli-{now}-texray"),
     )
-    .wrap_err("Failed to initialise the logger")
+    .wrap_err("Failed to initialize the logger")
     .generalize()?;
 
     let nng_listen_url = format!("ipc://hash-orchestrator-{now}");

--- a/packages/engine/bin/hash_engine/src/main.rs
+++ b/packages/engine/bin/hash_engine/src/main.rs
@@ -19,18 +19,21 @@ async fn main() -> Result<()> {
         &format!("experiment-{}", args.experiment_id),
         &format!("experiment-{}-texray", args.experiment_id),
     )
-    .wrap_err("Failed to initialise the logger")?;
+    .wrap_err("Failed to initialise the logger")
+    .generalize()?;
 
     let mut env = env::<ExperimentRun>(&args)
         .await
-        .wrap_err("Could not create environment for experiment")?;
+        .wrap_err("Could not create environment for experiment")
+        .generalize()?;
     // Fetch all dependencies of the experiment run such as datasets
     env.experiment
         .fetch_deps()
         .await
-        .wrap_err("Could not fetch dependencies for experiment")?;
+        .wrap_err("Could not fetch dependencies for experiment")
+        .generalize()?;
     // Generate the configuration for packages from the environment
-    let config = experiment_config(&args, &env).await?;
+    let config = experiment_config(&args, &env).await.generalize()?;
 
     tracing::info!(
         "HASH Engine process started for experiment {}",
@@ -39,7 +42,8 @@ async fn main() -> Result<()> {
 
     let experiment_result = run_experiment(config, env)
         .await
-        .wrap_err("Could not run experiment");
+        .wrap_err("Could not run experiment")
+        .generalize();
 
     cleanup_experiment(args.experiment_id);
 

--- a/packages/engine/bin/hash_engine/src/main.rs
+++ b/packages/engine/bin/hash_engine/src/main.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
         &format!("experiment-{}", args.experiment_id),
         &format!("experiment-{}-texray", args.experiment_id),
     )
-    .wrap_err("Failed to initialise the logger")
+    .wrap_err("Failed to initialize the logger")
     .generalize()?;
 
     let mut env = env::<ExperimentRun>(&args)

--- a/packages/engine/lib/error/src/error.rs
+++ b/packages/engine/lib/error/src/error.rs
@@ -1,0 +1,27 @@
+use std::{error::Error, panic::Location};
+
+use crate::{Frame, Report};
+
+#[cfg(feature = "std")]
+impl<E> From<E> for Report<E>
+where
+    E: Error + Send + Sync + 'static,
+{
+    #[track_caller]
+    fn from(error: E) -> Self {
+        #[cfg(nightly)]
+        let backtrace = if error.backtrace().is_some() {
+            None
+        } else {
+            Some(std::backtrace::Backtrace::capture())
+        };
+
+        Self::from_frame(
+            Frame::from_std(error, Location::caller(), None),
+            #[cfg(all(nightly, feature = "std"))]
+            backtrace,
+            #[cfg(feature = "spantrace")]
+            Some(tracing_error::SpanTrace::capture()),
+        )
+    }
+}

--- a/packages/engine/lib/error/src/error.rs
+++ b/packages/engine/lib/error/src/error.rs
@@ -18,7 +18,7 @@ where
 
         Self::from_frame(
             Frame::from_std(error, Location::caller(), None),
-            #[cfg(all(nightly, feature = "std"))]
+            #[cfg(nightly)]
             backtrace,
             #[cfg(feature = "spantrace")]
             Some(tracing_error::SpanTrace::capture()),

--- a/packages/engine/lib/error/src/hook.rs
+++ b/packages/engine/lib/error/src/hook.rs
@@ -112,7 +112,10 @@ impl Report {
 }
 
 impl<T> Report<T> {
-    /// Converts the `&Report<Context>` to `&Report<()>` without modifying the frame stack.
+    /// Converts the `&Report<T>` to `&Report<()>` without modifying the frame stack.
+    ///
+    /// Changing `Report<T>` to `Report<()>` is only used internally for calling [`debug_hook`] and
+    /// [`display_hook`] and is intentionally not exposed.
     pub(crate) const fn generalized(&self) -> &Report {
         // SAFETY: `Report` is repr(transparent), so it's safe to cast between `Report<A>` and
         //         `Report<B>`

--- a/packages/engine/lib/error/src/hook.rs
+++ b/packages/engine/lib/error/src/hook.rs
@@ -116,6 +116,9 @@ impl<T> Report<T> {
     ///
     /// Changing `Report<T>` to `Report<()>` is only used internally for calling [`debug_hook`] and
     /// [`display_hook`] and is intentionally not exposed.
+    ///
+    /// [`debug_hook`]: Self::debug_hook
+    /// [`display_hook`]: Self::display_hook
     pub(crate) const fn generalized(&self) -> &Report {
         // SAFETY: `Report` is repr(transparent), so it's safe to cast between `Report<A>` and
         //         `Report<B>`

--- a/packages/engine/lib/error/src/hook.rs
+++ b/packages/engine/lib/error/src/hook.rs
@@ -110,3 +110,12 @@ impl Report {
         DISPLAY_HOOK.get()
     }
 }
+
+impl<T> Report<T> {
+    /// Converts the `&Report<Context>` to `&Report<()>` without modifying the frame stack.
+    pub(crate) const fn generalized(&self) -> &Report {
+        // SAFETY: `Report` is repr(transparent), so it's safe to cast between `Report<A>` and
+        //         `Report<B>`
+        unsafe { &*(self as *const Self).cast() }
+    }
+}

--- a/packages/engine/lib/error/src/lib.rs
+++ b/packages/engine/lib/error/src/lib.rs
@@ -159,13 +159,16 @@
 extern crate alloc;
 
 mod frame;
-#[cfg(feature = "futures")]
-mod future_ext;
 #[cfg(feature = "hooks")]
 mod hook;
 mod iter;
 mod macros;
 mod report;
+
+#[cfg(feature = "std")]
+mod error;
+#[cfg(feature = "futures")]
+mod future_ext;
 mod result_ext;
 // pub mod tags;
 
@@ -221,7 +224,7 @@ pub use self::{
 /// use error::{ResultExt, Result};
 ///
 /// fn main() -> Result<()> {
-///     # fn fake_main() -> Result<()> {
+///     # fn fake_main() -> Result<(), impl core::fmt::Debug> {
 ///     let config_path = "./path/to/config.file";
 ///     # #[cfg(all(not(miri), feature = "std"))]
 ///     # #[allow(unused_variables)]
@@ -320,9 +323,9 @@ pub use self::{
 /// ```
 #[must_use]
 #[repr(transparent)]
-pub struct Report<C = ()> {
+pub struct Report<T = ()> {
     inner: Box<ReportImpl>,
-    _context: PhantomData<C>,
+    _context: PhantomData<T>,
 }
 
 /// A single error, contextual message, or error context inside of a [`Report`].

--- a/packages/engine/lib/error/src/macros.rs
+++ b/packages/engine/lib/error/src/macros.rs
@@ -37,7 +37,10 @@ pub mod __private {
         pub struct ErrorReporter;
         #[cfg(feature = "std")]
         impl ErrorReporter {
-            pub fn report<C: std::error::Error + Send + Sync + 'static>(self, error: C) -> Report {
+            pub fn report<C: std::error::Error + Send + Sync + 'static>(
+                self,
+                error: C,
+            ) -> Report<C> {
                 Report::from(error)
             }
         }
@@ -95,14 +98,14 @@ pub mod __private {
 /// # #[cfg(not(miri))]
 /// # use std::fs;
 /// # use error::report;
-/// # fn func() -> error::Result<()> {
+/// # fn func() -> error::Result<(), impl std::fmt::Debug> {
 /// # #[cfg(not(miri))]
 /// match fs::read_to_string("/path/to/file") {
 ///     Ok(content) => println!("File contents: {content}"),
 ///     Err(err) => return Err(report!(err)),
 /// }
 /// # #[cfg(miri)]
-/// # error::bail!("");
+/// # error::bail!(std::io::Error::from(std::io::ErrorKind::NotFound));
 /// # Ok(())
 /// # }
 /// # let err = func().unwrap_err();
@@ -196,14 +199,14 @@ macro_rules! report {
 /// ```
 /// # use std::fs;
 /// # use error::bail;
-/// # fn func() -> error::Result<()> {
+/// # fn func() -> error::Result<(), impl std::fmt::Debug> {
 /// # #[cfg(not(miri))]
 /// match fs::read_to_string("/path/to/file") {
 ///     Ok(content) => println!("File contents: {content}"),
 ///     Err(err) => bail!(err),
 /// }
 /// # #[cfg(miri)]
-/// # bail!("");
+/// # bail!(std::io::Error::from(std::io::ErrorKind::NotFound));
 /// # Ok(())
 /// # }
 /// # let err = func().unwrap_err();

--- a/packages/engine/lib/error/src/report.rs
+++ b/packages/engine/lib/error/src/report.rs
@@ -141,7 +141,8 @@ impl<T> Report<T> {
         )
     }
 
-    /// Converts the `Report<Context>` to `Report<()>` without modifying the frame stack.
+    /// Converts the `Report<T>` to `Report<()>` without modifying the frame stack.
+    #[doc(hidden)]
     #[allow(clippy::missing_const_for_fn)] // False positive
     pub fn generalize(self) -> Report {
         Report {
@@ -198,12 +199,12 @@ impl<T> Report<T> {
         Frames::new(self)
     }
 
-    /// Creates an iterator over the [`Frame`] stack requesting references of type `T`.
+    /// Creates an iterator over the [`Frame`] stack requesting references of type `R`.
     pub const fn request_ref<R: ?Sized + 'static>(&self) -> RequestRef<'_, R> {
         RequestRef::new(self)
     }
 
-    /// Creates an iterator over the [`Frame`] stack requesting values of type `T`.
+    /// Creates an iterator over the [`Frame`] stack requesting values of type `R`.
     pub const fn request_value<R: 'static>(&self) -> RequestValue<'_, R> {
         RequestValue::new(self)
     }

--- a/packages/engine/lib/error/src/report.rs
+++ b/packages/engine/lib/error/src/report.rs
@@ -150,13 +150,6 @@ impl<T> Report<T> {
         }
     }
 
-    /// Converts the `&Report<Context>` to `&Report<()>` without modifying the frame stack.
-    pub const fn generalized(&self) -> &Report {
-        // SAFETY: `Report` is repr(transparent), so it's safe to cast between `Report<A>` and
-        //         `Report<B>`
-        unsafe { &*(self as *const Self).cast() }
-    }
-
     /// Returns the backtrace of the error, if captured.
     ///
     /// Note, that `RUST_BACKTRACE` or `RUST_LIB_BACKTRACE` has to be set to enable backtraces.

--- a/packages/engine/lib/error/src/result_ext.rs
+++ b/packages/engine/lib/error/src/result_ext.rs
@@ -115,7 +115,7 @@ pub trait ResultExt {
 
     // TODO: Temporary, remove before releasing
     //   Currently only used to be backward compatible with hEngine. After binaries and orchestrator
-    //   were adjusted, this can safely be removed.
+    //   are adjusted, this can safely be removed.
     #[doc(hidden)]
     fn generalize(self) -> Result<Self::Ok>;
 }

--- a/packages/engine/lib/error/src/result_ext.rs
+++ b/packages/engine/lib/error/src/result_ext.rs
@@ -114,6 +114,8 @@ pub trait ResultExt {
         F: FnOnce() -> C;
 
     // TODO: Temporary, remove before releasing
+    //   Currently only used to be backward compatible with hEngine. After binaries and orchestrator
+    //   were adjusted, this can safely be removed.
     #[doc(hidden)]
     fn generalize(self) -> Result<Self::Ok>;
 }

--- a/packages/engine/lib/error/src/result_ext.rs
+++ b/packages/engine/lib/error/src/result_ext.rs
@@ -119,11 +119,11 @@ impl<T, E> ResultExt for std::result::Result<T, E>
 where
     E: std::error::Error + Send + Sync + 'static,
 {
-    type Context = ();
+    type Context = E;
     type Ok = T;
 
     #[track_caller]
-    fn wrap_err<M>(self, message: M) -> Result<T>
+    fn wrap_err<M>(self, message: M) -> Result<T, E>
     where
         M: Message,
     {
@@ -135,7 +135,7 @@ where
     }
 
     #[track_caller]
-    fn wrap_err_lazy<M, F>(self, message: F) -> Result<T>
+    fn wrap_err_lazy<M, F>(self, message: F) -> Result<T, E>
     where
         M: Message,
         F: FnOnce() -> M,

--- a/packages/engine/lib/error/src/result_ext.rs
+++ b/packages/engine/lib/error/src/result_ext.rs
@@ -112,6 +112,10 @@ pub trait ResultExt {
     where
         C: Context,
         F: FnOnce() -> C;
+
+    // TODO: Temporary, remove before releasing
+    #[doc(hidden)]
+    fn generalize(self) -> Result<Self::Ok>;
 }
 
 #[cfg(feature = "std")]
@@ -171,6 +175,10 @@ where
             Err(error) => Err(Report::from(error).provide_context(context())),
         }
     }
+
+    fn generalize(self) -> Result<T> {
+        self.map_err(|error| Report::from_error(error).generalize())
+    }
 }
 
 impl<T, C> ResultExt for Result<T, C> {
@@ -225,5 +233,9 @@ impl<T, C> ResultExt for Result<T, C> {
             Ok(ok) => Ok(ok),
             Err(report) => Err(report.provide_context(context())),
         }
+    }
+
+    fn generalize(self) -> Result<T> {
+        self.map_err(Report::generalize)
     }
 }

--- a/packages/engine/lib/nano/src/client.rs
+++ b/packages/engine/lib/nano/src/client.rs
@@ -41,7 +41,7 @@ impl fmt::Debug for WorkerHandle {
 }
 
 impl Worker {
-    fn new(url: &str, request_rx: spmc::Receiver<Request>) -> Result<Self, ()> {
+    fn new(url: &str, request_rx: spmc::Receiver<Request>) -> Result<Self, nng::Error> {
         let socket =
             nng::Socket::new(nng::Protocol::Req0).wrap_err("Could not create nng socket")?;
 

--- a/packages/engine/lib/nano/src/server.rs
+++ b/packages/engine/lib/nano/src/server.rs
@@ -54,7 +54,7 @@ impl Worker {
     /// - a [`Sleep`] message occurred.
     ///
     /// [`Sleep`]: nng::AioResult::Sleep
-    fn new(socket: &nng::Socket, sender: MsgSender, url: &str) -> Result<Self, ()> {
+    fn new(socket: &nng::Socket, sender: MsgSender, url: &str) -> Result<Self, nng::Error> {
         let ctx_orig = nng::Context::new(socket).wrap_err("Could not create context")?;
         let ctx = ctx_orig.clone();
 

--- a/packages/engine/lib/orchestrator/src/experiment.rs
+++ b/packages/engine/lib/orchestrator/src/experiment.rs
@@ -244,7 +244,8 @@ impl Experiment {
             engine_handle.recv(),
         )
         .await
-        .wrap_err("engine start timeout");
+        .wrap_err("engine start timeout")
+        .generalize();
         match msg {
             Ok(proto::EngineStatus::Started) => {}
             Ok(m) => {

--- a/packages/engine/lib/orchestrator/src/experiment.rs
+++ b/packages/engine/lib/orchestrator/src/experiment.rs
@@ -451,9 +451,11 @@ fn get_simple_experiment_config(
         .clone()
         .ok_or_else(|| report!("Experiment configuration not found: experiments.json"))?;
     let parsed = serde_json::from_str(&experiments_manifest)
-        .wrap_err("Could not parse experiment manifest")?;
+        .wrap_err("Could not parse experiment manifest")
+        .generalize()?;
     let plan = create_experiment_plan(&parsed, &experiment_name)
-        .wrap_err("Could not read experiment plan")?;
+        .wrap_err("Could not read experiment plan")
+        .generalize()?;
 
     let max_sims_in_parallel = parsed
         .get("max_sims_in_parallel")
@@ -518,7 +520,8 @@ fn create_multiparameter_variant(
     }
 
     let var: MultiparameterVariant = serde_json::from_value(selected_experiment.clone())
-        .wrap_err("Could not parse multiparameter variant")?;
+        .wrap_err("Could not parse multiparameter variant")
+        .generalize()?;
     let subplans = var
         .runs
         .iter()
@@ -570,7 +573,7 @@ fn create_group_variant(
         steps: f64,
         runs: Vec<ExperimentName>,
     }
-    let var: GroupVariant = serde_json::from_value(selected_experiment.clone())?;
+    let var: GroupVariant = serde_json::from_value(selected_experiment.clone()).generalize()?;
     var.runs.iter().try_fold(
         SimpleExperimentPlan::new(var.steps as usize),
         |mut acc, name| {
@@ -664,26 +667,33 @@ fn create_monte_carlo_variant_plan(
             let distribution = match self.distribution.as_str() {
                 "normal" => Box::new(
                     Normal::new(self.mean.unwrap_or(1.0), self.std.unwrap_or(1.0))
-                        .wrap_err("Unable to create normal distribution")?,
+                        .wrap_err("Unable to create normal distribution")
+                        .generalize()?,
                 ) as Box<dyn DynDistribution<f64>>,
                 "log-normal" => Box::new(
                     LogNormal::new(self.mu.unwrap_or(1.0), self.sigma.unwrap_or(1.0))
-                        .wrap_err("Unable to create log-normal distribution")?,
+                        .wrap_err("Unable to create log-normal distribution")
+                        .generalize()?,
                 ),
                 "poisson" => Box::new(
                     Poisson::new(self.rate.unwrap_or(1.0))
-                        .wrap_err("Unable to create poisson distribution")?,
+                        .wrap_err("Unable to create poisson distribution")
+                        .generalize()?,
                 ),
                 "beta" => Box::new(
                     Beta::new(self.alpha.unwrap_or(1.0), self.beta.unwrap_or(1.0))
-                        .wrap_err("Unable to create beta distribution")?,
+                        .wrap_err("Unable to create beta distribution")
+                        .generalize()?,
                 ),
                 "gamma" => Box::new(
                     rand_distr::Gamma::new(self.shape.unwrap_or(1.0), self.scale.unwrap_or(1.0))
-                        .wrap_err("Unable to create gamma distribution")?,
+                        .wrap_err("Unable to create gamma distribution")
+                        .generalize()?,
                 ),
                 _ => Box::new(
-                    Normal::new(1.0, 1.0).wrap_err("Unable to create normal distribution")?,
+                    Normal::new(1.0, 1.0)
+                        .wrap_err("Unable to create normal distribution")
+                        .generalize()?,
                 ),
             };
             Ok(Box::new(move |_, _| {
@@ -693,7 +703,8 @@ fn create_monte_carlo_variant_plan(
         }
     }
 
-    let var: MonteCarloVariant = serde_json::from_value(selected_experiment.clone())?;
+    let var: MonteCarloVariant =
+        serde_json::from_value(selected_experiment.clone()).generalize()?;
     let values: Vec<_> = (0..var.samples as usize).map(|_| 0.into()).collect();
     Ok(create_variant_with_mapped_value(
         &var.field,
@@ -714,7 +725,8 @@ fn create_value_variant_plan(selected_experiment: &SerdeValue) -> Result<SimpleE
     }
 
     let var: ValueVariant = serde_json::from_value(selected_experiment.clone())
-        .wrap_err("Could not parse value variant")?;
+        .wrap_err("Could not parse value variant")
+        .generalize()?;
     let mapper: Mapper = Box::new(|val, _index| val);
     Ok(create_variant_with_mapped_value(
         &var.field,
@@ -735,7 +747,7 @@ fn create_linspace_variant_plan(selected_experiment: &SerdeValue) -> Result<Simp
         start: f64,
         stop: f64,
     }
-    let var: LinspaceVariant = serde_json::from_value(selected_experiment.clone())?;
+    let var: LinspaceVariant = serde_json::from_value(selected_experiment.clone()).generalize()?;
     let values: Vec<_> = (0..var.samples as usize).map(|_| 0.into()).collect();
 
     let closure_var = var.clone();
@@ -769,7 +781,7 @@ fn create_arange_variant_plan(selected_experiment: &SerdeValue) -> Result<Simple
         start: f64,
         stop: f64,
     }
-    let var: ArangeVariant = serde_json::from_value(selected_experiment.clone())?;
+    let var: ArangeVariant = serde_json::from_value(selected_experiment.clone()).generalize()?;
     let mut values = vec![];
     let mut cur = var.start;
     while cur <= var.stop {
@@ -797,7 +809,7 @@ fn create_meshgrid_variant_plan(selected_experiment: &SerdeValue) -> Result<Simp
         // [start, stop, num_samples]
         y: [f64; 3], // [start, stop, num_samples]
     }
-    let var: MeshgridVariant = serde_json::from_value(selected_experiment.clone())?;
+    let var: MeshgridVariant = serde_json::from_value(selected_experiment.clone()).generalize()?;
 
     let mut plan = SimpleExperimentPlan::new(var.steps as usize);
     let x_space = linspace(var.x[0], var.x[1], var.x[2] as usize);

--- a/packages/engine/lib/orchestrator/src/manifest.rs
+++ b/packages/engine/lib/orchestrator/src/manifest.rs
@@ -275,7 +275,8 @@ impl Manifest {
         debug!("Reading behaviors in {src_folder:?}");
         for entry in src_folder
             .read_dir()
-            .wrap_err_lazy(|| format!("Could not read behavior directory: {src_folder:?}"))?
+            .wrap_err_lazy(|| format!("Could not read behavior directory: {src_folder:?}"))
+            .generalize()?
         {
             match entry {
                 Ok(entry) => {
@@ -319,7 +320,8 @@ impl Manifest {
 
         if file_extension == "csv" {
             data = parse_raw_csv_into_json(data)
-                .wrap_err_lazy(|| format!("Could not convert csv into json: {path:?}"))?;
+                .wrap_err_lazy(|| format!("Could not convert csv into json: {path:?}"))
+                .generalize()?;
         }
 
         let filename = path.file_name().unwrap().to_string_lossy().to_string();
@@ -349,7 +351,8 @@ impl Manifest {
         debug!("Reading datasets in {src_folder:?}");
         for entry in src_folder
             .read_dir()
-            .wrap_err_lazy(|| format!("Could not read dataset directory: {src_folder:?}"))?
+            .wrap_err_lazy(|| format!("Could not read dataset directory: {src_folder:?}"))
+            .generalize()?
         {
             match entry {
                 Ok(entry) => {
@@ -665,7 +668,7 @@ fn _try_read_local_dependencies<P: AsRef<Path>>(dependency_path: P) -> Result<Ve
     debug!("Parsing the dependencies folder: {dependency_path:?}");
 
     let mut entries = dependency_path
-        .read_dir()?
+        .read_dir().generalize()?
         .filter_map(|dir_res| {
             if let Ok(entry) = dir_res {
                 // check it's a folder and matches the pattern of a user namespace (i.e. `@user`)
@@ -675,7 +678,7 @@ fn _try_read_local_dependencies<P: AsRef<Path>>(dependency_path: P) -> Result<Ve
             }
             None
         })
-        .map(|user_dir| user_dir.path().read_dir().wrap_err_lazy(|| format!("Could not read directory {:?}", user_dir.path())))
+        .map(|user_dir| user_dir.path().read_dir().wrap_err_lazy(|| format!("Could not read directory {:?}", user_dir.path())).generalize())
         .collect::<Result<Vec<_>>>()? // Intermediary collect and iter to handle errors from read_dir
         .into_iter()
         .flatten()
@@ -709,7 +712,9 @@ fn file_extension<P: AsRef<Path>>(path: P) -> Result<String> {
 fn file_contents<P: AsRef<Path>>(path: P) -> Result<String> {
     let path = path.as_ref();
     debug!("Reading contents at path: {path:?}");
-    std::fs::read_to_string(path).wrap_err_lazy(|| format!("Could not read file: {path:?}"))
+    std::fs::read_to_string(path)
+        .wrap_err_lazy(|| format!("Could not read file: {path:?}"))
+        .generalize()
 }
 
 fn file_contents_opt<P: AsRef<Path>>(path: P) -> Result<Option<String>> {
@@ -724,7 +729,10 @@ fn file_contents_opt<P: AsRef<Path>>(path: P) -> Result<Option<String>> {
 fn parse_file<T: DeserializeOwned, P: AsRef<Path>>(path: P) -> Result<T> {
     let path = path.as_ref();
     serde_json::from_reader(BufReader::new(
-        File::open(path).wrap_err_lazy(|| format!("Could not read file {path:?}"))?,
+        File::open(path)
+            .wrap_err_lazy(|| format!("Could not read file {path:?}"))
+            .generalize()?,
     ))
     .wrap_err_lazy(|| format!("Could not parse {path:?}"))
+    .generalize()
 }

--- a/packages/engine/lib/orchestrator/src/process/local.rs
+++ b/packages/engine/lib/orchestrator/src/process/local.rs
@@ -87,7 +87,7 @@ impl process::Process for LocalProcess {
                             self.engine_url
                         )
                     })
-                    .map_err(Report::generalize)?,
+                    .generalize()?,
             );
         }
         self.client
@@ -96,7 +96,7 @@ impl process::Process for LocalProcess {
             .send(msg)
             .await
             .wrap_err("Could not send engine message")
-            .map_err(Report::generalize)
+            .generalize()
     }
 
     async fn wait(&mut self) -> Result<ExitStatus> {
@@ -104,6 +104,7 @@ impl process::Process for LocalProcess {
             .wait()
             .await
             .wrap_err("Could not wait for the process to exit")
+            .generalize()
     }
 }
 
@@ -209,7 +210,8 @@ impl process::Command for LocalCommand {
 
         let child = cmd
             .spawn()
-            .wrap_err_lazy(|| format!("Could not run command: {process_path:?}"))?;
+            .wrap_err_lazy(|| format!("Could not run command: {process_path:?}"))
+            .generalize()?;
         debug!("Spawned local engine process for experiment");
 
         Ok(Box::new(LocalProcess {

--- a/packages/engine/tests/experiment/mod.rs
+++ b/packages/engine/tests/experiment/mod.rs
@@ -357,9 +357,12 @@ pub async fn run_test<P: AsRef<Path>>(
 fn parse_file<T: DeserializeOwned, P: AsRef<Path>>(path: P) -> Result<T> {
     let path = path.as_ref();
     serde_json::from_reader(BufReader::new(
-        File::open(path).wrap_err_lazy(|| format!("Could not open file {path:?}"))?,
+        File::open(path)
+            .wrap_err_lazy(|| format!("Could not open file {path:?}"))
+            .generalize()?,
     ))
     .wrap_err_lazy(|| format!("Could not parse {path:?}"))
+    .generalize()
 }
 
 pub fn read_config<P: AsRef<Path>>(path: P) -> Result<Vec<(ExperimentType, Vec<ExpectedOutput>)>> {
@@ -464,7 +467,8 @@ impl ExpectedOutput {
         for (step, expected_states) in json_state {
             let step = step
                 .parse::<usize>()
-                .wrap_err_lazy(|| format!("Could not parse {step:?} as number of a step"))?;
+                .wrap_err_lazy(|| format!("Could not parse {step:?} as number of a step"))
+                .generalize()?;
             let result_states = agent_states
                 .get(step)
                 .ok_or_else(|| report!("Experiment output does not contain {step} steps"))?;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When creating `Report` from `Error`, the resulting type should be `Report<Error>` instead of `Report<()>`.

## 🚫 Blocked by

- #591 

## 🔍 What does this change?

- Change the return type when creating `Report` from `Error`: 148265979eeae52c6eab9c4f318bbfb4a9eb05b6
- Apply changes to `nano` crate: a58854cb552e2db1e00769ba3439d52292a4333c
- ~Add an extension trait for `Error` to convert it to `Report` by adding context~

## ⚠️ Known issues

The binary crates, the orchestrator, and the test suite is using `Report<()>`. It's out of scope to change this in this PR, thus this PR adds a workaround `ResultExt::generalize`, which needs to be removed before release. The method is marked as `#[doc(hidden)]`.

## 🐾 Next steps

- Change the context type for the crates mentioned above and remove `ResultExt::generalize`

## 🎥 Demo

**Before:**

```rust
let report: Report<()> = report!(std::io::Error { .. });
```

**After:**

```rust
let report: Report<std::io::Error> = report!(std::io::Error { .. });
```
