### PR TITLE
Deduplicate methods for interactions with Graph Database

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
@@ -161,7 +161,7 @@ pub trait Datastore: Clone + Send + Sync + 'static {
     ///
     /// - [`DatastoreError`], if the account referred to by `created_by` does not exist.
     async fn create_data_type(
-        &mut self,
+        &self,
         data_type: DataType,
         created_by: AccountId,
     ) -> Result<Qualified<DataType>, InsertionError>;
@@ -182,13 +182,13 @@ pub trait Datastore: Clone + Send + Sync + 'static {
     ///
     /// - [`DatastoreError`], if the [`DataType`] doesn't exist.
     async fn update_data_type(
-        &mut self,
+        &self,
         data_type: DataType,
         updated_by: AccountId,
     ) -> Result<Qualified<DataType>, UpdateError>;
 
     async fn create_property_type(
-        &mut self,
+        &self,
         property_type: PropertyType,
         created_by: AccountId,
     ) -> Result<Qualified<PropertyType>, InsertionError>;
@@ -201,13 +201,13 @@ pub trait Datastore: Clone + Send + Sync + 'static {
     async fn get_property_type_many() -> Result<(), QueryError>;
 
     async fn update_property_type(
-        &mut self,
+        &self,
         property_type: PropertyType,
         updated_by: AccountId,
     ) -> Result<Qualified<PropertyType>, UpdateError>;
 
     async fn create_entity_type(
-        &mut self,
+        &self,
         entity_type: EntityType,
         created_by: AccountId,
     ) -> Result<Qualified<EntityType>, InsertionError>;
@@ -220,7 +220,7 @@ pub trait Datastore: Clone + Send + Sync + 'static {
     async fn get_entity_type_many() -> Result<(), QueryError>;
 
     async fn update_entity_type(
-        &mut self,
+        &self,
         entity_type: EntityType,
         updated_by: AccountId,
     ) -> Result<Qualified<EntityType>, UpdateError>;

--- a/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
@@ -159,7 +159,8 @@ pub trait Datastore: Clone + Send + Sync + 'static {
     ///
     /// # Errors:
     ///
