### PR TITLE
Fix stacked borrows for new miri version

### DIFF
--- a/packages/libs/error-stack/src/frame/erasable.rs
+++ b/packages/libs/error-stack/src/frame/erasable.rs
@@ -1,4 +1,5 @@
 use alloc::boxed::Box;
+use core::ptr::NonNull;
 
 use crate::frame::VTable;
 
@@ -20,14 +21,15 @@ impl<T> ErasableFrame<T> {
     /// # Safety
     ///
     /// Must not be dropped without calling `vtable.object_drop`
-    pub(in crate::frame) unsafe fn new(object: T, vtable: &'static VTable) -> Box<ErasableFrame> {
+    pub(in crate::frame) unsafe fn new(
+        object: T,
+        vtable: &'static VTable,
+    ) -> NonNull<ErasableFrame> {
         let unerased_frame = Self {
             vtable,
             _unerased: object,
         };
-        let unerased_box = Box::new(unerased_frame);
-        // erase the frame by casting the pointer to `ErasableFrame<()>`
-        Box::from_raw(Box::into_raw(unerased_box).cast())
+        NonNull::from(Box::leak(Box::new(unerased_frame))).cast()
     }
 }
 

--- a/packages/libs/error-stack/src/frame/erasable.rs
+++ b/packages/libs/error-stack/src/frame/erasable.rs
@@ -17,14 +17,7 @@ impl<T> ErasableFrame<T> {
     /// Creates a new [`Frame`] from an unerased object.
     ///
     /// [`Frame`]: crate::Frame
-    ///
-    /// # Safety
-    ///
-    /// Must not be dropped without calling `vtable.object_drop`
-    pub(in crate::frame) unsafe fn new(
-        object: T,
-        vtable: &'static VTable,
-    ) -> NonNull<ErasableFrame> {
+    pub(in crate::frame) fn new(object: T, vtable: &'static VTable) -> NonNull<ErasableFrame> {
         let unerased_frame = Self {
             vtable,
             _unerased: object,

--- a/packages/libs/error-stack/src/frame/mod.rs
+++ b/packages/libs/error-stack/src/frame/mod.rs
@@ -6,7 +6,7 @@ mod vtable;
 use alloc::boxed::Box;
 #[cfg(nightly)]
 use core::any::{self, Demand, Provider};
-use core::{fmt, mem, mem::ManuallyDrop, panic::Location, ptr::NonNull};
+use core::{fmt, marker::PhantomData, panic::Location, ptr::NonNull};
 
 pub use self::kind::{AttachmentKind, FrameKind};
 use self::{erasable::ErasableFrame, vtable::VTable};
@@ -24,9 +24,13 @@ use crate::{frame::attachment::AttachmentProvider, Context};
 /// [`Report::new()`]: crate::Report::new
 /// [`Report::request_ref()`]: crate::Report::request_ref
 pub struct Frame {
-    erased_frame: ManuallyDrop<Box<ErasableFrame>>,
+    erased_frame: NonNull<ErasableFrame>,
     location: &'static Location<'static>,
-    source: Option<Box<Frame>>,
+    source: Option<Box<Self>>,
+    // NOTE: this marker has no consequences for variance, but is necessary for dropck to
+    //   understand that we logically own a `T`. For details, see
+    //   https://github.com/rust-lang/rfcs/blob/master/text/0769-sound-generic-drop.md#phantom-data
+    _marker: PhantomData<ErasableFrame>,
 }
 
 impl Frame {
@@ -40,9 +44,10 @@ impl Frame {
         Self {
             // SAFETY: `ErasableFrame` must not be dropped without using the vtable, so it's wrapped
             //   in `ManuallyDrop`. A custom drop implementation is provided to takes care of this.
-            erased_frame: unsafe { ManuallyDrop::new(ErasableFrame::new(object, vtable)) },
+            erased_frame: unsafe { ErasableFrame::new(object, vtable) },
             location,
             source,
+            _marker: PhantomData,
         }
     }
 
@@ -95,6 +100,11 @@ impl Frame {
         )
     }
 
+    fn vtable(&self) -> &'static VTable {
+        // SAFETY: Use vtable to attach the frames' native vtable for the right original type.
+        unsafe { self.erased_frame.as_ref().vtable() }
+    }
+
     /// Returns the location where this `Frame` was created.
     #[must_use]
     pub const fn location(&self) -> &'static Location<'static> {
@@ -130,7 +140,7 @@ impl Frame {
     /// Returns how the `Frame` was created.
     #[must_use]
     pub fn kind(&self) -> FrameKind<'_> {
-        self.erased_frame.vtable().unerase(&self.erased_frame)
+        self.vtable().unerase(&self.erased_frame)
     }
 
     /// Requests the reference to `T` from the `Frame` if provided.
@@ -162,24 +172,25 @@ impl Frame {
     /// Downcasts this frame if the held context or attachment is the same as `T`.
     #[must_use]
     pub fn downcast_ref<T: Send + Sync + 'static>(&self) -> Option<&T> {
-        self.erased_frame.vtable().downcast_ref(&self.erased_frame)
+        self.vtable().downcast_ref(self.erased_frame)
     }
 
     /// Downcasts this frame if the held context or attachment is the same as `T`.
     #[must_use]
     pub fn downcast_mut<T: Send + Sync + 'static>(&mut self) -> Option<&mut T> {
-        self.erased_frame
-            .vtable()
-            .downcast_mut(&mut self.erased_frame)
+        self.vtable().downcast_mut(self.erased_frame)
     }
 }
+
+// SAFETY: We own the data contained in Frame and the owned data is guaranteed to be `Send`
+unsafe impl Send for Frame {}
+// SAFETY: We own the data contained in Frame and the owned data is guaranteed to be `Sync`
+unsafe impl Sync for Frame {}
 
 #[cfg(nightly)]
 impl Provider for Frame {
     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
-        self.erased_frame
-            .vtable()
-            .provide(&self.erased_frame, demand);
+        self.vtable().provide(self.erased_frame, demand);
         demand.provide_value(|| self.location);
         if let Some(source) = &self.source {
             demand.provide_ref::<Self>(source);
@@ -208,13 +219,7 @@ impl fmt::Debug for Frame {
 
 impl Drop for Frame {
     fn drop(&mut self) {
-        // SAFETY: `inner` is not used after moving out.
-        let erased = unsafe { ManuallyDrop::take(&mut self.erased_frame) };
-
-        // Avoid aliasing by forgetting the `Box`
-        let ptr = NonNull::from(&*erased);
-        mem::forget(erased);
-        self.erased_frame.vtable().drop(ptr);
+        self.vtable().drop(self.erased_frame);
     }
 }
 

--- a/packages/libs/error-stack/src/frame/mod.rs
+++ b/packages/libs/error-stack/src/frame/mod.rs
@@ -42,9 +42,7 @@ impl Frame {
         vtable: &'static VTable,
     ) -> Self {
         Self {
-            // SAFETY: `ErasableFrame` must not be dropped without using the vtable, so it's wrapped
-            //   in `ManuallyDrop`. A custom drop implementation is provided to takes care of this.
-            erased_frame: unsafe { ErasableFrame::new(object, vtable) },
+            erased_frame: ErasableFrame::new(object, vtable),
             location,
             source,
             _marker: PhantomData,

--- a/packages/libs/error-stack/src/frame/vtable.rs
+++ b/packages/libs/error-stack/src/frame/vtable.rs
@@ -4,7 +4,7 @@ use core::any::{Demand, Provider};
 use core::{
     any::TypeId,
     fmt,
-    ptr::{addr_of, NonNull},
+    ptr::{addr_of_mut, NonNull},
 };
 
 #[cfg(nightly)]
@@ -24,10 +24,10 @@ use crate::{
 /// [`Frame`]: crate::Frame
 pub(in crate::frame) struct VTable {
     object_drop: unsafe fn(NonNull<ErasableFrame>),
-    object_downcast: unsafe fn(&ErasableFrame, target: TypeId) -> Option<NonNull<()>>,
-    unerase: unsafe fn(&ErasableFrame) -> FrameKind<'_>,
+    object_downcast: unsafe fn(NonNull<ErasableFrame>, target: TypeId) -> Option<NonNull<()>>,
+    unerase: unsafe fn(&NonNull<ErasableFrame>) -> FrameKind<'_>,
     #[cfg(nightly)]
-    provide: unsafe fn(&ErasableFrame, &mut Demand),
+    provide: unsafe fn(NonNull<ErasableFrame>, &mut Demand),
 }
 
 impl VTable {
@@ -71,14 +71,14 @@ impl VTable {
     }
 
     /// Unerases the `frame` as a [`FrameKind`].
-    pub(in crate::frame) fn unerase<'f>(&self, frame: &'f ErasableFrame) -> FrameKind<'f> {
+    pub(in crate::frame) fn unerase<'f>(&self, frame: &'f NonNull<ErasableFrame>) -> FrameKind<'f> {
         // SAFETY: Use vtable to attach the frames' native vtable for the right original type.
         unsafe { (self.unerase)(frame) }
     }
 
     /// Calls `provide` on `frame`.
     #[cfg(nightly)]
-    pub(in crate::frame) fn provide(&self, frame: &ErasableFrame, demand: &mut Demand) {
+    pub(in crate::frame) fn provide(&self, frame: NonNull<ErasableFrame>, demand: &mut Demand) {
         // SAFETY: Use vtable to attach the frames' native vtable for the right original type.
         unsafe { (self.provide)(frame, demand) }
     }
@@ -86,7 +86,7 @@ impl VTable {
     /// Attempts to downcast `frame` as a shared reference to `T`.
     pub(in crate::frame) fn downcast_ref<'f, T: Send + Sync + 'static>(
         &self,
-        frame: &'f ErasableFrame,
+        frame: NonNull<ErasableFrame>,
     ) -> Option<&'f T> {
         // SAFETY: Use vtable to attach the frames' native vtable for the right original type.
         unsafe { (self.object_downcast)(frame, TypeId::of::<T>()).map(|ptr| ptr.cast().as_ref()) }
@@ -95,7 +95,7 @@ impl VTable {
     /// Attempts to downcast `frame` as a unique reference to `T`.
     pub(in crate::frame) fn downcast_mut<'f, T: Send + Sync + 'static>(
         &self,
-        frame: &'f mut ErasableFrame,
+        frame: NonNull<ErasableFrame>,
     ) -> Option<&'f mut T> {
         // SAFETY: Use vtable to attach the frames' native vtable for the right original type.
         unsafe { (self.object_downcast)(frame, TypeId::of::<T>()).map(|ptr| ptr.cast().as_mut()) }
@@ -114,10 +114,6 @@ impl VTable {
     /// - Layout of `*frame` must match `ErasableFrame<T>`.
     unsafe fn object_drop<T>(frame: NonNull<ErasableFrame>) {
         // Attach T's native vtable onto the pointer to `self._unerased`
-        // Note: This must not use `mem::transmute` because it tries to reborrow the `Unique`
-        //   contained in `Box`, which must not be done. In practice this probably won't make any
-        //   difference by now, but technically it's unsound.
-        //   see: https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md
         let unerased: Box<ErasableFrame<T>> = Box::from_raw(frame.as_ptr().cast());
         drop(unerased);
     }
@@ -128,12 +124,12 @@ impl VTable {
     ///
     /// - Layout of `frame` must match `ErasableFrame<C>`.
     #[cfg(nightly)]
-    unsafe fn context_provide<C: Context>(frame: &ErasableFrame, demand: &mut Demand) {
+    unsafe fn context_provide<C: Context>(frame: NonNull<ErasableFrame>, demand: &mut Demand) {
         // Attach C's native vtable onto the pointer to `self._unerased`
-        let unerased: *const ErasableFrame<C> = (frame as *const ErasableFrame).cast();
+        let unerased: NonNull<ErasableFrame<C>> = frame.cast();
         // inside of vtable it's allowed to access `_unerased`
         #[allow(clippy::used_underscore_binding)]
-        (*(unerased))._unerased.provide(demand);
+        unerased.as_ref()._unerased.provide(demand);
     }
 
     /// Unerase the object as None.
@@ -142,13 +138,12 @@ impl VTable {
     ///
     /// - Layout of `frame` must match `ErasableFrame<AttachmentProvider<A>>`.
     #[cfg(nightly)]
-    unsafe fn self_provide<A: 'static>(frame: &ErasableFrame, demand: &mut Demand) {
+    unsafe fn self_provide<A: 'static>(frame: NonNull<ErasableFrame>, demand: &mut Demand) {
         // Attach A's native vtable onto the pointer to `self._unerased`
-        let unerased: *const ErasableFrame<AttachmentProvider<A>> =
-            (frame as *const ErasableFrame).cast();
+        let unerased: NonNull<ErasableFrame<AttachmentProvider<A>>> = frame.cast();
         // inside of vtable it's allowed to access `_unerased`
         #[allow(clippy::used_underscore_binding)]
-        (*(unerased))._unerased.provide(demand);
+        unerased.as_ref()._unerased.provide(demand);
     }
 
     /// Unerase the object as `&dyn Context`.
@@ -156,12 +151,12 @@ impl VTable {
     /// # Safety
     ///
     /// - Layout of `frame` must match `ErasableFrame<C>`.
-    unsafe fn unerase_context<C: Context>(frame: &ErasableFrame) -> FrameKind<'_> {
+    unsafe fn unerase_context<C: Context>(frame: &NonNull<ErasableFrame>) -> FrameKind<'_> {
         // Attach C's native vtable onto the pointer to `self._unerased`
-        let unerased: *const ErasableFrame<C> = (frame as *const ErasableFrame).cast();
+        let unerased: NonNull<ErasableFrame<C>> = frame.cast();
         // inside of vtable it's allowed to access `_unerased`
         #[allow(clippy::used_underscore_binding)]
-        FrameKind::Context(&(*(unerased))._unerased)
+        FrameKind::Context(&unerased.as_ref()._unerased)
     }
 
     /// Unerase the object as generic attachment.
@@ -170,15 +165,15 @@ impl VTable {
     ///
     /// - Layout of `frame` must match `ErasableFrame<AttachmentProvider<A>>`.
     unsafe fn unerase_generic_attachment<A: Send + Sync + 'static>(
-        frame: &ErasableFrame,
+        frame: &NonNull<ErasableFrame>,
     ) -> FrameKind<'_> {
         // Attach A's native vtable onto the pointer to `self._unerased`
         // Casting from `AttachmentProvider<A>` to `A` is allowed as `AttachmentProvider` is
         // `repr(transparent)`
-        let unerased: *const ErasableFrame<A> = (frame as *const ErasableFrame).cast();
+        let unerased: NonNull<ErasableFrame<A>> = frame.cast();
         // inside of vtable it's allowed to access `_unerased`
         #[allow(clippy::used_underscore_binding)]
-        FrameKind::Attachment(AttachmentKind::Opaque(&(*(unerased))._unerased))
+        FrameKind::Attachment(AttachmentKind::Opaque(&unerased.as_ref()._unerased))
     }
 
     /// Unerase the object as `&dyn Debug + Display`.
@@ -187,15 +182,15 @@ impl VTable {
     ///
     /// - Layout of `frame` must match `ErasableFrame<AttachmentProvider<A>>`.
     unsafe fn unerase_printable_attachment<A: fmt::Debug + fmt::Display + Send + Sync + 'static>(
-        frame: &ErasableFrame,
+        frame: &NonNull<ErasableFrame>,
     ) -> FrameKind<'_> {
         // Attach A's native vtable onto the pointer to `self._unerased`
         // Casting from `AttachmentProvider<A>` to `A` is allowed as `AttachmentProvider` is
         // `repr(transparent)`
-        let unerased: *const ErasableFrame<A> = (frame as *const ErasableFrame).cast();
+        let unerased: NonNull<ErasableFrame<A>> = frame.cast();
         // inside of vtable it's allowed to access `_unerased`
         #[allow(clippy::used_underscore_binding)]
-        FrameKind::Attachment(AttachmentKind::Printable(&(*(unerased))._unerased))
+        FrameKind::Attachment(AttachmentKind::Printable(&unerased.as_ref()._unerased))
     }
 
     /// Downcasts the object to `T`.
@@ -204,18 +199,16 @@ impl VTable {
     ///
     /// - Layout of `frame` must match `ErasableFrame<T>`.
     unsafe fn object_downcast<T: Send + Sync + 'static>(
-        frame: &ErasableFrame,
+        frame: NonNull<ErasableFrame>,
         target: TypeId,
     ) -> Option<NonNull<()>> {
-        if TypeId::of::<T>() == target {
+        (TypeId::of::<T>() == target).then(|| {
             // Attach T's native vtable onto the pointer to `self._unerased`
-            let unerased: *const ErasableFrame<T> = (frame as *const ErasableFrame).cast();
+            let unerased: NonNull<ErasableFrame<T>> = frame.cast();
+
             // inside of vtable it's allowed to access `_unerased`
             #[allow(clippy::used_underscore_binding)]
-            let addr = addr_of!((*(unerased))._unerased) as *mut ();
-            Some(NonNull::new_unchecked(addr))
-        } else {
-            None
-        }
+            NonNull::new_unchecked(addr_of_mut!((*(unerased.as_ptr()))._unerased)).cast()
+        })
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`miri` recently became smarter on detecting stacked borrows (basically references, which must not exist). This means, that no reference to `ErasableFrame<()>` must exist.

## 🔍 What does this change?

- Use `NonNull<...>` instead of `ManuallyDrop<Box<...>>`