### PR TITLE
Move `getPhoto` to a separate file to fix hashdev build

### DIFF
--- a/sites/hashdev/src/pages/blog/[...blogSlug].page.tsx
+++ b/sites/hashdev/src/pages/blog/[...blogSlug].page.tsx
@@ -1,18 +1,14 @@
-import { imageSize as legacyImageSize } from "image-size";
 import { GetStaticPaths, GetStaticProps, NextPage } from "next";
 import { MDXRemoteSerializeResult } from "next-mdx-remote";
-import { promisify } from "util";
 import {
   BlogPagePhotos,
   BlogPostContent,
   BlogPostHead,
-  BlogPostPagePhoto,
   BlogPostPhotosContext,
 } from "../../components/BlogPost";
 import { MdxPageContent } from "../../components/MdxPageContent";
 import { getAllPageHrefs, getSerializedPage } from "../../util/mdxUtil";
-
-const imageSize = promisify(legacyImageSize);
+import { getPhoto } from "./shared/get-photo";
 
 export type BlogPostProps = {
   title: string;
@@ -51,21 +47,6 @@ export const getStaticPaths: GetStaticPaths<
     paths,
     fallback: false,
   };
-};
-
-export const getPhoto = async (
-  src: string | null,
-): Promise<BlogPostPagePhoto | null> => {
-  if (!src) return null;
-  const fullUrl = `/public/${src}`;
-  // @todo this is relative to CLI dir – need to make it absolute
-  const size = await imageSize(`.${fullUrl}`);
-
-  if (!size || size.width === undefined || size.height === undefined) {
-    return null;
-  }
-
-  return { src: `/${src}`, height: size.height, width: size.width };
 };
 
 export const getStaticProps: GetStaticProps<

--- a/sites/hashdev/src/pages/blog/index.page.tsx
+++ b/sites/hashdev/src/pages/blog/index.page.tsx
@@ -18,7 +18,8 @@ import { Subscribe } from "../../components/PreFooter";
 import { parseNameFromFileName } from "../../util/clientMdxUtil";
 import { getAllPages, Page } from "../../util/mdxUtil";
 import { NextPageWithLayout } from "../../util/nextTypes";
-import { BlogPostProps, getPhoto } from "./[...blogSlug].page";
+import { getPhoto } from "./shared/get-photo";
+import { BlogPostProps } from "./[...blogSlug].page";
 
 type BlogIndividualPage = Page<BlogPostProps> & {
   photos: {

--- a/sites/hashdev/src/pages/blog/shared/get-photo.ts
+++ b/sites/hashdev/src/pages/blog/shared/get-photo.ts
@@ -1,0 +1,20 @@
+import { promisify } from "util";
+import { imageSize as legacyImageSize } from "image-size";
+import { BlogPostPagePhoto } from "../../../components/BlogPost";
+
+const imageSize = promisify(legacyImageSize);
+
+export const getPhoto = async (
+  src: string | null,
+): Promise<BlogPostPagePhoto | null> => {
+  if (!src) return null;
+  const fullUrl = `/public/${src}`;
+  // @todo this is relative to CLI dir – need to make it absolute
+  const size = await imageSize(`.${fullUrl}`);
+
+  if (!size || size.width === undefined || size.height === undefined) {
+    return null;
+  }
+
+  return { src: `/${src}`, height: size.height, width: size.width };
+};


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Upgrading Next to 12.2 in #757 broke `yarn workspace @hashintel/hashdev build`. This PR fixes the build (see [logs on Vercel](https://vercel.com/hashintel/hashdev/QSFzEEV4KxMpHAdyy2ddHF4Fr8Yw)).
 
<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202482456346915/1202552815181167/f) _(internal)_
- [Slack thread](https://hashintel.slack.com/archives/C022217GAHF/p1657210605084789) _(internal)_

## 🔍 What does this change?

Next 12.2 must have changed some tree-shaking nuances compared to 12.1. I believe that `const imageSize = promisify(legacyImageSize)` is now preventing tree-shaking, thus making `image-size` a part of the client bundle. Build crashes because it cannot resolve `fs` which `image-size` relies on. Moving `getImage` to a separate file re-enables tree-shaking because the function is only used in `getStaticProps`. This matches conventional usage of server-only imports in Next.


## 📜 Does this require a change to the docs?

No

## ⚠️ Known issues

I did not notice the problem in time because

- `yarn workspace @hashintel/hashdev dev` worked without problems

- CI was skipped so all checks in #757 were ✅:
  <img width="861" alt="Screenshot 2022-07-07 at 17 52 45" src="https://user-images.githubusercontent.com/608862/177831835-062bf7e6-a993-4559-b2f9-e4b8d5eb837f.png">

We should investigate the skip logic on Vercel to avoid similar issues in the future.

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🛡 What tests cover this?

CI

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch / view the deployment
1.  `yarn workspace @hashintel/hashdev build`

## 📹 Demo

```
yarn workspace v1.22.15
yarn run v1.22.15
$ next build
info  - Skipping validation of types
info  - Skipping linting
info  - Creating an optimized production build  
info  - Compiled successfully
info  - Collecting page data  
info  - Generating static pages (11/11)
info  - Finalizing page optimization  

Page                                               Size     First Load JS
┌ ○ / (423 ms)                                     2.75 kB         160 kB
├   /_app                                          0 B             157 kB
├ ○ /404                                           193 B           157 kB
├ λ /api/subscribe                                 0 B             157 kB
├ ● /blog (600 ms)                                 3.96 kB         167 kB
└ ● /blog/[...blogSlug] (2989 ms)                  15.3 kB         178 kB
    ├ /blog/block-design (643 ms)
    ├ /blog/open-source (609 ms)
    ├ /blog/announcing-error-stack (451 ms)
    ├ /blog/build-blocks-in-any-language (450 ms)
    ├ /blog/one-principle (381 ms)
    ├ /blog/block-protocol-v02
    └ /blog/block-paved-path
+ First Load JS shared by all                      157 kB
  ├ chunks/framework-0bff4c72fef67389.js           42 kB
  ├ chunks/main-775d11972af27efb.js                30.8 kB
  ├ chunks/pages/_app-66175a3d196637c6.js          82.4 kB
  ├ chunks/webpack-c324b6eabfa84c69.js             1.9 kB
  └ css/6ced21e6c57912bd.css                       699 B

λ  (Server)  server-side renders at runtime (uses getInitialProps or getServerSideProps)
○  (Static)  automatically rendered as static HTML (uses no initial props)
●  (SSG)     automatically generated as static HTML + JSON (uses getStaticProps)
```