### PR TITLE
Basic Constraints on Links in Entity Types

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/types/schema/combinator.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/combinator.rs
@@ -3,13 +3,6 @@ use serde::{Deserialize, Serialize};
 use crate::types::schema::ValidationError;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged, deny_unknown_fields)]
-pub enum Optional<T> {
-    None {},
-    Some(T),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct OneOfRepr<T> {
     one_of: Vec<T>,
@@ -70,20 +63,6 @@ mod tests {
 
     use super::*;
     use crate::types::schema::tests::{check, check_invalid_json};
-
-    mod optional {
-        use super::*;
-
-        #[test]
-        fn none() -> Result<(), serde_json::Error> {
-            check(&Optional::<()>::None {}, json!({}))
-        }
-
-        #[test]
-        fn some() -> Result<(), serde_json::Error> {
-            check(&Optional::Some("value".to_owned()), json!("value"))
-        }
-    }
 
     mod one_of {
         use std::error::Error;

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/combinator.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/combinator.rs
@@ -1,35 +1,12 @@
 use serde::{Deserialize, Serialize};
 
-use crate::types::{
-    schema::{
-        array::{Array, Itemized},
-        object::ValidateUri,
-        ValidationError,
-    },
-    BaseUri,
-};
+use crate::types::schema::ValidationError;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Optional<T> {
     None {},
     Some(T),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged, deny_unknown_fields)]
-pub enum ValueOrArray<T> {
-    Value(T),
-    Array(Itemized<Array, T>),
-}
-
-impl<T: ValidateUri> ValidateUri for ValueOrArray<T> {
-    fn validate_uri(&self, base_uri: &BaseUri) -> error_stack::Result<(), ValidationError> {
-        match self {
-            Self::Value(value) => value.validate_uri(base_uri),
-            Self::Array(array) => array.items().validate_uri(base_uri),
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -105,26 +82,6 @@ mod tests {
         #[test]
         fn some() -> Result<(), serde_json::Error> {
             check(&Optional::Some("value".to_owned()), json!("value"))
-        }
-    }
-
-    mod value_or_array {
-        use super::*;
-
-        #[test]
-        fn value() -> Result<(), serde_json::Error> {
-            check(&ValueOrArray::Value("value".to_owned()), json!("value"))
-        }
-
-        #[test]
-        fn array() -> Result<(), serde_json::Error> {
-            check(
-                &ValueOrArray::Array(Itemized::new(Array::default(), "string".to_owned())),
-                json!({
-                    "type": "array",
-                    "items": "string",
-                }),
-            )
         }
     }
 

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/link.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/link.rs
@@ -4,19 +4,16 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::{
     schema::{
-        array::{Array, Itemized},
-        entity_type::EntityTypeReference,
-        object::ValidateUri,
-        ValidationError,
+        array::Array, entity_type::EntityTypeReference, object::ValidateUri, ValidationError,
     },
     BaseUri, VersionedUri,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct MaybeOrderedArray<T> {
     #[serde(flatten)]
-    array: Itemized<Array, T>,
+    array: Array<T>,
     // By default, this will not be ordered.
     #[serde(default)]
     ordered: bool,
@@ -31,13 +28,13 @@ impl<T> MaybeOrderedArray<T> {
         max_items: Option<usize>,
     ) -> Self {
         Self {
-            array: Itemized::new(Array::new(min_items, max_items), items),
+            array: Array::new(items, min_items, max_items),
             ordered,
         }
     }
 
     #[must_use]
-    pub const fn array(&self) -> &Itemized<Array, T> {
+    pub const fn array(&self) -> &Array<T> {
         &self.array
     }
 
@@ -218,7 +215,7 @@ mod tests {
 
         #[test]
         fn additional_properties() {
-            check_invalid_json::<MaybeOrderedArray<Array>>(json!({
+            check_invalid_json::<MaybeOrderedArray<StringTypeStruct>>(json!({
                 "type": "array",
                 "items": {
                     "type": "string"

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/mod.rs
@@ -86,6 +86,20 @@ mod tests {
 
     use serde::{Deserialize, Serialize};
 
+    /// Will serialize as a constant value `"string"`
+    #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub(super) enum StringTypeTag {
+        #[default]
+        String,
+    }
+
+    #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
+    pub struct StringTypeStruct {
+        r#type: StringTypeTag,
+    }
+
     pub(super) fn check_serialization<T>(
         value: &T,
         json: &serde_json::Value,

--- a/packages/graph/hash_graph/lib/graph/src/types/schema/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/schema/property_type.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::{
     schema::{
-        array::{Array, Itemized},
+        array::Array,
         combinator::OneOf,
         data_type::DataTypeReference,
         object::{Object, ValidateUri},
@@ -52,7 +52,7 @@ impl ValidateUri for PropertyTypeReference {
 #[serde(untagged, deny_unknown_fields)]
 pub enum ValueOrArray<T> {
     Value(T),
-    Array(Itemized<Array, T>),
+    Array(Array<T>),
 }
 
 impl<T: ValidateUri> ValidateUri for ValueOrArray<T> {
@@ -70,7 +70,7 @@ impl<T: ValidateUri> ValidateUri for ValueOrArray<T> {
 pub enum PropertyValues {
     DataTypeReference(DataTypeReference),
     PropertyTypeObject(Object<ValueOrArray<PropertyTypeReference>, 1>),
-    ArrayOfPropertyValues(Itemized<Array, OneOf<Self>>),
+    ArrayOfPropertyValues(Array<OneOf<Self>>),
 }
 
 impl PropertyValues {
@@ -358,7 +358,7 @@ mod tests {
         #[test]
         fn array() -> Result<(), serde_json::Error> {
             check(
-                &ValueOrArray::Array(Itemized::new(Array::default(), StringTypeStruct::default())),
+                &ValueOrArray::Array(Array::new(StringTypeStruct::default(), None, None)),
                 json!({
                     "type": "array",
                     "items": {

--- a/packages/graph/hash_graph/tests/test_data/entity_type/book_v1.json
+++ b/packages/graph/hash_graph/tests/test_data/entity_type/book_v1.json
@@ -14,7 +14,5 @@
       "$ref": "https://blockprotocol.org/@alice/types/property-type/published-on/v/1"
     }
   },
-  "required": [
-    "https://blockprotocol.org/@alice/types/property-type/name"
-  ]
+  "required": ["https://blockprotocol.org/@alice/types/property-type/name"]
 }

--- a/packages/graph/hash_graph/tests/test_data/entity_type/book_v1.json
+++ b/packages/graph/hash_graph/tests/test_data/entity_type/book_v1.json
@@ -14,5 +14,7 @@
       "$ref": "https://blockprotocol.org/@alice/types/property-type/published-on/v/1"
     }
   },
-  "required": ["https://blockprotocol.org/@alice/types/property-type/name"]
+  "required": [
+    "https://blockprotocol.org/@alice/types/property-type/name"
+  ]
 }

--- a/packages/graph/hash_graph/tests/test_data/entity_type/book_v2.json
+++ b/packages/graph/hash_graph/tests/test_data/entity_type/book_v2.json
@@ -14,11 +14,15 @@
       "$ref": "https://blockprotocol.org/@alice/types/property-type/published-on/v/1"
     }
   },
-  "required": ["https://blockprotocol.org/@alice/types/property-type/name"],
+  "required": [
+    "https://blockprotocol.org/@alice/types/property-type/name"
+  ],
   "links": {
-    "https://blockprotocol.org/@alice/types/property-type/written-by/v/1": {}
+    "https://blockprotocol.org/@alice/types/link-type/written-by/v/1": {
+      "$ref": "https://blockprotocol.org/@alice/types/entity-type/person/v/1"
+    }
   },
   "requiredLinks": [
-    "https://blockprotocol.org/@alice/types/property-type/written-by/v/1"
+    "https://blockprotocol.org/@alice/types/link-type/written-by/v/1"
   ]
 }

--- a/packages/graph/hash_graph/tests/test_data/entity_type/book_v2.json
+++ b/packages/graph/hash_graph/tests/test_data/entity_type/book_v2.json
@@ -14,9 +14,7 @@
       "$ref": "https://blockprotocol.org/@alice/types/property-type/published-on/v/1"
     }
   },
-  "required": [
-    "https://blockprotocol.org/@alice/types/property-type/name"
-  ],
+  "required": ["https://blockprotocol.org/@alice/types/property-type/name"],
   "links": {
     "https://blockprotocol.org/@alice/types/link-type/written-by/v/1": {
       "$ref": "https://blockprotocol.org/@alice/types/entity-type/person/v/1"

--- a/packages/graph/hash_graph/tests/test_data/entity_type/building.json
+++ b/packages/graph/hash_graph/tests/test_data/entity_type/building.json
@@ -2,10 +2,14 @@
   "kind": "entityType",
   "$id": "https://blockprotocol.org/@alice/types/entity-type/building/v/1",
   "type": "object",
-  "title": "Bulding",
+  "title": "Building",
   "properties": {},
   "links": {
-    "https://blockprotocol.org/@alice/types/property-type/located-at/v/1": {},
-    "https://blockprotocol.org/@alice/types/property-type/tenant/v/1": {}
+    "https://blockprotocol.org/@alice/types/link-type/located-at/v/1": {
+      "$ref": "https://blockprotocol.org/@alice/types/entity-type/uk-address/v/1"
+    },
+    "https://blockprotocol.org/@alice/types/link-type/tenant/v/1": {
+      "$ref": "https://blockprotocol.org/@alice/types/entity-type/person/v/1"
+    }
   }
 }

--- a/packages/graph/hash_graph/tests/test_data/entity_type/page.json
+++ b/packages/graph/hash_graph/tests/test_data/entity_type/page.json
@@ -9,9 +9,14 @@
     }
   },
   "links": {
-    "https://blockprotocol.org/@alice/types/property-type/written-by/v/1": {},
-    "https://blockprotocol.org/@alice/types/property-type/contains/v/1": {
+    "https://blockprotocol.org/@alice/types/link-type/written-by/v/1": {
+      "$ref": "https://blockprotocol.org/@alice/types/entity-type/person/v/1"
+    },
+    "https://blockprotocol.org/@alice/types/link-type/contains/v/1": {
       "type": "array",
+      "items": {
+        "$ref": "https://hash.ai/@hash/types/entity-type/block/v/1"
+      },
       "ordered": true
     }
   }

--- a/packages/graph/hash_graph/tests/test_data/entity_type/person.json
+++ b/packages/graph/hash_graph/tests/test_data/entity_type/person.json
@@ -9,8 +9,11 @@
     }
   },
   "links": {
-    "https://blockprotocol.org/@alice/types/property-type/friend-of/v/1": {
+    "https://blockprotocol.org/@alice/types/link-type/friend-of/v/1": {
       "type": "array",
+      "items": {
+        "$ref": "https://blockprotocol.org/@alice/types/entity-type/person/v/1"
+      },
       "ordered": false
     }
   }

--- a/packages/graph/hash_graph/tests/test_data/entity_type/playlist.json
+++ b/packages/graph/hash_graph/tests/test_data/entity_type/playlist.json
@@ -9,8 +9,11 @@
     }
   },
   "links": {
-    "https://blockprotocol.org/@alice/types/property-type/contains/v/1": {
+    "https://blockprotocol.org/@alice/types/link-type/contains/v/1": {
       "type": "array",
+      "items": {
+        "$ref": "https://blockprotocol.org/@alice/types/entity-type/song/v/1"
+      },
       "ordered": true
     }
   }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

While we await completion of the the [Link Constraints RFC](https://github.com/blockprotocol/blockprotocol/pull/354) we're going to go ahead with a temporary design to unblock ourselves. Entity Types will constraint the destinations of their links by specifying a reference to an Entity Type, either inline, or inside the `"items"` when the links are an array.

**This is a temporary solution, we shall be updating it in the future**

I also unfortunately came across some issues with our combinator design so I've had to modify those files and polluted the PR with some drivebys.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1200211978612931/1202510175233302/f) _(internal)_

## 🔍 What does this change?

- Moves `ValueOrArray` to the property type module as it was only used there
- Creates a `ValueOrMaybeOrderedArray` enum to use inside the Link Type
- Creates an `EntityTypeReference` struct
- Updates the Link Type struct to now require a "type" field to be defined inside the link definitions
- Updates the tests to work with the new layout
- _Drive-by_: fixes the tests where we had `"items": "string"` to now be `"items": { "type": "string" }`
- _Drive-by_: fixes link-types referenced in tests which had "property-type" in the URI

## 📜 Does this require a change to the docs?

- As this is a temporary solution and we're awaiting changes upstream in the BlockProtocol spec, we don't need to update docs for now.

## ⚠️ Known issues

- Without anonymous enums there's a lot of boilerplate
- The combinator approach for `ValueOrArray` didn't really play nicely with adding `MaybeOrdered<Array...`

## 🐾 Next steps

Implement methods on the datastore for CRU of Link Types

## 🛡 What tests cover this?

- The unit and integration testing suites

## ❓ How to test this?

1.  Checkout the branch / view the deployment
1.  Follow the instructions in the README for running the tests

## 📹 Demo

<img width="568" alt="image" src="https://user-images.githubusercontent.com/25749103/179521805-18c7a1bd-74b9-4ad8-8abe-3914e34c560f.png">
<img width="671" alt="image" src="https://user-images.githubusercontent.com/25749103/179523376-929f11af-5777-46ec-bb3c-186942be8840.png">
