### PR TITLE
Stick Rust version for the Graph crate

### DIFF
--- a/packages/graph/rust-toolchain.toml
+++ b/packages/graph/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2022-06-26"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Sticks the Rust version to `nightly-2022-06-26`