### PR TITLE
Bump Rust toolchain to `nightly-2022-06-26`

### DIFF
--- a/packages/engine/lib/execution/src/package/simulation/context/creator.rs
+++ b/packages/engine/lib/execution/src/package/simulation/context/creator.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, lazy::SyncOnceCell};
+use std::{collections::HashMap, sync::OnceLock};
 
 use crate::{
     package::simulation::{
@@ -17,7 +17,7 @@ pub struct ContextPackageCreators {
 
 impl ContextPackageCreators {
     pub fn initialize_for_experiment_run(_config: &PackageInitConfig) -> Result<&'static Self> {
-        static PACKAGE_CREATORS: SyncOnceCell<ContextPackageCreators> = SyncOnceCell::new();
+        static PACKAGE_CREATORS: OnceLock<ContextPackageCreators> = OnceLock::new();
         PACKAGE_CREATORS.get_or_try_init(|| {
             tracing::debug!("Initializing Context Package Creators");
             let mut creators = HashMap::<_, Box<dyn ContextPackageCreator>>::with_capacity(3);

--- a/packages/engine/lib/execution/src/package/simulation/init/creator.rs
+++ b/packages/engine/lib/execution/src/package/simulation/init/creator.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, lazy::SyncOnceCell};
+use std::{collections::HashMap, sync::OnceLock};
 
 use crate::{
     package::simulation::{
@@ -16,7 +16,7 @@ pub struct InitPackageCreators {
 
 impl InitPackageCreators {
     pub fn initialize_for_experiment_run(_config: &PackageInitConfig) -> Result<&'static Self> {
-        static PACKAGE_CREATORS: SyncOnceCell<InitPackageCreators> = SyncOnceCell::new();
+        static PACKAGE_CREATORS: OnceLock<InitPackageCreators> = OnceLock::new();
         PACKAGE_CREATORS.get_or_try_init(|| {
             tracing::debug!("Initializing Init Package Creators");
             let mut creators = HashMap::<_, Box<dyn InitPackageCreator>>::with_capacity(2);

--- a/packages/engine/lib/execution/src/package/simulation/init/js_py/mod.rs
+++ b/packages/engine/lib/execution/src/package/simulation/init/js_py/mod.rs
@@ -93,13 +93,11 @@ impl InitPackageCreator for JsPyInitCreator {
                 initial_state: init_config.initial_state.clone(),
                 comms,
             })),
-            name => {
-                return Err(Error::from(format!(
-                    "Trying to create a JS/Python init package but the initial state source \
-                     didn't end in '.js' or '.py': {:?}",
-                    name
-                )));
-            }
+            name => Err(Error::from(format!(
+                "Trying to create a JS/Python init package but the initial state source didn't \
+                 end in '.js' or '.py': {:?}",
+                name
+            ))),
         }
     }
 }

--- a/packages/engine/lib/execution/src/package/simulation/init/json/mod.rs
+++ b/packages/engine/lib/execution/src/package/simulation/init/json/mod.rs
@@ -50,13 +50,11 @@ impl InitPackageCreator for JsonInitCreator {
             InitialStateName::InitJson => Ok(Box::new(JsonInit {
                 initial_state_src: init_config.initial_state.src.clone(),
             })),
-            name => {
-                return Err(Error::from(format!(
-                    "Trying to create a JSON init package but the init file didn't end in .json \
-                     but instead was: {:?}",
-                    name
-                )));
-            }
+            name => Err(Error::from(format!(
+                "Trying to create a JSON init package but the init file didn't end in .json but \
+                 instead was: {:?}",
+                name
+            ))),
         }
     }
 }

--- a/packages/engine/lib/execution/src/package/simulation/output/creator.rs
+++ b/packages/engine/lib/execution/src/package/simulation/output/creator.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, lazy::SyncOnceCell};
+use std::{collections::HashMap, sync::OnceLock};
 
 use crate::{
     package::simulation::{
@@ -17,7 +17,7 @@ pub struct OutputPackageCreators {
 
 impl OutputPackageCreators {
     pub fn initialize_for_experiment_run(_config: &PackageInitConfig) -> Result<&'static Self> {
-        static PACKAGE_CREATORS: SyncOnceCell<OutputPackageCreators> = SyncOnceCell::new();
+        static PACKAGE_CREATORS: OnceLock<OutputPackageCreators> = OnceLock::new();
         PACKAGE_CREATORS.get_or_try_init(|| {
             tracing::debug!("Initializing Output Package Creators");
             let mut creators = HashMap::<_, Box<dyn OutputPackageCreator>>::with_capacity(2);

--- a/packages/engine/lib/execution/src/package/simulation/state/creator.rs
+++ b/packages/engine/lib/execution/src/package/simulation/state/creator.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, lazy::SyncOnceCell};
+use std::{collections::HashMap, sync::OnceLock};
 
 use crate::{
     package::simulation::{
@@ -17,7 +17,7 @@ pub struct StatePackageCreators {
 
 impl StatePackageCreators {
     pub fn initialize_for_experiment_run(config: &PackageInitConfig) -> Result<&'static Self> {
-        static PACKAGE_CREATORS: SyncOnceCell<StatePackageCreators> = SyncOnceCell::new();
+        static PACKAGE_CREATORS: OnceLock<StatePackageCreators> = OnceLock::new();
         PACKAGE_CREATORS.get_or_try_init(|| {
             tracing::debug!("Initializing State Package Creators");
             let mut creators = HashMap::<_, Box<dyn StatePackageCreator>>::with_capacity(2);

--- a/packages/engine/lib/execution/src/package/simulation/state/topology/config.rs
+++ b/packages/engine/lib/execution/src/package/simulation/state/topology/config.rs
@@ -97,7 +97,7 @@ impl<'de> Deserialize<'de> for AxisBoundary {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Debug, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WrappingBehavior {
     /// Agents crossing the border re-enter on the other side
@@ -263,7 +263,7 @@ impl Default for WrappingBehavior {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Debug, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WrappingPreset {
     Spherical,
@@ -272,7 +272,7 @@ pub enum WrappingPreset {
     Reflection,
 }
 
-#[derive(Clone, Copy, PartialEq, Debug, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DistanceFunction {
     /// The distance function associated with the L-1 norm

--- a/packages/engine/lib/execution/src/runner/comms/outbound.rs
+++ b/packages/engine/lib/execution/src/runner/comms/outbound.rs
@@ -61,7 +61,7 @@ impl From<flatbuffers_gen::runner_warning_generated::RunnerWarning<'_>> for Runn
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UserError(pub String);
 
 impl From<flatbuffers_gen::user_error_generated::UserError<'_>> for UserError {
@@ -76,7 +76,7 @@ impl std::fmt::Display for UserError {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UserWarning {
     pub message: String,
     pub details: Option<String>,
@@ -101,7 +101,7 @@ impl std::fmt::Display for UserWarning {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PackageError(pub String);
 
 impl From<flatbuffers_gen::package_error_generated::PackageError<'_>> for PackageError {

--- a/packages/engine/lib/execution/src/runner/error.rs
+++ b/packages/engine/lib/execution/src/runner/error.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Clone, Debug, Default, PartialEq)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default, PartialEq, Eq)]
 pub struct RunnerError {
     // TODO: Rename, because "runner errors" should always be internal,
     //       but this might not be.

--- a/packages/engine/lib/memory/src/arrow/meta/buffer.rs
+++ b/packages/engine/lib/memory/src/arrow/meta/buffer.rs
@@ -36,7 +36,7 @@ impl Buffer {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BufferType {
     /// This buffer contains the null bitmap of the node or is just binary data
     BitMap { is_null_bitmap: bool },

--- a/packages/engine/lib/memory/src/arrow/meta/node.rs
+++ b/packages/engine/lib/memory/src/arrow/meta/node.rs
@@ -41,7 +41,7 @@ impl NodeMapping {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NodeStatic {
     /// 1 if is row-level or other buffers point to a non-fixed-size list,
     /// > 1 if direct child of fixed size list

--- a/packages/engine/lib/memory/src/shared_memory/ffi.rs
+++ b/packages/engine/lib/memory/src/shared_memory/ffi.rs
@@ -40,10 +40,7 @@ unsafe extern "C" fn free_memory(c_memory: *mut CSegment) {
     Box::from_raw((*c_memory).segment as *mut Segment);
 }
 
-// Hack to get a compile-time error if the Raw File
-// descriptor is of an unexpected size
-fn _size_check() {
-    unsafe {
-        std::mem::transmute::<RawFd, i32>(0);
-    }
-}
+const _: () = assert!(
+    std::mem::size_of::<RawFd>() == 4,
+    "RawFd must be 4 bytes in size"
+);

--- a/packages/engine/lib/memory/src/shared_memory/metaversion.rs
+++ b/packages/engine/lib/memory/src/shared_memory/metaversion.rs
@@ -160,7 +160,7 @@ use crate::{
 /// Simple way for every component (language runners + main loop) using the datastore to track
 /// whether it has to reload memory or reload the record batch.
 #[must_use]
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct Metaversion {
     memory: u32,
     batch: u32,

--- a/packages/engine/lib/memory/src/shared_memory/segment.rs
+++ b/packages/engine/lib/memory/src/shared_memory/segment.rs
@@ -47,7 +47,7 @@ impl<'a> Buffers<'a> {
 ///
 /// Holds a UUID and a random suffix. The UUID can be reused for different [`Segment`]s and can all
 /// be cleaned up by calling [`cleanup_by_base_id`].
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct MemoryId {
     id: Uuid,
     suffix: u16,

--- a/packages/engine/lib/simulation-control/src/command/mod.rs
+++ b/packages/engine/lib/simulation-control/src/command/mod.rs
@@ -69,7 +69,7 @@ impl Default for StopStatus {
 /// Command to stop the simulation.
 ///
 /// Stores the [`StopMessage`] and the agent's UUID.
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StopCommand {
     pub message: StopMessage,
     pub agent: AgentId,
@@ -80,7 +80,7 @@ pub struct StopCommand {
 /// See the [HASH-documentation] for more information.
 ///
 /// [HASH-documentation]: https://hash.ai/docs/simulation/creating-simulations/agent-messages/built-in-message-handlers#Stopping-a-simulation
-#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StopMessage {
     pub status: StopStatus,
     pub reason: Option<String>,

--- a/packages/engine/lib/simulation-control/src/engine_status.rs
+++ b/packages/engine/lib/simulation-control/src/engine_status.rs
@@ -10,7 +10,7 @@ use stateful::global::Globals;
 
 use crate::SimStatus;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum EngineStatus {
     Started,
     SimStatus(SimStatus),

--- a/packages/engine/lib/simulation-control/src/status.rs
+++ b/packages/engine/lib/simulation-control/src/status.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::{command::StopCommand, Result};
 
 // Sent from sim runs to experiment main loop.
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SimStatus {
     pub sim_id: SimulationId,
     pub steps_taken: isize,

--- a/packages/engine/lib/stateful/src/agent/arrow/array.rs
+++ b/packages/engine/lib/stateful/src/agent/arrow/array.rs
@@ -218,7 +218,7 @@ fn builder_add_id(builder: &mut FixedSizeBinaryBuilder, id: AgentId) -> Result<(
     Ok(builder.append_value(id.as_bytes())?)
 }
 
-pub(in crate) fn get_agent_id_array(agent_ids: &[AgentId]) -> Result<FixedSizeBinaryArray> {
+pub(crate) fn get_agent_id_array(agent_ids: &[AgentId]) -> Result<FixedSizeBinaryArray> {
     let mut builder =
         FixedSizeBinaryBuilder::new(agent_ids.len() * UUID_V4_LEN, UUID_V4_LEN as i32);
     for agent_id in agent_ids {

--- a/packages/engine/lib/stateful/src/agent/arrow/boolean.rs
+++ b/packages/engine/lib/stateful/src/agent/arrow/boolean.rs
@@ -8,7 +8,7 @@ pub struct BooleanColumn {
 
 impl BooleanColumn {
     // Assumes underlying array is a non-nullable boolean array
-    pub(in crate) fn new_non_nullable(array: &Arc<dyn Array>) -> Self {
+    pub(crate) fn new_non_nullable(array: &Arc<dyn Array>) -> Self {
         let data = array.data_ref();
         let bool_buffer = &data.buffers()[0];
         Self {

--- a/packages/engine/lib/stateful/src/agent/arrow/mod.rs
+++ b/packages/engine/lib/stateful/src/agent/arrow/mod.rs
@@ -1,7 +1,7 @@
 //! Low-level interface to [`AgentBatch`].
 
-pub(in crate) mod array;
-pub(in crate) mod boolean;
+pub(crate) mod array;
+pub(crate) mod boolean;
 
 mod batch;
 mod iterator;

--- a/packages/engine/lib/stateful/src/agent/arrow/record_batch.rs
+++ b/packages/engine/lib/stateful/src/agent/arrow/record_batch.rs
@@ -11,7 +11,7 @@ use crate::{
 
 // TODO: Use in Rust runner, and look up column without using PREVIOUS_INDEX_COLUMN_INDEX
 #[allow(unused, unreachable_code, clippy::diverging_sub_expression)]
-pub(in crate) fn get_old_message_index(
+pub(crate) fn get_old_message_index(
     record_batch: &RecordBatch,
     row_index: usize,
 ) -> Result<Option<&[u32; 2]>> {
@@ -69,7 +69,7 @@ pub(crate) fn agent_id_iter(
     }))
 }
 
-pub(in crate) fn agent_name_iter(
+pub(crate) fn agent_name_iter(
     record_batch: &RecordBatch,
 ) -> Result<impl Iterator<Item = Option<&str>>> {
     let column_name = AgentStateField::AgentName.name();
@@ -226,7 +226,7 @@ pub(crate) fn topology_mut_iter(
     ))
 }
 
-pub(in crate) fn position_iter(
+pub(crate) fn position_iter(
     record_batch: &RecordBatch,
 ) -> Result<impl Iterator<Item = Option<&[f64; POSITION_DIM]>>> {
     let column_name = AgentStateField::Position.name();
@@ -305,7 +305,7 @@ pub(crate) fn direction_iter(
     }))
 }
 
-pub(in crate) fn search_radius_iter(
+pub(crate) fn search_radius_iter(
     record_batch: &RecordBatch,
 ) -> Result<impl Iterator<Item = Option<f64>> + '_> {
     // TODO[1] remove dependency on neighbors package
@@ -313,7 +313,7 @@ pub(in crate) fn search_radius_iter(
     f64_iter(record_batch, column_name)
 }
 
-pub(in crate) fn f64_iter<'a>(
+pub(crate) fn f64_iter<'a>(
     record_batch: &'a RecordBatch,
     column_name: &str,
 ) -> Result<impl Iterator<Item = Option<f64>> + 'a> {
@@ -336,7 +336,7 @@ pub(in crate) fn f64_iter<'a>(
     }))
 }
 
-pub(in crate) fn exists_iter<'a>(
+pub(crate) fn exists_iter<'a>(
     record_batch: &'a RecordBatch,
     column_name: &str,
 ) -> Result<impl Iterator<Item = bool> + 'a> {
@@ -346,7 +346,7 @@ pub(in crate) fn exists_iter<'a>(
     Ok((0..row_count).map(move |i| column.is_valid(i)))
 }
 
-pub(in crate) fn str_iter<'a>(
+pub(crate) fn str_iter<'a>(
     record_batch: &'a RecordBatch,
     column_name: &str,
 ) -> Result<impl Iterator<Item = Option<&'a str>>> {
@@ -369,7 +369,7 @@ pub(in crate) fn str_iter<'a>(
     }))
 }
 
-pub(in crate) fn bool_iter<'a>(
+pub(crate) fn bool_iter<'a>(
     record_batch: &'a RecordBatch,
     column_name: &str,
 ) -> Result<impl Iterator<Item = Option<bool>> + 'a> {
@@ -393,7 +393,7 @@ pub(in crate) fn bool_iter<'a>(
 }
 
 // Iterate string fields and deserialize them into serde_json::Value objects
-pub(in crate) fn json_deserialize_str_value_iter<'a>(
+pub(crate) fn json_deserialize_str_value_iter<'a>(
     record_batch: &'a RecordBatch,
     column_name: &str,
 ) -> Result<impl Iterator<Item = serde_json::Value> + 'a> {
@@ -413,7 +413,7 @@ pub(in crate) fn json_deserialize_str_value_iter<'a>(
 
 // Iterate over any non-serialized fields (like f64, array, struct, ...) and serialize them into
 // serde_json::Value objects
-pub(in crate) fn json_values(
+pub(crate) fn json_values(
     record_batch: &RecordBatch,
     column_name: &str,
     data_type: &DataType,

--- a/packages/engine/lib/stateful/src/agent/field.rs
+++ b/packages/engine/lib/stateful/src/agent/field.rs
@@ -176,7 +176,7 @@ pub(crate) const BUILTIN_FIELDS: [&str; 12] = [
     AgentStateField::Hidden.name(),
 ];
 
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct AgentId {
     id: Uuid,

--- a/packages/engine/lib/stateful/src/agent/name.rs
+++ b/packages/engine/lib/stateful/src/agent/name.rs
@@ -3,7 +3,7 @@ use core::ops::Deref;
 use serde::{Deserialize, Serialize};
 use serde_aux::prelude::deserialize_string_from_number;
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct AgentName(#[serde(deserialize_with = "deserialize_string_from_number")] pub String);
 
 impl Deref for AgentName {

--- a/packages/engine/lib/stateful/src/agent/required.rs
+++ b/packages/engine/lib/stateful/src/agent/required.rs
@@ -9,7 +9,7 @@ const REQUIRED: [AgentStateField; 4] = [
     AgentStateField::Direction,
 ];
 
-pub(in crate) trait IsRequired {
+pub(crate) trait IsRequired {
     fn is_required(&self) -> bool;
 }
 

--- a/packages/engine/lib/stateful/src/field/mod.rs
+++ b/packages/engine/lib/stateful/src/field/mod.rs
@@ -26,9 +26,9 @@ mod spec_map;
 ///
 /// This means their length is 128 bits i.e. 16 bytes
 pub const UUID_V4_LEN: usize = std::mem::size_of::<u128>();
-pub(in crate) const POSITION_DIM: usize = 3;
+pub(crate) const POSITION_DIM: usize = 3;
 
-pub(in crate) use self::fixed_size::IsFixedSize;
+pub(crate) use self::fixed_size::IsFixedSize;
 pub use self::{
     accessor::FieldSpecMapAccessor,
     field_type::{FieldType, FieldTypeVariant, PresetFieldType},

--- a/packages/engine/lib/stateful/src/global/globals.rs
+++ b/packages/engine/lib/stateful/src/global/globals.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 /// For a high-level concept of globals, please see the [HASH documentation].
 ///
 /// [HASH documentation]: https://hash.ai/docs/simulation/creating-simulations/configuration
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Globals(pub serde_json::Value);
 
 impl Globals {

--- a/packages/engine/lib/stateful/src/message/arrow/array.rs
+++ b/packages/engine/lib/stateful/src/message/arrow/array.rs
@@ -125,7 +125,7 @@ impl ArrayBuilder for MessageBuilder {
 
 #[derive(Debug)]
 #[repr(transparent)] // Required for `&ListArray -> &OutboundArray`
-pub(in crate) struct MessageArray(pub ListArray);
+pub(crate) struct MessageArray(pub ListArray);
 
 impl MessageArray {
     pub fn new(len: usize) -> Result<Self> {

--- a/packages/engine/lib/stateful/src/message/arrow/record_batch.rs
+++ b/packages/engine/lib/stateful/src/message/arrow/record_batch.rs
@@ -10,7 +10,7 @@ use crate::{
     Error, Result,
 };
 
-pub(in crate) fn message_usize_index_iter(
+pub(crate) fn message_usize_index_iter(
     record_batch: &RecordBatch,
     batch_index: usize,
 ) -> impl IndexedParallelIterator<Item = impl ParallelIterator<Item = MessageReference>> {
@@ -32,7 +32,7 @@ pub(in crate) fn message_usize_index_iter(
     })
 }
 
-pub(in crate) fn message_recipients_iter(
+pub(crate) fn message_recipients_iter(
     record_batch: &RecordBatch,
 ) -> impl IndexedParallelIterator<Item = impl ParallelIterator<Item = Vec<&str>>> {
     let num_agents = record_batch.num_rows();

--- a/packages/engine/lib/stateful/src/message/kind.rs
+++ b/packages/engine/lib/stateful/src/message/kind.rs
@@ -1,19 +1,19 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum CreateAgent {
     #[serde(rename = "create_agent")]
     Type,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum RemoveAgent {
     // one bad thing about serde is how we still have to retype literals
     #[serde(rename = "remove_agent")]
     Type,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum StopSim {
     #[serde(rename = "stop")]
     Type,

--- a/packages/engine/lib/stateful/src/message/mod.rs
+++ b/packages/engine/lib/stateful/src/message/mod.rs
@@ -34,7 +34,7 @@ pub use self::{
     pool::{MessageBatchPool, MessageReader},
     schema::MessageSchema,
 };
-pub(in crate) use self::{
+pub(crate) use self::{
     kind::{CreateAgent, RemoveAgent, StopSim},
     outbound::Error as OutboundError,
 };

--- a/packages/engine/lib/stateful/src/message/outbound.rs
+++ b/packages/engine/lib/stateful/src/message/outbound.rs
@@ -253,7 +253,7 @@ impl Message {
     ///
     /// This function will panic if `value` is not a valid JSON array.
     /// TODO: Make sure this function is named as unchecekd to prevent unknown panics
-    pub(in crate) fn from_json_array_with_state(
+    pub(crate) fn from_json_array_with_state(
         value: serde_json::Value,
         agent_state: &Agent,
     ) -> Result<Vec<Message>, Error> {

--- a/packages/engine/lib/stateful/src/message/payload.rs
+++ b/packages/engine/lib/stateful/src/message/payload.rs
@@ -41,12 +41,12 @@ impl CreateAgent {
     pub const KIND: &'static str = "create_agent";
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct RemoveAgentData {
     pub agent_id: AgentId,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct RemoveAgent {
     pub r#type: message::RemoveAgent,
     #[serde(deserialize_with = "value_or_string_array")]
@@ -58,7 +58,7 @@ impl RemoveAgent {
     pub const KIND: &'static str = "remove_agent";
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct StopSim {
     pub r#type: message::StopSim,
     #[serde(deserialize_with = "value_or_string_array")]
@@ -71,7 +71,7 @@ impl StopSim {
 }
 
 /// Payload for arbitrary JSON data.
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct Generic {
     pub r#type: String,
 

--- a/packages/engine/rust-toolchain.toml
+++ b/packages/engine/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2022-05-10"
+channel = "nightly-2022-06-26"

--- a/packages/libs/error-stack/src/iter.rs
+++ b/packages/libs/error-stack/src/iter.rs
@@ -27,7 +27,7 @@ impl<'r> Iterator for Frames<'r> {
     fn next(&mut self) -> Option<Self::Item> {
         self.current.take().map(|current| {
             if let Some(source) = current.source() {
-                self.current = Some(&*source);
+                self.current = Some(source);
             }
             current
         })

--- a/packages/libs/error-stack/src/test_helper.rs
+++ b/packages/libs/error-stack/src/test_helper.rs
@@ -6,7 +6,7 @@ use core::{fmt, fmt::Formatter};
 
 use crate::{AttachmentKind, Context, Frame, FrameKind, Report};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ContextA;
 
 impl fmt::Display for ContextA {
@@ -17,7 +17,7 @@ impl fmt::Display for ContextA {
 
 impl Context for ContextA {}
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ContextB;
 
 impl fmt::Display for ContextB {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `nightly-2022-06-26` toolchain contains a bunch of new clippy lints and the `provide_any` feature.

## 🔍 What does this change?

- Bump toolchain
- `lazy::SyncOnceCell` was renamed to `sync::OnceLock`, update our usages
- Apply `clippy` lints:
    - Derive `Eq` if possible and `PartialEq` is derived
    - Remove unneeded `return`s
    - Rewrite a workaround to a static assertion
- Apply `rustfmt`