### PR TITLE
Remove usage of generalize

### DIFF
--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -80,7 +80,7 @@ pub struct CliError;
 
 impl fmt::Display for CliError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.write_str("Could not run engine")
+        fmt.write_str("CLI encountered an error during execution")
     }
 }
 

--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::module_inception)]
 
 use std::{
+    error::Error,
+    fmt,
     fmt::Debug,
     path::PathBuf,
     time::{SystemTime, UNIX_EPOCH},
@@ -73,8 +75,19 @@ pub struct SimpleExperimentArgs {
     experiment_name: ExperimentName,
 }
 
+#[derive(Debug)]
+pub struct CliError;
+
+impl fmt::Display for CliError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.write_str("Could not run engine")
+    }
+}
+
+impl Error for CliError {}
+
 #[tokio::main]
-async fn main() -> Result<(), ()> {
+async fn main() -> Result<(), CliError> {
     let args = Args::parse();
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -91,7 +104,7 @@ async fn main() -> Result<(), ()> {
     )
     .report()
     .attach_message("Failed to initialize the logger")
-    .generalize()?;
+    .change_context(CliError)?;
 
     let nng_listen_url = format!("ipc://hash-orchestrator-{now}");
 
@@ -103,19 +116,19 @@ async fn main() -> Result<(), ()> {
         .canonicalize()
         .report()
         .attach_message_lazy(|| format!("Could not canonicalize project path: {:?}", args.project))
-        .generalize()?;
+        .change_context(CliError)?;
     let manifest = Manifest::from_local(&absolute_project_path)
         .attach_message_lazy(|| format!("Could not read local project {absolute_project_path:?}"))
-        .generalize()?;
+        .change_context(CliError)?;
     let experiment_run = manifest
         .read(args.r#type.into())
         .attach_message("Could not read manifest")
-        .generalize()?;
+        .change_context(CliError)?;
 
     let experiment = Experiment::new(args.experiment_config);
 
     experiment
         .run(experiment_run, handler, None)
         .await
-        .generalize()
+        .change_context(CliError)
 }

--- a/packages/engine/bin/hash_engine/src/main.rs
+++ b/packages/engine/bin/hash_engine/src/main.rs
@@ -15,7 +15,7 @@ pub struct EngineError;
 
 impl fmt::Display for EngineError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.write_str("Could not run engine")
+        fmt.write_str("Engine encountered an error during execution")
     }
 }
 

--- a/packages/engine/bin/hash_engine/src/main.rs
+++ b/packages/engine/bin/hash_engine/src/main.rs
@@ -1,3 +1,5 @@
+use std::{error::Error, fmt};
+
 use error::{IntoReport, Result, ResultExt};
 use hash_engine_lib::{
     config::experiment_config,
@@ -8,8 +10,19 @@ use hash_engine_lib::{
     utils::init_logger,
 };
 
+#[derive(Debug)]
+pub struct EngineError;
+
+impl fmt::Display for EngineError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.write_str("Could not run engine")
+    }
+}
+
+impl Error for EngineError {}
+
 #[tokio::main]
-async fn main() -> Result<(), ()> {
+async fn main() -> Result<(), EngineError> {
     let args = hash_engine_lib::args();
     let _guard = init_logger(
         args.log_format,
@@ -21,22 +34,25 @@ async fn main() -> Result<(), ()> {
     )
     .report()
     .attach_message("Failed to initialize the logger")
-    .generalize()?;
+    .change_context(EngineError)?;
 
     let mut env = env::<ExperimentRun>(&args)
         .await
         .report()
         .attach_message("Could not create environment for experiment")
-        .generalize()?;
+        .change_context(EngineError)?;
     // Fetch all dependencies of the experiment run such as datasets
     env.experiment
         .fetch_deps()
         .await
         .report()
         .attach_message("Could not fetch dependencies for experiment")
-        .generalize()?;
+        .change_context(EngineError)?;
     // Generate the configuration for packages from the environment
-    let config = experiment_config(&args, &env).await.report().generalize()?;
+    let config = experiment_config(&args, &env)
+        .await
+        .report()
+        .change_context(EngineError)?;
 
     tracing::info!(
         "HASH Engine process started for experiment {}",
@@ -47,7 +63,7 @@ async fn main() -> Result<(), ()> {
         .await
         .report()
         .attach_message("Could not run experiment")
-        .generalize();
+        .change_context(EngineError);
 
     cleanup_experiment(args.experiment_id);
 

--- a/packages/engine/lib/error/src/report.rs
+++ b/packages/engine/lib/error/src/report.rs
@@ -279,16 +279,6 @@ impl<T> Report<T> {
         )
     }
 
-    /// Converts the `Report<T>` to `Report<()>` without modifying the frame stack.
-    #[doc(hidden)]
-    #[allow(clippy::missing_const_for_fn)] // False positive
-    pub fn generalize(self) -> Report<()> {
-        Report {
-            inner: self.inner,
-            _context: PhantomData,
-        }
-    }
-
     /// Returns the backtrace of the error, if captured.
     ///
     /// Note, that `RUST_BACKTRACE` or `RUST_LIB_BACKTRACE` has to be set to enable backtraces.

--- a/packages/engine/lib/error/src/result.rs
+++ b/packages/engine/lib/error/src/result.rs
@@ -159,12 +159,6 @@ pub trait ResultExt {
     where
         C: Context,
         F: FnOnce() -> C;
-
-    // TODO: Temporary, remove before releasing
-    //   Currently only used to be backward compatible with hEngine. After binaries and orchestrator
-    //   are adjusted, this can safely be removed.
-    #[doc(hidden)]
-    fn generalize(self) -> Result<Self::Ok, ()>;
 }
 
 impl<T, C> ResultExt for Result<T, C> {
@@ -245,10 +239,6 @@ impl<T, C> ResultExt for Result<T, C> {
             Ok(ok) => Ok(ok),
             Err(report) => Err(report.change_context(context())),
         }
-    }
-
-    fn generalize(self) -> Result<T, ()> {
-        self.map_err(Report::generalize)
     }
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We used an anonymous Report as workaround, this needs to be removed

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201893074552404/1201481007343178/f) _(internal)_

## 🔍 What does this change?

- Removes calls to `generalize`
- Removes the `generalize` method

## 📜 Does this require a change to the docs?

The documentation for this methods were already hidden
