### PR TITLE
Optimize CI cache and runs for Rust

### DIFF
--- a/.github/scripts/rust/Makefile.toml
+++ b/.github/scripts/rust/Makefile.toml
@@ -1,10 +1,26 @@
+[config]
+default_to_workspace = false
+
 [config.modify_core_tasks]
 private = true
 namespace = "default"
 
 [env]
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
-CARGO_HACK_FLAGS = "--feature-powerset --exclude-features default"
+CARGO_BUILD_FLAGS = "--workspace"
+CARGO_RUN_FLAGS = ""
+CARGO_FORMAT_FLAGS = ""
+CARGO_FORMAT_HACK_FLAGS = "--workspace"
+CARGO_CLIPPY_FLAGS = "--no-deps --tests"
+CARGO_CLIPPY_HACK_FLAGS = "--workspace --feature-powerset"
+CARGO_DOC_FLAGS = "--no-deps --all-features -Zunstable-options -Zrustdoc-scrape-examples=examples"
+CARGO_DOC_HACK_FLAGS = "--workspace"
+CARGO_RUSTDOC_FLAGS = "--all-features -Zunstable-options -Zrustdoc-scrape-examples=examples -- -Zunstable-options"
+CARGO_RUSTDOC_HACK_FLAGS = "--workspace"
+CARGO_TEST_FLAGS = ""
+CARGO_TEST_HACK_FLAGS = "--workspace --feature-powerset"
+CARGO_MIRI_FLAGS = ""
+CARGO_MIRI_HACK_FLAGS = "--workspace --feature-powerset"
 
 [env.production]
 CARGO_MAKE_CARGO_PROFILE = "release"
@@ -15,134 +31,121 @@ extend = "build"
 category = ""
 
 [tasks.all]
-description = "Builds the project, checks lints, and runs the tests. Additional parameters are passed to `build` and `test`."
+description = "Builds the project, checks lints, and runs the tests."
 run_task = { name = ["build", "lint", "test"] }
 
+
+[tasks.task]
+private = true
+command = "cargo"
 
 ################################################################################
 ## Build                                                                      ##
 ################################################################################
 [tasks.build]
-description = "Builds the crate"
 category = "Build"
-workspace = false
-command = "cargo"
-args = ["build", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "${@}"]
+description = "Builds the crate"
+run_task = { name = "build-task" }
+
+[tasks.build-task]
+extend = "task"
+args = ["build", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_BUILD_FLAGS, )", "${@}"]
 
 
 ################################################################################
 ## Run                                                                        ##
 ################################################################################
 [tasks.run]
-description = "Builds the binary and runs it"
 category = "Run"
-workspace = false
-command = "cargo"
-args = ["run", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "${@}"]
+description = "Builds the binary and runs it"
+run_task = { name = "run-task" }
+
+[tasks.run-task]
+extend = "task"
+args = ["run", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_RUN_FLAGS, )", "${@}"]
 
 
 ################################################################################
 ## Lints                                                                      ##
 ################################################################################
 [tasks.lint]
-description = "Runs all lints"
 category = "Lint"
-run_task = { name = ["format-task-check", "clippy-task-check", "doc-task-check-public", "doc-task-check-private"] }
+description = "Runs all lints"
+run_task = { name = ["format", "clippy", "doc"] }
+
 
 [tasks.format]
-condition = { channels = ["nightly"] }
-description = "Runs the rustfmt formatter"
 category = "Lint"
-workspace = false
-run_task = [
-    { name = ["format-task-check"] , condition = { env_true = ["CARGO_MAKE_CI" ] } },
-    { name = ["format-task"] },
-]
+description = "Runs the rustfmt formatter"
+run_task = { name = ["format-task"] }
 
 [tasks.format-task]
-private = true
-command = "cargo"
-args = ["fmt", "${@}"]
+extend = "task"
+args = ["hack", "@@split(CARGO_FORMAT_HACK_FLAGS, )", "fmt", "@@split(CARGO_FORMAT_FLAGS, )", "${@}"]
 dependencies = ["install-rustfmt"]
 
-[tasks.format-task-check]
-extend = "format-task"
-args = ["fmt", "--", "--check"]
 
 [tasks.clippy]
 description = "Runs clippy with all feature flag permutations"
 category = "Lint"
-run_task = [
-    { name = ["clippy-task-check"] , condition = { env_true = ["CARGO_MAKE_CI" ] } },
-    { name = ["clippy-task"] },
-]
+run_task = { name = ["clippy-task"] }
 
 [tasks.clippy-task]
