### PR TITLE
prevent words from breaking across lines

### DIFF
--- a/packages/hash/frontend/src/blocks/page/style.module.css
+++ b/packages/hash/frontend/src/blocks/page/style.module.css
@@ -19,8 +19,9 @@
   display: flex;
   justify-content: center;
   align-items: flex-start;
-  word-break: break-all;
   margin: 30px 0;
+  word-break: break-word;
+  white-space: pre-wrap;
   outline: none !important;
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Words in text blocks were breaking at the end of each line. This was because we had set `word-break: break-all` on blocks.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201095311341924/1202567646653901/f) _(internal)_

## 🔍 What does this change?

Changed `word-break` to `break-word` so that words don't break when they reach the end of the line. 
Also changed `white-space` to `pre-wrap` so that new lines can't be inserted by adding empty spaces, only by entering text or pressing Shift + Enter.

## ❓ How to test this?

Type some text into various text blocks and check if words are breaking across lines.

## 📹 Demo

![white-space](https://user-images.githubusercontent.com/37453800/177856977-495846d8-bf71-4a0a-8559-dc943005125d.gif)

