### PR TITLE
Remove unsupported block types from swap list

### DIFF
--- a/packages/hash/frontend/src/blocks/page/BlockContext.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockContext.tsx
@@ -1,0 +1,24 @@
+import React, { useContext } from "react";
+
+type BlockContextType = {
+  id: string;
+  error: boolean;
+  setError: (error: boolean) => void;
+};
+
+/** used to detect whether or not a context value was provided */
+const nullBlockView = {};
+
+export const BlockContext = React.createContext<BlockContextType>(
+  nullBlockView as BlockContextType,
+);
+
+export const useBlockContext = () => {
+  const blockContext = useContext(BlockContext);
+
+  if (blockContext === nullBlockView) {
+    throw new Error("no BlockViewContext value has been provided");
+  }
+
+  return blockContext;
+};

--- a/packages/hash/frontend/src/blocks/page/BlockContext.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockContext.tsx
@@ -6,17 +6,12 @@ type BlockContextType = {
   setError: (error: boolean) => void;
 };
 
-/** used to detect whether or not a context value was provided */
-const nullBlockView = {};
-
-export const BlockContext = React.createContext<BlockContextType>(
-  nullBlockView as BlockContextType,
-);
+export const BlockContext = React.createContext<BlockContextType | null>(null);
 
 export const useBlockContext = () => {
   const blockContext = useContext(BlockContext);
 
-  if (blockContext === nullBlockView) {
+  if (!blockContext) {
     throw new Error("no BlockViewContext value has been provided");
   }
 

--- a/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockContextMenu.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockContextMenu.tsx
@@ -42,6 +42,7 @@ type BlockContextMenuProps = {
   entityId: string | null;
   openConfigMenu: () => void;
   popupState: PopupState;
+  swapType: boolean;
 };
 
 const LOAD_BLOCK_ENTITY_UI = "hash-load-entity-ui";
@@ -57,6 +58,7 @@ const BlockContextMenu: ForwardRefRenderFunction<
     entityId,
     openConfigMenu,
     popupState,
+    swapType,
   },
   ref,
 ) => {
@@ -106,15 +108,21 @@ const BlockContextMenu: ForwardRefRenderFunction<
         icon: <FontAwesomeIcon icon={faTrashCan} />,
         onClick: deleteBlock,
       },