-private = true
-command = "cargo"
-args = ["hack", "clippy", "--no-deps", "--tests", "@@split(CARGO_HACK_FLAGS, )", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "${@}"]
-dependencies = ["install-cargo-hack", "install-clippy"]
-
-[tasks.clippy-task-check]
-extend = "clippy-task"
-args = ["hack", "clippy", "--no-deps", "--tests", "@@split(CARGO_HACK_FLAGS, )", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "--", "-D", "warnings"]
+extend = "task"
+args = ["hack", "@@split(CARGO_CLIPPY_HACK_FLAGS, )", "clippy", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_CLIPPY_FLAGS, )", "${@}"]
+dependencies = ["install-clippy"]
 
 
 ################################################################################
 ## Docs                                                                       ##
 ################################################################################
 [tasks.doc]
-condition = { channels = ["nightly"] }
-description = "Builds the documentation for the crate"
 category = "Docs"
-workspace = false
-run_task = [
-    { name = ["doc-task-check-public", "doc-task-check-private"] , fork = true, condition = { env_true = ["CARGO_MAKE_CI" ] } },
-    { name = ["doc-task"] },
-]
+description = "Builds the documentation for the crate"
+run_task = { name = ["doc-task"] }
 
 [tasks.doc-task]
-condition = { env_false = ["CARGO_MAKE_CI"] }
-private = true
-command = "cargo"
-args = ["doc", "--workspace", "--all-features", "--no-deps", "${@}"]
+extend = "task"
+args = ["hack", "@@split(CARGO_DOC_HACK_FLAGS, )", "doc", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_DOC_FLAGS, )", "${@}"]
 
-[tasks.doc-task-check-public]
-private = true
-command = "cargo"
-args = ["rustdoc", "--all-features", "--", "-Z", "unstable-options", "--check", "-D", "warnings"]
 
-[tasks.doc-task-check-private]
-extend = "doc-task-check-public"
-args = ["rustdoc", "--all-features", "--", "-Z", "unstable-options", "--check", "--document-private-items", "-D", "warnings"]
+[tasks.rustdoc]
+category = "Docs"
+description = "Builds the documentation for the crate"
+run_task = { name = ["rustdoc-task"] }
+
+[tasks.rustdoc-task]
+extend = "task"
+args = ["hack", "@@split(CARGO_RUSTDOC_HACK_FLAGS, )", "rustdoc", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_RUSTDOC_FLAGS, )", "${@}"]
 
 
 ################################################################################
 ## Tests                                                                      ##
 ################################################################################
 [tasks.test]
-description = "Runs the test suite with all feature flag permutations"
 category = "Test"
-command = "cargo"
-args = ["hack", "test", "--no-fail-fast", "@@split(CARGO_HACK_FLAGS, )", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "${@}"]
-dependencies = ["install-cargo-hack"]
+description = "Runs the test suite"
+run_task = { name = ["test-task"] }
+
+[tasks.test-task]
+extend = "task"
+args = ["hack", "@@split(CARGO_TEST_HACK_FLAGS, )", "test", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_TEST_FLAGS, )", "${@}"]
+
 
 [tasks.miri]
-condition = { channels = ["nightly"] }
-description = "Runs miri tests with all feature flag permutations"
 category = "Test"
-command = "cargo"
-args = ["hack", "miri", "test", "@@split(CARGO_HACK_FLAGS, )", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "${@}"]
-dependencies = ["install-cargo-hack", "install-miri"]
+description = "Runs miri tests suite"
+run_task = { name = ["miri-task"] }
+
+[tasks.miri-task]
+extend = "task"
+args = ["hack", "@@split(CARGO_MIRI_HACK_FLAGS, )", "miri", "test", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_MIRI_FLAGS, )", "${@}"]
+dependencies = ["install-miri"]
 
 
 ################################################################################
 ## Tools                                                                      ##
 ################################################################################
