### PR TITLE
Add `A-libs` tag to GitHub labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -31,6 +31,12 @@ A-learn:
   - "resources/**/*"
   - "resources/**/.*"
 
+A-libs:
+  - "packages/libs/*"
+  - "packages/libs/.*"
+  - "packages/libs/**/*"
+  - "packages/libs/**/.*"
+
 C-dependencies:
   - "**/Cargo.lock"
   - "**/yarn.lock"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds the `A-libs` tag for libraries in _packages/libs_

## 🎥  Demo

![image](https://user-images.githubusercontent.com/21277928/173065663-0f24295f-849b-4c03-812b-82574617fb1b.png) 
![image](https://user-images.githubusercontent.com/21277928/173065732-e3c672d5-3f72-4ff3-948d-a86bd4896288.png)
