### PR TITLE
Insert type references into the database

### DIFF
--- a/packages/graph/hash_graph/Cargo.lock
+++ b/packages/graph/hash_graph/Cargo.lock
@@ -384,21 +384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,17 +400,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
-name = "futures-executor"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-intrusive"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,23 +408,6 @@ dependencies = [
  "futures-core",
  "lock_api",
  "parking_lot",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -471,16 +428,11 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -512,7 +464,6 @@ dependencies = [
  "axum",
  "clap",
  "error-stack",
- "futures",
  "serde",
  "serde_json",
  "sqlx",
@@ -1267,12 +1218,6 @@ checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "slab"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"

--- a/packages/graph/hash_graph/lib/graph/Cargo.toml
+++ b/packages/graph/hash_graph/lib/graph/Cargo.toml
@@ -11,7 +11,6 @@ async-trait = "0.1.56"
 axum = "0.5.11"
 clap = { version = "3.2.10", features = ["derive", "env"], optional = true }
 error-stack = "0.1.1"
-futures = "0.3.21"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 sqlx = { version = "0.6.0", features = ["runtime-tokio-native-tls", "postgres", "macros", "uuid", "time", "json", "sqlx-macros"] }

--- a/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
@@ -12,7 +12,7 @@ pub use self::{
 };
 use crate::types::{
     schema::{DataType, EntityType, PropertyType},
-    AccountId, Qualified, VersionId, VersionedUri,
+    AccountId, Qualified, VersionId,
 };
 
 #[derive(Debug)]

--- a/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
@@ -160,13 +160,6 @@ impl fmt::Display for DatabaseConnectionInfo {
 /// raised depending on the implementation, e.g. connection issues.
 #[async_trait]
 pub trait Datastore: Clone + Send + Sync + 'static {
-    /// Fetches the [`VersionId`] of the specified [`VersionedUri`].
-    ///
-    /// # Errors:
-    ///
-    /// - if the entry referred to by `uri` does not exist.
-    async fn version_id_by_uri(&self, uri: &VersionedUri) -> Result<VersionId, QueryError>;
-
     /// Creates a new [`DataType`].
     ///
     /// # Errors:

--- a/packages/graph/hash_graph/lib/graph/src/datastore/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/postgres/mod.rs
@@ -489,7 +489,7 @@ impl PostgresDatabase {
         Ok(ids)
     }
 
-    /// Returns the [`VersionId`] mapped from the specified [`VersionedUri`].
+    /// Fetches the [`VersionId`] of the specified [`VersionedUri`].
     ///
     /// # Errors:
     ///

--- a/packages/graph/hash_graph/lib/graph/src/datastore/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/postgres/mod.rs
@@ -3,7 +3,7 @@ mod database_type;
 use async_trait::async_trait;
 use error_stack::{IntoReport, Report, Result, ResultExt};
 use serde::{de::DeserializeOwned, Serialize};
-use sqlx::{Executor, PgPool, Postgres};
+use sqlx::{Executor, PgPool, Postgres, Row, Transaction};
 use uuid::Uuid;
 
 use crate::{
@@ -48,20 +48,27 @@ impl PostgresDatabase {
     /// - [`DatastoreError`], if checking for the [`BaseUri`] failed.
     ///
     /// [`BaseUri`]: crate::types::BaseUri
-    async fn contains_base_uri<'e, E>(executor: E, base_uri: &BaseUri) -> Result<bool, QueryError>
-    where
-        E: Executor<'e, Database = Postgres>,
-    {
-        let (exists,) =
-            sqlx::query_as(r#"SELECT EXISTS(SELECT 1 FROM base_uris WHERE base_uri = $1);"#)
-                .bind(base_uri)
-                .fetch_one(executor)
-                .await
-                .report()
-                .change_context(QueryError)
-                .attach_printable_lazy(|| base_uri.clone())?;
-
-        Ok(exists)
+    async fn contains_base_uri(
+        transaction: &mut Transaction<'_, Postgres>,
+        base_uri: &BaseUri,
+    ) -> Result<bool, QueryError> {
+        Ok(transaction
+            .fetch_one(
+                sqlx::query(
+                    r#"
+                        SELECT EXISTS(
+                            SELECT 1
+                            FROM base_uris
+                            WHERE base_uri = $1
+                        );"#,
+                )
+                .bind(base_uri),
+            )
+            .await
+            .report()
+            .change_context(QueryError)
+            .attach_printable_lazy(|| base_uri.clone())?
+            .get(0))
     }
 
     /// Checks if the specified [`VersionedUri`] exists in the database.
@@ -69,22 +76,28 @@ impl PostgresDatabase {
     /// # Errors
     ///
     /// - [`DatastoreError`], if checking for the [`VersionedUri`] failed.
-    async fn contains_uri<'e, E>(executor: E, uri: &VersionedUri) -> Result<bool, QueryError>
-    where
-        E: Executor<'e, Database = Postgres>,
-    {
-        let (exists,) = sqlx::query_as(
-            r#"SELECT EXISTS(SELECT 1 FROM ids WHERE base_uri = $1 AND version = $2);"#,
-        )
-        .bind(uri.base_uri())
-        .bind(i64::from(uri.version()))
-        .fetch_one(executor)
-        .await
-        .report()
-        .change_context(QueryError)
-        .attach_printable_lazy(|| uri.clone())?;
-
-        Ok(exists)
+    async fn contains_uri(
+        transaction: &mut Transaction<'_, Postgres>,
+        uri: &VersionedUri,
+    ) -> Result<bool, QueryError> {
+        Ok(transaction
+            .fetch_one(
+                sqlx::query(
+                    r#"
+                        SELECT EXISTS(
+                            SELECT 1
+                            FROM ids
+                            WHERE base_uri = $1 AND version = $2
+                        );"#,
+                )
+                .bind(uri.base_uri())
+                .bind(i64::from(uri.version())),
+            )
+            .await
+            .report()
+            .change_context(QueryError)
+            .attach_printable_lazy(|| uri.clone())?
+            .get(0))
     }
 
     /// Inserts the specified [`VersionedUri`] into the database.
@@ -92,29 +105,28 @@ impl PostgresDatabase {
     /// # Errors
     ///
     /// - [`DatastoreError`], if inserting the [`VersionedUri`] failed.
-    async fn insert_uri<'e, E>(
-        executor: E,
+    async fn insert_uri(
+        transaction: &mut Transaction<'_, Postgres>,
         uri: &VersionedUri,
         version_id: VersionId,
-    ) -> Result<(), InsertionError>
-    where
-        E: Executor<'e, Database = Postgres>,
-    {
-        let _version_id: (VersionId,) = sqlx::query_as(
-            r#"
-            INSERT INTO ids (base_uri, version, version_id)
-            VALUES ($1, $2, $3)
-            RETURNING version_id;
-            "#,
-        )
-        .bind(uri.base_uri())
-        .bind(i64::from(uri.version()))
-        .bind(version_id)
-        .fetch_one(executor)
-        .await
-        .report()
-        .change_context(InsertionError)
-        .attach_printable_lazy(|| uri.clone())?;
+    ) -> Result<(), InsertionError> {
+        transaction
+            .fetch_one(
+                sqlx::query(
+                    r#"
+                    INSERT INTO ids (base_uri, version, version_id)
+                    VALUES ($1, $2, $3)
+                    RETURNING version_id;
+                    "#,
+                )
+                .bind(uri.base_uri())
+                .bind(i64::from(uri.version()))
+                .bind(version_id),
+            )
+            .await
+            .report()
+            .change_context(InsertionError)
+            .attach_printable_lazy(|| uri.clone())?;
 
         Ok(())
     }
@@ -126,23 +138,25 @@ impl PostgresDatabase {
     /// - [`DatastoreError`], if inserting the [`BaseUri`] failed.
     ///
     /// [`BaseUri`]: crate::types::BaseUri
-    async fn insert_base_uri<'e, E>(executor: E, base_uri: &BaseUri) -> Result<(), InsertionError>
-    where
-        E: Executor<'e, Database = Postgres>,
-    {
-        let _base_uri: (BaseUri,) = sqlx::query_as(
-            r#"
-            INSERT INTO base_uris (base_uri) 
-            VALUES ($1)
-            RETURNING base_uri;
-            "#,
-        )
-        .bind(base_uri)
-        .fetch_one(executor)
-        .await
-        .report()
-        .change_context(InsertionError)
-        .attach_printable_lazy(|| base_uri.clone())?;
+    async fn insert_base_uri(
+        transaction: &mut Transaction<'_, Postgres>,
+        base_uri: &BaseUri,
+    ) -> Result<(), InsertionError> {
+        transaction
+            .fetch_one(
+                sqlx::query(
+                    r#"
+                    INSERT INTO base_uris (base_uri) 
+                    VALUES ($1)
+                    RETURNING base_uri;
+                    "#,
+                )
+                .bind(base_uri),
+            )
+            .await
+            .report()
+            .change_context(InsertionError)
+            .attach_printable_lazy(|| base_uri.clone())?;
 
         Ok(())
     }
@@ -152,26 +166,25 @@ impl PostgresDatabase {
     /// # Errors
     ///
     /// - [`DatastoreError`], if inserting the [`VersionId`] failed.
-    async fn insert_version_id<'e, E>(
-        executor: E,
+    async fn insert_version_id(
+        transaction: &mut Transaction<'_, Postgres>,
         version_id: VersionId,
-    ) -> Result<(), InsertionError>
-    where
-        E: Executor<'e, Database = Postgres>,
-    {
-        let _version_id: (VersionId,) = sqlx::query_as(
-            r#"
-            INSERT INTO version_ids (version_id) 
-            VALUES ($1)
-            RETURNING version_id;
-            "#,
-        )
-        .bind(version_id)
-        .fetch_one(executor)
-        .await
-        .report()
-        .change_context(InsertionError)
-        .attach_printable(version_id)?;
+    ) -> Result<(), InsertionError> {
+        transaction
+            .fetch_one(
+                sqlx::query(
+                    r#"
+                    INSERT INTO version_ids (version_id) 
+                    VALUES ($1)
+                    RETURNING version_id;
+                    "#,
+                )
+                .bind(version_id),
+            )
+            .await
+            .report()
+            .change_context(InsertionError)
+            .attach_printable(version_id)?;
 
         Ok(())
     }
@@ -188,7 +201,7 @@ impl PostgresDatabase {
     ///
     /// [`BaseUri`]: crate::types::BaseUri
     async fn create<T>(
-        &self,
+        transaction: &mut Transaction<'_, Postgres>,
         database_type: T,
         created_by: AccountId,
     ) -> Result<Qualified<T>, InsertionError>
@@ -197,14 +210,7 @@ impl PostgresDatabase {
     {
         let uri = database_type.uri();
 
-        let mut transaction = self
-            .pool
-            .begin()
-            .await
-            .report()
-            .change_context(InsertionError)?;
-
-        if Self::contains_base_uri(&mut transaction, uri.base_uri())
+        if Self::contains_base_uri(transaction, uri.base_uri())
             .await
             .change_context(InsertionError)?
         {
@@ -213,9 +219,9 @@ impl PostgresDatabase {
                 .change_context(InsertionError));
         }
 
-        Self::insert_base_uri(&mut transaction, uri.base_uri()).await?;
+        Self::insert_base_uri(transaction, uri.base_uri()).await?;
 
-        if Self::contains_uri(&mut transaction, uri)
+        if Self::contains_uri(transaction, uri)
             .await
             .change_context(InsertionError)?
         {
@@ -225,15 +231,9 @@ impl PostgresDatabase {
         }
 
         let version_id = VersionId::new(Uuid::new_v4());
-        Self::insert_version_id(&mut transaction, version_id).await?;
-        Self::insert_uri(&mut transaction, uri, version_id).await?;
-        Self::insert_with_id(&mut transaction, version_id, &database_type, created_by).await?;
-
-        transaction
-            .commit()
-            .await
-            .report()
-            .change_context(InsertionError)?;
+        Self::insert_version_id(transaction, version_id).await?;
+        Self::insert_uri(transaction, uri, version_id).await?;
+        Self::insert_with_id(transaction, version_id, &database_type, created_by).await?;
 
         Ok(Qualified::new(version_id, database_type, created_by))
     }
@@ -249,7 +249,7 @@ impl PostgresDatabase {
     ///
     /// [`BaseUri`]: crate::types::BaseUri
     async fn update<T>(
-        &self,
+        transaction: &mut Transaction<'_, Postgres>,
         database_type: T,
         updated_by: AccountId,
     ) -> Result<Qualified<T>, UpdateError>
@@ -258,14 +258,7 @@ impl PostgresDatabase {
     {
         let uri = database_type.uri();
 
-        let mut transaction = self
-            .pool
-            .begin()
-            .await
-            .report()
-            .change_context(UpdateError)?;
-
-        if !Self::contains_base_uri(&mut transaction, uri.base_uri())
+        if !Self::contains_base_uri(transaction, uri.base_uri())
             .await
             .change_context(UpdateError)?
         {
@@ -275,20 +268,14 @@ impl PostgresDatabase {
         }
 
         let version_id = VersionId::new(Uuid::new_v4());
-        Self::insert_version_id(&mut transaction, version_id)
+        Self::insert_version_id(transaction, version_id)
             .await
             .change_context(UpdateError)?;
-        Self::insert_uri(&mut transaction, uri, version_id)
+        Self::insert_uri(transaction, uri, version_id)
             .await
             .change_context(UpdateError)?;
-        Self::insert_with_id(&mut transaction, version_id, &database_type, updated_by)
+        Self::insert_with_id(transaction, version_id, &database_type, updated_by)
             .await
-            .change_context(UpdateError)?;
-
-        transaction
-            .commit()
-            .await
-            .report()
             .change_context(UpdateError)?;
 
         Ok(Qualified::new(version_id, database_type, updated_by))
@@ -467,7 +454,22 @@ impl Datastore for PostgresDatabase {
         data_type: DataType,
         created_by: AccountId,
     ) -> Result<Qualified<DataType>, InsertionError> {
-        self.create(data_type, created_by).await
+        let mut transaction = self
+            .pool
+            .begin()
+            .await
+            .report()
+            .change_context(InsertionError)?;
+
+        let qualified = Self::create(&mut transaction, data_type, created_by).await?;
+
+        transaction
+            .commit()
+            .await
+            .report()
+            .change_context(InsertionError)?;
+
+        Ok(qualified)
     }
 
     async fn get_data_type(
@@ -482,7 +484,22 @@ impl Datastore for PostgresDatabase {
         data_type: DataType,
         updated_by: AccountId,
     ) -> Result<Qualified<DataType>, UpdateError> {
-        self.update(data_type, updated_by).await
+        let mut transaction = self
+            .pool
+            .begin()
+            .await
+            .report()
+            .change_context(UpdateError)?;
+
+        let qualified = Self::update(&mut transaction, data_type, updated_by).await?;
+
+        transaction
+            .commit()
+            .await
+            .report()
+            .change_context(UpdateError)?;
+
+        Ok(qualified)
     }
 
     async fn create_property_type(
@@ -495,7 +512,23 @@ impl Datastore for PostgresDatabase {
             .change_context(InsertionError)
             .attach_printable("Could not insert references for property type")
             .attach_lazy(|| property_type.clone())?;
-        self.create(property_type, created_by).await
+
+        let mut transaction = self
+            .pool
+            .begin()
+            .await
+            .report()
+            .change_context(InsertionError)?;
+
+        let qualified = Self::create(&mut transaction, property_type, created_by).await?;
+
+        transaction
+            .commit()
+            .await
+            .report()
+            .change_context(InsertionError)?;
+
+        Ok(qualified)
     }
 
     async fn get_property_type(
@@ -515,7 +548,23 @@ impl Datastore for PostgresDatabase {
             .change_context(UpdateError)
             .attach_printable("Could not insert references for property type")
             .attach_lazy(|| property_type.clone())?;
-        self.update(property_type, updated_by).await
+
+        let mut transaction = self
+            .pool
+            .begin()
+            .await
+            .report()
+            .change_context(UpdateError)?;
+
+        let qualified = Self::update(&mut transaction, property_type, updated_by).await?;
+
+        transaction
+            .commit()
+            .await
+            .report()
+            .change_context(UpdateError)?;
+
+        Ok(qualified)
     }
 
     async fn create_entity_type(
@@ -528,7 +577,23 @@ impl Datastore for PostgresDatabase {
             .change_context(InsertionError)
             .attach_printable("Could not insert references for entity type")
             .attach_lazy(|| entity_type.clone())?;
-        self.create(entity_type, created_by).await
+
+        let mut transaction = self
+            .pool
+            .begin()
+            .await
+            .report()
+            .change_context(InsertionError)?;
+
+        let qualified = Self::create(&mut transaction, entity_type, created_by).await?;
+
+        transaction
+            .commit()
+            .await
+            .report()
+            .change_context(InsertionError)?;
+
+        Ok(qualified)
     }
 
     async fn get_entity_type(
@@ -548,7 +613,23 @@ impl Datastore for PostgresDatabase {
             .change_context(UpdateError)
             .attach_printable("Could not insert references for entity type")
             .attach_lazy(|| entity_type.clone())?;
-        self.update(entity_type, updated_by).await
+
+        let mut transaction = self
+            .pool
+            .begin()
+            .await
+            .report()
+            .change_context(UpdateError)?;
+
+        let qualified = Self::update(&mut transaction, entity_type, updated_by).await?;
+
+        transaction
+            .commit()
+            .await
+            .report()
+            .change_context(UpdateError)?;
+
+        Ok(qualified)
     }
 
     async fn create_entity() -> Result<(), InsertionError> {

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -132,11 +132,13 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         type: "UUID",
         notNull: true,
         references: "property_types",
+        onDelete: "CASCADE",
       },
       target_property_type_version_id: {
         type: "UUID",
         notNull: true,
         references: "property_types",
+        onDelete: "CASCADE",
       },
     },
     {
@@ -151,11 +153,13 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         type: "UUID",
         notNull: true,
         references: "property_types",
+        onDelete: "CASCADE",
       },
       target_data_type_version_id: {
         type: "UUID",
         notNull: true,
         references: "data_types",
+        onDelete: "CASCADE",
       },
     },
     {
@@ -194,11 +198,13 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         type: "UUID",
         notNull: true,
         references: "entity_types",
+        onDelete: "CASCADE",
       },
       target_property_type_version_id: {
         type: "UUID",
         notNull: true,
         references: "property_types",
+        onDelete: "CASCADE",
       },
     },
     {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Previously, we only checked if a reference is valid, this PR also inserts it into the database

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1200211978612931/1202597697815314/f) _(internal)_

## 🚫 Blocked by

- #821 

## 🔍 What does this change?

- Because `sqlx::Executor` is only implemented for references, change the implementation to use `Transaction` instead
- Use transactions to read the references
- Store the references in the database

## ⚠️ Known issues

We have quite a few code duplication here as we need the logic for different types.

## 🐾 Next steps

- Add tests to the test suite, which passes invalid date: [Asana task](https://app.asana.com/0/1200211978612931/1202598311667201/f) (_internal_)

## 🛡 What tests cover this?

The integration test suite covers this