### PR TITLE
Add REST endpoint for entity types

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -130,7 +130,7 @@ async fn get_entity_type<D: Datastore>(
 struct UpdateEntityTypeRequest {
     #[component(value_type = Any)]
     schema: EntityType,
-    created_by: AccountId,
+    account_id: AccountId,
 }
 
 #[utoipa::path(
@@ -155,7 +155,7 @@ async fn update_entity_type<D: Datastore>(
 
     datastore
         .clone()
-        .update_entity_type(body.schema, body.created_by)
+        .update_entity_type(body.schema, body.account_id)
         .await
         .map_err(|report| {
             if report.contains::<BaseUriDoesNotExist>() {

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -1,0 +1,169 @@
+//! Web routes for CRU operations on Entity types.
+
+use axum::{
+    extract::Path,
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Extension, Json, Router,
+};
+use serde::{Deserialize, Serialize};
+use utoipa::{Component, OpenApi};
+use uuid::Uuid;
+
+use super::api_resource::RoutedResource;
+use crate::{
+    datastore::{BaseUriAlreadyExists, BaseUriDoesNotExist, Datastore, QueryError},
+    types::{schema::EntityType, AccountId, Qualified, QualifiedEntityType, VersionId},
+};
+
+#[derive(OpenApi)]
+#[openapi(
+    handlers(
+        create_entity_type,
+        get_entity_type,
+        update_entity_type
+    ),
+    components(CreateEntityTypeRequest, UpdateEntityTypeRequest, AccountId, QualifiedEntityType),
+    tags(
+        (name = "EntityType", description = "Entity type management API")
+    )
+)]
+pub struct EntityTypeResource;
+
+impl RoutedResource for EntityTypeResource {
+    /// Create routes for interacting with entity types.
+    fn routes<D: Datastore>() -> Router {
+        // TODO: The URL format here is preliminary and will have to change.
+        Router::new().nest(
+            "/entity-type",
+            Router::new()
+                .route(
+                    "/",
+                    post(create_entity_type::<D>).put(update_entity_type::<D>),
+                )
+                .route("/:version_id", get(get_entity_type::<D>)),
+        )
+    }
+}
+
+#[derive(Serialize, Deserialize, Component)]
+struct CreateEntityTypeRequest {
+    #[component(value_type = Any)]
+    schema: EntityType,
+    account_id: AccountId,
+}
+
+#[utoipa::path(
+    post,
+    path = "/entity-type",
+    request_body = CreateEntityTypeRequest,
+    tag = "EntityType",
+    responses(
+      (status = 201, content_type = "application/json", description = "Entity type created successfully", body = QualifiedEntityType),
+      (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
+
+      (status = 409, description = "Unable to create entity type in the datastore as the base entity type ID already exists"),
+      (status = 500, description = "Datastore error occurred"),
+    ),
+    request_body = CreateEntityTypeRequest,
+)]
+async fn create_entity_type<D: Datastore>(
+    body: Json<CreateEntityTypeRequest>,
+    datastore: Extension<D>,
+) -> Result<Json<Qualified<EntityType>>, StatusCode> {
+    let Json(body) = body;
+    let Extension(datastore) = datastore;
+
+    datastore
+        .clone()
+        .create_entity_type(body.schema, body.account_id)
+        .await
+        .map_err(|report| {
+            if report.contains::<BaseUriAlreadyExists>() {
+                return StatusCode::CONFLICT;
+            }
+
+            // Insertion/update errors are considered internal server errors.
+            StatusCode::INTERNAL_SERVER_ERROR
+        })
+        .map(Json)
+}
+
+#[utoipa::path(
+    get,
+    path = "/entity-type/{versionId}",
+    tag = "EntityType",
+    responses(
+        (status = 200, content_type = "application/json", description = "Entity type found", body = QualifiedEntityType),
+        (status = 422, content_type = "text/plain", description = "Provided version_id is invalid"),
+
+        (status = 404, description = "Entity type was not found"),
+        (status = 500, description = "Datastore error occurred"),
+    ),
+    params(
+        ("versionId" = Uuid, Path, description = "The version ID of entity type"),
+    )
+)]
+async fn get_entity_type<D: Datastore>(
+    version_id: Path<Uuid>,
+    datastore: Extension<D>,
+) -> Result<Json<Qualified<EntityType>>, impl IntoResponse> {
+    let Path(version_id) = version_id;
+    let Extension(datastore) = datastore;
+
+    datastore
+        .get_entity_type(VersionId::new(version_id))
+        .await
+        .map_err(|report| {
+            if report.contains::<QueryError>() {
+                return StatusCode::NOT_FOUND;
+            }
+
+            // Datastore errors such as connection failure are considered internal server errors.
+            StatusCode::INTERNAL_SERVER_ERROR
+        })
+        .map(Json)
+}
+
+#[derive(Component, Serialize, Deserialize)]
+struct UpdateEntityTypeRequest {
+    #[component(value_type = Any)]
+    schema: EntityType,
+    created_by: AccountId,
+}
+
+#[utoipa::path(
+    put,
+    path = "/entity-type",
+    tag = "EntityType",
+    responses(
+        (status = 200, content_type = "application/json", description = "Entity type updated successfully", body = QualifiedEntityType),
+        (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
+
+        (status = 404, description = "Base entity type ID was not found"),
+        (status = 500, description = "Datastore error occurred"),
+    ),
+    request_body = UpdateEntityTypeRequest,
+)]
+async fn update_entity_type<D: Datastore>(
+    body: Json<UpdateEntityTypeRequest>,
+    datastore: Extension<D>,
+) -> Result<Json<Qualified<EntityType>>, StatusCode> {
+    let Json(body) = body;
+    let Extension(datastore) = datastore;
+
+    datastore
+        .clone()
+        .update_entity_type(body.schema, body.created_by)
+        .await
+        .map_err(|report| {
+            if report.contains::<BaseUriDoesNotExist>() {
+                return StatusCode::NOT_FOUND;
+            }
+
+            // Insertion/update errors are considered internal server errors.
+            StatusCode::INTERNAL_SERVER_ERROR
+        })
+        .map(Json)
+}

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
@@ -4,6 +4,7 @@
 
 mod api_resource;
 mod data_type;
