### PR TITLE
Add rust-mode workaround for `error-stack` errors

### DIFF
--- a/packages/libs/error-stack/README.md
+++ b/packages/libs/error-stack/README.md
@@ -114,11 +114,12 @@ Please see the [documentation] for a full description.
 
 ## Troubleshooting
 
-### Emacs [rust-mode](https://github.com/rust-lang/rust-mode) workaround.
+### Emacs [rust-mode](https://github.com/rust-lang/rust-mode) workaround
 
 Due to [rust-lang/rust-mode#452](https://github.com/rust-lang/rust-mode/issues/452), errors messages are improperly parsed. As a result, the error messages show incorrect highlighting but also yield an incorrect hyperlink.
 
 The one workaround is to modify the regular expression used to format the string and create a hyperlink.
+
 ```emacs-lisp
 (setq cargo-compilation-regexps
       '("\\(?:at\\|',\\) \\(\\([^:\s]+\\):\\([0-9]+\\)\\)"

--- a/packages/libs/error-stack/README.md
+++ b/packages/libs/error-stack/README.md
@@ -111,3 +111,15 @@ Caused by:
 ```
 
 Please see the [documentation] for a full description.
+
+## Emacs [rust-mode](https://github.com/rust-lang/rust-mode) workaround.
+Due to [rust-lang/rust-mode#452](https://github.com/rust-lang/rust-mode/issues/452), errors messages are improperly parsed. As a result, the error messages show incorrect highlighting but also yield an incorrect hyperlink.
+
+The one workaround is to modify the regular expression for `cargo-mode`, contained within `compilation-error-regexp-alist-alist`, which is used to format the string and create a hyperlink.
+```emacs-lisp
+(setq error_stack-regexps
+      '("\\(?:at\\|',\\) \\(\\([^:\s]+\\):\\([0-9]+\\)\\)"
+        2 3 nil nil 1))
+(setf (cdr (assoc 'cargo compilation-error-regexp-alist-alist))
+      error_stack-regexps)
+```

--- a/packages/libs/error-stack/README.md
+++ b/packages/libs/error-stack/README.md
@@ -112,7 +112,10 @@ Caused by:
 
 Please see the [documentation] for a full description.
 
-## Emacs [rust-mode](https://github.com/rust-lang/rust-mode) workaround.
+## Troubleshooting
+
+### Emacs [rust-mode](https://github.com/rust-lang/rust-mode) workaround.
+
 Due to [rust-lang/rust-mode#452](https://github.com/rust-lang/rust-mode/issues/452), errors messages are improperly parsed. As a result, the error messages show incorrect highlighting but also yield an incorrect hyperlink.
 
 The one workaround is to modify the regular expression used to format the string and create a hyperlink.

--- a/packages/libs/error-stack/README.md
+++ b/packages/libs/error-stack/README.md
@@ -115,11 +115,9 @@ Please see the [documentation] for a full description.
 ## Emacs [rust-mode](https://github.com/rust-lang/rust-mode) workaround.
 Due to [rust-lang/rust-mode#452](https://github.com/rust-lang/rust-mode/issues/452), errors messages are improperly parsed. As a result, the error messages show incorrect highlighting but also yield an incorrect hyperlink.
 
-The one workaround is to modify the regular expression for `cargo-mode`, contained within `compilation-error-regexp-alist-alist`, which is used to format the string and create a hyperlink.
+The one workaround is to modify the regular expression used to format the string and create a hyperlink.
 ```emacs-lisp
-(setq error_stack-regexps
+(setq cargo-compilation-regexps
       '("\\(?:at\\|',\\) \\(\\([^:\s]+\\):\\([0-9]+\\)\\)"
         2 3 nil nil 1))
-(setf (cdr (assoc 'cargo compilation-error-regexp-alist-alist))
-      error_stack-regexps)
 ```


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Basically, I added a workaround to the readme so that `error_stack` errors can be properly parsed by emacs.

## 🔗 Related links

More details can be found here: https://github.com/rust-lang/rust-mode/issues/452
Also here: #811 

## 📜 Does this require a change to the docs?

This is a docs change, so I just need to know any other places this information should show up.

## ⚠️ Known issues

I think this fix is a bit hacky due to the fact it matches on two specific things to determine the start of the filename `at` and `',`.
It also overwrites a variable in `rust-mode` defined in [rust-compile.el](https://github.com/rust-lang/rust-mode/blob/master/rust-compile.el#L39-L41).

## 🛡 What tests cover this?

I don't think you want emacs in you CI pipeline.

## ❓ How to test this?

Copy paste the code I provided in the readme into your `init.el` or wherever you place your user config.
Try seeing what an error_stack message looks like.
Do all links jump to the correct file? Are they underlined and colored properly?

## 📹 Demo

![image](https://user-images.githubusercontent.com/77174844/179195410-588f3d3f-a50d-4532-b569-275bb4931403.png)