### PR TITLE
Add `*.stage.hash.ai` as valid CORS origin

### DIFF
--- a/packages/hash/api/src/lib/config.ts
+++ b/packages/hash/api/src/lib/config.ts
@@ -29,5 +29,5 @@ export const FRONTEND_URL = `http${
 
 export const CORS_CONFIG: corsMiddleware.CorsOptions = {
   credentials: true,
-  origin: [/-hashintel\.vercel\.app$/, FRONTEND_URL],
+  origin: [/-hashintel\.vercel\.app$/, /\.stage\.hash\.ai$/, FRONTEND_URL],
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In order to use our Vercel preview deployments with our deployed HASH API, we need them to use a cookie with a `*.hash.ai` domain. We've therefore updated Vercel deployments to be under `*.stage.hash.ai` rather than `-hashintel.vercel.app`

This PR adds `*.stage.hash.ai` to the list of permitted CORS origins.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1200211978612931/1202590106842629/f) _(internal)_

## ⚠️ Known issues

Because we are using a single API at the moment, there is no 'staging' environment for preview deployments to target, so every single preview deployment _and_ the "production" deployment (i.e. the thing built off `main`) are using the same API, and therefore operating on the same data, and the same session cookie will be used across all of them.

This is fine until we introduce preview builds for the API, via short-lived Kubernetes pods.

## ❓ How to test this?

Ultimately we'll only know it works when this is merged to `main` and the new API deploys. Then we can check that we can log in from Vercel preview deployments.

It's possible to run the API locally and making a request to it with an `Origin` header of `[something].stage.hash.ai` and see what the `Access-Control-` headers are, but it probably isn't worth it. Unless there's a mistake in the RegExp it should work for this the same it does for `*.vercel.app` domains.
