### PR TITLE
Add `DatabaseConnectionInfo`

### DIFF
--- a/packages/graph/hash_graph/Cargo.lock
+++ b/packages/graph/hash_graph/Cargo.lock
@@ -34,6 +34,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +100,55 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "3.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
+ "strsim",
+ "termcolor",
+ "terminal_size",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_complete"
+version = "3.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ead064480dfc4880a10764488415a97fdd36a4cf1bb022d372f02e8faf8386e1"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
 
 [[package]]
 name = "core-foundation"
@@ -331,6 +391,7 @@ name = "graph"
 version = "0.0.0"
 dependencies = [
  "async-trait",
+ "clap",
  "error-stack",
  "serde",
  "serde_json",
@@ -342,6 +403,8 @@ dependencies = [
 name = "hash-graph"
 version = "0.0.0"
 dependencies = [
+ "clap",
+ "clap_complete",
  "error-stack",
  "graph",
  "tokio",
@@ -639,6 +702,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +787,30 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1049,6 +1142,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,6 +1176,34 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+dependencies = [
+ "terminal_size",
 ]
 
 [[package]]
@@ -1346,6 +1473,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/packages/graph/hash_graph/Makefile.toml
+++ b/packages/graph/hash_graph/Makefile.toml
@@ -1,4 +1,7 @@
 extend = { path = "../../../.github/scripts/rust/Makefile.toml" }
 
+[env]
+CARGO_HACK_FLAGS = "--feature-powerset --optional-deps clap"
+
 [env.production]
 CARGO_MAKE_CARGO_PROFILE = "production"

--- a/packages/graph/hash_graph/bin/hash_graph/Cargo.toml
+++ b/packages/graph/hash_graph/bin/hash_graph/Cargo.toml
@@ -2,11 +2,16 @@
 name = "hash-graph"
 version = "0.0.0"
 edition = "2021"
+authors = ["HASH"]
 publish = false
+description = "The entity-graph query-layer for the HASH datastore"
 
 
 [dependencies]
 error-stack = { version = "0.1.1", features = ["futures"] }
 
-graph = { path = "../../lib/graph" }
+graph = { path = "../../lib/graph", features = ["clap"] }
 tokio = { version = "1.18.2", features = ["rt", "macros"] }
+
+clap = { version = "3.2.7", features = ["cargo", "derive", "env", "wrap_help"] }
+clap_complete = "3.2.3"

--- a/packages/graph/hash_graph/bin/hash_graph/src/args.rs
+++ b/packages/graph/hash_graph/bin/hash_graph/src/args.rs
@@ -1,0 +1,33 @@
+use clap::{AppSettings::DeriveDisplayOrder, Args as _, Command, Parser};
+use clap_complete::Shell;
+use graph::datastore::DatabaseConnectionInfo;
+
+/// Arguments passed to the program.
+#[derive(Debug, Parser)]
+#[clap(version, author, about, long_about = None, setting = DeriveDisplayOrder)]
+pub struct Args {
+    #[clap(flatten)]
+    pub db_info: DatabaseConnectionInfo,
+
+    /// Generate a completion script for the given shell and outputs it to stdout.
+    #[clap(long, arg_enum, exclusive = true)]
+    generate_completion: Option<Shell>,
+}
+
+impl Args {
+    /// Parse the arguments passed to the program.
+    pub fn parse() -> Self {
+        let args = <Args as Parser>::parse();
+        if let Some(shell) = args.generate_completion {
+            clap_complete::generate(
+                shell,
+                &mut Args::augment_args(Command::new(env!("CARGO_PKG_NAME"))),
+                env!("CARGO_PKG_NAME"),
+                &mut std::io::stdout(),
+            );
+            std::process::exit(0);
+        }
+
+        args
+    }
+}

--- a/packages/graph/hash_graph/bin/hash_graph/src/main.rs
+++ b/packages/graph/hash_graph/bin/hash_graph/src/main.rs
@@ -1,7 +1,11 @@
+mod args;
+
 use std::fmt;
 
 use error_stack::{Context, FutureExt, Result};
 use graph::datastore::PostgresDatabase;
+
+use crate::args::Args;
 
 #[derive(Debug)]
 pub struct GraphError;
@@ -15,8 +19,8 @@ impl fmt::Display for GraphError {
 
 #[tokio::main]
 async fn main() -> Result<(), GraphError> {
-    // TODO: stop hardcoding the connection parameters
-    let _datastore = PostgresDatabase::new("postgres", "postgres", "localhost", 5432, "graph")
+    let args = Args::parse();
+    let _datastore = PostgresDatabase::new(&args.db_info)
         .change_context(GraphError)
         .await?;
 

--- a/packages/graph/hash_graph/lib/graph/Cargo.toml
+++ b/packages/graph/hash_graph/lib/graph/Cargo.toml
@@ -12,9 +12,11 @@ async-trait = "0.1.56"
 sqlx = { version = "0.6.0", features = ["runtime-tokio-native-tls", "postgres", "macros", "uuid", "time", "json"] }
 tokio = { version = "1.18.2", features = ["rt", "macros"] }
 error-stack = "0.1.1"
+clap = { version = "3.2.7", features = ["derive", "env"], optional = true }
 
 [dev-dependencies]
 
 [build-dependencies]
 
 [features]
+clap = ["dep:clap"]

--- a/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
@@ -17,6 +17,119 @@ impl fmt::Display for DatastoreError {
     }
 }
 
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "clap", derive(clap::ArgEnum))]
+pub enum DatabaseType {
+    #[default]
+    Postgres,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "clap", derive(clap::Args))]
+pub struct DatabaseConnectionInfo {
+    /// The Database type to connect to
+    #[cfg_attr(feature = "clap", clap(long, default_value = "postgres", arg_enum))]
+    database_type: DatabaseType,
+
+    /// Database username
+    #[cfg_attr(
+        feature = "clap",
+        clap(long, default_value = "postgres", env = "HASH_GRAPH_USER")
+    )]
+    user: String,
+
+    /// Database password for authentication
+    #[cfg_attr(
+        feature = "clap",
+        clap(long, default_value = "postgres", env = "HASH_GRAPH_PASSWORD")
+    )]
+    password: String,
+
+    /// The host to connect to
+    #[cfg_attr(
+        feature = "clap",
+        clap(long, default_value = "localhost", env = "HASH_GRAPH_HOST")
+    )]
+    host: String,
+
+    /// The port to connect to
+    #[cfg_attr(
+        feature = "clap",
+        clap(long, default_value = "5432", env = "HASH_GRAPH_PORT")
+    )]
+    port: u16,
+
+    /// The database name to use
+    #[cfg_attr(
+        feature = "clap",
+        clap(long, default_value = "graph", env = "HASH_GRAPH_DATABASE")
+    )]
+    database: String,
+}
+
+impl DatabaseConnectionInfo {
+    pub const fn new(
+        database_type: DatabaseType,
+        user: String,
+        password: String,
+        host: String,
+        port: u16,
+        database: String,
+    ) -> Self {
+        Self {
+            database_type,
+            user,
+            password,
+            host,
+            port,
+            database,
+        }
+    }
+
+    fn url(&self) -> String {
+        let db_type = match self.database_type {
+            DatabaseType::Postgres => "postgres",
+        };
+        format!(
+            "{}://{}:{}@{}:{}/{}",
+            db_type, self.user, self.password, self.host, self.port, self.database
+        )
+    }
+
+    pub const fn database_type(&self) -> DatabaseType {
+        self.database_type
+    }
+
+    pub fn user(&self) -> &str {
+        &self.user
+    }
+
+    pub fn host(&self) -> &str {
+        &self.host
+    }
+
+    pub const fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub fn database(&self) -> &str {
+        &self.database
+    }
+}
+
+impl fmt::Display for DatabaseConnectionInfo {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let db_type = match self.database_type {
+            DatabaseType::Postgres => "postgres",
+        };
+        write!(
+            fmt,
+            "{}://{}:***@{}:{}/{}",
+            db_type, self.user, self.host, self.port, self.database
+        )
+    }
+}
+
 /// Describes the API of a Datastore implementation
 #[async_trait]
 trait Datastore {

--- a/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
@@ -87,6 +87,12 @@ impl DatabaseConnectionInfo {
         }
     }
 