-    /// - [`DatastoreError`], if the account referred to by `created_by` does not exist.
+    /// - if the account referred to by `created_by` does not exist.
+    /// - if the [`BaseUri`] of the `data_type` already exist.
     async fn create_data_type(
         &self,
         data_type: DataType,
@@ -170,55 +171,81 @@ pub trait Datastore: Clone + Send + Sync + 'static {
     ///
     /// # Errors
     ///
-    /// - [`DatastoreError`], if the [`DataType`] doesn't exist.
+    /// - if the requested [`DataType`] doesn't exist.
     async fn get_data_type(&self, version_id: VersionId)
     -> Result<Qualified<DataType>, QueryError>;
-
-    async fn get_data_type_many() -> Result<(), QueryError>;
 
     /// Update the definition of an existing [`DataType`].
     ///
     /// # Errors
     ///
-    /// - [`DatastoreError`], if the [`DataType`] doesn't exist.
+    /// - if the [`DataType`] doesn't exist.
     async fn update_data_type(
         &self,
         data_type: DataType,
         updated_by: AccountId,
     ) -> Result<Qualified<DataType>, UpdateError>;
 
+    /// Creates a new [`PropertyType`].
+    ///
+    /// # Errors:
+    ///
+    /// - if the account referred to by `created_by` does not exist.
+    /// - if the [`BaseUri`] of the `property_type` already exist.
     async fn create_property_type(
         &self,
         property_type: PropertyType,
         created_by: AccountId,
     ) -> Result<Qualified<PropertyType>, InsertionError>;
 
+    /// Get an existing [`PropertyType`] by a [`VersionId`].
+    ///
+    /// # Errors
+    ///
+    /// - if the requested [`PropertyType`] doesn't exist.
     async fn get_property_type(
         &self,
         version_id: VersionId,
     ) -> Result<Qualified<PropertyType>, QueryError>;
 
-    async fn get_property_type_many() -> Result<(), QueryError>;
-
+    /// Update the definition of an existing [`PropertyType`].
+    ///
+    /// # Errors
+    ///
+    /// - if the [`PropertyType`] doesn't exist.
     async fn update_property_type(
         &self,
         property_type: PropertyType,
         updated_by: AccountId,
     ) -> Result<Qualified<PropertyType>, UpdateError>;
 
+    /// Creates a new [`EntityType`].
+    ///
+    /// # Errors:
+    ///
+    /// - if the account referred to by `created_by` does not exist.
+    /// - if the [`BaseUri`] of the `entity_type` already exist.
     async fn create_entity_type(
         &self,
         entity_type: EntityType,
         created_by: AccountId,
     ) -> Result<Qualified<EntityType>, InsertionError>;
 
+    /// Get an existing [`EntityType`] by a [`VersionId`].
+    ///
+    /// # Errors
+    ///
+    /// - if the requested [`EntityType`] doesn't exist.
     async fn get_entity_type(
         &self,
         version_id: VersionId,
     ) -> Result<Qualified<EntityType>, QueryError>;
 
-    async fn get_entity_type_many() -> Result<(), QueryError>;
-
+    /// Update the definition of an existing [`EntityType`].
+    ///
+    /// # Errors
+    ///
+    /// - if the [`EntityType`] doesn't exist.
     async fn update_entity_type(
         &self,
         entity_type: EntityType,
@@ -227,11 +254,20 @@ pub trait Datastore: Clone + Send + Sync + 'static {
 
     // TODO - perhaps we want to separate the Datastore into the Type Graph and the Data Graph
 
+    /// Creates a new `Entity`.
     async fn create_entity() -> Result<(), InsertionError>;
 
+    /// Get an existing `Entity`.
+    ///
+    /// # Errors
+    ///
+    /// - if the requested `Entity` doesn't exist.
     async fn get_entity() -> Result<(), QueryError>;
 
-    async fn get_entity_many() -> Result<(), QueryError>;
-
+    /// Updates an existing `Entity`.
+    ///
+    /// # Errors
+    ///
+    /// - if the `Entity` doesn't exist.
     async fn update_entity() -> Result<(), UpdateError>;
 }

--- a/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
@@ -161,6 +161,8 @@ pub trait Datastore: Clone + Send + Sync + 'static {
     ///
     /// - if the account referred to by `created_by` does not exist.
     /// - if the [`BaseUri`] of the `data_type` already exist.
+    ///
+    /// [`BaseUri`]: crate::types::BaseUri
     async fn create_data_type(
         &self,
         data_type: DataType,
@@ -192,6 +194,8 @@ pub trait Datastore: Clone + Send + Sync + 'static {
     ///
     /// - if the account referred to by `created_by` does not exist.
     /// - if the [`BaseUri`] of the `property_type` already exist.
+    ///
+    /// [`BaseUri`]: crate::types::BaseUri
     async fn create_property_type(
         &self,
         property_type: PropertyType,
@@ -225,6 +229,8 @@ pub trait Datastore: Clone + Send + Sync + 'static {
     ///
     /// - if the account referred to by `created_by` does not exist.
     /// - if the [`BaseUri`] of the `entity_type` already exist.
+    ///
+    /// [`BaseUri`]: crate::types::BaseUri
     async fn create_entity_type(
         &self,
         entity_type: EntityType,

--- a/packages/graph/hash_graph/lib/graph/src/datastore/postgres/database_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/postgres/database_type.rs
@@ -3,13 +3,13 @@ use crate::types::{
     VersionedUri,
 };
 
-pub trait DataBaseType {
+pub trait DatabaseType {
     fn id(&self) -> &VersionedUri;
 
     fn table() -> &'static str;
 }
 
-impl DataBaseType for DataType {
+impl DatabaseType for DataType {
     fn id(&self) -> &VersionedUri {
         DataType::id(self)
     }
@@ -19,7 +19,7 @@ impl DataBaseType for DataType {
     }
 }
 
-impl DataBaseType for PropertyType {
+impl DatabaseType for PropertyType {
     fn id(&self) -> &VersionedUri {
         PropertyType::id(self)
     }
@@ -29,7 +29,7 @@ impl DataBaseType for PropertyType {
     }
 }
 
-impl DataBaseType for EntityType {
+impl DatabaseType for EntityType {
     fn id(&self) -> &VersionedUri {
         EntityType::id(self)
     }

--- a/packages/graph/hash_graph/lib/graph/src/datastore/postgres/database_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/postgres/database_type.rs
@@ -4,14 +4,14 @@ use crate::types::{
 };
 
 pub trait DatabaseType {
-    fn id(&self) -> &VersionedUri;
+    fn uri(&self) -> &VersionedUri;
 
     fn table() -> &'static str;
 }
 
 impl DatabaseType for DataType {
-    fn id(&self) -> &VersionedUri {
-        DataType::id(self)
+    fn uri(&self) -> &VersionedUri {
+        self.id()
     }
 
     fn table() -> &'static str {
@@ -20,8 +20,8 @@ impl DatabaseType for DataType {
 }
 
 impl DatabaseType for PropertyType {
-    fn id(&self) -> &VersionedUri {
-        PropertyType::id(self)
+    fn uri(&self) -> &VersionedUri {
+        self.id()
     }
 
     fn table() -> &'static str {
@@ -30,8 +30,8 @@ impl DatabaseType for PropertyType {
 }
 
 impl DatabaseType for EntityType {
-    fn id(&self) -> &VersionedUri {
-        EntityType::id(self)
+    fn uri(&self) -> &VersionedUri {
+        self.id()
     }
 
     fn table() -> &'static str {

--- a/packages/graph/hash_graph/lib/graph/src/datastore/postgres/database_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/postgres/database_type.rs
@@ -1,0 +1,40 @@
+use crate::types::{
+    schema::{DataType, EntityType, PropertyType},
+    VersionedUri,
+};
+
+pub trait DataBaseType {
+    fn id(&self) -> &VersionedUri;
+
+    fn table() -> &'static str;
+}
+
+impl DataBaseType for DataType {
+    fn id(&self) -> &VersionedUri {
+        DataType::id(self)
+    }
+
+    fn table() -> &'static str {
+        "data_types"
+    }
+}
+
+impl DataBaseType for PropertyType {
+    fn id(&self) -> &VersionedUri {
+        PropertyType::id(self)
+    }
+
+    fn table() -> &'static str {
+        "property_types"
+    }
+}
+
+impl DataBaseType for EntityType {
+    fn id(&self) -> &VersionedUri {
+        EntityType::id(self)
+    }
+
+    fn table() -> &'static str {
+        "entity_types"
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/datastore/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/postgres/mod.rs
@@ -169,7 +169,7 @@ impl PostgresDatabase {
     where
         T: DatabaseType + Serialize + Send + Sync,
     {
-        let uri = database_type.id();
+        let uri = database_type.uri();
 
         if self
             .contains_base_uri(uri.base_uri())
@@ -209,7 +209,7 @@ impl PostgresDatabase {
     where
         T: DatabaseType + Serialize + Send + Sync,
     {
-        let uri = database_type.id();
+        let uri = database_type.uri();
 
         if !self
             .contains_base_uri(uri.base_uri())

--- a/packages/graph/hash_graph/lib/graph/src/datastore/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/postgres/mod.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 
 use crate::{
     datastore::{
-        error::VersionedUriAlreadyExists, postgres::database_type::DataBaseType,
+        error::VersionedUriAlreadyExists, postgres::database_type::DatabaseType,
         BaseUriAlreadyExists, BaseUriDoesNotExist, DatabaseConnectionInfo, Datastore,
         DatastoreError, InsertionError, QueryError, UpdateError,
     },
@@ -150,7 +150,7 @@ impl PostgresDatabase {
         Ok(())
     }
 
-    /// Inserts the specified [`DataBaseType`].
+    /// Inserts the specified [`DatabaseType`].
     ///
     /// This first checks, if the [`BaseUri`] of the type does not already exist. If not, it will
     /// insert the [`BaseUri`] and creates a new [`VersionId`] from the contained [`VersionedUri`]
@@ -167,7 +167,7 @@ impl PostgresDatabase {
         created_by: AccountId,
     ) -> Result<Qualified<T>, InsertionError>
     where
-        T: DataBaseType + Serialize + Send + Sync,
+        T: DatabaseType + Serialize + Send + Sync,
     {
         let uri = database_type.id();
 
@@ -191,7 +191,7 @@ impl PostgresDatabase {
         Ok(Qualified::new(version_id, database_type, created_by))
     }
 
-    /// Updates the specified [`DataBaseType`].
+    /// Updates the specified [`DatabaseType`].
     ///
     /// This first checks, if the [`BaseUri`] of the type does exist. It will then creates a new
     /// [`VersionId`] from the contained [`VersionedUri`] and inserts the type.
@@ -207,7 +207,7 @@ impl PostgresDatabase {
         updated_by: AccountId,
     ) -> Result<Qualified<T>, UpdateError>
     where
-        T: DataBaseType + Serialize + Send + Sync,
+        T: DatabaseType + Serialize + Send + Sync,
     {
         let uri = database_type.id();
 
@@ -230,7 +230,7 @@ impl PostgresDatabase {
         Ok(Qualified::new(version_id, database_type, updated_by))
     }
 
-    /// Inserts a [`DataBaseType`] identified by [`VersionId`], and associated with an
+    /// Inserts a [`DatabaseType`] identified by [`VersionId`], and associated with an
     /// [`AccountId`], into the database.
     ///
     /// # Errors
@@ -243,7 +243,7 @@ impl PostgresDatabase {
         created_by: AccountId,
     ) -> Result<(), InsertionError>
     where
-        T: DataBaseType + Serialize + Sync,
+        T: DatabaseType + Serialize + Sync,
     {
         sqlx::query(&format!(
             r#"
@@ -270,13 +270,13 @@ impl PostgresDatabase {
         Ok(())
     }
 
-    /// Returns the specified [`DataBaseType`].
+    /// Returns the specified [`DatabaseType`].
     ///
     /// # Errors
     ///
     /// - If the specified [`VersionId`] does not already exist.
     // TODO: We can't distinguish between an DB error and a non-existing version currently
-    async fn get_by_version<T: DataBaseType + DeserializeOwned>(
+    async fn get_by_version<T: DatabaseType + DeserializeOwned>(
         &self,
         version_id: VersionId,
     ) -> Result<Qualified<T>, QueryError> {

--- a/packages/graph/hash_graph/lib/graph/src/datastore/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/postgres/mod.rs
@@ -150,6 +150,17 @@ impl PostgresDatabase {
         Ok(())
     }
 
+    /// Inserts the specified [`DataBaseType`].
+    ///
+    /// This first checks, if the [`BaseUri`] of the type does not already exist. If not, it will
+    /// insert the [`BaseUri`] and creates a new [`VersionId`] from the contained [`VersionedUri`]
+    /// and inserts the type.
+    ///
+    /// # Errors
+    ///
+    /// - If the [`BaseUri`] already exists
+    ///
+    /// [`BaseUri`]: crate::types::BaseUri
     async fn create<T>(
         &self,
         database_type: T,
@@ -180,6 +191,16 @@ impl PostgresDatabase {
         Ok(Qualified::new(version_id, database_type, created_by))
     }
 
+    /// Updates the specified [`DataBaseType`].
+    ///
+    /// This first checks, if the [`BaseUri`] of the type does exist. It will then creates a new
+    /// [`VersionId`] from the contained [`VersionedUri`] and inserts the type.
+    ///
+    /// # Errors
+    ///
+    /// - If the [`BaseUri`] does not already exist
+    ///
+    /// [`BaseUri`]: crate::types::BaseUri
     async fn update<T>(
         &self,
         database_type: T,
@@ -249,6 +270,12 @@ impl PostgresDatabase {
         Ok(())
     }
 
+    /// Returns the specified [`DataBaseType`].
+    ///
+    /// # Errors
+    ///
+    /// - If the specified [`VersionId`] does not already exist.
+    // TODO: We can't distinguish between an DB error and a non-existing version currently
     async fn get_by_version<T: DataBaseType + DeserializeOwned>(
         &self,
         version_id: VersionId,
@@ -294,10 +321,6 @@ impl Datastore for PostgresDatabase {
         self.get_by_version(version_id).await
     }
 
-    async fn get_data_type_many() -> Result<(), QueryError> {
-        todo!()
-    }
-
     async fn update_data_type(
         &self,
         data_type: DataType,
@@ -319,10 +342,6 @@ impl Datastore for PostgresDatabase {
         version_id: VersionId,
     ) -> Result<Qualified<PropertyType>, QueryError> {
         self.get_by_version(version_id).await
-    }
-
-    async fn get_property_type_many() -> Result<(), QueryError> {
-        todo!()
     }
 
     async fn update_property_type(
@@ -348,10 +367,6 @@ impl Datastore for PostgresDatabase {
         self.get_by_version(version_id).await
     }
 
-    async fn get_entity_type_many() -> Result<(), QueryError> {
-        todo!()
-    }
-
     async fn update_entity_type(
         &self,
         entity_type: EntityType,
@@ -365,10 +380,6 @@ impl Datastore for PostgresDatabase {
     }
 
     async fn get_entity() -> Result<(), QueryError> {
-        todo!()
-    }
-
-    async fn get_entity_many() -> Result<(), QueryError> {
         todo!()
     }
 

--- a/packages/graph/hash_graph/lib/graph/src/lib.rs
+++ b/packages/graph/hash_graph/lib/graph/src/lib.rs
@@ -22,7 +22,6 @@
     clippy::print_stderr,
     clippy::rc_buffer,
     clippy::rc_mutex,
-    clippy::same_name_method,
     clippy::str_to_string,
     clippy::string_add,
     clippy::string_slice,

--- a/packages/graph/hash_graph/lib/graph/src/lib.rs
+++ b/packages/graph/hash_graph/lib/graph/src/lib.rs
@@ -22,6 +22,7 @@
     clippy::print_stderr,
     clippy::rc_buffer,
     clippy::rc_mutex,
+    clippy::same_name_method,
     clippy::str_to_string,
     clippy::string_add,
     clippy::string_slice,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We currently have a bunch of duplicated code when interacting with the database.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201095311341924/1202603488490980) _(internal)_

## 🔍 What does this change?

- Add a (module local) `DatabaseType` trait
- Unify CRU operations in one function for each operation type (removing 66% of the functions)
Drive-bys:
    - Remove `DataStore::*_many` variants
    - Improve documentation on `DataStore`
    - Revert `&mut self` to `&self`

## 📜 Does this require a change to the docs?

The documentation were adjusted/added