### PR TITLE
Don't run "CI" on hEngine or error-stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - "packages/engine/**"
+      - "packages/libs/error-stack/**"
 
 jobs:
   linting:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When `hEngine` or `error-stack` is changed, the hash-CI doesn't need to run.

## 🔗 Related links

- [Conversation](https://hashintel.slack.com/archives/C02TWBTT3ED/p1654539815241949) _(internal)_

## 🔍 What does this change?

- Adds a filter to only run the CI if files outside of "packages/engine" or "packages/libs/error-stack" are changed