-[tasks.install-cargo-hack]
-private = true
-install_crate = { crate_name = "cargo-hack", binary = "cargo", test_arg = ["hack", "--version"] }
-
 [tasks.install-clippy]
 private = true
 install_crate = { rustup_component_name = "clippy" }

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,7 @@ jobs:
       nightly: ${{ steps.toolchains.outputs.nightly }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
@@ -68,12 +68,13 @@ jobs:
       matrix:
         directory: ${{ fromJSON(needs.setup.outputs.lint) }}
         toolchain:
-          - stable
           - ${{ needs.setup.outputs.nightly }}
+        profile:
+          - development
         exclude: ${{ fromJSON(needs.setup.outputs.exclude) }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
@@ -82,11 +83,9 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           override: true
 
-      - name: Install cargo-make
-        run: cargo install cargo-make
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
+      - name: Cache Rust dependencies
+        id: rust-cache
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/.crates.toml
@@ -96,22 +95,34 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/checkouts
             **/target/
-          key: ${{ runner.os }}-lint-${{ matrix.directory }}-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-lint-${{ matrix.directory }}-${{ matrix.toolchain }}
+          key: lint-${{ matrix.directory }}-${{ matrix.toolchain }}-${{ matrix.profile }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: lint-${{ matrix.directory }}-${{ matrix.toolchain }}-${{ matrix.profile }}-
+
+      - name: Install cargo-make
+        shell: bash
+        run: cargo install cargo-make
 
       - name: Check formatting
-        if: matrix.toolchain != 'stable'
         working-directory: ${{ matrix.directory }}
-        run: cargo make format
+        run: cargo make format -- --check
 
       - name: Check clippy
         working-directory: ${{ matrix.directory }}
-        run: cargo make clippy
+        run: cargo make clippy -- -D warnings
 
-      - name: Check documentation
-        if: matrix.toolchain != 'stable'
+      - name: Check public documentation
         working-directory: ${{ matrix.directory }}
-        run: cargo make doc
+        run: cargo make rustdoc --check -D warnings --show-coverage
+
+      - name: Check private documentation
+        working-directory: ${{ matrix.directory }}
+        run: cargo make rustdoc --check -D warnings --show-coverage --document-private-items
+
+      - name: Clear cargo cache
+        if: steps.rust-cache.outputs.cache-hit != 'true'
+        run: |
+          cargo install cargo-cache
+          cargo cache --autoclean-expensive
 
   test:
     name: test
@@ -134,26 +145,25 @@ jobs:
       RUST_BACKTRACE: 1
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Rust
-        id: toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
           override: true
 
-      - name: Install cargo-make
-        run: cargo install cargo-make
-
-      - name: Install Python
-        uses: actions/setup-python@v2
+      - name: Cache Node dependencies
+        uses: actions/cache@v3
         with:
-          python-version: "3.7"
+          path: |
+            **/node_modules
+          key: ${{ hashFiles('**/yarn.lock') }}
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
+      - name: Cache Rust dependencies
+        id: rust-cache
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/.crates.toml
@@ -163,25 +173,30 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/checkouts
             **/target/
-          key: ${{ runner.os }}-test-${{ matrix.directory }}-${{ matrix.toolchain }}-${{ matrix.profile }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-test-${{ matrix.directory }}-${{ matrix.toolchain }}-${{ matrix.profile }}
+          key: test-${{ matrix.directory }}-${{ matrix.toolchain }}-${{ matrix.profile }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: test-${{ matrix.directory }}-${{ matrix.toolchain }}-${{ matrix.profile }}-
+
+      - name: Install cargo-make
+        shell: bash
+        run: cargo install cargo-make
+
+      - name: Install Python
+        if: matrix.directory == 'packages/engine'
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
 
       - name: Run tests
         working-directory: ${{ matrix.directory }}
-        run: cargo make --profile ${{ matrix.profile }} test
+        run: cargo make --profile ${{ matrix.profile }} test --no-fail-fast
 
       - name: Run miri
         if: matrix.toolchain != 'stable'
         working-directory: ${{ matrix.directory }}
-        run: cargo make --profile ${{ matrix.profile }} miri
+        run: cargo make --profile ${{ matrix.profile }} miri --no-fail-fast
 
-      # Non-empty diff could be a Cargo.lock that wasn't committed.
       - name: Ensure empty git diff
-        run: |
-          # Restore files modified for CI
-          git checkout HEAD -- "${{ matrix.directory }}/Cargo.toml"
-
-          git --no-pager diff --exit-code --color
+        run: git --no-pager diff --exit-code --color
 
       - name: Upload to DataDog
         if: matrix.directory == 'packages/engine' && matrix.profile == 'production'
@@ -202,6 +217,12 @@ jobs:
                     --arg ddtags "$tags" \
                     '{ message: $message, ddsource: "hash-gh-actions", hostname: "github", service: "actions", ddtags: $ddtags }')
 
+      - name: Clear cargo cache
+        if: steps.rust-cache.outputs.cache-hit != 'true'
+        run: |
+          cargo install cargo-cache
+          cargo cache --autoclean-expensive
+
   publish:
     name: publish
     needs: setup
@@ -215,7 +236,7 @@ jobs:
           - ${{ needs.setup.outputs.nightly }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Rust
         id: toolchain
@@ -236,7 +257,7 @@ jobs:
         run: cargo publish --all-features --dry-run
 
       - name: Publish
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.ref == 'ref/head/main'
         working-directory: ${{ matrix.directory }}
         run: cargo publish --all-features
 

--- a/packages/engine/Makefile.toml
+++ b/packages/engine/Makefile.toml
@@ -1,44 +1,31 @@
 extend = { path = "../../.github/scripts/rust/Makefile.toml" }
 
 [env]
-CARGO_HACK_FLAGS = "--feature-powerset --features build-nng --exclude-features default --ignore-unknown-features --optional-deps clap"
+CARGO_CLIPPY_HACK_FLAGS= "--workspace --feature-powerset --features build-nng --exclude-features default --ignore-unknown-features --optional-deps clap"
+CARGO_TEST_HACK_FLAGS= "--workspace --feature-powerset --features build-nng --exclude-features default --ignore-unknown-features --optional-deps clap"
+CARGO_MIRI_HACK_FLAGS= "--workspace --feature-powerset --features build-nng --exclude-features default --ignore-unknown-features --optional-deps clap"
 
 # The `test` task will execute these task in the folloing order:
 #  1. Run unit tests
 #  2. Build the test dependencies (CI only)
 #  3. Setup python (CI only)
 #  4. Run the integration tests
-# This workaround is needed as `tasks.setup-python` must only be executed from the workspace root, so `tasks.test` has
-# `workspace` set to `false`.
 
 [tasks.test]
-clear = true
-workspace = false
-description = "Runs the test suite"
-category = "Test"
-run_task = { name = ["run-test-suite", "run-integrations"] }
+run_task = { name = ["test-task", "run-integrations"] }
 
 [tasks.build-test-deps]
-condition = { env_true = ["CARGO_MAKE_CI" ] }
+condition = { env_true = ["CARGO_MAKE_CI"] }
 private = true
-extend = "build"
+extend = "build-task"
 args = ["build", "-p", "memory", "--profile", "${CARGO_MAKE_CARGO_PROFILE}"]
 
 [tasks.setup-python]
-condition = { env_true = ["CARGO_MAKE_CI" ] }
+condition = { env_true = ["CARGO_MAKE_CI"] }
 private = true
 command = "bash"
 args = ["lib/execution/src/runner/python/setup.sh", "python3.7"]
 dependencies = ["build-test-deps"]
-
-[tasks.run-test-suite]
-private = true
-run_task = { name = "run-tests", fork = true }
-
-[tasks.run-tests]
-private = true
-command = "cargo"
-args = ["hack", "test", "--no-fail-fast", "@@split(CARGO_HACK_FLAGS, )", "--profile", "${CARGO_MAKE_CARGO_PROFILE}"]
 
 [tasks.run-integrations]
 private = true
@@ -46,11 +33,11 @@ command = "cargo"
 args = ["test", "--workspace", "--test", "integration", "--no-fail-fast", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "--all-features"]
 dependencies = ["setup-python"]
 
-
 # The workspace crate (`hash_engine_lib`) does not have any source files but only the integration tests. `rustdoc` will
 # error when running on an empty crate, so disable running it on the workspace crate.
-[tasks.doc-task-check-public]
-condition = { env_false = ["CARGO_MAKE_CRATE_IS_WORKSPACE"] }
+[tasks.rustdoc]
+workspace = true
 
-[tasks.doc-task-check-private]
+[tasks.rustdoc-task]
 condition = { env_false = ["CARGO_MAKE_CRATE_IS_WORKSPACE"] }
+args = ["rustdoc", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_RUSTDOC_FLAGS, )", "${@}"]

--- a/packages/libs/error-stack/Makefile.toml
+++ b/packages/libs/error-stack/Makefile.toml
@@ -1,1 +1,6 @@
 extend = { path = "../../../.github/scripts/rust/Makefile.toml" }
+
+[env]
+CARGO_CLIPPY_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default"
+CARGO_TEST_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default"
+CARGO_MIRI_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Improves the Rust CI cache sizes and improves test behavior.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/0/1202543415238115/f) _(internal)_
- #733

## 🔍 What does this change?

- Adjust Makefile.toml to make them more readable by re-using the same pattern
- Greatly enhance CI speed by shrinking the uploaded cache and caching on `dev/graph`

## 📹 Demo

Caching cleanup report for hEngine:

```
Total:                                    1.14 GB => 494.93 MB
  22 installed binaries:                             287.81 MB
  Registry:                             846.93 MB => 206.78 MB
    Registry index:                     247.78 MB => 111.88 MB
    428 crate archives:                               94.91 MB
    428 => 0 crate source checkouts:         504.24 MB => 0  B
  Git db:                               864.99 KB => 338.44 KB
    1 bare git repos:                   365.52 KB => 338.44 KB
    1 => 0 git repo checkouts:               499.47 KB => 0  B
Size changed 1.14 GB => 494.93 MB (-640.67 MB, -56.41%)
```

This implies a much smaller cache to download at every run.
