### PR TITLE
Change `<pre>` base color in blog posts to `gray[40]`

### DIFF
--- a/sites/hashdev/src/components/MdxPre.tsx
+++ b/sites/hashdev/src/components/MdxPre.tsx
@@ -15,7 +15,7 @@ export const MdxPre = ({ children: codeEl }: { children: ReactElement }) => {
         overflow: "auto",
         display: "block",
         fontSize: "90%",
-        color: theme.palette.grey[40],
+        color: theme.palette.gray[40],
         background: "#161a1f",
         padding: theme.spacing(3),
         borderWidth: 1,

--- a/sites/hashdev/src/components/MdxPre.tsx
+++ b/sites/hashdev/src/components/MdxPre.tsx
@@ -15,7 +15,7 @@ export const MdxPre = ({ children: codeEl }: { children: ReactElement }) => {
         overflow: "auto",
         display: "block",
         fontSize: "90%",
-        color: theme.palette.purple[600],
+        color: theme.palette.grey[40],
         background: "#161a1f",
         padding: theme.spacing(3),
         borderWidth: 1,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The base color for `<pre>` currently is `purple[600]`. To make this more readable, this is changed to `grey[40]`.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Slack](https://hashintel.slack.com/archives/C02NW18QGUR/p1654945808477039?thread_ts=1654853213.971799&cid=C02NW18QGUR) _(internal)_

## 🎥  Demo

**Before:**
![image](https://user-images.githubusercontent.com/21277928/173185576-60b5cf81-5e84-4037-87fb-a818f0fc9144.png)


**Now:**
![image](https://user-images.githubusercontent.com/21277928/173185554-c5dccb89-33a8-47cd-acc0-142aa88b6889.png)

