### PR TITLE
Adding missing Python dependency

### DIFF
--- a/packages/engine/lib/execution/src/runner/python/requirements.txt
+++ b/packages/engine/lib/execution/src/runner/python/requirements.txt
@@ -2,4 +2,5 @@ pyarrow == 0.17
 flatbuffers == 1.12
 pynng == 0.6.2
 Cython == 0.29.21
-numpy == 1.21.1 # Pyodide is 1.15.1, but we need this
+numpy == 1.21.1
+scipy == 1.7.0


### PR DESCRIPTION
We have scipy in the Python venv in cloud but were missing it in hEngine due to removing Pyodide. I've added quite an old version to match the one we had, as we haven't been updating the Python dependencies yet (but should soon)
