### PR TITLE
Cache frontend `.next` folder in CI

### DIFF
--- a/.github/actions/warm-up-repo/action.yml
+++ b/.github/actions/warm-up-repo/action.yml
@@ -4,7 +4,7 @@ description: Prepares Node and Yarn dependencies
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: 18
         cache: yarn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     name: Linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./.github/actions/warm-up-repo
 
@@ -125,7 +125,7 @@ jobs:
     name: Backend integration tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./.github/actions/warm-up-repo
 
@@ -180,7 +180,15 @@ jobs:
     name: Playwright tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        with:
+          path: packages/hash/frontend/.next/cache
+          key: ${{ runner.os }}-frontend-next-cache-${{ hashFiles('yarn.lock') }}-${{ hashFiles('packages/hash/frontend/**') }}
+          restore-keys: |
+            ${{ runner.os }}-frontend-next-cache-${{ hashFiles('yarn.lock') }}-
+            ${{ runner.os }}-frontend-next-cache
 
       - uses: ./.github/actions/warm-up-repo
 
@@ -257,7 +265,7 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./.github/actions/warm-up-repo
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -33,7 +33,7 @@ jobs:
     name: Build and push HASH api image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Docker image build through docker-build-push
         uses: ./.github/actions/docker-build-push
@@ -52,7 +52,7 @@ jobs:
     name: Build and push HASH realtime image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Docker image build through docker-build-push
         uses: ./.github/actions/docker-build-push
@@ -71,7 +71,7 @@ jobs:
     name: Build and push HASH searchloader image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Docker image build through docker-build-push
         uses: ./.github/actions/docker-build-push
@@ -94,7 +94,7 @@ jobs:
       - build-realtime
       - build-searchloader
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./.github/actions/docker-ecr-login
         with:
@@ -103,7 +103,7 @@ jobs:
           AWS_REGION: ${{ env.AWS_REGION }}
 
       # Node is used for migrating the DB
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: yarn

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v3
+      - uses: actions/labeler@v4
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/sync-algolia-index.yml
+++ b/.github/workflows/sync-algolia-index.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
           cache: yarn


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

While working on https://github.com/blockprotocol/blockprotocol/pull/434, I noticed ≈ 10-30 seconds of CI savings after caching `.next/cache` folder. This PR does the same for HASH frontend, which should speed up Playwright tests.

I’ve also bumped action versions given the opportunity, similar to what I’ve done in https://github.com/blockprotocol/blockprotocol/pull/431. New versions run on Node 16 instead of Node 12.
- https://github.com/actions/checkout/releases
- https://github.com/actions/labeler/releases
- https://github.com/actions/setup-node/releases

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202482456346918/1202605360401408/f) _(internal)_


## ❓ How to test this?

Check CI output

## 📷 Demo

`next build`
- without cache: [53.93s](https://github.com/hashintel/hash/runs/7343569230?check_suite_focus=true#step:9:56)
- with cache: [18.06s](https://github.com/hashintel/hash/runs/7343762467?check_suite_focus=true#step:9:50)