### PR TITLE
Update Semgrep yaml file to fix CI

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -3,16 +3,16 @@ on:
   push:
     branches:
       - main
-      - master
 name: Semgrep
 jobs:
   semgrep:
     name: Scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+    container:
+      image: returntocorp/semgrep
     steps:
-      - uses: actions/checkout@v2
-      - uses: returntocorp/semgrep-action@v1
-        with:
-          auditOn: push
-          publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
-          publishDeployment: 1266
+      - uses: actions/checkout@v3
+      - run: semgrep ci
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+          SEMGREP_AUDIT_ON: push

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,15 +1,18 @@
+name: Semgrep
+
 on:
   pull_request: {}
   push:
     branches:
       - main
-name: Semgrep
+
 jobs:
   semgrep:
     name: Scan
     runs-on: ubuntu-20.04
     container:
       image: returntocorp/semgrep
+    if: (github.actor != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
       - run: semgrep ci


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR fixes Semgrep CI which started failing because of breaking changes upstream

```
=========== DEPRECATION WARNING ===========
Semgrep's audit mode setting will be removed by 2022 May.
Please update your CI configuration. Your CI script should run this command to ignore findings:
    $ semgrep ci || true
We recommend setting up separate CI jobs for pull request and push events, so that you can ignore findings only on push events.
For questions or support, please reach out at https://r2c.dev/slack
=== Running: SEMGREP_AUDIT_ON="push" semgrep ci
run `semgrep login` before using `semgrep ci` or set `--config`
```

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202250835094702/1202435394337592/f) _(internal)_
- [Slack thread](https://hashintel.slack.com/archives/C02TWBTT3ED/p1655136605181019) _(internal)_
- [Action on GitHub](https://github.com/returntocorp/semgrep-action) (no longer needed)
- [Official docs](https://semgrep.dev/docs/semgrep-ci/sample-ci-configs/#github-actions) ← the new yaml is pretty much copied from there

## 🔍 What does this change?

Semgrep works again

## 📜 Does this require a change to the docs?

No

## 🛡 What tests cover this?

CI

## ❓ How to test this?

Check CI

## 📺 Demo

https://github.com/hashintel/hash/runs/6866907407?check_suite_focus=true

<img width="711" alt="Screenshot 2022-06-13 at 19 07 05" src="https://user-images.githubusercontent.com/608862/173416913-83b3ced1-7d94-4208-b750-42053fa5c4e2.png">

