### PR TITLE
Change to upstream error-stack

### DIFF
--- a/packages/engine/Cargo.lock
+++ b/packages/engine/Cargo.lock
@@ -664,7 +664,9 @@ dependencies = [
 
 [[package]]
 name = "error-stack"
-version = "0.1.0"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5975af488b218348f3f183862f88e8699a91a809f0ee2658fcafaa6239d6759e"
 dependencies = [
  "rustc_version",
  "tracing-error",

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -8,13 +8,14 @@ members = [".", "bin/*", "lib/*"]
 default-members = [".", "bin/*", "lib/*"]
 
 [dependencies]
-error-stack = { path = "../libs/error-stack", features = ["spantrace"] }
 flatbuffers_gen = { path = "lib/flatbuffers_gen" }
 nano = { path = "lib/nano", default-features = false }
 memory = { path = "lib/memory" }
 stateful = { path = "lib/stateful" }
 simulation_structure = { path = "lib/simulation_structure" }
 execution = { path = "lib/execution", default-features = false }
+
+error-stack = { version = "0.1.1", features = ["spantrace"] }
 
 arr_macro = "0.1.3"
 arrow = { version = "10.0.0", default-features = false, features = ["ipc"] }

--- a/packages/engine/bin/cli/Cargo.toml
+++ b/packages/engine/bin/cli/Cargo.toml
@@ -7,9 +7,10 @@ description = "The hEngine Command line interface"
 
 [dependencies]
 hash_engine_lib = { path = "../..", default-features = false }
-error-stack = { path = "../../../libs/error-stack", features = ["spantrace"] }
 execution = { path = "../../lib/execution", default-features = false }
 orchestrator = { path = "../../lib/orchestrator", default-features = false, features = ["clap"] }
+
+error-stack = { version = "0.1.1", features = ["spantrace"] }
 
 clap = { version = "3.0.0", features = ["cargo", "derive", "env"] }
 serde = { version = "1.0.111", features = ["derive"] }

--- a/packages/engine/bin/hash_engine/Cargo.toml
+++ b/packages/engine/bin/hash_engine/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 
 [dependencies]
 hash_engine_lib = { path = "../..", default-features = false }
-error-stack = { path = "../../../libs/error-stack", features = ["spantrace"] }
+
+error-stack = { version = "0.1.1", features = ["spantrace"] }
 
 tokio = "1.18.2"
 tracing = "0.1.29"

--- a/packages/engine/lib/nano/Cargo.toml
+++ b/packages/engine/lib/nano/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-error-stack = { path = "../../../libs/error-stack", features = ["spantrace"] }
+error-stack = { version = "0.1.1", features = ["spantrace"] }
 
 nng = { version = "1.0.1", default-features = false }
 serde = { version = "1.0.111", features = ["derive"] }

--- a/packages/engine/lib/orchestrator/Cargo.toml
+++ b/packages/engine/lib/orchestrator/Cargo.toml
@@ -4,13 +4,14 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-error-stack = { path = "../../../libs/error-stack", features = ["spantrace"] }
 nano = { path = "../nano", default-features = false }
 stateful = { path = "../stateful", default-features = false }
 simulation_structure = { path = "../simulation_structure" }
 execution = { path = "../execution", default-features = false }
 hash_engine_lib = { path = "../..", default-features = false }
 hash_engine = { path = "../../bin/hash_engine", default-features = false, artifact = "bin" }
+
+error-stack = { version = "0.1.1", features = ["spantrace"] }
 
 async-trait = "0.1.48"
 clap = { version = "3.0.13", optional = true }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`error-stack` is now published. Instead of using the local version, we switch to the upstream version.