+    /// Creates a database connection url.
+    ///
+    /// Note, that this will reveal the password, so output should not be printed. The [`Display`]
+    /// implementation should be used instead, which will mask the password.
+    ///
+    /// [`Display`]: core::fmt::Display.
     #[must_use]
     fn url(&self) -> String {
         let db_type = match self.database_type {

--- a/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
@@ -68,6 +68,7 @@ pub struct DatabaseConnectionInfo {
 }
 
 impl DatabaseConnectionInfo {
+    #[must_use]
     pub const fn new(
         database_type: DatabaseType,
         user: String,
@@ -86,6 +87,7 @@ impl DatabaseConnectionInfo {
         }
     }
 
+    #[must_use]
     fn url(&self) -> String {
         let db_type = match self.database_type {
             DatabaseType::Postgres => "postgres",
@@ -96,22 +98,27 @@ impl DatabaseConnectionInfo {
         )
     }
 
+    #[must_use]
     pub const fn database_type(&self) -> DatabaseType {
         self.database_type
     }
 
+    #[must_use]
     pub fn user(&self) -> &str {
         &self.user
     }
 
+    #[must_use]
     pub fn host(&self) -> &str {
         &self.host
     }
 
+    #[must_use]
     pub const fn port(&self) -> u16 {
         self.port
     }
 
+    #[must_use]
     pub fn database(&self) -> &str {
         &self.database
     }

--- a/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
@@ -27,7 +27,7 @@ pub enum DatabaseType {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "clap", derive(clap::Args))]
 pub struct DatabaseConnectionInfo {
-    /// The Database type to connect to
+    /// The database type to connect to
     #[cfg_attr(feature = "clap", clap(long, default_value = "postgres", arg_enum))]
     database_type: DatabaseType,
 

--- a/packages/graph/hash_graph/lib/graph/src/lib.rs
+++ b/packages/graph/hash_graph/lib/graph/src/lib.rs
@@ -1,6 +1,6 @@
 //! The entity-graph query-layer for the HASH datastore
 
-#![feature(lint_reasons)]
+#![feature(lint_reasons, once_cell)]
 #![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
 #![cfg_attr(not(miri), doc(test(attr(deny(warnings, clippy::all)))))]
 #![warn(
@@ -38,6 +38,9 @@
     clippy::module_name_repetitions,
     reason = "This encourages importing `as` which breaks IDEs"
 )]
-
+#[allow(
+    clippy::must_use_candidate,
+    reason = "#[must_use] adds boilerplate code, which isn't worth it"
+)]
 pub mod datastore;
 pub mod types;

