### PR TITLE
Make retrieving hooks internal

### DIFF
--- a/packages/engine/lib/error/src/hook.rs
+++ b/packages/engine/lib/error/src/hook.rs
@@ -56,7 +56,7 @@ impl Report {
     ///
     /// [`set_debug_hook`]: Self::set_debug_hook
     #[cfg(feature = "hooks")]
-    pub fn debug_hook()
+    pub(crate) fn debug_hook()
     -> Option<&'static (impl Fn(&Self, &mut fmt::Formatter) -> fmt::Result + Send + Sync + 'static)>
     {
         DEBUG_HOOK.get()
@@ -104,7 +104,7 @@ impl Report {
     ///
     /// [`set_display_hook`]: Self::set_display_hook
     #[cfg(feature = "hooks")]
-    pub fn display_hook()
+    pub(crate) fn display_hook()
     -> Option<&'static (impl Fn(&Self, &mut fmt::Formatter) -> fmt::Result + Send + Sync + 'static)>
     {
         DISPLAY_HOOK.get()

--- a/packages/engine/lib/error/src/lib.rs
+++ b/packages/engine/lib/error/src/lib.rs
@@ -139,9 +139,6 @@
 //!
 //! Using the `backtrace` crate instead of `std::backtrace` is a considered feature to support
 //! backtraces on non-nightly channels and can be prioritized depending on demand.
-//!
-//! [`display_hook`]: Report::display_hook
-//! [`debug_hook`]: Report::debug_hook
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Instead of calling `debug_hook` or `display_hook`, it's better to call `Debug` or `Display` instead.

## 🔍 What does this change?

Makes `debug_hook` and `display_hook` internal

## 📜 Does this require a change to the docs?

Docs are changed in #587 
