### PR TITLE
Add `PropertyType` Rust schema and validations

### DIFF
--- a/packages/graph/hash_graph/Cargo.lock
+++ b/packages/graph/hash_graph/Cargo.lock
@@ -1368,6 +1368,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]

--- a/packages/graph/hash_graph/lib/graph/Cargo.toml
+++ b/packages/graph/hash_graph/lib/graph/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 sqlx = { version = "0.6.0", features = ["runtime-tokio-native-tls", "postgres", "macros", "uuid", "time", "json", "sqlx-macros"] }
 tokio = { version = "1.18.2", features = ["rt", "macros"] }
-uuid = { version = "1.1.2", features = ["v4"] }
+uuid = { version = "1.1.2", features = ["v4", "serde"] }
 
 [dev-dependencies]
 

--- a/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use error_stack::{Context, Result};
 pub use postgres::PostgresDatabase;
 
-use crate::types::{AccountId, BaseId, DataType, Identifier, PropertyType, Qualified};
+use crate::types::{schema::PropertyType, AccountId, BaseId, DataType, Identifier, Qualified};
 
 #[derive(Debug)]
 pub struct DatastoreError;
@@ -195,7 +195,6 @@ trait Datastore {
 
     async fn update_property_type(
         &mut self,
-        base_id: BaseId,
         property_type: PropertyType,
         updated_by: AccountId,
     ) -> Result<Qualified<PropertyType>, DatastoreError>;

--- a/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use error_stack::{Context, Result};
 pub use postgres::PostgresDatabase;
 
-use crate::types::{AccountId, BaseId, DataType, Identifier, Qualified};
+use crate::types::{AccountId, BaseId, DataType, Identifier, PropertyType, Qualified};
 
 #[derive(Debug)]
 pub struct DatastoreError;
@@ -180,13 +180,25 @@ trait Datastore {
         updated_by: AccountId,
     ) -> Result<Qualified<DataType>, DatastoreError>;
 
-    async fn create_property_type() -> Result<(), DatastoreError>;
+    async fn create_property_type(
+        &self,
+        property_type: PropertyType,
+        created_by: AccountId,
+    ) -> Result<Qualified<PropertyType>, DatastoreError>;
 
-    async fn get_property_type() -> Result<(), DatastoreError>;
+    async fn get_property_type(
+        &self,
+        id: &Identifier,
+    ) -> Result<Qualified<PropertyType>, DatastoreError>;
 
     async fn get_property_type_many() -> Result<(), DatastoreError>;
 
-    async fn update_property_type() -> Result<(), DatastoreError>;
+    async fn update_property_type(
+        &self,
+        base_id: BaseId,
+        property_type: PropertyType,
+        updated_by: AccountId,
+    ) -> Result<Qualified<PropertyType>, DatastoreError>;
 
     async fn create_entity_type() -> Result<(), DatastoreError>;
 

--- a/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
@@ -154,7 +154,7 @@ trait Datastore {
     ///
     /// - [`DatastoreError`], if the account referred to by `created_by` does not exist.
     async fn create_data_type(
-        &self,
+        &mut self,
         data_type: DataType,
         created_by: AccountId,
     ) -> Result<Qualified<DataType>, DatastoreError>;
@@ -174,14 +174,14 @@ trait Datastore {
     ///
     /// - [`DatastoreError`], if the [`DataType`] doesn't exist.
     async fn update_data_type(
-        &self,
+        &mut self,
         base_id: BaseId,
         data_type: DataType,
         updated_by: AccountId,
     ) -> Result<Qualified<DataType>, DatastoreError>;
 
     async fn create_property_type(
-        &self,
+        &mut self,
         property_type: PropertyType,
         created_by: AccountId,
     ) -> Result<Qualified<PropertyType>, DatastoreError>;
@@ -194,7 +194,7 @@ trait Datastore {
     async fn get_property_type_many() -> Result<(), DatastoreError>;
 
     async fn update_property_type(
-        &self,
+        &mut self,
         base_id: BaseId,
         property_type: PropertyType,
         updated_by: AccountId,

--- a/packages/graph/hash_graph/lib/graph/src/datastore/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/postgres/mod.rs
@@ -35,7 +35,7 @@ impl PostgresDatabase {
     }
 
     /// Inserts a `version_id` and `base_id` into the `ids` table in the database
-    async fn insert_version_id(&self, id: &Identifier) -> Result<(), DatastoreError> {
+    async fn insert_version_id(&mut self, id: &Identifier) -> Result<(), DatastoreError> {
         sqlx::query(r#"INSERT INTO ids (version_id, base_id) VALUES ($1, $2);"#)
             .bind(&id.version_id)
             .bind(&id.base_id)
@@ -51,7 +51,7 @@ impl PostgresDatabase {
 
     /// Inserts a data type into the `data_types` table in the database
     async fn insert_data_type(
-        &self,
+        &mut self,
         id: &Identifier,
         data_type: &DataType,
         created_by: AccountId,
@@ -81,7 +81,7 @@ impl PostgresDatabase {
 
     /// Inserts a data type into the `property_types` table in the database.
     async fn insert_property_type(
-        &self,
+        &mut self,
         id: &Identifier,
         property_type: &PropertyType,
         created_by: AccountId,
@@ -113,7 +113,7 @@ impl PostgresDatabase {
 #[async_trait]
 impl Datastore for PostgresDatabase {
     async fn create_data_type(
-        &self,
+        &mut self,
         data_type: DataType,
         created_by: AccountId,
     ) -> Result<Qualified<DataType>, DatastoreError> {
@@ -156,7 +156,7 @@ impl Datastore for PostgresDatabase {
     }
 
     async fn update_data_type(
-        &self,
+        &mut self,
         base_id: BaseId,
         data_type: DataType,
         updated_by: AccountId,
@@ -171,7 +171,7 @@ impl Datastore for PostgresDatabase {
     }
 
     async fn create_property_type(
-        &self,
+        &mut self,
         property_type: PropertyType,
         created_by: AccountId,
     ) -> Result<Qualified<PropertyType>, DatastoreError> {
@@ -218,7 +218,7 @@ impl Datastore for PostgresDatabase {
     }
 
     async fn update_property_type(
-        &self,
+        &mut self,
         base_id: BaseId,
         property_type: PropertyType,
         updated_by: AccountId,
@@ -335,7 +335,7 @@ mod tests {
     #[tokio::test]
     #[cfg_attr(miri, ignore = "miri can't run in async context")]
     async fn create_data_type() -> Result<(), DatastoreError> {
-        let db = PostgresDatabase::new(&DB_INFO).await?;
+        let mut db = PostgresDatabase::new(&DB_INFO).await?;
 
         let account_id = create_account_id(&db.pool).await?;
 
@@ -351,7 +351,7 @@ mod tests {
     #[tokio::test]
     #[cfg_attr(miri, ignore = "miri can't run in async context")]
     async fn get_data_type_by_identifier() -> Result<(), DatastoreError> {
-        let db = PostgresDatabase::new(&DB_INFO).await?;
+        let mut db = PostgresDatabase::new(&DB_INFO).await?;
 
         let account_id = create_account_id(&db.pool).await?;
 
@@ -372,7 +372,7 @@ mod tests {
     #[tokio::test]
     #[cfg_attr(miri, ignore = "miri can't run in async context")]
     async fn update_existing_data_type() -> Result<(), DatastoreError> {
-        let db = PostgresDatabase::new(&DB_INFO).await?;
+        let mut db = PostgresDatabase::new(&DB_INFO).await?;
 
         let account_id = create_account_id(&db.pool).await?;
 
@@ -402,7 +402,7 @@ mod tests {
     #[tokio::test]
     #[cfg_attr(miri, ignore = "miri can't run in async context")]
     async fn create_property_type() -> Result<(), DatastoreError> {
-        let db = PostgresDatabase::new(&DB_INFO).await?;
+        let mut db = PostgresDatabase::new(&DB_INFO).await?;
 
         let account_id = create_account_id(&db.pool).await?;
 
@@ -418,7 +418,7 @@ mod tests {
     #[tokio::test]
     #[cfg_attr(miri, ignore = "miri can't run in async context")]
     async fn get_property_type_by_identifier() -> Result<(), DatastoreError> {
-        let db = PostgresDatabase::new(&DB_INFO).await?;
+        let mut db = PostgresDatabase::new(&DB_INFO).await?;
 
         let account_id = create_account_id(&db.pool).await?;
 
@@ -439,7 +439,7 @@ mod tests {
     #[tokio::test]
     #[cfg_attr(miri, ignore = "miri can't run in async context")]
     async fn update_existing_property_type() -> Result<(), DatastoreError> {
-        let db = PostgresDatabase::new(&DB_INFO).await?;
+        let mut db = PostgresDatabase::new(&DB_INFO).await?;
 
         let account_id = create_account_id(&db.pool).await?;
 

--- a/packages/graph/hash_graph/lib/graph/src/datastore/postgres/row_types.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/postgres/row_types.rs
@@ -3,7 +3,7 @@
 
 use sqlx::{types::Uuid, FromRow};
 
-use crate::types::{AccountId, DataType};
+use crate::types::{AccountId, DataType, PropertyType};
 
 #[derive(Debug, FromRow)]
 pub struct DataTypeRow {
@@ -15,7 +15,7 @@ pub struct DataTypeRow {
 #[derive(Debug, FromRow)]
 pub struct PropertyTypeRow {
     pub version_id: Uuid,
-    pub schema: serde_json::Value,
+    pub schema: PropertyType,
     pub created_by: AccountId,
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/datastore/postgres/row_types.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/postgres/row_types.rs
@@ -3,7 +3,7 @@
 
 use sqlx::{types::Uuid, FromRow};
 
-use crate::types::{AccountId, DataType, PropertyType};
+use crate::types::{AccountId, DataType};
 
 #[derive(Debug, FromRow)]
 pub struct DataTypeRow {
@@ -15,7 +15,7 @@ pub struct DataTypeRow {
 #[derive(Debug, FromRow)]
 pub struct PropertyTypeRow {
     pub version_id: Uuid,
-    pub schema: PropertyType,
+    pub schema: serde_json::Value,
     pub created_by: AccountId,
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/types/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/mod.rs
@@ -1,5 +1,7 @@
 //! Model types used across datastores
 
+pub mod schema;
+
 use std::fmt;
 
 use uuid::Uuid;
@@ -69,18 +71,6 @@ impl fmt::Display for Identifier {
 pub struct DataType(serde_json::Value);
 
 impl DataType {
-    #[must_use]
-    pub const fn new(schema: serde_json::Value) -> Self {
-        Self(schema)
-    }
-}
-
-#[repr(transparent)]
-#[derive(Clone, Debug, sqlx::Type, PartialEq, Eq)]
-#[sqlx(transparent)]
-pub struct PropertyType(serde_json::Value);
-
-impl PropertyType {
     #[must_use]
     pub const fn new(schema: serde_json::Value) -> Self {
         Self(schema)

--- a/packages/graph/hash_graph/lib/graph/src/types/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/mod.rs
@@ -75,6 +75,18 @@ impl DataType {
     }
 }
 
+#[repr(transparent)]
+#[derive(Clone, Debug, sqlx::Type, PartialEq, Eq)]
+#[sqlx(transparent)]
+pub struct PropertyType(serde_json::Value);
+
+impl PropertyType {
+    #[must_use]
+    pub const fn new(schema: serde_json::Value) -> Self {
+        Self(schema)
+    }
+}
+
 // TODO: constrain this to only work for valid inner Types.
 #[derive(Clone, Debug)]
 pub struct Qualified<T> {

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/helper.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/helper.rs
@@ -1,0 +1,291 @@
+use serde::{Deserialize, Serialize};
+
+use crate::types::schema::{Validate, ValidationError};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    try_from = "ArrayRepr<T>",
+    tag = "type",
+    rename = "array",
+    rename_all = "camelCase"
+)]
+pub struct Array<T> {
+    items: T,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    min_items: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_items: Option<usize>,
+}
+
+impl<T> Array<T> {
+    /// Creates a new `Array` without validating.
+    #[must_use]
+    pub fn new_unchecked<A: Into<Option<usize>>, B: Into<Option<usize>>>(
+        items: T,
+        min_items: A,
+        max_items: B,
+    ) -> Self {
+        Self {
+            items,
+            min_items: min_items.into(),
+            max_items: max_items.into(),
+        }
+    }
+
+    /// Creates a new `Array` from the given `items`, `min_items` and `max_items`.
+    ///
+    /// # Errors
+    ///
+    /// - [`ValidationError`] if validation is failing.
+    pub fn new<A: Into<Option<usize>>, B: Into<Option<usize>>>(
+        items: T,
+        min_items: A,
+        max_items: B,
+    ) -> Result<Self, ValidationError> {
+        let array = Self::new_unchecked(items, min_items, max_items);
+        array.validate()?;
+        Ok(array)
+    }
+
+    #[must_use]
+    pub const fn items(&self) -> &T {
+        &self.items
+    }
+
+    #[must_use]
+    pub const fn min_items(&self) -> Option<usize> {
+        self.min_items
+    }
+
+    #[must_use]
+    pub const fn max_items(&self) -> Option<usize> {
+        self.max_items
+    }
+}
+
+impl<T> Validate for Array<T> {
+    fn validate(&self) -> Result<(), ValidationError> {
+        Ok(())
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum ArrayTypeTag {
+    Array,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ArrayRepr<T> {
+    #[serde(rename = "type")]
+    _type: ArrayTypeTag,
+    items: T,
+    min_items: Option<usize>,
+    max_items: Option<usize>,
+}
+
+impl<T> TryFrom<ArrayRepr<T>> for Array<T> {
+    type Error = ValidationError;
+
+    fn try_from(array: ArrayRepr<T>) -> Result<Self, Self::Error> {
+        Self::new(array.items, array.min_items, array.max_items)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum OneOrMany<T> {
+    One(T),
+    Array(Array<T>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "OneOfRepr<T>", rename_all = "camelCase")]
+pub struct OneOf<T> {
+    one_of: Vec<T>,
+}
+
+impl<T> OneOf<T> {
+    /// Creates a new `OneOf` without validating.
+    pub fn new_unchecked<U: Into<Vec<T>>>(one_of: U) -> Self {
+        Self {
+            one_of: one_of.into(),
+        }
+    }
+
+    /// Creates a new `OneOf` from the given vector.
+    ///
+    /// # Errors
+    ///
+    /// - [`ValidationError`] if the object is not in a valid state.
+    pub fn new<U: Into<Vec<T>>>(one_of: U) -> Result<Self, ValidationError> {
+        let one_of = Self::new_unchecked(one_of);
+        one_of.validate()?;
+        Ok(one_of)
+    }
+
+    #[must_use]
+    pub fn one_of(&self) -> &[T] {
+        &self.one_of
+    }
+}
+
+impl<T> Validate for OneOf<T> {
+    fn validate(&self) -> Result<(), ValidationError> {
+        if self.one_of.is_empty() {
+            return Err(ValidationError::OneOfEmpty);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OneOfRepr<T> {
+    one_of: Vec<T>,
+}
+
+impl<T> TryFrom<OneOfRepr<T>> for OneOf<T> {
+    type Error = ValidationError;
+
+    fn try_from(one_of: OneOfRepr<T>) -> Result<Self, Self::Error> {
+        Self::new(one_of.one_of)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+
+    use serde_json::json;
+
+    use super::*;
+    use crate::types::schema::Uri;
+
+    #[test]
+    fn array() -> Result<(), Box<dyn Error>> {
+        let array = Array::new(Uri::new("https://example.com/data_type")?, None, None)?;
+
+        let json = serde_json::to_value(&array)?;
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "type": "array",
+                "items": "https://example.com/data_type",
+            })
+        );
+
+        let array2 = serde_json::from_value(json)?;
+        assert_eq!(array, array2);
+
+        let array = Array::new(Uri::new("https://example.com/data_type")?, 1, 2)?;
+
+        let json = serde_json::to_value(&array)?;
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "type": "array",
+                "items": "https://example.com/data_type",
+                "minItems": 1,
+                "maxItems": 2,
+            })
+        );
+
+        let array2 = serde_json::from_value(json)?;
+        assert_eq!(array, array2);
+
+        let json = json!({
+            "items": "https://example.com/data_type"
+        });
+        assert!(serde_json::from_value::<Array<Uri>>(json).is_err());
+
+        let json = json!({
+            "type": "array",
+            "items": "https://example.com/data_type",
+            "minItems": 1
+        });
+        assert!(serde_json::from_value::<Array<Uri>>(json).is_ok());
+
+        let json = json!({
+            "type": "array",
+            "items": "https://example.com/data_type",
+            "maxItems": 1
+        });
+        assert!(serde_json::from_value::<Array<Uri>>(json).is_ok());
+
+        let json = json!({
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 1
+        });
+        assert!(serde_json::from_value::<Array<Uri>>(json).is_err());
+
+        let json = json!({
+            "type": "array",
+            "items": "https://example.com/data_type",
+            "numItems": 1,
+        });
+        assert!(serde_json::from_value::<Array<Uri>>(json).is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn one_or_many_single() -> Result<(), Box<dyn Error>> {
+        let one = OneOrMany::One(Uri::new("https://example.com/data_type")?);
+
+        let json = serde_json::to_value(&one)?;
+        assert_eq!(json, serde_json::json!("https://example.com/data_type"));
+
+        let one2 = serde_json::from_value(json)?;
+        assert_eq!(one, one2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn one_or_many_array() -> Result<(), Box<dyn Error>> {
+        let array = OneOrMany::Array(Array::new(
+            Uri::new("https://example.com/data_type")?,
+            None,
+            None,
+        )?);
+
+        let json = serde_json::to_value(&array)?;
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "type": "array",
+                "items": "https://example.com/data_type",
+            })
+        );
+
+        let array2 = serde_json::from_value(json)?;
+        assert_eq!(array, array2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn one_of() -> Result<(), Box<dyn Error>> {
+        let one = OneOf::new([Uri::new("https://example.com/data_type")?])?;
+
+        let json = serde_json::to_value(&one)?;
+        assert_eq!(
+            json,
+            serde_json::json!({ "oneOf": ["https://example.com/data_type"] })
+        );
+
+        let one2 = serde_json::from_value(json)?;
+        assert_eq!(one, one2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn one_of_validation() {
+        let json = json!({ "oneOf": [] });
+        assert!(serde_json::from_value::<OneOf<Uri>>(json).is_err());
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/mod.rs
@@ -1,0 +1,43 @@
+mod helper;
+pub mod properties;
+mod reference;
+
+use core::fmt;
+
+pub trait Validate {
+    /// Validates the schema of the object.
+    ///
+    /// This does only check the validity of this object, not it's child data. A validation also
+    /// happens when the type is created.
+    ///
+    /// # Errors
+    ///
+    /// - [`ValidationError`] if the object is not in a valid state.
+    fn validate(&self) -> Result<(), ValidationError>;
+}
+
+#[doc(inline)]
+pub use self::{
+    helper::{Array, OneOf, OneOrMany},
+    properties::PropertyType,
+    reference::{DataTypeReference, PropertyTypeReference, Uri},
+};
+
+#[derive(Debug)]
+pub enum ValidationError {
+    PropertyMissing(Uri),
+    OneOfEmpty,
+}
+
+impl fmt::Display for ValidationError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::PropertyMissing(uri) => {
+                write!(fmt, "Required field {uri} is not used in `properties`")
+            }
+            Self::OneOfEmpty => fmt.write_str("`one_of` must have at least one item"),
+        }
+    }
+}
+
+impl std::error::Error for ValidationError {}

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/properties.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/properties.rs
@@ -1,0 +1,581 @@
+#![allow(
+    clippy::use_self,
+    reason = "Weird false positive on `PropertyValues` which somehow can't be disabled locally"
+)]
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::schema::{
+    Array, DataTypeReference, OneOf, OneOrMany, PropertyTypeReference, Uri, Validate,
+    ValidationError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    try_from = "PropertyTypeObjectRepr",
+    tag = "type",
+    rename = "object",
+    rename_all = "camelCase"
+)]
+pub struct PropertyTypeObject {
+    /// Property names must be a valid URI to a property-type
+    properties: HashMap<Uri, OneOrMany<PropertyTypeReference>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    required: Vec<Uri>,
+}
+
+impl PropertyTypeObject {
+    /// Creates a new `PropertyTypeObject` without validating.
+    #[must_use]
+    pub const fn new_unchecked(
+        properties: HashMap<Uri, OneOrMany<PropertyTypeReference>>,
+        required: Vec<Uri>,
+    ) -> Self {
+        Self {
+            properties,
+            required,
+        }
+    }
+
+    /// Creates a new `PropertyTypeObject` with the given properties and required properties.
+    ///
+    /// # Errors
+    ///
+    /// - [`ValidationError::PropertyMissing`] if a required property is not a key in `properties`.
+    pub fn new(
+        properties: HashMap<Uri, OneOrMany<PropertyTypeReference>>,
+        required: Vec<Uri>,
+    ) -> Result<Self, ValidationError> {
+        let object = Self::new_unchecked(properties, required);
+        object.validate()?;
+        Ok(object)
+    }
+}
+
+impl Validate for PropertyTypeObject {
+    fn validate(&self) -> Result<(), ValidationError> {
+        for uri in &self.required {
+            if !self.properties.contains_key(uri) {
+                return Err(ValidationError::PropertyMissing(uri.clone()));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum ObjectTypeTag {
+    Object,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct PropertyTypeObjectRepr {
+    #[serde(rename = "type")]
+    _type: ObjectTypeTag,
+    /// Property names must be a valid URI to a property-type
+    properties: HashMap<Uri, OneOrMany<PropertyTypeReference>>,
+    #[serde(default)]
+    required: Vec<Uri>,
+}
+
+impl TryFrom<PropertyTypeObjectRepr> for PropertyTypeObject {
+    type Error = ValidationError;
+
+    fn try_from(object: PropertyTypeObjectRepr) -> Result<Self, ValidationError> {
+        Self::new(object.properties, object.required)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum PropertyValues {
+    PropertyTypeObject(PropertyTypeObject),
+    DataTypeReference(DataTypeReference),
+    PropertyTypeValues(Array<OneOf<Self>>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    try_from = "PropertyTypeRepr",
+    tag = "kind",
+    rename = "propertyType",
+    rename_all = "camelCase"
+)]
+pub struct PropertyType {
+    #[serde(rename = "$id")]
+    id: Uri,
+    title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(flatten)]
+    one_of: OneOf<PropertyValues>,
+}
+
+impl PropertyType {
+    /// Creates a new `PropertyType` without validating.
+    #[must_use]
+    pub const fn new_unchecked(
+        id: Uri,
+        title: String,
+        description: Option<String>,
+        one_of: OneOf<PropertyValues>,
+    ) -> Self {
+        Self {
+            id,
+            title,
+            description,
+            one_of,
+        }
+    }
+
+    /// Creates a new `PropertyType`.
+    ///
+    /// # Errors
+    ///
+    /// - [`ValidationError`] if validation is failing.
+    pub fn new(
+        id: Uri,
+        title: String,
+        description: Option<String>,
+        one_of: OneOf<PropertyValues>,
+    ) -> Result<Self, ValidationError> {
+        let property_type = Self::new_unchecked(id, title, description, one_of);
+        property_type.validate()?;
+        Ok(property_type)
+    }
+
+    #[must_use]
+    pub const fn id(&self) -> &Uri {
+        &self.id
+    }
+
+    #[must_use]
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    #[must_use]
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
+    #[must_use]
+    pub fn one_of(&self) -> &[PropertyValues] {
+        self.one_of.one_of()
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum PropertyTypeTag {
+    PropertyType,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PropertyTypeRepr {
+    #[serde(rename = "kind")]
+    _type: PropertyTypeTag,
+    #[serde(rename = "$id")]
+    id: Uri,
+    title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(flatten)]
+    one_of: OneOf<PropertyValues>,
+}
+
+impl TryFrom<PropertyTypeRepr> for PropertyType {
+    type Error = ValidationError;
+
+    fn try_from(property_type: PropertyTypeRepr) -> Result<Self, ValidationError> {
+        Self::new(
+            property_type.id,
+            property_type.title,
+            property_type.description,
+            property_type.one_of,
+        )
+    }
+}
+
+impl Validate for PropertyType {
+    fn validate(&self) -> Result<(), ValidationError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+
+    use serde_json::json;
+
+    use super::*;
+    use crate::types::schema::Array;
+
+    #[test]
+    fn one_object() -> Result<(), Box<dyn Error>> {
+        let object = PropertyTypeObject {
+            properties: [(
+                Uri::new("https://example.com/property_type")?,
+                OneOrMany::One(PropertyTypeReference::new(Uri::new(
+                    "https://example.com/property_type",
+                )?)?),
+            )]
+            .into_iter()
+            .collect(),
+            required: vec![],
+        };
+
+        let json = serde_json::to_value(&object)?;
+        assert_eq!(
+            json,
+            json!({
+                "type": "object",
+                "properties": {
+                    "https://example.com/property_type": {
+                        "$ref": "https://example.com/property_type"
+                    },
+                }
+            })
+        );
+
+        let object2 = serde_json::from_value(json)?;
+        assert_eq!(object, object2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn many_objects() -> Result<(), Box<dyn Error>> {
+        let object = PropertyTypeObject {
+            properties: [(
+                Uri::new("https://example.com/property_type")?,
+                OneOrMany::Array(Array::new(
+                    PropertyTypeReference::new(Uri::new("https://example.com/property_type")?)?,
+                    None,
+                    None,
+                )?),
+            )]
+            .into_iter()
+            .collect(),
+            required: vec![],
+        };
+
+        let json = serde_json::to_value(&object)?;
+        assert_eq!(
+            json,
+            json!({
+                "type": "object",
+                "properties": {
+                    "https://example.com/property_type": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "https://example.com/property_type"
+                        }
+                    },
+                }
+            })
+        );
+
+        let object2 = serde_json::from_value(json)?;
+        assert_eq!(object, object2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn required_object() -> Result<(), Box<dyn Error>> {
+        let object = PropertyTypeObject {
+            properties: [(
+                Uri::new("https://example.com/property_type")?,
+                OneOrMany::One(PropertyTypeReference::new(Uri::new(
+                    "https://example.com/property_type",
+                )?)?),
+            )]
+            .into_iter()
+            .collect(),
+            required: vec![Uri::new("https://example.com/property_type")?],
+        };
+
+        let json = serde_json::to_value(&object)?;
+        assert_eq!(
+            json,
+            json!({
+                "type": "object",
+                "properties": {
+                    "https://example.com/property_type": {
+                        "$ref": "https://example.com/property_type"
+                    },
+                },
+                "required": ["https://example.com/property_type"]
+            })
+        );
+
+        let object2 = serde_json::from_value(json)?;
+        assert_eq!(object, object2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn validate_object() {
+        let json = json!({
+            "type": "object",
+            "properties": {
+                "https://example.com/property_type": {
+                    "$ref": "https://example.com/property_type"
+                },
+            },
+            "required": ["https://example.com/property_type"]
+        });
+        assert!(serde_json::from_value::<PropertyTypeObject>(json).is_ok());
+
+        let json = json!({
+            "type": "object",
+            "properties": {
+                "https://example.com/property_type": {
+                    "$ref": "https://example.com/property_type"
+                },
+            },
+            "required": ["https://example.com/property_type_2"]
+        });
+        assert!(serde_json::from_value::<PropertyTypeObject>(json).is_err());
+    }
+
+    #[test]
+    fn property_value_object() -> Result<(), Box<dyn Error>> {
+        let object = PropertyValues::PropertyTypeObject(PropertyTypeObject {
+            properties: [(
+                Uri::new("https://example.com/property_type")?,
+                OneOrMany::One(PropertyTypeReference::new(Uri::new(
+                    "https://example.com/property_type",
+                )?)?),
+            )]
+            .into_iter()
+            .collect(),
+            required: vec![],
+        });
+
+        let json = serde_json::to_value(&object)?;
+        assert_eq!(
+            json,
+            json!({
+                "type": "object",
+                "properties": {
+                    "https://example.com/property_type": {
+                        "$ref": "https://example.com/property_type"
+                    },
+                }
+            })
+        );
+
+        let object2 = serde_json::from_value(json)?;
+        assert_eq!(object, object2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn property_value_reference() -> Result<(), Box<dyn Error>> {
+        let object = PropertyValues::DataTypeReference(DataTypeReference::new(Uri::new(
+            "https://example.com/property_type",
+        )?)?);
+
+        let json = serde_json::to_value(&object)?;
+        assert_eq!(
+            json,
+            json!({
+                "$ref": "https://example.com/property_type"
+            })
+        );
+
+        let object2 = serde_json::from_value(json)?;
+        assert_eq!(object, object2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn property_values() -> Result<(), Box<dyn Error>> {
+        let object = PropertyValues::PropertyTypeValues(Array::new(
+            OneOf::new([PropertyValues::DataTypeReference(DataTypeReference::new(
+                Uri::new("https://example.com/property_type")?,
+            )?)])?,
+            None,
+            None,
+        )?);
+
+        let json = serde_json::to_value(&object)?;
+        assert_eq!(
+            json,
+            json!({
+                "type": "array",
+                "items": {
+                    "oneOf": [
+                        {
+                            "$ref": "https://example.com/property_type"
+                        }
+                    ]
+                }
+            })
+        );
+
+        let object2 = serde_json::from_value(json)?;
+        assert_eq!(object, object2);
+
+        Ok(())
+    }
+
+    mod property_type {
+        use super::*;
+
+        fn test_property_type_schema(schema: serde_json::Value) {
+            serde_json::from_value::<PropertyType>(schema).expect("Not a valid schema");
+        }
+
+        #[test]
+        fn favorite_quote() {
+            test_property_type_schema(json!({
+              "kind": "propertyType",
+              "$id": "https://blockprotocol.org/types/@alice/property-type/favorite-quote",
+              "title": "Favorite Quote",
+              "oneOf": [
+                { "$ref": "https://blockprotocol.org/types/@blockprotocol/data-type/text" }
+              ]
+            }));
+        }
+
+        #[test]
+        fn age() {
+            test_property_type_schema(json!({
+              "kind": "propertyType",
+              "$id": "https://blockprotocol.org/types/@alice/property-type/age",
+              "title": "Age",
+              "oneOf": [
+                {
+                  "$ref": "https://blockprotocol.org/types/@blockprotocol/data-type/Number"
+                }
+              ]
+            }));
+        }
+
+        #[test]
+        fn user_id() {
+            test_property_type_schema(json!({
+              "kind": "propertyType",
+              "$id": "https://blockprotocol.org/types/@alice/property-type/user-id",
+              "title": "User ID",
+              "oneOf": [
+                { "$ref": "https://blockprotocol.org/types/@blockprotocol/data-type/text" },
+                {
+                  "$ref": "https://blockprotocol.org/types/@blockprotocol/data-type/number"
+                }
+              ]
+            }));
+        }
+
+        #[test]
+        fn contact_information() {
+            test_property_type_schema(json!({
+              "kind": "propertyType",
+              "$id": "https://blockprotocol.org/types/@alice/property-type/contact-information",
+              "title": "Contact Information",
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "https://blockprotocol.org/types/@blockprotocol/property-type/email": {
+                      "$ref": "https://blockprotocol.org/types/@blockprotocol/property-type/email"
+                    },
+                    "https://blockprotocol.org/types/@blockprotocol/property-type/phone-number": {
+                      "$ref": "https://blockprotocol.org/types/@blockprotocol/property-type/phone-number"
+                    }
+                  },
+                  "required": [
+                    "https://blockprotocol.org/types/@blockprotocol/property-type/email"
+                  ]
+                }
+              ]
+            }));
+        }
+
+        #[test]
+        fn interests() {
+            test_property_type_schema(json!({
+              "kind": "propertyType",
+              "$id": "https://blockprotocol.org/types/@alice/property-type/interests",
+              "title": "Interests",
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "https://blockprotocol.org/types/@blockprotocol/property-type/favorite-film": {
+                      "$ref": "https://blockprotocol.org/types/@blockprotocol/property-type/favorite-film"
+                    },
+                    "https://blockprotocol.org/types/@blockprotocol/property-type/favorite-song": {
+                      "$ref": "https://blockprotocol.org/types/@blockprotocol/property-type/favorite-song"
+                    },
+                    "https://blockprotocol.org/types/@blockprotocol/property-type/hobby": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "https://blockprotocol.org/types/@blockprotocol/property-type/hobby"
+                      }
+                    }
+                  }
+                }
+              ]
+            }));
+        }
+
+        #[test]
+        fn numbers() {
+            test_property_type_schema(json!({
+              "kind": "propertyType",
+              "$id": "https://blockprotocol.org/types/@alice/property-type/numbers",
+              "title": "Numbers",
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "https://blockprotocol.org/types/@blockprotocol/data-type/number"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }));
+        }
+
+        #[test]
+        fn contrived_property() {
+            test_property_type_schema(json!({
+              "kind": "propertyType",
+              "$id": "https://blockprotocol.org/types/@alice/property-type/contrived-property",
+              "title": "Contrived Property",
+              "oneOf": [
+                {
+                  "$ref": "https://blockprotocol.org/types/@blockprotocol/data-type/number"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "https://blockprotocol.org/types/@blockprotocol/data-type/number"
+                      }
+                    ]
+                  },
+                  "maxItems": 4
+                }
+              ]
+            }));
+        }
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/reference.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/reference.rs
@@ -1,0 +1,142 @@
+use core::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::schema::{Validate, ValidationError};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Uri(String);
+
+impl Uri {
+    /// Creates a new `Uri` without validating.
+    #[must_use]
+    pub fn new_unchecked<T: Into<String>>(uri: T) -> Self {
+        Self(uri.into())
+    }
+
+    /// Creates a new `Uri` from the given string.
+    ///
+    /// # Errors
+    ///
+    /// - [`ValidationError`] if validation is failing.
+    pub fn new<T: Into<String>>(uri: T) -> Result<Self, ValidationError> {
+        let uri = Self::new_unchecked(uri);
+        uri.validate()?;
+        Ok(uri)
+    }
+}
+
+impl fmt::Display for Uri {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.0)
+    }
+}
+
+impl Validate for Uri {
+    fn validate(&self) -> Result<(), ValidationError> {
+        Ok(())
+    }
+}
+
+/// Property Object values must be defined through references to the same valid URI to a Property
+/// Type.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PropertyTypeReference {
+    #[serde(rename = "$ref")]
+    reference: Uri,
+}
+
+impl PropertyTypeReference {
+    /// Creates a new `PropertyTypeReference` without validating.
+    #[must_use]
+    pub const fn new_unchecked(reference: Uri) -> Self {
+        Self { reference }
+    }
+
+    /// Creates a new `PropertyTypeReference` from the given `reference`.
+    ///
+    /// # Errors
+    ///
+    /// - [`ValidationError`] if validation is failing.
+    pub fn new(reference: Uri) -> Result<Self, ValidationError> {
+        let reference = Self::new_unchecked(reference);
+        reference.validate()?;
+        Ok(reference)
+    }
+
+    #[must_use]
+    pub const fn reference(&self) -> &Uri {
+        &self.reference
+    }
+}
+
+impl Validate for PropertyTypeReference {
+    fn validate(&self) -> Result<(), ValidationError> {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DataTypeReference {
+    #[serde(rename = "$ref")]
+    reference: Uri,
+}
+
+impl DataTypeReference {
+    /// Creates a new `DataTypeReference` without validating.
+    #[must_use]
+    pub const fn new_unchecked(reference: Uri) -> Self {
+        Self { reference }
+    }
+
+    /// Creates a new `DataTypeReference` from the given `reference`.
+    ///
+    /// # Errors
+    ///
+    /// - [`ValidationError`] if validation is failing.
+    pub fn new(reference: Uri) -> Result<Self, ValidationError> {
+        let reference = Self::new_unchecked(reference);
+        reference.validate()?;
+        Ok(reference)
+    }
+
+    #[must_use]
+    pub const fn reference(&self) -> &Uri {
+        &self.reference
+    }
+}
+
+impl Validate for DataTypeReference {
+    fn validate(&self) -> Result<(), ValidationError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn data_type_reference() -> Result<(), Box<dyn Error>> {
+        let reference = DataTypeReference::new(Uri::new("https://example.com/data_type")?)?;
+        let json = serde_json::to_value(&reference)?;
+
+        assert_eq!(
+            json,
+            json!({
+                "$ref": "https://example.com/data_type"
+            })
+        );
+
+        let reference2: DataTypeReference = serde_json::from_value(json)?;
+        assert_eq!(reference, reference2);
+        Ok(())
+    }
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In order to extract information from the property schemas, this PR adds a Rust representation of [the schema](https://github.com/blockprotocol/blockprotocol/blob/main/rfcs/text/0352-graph-type-system.md#property-types-1).

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1200211978612931/1202510174412970) _(internal)_

## 🔍 What does this change?

- Adds the `PropertyType` schema
- Add schema validation to `PropertyType` (not resolving `$ref` but the schema structure and logic like e.g. ensuring, that items in a `required` array are present in the corresponding `properties` map)
- Check property URIs before inserting them into the database

## 📜 Does this require a change to the docs?

Documentation were added, but could be improved in a follow-up PR

## ⚠️ Known issues

Until we have versions implemented, we are not able to properly update property types

## 🐾 Next steps

Add the references of property types to other property types or data types to the database

## 🛡 What tests cover this?

A bunch of tests was added to test the schema
