### PR TITLE
Use URIs in REST endpoints rather the the database id

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -79,6 +79,8 @@ async fn create_data_type<S: Store>(
         .create_data_type(body.schema, body.account_id)
         .await
         .map_err(|report| {
+            tracing::error!(error=?report, "Could not create data type");
+
             if report.contains::<BaseUriAlreadyExists>() {
                 return StatusCode::CONFLICT;
             }
@@ -124,6 +126,8 @@ async fn get_data_type<S: Store>(
         .get_data_type(version_id)
         .await
         .map_err(|report| {
+            tracing::error!(error=?report, "Could not query data type");
+
             if report.contains::<QueryError>() {
                 return StatusCode::NOT_FOUND;
             }
@@ -166,6 +170,8 @@ async fn update_data_type<S: Store>(
         .update_data_type(body.schema, body.account_id)
         .await
         .map_err(|report| {
+            tracing::error!(error=?report, "Could not update data type");
+
             if report.contains::<BaseUriDoesNotExist>() {
                 return StatusCode::NOT_FOUND;
             }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -114,6 +114,8 @@ async fn get_data_type<S: Store>(
     let Extension(store) = store;
 
     let version_id = store.version_id_by_uri(&uri).await.map_err(|report| {
+        tracing::error!(error=?report, "Could not resolve URI");
+
         if report.contains::<QueryError>() {
             return StatusCode::NOT_FOUND;
         }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -120,7 +120,7 @@ async fn get_entity_type<S: Store>(
     let Extension(store) = store;
 
     let version_id = store.version_id_by_uri(&uri).await.map_err(|report| {
-        tracing::error!(error=?report, "Could not query entity type");
+        tracing::error!(error=?report, "Could not resolve URI");
 
         if report.contains::<QueryError>() {
             return StatusCode::NOT_FOUND;
@@ -134,6 +134,8 @@ async fn get_entity_type<S: Store>(
         .get_entity_type(version_id)
         .await
         .map_err(|report| {
+            tracing::error!(error=?report, "Could not query entity type");
+
             if report.contains::<QueryError>() {
                 return StatusCode::NOT_FOUND;
             }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -85,7 +85,7 @@ async fn create_entity_type<S: Store>(
         .create_entity_type(body.schema, body.account_id)
         .await
         .map_err(|report| {
-            tracing::error!(error=?report, "Could not insert entity type");
+            tracing::error!(error=?report, "Could not create entity type");
 
             if report.contains::<BaseUriAlreadyExists>() {
                 return StatusCode::CONFLICT;

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -85,6 +85,8 @@ async fn create_entity_type<S: Store>(
         .create_entity_type(body.schema, body.account_id)
         .await
         .map_err(|report| {
+            tracing::error!(error=?report, "Could not insert entity type");
+
             if report.contains::<BaseUriAlreadyExists>() {
                 return StatusCode::CONFLICT;
             }
@@ -118,6 +120,8 @@ async fn get_entity_type<S: Store>(
     let Extension(store) = store;
 
     let version_id = store.version_id_by_uri(&uri).await.map_err(|report| {
+        tracing::error!(error=?report, "Could not query entity type");
+
         if report.contains::<QueryError>() {
             return StatusCode::NOT_FOUND;
         }
@@ -172,6 +176,8 @@ async fn update_entity_type<S: Store>(
         .update_entity_type(body.schema, body.account_id)
         .await
         .map_err(|report| {
+            tracing::error!(error=?report, "Could not update entity type");
+
             if report.contains::<BaseUriDoesNotExist>() {
                 return StatusCode::NOT_FOUND;
             }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -114,7 +114,7 @@ async fn get_link_type<S: Store>(
     let Extension(store) = store;
 
     let version_id = store.version_id_by_uri(&uri).await.map_err(|report| {
-        tracing::error!(error=?report, "Could not query link type");
+        tracing::error!(error=?report, "Could not resolve URI");
 
         if report.contains::<QueryError>() {
             return StatusCode::NOT_FOUND;
@@ -128,6 +128,8 @@ async fn get_link_type<S: Store>(
         .get_link_type(version_id)
         .await
         .map_err(|report| {
+            tracing::error!(error=?report, "Could not query link type");
+
             if report.contains::<QueryError>() {
                 return StatusCode::NOT_FOUND;
             }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -9,13 +9,12 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use utoipa::{Component, OpenApi};
-use uuid::Uuid;
 
 use super::api_resource::RoutedResource;
 use crate::{
     ontology::{
-        types::{LinkType, Persisted, PersistedLinkType},
-        AccountId, VersionId,
+        types::{uri::VersionedUri, LinkType, Persisted, PersistedLinkType},
+        AccountId,
     },
     store::{BaseUriAlreadyExists, BaseUriDoesNotExist, QueryError, Store},
 };
@@ -92,28 +91,37 @@ async fn create_link_type<S: Store>(
 
 #[utoipa::path(
     get,
-    path = "/link-type/{versionId}",
+    path = "/link-type/{uri}",
     tag = "LinkType",
     responses(
         (status = 200, content_type = "application/json", description = "Link type found", body = PersistedLinkType),
-        (status = 422, content_type = "text/plain", description = "Provided version_id is invalid"),
+        (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 404, description = "Link type was not found"),
         (status = 500, description = "Store error occurred"),
     ),
     params(
-        ("versionId" = Uuid, Path, description = "The version ID of link type"),
+        ("uri" = String, Path, description = "The URI of link type"),
     )
 )]
 async fn get_link_type<S: Store>(
-    version_id: Path<Uuid>,
+    uri: Path<VersionedUri>,
     store: Extension<S>,
 ) -> Result<Json<Persisted<LinkType>>, impl IntoResponse> {
-    let Path(version_id) = version_id;
+    let Path(uri) = uri;
     let Extension(store) = store;
 
+    let version_id = store.version_id_by_uri(&uri).await.map_err(|report| {
+        if report.contains::<QueryError>() {
+            return StatusCode::NOT_FOUND;
+        }
+
+        // Datastore errors such as connection failure are considered internal server errors.
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
     store
-        .get_link_type(VersionId::new(version_id))
+        .get_link_type(version_id)
         .await
         .map_err(|report| {
             if report.contains::<QueryError>() {

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -79,6 +79,8 @@ async fn create_link_type<S: Store>(
         .create_link_type(body.schema, body.account_id)
         .await
         .map_err(|report| {
+            tracing::error!(error=?report, "Could not create link type");
+
             if report.contains::<BaseUriAlreadyExists>() {
                 return StatusCode::CONFLICT;
             }
@@ -112,6 +114,8 @@ async fn get_link_type<S: Store>(
     let Extension(store) = store;
 
     let version_id = store.version_id_by_uri(&uri).await.map_err(|report| {
+        tracing::error!(error=?report, "Could not query link type");
+
         if report.contains::<QueryError>() {
             return StatusCode::NOT_FOUND;
         }
@@ -166,6 +170,8 @@ async fn update_link_type<S: Store>(
         .update_link_type(body.schema, body.account_id)
         .await
         .map_err(|report| {
+            tracing::error!(error=?report, "Could not update link type");
+
             if report.contains::<BaseUriDoesNotExist>() {
                 return StatusCode::NOT_FOUND;
             }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -82,6 +82,8 @@ async fn create_property_type<S: Store>(
         .create_property_type(body.schema, body.account_id)
         .await
         .map_err(|report| {
+            tracing::error!(error=?report, "Could not create property type");
+
             if report.contains::<BaseUriAlreadyExists>() {
                 return StatusCode::CONFLICT;
             }
@@ -127,6 +129,8 @@ async fn get_property_type<S: Store>(
         .get_property_type(version_id)
         .await
         .map_err(|report| {
+            tracing::error!(error=?report, "Could not query property type");
+
             if report.contains::<QueryError>() {
                 return StatusCode::NOT_FOUND;
             }
@@ -169,6 +173,8 @@ async fn update_property_type<S: Store>(
         .update_property_type(body.schema, body.account_id)
         .await
         .map_err(|report| {
+            tracing::error!(error=?report, "Could not update property type");
+
             if report.contains::<BaseUriDoesNotExist>() {
                 return StatusCode::NOT_FOUND;
             }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -117,6 +117,8 @@ async fn get_property_type<S: Store>(
     let Extension(store) = store;
 
     let version_id = store.version_id_by_uri(&uri).await.map_err(|report| {
+        tracing::error!(error=?report, "Could not resolve URI");
+
         if report.contains::<QueryError>() {
             return StatusCode::NOT_FOUND;
         }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -9,13 +9,12 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use utoipa::{Component, OpenApi};
-use uuid::Uuid;
 
 use super::api_resource::RoutedResource;
 use crate::{
     ontology::{
-        types::{Persisted, PersistedPropertyType, PropertyType},
-        AccountId, VersionId,
+        types::{uri::VersionedUri, Persisted, PersistedPropertyType, PropertyType},
+        AccountId,
     },
     store::{BaseUriAlreadyExists, BaseUriDoesNotExist, QueryError, Store},
 };
@@ -95,28 +94,37 @@ async fn create_property_type<S: Store>(
 
 #[utoipa::path(
     get,
-    path = "/property-type/{versionId}",
+    path = "/property-type/{uri}",
     tag = "PropertyType",
     responses(
         (status = 200, content_type = "application/json", description = "Property type found", body = PersistedPropertyType),
-        (status = 422, content_type = "text/plain", description = "Provided version_id is invalid"),
+        (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 404, description = "Property type was not found"),
         (status = 500, description = "Store error occurred"),
     ),
     params(
-        ("versionId" = Uuid, Path, description = "The version ID of property type"),
+        ("uri" = String, Path, description = "The URI of property type"),
     )
 )]
 async fn get_property_type<S: Store>(
-    version_id: Path<Uuid>,
+    uri: Path<VersionedUri>,
     store: Extension<S>,
 ) -> Result<Json<Persisted<PropertyType>>, impl IntoResponse> {
-    let Path(version_id) = version_id;
+    let Path(uri) = uri;
     let Extension(store) = store;
 
+    let version_id = store.version_id_by_uri(&uri).await.map_err(|report| {
+        if report.contains::<QueryError>() {
+            return StatusCode::NOT_FOUND;
+        }
+
+        // Datastore errors such as connection failure are considered internal server errors.
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
     store
-        .get_property_type(VersionId::new(version_id))
+        .get_property_type(version_id)
         .await
         .map_err(|report| {
             if report.contains::<QueryError>() {

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -11,7 +11,7 @@ pub use self::{
     postgres::PostgresDatabase,
 };
 use crate::ontology::{
-    types::{DataType, EntityType, LinkType, Persisted, PropertyType},
+    types::{uri::VersionedUri, DataType, EntityType, LinkType, Persisted, PropertyType},
     AccountId, VersionId,
 };
 
@@ -168,6 +168,12 @@ impl fmt::Display for DatabaseConnectionInfo {
 /// raised depending on the implementation, e.g. connection issues.
 #[async_trait]
 pub trait Store: Clone + Send + Sync + 'static {
+    /// Fetches the [`VersionId`] of the specified [`VersionedUri`].
+    ///
+    /// # Errors:
+    ///
+    /// - if the entry referred to by `uri` does not exist.
+    async fn version_id_by_uri(&self, uri: &VersionedUri) -> Result<VersionId, QueryError>;
     /// Creates a new [`DataType`].
     ///
     /// # Errors:

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -655,6 +655,7 @@ impl Store for PostgresDatabase {
     async fn version_id_by_uri(&self, uri: &VersionedUri) -> Result<VersionId, QueryError> {
         Self::version_id_by_uri_impl(&self.pool, uri).await
     }
+
     async fn create_data_type(
         &self,
         data_type: DataType,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -615,16 +615,11 @@ impl PostgresDatabase {
         Ok(ids)
     }
 
-    /// Fetches the [`VersionId`] of the specified [`VersionedUri`].
-    ///
-    /// # Errors:
-    ///
-    /// - if the entry referred to by `uri` does not exist.
-    async fn version_id_by_uri(
-        transaction: &mut Transaction<'_, Postgres>,
+    async fn version_id_by_uri_impl(
+        executor: impl Executor<'_, Database = Postgres>,
         uri: &VersionedUri,
     ) -> Result<VersionId, QueryError> {
-        Ok(transaction
+        Ok(executor
             .fetch_one(
                 sqlx::query(
                     r#"
@@ -642,10 +637,24 @@ impl PostgresDatabase {
             .attach_printable_lazy(|| uri.clone())?
             .get(0))
     }
+
+    #[allow(
+        clippy::same_name_method,
+        reason = "This is required because the way SQLx implements their executors"
+    )]
+    async fn version_id_by_uri(
+        transaction: &mut Transaction<'_, Postgres>,
+        uri: &VersionedUri,
+    ) -> Result<VersionId, QueryError> {
+        Self::version_id_by_uri_impl(transaction, uri).await
+    }
 }
 
 #[async_trait]
 impl Store for PostgresDatabase {
+    async fn version_id_by_uri(&self, uri: &VersionedUri) -> Result<VersionId, QueryError> {
+        Self::version_id_by_uri_impl(&self.pool, uri).await
+    }
     async fn create_data_type(
         &self,
         data_type: DataType,

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -19,11 +19,10 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("text_data_type_id", response.body.version_id);
 %}
 
 ### Get Text data type
-GET http://127.0.0.1:3000/data-type/{{text_data_type_id}}
+GET http://127.0.0.1:3000/data-type/https%3A%2F%2Fblockprotocol.org%2F%40blockprotocol%2Ftypes%2Fdata-type%2Ftext%2Fv%2F1
 
 > {%
     client.test("status", function() {
@@ -76,11 +75,10 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("person_property_type_id", response.body.version_id);
 %}
 
 ### Get Name property type
-GET http://127.0.0.1:3000/property-type/{{person_property_type_id}}
+GET http://127.0.0.1:3000/property-type/https%3A%2F%2Fblockprotocol.org%2F%40alice%2Ftypes%2Fproperty-type%2Fname%2Fv%2F1
 
 > {%
     client.test("status", function() {
@@ -133,11 +131,10 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("friend_of_link_type_id", response.body.version_id);
 %}
 
 ### Get FriendOf link type
-GET http://127.0.0.1:3000/link-type/{{friend_of_link_type_id}}
+GET http://127.0.0.1:3000/link-type/https%3A%2F%2Fblockprotocol.org%2F%40alice%2Ftypes%2Flink-type%2Ffriend-of%2Fv%2F1
 
 > {%
     client.test("status", function() {
@@ -193,11 +190,10 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("page_person_type_id", response.body.version_id);
 %}
 
 ### Get Person entity type
-GET http://127.0.0.1:3000/entity-type/{{page_person_type_id}}
+GET http://127.0.0.1:3000/entity-type/https%3A%2F%2Fblockprotocol.org%2F%40alice%2Ftypes%2Fentity-type%2Fperson%2Fv%2F1
 
 > {%
     client.test("status", function() {

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -19,10 +19,11 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
+    client.global.set("text_data_type_uri", encodeURIComponent(response.body.inner["$id"]));
 %}
 
 ### Get Text data type
-GET http://127.0.0.1:3000/data-type/https%3A%2F%2Fblockprotocol.org%2F%40blockprotocol%2Ftypes%2Fdata-type%2Ftext%2Fv%2F1
+GET http://127.0.0.1:3000/data-type/{{text_data_type_uri}}
 
 > {%
     client.test("status", function() {
@@ -75,10 +76,11 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
+    client.global.set("person_property_type_uri", encodeURIComponent(response.body.inner["$id"]));
 %}
 
 ### Get Name property type
-GET http://127.0.0.1:3000/property-type/https%3A%2F%2Fblockprotocol.org%2F%40alice%2Ftypes%2Fproperty-type%2Fname%2Fv%2F1
+GET http://127.0.0.1:3000/property-type/{{person_property_type_uri}}
 
 > {%
     client.test("status", function() {
@@ -131,10 +133,11 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
+    client.global.set("friend_of_link_type_uri", encodeURIComponent(response.body.inner["$id"]));
 %}
 
 ### Get FriendOf link type
-GET http://127.0.0.1:3000/link-type/https%3A%2F%2Fblockprotocol.org%2F%40alice%2Ftypes%2Flink-type%2Ffriend-of%2Fv%2F1
+GET http://127.0.0.1:3000/link-type/{{friend_of_link_type_uri}}
 
 > {%
     client.test("status", function() {
@@ -190,10 +193,11 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
+    client.global.set("page_person_type_uri", encodeURIComponent(response.body.inner["$id"]));
 %}
 
 ### Get Person entity type
-GET http://127.0.0.1:3000/entity-type/https%3A%2F%2Fblockprotocol.org%2F%40alice%2Ftypes%2Fentity-type%2Fperson%2Fv%2F1
+GET http://127.0.0.1:3000/entity-type/{{page_person_type_uri}}
 
 > {%
     client.test("status", function() {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `VersionId` is supposed to be an implementation detail. Also, it's not possible to read the id for a type when it was already created.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201095311341924/1202642946839413) _(internal)_

## 🔍 What does this change?

- Add a public conversion method to get a version id by URI
- Use URIs in REST GET endpoints
- drive-by: Add error-logging output when REST methods are failing

## ⚠️ Known issues

- Due to the way SQLx implements their `Executor` trait, the functionality for getting a URI by id needs two entrypoints, but can rely on the same internal methods. This will be solved by a follow-up task

## 🛡 What tests cover this?

The test-requests were adjusted to use URL-encoded URIs instead

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

- Install dependencies:

    ```sh
    cargo make yarn
    ```

- Deploy the database and populate it:

    ```sh
    cargo make deployment-up
    cargo make recreate-db
    cargo make migrate-up
    ```

- Run the binary

    ```sh
    cargo make run
    ```

- Run the tests

    ```sh
    cargo make test-rest-api
    ```

## 📹 Demo

![image](https://user-images.githubusercontent.com/21277928/180169288-1ae5f3b4-113e-4934-b799-ab317525ef27.png)
