### PR TITLE
Clean up Graph unit tests

### DIFF
--- a/packages/graph/hash_graph/.config/nextest.toml
+++ b/packages/graph/hash_graph/.config/nextest.toml
@@ -1,5 +1,0 @@
-[profile.default]
-# TODO: Remove this. Currently, it's required as we are using unit-tests for integration tests. This means that our
-#   tests have dependencies on the database, and multiple threads mean that tests pollute each other and may break
-#   constraints
-test-threads = 1

--- a/packages/graph/hash_graph/Makefile.toml
+++ b/packages/graph/hash_graph/Makefile.toml
@@ -10,7 +10,7 @@ CARGO_MAKE_CARGO_PROFILE = "production"
 
 [tasks.test]
 run_task = [
-    { name = ["test-task", "yarn", "deployment-up", "recreate-db", "migrate-up", "test-integration", "deployment-down"], condition = { env_false = ["CARGO_MAKE_CI" ] } },
+    { name = ["test-task", "yarn", "deployment-up", "recreate-db", "migrate-up", "test-integration", "deployment-down"], condition = { env_true = ["CARGO_MAKE_CI" ] } },
     { name = ["test-task"] }
 ]
 

--- a/packages/graph/hash_graph/Makefile.toml
+++ b/packages/graph/hash_graph/Makefile.toml
@@ -10,7 +10,7 @@ CARGO_MAKE_CARGO_PROFILE = "production"
 
 [tasks.test]
 run_task = [
-    { name = ["yarn", "deployment-up", "recreate-db", "migrate-up", "test-task", "test-integration", "deployment-down"], condition = { env_true = ["CARGO_MAKE_CI" ] } },
+    { name = ["test-task", "yarn", "deployment-up", "recreate-db", "migrate-up", "test-integration", "deployment-down"], condition = { env_false = ["CARGO_MAKE_CI" ] } },
     { name = ["test-task"] }
 ]
 

--- a/packages/graph/hash_graph/lib/graph/src/datastore/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/postgres/mod.rs
@@ -455,38 +455,3 @@ impl Datastore for PostgresDatabase {
         todo!()
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use std::sync::LazyLock;
-
-    use super::*;
-    use crate::datastore::DatabaseType;
-
-    const USER: &str = "postgres";
-    const PASSWORD: &str = "postgres";
-    const HOST: &str = "localhost";
-    const PORT: u16 = 5432;
-    const DATABASE: &str = "graph";
-
-    static DB_INFO: LazyLock<DatabaseConnectionInfo> = LazyLock::new(|| {
-        DatabaseConnectionInfo::new(
-            DatabaseType::Postgres,
-            USER.to_owned(),
-            PASSWORD.to_owned(),
-            HOST.to_owned(),
-            PORT,
-            DATABASE.to_owned(),
-        )
-    });
-
-    // TODO - long term we likely want to gate these behind config or something, probably do not
-    //  want to add a dependency on the external service for *unit* tests
-    #[tokio::test]
-    #[cfg_attr(miri, ignore = "miri can't run in async context")]
-    async fn can_connect() -> Result<(), DatastoreError> {
-        PostgresDatabase::new(&DB_INFO).await?;
-
-        Ok(())
-    }
-}

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -233,3 +233,8 @@ async fn remove_by_base_uri(connection: &mut PgConnection, base_uri: &BaseUri) {
         .await
         .expect("could not remove base_uri");
 }
+
+#[test]
+fn can_connect() {
+    DatabaseTestWrapper::new();
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We want to move all database related tests out of the unit tests, so it's possible to run the unit tests without having a database set up.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1200211978612931/1202597697815312) _(internal)_

## 🚫 Blocked by

- #814
- #815
- #816

## 🔍 What does this change?

- Move the `can_connect` test to the integration test suite
- Remove the test thread limit (it's not needed anymore)