### PR TITLE
override outline style

### DIFF
--- a/packages/hash/frontend/src/blocks/page/style.module.css
+++ b/packages/hash/frontend/src/blocks/page/style.module.css
@@ -20,6 +20,7 @@
   align-items: flex-start;
   word-break: break-all;
   margin: 30px 0;
+  outline: none !important;
 }
 
 /**


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

After dragging a block inside a page and reordering it, an outline is displayed around the block that was selected. This is because of the class `ProseMirror-selectednode` applied by ProseMirror automatically. This was fixed by overriding the `outline` of blocks to `none`. 

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201095311341924/1202341139706564/f) _(internal)_

## ⚠️ Known issues

As can be seen in the demo, when navigating the page's blocks with the keyboard, only the Block handles are focused. I'm not sure if this is the intended behaviour or if we want the full block to be outlined (much like it was before when reordering blocks).

## ❓ How to test this?

1.  Reorder two blocks and check if any outline is displayed.

## 📹 Demo

Before:

![before](https://user-images.githubusercontent.com/37453800/173463004-95fcba40-7ddb-4e64-ac42-c2a1c02c729d.gif)

After:

![after](https://user-images.githubusercontent.com/37453800/173463009-24f158f5-b191-42b9-b97e-0972c16e4361.gif)

