### PR TITLE
Add compatibility layer for `eyre` and `anyhow`

### DIFF
--- a/packages/libs/error-stack/CHANGELOG.md
+++ b/packages/libs/error-stack/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to `error-stack` will be documented in this file.
 - Implement [`Termination`](https://doc.rust-lang.org/stable/std/process/trait.Termination.html) for `Report` ([#671](https://github.com/hashintel/hash/pull/671))
 - Add support for async `Stream`s ([#718](https://github.com/hashintel/hash/pull/718))
 - Add support for `Iterator`s ([#716](https://github.com/hashintel/hash/pull/716))
+- Add compatibility support for `anyhow` and `eyre` ([#763](https://github.com/hashintel/hash/pull/763))
+
+  Do you want to support your error type as well? Implement [`Context`](https://docs.rs/error-stack/latest/error_stack/trait.Context.html) and you are set!
 
 ### Deprecations
 

--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -17,6 +17,7 @@ tracing-error = { version = "0.2.0", optional = true }
 once_cell = { version = "1.10.0", optional = true }
 pin-project = { version = "1.0.10", optional = true }
 futures-core = { version = "0.3.21", optional = true, default-features = false }
+anyhow = { version = "1.0.58", default-features = false, optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0.137", features = ["derive"] }
@@ -28,7 +29,7 @@ rustc_version = "0.2.3"
 
 [features]
 default = ["std"]
-std = []
+std = ["anyhow?/std"]
 hooks = ["dep:once_cell", "std"]
 spantrace = ["dep:tracing-error"]
 futures = ["dep:pin-project", "dep:futures-core"]

--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -18,6 +18,7 @@ once_cell = { version = "1.10.0", optional = true }
 pin-project = { version = "1.0.10", optional = true }
 futures-core = { version = "0.3.21", optional = true, default-features = false }
 anyhow = { version = "1.0.58", default-features = false, optional = true }
+eyre = { version = "0.6.8", default-features = false, optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0.137", features = ["derive"] }

--- a/packages/libs/error-stack/Makefile.toml
+++ b/packages/libs/error-stack/Makefile.toml
@@ -1,6 +1,6 @@
 extend = { path = "../../../.github/scripts/rust/Makefile.toml" }
 
 [env]
-CARGO_CLIPPY_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default"
-CARGO_TEST_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default"
-CARGO_MIRI_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default"
+CARGO_CLIPPY_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default --optional-deps eyre,anyhow"
+CARGO_TEST_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default --optional-deps eyre,anyhow"
+CARGO_MIRI_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default --optional-deps eyre,anyhow"

--- a/packages/libs/error-stack/src/compat/anyhow.rs
+++ b/packages/libs/error-stack/src/compat/anyhow.rs
@@ -1,0 +1,40 @@
+use core::panic::Location;
+
+use anyhow::Error;
+
+use crate::{Compat, Frame, Report, Result};
+
+impl<T> Compat for core::result::Result<T, Error> {
+    type Err = Error;
+    type Ok = T;
+
+    #[track_caller]
+    fn into_report(self) -> Result<T, Error> {
+        match self {
+            Ok(t) => Ok(t),
+            Err(anyhow) => {
+                #[cfg(feature = "std")]
+                let sources = anyhow
+                    .chain()
+                    .skip(1)
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>();
+
+                let mut report = Report::from_frame(
+                    Frame::from_compat(anyhow, Location::caller()),
+                    #[cfg(all(nightly, feature = "std"))]
+                    Some(std::backtrace::Backtrace::capture()),
+                    #[cfg(feature = "spantrace")]
+                    Some(tracing_error::SpanTrace::capture()),
+                );
+
+                #[cfg(feature = "std")]
+                for source in sources {
+                    report = report.attach_printable(source);
+                }
+
+                Err(report)
+            }
+        }
+    }
+}

--- a/packages/libs/error-stack/src/compat/eyre.rs
+++ b/packages/libs/error-stack/src/compat/eyre.rs
@@ -1,0 +1,36 @@
+use core::panic::Location;
+
+use crate::{Compat, Frame, Report, Result};
+
+impl<T> Compat for core::result::Result<T, eyre::Report> {
+    type Err = eyre::Report;
+    type Ok = T;
+
+    #[track_caller]
+    fn into_report(self) -> Result<T, eyre::Report> {
+        match self {
+            Ok(t) => Ok(t),
+            Err(eyre) => {
+                let sources = eyre
+                    .chain()
+                    .skip(1)
+                    .map(alloc::string::ToString::to_string)
+                    .collect::<alloc::vec::Vec<_>>();
+
+                let mut report = Report::from_frame(
+                    Frame::from_compat(eyre, Location::caller()),
+                    #[cfg(all(nightly, feature = "std"))]
+                    Some(std::backtrace::Backtrace::capture()),
+                    #[cfg(feature = "spantrace")]
+                    Some(tracing_error::SpanTrace::capture()),
+                );
+
+                for source in sources {
+                    report = report.attach_printable(source);
+                }
+
+                Err(report)
+            }
+        }
+    }
+}

--- a/packages/libs/error-stack/src/compat/mod.rs
+++ b/packages/libs/error-stack/src/compat/mod.rs
@@ -1,0 +1,22 @@
+#[cfg(feature = "anyhow")]
+pub(crate) mod anyhow;
+
+use crate::Result;
+
+/// Compatibility trait to convert from external libraries to [`Report`].
+///
+/// [`Report`]: crate::Report
+pub trait Compat: Sized {
+    /// Type of the [`Ok`] value in the [`Result`]
+    type Ok;
+
+    /// Type of the resulting [`Err`] variant wrapped inside a [`Report<E>`].
+    ///
+    /// [`Report<E>`]: crate::Report
+    type Err;
+
+    /// Converts the [`Err`] variant of the [`Result`] to a [`Report`]
+    ///
+    /// [`Report`]: crate::Report
+    fn into_report(self) -> Result<Self::Ok, Self::Err>;
+}

--- a/packages/libs/error-stack/src/compat/mod.rs
+++ b/packages/libs/error-stack/src/compat/mod.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "anyhow")]
-pub(crate) mod anyhow;
+mod anyhow;
+#[cfg(feature = "eyre")]
+mod eyre;
 
 use crate::Result;
 

--- a/packages/libs/error-stack/src/frame/compat.rs
+++ b/packages/libs/error-stack/src/frame/compat.rs
@@ -1,0 +1,20 @@
+use core::fmt;
+
+use crate::Context;
+
+#[repr(transparent)]
+pub(crate) struct CompatContext<T>(T);
+
+impl<T: fmt::Debug> fmt::Debug for CompatContext<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, fmt)
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for CompatContext<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, fmt)
+    }
+}
+
+impl<T: fmt::Debug + fmt::Display + Send + Sync + 'static> Context for CompatContext<T> {}

--- a/packages/libs/error-stack/src/frame/compat.rs
+++ b/packages/libs/error-stack/src/frame/compat.rs
@@ -3,7 +3,7 @@ use core::fmt;
 use crate::Context;
 
 #[repr(transparent)]
-pub(crate) struct CompatContext<T>(T);
+pub struct CompatContext<T>(T);
 
 impl<T: fmt::Debug> fmt::Debug for CompatContext<T> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/packages/libs/error-stack/src/frame/mod.rs
+++ b/packages/libs/error-stack/src/frame/mod.rs
@@ -1,5 +1,5 @@
 mod attachment;
-#[cfg(feature = "anyhow")]
+#[cfg(any(feature = "eyre", feature = "anyhow"))]
 mod compat;
 mod erasable;
 mod kind;
@@ -98,7 +98,7 @@ impl Frame {
     }
 
     /// Crates a frame from [`anyhow::Error`].
-    #[cfg(feature = "anyhow")]
+    #[cfg(any(feature = "anyhow", feature = "eyre"))]
     pub(crate) fn from_compat<T>(compat: T, location: &'static Location<'static>) -> Self
     where
         T: fmt::Display + fmt::Debug + Send + Sync + 'static,

--- a/packages/libs/error-stack/src/frame/mod.rs
+++ b/packages/libs/error-stack/src/frame/mod.rs
@@ -1,4 +1,6 @@
 mod attachment;
+#[cfg(feature = "anyhow")]
+mod compat;
 mod erasable;
 mod kind;
 mod vtable;
@@ -93,6 +95,15 @@ impl Frame {
             source,
             VTable::new_printable_attachment::<A>(),
         )
+    }
+
+    /// Crates a frame from [`anyhow::Error`].
+    #[cfg(feature = "anyhow")]
+    pub(crate) fn from_compat<T>(compat: T, location: &'static Location<'static>) -> Self
+    where
+        T: fmt::Display + fmt::Debug + Send + Sync + 'static,
+    {
+        Self::from_unerased(compat, location, None, VTable::new_compat::<T>())
     }
 
     /// Returns the location where this `Frame` was created.

--- a/packages/libs/error-stack/src/frame/vtable.rs
+++ b/packages/libs/error-stack/src/frame/vtable.rs
@@ -73,7 +73,7 @@ impl VTable {
     /// Creates a `VTable` for a [`compat`].
     ///
     /// [`Compat`]: crate::Compat
-    #[cfg(feature = "anyhow")]
+    #[cfg(any(feature = "anyhow", feature = "eyre"))]
     pub fn new_compat<T>() -> &'static Self
     where
         T: fmt::Display + fmt::Debug + Send + Sync + 'static,

--- a/packages/libs/error-stack/src/frame/vtable.rs
+++ b/packages/libs/error-stack/src/frame/vtable.rs
@@ -70,6 +70,24 @@ impl VTable {
         }
     }
 
+    /// Creates a `VTable` for a [`compat`].
+    ///
+    /// [`Compat`]: crate::Compat
+    #[cfg(feature = "anyhow")]
+    pub fn new_compat<T>() -> &'static Self
+    where
+        T: fmt::Display + fmt::Debug + Send + Sync + 'static,
+    {
+        use crate::frame::compat::CompatContext;
+        &Self {
+            object_drop: Self::object_drop::<CompatContext<T>>,
+            object_downcast: Self::object_downcast::<T>,
+            unerase: Self::unerase_context::<CompatContext<T>>,
+            #[cfg(nightly)]
+            provide: Self::self_provide::<T>,
+        }
+    }
+
     /// Unerases the `frame` as a [`FrameKind`].
     pub(in crate::frame) fn unerase<'f>(&self, frame: &'f ErasableFrame) -> FrameKind<'f> {
         // SAFETY: Use vtable to attach the frames' native vtable for the right original type.

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -357,6 +357,7 @@
 //!  `hooks`   |Enables the usage of [`set_display_hook`] and [`set_debug_hook`]| `std`   | disabled
 //! `spantrace`| Enables the capturing of [`SpanTrace`]s                        |         | disabled
 //!  `futures` | Provides a [`FutureExt`] adaptor                               |         | disabled
+//!  `anyhow`  | Provides conversion from [`anyhow::Error`] to [`Report`]       |         | disabled
 //!
 //! [`set_display_hook`]: Report::set_display_hook
 //! [`set_debug_hook`]: Report::set_debug_hook
@@ -383,6 +384,7 @@
 
 extern crate alloc;
 
+pub(crate) mod compat;
 mod frame;
 pub mod iter;
 mod macros;
@@ -395,6 +397,8 @@ mod hook;
 #[cfg(test)]
 pub(crate) mod test_helper;
 
+#[cfg(feature = "anyhow")]
+pub use self::compat::Compat;
 #[doc(inline)]
 pub use self::ext::*;
 #[cfg(feature = "hooks")]

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -358,6 +358,7 @@
 //! `spantrace`| Enables the capturing of [`SpanTrace`]s                        |         | disabled
 //!  `futures` | Provides a [`FutureExt`] adaptor                               |         | disabled
 //!  `anyhow`  | Provides conversion from [`anyhow::Error`] to [`Report`]       |         | disabled
+//!   `eyre`   | Provides conversion from [`eyre::Report`] to [`Report`]        |         | disabled
 //!
 //! [`set_display_hook`]: Report::set_display_hook
 //! [`set_debug_hook`]: Report::set_debug_hook
@@ -397,7 +398,7 @@ mod hook;
 #[cfg(test)]
 pub(crate) mod test_helper;
 
-#[cfg(feature = "anyhow")]
+#[cfg(any(feature = "anyhow", feature = "eyre"))]
 pub use self::compat::Compat;
 #[doc(inline)]
 pub use self::ext::*;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`eyre` and `anyhow` are popular error libraries. Converting their error type into `error_stack::Report` is a convenient feature, which is not easily possible without adding built-in support.

## 🔗 Related links

- Closes https://github.com/hashintel/hash/discussions/761

## 🔍 What does this change?

- Add a `Compat` trait, which acts like `IntoReport` (implementing `IntoReport` is not possible as this relies on `Error`, which we can't implement on upstream error types)
- Add a wrapper to allow creating `Report<anyhow::Error>` and `Report<eyre::Report>`

## 📜 Does this require a change to the docs?

The features were added to the documentation

## ⚠️ Known issues

It's not possible on no-std environments to fully reconstruct `anyhow::Error` as it relies on `StdError`
