### PR TITLE
Move `provider` API to `error` crate

### DIFF
--- a/packages/engine/Cargo.lock
+++ b/packages/engine/Cargo.lock
@@ -670,7 +670,6 @@ dependencies = [
  "futures-core",
  "once_cell",
  "pin-project",
- "provider",
  "rustc_version",
  "serde_json",
  "tracing-error",
@@ -988,7 +987,6 @@ dependencies = [
  "num_cpus",
  "orchestrator",
  "parking_lot",
- "provider",
  "rand 0.8.4",
  "rayon",
  "regex",
@@ -1430,7 +1428,6 @@ version = "0.0.0"
 dependencies = [
  "error",
  "nng",
- "provider",
  "serde",
  "serde_json",
  "thiserror",
@@ -1783,10 +1780,6 @@ checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
-
-[[package]]
-name = "provider"
-version = "0.0.0"
 
 [[package]]
 name = "quote"

--- a/packages/engine/Cargo.lock
+++ b/packages/engine/Cargo.lock
@@ -1616,7 +1616,6 @@ dependencies = [
  "hash_engine_lib",
  "nano",
  "num_cpus",
- "provider",
  "rand 0.8.4",
  "rand_distr",
  "serde",

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -48,7 +48,6 @@ tracing-texray = { version = "0.1.2", optional = true }
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
 
 [dev-dependencies]
-provider = { path = "lib/provider" }
 error = { path = "lib/error" }
 orchestrator = { path = "lib/orchestrator", default-features = false }
 num_cpus = "1.13.1"

--- a/packages/engine/lib/error/Cargo.toml
+++ b/packages/engine/lib/error/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-provider = { path = "../provider" }
-
 tracing-error = { version = "0.2.0", optional = true }
 once_cell = { version = "1.10.0", optional = true }
 pin-project = { version = "1.0.10", optional = true }

--- a/packages/engine/lib/error/src/frame.rs
+++ b/packages/engine/lib/error/src/frame.rs
@@ -13,9 +13,10 @@ use core::{
 #[cfg(feature = "std")]
 use std::error::Error;
 
-use provider::{self, Demand, Provider};
-
-use crate::{Context, Message};
+use crate::{
+    provider::{self, Demand, Provider},
+    Context, Message,
+};
 
 /// A single error, contextual message, or error context inside of a [`Report`].
 ///

--- a/packages/engine/lib/error/src/future.rs
+++ b/packages/engine/lib/error/src/future.rs
@@ -175,7 +175,7 @@ pub trait FutureExt: Future + Sized {
     /// # struct Resource;
     /// # #[derive(Debug)] struct ResourceError;
     /// # impl fmt::Display for ResourceError { fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result { Ok(()) }}
-    /// # impl provider::Provider for ResourceError { fn provide<'a>(&'a self, _: &mut provider::Demand<'a>) {} }
+    /// # impl error::provider::Provider for ResourceError { fn provide<'a>(&'a self, _: &mut error::provider::Demand<'a>) {} }
     /// use error::{FutureExt, Result};
     ///
     /// # #[allow(unused_variables)]
@@ -218,7 +218,7 @@ pub trait FutureExt: Future + Sized {
     /// # impl fmt::Display for Resource { fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result { Ok(()) }}
     /// # #[derive(Debug)] struct ResourceError;
     /// # impl fmt::Display for ResourceError { fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result { Ok(()) }}
-    /// # impl provider::Provider for ResourceError { fn provide<'a>(&'a self, _: &mut provider::Demand<'a>) {} }
+    /// # impl error::provider::Provider for ResourceError { fn provide<'a>(&'a self, _: &mut error::provider::Demand<'a>) {} }
     /// use error::{FutureExt, Result};
     ///
     /// # #[allow(unused_variables)]

--- a/packages/engine/lib/error/src/lib.rs
+++ b/packages/engine/lib/error/src/lib.rs
@@ -58,7 +58,7 @@
 //! # impl core::fmt::Display for AccessError {
 //! #    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { Ok(()) }
 //! # }
-//! # impl provider::Provider for AccessError { fn provide<'a>(&'a self, _: &mut provider::Demand<'a>) {} }
+//! # impl error::provider::Provider for AccessError { fn provide<'a>(&'a self, _: &mut error::provider::Demand<'a>) {} }
 //! use error::{ensure, Result};
 //!
 //! fn main() -> Result<(), AccessError> {
@@ -103,7 +103,7 @@
 //! # #[cfg(feature = "std")]
 //! impl Error for LookupError {}
 //! # #[cfg(not(feature = "std"))]
-//! impl provider::Provider for LookupError { fn provide<'a>(&'a self, _: &mut provider::Demand<'a>) {}}
+//! impl error::provider::Provider for LookupError { fn provide<'a>(&'a self, _: &mut error::provider::Demand<'a>) {}}
 //!
 //! fn lookup_key(map: &HashMap<&str, u64>, key: &str) -> Result<u64, LookupError> {
 //! // `ensure!` returns `Err(Report)` if the condition fails
@@ -210,6 +210,7 @@ mod error;
 pub mod future;
 #[cfg(feature = "hooks")]
 mod hook;
+pub mod provider;
 
 use core::fmt;
 
@@ -253,9 +254,10 @@ pub(crate) mod test_helper {
     };
     use core::{fmt, fmt::Formatter};
 
-    use provider::{Demand, Provider};
-
-    use crate::Report;
+    use crate::{
+        provider::{Demand, Provider},
+        Report,
+    };
 
     #[derive(Debug)]
     pub struct ContextA(pub u32);

--- a/packages/engine/lib/error/src/macros.rs
+++ b/packages/engine/lib/error/src/macros.rs
@@ -98,8 +98,10 @@ pub mod __private {
 /// # impl fmt::Display for Resource { fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result { Ok(()) }}
 /// use core::fmt;
 ///
-/// use error::Report;
-/// use provider::{Demand, Provider};
+/// use error::{
+///     provider::{Demand, Provider},
+///     Report,
+/// };
 ///
 /// #[derive(Debug)]
 /// struct PermissionDenied(User, Resource);
@@ -176,8 +178,10 @@ macro_rules! report {
 /// # impl fmt::Display for Resource { fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result { Ok(()) }}
 /// use core::fmt;
 ///
-/// use error::Report;
-/// use provider::{Demand, Provider};
+/// use error::{
+///     provider::{Demand, Provider},
+///     Report,
+/// };
 ///
 /// #[derive(Debug)]
 /// struct PermissionDenied(User, Resource);
@@ -231,8 +235,10 @@ macro_rules! bail {
 /// # impl fmt::Display for Resource { fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result { Ok(()) }}
 /// use core::fmt;
 ///
-/// use error::Report;
-/// use provider::{Demand, Provider};
+/// use error::{
+///     provider::{Demand, Provider},
+///     Report,
+/// };
 ///
 /// #[derive(Debug)]
 /// struct PermissionDenied(User, Resource);

--- a/packages/engine/lib/error/src/report.rs
+++ b/packages/engine/lib/error/src/report.rs
@@ -9,7 +9,7 @@ use tracing_error::{SpanTrace, SpanTraceStatus};
 use super::Frame;
 use crate::{
     iter::{Frames, RequestRef, RequestValue},
-    Context, Message,
+    provider, Context, Message,
 };
 
 /// Contains a [`Frame`] stack consisting of an original error, context information, and optionally
@@ -70,7 +70,7 @@ use crate::{
 /// use core::fmt;
 /// use std::path::{Path, PathBuf};
 ///
-/// use provider::{Demand, Provider};
+/// use error::provider::{Demand, Provider};
 /// # #[cfg_attr(any(miri, not(feature = "std")), allow(unused_imports))]
 /// use error::{IntoReport, Report, ResultExt};
 ///

--- a/packages/engine/lib/error/src/result.rs
+++ b/packages/engine/lib/error/src/result.rs
@@ -19,7 +19,7 @@ use crate::{Context, Message, Report};
 /// # impl core::fmt::Display for AccessError {
 /// #    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { Ok(()) }
 /// # }
-/// # impl provider::Provider for AccessError { fn provide<'a>(&'a self, _: &mut provider::Demand<'a>) {} }
+/// # impl error::provider::Provider for AccessError { fn provide<'a>(&'a self, _: &mut error::provider::Demand<'a>) {} }
 /// use error::{ensure, Result};
 ///
 /// fn main() -> Result<(), AccessError> {

--- a/packages/engine/lib/nano/Cargo.toml
+++ b/packages/engine/lib/nano/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-provider = { path = "../provider" }
 error = { path = "../error" }
 
 nng = { version = "1.0.1", default-features = false }

--- a/packages/engine/lib/nano/src/error.rs
+++ b/packages/engine/lib/nano/src/error.rs
@@ -1,4 +1,4 @@
-use provider::{Demand, Provider};
+use error::provider::{Demand, Provider};
 use thiserror::Error as ThisError;
 
 pub type Result<T, E = ErrorKind> = error::Result<T, E>;

--- a/packages/engine/lib/orchestrator/Cargo.toml
+++ b/packages/engine/lib/orchestrator/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 error = { path = "../../lib/error", features = ["spantrace"] }
-provider = { path = "../../lib/provider" }
 nano = { path = "../nano", default-features = false }
 stateful = { path = "../stateful", default-features = false }
 simulation_structure = { path = "../simulation_structure" }

--- a/packages/engine/lib/orchestrator/src/error.rs
+++ b/packages/engine/lib/orchestrator/src/error.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use provider::{Demand, Provider};
+use error::provider::{Demand, Provider};
 
 pub type Result<T, E = OrchestratorError> = error::Result<T, E>;
 

--- a/packages/engine/lib/provider/Cargo.toml
+++ b/packages/engine/lib/provider/Cargo.toml
@@ -1,6 +1,0 @@
-[package]
-name = "provider"
-version = "0.0.0"
-edition = "2021"
-description = "`Provider` trait and accompanying API"
-publish = false

--- a/packages/engine/tests/experiment/error.rs
+++ b/packages/engine/tests/experiment/error.rs
@@ -1,6 +1,6 @@
 use std::{error::Error, fmt, path::PathBuf};
 
-use provider::{Demand, Provider};
+use error::provider::{Demand, Provider};
 use serde_json::Value;
 
 pub type Result<T, C = TestContext> = error::Result<T, C>;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In order to publish the error crate, we want to avoid publishing the `provider` crate as it's soon to be expected to land on `core` soon.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1199548034582004/1202128277084777/f) _(internal)_

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

- #598

## 🔍 What does this change?

- Move provider API to `error` crate
- Apply fixes to usages
- Move `Demand` creation to it's own function (as in a review upstream)
- Apply clippy lints

## 📜 Does this require a change to the docs?

Doc tests were updated
