### PR TITLE
Rename `reference` field to `uri`

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/types/schema/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/data_type.rs
@@ -10,19 +10,19 @@ use crate::types::schema::VersionedUri;
 pub struct DataTypeReference {
     // TODO: Test if the URI is an actual data type
     #[serde(rename = "$ref")]
-    reference: VersionedUri,
+    uri: VersionedUri,
 }
 
 impl DataTypeReference {
-    /// Creates a new `DataTypeReference` from the given `reference`.
+    /// Creates a new `DataTypeReference` from the given [`VersionedUri`].
     #[must_use]
-    pub const fn new(reference: VersionedUri) -> Self {
-        Self { reference }
+    pub const fn new(uri: VersionedUri) -> Self {
+        Self { uri }
     }
 
     #[must_use]
     pub const fn uri(&self) -> &VersionedUri {
-        &self.reference
+        &self.uri
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/property_type.rs
@@ -15,19 +15,19 @@ use crate::types::schema::{
 pub struct PropertyTypeReference {
     // TODO: Test if the URI is an actual property type
     #[serde(rename = "$ref")]
-    reference: VersionedUri,
+    uri: VersionedUri,
 }
 
 impl PropertyTypeReference {
-    /// Creates a new `PropertyTypeReference` from the given `reference`.
+    /// Creates a new `PropertyTypeReference` from the given [`VersionedUri`].
     #[must_use]
-    pub const fn new(reference: VersionedUri) -> Self {
-        Self { reference }
+    pub const fn new(uri: VersionedUri) -> Self {
+        Self { uri }
     }
 
     #[must_use]
     pub const fn uri(&self) -> &VersionedUri {
-        &self.reference
+        &self.uri
     }
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`DataTypeReference` and `PropertyTypeReference` has a `reference` fields (`"$ref"`). We already renamed the function to return it to `uri()` in e3f794526f80cf6d7b96468ef09f29baa15d3c9a, this PR also renames the field

## 🔗 Related links

- #790