### PR TITLE
Use `cargo make` in CI

### DIFF
--- a/.github/scripts/rust/Makefile.toml
+++ b/.github/scripts/rust/Makefile.toml
@@ -10,6 +10,15 @@ CARGO_HACK_FLAGS = "--feature-powerset --exclude-features default"
 CARGO_MAKE_CARGO_PROFILE = "release"
 
 
+[tasks.default]
+extend = "build"
+category = ""
+
+[tasks.all]
+description = "Builds the project, checks lints, and runs the tests. Additional parameters are passed to `build` and `test`."
+run_task = { name = ["build", "lint", "test"] }
+
+
 ################################################################################
 ## Build                                                                      ##
 ################################################################################
@@ -35,6 +44,11 @@ args = ["run", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "${@}"]
 ################################################################################
 ## Lints                                                                      ##
 ################################################################################
+[tasks.lint]
+description = "Runs all lints"
+category = "Lint"
+run_task = { name = ["format-task-ci", "clippy-task-ci", "doc-task-ci-public", "doc-task-ci-private"] }
+
 [tasks.format]
 condition = { channels = ["nightly"] }
 description = "Runs the rustfmt formatter"
@@ -54,13 +68,6 @@ dependencies = ["install-rustfmt"]
 [tasks.format-task-ci]
 extend = "format-task"
 args = ["fmt", "--", "--check"]
-
-[tasks.check]
-description = "Checks the crate with all feature flag permutations"
-category = "Lint"
-command = "cargo"
-args = ["hack", "check", "--tests", "@@split(CARGO_HACK_FLAGS, )", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "${@}"]
-dependencies = ["install-cargo-hack"]
 
 [tasks.clippy]
 description = "Runs clippy with all feature flag permutations"