--- a/packages/graph/hash_graph/lib/graph/src/lib.rs
+++ b/packages/graph/hash_graph/lib/graph/src/lib.rs
@@ -38,9 +38,6 @@
     clippy::module_name_repetitions,
     reason = "This encourages importing `as` which breaks IDEs"
 )]
-#[allow(
-    clippy::must_use_candidate,
-    reason = "#[must_use] adds boilerplate code, which isn't worth it"
-)]
+
 pub mod datastore;
 pub mod types;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, we have the database information hardcoded. This adds a `DatabaseConnectionInfo` struct, which is used for (a) provide information how to connect to a database and (b) can be used from the command line.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201095311341924/1202510174412962) _(internal)_

## 🚫 Blocked by

## 🔍 What does this change?

- Add the `DatabaseConnectionInfo` struct and use it for connecting
- Change the tests to use `DatabaseConnectionInfo`
- Add `clap` to use `DatabaseConnectionInfo` in the command line

## 🛡 What tests cover this?

The struct is used in the tests

## ❓ How to test this?

Run `cargo run -- --help` in `packages/graph/hash_graph`

## 📹 Demo

![image](https://user-images.githubusercontent.com/21277928/176858527-9dc62118-50f8-44e7-aa9f-348d15af74f2.png)

It's possible to generate completions by running `cargo run -- --generate-completion zsh`:
![image](https://user-images.githubusercontent.com/21277928/176858783-af1dad73-4304-41fe-9a73-d4d3624223cf.png)
