### PR TITLE
Use new @blockprotocol/graph version

### DIFF
--- a/packages/blocks/callout/package.json
+++ b/packages/blocks/callout/package.json
@@ -19,7 +19,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.11-canary.4"
+    "@blockprotocol/graph": "0.0.11-canary.24"
   },
   "devDependencies": {
     "block-scripts": "0.0.13",

--- a/packages/blocks/code/package.json
+++ b/packages/blocks/code/package.json
@@ -19,7 +19,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.11-canary.4",
+    "@blockprotocol/graph": "0.0.11-canary.24",
     "prismjs": "1.28.0",
     "styled-components": "5.3.5"
   },

--- a/packages/blocks/countdown/package.json
+++ b/packages/blocks/countdown/package.json
@@ -22,7 +22,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.11-canary.4",
+    "@blockprotocol/graph": "0.0.11-canary.24",
     "date-fns": "2.28.0",
     "react-datepicker": "4.7.0"
   },

--- a/packages/blocks/drawing/package.json
+++ b/packages/blocks/drawing/package.json
@@ -22,7 +22,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.11-canary.4",
+    "@blockprotocol/graph": "0.0.11-canary.24",
     "@tldraw/tldraw": "1.16.0",
     "@types/react-resizable": "1.7.4",
     "react-resizable": "^3.0.4"

--- a/packages/blocks/github-pr-overview/package.json
+++ b/packages/blocks/github-pr-overview/package.json
@@ -24,7 +24,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.11-canary.4",
+    "@blockprotocol/graph": "0.0.11-canary.24",
     "@hashintel/hash-design-system": "0.0.0",
     "@mui/icons-material": "5.4.2",
     "@mui/lab": "5.0.0-alpha.71",

--- a/packages/blocks/header/package.json
+++ b/packages/blocks/header/package.json
@@ -19,7 +19,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.11-canary.4"
+    "@blockprotocol/graph": "0.0.11-canary.24"
   },
   "devDependencies": {
     "block-scripts": "0.0.13",

--- a/packages/blocks/image/package.json
+++ b/packages/blocks/image/package.json
@@ -19,7 +19,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.11-canary.4"
+    "@blockprotocol/graph": "0.0.11-canary.24"
   },
   "devDependencies": {
     "block-scripts": "0.0.13",

--- a/packages/blocks/person/package.json
+++ b/packages/blocks/person/package.json
@@ -19,7 +19,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.11-canary.4",
+    "@blockprotocol/graph": "0.0.11-canary.24",
     "dompurify": "2.3.6"
   },
   "devDependencies": {

--- a/packages/blocks/table/package.json
+++ b/packages/blocks/table/package.json
@@ -19,7 +19,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.11-canary.4",
+    "@blockprotocol/graph": "0.0.11-canary.24",
     "@headlessui/react": "1.4.1",
     "immer": "9.0.6",
     "lodash": "4.17.21",

--- a/packages/blocks/timer/package.json
+++ b/packages/blocks/timer/package.json
@@ -17,7 +17,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.11-canary.4",
+    "@blockprotocol/graph": "0.0.11-canary.24",
     "date-fns": "2.28.0",
     "duration-fns": "3.0.1"
   },

--- a/packages/blocks/video/package.json
+++ b/packages/blocks/video/package.json
@@ -19,7 +19,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.11-canary.4"
+    "@blockprotocol/graph": "0.0.11-canary.24"
   },
   "devDependencies": {
     "block-scripts": "0.0.13",

--- a/packages/hash/frontend/package.json
+++ b/packages/hash/frontend/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@apollo/client": "3.6.9",
     "@blockprotocol/core": "0.0.8",
-    "@blockprotocol/graph": "0.0.11-canary.4",
+    "@blockprotocol/graph": "0.0.11-canary.24",
     "@emotion/cache": "11.7.1",
     "@emotion/react": "11.9.0",
     "@emotion/server": "11.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3069,10 +3069,10 @@
     es-module-lexer "^0.10.5"
     uuid "^8.3.2"
 
-"@blockprotocol/graph@0.0.11-canary.4":
-  version "0.0.11-canary.4"
-  resolved "https://registry.yarnpkg.com/@blockprotocol/graph/-/graph-0.0.11-canary.4.tgz#8dea16358c6fa812fcd8a4f9729719440b820e69"
-  integrity sha512-uEdDneOBjDwHrdcHRj2zpAf27jl9ZF7t3WvUYDj80aIX2GudnOsLNOuqxDWALi/h/yBobdawazdovZV018kyKw==
+"@blockprotocol/graph@0.0.11-canary.24":
+  version "0.0.11-canary.24"
+  resolved "https://registry.yarnpkg.com/@blockprotocol/graph/-/graph-0.0.11-canary.24.tgz#e1018ad577d1eb4924ea2f068dec5259649c209e"
+  integrity sha512-us4h4ilVwuDKdHZPIeRMQiN1ak+vWcuF1vn4g1B6Rgf/dwG5Hf+8ube01QhUbg7JGIXVppwIN1OGoPWLxLyMYg==
   dependencies:
     "@blockprotocol/core" "0.0.8"
     lit "^2.2.5"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Update the version of `@blockprotocol/graph` used in the repo.

This new version removes some code that was importing a JSON file, because the deployment on Vercel is built in such a way that it (a) doesn't preserve the JSON file but (b) _does_ preserve an import statement referencing it, causing a crash on any page using blocks. 

We should fix this properly (tracked in [this internal task](https://app.asana.com/0/1202542409311090/1202614421149286/f)), but in the meantime this version gets pages on alpha.hash.ai working again.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1202482456346918/1202600431594490/f) _(internal)_

## 🐾 Next steps

- Fix the problem properly so that we can restore the code removed from `@blockprotocol/graph` (which was checking if a callback attempted to be registered corresponded to an actual message named in the graph service)

## ❓ How to test this?

1. Visit a page on the deployment (with blocks), check it works
