### PR TITLE
Update URLs to Þ docs and specs

### DIFF
--- a/sites/hashdev/src/_pages/blog/1_block-design.mdx
+++ b/sites/hashdev/src/_pages/blog/1_block-design.mdx
@@ -40,7 +40,7 @@ We've set up our [block starter template](https://github.com/blockprotocol/block
 
 Our base styles file is lightly opinionated and sets up a styling base that will help your block look and feel similar to others.
 
-It comes with a default palette of colors you can use, a typographic scale, a spacing scale, and other similar base styles. You can read more details about what the base stylesheet includes in our [documentation](https://blockprotocol.org/spec/block-types#styling).
+It comes with a default palette of colors you can use, a typographic scale, a spacing scale, and other similar base styles. You can read more details about what the base stylesheet includes in our [documentation](https://blockprotocol.org/docs/spec/rfcs_and_roadmap#styling).
 
 ### Accepting styles from embedding applications
 
@@ -50,7 +50,7 @@ The protocol gives embedding applications control over the way blocks appear wit
 
 Every Block Protocol block you build should accept a `styleVariables` object that the embedding application can pass in.
 
-This object defines a set of variables that control the basic styles of the block. We've designed these to maximize consistency and simplicity within your block. You can see the full list of these in the [styling section](https://blockprotocol.org/spec/block-types#styling) of our documentation. Here's a rundown of the major categories:
+This object defines a set of variables that control the basic styles of the block. We've designed these to maximize consistency and simplicity within your block. You can see the full list of these in the [styling section](https://blockprotocol.org/docs/spec/rfcs_and_roadmap#styling) of our documentation. Here's a rundown of the major categories:
 
 1.  Colors - a range of shades for neutrals, primary, secondary, tertiary, warning, and danger.
 1.  Typography – font family, base size, scaling ratios, and line heights

--- a/sites/hashdev/src/_pages/blog/5_build-blocks-in-any-language.mdx
+++ b/sites/hashdev/src/_pages/blog/5_build-blocks-in-any-language.mdx
@@ -22,13 +22,13 @@ The purpose of the Block Protocol is to provide a standardized interface for any
 
 Although the UI is basic, the dropdowns are particularly important for this block: they select the type of entities to fetch and make available for each row. For example, selecting the `Person` Entity Type in row one will load a collection of `Person` entities from the embedding application, allowing cells within row one to aggregate on them. In terms familiar to F# developers, Entity Types can be thought of as user-defined _domain types_ which are declared from the Embedding Application.
 
-Read more about Entities, Entity Types and embedding applications in the Block Protocol [specification](https://blockprotocol.org/spec).
+Read more about Entities, Entity Types and embedding applications in the Block Protocol [specification](https://blockprotocol.org/docs/spec).
 
 ## Implementing the Block Protocol in F\#
 
 The Block Protocol defines a communication standard which allows blocks to create, read, update, and delete data. With this use case, we will end up with a block which can be used to explore the structured data in an embedding application.
 
-The is possible because of the Block Protocol [Graph Service](https://blockprotocol.org/spec/graph-service-specification). This service allows querying against Entities, Entity Types, and Links. For example, we can request to fetch all Entity Types from the Embedding Application and use those for the row dropdowns shown above. Once an Entity Type has been selected, all relevant Entities of that type can be requested, loaded, and made available for cell expressions.
+The is possible because of the Block Protocol [Graph Service](https://blockprotocol.org/docs/spec/graph-service-specification). This service allows querying against Entities, Entity Types, and Links. For example, we can request to fetch all Entity Types from the Embedding Application and use those for the row dropdowns shown above. Once an Entity Type has been selected, all relevant Entities of that type can be requested, loaded, and made available for cell expressions.
 
 To implement the Block Protocol in a language other than JavaScript or TypeScript:
 
@@ -85,7 +85,7 @@ let BlockProtocolInitMessage () =
 
 There's not much to this message, for now it's mostly a declaration of existence the block makes to the embedding application. The message does, however, expect a response: the `initResponse` message.
 
-In order to properly explain the response to this initial message, it's helpful to look at how the Graph Service [specification](https://blockprotocol.org/spec/graph-service-specification) can be typed.
+In order to properly explain the response to this initial message, it's helpful to look at how the Graph Service [specification](https://blockprotocol.org/docs/spec/graph-service-specification) can be typed.
 
 ### Block Protocol Graph Service types
 
@@ -492,4 +492,4 @@ if all goes well. Otherwise, the raw value of the cell is shown.
 
 We've seen how the Block Protocol isn't tied to JavaScript, TypeScript, or React, and how you can build a block with your favorite JavaScript transpilation source—F#, in my case! There's no need to change the way you write frontend code. The Elmish component doesn't have any special knowledge about the Block Protocol, for example, and relies instead on a couple of asynchronous functions which disguise a simple way of communicating through DOM events.
 
-You can browse the full source code for the calculation block [on GitHub](https://github.com/hashdeps/calculation-table-block). If you feel inspired to build a block without TypeScript, we'd love to [hear from you on Discord](https://hash.ai/discord). And to learn more about the technical details of the Block Protocol, take a look at the [specification](https://blockprotocol.org/spec).
+You can browse the full source code for the calculation block [on GitHub](https://github.com/hashdeps/calculation-table-block). If you feel inspired to build a block without TypeScript, we'd love to [hear from you on Discord](https://hash.ai/discord). And to learn more about the technical details of the Block Protocol, take a look at the [specification](https://blockprotocol.org/docs/spec).

--- a/sites/hashdev/src/_pages/blog/6_block-protocol-v02.mdx
+++ b/sites/hashdev/src/_pages/blog/6_block-protocol-v02.mdx
@@ -52,10 +52,10 @@ We don’t expect all embedding applications to support all services. Instead, w
 
 In addition to the v0.2 Core Specification, we are introducing the first Block Protocol service: the Graph Service. This replaces v0.1’s data transfer methods. We expect most blocks to use the Graph Service as it enables blocks to create, read, update, and delete data in embedding applications, a common requirement for interoperability.
 
-The best way to learn about version 0.2 of the Block Protocol is to build a block. You can get started in a matter of minutes with [our tutorial](https://blockprotocol.org/docs/developing-blocks). For all the technical details, read the new specifications [here](https://blockprotocol.org/spec).
+The best way to learn about version 0.2 of the Block Protocol is to build a block. You can get started in a matter of minutes with [our tutorial](https://blockprotocol.org/docs/developing-blocks). For all the technical details, read the new specifications [here](https://blockprotocol.org/docs/spec).
 
 ## Help us build the Block Protocol
 
 We are building the Block Protocol in the open and we’d love your help.
 
-With the introduction of version 0.2, we’re sharing a list of new services we’re considering, from Commenting to Versioning. We also have a number of important, open questions around updates we’re considering for the Core Specification and the Graph Services Specification. You can find all the details in the [RFCs & Roadmap section](https://blockprotocol.org/spec/rfcs_and_roadmap) of the spec and [join the discussion on GitHub](https://github.com/blockprotocol/blockprotocol/discussions).
+With the introduction of version 0.2, we’re sharing a list of new services we’re considering, from Commenting to Versioning. We also have a number of important, open questions around updates we’re considering for the Core Specification and the Graph Services Specification. You can find all the details in the [RFCs & Roadmap section](https://blockprotocol.org/docs/spec/rfcs_and_roadmap) of the spec and [join the discussion on GitHub](https://github.com/blockprotocol/blockprotocol/discussions).


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR updates a few links to blockprotocol.org which changed as we migrated to Þ 0.2.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202250835094702/1202440221033864/f) _(internal)_
- https://github.com/blockprotocol/blockprotocol/pull/411 (similar PR)