+mod entity_type;
 mod link_type;
 mod property_type;
 
@@ -18,6 +19,7 @@ fn api_resources<T: Datastore>() -> Vec<Router> {
         data_type::DataTypeResource::routes::<T>(),
         property_type::PropertyTypeResource::routes::<T>(),
         link_type::LinkTypeResource::routes::<T>(),
+        entity_type::EntityTypeResource::routes::<T>(),
     ]
 }
 
@@ -26,6 +28,7 @@ fn api_documentation() -> Vec<openapi::OpenApi> {
         data_type::DataTypeResource::documentation(),
         property_type::PropertyTypeResource::documentation(),
         link_type::LinkTypeResource::documentation(),
+        entity_type::EntityTypeResource::documentation(),
     ]
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/types/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/types/mod.rs
@@ -10,7 +10,7 @@ use utoipa::Component;
 use uuid::Uuid;
 
 pub use self::uri::{BaseUri, VersionedUri};
-use crate::types::schema::{DataType, LinkType, PropertyType};
+use crate::types::schema::{DataType, EntityType, LinkType, PropertyType};
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, sqlx::Type, PartialEq, Eq, Serialize, Deserialize, Component)]
@@ -48,6 +48,7 @@ impl fmt::Display for VersionId {
     QualifiedDataType = Qualified<DataType>,
     QualifiedPropertyType = Qualified<PropertyType>,
     QualifiedLinkType = Qualified<LinkType>,
+    QualifiedEntityType = Qualified<EntityType>,
 )]
 pub struct Qualified<T> {
     version_id: VersionId,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Provide a REST endpoint for CRU operations on entity types

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202542409311090/1202622269244647/f) _(internal)_

## 🔍 What does this change?

- Adds the Endpoint to the REST API

## 🐾 Next steps

- Add very basic tests (like an HTTP request file) to test the REST API (direct follow-up)

## 🛡 What tests cover this?

Currently none, tested locally.

## ❓ How to test this?

Run the binary and make the following requests (requires some data types, property types, and link types to be inserted into the database before):

Insertions:
```http
POST localhost:3000/entity-type
Content-Type: application/json
Accept: application/json

{
  "account_id": "00000000-0000-0000-0000-000000000000",
  "schema": {
    "kind": "entityType",
    "$id": "https://blockprotocol.org/@alice/types/entity-type/person/v/1",
    "type": "object",
    "title": "Person",
    "properties": {
      "https://blockprotocol.org/@alice/types/property-type/name": {
        "$ref": "https://blockprotocol.org/@alice/types/property-type/name/v/1"
      }
    }
  }
}
```

Querying:
```http
GET localhost:3000/entity-type/{{version_id_returned_from_above}}
```

Updating:
```http
PUT localhost:3000/entity-type
Content-Type: application/json
Accept: application/json

{
  "account_id": "00000000-0000-0000-0000-000000000000",
  "schema": {
    "kind": "entityType",
    "$id": "https://blockprotocol.org/@alice/types/entity-type/person/v/2",
    "type": "object",
    "title": "Person",
    "properties": {
      "https://blockprotocol.org/@alice/types/property-type/name": {
        "$ref": "https://blockprotocol.org/@alice/types/property-type/name/v/2"
      }
    },
    "links": {
      "https://blockprotocol.org/@alice/types/link-type/friend-of/v/2": {
        "type": "array",
        "items": {
          "$ref": "https://blockprotocol.org/@alice/types/entity-type/person/v/2"
        },
        "ordered": false
      }
    }
  }
}
```

## 📹 Demo

```
http://localhost:3000/entity-type

HTTP/1.1 200 OK
content-type: application/json
content-length: 319
date: Wed, 20 Jul 2022 13:49:57 GMT
```
