### PR TITLE
Change logging of queries to `Trace`

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
@@ -124,6 +124,11 @@ impl DatabaseConnectionInfo {
     }
 
     #[must_use]
+    pub fn password(&self) -> &str {
+        &self.password
+    }
+
+    #[must_use]
     pub fn host(&self) -> &str {
         &self.host
     }

--- a/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/datastore/mod.rs
@@ -98,8 +98,8 @@ impl DatabaseConnectionInfo {
 
     /// Creates a database connection url.
     ///
-    /// Note, that this will reveal the password, so output should not be printed. The [`Display`]
-    /// implementation should be used instead, which will mask the password.
+    /// Note, that this will reveal the password, so the returned output should not be printed. The
+    /// [`Display`] implementation should be used instead, which will mask the password.
     ///
     /// [`Display`]: core::fmt::Display.
     #[must_use]
@@ -123,6 +123,9 @@ impl DatabaseConnectionInfo {
         &self.user
     }
 
+    /// Returns the password in plain text.
+    ///
+    /// Note, that this will reveal the password, so the returned output should not be printed.
     #[must_use]
     pub fn password(&self) -> &str {
         &self.password


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

By default, all statements are logged with the `Info` log level. This is very verbose, so this PR changes the logging level.

## ⚠️ Known issues

The `PgConnectOptions` is very poorly designed, so first, the options have to be created, then the logging can be set, then it can be passed to the pool creations. It's also not possible to pass a URI.