### PR TITLE
Add REST endpoint for link types

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -39,7 +39,6 @@ impl RoutedResource for DataTypeResource {
             "/data-type",
             Router::new()
                 .route("/", post(create_data_type::<D>).put(update_data_type::<D>))
-                // .route("/query", get(get_data_type_many))
                 .route("/:version_id", get(get_data_type::<D>)),
         )
     }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -83,7 +83,7 @@ async fn create_data_type<D: Datastore>(
                 return StatusCode::CONFLICT;
             }
 
-            // Insertion/upddate errors are considered internal server errors.
+            // Insertion/update errors are considered internal server errors.
             StatusCode::INTERNAL_SERVER_ERROR
         })
         .map(Json)
@@ -165,7 +165,7 @@ async fn update_data_type<D: Datastore>(
                 return StatusCode::NOT_FOUND;
             }
 
-            // Insertion/upddate errors are considered internal server errors.
+            // Insertion/update errors are considered internal server errors.
             StatusCode::INTERNAL_SERVER_ERROR
         })
         .map(Json)

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -22,7 +22,6 @@ use crate::{
     handlers(
         create_data_type,
         get_data_type,
-        // get_data_type_many,
         update_data_type
     ),
     components(CreateDataTypeRequest, UpdateDataTypeRequest, AccountId, QualifiedDataType),
@@ -124,10 +123,6 @@ async fn get_data_type<D: Datastore>(
         })
         .map(Json)
 }
-
-// async fn get_data_type_many() -> Result<String, StatusCode> {
-//     unimplemented!()
-// }
 
 #[derive(Component, Serialize, Deserialize)]
 struct UpdateDataTypeRequest {

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -83,7 +83,7 @@ async fn create_link_type<D: Datastore>(
                 return StatusCode::CONFLICT;
             }
 
-            // Insertion/upddate errors are considered internal server errors.
+            // Insertion/update errors are considered internal server errors.
             StatusCode::INTERNAL_SERVER_ERROR
         })
         .map(Json)
@@ -165,7 +165,7 @@ async fn update_link_type<D: Datastore>(
                 return StatusCode::NOT_FOUND;
             }
 
