### PR TITLE
Fix Python setup on macOS

### DIFF
--- a/packages/engine/lib/execution/src/runner/python/setup.py
+++ b/packages/engine/lib/execution/src/runner/python/setup.py
@@ -14,14 +14,15 @@ sys.argv.remove(script_path)
 
 # TODO: Use `Pathlib` instead of `os`
 #   see https://app.asana.com/0/1199548034582004/1202011714603651/f
-def find_directory(pattern, path):
+def find_directory(patterns, path):
     result = []
     for root, _dirs, files in os.walk(path):
         for name in files:
-            if fnmatch.fnmatch(name, pattern):
-                file = os.path.join(root, name)
-                file = os.path.abspath(file)
-                result.append(os.path.dirname(file))
+            for pattern in patterns:
+                if fnmatch.fnmatch(name, pattern):
+                    file = os.path.join(root, name)
+                    file = os.path.abspath(file)
+                    result.append(os.path.dirname(file))
     return result
 
 
@@ -29,7 +30,7 @@ def last_modified(path):
     return os.path.getmtime(path)
 
 library_dirs = sorted(
-    find_directory("libmemory.so", f"{script_path}/../../../../../"),
+    find_directory(["libmemory.so", "libmemory.dylib"], f"{script_path}/../../../../../"),
     key=last_modified,
     reverse=True,
 )


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

During some of the separation of crates work we improved the `setup.py` script which tries to dynamically find the most recent build target folder. It was searching for an artifact that only appears on Linux so this updates it to also find it on macOS.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  If you have a mac, checkout this branch and follow the README to setup Python.

