### PR TITLE
Update v8 to latest version

### DIFF
--- a/packages/engine/Cargo.lock
+++ b/packages/engine/Cargo.lock
@@ -2635,9 +2635,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.42.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d743ec43aa5297faec64715b85411340495cac129e34e9cce1a0e879557d32c"
+checksum = "4afe785c0357a4c1b0a6464ab72899e688d26eafc63e0b626e2ce2d35b147477"
 dependencies = [
  "bitflags",
  "fslock",

--- a/packages/engine/lib/execution/Cargo.toml
+++ b/packages/engine/lib/execution/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "1.0.31"
 tokio = { version = "1.19.2", features = ["macros", "rt", "sync", "process", "time"] }
 tracing = "0.1.35"
 uuid = "1.1.2"
-v8 = "=0.42.0"
+v8 = "0.45.0"
 
 [features]
 default = ["build-nng"]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

- Updates the `v8` crate to the latest version.

note: previously we had encountered a problem involving the cache which I (most likely erroneously) assumed was caused by upgrading v8. Instead it seems that the problem was caused by the size of the cache (and hopefully has been fixed by Tim's PR to reduce cache size).