-            // Insertion/upddate errors are considered internal server errors.
+            // Insertion/update errors are considered internal server errors.
             StatusCode::INTERNAL_SERVER_ERROR
         })
         .map(Json)

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -1,0 +1,172 @@
+//! Web routes for CRU operations on Link types.
+
+use axum::{
+    extract::Path,
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Extension, Json, Router,
+};
+use serde::{Deserialize, Serialize};
+use utoipa::{Component, OpenApi};
+use uuid::Uuid;
+
+use super::api_resource::RoutedResource;
+use crate::{
+    datastore::{BaseUriAlreadyExists, BaseUriDoesNotExist, Datastore, QueryError},
+    types::{schema::LinkType, AccountId, Qualified, QualifiedLinkType, VersionId},
+};
+
+#[derive(OpenApi)]
+#[openapi(
+    handlers(
+        create_link_type,
+        get_link_type,
+        // get_link_type_many,
+        update_link_type
+    ),
+    components(CreateLinkTypeRequest, UpdateLinkTypeRequest, AccountId, QualifiedLinkType),
+    tags(
+        (name = "LinkType", description = "Link type management API")
+    )
+)]
+pub struct LinkTypeResource;
+
+impl RoutedResource for LinkTypeResource {
+    /// Create routes for interacting with link types.
+    fn routes<D: Datastore>() -> Router {
+        // TODO: The URL format here is preliminary and will have to change.
+        Router::new().nest(
+            "/link-type",
+            Router::new()
+                .route("/", post(create_link_type::<D>).put(update_link_type::<D>))
+                // .route("/query", get(get_link_type_many))
+                .route("/:version_id", get(get_link_type::<D>)),
+        )
+    }
+}
+
+#[derive(Serialize, Deserialize, Component)]
+struct CreateLinkTypeRequest {
+    #[component(value_type = Any)]
+    schema: LinkType,
+    account_id: AccountId,
+}
+
+#[utoipa::path(
+    post,
+    path = "/link-type",
+    request_body = CreateLinkTypeRequest,
+    tag = "LinkType",
+    responses(
+      (status = 201, content_type = "application/json", description = "Link type created successfully", body = QualifiedLinkType),
+      (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
+
+      (status = 409, description = "Unable to create link type in the datastore as the base link type ID already exists"),
+      (status = 500, description = "Datastore error occurred"),
+    ),
+    request_body = CreateLinkTypeRequest,
+)]
+async fn create_link_type<D: Datastore>(
+    body: Json<CreateLinkTypeRequest>,
+    datastore: Extension<D>,
+) -> Result<Json<Qualified<LinkType>>, StatusCode> {
+    let Json(body) = body;
+    let Extension(datastore) = datastore;
+
+    datastore
+        .clone()
+        .create_link_type(body.schema, body.account_id)
+        .await
+        .map_err(|report| {
+            if report.contains::<BaseUriAlreadyExists>() {
+                return StatusCode::CONFLICT;
+            }
+
+            // Insertion/upddate errors are considered internal server errors.
+            StatusCode::INTERNAL_SERVER_ERROR
+        })
+        .map(Json)
+}
+
+#[utoipa::path(
+    get,
+    path = "/link-type/{versionId}",
+    tag = "LinkType",
+    responses(
+        (status = 200, content_type = "application/json", description = "Link type found", body = QualifiedLinkType),
+        (status = 422, content_type = "text/plain", description = "Provided version_id is invalid"),
+
+        (status = 404, description = "Link type was not found"),
+        (status = 500, description = "Datastore error occurred"),
+    ),
+    params(
+        ("versionId" = Uuid, Path, description = "The version ID of link type"),
+    )
+)]
+async fn get_link_type<D: Datastore>(
+    version_id: Path<Uuid>,
+    datastore: Extension<D>,
+) -> Result<Json<Qualified<LinkType>>, impl IntoResponse> {
+    let Path(version_id) = version_id;
+    let Extension(datastore) = datastore;
+
+    datastore
+        .get_link_type(VersionId::new(version_id))
+        .await
+        .map_err(|report| {
+            if report.contains::<QueryError>() {
+                return StatusCode::NOT_FOUND;
+            }
+
+            // Datastore errors such as connection failure are considered internal server errors.
+            StatusCode::INTERNAL_SERVER_ERROR
+        })
+        .map(Json)
+}
+
+// async fn get_link_type_many() -> Result<String, StatusCode> {
+//     unimplemented!()
+// }
+
+#[derive(Component, Serialize, Deserialize)]
+struct UpdateLinkTypeRequest {
+    #[component(value_type = Any)]
+    schema: LinkType,
+    account_id: AccountId,
+}
+
+#[utoipa::path(
+    put,
+    path = "/link-type",
+    tag = "LinkType",
+    responses(
+        (status = 200, content_type = "application/json", description = "Link type updated successfully", body = QualifiedLinkType),
+        (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
+
+        (status = 404, description = "Base link type ID was not found"),
+        (status = 500, description = "Datastore error occurred"),
+    ),
+    request_body = UpdateLinkTypeRequest,
+)]
+async fn update_link_type<D: Datastore>(
+    body: Json<UpdateLinkTypeRequest>,
+    datastore: Extension<D>,
+) -> Result<Json<Qualified<LinkType>>, StatusCode> {
+    let Json(body) = body;
+    let Extension(datastore) = datastore;
+
+    datastore
+        .clone()
+        .update_link_type(body.schema, body.account_id)
+        .await
+        .map_err(|report| {
+            if report.contains::<BaseUriDoesNotExist>() {
+                return StatusCode::NOT_FOUND;
+            }
+
+            // Insertion/upddate errors are considered internal server errors.
+            StatusCode::INTERNAL_SERVER_ERROR
+        })
+        .map(Json)
+}

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -40,7 +40,6 @@ impl RoutedResource for LinkTypeResource {
             "/link-type",
             Router::new()
                 .route("/", post(create_link_type::<D>).put(update_link_type::<D>))
-                // .route("/query", get(get_link_type_many))
                 .route("/:version_id", get(get_link_type::<D>)),
         )
     }
@@ -124,10 +123,6 @@ async fn get_link_type<D: Datastore>(
         })
         .map(Json)
 }