--- a/.github/scripts/rust/Makefile.toml
+++ b/.github/scripts/rust/Makefile.toml
@@ -1,0 +1,150 @@
+[config.modify_core_tasks]
+private = true
+namespace = "default"
+
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+CARGO_HACK_FLAGS = "--feature-powerset --exclude-features default"
+
+[env.production]
+CARGO_MAKE_CARGO_PROFILE = "release"
+
+
+################################################################################
+## Build                                                                      ##
+################################################################################
+[tasks.build]
+description = "Builds the crate"
+category = "Build"
+workspace = false
+command = "cargo"
+args = ["build", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "${@}"]
+
+
+################################################################################
+## Run                                                                        ##
+################################################################################
+[tasks.run]
+description = "Builds the binary and runs it"
+category = "Run"
+workspace = false
+command = "cargo"
+args = ["run", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "${@}"]
+
+
+################################################################################
+## Lints                                                                      ##
+################################################################################
+[tasks.format]
+condition = { channels = ["nightly"] }
+description = "Runs the rustfmt formatter"
+category = "Lint"
+workspace = false
+run_task = [
+    { name = ["format-task-ci"] , condition = { env_true = ["CARGO_MAKE_CI" ] } },
+    { name = ["format-task"] },
+]
+
+[tasks.format-task]
+private = true
+command = "cargo"
+args = ["fmt", "${@}"]
+dependencies = ["install-rustfmt"]
+
+[tasks.format-task-ci]
+extend = "format-task"
+args = ["fmt", "--", "--check"]
+
+[tasks.check]
+description = "Checks the crate with all feature flag permutations"
+category = "Lint"
+command = "cargo"
+args = ["hack", "check", "--tests", "@@split(CARGO_HACK_FLAGS, )", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "${@}"]
+dependencies = ["install-cargo-hack"]
+
+[tasks.clippy]
+description = "Runs clippy with all feature flag permutations"
+category = "Lint"
+run_task = [
+    { name = ["clippy-task-ci"] , condition = { env_true = ["CARGO_MAKE_CI" ] } },
+    { name = ["clippy-task"] },
+]
+
+[tasks.clippy-task]
+private = true
+command = "cargo"
+args = ["hack", "clippy", "--no-deps", "--tests", "@@split(CARGO_HACK_FLAGS, )", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "${@}"]
+dependencies = ["install-cargo-hack", "install-clippy"]
+
+[tasks.clippy-task-ci]
+extend = "clippy-task"
+args = ["hack", "clippy", "--no-deps", "--tests", "@@split(CARGO_HACK_FLAGS, )", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "--", "-D", "warnings"]
+
+
+################################################################################
+## Docs                                                                       ##
+################################################################################
+[tasks.doc]
+condition = { channels = ["nightly"] }
+description = "Builds the documentation for the crate"
+category = "Docs"
+workspace = false
+run_task = [
+    { name = ["doc-task-ci-public", "doc-task-ci-private"] , fork = true, condition = { env_true = ["CARGO_MAKE_CI" ] } },
+    { name = ["doc-task"] },
+]
+
+[tasks.doc-task]
+condition = { env_false = ["CARGO_MAKE_CI"] }
+private = true
+command = "cargo"
+args = ["doc", "--workspace", "--all-features", "--no-deps", "${@}"]
+
+[tasks.doc-task-ci-public]
+private = true
+command = "cargo"
+args = ["rustdoc", "--all-features", "--", "-Z", "unstable-options", "--check", "-D", "warnings"]
+
+[tasks.doc-task-ci-private]
+extend = "doc-task-ci-public"
+args = ["rustdoc", "--all-features", "--", "-Z", "unstable-options", "--check", "--document-private-items", "-D", "warnings"]
+
+
+################################################################################
+## Tests                                                                      ##
+################################################################################
+[tasks.test]
+description = "Runs the test suite with all feature flag permutations"
+category = "Test"
+command = "cargo"
+args = ["hack", "test", "--no-fail-fast", "@@split(CARGO_HACK_FLAGS, )", "--profile", "${CARGO_MAKE_CARGO_PROFILE}"]
+dependencies = ["install-cargo-hack"]
+
+[tasks.miri]
+condition = { channels = ["nightly"] }
+description = "Runs miri tests with all feature flag permutations"
+category = "Test"
+command = "cargo"
+args = ["hack", "miri", "test", "@@split(CARGO_HACK_FLAGS, )", "--profile", "${CARGO_MAKE_CARGO_PROFILE}"]
+dependencies = ["install-cargo-hack", "install-miri"]
+
+
+################################################################################
+## Tools                                                                      ##
+################################################################################
+[tasks.install-cargo-hack]
+private = true
+install_crate = { crate_name = "cargo-hack", binary = "cargo", test_arg = ["hack", "--version"] }
+
+[tasks.install-clippy]
+private = true
+install_crate = { rustup_component_name = "clippy" }
+
+[tasks.install-rustfmt]
+private = true
+install_crate = { rustup_component_name = "rustfmt" }
+
+[tasks.install-miri]
+private = true
+condition = { channels = ["nightly"] }
+install_crate = { rustup_component_name = "miri" }

--- a/.github/scripts/rust/Makefile.toml
+++ b/.github/scripts/rust/Makefile.toml
@@ -47,7 +47,7 @@ args = ["run", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "${@}"]
 [tasks.lint]
 description = "Runs all lints"
 category = "Lint"
-run_task = { name = ["format-task-ci", "clippy-task-ci", "doc-task-ci-public", "doc-task-ci-private"] }
+run_task = { name = ["format-task-check", "clippy-task-check", "doc-task-check-public", "doc-task-check-private"] }
 
 [tasks.format]
 condition = { channels = ["nightly"] }
@@ -55,7 +55,7 @@ description = "Runs the rustfmt formatter"
 category = "Lint"
 workspace = false
 run_task = [
-    { name = ["format-task-ci"] , condition = { env_true = ["CARGO_MAKE_CI" ] } },
+    { name = ["format-task-check"] , condition = { env_true = ["CARGO_MAKE_CI" ] } },
     { name = ["format-task"] },
 ]
 
@@ -65,7 +65,7 @@ command = "cargo"
 args = ["fmt", "${@}"]
 dependencies = ["install-rustfmt"]
 
-[tasks.format-task-ci]
+[tasks.format-task-check]
 extend = "format-task"
 args = ["fmt", "--", "--check"]
 
