### PR TITLE
Improve 'view the crate on GitHub' visibility

### DIFF
--- a/sites/hashdev/src/_pages/blog/4_announcing-error-stack.mdx
+++ b/sites/hashdev/src/_pages/blog/4_announcing-error-stack.mdx
@@ -10,7 +10,7 @@ date: "2022-06-10"
 
 We are proud to announce a new error library for Rust: `error-stack` - a context-aware error library with arbitrary attached user data.
 
-[View the crate on GitHub >](https://github.com/hashintel/hash/tree/main/packages/libs/error-stack)
+- [View the crate on GitHub >](https://github.com/hashintel/hash/tree/main/packages/libs/error-stack)
 
 This post outlines some of our experiences with error-handling in Rust, why we built the `error-stack` library, the architectural choices we made along the way, and what you can expect from the crate.
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

It seems that a link which is not contained by a paragraph does not get proper styling, which means the current 'View the crate on GitHub' link is not very visible.

As a temporary solution I've put it in a list item.

**Before**
![Screenshot 2022-06-10 at 18 15 36](https://user-images.githubusercontent.com/37743469/173118190-d6614d85-547d-4c30-b231-0858d33e546f.png)



**After**
![Screenshot 2022-06-10 at 18 15 33](https://user-images.githubusercontent.com/37743469/173118147-50e59233-85fc-419e-8774-bc37d09c3a4e.png)