### PR TITLE
Run REST endpoint tests in CI

### DIFF
--- a/packages/graph/hash_graph/Makefile.toml
+++ b/packages/graph/hash_graph/Makefile.toml
@@ -3,6 +3,7 @@ extend = { path = "../Makefile.toml" }
 [env]
 CARGO_CLIPPY_HACK_FLAGS = "--workspace --feature-powerset --optional-deps clap"
 CARGO_TEST_HACK_FLAGS = "--workspace --feature-powerset --optional-deps clap"
+RUST_LOG = "debug,hyper=warn"
 
 [env.production]
 CARGO_MAKE_CARGO_PROFILE = "production"
@@ -25,5 +26,5 @@ dependencies = ["install-nextest"]
 script = """
 cargo build
 cargo run&
-yarn httpyac send --all ${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/tests/rest-test.http
+#yarn httpyac send --all ${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/tests/rest-test.http
 """

--- a/packages/graph/hash_graph/Makefile.toml
+++ b/packages/graph/hash_graph/Makefile.toml
@@ -25,9 +25,5 @@ dependencies = ["install-nextest"]
 script = """
 cargo build
 cargo run&
-pid=$!
 yarn httpyac send --all ${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/tests/rest-test.http
-ret=$?
-kill "$pid"
-exit $ret
 """

--- a/packages/graph/hash_graph/Makefile.toml
+++ b/packages/graph/hash_graph/Makefile.toml
@@ -10,7 +10,7 @@ CARGO_MAKE_CARGO_PROFILE = "production"
 
 [tasks.test]
 run_task = [
-    { name = ["test-task", "yarn", "deployment-up", "recreate-db", "migrate-up", "test-integration", "deployment-down"], condition = { env_true = ["CARGO_MAKE_CI" ] } },
+    { name = ["test-task", "yarn", "deployment-up", "recreate-db", "migrate-up", "test-integration", "test-rest-api", "deployment-down"], condition = { env_true = ["CARGO_MAKE_CI" ] } },
     { name = ["test-task"] }
 ]
 
@@ -21,5 +21,13 @@ args = ["nextest", "run", "--cargo-profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@s
 dependencies = ["install-nextest"]
 
 [tasks.test-rest-api]
-command = "yarn"
-args = ["httpyac", "send", "--all", "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/tests/rest-test.http"]
+# This is a temporary solution until we have e2e tests in place
+script = """
+cargo build
+cargo run&
+pid=$!
+yarn httpyac send --all ${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/tests/rest-test.http
+ret=$?
+kill "$pid"
+exit $ret
+"""

--- a/packages/graph/hash_graph/Makefile.toml
+++ b/packages/graph/hash_graph/Makefile.toml
@@ -26,5 +26,9 @@ dependencies = ["install-nextest"]
 script = """
 cargo build
 cargo run&
-#yarn httpyac send --all ${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/tests/rest-test.http
+pid=$!
+yarn httpyac send --all ${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/tests/rest-test.http
+ret=$?
+kill "$pid"
+exit $ret
 """

--- a/packages/graph/hash_graph/README.md
+++ b/packages/graph/hash_graph/README.md
@@ -46,7 +46,7 @@ For the integration tests, the database needs to be deployed [as specified here]
 cargo make test-integration
 ```
 
-If the binary is running, the REST API can be tested as well:
+The REST API can be tested as well. Note, that this does not clean up the database after running:
 
 ```shell
 cargo make test-rest-api


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, the tests for the REST endpoints are manual tests, this enables them in the CI

- [Asana task](https://app.asana.com/0/1201095311341924/1202643529167462/f) _(internal)_

## 🔍 What does this change?

Modify the `Makefile.toml` to run the binary, then run the tests

## ⚠️ Known issues

This is using a bash script to run the tests, which is working but not a nice solution. This will be revisited once we have e2e tests in place