### PR TITLE
Add badge to `error-stack` readme for required version

### DIFF
--- a/packages/libs/error-stack/README.md
+++ b/packages/libs/error-stack/README.md
@@ -1,12 +1,14 @@
 [announcement post]: https://hash.dev/blog/announcing-error-stack
 [crates.io]: https://crates.io/crates/error-stack
 [libs.rs]: https://lib.rs/crates/error-stack
+[rust-version]: https://www.rust-lang.org
 [documentation]: https://docs.rs/error-stack
 [license]: ./LICENSE.md
 [discord]: https://hash.ai/discord?utm_medium=organic&utm_source=github_readme_hash-repo_error-stack
 
 [![crates.io](https://img.shields.io/crates/v/error-stack)][crates.io]
 [![libs.rs](https://img.shields.io/badge/libs.rs-error--stack-orange)][libs.rs]
+[![rust-version](https://img.shields.io/badge/Rust-1.61.0-orange)][rust-version]
 [![documentation](https://img.shields.io/docsrs/error-stack)][documentation]
 [![license](https://img.shields.io/crates/l/error-stack)][license]
 [![discord](https://img.shields.io/discord/840573247803097118)][discord]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Even though we can specify the required rust version, it's not displayed on crates.io or libs.rs. This PR adds a badge to the readme to avoid confusion.

## 🔗 Related links

- https://github.com/hashintel/hash/issues/775