### PR TITLE
Implement `EntityType` and it's schema validation

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/types/schema/combinator.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/combinator.rs
@@ -6,14 +6,14 @@ use crate::types::schema::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum Optional<T> {
     None {},
     Some(T),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum ValueOrArray<T> {
     Value(T),
     Array(Itemized<Array, T>),
@@ -26,7 +26,7 @@ pub struct OneOfRepr<T> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(try_from = "OneOfRepr<T>", rename_all = "camelCase")]
+#[serde(try_from = "OneOfRepr<T>")]
 pub struct OneOf<T> {
     #[serde(flatten)]
     repr: OneOfRepr<T>,

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/entity_type.rs
@@ -192,12 +192,12 @@ mod tests {
 
     use super::*;
 
-    fn test_entity_type_schema(schema: serde_json::Value) -> EntityType {
+    fn test_entity_type_schema(schema: &serde_json::Value) -> EntityType {
         let entity_type: EntityType =
             serde_json::from_value(schema.clone()).expect("invalid schema");
         assert_eq!(
             serde_json::to_value(entity_type.clone()).expect("Could not serialize"),
-            schema,
+            *schema,
             "{entity_type:#?}"
         );
         entity_type
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     fn book() {
-        let entity_type = test_entity_type_schema(json!({
+        let entity_type = test_entity_type_schema(&json!({
             "kind": "entityType",
             "$id": "https://blockprotocol.org/types/@alice/entity-type/book",
             "title": "Book",
@@ -265,7 +265,7 @@ mod tests {
 
     #[test]
     fn address() {
-        let entity_type = test_entity_type_schema(json!({
+        let entity_type = test_entity_type_schema(&json!({
             "kind": "entityType",
             "$id": "https://blockprotocol.org/types/@alice/entity-type/uk-address",
             "type": "object",
@@ -299,7 +299,7 @@ mod tests {
 
     #[test]
     fn organization() {
-        let entity_type = test_entity_type_schema(json!({
+        let entity_type = test_entity_type_schema(&json!({
             "kind": "entityType",
             "$id": "https://blockprotocol.org/types/@alice/entity-type/organization",
             "type": "object",
@@ -320,7 +320,7 @@ mod tests {
 
     #[test]
     fn building() {
-        let entity_type = test_entity_type_schema(json!({
+        let entity_type = test_entity_type_schema(&json!({
             "kind": "entityType",
             "$id": "https://blockprotocol.org/types/@alice/entity-type/building",
             "type": "object",
@@ -342,7 +342,7 @@ mod tests {
 
     #[test]
     fn person() {
-        let entity_type = test_entity_type_schema(json!({
+        let entity_type = test_entity_type_schema(&json!({
             "kind": "entityType",
             "$id": "https://blockprotocol.org/types/@alice/entity-type/person",
             "type": "object",
@@ -371,7 +371,7 @@ mod tests {
 
     #[test]
     fn playlist() {
-        let entity_type = test_entity_type_schema(json!({
+        let entity_type = test_entity_type_schema(&json!({
             "kind": "entityType",
             "$id": "https://blockprotocol.org/types/@alice/entity-type/playlist",
             "type": "object",
@@ -399,7 +399,7 @@ mod tests {
 
     #[test]
     fn song() {
-        let entity_type = test_entity_type_schema(json!({
+        let entity_type = test_entity_type_schema(&json!({
             "kind": "entityType",
             "$id": "https://blockprotocol.org/types/@alice/entity-type/Song",
             "type": "object",
@@ -420,7 +420,7 @@ mod tests {
 
     #[test]
     fn page() {
-        let entity_type = test_entity_type_schema(json!({
+        let entity_type = test_entity_type_schema(&json!({
             "kind": "entityType",
             "$id": "https://blockprotocol.org/types/@alice/entity-type/page",
             "type": "object",

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/entity_type.rs
@@ -1,0 +1,444 @@
+use std::collections::{HashMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::schema::{
+    array::{Array, MaybeOrdered},
+    combinator::Optional,
+    object::Object,
+    property_type::PropertyTypeReference,
+    Uri, ValidationError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(clippy::use_self)]
+pub enum EntityTypeTag {
+    EntityType,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct EntityTypeRepr {
+    kind: EntityTypeTag,
+    #[serde(rename = "$id")]
+    id: Uri,
+    title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(default)]
+    default: HashMap<Uri, serde_json::Value>,
+    #[serde(default)]
+    examples: Vec<HashMap<Uri, serde_json::Value>>,
+    #[serde(flatten)]
+    properties: Object<PropertyTypeReference>,
+    #[serde(default)]
+    links: HashMap<String, Optional<MaybeOrdered<Array>>>,
+    #[serde(default)]
+    required_links: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "EntityTypeRepr")]
+pub struct EntityType {
+    #[serde(flatten)]
+    repr: EntityTypeRepr,
+}
+
+impl EntityType {
+    /// Creates a new `EntityType` without validating.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_unchecked(
+        id: Uri,
+        title: impl Into<String>,
+        description: impl Into<Option<String>>,
+        default: impl Into<HashMap<Uri, serde_json::Value>>,
+        examples: impl Into<Vec<HashMap<Uri, serde_json::Value>>>,
+        properties: impl Into<HashMap<Uri, PropertyTypeReference>>,
+        required: impl Into<Vec<Uri>>,
+        links: impl Into<HashMap<String, Optional<MaybeOrdered<Array>>>>,
+        required_links: impl Into<Vec<String>>,
+    ) -> Self {
+        Self {
+            repr: EntityTypeRepr {
+                kind: EntityTypeTag::EntityType,
+                id,
+                title: title.into(),
+                description: description.into(),
+                default: default.into(),
+                examples: examples.into(),
+                properties: Object::new_unchecked(properties, required),
+                links: links.into(),
+                required_links: required_links.into(),
+            },
+        }
+    }
+
+    /// Creates a new `PropertyType`.
+    ///
+    /// # Errors
+    ///
+    /// - [`ValidationError::MissingRequiredProperty`] if a required property is not a key in
+    ///   `properties`.
+    /// - [`ValidationError::MissingRequiredLink`] if a required link is not a key in `links`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: Uri,
+        title: impl Into<String>,
+        description: impl Into<Option<String>>,
+        default: impl Into<HashMap<Uri, serde_json::Value>>,
+        examples: impl Into<Vec<HashMap<Uri, serde_json::Value>>>,
+        properties: impl Into<HashMap<Uri, PropertyTypeReference>>,
+        required: impl Into<Vec<Uri>>,
+        links: impl Into<HashMap<String, Optional<MaybeOrdered<Array>>>>,
+        required_links: impl Into<Vec<String>>,
+    ) -> Result<Self, ValidationError> {
+        let entity_type = Self {
+            repr: EntityTypeRepr {
+                kind: EntityTypeTag::EntityType,
+                id,
+                title: title.into(),
+                description: description.into(),
+                default: default.into(),
+                examples: examples.into(),
+                properties: Object::new(properties, required)?,
+                links: links.into(),
+                required_links: required_links.into(),
+            },
+        };
+        entity_type.validate()?;
+        Ok(entity_type)
+    }
+
+    fn validate(&self) -> Result<(), ValidationError> {
+        for link in self.required_links() {
+            if !self.links().contains_key(link) {
+                return Err(ValidationError::MissingRequiredLink(link.clone()));
+            }
+        }
+        Ok(())
+    }
+
+    #[must_use]
+    pub const fn id(&self) -> &Uri {
+        &self.repr.id
+    }
+
+    #[must_use]
+    pub fn title(&self) -> &str {
+        &self.repr.title
+    }
+
+    #[must_use]
+    pub fn description(&self) -> Option<&str> {
+        self.repr.description.as_deref()
+    }
+
+    #[must_use]
+    pub const fn default(&self) -> &HashMap<Uri, serde_json::Value> {
+        &self.repr.default
+    }
+
+    #[must_use]
+    pub const fn examples(&self) -> &Vec<HashMap<Uri, serde_json::Value>> {
+        &self.repr.examples
+    }
+
+    #[must_use]
+    pub const fn properties(&self) -> &HashMap<Uri, PropertyTypeReference> {
+        self.repr.properties.properties()
+    }
+
+    #[must_use]
+    pub fn required(&self) -> &[Uri] {
+        self.repr.properties.required()
+    }
+
+    #[must_use]
+    pub const fn links(&self) -> &HashMap<String, Optional<MaybeOrdered<Array>>> {
+        &self.repr.links
+    }
+
+    #[must_use]
+    pub fn required_links(&self) -> &[String] {
+        &self.repr.required_links
+    }
+
+    #[must_use]
+    pub fn property_type_references(&self) -> HashSet<&PropertyTypeReference> {
+        self.properties().iter().map(|(_, uri)| uri).collect()
+    }
+
+    #[must_use]
+    pub fn link_references(&self) -> HashSet<&str> {
+        self.links().iter().map(|(link, _)| link.as_str()).collect()
+    }
+}
+
+impl TryFrom<EntityTypeRepr> for EntityType {
+    type Error = ValidationError;
+
+    fn try_from(entity_type: EntityTypeRepr) -> Result<Self, ValidationError> {
+        let entity_type = Self { repr: entity_type };
+        entity_type.validate()?;
+        Ok(entity_type)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn test_entity_type_schema(schema: serde_json::Value) -> EntityType {
+        serde_json::from_value(schema).expect("invalid schema")
+    }
+
+    fn test_property_refs(entity_type: &EntityType, uris: impl IntoIterator<Item = &'static str>) {
+        let expected_property_references = uris.into_iter().map(Uri::new).collect::<HashSet<_>>();
+
+        let property_references = entity_type
+            .property_type_references()
+            .into_iter()
+            .map(PropertyTypeReference::reference)
+            .cloned()
+            .collect::<HashSet<_>>();
+
+        assert_eq!(property_references, expected_property_references);
+    }
+
+    fn test_link_refs(entity_type: &EntityType, links: impl IntoIterator<Item = &'static str>) {
+        let expected_link_references = links.into_iter().collect::<HashSet<_>>();
+        let link_references = entity_type.link_references();
+
+        assert_eq!(link_references, expected_link_references);
+    }
+
+    #[test]
+    fn book() {
+        let entity_type = test_entity_type_schema(json!({
+            "kind": "entityType",
+            "$id": "https://blockprotocol.org/types/@alice/entity-type/book",
+            "title": "Book",
+            "type": "object",
+            "properties": {
+                "https://blockprotocol.org/types/@alice/property-type/name": {
+                    "$ref": "https://blockprotocol.org/types/@alice/property-type/name"
+                },
+                "https://blockprotocol.org/types/@alice/property-type/blurb": {
+                    "$ref": "https://blockprotocol.org/types/@alice/property-type/blurb"
+                },
+                "https://blockprotocol.org/types/@alice/property-type/published-on": {
+                    "$ref": "https://blockprotocol.org/types/@alice/property-type/published-on"
+                }
+            },
+            "required": [
+                "https://blockprotocol.org/types/@alice/property-type/name"
+            ],
+            "links": {
+                "https://blockprotocol.org/types/@alice/property-type/written-by": {}
+            },
+            "requiredLinks": [
+                "https://blockprotocol.org/types/@alice/property-type/written-by"
+            ]
+        }));
+
+        test_property_refs(&entity_type, [
+            "https://blockprotocol.org/types/@alice/property-type/name",
+            "https://blockprotocol.org/types/@alice/property-type/blurb",
+            "https://blockprotocol.org/types/@alice/property-type/published-on",
+        ]);
+
+        test_link_refs(&entity_type, [
+            "https://blockprotocol.org/types/@alice/property-type/written-by",
+        ]);
+    }
+
+    #[test]
+    fn address() {
+        let entity_type = test_entity_type_schema(json!({
+            "kind": "entityType",
+            "$id": "https://blockprotocol.org/types/@alice/entity-type/uk-address",
+            "type": "object",
+            "title": "UK Address",
+            "properties": {
+                "https://blockprotocol.org/types/@alice/property-type/address-line-1": {
+                    "$ref": "https://blockprotocol.org/types/@alice/property-type/address-line-1"
+                },
+                "https://blockprotocol.org/types/@alice/property-type/postcode": {
+                    "$ref": "https://blockprotocol.org/types/@alice/property-type/postcode"
+                },
+                "https://blockprotocol.org/types/@alice/property-type/city": {
+                    "$ref": "https://blockprotocol.org/types/@alice/property-type/city"
+                }
+            },
+            "required": [
+                "https://blockprotocol.org/types/@alice/property-type/address-line-1",
+                "https://blockprotocol.org/types/@alice/property-type/postcode",
+                "https://blockprotocol.org/types/@alice/property-type/city"
+            ]
+        }));
+
+        test_property_refs(&entity_type, [
+            "https://blockprotocol.org/types/@alice/property-type/address-line-1",
+            "https://blockprotocol.org/types/@alice/property-type/postcode",
+            "https://blockprotocol.org/types/@alice/property-type/city",
+        ]);
+
+        test_link_refs(&entity_type, []);
+    }
+
+    #[test]
+    fn organization() {
+        let entity_type = test_entity_type_schema(json!({
+            "kind": "entityType",
+            "$id": "https://blockprotocol.org/types/@alice/entity-type/organization",
+            "type": "object",
+            "title": "Organization",
+            "properties": {
+                "https://blockprotocol.org/types/@alice/property-type/name": {
+                    "$ref": "https://blockprotocol.org/types/@alice/property-type/name"
+                }
+            }
+        }));
+
+        test_property_refs(&entity_type, [
+            "https://blockprotocol.org/types/@alice/property-type/name",
+        ]);
+
+        test_link_refs(&entity_type, []);
+    }
+
+    #[test]
+    fn building() {
+        let entity_type = test_entity_type_schema(json!({
+            "kind": "entityType",
+            "$id": "https://blockprotocol.org/types/@alice/entity-type/building",
+            "type": "object",
+            "title": "Bulding",
+            "properties": {},
+            "links": {
+                "https://blockprotocol.org/types/@alice/property-type/located-at": {},
+                "https://blockprotocol.org/types/@alice/property-type/tenant": {}
+            }
+        }));
+
+        test_property_refs(&entity_type, []);
+
+        test_link_refs(&entity_type, [
+            "https://blockprotocol.org/types/@alice/property-type/located-at",
+            "https://blockprotocol.org/types/@alice/property-type/tenant",
+        ]);
+    }
+
+    #[test]
+    fn person() {
+        let entity_type = test_entity_type_schema(json!({
+            "kind": "entityType",
+            "$id": "https://blockprotocol.org/types/@alice/entity-type/person",
+            "type": "object",
+            "title": "Person",
+            "properties": {
+                "https://blockprotocol.org/types/@alice/property-type/name": {
+                    "$ref": "https://blockprotocol.org/types/@alice/property-type/name"
+                }
+            },
+            "links": {
+                "https://blockprotocol.org/types/@alice/property-type/friend-of": {
+                    "type": "array",
+                    "ordered": false
+                }
+            }
+        }));
+
+        test_property_refs(&entity_type, [
+            "https://blockprotocol.org/types/@alice/property-type/name",
+        ]);
+
+        test_link_refs(&entity_type, [
+            "https://blockprotocol.org/types/@alice/property-type/friend-of",
+        ]);
+    }
+
+    #[test]
+    fn playlist() {
+        let entity_type = test_entity_type_schema(json!({
+            "kind": "entityType",
+            "$id": "https://blockprotocol.org/types/@alice/entity-type/playlist",
+            "type": "object",
+            "title": "Playlist",
+            "properties": {
+                "https://blockprotocol.org/types/@alice/property-type/name": {
+                    "$ref": "https://blockprotocol.org/types/@alice/property-type/name"}
+            },
+            "links": {
+                "https://blockprotocol.org/types/@alice/property-type/contains": {
+                    "type": "array",
+                    "ordered": true
+                }
+            }
+        }));
+
+        test_property_refs(&entity_type, [
+            "https://blockprotocol.org/types/@alice/property-type/name",
+        ]);
+
+        test_link_refs(&entity_type, [
+            "https://blockprotocol.org/types/@alice/property-type/contains",
+        ]);
+    }
+
+    #[test]
+    fn song() {
+        let entity_type = test_entity_type_schema(json!({
+            "kind": "entityType",
+            "$id": "https://blockprotocol.org/types/@alice/entity-type/Song",
+            "type": "object",
+            "title": "Song",
+            "properties": {
+                "https://blockprotocol.org/types/@alice/property-type/name": {
+                    "$ref": "https://blockprotocol.org/types/@alice/property-type/name"
+                }
+            }
+        }));
+
+        test_property_refs(&entity_type, [
+            "https://blockprotocol.org/types/@alice/property-type/name",
+        ]);
+
+        test_link_refs(&entity_type, []);
+    }
+
+    #[test]
+    fn page() {
+        let entity_type = test_entity_type_schema(json!({
+            "kind": "entityType",
+            "$id": "https://blockprotocol.org/types/@alice/entity-type/page",
+            "type": "object",
+            "title": "Page",
+            "properties": {
+                "https://blockprotocol.org/types/@alice/property-type/text": {
+                    "$ref": "https://blockprotocol.org/types/@alice/property-type/text"
+                }
+            },
+            "links": {
+                "https://blockprotocol.org/types/@alice/property-type/written-by": {},
+                "https://blockprotocol.org/types/@alice/property-type/contains": {
+                    "type": "array",
+                    "ordered": true
+                }
+            }
+        }));
+
+        test_property_refs(&entity_type, [
+            "https://blockprotocol.org/types/@alice/property-type/text",
+        ]);
+
+        test_link_refs(&entity_type, [
+            "https://blockprotocol.org/types/@alice/property-type/written-by",
+            "https://blockprotocol.org/types/@alice/property-type/contains",
+        ]);
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/entity_type.rs
@@ -33,9 +33,9 @@ pub struct EntityTypeRepr {
     #[serde(flatten)]
     properties: Object<PropertyTypeReference>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    links: HashMap<String, Optional<MaybeOrdered<Array>>>,
+    links: HashMap<Uri, Optional<MaybeOrdered<Array>>>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    required_links: Vec<String>,
+    required_links: Vec<Uri>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -57,8 +57,8 @@ impl EntityType {
         examples: impl Into<Vec<HashMap<Uri, serde_json::Value>>>,
         properties: impl Into<HashMap<Uri, PropertyTypeReference>>,
         required: impl Into<Vec<Uri>>,
-        links: impl Into<HashMap<String, Optional<MaybeOrdered<Array>>>>,
-        required_links: impl Into<Vec<String>>,
+        links: impl Into<HashMap<Uri, Optional<MaybeOrdered<Array>>>>,
+        required_links: impl Into<Vec<Uri>>,
     ) -> Self {
         Self {
             repr: EntityTypeRepr {
@@ -91,8 +91,8 @@ impl EntityType {
         examples: impl Into<Vec<HashMap<Uri, serde_json::Value>>>,
         properties: impl Into<HashMap<Uri, PropertyTypeReference>>,
         required: impl Into<Vec<Uri>>,
-        links: impl Into<HashMap<String, Optional<MaybeOrdered<Array>>>>,
-        required_links: impl Into<Vec<String>>,
+        links: impl Into<HashMap<Uri, Optional<MaybeOrdered<Array>>>>,
+        required_links: impl Into<Vec<Uri>>,
     ) -> Result<Self, ValidationError> {
         let entity_type = Self {
             repr: EntityTypeRepr {
@@ -156,12 +156,12 @@ impl EntityType {
     }
 
     #[must_use]
-    pub const fn links(&self) -> &HashMap<String, Optional<MaybeOrdered<Array>>> {
+    pub const fn links(&self) -> &HashMap<Uri, Optional<MaybeOrdered<Array>>> {
         &self.repr.links
     }
 
     #[must_use]
-    pub fn required_links(&self) -> &[String] {
+    pub fn required_links(&self) -> &[Uri] {
         &self.repr.required_links
     }
 
@@ -171,8 +171,8 @@ impl EntityType {
     }
 
     #[must_use]
-    pub fn link_references(&self) -> HashSet<&str> {
-        self.links().iter().map(|(link, _)| link.as_str()).collect()
+    pub fn link_references(&self) -> HashSet<&Uri> {
+        self.links().iter().map(|(link, _)| link).collect()
     }
 }
 
@@ -217,8 +217,12 @@ mod tests {
     }
 
     fn test_link_refs(entity_type: &EntityType, links: impl IntoIterator<Item = &'static str>) {
-        let expected_link_references = links.into_iter().collect::<HashSet<_>>();
-        let link_references = entity_type.link_references();
+        let expected_link_references = links.into_iter().map(Uri::new).collect::<HashSet<_>>();
+        let link_references = entity_type
+            .link_references()
+            .into_iter()
+            .cloned()
+            .collect::<HashSet<_>>();
 
         assert_eq!(link_references, expected_link_references);
     }

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/entity_type.rs
@@ -75,7 +75,7 @@ impl EntityType {
         }
     }
 
-    /// Creates a new `PropertyType`.
+    /// Creates a new `EntityType`.
     ///
     /// # Errors
     ///

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/entity_type.rs
@@ -26,15 +26,15 @@ pub struct EntityTypeRepr {
     title: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     default: HashMap<Uri, serde_json::Value>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     examples: Vec<HashMap<Uri, serde_json::Value>>,
     #[serde(flatten)]
     properties: Object<PropertyTypeReference>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     links: HashMap<String, Optional<MaybeOrdered<Array>>>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     required_links: Vec<String>,
 }
 
@@ -193,7 +193,14 @@ mod tests {
     use super::*;
 
     fn test_entity_type_schema(schema: serde_json::Value) -> EntityType {
-        serde_json::from_value(schema).expect("invalid schema")
+        let entity_type: EntityType =
+            serde_json::from_value(schema.clone()).expect("invalid schema");
+        assert_eq!(
+            serde_json::to_value(entity_type.clone()).expect("Could not serialize"),
+            schema,
+            "{entity_type:#?}"
+        );
+        entity_type
     }
 
     fn test_property_refs(entity_type: &EntityType, uris: impl IntoIterator<Item = &'static str>) {

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/mod.rs
@@ -24,7 +24,7 @@ pub enum ValidationError {
     /// the `properties`.
     MissingRequiredProperty(Uri),
     /// A schema has marked a link as required but the link does not exist in schema.
-    MissingRequiredLink(String),
+    MissingRequiredLink(Uri),
     /// At least `expected` number of properties are required, but only `actual` were provided.
     MismatchedPropertyCount { actual: usize, expected: usize },
     /// [`OneOf`] requires at least one element.

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/mod.rs
@@ -23,7 +23,7 @@ pub enum ValidationError {
     /// A schema has marked a property with a [`Uri`] as required but the [`Uri`] does not exist in
     /// the `properties`.
     MissingRequiredProperty(Uri),
-    /// A schema has marked a link as required but the link does not exist in schema.
+    /// A schema has marked a link as required but the link does not exist in the schema.
     MissingRequiredLink(Uri),
     /// At least `expected` number of properties are required, but only `actual` were provided.
     MismatchedPropertyCount { actual: usize, expected: usize },

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/mod.rs
@@ -27,7 +27,7 @@ pub enum ValidationError {
     MissingRequiredLink(Uri),
     /// At least `expected` number of properties are required, but only `actual` were provided.
     MismatchedPropertyCount { actual: usize, expected: usize },
-    /// [`OneOf`] requires at least one element.
+    /// `oneOf` requires at least one element.
     EmptyOneOf,
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/mod.rs
@@ -5,20 +5,17 @@
 //!
 //! [`datastore`]: crate::datastore
 
-pub mod array;
-pub mod combinator;
+mod array;
+mod combinator;
 mod data_type;
+mod entity_type;
 mod object;
-pub mod property_type;
+mod property_type;
 
 use core::fmt;
 
 #[doc(inline)]
-pub use self::{
-    combinator::{OneOf, ValueOrArray},
-    data_type::DataType,
-    property_type::PropertyType,
-};
+pub use self::{data_type::DataType, entity_type::EntityType, property_type::PropertyType};
 use crate::types::Uri;
 
 #[derive(Debug)]
@@ -26,6 +23,8 @@ pub enum ValidationError {
     /// A schema has marked a property with a [`Uri`] as required but the [`Uri`] does not exist in
     /// the `properties`.
     MissingRequiredProperty(Uri),
+    /// A schema has marked a link as required but the link does not exist in schema.
+    MissingRequiredLink(String),
     /// At least `expected` number of properties are required, but only `actual` were provided.
     MismatchedPropertyCount { actual: usize, expected: usize },
     /// [`OneOf`] requires at least one element.
@@ -40,6 +39,13 @@ impl fmt::Display for ValidationError {
                     fmt,
                     "The schema has marked the \"{uri}\" property as required, but it wasn't \
                      defined in the `\"properties\"` object"
+                )
+            }
+            Self::MissingRequiredLink(link) => {
+                write!(
+                    fmt,
+                    "The schema has marked the \"{link}\" link as required, but it wasn't defined \
+                     in the `\"links\"` object"
                 )
             }
             Self::MismatchedPropertyCount { actual, expected } => {

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/property_type.rs
@@ -4,9 +4,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::schema::{
     array::{Array, Itemized},
+    combinator::{OneOf, ValueOrArray},
     data_type::DataTypeReference,
     object::Object,
-    OneOf, Uri, ValueOrArray,
+    Uri,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -32,6 +33,7 @@ impl PropertyTypeReference {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
+#[allow(clippy::enum_variant_names)]
 pub enum PropertyValues {
     DataTypeReference(DataTypeReference),
     // TODO: Check if `Objcet::properties` matches the URI specified in `PropertyTypeReference`

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/property_type.rs
@@ -163,7 +163,14 @@ mod tests {
     use super::*;
 
     fn test_property_type_schema(schema: serde_json::Value) -> PropertyType {
-        serde_json::from_value::<PropertyType>(schema).expect("Not a valid schema")
+        let property_type: PropertyType =
+            serde_json::from_value(schema.clone()).expect("invalid schema");
+        assert_eq!(
+            serde_json::to_value(property_type.clone()).expect("Could not serialize"),
+            schema,
+            "{property_type:#?}"
+        );
+        property_type
     }
 
     fn test_property_type_data_refs(

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/property_type.rs
@@ -162,12 +162,12 @@ mod tests {
 
     use super::*;
 
-    fn test_property_type_schema(schema: serde_json::Value) -> PropertyType {
+    fn test_property_type_schema(schema: &serde_json::Value) -> PropertyType {
         let property_type: PropertyType =
             serde_json::from_value(schema.clone()).expect("invalid schema");
         assert_eq!(
             serde_json::to_value(property_type.clone()).expect("Could not serialize"),
-            schema,
+            *schema,
             "{property_type:#?}"
         );
         property_type
@@ -207,7 +207,7 @@ mod tests {
 
     #[test]
     fn favorite_quote() {
-        let property_type = test_property_type_schema(json!({
+        let property_type = test_property_type_schema(&json!({
           "kind": "propertyType",
           "$id": "https://blockprotocol.org/types/@alice/property-type/favorite-quote",
           "title": "Favorite Quote",
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     fn age() {
-        let property_type = test_property_type_schema(json!({
+        let property_type = test_property_type_schema(&json!({
           "kind": "propertyType",
           "$id": "https://blockprotocol.org/types/@alice/property-type/age",
           "title": "Age",
@@ -245,7 +245,7 @@ mod tests {
 
     #[test]
     fn user_id() {
-        let property_type = test_property_type_schema(json!({
+        let property_type = test_property_type_schema(&json!({
           "kind": "propertyType",
           "$id": "https://blockprotocol.org/types/@alice/property-type/user-id",
           "title": "User ID",
@@ -267,7 +267,7 @@ mod tests {
 
     #[test]
     fn contact_information() {
-        let property_type = test_property_type_schema(json!({
+        let property_type = test_property_type_schema(&json!({
           "kind": "propertyType",
           "$id": "https://blockprotocol.org/types/@alice/property-type/contact-information",
           "title": "Contact Information",
@@ -299,7 +299,7 @@ mod tests {
 
     #[test]
     fn interests() {
-        let property_type = test_property_type_schema(json!({
+        let property_type = test_property_type_schema(&json!({
           "kind": "propertyType",
           "$id": "https://blockprotocol.org/types/@alice/property-type/interests",
           "title": "Interests",
@@ -335,7 +335,7 @@ mod tests {
 
     #[test]
     fn numbers() {
-        let property_type = test_property_type_schema(json!({
+        let property_type = test_property_type_schema(&json!({
           "kind": "propertyType",
           "$id": "https://blockprotocol.org/types/@alice/property-type/numbers",
           "title": "Numbers",
@@ -362,7 +362,7 @@ mod tests {
 
     #[test]
     fn contrived_property() {
-        let property_type = test_property_type_schema(json!({
+        let property_type = test_property_type_schema(&json!({
           "kind": "propertyType",
           "$id": "https://blockprotocol.org/types/@alice/property-type/contrived-property",
           "title": "Contrived Property",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Implements `EntityType` and it's schema validation

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/0/1202590061714999/f) _(internal)_

## 🔍 What does this change?

- Implement `EntityType`
- Fix an issue for `Optional`: If `json!({ ... })` is passed, it's parsed as `Empty`. With `deny_unknown_fields`, it will correctly be picked up. Denying unknown fields is good anyway.

## 🛡 What tests cover this?

Tests were added to check the schema. Test data were taken from the [Graph Type System RFC](https://github.com/blockprotocol/blockprotocol/blob/main/rfcs/text/0352-graph-type-system.md).