### PR TITLE
Validate `BaseUri` keys to match the `VersionedUri`

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/types/schema/combinator.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/combinator.rs
@@ -1,8 +1,12 @@
 use serde::{Deserialize, Serialize};
 
-use crate::types::schema::{
-    array::{Array, Itemized},
-    ValidationError,
+use crate::types::{
+    schema::{
+        array::{Array, Itemized},
+        object::ValidateUri,
+        ValidationError,
+    },
+    BaseUri,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -17,6 +21,15 @@ pub enum Optional<T> {
 pub enum ValueOrArray<T> {
     Value(T),
     Array(Itemized<Array, T>),
+}
+
+impl<T: ValidateUri> ValidateUri for ValueOrArray<T> {
+    fn validate_uri(&self, base_uri: &BaseUri) -> error_stack::Result<(), ValidationError> {
+        match self {
+            Self::Value(value) => value.validate_uri(base_uri),
+            Self::Array(array) => array.items().validate_uri(base_uri),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/data_type.rs
@@ -33,10 +33,10 @@ impl DataTypeReference {
 impl ValidateUri for DataTypeReference {
     fn validate_uri(&self, base_uri: &BaseUri) -> Result<(), ValidationError> {
         ensure!(
-            base_uri == self.reference.base_uri(),
+            base_uri == self.uri().base_uri(),
             ValidationError::BaseUriMismatch {
                 base_uri: base_uri.clone(),
-                versioned_uri: self.reference.clone()
+                versioned_uri: self.uri().clone()
             }
         );
         Ok(())

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/data_type.rs
@@ -1,9 +1,13 @@
 use std::collections::HashMap;
 
+use error_stack::{ensure, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use crate::types::schema::VersionedUri;
+use crate::types::{
+    schema::{object::ValidateUri, ValidationError, VersionedUri},
+    BaseUri,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -23,6 +27,19 @@ impl DataTypeReference {
     #[must_use]
     pub const fn uri(&self) -> &VersionedUri {
         &self.reference
+    }
+}
+
+impl ValidateUri for DataTypeReference {
+    fn validate_uri(&self, base_uri: &BaseUri) -> Result<(), ValidationError> {
+        ensure!(
+            base_uri == self.reference.base_uri(),
+            ValidationError::BaseUriMismatch {
+                base_uri: base_uri.clone(),
+                versioned_uri: self.reference.clone()
+            }
+        );
+        Ok(())
     }
 }
 
@@ -195,7 +212,7 @@ impl DataType {
 
 #[cfg(test)]
 mod tests {
-    use std::error::Error;
+    use std::{error::Error, result::Result};
 
     use super::*;
 

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/entity_type.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use error_stack::Result;
 use serde::{Deserialize, Serialize};
 
 use crate::types::{

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/mod.rs
@@ -24,6 +24,12 @@ pub enum ValidationError {
     /// A schema has marked a property with a [`BaseUri`] as required but the [`BaseUri`] does not
     /// exist in the `properties`.
     MissingRequiredProperty(BaseUri),
+    /// Referring to a [`VersionUri`] from a [`BaseUri`] requires that the [`VersionUri::base_uri`]
+    /// matches the [`BaseUri`].
+    BaseUriMismatch {
+        base_uri: BaseUri,
+        versioned_uri: VersionedUri,
+    },
     /// A schema has marked a link as required but the link does not exist in the schema.
     MissingRequiredLink(VersionedUri),
     /// At least `expected` number of properties are required, but only `actual` were provided.
@@ -38,21 +44,31 @@ impl fmt::Display for ValidationError {
             Self::MissingRequiredProperty(uri) => {
                 write!(
                     fmt,
-                    "The schema has marked the \"{uri}\" property as required, but it wasn't \
+                    "the schema has marked the \"{uri}\" property as required, but it wasn't \
                      defined in the `\"properties\"` object"
+                )
+            }
+            Self::BaseUriMismatch {
+                base_uri,
+                versioned_uri,
+            } => {
+                write!(
+                    fmt,
+                    "the base URI ({base_uri}) of the referenced versioned URI ({versioned_uri}) \
+                     is not matching"
                 )
             }
             Self::MissingRequiredLink(link) => {
                 write!(
                     fmt,
-                    "The schema has marked the \"{link}\" link as required, but it wasn't defined \
+                    "the schema has marked the \"{link}\" link as required, but it wasn't defined \
                      in the `\"links\"` object"
                 )
             }
             Self::MismatchedPropertyCount { actual, expected } => {
                 write!(
                     fmt,
-                    "At least {expected} properties are required, but only {actual} were provided"
+                    "at least {expected} properties are required, but only {actual} were provided"
                 )
             }
             Self::EmptyOneOf => fmt.write_str("`\"one_of\"` must have at least one item"),

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/mod.rs
@@ -24,8 +24,11 @@ pub enum ValidationError {
     /// A schema has marked a property with a [`BaseUri`] as required but the [`BaseUri`] does not
     /// exist in the `properties`.
     MissingRequiredProperty(BaseUri),
-    /// Referring to a [`VersionUri`] from a [`BaseUri`] requires that the [`VersionUri::base_uri`]
-    /// matches the [`BaseUri`].
+    /// Referring to a [`VersionedUri`] from a [`BaseUri`] requires that the
+    /// [`VersionedUri::base_uri`] matches the [`BaseUri`].
+    ///
+    /// [`VersionedUri`]: crate::types::VersionedUri
+    /// [`VersionedUri::base_uri`]: crate::types::VersionedUri::base_uri
     BaseUriMismatch {
         base_uri: BaseUri,
         versioned_uri: VersionedUri,

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/mod.rs
@@ -56,8 +56,7 @@ impl fmt::Display for ValidationError {
             } => {
                 write!(
                     fmt,
-                    "the base URI ({base_uri}) of the referenced versioned URI ({versioned_uri}) \
-                     is not matching"
+                    "expected base URI {base_uri} differed from the base URI of {versioned_uri}"
                 )
             }
             Self::MissingRequiredLink(link) => {

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/mod.rs
@@ -24,10 +24,9 @@ pub enum ValidationError {
     /// A schema has marked a property with a [`BaseUri`] as required but the [`BaseUri`] does not
     /// exist in the `properties`.
     MissingRequiredProperty(BaseUri),
-    /// Referring to a [`VersionedUri`] from a [`BaseUri`] requires that the
-    /// [`VersionedUri::base_uri`] matches the [`BaseUri`].
+    /// When associating a property name with a reference to a Type, we expect the name to match
+    /// the [`VersionedUri::base_uri`] inside the reference.
     ///
-    /// [`VersionedUri`]: crate::types::VersionedUri
     /// [`VersionedUri::base_uri`]: crate::types::VersionedUri::base_uri
     BaseUriMismatch {
         base_uri: BaseUri,

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/mod.rs
@@ -56,7 +56,8 @@ impl fmt::Display for ValidationError {
             } => {
                 write!(
                     fmt,
-                    "expected base URI {base_uri} differed from the base URI of {versioned_uri}"
+                    "expected base URI ({base_uri}) differed from the base URI of \
+                     ({versioned_uri})"
                 )
             }
             Self::MissingRequiredLink(link) => {

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/object.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/object.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
-use serde::{Deserialize, Serialize};
+use error_stack::{ensure, Result};
+use serde::{de, Deserialize, Deserializer, Serialize};
 
 use crate::types::{schema::ValidationError, BaseUri};
 
@@ -20,14 +21,17 @@ struct ObjectRepr<V> {
     required: Vec<BaseUri>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(try_from = "ObjectRepr<V>", rename_all = "camelCase")]
+pub trait ValidateUri {
+    fn validate_uri(&self, base_uri: &BaseUri) -> Result<(), ValidationError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Object<V, const MIN: usize = 0> {
     #[serde(flatten)]
     repr: ObjectRepr<V>,
 }
 
-impl<V, const MIN: usize> Object<V, MIN> {
+impl<V: ValidateUri, const MIN: usize> Object<V, MIN> {
     /// Creates a new `Object` without validating.
     #[must_use]
     pub fn new_unchecked(properties: HashMap<BaseUri, V>, required: Vec<BaseUri>) -> Self {
@@ -59,17 +63,24 @@ impl<V, const MIN: usize> Object<V, MIN> {
 
     fn validate(&self) -> Result<(), ValidationError> {
         let num_properties = self.properties().len();
-        if num_properties < MIN {
-            return Err(ValidationError::MismatchedPropertyCount {
+        ensure!(
+            num_properties >= MIN,
+            ValidationError::MismatchedPropertyCount {
                 actual: num_properties,
                 expected: MIN,
-            });
-        }
-        for uri in self.required() {
-            if !self.properties().contains_key(uri) {
-                return Err(ValidationError::MissingRequiredProperty(uri.clone()));
             }
+        );
+
+        for uri in self.required() {
+            ensure!(
+                self.properties().contains_key(uri),
+                ValidationError::MissingRequiredProperty(uri.clone())
+            );
         }
+        for (base_uri, referenced) in self.properties() {
+            referenced.validate_uri(base_uri)?;
+        }
+
         Ok(())
     }
 
@@ -82,35 +93,40 @@ impl<V, const MIN: usize> Object<V, MIN> {
     }
 }
 
-impl<V, const MIN: usize> TryFrom<ObjectRepr<V>> for Object<V, MIN> {
-    type Error = ValidationError;
-
-    fn try_from(object: ObjectRepr<V>) -> Result<Self, ValidationError> {
-        Self::new(object.properties, object.required)
+impl<'de, V: ValidateUri + Deserialize<'de>, const MIN: usize> Deserialize<'de> for Object<V, MIN> {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let object = Self {
+            repr: ObjectRepr::deserialize(deserializer)?,
+        };
+        object.validate().map_err(de::Error::custom)?;
+        Ok(object)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::error::Error;
-
     use serde_json::json;
 
     use super::*;
     use crate::types::{
-        schema::tests::{check, check_invalid_json},
+        schema::{
+            property_type::PropertyTypeReference,
+            tests::{check, check_invalid_json},
+        },
         VersionedUri,
     };
 
     mod unconstrained {
         use super::*;
-        use crate::types::VersionedUri;
-        type Object = super::Object<String, 0>;
+        type Object = super::Object<PropertyTypeReference, 0>;
 
         #[test]
-        fn empty() -> Result<(), Box<dyn Error>> {
+        fn empty() -> Result<(), serde_json::Error> {
             check(
-                &Object::new(HashMap::new(), vec![])?,
+                &Object::new_unchecked(HashMap::new(), vec![]),
                 json!({
                     "type": "object",
                     "properties": {}
@@ -120,21 +136,17 @@ mod tests {
         }
 
         #[test]
-        fn one() -> Result<(), Box<dyn Error>> {
+        fn one() -> Result<(), serde_json::Error> {
+            let uri = VersionedUri::new("https://example.com/property_type".to_owned(), 1);
             check(
-                &Object::new(
-                    HashMap::from([(
-                        VersionedUri::new("https://example.com/property_type".to_owned(), 1)
-                            .base_uri()
-                            .clone(),
-                        "value".to_owned(),
-                    )]),
+                &Object::new_unchecked(
+                    HashMap::from([(uri.base_uri().clone(), PropertyTypeReference::new(uri))]),
                     vec![],
-                )?,
+                ),
                 json!({
                     "type": "object",
                     "properties": {
-                        "https://example.com/property_type": "value",
+                        "https://example.com/property_type": { "$ref": "https://example.com/property_type/v/1" },
                     }
                 }),
             )?;
@@ -142,30 +154,22 @@ mod tests {
         }
 
         #[test]
-        fn multiple() -> Result<(), Box<dyn Error>> {
+        fn multiple() -> Result<(), serde_json::Error> {
+            let uri_a = VersionedUri::new("https://example.com/property_type_a".to_owned(), 1);
+            let uri_b = VersionedUri::new("https://example.com/property_type_b".to_owned(), 1);
             check(
-                &Object::new(
+                &Object::new_unchecked(
                     HashMap::from([
-                        (
-                            VersionedUri::new("https://example.com/property_type_a".to_owned(), 1)
-                                .base_uri()
-                                .clone(),
-                            "value_a".to_owned(),
-                        ),
-                        (
-                            VersionedUri::new("https://example.com/property_type_b".to_owned(), 1)
-                                .base_uri()
-                                .clone(),
-                            "value_b".to_owned(),
-                        ),
+                        (uri_a.base_uri().clone(), PropertyTypeReference::new(uri_a)),
+                        (uri_b.base_uri().clone(), PropertyTypeReference::new(uri_b)),
                     ]),
                     vec![],
-                )?,
+                ),
                 json!({
                     "type": "object",
                     "properties": {
-                        "https://example.com/property_type_a": "value_a",
-                        "https://example.com/property_type_b": "value_b",
+                        "https://example.com/property_type_a": { "$ref": "https://example.com/property_type_a/v/1" },
+                        "https://example.com/property_type_b": { "$ref": "https://example.com/property_type_b/v/1" },
                     }
                 }),
             )?;
@@ -176,7 +180,7 @@ mod tests {
     mod constrained {
         use super::*;
         use crate::types::VersionedUri;
-        type Object = super::Object<String, 1>;
+        type Object = super::Object<PropertyTypeReference, 1>;
 
         #[test]
         fn empty() {
@@ -187,21 +191,17 @@ mod tests {
         }
 
         #[test]
-        fn one() -> Result<(), Box<dyn Error>> {
+        fn one() -> Result<(), serde_json::Error> {
+            let uri = VersionedUri::new("https://example.com/property_type".to_owned(), 1);
             check(
-                &Object::new(
-                    HashMap::from([(
-                        VersionedUri::new("https://example.com/property_type".to_owned(), 1)
-                            .base_uri()
-                            .clone(),
-                        "value".to_owned(),
-                    )]),
+                &Object::new_unchecked(
+                    HashMap::from([(uri.base_uri().clone(), PropertyTypeReference::new(uri))]),
                     vec![],
-                )?,
+                ),
                 json!({
                     "type": "object",
                     "properties": {
-                        "https://example.com/property_type": "value",
+                        "https://example.com/property_type": { "$ref": "https://example.com/property_type/v/1" },
                     }
                 }),
             )?;
@@ -209,30 +209,22 @@ mod tests {
         }
 
         #[test]
-        fn multiple() -> Result<(), Box<dyn Error>> {
+        fn multiple() -> Result<(), serde_json::Error> {
+            let uri_a = VersionedUri::new("https://example.com/property_type_a".to_owned(), 1);
+            let uri_b = VersionedUri::new("https://example.com/property_type_b".to_owned(), 1);
             check(
-                &Object::new(
+                &Object::new_unchecked(
                     HashMap::from([
-                        (
-                            VersionedUri::new("https://example.com/property_type_a".to_owned(), 1)
-                                .base_uri()
-                                .clone(),
-                            "value_a".to_owned(),
-                        ),
-                        (
-                            VersionedUri::new("https://example.com/property_type_b".to_owned(), 1)
-                                .base_uri()
-                                .clone(),
-                            "value_b".to_owned(),
-                        ),
+                        (uri_a.base_uri().clone(), PropertyTypeReference::new(uri_a)),
+                        (uri_b.base_uri().clone(), PropertyTypeReference::new(uri_b)),
                     ]),
                     vec![],
-                )?,
+                ),
                 json!({
                     "type": "object",
                     "properties": {
-                        "https://example.com/property_type_a": "value_a",
-                        "https://example.com/property_type_b": "value_b",
+                        "https://example.com/property_type_a": { "$ref": "https://example.com/property_type_a/v/1" },
+                        "https://example.com/property_type_b": { "$ref": "https://example.com/property_type_b/v/1" },
                     }
                 }),
             )?;
@@ -241,34 +233,25 @@ mod tests {
     }
 
     #[test]
-    fn required() -> Result<(), Box<dyn Error>> {
+    fn required() -> Result<(), serde_json::Error> {
+        let uri_a = VersionedUri::new("https://example.com/property_type_a".to_owned(), 1);
+        let uri_b = VersionedUri::new("https://example.com/property_type_b".to_owned(), 1);
         check(
-            &Object::<String>::new(
+            &Object::<_, 0>::new_unchecked(
                 HashMap::from([
                     (
-                        VersionedUri::new("https://example.com/property_type_a".to_owned(), 1)
-                            .base_uri()
-                            .clone(),
-                        "value_a".to_owned(),
+                        uri_a.base_uri().clone(),
+                        PropertyTypeReference::new(uri_a.clone()),
                     ),
-                    (
-                        VersionedUri::new("https://example.com/property_type_b".to_owned(), 1)
-                            .base_uri()
-                            .clone(),
-                        "value_b".to_owned(),
-                    ),
+                    (uri_b.base_uri().clone(), PropertyTypeReference::new(uri_b)),
                 ]),
-                vec![
-                    VersionedUri::new("https://example.com/property_type_a".to_owned(), 1)
-                        .base_uri()
-                        .clone(),
-                ],
-            )?,
+                vec![uri_a.base_uri().clone()],
+            ),
             json!({
                 "type": "object",
                 "properties": {
-                    "https://example.com/property_type_a": "value_a",
-                    "https://example.com/property_type_b": "value_b",
+                    "https://example.com/property_type_a": { "$ref": "https://example.com/property_type_a/v/1" },
+                    "https://example.com/property_type_b": { "$ref": "https://example.com/property_type_b/v/1" },
                 },
                 "required": [
                     "https://example.com/property_type_a"
@@ -280,23 +263,33 @@ mod tests {
 
     #[test]
     fn additional_properties() {
-        check_invalid_json::<Object<String>>(json!({
+        check_invalid_json::<Object<PropertyTypeReference>>(json!({
             "type": "object",
             "properties": {
-                "https://example.com/property_type_a": "value_a",
-                "https://example.com/property_type_b": "value_b",
+                "https://example.com/property_type_a": { "$ref": "https://example.com/property_type_a/v/1" },
+                "https://example.com/property_type_b": { "$ref": "https://example.com/property_type_b/v/1" },
             },
             "additional_properties": 10
         }));
     }
 
     #[test]
-    fn invalid_required() {
-        check_invalid_json::<Object<String>>(json!({
+    fn invalid_uri() {
+        check_invalid_json::<Object<PropertyTypeReference>>(json!({
             "type": "object",
             "properties": {
-                "https://example.com/property_type_a": "value_a",
-                "https://example.com/property_type_b": "value_b",
+                "https://example.com/property_type_a": { "$ref": "https://example.com/property_type_b/v/1" }
+            }
+        }));
+    }
+
+    #[test]
+    fn invalid_required() {
+        check_invalid_json::<Object<PropertyTypeReference>>(json!({
+            "type": "object",
+            "properties": {
+                "https://example.com/property_type_a": { "$ref": "https://example.com/property_type_a/v/1" },
+                "https://example.com/property_type_b": { "$ref": "https://example.com/property_type_b/v/1" },
             },
             "required": [
                 "https://example.com/property_type_c"

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/object.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/object.rs
@@ -77,8 +77,8 @@ impl<V: ValidateUri, const MIN: usize> Object<V, MIN> {
                 ValidationError::MissingRequiredProperty(uri.clone())
             );
         }
-        for (base_uri, referenced) in self.properties() {
-            referenced.validate_uri(base_uri)?;
+        for (base_uri, reference) in self.properties() {
+            reference.validate_uri(base_uri)?;
         }
 
         Ok(())

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/property_type.rs
@@ -1,13 +1,17 @@
 use std::collections::HashSet;
 
+use error_stack::{ensure, Result};
 use serde::{Deserialize, Serialize};
 
-use crate::types::schema::{
-    array::{Array, Itemized},
-    combinator::{OneOf, ValueOrArray},
-    data_type::DataTypeReference,
-    object::Object,
-    VersionedUri,
+use crate::types::{
+    schema::{
+        array::{Array, Itemized},
+        combinator::{OneOf, ValueOrArray},
+        data_type::DataTypeReference,
+        object::{Object, ValidateUri},
+        ValidationError, VersionedUri,
+    },
+    BaseUri,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -31,12 +35,24 @@ impl PropertyTypeReference {
     }
 }
 
+impl ValidateUri for PropertyTypeReference {
+    fn validate_uri(&self, base_uri: &BaseUri) -> Result<(), ValidationError> {
+        ensure!(
+            base_uri == self.reference.base_uri(),
+            ValidationError::BaseUriMismatch {
+                base_uri: base_uri.clone(),
+                versioned_uri: self.reference.clone()
+            }
+        );
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 #[allow(clippy::enum_variant_names)]
 pub enum PropertyValues {
     DataTypeReference(DataTypeReference),
-    // TODO: Check if `Object::properties` matches the URI specified in `PropertyTypeReference`
     PropertyTypeObject(Object<ValueOrArray<PropertyTypeReference>, 1>),
     ArrayOfPropertyValues(Itemized<Array, OneOf<Self>>),
 }
@@ -74,6 +90,15 @@ impl PropertyValues {
                     ValueOrArray::Array(array) => array.items(),
                 })
                 .collect(),
+        }
+    }
+}
+
+impl ValidateUri for PropertyValues {
+    fn validate_uri(&self, base_uri: &BaseUri) -> Result<(), ValidationError> {
+        match self {
+            Self::DataTypeReference(reference) => reference.validate_uri(base_uri),
+            _ => Ok(()),
         }
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/property_type.rs
@@ -94,15 +94,6 @@ impl PropertyValues {
     }
 }
 
-impl ValidateUri for PropertyValues {
-    fn validate_uri(&self, base_uri: &BaseUri) -> Result<(), ValidationError> {
-        match self {
-            Self::DataTypeReference(reference) => reference.validate_uri(base_uri),
-            _ => Ok(()),
-        }
-    }
-}
-
 /// Will serialize as a constant value `"propertyType"`
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/property_type.rs
@@ -38,10 +38,10 @@ impl PropertyTypeReference {
 impl ValidateUri for PropertyTypeReference {
     fn validate_uri(&self, base_uri: &BaseUri) -> Result<(), ValidationError> {
         ensure!(
-            base_uri == self.reference.base_uri(),
+            base_uri == self.uri().base_uri(),
             ValidationError::BaseUriMismatch {
                 base_uri: base_uri.clone(),
-                versioned_uri: self.reference.clone()
+                versioned_uri: self.uri().clone()
             }
         );
         Ok(())


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

URIs in `"$ref"` must match the base URI by which it is referenced. This PR validates the URIs.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201095311341924/1202598517577618/f) _(internal)_

## 🔍 What does this change?

- It isn't straight forward to implement this validation, because the versioned URI lives in `*TypeReference`s, but the key could be anywhere else. To work around this, this PR adds a module-scoped trait `ValidateUri` trait. This trait is implemented on the `*TypeReference`s are called when validating the wrapping structs.
- Implement `Object: Deserialize` by hand (using `ObjectRepr`) because the required trait bound
- Adjust tests to pass the validation
- Add a test to check the validation