### PR TITLE
Send entity type for root entity to blocks

### DIFF
--- a/packages/hash/frontend/src/blocks/page/ComponentView.tsx
+++ b/packages/hash/frontend/src/blocks/page/ComponentView.tsx
@@ -151,6 +151,7 @@ export class ComponentView implements NodeView<Schema> {
           <BlockLoader
             sourceUrl={this.sourceName}
             blockEntityId={entityId}
+            entityType={childEntity?.entityType}
             blockMetadata={this.meta.componentMetadata}
             // @todo uncomment this when sandbox is fixed
             // shouldSandbox={!this.editable}

--- a/packages/hash/frontend/src/components/BlockLoader/BlockLoader.tsx
+++ b/packages/hash/frontend/src/components/BlockLoader/BlockLoader.tsx
@@ -38,10 +38,10 @@ import { EntityType as ApiEntityType } from "../../graphql/apiTypes.gen";
 type BlockLoaderProps = {
   accountId: string;
   blockEntityId: string;
-  blockEntityType?: ApiEntityType;
   blockMetadata: BlockConfig;
   editableRef: unknown;
   entityId: string;
+  entityType?: Pick<ApiEntityType, "entityId" | "properties">;
   entityTypeId: string;
   entityProperties: {};
   linkGroups: BlockEntity["properties"]["entity"]["linkGroups"];
@@ -60,10 +60,10 @@ type BlockLoaderProps = {
 export const BlockLoader: VoidFunctionComponent<BlockLoaderProps> = ({
   accountId,
   blockEntityId,
-  blockEntityType,
   blockMetadata,
   editableRef,
   entityId,
+  entityType,
   entityTypeId,
   entityProperties,
   linkGroups,
@@ -93,10 +93,9 @@ export const BlockLoader: VoidFunctionComponent<BlockLoaderProps> = ({
   >(() => {
     const convertedEntityTypesForProvidedEntities: BpEntityType[] = [];
 
-    // @todo feed this through from ComponentView
-    if (blockEntityType) {
+    if (entityType) {
       convertedEntityTypesForProvidedEntities.push(
-        convertApiEntityTypeToBpEntityType(blockEntityType),
+        convertApiEntityTypeToBpEntityType(entityType),
       );
     }
 
@@ -115,7 +114,9 @@ export const BlockLoader: VoidFunctionComponent<BlockLoaderProps> = ({
       );
       convertedEntityTypesForProvidedEntities.push(
         ...convertApiEntityTypesToBpEntityTypes(
-          linkedAggregation.results.map(({ entityType }) => entityType),
+          linkedAggregation.results.map(
+            ({ entityType: resultEntityType }) => resultEntityType,
+          ),
         ),
       );
     }
@@ -142,7 +143,7 @@ export const BlockLoader: VoidFunctionComponent<BlockLoaderProps> = ({
     };
   }, [
     accountId,
-    blockEntityType,
+    entityType,
     entityId,
     entityProperties,
     entityTypeId,

--- a/packages/hash/shared/src/entityStore.ts
+++ b/packages/hash/shared/src/entityStore.ts
@@ -2,6 +2,7 @@ import { Draft, produce } from "immer";
 import { createDraftIdForEntity } from "./entityStorePlugin";
 import { BlockEntity, isTextContainingEntityProperties } from "./entity";
 import { DistributiveOmit } from "./util";
+import { MinimalEntityTypeFieldsFragment } from "./graphql/apiTypes.gen";
 
 export type EntityStoreType = BlockEntity | BlockEntity["properties"]["entity"];
 
@@ -22,6 +23,7 @@ export type DraftEntity<Type extends EntityStoreType = EntityStoreType> = {
   entityId: string | null;
   entityTypeId?: string | null;
   entityVersionId?: string | null;
+  entityType?: MinimalEntityTypeFieldsFragment;
 
   // @todo thinking about removing this – as they're keyed by this anyway
   //  and it makes it complicated to deal with types – should probably just


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In #752 we started sending the `entityTypes` message (and prop) to blocks. This is [defined](https://blockprotocol.org/docs/spec/graph-service-specification#message-definitions) in the spec as:

> the entity type definitions for any entities provided to the block in other messages

One thing I left out of that PR is sending the entity type for the `blockEntity` to the block – it was only sending entity types for entities in the wider block graph (e.g. for any entities in `linkedEntities`).

This PR fixes that by also including the block entity's entity type in the `entityTypes` array.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202482456346915/1202566631614518/f) _(internal)_

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Log out `graphProperties.entityTypes` in `RemoteBlock`
2. Check that the correct entity types are sent to any chosen block (e.g. the `Table` block should have both a `Table` entity type _and_ the entity type for whichever entity is selected in the table, if any)
