### PR TITLE
Improve `Debug` implementation for `Frame` and `Report`

### DIFF
--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -33,3 +33,7 @@ required-features = ["hooks"]
 [[example]]
 name = "contextual_messages"
 required-features = ["std"]
+
+[[example]]
+name = "parse_config"
+required-features = ["std"]

--- a/packages/libs/error-stack/examples/contextual_messages.rs
+++ b/packages/libs/error-stack/examples/contextual_messages.rs
@@ -1,5 +1,3 @@
-// This is the same example also used in `lib.rs`. When updating this, don't forget updating the doc
-// example as well. This example is mainly used to generate the output shown in the documentation.
 use std::{collections::HashMap, error::Error, fmt};
 
 use error_stack::{ensure, Report, Result, ResultExt};

--- a/packages/libs/error-stack/examples/parse_config.rs
+++ b/packages/libs/error-stack/examples/parse_config.rs
@@ -50,6 +50,7 @@ fn parse_config(path: impl AsRef<Path>) -> Result<Config, Report<ParseConfigErro
 fn main() {
     if let Err(report) = parse_config("config.json") {
         eprintln!("{report:?}");
+        #[cfg(nightly)]
         for suggestion in report.request_ref::<Suggestion>() {
             eprintln!("Suggestion: {suggestion}");
         }

--- a/packages/libs/error-stack/examples/parse_config.rs
+++ b/packages/libs/error-stack/examples/parse_config.rs
@@ -1,0 +1,57 @@
+// This is the same example also used in `lib.rs`. When updating this, don't forget updating the doc
+// example as well. This example is mainly used to generate the output shown in the documentation.
+
+use std::{fs, path::Path};
+
+use error_stack::{Context, IntoReport, Report, ResultExt};
+
+pub type Config = String;
+
+#[derive(Debug)]
+struct ParseConfigError;
+
+impl ParseConfigError {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl std::fmt::Display for ParseConfigError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt.write_str("Could not parse configuration file")
+    }
+}
+
+impl Context for ParseConfigError {}
+
+#[derive(Debug)]
+struct Suggestion(&'static str);
+
+impl std::fmt::Display for Suggestion {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(fmt, "{}", self.0)
+    }
+}
+
+impl Context for Suggestion {}
+
+fn parse_config(path: impl AsRef<Path>) -> Result<Config, Report<ParseConfigError>> {
+    let path = path.as_ref();
+
+    let content = fs::read_to_string(path)
+        .report()
+        .change_context(ParseConfigError::new())
+        .attach(Suggestion("Use a file you can read next time!"))
+        .attach_lazy(|| format!("Could not read file {path:?}"))?;
+
+    Ok(content)
+}
+
+fn main() {
+    if let Err(report) = parse_config("config.json") {
+        eprintln!("{report:?}");
+        for suggestion in report.request_ref::<Suggestion>() {
+            eprintln!("Suggestion: {suggestion}");
+        }
+    }
+}

--- a/packages/libs/error-stack/src/frame.rs
+++ b/packages/libs/error-stack/src/frame.rs
@@ -200,9 +200,13 @@ impl Provider for Frame {
 
 impl fmt::Debug for Frame {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // TODO: Change output depending on FrameKind
+        let field_name = match self.kind() {
+            FrameKind::Context => "context",
+            FrameKind::Attachment => "attachment",
+        };
+
         fmt.debug_struct("Frame")
-            .field("object", &self.inner.unerase())
+            .field(field_name, &self.inner.unerase())
             .field("location", &self.location)
             .finish()
     }

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -119,6 +119,7 @@
 //! fn main() {
 //!     if let Err(report) = parse_config("config.json") {
 //!         eprintln!("{report:?}");
+//!         # #[cfg(nightly)]
 //!         for suggestion in report.request_ref::<Suggestion>() {
 //!             eprintln!("Suggestion: {suggestion}");
 //!         }

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -127,7 +127,7 @@
 //! }
 //! ```
 //!
-//! which will produce an error and will output somethink like
+//! which will produce an error and will output something like
 //!
 //! ```text
 //! Could not parse configuration file


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Since we support getting the type of a `Frame`, this can be used for better printing

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201893074552404/1201481007343178/f) _(internal)_

## 🔍 What does this change?

- Improve `Debug` output for `Frame` and `Report`
- Add a new example to the crate-level docs, which shows the new output better

## 📜 Does this require a change to the docs?

- An example was added, that shows these changes

## 📹 Demo

Output of the following code:
```rust
let content = fs::read_to_string(path)
    .report()
    .change_context(ParseConfigError::new())
    .attach(Suggestion("Use a file you can read next time!"))
    .attach_lazy(|| format!("Could not read file {path:?}"))?;
```
**Before:**
```
Could not read file "config.json"
             at examples/parse_config.rs:45:10

Caused by:
   0: Use a file you can read next time!
             at examples/parse_config.rs:44:10
   1: Could not parse configuration file
             at examples/parse_config.rs:43:10
   2: No such file or directory (os error 2)
             at examples/parse_config.rs:42:10
```

**Now:**:
```
Could not parse configuration file
             at examples/parse_config.rs:43:10
      - Could not read file "config.json"
      - Use a file you can read next time!

Caused by:
   0: No such file or directory (os error 2)
             at examples/parse_config.rs:42:10
```

Output of the above code when using `Frame as Debug`:
```rust
for frame in report.frames() {
    println!("{frame:?}")
}
```

**Before:**
```
Frame { object: "Could not read file \"config.json\"", location: Location { file: "examples/parse_config.rs", line: 45, col: 10 } }
Frame { object: Suggestion("Use a file you can read next time!"), location: Location { file: "examples/parse_config.rs", line: 44, col: 10 } }
Frame { object: ParseConfigError, location: Location { file: "examples/parse_config.rs", line: 43, col: 10 } }
Frame { object: Os { code: 2, kind: NotFound, message: "No such file or directory" }, location: Location { file: "examples/parse_config.rs", line: 42, col: 10 } }

```

**Now:**
```
Frame { attachment: "Could not read file \"config.json\"", location: Location { file: "examples/parse_config.rs", line: 45, col: 10 } }
Frame { attachment: Suggestion("Use a file you can read next time!"), location: Location { file: "examples/parse_config.rs", line: 44, col: 10 } }
Frame { context: ParseConfigError, location: Location { file: "examples/parse_config.rs", line: 43, col: 10 } }
Frame { context: Os { code: 2, kind: NotFound, message: "No such file or directory" }, location: Location { file: "examples/parse_config.rs", line: 42, col: 10 } }
```