### PR TITLE
Skip Playwright downloads by default to speed up CI

### DIFF
--- a/.github/actions/warm-up-repo/action.yml
+++ b/.github/actions/warm-up-repo/action.yml
@@ -1,6 +1,12 @@
 name: Warm-up repo
 description: Prepares Node and Yarn dependencies
 
+inputs:
+  playwright-deps:
+    default: ""
+    description: "List of "
+    required: false
+
 runs:
   using: composite
   steps:
@@ -10,4 +16,10 @@ runs:
         cache: yarn
 
     - run: yarn install
+      shell: bash
+      env:
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: ${{ inputs.playwright-deps == '' }}
+
+    - run: yarn playwright install-deps ${{ inputs.playwright-deps }}
+      if: ${{ success() || failure() }}
       shell: bash

--- a/.github/actions/warm-up-repo/action.yml
+++ b/.github/actions/warm-up-repo/action.yml
@@ -4,7 +4,7 @@ description: Prepares Node and Yarn dependencies
 inputs:
   playwright-deps:
     default: ""
-    description: "List of "
+    description: "List of browsers separated by space, e.g. 'chrome firefox'"
     required: false
 
 runs:
@@ -21,5 +21,5 @@ runs:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: ${{ inputs.playwright-deps == '' }}
 
     - run: yarn playwright install-deps ${{ inputs.playwright-deps }}
-      if: ${{ success() || failure() }}
+      if: ${{ inputs.playwright-deps != '' }}
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: ./.github/actions/warm-up-repo
+        with:
+          playwright-deps: chrome firefox
 
       - name: Create temp files and folders
         run: |
@@ -212,9 +214,6 @@ jobs:
           yarn workspace @hashintel/hash-frontend next build
           yarn workspace @hashintel/hash-frontend start 2>&1 | tee var/logs/frontend.log & ## ampersand enables background mode
           yarn wait-on --timeout 30000 http://0.0.0.0:3000
-
-      - run: yarn playwright install-deps chrome firefox
-        if: ${{ success() || failure() }}
 
       - name: Run Playwright tests
         if: ${{ success() || failure() }}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The goal of this PR is to leverage [`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD`](https://playwright.dev/docs/browsers#skip-browser-downloads), which can speed up most jobs in GitHub workflow.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202482456346918/1202605360401430/f) _(internal)_

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

`yarn install` runs with `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=true`, unless `playwright-deps` input is provided. This skips unused browser downloads and thus speeds up the install process. 

## 🛡 What tests cover this?

- CI