@@ -73,7 +73,7 @@ args = ["fmt", "--", "--check"]
 description = "Runs clippy with all feature flag permutations"
 category = "Lint"
 run_task = [
-    { name = ["clippy-task-ci"] , condition = { env_true = ["CARGO_MAKE_CI" ] } },
+    { name = ["clippy-task-check"] , condition = { env_true = ["CARGO_MAKE_CI" ] } },
     { name = ["clippy-task"] },
 ]
 
@@ -83,7 +83,7 @@ command = "cargo"
 args = ["hack", "clippy", "--no-deps", "--tests", "@@split(CARGO_HACK_FLAGS, )", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "${@}"]
 dependencies = ["install-cargo-hack", "install-clippy"]
 
-[tasks.clippy-task-ci]
+[tasks.clippy-task-check]
 extend = "clippy-task"
 args = ["hack", "clippy", "--no-deps", "--tests", "@@split(CARGO_HACK_FLAGS, )", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "--", "-D", "warnings"]
 
@@ -97,7 +97,7 @@ description = "Builds the documentation for the crate"
 category = "Docs"
 workspace = false
 run_task = [
-    { name = ["doc-task-ci-public", "doc-task-ci-private"] , fork = true, condition = { env_true = ["CARGO_MAKE_CI" ] } },
+    { name = ["doc-task-check-public", "doc-task-check-private"] , fork = true, condition = { env_true = ["CARGO_MAKE_CI" ] } },
     { name = ["doc-task"] },
 ]
 
@@ -107,13 +107,13 @@ private = true
 command = "cargo"
 args = ["doc", "--workspace", "--all-features", "--no-deps", "${@}"]
 
-[tasks.doc-task-ci-public]
+[tasks.doc-task-check-public]
 private = true
 command = "cargo"
 args = ["rustdoc", "--all-features", "--", "-Z", "unstable-options", "--check", "-D", "warnings"]
 
-[tasks.doc-task-ci-private]
-extend = "doc-task-ci-public"
+[tasks.doc-task-check-private]
+extend = "doc-task-check-public"
 args = ["rustdoc", "--all-features", "--", "-Z", "unstable-options", "--check", "--document-private-items", "-D", "warnings"]
 
 

--- a/.github/scripts/rust/setup.py
+++ b/.github/scripts/rust/setup.py
@@ -30,18 +30,14 @@ def find_local_crates():
     """
     Returns all available crates in the workspace.
 
-    If the crate is in a sub-crate of another crate, only the super-crate will be returned.
+    If a crate is in a sub-crate of another crate, only the super-crate will be returned because `cargo-make` will run
+    the sub-crate automatically.
     :return: a list of crate paths
     """
     all_crates = [path.relative_to(CWD).parent for path in CWD.rglob("Cargo.toml")]
     checked_crates = []
     for crate in all_crates:
-        seen = False
-        for other_crate in all_crates:
-            if str(crate).startswith(str(other_crate)) and crate != other_crate:
-                seen = True
-                break
-        if not seen:
+        if not any([path in crate.parents for path in all_crates]):
             checked_crates.append(crate)
     return checked_crates
 

--- a/.github/scripts/rust/setup.py
+++ b/.github/scripts/rust/setup.py
@@ -8,15 +8,8 @@ CWD = Path.cwd()
 # All jobs for all crates will run if any of these paths change
 ALWAYS_RUN_PATTERNS = ["**/rust-toolchain.toml", ".github/**"]
 
-# Crates which will be tested in release mode
-TEST_IN_RELEASE_CRATES = ["packages/engine"]
-
 # Exclude the stable channel for these crates
-DISABLE_STABLE_PATTERNS = ["packages/engine**"]
-
-# Exclude these crates to run `rustdoc` at
-# Note: This will run `rustdoc` for all crates except the virtual package in `packages/engine`
-DISABLE_DOC_PATTERNS = ["packages/engine"]
+DISABLE_STABLE_PATTERNS = ["packages/engine**", "packages/graph/hash_graph**"]
 
 # Try and publish these crates when their version is changed in Cargo.toml
 PUBLISH_PATTERNS = ["packages/libs/error-stack"]
@@ -35,10 +28,22 @@ def generate_diffs():
 
 def find_local_crates():
     """
-    Returns all available crates in the workspace
+    Returns all available crates in the workspace.
+
+    If the crate is in a sub-crate of another crate, only the super-crate will be returned.
     :return: a list of crate paths
     """
