### PR TITLE
Simplify portal implementation, improving performance

### DIFF
--- a/packages/hash/frontend/src/blocks/page/usePortals.tsx
+++ b/packages/hash/frontend/src/blocks/page/usePortals.tsx
@@ -1,11 +1,4 @@
-import React, {
-  Fragment,
-  ReactNode,
-  useCallback,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
+import React, { Fragment, ReactNode, useCallback, useState } from "react";
 import { createPortal } from "react-dom";
 import { v4 as uuid } from "uuid";
 
@@ -16,29 +9,18 @@ export type RenderPortal = (
   node: HTMLElement | null,
 ) => void;
 
+const blankPortals = new Map();
+
 /**
  * In order to integrate with Prosemirror, we want to be able to render to any
  * arbitrary DOM node whilst staying within our single React root. React-dom
  * includes a feature called portals for this, but they return elements that
  * need to be returned by a React component, so we need to provide a function
  * that can be called from within prosemirror that will update a piece of state
- * which we can map to portals. A further complication is we don't want to
- * re-render immediately every time a request is made to update a portal, as
- * individual prosemirror nodes will make their requests one at a time, so we
- * should defer all re-renders to the end of the current tick. Finally, in
- * theory, the same JSX could be moved to a different DOM node, so the API
- * needs to support changing the DOM target of a given portal.
+ * which we can map to portals.
  */
 export const usePortals = () => {
-  // @todo I think this should use external state, so we can update it from
-  //  outside of React, without having to pass functions around
-  const [portals, setPortals] = useState<PortalSet>(new Map());
-
-  const portalQueue = useRef<((set: PortalSet) => void)[]>([]);
-  const portalQueueTimeout = useRef<ReturnType<typeof setImmediate> | null>(
-    null,
-  );
-
+  const [portals, setPortals] = useState<PortalSet>(blankPortals);
   /**
    * Call this to render a piece of JSX to a given DOM node in a portal
    *
@@ -47,12 +29,10 @@ export const usePortals = () => {
    * To clear, pass null for jsx
    */
   const renderPortal = useCallback<RenderPortal>((reactNode, node) => {
-    if (portalQueueTimeout.current !== null) {
-      clearImmediate(portalQueueTimeout.current);
-    }
+    if (node) {
+      setPortals((prevPortals) => {
+        const nextPortals = new Map(prevPortals);
 
-    portalQueue.current.push((nextPortals) => {
-      if (node) {
         if (reactNode) {
           const key = nextPortals.get(node)?.key ?? uuid();
 
@@ -60,34 +40,15 @@ export const usePortals = () => {
         } else {
           nextPortals.delete(node);
         }
-      }
-    });
-
-    portalQueueTimeout.current = setImmediate(() => {
-      const queue = portalQueue.current;
-      portalQueue.current = [];
-
-      setPortals((prevPortals) => {
-        const nextPortals = new Map(prevPortals);
-
-        for (const cb of queue) {
-          cb(nextPortals);
-        }
 
         return nextPortals;
       });
-    });
+    }
   }, []);
 
-  useLayoutEffect(() => {
-    return () => {
-      if (portalQueueTimeout.current !== null) {
-        clearImmediate(portalQueueTimeout.current);
-      }
-    };
+  const clearPortals = useCallback(() => {
+    setPortals(blankPortals);
   }, []);
-
-  const clearPortals = useCallback(() => setPortals(new Map()), []);
 
   const renderedPortals = Array.from(portals.entries()).map(
     ([target, { key, reactNode }]) => (


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

While working on another ticket, I discovered our portals implementation can be simplified, relying on React 18's state batching behaviour. 

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

N/A

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

N/A

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

Currently, whenever part of the app calls `renderPortal`, we defer a task to the end of the tick in order to collect any further calls to `renderPortal` within this tick, before calling `setPortals` and triggering a re-render. This is to ensure sequential calls to render portal don't trigger sequential renders. Now, React batches calls to `setState` within a tick for us, so we don't need to do any schedule management. In fact, our current implementation takes *longer* than necessary, because we queue a task to call set state, which queues a state to re-render. We could have done this all in one task. But now React 18 batches, we don't need to worry about this.

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

No

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

No

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

@luisbettencourt is introducing code to group portals by block, so they can share context.

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

Playwright tests on general editor functionality

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Ensure app works as expected.