### PR TITLE
Bump block-scripts to 0.0.11

### DIFF
--- a/packages/blocks/callout/package.json
+++ b/packages/blocks/callout/package.json
@@ -22,7 +22,7 @@
     "blockprotocol": "0.0.10"
   },
   "devDependencies": {
-    "block-scripts": "0.0.10",
+    "block-scripts": "0.0.11",
     "eslint": "8.13.0",
     "mock-block-dock": "0.0.10",
     "react": "^17.0.2",

--- a/packages/blocks/chart/package.json
+++ b/packages/blocks/chart/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/lodash.debounce": "4.0.7",
-    "block-scripts": "0.0.10",
+    "block-scripts": "0.0.11",
     "mock-block-dock": "0.0.10",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/packages/blocks/code/package.json
+++ b/packages/blocks/code/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/prismjs": "1.26.0",
     "@types/styled-components": "5.1.25",
-    "block-scripts": "0.0.10",
+    "block-scripts": "0.0.11",
     "mock-block-dock": "0.0.15",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/packages/blocks/countdown/package.json
+++ b/packages/blocks/countdown/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@types/react-datepicker": "^4.4.1",
-    "block-scripts": "0.0.10",
+    "block-scripts": "0.0.11",
     "mock-block-dock": "0.0.15",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/packages/blocks/divider/package.json
+++ b/packages/blocks/divider/package.json
@@ -22,7 +22,7 @@
     "blockprotocol": "0.0.10"
   },
   "devDependencies": {
-    "block-scripts": "0.0.10",
+    "block-scripts": "0.0.11",
     "eslint": "8.13.0",
     "mock-block-dock": "0.0.10",
     "react": "^17.0.2",

--- a/packages/blocks/drawing/package.json
+++ b/packages/blocks/drawing/package.json
@@ -28,7 +28,7 @@
     "react-resizable": "^3.0.4"
   },
   "devDependencies": {
-    "block-scripts": "0.0.10",
+    "block-scripts": "0.0.11",
     "mobx": "6.5.0",
     "mock-block-dock": "0.0.15",
     "react": "^17.0.2",

--- a/packages/blocks/embed/package.json
+++ b/packages/blocks/embed/package.json
@@ -23,7 +23,7 @@
     "lodash": "4.17.21"
   },
   "devDependencies": {
-    "block-scripts": "0.0.10",
+    "block-scripts": "0.0.11",
     "eslint": "8.13.0",
     "mock-block-dock": "0.0.10",
     "react": "^17.0.2",

--- a/packages/blocks/github-pr-overview/package.json
+++ b/packages/blocks/github-pr-overview/package.json
@@ -33,7 +33,7 @@
     "lodash": "4.17.21"
   },
   "devDependencies": {
-    "block-scripts": "0.0.10",
+    "block-scripts": "0.0.11",
     "mock-block-dock": "0.0.10",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/packages/blocks/header/package.json
+++ b/packages/blocks/header/package.json
@@ -22,7 +22,7 @@
     "blockprotocol": "0.0.10"
   },
   "devDependencies": {
-    "block-scripts": "0.0.10",
+    "block-scripts": "0.0.11",
     "eslint": "8.13.0",
     "mock-block-dock": "0.0.10",
     "react": "^17.0.2",

--- a/packages/blocks/image/package.json
+++ b/packages/blocks/image/package.json
@@ -22,7 +22,7 @@
     "@blockprotocol/graph": "0.0.8"
   },
   "devDependencies": {
-    "block-scripts": "0.0.10",
+    "block-scripts": "0.0.11",
     "eslint": "8.13.0",
     "mock-block-dock": "0.0.15",
     "react": "^17.0.2",

--- a/packages/blocks/paragraph/package.json
+++ b/packages/blocks/paragraph/package.json
@@ -22,7 +22,7 @@
     "blockprotocol": "0.0.10"
   },
   "devDependencies": {
-    "block-scripts": "0.0.10",
+    "block-scripts": "0.0.11",
     "eslint": "8.13.0",
     "mock-block-dock": "0.0.10",
     "react": "^17.0.2",

--- a/packages/blocks/person/package.json
+++ b/packages/blocks/person/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/dompurify": "2.3.3",
-    "block-scripts": "0.0.10",
+    "block-scripts": "0.0.11",
     "eslint": "8.13.0",
     "mock-block-dock": "0.0.15",
     "react": "^17.0.2",

--- a/packages/blocks/stopwatch/package.json
+++ b/packages/blocks/stopwatch/package.json
@@ -20,7 +20,7 @@
     "blockprotocol": "0.0.10"
   },
   "devDependencies": {
-    "block-scripts": "0.0.10",
+    "block-scripts": "0.0.11",
     "mock-block-dock": "0.0.10",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/packages/blocks/table/package.json
+++ b/packages/blocks/table/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@types/react-table": "7.7.1",
-    "block-scripts": "0.0.10",
+    "block-scripts": "0.0.11",
     "eslint": "8.13.0",
     "mock-block-dock": "0.0.15",
     "react": "^17.0.2",

--- a/packages/blocks/timer/package.json
+++ b/packages/blocks/timer/package.json
@@ -22,7 +22,7 @@
     "duration-fns": "3.0.1"
   },
   "devDependencies": {
-    "block-scripts": "0.0.10",
+    "block-scripts": "0.0.11",
     "mock-block-dock": "0.0.15",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/packages/blocks/toggle-item/package.json
+++ b/packages/blocks/toggle-item/package.json
@@ -20,7 +20,7 @@
     "blockprotocol": "0.0.10"
   },
   "devDependencies": {
-    "block-scripts": "0.0.10",
+    "block-scripts": "0.0.11",
     "mock-block-dock": "0.0.10",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/packages/blocks/video/package.json
+++ b/packages/blocks/video/package.json
@@ -22,7 +22,7 @@
     "@blockprotocol/graph": "0.0.8"
   },
   "devDependencies": {
-    "block-scripts": "0.0.10",
+    "block-scripts": "0.0.11",
     "eslint": "8.13.0",
     "mock-block-dock": "0.0.15",
     "react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9116,10 +9116,10 @@ bl@^4.0.3:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-block-scripts@0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/block-scripts/-/block-scripts-0.0.10.tgz#fed9b65faf24ee1c6da9f9d26f0523f0d0682923"
-  integrity sha512-a2lyYj3t2lyvrqnHZnTr8iRUlwyJKhomxZqOYVwLLJ8dgo+A2Ac6olGVdhB74teQK/WYVCau0VPWxaXfrdA57A==
+block-scripts@0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/block-scripts/-/block-scripts-0.0.11.tgz#5cf21c033aa912a67606d388c9f139fb447ef85c"
+  integrity sha512-34Iqie0UwYVrzGGu2ErjMjdzJV70YtOVsOhYKA/jkwIbYl8gO1uVLknUkFdY705im76c156ZOSnr8IEAOvK1/w==
   dependencies:
     "@babel/cli" "^7.17.6"
     "@babel/core" "^7.17.9"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Bumping all block-scripts to 0.0.11 to get smaller bundle sizes!

