### PR TITLE
Fix usage statement for `feature = "spantrace"`

### DIFF
--- a/packages/libs/error-stack/src/report.rs
+++ b/packages/libs/error-stack/src/report.rs
@@ -1,12 +1,9 @@
 use alloc::{boxed::Box, string::ToString, vec::Vec};
 use core::{fmt, fmt::Write, marker::PhantomData, panic::Location};
+#[cfg(all(nightly, feature = "std"))]
+use std::backtrace::{Backtrace, BacktraceStatus};
 #[cfg(feature = "std")]
 use std::process::ExitCode;
-#[cfg(all(nightly, feature = "std"))]
-use std::{
-    any,
-    backtrace::{Backtrace, BacktraceStatus},
-};
 
 #[cfg(feature = "spantrace")]
 use tracing_error::{SpanTrace, SpanTraceStatus};
@@ -188,14 +185,14 @@ impl<C> Report<C> {
         let provider = temporary_provider(&context);
 
         #[cfg(all(nightly, feature = "std"))]
-        let backtrace = if any::request_ref::<Backtrace, _>(&provider).is_some() {
+        let backtrace = if core::any::request_ref::<Backtrace, _>(&provider).is_some() {
             None
         } else {
             Some(Backtrace::capture())
         };
 
         #[cfg(all(nightly, feature = "spantrace"))]
-        let span_trace = if any::request_ref::<SpanTrace, _>(&provider).is_some() {
+        let span_trace = if core::any::request_ref::<SpanTrace, _>(&provider).is_some() {
             None
         } else {
             Some(SpanTrace::capture())


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

https://github.com/hashintel/hash/pull/697 introduced a compilation failure if `feature = "spantrace"` is set but *not* `feature = "std"`.

## 🔗 Related links

- Bug discovered by #694