### PR TITLE
Enable Page Archiving

### DIFF
--- a/packages/hash/api/src/graphql/resolvers/pages/accountPages.ts
+++ b/packages/hash/api/src/graphql/resolvers/pages/accountPages.ts
@@ -7,10 +7,12 @@ export const accountPages: Resolver<
   {},
   GraphQLContext,
   QueryAccountPagesArgs
-> = async (_, { accountId }, { dataSources }) => {
+> = async (_, { accountId, archived }, { dataSources }) => {
   const pages = await Page.getAllPagesInAccount(dataSources.db, {
     accountId,
   });
 
-  return pages.map((page) => page.toGQLUnknownEntity());
+  return pages
+    .filter((page) => !!page.properties.archived === archived)
+    .map((page) => page.toGQLUnknownEntity());
 };

--- a/packages/hash/api/src/graphql/typeDefs/page.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/page.typedef.ts
@@ -146,7 +146,7 @@ export const pageTypedef = gql`
     """
     Return a list of pages belonging to an account
     """
-    accountPages(accountId: ID!): [Page!]!
+    accountPages(accountId: ID!, archived: Boolean = false): [Page!]!
 
     """
     Search for pages matching a query string.
@@ -169,6 +169,7 @@ export const pageTypedef = gql`
     contents: [JSONObject!]
     title: String
     summary: String
+    archived: Boolean
   }
 
   """

--- a/packages/hash/frontend/src/components/hooks/useArchivePage.ts
+++ b/packages/hash/frontend/src/components/hooks/useArchivePage.ts
@@ -1,0 +1,45 @@
+import { useMutation } from "@apollo/client";
+import { useRouter } from "next/router";
+import {
+  UpdatePageMutation,
+  UpdatePageMutationVariables,
+} from "@hashintel/hash-shared/graphql/apiTypes.gen";
+import { updatePage } from "@hashintel/hash-shared/queries/page.queries";
+
+import { useCallback } from "react";
+import { getAccountPages } from "../../graphql/queries/account.queries";
+
+export const useArchivePage = (accountId: string) => {
+  const router = useRouter();
+
+  const [updateEntityFn] = useMutation<
+    UpdatePageMutation,
+    UpdatePageMutationVariables
+  >(updatePage, {
+    refetchQueries: () => [
+      {
+        query: getAccountPages,
+        variables: { accountId },
+      },
+    ],
+  });
+
+  const archivePage = useCallback(
+    async (pageEntityId: string) => {
+      await updateEntityFn({
+        variables: {
+          accountId,
+          entityId: pageEntityId,
+          properties: { archived: true },
+        },
+      });
+
+      if (router.asPath === `/${accountId}/${pageEntityId}`) {
+        return router.push(`/${accountId}`);
+      }
+    },
+    [updateEntityFn, accountId, router],
+  );
+
+  return archivePage;
+};

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-menu.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-menu.tsx
@@ -1,9 +1,10 @@
 import { VFC, useMemo, useState } from "react";
 import { ListItemIcon, ListItemText, Menu } from "@mui/material";
 import { bindMenu, PopupState } from "material-ui-popup-state/hooks";
-import { faLink } from "@fortawesome/free-solid-svg-icons";
+import { faArchive, faLink } from "@fortawesome/free-solid-svg-icons";
 import { faFileAlt } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon } from "@hashintel/hash-design-system";
+import { useArchivePage } from "../../../../components/hooks/useArchivePage";
 import { useRouteAccountInfo } from "../../../routing";
 import { useCreatePage } from "../../../../components/hooks/useCreatePage";
 import { MenuItem } from "../../../ui";
@@ -17,6 +18,7 @@ export const PageMenu: VFC<PageMenuProps> = ({ popupState, entityId }) => {
   const [copied, setCopied] = useState(false);
   const { accountId } = useRouteAccountInfo();
   const { createSubPage } = useCreatePage(accountId);
+  const archivePage = useArchivePage(accountId);
 
   // Commented out menu items whose functionality have not been
   // implemented yet
@@ -56,6 +58,21 @@ export const PageMenu: VFC<PageMenuProps> = ({ popupState, entityId }) => {
           }, 2000);
         },
       },
+      {
+        title: "Archive page",
+        icon: faArchive,
+        onClick: async () => {
+          try {
+            // @todo handle loading/error states properly
+            await archivePage(entityId);
+          } catch (err) {
+            // eslint-disable-next-line no-console -- TODO: consider using logger
+            console.log("err ==> ", err);
+          } finally {
+            popupState.close();
+          }
+        },
+      },
       // {
       //   title: "Duplicate Page",
       //   icon: faCopy,
@@ -81,7 +98,7 @@ export const PageMenu: VFC<PageMenuProps> = ({ popupState, entityId }) => {
       //   faded: true
       // },
     ],
-    [copied, popupState, createSubPage, accountId, entityId],
+    [copied, popupState, createSubPage, accountId, entityId, archivePage],
   );
   return (
     <Menu {...bindMenu(popupState)}>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR adds the functionality to archive a page, hiding it from the account pages menu.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1200211978612931/1202229587925502/f) _(internal)_

## 🔍 What does this change?

- Added an archive button to the page-menu popover, when the user clicks it the page is archived (disappearing from the account pages menu) and the user is taken to the homepage (if he was inside the page that was archived);
-  Added the parameter `archived` to the query `accountPages`, defaulted to `false`, and changed its resolver to filter pages based on this parameter.

## ⚠️ Known issues

- Right now there's no confirmation request when archiving a page, is this something to consider?
- When a page is archived, it can still be viewed by navigating to its URL. Is this intended or should archived pages not be viewable?

## 🐾 Next steps

- Error Handling

## ❓ How to test this?

1.  Create a page;
2.  While viewing the page, open the page menu on the left sidebar and click on `Archive page`;
3. Check that you are redirected to the homepage and the page disappears from the sidebar;

## 📹 Demo

![deletePage](https://user-images.githubusercontent.com/37453800/175359848-ead6c69e-3696-451c-97e4-44c1968ddeee.gif)

