### PR TITLE
Add a function to return the latest context

### DIFF
--- a/packages/engine/lib/error/src/lib.rs
+++ b/packages/engine/lib/error/src/lib.rs
@@ -259,7 +259,7 @@ pub(crate) mod test_helper {
         Report,
     };
 
-    #[derive(Debug)]
+    #[derive(Debug, PartialEq)]
     pub struct ContextA(pub u32);
 
     impl fmt::Display for ContextA {

--- a/packages/engine/lib/error/src/macros.rs
+++ b/packages/engine/lib/error/src/macros.rs
@@ -286,12 +286,14 @@ mod tests {
     fn error() {
         let err = capture_error(|| Err(report!(ContextA(10))));
         assert!(err.contains::<ContextA>());
+        assert_eq!(err.current_context(), &ContextA(10));
         assert_eq!(err.frames().count(), 1);
         assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
         assert_eq!(request_messages(&err), ["Context A"]);
 
         let err = report!(err);
         assert!(err.contains::<ContextA>());
+        assert_eq!(err.current_context(), &ContextA(10));
         assert_eq!(err.frames().count(), 1);
         assert_eq!(err.request_value().collect::<Vec<u32>>(), [10]);
         assert_eq!(request_messages(&err), ["Context A"]);
@@ -300,6 +302,7 @@ mod tests {
         {
             let io_err = std::io::Error::from(std::io::ErrorKind::Other);
             let err = capture_error(|| Err(report!(io_err)));
+            assert_eq!(err.current_context().kind(), std::io::ErrorKind::Other);
             assert!(err.contains::<std::io::Error>());
             assert_eq!(err.frames().count(), 1);
             assert_eq!(request_messages(&err), ["other error"]);

--- a/packages/engine/lib/error/src/report.rs
+++ b/packages/engine/lib/error/src/report.rs
@@ -388,9 +388,9 @@ impl<T: Context> Report<T> {
     where
         T: Any,
     {
-        // Panics if there isn't an attached context, which is matching `T`. As it's not possible to
+        // Panics if there isn't an attached context which matches `T`. As it's not possible to
         // create a `Report` without a valid context and this method can only be called when `T` is
-        // a valid context, it's guaranteed, that the context is available when calling
+        // a valid context, it's guaranteed that the context is available when calling
         // `current_context`.
         self.downcast_ref().expect(
             "Report does not contain a context. This is considered a bug and should be reported \

--- a/packages/engine/lib/error/src/report.rs
+++ b/packages/engine/lib/error/src/report.rs
@@ -367,6 +367,12 @@ impl<T> Report<T> {
         self.frames().find_map(Frame::downcast_ref::<A>)
     }
 
+    pub(crate) const fn frame(&self) -> &Frame {
+        &self.inner.frame
+    }
+}
+
+impl<T: Context> Report<T> {
     /// Returns the current context of the `Report`.
     ///
     /// If the user want to get the latest context, `current_context` can be called. If the user
@@ -377,20 +383,19 @@ impl<T> Report<T> {
     /// This is one disadvantage of the library in comparison to plain Errors, as in these cases,
     /// all context types are known.
     #[must_use]
-    #[allow(clippy::missing_panics_doc)]
+    #[allow(clippy::missing_panics_doc)] // Panicking here is a bug
     pub fn current_context(&self) -> &T
     where
         T: Any,
     {
-        // Panics if no context is attached which should only happen when using the hooks.
+        // Panics if there isn't an attached context, which is matching `T`. As it's not possible to
+        // create a `Report` without a valid context and this method can only be called when `T` is
+        // a valid context, it's guaranteed, that the context is available when calling
+        // `current_context`.
         self.downcast_ref().expect(
             "Report does not contain a context. This is considered a bug and should be reported \
              to https://github.com/hashintel/hash/issues/new",
         )
-    }
-
-    pub(crate) const fn frame(&self) -> &Frame {
-        &self.inner.frame
     }
 }
 

--- a/packages/engine/lib/error/src/report.rs
+++ b/packages/engine/lib/error/src/report.rs
@@ -348,11 +348,17 @@ impl<T> Report<T> {
     ///
     /// This is one disadvantage of the library in comparison to plain Errors, as in these cases,
     /// all context types are known.
+    #[must_use]
+    #[allow(clippy::missing_panics_doc)]
     pub fn current_context(&self) -> &T
     where
         T: Any,
     {
-        self.frame().downcast_ref().unwrap()
+        // Panics if no context is attached which should only happen when using the hooks.
+        self.frame().downcast_ref().expect(
+            "Report does not contain a context. This is considered a bug and should be reported \
+             to https://github.com/hashintel/hash/issues/new",
+        )
     }
 
     pub(crate) const fn frame(&self) -> &Frame {

--- a/packages/engine/lib/error/src/report.rs
+++ b/packages/engine/lib/error/src/report.rs
@@ -338,9 +338,20 @@ impl<T> Report<T> {
     pub fn downcast_ref<C: Any>(&self) -> Option<&C> {
         self.frames().find_map(Frame::downcast_ref::<C>)
     }
-}
 
-impl<T> Report<T> {
+    /// Returns the current context of the `Report`.
+    ///
+    /// If the user want to get the latest context, `current_context` can be called. If the user
+    /// wants to handle the error, the context can then be used to directly access the context's
+    /// type. This is only possible for the latest context as the Report does not have multiple
+    /// generics as this would either require variadic generics or a workaround like tuple-list.
+    ///
+    /// This is one disadvantage of the library in comparison to plain Errors, as in these cases,
+    /// all context types are known.
+    pub fn current_context(&self) -> &T {
+        self.frame().downcast_ref().unwrap()
+    }
+
     pub(crate) const fn frame(&self) -> &Frame {
         &self.inner.frame
     }

--- a/packages/engine/lib/error/src/report.rs
+++ b/packages/engine/lib/error/src/report.rs
@@ -348,7 +348,10 @@ impl<T> Report<T> {
     ///
     /// This is one disadvantage of the library in comparison to plain Errors, as in these cases,
     /// all context types are known.
-    pub fn current_context(&self) -> &T {
+    pub fn current_context(&self) -> &T
+    where
+        T: Any,
+    {
         self.frame().downcast_ref().unwrap()
     }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

It's reasonable to get the current context without the need of explicit downcasting.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1199548034582004/1201481007343178/f) _(internal)_

## 🔍 What does this change?

- Adds a function to return the current context
