### PR TITLE
Change `libs` label to `error-stack`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -31,11 +31,11 @@ A-learn:
   - "sites/hashai/resources/**/*"
   - "sites/hashai/resources/**/.*"
 
-A-libs:
-  - "packages/libs/*"
-  - "packages/libs/.*"
-  - "packages/libs/**/*"
-  - "packages/libs/**/.*"
+A-error-stack:
+  - "packages/libs/error-stack/*"
+  - "packages/libs/error-stack/.*"
+  - "packages/libs/error-stack/**/*"
+  - "packages/libs/error-stack/**/.*"
 
 C-dependencies:
   - "**/Cargo.lock"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We currently only have `error-stack` in `libs` and `error-stack` is used often in issues/discussions/PRs.