### PR TITLE
Rename methods on error library and add `attach_provider`

### DIFF
--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -90,7 +90,7 @@ async fn main() -> Result<(), ()> {
         &format!("cli-{now}-texray"),
     )
     .report()
-    .wrap_err("Failed to initialize the logger")
+    .attach_message("Failed to initialize the logger")
     .generalize()?;
 
     let nng_listen_url = format!("ipc://hash-orchestrator-{now}");
@@ -102,14 +102,14 @@ async fn main() -> Result<(), ()> {
         .project
         .canonicalize()
         .report()
-        .wrap_err_lazy(|| format!("Could not canonicalize project path: {:?}", args.project))
+        .attach_message_lazy(|| format!("Could not canonicalize project path: {:?}", args.project))
         .generalize()?;
     let manifest = Manifest::from_local(&absolute_project_path)
-        .wrap_err_lazy(|| format!("Could not read local project {absolute_project_path:?}"))
+        .attach_message_lazy(|| format!("Could not read local project {absolute_project_path:?}"))
         .generalize()?;
     let experiment_run = manifest
         .read(args.r#type.into())
-        .wrap_err("Could not read manifest")
+        .attach_message("Could not read manifest")
         .generalize()?;
 
     let experiment = Experiment::new(args.experiment_config);

--- a/packages/engine/bin/hash_engine/src/main.rs
+++ b/packages/engine/bin/hash_engine/src/main.rs
@@ -20,20 +20,20 @@ async fn main() -> Result<(), ()> {
         &format!("experiment-{}-texray", args.experiment_id),
     )
     .report()
-    .wrap_err("Failed to initialize the logger")
+    .attach_message("Failed to initialize the logger")
     .generalize()?;
 
     let mut env = env::<ExperimentRun>(&args)
         .await
         .report()
-        .wrap_err("Could not create environment for experiment")
+        .attach_message("Could not create environment for experiment")
         .generalize()?;
     // Fetch all dependencies of the experiment run such as datasets
     env.experiment
         .fetch_deps()
         .await
         .report()
-        .wrap_err("Could not fetch dependencies for experiment")
+        .attach_message("Could not fetch dependencies for experiment")
         .generalize()?;
     // Generate the configuration for packages from the environment
     let config = experiment_config(&args, &env).await.report().generalize()?;
@@ -46,7 +46,7 @@ async fn main() -> Result<(), ()> {
     let experiment_result = run_experiment(config, env)
         .await
         .report()
-        .wrap_err("Could not run experiment")
+        .attach_message("Could not run experiment")
         .generalize();
 
     cleanup_experiment(args.experiment_id);

--- a/packages/engine/lib/error/Cargo.toml
+++ b/packages/engine/lib/error/Cargo.toml
@@ -19,7 +19,7 @@ rustc_version = "0.2.3"
 [features]
 default = ["std", "hooks"]
 std = []
-hooks = ["dep:once_cell"]
+hooks = ["dep:once_cell", "std"]
 spantrace = ["dep:tracing-error"]
 futures = ["dep:pin-project"]
 

--- a/packages/engine/lib/error/examples/contextual_messages.rs
+++ b/packages/engine/lib/error/examples/contextual_messages.rs
@@ -36,14 +36,14 @@ fn parse_config(config: &HashMap<&str, u64>) -> Result<u64, LookupError> {
 
     // `ResultExt` provides different methods for adding additional information to the `Report`
     let value =
-        lookup_key(config, key).wrap_err_lazy(|| format!("Could not lookup key {key:?}"))?;
+        lookup_key(config, key).attach_message_lazy(|| format!("Could not lookup key {key:?}"))?;
 
     Ok(value)
 }
 
 fn main() -> Result<(), LookupError> {
     let config = HashMap::default();
-    let _config_value = parse_config(&config).wrap_err("Unable to parse config")?;
+    let _config_value = parse_config(&config).attach_message("Unable to parse config")?;
 
     Ok(())
 }

--- a/packages/engine/lib/error/examples/json_output.rs
+++ b/packages/engine/lib/error/examples/json_output.rs
@@ -18,7 +18,7 @@ impl fmt::Display for MapError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Occupied { key, value } => {
-                write!(fmt, "Entry {key} is already occupied by {value}")
+                write!(fmt, "Entry \"{key}\" is already occupied by {value}")
             }
         }
     }
@@ -62,11 +62,11 @@ fn main() -> Result<(), MapError> {
     let mut config = HashMap::default();
 
     // Create an entry with "foo" as key
-    create_new_entry(&mut config, "foo", 1).wrap_err("Could not create new entry")?;
+    create_new_entry(&mut config, "foo", 1).attach_message("Could not create new entry")?;
 
     // Purposefully cause an error by attempting to create another entry with "foo" as key
     let creation_result =
-        create_new_entry(&mut config, "foo", 2).wrap_err("Could not create new entry");
+        create_new_entry(&mut config, "foo", 2).attach_message("Could not create new entry");
 
     assert_eq!(
         format!("{:?}", creation_result.unwrap_err()),

--- a/packages/engine/lib/error/src/error.rs
+++ b/packages/engine/lib/error/src/error.rs
@@ -1,6 +1,6 @@
-use std::{error::Error, panic::Location};
+use std::error::Error;
 
-use crate::{Frame, Report};
+use crate::Report;
 
 #[cfg(feature = "std")]
 impl<E> From<E> for Report<E>
@@ -8,20 +8,8 @@ where
     E: Error + Send + Sync + 'static,
 {
     #[track_caller]
+    #[inline]
     fn from(error: E) -> Self {
-        #[cfg(nightly)]
-        let backtrace = if error.backtrace().is_some() {
-            None
-        } else {
-            Some(std::backtrace::Backtrace::capture())
-        };
-
-        Self::from_frame(
-            Frame::from_std(error, Location::caller(), None),
-            #[cfg(nightly)]
-            backtrace,
-            #[cfg(feature = "spantrace")]
-            Some(tracing_error::SpanTrace::capture()),
-        )
+        Self::from_error(error)
     }
 }

--- a/packages/engine/lib/error/src/frame.rs
+++ b/packages/engine/lib/error/src/frame.rs
@@ -16,7 +16,7 @@ use std::error::Error;
 use crate::provider::{self, Demand, Provider};
 use crate::Context;
 
-/// A [`Frame`] needs to implement all of the dependent traits so it's captured type needs these
+/// A [`Frame`] needs to implement all of the dependent traits so its captured type needs these
 /// traits as well.
 ///
 /// This is a convenient trait alias to avoid writing down each trait explicitly every time.

--- a/packages/engine/lib/error/src/frame.rs
+++ b/packages/engine/lib/error/src/frame.rs
@@ -40,6 +40,7 @@ impl<T> Unerased for T where T: fmt::Debug + fmt::Display + Send + Sync + 'stati
 pub struct Frame {
     inner: ManuallyDrop<Box<FrameRepr>>,
     location: &'static Location<'static>,
+    // `pub(crate)` required for `Frames` implementation for non-nightly builds
     pub(crate) source: Option<Box<Frame>>,
 }
 

--- a/packages/engine/lib/error/src/frame.rs
+++ b/packages/engine/lib/error/src/frame.rs
@@ -202,10 +202,10 @@ struct VTable {
     object_downcast: unsafe fn(&FrameRepr, target: TypeId) -> Option<NonNull<()>>,
 }
 
-/// Wrapper around [`Message`].
+/// Wrapper around a contextual message.
 ///
-/// As [`Message`] does not necessarily implement [`Provider`], an empty implementation is provided.
-/// If a [`Provider`] is required use it directly instead of [`Message`].
+/// A message does not necessarily implement [`Provider`], an empty implementation is provided.
+/// If a [`Provider`] is required attach it directly rather than attaching a message.
 struct MessageRepr<M>(M);
 
 impl<C: fmt::Display> fmt::Display for MessageRepr<C> {
@@ -225,7 +225,7 @@ impl<C: Context> Context for MessageRepr<C> {}
 #[cfg(nightly)]
 impl<C: fmt::Display + fmt::Debug + Send + Sync + 'static> Provider for MessageRepr<C> {
     fn provide<'a>(&'a self, _: &mut Demand<'a>) {
-        // Empty definition as `Message` does not convey provider information
+        // Empty definition as a contextual message does not convey provider information
     }
 }
 

--- a/packages/engine/lib/error/src/frame.rs
+++ b/packages/engine/lib/error/src/frame.rs
@@ -106,7 +106,8 @@ impl Frame {
     where
         E: Error + Send + Sync + 'static,
     {
-        Self::from_provider(ErrorRepr(error), location, source)
+        // TODO: Pass error directly when the Provider API hits stable
+        Self::from_unerased(ErrorRepr(error), location, source)
     }
 
     /// Returns the location where this `Frame` was created.
@@ -258,7 +259,7 @@ impl<C> Provider for ContextRepr<C> {
     }
 }
 
-/// Wrapper around [`Error`].
+/// Temporary wrapper around [`Error`] to implement Provider.
 ///
 /// As [`Error`] does not necessarily implement [`Provider`], an implementation is provided. As soon
 /// as [`Provider`] is implemented on [`Error`], this struct will be removed and used directly

--- a/packages/engine/lib/error/src/frame.rs
+++ b/packages/engine/lib/error/src/frame.rs
@@ -25,6 +25,12 @@ use crate::Context;
 trait Unerased: Provider + fmt::Debug + fmt::Display + Send + Sync + 'static {}
 #[cfg(nightly)]
 impl<T> Unerased for T where T: Provider + fmt::Debug + fmt::Display + Send + Sync + 'static {}
+
+/// Trait alias to require all required traits used on a [`Frame`].
+///
+/// In order to implement these traits on a [`Frame`], the underlying type requires these types as
+/// well. After creation of the [`Frame`] it's erased. To unerase it later on to act on the actual
+/// Frame implementation, this trait is used.
 #[cfg(not(nightly))]
 trait Unerased: fmt::Debug + fmt::Display + Send + Sync + 'static {}
 #[cfg(not(nightly))]

--- a/packages/engine/lib/error/src/frame.rs
+++ b/packages/engine/lib/error/src/frame.rs
@@ -106,7 +106,7 @@ impl Frame {
     where
         E: Error + Send + Sync + 'static,
     {
-        // TODO: Pass error directly when the Provider API hits stable
+        // TODO: Pass error directly when Provider is implemented on errors
         Self::from_unerased(ErrorRepr(error), location, source)
     }
 
@@ -264,6 +264,7 @@ impl<C> Provider for ContextRepr<C> {
 /// As [`Error`] does not necessarily implement [`Provider`], an implementation is provided. As soon
 /// as [`Provider`] is implemented on [`Error`], this struct will be removed and used directly
 /// instead.
+// TODO: Remove when Provider is implemented on errors
 #[cfg(feature = "std")]
 #[repr(transparent)]
 struct ErrorRepr<E>(E);

--- a/packages/engine/lib/error/src/frame.rs
+++ b/packages/engine/lib/error/src/frame.rs
@@ -226,8 +226,9 @@ impl<C: fmt::Display + fmt::Debug + Send + Sync + 'static> Provider for MessageR
 
 /// Wrapper around [`Context`].
 ///
-/// As [`Context`] does not necessarily implement [`Provider`], an empty implementation is provided.
-/// If a [`Provider`] is required use it directly instead of [`Context`].
+/// As [`Context`] does not necessarily implement [`Provider`] but [`Unerased`] requires it (on
+/// nightly), an empty implementation is provided. If a [`Provider`] is required use it directly
+/// instead of [`Context`].
 #[repr(transparent)]
 struct ContextRepr<C>(C);
 

--- a/packages/engine/lib/error/src/frame.rs
+++ b/packages/engine/lib/error/src/frame.rs
@@ -16,6 +16,10 @@ use std::error::Error;
 use crate::provider::{self, Demand, Provider};
 use crate::Context;
 
+/// A [`Frame`] needs to implement all of the dependent traits so it's captured type needs these
+/// traits as well.
+///
+/// This is a convenient trait alias to avoid writing down each trait explicitly every time.
 #[cfg(nightly)]
 trait Unerased: Provider + fmt::Debug + fmt::Display + Send + Sync + 'static {}
 #[cfg(nightly)]

--- a/packages/engine/lib/error/src/frame.rs
+++ b/packages/engine/lib/error/src/frame.rs
@@ -16,10 +16,11 @@ use std::error::Error;
 use crate::provider::{self, Demand, Provider};
 use crate::Context;
 
-/// A [`Frame`] needs to implement all of the dependent traits so its captured type needs these
-/// traits as well.
+/// Trait alias to require all required traits used on a [`Frame`].
 ///
-/// This is a convenient trait alias to avoid writing down each trait explicitly every time.
+/// In order to implement these traits on a [`Frame`], the underlying type requires these types as
+/// well. After creation of the [`Frame`] it's erased. To unerase it later on to act on the actual
+/// Frame implementation, this trait is used.
 #[cfg(nightly)]
 trait Unerased: Provider + fmt::Debug + fmt::Display + Send + Sync + 'static {}
 #[cfg(nightly)]

--- a/packages/engine/lib/error/src/frame.rs
+++ b/packages/engine/lib/error/src/frame.rs
@@ -193,11 +193,12 @@ impl Drop for Frame {
     }
 }
 
-/// Stores functions to act on the associated context without knowing the internal type.
+/// Stores functions to act on the underlying [`Frame`] type without knowing the unerased type.
 ///
 /// This works around the limitation of not being able to coerce from `Box<dyn Unerased>` to
 /// `Box<dyn Any>` to add downcasting. Also this works around dynamic dispatching, as the functions
-/// are stored and called directly.
+/// are stored and called directly. In addition this reduces the memory usage by one pointer, as the
+/// `VTable` is stored next to the object.
 struct VTable {
     object_drop: unsafe fn(Box<FrameRepr>),
     object_ref: unsafe fn(&FrameRepr) -> &dyn Unerased,

--- a/packages/engine/lib/error/src/frame.rs
+++ b/packages/engine/lib/error/src/frame.rs
@@ -286,7 +286,6 @@ impl<C: Context> Context for ErrorRepr<C> {}
 #[cfg(all(nightly, feature = "std"))]
 impl<E: Error> Provider for ErrorRepr<E> {
     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
-        // ErrorProviderSpec::provide(self, demand);
         if let Some(backtrace) = self.0.backtrace() {
             demand.provide_ref(backtrace);
         }

--- a/packages/engine/lib/error/src/frame.rs
+++ b/packages/engine/lib/error/src/frame.rs
@@ -56,8 +56,8 @@ impl Frame {
         source: Option<Box<Self>>,
     ) -> Self {
         Self {
-            // SAFETY: `FrameRepr` is wrapped in `ManuallyDrop`. `Frame` implements drop which is
-            // using `vtable.object_drop`.
+            // SAFETY: `FrameRepr` must not be dropped without using the vtable, so it's wrapped in
+            //   `ManuallyDrop`. A custom drop implementation is provided that takes care of this.
             inner: unsafe { ManuallyDrop::new(FrameRepr::new(object)) },
             location,
             source,

--- a/packages/engine/lib/error/src/future.rs
+++ b/packages/engine/lib/error/src/future.rs
@@ -95,6 +95,7 @@ pub struct FutureWithProvider<Fut, P> {
     provider: Option<P>,
 }
 
+#[cfg(nightly)]
 impl<Fut, P> Future for FutureWithProvider<Fut, P>
 where
     Fut: Future,
@@ -130,6 +131,7 @@ pub struct FutureWithLazyProvider<Fut, F> {
     op: Option<F>,
 }
 
+#[cfg(nightly)]
 impl<Fut, F, M> Future for FutureWithLazyProvider<Fut, F>
 where
     Fut: Future,

--- a/packages/engine/lib/error/src/future.rs
+++ b/packages/engine/lib/error/src/future.rs
@@ -6,6 +6,7 @@
 //! [`poll`]: Future::poll
 
 use core::{
+    fmt,
     future::Future,
     pin::Pin,
     task::{Context as TaskContext, Poll},
@@ -13,24 +14,25 @@ use core::{
 
 use pin_project::pin_project;
 
-use crate::{Context, Message, Result, ResultExt};
+#[cfg(nightly)]
+use crate::provider::Provider;
+use crate::{Context, Result, ResultExt};
 
-/// Adaptor returned by [`FutureExt::wrap_err`].
+/// Adaptor returned by [`FutureExt::attach_message`].
 #[pin_project]
-#[cfg(feature = "futures")]
-pub struct FutureWithErr<Fut, M> {
+pub struct FutureWithMessage<Fut, M> {
     #[pin]
     inner: Fut,
     message: Option<M>,
 }
 
-impl<Fut, M> Future for FutureWithErr<Fut, M>
+impl<Fut, M> Future for FutureWithMessage<Fut, M>
 where
     Fut: Future,
     Fut::Output: ResultExt,
-    M: Message,
+    M: fmt::Display + fmt::Debug + Send + Sync + 'static,
 {
-    type Output = Result<<Fut::Output as ResultExt>::Ok, <Fut::Output as ResultExt>::Context>;
+    type Output = Fut::Output;
 
     #[track_caller]
     fn poll(self: Pin<&mut Self>, cx: &mut TaskContext) -> Poll<Self::Output> {
@@ -40,7 +42,7 @@ where
 
         // Can't use `map` as `#[track_caller]` is unstable on closures
         match inner.poll(cx) {
-            Poll::Ready(value) => Poll::Ready(value.wrap_err({
+            Poll::Ready(value) => Poll::Ready(value.attach_message({
                 message
                     .take()
                     .expect("Cannot poll context after it resolves")
@@ -50,23 +52,22 @@ where
     }
 }
 
-/// Adaptor returned by [`FutureExt::wrap_err_lazy`].
+/// Adaptor returned by [`FutureExt::attach_message_lazy`].
 #[pin_project]
-#[cfg(feature = "futures")]
-pub struct FutureWithLazyErr<Fut, F> {
+pub struct FutureWithLazyMessage<Fut, F> {
     #[pin]
     inner: Fut,
     op: Option<F>,
 }
 
-impl<Fut, F, M> Future for FutureWithLazyErr<Fut, F>
+impl<Fut, F, M> Future for FutureWithLazyMessage<Fut, F>
 where
     Fut: Future,
     Fut::Output: ResultExt,
     F: FnOnce() -> M,
-    M: Message,
+    M: fmt::Display + fmt::Debug + Send + Sync + 'static,
 {
-    type Output = Result<<Fut::Output as ResultExt>::Ok, <Fut::Output as ResultExt>::Context>;
+    type Output = Fut::Output;
 
     #[track_caller]
     fn poll(self: Pin<&mut Self>, cx: &mut TaskContext) -> Poll<Self::Output> {
@@ -77,16 +78,86 @@ where
         // Can't use `map` as `#[track_caller]` is unstable on closures
         match inner.poll(cx) {
             Poll::Ready(value) => Poll::Ready(
-                value.wrap_err_lazy(op.take().expect("Cannot poll context after it resolves")),
+                value
+                    .attach_message_lazy(op.take().expect("Cannot poll context after it resolves")),
             ),
             Poll::Pending => Poll::Pending,
         }
     }
 }
 
-/// Adaptor returned by [`FutureExt::provide_context`].
+/// Adaptor returned by [`FutureExt::attach_provider`].
 #[pin_project]
-#[cfg(feature = "futures")]
+#[cfg(nightly)]
+pub struct FutureWithProvider<Fut, P> {
+    #[pin]
+    inner: Fut,
+    provider: Option<P>,
+}
+
+impl<Fut, P> Future for FutureWithProvider<Fut, P>
+where
+    Fut: Future,
+    Fut::Output: ResultExt,
+    P: Provider + fmt::Display + fmt::Debug + Send + Sync + 'static,
+{
+    type Output = Fut::Output;
+
+    #[track_caller]
+    fn poll(self: Pin<&mut Self>, cx: &mut TaskContext) -> Poll<Self::Output> {
+        let projection = self.project();
+        let inner = projection.inner;
+        let provider = projection.provider;
+
+        // Can't use `map` as `#[track_caller]` is unstable on closures
+        match inner.poll(cx) {
+            Poll::Ready(value) => Poll::Ready(value.attach_provider({
+                provider
+                    .take()
+                    .expect("Cannot poll context after it resolves")
+            })),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// Adaptor returned by [`FutureExt::attach_provider_lazy`].
+#[pin_project]
+#[cfg(nightly)]
+pub struct FutureWithLazyProvider<Fut, F> {
+    #[pin]
+    inner: Fut,
+    op: Option<F>,
+}
+
+impl<Fut, F, M> Future for FutureWithLazyProvider<Fut, F>
+where
+    Fut: Future,
+    Fut::Output: ResultExt,
+    F: FnOnce() -> M,
+    M: Provider + fmt::Display + fmt::Debug + Send + Sync + 'static,
+{
+    type Output = Fut::Output;
+
+    #[track_caller]
+    fn poll(self: Pin<&mut Self>, cx: &mut TaskContext) -> Poll<Self::Output> {
+        let projection = self.project();
+        let inner = projection.inner;
+        let op = projection.op;
+
+        // Can't use `map` as `#[track_caller]` is unstable on closures
+        match inner.poll(cx) {
+            Poll::Ready(value) => Poll::Ready(
+                value
+                    .attach_message_lazy(op.take().expect("Cannot poll context after it resolves")),
+            ),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// Adaptor returned by [`FutureExt::change_context`].
+#[pin_project]
 pub struct FutureWithContext<Fut, C> {
     #[pin]
     inner: Fut,
@@ -109,7 +180,7 @@ where
 
         // Can't use `map` as `#[track_caller]` is unstable on closures
         match inner.poll(cx) {
-            Poll::Ready(value) => Poll::Ready(value.provide_context({
+            Poll::Ready(value) => Poll::Ready(value.change_context({
                 context
                     .take()
                     .expect("Cannot poll context after it resolves")
@@ -119,9 +190,8 @@ where
     }
 }
 
-/// Adaptor returned by [`FutureExt::provide_context_lazy`].
+/// Adaptor returned by [`FutureExt::change_context_lazy`].
 #[pin_project]
-#[cfg(feature = "futures")]
 pub struct FutureWithLazyContext<Fut, F> {
     #[pin]
     inner: Fut,
@@ -145,11 +215,10 @@ where
 
         // Can't use `map` as `#[track_caller]` is unstable on closures
         match inner.poll(cx) {
-            Poll::Ready(value) => {
-                Poll::Ready(value.provide_context_lazy(
-                    op.take().expect("Cannot poll context after it resolves"),
-                ))
-            }
+            Poll::Ready(value) => Poll::Ready(
+                value
+                    .change_context_lazy(op.take().expect("Cannot poll context after it resolves")),
+            ),
             Poll::Pending => Poll::Pending,
         }
     }
@@ -158,7 +227,6 @@ where
 /// Extension trait for [`Future`] to provide contextual information on [`Report`]s.
 ///
 /// [`Report`]: crate::Report
-#[cfg(feature = "futures")]
 pub trait FutureExt: Future + Sized {
     /// Adds new contextual message to the [`Frame`] stack of a [`Report`] when [`poll`]ing the
     /// [`Future`].
@@ -175,7 +243,7 @@ pub trait FutureExt: Future + Sized {
     /// # struct Resource;
     /// # #[derive(Debug)] struct ResourceError;
     /// # impl fmt::Display for ResourceError { fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result { Ok(()) }}
-    /// # impl error::provider::Provider for ResourceError { fn provide<'a>(&'a self, _: &mut error::provider::Demand<'a>) {} }
+    /// # impl error::Context for ResourceError {}
     /// use error::{FutureExt, Result};
     ///
     /// # #[allow(unused_variables)]
@@ -189,16 +257,16 @@ pub trait FutureExt: Future + Sized {
     ///     # let user = User;
     ///     # let resource = Resource;
     ///     // A contextual message can be provided before polling the `Future`
-    ///     load_resource(&user, &resource).wrap_err("Could not load resource").await
+    ///     load_resource(&user, &resource).attach_message("Could not load resource").await
     /// # };
     /// # #[cfg(not(miri))]
     /// # assert_eq!(futures::executor::block_on(fut).unwrap_err().frames().count(), 2);
     /// # Result::<_, ResourceError>::Ok(())
     /// ```
     #[track_caller]
-    fn wrap_err<M>(self, message: M) -> FutureWithErr<Self, M>
+    fn attach_message<M>(self, message: M) -> FutureWithMessage<Self, M>
     where
-        M: Message;
+        M: fmt::Display + fmt::Debug + Send + Sync + 'static;
 
     /// Lazily adds new contextual message to the [`Frame`] stack of a [`Report`] when [`poll`]ing
     /// the [`Future`].
@@ -218,7 +286,7 @@ pub trait FutureExt: Future + Sized {
     /// # impl fmt::Display for Resource { fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result { Ok(()) }}
     /// # #[derive(Debug)] struct ResourceError;
     /// # impl fmt::Display for ResourceError { fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result { Ok(()) }}
-    /// # impl error::provider::Provider for ResourceError { fn provide<'a>(&'a self, _: &mut error::provider::Demand<'a>) {} }
+    /// # impl error::Context for ResourceError {}
     /// use error::{FutureExt, Result};
     ///
     /// # #[allow(unused_variables)]
@@ -232,41 +300,79 @@ pub trait FutureExt: Future + Sized {
     ///     # let user = User;
     ///     # let resource = Resource;
     ///     // A contextual message can be provided before polling the `Future`
-    ///     load_resource(&user, &resource).wrap_err_lazy(|| format!("Could not load resource {resource}")).await
+    ///     load_resource(&user, &resource).attach_message_lazy(|| format!("Could not load resource {resource}")).await
     /// # };
     /// # #[cfg(not(miri))]
     /// # assert_eq!(futures::executor::block_on(fut).unwrap_err().frames().count(), 2);
     /// # Result::<_, ResourceError>::Ok(())
     /// ```
     #[track_caller]
-    fn wrap_err_lazy<M, F>(self, op: F) -> FutureWithLazyErr<Self, F>
+    fn attach_message_lazy<M, F>(self, message: F) -> FutureWithLazyMessage<Self, F>
     where
-        M: Message,
+        M: fmt::Display + fmt::Debug + Send + Sync + 'static,
         F: FnOnce() -> M;
 
-    /// Adds a context provider to the [`Frame`] stack of a [`Report`] when [`poll`]ing the
-    /// [`Future`] returning [`Result<T, C>`].
+    /// Adds a [`Provider`] to the [`Frame`] stack when [`poll`]ing the [`Future`].
     ///
+    /// The provider is used to [`provide`] values either by calling
+    /// [`request_ref()`]/[`request_value()`] to return an iterator over all specified values, or by
+    /// using the [`Provider`] implementation on a [`Frame`].
+    ///
+    /// [`provide`]: Provider::provide
+    /// [`request_ref()`]: crate::Report::request_ref
+    /// [`request_value()`]: crate::Report::request_value
     /// [`Frame`]: crate::Frame
-    /// [`Report`]: crate::Report
     /// [`poll`]: Future::poll
-    // TODO: come up with a decent example
-    #[track_caller]
-    fn provide_context<C>(self, context: C) -> FutureWithContext<Self, C>
+    #[cfg(nightly)]
+    fn attach_provider<P>(self, provider: P) -> FutureWithProvider<Self, P>
     where
-        C: Context;
+        P: Provider + fmt::Display + fmt::Debug + Send + Sync + 'static;
 
-    /// Lazily adds a context provider to the [`Frame`] stack of a [`Report`] when [`poll`]ing the
-    /// [`Future`] returning [`Result<T, C>`].
+    /// Lazily adds a [`Provider`] to the [`Frame`] stack when [`poll`]ing the [`Future`].
+    ///
+    /// The provider is used to [`provide`] values either by calling
+    /// [`request_ref()`]/[`request_value()`] to return an iterator over all specified values, or by
+    /// using the [`Provider`] implementation on a [`Frame`].
     ///
     /// The function is only executed in the `Err` arm.
     ///
+    /// [`provide`]: Provider::provide
+    /// [`request_ref()`]: crate::Report::request_ref
+    /// [`request_value()`]: crate::Report::request_value
+    /// [`Frame`]: crate::Frame
+    /// [`poll`]: Future::poll
+    #[cfg(nightly)]
+    fn attach_provider_lazy<P, F>(self, provider: F) -> FutureWithLazyProvider<Self, F>
+    where
+        P: Provider + fmt::Display + fmt::Debug + Send + Sync + 'static,
+        F: FnOnce() -> P;
+
+    /// Changes the [`Context`] of a [`Report`] when [`poll`]ing the [`Future`] returning
+    /// [`Result<T, C>`].
+    ///
+    /// Please see the [`Context`] documentation for more information.
+    ///
     /// [`Frame`]: crate::Frame
     /// [`Report`]: crate::Report
     /// [`poll`]: Future::poll
     // TODO: come up with a decent example
     #[track_caller]
-    fn provide_context_lazy<C, F>(self, context: F) -> FutureWithLazyContext<Self, F>
+    fn change_context<C>(self, context: C) -> FutureWithContext<Self, C>
+    where
+        C: Context;
+
+    /// Lazily changes the [`Context`] of a [`Report`] when [`poll`]ing the [`Future`] returning
+    /// [`Result<T, C>`].
+    ///
+    /// The function is only executed in the `Err` arm.
+    ///
+    /// Please see the [`Context`] documentation for more information.
+    ///
+    /// [`Report`]: crate::Report
+    /// [`poll`]: Future::poll
+    // TODO: come up with a decent example
+    #[track_caller]
+    fn change_context_lazy<C, F>(self, context: F) -> FutureWithLazyContext<Self, F>
     where
         C: Context,
         F: FnOnce() -> C;
@@ -276,30 +382,55 @@ impl<Fut: Future> FutureExt for Fut
 where
     Fut::Output: ResultExt,
 {
-    fn wrap_err<M>(self, message: M) -> FutureWithErr<Self, M>
+    fn attach_message<M>(self, message: M) -> FutureWithMessage<Self, M>
     where
-        M: Message,
+        M: fmt::Display + fmt::Debug + Send + Sync + 'static,
     {
-        FutureWithErr {
+        FutureWithMessage {
             inner: self,
             message: Some(message),
         }
     }
 
     #[track_caller]
-    fn wrap_err_lazy<M, F>(self, op: F) -> FutureWithLazyErr<Self, F>
+    fn attach_message_lazy<M, F>(self, message: F) -> FutureWithLazyMessage<Self, F>
     where
-        M: Message,
+        M: fmt::Display + fmt::Debug + Send + Sync + 'static,
         F: FnOnce() -> M,
     {
-        FutureWithLazyErr {
+        FutureWithLazyMessage {
             inner: self,
-            op: Some(op),
+            op: Some(message),
+        }
+    }
+
+    #[cfg(nightly)]
+    #[track_caller]
+    fn attach_provider<P>(self, provider: P) -> FutureWithProvider<Self, P>
+    where
+        P: Provider + fmt::Display + fmt::Debug + Send + Sync + 'static,
+    {
+        FutureWithProvider {
+            inner: self,
+            provider: Some(provider),
+        }
+    }
+
+    #[cfg(nightly)]
+    #[track_caller]
+    fn attach_provider_lazy<P, F>(self, provider: F) -> FutureWithLazyProvider<Self, F>
+    where
+        P: Provider + fmt::Display + fmt::Debug + Send + Sync + 'static,
+        F: FnOnce() -> P,
+    {
+        FutureWithLazyProvider {
+            inner: self,
+            op: Some(provider),
         }
     }
 
     #[track_caller]
-    fn provide_context<C>(self, context: C) -> FutureWithContext<Self, C>
+    fn change_context<C>(self, context: C) -> FutureWithContext<Self, C>
     where
         C: Context,
     {
@@ -310,7 +441,7 @@ where
     }
 
     #[track_caller]
-    fn provide_context_lazy<C, F>(self, context: F) -> FutureWithLazyContext<Self, F>
+    fn change_context_lazy<C, F>(self, context: F) -> FutureWithLazyContext<Self, F>
     where
         C: Context,
         F: FnOnce() -> C,

--- a/packages/engine/lib/error/src/iter.rs
+++ b/packages/engine/lib/error/src/iter.rs
@@ -1,6 +1,8 @@
 //! Iterators over [`Frame`]s.
 
-use core::{fmt, fmt::Formatter, iter::FusedIterator, marker::PhantomData};
+#[cfg(nightly)]
+use core::marker::PhantomData;
+use core::{fmt, fmt::Formatter, iter::FusedIterator};
 
 use crate::{Frame, Report};
 

--- a/packages/engine/lib/error/src/iter.rs
+++ b/packages/engine/lib/error/src/iter.rs
@@ -14,7 +14,7 @@ pub struct Frames<'r> {
 }
 
 impl<'r> Frames<'r> {
-    pub(super) const fn new<C>(report: &'r Report<C>) -> Self {
+    pub(crate) const fn new<C>(report: &'r Report<C>) -> Self {
         Self {
             current: Some(report.frame()),
         }
@@ -26,7 +26,9 @@ impl<'r> Iterator for Frames<'r> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.current.take().map(|current| {
-            self.current = current.request_ref::<Frame>();
+            if let Some(source) = &current.source {
+                self.current = Some(&*source);
+            }
             current
         })
     }
@@ -44,11 +46,13 @@ impl fmt::Debug for Frames<'_> {
 ///
 /// Use [`Report::request_ref()`] to create this iterator.
 #[must_use]
+#[cfg(nightly)]
 pub struct RequestRef<'r, T: ?Sized> {
     frames: Frames<'r>,
     _marker: PhantomData<&'r T>,
 }
 
+#[cfg(nightly)]
 impl<'r, T: ?Sized> RequestRef<'r, T> {
     pub(super) const fn new<Context>(report: &'r Report<Context>) -> Self {
         Self {
@@ -58,6 +62,7 @@ impl<'r, T: ?Sized> RequestRef<'r, T> {
     }
 }
 
+#[cfg(nightly)]
 impl<'r, T> Iterator for RequestRef<'r, T>
 where
     T: ?Sized + 'static,
@@ -69,8 +74,10 @@ where
     }
 }
 
+#[cfg(nightly)]
 impl<'r, T> FusedIterator for RequestRef<'r, T> where T: ?Sized + 'static {}
 
+#[cfg(nightly)]
 impl<T: ?Sized> Clone for RequestRef<'_, T> {
     fn clone(&self) -> Self {
         Self {
@@ -80,6 +87,7 @@ impl<T: ?Sized> Clone for RequestRef<'_, T> {
     }
 }
 
+#[cfg(nightly)]
 impl<'r, T> fmt::Debug for RequestRef<'r, T>
 where
     T: ?Sized + fmt::Debug + 'static,
@@ -93,11 +101,13 @@ where
 ///
 /// Use [`Report::request_value()`] to create this iterator.
 #[must_use]
+#[cfg(nightly)]
 pub struct RequestValue<'r, T> {
     frames: Frames<'r>,
     _marker: PhantomData<T>,
 }
 
+#[cfg(nightly)]
 impl<'r, T> RequestValue<'r, T> {
     pub(super) const fn new<Context>(report: &'r Report<Context>) -> Self {
         Self {
@@ -107,6 +117,7 @@ impl<'r, T> RequestValue<'r, T> {
     }
 }
 
+#[cfg(nightly)]
 impl<'r, T> Iterator for RequestValue<'r, T>
 where
     T: 'static,
@@ -118,8 +129,10 @@ where
     }
 }
 
+#[cfg(nightly)]
 impl<'r, T> FusedIterator for RequestValue<'r, T> where T: 'static {}
 
+#[cfg(nightly)]
 impl<T> Clone for RequestValue<'_, T> {
     fn clone(&self) -> Self {
         Self {
@@ -129,6 +142,7 @@ impl<T> Clone for RequestValue<'_, T> {
     }
 }
 
+#[cfg(nightly)]
 impl<'r, T> fmt::Debug for RequestValue<'r, T>
 where
     T: fmt::Debug + 'static,

--- a/packages/engine/lib/error/src/lib.rs
+++ b/packages/engine/lib/error/src/lib.rs
@@ -226,15 +226,14 @@ pub use self::{
 
 /// Defines the current context of a [`Report`].
 ///
-/// Every [`Error`] also can act as a `Context`. If [`Error`] is not implemented or in a non-std
-/// environment, this trait can be implemented manually. In most cases, implementing this is not
-/// needed.
+/// When in a `std` environment, every [`Error`] is a valid `Context`. This trait is not limited to
+/// [`Error`]s and can also be manually implemented for custom objects.
 ///
 /// [`Error`]: std::error::Error
 ///
 /// ## Example
 ///
-/// Used for creating a [`Report`] or for switching the [`Report`]s context:
+/// Used for creating a [`Report`] or for switching the [`Report`]'s context:
 ///
 /// ```rust
 /// # #![cfg_attr(any(not(feature = "std"), miri), allow(unused_imports))]
@@ -257,7 +256,8 @@ pub use self::{
 ///     }
 /// }
 ///
-/// // `Error` is not implemented for `ConfigError` for any reason, so implement `Context` manually.
+/// // In this scenario,`Error` is not implemented for `ConfigError` for some reason, so implement
+/// // `Context` manually.
 /// impl Context for ConfigError {}
 ///
 /// # #[cfg(any(not(feature = "std"), miri))]

--- a/packages/engine/lib/error/src/lib.rs
+++ b/packages/engine/lib/error/src/lib.rs
@@ -256,7 +256,7 @@ pub use self::{
 ///     }
 /// }
 ///
-/// // In this scenario,`Error` is not implemented for `ConfigError` for some reason, so implement
+/// // In this scenario, `Error` is not implemented for `ConfigError` for some reason, so implement
 /// // `Context` manually.
 /// impl Context for ConfigError {}
 ///

--- a/packages/engine/lib/error/src/macros.rs
+++ b/packages/engine/lib/error/src/macros.rs
@@ -10,15 +10,15 @@ pub mod __private {
         //! for macros.
         //!
         //! This is a stable implementation for specialization (only possible within macros, as
-        //! there is no trait bound for this things).
+        //! there is no trait bound for these things).
         //!
         //! The different tags [`ReportTag`], [`ErrorTag`], and [`ContextTag`] have a blanket
         //! implementation returning a concrete type. This type is then used to create a [`Report`].
         //!
         //! [`ErrorTag`] is implemented for `T: `[`Error`]s, [`ContextTag`] is implemented for `&T:
-        //! `[`Context`]s. As [`ContextTag`] is implemented references, [`ErrorTag`] has a higher
-        //! precedence and will be picked up first. So calling `my_error.kind()` will always
-        //! [`ErrorReporter`]. This can then be used to create a [`Report`] by calling
+        //! `[`Context`]s. As [`ContextTag`] is implemented for references, [`ErrorTag`] has a
+        //! higher precedence and will be picked up first. So calling `my_error.__kind()` will
+        //! always return [`ErrorReporter`]. This can then be used to create a [`Report`] by calling
         //! `my_error.__kind().report(my_error)`, which will then use [`Report::from_error`]. For
         //! [`ContextTag`], [`Report::from_context`] will be used.
         //!
@@ -90,7 +90,7 @@ pub mod __private {
         }
     }
 
-    // Import anonymous to allow calling `__kind` but forbid implementing the tag-traits.
+    // Import anonymously to allow calling `__kind` but forbid implementing the tag-traits.
     #[cfg(feature = "std")]
     pub use self::specialization::ErrorTag as _;
     pub use self::specialization::{ContextTag as _, ReportTag as _};

--- a/packages/engine/lib/error/src/macros.rs
+++ b/packages/engine/lib/error/src/macros.rs
@@ -1,62 +1,99 @@
 #[doc(hidden)]
 pub mod __private {
-    #![allow(clippy::unused_self)]
-    //! Uses [autoref-based stable specialization](https://github.com/dtolnay/case-studies/blob/master/autoref-specialization/README.md).
-    // TODO: Expand documentation when string literals are forbidden as this will shrink the
-    //   implementation by a fair bit.
+    //! Implementation detail for macros.
+    //!
+    //! ⚠️ **Functionality in this module is considered unstable and is subject to change at any time
+    //! without a major version bump!** ⚠️
+    mod specialization {
+        #![allow(clippy::unused_self)]
+        //! [Autoref-Based Stable Specialization](https://github.com/dtolnay/case-studies/blob/master/autoref-specialization/README.md)
+        //! for macros.
+        //!
+        //! This is a stable implementation for specialization (only possible within macros, as
+        //! there is no trait bound for this things).
+        //!
+        //! The different tags [`ReportTag`], [`ErrorTag`], and [`ContextTag`] have a blanket
+        //! implementation returning a concrete type. This type is then used to create a [`Report`].
+        //!
+        //! [`ErrorTag`] is implemented for `T: `[`Error`]s, [`ContextTag`] is implemented for `&T:
+        //! `[`Context`]s. As [`ContextTag`] is implemented references, [`ErrorTag`] has a higher
+        //! precedence and will be picked up first. So calling `my_error.kind()` will always
+        //! [`ErrorReporter`]. This can then be used to create a [`Report`] by calling
+        //! `my_error.__kind().report(my_error)`, which will then use [`Report::from_error`]. For
+        //! [`ContextTag`], [`Report::from_context`] will be used.
+        //!
+        //! [`ReportTag`] is a special case, which is implemented for any [`Report<T>`], so this has
+        //! the highest precedence when calling `report.__kind()`. This will use an identity
+        //! function when creating a [`Report`] to ensure that no information will be lost.
+        //!
+        //! Note: The methods on the tags are called `__kind` instead of `kind` to avoid misleading
+        //! suggestions from the Rust compiler, when calling `kind`. It would suggest implementing a
+        //! tag for the type which cannot and should not be implemented.
+        //!
+        //! [`Error`]: std::error::Error
 
-    use crate::{Context, Report};
+        pub trait ReportTag {
+            #[inline]
+            fn __kind(&self) -> Reporter {
+                Reporter
+            }
+        }
+        impl<T> ReportTag for Report<T> {}
 
-    pub trait ReportTag {
-        #[inline]
-        fn __kind(&self) -> Reporter {
-            Reporter
+        #[cfg(feature = "std")]
+        pub trait ErrorTag {
+            #[inline]
+            fn __kind(&self) -> ErrorReporter {
+                ErrorReporter
+            }
         }
-    }
-    impl<T> ReportTag for Report<T> {}
-    pub struct Reporter;
-    impl Reporter {
-        #[inline]
-        pub const fn report<T>(self, report: Report<T>) -> Report<T> {
-            report
+        #[cfg(feature = "std")]
+        impl<T> ErrorTag for T where T: ?Sized + std::error::Error + Send + Sync + 'static {}
+
+        pub trait ContextTag {
+            #[inline]
+            fn __kind(&self) -> ContextReporter {
+                ContextReporter
+            }
+        }
+        impl<T> ContextTag for &T where T: ?Sized + Context {}
+        use crate::{Context, Report};
+
+        pub struct Reporter;
+        impl Reporter {
+            #[inline]
+            pub const fn report<T>(self, report: Report<T>) -> Report<T> {
+                report
+            }
+        }
+
+        #[cfg(feature = "std")]
+        pub struct ErrorReporter;
+        #[cfg(feature = "std")]
+        impl ErrorReporter {
+            #[inline]
+            #[track_caller]
+            pub fn report<C: std::error::Error + Send + Sync + 'static>(
+                self,
+                error: C,
+            ) -> Report<C> {
+                Report::from(error)
+            }
+        }
+        pub struct ContextReporter;
+        impl ContextReporter {
+            #[inline]
+            #[track_caller]
+            pub fn report<C: Context>(self, context: C) -> Report<C> {
+                Report::from_context(context)
+            }
         }
     }
 
+    // Import anonymous to allow calling `__kind` but forbid implementing the tag-traits.
     #[cfg(feature = "std")]
-    pub trait ErrorTag {
-        #[inline]
-        fn __kind(&self) -> ErrorReporter {
-            ErrorReporter
-        }
-    }
-    #[cfg(feature = "std")]
-    impl<T> ErrorTag for &T where T: ?Sized + std::error::Error + Send + Sync + 'static {}
-    #[cfg(feature = "std")]
-    pub struct ErrorReporter;
-    #[cfg(feature = "std")]
-    impl ErrorReporter {
-        #[inline]
-        #[track_caller]
-        pub fn report<C: std::error::Error + Send + Sync + 'static>(self, error: C) -> Report<C> {
-            Report::from(error)
-        }
-    }
-
-    pub trait ContextTag {
-        #[inline]
-        fn __kind(&self) -> ContextReporter {
-            ContextReporter
-        }
-    }
-    impl<T> ContextTag for T where T: ?Sized + Context {}
-    pub struct ContextReporter;
-    impl ContextReporter {
-        #[inline]
-        #[track_caller]
-        pub fn report<C: Context>(self, context: C) -> Report<C> {
-            Report::from_context(context)
-        }
-    }
+    pub use self::specialization::ErrorTag as _;
+    pub use self::specialization::{ContextTag as _, ReportTag as _};
 }
 
 /// Creates a [`Report`] from the given parameters.
@@ -90,43 +127,32 @@ pub mod __private {
 /// Create a [`Report`] from [`Context`]:
 ///
 /// ```
-/// # fn has_permission(_: &User, _: &Resource) -> bool { false }
-/// # #[derive(Debug)] struct User;
-/// # #[derive(Debug)] struct Resource;
-/// # use error::report;
-/// # impl fmt::Display for User { fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result { Ok(()) }}
-/// # impl fmt::Display for Resource { fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result { Ok(()) }}
+/// # fn has_permission(_: &u32, _: &u32) -> bool { true }
+/// # type User = u32;
+/// # let user = 0;
+/// # type Resource = u32;
+/// # let resource = 0;
 /// use core::fmt;
 ///
-/// use error::{
-///     provider::{Demand, Provider},
-///     Report,
-/// };
+/// use error::{report, Context};
 ///
 /// #[derive(Debug)]
 /// struct PermissionDenied(User, Resource);
 ///
 /// impl fmt::Display for PermissionDenied {
+///     # #[allow(unused_variables)]
 ///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-///         write!(fmt, "{} must not access {}", self.0, self.1)
-///     }
+///         # const _: &str = stringify! {
+///         ...
+///         # }; Ok(())}
 /// }
 ///
-/// impl Provider for PermissionDenied {
-///     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
-///         demand.provide_ref(&self.0).provide_ref(&self.1);
-///     }
-/// }
+/// impl Context for PermissionDenied {}
 ///
-/// # fn use_resource(user: User, resource: Resource) -> Result<(), Report<PermissionDenied>> {
 /// if !has_permission(&user, &resource) {
 ///     return Err(report!(PermissionDenied(user, resource)));
 /// }
-/// # Ok(()) }
-/// # let err = use_resource(User, Resource).unwrap_err();
-/// # assert_eq!(err.frames().count(), 1);
-/// # assert_eq!(err.request_ref::<User>().count(), 1);
-/// # assert_eq!(err.request_ref::<Resource>().count(), 1);
+/// # Ok(())
 /// ```
 #[macro_export]
 macro_rules! report {
@@ -170,43 +196,32 @@ macro_rules! report {
 /// [`Context`]: crate::Context
 ///
 /// ```
-/// # fn has_permission(_: &User, _: &Resource) -> bool { false }
-/// # #[derive(Debug)] struct User;
-/// # #[derive(Debug)] struct Resource;
-/// # use error::bail;
-/// # impl fmt::Display for User { fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result { Ok(()) }}
-/// # impl fmt::Display for Resource { fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result { Ok(()) }}
+/// # fn has_permission(_: &u32, _: &u32) -> bool { true }
+/// # type User = u32;
+/// # let user = 0;
+/// # type Resource = u32;
+/// # let resource = 0;
 /// use core::fmt;
 ///
-/// use error::{
-///     provider::{Demand, Provider},
-///     Report,
-/// };
+/// use error::{bail, Context};
 ///
 /// #[derive(Debug)]
 /// struct PermissionDenied(User, Resource);
 ///
 /// impl fmt::Display for PermissionDenied {
+///     # #[allow(unused_variables)]
 ///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-///         write!(fmt, "{} must not access {}", self.0, self.1)
-///     }
+///         # const _: &str = stringify! {
+///         ...
+///         # }; Ok(())}
 /// }
 ///
-/// impl Provider for PermissionDenied {
-///     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
-///         demand.provide_ref(&self.0).provide_ref(&self.1);
-///     }
-/// }
+/// impl Context for PermissionDenied {}
 ///
-/// # fn use_resource(user: User, resource: Resource) -> Result<(), Report<PermissionDenied>> {
 /// if !has_permission(&user, &resource) {
 ///     bail!(PermissionDenied(user, resource));
 /// }
-/// # Ok(()) }
-/// # let err = dbg!(use_resource(User, Resource).unwrap_err());
-/// # assert_eq!(err.frames().count(), 1);
-/// # assert_eq!(err.request_ref::<Resource>().count(), 1);
-/// # assert_eq!(err.request_ref::<User>().count(), 1);
+/// # Ok(())
 /// ```
 #[macro_export]
 macro_rules! bail {
@@ -224,50 +239,40 @@ macro_rules! bail {
 ///
 /// Create a [`Report`] from [`Context`]:
 ///
+/// [`Report`]: crate::Report
 /// [`Context`]: crate::Context
 ///
 /// ```
-/// # fn has_permission(_: &User, _: &Resource) -> bool { false }
-/// # #[derive(Debug)] struct User;
-/// # #[derive(Debug)] struct Resource;
-/// # use error::ensure;
-/// # impl fmt::Display for User { fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result { Ok(()) }}
-/// # impl fmt::Display for Resource { fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result { Ok(()) }}
-/// use core::fmt;
+/// # fn has_permission(_: &u32, _: &u32) -> bool { true }
+/// # type User = u32;
+/// # let user = 0;
+/// # type Resource = u32;
+/// # let resource = 0;
+/// # use core::fmt;
 ///
-/// use error::{
-///     provider::{Demand, Provider},
-///     Report,
-/// };
+/// use error::{ensure, Context};
 ///
 /// #[derive(Debug)]
 /// struct PermissionDenied(User, Resource);
 ///
 /// impl fmt::Display for PermissionDenied {
+///     # #[allow(unused_variables)]
 ///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-///         write!(fmt, "{} must not access {}", self.0, self.1)
+///         const _: &str = stringify! {
+///         ...
+///          };
+///         Ok(())
 ///     }
 /// }
 ///
-/// impl Provider for PermissionDenied {
-///     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
-///         demand.provide_ref(&self.0).provide_ref(&self.1);
-///     }
-/// }
+/// impl Context for PermissionDenied {}
 ///
-/// # fn use_resource(user: User, resource: Resource) -> Result<(), Report<PermissionDenied>> {
 /// ensure!(
 ///     has_permission(&user, &resource),
-///     PermissionDenied(user, resource),
+///     PermissionDenied(user, resource)
 /// );
-/// # Ok(()) }
-/// # let err = use_resource(User, Resource).unwrap_err();
-/// # assert_eq!(err.frames().count(), 1);
-/// # assert_eq!(err.request_ref::<User>().count(), 1);
-/// # assert_eq!(err.request_ref::<Resource>().count(), 1);
+/// # Ok(())
 /// ```
-///
-/// [`Report`]: crate::Report
 #[macro_export]
 macro_rules! ensure {
     ($cond:expr, $err:expr $(,)?) => {{
@@ -283,80 +288,89 @@ mod tests {
     use crate::test_helper::*;
 
     #[test]
-    fn error() {
-        let err = capture_error(|| Err(report!(ContextA(10))));
+    fn report() {
+        let err = capture_error(|| Err(report!(ContextA)));
+        let err = err.attach_message("additional message");
         assert!(err.contains::<ContextA>());
-        assert_eq!(err.frames().count(), 1);
-        assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
-        assert_eq!(request_messages(&err), ["Context A"]);
+        assert_eq!(err.frames().count(), 2);
+        assert_eq!(messages(&err), ["additional message", "Context A"]);
+        // TODO: check `err.frames().next().kind() == FrameKind::Context`
 
-        let err = report!(err);
+        let err = capture_error(|| Err(report!(err)));
         assert!(err.contains::<ContextA>());
-        assert_eq!(err.frames().count(), 1);
-        assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
-        assert_eq!(request_messages(&err), ["Context A"]);
+        assert_eq!(err.frames().count(), 2);
+        assert_eq!(messages(&err), ["additional message", "Context A"]);
+        // TODO: check `err.frames().next().kind() == FrameKind::Context`
 
         #[cfg(feature = "std")]
         {
-            let io_err = std::io::Error::from(std::io::ErrorKind::Other);
-            let err = capture_error(|| Err(report!(io_err)));
-            assert!(err.contains::<std::io::Error>());
-            assert_eq!(err.frames().count(), 1);
-            assert_eq!(request_messages(&err), ["other error"]);
+            let err = capture_error(|| Err(report!(ContextB)));
+            let err = err.attach_message("additional message");
+            assert!(err.contains::<ContextB>());
+            assert_eq!(err.frames().count(), 2);
+            assert_eq!(messages(&err), ["additional message", "Context B"]);
+            // TODO: check `err.frames().next().kind() == FrameKind::Error`
         }
     }
 
     #[test]
     fn bail() {
-        let err = capture_error(|| bail!(ContextA(10)));
+        let err = capture_error(|| bail!(ContextA));
+        let err = err.attach_message("additional message");
         assert!(err.contains::<ContextA>());
-        assert_eq!(err.frames().count(), 1);
-        assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
-        assert_eq!(request_messages(&err), ["Context A"]);
+        assert_eq!(err.frames().count(), 2);
+        assert_eq!(messages(&err), ["additional message", "Context A"]);
+        // TODO: check `err.frames().next().kind() == FrameKind::Context`
 
-        let err = report!(err);
+        let err = capture_error(|| bail!(err));
         assert!(err.contains::<ContextA>());
-        assert_eq!(err.frames().count(), 1);
-        assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
-        assert_eq!(request_messages(&err), ["Context A"]);
+        assert_eq!(err.frames().count(), 2);
+        assert_eq!(messages(&err), ["additional message", "Context A"]);
+        // TODO: check `err.frames().next().kind() == FrameKind::Context`
 
         #[cfg(feature = "std")]
         {
-            let io_err = std::io::Error::from(std::io::ErrorKind::Other);
-            let err = capture_error(|| bail!(io_err));
-            assert!(err.contains::<std::io::Error>());
-            assert_eq!(err.frames().count(), 1);
-            assert_eq!(request_messages(&err), ["other error"]);
+            let err = capture_error(|| bail!(ContextB));
+            let err = err.attach_message("additional message");
+            assert!(err.contains::<ContextB>());
+            assert_eq!(err.frames().count(), 2);
+            assert_eq!(messages(&err), ["additional message", "Context B"]);
+            // TODO: check `err.frames().next().kind() == FrameKind::Error`
         }
     }
 
     #[test]
     fn ensure() {
         let err = capture_error(|| {
-            ensure!(false, ContextA(10));
+            ensure!(false, ContextA);
+            Ok(())
+        });
+        let err = err.attach_message("additional message");
+        assert!(err.contains::<ContextA>());
+        assert_eq!(err.frames().count(), 2);
+        assert_eq!(messages(&err), ["additional message", "Context A"]);
+        // TODO: check `err.frames().next().kind() == FrameKind::Context`
+
+        let err = capture_error(|| {
+            ensure!(false, err);
             Ok(())
         });
         assert!(err.contains::<ContextA>());
-        assert_eq!(err.frames().count(), 1);
-        assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
-        assert_eq!(request_messages(&err), ["Context A"]);
-
-        let err = report!(err);
-        assert!(err.contains::<ContextA>());
-        assert_eq!(err.frames().count(), 1);
-        assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
-        assert_eq!(request_messages(&err), ["Context A"]);
+        assert_eq!(err.frames().count(), 2);
+        assert_eq!(messages(&err), ["additional message", "Context A"]);
+        // TODO: check `err.frames().next().kind() == FrameKind::Context`
 
         #[cfg(feature = "std")]
         {
-            let io_err = std::io::Error::from(std::io::ErrorKind::Other);
             let err = capture_error(|| {
-                ensure!(false, io_err);
+                ensure!(false, ContextB);
                 Ok(())
             });
-            assert!(err.contains::<std::io::Error>());
-            assert_eq!(err.frames().count(), 1);
-            assert_eq!(request_messages(&err), ["other error"]);
+            let err = err.attach_message("additional message");
+            assert!(err.contains::<ContextB>());
+            assert_eq!(err.frames().count(), 2);
+            assert_eq!(messages(&err), ["additional message", "Context B"]);
+            // TODO: check `err.frames().next().kind() == FrameKind::Error`
         }
     }
 }

--- a/packages/engine/lib/error/src/result.rs
+++ b/packages/engine/lib/error/src/result.rs
@@ -1,4 +1,8 @@
-use crate::{Context, Message, Report};
+use core::fmt;
+
+#[cfg(nightly)]
+use crate::provider::Provider;
+use crate::{Context, Report};
 
 /// [`Result`](std::result::Result)`<T, `[`Report<C>`](Report)`>`
 ///
@@ -19,7 +23,7 @@ use crate::{Context, Message, Report};
 /// # impl core::fmt::Display for AccessError {
 /// #    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { Ok(()) }
 /// # }
-/// # impl error::provider::Provider for AccessError { fn provide<'a>(&'a self, _: &mut error::provider::Demand<'a>) {} }
+/// # impl error::Context for AccessError {}
 /// use error::{ensure, Result};
 ///
 /// fn main() -> Result<(), AccessError> {
@@ -44,9 +48,6 @@ pub trait ResultExt {
     /// Type of the [`Ok`] value in the [`Result`]
     type Ok;
 
-    /// Type of the resulting context `C` inside of [`Report<C>`] when not providing a context.
-    type Context;
-
     /// Adds new contextual message to the [`Frame`] stack of a [`Report`].
     ///
     /// [`Frame`]: crate::Frame
@@ -63,12 +64,13 @@ pub trait ResultExt {
     /// # let user = User;
     /// # let resource = Resource;
     /// # #[allow(unused_variables)]
-    /// let resource = load_resource(&user, &resource).wrap_err("Could not load resource")?;
+    /// let resource = load_resource(&user, &resource).attach_message("Could not load resource")?;
     /// # Result::Ok(())
     /// ```
-    fn wrap_err<M>(self, message: M) -> Result<Self::Ok, Self::Context>
+    #[must_use]
+    fn attach_message<M>(self, message: M) -> Self
     where
-        M: Message;
+        M: fmt::Display + fmt::Debug + Send + Sync + 'static;
 
     /// Lazily adds new contextual message to the [`Frame`] stack of a [`Report`].
     ///
@@ -91,30 +93,69 @@ pub trait ResultExt {
     /// # let resource = Resource;
     /// # #[allow(unused_variables)]
     /// let resource = load_resource(&user, &resource)
-    ///     .wrap_err_lazy(|| format!("Could not load resource {resource}"))?;
+    ///     .attach_message_lazy(|| format!("Could not load resource {resource}"))?;
     /// # Result::Ok(())
     /// ```
-    fn wrap_err_lazy<M, F>(self, op: F) -> Result<Self::Ok, Self::Context>
+    #[must_use]
+    fn attach_message_lazy<M, F>(self, op: F) -> Self
     where
-        M: Message,
+        M: fmt::Display + fmt::Debug + Send + Sync + 'static,
         F: FnOnce() -> M;
 
-    /// Adds a context provider to the [`Frame`] stack of a [`Report`] returning [`Result<T, C>`].
+    /// Adds a [`Provider`] to the [`Frame`] stack.
+    ///
+    /// The provider is used to [`provide`] values either by calling
+    /// [`request_ref()`]/[`request_value()`] to return an iterator over all specified values, or by
+    /// using the [`Provider`] implementation on a [`Frame`].
+    ///
+    /// [`provide`]: Provider::provide
+    /// [`request_ref()`]: crate::Report::request_ref
+    /// [`request_value()`]: crate::Report::request_value
+    /// [`Frame`]: crate::Frame
+    #[cfg(nightly)]
+    #[must_use]
+    fn attach_provider<P>(self, provider: P) -> Self
+    where
+        P: Provider + fmt::Display + fmt::Debug + Send + Sync + 'static;
+
+    /// Lazily adds a [`Provider`] to the [`Frame`] stack.
+    ///
+    /// The provider is used to [`provide`] values either by calling
+    /// [`request_ref()`]/[`request_value()`] to return an iterator over all specified values, or by
+    /// using the [`Provider`] implementation on a [`Frame`].
+    ///
+    /// The function is only executed in the `Err` arm.
+    ///
+    /// [`provide`]: Provider::provide
+    /// [`request_ref()`]: crate::Report::request_ref
+    /// [`request_value()`]: crate::Report::request_value
+    /// [`Frame`]: crate::Frame
+    #[cfg(nightly)]
+    #[must_use]
+    fn attach_provider_lazy<P, F>(self, provider: F) -> Self
+    where
+        P: Provider + fmt::Display + fmt::Debug + Send + Sync + 'static,
+        F: FnOnce() -> P;
+
+    /// Changes the [`Context`] of a [`Report`] returning [`Result<T, C>`].
+    ///
+    /// Please see the [`Context`] documentation for more information.
     ///
     /// [`Frame`]: crate::Frame
     // TODO: come up with a decent example
-    fn provide_context<C>(self, context: C) -> Result<Self::Ok, C>
+    fn change_context<C>(self, context: C) -> Result<Self::Ok, C>
     where
         C: Context;
 
-    /// Lazily adds a context provider to the [`Frame`] stack of a [`Report`] returning
-    /// [`Result<T, C>`].
+    /// Lazily changes the [`Context`] of a [`Report`] returning [`Result<T, C>`].
+    ///
+    /// Please see the [`Context`] documentation for more information.
     ///
     /// The function is only executed in the `Err` arm.
     ///
     /// [`Frame`]: crate::Frame
     // TODO: come up with a decent example
-    fn provide_context_lazy<C, F>(self, op: F) -> Result<Self::Ok, C>
+    fn change_context_lazy<C, F>(self, op: F) -> Result<Self::Ok, C>
     where
         C: Context,
         F: FnOnce() -> C;
@@ -127,48 +168,74 @@ pub trait ResultExt {
 }
 
 impl<T, C> ResultExt for Result<T, C> {
-    type Context = C;
     type Ok = T;
 
     #[track_caller]
-    fn wrap_err<M>(self, message: M) -> Self
+    fn attach_message<M>(self, message: M) -> Self
     where
-        M: Message,
+        M: fmt::Display + fmt::Debug + Send + Sync + 'static,
     {
         // Can't use `map_err` as `#[track_caller]` is unstable on closures
         match self {
             Ok(ok) => Ok(ok),
-            Err(report) => Err(report.wrap(message)),
+            Err(report) => Err(report.attach_message(message)),
         }
     }
 
     #[track_caller]
-    fn wrap_err_lazy<M, F>(self, message: F) -> Self
+    fn attach_message_lazy<M, F>(self, message: F) -> Self
     where
-        M: Message,
+        M: fmt::Display + fmt::Debug + Send + Sync + 'static,
         F: FnOnce() -> M,
     {
         // Can't use `map_err` as `#[track_caller]` is unstable on closures
         match self {
             Ok(ok) => Ok(ok),
-            Err(report) => Err(report.wrap(message())),
+            Err(report) => Err(report.attach_message(message())),
+        }
+    }
+
+    #[cfg(nightly)]
+    #[track_caller]
+    fn attach_provider<P>(self, provider: P) -> Self
+    where
+        P: Provider + fmt::Display + fmt::Debug + Send + Sync + 'static,
+    {
+        // Can't use `map_err` as `#[track_caller]` is unstable on closures
+        match self {
+            Ok(ok) => Ok(ok),
+            Err(report) => Err(report.attach_provider(provider)),
+        }
+    }
+
+    #[cfg(nightly)]
+    #[track_caller]
+    fn attach_provider_lazy<P, F>(self, provider: F) -> Self
+    where
+        P: Provider + fmt::Display + fmt::Debug + Send + Sync + 'static,
+        F: FnOnce() -> P,
+    {
+        // Can't use `map_err` as `#[track_caller]` is unstable on closures
+        match self {
+            Ok(ok) => Ok(ok),
+            Err(report) => Err(report.attach_provider(provider())),
         }
     }
 
     #[track_caller]
-    fn provide_context<C2>(self, context: C2) -> Result<T, C2>
+    fn change_context<C2>(self, context: C2) -> Result<T, C2>
     where
         C2: Context,
     {
         // Can't use `map_err` as `#[track_caller]` is unstable on closures
         match self {
             Ok(ok) => Ok(ok),
-            Err(report) => Err(report.provide_context(context)),
+            Err(report) => Err(report.change_context(context)),
         }
     }
 
     #[track_caller]
-    fn provide_context_lazy<C2, F>(self, context: F) -> Result<T, C2>
+    fn change_context_lazy<C2, F>(self, context: F) -> Result<T, C2>
     where
         C2: Context,
         F: FnOnce() -> C2,
@@ -176,7 +243,7 @@ impl<T, C> ResultExt for Result<T, C> {
         // Can't use `map_err` as `#[track_caller]` is unstable on closures
         match self {
             Ok(ok) => Ok(ok),
-            Err(report) => Err(report.provide_context(context())),
+            Err(report) => Err(report.change_context(context())),
         }
     }
 

--- a/packages/engine/lib/nano/src/client.rs
+++ b/packages/engine/lib/nano/src/client.rs
@@ -44,35 +44,35 @@ impl Worker {
     fn new(url: &str, request_rx: spmc::Receiver<Request>) -> Result<Self, nng::Error> {
         let socket = nng::Socket::new(nng::Protocol::Req0)
             .report()
-            .wrap_err("Could not create nng socket")?;
+            .attach_message("Could not create nng socket")?;
 
         let builder = nng::DialerBuilder::new(&socket, url)
             .report()
-            .wrap_err("Could not create nng dialer")?;
+            .attach_message("Could not create nng dialer")?;
         builder
             .set_opt::<ReconnectMaxTime>(Some(RECONNECT_MAX_TIME))
             .report()
-            .wrap_err_lazy(|| {
+            .attach_message_lazy(|| {
                 format!("Could not set maximum reconnection time to {RECONNECT_MAX_TIME:?}")
             })?;
         builder
             .set_opt::<ReconnectMinTime>(Some(RECONNECT_MIN_TIME))
             .report()
-            .wrap_err_lazy(|| {
+            .attach_message_lazy(|| {
                 format!("Could not set minimum reconnection time to {RECONNECT_MIN_TIME:?}")
             })?;
         let dialer = builder
             .start(false)
             .map_err(|(_, error)| error)
             .report()
-            .wrap_err("Could not start nng dialer")?;
+            .attach_message("Could not start nng dialer")?;
 
         let ctx = nng::Context::new(&socket)
             .report()
-            .wrap_err("Could not create nng context")?;
+            .attach_message("Could not create nng context")?;
         ctx.set_opt::<ResendTime>(Some(RESEND_TIME))
             .report()
-            .wrap_err_lazy(|| format!("Could not set resend time to {RESEND_TIME:?}"))?;
+            .attach_message_lazy(|| format!("Could not set resend time to {RESEND_TIME:?}"))?;
 
         // There will only ever be one message in the channel. But, it needs to be
         // unbounded because we can't .await inside an nng::Aio.
@@ -93,7 +93,7 @@ impl Worker {
                         message
                             .map(|_| ())
                             .report()
-                            .provide_context(ErrorKind::Receive),
+                            .change_context(ErrorKind::Receive),
                     )
                     .expect(SEND_EXPECT_MESSAGE);
             }
@@ -102,7 +102,7 @@ impl Worker {
             }
         })
         .report()
-        .wrap_err("Could not create asynchronous I/O context")?;
+        .attach_message("Could not create asynchronous I/O context")?;
 
         Ok(Self {
             _socket: socket,
@@ -119,7 +119,7 @@ impl Worker {
         if let Err(report) = self
             .ctx
             .send(&self.aio, msg)
-            .map_err(|(_, error)| report!(error).provide_context(ErrorKind::Send))
+            .map_err(|(_, error)| report!(error).change_context(ErrorKind::Send))
         {
             sender.send(Err(report)).expect(SEND_EXPECT_MESSAGE);
             return;
@@ -156,8 +156,8 @@ impl Client {
         let workers = (0..num_workers)
             .map(|_| {
                 let mut worker = Worker::new(url, receiver.clone())
-                    .wrap_err("Could not create nng worker")
-                    .provide_context(ErrorKind::ClientCreation)?;
+                    .attach_message("Could not create nng worker")
+                    .change_context(ErrorKind::ClientCreation)?;
                 // let (stop_tx, stop_rx) = mpsc::channel(1);
                 let (stop_tx, stop_rx) = mpsc::unbounded_channel();
                 let handle = tokio::spawn(async move { worker.run(stop_rx).await });
@@ -193,8 +193,8 @@ impl Client {
         let mut nng_msg = nng::Message::new();
         serde_json::to_writer(&mut nng_msg, msg)
             .report()
-            .wrap_err("Could not serialize message")
-            .provide_context(ErrorKind::Send)?;
+            .attach_message("Could not serialize message")
+            .change_context(ErrorKind::Send)?;
 
         let (tx, rx) = oneshot::channel();
         self.sender
@@ -203,8 +203,8 @@ impl Client {
             .expect(SEND_EXPECT_MESSAGE);
         rx.await
             .expect(RECV_EXPECT_MESSAGE)
-            .wrap_err("Could not receive response")
-            .provide_context(ErrorKind::Send)
+            .attach_message("Could not receive response")
+            .change_context(ErrorKind::Send)
     }
 }
 

--- a/packages/engine/lib/nano/src/error.rs
+++ b/packages/engine/lib/nano/src/error.rs
@@ -1,4 +1,3 @@
-use error::provider::{Demand, Provider};
 use thiserror::Error as ThisError;
 
 pub type Result<T, E = ErrorKind> = error::Result<T, E>;
@@ -17,10 +16,4 @@ pub enum ErrorKind {
 
     #[error("Could not receive value")]
     Receive,
-}
-
-impl Provider for ErrorKind {
-    fn provide<'a>(&'a self, _demand: &mut Demand<'a>) {
-        // Empty implementation
-    }
 }

--- a/packages/engine/lib/nano/src/spmc.rs
+++ b/packages/engine/lib/nano/src/spmc.rs
@@ -40,7 +40,7 @@ impl<T: Send> Sender<T> {
         self.sender
             .send(value)
             .await
-            .map_err(|_send_error| Report::from(SendError(())).provide_context(ErrorKind::Send))
+            .map_err(|_send_error| Report::from(SendError(())).change_context(ErrorKind::Send))
     }
 }
 

--- a/packages/engine/lib/orchestrator/src/error.rs
+++ b/packages/engine/lib/orchestrator/src/error.rs
@@ -1,7 +1,5 @@
 use std::fmt;
 
-use error::provider::{Demand, Provider};
-
 pub type Result<T, E = OrchestratorError> = error::Result<T, E>;
 
 // TODO: Use proper context type
@@ -24,10 +22,6 @@ impl fmt::Display for OrchestratorError {
 }
 
 impl std::error::Error for OrchestratorError {}
-
-impl Provider for OrchestratorError {
-    fn provide<'a>(&'a self, _: &mut Demand<'a>) {}
-}
 
 impl From<&'static str> for OrchestratorError {
     fn from(error: &'static str) -> Self {

--- a/packages/engine/lib/orchestrator/src/experiment.rs
+++ b/packages/engine/lib/orchestrator/src/experiment.rs
@@ -161,7 +161,7 @@ impl ExperimentType {
             )),
             ExperimentType::Simple { name } => Ok(ExperimentPackageConfig::Simple(
                 get_simple_experiment_config(base, name)
-                    .wrap_err("Could not read simple experiment config")?,
+                    .attach_message("Could not read simple experiment config")?,
             )),
         }
     }
@@ -225,7 +225,9 @@ impl Experiment {
         let mut engine_handle = handler
             .register_experiment(experiment_run.base.id)
             .await
-            .wrap_err_lazy(|| format!("Could not register experiment \"{experiment_name}\""))?;
+            .attach_message_lazy(|| {
+                format!("Could not register experiment \"{experiment_name}\"")
+            })?;
 
         // Create and start the experiment run
         let cmd = self.create_engine_command(
@@ -235,7 +237,7 @@ impl Experiment {
             self.config.js_runner_initial_heap_constraint,
             self.config.js_runner_max_heap_size,
         );
-        let mut engine_process = cmd.run().await.wrap_err("Could not run experiment")?;
+        let mut engine_process = cmd.run().await.attach_message("Could not run experiment")?;
 
         // Wait to receive a message that the experiment has started before sending the init
         // message.
@@ -245,7 +247,7 @@ impl Experiment {
         )
         .await
         .report()
-        .provide_context(OrchestratorError::from("engine start timeout"));
+        .change_context(OrchestratorError::from("engine start timeout"));
         match msg {
             Ok(proto::EngineStatus::Started) => {}
             Ok(m) => {
@@ -259,8 +261,8 @@ impl Experiment {
                 engine_process
                     .exit_and_cleanup(experiment_run.base.id)
                     .await
-                    .wrap_err("Failed to cleanup after failed start")?;
-                bail!(e.provide_context(OrchestratorError::from(format!(
+                    .attach_message("Failed to cleanup after failed start")?;
+                bail!(e.change_context(OrchestratorError::from(format!(
                     "Engine start timeout for experiment \"{experiment_name}\""
                 ))));
             }
@@ -282,7 +284,7 @@ impl Experiment {
         if let Err(err) = engine_process
             .send(&proto::EngineMsg::Init(init_message))
             .await
-            .wrap_err("Could not send `Init` message")
+            .attach_message("Could not send `Init` message")
         {
             // TODO: Wait for threads to finish before starting a forced cleanup
             warn!("Engine didn't exit gracefully, waiting for subprocesses to finish.");
@@ -291,7 +293,7 @@ impl Experiment {
             if let Err(cleanup_err) = engine_process
                 .exit_and_cleanup(experiment_run.base.id)
                 .await
-                .wrap_err("Failed to cleanup after failed start")
+                .attach_message("Failed to cleanup after failed start")
             {
                 warn!("{cleanup_err}");
             }
@@ -434,7 +436,7 @@ impl Experiment {
         engine_process
             .exit_and_cleanup(experiment_run.base.id)
             .await
-            .wrap_err("Could not cleanup after finish")?;
+            .attach_message("Could not cleanup after finish")?;
 
         ensure!(
             graceful_finish,
@@ -458,11 +460,11 @@ fn get_simple_experiment_config(
     })?;
     let parsed = serde_json::from_str(&experiments_manifest)
         .report()
-        .provide_context(OrchestratorError::from(
+        .change_context(OrchestratorError::from(
             "Could not parse experiment manifest",
         ))?;
     let plan = create_experiment_plan(&parsed, &experiment_name)
-        .wrap_err("Could not read experiment plan")?;
+        .attach_message("Could not read experiment plan")?;
 
     let max_sims_in_parallel = parsed
         .get("max_sims_in_parallel")
@@ -522,7 +524,7 @@ fn create_experiment_plan(
             "Not implemented for optimization experiment types"
         )),
         _ => create_basic_variant(selected_experiment, experiment_type)
-            .wrap_err("Could not parse basic variant"),
+            .attach_message("Could not parse basic variant"),
     }
 }
 
@@ -540,7 +542,7 @@ fn create_multiparameter_variant(
 
     let var: MultiparameterVariant = serde_json::from_value(selected_experiment.clone())
         .report()
-        .provide_context(OrchestratorError::from(
+        .change_context(OrchestratorError::from(
             "Could not parse multiparameter variant",
         ))?;
     let subplans = var
@@ -554,11 +556,11 @@ fn create_multiparameter_variant(
                         "Experiment plan does not define the specified experiment: {run_name}"
                     ))
                 })
-                .wrap_err("Could not parse experiment file")?;
-            create_basic_variant(selected, run_name).wrap_err("Could not parse basic variant")
+                .attach_message("Could not parse experiment file")?;
+            create_basic_variant(selected, run_name).attach_message("Could not parse basic variant")
         })
         .collect::<Result<Vec<SimpleExperimentPlan>>>()
-        .wrap_err("Unable to create sub plans")?;
+        .attach_message("Unable to create sub plans")?;
 
     let mut variant_list: Vec<ExperimentPlanEntry> = vec![];
     for (i, subplan) in subplans.into_iter().enumerate() {
@@ -598,12 +600,12 @@ fn create_group_variant(
     }
     let var: GroupVariant = serde_json::from_value(selected_experiment.clone())
         .report()
-        .provide_context(OrchestratorError::from("Could not create group variant"))?;
+        .change_context(OrchestratorError::from("Could not create group variant"))?;
     var.runs.iter().try_fold(
         SimpleExperimentPlan::new(var.steps as usize),
         |mut acc, name| {
             let variants = create_experiment_plan(experiments, name)
-                .wrap_err("Could not read experiment plan")?;
+                .attach_message("Could not read experiment plan")?;
             variants.inner.into_iter().for_each(|v| {
                 acc.push(v);
             });
@@ -696,39 +698,39 @@ fn create_monte_carlo_variant_plan(
                 "normal" => Box::new(
                     Normal::new(self.mean.unwrap_or(1.0), self.std.unwrap_or(1.0))
                         .report()
-                        .provide_context(OrchestratorError::from(
+                        .change_context(OrchestratorError::from(
                             "Unable to create normal distribution",
                         ))?,
                 ) as Box<dyn DynDistribution<f64>>,
                 "log-normal" => Box::new(
                     LogNormal::new(self.mu.unwrap_or(1.0), self.sigma.unwrap_or(1.0))
                         .report()
-                        .provide_context(OrchestratorError::from(
+                        .change_context(OrchestratorError::from(
                             "Unable to create log-normal distribution",
                         ))?,
                 ),
                 "poisson" => Box::new(
                     Poisson::new(self.rate.unwrap_or(1.0))
                         .report()
-                        .provide_context(OrchestratorError::from(
+                        .change_context(OrchestratorError::from(
                             "Unable to create poisson distribution",
                         ))?,
                 ),
                 "beta" => Box::new(
                     Beta::new(self.alpha.unwrap_or(1.0), self.beta.unwrap_or(1.0))
                         .report()
-                        .provide_context(OrchestratorError::from(
+                        .change_context(OrchestratorError::from(
                             "Unable to create beta distribution",
                         ))?,
                 ),
                 "gamma" => Box::new(
                     rand_distr::Gamma::new(self.shape.unwrap_or(1.0), self.scale.unwrap_or(1.0))
                         .report()
-                        .provide_context(OrchestratorError::from(
+                        .change_context(OrchestratorError::from(
                             "Unable to create gamma distribution",
                         ))?,
                 ),
-                _ => Box::new(Normal::new(1.0, 1.0).report().provide_context(
+                _ => Box::new(Normal::new(1.0, 1.0).report().change_context(
                     OrchestratorError::from("Unable to create normal distribution"),
                 )?),
             };
@@ -741,7 +743,7 @@ fn create_monte_carlo_variant_plan(
 
     let var: MonteCarloVariant = serde_json::from_value(selected_experiment.clone())
         .report()
-        .provide_context(OrchestratorError::from(
+        .change_context(OrchestratorError::from(
             "Could not create monte carlo distribution",
         ))?;
     let values: Vec<_> = (0..var.samples as usize).map(|_| 0.into()).collect();
@@ -765,7 +767,7 @@ fn create_value_variant_plan(selected_experiment: &SerdeValue) -> Result<SimpleE
 
     let var: ValueVariant = serde_json::from_value(selected_experiment.clone())
         .report()
-        .provide_context(OrchestratorError::from("Could not parse value variant"))?;
+        .change_context(OrchestratorError::from("Could not parse value variant"))?;
     let mapper: Mapper = Box::new(|val, _index| val);
     Ok(create_variant_with_mapped_value(
         &var.field,
@@ -788,7 +790,7 @@ fn create_linspace_variant_plan(selected_experiment: &SerdeValue) -> Result<Simp
     }
     let var: LinspaceVariant = serde_json::from_value(selected_experiment.clone())
         .report()
-        .provide_context(OrchestratorError::from("Could not create linspace variant"))?;
+        .change_context(OrchestratorError::from("Could not create linspace variant"))?;
     let values: Vec<_> = (0..var.samples as usize).map(|_| 0.into()).collect();
 
     let closure_var = var.clone();
@@ -824,7 +826,7 @@ fn create_arange_variant_plan(selected_experiment: &SerdeValue) -> Result<Simple
     }
     let var: ArangeVariant = serde_json::from_value(selected_experiment.clone())
         .report()
-        .provide_context(OrchestratorError::from("Could not create arange variant"))?;
+        .change_context(OrchestratorError::from("Could not create arange variant"))?;
     let mut values = vec![];
     let mut cur = var.start;
     while cur <= var.stop {
@@ -854,7 +856,7 @@ fn create_meshgrid_variant_plan(selected_experiment: &SerdeValue) -> Result<Simp
     }
     let var: MeshgridVariant = serde_json::from_value(selected_experiment.clone())
         .report()
-        .provide_context(OrchestratorError::from("Could not create meshgrid variant"))?;
+        .change_context(OrchestratorError::from("Could not create meshgrid variant"))?;
 
     let mut plan = SimpleExperimentPlan::new(var.steps as usize);
     let x_space = linspace(var.x[0], var.x[1], var.x[2] as usize);

--- a/packages/engine/lib/orchestrator/src/process/local.rs
+++ b/packages/engine/lib/orchestrator/src/process/local.rs
@@ -44,7 +44,7 @@ impl process::Process for LocalProcess {
                 std::io::ErrorKind::InvalidInput => Ok(()),
                 _ => Err(Report::from_error(e)),
             })
-            .provide_context(OrchestratorError::from("Could not kill the process"));
+            .change_context(OrchestratorError::from("Could not kill the process"));
 
         let engine_socket_path = format!("run-{experiment_id}");
         match remove_file(&engine_socket_path) {
@@ -79,7 +79,7 @@ impl process::Process for LocalProcess {
         // We create the client on the first call here, rather than when the LocalCommand is run,
         // because the engine process needs some time before it's ready to accept NNG connections.
         if self.client.is_none() {
-            self.client = Some(nano::Client::new(&self.engine_url, 1).provide_context_lazy(
+            self.client = Some(nano::Client::new(&self.engine_url, 1).change_context_lazy(
                 || {
                     OrchestratorError::from(format!(
                         "Could not create nano client for engine at {:?}",
@@ -94,7 +94,7 @@ impl process::Process for LocalProcess {
             .unwrap()
             .send(msg)
             .await
-            .provide_context(OrchestratorError::from("Could not send engine message"))?)
+            .change_context(OrchestratorError::from("Could not send engine message"))?)
     }
 
     async fn wait(&mut self) -> Result<ExitStatus> {
@@ -103,7 +103,7 @@ impl process::Process for LocalProcess {
             .wait()
             .await
             .report()
-            .provide_context(OrchestratorError::from(
+            .change_context(OrchestratorError::from(
                 "Could not wait for the process to exit",
             ))?)
     }
@@ -209,7 +209,7 @@ impl process::Command for LocalCommand {
         }
         debug!("Running `{cmd:?}`");
 
-        let child = cmd.spawn().report().provide_context_lazy(|| {
+        let child = cmd.spawn().report().change_context_lazy(|| {
             OrchestratorError::from(format!("Could not run command: {process_path:?}"))
         })?;
         debug!("Spawned local engine process for experiment");

--- a/packages/engine/src/env.rs
+++ b/packages/engine/src/env.rs
@@ -57,7 +57,7 @@ pub struct OrchClient {
 impl OrchClient {
     pub fn new(url: &str, experiment_id: ExperimentId) -> Result<Self> {
         let client = nano::Client::new(url, 1)
-            .wrap_err_lazy(|| format!("Could not create orchestrator client for {url:?}"))?;
+            .attach_message_lazy(|| format!("Could not create orchestrator client for {url:?}"))?;
         Ok(OrchClient {
             url: url.into(),
             experiment_id,

--- a/packages/engine/tests/experiment/error.rs
+++ b/packages/engine/tests/experiment/error.rs
@@ -1,6 +1,9 @@
 use std::{error::Error, fmt, path::PathBuf};
 
-use error::provider::{Demand, Provider};
+use error::{
+    provider::{Demand, Provider},
+    Context,
+};
 use serde_json::Value;
 
 pub type Result<T, C = TestContext> = error::Result<T, C>;
@@ -29,11 +32,7 @@ impl fmt::Display for TestContext {
     }
 }
 
-impl Provider for TestContext {
-    fn provide<'a>(&'a self, _: &mut Demand<'a>) {
-        // Empty implementation
-    }
-}
+impl Context for TestContext {}
 
 #[derive(Debug)]
 pub enum TestError {

--- a/packages/engine/tests/experiment/error.rs
+++ b/packages/engine/tests/experiment/error.rs
@@ -1,9 +1,6 @@
 use std::{error::Error, fmt, path::PathBuf};
 
-use error::{
-    provider::{Demand, Provider},
-    Context,
-};
+use error::Context;
 use serde_json::Value;
 
 pub type Result<T, C = TestContext> = error::Result<T, C>;
@@ -144,9 +141,3 @@ impl fmt::Display for TestError {
 }
 
 impl Error for TestError {}
-
-impl Provider for TestError {
-    fn provide<'a>(&'a self, _: &mut Demand<'a>) {
-        // Empty implementation
-    }
-}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This makes the naming on methods more consistent and adds a method to attach a provider without changing the current context.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201893074552404/1201481007343178/f) _(internal)_

## 🚫 Blocked by

- #599 

## 🔍 What does this change?

- Rename `wrap_err` to `attach_message`
- Rename `provide_context` to `change_context`
    - This implies a new trait `Context: Display + Debug` and changes to the internal `Frame` representation
- Add `attach_provider`:
    ```rust
    fn attach_provider<P: Provider + Display + Debug>(self, provider: P) -> Self;
   ```
- Make the provider API a nightly-only feature to make this crate to be used on stable as well. (We will switch to the upstream implementation of `Provider` as soon as it lands on `core`)
- Adjust `Report` so that `Report` will always have a `Context` associated (forbid `Provider` as context) and adjust the macros
- Greatly improve internal macro documentation
- Add an example to `Context` how is it used
- Small other drive-bys:
    -  implying `std` feature when `hooks` are enabled
    - Switch implementation location from `From::from` and `Report::from_error`

## 📜 Does this require a change to the docs?

The docs were adjusted

## 📹 Demo

Example used in documentation
```rust
use std::{fmt, fs, io};

use error::{Context, IntoReport, Result, ResultExt};

#[derive(Debug)]
pub enum ConfigError {
    ParseError,
}

impl fmt::Display for ConfigError {
    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
        ...
    }
}

// `Error` is not implemented for `ConfigError` for any reason, so implement `Context` manually.
impl Context for ConfigError {}

pub fn read_file(path: &str) -> Result<String, io::Error> {
    // Creates a `Report` from `io::Error`, the current context is `io::Error`
    fs::read_to_string(path).report()
}

pub fn parse_config(path: &str) -> Result<Config, ConfigError> {
    // The return type of `parse_config` requires another context. By calling `change_context`
    // the context may be changed.
    read_file(path).change_context(ConfigError::ParseError)?;

    ...
}
```
