### PR TITLE
Run `nextest` with only one test thread

### DIFF
--- a/packages/graph/hash_graph/.config/nextest.toml
+++ b/packages/graph/hash_graph/.config/nextest.toml
@@ -1,0 +1,5 @@
+[profile.default]
+# TODO: Remove this. Currently, it's required as we are using unit-tests for integration tests. This means that our
+#   tests have dependencies on the database, and multiple threads mean that tests pollute each other and may break
+#   constraints
+test-threads = 1

--- a/packages/graph/hash_graph/Makefile.toml
+++ b/packages/graph/hash_graph/Makefile.toml
@@ -9,10 +9,6 @@ CARGO_MAKE_CARGO_PROFILE = "production"
 
 
 [tasks.test]
-# TODO: Remove this. Currently, it's required as we are using unit-tests for integration tests. This means that our
-#  tests have dependencies on the database, and multiple threads mean that tests pollute each other and may break
-# constraints
-env = { RUST_TEST_THREADS = "1" }
 run_task = [
     { name = ["yarn", "deployment-up", "recreate-db", "migrate-up", "test-task", "deployment-down"], condition = { env_true = ["CARGO_MAKE_CI" ] } },
     { name = ["test-task"] }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Ensure, that `nextest` will always run with only one test thread for the Graph until we can run multiple tests at once