### PR TITLE
Check path of `memory_id` not `id` when creating a `MemoryId`

### DIFF
--- a/packages/engine/lib/memory/src/shared_memory/segment.rs
+++ b/packages/engine/lib/memory/src/shared_memory/segment.rs
@@ -64,7 +64,7 @@ impl MemoryId {
                 id,
                 suffix: rand::random::<u16>(),
             };
-            if !Path::new(&format!("/dev/shm/{id}")).exists() {
+            if !Path::new(&format!("/dev/shm/{memory_id}")).exists() {
                 return memory_id;
             }
         }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

- Prevents an infinite loop when creating a `MemoryId` 