-
-// async fn get_link_type_many() -> Result<String, StatusCode> {
-//     unimplemented!()
-// }
 
 #[derive(Component, Serialize, Deserialize)]
 struct UpdateLinkTypeRequest {

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -22,7 +22,6 @@ use crate::{
     handlers(
         create_link_type,
         get_link_type,
-        // get_link_type_many,
         update_link_type
     ),
     components(CreateLinkTypeRequest, UpdateLinkTypeRequest, AccountId, QualifiedLinkType),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
@@ -4,6 +4,7 @@
 
 mod api_resource;
 mod data_type;
+mod link_type;
 mod property_type;
 
 use axum::{routing::get, Extension, Json, Router};
@@ -16,6 +17,7 @@ fn api_resources<T: Datastore>() -> Vec<Router> {
     vec![
         data_type::DataTypeResource::routes::<T>(),
         property_type::PropertyTypeResource::routes::<T>(),
+        link_type::LinkTypeResource::routes::<T>(),
     ]
 }
 
@@ -23,6 +25,7 @@ fn api_documentation() -> Vec<openapi::OpenApi> {
     vec![
         data_type::DataTypeResource::documentation(),
         property_type::PropertyTypeResource::documentation(),
+        link_type::LinkTypeResource::documentation(),
     ]
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -22,7 +22,6 @@ use crate::{
     handlers(
         create_property_type,
         get_property_type,
-        // get_property_type_many,
         update_property_type
     ),
     components(CreatePropertyTypeRequest, UpdatePropertyTypeRequest, AccountId, QualifiedPropertyType),
@@ -124,10 +123,6 @@ async fn get_property_type<D: Datastore>(
         })
         .map(Json)
 }
-
-// async fn get_property_type_many() -> Result<String, StatusCode> {
-//     unimplemented!()
-// }
 
 #[derive(Component, Serialize, Deserialize)]
 struct UpdatePropertyTypeRequest {

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -38,8 +38,10 @@ impl RoutedResource for PropertyTypeResource {
         Router::new().nest(
             "/property-type",
             Router::new()
-                .route("/", post(create_property_type::<D>).put(update_property_type::<D>))
-                // .route("/query", get(get_property_type_many))
+                .route(
+                    "/",
+                    post(create_property_type::<D>).put(update_property_type::<D>),
+                )
                 .route("/:version_id", get(get_property_type::<D>)),
         )
     }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -83,7 +83,7 @@ async fn create_property_type<D: Datastore>(
                 return StatusCode::CONFLICT;
             }
 
-            // Insertion/upddate errors are considered internal server errors.
+            // Insertion/update errors are considered internal server errors.
             StatusCode::INTERNAL_SERVER_ERROR
         })
         .map(Json)
@@ -165,7 +165,7 @@ async fn update_property_type<D: Datastore>(
                 return StatusCode::NOT_FOUND;
             }
 
-            // Insertion/upddate errors are considered internal server errors.
+            // Insertion/update errors are considered internal server errors.
             StatusCode::INTERNAL_SERVER_ERROR
         })
         .map(Json)

--- a/packages/graph/hash_graph/lib/graph/src/types/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/mod.rs
@@ -10,7 +10,7 @@ use utoipa::Component;
 use uuid::Uuid;
 
 pub use self::uri::{BaseUri, VersionedUri};
-use crate::types::schema::{DataType, PropertyType};
+use crate::types::schema::{DataType, LinkType, PropertyType};
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, sqlx::Type, PartialEq, Eq, Serialize, Deserialize, Component)]
@@ -44,7 +44,11 @@ impl fmt::Display for VersionId {
 
 // TODO: constrain this to only work for valid inner Types.
 #[derive(Clone, Debug, Serialize, Deserialize, Component)]
-#[aliases(QualifiedDataType = Qualified<DataType>, QualifiedPropertyType = Qualified<PropertyType>)]
+#[aliases(
+    QualifiedDataType = Qualified<DataType>,
+    QualifiedPropertyType = Qualified<PropertyType>,
+    QualifiedLinkType = Qualified<LinkType>,
+)]
 pub struct Qualified<T> {
     version_id: VersionId,
     // TODO: we would want the inner types to be represented in the OpenAPI components list. This


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Provide a REST endpoint for CRU operations on link types

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202542409311090/1202622269244648/f) _(internal)_

## 🔍 What does this change?

- Adds the REST Endpoint to the REST API

## 🐾 Next steps

- Add the endpoint for entity types (since #827 link types are required for inserting entity types, thus this was done first) (direct follow-up)
- Add very basic tests (like an HTTP request file) to test the REST API (direct follow-up)

## 🛡 What tests cover this?

Currently none, tested locally.

## ❓ How to test this?

Run the binary and make the following requests:

Insertions:
```http
POST localhost:3000/link-type
Content-Type: application/json
Accept: application/json

{
  "account_id": "00000000-0000-0000-0000-000000000000",
  "schema": {
    "kind": "linkType",
    "$id": "https://blockprotocol.org/@alice/types/link-type/friend-of/v/1",
    "title": "Friend Of",
    "description": "Someone who has a shared bond of mutual affection",
    "relatedKeywords": []
  }
}
```

Querying:
```http
GET localhost:3000/link-type/{{version_id_returned_from_above}}
```

Updating:
```http
PUT localhost:3000/link-type
Content-Type: application/json
Accept: application/json

{
  "account_id": "00000000-0000-0000-0000-000000000000",
  "schema": {
    "kind": "linkType",
    "$id": "https://blockprotocol.org/@alice/types/link-type/friend-of/v/2",
    "title": "Friend Of",
    "description": "Someone who has a shared bond of mutual affection",
    "relatedKeywords": ["social"]
  }
}
```

## 📹 Demo

```
http://localhost:3000/link-type

HTTP/1.1 200 OK
content-type: application/json
content-length: 319
date: Wed, 20 Jul 2022 11:49:57 GMT
```