-      {
-        key: "swap-block",
-        title: "Swap block type",
-        icon: <FontAwesomeIcon icon={faRefresh} />,
-        subMenu: (
-          <BlockListMenuContent blockSuggesterProps={blockSuggesterProps} />
-        ),
-        subMenuWidth: 228,
-      },
+      ...(swapType
+        ? [
+            {
+              key: "swap-block",
+              title: "Swap block type",
+              icon: <FontAwesomeIcon icon={faRefresh} />,
+              subMenu: (
+                <BlockListMenuContent
+                  blockSuggesterProps={blockSuggesterProps}
+                />
+              ),
+              subMenuWidth: 228,
+            },
+          ]
+        : []),
       {
         key: "move-to-page",
         title: "Move to page",
@@ -143,6 +151,7 @@ const BlockContextMenu: ForwardRefRenderFunction<
     deleteBlock,
     openConfigMenu,
     popupState,
+    swapType,
   ]);
 
   useKey(["Escape"], () => {

--- a/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockListMenuContent.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockListMenuContent.tsx
@@ -27,7 +27,7 @@ export const BlockListMenuContent: VFC<BlockListMenuContentProps> = ({
   const [searchQuery, setSearchQuery] = useState("");
   const searchInputRef = useRef<HTMLInputElement>(null);
   const { value: userBlocks } = useUserBlocks();
-  const blocks = useFilteredBlocks(searchQuery, userBlocks);
+  const blocks = useFilteredBlocks(searchQuery, userBlocks, true);
 
   // The essence of this is to autoFocus the input when
   // the blocklist menu comes up. We have a listener for

--- a/packages/hash/frontend/src/blocks/page/BlockHandle.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockHandle.tsx
@@ -15,6 +15,7 @@ import { BlockConfigMenu } from "./BlockConfigMenu/BlockConfigMenu";
 import { BlockContextMenu } from "./BlockContextMenu/BlockContextMenu";
 import { useBlockView } from "./BlockViewContext";
 import { BlockSuggesterProps } from "./createSuggester/BlockSuggester";
+import { isBlockSwappable } from "./createSuggester/useFilteredBlocks";
 
 type BlockHandleProps = {
   deleteBlock: () => void;
@@ -114,7 +115,7 @@ const BlockHandle: ForwardRefRenderFunction<
         popupState={contextMenuPopupState}
         ref={blockMenuRef}
         swapType={
-          !!blockSchema?.properties?.text ||
+          isBlockSwappable(blockEntity?.properties.componentId) ||
           !!document
             .querySelector(`[data-entity-id="${entityId}"]`)
             ?.getAttribute("data-error")

--- a/packages/hash/frontend/src/blocks/page/BlockHandle.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockHandle.tsx
@@ -113,6 +113,12 @@ const BlockHandle: ForwardRefRenderFunction<
         openConfigMenu={configMenuPopupState.open}
         popupState={contextMenuPopupState}
         ref={blockMenuRef}
+        swapType={
+          !!blockSchema?.properties?.text ||
+          !!document
+            .querySelector(`[data-entity-id="${entityId}"]`)
+            ?.getAttribute("data-error")
+        }
       />
 
       <BlockConfigMenu

--- a/packages/hash/frontend/src/blocks/page/BlockHandle.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockHandle.tsx
@@ -14,6 +14,7 @@ import { useUserBlocks } from "../userBlocks";
 import { BlockConfigMenu } from "./BlockConfigMenu/BlockConfigMenu";
 import { BlockContextMenu } from "./BlockContextMenu/BlockContextMenu";
 import { useBlockView } from "./BlockViewContext";
+import { useBlockContext } from "./BlockContext";
 import { BlockSuggesterProps } from "./createSuggester/BlockSuggester";
 import { isBlockSwappable } from "./createSuggester/useFilteredBlocks";
 
@@ -86,6 +87,8 @@ const BlockHandle: ForwardRefRenderFunction<
     ? blocksMetaMap[blockEntity.properties.componentId]?.componentSchema
     : null;
 
+  const blockContext = useBlockContext();
+
   return (
     <Box ref={ref} data-testid="block-handle">
       <IconButton
@@ -116,9 +119,7 @@ const BlockHandle: ForwardRefRenderFunction<
         ref={blockMenuRef}
         swapType={
           isBlockSwappable(blockEntity?.properties.componentId) ||
-          !!document
-            .querySelector(`[data-entity-id="${entityId}"]`)
-            ?.getAttribute("data-error")
+          blockContext.error
         }
       />
 

--- a/packages/hash/frontend/src/blocks/page/BlockPortals.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockPortals.tsx
@@ -1,0 +1,30 @@
+import { Fragment, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { Block } from "./usePortals";
+import { BlockContext } from "./BlockContext";
+
+export interface PortalProps {
+  draftId: string;
+  portals: [HTMLElement, Block][];
+}
+
+export const BlockPortals = ({ draftId, portals }: PortalProps) => {
+  const [error, setError] = useState(false);
+
+  const context = useMemo(
+    () => ({
+      id: draftId,
+      error,
+      setError,
+    }),
+    [draftId, error, setError],
+  );
+
+  return (
+    <BlockContext.Provider key={draftId} value={context}>
+      {portals.map(([target, { key, reactNode }]) => {
+        return <Fragment key={key}>{createPortal(reactNode, target)}</Fragment>;
+      })}
+    </BlockContext.Provider>
+  );
+};

--- a/packages/hash/frontend/src/blocks/page/BlockPortals.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockPortals.tsx
@@ -1,11 +1,11 @@
 import { Fragment, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
-import { Block } from "./usePortals";
+import { BlockPortal } from "./usePortals";
 import { BlockContext } from "./BlockContext";
 
 export interface PortalProps {
   draftId: string;
-  portals: [HTMLElement, Block][];
+  portals: [HTMLElement, BlockPortal][];
 }
 
 export const BlockPortals = ({ draftId, portals }: PortalProps) => {

--- a/packages/hash/frontend/src/blocks/page/BlockView.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockView.tsx
@@ -215,6 +215,7 @@ export class BlockView implements NodeView<Schema> {
         />
       </BlockViewContext.Provider>,
       this.selectContainer,
+      this.node.firstChild?.attrs.draftId,
     );
 
     return true;

--- a/packages/hash/frontend/src/blocks/page/ComponentView.tsx
+++ b/packages/hash/frontend/src/blocks/page/ComponentView.tsx
@@ -153,13 +153,13 @@ export class ComponentView implements NodeView<Schema> {
                 <ErrorBlock
                   {...props}
                   onRetry={() => {
-                    ctx.setError(false);
+                    ctx?.setError(false);
                     onRetry();
                   }}
                 />
               )}
               onError={() => {
-                ctx.setError(true);
+                ctx?.setError(true);
               }}
             >
               <BlockLoader

--- a/packages/hash/frontend/src/blocks/page/ComponentView.tsx
+++ b/packages/hash/frontend/src/blocks/page/ComponentView.tsx
@@ -147,6 +147,7 @@ export class ComponentView implements NodeView<Schema> {
         <Sentry.ErrorBoundary
           beforeCapture={beforeCapture}
           fallback={(props) => <ErrorBlock {...props} onRetry={onRetry} />}
+          onError={() => this.target.setAttribute("data-error", "true")}
         >
           <BlockLoader
             sourceUrl={this.sourceName}

--- a/packages/hash/frontend/src/blocks/page/createSuggester/createSuggester.tsx
+++ b/packages/hash/frontend/src/blocks/page/createSuggester/createSuggester.tsx
@@ -182,13 +182,12 @@ export const createSuggester = (
             getManager()
               .createRemoteBlockTr(blockMeta.componentId, null, variant)
               .then(([tr, node, meta]) => {
-                const $end = view.state.doc.resolve(to);
-                const endPosition = $end.end(1);
+                const endPosition = view.state.doc.resolve(to).pos;
                 tr.insert(endPosition, node);
 
                 if (blockComponentRequiresText(meta.componentSchema)) {
                   tr.setSelection(
-                    TextSelection.create<Schema>(tr.doc, endPosition),
+                    TextSelection.create<Schema>(tr.doc, endPosition + 1),
                   );
                 }
                 tr.replaceWith(from, to, []);

--- a/packages/hash/frontend/src/blocks/page/createSuggester/useFilteredBlocks.tsx
+++ b/packages/hash/frontend/src/blocks/page/createSuggester/useFilteredBlocks.tsx
@@ -1,4 +1,7 @@
-import { BlockMeta } from "@hashintel/hash-shared/blockMeta";
+import {
+  blockComponentRequiresText,
+  BlockMeta,
+} from "@hashintel/hash-shared/blockMeta";
 import { BlockVariant } from "@blockprotocol/core";
 import { useMemo } from "react";
 
@@ -10,6 +13,15 @@ type Option = {
   meta: BlockMeta["componentMetadata"];
 };
 
+const SWAPPABLE_BLOCKS = [
+  "https://blockprotocol.org/blocks/@hash/paragraph",
+  "https://blockprotocol.org/blocks/@hash/header",
+  "https://blockprotocol.org/blocks/@hash/callout",
+];
+
+export const isBlockSwappable = (blockId: string = "") =>
+  SWAPPABLE_BLOCKS.includes(blockId);
+
 export const useFilteredBlocks = (
   searchText: string,
   blocksMetaMap: BlocksMetaMap,
@@ -18,7 +30,9 @@ export const useFilteredBlocks = (
   return useMemo(() => {
     const allOptions: Option[] = Object.values(blocksMetaMap)
       .filter(
-        (block) => !textBlocksOnly || block?.componentSchema?.properties?.text,
+        (block) =>
+          !textBlocksOnly ||
+          isBlockSwappable(block.componentMetadata.componentId),
       )
       .flatMap(({ componentMetadata: blockMeta }) =>
         // Assumes that variants have been built for all blocks in toBlockConfig

--- a/packages/hash/frontend/src/blocks/page/createSuggester/useFilteredBlocks.tsx
+++ b/packages/hash/frontend/src/blocks/page/createSuggester/useFilteredBlocks.tsx
@@ -1,7 +1,4 @@
-import {
-  blockComponentRequiresText,
-  BlockMeta,
-} from "@hashintel/hash-shared/blockMeta";
+import { BlockMeta } from "@hashintel/hash-shared/blockMeta";
 import { BlockVariant } from "@blockprotocol/core";
 import { useMemo } from "react";
 

--- a/packages/hash/frontend/src/blocks/page/createSuggester/useFilteredBlocks.tsx
+++ b/packages/hash/frontend/src/blocks/page/createSuggester/useFilteredBlocks.tsx
@@ -13,17 +13,21 @@ type Option = {
 export const useFilteredBlocks = (
   searchText: string,
   blocksMetaMap: BlocksMetaMap,
+  textBlocksOnly = false,
 ) => {
   return useMemo(() => {
-    const allOptions: Option[] = Object.values(blocksMetaMap).flatMap(
-      ({ componentMetadata: blockMeta }) =>
+    const allOptions: Option[] = Object.values(blocksMetaMap)
+      .filter(
+        (block) => !textBlocksOnly || block?.componentSchema?.properties?.text,
+      )
+      .flatMap(({ componentMetadata: blockMeta }) =>
         // Assumes that variants have been built for all blocks in toBlockConfig
         // any required changes to block metadata should happen there
         (blockMeta.variants ?? []).map((variant) => ({
           variant,
           meta: blockMeta,
         })),
-    );
+      );
 
     return fuzzySearchBy(
       allOptions,

--- a/packages/hash/frontend/src/blocks/page/createSuggester/useFilteredBlocks.tsx
+++ b/packages/hash/frontend/src/blocks/page/createSuggester/useFilteredBlocks.tsx
@@ -34,5 +34,5 @@ export const useFilteredBlocks = (
       searchText,
       (option) => option.variant.name ?? "",
     );
-  }, [blocksMetaMap, searchText]);
+  }, [blocksMetaMap, textBlocksOnly, searchText]);
 };

--- a/packages/hash/frontend/src/blocks/page/usePortals.tsx
+++ b/packages/hash/frontend/src/blocks/page/usePortals.tsx
@@ -9,7 +9,7 @@ type PortalSet = Map<HTMLElement, BlockPortal>;
 export type RenderPortal = (
   reactNode: React.ReactNode | null,
   node: HTMLElement | null,
-  id: string,
+  id?: string,
 ) => void;
 
 const blankPortals = new Map();

--- a/packages/hash/frontend/src/blocks/page/usePortals.tsx
+++ b/packages/hash/frontend/src/blocks/page/usePortals.tsx
@@ -60,7 +60,7 @@ export const usePortals = () => {
       return { ...obj, [id]: [...(obj[id] || []), portal] };
     },
     {} as {
-      [id: string]: Array<[HTMLElement, BlockPortal]>;
+      [id: string]: [HTMLElement, BlockPortal][];
     },
   );
 

--- a/packages/hash/frontend/src/blocks/page/usePortals.tsx
+++ b/packages/hash/frontend/src/blocks/page/usePortals.tsx
@@ -9,7 +9,7 @@ type PortalSet = Map<HTMLElement, BlockPortal>;
 export type RenderPortal = (
   reactNode: React.ReactNode | null,
   node: HTMLElement | null,
-  id?: string,
+  id: string,
 ) => void;
 
 const blankPortals = new Map();

--- a/packages/hash/frontend/src/components/ErrorBlock/ErrorBlock.tsx
+++ b/packages/hash/frontend/src/components/ErrorBlock/ErrorBlock.tsx
@@ -16,6 +16,7 @@ export interface ErrorBlockProps extends FallbackRenderProps {
 export const ErrorBlock: React.VFC<ErrorBlockProps> = ({ error, onRetry }) => (
   <div
     className={tw`flex flex-row items-baseline px-3 py-2 border-2 border-red-300 rounded`}
+    contentEditable="false"
   >
     Error:{" "}
     <span className={tw`flex-grow truncate font-mono`}>{error.message}</span>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When switching the type of a block from a basic text-type (paragraph, header, callout) to a non text-type block (table for example), the text is gone. This PR removes the unsupported block types from the swap list, until there is a proper data-mapping implementation.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1200211978612931/1202500568584727/f) _(internal)_

## 🔍 What does this change?

- Swap type menu is only shown if block is of type Paragraph, Header or Callout or if the fallback error block is displayed.
- Swap type menu only includes the Paragraph, Header or Callout types.
- 
## ⚠️ Known issues

Retaining the text property in the code block would need to be hardcoded, as it doesn't have a `text` property. So we're skipping this for now.

## ❓ How to test this?

1.  Checkout the branch / view the deployment
1.  Create a text block and insert text
1.  Test swapping types and check if the text is kept

## 📹 Demo

![swap](https://user-images.githubusercontent.com/37453800/178944451-d8ef1b25-602d-4a2e-8283-716209bc99d2.gif)

