### PR TITLE
Improve Rust CI performance

### DIFF
--- a/.github/scripts/rust/Makefile.toml
+++ b/.github/scripts/rust/Makefile.toml
@@ -19,8 +19,8 @@ CARGO_RUSTDOC_FLAGS = "--all-features -Zunstable-options -Zrustdoc-scrape-exampl
 CARGO_RUSTDOC_HACK_FLAGS = "--workspace"
 CARGO_TEST_FLAGS = ""
 CARGO_TEST_HACK_FLAGS = "--workspace --feature-powerset"
-CARGO_MIRI_FLAGS = "--tests --lib"
-CARGO_MIRI_HACK_FLAGS = "--workspace --feature-powerset"
+CARGO_MIRI_FLAGS = "--all-features --tests --lib"
+CARGO_MIRI_HACK_FLAGS = "--workspace"
 
 [env.production]
 CARGO_MAKE_CARGO_PROFILE = "release"

--- a/.github/scripts/rust/Makefile.toml
+++ b/.github/scripts/rust/Makefile.toml
@@ -128,8 +128,16 @@ description = "Runs the test suite"
 run_task = { name = ["test-task"] }
 
 [tasks.test-task]
+private = true
+run_task = { name = ["test-task-lib", "test-task-doc"]}
+
+[tasks.test-task-lib]
 extend = "task"
-args = ["hack", "@@split(CARGO_TEST_HACK_FLAGS, )", "test", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_TEST_FLAGS, )", "${@}"]
+args = ["hack", "@@split(CARGO_TEST_HACK_FLAGS, )", "nextest", "run", "--cargo-profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_TEST_FLAGS, )", "${@}"]
+
+[tasks.test-task-doc]
+extend = "task"
+args = ["test", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_TEST_FLAGS, )", "--doc", "--all-features"]
 
 
 [tasks.miri]
@@ -158,3 +166,7 @@ install_crate = { rustup_component_name = "rustfmt" }
 private = true
 condition = { channels = ["nightly"] }
 install_crate = { rustup_component_name = "miri" }
+
+[tasks.install-nextest]
+private = true
+install_crate = { crate_name = "nextest", binary = "cargo", test_arg = ["nextest", "--version"] }

--- a/.github/scripts/rust/Makefile.toml
+++ b/.github/scripts/rust/Makefile.toml
@@ -19,7 +19,7 @@ CARGO_RUSTDOC_FLAGS = "--all-features -Zunstable-options -Zrustdoc-scrape-exampl
 CARGO_RUSTDOC_HACK_FLAGS = "--workspace"
 CARGO_TEST_FLAGS = ""
 CARGO_TEST_HACK_FLAGS = "--workspace --feature-powerset"
-CARGO_MIRI_FLAGS = ""
+CARGO_MIRI_FLAGS = "--tests --lib"
 CARGO_MIRI_HACK_FLAGS = "--workspace --feature-powerset"
 
 [env.production]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -112,11 +112,11 @@ jobs:
 
       - name: Check public documentation
         working-directory: ${{ matrix.directory }}
-        run: cargo make rustdoc --check -D warnings --show-coverage
+        run: cargo make rustdoc --check -D warnings
 
       - name: Check private documentation
         working-directory: ${{ matrix.directory }}
-        run: cargo make rustdoc --check -D warnings --show-coverage --document-private-items
+        run: cargo make rustdoc --check -D warnings --document-private-items
 
       - name: Clear cargo cache
         if: steps.rust-cache.outputs.cache-hit != 'true'

--- a/packages/libs/error-stack/Makefile.toml
+++ b/packages/libs/error-stack/Makefile.toml
@@ -3,4 +3,3 @@ extend = { path = "../../../.github/scripts/rust/Makefile.toml" }
 [env]
 CARGO_CLIPPY_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default --optional-deps eyre,anyhow"
 CARGO_TEST_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default --optional-deps eyre,anyhow"
-CARGO_MIRI_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default --optional-deps eyre,anyhow"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Using [`nextest`](https://nexte.st/index.html) is faster when running the tests. Also, it's currently pretty hard to write doc-tests as they run with different features. Additionally, `miri` makes it not easier to write those tests.

## 🔍 What does this change?

- Use `nextest` to run non-doc tests (doc-tests are not supported currently)
- Run doc-tests separately, but only with `--all-features`
- Don't run `miri` on permuated features, this should already be covered by the tests
- Don't run `miri` on doc-tests. This should be covered in proper tests, where it's easier to write extensive tests
- Drive-by: Fix checking for documentation

## 📹 Demo

Running `cargo make test` for `error-stack` on pre-compiled tests:
- before: 1m 24s
- now: 6s
