### PR TITLE
Make conversion to `Report` explicit

### DIFF
--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use clap::{AppSettings, Parser};
-use error::{Result, ResultExt};
+use error::{IntoReport, Result, ResultExt};
 use execution::package::experiment::ExperimentName;
 use hash_engine_lib::utils::init_logger;
 use orchestrator::{Experiment, ExperimentConfig, Manifest, Server};
@@ -89,6 +89,7 @@ async fn main() -> Result<()> {
         &format!("cli-{now}"),
         &format!("cli-{now}-texray"),
     )
+    .report()
     .wrap_err("Failed to initialize the logger")
     .generalize()?;
 
@@ -100,6 +101,7 @@ async fn main() -> Result<()> {
     let absolute_project_path = args
         .project
         .canonicalize()
+        .report()
         .wrap_err_lazy(|| format!("Could not canonicalize project path: {:?}", args.project))
         .generalize()?;
     let manifest = Manifest::from_local(&absolute_project_path)

--- a/packages/engine/bin/hash_engine/src/main.rs
+++ b/packages/engine/bin/hash_engine/src/main.rs
@@ -1,4 +1,4 @@
-use error::{Result, ResultExt};
+use error::{IntoReport, Result, ResultExt};
 use hash_engine_lib::{
     config::experiment_config,
     env::env,
@@ -19,21 +19,24 @@ async fn main() -> Result<()> {
         &format!("experiment-{}", args.experiment_id),
         &format!("experiment-{}-texray", args.experiment_id),
     )
+    .report()
     .wrap_err("Failed to initialize the logger")
     .generalize()?;
 
     let mut env = env::<ExperimentRun>(&args)
         .await
+        .report()
         .wrap_err("Could not create environment for experiment")
         .generalize()?;
     // Fetch all dependencies of the experiment run such as datasets
     env.experiment
         .fetch_deps()
         .await
+        .report()
         .wrap_err("Could not fetch dependencies for experiment")
         .generalize()?;
     // Generate the configuration for packages from the environment
-    let config = experiment_config(&args, &env).await.generalize()?;
+    let config = experiment_config(&args, &env).await.report().generalize()?;
 
     tracing::info!(
         "HASH Engine process started for experiment {}",
@@ -42,6 +45,7 @@ async fn main() -> Result<()> {
 
     let experiment_result = run_experiment(config, env)
         .await
+        .report()
         .wrap_err("Could not run experiment")
         .generalize();
 

--- a/packages/engine/lib/error/src/lib.rs
+++ b/packages/engine/lib/error/src/lib.rs
@@ -165,6 +165,7 @@
 )]
 
 extern crate alloc;
+extern crate core;
 
 mod frame;
 pub mod iter;
@@ -190,7 +191,7 @@ pub use self::{
     frame::Frame,
     macros::*,
     report::Report,
-    result::{Result, ResultExt},
+    result::{IntoReport, Result, ResultExt},
 };
 
 /// Trait alias for an error context.

--- a/packages/engine/lib/error/src/report.rs
+++ b/packages/engine/lib/error/src/report.rs
@@ -22,13 +22,13 @@ use crate::{
 /// Context information can be added by using [`wrap()`] or [`ResultExt`]. The [`Frame`] stack can
 /// be iterated by using [`frames()`].
 ///
-/// To enforce context information generation, an context [`Provider`] needs to be used. When
-/// creating a `Report` by using [`from_error()`] or [`from_context()`], the
-/// parameter is used as context in the `Report`. It's also possible to convert a [`Result`]s
-/// [`Err`] variant to a `Report` with [`IntoReport`]. To provide a new context, use
-/// [`provide_context()`] or [`ResultExt`] to add it to the [`Frame`] stack, which may also be used
-/// to provide more context information than only a display message. This information can the be
-/// retrieved by calling [`request_ref()`] or [`request_value()`].
+/// To enforce context information generation, a context [`Provider`] needs to be used. When
+/// creating a `Report` by using [`from_error()`] or [`from_context()`], the parameter is used as
+/// context in the `Report`. It's also possible to convert a [`Result`]s [`Err`] variant to
+/// `Report` with [`IntoReport::report()`]. To provide a new context, use [`provide_context()`] or
+/// [`ResultExt`] to add it to the [`Frame`] stack, which may also be used to provide more context
+/// information than only a display message. This information can the be retrieved by calling
+/// [`request_ref()`] or [`request_value()`].
 ///
 /// [`Backtrace`]: std::backtrace::Backtrace
 /// [`SpanTrace`]: tracing_error::SpanTrace
@@ -36,7 +36,7 @@ use crate::{
 /// [`wrap()`]: Self::wrap
 /// [`from_error()`]: Self::from_error
 /// [`from_context()`]: Self::from_context
-/// [`IntoReport`]: crate::IntoReport
+/// [`IntoReport::report()`]: crate::IntoReport::report
 /// [`frames()`]: Self::frames
 /// [`provide_context()`]: Self::provide_context
 /// [`request_ref()`]: Self::request_ref

--- a/packages/engine/lib/error/src/report.rs
+++ b/packages/engine/lib/error/src/report.rs
@@ -22,20 +22,22 @@ use crate::{
 /// Context information can be added by using [`wrap()`] or [`ResultExt`]. The [`Frame`] stack can
 /// be iterated by using [`frames()`].
 ///
-/// To enforce context information generation, an optional context [`Provider`] may be used. When
-/// creating a `Report` from a message with [`new()`] or from an std-error by using [`from()`], the
-/// `Report` does not have an context associated. To provide one, the [`provider`] API is used. Use
-/// [`provide_context()`] or [`ResultExt`] to add it, which may also be used to provide more context
-/// information than only a display message. This information can the be retrieved by calling
-/// [`request_ref()`] or [`request_value()`].
+/// To enforce context information generation, an context [`Provider`] needs to be used. When
+/// creating a `Report` by using [`from_error()`] or [`from_context()`], the
+/// parameter is used as context in the `Report`. It's also possible to convert a [`Result`]s
+/// [`Err`] variant to a `Report` with [`IntoReport`]. To provide a new context, use
+/// [`provide_context()`] or [`ResultExt`] to add it to the [`Frame`] stack, which may also be used
+/// to provide more context information than only a display message. This information can the be
+/// retrieved by calling [`request_ref()`] or [`request_value()`].
 ///
 /// [`Backtrace`]: std::backtrace::Backtrace
 /// [`SpanTrace`]: tracing_error::SpanTrace
 /// [`ErrorLayer`]: tracing_error::ErrorLayer
 /// [`wrap()`]: Self::wrap
-/// [`from()`]: Self::from
+/// [`from_error()`]: Self::from_error
+/// [`from_context()`]: Self::from_context
+/// [`IntoReport`]: crate::IntoReport
 /// [`frames()`]: Self::frames
-/// [`new()`]: Self::new
 /// [`provide_context()`]: Self::provide_context
 /// [`request_ref()`]: Self::request_ref
 /// [`request_value()`]: Self::request_value
@@ -48,7 +50,8 @@ use crate::{
 ///
 ///
 /// ```
-/// use error::{ResultExt, Result};
+/// # #[cfg_attr(any(miri, not(feature = "std")), allow(unused_imports))]
+/// use error::{IntoReport, ResultExt, Result};
 ///
 /// fn main() -> Result<()> {
 ///     # fn fake_main() -> Result<(), impl core::fmt::Debug> {
@@ -56,6 +59,7 @@ use crate::{
 ///     # #[cfg(all(not(miri), feature = "std"))]
 ///     # #[allow(unused_variables)]
 ///     let content = std::fs::read_to_string(config_path)
+///         .report()
 ///         .wrap_err_lazy(|| format!("Failed to read config file {config_path:?}"))?;
 ///     # #[cfg(any(miri, not(feature = "std")))]
 ///     # Err(error::report!("")).wrap_err_lazy(|| format!("Failed to read config file {config_path:?}"))?;
@@ -77,7 +81,8 @@ use crate::{
 /// use std::path::{Path, PathBuf};
 ///
 /// use provider::{Demand, Provider};
-/// use error::{Report, ResultExt};
+/// # #[cfg_attr(any(miri, not(feature = "std")), allow(unused_imports))]
+/// use error::{IntoReport, Report, ResultExt};
 ///
 /// #[derive(Debug)]
 /// # #[derive(PartialEq)]
@@ -127,7 +132,7 @@ use crate::{
 ///     # #[cfg(any(miri, not(feature = "std")))]
 ///     # return Err(error::report!("No such file").provide_context(ConfigError::IoError));
 ///     # #[cfg(all(not(miri), feature = "std"))]
-///     std::fs::read_to_string(path.as_ref()).provide_context(ConfigError::IoError)
+///     std::fs::read_to_string(path.as_ref()).report().provide_context(ConfigError::IoError)
 /// }
 ///
 /// fn main() -> Result<(), Report<RuntimeError>> {

--- a/packages/engine/lib/error/src/result.rs
+++ b/packages/engine/lib/error/src/result.rs
@@ -120,69 +120,6 @@ pub trait ResultExt {
     fn generalize(self) -> Result<Self::Ok>;
 }
 
-#[cfg(feature = "std")]
-impl<T, E> ResultExt for std::result::Result<T, E>
-where
-    E: std::error::Error + Send + Sync + 'static,
-{
-    type Context = E;
-    type Ok = T;
-
-    #[track_caller]
-    fn wrap_err<M>(self, message: M) -> Result<T, E>
-    where
-        M: Message,
-    {
-        // Can't use `map_err` as `#[track_caller]` is unstable on closures
-        match self {
-            Ok(ok) => Ok(ok),
-            Err(error) => Err(Report::from(error).wrap(message)),
-        }
-    }
-
-    #[track_caller]
-    fn wrap_err_lazy<M, F>(self, message: F) -> Result<T, E>
-    where
-        M: Message,
-        F: FnOnce() -> M,
-    {
-        // Can't use `map_err` as `#[track_caller]` is unstable on closures
-        match self {
-            Ok(ok) => Ok(ok),
-            Err(error) => Err(Report::from(error).wrap(message())),
-        }
-    }
-
-    #[track_caller]
-    fn provide_context<C>(self, context: C) -> Result<T, C>
-    where
-        C: Context,
-    {
-        // Can't use `map_err` as `#[track_caller]` is unstable on closures
-        match self {
-            Ok(ok) => Ok(ok),
-            Err(error) => Err(Report::from(error).provide_context(context)),
-        }
-    }
-
-    #[track_caller]
-    fn provide_context_lazy<C, F>(self, context: F) -> Result<T, C>
-    where
-        C: Context,
-        F: FnOnce() -> C,
-    {
-        // Can't use `map_err` as `#[track_caller]` is unstable on closures
-        match self {
-            Ok(ok) => Ok(ok),
-            Err(error) => Err(Report::from(error).provide_context(context())),
-        }
-    }
-
-    fn generalize(self) -> Result<T> {
-        self.map_err(|error| Report::from_error(error).generalize())
-    }
-}
-
 impl<T, C> ResultExt for Result<T, C> {
     type Context = C;
     type Ok = T;
@@ -239,5 +176,33 @@ impl<T, C> ResultExt for Result<T, C> {
 
     fn generalize(self) -> Result<T> {
         self.map_err(Report::generalize)
+    }
+}
+
+/// Extends [`Result`] to convert the [`Err`] variant to a [`Report`]
+pub trait IntoReport: Sized {
+    /// Type of the [`Ok`] value in the [`Result`]
+    type Ok;
+
+    /// Type of the resulting [`Err`] variant wrapped inside a [`Report<E>`].
+    type Err;
+
+    /// Converts the [`Err`] variant of the [`Result`] to a [`Report`]
+    fn report(self) -> Result<Self::Ok, Self::Err>;
+}
+
+impl<T, E> IntoReport for core::result::Result<T, E>
+where
+    Report<E>: From<E>,
+{
+    type Err = E;
+    type Ok = T;
+
+    #[track_caller]
+    fn report(self) -> Result<T, E> {
+        match self {
+            Ok(value) => Ok(value),
+            Err(error) => Err(Report::from(error)),
+        }
     }
 }

--- a/packages/engine/lib/nano/src/spmc.rs
+++ b/packages/engine/lib/nano/src/spmc.rs
@@ -1,8 +1,8 @@
 use core::fmt;
 use std::sync::Arc;
 
-use error::report;
-use tokio::sync::{mpsc, Mutex};
+use error::Report;
+use tokio::sync::{mpsc, mpsc::error::SendError, Mutex};
 
 use crate::error::{ErrorKind, Result};
 
@@ -40,7 +40,7 @@ impl<T: Send> Sender<T> {
         self.sender
             .send(value)
             .await
-            .map_err(|e| report!("{e}").provide_context(ErrorKind::Send))
+            .map_err(|_send_error| Report::from(SendError(())).provide_context(ErrorKind::Send))
     }
 }
 

--- a/packages/engine/lib/orchestrator/src/experiment.rs
+++ b/packages/engine/lib/orchestrator/src/experiment.rs
@@ -4,7 +4,7 @@
 
 use std::{collections::HashMap, path::PathBuf, time::Duration};
 
-use error::{bail, ensure, report, Result, ResultExt};
+use error::{bail, ensure, report, IntoReport, Result, ResultExt};
 use execution::package::experiment::{
     ExperimentName, ExperimentPackageConfig, SimpleExperimentConfig, SingleRunExperimentConfig,
 };
@@ -244,6 +244,7 @@ impl Experiment {
             engine_handle.recv(),
         )
         .await
+        .report()
         .wrap_err("engine start timeout")
         .generalize();
         match msg {
@@ -452,6 +453,7 @@ fn get_simple_experiment_config(
         .clone()
         .ok_or_else(|| report!("Experiment configuration not found: experiments.json"))?;
     let parsed = serde_json::from_str(&experiments_manifest)
+        .report()
         .wrap_err("Could not parse experiment manifest")
         .generalize()?;
     let plan = create_experiment_plan(&parsed, &experiment_name)
@@ -521,6 +523,7 @@ fn create_multiparameter_variant(
     }
 
     let var: MultiparameterVariant = serde_json::from_value(selected_experiment.clone())
+        .report()
         .wrap_err("Could not parse multiparameter variant")
         .generalize()?;
     let subplans = var
@@ -574,7 +577,9 @@ fn create_group_variant(
         steps: f64,
         runs: Vec<ExperimentName>,
     }
-    let var: GroupVariant = serde_json::from_value(selected_experiment.clone()).generalize()?;
+    let var: GroupVariant = serde_json::from_value(selected_experiment.clone())
+        .report()
+        .generalize()?;
     var.runs.iter().try_fold(
         SimpleExperimentPlan::new(var.steps as usize),
         |mut acc, name| {
@@ -668,31 +673,37 @@ fn create_monte_carlo_variant_plan(
             let distribution = match self.distribution.as_str() {
                 "normal" => Box::new(
                     Normal::new(self.mean.unwrap_or(1.0), self.std.unwrap_or(1.0))
+                        .report()
                         .wrap_err("Unable to create normal distribution")
                         .generalize()?,
                 ) as Box<dyn DynDistribution<f64>>,
                 "log-normal" => Box::new(
                     LogNormal::new(self.mu.unwrap_or(1.0), self.sigma.unwrap_or(1.0))
+                        .report()
                         .wrap_err("Unable to create log-normal distribution")
                         .generalize()?,
                 ),
                 "poisson" => Box::new(
                     Poisson::new(self.rate.unwrap_or(1.0))
+                        .report()
                         .wrap_err("Unable to create poisson distribution")
                         .generalize()?,
                 ),
                 "beta" => Box::new(
                     Beta::new(self.alpha.unwrap_or(1.0), self.beta.unwrap_or(1.0))
+                        .report()
                         .wrap_err("Unable to create beta distribution")
                         .generalize()?,
                 ),
                 "gamma" => Box::new(
                     rand_distr::Gamma::new(self.shape.unwrap_or(1.0), self.scale.unwrap_or(1.0))
+                        .report()
                         .wrap_err("Unable to create gamma distribution")
                         .generalize()?,
                 ),
                 _ => Box::new(
                     Normal::new(1.0, 1.0)
+                        .report()
                         .wrap_err("Unable to create normal distribution")
                         .generalize()?,
                 ),
@@ -704,8 +715,9 @@ fn create_monte_carlo_variant_plan(
         }
     }
 
-    let var: MonteCarloVariant =
-        serde_json::from_value(selected_experiment.clone()).generalize()?;
+    let var: MonteCarloVariant = serde_json::from_value(selected_experiment.clone())
+        .report()
+        .generalize()?;
     let values: Vec<_> = (0..var.samples as usize).map(|_| 0.into()).collect();
     Ok(create_variant_with_mapped_value(
         &var.field,
@@ -726,6 +738,7 @@ fn create_value_variant_plan(selected_experiment: &SerdeValue) -> Result<SimpleE
     }
 
     let var: ValueVariant = serde_json::from_value(selected_experiment.clone())
+        .report()
         .wrap_err("Could not parse value variant")
         .generalize()?;
     let mapper: Mapper = Box::new(|val, _index| val);
@@ -748,7 +761,9 @@ fn create_linspace_variant_plan(selected_experiment: &SerdeValue) -> Result<Simp
         start: f64,
         stop: f64,
     }
-    let var: LinspaceVariant = serde_json::from_value(selected_experiment.clone()).generalize()?;
+    let var: LinspaceVariant = serde_json::from_value(selected_experiment.clone())
+        .report()
+        .generalize()?;
     let values: Vec<_> = (0..var.samples as usize).map(|_| 0.into()).collect();
 
     let closure_var = var.clone();
@@ -782,7 +797,9 @@ fn create_arange_variant_plan(selected_experiment: &SerdeValue) -> Result<Simple
         start: f64,
         stop: f64,
     }
-    let var: ArangeVariant = serde_json::from_value(selected_experiment.clone()).generalize()?;
+    let var: ArangeVariant = serde_json::from_value(selected_experiment.clone())
+        .report()
+        .generalize()?;
     let mut values = vec![];
     let mut cur = var.start;
     while cur <= var.stop {
@@ -810,7 +827,9 @@ fn create_meshgrid_variant_plan(selected_experiment: &SerdeValue) -> Result<Simp
         // [start, stop, num_samples]
         y: [f64; 3], // [start, stop, num_samples]
     }
-    let var: MeshgridVariant = serde_json::from_value(selected_experiment.clone()).generalize()?;
+    let var: MeshgridVariant = serde_json::from_value(selected_experiment.clone())
+        .report()
+        .generalize()?;
 
     let mut plan = SimpleExperimentPlan::new(var.steps as usize);
     let x_space = linspace(var.x[0], var.x[1], var.x[2] as usize);

--- a/packages/engine/lib/orchestrator/src/experiment_server.rs
+++ b/packages/engine/lib/orchestrator/src/experiment_server.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::HashMap, fmt::Display};
 
-use error::{bail, report, Result, ResultExt};
+use error::{bail, report, IntoReport, Result, ResultExt};
 use hash_engine_lib::{proto, proto::EngineStatus};
 use simulation_structure::ExperimentId;
 use tokio::sync::{mpsc, mpsc::error::SendError, oneshot};
@@ -87,6 +87,7 @@ impl Handler {
             .map_err(|_| report!("Could not send control message to server"))?;
         result_rx
             .await
+            .report()
             .wrap_err("Failed to receive response from")
             .generalize()?
     }
@@ -217,6 +218,7 @@ impl Server {
             }
             Some(sender) => sender
                 .send(msg.body)
+                .report()
                 .wrap_err_lazy(|| format!("Routing message for experiment {}", msg.experiment_id)),
         }
     }

--- a/packages/engine/lib/orchestrator/src/process/local.rs
+++ b/packages/engine/lib/orchestrator/src/process/local.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use error::{Report, Result, ResultExt};
+use error::{IntoReport, Report, Result, ResultExt};
 use hash_engine_lib::{
     experiment::controller::run::cleanup_experiment,
     proto::EngineMsg,
@@ -103,6 +103,7 @@ impl process::Process for LocalProcess {
         self.child
             .wait()
             .await
+            .report()
             .wrap_err("Could not wait for the process to exit")
             .generalize()
     }
@@ -210,6 +211,7 @@ impl process::Command for LocalCommand {
 
         let child = cmd
             .spawn()
+            .report()
             .wrap_err_lazy(|| format!("Could not run command: {process_path:?}"))
             .generalize()?;
         debug!("Spawned local engine process for experiment");

--- a/packages/engine/tests/experiment/mod.rs
+++ b/packages/engine/tests/experiment/mod.rs
@@ -7,7 +7,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use error::{bail, ensure, report, Result, ResultExt};
+use error::{bail, ensure, report, IntoReport, Result, ResultExt};
 use execution::{package::experiment::ExperimentName, runner::Language};
 use hash_engine_lib::utils::{LogFormat, LogLevel, OutputLocation};
 use orchestrator::{ExperimentConfig, ExperimentType, Manifest, Server};
@@ -358,9 +358,11 @@ fn parse_file<T: DeserializeOwned, P: AsRef<Path>>(path: P) -> Result<T> {
     let path = path.as_ref();
     serde_json::from_reader(BufReader::new(
         File::open(path)
+            .report()
             .wrap_err_lazy(|| format!("Could not open file {path:?}"))
             .generalize()?,
     ))
+    .report()
     .wrap_err_lazy(|| format!("Could not parse {path:?}"))
     .generalize()
 }
@@ -467,6 +469,7 @@ impl ExpectedOutput {
         for (step, expected_states) in json_state {
             let step = step
                 .parse::<usize>()
+                .report()
                 .wrap_err_lazy(|| format!("Could not parse {step:?} as number of a step"))
                 .generalize()?;
             let result_states = agent_states


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, we can convert any `Result<T, E: Error>` to `Result<T, Report<E>>` by calling `wrap_err(_lazy)` or `provide_context(_lazy)` on it. This might be bad because this silently converts `E` to `Report<E>`, which may have performance implications for allocating heap memory to store `E` and may capture a backtrace or a span trace.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1199550852792314/1201586921294315) _(internal)_

## 🔍 What does this change?

- Remove `impl ResultExt for Result<T, E: Error>`
- Add an `IntoReport` trait and implement it for `Result<T, E: Into<Report<E>>>`
- Adjust tests
- Apply changes to hEngine

## 📜 Does this require a change to the docs?

The docs were updated to reflect these changes. A major documentation overhaul is coming soon

## ⚠️ Known issues

- This adds a bit of boilerplate.

## 🐾 Next steps

- Forbid creating `Report<()>`

## 🛡 What tests cover this?

The unit test suite from the error crate is covering this.