### PR TITLE
Update labeler to include backend

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -37,6 +37,12 @@ A-libs:
   - "packages/libs/**/*"
   - "packages/libs/**/.*"
 
+A-backend:
+  - "packages/graph/*"
+  - "packages/graph/.*"
+  - "packages/graph/**/*"
+  - "packages/graph/**/.*"
+
 C-dependencies:
   - "**/Cargo.lock"
   - "**/yarn.lock"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Let the GH labeler also label the backend label