-    return [path.relative_to(CWD).parent for path in CWD.rglob("Cargo.toml")]
+    all_crates = [path.relative_to(CWD).parent for path in CWD.rglob("Cargo.toml")]
+    checked_crates = []
+    for crate in all_crates:
+        seen = False
+        for other_crate in all_crates:
+            if str(crate).startswith(str(other_crate)) and crate != other_crate:
+                seen = True
+                break
+        if not seen:
+            checked_crates.append(crate)
+    return checked_crates
 
 
 def filter_for_changed_crates(diffs, crates):
@@ -91,24 +96,6 @@ def filter_for_nightly_only_crates(crates):
     return [crate for crate in crates for pattern in DISABLE_STABLE_PATTERNS if fnmatch(crate, pattern)]
 
 
-def filter_for_crates_to_document(crates):
-    """
-    Returns the crates which should be documented
-    :param crates: a list of paths to crates
-    :return: a list of crate paths
-    """
-    return [crate for crate in crates for pattern in DISABLE_DOC_PATTERNS if not fnmatch(crate, pattern)]
-
-
-def filter_for_crates_with_release_tests(crates):
-    """
-    Returns the crates which should run their test in release mode as well
-    :param crates: a list of paths to crates
-    :return: a list of crate paths
-    """
-    return [crate for crate in crates for pattern in TEST_IN_RELEASE_CRATES if fnmatch(crate, pattern)]
-
-
 def filter_for_publishable_crates(crates):
     """
     Returns the crates which are allowed to be published
@@ -146,14 +133,10 @@ def output(name, crates):
 def main():
     diffs = generate_diffs()
     available_crates = find_local_crates()
-    changed_crates = filter_for_changed_crates(diffs, available_crates)
+    changed_crates = list(set(filter_for_changed_crates(diffs, available_crates)))
 
-    output("rustfmt", changed_crates)
-    output("clippy", changed_crates)
+    output("lint", changed_crates)
     output("test", changed_crates)
-    output("bench", filter_for_crates_with_release_tests(changed_crates))
-    output("miri", changed_crates)
-    output("doc", filter_for_crates_to_document(changed_crates))
     output("publish", filter_crates_by_changed_version(diffs, filter_for_publishable_crates(changed_crates)))
     output_exclude(changed_crates)
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,23 +16,19 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_HACK_FLAGS: --feature-powerset --features build-nng --exclude-features default --ignore-unknown-features --optional-deps clap
 
 jobs:
   setup:
     name: setup
     runs-on: ubuntu-latest
     outputs:
-      rustfmt: ${{ steps.crates.outputs.rustfmt }}
-      clippy: ${{ steps.crates.outputs.clippy }}
+      lint: ${{ steps.crates.outputs.lint }}
       test: ${{ steps.crates.outputs.test }}
       bench: ${{ steps.crates.outputs.bench }}
-      miri: ${{ steps.crates.outputs.miri }}
-      doc: ${{ steps.crates.outputs.doc }}
       publish: ${{ steps.crates.outputs.publish }}
+      exclude: ${{ steps.crates.outputs.exclude }}
       samples: ${{ steps.samples.outputs.samples }}
       nightly: ${{ steps.toolchains.outputs.nightly }}
-      exclude: ${{ steps.crates.outputs.exclude }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -61,58 +57,16 @@ jobs:
           else
             echo "::set-output name=samples::10"
           fi
-  rustfmt:
-    name: rustfmt
+
+  lint:
+    name: lint
     needs: setup
-    if: needs.setup.outputs.rustfmt != '[]'
+    if: needs.setup.outputs.lint != '[]'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        directory: ${{ fromJSON(needs.setup.outputs.rustfmt) }}
-        toolchain:
-          - ${{ needs.setup.outputs.nightly }}
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v2
-
-      - name: Remove default members
-        run: sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.toolchain }}
-          override: true
-          components: rustfmt
-
-      - name: Check rustfmt
-        working-directory: ${{ matrix.directory }}
-        run: cargo fmt -- --check
-
-      - name: Setup PHP
-        if: ${{ failure() }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 7.3
-          coverage: none
-          tools: cs2pr
-
-      - name: Annotate
-        if: ${{ failure() }}
-        working-directory: ${{ matrix.directory }}
-        run: cargo fmt -- --emit checkstyle | cs2pr
-
-  clippy:
-    name: clippy
-    needs: setup
-    if: needs.setup.outputs.clippy != '[]'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        directory: ${{ fromJSON(needs.setup.outputs.clippy) }}
+        directory: ${{ fromJSON(needs.setup.outputs.lint) }}
         toolchain:
           - stable
           - ${{ needs.setup.outputs.nightly }}
@@ -121,20 +75,17 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v2
 
-      - name: Remove default members
-        run: sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
-
       - name: Install Rust
-        id: toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
           override: true
-          components: clippy
 
-      - name: Install tools
-        uses: taiki-e/install-action@cargo-hack
+      - name: Install cargo-make
+        run: |
+          cargo install --debug cargo-quickinstall
+          cargo quickinstall cargo-make
 
       - name: Cache dependencies
         uses: actions/cache@v2
@@ -147,12 +98,22 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/checkouts
             **/target/
-          key: ${{ runner.os }}-clippy-${{ matrix.directory }}-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-clippy-${{ matrix.directory }}-${{ matrix.toolchain }}
+          key: ${{ runner.os }}-lint-${{ matrix.directory }}-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-lint-${{ matrix.directory }}-${{ matrix.toolchain }}
 
-      - name: Run clippy
+      - name: Check formatting
+        if: matrix.toolchain != 'stable'
         working-directory: ${{ matrix.directory }}
-        run: cargo hack clippy $CARGO_HACK_FLAGS --no-deps --tests -- -D warnings
+        run: cargo make format
+
+      - name: Check clippy
+        working-directory: ${{ matrix.directory }}
+        run: cargo make clippy
+
+      - name: Check documentation
+        if: matrix.toolchain != 'stable'
+        working-directory: ${{ matrix.directory }}
+        run: cargo make doc
 
   test:
     name: test
@@ -166,6 +127,9 @@ jobs:
         toolchain:
           - stable
           - ${{ needs.setup.outputs.nightly }}
+        profile:
+          - development
+          - production
         exclude: ${{ fromJSON(needs.setup.outputs.exclude) }}
     env:
       OUTPUT_DIRECTORY: test-results
@@ -173,9 +137,6 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
-
-      - name: Remove default members
-        run: sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
 
       - name: Install Rust
         id: toolchain
@@ -185,8 +146,10 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           override: true
 
-      - name: Install tools
-        uses: taiki-e/install-action@cargo-hack
+      - name: Install cargo-make
+        run: |
+          cargo install --debug cargo-quickinstall
+          cargo quickinstall cargo-make
 
       - name: Install Python
         uses: actions/setup-python@v2
@@ -204,22 +167,17 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/checkouts
             **/target/
-          key: ${{ runner.os }}-test-${{ matrix.directory }}-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-test-${{ matrix.directory }}-${{ matrix.toolchain }}
-
-      - name: Build tests
-        if: matrix.directory == 'packages/engine'
-        working-directory: ${{ matrix.directory }}
-        run: cargo test --no-run --all-features
-
-      - name: Setup Python environment
-        if: matrix.directory == 'packages/engine'
-        working-directory: ${{ matrix.directory }}
-        run: lib/execution/src/runner/python/setup.sh python3.7
+          key: ${{ runner.os }}-test-${{ matrix.directory }}-${{ matrix.toolchain }}-${{ matrix.profile }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-test-${{ matrix.directory }}-${{ matrix.toolchain }}-${{ matrix.profile }}
 
       - name: Run tests
         working-directory: ${{ matrix.directory }}
-        run: cargo hack test $CARGO_HACK_FLAGS --no-fail-fast
+        run: cargo make --profile ${{ matrix.profile }} test
+
+      - name: Run miri
+        if: matrix.toolchain != 'stable'
+        working-directory: ${{ matrix.directory }}
+        run: cargo make --profile ${{ matrix.profile }} miri
 
       # Non-empty diff could be a Cargo.lock that wasn't committed.
       - name: Ensure empty git diff
@@ -229,75 +187,8 @@ jobs:
 
           git --no-pager diff --exit-code --color
 
-  bench:
-    name: bench
-    needs: setup
-    if: needs.setup.outputs.bench != '[]'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        directory: ${{ fromJSON(needs.setup.outputs.bench) }}
-        toolchain:
-          - stable
-          - ${{ needs.setup.outputs.nightly }}
-        exclude: ${{ fromJSON(needs.setup.outputs.exclude) }}
-    env:
-      OUTPUT_DIRECTORY: test-results
-      SAMPLES: ${{ needs.setup.outputs.samples }}
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v2
-
-      - name: Remove default members
-        run: sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
-
-      - name: Install Rust
-        id: toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.toolchain }}
-          override: true
-
-      - name: Install tools
-        uses: taiki-e/install-action@cargo-hack
-
-      - name: Install Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.7"
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/.crates.toml
-            ~/.cargo/.crates2.json
-            ~/.cargo/bin
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/checkouts
-            **/target/
-          key: ${{ runner.os }}-bench-${{ matrix.directory }}-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-bench-${{ matrix.directory }}-${{ matrix.toolchain }}
-
-      - name: Build tests
-        if: matrix.directory == 'packages/engine'
-        working-directory: ${{ matrix.directory }}
-        run: cargo test --no-run --release --all-features
-
-      - name: Setup Python environment
-        if: matrix.directory == 'packages/engine'
-        working-directory: ${{ matrix.directory }}
-        run: lib/execution/src/runner/python/setup.sh python3.7
-
-      - name: Run tests
-        working-directory: ${{ matrix.directory }}
-        run: cargo hack test $CARGO_HACK_FLAGS --no-fail-fast --release -- --test-threads 1
-
       - name: Upload to DataDog
-        if: always()
+        if: matrix.directory == 'packages/engine' && matrix.profile == 'production'
         run: |
           message=$(find ${{ matrix.directory }}/${{ env.OUTPUT_DIRECTORY }} -name timing.json -exec cat {} + \
                     | sed 's|::|-|g' \
@@ -314,120 +205,6 @@ jobs:
                     --argjson message "$message" \
                     --arg ddtags "$tags" \
                     '{ message: $message, ddsource: "hash-gh-actions", hostname: "github", service: "actions", ddtags: $ddtags }')
-
-  miri:
-    name: miri
-    needs: setup
-    if: needs.setup.outputs.miri != '[]'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        directory: ${{ fromJSON(needs.setup.outputs.miri) }}
-        toolchain:
-          - ${{ needs.setup.outputs.nightly }}
-        exclude: ${{ fromJSON(needs.setup.outputs.exclude) }}
-    env:
-      OUTPUT_DIRECTORY: test-results
-      RUST_BACKTRACE: 1
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v2
-
-      - name: Remove default members
-        run: sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
-
-      - name: Install Rust
-        id: toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.toolchain }}
-          override: true
-          components: miri
-
-      - name: Install tools
-        uses: taiki-e/install-action@cargo-hack
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/.crates.toml
-            ~/.cargo/.crates2.json
-            ~/.cargo/bin
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/checkouts
-            **/target/
-          key: ${{ runner.os }}-miri-${{ matrix.directory }}-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-miri-${{ matrix.directory }}-${{ matrix.toolchain }}
-
-      - name: Setup miri
-        working-directory: ${{ matrix.directory }}
-        run: cargo miri setup
-
-      - name: Run miri
-        working-directory: ${{ matrix.directory }}
-        run: cargo hack miri test $CARGO_HACK_FLAGS --no-fail-fast
-
-  doc:
-    name: doc
-    needs: setup
-    if: needs.setup.outputs.doc != '[]'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        directory: ${{ fromJSON(needs.setup.outputs.doc) }}
-        toolchain:
-          - ${{ needs.setup.outputs.nightly }}
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v2
-
-      - name: Remove default members
-        run: sed '/default-members/d' -i ${{ matrix.directory }}/Cargo.toml
-
-      - name: Install Rust
-        id: toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.toolchain }}
-          override: true
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/.crates.toml
-            ~/.cargo/.crates2.json
-            ~/.cargo/bin
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/checkouts
-            **/target/
-          key: ${{ runner.os }}-doc-${{ matrix.directory }}-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-doc-${{ matrix.directory }}-${{ matrix.toolchain }}
-
-      - name: Check public documentation
-        working-directory: ${{ matrix.directory }}
-        run: cargo rustdoc --all-features -- -Z unstable-options --check -D warnings
-
-      - name: Check private documentation
-        working-directory: ${{ matrix.directory }}
-        run: cargo rustdoc --all-features -- -Z unstable-options --check --document-private-items -D warnings
-
-      - name: Show public coverage
-        if: always()
-        working-directory: ${{ matrix.directory }}
-        run: cargo rustdoc --all-features -- -Z unstable-options --show-coverage
-
-      - name: Show private coverage
-        if: always()
-        working-directory: ${{ matrix.directory }}
-        run: cargo rustdoc --all-features -- -Z unstable-options --show-coverage --document-private-items
 
   publish:
     name: publish
@@ -469,28 +246,16 @@ jobs:
 
   merging-enabled:
     name: merging enabled
-    needs: [rustfmt, clippy, test, bench, miri, doc, publish]
+    needs: [lint, test, publish]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: check rustfmt
+      - name: check lint
         run: |
-          [[ ${{ needs.rustfmt.result }} =~ success|skipped ]]
-      - name: check clippy
-        run: |
-          [[ ${{ needs.clippy.result }} =~ success|skipped ]]
+          [[ ${{ needs.lint.result }} =~ success|skipped ]]
       - name: check test
         run: |
           [[ ${{ needs.test.result }} =~ success|skipped ]]
-      - name: check bench
-        run: |
-          [[ ${{ needs.bench.result }} =~ success|skipped ]]
-      - name: check miri
-        run: |
-          [[ ${{ needs.miri.result }} =~ success|skipped ]]
-      - name: check doc
-        run: |
-          [[ ${{ needs.doc.result }} =~ success|skipped ]]
       - name: check publish
         run: |
           [[ ${{ needs.publish.result }} =~ success|skipped ]]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,9 +83,7 @@ jobs:
           override: true
 
       - name: Install cargo-make
-        run: |
-          cargo install --debug cargo-quickinstall
-          cargo quickinstall cargo-make
+        run: cargo install cargo-make
 
       - name: Cache dependencies
         uses: actions/cache@v2
@@ -147,9 +145,7 @@ jobs:
           override: true
 
       - name: Install cargo-make
-        run: |
-          cargo install --debug cargo-quickinstall
-          cargo quickinstall cargo-make
+        run: cargo install cargo-make
 
       - name: Install Python
         uses: actions/setup-python@v2

--- a/packages/engine/Makefile.toml
+++ b/packages/engine/Makefile.toml
@@ -47,9 +47,10 @@ args = ["test", "--workspace", "--test", "integration", "--no-fail-fast", "--pro
 dependencies = ["setup-python"]
 
 
-# Rustdoc must not be executed on the workspace root.
-[tasks.doc-task-ci-public]
+# The workspace crate (`hash_engine_lib`) does not have any source files but only the integration tests. `rustdoc` will
+# error when running on an empty crate, so disable running it on the workspace crate.
+[tasks.doc-task-check-public]
 condition = { env_false = ["CARGO_MAKE_CRATE_IS_WORKSPACE"] }
 
-[tasks.doc-task-ci-private]
+[tasks.doc-task-check-private]
 condition = { env_false = ["CARGO_MAKE_CRATE_IS_WORKSPACE"] }

--- a/packages/engine/Makefile.toml
+++ b/packages/engine/Makefile.toml
@@ -3,9 +3,6 @@ extend = { path = "../../.github/scripts/rust/Makefile.toml" }
 [env]
 CARGO_HACK_FLAGS = "--feature-powerset --features build-nng --exclude-features default --ignore-unknown-features --optional-deps clap"
 
-[tasks.default]
-alias = "run"
-
 # The `test` task will execute these task in the folloing order:
 #  1. Run unit tests
 #  2. Build the test dependencies (CI only)

--- a/packages/engine/Makefile.toml
+++ b/packages/engine/Makefile.toml
@@ -1,0 +1,58 @@
+extend = { path = "../../.github/scripts/rust/Makefile.toml" }
+
+[env]
+CARGO_HACK_FLAGS = "--feature-powerset --features build-nng --exclude-features default --ignore-unknown-features --optional-deps clap"
+
+[tasks.default]
+alias = "run"
+
+# The `test` task will execute these task in the folloing order:
+#  1. Run unit tests
+#  2. Build the test dependencies (CI only)
+#  3. Setup python (CI only)
+#  4. Run the integration tests
+# This workaround is needed as `tasks.setup-python` must only be executed from the workspace root, so `tasks.test` has
+# `workspace` set to `false`.
+
+[tasks.test]
+clear = true
+workspace = false
+description = "Runs the test suite"
+category = "Test"
+run_task = { name = ["run-test-suite", "run-integrations"] }
+
+[tasks.build-test-deps]
+condition = { env_true = ["CARGO_MAKE_CI" ] }
+private = true
+extend = "build"
+args = ["build", "-p", "memory", "--profile", "${CARGO_MAKE_CARGO_PROFILE}"]
+
+[tasks.setup-python]
+condition = { env_true = ["CARGO_MAKE_CI" ] }
+private = true
+command = "bash"
+args = ["lib/execution/src/runner/python/setup.sh", "python3.7"]
+dependencies = ["build-test-deps"]
+
+[tasks.run-test-suite]
+private = true
+run_task = { name = "run-tests", fork = true }
+
+[tasks.run-tests]
+private = true
+command = "cargo"
+args = ["hack", "test", "--no-fail-fast", "@@split(CARGO_HACK_FLAGS, )", "--profile", "${CARGO_MAKE_CARGO_PROFILE}"]
+
+[tasks.run-integrations]
+private = true
+command = "cargo"
+args = ["test", "--workspace", "--test", "integration", "--no-fail-fast", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "--all-features"]
+dependencies = ["setup-python"]
+
+
+# Rustdoc must not be executed on the workspace root.
+[tasks.doc-task-ci-public]
+condition = { env_false = ["CARGO_MAKE_CRATE_IS_WORKSPACE"] }
+
+[tasks.doc-task-ci-private]
+condition = { env_false = ["CARGO_MAKE_CRATE_IS_WORKSPACE"] }

--- a/packages/engine/tests/integration.rs
+++ b/packages/engine/tests/integration.rs
@@ -1,9 +1,3 @@
-// Run only with texray in production builds and without texray in debug builds
-#![cfg(any(
-    all(not(debug_assertions), feature = "texray"),
-    all(debug_assertions, not(feature = "texray")),
-))]
-
 //! The hEngine integration test suite runs a variety of specially-designed simulations and
 //! experiments of specific functionalities to verify outputs.
 

--- a/packages/libs/error-stack/Makefile.toml
+++ b/packages/libs/error-stack/Makefile.toml
@@ -1,0 +1,4 @@
+extend = { path = "../../../.github/scripts/rust/Makefile.toml" }
+
+[tasks.default]
+alias = "lint-flow"

--- a/packages/libs/error-stack/Makefile.toml
+++ b/packages/libs/error-stack/Makefile.toml
@@ -1,4 +1,1 @@
 extend = { path = "../../../.github/scripts/rust/Makefile.toml" }
-
-[tasks.default]
-alias = "lint-flow"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

[cargo-make](https://sagiegurari.github.io/cargo-make/) is a task runner with Rust as it's primary target.
We chose to give `cargo-make` a try in order to simplify development.

Side effect: this hugely improves the number of jobs in CI, see the `checks` section below.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/0/1202518779738147) _(internal)_

## 🔍 What does this change?

- Adds a base configuration to `.github/scripts/rust/Makefile.toml`
- Adds extending configurations to `packages/engine` and `packages/libs/error-stack`
- Change the CI to use `cargo make`

## 📜 Does this require a change to the docs?

A summary of available commands can be printed by running `cargo make --list-all-steps`

## 🛡 What tests cover this?

The CI uses `cargo make` as well, so the setup is tested automatically

## ❓ How to test this?

Please checkout the branch and run a variety of `cargo make` commands on these crates:
- `packages/libs/error-stack`
- `packages/engine` (takes longer if not compiled before)

for example:
```shell
cargo make build
cargo make check
cargo make test
cargo make doc --open
```
