### PR TITLE
Speed up object downcasting by specifying the type in the VTable

### DIFF
--- a/packages/libs/error-stack/src/frame.rs
+++ b/packages/libs/error-stack/src/frame.rs
@@ -116,10 +116,7 @@ impl Frame {
     /// Downcasts this frame if the held context or attachment is the same as `T`.
     #[must_use]
     pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
-        self.inner.as_ref().downcast().map(|addr| {
-            // SAFETY: Dereferencing is safe as T has the same lifetimes as Self
-            unsafe { addr.as_ref() }
-        })
+        self.inner.downcast_ref()
     }
 }
 
@@ -317,8 +314,10 @@ impl FrameRepr {
         unsafe { (self.vtable.object_ref)(self) }
     }
 
-    fn downcast<T: Any>(&self) -> Option<NonNull<T>> {
+    fn downcast_ref<T: Any>(&self) -> Option<&T> {
         // SAFETY: Use vtable to attach T's native vtable for the right original type T.
-        unsafe { (self.vtable.object_downcast)(self, TypeId::of::<T>()).map(NonNull::cast) }
+        unsafe {
+            (self.vtable.object_downcast)(self, TypeId::of::<T>()).map(|ptr| ptr.cast().as_ref())
+        }
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

For downcasting we currently optimistically try each frame type.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201893074552404/1201481007343178/f) _(internal)_

## 🔍 What does this change?

- Introduce a dedicated method for attachment downcasting
- Simplify logic for downcasting

## 📹 Demo

Output for calling `downcast_ref::<u64>`.

**Before:**
```asm
error_stack::frame::Frame::downcast_ref:
 push    rbx
 mov     rbx, qword, ptr, [rdi]
 mov     rax, qword, ptr, [rbx]
 movabs  rsi, -4415644426573220325
 mov     rdi, rbx
 call    qword, ptr, [rax, +, 16]
 test    rax, rax
 je      .LBB5_2
 pop     rbx
 ret
.LBB5_2:
 mov     rax, qword, ptr, [rbx]
 mov     rax, qword, ptr, [rax, +, 16]
 movabs  rsi, 8221235708928728630
 mov     rdi, rbx
 pop     rbx
 jmp     rax
```

**After:**
```asm
error_stack::frame::Frame::downcast_ref:
 mov     rdi, qword, ptr, [rdi]
 mov     rax, qword, ptr, [rdi]
 mov     rax, qword, ptr, [rax, +, 16]
 movabs  rsi, -4415644426573220325
 jmp     rax
```
