### PR TITLE
Align React imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,8 +12,6 @@
   "ignorePatterns": ["**/*.gen.*"],
   "globals": {
     "NodeJS": true,
-    "React": true,
-    "JSX": true,
     "FixMeLater": "readonly",
     "globalThis": "readonly"
   },
@@ -160,6 +158,11 @@
       {
         "paths": [
           {
+            "name": "react",
+            "importNames": ["FC", "VFC", "VoidFunctionComponent"],
+            "message": "Please use FunctionComponent instead."
+          },
+          {
             "name": "@testing-library/react",
             "importNames": ["render"],
             "message": "Please use ./src/tests/testUtils.tsx#render instead"
@@ -281,6 +284,15 @@
           "$scope",
           "staticContext"
         ]
+      }
+    ],
+    "unicorn/import-style": [
+      "error",
+      {
+        "styles": {
+          "react": { "named": true },
+          "react-dom": { "named": true }
+        }
       }
     ]
   },

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,7 @@
   "root": true,
   // this is the highest config lower ones will automatically extend
   "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint", "react-hooks", "jest"],
+  "plugins": ["@typescript-eslint", "react-hooks", "jest", "unicorn"],
   "extends": [
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "airbnb",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -160,7 +160,7 @@
           {
             "name": "react",
             "importNames": ["FC", "VFC", "VoidFunctionComponent"],
-            "message": "Please use FunctionComponent instead."
+            "message": "Please use FunctionComponent instead"
           },
           {
             "name": "@testing-library/react",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "concurrently": "7.0.0",
     "cross-env": "7.0.3",
     "dotenv-flow": "3.2.0",
+    "eslint-plugin-unicorn": "43.0.2",
     "husky": "7.0.4",
     "lint-staged": "12.3.3",
     "lockfile-lint": "4.6.2",

--- a/packages/blocks/calculation/src/dev.tsx
+++ b/packages/blocks/calculation/src/dev.tsx
@@ -3,8 +3,7 @@
  * This file is not bundled with the block during the build process.
  */
 import { MockBlockDock } from "mock-block-dock";
-import React from "react";
-import ReactDOM from "react-dom";
+import { render } from "react-dom";
 
 import Component from "./index";
 
@@ -38,4 +37,4 @@ const DevApp = () => {
   );
 };
 
-ReactDOM.render(<DevApp />, node);
+render(<DevApp />, node);

--- a/packages/blocks/callout/src/app.tsx
+++ b/packages/blocks/callout/src/app.tsx
@@ -2,7 +2,7 @@ import {
   BlockComponent,
   useGraphBlockService,
 } from "@blockprotocol/graph/react";
-import React, { RefCallback, useRef } from "react";
+import { RefCallback, useRef } from "react";
 
 import { EmojiIcon } from "./emoji-icon";
 

--- a/packages/blocks/callout/src/dev.tsx
+++ b/packages/blocks/callout/src/dev.tsx
@@ -2,8 +2,7 @@
  * webpack-dev-server entry point for debugging.
  * This file is not bundled with the library during the build process.
  */
-import React from "react";
-import ReactDOM from "react-dom";
+import { render } from "react-dom";
 import { MockBlockDock } from "mock-block-dock";
 
 import Component from "./index";
@@ -24,4 +23,4 @@ const App = () => (
   />
 );
 
-ReactDOM.render(<App />, node);
+render(<App />, node);

--- a/packages/blocks/callout/src/emoji-icon.tsx
+++ b/packages/blocks/callout/src/emoji-icon.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEventHandler, VoidFunctionComponent } from "react";
+import { MouseEventHandler, FunctionComponent } from "react";
 
 export interface EmojiIconProps {
   disabled?: boolean;
@@ -8,7 +8,7 @@ export interface EmojiIconProps {
 
 const variants = ["📢", "💡", "🤔", "👉", "📣", "📌", "🚧"];
 
-export const EmojiIcon: VoidFunctionComponent<EmojiIconProps> = ({
+export const EmojiIcon: FunctionComponent<EmojiIconProps> = ({
   disabled,
   onChange,
   value,

--- a/packages/blocks/chart/src/app.tsx
+++ b/packages/blocks/chart/src/app.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
 import { BlockProtocolEntityType } from "blockprotocol";
 
 import { BlockComponent } from "blockprotocol/react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Chart,
   ChartConfigProperties,
@@ -66,7 +66,7 @@ export const App: BlockComponent<BlockEntityProperties> = ({
     throw new Error("linkedAggregations is required to render the Chart block");
   }
 
-  const currentConfigProperties = React.useMemo<ChartConfigProperties>(
+  const currentConfigProperties = useMemo<ChartConfigProperties>(
     () => ({
       displayDataPointLabels,
       displayLegend,
@@ -74,7 +74,7 @@ export const App: BlockComponent<BlockEntityProperties> = ({
     [displayDataPointLabels, displayLegend],
   );
 
-  const currentProperties = React.useMemo<ChartEntityProperties>(
+  const currentProperties = useMemo<ChartEntityProperties>(
     () => ({
       title,
       xAxisLabel,
@@ -85,11 +85,11 @@ export const App: BlockComponent<BlockEntityProperties> = ({
     [title, xAxisLabel, yAxisLabel, series, currentConfigProperties],
   );
 
-  const [possibleEntityTypes, setPossibleEntityTypes] = React.useState<
+  const [possibleEntityTypes, setPossibleEntityTypes] = useState<
     BlockProtocolEntityType[]
   >([]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!aggregateEntityTypes) {
       throw new Error(
         "aggregateEntityTypes is required to render the Chart block",
@@ -100,7 +100,7 @@ export const App: BlockComponent<BlockEntityProperties> = ({
     );
   }, [aggregateEntityTypes, accountId]);
 
-  const updateChartEntityProperties = React.useCallback(
+  const updateChartEntityProperties = useCallback(
     async (updatedProperties: Partial<ChartEntityProperties>) => {
       if (!updateEntities) {
         throw new Error("updateEntities is required to render the Chart block");
@@ -123,7 +123,7 @@ export const App: BlockComponent<BlockEntityProperties> = ({
     [updateEntities, entityId, accountId, currentProperties],
   );
 
-  const seriesDefinitions = React.useMemo<SeriesDefinition[]>(
+  const seriesDefinitions = useMemo<SeriesDefinition[]>(
     () =>
       series
         .map(({ seriesId, ...definition }) => {
@@ -152,7 +152,7 @@ export const App: BlockComponent<BlockEntityProperties> = ({
     [series, linkedAggregations],
   );
 
-  const handleUpdateSeriesDefinition = React.useCallback(
+  const handleUpdateSeriesDefinition = useCallback(
     async (params: {
       seriesId: string;
       updatedDefinition: Partial<Omit<SeriesDefinition, "seriesId">>;
@@ -239,7 +239,7 @@ export const App: BlockComponent<BlockEntityProperties> = ({
     ],
   );
 
-  const handleCreateSeriesDefinition = React.useCallback(
+  const handleCreateSeriesDefinition = useCallback(
     async (params: {
       definition: Omit<SeriesDefinition, "seriesId" | "aggregationResults">;
     }): Promise<void> => {
@@ -289,7 +289,7 @@ export const App: BlockComponent<BlockEntityProperties> = ({
     ],
   );
 
-  const handleDeleteSeriesDefinition = React.useCallback(
+  const handleDeleteSeriesDefinition = useCallback(
     async (params: { seriesId: string }) => {
       if (!deleteLinkedAggregations) {
         throw new Error(

--- a/packages/blocks/chart/src/app.tsx
+++ b/packages/blocks/chart/src/app.tsx
@@ -1,7 +1,7 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { BlockProtocolEntityType } from "blockprotocol";
 
 import { BlockComponent } from "blockprotocol/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Chart,
   ChartConfigProperties,

--- a/packages/blocks/chart/src/chart.tsx
+++ b/packages/blocks/chart/src/chart.tsx
@@ -1,4 +1,5 @@
 import { BlockProtocolEntity, BlockProtocolEntityType } from "blockprotocol";
+import { FunctionComponent, useCallback, useMemo, useState } from "react";
 import debounce from "lodash.debounce";
 // eslint-disable-next-line no-restricted-imports
 import Button from "@mui/material/Button";
@@ -15,7 +16,6 @@ import Select from "@mui/material/Select";
 import InputLabel from "@mui/material/InputLabel";
 import FormControl from "@mui/material/FormControl";
 
-import { FunctionComponent, useCallback, useMemo, useState } from "react";
 import { EChart, SeriesOption, ECOption } from "./e-chart";
 
 const StyledTextField = styled(TextField)(({ theme }) => ({

--- a/packages/blocks/chart/src/chart.tsx
+++ b/packages/blocks/chart/src/chart.tsx
@@ -1,5 +1,4 @@
 import { BlockProtocolEntity, BlockProtocolEntityType } from "blockprotocol";
-import * as React from "react";
 import debounce from "lodash.debounce";
 // eslint-disable-next-line no-restricted-imports
 import Button from "@mui/material/Button";
@@ -16,6 +15,7 @@ import Select from "@mui/material/Select";
 import InputLabel from "@mui/material/InputLabel";
 import FormControl from "@mui/material/FormControl";
 
+import { FunctionComponent, useCallback, useMemo, useState } from "react";
 import { EChart, SeriesOption, ECOption } from "./e-chart";
 
 const StyledTextField = styled(TextField)(({ theme }) => ({
@@ -38,14 +38,13 @@ type EditableChartTitleProps = {
   updateTitle: (updatedTitle: string) => Promise<void>;
 };
 
-const EditableChartTitle: React.FC<EditableChartTitleProps> = ({
+const EditableChartTitle: FunctionComponent<EditableChartTitleProps> = ({
   title: initialTitle,
   updateTitle,
 }) => {
-  const [textFieldValue, setTextFieldValue] =
-    React.useState<string>(initialTitle);
+  const [textFieldValue, setTextFieldValue] = useState<string>(initialTitle);
 
-  const debouncedUpdateTitle = React.useMemo(
+  const debouncedUpdateTitle = useMemo(
     () =>
       debounce(async (updatedTitle: string) => updateTitle(updatedTitle), 500),
     [updateTitle],
@@ -108,14 +107,14 @@ const parsePossiblePropertyKeysFromEntityType = (
         .map(([propertyKey]) => propertyKey)
     : [];
 
-const CreateNewSeriesDefinition: React.FC<{
+const CreateNewSeriesDefinition: FunctionComponent<{
   possibleEntityTypes: BlockProtocolEntityType[];
   createDefinition: (params: {
     definition: Omit<SeriesDefinition, "seriesId" | "aggregationResults">;
   }) => Promise<void>;
   cancel: () => void;
 }> = ({ createDefinition, cancel, possibleEntityTypes }) => {
-  const [newDefinition, setNewDefinition] = React.useState<{
+  const [newDefinition, setNewDefinition] = useState<{
     entityType?: BlockProtocolEntityType;
     seriesName?: string;
     seriesType: SeriesType;
@@ -123,12 +122,12 @@ const CreateNewSeriesDefinition: React.FC<{
     yAxisPropertyKey?: string;
   }>({ seriesType: "scatter" });
 
-  const reset = React.useCallback(
+  const reset = useCallback(
     () => setNewDefinition({ seriesType: "scatter" }),
     [],
   );
 
-  const possiblePropertyKeys = React.useMemo(
+  const possiblePropertyKeys = useMemo(
     () =>
       newDefinition.entityType
         ? parsePossiblePropertyKeysFromEntityType(newDefinition.entityType)
@@ -136,7 +135,7 @@ const CreateNewSeriesDefinition: React.FC<{
     [newDefinition.entityType],
   );
 
-  const handleCreate = React.useCallback(() => {
+  const handleCreate = useCallback(() => {
     const {
       entityType,
       xAxisPropertyKey,
@@ -166,7 +165,7 @@ const CreateNewSeriesDefinition: React.FC<{
     });
   }, [newDefinition, createDefinition, reset]);
 
-  const handleCancel = React.useCallback(() => {
+  const handleCancel = useCallback(() => {
     reset();
     cancel();
   }, [reset, cancel]);
@@ -310,7 +309,7 @@ const CreateNewSeriesDefinition: React.FC<{
   );
 };
 
-const EditableChartSeriesDefinition: React.FC<{
+const EditableChartSeriesDefinition: FunctionComponent<{
   possibleEntityTypes: BlockProtocolEntityType[];
   seriesDefinition: SeriesDefinition;
   updateSeriesDefinition: (params: {
@@ -325,14 +324,14 @@ const EditableChartSeriesDefinition: React.FC<{
   updateSeriesDefinition,
   deleteSeriesDefinition,
 }) => {
-  const [isUpdating, setIsUpdating] = React.useState<boolean>(false);
-  const [isDeleting, setIsDeleting] = React.useState<boolean>(false);
+  const [isUpdating, setIsUpdating] = useState<boolean>(false);
+  const [isDeleting, setIsDeleting] = useState<boolean>(false);
 
-  const [seriesName, setSeriesName] = React.useState<string>(
+  const [seriesName, setSeriesName] = useState<string>(
     seriesDefinition.seriesName,
   );
 
-  const debouncedUpdateSeriesName = React.useMemo(
+  const debouncedUpdateSeriesName = useMemo(
     () =>
       debounce(async (updatedSeriesName: string) => {
         setIsUpdating(true);
@@ -490,7 +489,7 @@ const EditableChartSeriesDefinition: React.FC<{
   );
 };
 
-const EditableChartSeriesDefinitions: React.FC<{
+const EditableChartSeriesDefinitions: FunctionComponent<{
   possibleEntityTypes: BlockProtocolEntityType[];
   seriesDefinitions: SeriesDefinition[];
   updateSeriesDefinition: (params: {
@@ -511,7 +510,7 @@ const EditableChartSeriesDefinitions: React.FC<{
   deleteSeriesDefinition,
 }) => {
   const [creatingNewDefinition, setCreatingNewDefinition] =
-    React.useState<boolean>(false);
+    useState<boolean>(false);
 
   const handleAddSeries = () => {
     setCreatingNewDefinition(true);
@@ -626,7 +625,7 @@ type ChartProps = {
   config: ChartConfigProperties;
 };
 
-export const Chart: React.FC<ChartProps> = ({
+export const Chart: FunctionComponent<ChartProps> = ({
   title,
   updateTitle,
   xAxisName,
@@ -638,7 +637,7 @@ export const Chart: React.FC<ChartProps> = ({
   deleteSeriesDefinition,
   config,
 }) => {
-  const series = React.useMemo(
+  const series = useMemo(
     () => mapSeriesDefinitionsToEChartSeries({ seriesDefinitions, config }),
     [seriesDefinitions, config],
   );

--- a/packages/blocks/chart/src/dev.tsx
+++ b/packages/blocks/chart/src/dev.tsx
@@ -2,8 +2,7 @@
  * This is the entry point for developing and debugging.
  * This file is not bundled with the block during the build process.
  */
-import React from "react";
-import ReactDOM from "react-dom";
+import { render } from "react-dom";
 
 import { MockBlockDock } from "mock-block-dock";
 
@@ -17,4 +16,4 @@ const App = () => (
   </MockBlockDock>
 );
 
-ReactDOM.render(<App />, node);
+render(<App />, node);

--- a/packages/blocks/chart/src/e-chart.tsx
+++ b/packages/blocks/chart/src/e-chart.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import * as echarts from "echarts/core";
 import {
   LineChart,
@@ -9,6 +7,7 @@ import {
 } from "echarts/charts";
 import { GridComponent } from "echarts/components";
 import { SVGRenderer } from "echarts/renderers";
+import { FunctionComponent, useEffect, useRef, useState } from "react";
 
 export type SeriesOption = LineSeriesOption | ScatterSeriesOption;
 
@@ -22,18 +21,18 @@ type GraphProps = {
   options: ECOption;
 };
 
-export const EChart: React.FC<GraphProps> = ({ options }) => {
-  const wrapperRef = React.useRef<HTMLDivElement>(null);
+export const EChart: FunctionComponent<GraphProps> = ({ options }) => {
+  const wrapperRef = useRef<HTMLDivElement>(null);
 
-  const [chart, setChart] = React.useState<echarts.ECharts>();
+  const [chart, setChart] = useState<echarts.ECharts>();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (wrapperRef.current) {
       setChart(echarts.init(wrapperRef.current));
     }
   }, [wrapperRef]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (chart) {
       chart.setOption(options, { notMerge: true });
     }

--- a/packages/blocks/code/src/app.tsx
+++ b/packages/blocks/code/src/app.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { tw } from "twind";
 
 import {

--- a/packages/blocks/code/src/components/editor.tsx
+++ b/packages/blocks/code/src/components/editor.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   ChangeEvent,
   KeyboardEvent,
   RefObject,

--- a/packages/blocks/code/src/dev.tsx
+++ b/packages/blocks/code/src/dev.tsx
@@ -2,8 +2,7 @@
  * This is the entry point for developing and debugging.
  * This file is not bundled with the library during the build process.
  */
-import React from "react";
-import ReactDOM from "react-dom";
+import { render } from "react-dom";
 import { tw } from "twind";
 import { MockBlockDock } from "mock-block-dock";
 
@@ -31,4 +30,4 @@ const App = () => {
   );
 };
 
-ReactDOM.render(<App />, node);
+render(<App />, node);

--- a/packages/blocks/code/src/icons.tsx
+++ b/packages/blocks/code/src/icons.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 export const CopyIcon = ({ size = 14 }) => {
   return (
     <svg

--- a/packages/blocks/countdown/src/app.tsx
+++ b/packages/blocks/countdown/src/app.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, useRef } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 
 import {
   BlockComponent,

--- a/packages/blocks/countdown/src/countdown-title.tsx
+++ b/packages/blocks/countdown/src/countdown-title.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useEffect, useRef, VFC } from "react";
+import { ChangeEvent, useEffect, useRef, FunctionComponent } from "react";
 
 type CountdownTitleProps = {
   value: string | undefined;
@@ -6,7 +6,7 @@ type CountdownTitleProps = {
   onBlur: () => void;
 };
 
-export const CountdownTitle: VFC<CountdownTitleProps> = ({
+export const CountdownTitle: FunctionComponent<CountdownTitleProps> = ({
   value,
   onChangeText,
   onBlur,

--- a/packages/blocks/countdown/src/date-picker-input.tsx
+++ b/packages/blocks/countdown/src/date-picker-input.tsx
@@ -1,5 +1,5 @@
-import React, {
-  FC,
+import {
+  FunctionComponent,
   forwardRef,
   HTMLAttributes,
   MutableRefObject,
@@ -7,7 +7,9 @@ import React, {
 } from "react";
 import DatePicker, { ReactDatePickerProps } from "react-datepicker";
 
-const CalenderIcon: FC<{ onClick: () => void }> = ({ onClick }) => {
+const CalenderIcon: FunctionComponent<{ onClick: () => void }> = ({
+  onClick,
+}) => {
   return (
     <svg
       width="17"

--- a/packages/blocks/countdown/src/dev.tsx
+++ b/packages/blocks/countdown/src/dev.tsx
@@ -2,8 +2,7 @@
  * This is the entry point for developing and debugging.
  * This file is not bundled with the block during the build process.
  */
-import React from "react";
-import ReactDOM from "react-dom";
+import { render } from "react-dom";
 
 import { MockBlockDock } from "mock-block-dock";
 
@@ -22,4 +21,4 @@ const App = () => (
   />
 );
 
-ReactDOM.render(<App />, node);
+render(<App />, node);

--- a/packages/blocks/countdown/src/display.tsx
+++ b/packages/blocks/countdown/src/display.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, VFC } from "react";
+import { useEffect, useState, FunctionComponent } from "react";
 import { Duration, intervalToDuration, isPast } from "date-fns";
 
 type DisplayProps = {
@@ -22,7 +22,10 @@ export const defaultDuration = {
   minutes: 0,
 } as Duration;
 
-export const Display: VFC<DisplayProps> = ({ targetDate, displayTime }) => {
+export const Display: FunctionComponent<DisplayProps> = ({
+  targetDate,
+  displayTime,
+}) => {
   const [_, setClock] = useState(new Date());
 
   useEffect(() => {

--- a/packages/blocks/divider/src/app.tsx
+++ b/packages/blocks/divider/src/app.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { BlockComponent } from "blockprotocol/react";
 
 type BlockEntityProperties = { color?: string; height?: string | number };

--- a/packages/blocks/divider/src/dev.tsx
+++ b/packages/blocks/divider/src/dev.tsx
@@ -2,8 +2,7 @@
  * This is the entry point for developing and debugging.
  * This file is not bundled with the library during the build process.
  */
-import React from "react";
-import ReactDOM from "react-dom";
+import { render } from "react-dom";
 import { MockBlockDock } from "mock-block-dock";
 
 import Component from "./index";
@@ -16,4 +15,4 @@ const App = () => (
   </MockBlockDock>
 );
 
-ReactDOM.render(<App />, node);
+render(<App />, node);

--- a/packages/blocks/drawing/src/app.tsx
+++ b/packages/blocks/drawing/src/app.tsx
@@ -1,9 +1,10 @@
-import React, {
+import {
   useState,
   useCallback,
   useRef,
   useEffect,
   useLayoutEffect,
+  SyntheticEvent,
 } from "react";
 
 import {
@@ -208,7 +209,7 @@ export const App: BlockComponent<BlockEntityProperties> = ({
   }, [localState.serializedDocument, entityId, localState.darkMode]);
 
   const updateDimensions = useCallback(
-    (_: React.SyntheticEvent, { size }: ResizeCallbackData) => {
+    (_: SyntheticEvent, { size }: ResizeCallbackData) => {
       setLocalState((prev) => ({
         ...prev,
         width: size.width,
@@ -219,7 +220,7 @@ export const App: BlockComponent<BlockEntityProperties> = ({
   );
 
   const updateRemoteDimensions = useCallback(
-    (_: React.SyntheticEvent, { size }: ResizeCallbackData) => {
+    (_: SyntheticEvent, { size }: ResizeCallbackData) => {
       updateRemoteData({
         width: size.width,
         height: size.height,

--- a/packages/blocks/drawing/src/dev.tsx
+++ b/packages/blocks/drawing/src/dev.tsx
@@ -2,8 +2,7 @@
  * This is the entry point for developing and debugging.
  * This file is not bundled with the block during the build process.
  */
-import React from "react";
-import ReactDOM from "react-dom";
+import { render } from "react-dom";
 
 import { MockBlockDock } from "mock-block-dock";
 
@@ -22,4 +21,4 @@ const App = () => (
   />
 );
 
-ReactDOM.render(<App />, node);
+render(<App />, node);

--- a/packages/blocks/embed/src/app.tsx
+++ b/packages/blocks/embed/src/app.tsx
@@ -1,9 +1,10 @@
-import React, {
+import {
   useEffect,
   useLayoutEffect,
   useRef,
   useReducer,
   useCallback,
+  Reducer,
 } from "react";
 
 import { tw } from "twind";
@@ -103,7 +104,7 @@ export const App: BlockComponent<BlockEntityProperties> = ({
       errorString,
     },
     dispatch,
-  ] = useReducer<React.Reducer<AppState, Actions>>(
+  ] = useReducer<Reducer<AppState, Actions>>(
     reducer,
     getInitialState({
       html: initialHtml,

--- a/packages/blocks/embed/src/components/edit-view.tsx
+++ b/packages/blocks/embed/src/components/edit-view.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { FormEvent, FunctionComponent } from "react";
 import { tw } from "twind";
 import Cross from "../svgs/cross";
 import Loader from "../svgs/loader";
@@ -15,7 +15,7 @@ type EditViewProps = {
   onSubmit: () => Promise<void>;
 };
 
-export const EditView: React.VFC<EditViewProps> = ({
+export const EditView: FunctionComponent<EditViewProps> = ({
   errorString,
   setErrorString,
   loading,
@@ -26,7 +26,7 @@ export const EditView: React.VFC<EditViewProps> = ({
   embedUrl,
   onSubmit,
 }) => {
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     void onSubmit();
   };

--- a/packages/blocks/embed/src/components/resize-block.tsx
+++ b/packages/blocks/embed/src/components/resize-block.tsx
@@ -5,7 +5,7 @@ import {
   useLayoutEffect,
   useMemo,
   useRef,
-  MouseEvent as ReactMouseEvent,
+  MouseEvent,
 } from "react";
 import { tw } from "twind";
 import { throttle } from "lodash";
@@ -113,13 +113,13 @@ export const ResizeBlock: FunctionComponent<ResizeBlockProps> = ({
   }, [width, height, updateLocalDimensions]);
 
   const handleResize = (
-    _evt: ReactMouseEvent,
+    _evt: MouseEvent,
     direction: typeof BLOCK_RESIZER_POSITIONS[number]["position"],
   ) => {
     if (!childrenWrapperRef.current) return;
     let isResizing = false;
 
-    function onMouseMove(mouseMoveEvt: MouseEvent) {
+    function onMouseMove(mouseMoveEvt: globalThis.MouseEvent) {
       if (!divRef.current) return;
       if (!childrenWrapperRef.current) return;
       /**

--- a/packages/blocks/embed/src/components/resize-block.tsx
+++ b/packages/blocks/embed/src/components/resize-block.tsx
@@ -1,4 +1,12 @@
-import React, { useCallback, useLayoutEffect, useMemo, useRef } from "react";
+import {
+  FunctionComponent,
+  ReactNode,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  MouseEvent as ReactMouseEvent,
+} from "react";
 import { tw } from "twind";
 import { throttle } from "lodash";
 import { MIN_WIDTH, MIN_HEIGHT } from "../constants";
@@ -11,7 +19,7 @@ type ResizeBlockProps = {
   maxWidth: number;
   updateDimensions: (width: number, height: number) => void;
   shouldRespectAspectRatio: boolean;
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
 const BLOCK_RESIZER_POSITIONS = [
@@ -43,7 +51,7 @@ const BLOCK_RESIZER_POSITIONS = [
  *  and should be imported from there
  */
 
-export const ResizeBlock: React.FC<ResizeBlockProps> = ({
+export const ResizeBlock: FunctionComponent<ResizeBlockProps> = ({
   children,
   width,
   height,
@@ -105,7 +113,7 @@ export const ResizeBlock: React.FC<ResizeBlockProps> = ({
   }, [width, height, updateLocalDimensions]);
 
   const handleResize = (
-    _evt: React.MouseEvent,
+    _evt: ReactMouseEvent,
     direction: typeof BLOCK_RESIZER_POSITIONS[number]["position"],
   ) => {
     if (!childrenWrapperRef.current) return;

--- a/packages/blocks/embed/src/dev.tsx
+++ b/packages/blocks/embed/src/dev.tsx
@@ -2,8 +2,8 @@
  * This is the entry point for developing and debugging.
  * This file is not bundled with the library during the build process.
  */
-import React, { useState } from "react";
-import ReactDOM from "react-dom";
+import { useState } from "react";
+import { render } from "react-dom";
 import { tw } from "twind";
 import { MockBlockDock } from "mock-block-dock";
 
@@ -59,7 +59,7 @@ const initialVariantIndex = 0;
 const initialState = getVariantProperties(variants[initialVariantIndex]!);
 
 /**
- * @type {import("react").VoidFunctionComponent}
+ * @type {import("react").FunctionComponent}
  */
 const AppComponent = () => {
   const [selectedVariantIndex, setSelectedVariantIndex] =
@@ -99,4 +99,4 @@ const App = () => {
   return <AppComponent />;
 };
 
-ReactDOM.render(<App />, node);
+render(<App />, node);

--- a/packages/blocks/embed/src/dev.tsx
+++ b/packages/blocks/embed/src/dev.tsx
@@ -2,7 +2,7 @@
  * This is the entry point for developing and debugging.
  * This file is not bundled with the library during the build process.
  */
-import { useState } from "react";
+import { FunctionComponent, useState } from "react";
 import { render } from "react-dom";
 import { tw } from "twind";
 import { MockBlockDock } from "mock-block-dock";
@@ -58,10 +58,7 @@ const initialVariantIndex = 0;
 
 const initialState = getVariantProperties(variants[initialVariantIndex]!);
 
-/**
- * @type {import("react").FunctionComponent}
- */
-const AppComponent = () => {
+const AppComponent: FunctionComponent = () => {
   const [selectedVariantIndex, setSelectedVariantIndex] =
     useState(initialVariantIndex);
 

--- a/packages/blocks/embed/src/html-block.tsx
+++ b/packages/blocks/embed/src/html-block.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, VoidFunctionComponent } from "react";
+import { useEffect, useRef, FunctionComponent } from "react";
 import { tw } from "twind";
 import { toCSSText } from "./utils";
 
@@ -8,7 +8,7 @@ type HtmlBlockProps = {
   [key: string]: any;
 };
 
-export const HtmlBlock: VoidFunctionComponent<HtmlBlockProps> = ({
+export const HtmlBlock: FunctionComponent<HtmlBlockProps> = ({
   html,
   dimensions,
   ...props

--- a/packages/blocks/embed/src/svgs/corner-resize.tsx
+++ b/packages/blocks/embed/src/svgs/corner-resize.tsx
@@ -1,11 +1,13 @@
-import React from "react";
+import { FunctionComponent } from "react";
 import { tw } from "twind";
 
 type CornerResizeProps = {
   position: string;
 };
 
-export const CornerResize: React.VFC<CornerResizeProps> = ({ position }) => {
+export const CornerResize: FunctionComponent<CornerResizeProps> = ({
+  position,
+}) => {
   return (
     <svg
       viewBox="0 0 16 16"

--- a/packages/blocks/embed/src/svgs/cross.tsx
+++ b/packages/blocks/embed/src/svgs/cross.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import { FunctionComponent } from "react";
 import { tw } from "twind";
 
-const Cross: React.VoidFunctionComponent = () => {
+const Cross: FunctionComponent = () => {
   return (
     <svg
       className={tw`fill-current h-6 w-6 text-red-500`}

--- a/packages/blocks/embed/src/svgs/loader.tsx
+++ b/packages/blocks/embed/src/svgs/loader.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import { FunctionComponent } from "react";
 import { tw } from "twind";
 
-const Loader: React.VoidFunctionComponent = () => {
+const Loader: FunctionComponent = () => {
   return (
     <svg
       className={tw`animate-spin h-4 text-white mr-2`}

--- a/packages/blocks/embed/src/svgs/pencil.tsx
+++ b/packages/blocks/embed/src/svgs/pencil.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import { FunctionComponent } from "react";
 
-const Pencil: React.VoidFunctionComponent = () => {
+const Pencil: FunctionComponent = () => {
   return (
     <svg
       width="24"

--- a/packages/blocks/github-pr-overview/src/app.tsx
+++ b/packages/blocks/github-pr-overview/src/app.tsx
@@ -1,11 +1,10 @@
-import * as React from "react";
-
 import {
   BlockComponent,
   useGraphBlockService,
 } from "@blockprotocol/graph/react";
 import { Box, CssBaseline, Theme, ThemeProvider } from "@mui/material";
 import { theme } from "@hashintel/hash-design-system";
+import { Reducer, useEffect, useReducer, useRef } from "react";
 import {
   PullRequestIdentifier,
   BlockState,
@@ -80,7 +79,7 @@ const getInitialState = (options: Partial<LocalState>) => ({
 export const App: BlockComponent<BlockEntityProperties> = ({
   graph: { blockEntity },
 }) => {
-  const blockRef = React.useRef<HTMLDivElement>(null);
+  const blockRef = useRef<HTMLDivElement>(null);
   const { graphService } = useGraphBlockService(blockRef);
   const {
     entityId,
@@ -99,13 +98,13 @@ export const App: BlockComponent<BlockEntityProperties> = ({
       infoMessage,
     },
     dispatch,
-  ] = React.useReducer<React.Reducer<LocalState, Actions>>(
+  ] = useReducer<Reducer<LocalState, Actions>>(
     reducer,
     getInitialState({
       selectedPullRequestIdentifier: remoteSelectedPullRequestIdentifier,
     }),
   );
-  const prevSelectedPullRequestIdRef = React.useRef(
+  const prevSelectedPullRequestIdRef = useRef(
     remoteSelectedPullRequestIdentifier,
   );
   if (
@@ -151,7 +150,7 @@ export const App: BlockComponent<BlockEntityProperties> = ({
     dispatch({ type: "RESET_SELECTED_PR" });
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!graphService) return;
     if (!githubEntityTypeIds || !allPrs) {
       dispatch({
@@ -188,7 +187,7 @@ export const App: BlockComponent<BlockEntityProperties> = ({
 
   // Fetch PR Details => pullRequest, events and reviews
   // if there's a selectedPullRequestId
-  React.useEffect(() => {
+  useEffect(() => {
     if (!blockRef.current || !graphService) return;
     if (selectedPullRequestIdentifier && githubEntityTypeIds) {
       dispatch({

--- a/packages/blocks/github-pr-overview/src/app.tsx
+++ b/packages/blocks/github-pr-overview/src/app.tsx
@@ -1,10 +1,10 @@
+import { Reducer, useEffect, useReducer, useRef } from "react";
 import {
   BlockComponent,
   useGraphBlockService,
 } from "@blockprotocol/graph/react";
 import { Box, CssBaseline, Theme, ThemeProvider } from "@mui/material";
 import { theme } from "@hashintel/hash-design-system";
-import { Reducer, useEffect, useReducer, useRef } from "react";
 import {
   PullRequestIdentifier,
   BlockState,

--- a/packages/blocks/github-pr-overview/src/dev.tsx
+++ b/packages/blocks/github-pr-overview/src/dev.tsx
@@ -2,8 +2,7 @@
  * This is the entry point for developing and debugging.
  * This file is not bundled with the block during the build process.
  */
-import React from "react";
-import ReactDOM from "react-dom";
+import { render } from "react-dom";
 
 import { MockBlockDock } from "mock-block-dock";
 
@@ -26,4 +25,4 @@ const App = () => (
   />
 );
 
-ReactDOM.render(<App />, node);
+render(<App />, node);

--- a/packages/blocks/github-pr-overview/src/icons.tsx
+++ b/packages/blocks/github-pr-overview/src/icons.tsx
@@ -1,5 +1,5 @@
 import { SvgIcon, SvgIconProps, SxProps, Theme } from "@mui/material";
-import React, { FC } from "react";
+import { FunctionComponent } from "react";
 
 const getBaseSx = (sx: SxProps<Theme>, fontSize: number = 16) => [
   {
@@ -10,7 +10,10 @@ const getBaseSx = (sx: SxProps<Theme>, fontSize: number = 16) => [
   ...(Array.isArray(sx) ? sx : [sx]),
 ];
 
-export const GithubIcon: FC<SvgIconProps> = ({ sx = [], ...props }) => {
+export const GithubIcon: FunctionComponent<SvgIconProps> = ({
+  sx = [],
+  ...props
+}) => {
   return (
     <SvgIcon sx={getBaseSx(sx, 20)} {...props} viewBox="0 0 20 20" fill="none">
       <path
@@ -21,7 +24,7 @@ export const GithubIcon: FC<SvgIconProps> = ({ sx = [], ...props }) => {
   );
 };
 
-export const PullRequestOpenIcon: FC<SvgIconProps> = ({
+export const PullRequestOpenIcon: FunctionComponent<SvgIconProps> = ({
   sx = [],
   ...props
 }) => {
@@ -36,7 +39,7 @@ export const PullRequestOpenIcon: FC<SvgIconProps> = ({
   );
 };
 
-export const PullRequestClosedIcon: FC<SvgIconProps> = ({
+export const PullRequestClosedIcon: FunctionComponent<SvgIconProps> = ({
   sx = [],
   ...props
 }) => {
@@ -51,7 +54,7 @@ export const PullRequestClosedIcon: FC<SvgIconProps> = ({
   );
 };
 
-export const PullRequestMergedIcon: FC<SvgIconProps> = ({
+export const PullRequestMergedIcon: FunctionComponent<SvgIconProps> = ({
   sx = [],
   ...props
 }) => {
@@ -66,7 +69,10 @@ export const PullRequestMergedIcon: FC<SvgIconProps> = ({
   );
 };
 
-export const LinkIcon: FC<SvgIconProps> = ({ sx = [], ...props }) => {
+export const LinkIcon: FunctionComponent<SvgIconProps> = ({
+  sx = [],
+  ...props
+}) => {
   return (
     <SvgIcon sx={getBaseSx(sx)} viewBox="0 0 20 17" fill="none" {...props}>
       <path
@@ -77,7 +83,10 @@ export const LinkIcon: FC<SvgIconProps> = ({ sx = [], ...props }) => {
   );
 };
 
-export const CommentIcon: FC<SvgIconProps> = ({ sx = [], ...props }) => {
+export const CommentIcon: FunctionComponent<SvgIconProps> = ({
+  sx = [],
+  ...props
+}) => {
   return (
     <SvgIcon sx={getBaseSx(sx)} viewBox="0 0 17 17" fill="none" {...props}>
       <path
@@ -88,7 +97,10 @@ export const CommentIcon: FC<SvgIconProps> = ({ sx = [], ...props }) => {
   );
 };
 
-export const ChevronDownIcon: FC<SvgIconProps> = ({ sx = [], ...props }) => {
+export const ChevronDownIcon: FunctionComponent<SvgIconProps> = ({
+  sx = [],
+  ...props
+}) => {
   return (
     <SvgIcon sx={getBaseSx(sx)} viewBox="0 0 12 12" fill="none" {...props}>
       <path
@@ -99,7 +111,10 @@ export const ChevronDownIcon: FC<SvgIconProps> = ({ sx = [], ...props }) => {
   );
 };
 
-export const CheckDoubleIcon: FC<SvgIconProps> = ({ sx = [], ...props }) => {
+export const CheckDoubleIcon: FunctionComponent<SvgIconProps> = ({
+  sx = [],
+  ...props
+}) => {
   return (
     <SvgIcon sx={getBaseSx(sx)} viewBox="0 0 16 16" fill="none" {...props}>
       <path
@@ -110,7 +125,10 @@ export const CheckDoubleIcon: FC<SvgIconProps> = ({ sx = [], ...props }) => {
   );
 };
 
-export const ClearIcon: FC<SvgIconProps> = ({ sx = [], ...props }) => {
+export const ClearIcon: FunctionComponent<SvgIconProps> = ({
+  sx = [],
+  ...props
+}) => {
   return (
     <SvgIcon sx={getBaseSx(sx)} viewBox="0 0 16 16" fill="none" {...props}>
       <path
@@ -121,7 +139,10 @@ export const ClearIcon: FC<SvgIconProps> = ({ sx = [], ...props }) => {
   );
 };
 
-export const CloseIcon: FC<SvgIconProps> = ({ sx = [], ...props }) => {
+export const CloseIcon: FunctionComponent<SvgIconProps> = ({
+  sx = [],
+  ...props
+}) => {
   return (
     <SvgIcon sx={getBaseSx(sx)} viewBox="0 0 16 17" fill="none" {...props}>
       <path

--- a/packages/blocks/github-pr-overview/src/info-ui.tsx
+++ b/packages/blocks/github-pr-overview/src/info-ui.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { FunctionComponent } from "react";
 import { Box, Typography } from "@mui/material";
 import { LoadingSpinner } from "@hashintel/hash-design-system";
 import { GithubIcon } from "./icons";
@@ -8,7 +8,7 @@ export type PullRequestSelectorProps = {
   loading?: boolean;
 };
 
-export const InfoUI: React.FunctionComponent<PullRequestSelectorProps> = ({
+export const InfoUI: FunctionComponent<PullRequestSelectorProps> = ({
   title,
   loading,
 }) => {

--- a/packages/blocks/github-pr-overview/src/overview/index.tsx
+++ b/packages/blocks/github-pr-overview/src/overview/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { FunctionComponent } from "react";
 import Avatar from "@mui/material/Avatar";
 import Stack from "@mui/material/Stack";
 import { uniqBy } from "lodash";
@@ -30,7 +30,7 @@ export type GithubPrOverviewProps = {
   reset: () => void;
 };
 
-const PRStatus: React.FC<{
+const PRStatus: FunctionComponent<{
   pullRequest: GithubPullRequestEntityType["properties"];
 }> = ({ pullRequest }) => {
   const status =
@@ -80,9 +80,12 @@ const PRStatus: React.FC<{
   );
 };
 
-export const GithubPrOverview: React.FunctionComponent<
-  GithubPrOverviewProps
-> = ({ pullRequest, reviews, events, reset }) => {
+export const GithubPrOverview: FunctionComponent<GithubPrOverviewProps> = ({
+  pullRequest,
+  reviews,
+  events,
+  reset,
+}) => {
   const uniqueReviewers = uniqBy(
     reviews.map(({ user }) => {
       return {

--- a/packages/blocks/github-pr-overview/src/overview/reviews.tsx
+++ b/packages/blocks/github-pr-overview/src/overview/reviews.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { FunctionComponent } from "react";
 import {
   Box,
   Typography,
@@ -16,7 +16,7 @@ type SectionProps = {
   }[];
 };
 
-const Section: React.FC<SectionProps> = ({ title, reviews }) => {
+const Section: FunctionComponent<SectionProps> = ({ title, reviews }) => {
   return (
     <Box>
       <Stack direction="row" alignItems="center">
@@ -86,7 +86,7 @@ type ReviewsProps = {
   }[];
 };
 
-export const Reviews: React.FC<ReviewsProps> = ({
+export const Reviews: FunctionComponent<ReviewsProps> = ({
   pendingReviews,
   completedReviews,
 }) => (

--- a/packages/blocks/github-pr-overview/src/pull-request-selector/custom-autocomplete.tsx
+++ b/packages/blocks/github-pr-overview/src/pull-request-selector/custom-autocomplete.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { forwardRef, ReactElement, Ref } from "react";
 import { KeyboardArrowDown } from "@mui/icons-material";
 import {
   AutocompleteProps as MuiAutocompleteProps,
@@ -26,7 +26,7 @@ const CustomAutocomplete = <T,>(
     sx = [],
     ...props
   }: AutocompleteProps<T>,
-  ref: React.Ref<HTMLDivElement>,
+  ref: Ref<HTMLDivElement>,
 ) => {
   const renderInput = (params: AutocompleteRenderInputParams) => {
     if (customRenderInput) {
@@ -85,12 +85,12 @@ const CustomAutocomplete = <T,>(
 };
 
 // type assertion approach inspiration from https://stackoverflow.com/a/58473012
-const CustomAutocompleteForwardRef = React.forwardRef(CustomAutocomplete) as <
+const CustomAutocompleteForwardRef = forwardRef(CustomAutocomplete) as <
   T extends {},
 >(
   props: AutocompleteProps<T> & {
-    ref?: React.Ref<HTMLDivElement>;
+    ref?: Ref<HTMLDivElement>;
   },
-) => React.ReactElement;
+) => ReactElement;
 
 export { CustomAutocompleteForwardRef as CustomAutocomplete };

--- a/packages/blocks/github-pr-overview/src/pull-request-selector/index.tsx
+++ b/packages/blocks/github-pr-overview/src/pull-request-selector/index.tsx
@@ -1,6 +1,6 @@
+import { FunctionComponent, useMemo, useState } from "react";
 import { Box, Typography } from "@mui/material";
 
-import { FunctionComponent, useMemo, useState } from "react";
 import { GithubPullRequestEntityType } from "../types";
 import { GithubIcon } from "../icons";
 import { CustomAutocomplete } from "./custom-autocomplete";

--- a/packages/blocks/github-pr-overview/src/pull-request-selector/index.tsx
+++ b/packages/blocks/github-pr-overview/src/pull-request-selector/index.tsx
@@ -1,7 +1,6 @@
-import * as React from "react";
-
 import { Box, Typography } from "@mui/material";
 
+import { FunctionComponent, useMemo, useState } from "react";
 import { GithubPullRequestEntityType } from "../types";
 import { GithubIcon } from "../icons";
 import { CustomAutocomplete } from "./custom-autocomplete";
@@ -11,14 +10,15 @@ export type PullRequestSelectorProps = {
   setSelectedPullRequestId: (x: any) => void;
 };
 
-export const PullRequestSelector: React.FunctionComponent<
+export const PullRequestSelector: FunctionComponent<
   PullRequestSelectorProps
 > = ({ allPrs, setSelectedPullRequestId }) => {
-  const [selectedRepository, setSelectedRepository] = React.useState<
-    string | null
+  const [selectedRepository, setSelectedRepository] = useState<string | null>(
+    null,
+  );
+  const [selectedPullRequestNumber, setSelectedPullRequestNumber] = useState<
+    number | null
   >(null);
-  const [selectedPullRequestNumber, setSelectedPullRequestNumber] =
-    React.useState<number | null>(null);
 
   const onClick = (pullRequest: number) => {
     setSelectedPullRequestId({
@@ -27,7 +27,7 @@ export const PullRequestSelector: React.FunctionComponent<
     });
   };
 
-  const reposToPrIds: { [k: string]: number[] } = React.useMemo(() => {
+  const reposToPrIds: { [k: string]: number[] } = useMemo(() => {
     const repoMap = {} as { [k: string]: number[] };
 
     Array.from(allPrs?.keys() ?? []).forEach((prId) => {

--- a/packages/blocks/github-pr-overview/src/timeline/config-panel.tsx
+++ b/packages/blocks/github-pr-overview/src/timeline/config-panel.tsx
@@ -18,14 +18,14 @@ import {
   Collapse,
 } from "@mui/material";
 import { startCase } from "lodash";
-import * as React from "react";
+import { Dispatch, FunctionComponent, SetStateAction, useState } from "react";
 import { ChevronDownIcon, CheckDoubleIcon, ClearIcon } from "../icons";
 import { getEventTypeColor } from "../utils";
 
 type ConfigPanelProps = {
   possibleEventTypes: string[];
   selectedEventTypes: string[];
-  setSelectedEventTypes: React.Dispatch<React.SetStateAction<string[]>>;
+  setSelectedEventTypes: Dispatch<SetStateAction<string[]>>;
 };
 
 const FilterBtn = styled(({ ...props }: BoxProps) => (
@@ -58,12 +58,12 @@ const FilterBtn = styled(({ ...props }: BoxProps) => (
   },
 }));
 
-export const ConfigPanel: React.FC<ConfigPanelProps> = ({
+export const ConfigPanel: FunctionComponent<ConfigPanelProps> = ({
   possibleEventTypes,
   selectedEventTypes,
   setSelectedEventTypes,
 }) => {
-  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 

--- a/packages/blocks/github-pr-overview/src/timeline/index.tsx
+++ b/packages/blocks/github-pr-overview/src/timeline/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { FunctionComponent, useMemo, useState } from "react";
 import Box from "@mui/material/Box";
 import Timeline, { timelineClasses } from "@mui/lab/Timeline";
 
@@ -104,12 +104,14 @@ export type GithubPrTimelineProps = {
   events: GithubIssueEventEntityType["properties"][];
 };
 
-export const GithubPrTimeline: React.FunctionComponent<
-  GithubPrTimelineProps
-> = ({ pullRequest, events, reviews }) => {
-  const [timelineOpacity, setTimelineOpacity] = React.useState(false);
+export const GithubPrTimeline: FunctionComponent<GithubPrTimelineProps> = ({
+  pullRequest,
+  events,
+  reviews,
+}) => {
+  const [timelineOpacity, setTimelineOpacity] = useState(false);
 
-  const nodes = React.useMemo(() => {
+  const nodes = useMemo(() => {
     // there isn't an issue event for opening so we manually make an object to append to the timeline
     const openedEvent = {
       id: pullRequest.node_id,
@@ -130,16 +132,16 @@ export const GithubPrTimeline: React.FunctionComponent<
     return sortBy([openedEvent, ...reviewEvents, ...events], "created_at");
   }, [pullRequest, events, reviews]);
 
-  const possibleEventTypes = React.useMemo(
+  const possibleEventTypes = useMemo(
     () => uniq(nodes.map((event) => event.event!)),
     [nodes],
   );
 
-  const [selectedEventTypes, setSelectedEventTypes] = React.useState(
+  const [selectedEventTypes, setSelectedEventTypes] = useState(
     addDefaultFromPossible(possibleEventTypes),
   );
 
-  const filteredNodes = React.useMemo(
+  const filteredNodes = useMemo(
     () =>
       nodes.filter(
         (event) =>

--- a/packages/blocks/github-pr-overview/src/timeline/timeline-item.tsx
+++ b/packages/blocks/github-pr-overview/src/timeline/timeline-item.tsx
@@ -18,7 +18,7 @@ import {
 } from "@mui/material";
 import { format } from "date-fns";
 import { startCase } from "lodash";
-import * as React from "react";
+import { FunctionComponent, useState } from "react";
 import {
   LinkIcon,
   PullRequestClosedIcon,
@@ -64,13 +64,13 @@ const getTimelineContentText = (event: TimelineItemProps["event"]) => {
   }
 };
 
-export const TimelineItem: React.FC<TimelineItemProps> = ({
+export const TimelineItem: FunctionComponent<TimelineItemProps> = ({
   event,
   hideConnector,
   setTimelineOpacity,
   hideDate,
 }) => {
-  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
   const copyToClipboard = (link: string | null | undefined) => {
     if (link) {

--- a/packages/blocks/header/src/app.tsx
+++ b/packages/blocks/header/src/app.tsx
@@ -1,5 +1,5 @@
 import { BlockComponent } from "@blockprotocol/graph/react";
-import React, { RefCallback } from "react";
+import { RefCallback } from "react";
 
 type BlockEntityProperties = {
   color?: string;

--- a/packages/blocks/header/src/dev.tsx
+++ b/packages/blocks/header/src/dev.tsx
@@ -2,8 +2,7 @@
  * webpack-dev-server entry point for debugging.
  * This file is not bundled with the library during the build process.
  */
-import React from "react";
-import ReactDOM from "react-dom";
+import { render } from "react-dom";
 import { MockBlockDock } from "mock-block-dock";
 
 import Component from "./index";
@@ -26,4 +25,4 @@ const App = () => (
   />
 );
 
-ReactDOM.render(<App />, node);
+render(<App />, node);

--- a/packages/blocks/image/src/components/error-alert.tsx
+++ b/packages/blocks/image/src/components/error-alert.tsx
@@ -1,10 +1,10 @@
-import React, { VFC } from "react";
+import { FunctionComponent } from "react";
 import { tw } from "twind";
 import Cross from "../svgs/cross";
 
 type ImageErrorAlertProps = { error: string | null; onClearError: () => void };
 
-export const ErrorAlert: VFC<ImageErrorAlertProps> = ({
+export const ErrorAlert: FunctionComponent<ImageErrorAlertProps> = ({
   error,
   onClearError,
 }) => (

--- a/packages/blocks/image/src/components/media-with-caption.tsx
+++ b/packages/blocks/image/src/components/media-with-caption.tsx
@@ -1,4 +1,4 @@
-import React, { VFC } from "react";
+import { FunctionComponent } from "react";
 import { tw } from "twind";
 import Pencil from "../svgs/pencil";
 import { ResizeImageBlock } from "./resize-image-block";
@@ -21,7 +21,7 @@ type MediaWithCaptionProps = {
     }
 );
 
-export const MediaWithCaption: VFC<MediaWithCaptionProps> = ({
+export const MediaWithCaption: FunctionComponent<MediaWithCaptionProps> = ({
   caption,
   src,
   onCaptionChange,

--- a/packages/blocks/image/src/components/media.tsx
+++ b/packages/blocks/image/src/components/media.tsx
@@ -14,7 +14,7 @@ import {
   BlockGraphProperties,
   UpdateEntityData,
 } from "@blockprotocol/graph";
-import React, {
+import {
   Dispatch,
   SetStateAction,
   useCallback,
@@ -22,7 +22,7 @@ import React, {
   useMemo,
   useRef,
   useState,
-  VoidFunctionComponent,
+  FunctionComponent,
 } from "react";
 import { unstable_batchedUpdates } from "react-dom";
 import { ErrorAlert } from "./error-alert";
@@ -124,7 +124,7 @@ const isSingleTargetLink = (link: Link): link is Link => "linkId" in link;
 /**
  * @todo Rewrite the state here to use a reducer, instead of batched updates
  */
-export const Media: VoidFunctionComponent<
+export const Media: FunctionComponent<
   BlockGraphProperties<MediaEntityProperties> & {
     mediaType: "image" | "video";
   }

--- a/packages/blocks/image/src/components/resize-image-block.tsx
+++ b/packages/blocks/image/src/components/resize-image-block.tsx
@@ -1,4 +1,9 @@
-import React, { useLayoutEffect, useRef } from "react";
+import {
+  FunctionComponent,
+  MouseEvent as ReactMouseEvent,
+  useLayoutEffect,
+  useRef,
+} from "react";
 import { tw } from "twind";
 
 type ResizeBlockProps = {
@@ -13,7 +18,7 @@ const MIN_WIDTH = 96;
 
 // @todo set a max-width
 
-export const ResizeImageBlock: React.VFC<ResizeBlockProps> = ({
+export const ResizeImageBlock: FunctionComponent<ResizeBlockProps> = ({
   imageSrc,
   width,
   updateWidth,
@@ -42,10 +47,7 @@ export const ResizeImageBlock: React.VFC<ResizeBlockProps> = ({
     }
   }, [width, imageSrc, updateWidth]);
 
-  const handleResize = (
-    _evt: React.MouseEvent,
-    direction: "left" | "right",
-  ) => {
+  const handleResize = (_evt: ReactMouseEvent, direction: "left" | "right") => {
     function onMouseMove(mouseMoveEvt: MouseEvent) {
       if (!imageRef.current) return;
       let newWidth;

--- a/packages/blocks/image/src/components/resize-image-block.tsx
+++ b/packages/blocks/image/src/components/resize-image-block.tsx
@@ -1,9 +1,4 @@
-import {
-  FunctionComponent,
-  MouseEvent as ReactMouseEvent,
-  useLayoutEffect,
-  useRef,
-} from "react";
+import { FunctionComponent, MouseEvent, useLayoutEffect, useRef } from "react";
 import { tw } from "twind";
 
 type ResizeBlockProps = {
@@ -47,8 +42,8 @@ export const ResizeImageBlock: FunctionComponent<ResizeBlockProps> = ({
     }
   }, [width, imageSrc, updateWidth]);
 
-  const handleResize = (_evt: ReactMouseEvent, direction: "left" | "right") => {
-    function onMouseMove(mouseMoveEvt: MouseEvent) {
+  const handleResize = (_evt: MouseEvent, direction: "left" | "right") => {
+    function onMouseMove(mouseMoveEvt: globalThis.MouseEvent) {
       if (!imageRef.current) return;
       let newWidth;
       const { left, right } = imageRef.current.getBoundingClientRect();

--- a/packages/blocks/image/src/components/upload-media-form.tsx
+++ b/packages/blocks/image/src/components/upload-media-form.tsx
@@ -1,4 +1,4 @@
-import React, { VFC } from "react";
+import { ChangeEvent, FunctionComponent } from "react";
 import { tw } from "twind";
 import Loader from "../svgs/loader";
 
@@ -10,7 +10,7 @@ type UploadMediaFormProps = {
   type: "image" | "video";
 };
 
-export const UploadMediaForm: VFC<UploadMediaFormProps> = ({
+export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
   loading,
   onFileChoose,
   onUrlChange,
@@ -71,7 +71,7 @@ export const UploadMediaForm: VFC<UploadMediaFormProps> = ({
               className={tw`hidden`}
               type="file"
               accept={`${type}/*`}
-              onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+              onChange={(event: ChangeEvent<HTMLInputElement>) =>
                 onFilesChoose(event.target.files)
               }
             />

--- a/packages/blocks/image/src/dev.tsx
+++ b/packages/blocks/image/src/dev.tsx
@@ -3,8 +3,7 @@
  * This file is not bundled with the library during the build process.
  */
 
-import React from "react";
-import ReactDOM from "react-dom";
+import { render } from "react-dom";
 import { MockBlockDock } from "mock-block-dock";
 
 import Component from "./index";
@@ -27,4 +26,4 @@ const App = () => {
   );
 };
 
-ReactDOM.render(<App />, node);
+render(<App />, node);

--- a/packages/blocks/image/src/image.tsx
+++ b/packages/blocks/image/src/image.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { BlockComponent } from "@blockprotocol/graph/react";
 import { Media, MediaEntityProperties } from "./components/media";
 

--- a/packages/blocks/image/src/svgs/cross.tsx
+++ b/packages/blocks/image/src/svgs/cross.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import { FunctionComponent } from "react";
 import { tw } from "twind";
 
-const Cross: React.VoidFunctionComponent = () => {
+const Cross: FunctionComponent = () => {
   return (
     <svg
       className={tw`fill-current h-6 w-6 text-red-500`}

--- a/packages/blocks/image/src/svgs/loader.tsx
+++ b/packages/blocks/image/src/svgs/loader.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import { FunctionComponent } from "react";
 import { tw } from "twind";
 
-const Loader: React.VoidFunctionComponent = () => {
+const Loader: FunctionComponent = () => {
   return (
     <svg
       className={tw`animate-spin h-4 text-white mr-2`}

--- a/packages/blocks/image/src/svgs/pencil.tsx
+++ b/packages/blocks/image/src/svgs/pencil.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import { FunctionComponent } from "react";
 
-const Pencil: React.VoidFunctionComponent = () => {
+const Pencil: FunctionComponent = () => {
   return (
     <svg
       width="24"

--- a/packages/blocks/paragraph/src/app.tsx
+++ b/packages/blocks/paragraph/src/app.tsx
@@ -1,4 +1,4 @@
-import React, { RefCallback } from "react";
+import { RefCallback } from "react";
 
 import { BlockComponent } from "blockprotocol/react";
 

--- a/packages/blocks/paragraph/src/dev.tsx
+++ b/packages/blocks/paragraph/src/dev.tsx
@@ -2,8 +2,7 @@
  * webpack-dev-server entry point for debugging.
  * This file is not bundled with the library during the build process.
  */
-import React from "react";
-import ReactDOM from "react-dom";
+import { render } from "react-dom";
 import { MockBlockDock } from "mock-block-dock";
 
 import Component from "./index";
@@ -16,4 +15,4 @@ const App = () => (
   </MockBlockDock>
 );
 
-ReactDOM.render(<App />, node);
+render(<App />, node);

--- a/packages/blocks/person/src/app.tsx
+++ b/packages/blocks/person/src/app.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, useMemo, useRef } from "react";
+import { CSSProperties, useMemo, useRef } from "react";
 import { BlockComponent } from "@blockprotocol/graph/react";
 import DOMPurify from "dompurify";
 

--- a/packages/blocks/person/src/dev.tsx
+++ b/packages/blocks/person/src/dev.tsx
@@ -2,8 +2,7 @@
  * webpack-dev-server entry point for debugging.
  * This file is not bundled with the library during the build process.
  */
-import React from "react";
-import ReactDOM from "react-dom";
+import { render } from "react-dom";
 import { MockBlockDock } from "mock-block-dock";
 
 import Component from "./index";
@@ -36,4 +35,4 @@ const App = () => (
   </div>
 );
 
-ReactDOM.render(<App />, node);
+render(<App />, node);

--- a/packages/blocks/person/src/icons/link-icon.tsx
+++ b/packages/blocks/person/src/icons/link-icon.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 export const LinkIcon = () => {
   return (
     <svg

--- a/packages/blocks/person/src/icons/mail-icon.tsx
+++ b/packages/blocks/person/src/icons/mail-icon.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 export const MailIcon = () => {
   return (
     <svg

--- a/packages/blocks/stopwatch/src/app.tsx
+++ b/packages/blocks/stopwatch/src/app.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { BlockComponent } from "blockprotocol/react";
 
 type BlockEntityProperties = {

--- a/packages/blocks/stopwatch/src/dev.tsx
+++ b/packages/blocks/stopwatch/src/dev.tsx
@@ -2,8 +2,7 @@
  * This is the entry point for developing and debugging.
  * This file is not bundled with the block during the build process.
  */
-import React from "react";
-import ReactDOM from "react-dom";
+import { render } from "react-dom";
 
 import { MockBlockDock } from "mock-block-dock";
 
@@ -17,4 +16,4 @@ const App = () => (
   </MockBlockDock>
 );
 
-ReactDOM.render(<App />, node);
+render(<App />, node);

--- a/packages/blocks/table/src/components/editable-cell.tsx
+++ b/packages/blocks/table/src/components/editable-cell.tsx
@@ -1,9 +1,9 @@
-import React, {
+import {
   ChangeEvent,
   useEffect,
   useRef,
   useState,
-  VoidFunctionComponent,
+  FunctionComponent,
 } from "react";
 import { Column, Row } from "react-table";
 import { GraphBlockHandler } from "@blockprotocol/graph";
@@ -18,7 +18,7 @@ type EditableCellProps = {
   updateEntity?: GraphBlockHandler["updateEntity"];
 };
 
-export const EditableCell: VoidFunctionComponent<EditableCellProps> = ({
+export const EditableCell: FunctionComponent<EditableCellProps> = ({
   value: initialValue,
   row,
   column,

--- a/packages/blocks/table/src/components/entity-type-dropdown.tsx
+++ b/packages/blocks/table/src/components/entity-type-dropdown.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
 import { tw } from "twind";
 import { EntityType } from "@blockprotocol/graph";
+import { FunctionComponent } from "react";
 
 type EntityTypeDropdownProps = {
   onChange?: (entityTypeId?: string) => void;
@@ -8,9 +8,11 @@ type EntityTypeDropdownProps = {
   options: EntityType[];
 };
 
-export const EntityTypeDropdown: React.VoidFunctionComponent<
-  EntityTypeDropdownProps
-> = ({ onChange, value, options }) => {
+export const EntityTypeDropdown: FunctionComponent<EntityTypeDropdownProps> = ({
+  onChange,
+  value,
+  options,
+}) => {
   return (
     <select
       onChange={(event) => onChange?.(event.target.value)}

--- a/packages/blocks/table/src/components/filter-detail.tsx
+++ b/packages/blocks/table/src/components/filter-detail.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import {
+  FunctionComponent,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { tw } from "twind";
 import { v4 as uuid } from "uuid";
 import { ColumnInstance } from "react-table";
@@ -59,7 +65,7 @@ type FilterDetailProps = {
   multiFilter: AggregateOperationInput["multiFilter"];
 };
 
-export const FilterDetail: React.VFC<FilterDetailProps> = ({
+export const FilterDetail: FunctionComponent<FilterDetailProps> = ({
   columns,
   onFilter,
   multiFilter,

--- a/packages/blocks/table/src/components/header.tsx
+++ b/packages/blocks/table/src/components/header.tsx
@@ -1,4 +1,4 @@
-import React, { VFC } from "react";
+import { FunctionComponent, ReactNode } from "react";
 import { tw } from "twind";
 import { AggregateOperationInput } from "@blockprotocol/graph";
 import { ColumnInstance } from "react-table";
@@ -17,11 +17,11 @@ type HeaderProps = {
   onAggregate: (args: AggregateArgs) => void;
   toggleHideColumn: (columnId: string) => void;
   aggregateOptions: Pick<AggregateOperationInput, "multiFilter" | "multiSort">;
-  entityTypeDropdown: React.ReactNode;
+  entityTypeDropdown: ReactNode;
   entityTypeId: string;
 };
 
-export const Header: VFC<HeaderProps> = ({
+export const Header: FunctionComponent<HeaderProps> = ({
   onAggregate,
   columns,
   toggleHideColumn,

--- a/packages/blocks/table/src/components/icons.tsx
+++ b/packages/blocks/table/src/components/icons.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import { FunctionComponent } from "react";
 
 type IconProps = {
   className: string;
 };
 
-export const SearchIcon: React.VFC<IconProps> = ({ className }) => {
+export const SearchIcon: FunctionComponent<IconProps> = ({ className }) => {
   return (
     <svg
       width="24"
@@ -33,7 +33,7 @@ export const SearchIcon: React.VFC<IconProps> = ({ className }) => {
   );
 };
 
-export const AddIcon: React.VFC<IconProps> = ({ className }) => {
+export const AddIcon: FunctionComponent<IconProps> = ({ className }) => {
   return (
     <svg
       width="24"

--- a/packages/blocks/table/src/components/menu.tsx
+++ b/packages/blocks/table/src/components/menu.tsx
@@ -1,10 +1,10 @@
-import React, { FC } from "react";
+import { FunctionComponent, ReactNode } from "react";
 import { Popover, Transition } from "@headlessui/react";
 import { tw } from "twind";
 
 type MenuProps = {
   label: string;
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
 /**
@@ -15,7 +15,7 @@ type MenuProps = {
  * @see https://stackoverflow.com/a/6433475/6789071
  */
 
-export const Menu: FC<MenuProps> = ({ children, label }) => {
+export const Menu: FunctionComponent<MenuProps> = ({ children, label }) => {
   return (
     <Popover className={tw`relative z-10`}>
       <Popover.Button

--- a/packages/blocks/table/src/components/pagination.tsx
+++ b/packages/blocks/table/src/components/pagination.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, VFC } from "react";
+import { useCallback, FunctionComponent } from "react";
 import { tw } from "twind";
 
 type PaginationProps = {
@@ -10,7 +10,7 @@ type PaginationProps = {
   isFetching: boolean;
 };
 
-export const Pagination: VFC<PaginationProps> = ({
+export const Pagination: FunctionComponent<PaginationProps> = ({
   pageCount,
   pageNumber,
   pageSize,

--- a/packages/blocks/table/src/components/sort-detail.tsx
+++ b/packages/blocks/table/src/components/sort-detail.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { FunctionComponent, useEffect, useState } from "react";
 import { tw } from "twind";
 import { ColumnInstance } from "react-table";
 import { v4 as uuid } from "uuid";
@@ -19,7 +19,7 @@ type SortFieldsWithId = (NonNullable<
   id: string;
 })[];
 
-export const SortDetail: React.VFC<SortDetailProps> = ({
+export const SortDetail: FunctionComponent<SortDetailProps> = ({
   columns,
   onSort,
   multiSort,

--- a/packages/blocks/table/src/components/toggle-columns-detail.tsx
+++ b/packages/blocks/table/src/components/toggle-columns-detail.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { FunctionComponent } from "react";
 import { ColumnInstance } from "react-table";
 import { tw } from "twind";
 
@@ -7,10 +7,9 @@ type ToggleColumnsDetailProps = {
   toggleHideColumn: (columnId: string, value?: boolean) => void;
 };
 
-export const ToggleColumnsDetail: React.VFC<ToggleColumnsDetailProps> = ({
-  columns,
-  toggleHideColumn,
-}) => {
+export const ToggleColumnsDetail: FunctionComponent<
+  ToggleColumnsDetailProps
+> = ({ columns, toggleHideColumn }) => {
   /**
    * @todo fix issue with the popup closing when the label is clicked on
    * @see https://github.com/tailwindlabs/headlessui/issues/514

--- a/packages/blocks/table/src/dev.tsx
+++ b/packages/blocks/table/src/dev.tsx
@@ -2,8 +2,7 @@
  * webpack-dev-server entry point for debugging.
  * This file is not bundled with the library during the build process.
  */
-import React from "react";
-import ReactDOM from "react-dom";
+import { render } from "react-dom";
 import { MockBlockDock } from "mock-block-dock";
 
 import Component from "./index";
@@ -26,4 +25,4 @@ const App = () => {
   );
 };
 
-ReactDOM.render(<App />, node);
+render(<App />, node);

--- a/packages/blocks/table/src/table.tsx
+++ b/packages/blocks/table/src/table.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   CellProps,
   Renderer,

--- a/packages/blocks/timer/src/app.tsx
+++ b/packages/blocks/timer/src/app.tsx
@@ -1,6 +1,6 @@
 import "./app.scss";
 
-import React, {
+import {
   useState,
   useCallback,
   useMemo,

--- a/packages/blocks/timer/src/app/duration-input.tsx
+++ b/packages/blocks/timer/src/app/duration-input.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   ChangeEventHandler,
   FocusEventHandler,
   KeyboardEventHandler,
@@ -7,7 +7,7 @@ import React, {
   useMemo,
   useRef,
   useState,
-  VoidFunctionComponent,
+  FunctionComponent,
 } from "react";
 import { clamp } from "./clamp";
 
@@ -59,7 +59,7 @@ const convertInputTextsToDurationInMs = (inputTexts: InputTexts): number => {
   return clamp(minutes, [0, 99]) * 60_000 + clamp(seconds, [0, 59]) * 1000;
 };
 
-export const DurationInput: VoidFunctionComponent<DurationInputProps> = ({
+export const DurationInput: FunctionComponent<DurationInputProps> = ({
   value,
   disabled,
   onChange,

--- a/packages/blocks/timer/src/dev.tsx
+++ b/packages/blocks/timer/src/dev.tsx
@@ -2,8 +2,7 @@
  * This is the entry point for developing and debugging.
  * This file is not bundled with the block during the build process.
  */
-import React from "react";
-import ReactDOM from "react-dom";
+import { render } from "react-dom";
 
 import { MockBlockDock } from "mock-block-dock";
 
@@ -22,4 +21,4 @@ const App = () => (
   />
 );
 
-ReactDOM.render(<App />, node);
+render(<App />, node);

--- a/packages/blocks/toggle-item/src/app.tsx
+++ b/packages/blocks/toggle-item/src/app.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { BlockComponent } from "blockprotocol/react";
 

--- a/packages/blocks/toggle-item/src/dev.tsx
+++ b/packages/blocks/toggle-item/src/dev.tsx
@@ -2,8 +2,7 @@
  * This is the entry point for developing and debugging.
  * This file is not bundled with the block during the build process.
  */
-import React from "react";
-import ReactDOM from "react-dom";
+import { render } from "react-dom";
 
 import { MockBlockDock } from "mock-block-dock";
 
@@ -22,4 +21,4 @@ const App = () => (
   </MockBlockDock>
 );
 
-ReactDOM.render(<App />, node);
+render(<App />, node);

--- a/packages/blocks/video/src/components/error-alert.tsx
+++ b/packages/blocks/video/src/components/error-alert.tsx
@@ -1,10 +1,10 @@
-import React, { VFC } from "react";
+import { FunctionComponent } from "react";
 import { tw } from "twind";
 import Cross from "../svgs/cross";
 
 type ImageErrorAlertProps = { error: string | null; onClearError: () => void };
 
-export const ErrorAlert: VFC<ImageErrorAlertProps> = ({
+export const ErrorAlert: FunctionComponent<ImageErrorAlertProps> = ({
   error,
   onClearError,
 }) => (

--- a/packages/blocks/video/src/components/media-with-caption.tsx
+++ b/packages/blocks/video/src/components/media-with-caption.tsx
@@ -1,4 +1,4 @@
-import React, { VFC } from "react";
+import { FunctionComponent } from "react";
 import { tw } from "twind";
 import Pencil from "../svgs/pencil";
 import { ResizeImageBlock } from "./resize-image-block";
@@ -21,7 +21,7 @@ type MediaWithCaptionProps = {
     }
 );
 
-export const MediaWithCaption: VFC<MediaWithCaptionProps> = ({
+export const MediaWithCaption: FunctionComponent<MediaWithCaptionProps> = ({
   caption,
   src,
   onCaptionChange,

--- a/packages/blocks/video/src/components/media.tsx
+++ b/packages/blocks/video/src/components/media.tsx
@@ -14,7 +14,7 @@ import {
   UpdateEntityData,
 } from "@blockprotocol/graph";
 import { useGraphBlockService } from "@blockprotocol/graph/react";
-import React, {
+import {
   Dispatch,
   SetStateAction,
   useCallback,
@@ -22,7 +22,7 @@ import React, {
   useMemo,
   useRef,
   useState,
-  VoidFunctionComponent,
+  FunctionComponent,
 } from "react";
 import { unstable_batchedUpdates } from "react-dom";
 import { ErrorAlert } from "./error-alert";
@@ -124,7 +124,7 @@ const isSingleTargetLink = (link: Link): link is Link => "linkId" in link;
 /**
  * @todo Rewrite the state here to use a reducer, instead of batched updates
  */
-export const Media: VoidFunctionComponent<
+export const Media: FunctionComponent<
   BlockGraphProperties<MediaEntityProperties> & {
     mediaType: "image" | "video";
   }

--- a/packages/blocks/video/src/components/resize-image-block.tsx
+++ b/packages/blocks/video/src/components/resize-image-block.tsx
@@ -1,4 +1,9 @@
-import React, { useLayoutEffect, useRef } from "react";
+import {
+  FunctionComponent,
+  MouseEvent as ReactMouseEvent,
+  useLayoutEffect,
+  useRef,
+} from "react";
 import { tw } from "twind";
 
 type ResizeBlockProps = {
@@ -13,7 +18,7 @@ const MIN_WIDTH = 96;
 
 // @todo set a max-width
 
-export const ResizeImageBlock: React.VFC<ResizeBlockProps> = ({
+export const ResizeImageBlock: FunctionComponent<ResizeBlockProps> = ({
   imageSrc,
   width,
   updateWidth,
@@ -42,10 +47,7 @@ export const ResizeImageBlock: React.VFC<ResizeBlockProps> = ({
     }
   }, [width, imageSrc, updateWidth]);
 
-  const handleResize = (
-    _evt: React.MouseEvent,
-    direction: "left" | "right",
-  ) => {
+  const handleResize = (_evt: ReactMouseEvent, direction: "left" | "right") => {
     function onMouseMove(mouseMoveEvt: MouseEvent) {
       if (!imageRef.current) return;
       let newWidth;

--- a/packages/blocks/video/src/components/resize-image-block.tsx
+++ b/packages/blocks/video/src/components/resize-image-block.tsx
@@ -1,9 +1,4 @@
-import {
-  FunctionComponent,
-  MouseEvent as ReactMouseEvent,
-  useLayoutEffect,
-  useRef,
-} from "react";
+import { FunctionComponent, MouseEvent, useLayoutEffect, useRef } from "react";
 import { tw } from "twind";
 
 type ResizeBlockProps = {
@@ -47,8 +42,8 @@ export const ResizeImageBlock: FunctionComponent<ResizeBlockProps> = ({
     }
   }, [width, imageSrc, updateWidth]);
 
-  const handleResize = (_evt: ReactMouseEvent, direction: "left" | "right") => {
-    function onMouseMove(mouseMoveEvt: MouseEvent) {
+  const handleResize = (_evt: MouseEvent, direction: "left" | "right") => {
+    function onMouseMove(mouseMoveEvt: globalThis.MouseEvent) {
       if (!imageRef.current) return;
       let newWidth;
       const { left, right } = imageRef.current.getBoundingClientRect();

--- a/packages/blocks/video/src/components/upload-media-form.tsx
+++ b/packages/blocks/video/src/components/upload-media-form.tsx
@@ -1,4 +1,4 @@
-import React, { VFC } from "react";
+import { ChangeEvent, FunctionComponent } from "react";
 import { tw } from "twind";
 import Loader from "../svgs/loader";
 
@@ -10,7 +10,7 @@ type UploadMediaFormProps = {
   type: "image" | "video";
 };
 
-export const UploadMediaForm: VFC<UploadMediaFormProps> = ({
+export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
   loading,
   onFileChoose,
   onUrlChange,
@@ -71,7 +71,7 @@ export const UploadMediaForm: VFC<UploadMediaFormProps> = ({
               className={tw`hidden`}
               type="file"
               accept={`${type}/*`}
-              onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+              onChange={(event: ChangeEvent<HTMLInputElement>) =>
                 onFilesChoose(event.target.files)
               }
             />

--- a/packages/blocks/video/src/dev.tsx
+++ b/packages/blocks/video/src/dev.tsx
@@ -3,8 +3,7 @@
  * This file is not bundled with the library during the build process.
  */
 
-import React from "react";
-import ReactDOM from "react-dom";
+import { render } from "react-dom";
 import { MockBlockDock } from "mock-block-dock";
 
 import Component from "./index";
@@ -27,4 +26,4 @@ const App = () => {
   );
 };
 
-ReactDOM.render(<App />, node);
+render(<App />, node);

--- a/packages/blocks/video/src/svgs/cross.tsx
+++ b/packages/blocks/video/src/svgs/cross.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import { FunctionComponent } from "react";
 import { tw } from "twind";
 
-const Cross: React.VoidFunctionComponent = () => {
+const Cross: FunctionComponent = () => {
   return (
     <svg
       className={tw`fill-current h-6 w-6 text-red-500`}

--- a/packages/blocks/video/src/svgs/loader.tsx
+++ b/packages/blocks/video/src/svgs/loader.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import { FunctionComponent } from "react";
 import { tw } from "twind";
 
-const Loader: React.VoidFunctionComponent = () => {
+const Loader: FunctionComponent = () => {
   return (
     <svg
       className={tw`animate-spin h-4 text-white mr-2`}

--- a/packages/blocks/video/src/svgs/pencil.tsx
+++ b/packages/blocks/video/src/svgs/pencil.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import { FunctionComponent } from "react";
 
-const Pencil: React.VoidFunctionComponent = () => {
+const Pencil: FunctionComponent = () => {
   return (
     <svg
       width="24"

--- a/packages/blocks/video/src/video.tsx
+++ b/packages/blocks/video/src/video.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { BlockComponent } from "@blockprotocol/graph/react";
 import { Media, MediaEntityProperties } from "./components/media";
 

--- a/packages/hash/design-system/assets.d.ts
+++ b/packages/hash/design-system/assets.d.ts
@@ -1,5 +1,5 @@
 declare module "*.svg" {
-  const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>;
+  const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement>>;
   // eslint-disable-next-line import/no-default-export -- third-party requirement
   export default ReactComponent;
 }

--- a/packages/hash/design-system/package.json
+++ b/packages/hash/design-system/package.json
@@ -41,7 +41,6 @@
     "eslint-plugin-jsx-a11y": "6.5.1",
     "eslint-plugin-react": "7.29.4",
     "eslint-plugin-react-hooks": "4.4.0",
-    "eslint-plugin-unicorn": "41.0.1",
     "typescript": "4.7.4"
   },
   "peerDependencies": {

--- a/packages/hash/design-system/src/avatar.tsx
+++ b/packages/hash/design-system/src/avatar.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { FunctionComponent } from "react";
 import { Box, BoxProps } from "@mui/material";
 
 interface AvatarProps extends BoxProps {
@@ -7,7 +7,7 @@ interface AvatarProps extends BoxProps {
   src?: string;
 }
 
-export const Avatar: React.VFC<AvatarProps> = ({
+export const Avatar: FunctionComponent<AvatarProps> = ({
   title,
   size = 20,
   src,

--- a/packages/hash/design-system/src/button.tsx
+++ b/packages/hash/design-system/src/button.tsx
@@ -4,24 +4,24 @@ import {
   ButtonProps as MuiButtonProps,
   useTheme,
 } from "@mui/material";
-import * as React from "react";
+import { forwardRef, FunctionComponent, ReactNode, useMemo } from "react";
 import { LoadingSpinner } from "./loading-spinner";
 
 export type ButtonProps = {
-  children: React.ReactNode;
+  children: ReactNode;
   loading?: boolean;
   loadingWithoutText?: boolean;
   disabledTooltipText?: string;
 } & MuiButtonProps & { rel?: string; target?: string }; // MUI button renders <a /> when href is provided, but typings miss rel and target
 
-const LoadingContent: React.VFC<{
+const LoadingContent: FunctionComponent<{
   withText: boolean;
   variant: ButtonProps["variant"];
   size: ButtonProps["size"];
 }> = ({ withText, size, variant = "primary" }) => {
   const theme = useTheme();
 
-  const spinnerSize = React.useMemo(() => {
+  const spinnerSize = useMemo(() => {
     switch (size) {
       case "large":
         return 20;
@@ -34,7 +34,7 @@ const LoadingContent: React.VFC<{
     }
   }, [size]);
 
-  const spinnerColor = React.useMemo(() => {
+  const spinnerColor = useMemo(() => {
     switch (variant) {
       case "tertiary":
       case "tertiary_quiet":
@@ -68,7 +68,7 @@ const LoadingContent: React.VFC<{
   );
 };
 
-export const Button: React.VFC<ButtonProps> = React.forwardRef(
+export const Button: FunctionComponent<ButtonProps> = forwardRef(
   ({ children, loading, loadingWithoutText, sx = [], ...props }, ref) => {
     return (
       <MuiButton

--- a/packages/hash/design-system/src/chip-group.tsx
+++ b/packages/hash/design-system/src/chip-group.tsx
@@ -1,8 +1,8 @@
-import * as React from "react";
+import { Children, forwardRef, FunctionComponent, ReactNode } from "react";
 import { Box, chipClasses, BoxProps } from "@mui/material";
 
 type ChipGroupProps = {
-  children: React.ReactNode;
+  children: ReactNode;
 } & BoxProps;
 
 // @todo consider adding size as a prop to ChipGroup
@@ -13,7 +13,7 @@ type ChipGroupProps = {
 // </ChipGroup>
 //
 
-export const ChipGroup: React.FC<ChipGroupProps> = React.forwardRef(
+export const ChipGroup: FunctionComponent<ChipGroupProps> = forwardRef(
   ({ children }, ref) => {
     return (
       <Box
@@ -26,7 +26,7 @@ export const ChipGroup: React.FC<ChipGroupProps> = React.forwardRef(
           // <ChipGroup>
           //   <Chip />
           // </ChipGroup>
-          ...(React.Children.count(children) > 0 && {
+          ...(Children.count(children) > 0 && {
             [` .${chipClasses.root}`]: {
               "&:not(:last-of-type)": {
                 borderTopRightRadius: 0,

--- a/packages/hash/design-system/src/chip.tsx
+++ b/packages/hash/design-system/src/chip.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
 import {
   Chip as MuiChip,
   chipClasses,
   ChipProps as MuiChipProps,
 } from "@mui/material";
 import { faCircle } from "@fortawesome/free-solid-svg-icons";
+import { forwardRef, FunctionComponent } from "react";
 import { FontAwesomeIcon } from "./fontawesome-icon";
 
 export type ChipProps = {
@@ -18,7 +18,7 @@ export type ChipProps = {
 // is passed in
 // @see https://github.com/mui/material-ui/blob/master/packages/mui-material/src/Chip/Chip.js#L444-L448
 
-export const Chip: React.FC<ChipProps> = React.forwardRef(
+export const Chip: FunctionComponent<ChipProps> = forwardRef(
   (
     {
       sx = [],

--- a/packages/hash/design-system/src/fontawesome-icon.tsx
+++ b/packages/hash/design-system/src/fontawesome-icon.tsx
@@ -7,48 +7,49 @@ type FontAwesomeIconProps = {
 } & SvgIconProps;
 
 // gotten from https://mui.com/components/icons/#font-awesome
-export const FontAwesomeIcon = forwardRef<SVGSVGElement, FontAwesomeIconProps>(
-  (props, ref) => {
-    const { icon, sx = [], ...otherProps } = props;
+export const FontAwesomeIcon = forwardRef<
+  SVGSVGElement,
+  FontAwesomeIconProps // https://github.com/prettier/prettier/issues/11923
+>((props, ref) => {
+  const { icon, sx = [], ...otherProps } = props;
 
-    const {
-      icon: [width, height, , , svgPathData],
-    } = icon;
+  const {
+    icon: [width, height, , , svgPathData],
+  } = icon;
 
-    return (
-      <SvgIcon
-        ref={ref}
-        viewBox={`0 0 ${width} ${height}`}
-        sx={[
-          {
-            color: "currentColor",
-            width: "1em",
-            height: "1em",
-            fontSize: "16px",
-          },
-          ...(Array.isArray(sx) ? sx : [sx]),
-        ]}
-        {...otherProps}
-      >
-        {typeof svgPathData === "string" ? (
-          <path d={svgPathData} />
-        ) : (
-          /**
-           * A multi-path Font Awesome icon seems to imply a duotune icon. The 0th path seems to
-           * be the faded element (referred to as the "secondary" path in the Font Awesome docs)
-           * of a duotone icon. 40% is the default opacity.
-           *
-           * @see https://fontawesome.com/how-to-use/on-the-web/styling/duotone-icons#changing-opacity
-           */
-          svgPathData.map((pathData: string, i: number) => (
-            <path
-              key={pathData}
-              style={{ opacity: i === 0 ? 0.4 : 1 }}
-              d={pathData}
-            />
-          ))
-        )}
-      </SvgIcon>
-    );
-  },
-);
+  return (
+    <SvgIcon
+      ref={ref}
+      viewBox={`0 0 ${width} ${height}`}
+      sx={[
+        {
+          color: "currentColor",
+          width: "1em",
+          height: "1em",
+          fontSize: "16px",
+        },
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
+      {...otherProps}
+    >
+      {typeof svgPathData === "string" ? (
+        <path d={svgPathData} />
+      ) : (
+        /**
+         * A multi-path Font Awesome icon seems to imply a duotune icon. The 0th path seems to
+         * be the faded element (referred to as the "secondary" path in the Font Awesome docs)
+         * of a duotone icon. 40% is the default opacity.
+         *
+         * @see https://fontawesome.com/how-to-use/on-the-web/styling/duotone-icons#changing-opacity
+         */
+        svgPathData.map((pathData: string, i: number) => (
+          <path
+            key={pathData}
+            style={{ opacity: i === 0 ? 0.4 : 1 }}
+            d={pathData}
+          />
+        ))
+      )}
+    </SvgIcon>
+  );
+});

--- a/packages/hash/design-system/src/fontawesome-icon.tsx
+++ b/packages/hash/design-system/src/fontawesome-icon.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { forwardRef } from "react";
 import { SvgIcon, SvgIconProps } from "@mui/material";
 import { IconDefinition } from "@fortawesome/free-solid-svg-icons";
 
@@ -7,49 +7,48 @@ type FontAwesomeIconProps = {
 } & SvgIconProps;
 
 // gotten from https://mui.com/components/icons/#font-awesome
-export const FontAwesomeIcon = React.forwardRef<
-  SVGSVGElement,
-  FontAwesomeIconProps
->((props, ref) => {
-  const { icon, sx = [], ...otherProps } = props;
+export const FontAwesomeIcon = forwardRef<SVGSVGElement, FontAwesomeIconProps>(
+  (props, ref) => {
+    const { icon, sx = [], ...otherProps } = props;
 
-  const {
-    icon: [width, height, , , svgPathData],
-  } = icon;
+    const {
+      icon: [width, height, , , svgPathData],
+    } = icon;
 
-  return (
-    <SvgIcon
-      ref={ref}
-      viewBox={`0 0 ${width} ${height}`}
-      sx={[
-        {
-          color: "currentColor",
-          width: "1em",
-          height: "1em",
-          fontSize: "16px",
-        },
-        ...(Array.isArray(sx) ? sx : [sx]),
-      ]}
-      {...otherProps}
-    >
-      {typeof svgPathData === "string" ? (
-        <path d={svgPathData} />
-      ) : (
-        /**
-         * A multi-path Font Awesome icon seems to imply a duotune icon. The 0th path seems to
-         * be the faded element (referred to as the "secondary" path in the Font Awesome docs)
-         * of a duotone icon. 40% is the default opacity.
-         *
-         * @see https://fontawesome.com/how-to-use/on-the-web/styling/duotone-icons#changing-opacity
-         */
-        svgPathData.map((pathData: string, i: number) => (
-          <path
-            key={pathData}
-            style={{ opacity: i === 0 ? 0.4 : 1 }}
-            d={pathData}
-          />
-        ))
-      )}
-    </SvgIcon>
-  );
-});
+    return (
+      <SvgIcon
+        ref={ref}
+        viewBox={`0 0 ${width} ${height}`}
+        sx={[
+          {
+            color: "currentColor",
+            width: "1em",
+            height: "1em",
+            fontSize: "16px",
+          },
+          ...(Array.isArray(sx) ? sx : [sx]),
+        ]}
+        {...otherProps}
+      >
+        {typeof svgPathData === "string" ? (
+          <path d={svgPathData} />
+        ) : (
+          /**
+           * A multi-path Font Awesome icon seems to imply a duotune icon. The 0th path seems to
+           * be the faded element (referred to as the "secondary" path in the Font Awesome docs)
+           * of a duotone icon. 40% is the default opacity.
+           *
+           * @see https://fontawesome.com/how-to-use/on-the-web/styling/duotone-icons#changing-opacity
+           */
+          svgPathData.map((pathData: string, i: number) => (
+            <path
+              key={pathData}
+              style={{ opacity: i === 0 ? 0.4 : 1 }}
+              d={pathData}
+            />
+          ))
+        )}
+      </SvgIcon>
+    );
+  },
+);

--- a/packages/hash/design-system/src/form-inline.tsx
+++ b/packages/hash/design-system/src/form-inline.tsx
@@ -1,8 +1,8 @@
-import * as React from "react";
+import { FunctionComponent, ReactNode } from "react";
 import { Box, buttonClasses, outlinedInputClasses } from "@mui/material";
 
 type FormInlineProps = {
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
 /**
@@ -13,7 +13,9 @@ type FormInlineProps = {
  * </FormInline>
  * @see https://www.figma.com/file/gydVGka9FjNEg9E2STwhi2/HASH-Editor?node-id=823%3A67158
  */
-export const FormInline: React.FC<FormInlineProps> = ({ children }) => {
+export const FormInline: FunctionComponent<FormInlineProps> = ({
+  children,
+}) => {
   return (
     <Box
       sx={{

--- a/packages/hash/design-system/src/icon-button.tsx
+++ b/packages/hash/design-system/src/icon-button.tsx
@@ -1,16 +1,15 @@
 import {
-  /* eslint-disable-next-line -- allow import of original icon button to extend it */
   IconButton as MuiIconButton,
   IconButtonProps as MuiIconButtonProps,
 } from "@mui/material";
-import * as React from "react";
+import { forwardRef, FunctionComponent } from "react";
 
 export type IconButtonProps = {
   unpadded?: boolean;
   rounded?: boolean;
 } & MuiIconButtonProps;
 
-export const IconButton: React.FC<IconButtonProps> = React.forwardRef(
+export const IconButton: FunctionComponent<IconButtonProps> = forwardRef(
   ({ children, unpadded, rounded, sx = [], ...props }, ref) => {
     return (
       <MuiIconButton

--- a/packages/hash/design-system/src/loading-spinner.tsx
+++ b/packages/hash/design-system/src/loading-spinner.tsx
@@ -1,5 +1,5 @@
 import { Box, CircularProgress, circularProgressClasses } from "@mui/material";
-import * as React from "react";
+import { FunctionComponent } from "react";
 
 const DEFAULT_THICKNESS = 5;
 const DEFAULT_SIZE = 20;
@@ -10,7 +10,7 @@ type LoadingSpinnerProps = {
   color?: string;
 };
 
-export const LoadingSpinner: React.VFC<LoadingSpinnerProps> = ({
+export const LoadingSpinner: FunctionComponent<LoadingSpinnerProps> = ({
   size = DEFAULT_SIZE,
   thickness = DEFAULT_THICKNESS,
   color = "currentColor",

--- a/packages/hash/design-system/src/menu-checkbox-item.tsx
+++ b/packages/hash/design-system/src/menu-checkbox-item.tsx
@@ -1,12 +1,12 @@
 import { Checkbox, ListItemIcon } from "@mui/material";
-import * as React from "react";
+import { forwardRef, ForwardRefRenderFunction, ReactNode } from "react";
 import { MenuItem, MenuItemProps } from "./menu-item";
 
 export type MenuCheckboxItemProps = {
-  children?: React.ReactNode;
+  children?: ReactNode;
 } & Omit<MenuItemProps, "noSelectBackground">;
 
-const MenuCheckboxItem: React.ForwardRefRenderFunction<
+const MenuCheckboxItem: ForwardRefRenderFunction<
   HTMLLIElement,
   MenuCheckboxItemProps
 > = ({ selected, children, ...props }, ref) => {
@@ -20,6 +20,6 @@ const MenuCheckboxItem: React.ForwardRefRenderFunction<
   );
 };
 
-const MenuCheckboxItemForwardRef = React.forwardRef(MenuCheckboxItem);
+const MenuCheckboxItemForwardRef = forwardRef(MenuCheckboxItem);
 
 export { MenuCheckboxItemForwardRef as MenuCheckboxItem };

--- a/packages/hash/design-system/src/menu-item.tsx
+++ b/packages/hash/design-system/src/menu-item.tsx
@@ -5,15 +5,15 @@ import {
   MenuItemProps as MuiMenuItemProps,
   typographyClasses,
 } from "@mui/material";
-import * as React from "react";
+import { forwardRef, FunctionComponent, ReactNode } from "react";
 
 export type MenuItemProps = {
-  children?: React.ReactNode;
+  children?: ReactNode;
   faded?: boolean;
   noSelectBackground?: boolean;
 } & MuiMenuItemProps;
 
-export const MenuItem: React.VFC<MenuItemProps> = React.forwardRef(
+export const MenuItem: FunctionComponent<MenuItemProps> = forwardRef(
   (
     { children, sx = [], faded, selected, noSelectBackground, ...props },
     ref,

--- a/packages/hash/design-system/src/popover.tsx
+++ b/packages/hash/design-system/src/popover.tsx
@@ -1,11 +1,11 @@
 import { Popover as MuiPopover, PopoverProps } from "@mui/material";
-import React from "react";
+import { FunctionComponent } from "react";
 import { useScrollLock } from "./use-scroll-lock";
 
 /**
  * Custom Popover re-implementing MUI's troublesome scroll-lock mechanism.
  */
-export const Popover: React.FC<PopoverProps> = ({
+export const Popover: FunctionComponent<PopoverProps> = ({
   disableScrollLock = false,
   ...props
 }) => {

--- a/packages/hash/design-system/src/select.tsx
+++ b/packages/hash/design-system/src/select.tsx
@@ -10,7 +10,7 @@ import {
   SelectProps as MuiSelectProps,
   Typography,
 } from "@mui/material";
-import React, { forwardRef, ReactNode, Ref, ReactElement } from "react";
+import { forwardRef, ReactNode, Ref, ReactElement } from "react";
 import { FontAwesomeIcon } from "./fontawesome-icon";
 
 export type SelectProps<T = unknown> = {

--- a/packages/hash/design-system/src/submit-button-wrapper.tsx
+++ b/packages/hash/design-system/src/submit-button-wrapper.tsx
@@ -12,7 +12,7 @@ import {
   styled,
   Collapse,
 } from "@mui/material";
-import * as React from "react";
+import { forwardRef, FunctionComponent } from "react";
 import { FontAwesomeIcon } from "./fontawesome-icon";
 
 const DisabledTooltip = styled(({ className, ...props }: TooltipProps) => (
@@ -35,8 +35,8 @@ export type SubmitButtonWrapperProps = {
   helperText: string;
 } & BoxProps;
 
-export const SubmitButtonWrapper: React.FC<SubmitButtonWrapperProps> =
-  React.forwardRef(({ children, useTooltip, helperText, ...props }, ref) => {
+export const SubmitButtonWrapper: FunctionComponent<SubmitButtonWrapperProps> =
+  forwardRef(({ children, useTooltip, helperText, ...props }, ref) => {
     if (useTooltip && helperText) {
       return (
         <DisabledTooltip

--- a/packages/hash/design-system/src/text-field.tsx
+++ b/packages/hash/design-system/src/text-field.tsx
@@ -11,7 +11,7 @@ import {
   TextFieldProps as MuiTextFieldProps,
   Typography,
 } from "@mui/material";
-import { forwardRef, VFC } from "react";
+import { forwardRef, FunctionComponent } from "react";
 import { FontAwesomeIcon } from "./fontawesome-icon";
 
 type TextFieldProps = {
@@ -20,7 +20,7 @@ type TextFieldProps = {
   autoResize?: boolean;
 } & MuiTextFieldProps;
 
-export const TextField: VFC<TextFieldProps> = forwardRef(
+export const TextField: FunctionComponent<TextFieldProps> = forwardRef(
   (
     {
       helperText,

--- a/packages/hash/design-system/src/theme-override.d.ts
+++ b/packages/hash/design-system/src/theme-override.d.ts
@@ -1,4 +1,5 @@
 import { Components } from "@mui/material";
+import { CSSProperties } from "react";
 
 declare module "@mui/material/styles" {
   interface ShadowSizes {
@@ -65,39 +66,39 @@ declare module "@mui/material/styles" {
   }
 
   interface TypographyVariants {
-    title: React.CSSProperties;
-    h1: React.CSSProperties;
-    h2: React.CSSProperties;
-    h3: React.CSSProperties;
-    h4: React.CSSProperties;
-    h5: React.CSSProperties;
-    mediumCaps: React.CSSProperties;
-    smallCaps: React.CSSProperties;
-    largeTextLabels: React.CSSProperties;
-    regularTextPages: React.CSSProperties;
-    regularTextParagraphs: React.CSSProperties;
-    regularTextLabels: React.CSSProperties;
-    smallTextParagraphs: React.CSSProperties;
-    smallTextLabels: React.CSSProperties;
-    microText: React.CSSProperties;
+    title: CSSProperties;
+    h1: CSSProperties;
+    h2: CSSProperties;
+    h3: CSSProperties;
+    h4: CSSProperties;
+    h5: CSSProperties;
+    mediumCaps: CSSProperties;
+    smallCaps: CSSProperties;
+    largeTextLabels: CSSProperties;
+    regularTextPages: CSSProperties;
+    regularTextParagraphs: CSSProperties;
+    regularTextLabels: CSSProperties;
+    smallTextParagraphs: CSSProperties;
+    smallTextLabels: CSSProperties;
+    microText: CSSProperties;
   }
 
   interface TypographyVariantsOptions {
-    title?: React.CSSProperties;
-    h1?: React.CSSProperties;
-    h2?: React.CSSProperties;
-    h3?: React.CSSProperties;
-    h4?: React.CSSProperties;
-    h5?: React.CSSProperties;
-    mediumCaps?: React.CSSProperties;
-    smallCaps?: React.CSSProperties;
-    largeTextLabels?: React.CSSProperties;
-    regularTextPages?: React.CSSProperties;
-    regularTextParagraphs?: React.CSSProperties;
-    regularTextLabels?: React.CSSProperties;
-    smallTextParagraphs?: React.CSSProperties;
-    smallTextLabels?: React.CSSProperties;
-    microText?: React.CSSProperties;
+    title?: CSSProperties;
+    h1?: CSSProperties;
+    h2?: CSSProperties;
+    h3?: CSSProperties;
+    h4?: CSSProperties;
+    h5?: CSSProperties;
+    mediumCaps?: CSSProperties;
+    smallCaps?: CSSProperties;
+    largeTextLabels?: CSSProperties;
+    regularTextPages?: CSSProperties;
+    regularTextParagraphs?: CSSProperties;
+    regularTextLabels?: CSSProperties;
+    smallTextParagraphs?: CSSProperties;
+    smallTextLabels?: CSSProperties;
+    microText?: CSSProperties;
   }
 }
 

--- a/packages/hash/design-system/src/theme/components/data-display/mui-chip-theme-options.tsx
+++ b/packages/hash/design-system/src/theme/components/data-display/mui-chip-theme-options.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { faClose } from "@fortawesome/free-solid-svg-icons";
 import { Box, ChipProps, Components, PaletteValue, Theme } from "@mui/material";
 import { FontAwesomeIcon } from "../../../fontawesome-icon";

--- a/packages/hash/design-system/src/theme/components/inputs/mui-checkbox-theme-options.tsx
+++ b/packages/hash/design-system/src/theme/components/inputs/mui-checkbox-theme-options.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Components, Theme, svgIconClasses } from "@mui/material";
 import { CheckboxBlankIcon } from "./mui-checkbox-theme-options/checkbox-blank-icon";
 import { CheckboxIcon } from "./mui-checkbox-theme-options/checkbox-icon";

--- a/packages/hash/design-system/src/theme/components/inputs/mui-checkbox-theme-options/checkbox-blank-icon.tsx
+++ b/packages/hash/design-system/src/theme/components/inputs/mui-checkbox-theme-options/checkbox-blank-icon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
+import { FunctionComponent } from "react";
 import { SvgIcon, SvgIconProps } from "@mui/material";
 
-export const CheckboxBlankIcon: React.FC<SvgIconProps> = ({
+export const CheckboxBlankIcon: FunctionComponent<SvgIconProps> = ({
   sx = [],
   ...otherProps
 }) => {

--- a/packages/hash/design-system/src/theme/components/inputs/mui-checkbox-theme-options/checkbox-icon.tsx
+++ b/packages/hash/design-system/src/theme/components/inputs/mui-checkbox-theme-options/checkbox-icon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
+import { FunctionComponent } from "react";
 import { SvgIcon, SvgIconProps } from "@mui/material";
 
-export const CheckboxIcon: React.FC<SvgIconProps> = ({
+export const CheckboxIcon: FunctionComponent<SvgIconProps> = ({
   sx = [],
   ...otherProps
 }) => {

--- a/packages/hash/design-system/src/theme/components/inputs/mui-radio-theme-options.tsx
+++ b/packages/hash/design-system/src/theme/components/inputs/mui-radio-theme-options.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Components, Theme } from "@mui/material";
 import { RadioCheckedIcon } from "./mui-radio-theme-options/radio-checked-icon";
 import { RadioUncheckedIcon } from "./mui-radio-theme-options/radio-unchecked-icon";

--- a/packages/hash/design-system/src/theme/components/inputs/mui-radio-theme-options/radio-checked-icon.tsx
+++ b/packages/hash/design-system/src/theme/components/inputs/mui-radio-theme-options/radio-checked-icon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
+import { FunctionComponent } from "react";
 import { SvgIcon, SvgIconProps } from "@mui/material";
 
-export const RadioCheckedIcon: React.FC<SvgIconProps> = ({
+export const RadioCheckedIcon: FunctionComponent<SvgIconProps> = ({
   sx = [],
   ...otherProps
 }) => {

--- a/packages/hash/design-system/src/theme/components/inputs/mui-radio-theme-options/radio-unchecked-icon.tsx
+++ b/packages/hash/design-system/src/theme/components/inputs/mui-radio-theme-options/radio-unchecked-icon.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
+import { FunctionComponent } from "react";
 import { SvgIcon, SvgIconProps } from "@mui/material";
 
-export const RadioUncheckedIcon: React.FC<SvgIconProps> = ({
+export const RadioUncheckedIcon: FunctionComponent<SvgIconProps> = ({
   sx = [],
   ...otherProps
 }) => {

--- a/packages/hash/design-system/src/theme/components/inputs/mui-select-theme-options.tsx
+++ b/packages/hash/design-system/src/theme/components/inputs/mui-select-theme-options.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { faAngleDown } from "@fortawesome/free-solid-svg-icons";
 import {
   Components,

--- a/packages/hash/frontend/assets.d.ts
+++ b/packages/hash/frontend/assets.d.ts
@@ -1,5 +1,5 @@
 declare module "*.svg" {
-  const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>;
+  const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement>>;
   // eslint-disable-next-line import/no-default-export -- third-party requirement
   export default ReactComponent;
 }

--- a/packages/hash/frontend/package.json
+++ b/packages/hash/frontend/package.json
@@ -124,7 +124,6 @@
     "eslint-plugin-jsx-a11y": "6.5.1",
     "eslint-plugin-react": "7.29.4",
     "eslint-plugin-react-hooks": "4.4.0",
-    "eslint-plugin-unicorn": "41.0.1",
     "html-webpack-plugin": "5.5.0",
     "identity-obj-proxy": "3.0.0",
     "jest": "28.1.2",

--- a/packages/hash/frontend/src/blocks/onBlockLoaded.tsx
+++ b/packages/hash/frontend/src/blocks/onBlockLoaded.tsx
@@ -1,5 +1,6 @@
 import {
   createContext,
+  FunctionComponent,
   ReactNode,
   useCallback,
   useContext,
@@ -17,10 +18,9 @@ type BlockLoadedProviderProps = {
   routeHash: string;
 };
 
-export const BlockLoadedProvider: React.FC<BlockLoadedProviderProps> = ({
-  routeHash,
-  children,
-}) => {
+export const BlockLoadedProvider: FunctionComponent<
+  BlockLoadedProviderProps
+> = ({ routeHash, children }) => {
   const scrollingComplete = useRef(false);
   const scrollFrameRequestIdRef = useRef<ReturnType<
     typeof requestAnimationFrame

--- a/packages/hash/frontend/src/blocks/page/BlockConfigMenu/BlockConfigMenu.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockConfigMenu/BlockConfigMenu.tsx
@@ -9,7 +9,7 @@ import {
   useEffect,
   useRef,
   useState,
-  VoidFunctionComponent,
+  FunctionComponent,
 } from "react";
 import { BlockEntity } from "@hashintel/hash-shared/entity";
 import { JsonSchema } from "@hashintel/hash-shared/json-utils";
@@ -40,7 +40,7 @@ const resolvePropertySchema = (
  * This is a temporary implementation of 'provide an input based on a property schema'
  * We will need a more comprehensive implementation for the full entity editor
  */
-const ConfigurationInput: VoidFunctionComponent<{
+const ConfigurationInput: FunctionComponent<{
   name: string;
   onChange: (value: any) => void;
   rootSchema: JsonSchema;
@@ -180,7 +180,7 @@ type BlockConfigMenuProps = {
  * Useful for when the block doesn't provide the UI to do so itself.
  * Only the properties listed in the block's schema as 'configProperties' are shown.
  */
-export const BlockConfigMenu: VoidFunctionComponent<BlockConfigMenuProps> = ({
+export const BlockConfigMenu: FunctionComponent<BlockConfigMenuProps> = ({
   anchorRef,
   blockEntity,
   blockSchema,

--- a/packages/hash/frontend/src/blocks/page/BlockContext.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockContext.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import { createContext, useContext } from "react";
 
 type BlockContextType = {
   id: string;
@@ -6,7 +6,7 @@ type BlockContextType = {
   setError: (error: boolean) => void;
 };
 
-export const BlockContext = React.createContext<BlockContextType | null>(null);
+export const BlockContext = createContext<BlockContextType | null>(null);
 
 export const useBlockContext = () => {
   const blockContext = useContext(BlockContext);

--- a/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockContextMenu.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockContextMenu.tsx
@@ -1,9 +1,4 @@
-import React, {
-  useRef,
-  forwardRef,
-  useMemo,
-  ForwardRefRenderFunction,
-} from "react";
+import { useRef, forwardRef, useMemo, ForwardRefRenderFunction } from "react";
 
 import { useKey } from "rooks";
 

--- a/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockContextMenuItem.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockContextMenuItem.tsx
@@ -10,6 +10,7 @@ import HoverPopover from "material-ui-popup-state/HoverPopover";
 import {
   cloneElement,
   forwardRef,
+  ReactElement,
   RefObject,
   useLayoutEffect,
   useRef,
@@ -21,9 +22,9 @@ import { MenuItem } from "../../../shared/ui";
 type BlockContextMenuItemProps = {
   itemKey: string;
   onClick?: () => void;
-  icon: JSX.Element;
+  icon: ReactElement;
   title: string;
-  subMenu?: JSX.Element;
+  subMenu?: ReactElement;
   subMenuWidth?: number;
 };
 

--- a/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockContextMenuUtils.ts
+++ b/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockContextMenuUtils.ts
@@ -1,3 +1,4 @@
+import { ReactElement } from "react";
 import { tw } from "twind";
 
 export type MenuState = {
@@ -11,7 +12,7 @@ export type ItemClickMethod = (key: string) => void;
 export type MenuItemType = {
   key: string;
   title: string;
-  icon: JSX.Element;
+  icon: ReactElement;
 };
 
 export const iconStyles = tw`!text-base mr-1`;

--- a/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockListMenuContent.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockListMenuContent.tsx
@@ -8,7 +8,7 @@ import {
   Typography,
 } from "@mui/material";
 import { PopupState } from "material-ui-popup-state/core";
-import { useRef, useState, VFC } from "react";
+import { useRef, useState, FunctionComponent } from "react";
 import { TextField, FontAwesomeIcon } from "@hashintel/hash-design-system";
 import { BlockSuggesterProps } from "../createSuggester/BlockSuggester";
 import { useFilteredBlocks } from "../createSuggester/useFilteredBlocks";
@@ -20,10 +20,9 @@ type BlockListMenuContentProps = {
   blockSuggesterProps: BlockSuggesterProps;
 };
 
-export const BlockListMenuContent: VFC<BlockListMenuContentProps> = ({
-  blockSuggesterProps,
-  popupState,
-}) => {
+export const BlockListMenuContent: FunctionComponent<
+  BlockListMenuContentProps
+> = ({ blockSuggesterProps, popupState }) => {
   const [searchQuery, setSearchQuery] = useState("");
   const searchInputRef = useRef<HTMLInputElement>(null);
   const { value: userBlocks } = useUserBlocks();

--- a/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockLoaderInput.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockLoaderInput.tsx
@@ -1,5 +1,5 @@
 import { Box, Collapse } from "@mui/material";
-import React, { useState, useRef, FormEvent } from "react";
+import { useState, useRef, FormEvent, FunctionComponent } from "react";
 import { unstable_batchedUpdates } from "react-dom";
 
 import { TextField } from "@hashintel/hash-design-system";
@@ -14,7 +14,7 @@ type BlockLoaderInputProps = {
   onLoad: () => void;
 };
 
-export const BlockLoaderInput: React.VFC<BlockLoaderInputProps> = ({
+export const BlockLoaderInput: FunctionComponent<BlockLoaderInputProps> = ({
   onLoad,
 }) => {
   const blockView = useBlockView();

--- a/packages/hash/frontend/src/blocks/page/BlockContextMenu/LoadEntityMenuContent.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockContextMenu/LoadEntityMenuContent.tsx
@@ -9,7 +9,13 @@ import {
   MenuList,
 } from "@mui/material";
 import { PopupState } from "material-ui-popup-state/core";
-import { useCallback, useEffect, useMemo, useRef, VFC } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  FunctionComponent,
+} from "react";
 import { BlockEntity } from "@hashintel/hash-shared/entity";
 import { EntityFieldsFragment } from "@hashintel/hash-shared/graphql/apiTypes.gen";
 import {
@@ -27,10 +33,9 @@ type LoadEntityMenuContentProps = {
   popupState?: PopupState;
 };
 
-export const LoadEntityMenuContent: VFC<LoadEntityMenuContentProps> = ({
-  entityId,
-  popupState,
-}) => {
+export const LoadEntityMenuContent: FunctionComponent<
+  LoadEntityMenuContentProps
+> = ({ entityId, popupState }) => {
   const { accountId } = useRouteAccountInfo();
   const blockView = useBlockView();
   // This depends on state external to react without subscribing to it

--- a/packages/hash/frontend/src/blocks/page/BlockViewContext.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockViewContext.tsx
@@ -1,11 +1,11 @@
-import React, { useContext } from "react";
+import { createContext, useContext } from "react";
 import type { BlockView } from "./BlockView";
 
 /** used to detect whether or not a context value was provided */
 const nullBlockView = {};
 
 /** used to hold the blockView instance */
-export const BlockViewContext = React.createContext<BlockView>(
+export const BlockViewContext = createContext<BlockView>(
   nullBlockView as BlockView,
 );
 

--- a/packages/hash/frontend/src/blocks/page/CollabPositionIndicator.tsx
+++ b/packages/hash/frontend/src/blocks/page/CollabPositionIndicator.tsx
@@ -1,18 +1,16 @@
 import { motion } from "framer-motion";
-import { FC } from "react";
+import { FunctionComponent, ReactNode } from "react";
 import { tw } from "twind";
 
 interface CollabPositionIndicatorProps {
   backgroundColor: string;
   title: string;
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
-export const CollabPositionIndicator: FC<CollabPositionIndicatorProps> = ({
-  backgroundColor,
-  title,
-  children,
-}) => (
+export const CollabPositionIndicator: FunctionComponent<
+  CollabPositionIndicatorProps
+> = ({ backgroundColor, title, children }) => (
   <motion.div
     initial={{
       opacity: 0,

--- a/packages/hash/frontend/src/blocks/page/CollabPositionIndicators.tsx
+++ b/packages/hash/frontend/src/blocks/page/CollabPositionIndicators.tsx
@@ -1,6 +1,6 @@
 import { CollabPosition } from "@hashintel/hash-shared/collab";
 import { AnimatePresence, motion } from "framer-motion";
-import { useMemo, VFC } from "react";
+import { useMemo, FunctionComponent } from "react";
 import { tw } from "twind";
 import { useCollabPositionContext } from "../../contexts/CollabPositionContext";
 import { CollabPositionIndicator } from "./CollabPositionIndicator";
@@ -20,9 +20,9 @@ interface CollabPositionIndicatorsProps {
   blockEntityId: string | null;
 }
 
-export const CollabPositionIndicators: VFC<CollabPositionIndicatorsProps> = ({
-  blockEntityId,
-}) => {
+export const CollabPositionIndicators: FunctionComponent<
+  CollabPositionIndicatorsProps
+> = ({ blockEntityId }) => {
   const collabPositions = useCollabPositionContext();
 
   const relevantPresenceIndicators: CollabPosition[] = useMemo(

--- a/packages/hash/frontend/src/blocks/page/MentionView/MentionDisplay.tsx
+++ b/packages/hash/frontend/src/blocks/page/MentionView/MentionDisplay.tsx
@@ -1,4 +1,4 @@
-import { useMemo, VFC } from "react";
+import { useMemo, FunctionComponent } from "react";
 import { tw } from "twind";
 import ArticleIcon from "@mui/icons-material/Article";
 
@@ -12,7 +12,7 @@ interface MentionDisplayProps {
   accountId: string;
 }
 
-export const MentionDisplay: VFC<MentionDisplayProps> = ({
+export const MentionDisplay: FunctionComponent<MentionDisplayProps> = ({
   entityId,
   mentionType,
   accountId,

--- a/packages/hash/frontend/src/blocks/page/PageBlock.tsx
+++ b/packages/hash/frontend/src/blocks/page/PageBlock.tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 import { Schema } from "prosemirror-model";
 import { EditorView } from "prosemirror-view";
 import "prosemirror-view/style/prosemirror.css";
-import React, { useLayoutEffect, useRef, VoidFunctionComponent } from "react";
+import { useLayoutEffect, useRef, FunctionComponent } from "react";
 import { useLocalstorageState } from "rooks";
 
 import { Button } from "@hashintel/hash-design-system";
@@ -25,7 +25,7 @@ type PageBlockProps = {
  * rendering child blocks from this and have a renderer, but it seems tricky to
  * do that
  */
-export const PageBlock: VoidFunctionComponent<PageBlockProps> = ({
+export const PageBlock: FunctionComponent<PageBlockProps> = ({
   blocksMeta,
   accountId,
   entityId,

--- a/packages/hash/frontend/src/blocks/page/PageTitle.tsx
+++ b/packages/hash/frontend/src/blocks/page/PageTitle.tsx
@@ -1,10 +1,10 @@
-import React, {
+import {
   ChangeEventHandler,
   FocusEventHandler,
   KeyboardEventHandler,
   useEffect,
   useState,
-  VoidFunctionComponent,
+  FunctionComponent,
 } from "react";
 import { tw } from "twind";
 import { useBlockProtocolUpdateEntity } from "../../components/hooks/blockProtocolFunctions/useBlockProtocolUpdateEntity";
@@ -23,7 +23,7 @@ const cleanUpTitle = (value: string): string =>
   value.trim().replace(/\s+/g, " ");
 
 // TODO: Add read-only mode based on page permissions
-export const PageTitle: VoidFunctionComponent<PageTitleProps> = ({
+export const PageTitle: FunctionComponent<PageTitleProps> = ({
   accountId,
   entityId,
   value,

--- a/packages/hash/frontend/src/blocks/page/createErrorPlugin.tsx
+++ b/packages/hash/frontend/src/blocks/page/createErrorPlugin.tsx
@@ -1,14 +1,14 @@
 import { Box, Dialog, Stack, Typography } from "@mui/material";
 import { Schema } from "prosemirror-model";
 import { Plugin, PluginKey, Transaction } from "prosemirror-state";
-import { VFC } from "react";
+import { FunctionComponent } from "react";
 import { Button } from "@hashintel/hash-design-system";
 import { ensureMounted } from "../../lib/dom";
 import { RenderPortal } from "./usePortals";
 
 type ErrorProps = { errored: boolean };
 
-const ErrorView: VFC<ErrorProps> = ({ errored }) => {
+const ErrorView: FunctionComponent<ErrorProps> = ({ errored }) => {
   return (
     <Dialog open={errored} maxWidth="md">
       <Box p={10} textAlign="center">

--- a/packages/hash/frontend/src/blocks/page/createFormatPlugins/LinkModal.tsx
+++ b/packages/hash/frontend/src/blocks/page/createFormatPlugins/LinkModal.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useRef, useState } from "react";
+import { FormEvent, FunctionComponent, useRef, useState } from "react";
 import { tw } from "twind";
 import LanguageIcon from "@mui/icons-material/Language";
 import DeleteIcon from "@mui/icons-material/Delete";
@@ -11,7 +11,7 @@ type LinkModalProps = {
   removeLink: () => void;
 };
 
-export const LinkModal: React.VFC<LinkModalProps> = ({
+export const LinkModal: FunctionComponent<LinkModalProps> = ({
   savedLinkMarkHref,
   updateLink,
   removeLink,

--- a/packages/hash/frontend/src/blocks/page/createFormatPlugins/MarksTooltip.tsx
+++ b/packages/hash/frontend/src/blocks/page/createFormatPlugins/MarksTooltip.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { FunctionComponent } from "react";
 import { tw } from "twind";
 import { DropdownIcon } from "../../../shared/icons";
 
@@ -28,7 +28,7 @@ const marks = [
   },
 ];
 
-export const MarksTooltip: React.VFC<MarksTooltipProps> = ({
+export const MarksTooltip: FunctionComponent<MarksTooltipProps> = ({
   activeMarks,
   toggleMark,
   focusEditorView,

--- a/packages/hash/frontend/src/blocks/page/createFormatPlugins/index.tsx
+++ b/packages/hash/frontend/src/blocks/page/createFormatPlugins/index.tsx
@@ -8,8 +8,8 @@ import {
   PluginKey,
 } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
-import React from "react";
 import { tw } from "twind";
+import { createRef } from "react";
 import { RenderPortal } from "../usePortals";
 import { ensureMounted } from "../../../lib/dom";
 import { MarksTooltip } from "./MarksTooltip";
@@ -38,7 +38,7 @@ const linkPluginKey = new PluginKey<LinkPluginState, Schema>("linkPlugin");
 export function createFormatPlugins(renderPortal: RenderPortal) {
   let timeout: NodeJS.Timeout;
 
-  const linkModalRef = React.createRef<HTMLDivElement>();
+  const linkModalRef = createRef<HTMLDivElement>();
 
   const marksTooltip = new Plugin<MarksTooltipState, Schema>({
     key: markPluginKey,

--- a/packages/hash/frontend/src/blocks/page/createSuggester/BlockSuggester.tsx
+++ b/packages/hash/frontend/src/blocks/page/createSuggester/BlockSuggester.tsx
@@ -1,5 +1,5 @@
 import { BlockVariant } from "@blockprotocol/core";
-import { VFC } from "react";
+import { FunctionComponent } from "react";
 import { tw } from "twind";
 import { Box, SxProps, Theme, Typography } from "@mui/material";
 import { BlockMeta } from "@hashintel/hash-shared/blockMeta";
@@ -20,7 +20,7 @@ export interface BlockSuggesterProps {
  *
  * @todo highlight variant of the prosemirror-node this suggester is attached to.
  */
-export const BlockSuggester: VFC<BlockSuggesterProps> = ({
+export const BlockSuggester: FunctionComponent<BlockSuggesterProps> = ({
   search = "",
   onChange,
   sx,

--- a/packages/hash/frontend/src/blocks/page/createSuggester/MentionSuggester.tsx
+++ b/packages/hash/frontend/src/blocks/page/createSuggester/MentionSuggester.tsx
@@ -1,4 +1,4 @@
-import { useMemo, VFC } from "react";
+import { useMemo, FunctionComponent } from "react";
 import { tw } from "twind";
 import ArticleIcon from "@mui/icons-material/Article";
 
@@ -21,7 +21,7 @@ type SearchableItem = {
   isActiveOrgMember?: boolean;
 };
 
-export const MentionSuggester: VFC<MentionSuggesterProps> = ({
+export const MentionSuggester: FunctionComponent<MentionSuggesterProps> = ({
   search = "",
   onChange,
   accountId,

--- a/packages/hash/frontend/src/blocks/page/createSuggester/Suggester.tsx
+++ b/packages/hash/frontend/src/blocks/page/createSuggester/Suggester.tsx
@@ -1,5 +1,5 @@
 import { Box, SxProps, Theme, Typography } from "@mui/material";
-import React, { ReactElement, useEffect, useRef, useState } from "react";
+import { ReactElement, useEffect, useRef, useState } from "react";
 import { useKey } from "rooks";
 import { tw } from "twind";
 import { SpinnerIcon } from "../../../shared/icons";

--- a/packages/hash/frontend/src/blocks/page/createSuggester/createSuggester.tsx
+++ b/packages/hash/frontend/src/blocks/page/createSuggester/createSuggester.tsx
@@ -11,7 +11,7 @@ import {
   PluginKey,
   TextSelection,
 } from "prosemirror-state";
-import React, { CSSProperties } from "react";
+import { CSSProperties, ReactElement } from "react";
 import { RenderPortal } from "../usePortals";
 import { ensureMounted } from "../../../lib/dom";
 import { BlockSuggester } from "./BlockSuggester";
@@ -213,7 +213,7 @@ export const createSuggester = (
             view.dispatch(tr);
           };
 
-          let jsx: JSX.Element | null = null;
+          let jsx: ReactElement | null = null;
 
           switch (triggerChar) {
             case "/":

--- a/packages/hash/frontend/src/blocks/page/usePortals.tsx
+++ b/packages/hash/frontend/src/blocks/page/usePortals.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useCallback, useState } from "react";
+import { ReactNode, useCallback, useState } from "react";
 import { v4 as uuid } from "uuid";
 import { BlockPortals } from "./BlockPortals";
 
@@ -7,7 +7,7 @@ export type BlockPortal = { id: string; key: string; reactNode: ReactNode };
 type PortalSet = Map<HTMLElement, BlockPortal>;
 
 export type RenderPortal = (
-  reactNode: React.ReactNode | null,
+  reactNode: ReactNode | null,
   node: HTMLElement | null,
   id?: string,
 ) => void;

--- a/packages/hash/frontend/src/blocks/userBlocks.tsx
+++ b/packages/hash/frontend/src/blocks/userBlocks.tsx
@@ -1,7 +1,7 @@
 import {
   createContext,
   Dispatch,
-  FC,
+  FunctionComponent,
   ReactNode,
   SetStateAction,
   useContext,
@@ -23,7 +23,7 @@ interface UserBlocksContextState {
 /** @private enforces use of custom provider */
 const UserBlocksContext = createContext<UserBlocksContextState | null>(null);
 
-export const UserBlocksProvider: FC<{
+export const UserBlocksProvider: FunctionComponent<{
   value: BlocksMetaMap;
   children?: ReactNode;
 }> = ({ value: initialUserBlocks, children }) => {

--- a/packages/hash/frontend/src/components/BlockLoader/BlockLoader.tsx
+++ b/packages/hash/frontend/src/components/BlockLoader/BlockLoader.tsx
@@ -7,7 +7,7 @@ import {
 } from "@blockprotocol/graph";
 import { BlockConfig } from "@hashintel/hash-shared/blockMeta";
 import { BlockEntity } from "@hashintel/hash-shared/entity";
-import React, { useCallback, useMemo, VoidFunctionComponent } from "react";
+import { useCallback, useMemo, FunctionComponent } from "react";
 import { uniqBy } from "lodash";
 
 import {
@@ -57,7 +57,7 @@ type BlockLoaderProps = {
  * Converts API data to Block Protocol-formatted data (e.g. entities, links),
  * and passes the correctly formatted data to RemoteBlock, along with message callbacks
  */
-export const BlockLoader: VoidFunctionComponent<BlockLoaderProps> = ({
+export const BlockLoader: FunctionComponent<BlockLoaderProps> = ({
   accountId,
   blockEntityId,
   blockMetadata,

--- a/packages/hash/frontend/src/components/Dropdowns/Dropdown.tsx
+++ b/packages/hash/frontend/src/components/Dropdowns/Dropdown.tsx
@@ -1,5 +1,5 @@
 import { Listbox, Transition } from "@headlessui/react";
-import { Fragment, ReactElement, VoidFunctionComponent } from "react";
+import { Fragment, ReactElement, FunctionComponent } from "react";
 import { tw } from "twind";
 
 import { DropdownIcon } from "../../shared/icons";
@@ -21,7 +21,7 @@ export type DropdownProps = {
  * Needs the styling sorting out
  * @see https://headlessui.dev/react/listbox for the example
  */
-export const Dropdown: VoidFunctionComponent<DropdownProps> = ({
+export const Dropdown: FunctionComponent<DropdownProps> = ({
   onChange,
   options,
   value,

--- a/packages/hash/frontend/src/components/Dropdowns/VersionDropdown.tsx
+++ b/packages/hash/frontend/src/components/Dropdowns/VersionDropdown.tsx
@@ -1,4 +1,4 @@
-import { VoidFunctionComponent, ChangeEvent } from "react";
+import { FunctionComponent, ChangeEvent } from "react";
 import { formatDistance } from "date-fns";
 import { Box } from "@mui/material";
 
@@ -11,7 +11,7 @@ type VersionDropdownProps = {
   }[];
 };
 
-export const VersionDropdown: VoidFunctionComponent<VersionDropdownProps> = ({
+export const VersionDropdown: FunctionComponent<VersionDropdownProps> = ({
   onChange,
   value,
   versions,

--- a/packages/hash/frontend/src/components/ErrorBlock/ErrorBlock.tsx
+++ b/packages/hash/frontend/src/components/ErrorBlock/ErrorBlock.tsx
@@ -1,5 +1,5 @@
 import type { FallbackRender } from "@sentry/react";
-import React from "react";
+import { FunctionComponent } from "react";
 import { tw } from "twind";
 import { Button } from "../../shared/ui";
 
@@ -13,7 +13,10 @@ export interface ErrorBlockProps extends FallbackRenderProps {
   onRetry(): void;
 }
 
-export const ErrorBlock: React.VFC<ErrorBlockProps> = ({ error, onRetry }) => (
+export const ErrorBlock: FunctionComponent<ErrorBlockProps> = ({
+  error,
+  onRetry,
+}) => (
   <div
     className={tw`flex flex-row items-baseline px-3 py-2 border-2 border-red-300 rounded`}
     contentEditable="false"

--- a/packages/hash/frontend/src/components/Modals/Modal.tsx
+++ b/packages/hash/frontend/src/components/Modals/Modal.tsx
@@ -1,7 +1,7 @@
 import { SxProps, Theme } from "@mui/material";
 import Box from "@mui/material/Box";
 import MuiModal, { ModalProps as MuiModalProps } from "@mui/material/Modal";
-import React from "react";
+import { FunctionComponent } from "react";
 
 import { useScrollLock } from "@hashintel/hash-design-system";
 
@@ -25,7 +25,7 @@ type ModalProps = MuiModalProps & {
   contentStyle?: SxProps<Theme>;
 };
 
-export const Modal: React.FC<ModalProps> = ({
+export const Modal: FunctionComponent<ModalProps> = ({
   open,
   children,
   disableScrollLock = false,

--- a/packages/hash/frontend/src/components/RemoteBlock/RemoteBlock.tsx
+++ b/packages/hash/frontend/src/components/RemoteBlock/RemoteBlock.tsx
@@ -4,7 +4,7 @@ import {
   EmbedderGraphMessageCallbacks,
 } from "@blockprotocol/graph";
 import { useGraphEmbedderService } from "@blockprotocol/graph/react";
-import React from "react";
+import { FunctionComponent, useEffect, useRef } from "react";
 import { BlockRenderer } from "./blockRenderer";
 
 import { useRemoteBlock } from "./useRemoteBlock";
@@ -27,7 +27,9 @@ type RemoteBlockProps = {
   sourceUrl: string;
 };
 
-export const BlockLoadingIndicator: React.VFC = () => <div>Loading...</div>;
+export const BlockLoadingIndicator: FunctionComponent = () => (
+  <div>Loading...</div>
+);
 
 /**
  * Loads and renders a block from a URL, instantiates the graph service handler,
@@ -35,7 +37,7 @@ export const BlockLoadingIndicator: React.VFC = () => <div>Loading...</div>;
  *
  * @see https://github.com/Paciolan/remote-component for the original inspiration
  */
-export const RemoteBlock: React.VFC<RemoteBlockProps> = ({
+export const RemoteBlock: FunctionComponent<RemoteBlockProps> = ({
   blockMetadata,
   crossFrame,
   editableRef,
@@ -50,32 +52,32 @@ export const RemoteBlock: React.VFC<RemoteBlockProps> = ({
     onBlockLoaded,
   );
 
-  const wrapperRef = React.useRef<HTMLDivElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
 
   const { graphService } = useGraphEmbedderService(wrapperRef, {
     callbacks: graphCallbacks,
     ...graphProperties,
   });
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (graphService) {
       graphService.blockEntity({ data: graphProperties.blockEntity });
     }
   }, [graphProperties.blockEntity, graphService]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (graphService) {
       graphService.blockGraph({ data: graphProperties.blockGraph });
     }
   }, [graphProperties.blockGraph, graphService]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (graphService) {
       graphService.entityTypes({ data: graphProperties.entityTypes });
     }
   }, [graphProperties.entityTypes, graphService]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (graphService) {
       graphService.linkedAggregations({
         data: graphProperties.linkedAggregations,

--- a/packages/hash/frontend/src/components/RemoteBlock/blockRenderer.tsx
+++ b/packages/hash/frontend/src/components/RemoteBlock/blockRenderer.tsx
@@ -1,5 +1,5 @@
 import { BlockMetadata, UnknownRecord } from "@blockprotocol/core";
-import React, { VoidFunctionComponent } from "react";
+import { ReactElement, FunctionComponent } from "react";
 
 import { CustomElementLoader } from "./blockRenderer/customElement";
 import { HtmlLoader } from "./blockRenderer/html";
@@ -12,7 +12,7 @@ type BlockRendererProps = {
   sourceUrl: string;
 };
 
-export const BlockRenderer: VoidFunctionComponent<BlockRendererProps> = ({
+export const BlockRenderer: FunctionComponent<BlockRendererProps> = ({
   blockSource,
   blockType,
   properties,
@@ -55,7 +55,7 @@ export const BlockRenderer: VoidFunctionComponent<BlockRendererProps> = ({
         `'react' entryPoint expects parsed source to be a function, but got: ${typeof blockSource}`,
       );
     }
-    const BlockComponent = blockSource as (...props: any[]) => JSX.Element;
+    const BlockComponent = blockSource as (...props: any[]) => ReactElement;
     return <BlockComponent {...properties} />;
   }
 

--- a/packages/hash/frontend/src/components/RemoteBlock/blockRenderer/customElement.tsx
+++ b/packages/hash/frontend/src/components/RemoteBlock/blockRenderer/customElement.tsx
@@ -1,5 +1,11 @@
 import { createComponent } from "@lit-labs/react";
-import React from "react";
+// eslint-disable-next-line unicorn/import-style -- React is used in createComponent()
+import React, {
+  FunctionComponent,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { CustomElementDefinition } from "../util";
 
 type CustomElementLoaderProps = {
@@ -9,19 +15,15 @@ type CustomElementLoaderProps = {
 /**
  * Registers (if not already registered) and loads a custom element.
  */
-export const CustomElementLoader: React.VFC<CustomElementLoaderProps> = ({
-  elementClass,
-  properties,
-  tagName,
-}) => {
-  const [CustomElement, setCustomElement] = React.useState<React.VFC | null>(
+export const CustomElementLoader: FunctionComponent<
+  CustomElementLoaderProps
+> = ({ elementClass, properties, tagName }) => {
+  const [CustomElement, setCustomElement] = useState<FunctionComponent | null>(
     null,
   );
-  const existingDefinitionRef = React.useRef<CustomElementDefinition | null>(
-    null,
-  );
+  const existingDefinitionRef = useRef<CustomElementDefinition | null>(null);
 
-  React.useLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (
       existingDefinitionRef.current?.elementClass === elementClass &&
       existingDefinitionRef.current?.tagName === tagName

--- a/packages/hash/frontend/src/components/RemoteBlock/blockRenderer/html.tsx
+++ b/packages/hash/frontend/src/components/RemoteBlock/blockRenderer/html.tsx
@@ -1,11 +1,13 @@
 import { HtmlBlockDefinition, renderHtmlBlock } from "@blockprotocol/core";
-import React, { useEffect, useRef, useState, VFC } from "react";
+import { useEffect, useRef, useState, FunctionComponent } from "react";
 
 type HtmlElementLoaderProps = {
   html: HtmlBlockDefinition;
 };
 
-export const HtmlLoader: VFC<HtmlElementLoaderProps> = ({ html }) => {
+export const HtmlLoader: FunctionComponent<HtmlElementLoaderProps> = ({
+  html,
+}) => {
   const ref = useRef<HTMLDivElement>(null);
   const [, setError] = useState<never>();
 

--- a/packages/hash/frontend/src/components/RemoteBlock/loadRemoteBlock.ts
+++ b/packages/hash/frontend/src/components/RemoteBlock/loadRemoteBlock.ts
@@ -1,3 +1,4 @@
+import { ReactElement } from "react";
 import { memoizeFetchFunction } from "../../lib/memoize";
 import { blockDependencies } from "../../../block.dependencies";
 import { crossFrameFetchFn } from "../sandbox/FramedBlock/util";
@@ -5,7 +6,7 @@ import { crossFrameFetchFn } from "../sandbox/FramedBlock/util";
 export type UnknownBlock =
   | string
   | typeof HTMLElement
-  | ((...props: any[]) => JSX.Element);
+  | ((...props: any[]) => ReactElement);
 
 export type FetchSourceFn = (
   url: string,

--- a/packages/hash/frontend/src/components/entityTypes/AccountEntityOfTypeList.tsx
+++ b/packages/hash/frontend/src/components/entityTypes/AccountEntityOfTypeList.tsx
@@ -4,7 +4,7 @@ import {
   AggregateEntityQuery,
   AggregateEntityQueryVariables,
 } from "@hashintel/hash-shared/graphql/apiTypes.gen";
-import { VoidFunctionComponent } from "react";
+import { FunctionComponent } from "react";
 import { tw } from "twind";
 import { Typography } from "@mui/material";
 import { guessEntityName } from "../../lib/entities";
@@ -15,7 +15,7 @@ type AccountEntityOfTypeListProps = {
   entityTypeId: string;
 };
 
-export const AccountEntityOfTypeList: VoidFunctionComponent<
+export const AccountEntityOfTypeList: FunctionComponent<
   AccountEntityOfTypeListProps
 > = ({ accountId, entityTypeId }) => {
   const { data, loading } = useQuery<

--- a/packages/hash/frontend/src/components/entityTypes/SchemaEditor/Inputs.tsx
+++ b/packages/hash/frontend/src/components/entityTypes/SchemaEditor/Inputs.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState, VoidFunctionComponent } from "react";
+import { useEffect, useState, FunctionComponent } from "react";
 import { tw } from "twind";
 import { Checkbox } from "../../forms/Checkbox";
 import { TextInput } from "../../forms/TextInput";
 
-export const TextInputOrDisplay: VoidFunctionComponent<{
+export const TextInputOrDisplay: FunctionComponent<{
   className?: string;
   clearOnUpdate?: boolean;
   placeholder?: string;
@@ -62,7 +62,7 @@ export const TextInputOrDisplay: VoidFunctionComponent<{
   );
 };
 
-export const ToggleInputOrDisplay: VoidFunctionComponent<{
+export const ToggleInputOrDisplay: FunctionComponent<{
   checked: boolean;
   onChange: (value: boolean) => void;
   readonly: boolean;

--- a/packages/hash/frontend/src/components/entityTypes/SchemaEditor/SchemaEditor.tsx
+++ b/packages/hash/frontend/src/components/entityTypes/SchemaEditor/SchemaEditor.tsx
@@ -3,7 +3,7 @@ import {
   EmbedderGraphMessageCallbacks,
   EntityType,
 } from "@blockprotocol/graph";
-import React, {
+import {
   createContext,
   FormEvent,
   useCallback,
@@ -11,7 +11,7 @@ import React, {
   useMemo,
   useReducer,
   useState,
-  VoidFunctionComponent,
+  FunctionComponent,
 } from "react";
 import { tw } from "twind";
 import { debounce, get } from "lodash";
@@ -26,7 +26,7 @@ import {
 import { SubSchemaItem } from "./SubSchemaItem";
 import { Button, Link } from "../../../shared/ui";
 
-export type SchemaSelectElementType = VoidFunctionComponent<{
+export type SchemaSelectElementType = FunctionComponent<{
   schemaRef: string;
 }>;
 
@@ -45,7 +45,7 @@ type JsonSchemaEditorProps = {
 const entityTypeIdMatchesSchema = (entityTypeId: string, schema: JsonSchema) =>
   !!schema.$id?.includes(entityTypeId);
 
-export const SchemaEditor: VoidFunctionComponent<JsonSchemaEditorProps> = ({
+export const SchemaEditor: FunctionComponent<JsonSchemaEditorProps> = ({
   aggregateEntityTypes,
   entityTypeId,
   GoToSchemaElement,

--- a/packages/hash/frontend/src/components/entityTypes/SchemaEditor/SchemaPropertiesTable.tsx
+++ b/packages/hash/frontend/src/components/entityTypes/SchemaEditor/SchemaPropertiesTable.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useState, VoidFunctionComponent } from "react";
+import { FormEvent, useState, FunctionComponent } from "react";
 import { tw } from "twind";
 import { JsonSchema } from "@hashintel/hash-shared/json-utils";
 import { SchemaSelectElementType } from "./SchemaEditor";
@@ -20,7 +20,7 @@ const thClasses = tw`sticky first:rounded-tl-2xl last:rounded-tr-2xl ${cellPaddi
 export const trClasses = tw`border border-gray-100 rounded-2xl odd:bg-gray-50 even:bg-gray-100`;
 export const tdClasses = tw`${cellPadding}`;
 
-export const SchemaPropertiesTable: VoidFunctionComponent<
+export const SchemaPropertiesTable: FunctionComponent<
   SchemaPropertiesTableProps
 > = ({ GoToSchemaElement, readonly, selectedSchema, dispatchSchemaUpdate }) => {
   const { properties, required } = selectedSchema;

--- a/packages/hash/frontend/src/components/entityTypes/SchemaEditor/SchemaPropertyRow.tsx
+++ b/packages/hash/frontend/src/components/entityTypes/SchemaEditor/SchemaPropertyRow.tsx
@@ -1,4 +1,4 @@
-import { VoidFunctionComponent } from "react";
+import { FunctionComponent } from "react";
 import { tw } from "twind";
 
 import { JsonSchema } from "@hashintel/hash-shared/json-utils";
@@ -18,9 +18,7 @@ type SchemaPropertyRowProps = {
   required: boolean;
 };
 
-export const SchemaPropertyRow: VoidFunctionComponent<
-  SchemaPropertyRowProps
-> = ({
+export const SchemaPropertyRow: FunctionComponent<SchemaPropertyRowProps> = ({
   dispatchSchemaUpdate,
   GoToSchemaElement,
   name,

--- a/packages/hash/frontend/src/components/entityTypes/SchemaEditor/SchemaPropertyTypeList.tsx
+++ b/packages/hash/frontend/src/components/entityTypes/SchemaEditor/SchemaPropertyTypeList.tsx
@@ -3,7 +3,7 @@ import {
   ReactNode,
   useContext,
   useMemo,
-  VoidFunctionComponent,
+  FunctionComponent,
 } from "react";
 import { Schema } from "jsonschema";
 
@@ -22,7 +22,7 @@ type SchemaPropertyTypeListProps = {
   updatePermittedType?: (newType: string) => void; // @todo support selecting multiple types
 };
 
-const PropertyTypeDisplay: VoidFunctionComponent<
+const PropertyTypeDisplay: FunctionComponent<
   Omit<SchemaPropertyTypeListProps, "readonly" | "updatePermittedType">
 > = ({ $ref, hasSubSchema, GoToSchemaElement, propertyName, type }) => {
   if ($ref) {
@@ -44,7 +44,7 @@ const PropertyTypeDisplay: VoidFunctionComponent<
   );
 };
 
-const PropertyTypeSelect: VoidFunctionComponent<
+const PropertyTypeSelect: FunctionComponent<
   Omit<
     SchemaPropertyTypeListProps,
     "hasSubSchema" | "GoToSchemaElement" | "propertyName" | "readonly"
@@ -108,7 +108,7 @@ const PropertyTypeSelect: VoidFunctionComponent<
   );
 };
 
-export const SchemaPropertyTypeList: VoidFunctionComponent<
+export const SchemaPropertyTypeList: FunctionComponent<
   SchemaPropertyTypeListProps
 > = ({ readonly, ...props }) => {
   if (!readonly) {

--- a/packages/hash/frontend/src/components/entityTypes/SchemaEditor/SubSchemaItem.tsx
+++ b/packages/hash/frontend/src/components/entityTypes/SchemaEditor/SubSchemaItem.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { useState, VoidFunctionComponent } from "react";
+import { useState, FunctionComponent } from "react";
 import { tw } from "twind";
 
 import { JsonSchema } from "@hashintel/hash-shared/json-utils";
@@ -19,7 +19,7 @@ type SubSchemaItemProps = {
   workingSchemaDraft: JsonSchema;
 };
 
-export const SubSchemaItem: VoidFunctionComponent<SubSchemaItemProps> = ({
+export const SubSchemaItem: FunctionComponent<SubSchemaItemProps> = ({
   dispatchSchemaUpdate,
   GoToSchemaElement,
   subSchema,

--- a/packages/hash/frontend/src/components/forms/Checkbox.tsx
+++ b/packages/hash/frontend/src/components/forms/Checkbox.tsx
@@ -1,4 +1,4 @@
-import { HTMLProps, VoidFunctionComponent } from "react";
+import { HTMLProps, FunctionComponent } from "react";
 
 type CheckboxProps = {
   checked: boolean;
@@ -6,7 +6,7 @@ type CheckboxProps = {
   label?: string;
 } & Omit<HTMLProps<HTMLInputElement>, "onChange">;
 
-export const Checkbox: VoidFunctionComponent<CheckboxProps> = ({
+export const Checkbox: FunctionComponent<CheckboxProps> = ({
   checked,
   label,
   onChangeChecked,

--- a/packages/hash/frontend/src/components/forms/SelectInput.tsx
+++ b/packages/hash/frontend/src/components/forms/SelectInput.tsx
@@ -1,5 +1,11 @@
 import { uniqueId } from "lodash";
-import React, { forwardRef, ChangeEvent, useCallback, useState } from "react";
+import {
+  forwardRef,
+  ChangeEvent,
+  useCallback,
+  useState,
+  HTMLProps,
+} from "react";
 import { tw } from "twind";
 
 type SelectInputProps = {
@@ -8,7 +14,7 @@ type SelectInputProps = {
   onChangeValue?: (value: string) => void;
   value?: string;
   options: { disabled?: boolean; label: string; value: string }[];
-} & Omit<React.HTMLProps<HTMLSelectElement>, "value">;
+} & Omit<HTMLProps<HTMLSelectElement>, "value">;
 
 export const SelectInput = forwardRef<HTMLSelectElement, SelectInputProps>(
   (

--- a/packages/hash/frontend/src/components/forms/TagsInput.tsx
+++ b/packages/hash/frontend/src/components/forms/TagsInput.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import { FunctionComponent, KeyboardEvent, useRef } from "react";
 import { tw } from "twind";
 
 type TagsInputProps = {
@@ -10,7 +10,7 @@ type TagsInputProps = {
   delimiters?: string[];
 };
 
-export const TagsInput: React.VFC<TagsInputProps> = ({
+export const TagsInput: FunctionComponent<TagsInputProps> = ({
   minHeight,
   tags,
   setTags,
@@ -20,7 +20,7 @@ export const TagsInput: React.VFC<TagsInputProps> = ({
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const handleKeyDown = (evt: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (evt: KeyboardEvent<HTMLInputElement>) => {
     if (!inputRef.current) return;
     const text = inputRef.current.value;
 

--- a/packages/hash/frontend/src/components/forms/TextInput.tsx
+++ b/packages/hash/frontend/src/components/forms/TextInput.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, forwardRef } from "react";
+import { ChangeEvent, forwardRef, HTMLProps } from "react";
 import { tw } from "twind";
 import { InputLabelWrapper } from "./InputLabelWrapper";
 
@@ -10,7 +10,7 @@ type TextInputProps = {
   value?: string;
   transparent?: boolean;
   inputClassName?: string;
-} & Omit<React.HTMLProps<HTMLInputElement>, "label" | "value" | "onChange">;
+} & Omit<HTMLProps<HTMLInputElement>, "label" | "value" | "onChange">;
 
 export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
   (

--- a/packages/hash/frontend/src/components/sandbox/BlockFramer/BlockFramer.tsx
+++ b/packages/hash/frontend/src/components/sandbox/BlockFramer/BlockFramer.tsx
@@ -3,7 +3,7 @@ import {
   useEffect,
   useMemo,
   useRef,
-  VoidFunctionComponent,
+  FunctionComponent,
 } from "react";
 import {
   BlockProtocolFunction,
@@ -28,7 +28,7 @@ const fetchSource = memoizeFetchFunction((url) =>
   fetch(url).then((resp) => resp.text()),
 );
 
-export const BlockFramer: VoidFunctionComponent<CrossFrameProxyProps> = ({
+export const BlockFramer: FunctionComponent<CrossFrameProxyProps> = ({
   sourceUrl,
   aggregateEntities,
   aggregateEntityTypes,

--- a/packages/hash/frontend/src/components/sandbox/FramedBlock/FramedBlock.tsx
+++ b/packages/hash/frontend/src/components/sandbox/FramedBlock/FramedBlock.tsx
@@ -7,7 +7,7 @@ import {
   BlockProtocolUpdateEntitiesFunction,
 } from "blockprotocol";
 import "iframe-resizer/js/iframeResizer.contentWindow";
-import { useCallback, useEffect, useState, VoidFunctionComponent } from "react";
+import { useCallback, useEffect, useState, FunctionComponent } from "react";
 
 import { FetchEmbedCodeFn } from "../../BlockLoader/fetchEmbedCode";
 // import { ErrorBlock } from "../../ErrorBlock/ErrorBlock";
@@ -20,7 +20,7 @@ import { sendMessage, settlePromiseFromResponse } from "./util";
 
 const params = new URL(window.location.href).searchParams;
 
-export const FramedBlock: VoidFunctionComponent = () => {
+export const FramedBlock: FunctionComponent = () => {
   const sourceUrl = params.get("sourceUrl");
   const properties = params.get("properties");
 

--- a/packages/hash/frontend/src/components/sandbox/FramedBlock/index.tsx
+++ b/packages/hash/frontend/src/components/sandbox/FramedBlock/index.tsx
@@ -1,10 +1,10 @@
-import React from "react";
-import ReactDOM from "react-dom";
+import { StrictMode } from "react";
+import { render } from "react-dom";
 import { FramedBlock } from "./FramedBlock";
 
-ReactDOM.render(
-  <React.StrictMode>
+render(
+  <StrictMode>
     <FramedBlock />
-  </React.StrictMode>,
+  </StrictMode>,
   document.getElementById("root"),
 );

--- a/packages/hash/frontend/src/pages/[account-slug]/[page-slug].page.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/[page-slug].page.tsx
@@ -8,12 +8,7 @@ import { GetStaticPaths, GetStaticProps } from "next";
 import Head from "next/head";
 import { Router, useRouter } from "next/router";
 
-import React, {
-  useEffect,
-  useMemo,
-  useState,
-  VoidFunctionComponent,
-} from "react";
+import { useEffect, useMemo, useState, FunctionComponent } from "react";
 import { useCollabPositionReporter } from "../../blocks/page/collab/useCollabPositionReporter";
 import { useCollabPositions } from "../../blocks/page/collab/useCollabPositions";
 import { useCollabPositionTracking } from "../../blocks/page/collab/useCollabPositionTracking";
@@ -57,7 +52,7 @@ export const getStaticProps: GetStaticProps<PageProps> = async () => {
   };
 };
 
-export const PageNotificationBanner: VoidFunctionComponent = () => {
+export const PageNotificationBanner: FunctionComponent = () => {
   const router = useRouter();
 
   const { accountId } = useRouteAccountInfo();

--- a/packages/hash/frontend/src/pages/[account-slug]/[page-slug].page/page-transfer-dropdown.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/[page-slug].page/page-transfer-dropdown.tsx
@@ -1,10 +1,4 @@
-import {
-  ChangeEvent,
-  useEffect,
-  useState,
-  VFC,
-  VoidFunctionComponent,
-} from "react";
+import { ChangeEvent, useEffect, useState, FunctionComponent } from "react";
 import { useRouter } from "next/router";
 import { useMutation, useQuery } from "@apollo/client";
 
@@ -24,7 +18,10 @@ type AccountSelectProps = {
   value: string;
 };
 
-export const AccountSelect: VFC<AccountSelectProps> = ({ onChange, value }) => {
+export const AccountSelect: FunctionComponent<AccountSelectProps> = ({
+  onChange,
+  value,
+}) => {
   const { data } = useQuery<GetAccountsQuery>(getAccounts);
 
   return (
@@ -56,7 +53,7 @@ type PageTransferDropdownType = {
   setPageState: (state: "normal" | "transferring") => void;
 };
 
-export const PageTransferDropdown: VoidFunctionComponent<
+export const PageTransferDropdown: FunctionComponent<
   PageTransferDropdownType
 > = ({ pageEntityId, accountId, setPageState }) => {
   const router = useRouter();

--- a/packages/hash/frontend/src/pages/[account-slug]/entities/[entity-id].page/block-based-entity-editor.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/entities/[entity-id].page/block-based-entity-editor.tsx
@@ -1,4 +1,4 @@
-import { VoidFunctionComponent } from "react";
+import { FunctionComponent } from "react";
 import { theme } from "@hashintel/hash-design-system";
 import { EntityPropertiesBlock } from "./entity-properties-block";
 import { LocalReactBlockContainer } from "./local-react-block-container";
@@ -8,7 +8,7 @@ export interface BlockBasedEntityEditorProps {
   entityId: string;
 }
 
-export const BlockBasedEntityEditor: VoidFunctionComponent<
+export const BlockBasedEntityEditor: FunctionComponent<
   BlockBasedEntityEditorProps
 > = ({ accountId, entityId }) => {
   return (

--- a/packages/hash/frontend/src/pages/[account-slug]/entities/[entity-id].page/local-react-block-container.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/entities/[entity-id].page/local-react-block-container.tsx
@@ -1,7 +1,7 @@
 import { BlockProtocolProps } from "blockprotocol";
 import { BlockComponent } from "blockprotocol/react";
 import { ComponentType, useEffect, useRef } from "react";
-import ReactDOM from "react-dom";
+import { render } from "react-dom";
 
 export const LocalReactBlockContainer: BlockComponent<{
   Component: ComponentType<BlockProtocolProps>;
@@ -9,7 +9,7 @@ export const LocalReactBlockContainer: BlockComponent<{
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    ReactDOM.render(<Component {...rest} />, ref.current);
+    render(<Component {...rest} />, ref.current);
   }, [Component, rest]);
 
   return <div ref={ref} />;

--- a/packages/hash/frontend/src/pages/[account-slug]/entities/shared/simple-entity-editor.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/entities/shared/simple-entity-editor.tsx
@@ -5,7 +5,7 @@ import {
   EmbedderGraphMessageCallbacks,
 } from "@blockprotocol/graph";
 import jsonpath from "jsonpath";
-import { FormEvent, useMemo, VoidFunctionComponent } from "react";
+import { FormEvent, useMemo, FunctionComponent } from "react";
 import { unset } from "lodash";
 import { ISubmitEvent } from "@rjsf/core";
 import { tw } from "twind";
@@ -138,9 +138,12 @@ const splitSchema = (
   };
 };
 
-export const SimpleEntityEditor: VoidFunctionComponent<
-  SimpleEntityEditorProps
-> = ({ aggregateEntities, refetchEntity, schema, ...variableProps }) => {
+export const SimpleEntityEditor: FunctionComponent<SimpleEntityEditorProps> = ({
+  aggregateEntities,
+  refetchEntity,
+  schema,
+  ...variableProps
+}) => {
   const onSubmit = (args: ISubmitEvent<any>, event: FormEvent) => {
     event.preventDefault();
     if ("entityProperties" in variableProps) {

--- a/packages/hash/frontend/src/pages/[account-slug]/entities/shared/simple-entity-editor/entity-field-link-editor.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/entities/shared/simple-entity-editor/entity-field-link-editor.tsx
@@ -4,13 +4,13 @@ import {
   Link,
 } from "@blockprotocol/graph";
 import { JsonObject } from "@blockprotocol/core";
-import React, {
+import {
   ChangeEvent,
   HTMLProps,
   useCallback,
   useEffect,
   useState,
-  VoidFunctionComponent,
+  FunctionComponent,
 } from "react";
 import { tw } from "twind";
 
@@ -38,7 +38,7 @@ type EntitySelectProps = {
 
 const noSelectionValue = "__none";
 
-const SelectInput: VoidFunctionComponent<
+const SelectInput: FunctionComponent<
   Required<Pick<HTMLProps<HTMLSelectElement>, "onChange" | "value">> & {
     options: MinimalEntity[];
     defaultLabel: string;
@@ -61,9 +61,7 @@ const SelectInput: VoidFunctionComponent<
 /**
  * Allows a user to select one or more entities of a given type
  */
-export const EntityFieldLinkEditor: VoidFunctionComponent<
-  EntitySelectProps
-> = ({
+export const EntityFieldLinkEditor: FunctionComponent<EntitySelectProps> = ({
   aggregateEntities,
   allowsMultipleSelections,
   createLinkFromEntity,

--- a/packages/hash/frontend/src/pages/[account-slug]/entities/shared/simple-entity-editor/entity-links-editor.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/entities/shared/simple-entity-editor/entity-links-editor.tsx
@@ -4,7 +4,7 @@ import {
   Link,
   LinkGroup,
 } from "@blockprotocol/graph";
-import { useMemo, VoidFunctionComponent } from "react";
+import { useMemo, FunctionComponent } from "react";
 import { tw } from "twind";
 
 import { CreateLinkFnWithFixedSource, EntityLinkDefinition } from "./types";
@@ -21,9 +21,7 @@ type EntityLinkEditorProps = {
 
 const pathToString = (pathAsArray: string[]) => pathAsArray.join(".");
 
-export const EntityLinksEditor: VoidFunctionComponent<
-  EntityLinkEditorProps
-> = ({
+export const EntityLinksEditor: FunctionComponent<EntityLinkEditorProps> = ({
   aggregateEntities,
   createLinkFromEntity,
   deleteLinkFromEntity,

--- a/packages/hash/frontend/src/pages/_app.page.tsx
+++ b/packages/hash/frontend/src/pages/_app.page.tsx
@@ -3,7 +3,7 @@
 require("setimmediate");
 
 import { ApolloProvider } from "@apollo/client/react";
-import { useEffect, useState } from "react";
+import { FunctionComponent, useEffect, useState } from "react";
 import { createApolloClient } from "@hashintel/hash-shared/graphql/createApolloClient";
 import withTwindApp from "@twind/next/app";
 import { ModalProvider } from "react-modal-hook";
@@ -33,7 +33,7 @@ type AppProps = {
   Component: NextPageWithLayout;
 } & NextAppProps;
 
-const App: React.VoidFunctionComponent<AppProps> = ({
+const App: FunctionComponent<AppProps> = ({
   Component,
   pageProps,
   emotionCache = clientSideEmotionCache,

--- a/packages/hash/frontend/src/pages/_document.page.tsx
+++ b/packages/hash/frontend/src/pages/_document.page.tsx
@@ -1,9 +1,9 @@
-import React from "react";
 import createEmotionServer from "@emotion/server/create-instance";
 import withTwindDocument from "@twind/next/document";
 import NextDocument, { Html, Head, Main, NextScript } from "next/document";
 
 import { createEmotionCache } from "@hashintel/hash-design-system";
+import { Children } from "react";
 import twindConfig from "../../twind.config";
 
 class Document extends NextDocument {
@@ -79,10 +79,7 @@ Document.getInitialProps = async (ctx) => {
   return {
     ...initialProps,
     // Styles fragment is rendered after the app and page rendering finish.
-    styles: [
-      ...React.Children.toArray(initialProps.styles),
-      ...emotionStyleTags,
-    ],
+    styles: [...Children.toArray(initialProps.styles), ...emotionStyleTags],
   };
 };
 

--- a/packages/hash/frontend/src/pages/invite.page.tsx
+++ b/packages/hash/frontend/src/pages/invite.page.tsx
@@ -1,7 +1,7 @@
 import { tw } from "twind";
 import { useRouter } from "next/router";
 import { useMutation } from "@apollo/client";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import { useUser } from "../components/hooks/useUser";
 
 import { AuthLayout } from "./shared/auth-layout";
@@ -91,7 +91,7 @@ const Page: NextPageWithLayout = () => {
     },
   });
 
-  const handleSubmit = (evt: React.FormEvent) => {
+  const handleSubmit = (evt: FormEvent) => {
     evt.preventDefault();
     if (!responsibility || !invitationInfo) return;
 

--- a/packages/hash/frontend/src/pages/login.page/login-intro.tsx
+++ b/packages/hash/frontend/src/pages/login.page/login-intro.tsx
@@ -1,9 +1,10 @@
 import { useRouter } from "next/router";
-import React, {
+import {
   useEffect,
   useRef,
   useState,
-  VoidFunctionComponent,
+  FunctionComponent,
+  FormEvent,
 } from "react";
 import { tw } from "twind";
 
@@ -35,7 +36,7 @@ type LoginIntroProps = {
   defaultLoginIdentifier: string | undefined;
 };
 
-export const LoginIntro: VoidFunctionComponent<LoginIntroProps> = ({
+export const LoginIntro: FunctionComponent<LoginIntroProps> = ({
   requestLoginCode,
   errorMessage,
   loading,
@@ -50,7 +51,7 @@ export const LoginIntro: VoidFunctionComponent<LoginIntroProps> = ({
     inputRef.current?.select();
   }, []);
 
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     requestLoginCode(emailOrShortname);
   };

--- a/packages/hash/frontend/src/pages/login.page/login-modal.tsx
+++ b/packages/hash/frontend/src/pages/login.page/login-modal.tsx
@@ -1,10 +1,11 @@
-import React, {
-  VoidFunctionComponent,
+import {
+  FunctionComponent,
   useEffect,
   useReducer,
   useMemo,
   useCallback,
   useState,
+  Reducer,
 } from "react";
 import { useRouter } from "next/router";
 
@@ -95,7 +96,7 @@ function reducer(state: State, action: Actions): State {
   }
 }
 
-export const LoginModal: VoidFunctionComponent<LoginModalProps> = ({
+export const LoginModal: FunctionComponent<LoginModalProps> = ({
   show,
   onClose,
   onLoggedIn,
@@ -110,7 +111,7 @@ export const LoginModal: VoidFunctionComponent<LoginModalProps> = ({
       syntheticLoading,
     },
     dispatch,
-  ] = useReducer<React.Reducer<State, Actions>>(reducer, initialState);
+  ] = useReducer<Reducer<State, Actions>>(reducer, initialState);
   const { invitationInfo, invitationInfoLoading } = useGetInvitationInfo();
   const router = useRouter();
   const [requestedLoginCodeForDefault, setRequestedLoginCodeForDefault] =

--- a/packages/hash/frontend/src/pages/login.test.tsx
+++ b/packages/hash/frontend/src/pages/login.test.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { mockUseRouter } from "../testUtils/mockUseRouter";
 import { render } from "../testUtils/testUtils";
 import Login from "./login.page";

--- a/packages/hash/frontend/src/pages/shared/auth-layout.tsx
+++ b/packages/hash/frontend/src/pages/shared/auth-layout.tsx
@@ -1,4 +1,4 @@
-import React, { VFC, ReactNode } from "react";
+import { FunctionComponent, ReactNode } from "react";
 import { tw } from "twind";
 
 import bgPattern from "../../assets/images/auth-bg-pattern.png";
@@ -11,7 +11,7 @@ export type AuthLayoutProps = {
   loading?: boolean;
 };
 
-export const AuthLayout: VFC<AuthLayoutProps> = ({
+export const AuthLayout: FunctionComponent<AuthLayoutProps> = ({
   children,
   onClose,
   showTopLogo,

--- a/packages/hash/frontend/src/pages/shared/auth-modal-layout.tsx
+++ b/packages/hash/frontend/src/pages/shared/auth-modal-layout.tsx
@@ -1,5 +1,5 @@
 import { Dialog } from "@headlessui/react";
-import { ReactNode, VFC } from "react";
+import { ReactNode, FunctionComponent } from "react";
 import { tw } from "twind";
 import { AuthLayout } from "./auth-layout";
 
@@ -10,7 +10,7 @@ export type AuthModalLayoutProps = {
   children: ReactNode;
 };
 
-export const AuthModalLayout: VFC<AuthModalLayoutProps> = ({
+export const AuthModalLayout: FunctionComponent<AuthModalLayoutProps> = ({
   onClose,
   show,
   children,

--- a/packages/hash/frontend/src/pages/shared/invite-header.tsx
+++ b/packages/hash/frontend/src/pages/shared/invite-header.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { FunctionComponent, memo } from "react";
 import { tw } from "twind";
 
 type InviteHeaderProps = {
@@ -9,7 +9,7 @@ type InviteHeaderProps = {
   };
 };
 
-export const InviteHeader: React.VFC<InviteHeaderProps> = React.memo(
+export const InviteHeader: FunctionComponent<InviteHeaderProps> = memo(
   ({ invitationInfo }) => {
     return (
       <p className={tw`font-bold text-2xl text-blue-500 mb-12`}>

--- a/packages/hash/frontend/src/pages/shared/verify-code.tsx
+++ b/packages/hash/frontend/src/pages/shared/verify-code.tsx
@@ -1,10 +1,11 @@
-import React, {
+import {
   useCallback,
   useEffect,
   useRef,
   useState,
-  VFC,
+  FunctionComponent,
   ClipboardEventHandler,
+  FormEvent,
 } from "react";
 import { tw } from "twind";
 
@@ -34,7 +35,7 @@ const doesVerificationCodeLookValid = (code: string) => {
   return units.length >= 4 && units?.[3]!.length > 0;
 };
 
-export const VerifyCode: VFC<VerifyCodeProps> = ({
+export const VerifyCode: FunctionComponent<VerifyCodeProps> = ({
   defaultCode,
   goBack,
   errorMessage,
@@ -70,7 +71,7 @@ export const VerifyCode: VFC<VerifyCodeProps> = ({
     [text],
   );
 
-  const onSubmit = (evt: React.FormEvent) => {
+  const onSubmit = (evt: FormEvent) => {
     evt.preventDefault();
     handleSubmit(text);
   };

--- a/packages/hash/frontend/src/pages/signup.page.tsx
+++ b/packages/hash/frontend/src/pages/signup.page.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useReducer } from "react";
+import { useEffect, useRef, useReducer, Reducer } from "react";
 import { useRouter } from "next/router";
 import { useMutation } from "@apollo/client";
 import { useUser } from "../components/hooks/useUser";
@@ -136,7 +136,7 @@ const Page: NextPageWithLayout = () => {
       createOrgInfo,
     },
     dispatch,
-  ] = useReducer<React.Reducer<State, Actions>>(reducer, initialState);
+  ] = useReducer<Reducer<State, Actions>>(reducer, initialState);
   const { invitationInfo, invitationInfoLoading } = useGetInvitationInfo();
   const accountUsageType = useRef<WayToUseHash | null>(null);
 

--- a/packages/hash/frontend/src/pages/signup.page/account-setup.tsx
+++ b/packages/hash/frontend/src/pages/signup.page/account-setup.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, VFC } from "react";
+import { useMemo, FunctionComponent } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { tw } from "twind";
 
@@ -25,7 +25,7 @@ type Inputs = {
   responsibility?: string;
 };
 
-export const AccountSetup: VFC<AccountSetupProps> = ({
+export const AccountSetup: FunctionComponent<AccountSetupProps> = ({
   onSubmit: setupAccount,
   loading,
   errorMessage,

--- a/packages/hash/frontend/src/pages/signup.page/account-usage.tsx
+++ b/packages/hash/frontend/src/pages/signup.page/account-usage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, VFC } from "react";
+import { useState, FunctionComponent } from "react";
 import { tw } from "twind";
 
 import { WayToUseHash } from "../../graphql/apiTypes.gen";
@@ -25,7 +25,7 @@ const USAGE_OPTIONS = [
   },
 ] as const;
 
-export const AccountUsage: VFC<AccountUsageProps> = ({
+export const AccountUsage: FunctionComponent<AccountUsageProps> = ({
   updateWayToUseHash,
   loading,
   errorMessage,

--- a/packages/hash/frontend/src/pages/signup.page/org-create.tsx
+++ b/packages/hash/frontend/src/pages/signup.page/org-create.tsx
@@ -189,7 +189,6 @@ export const OrgCreate: FunctionComponent<OrgCreateProps> = ({
     <div className={tw`flex flex-col items-center`}>
       <h1 className={tw`text-3xl font-bold mb-12`}>Create a team workspace</h1>
       <div className={tw`text-center mb-6`}>
-        {}
         <label className={tw`flex flex-col cursor-pointer`}>
           {avatarImg ? (
             <img

--- a/packages/hash/frontend/src/pages/signup.page/org-create.tsx
+++ b/packages/hash/frontend/src/pages/signup.page/org-create.tsx
@@ -1,4 +1,10 @@
-import React, { ChangeEvent, useMemo, VFC, useState } from "react";
+import {
+  ChangeEvent,
+  useMemo,
+  FunctionComponent,
+  useState,
+  Fragment,
+} from "react";
 import { useForm, Controller, RegisterOptions } from "react-hook-form";
 import { tw } from "twind";
 import { useMutation } from "@apollo/client";
@@ -96,7 +102,7 @@ const getInitials = (name: string) => {
   if (initials.length > 1) return initials[0]![0]! + initials[1]![0]!;
 };
 
-export const OrgCreate: VFC<OrgCreateProps> = ({
+export const OrgCreate: FunctionComponent<OrgCreateProps> = ({
   // accountId,
   onCreateOrgSuccess,
 }) => {
@@ -183,7 +189,7 @@ export const OrgCreate: VFC<OrgCreateProps> = ({
     <div className={tw`flex flex-col items-center`}>
       <h1 className={tw`text-3xl font-bold mb-12`}>Create a team workspace</h1>
       <div className={tw`text-center mb-6`}>
-        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+        {}
         <label className={tw`flex flex-col cursor-pointer`}>
           {avatarImg ? (
             <img
@@ -220,7 +226,7 @@ export const OrgCreate: VFC<OrgCreateProps> = ({
             index,
           ) => {
             return (
-              <React.Fragment key={name}>
+              <Fragment key={name}>
                 <Controller
                   control={control}
                   name={name}
@@ -271,7 +277,7 @@ export const OrgCreate: VFC<OrgCreateProps> = ({
                 {index !== FORM_INPUTS.length - 1 && (
                   <div className={tw`mb-6`} />
                 )}
-              </React.Fragment>
+              </Fragment>
             );
           },
         )}

--- a/packages/hash/frontend/src/pages/signup.page/org-invite.tsx
+++ b/packages/hash/frontend/src/pages/signup.page/org-invite.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from "@apollo/client";
-import React, { VFC, useState, useMemo } from "react";
+import { FunctionComponent, useState, useMemo } from "react";
 import { tw } from "twind";
 import {
   CreateOrgEmailInvitationMutation,
@@ -22,7 +22,7 @@ const isValidEmail = (email: string) => {
   return EMAIL_REGEX.test(email);
 };
 
-export const OrgInvite: VFC<OrgInviteProps> = ({
+export const OrgInvite: FunctionComponent<OrgInviteProps> = ({
   navigateToHome,
   createOrgInfo,
 }) => {

--- a/packages/hash/frontend/src/pages/signup.page/signup-intro.tsx
+++ b/packages/hash/frontend/src/pages/signup.page/signup-intro.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useState, useRef, VFC } from "react";
+import {
+  useEffect,
+  useState,
+  useRef,
+  FunctionComponent,
+  FormEvent,
+} from "react";
 import { tw } from "twind";
 import { useRouter } from "next/router";
 
@@ -16,7 +22,7 @@ type SignupIntroProps = {
   invitationInfo: InvitationInfo | null;
 };
 
-export const SignupIntro: VFC<SignupIntroProps> = ({
+export const SignupIntro: FunctionComponent<SignupIntroProps> = ({
   handleSubmit,
   loading,
   errorMessage,
@@ -37,7 +43,7 @@ export const SignupIntro: VFC<SignupIntroProps> = ({
     }
   }, [user, router]);
 
-  const onSubmit = (evt: React.FormEvent) => {
+  const onSubmit = (evt: FormEvent) => {
     evt.preventDefault();
     handleSubmit(email);
   };

--- a/packages/hash/frontend/src/pages/signup.test.tsx
+++ b/packages/hash/frontend/src/pages/signup.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { waitFor } from "@testing-library/dom";
 
 import { mockUseRouter } from "../testUtils/mockUseRouter";

--- a/packages/hash/frontend/src/shared/icons/fontawesome-icon.tsx
+++ b/packages/hash/frontend/src/shared/icons/fontawesome-icon.tsx
@@ -7,48 +7,49 @@ type FontAwesomeIconProps = {
 } & SvgIconProps;
 
 // gotten from https://mui.com/components/icons/#font-awesome
-export const FontAwesomeIcon = forwardRef<SVGSVGElement, FontAwesomeIconProps>(
-  (props, ref) => {
-    const { icon, sx = [], ...otherProps } = props;
+export const FontAwesomeIcon = forwardRef<
+  SVGSVGElement,
+  FontAwesomeIconProps // https://github.com/prettier/prettier/issues/11923
+>((props, ref) => {
+  const { icon, sx = [], ...otherProps } = props;
 
-    const {
-      icon: [width, height, , , svgPathData],
-    } = icon;
+  const {
+    icon: [width, height, , , svgPathData],
+  } = icon;
 
-    return (
-      <SvgIcon
-        ref={ref}
-        viewBox={`0 0 ${width} ${height}`}
-        sx={[
-          {
-            color: "currentColor",
-            width: "1em",
-            height: "1em",
-            fontSize: "16px",
-          },
-          ...(Array.isArray(sx) ? sx : [sx]),
-        ]}
-        {...otherProps}
-      >
-        {typeof svgPathData === "string" ? (
-          <path d={svgPathData} />
-        ) : (
-          /**
-           * A multi-path Font Awesome icon seems to imply a duotune icon. The 0th path seems to
-           * be the faded element (referred to as the "secondary" path in the Font Awesome docs)
-           * of a duotone icon. 40% is the default opacity.
-           *
-           * @see https://fontawesome.com/how-to-use/on-the-web/styling/duotone-icons#changing-opacity
-           */
-          svgPathData.map((pathData: string, i: number) => (
-            <path
-              key={pathData}
-              style={{ opacity: i === 0 ? 0.4 : 1 }}
-              d={pathData}
-            />
-          ))
-        )}
-      </SvgIcon>
-    );
-  },
-);
+  return (
+    <SvgIcon
+      ref={ref}
+      viewBox={`0 0 ${width} ${height}`}
+      sx={[
+        {
+          color: "currentColor",
+          width: "1em",
+          height: "1em",
+          fontSize: "16px",
+        },
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
+      {...otherProps}
+    >
+      {typeof svgPathData === "string" ? (
+        <path d={svgPathData} />
+      ) : (
+        /**
+         * A multi-path Font Awesome icon seems to imply a duotune icon. The 0th path seems to
+         * be the faded element (referred to as the "secondary" path in the Font Awesome docs)
+         * of a duotone icon. 40% is the default opacity.
+         *
+         * @see https://fontawesome.com/how-to-use/on-the-web/styling/duotone-icons#changing-opacity
+         */
+        svgPathData.map((pathData: string, i: number) => (
+          <path
+            key={pathData}
+            style={{ opacity: i === 0 ? 0.4 : 1 }}
+            d={pathData}
+          />
+        ))
+      )}
+    </SvgIcon>
+  );
+});

--- a/packages/hash/frontend/src/shared/icons/fontawesome-icon.tsx
+++ b/packages/hash/frontend/src/shared/icons/fontawesome-icon.tsx
@@ -1,55 +1,54 @@
-import * as React from "react";
 import { SvgIcon, SvgIconProps } from "@mui/material";
 import { IconDefinition } from "@fortawesome/free-solid-svg-icons";
+import { forwardRef } from "react";
 
 type FontAwesomeIconProps = {
   icon: IconDefinition;
 } & SvgIconProps;
 
 // gotten from https://mui.com/components/icons/#font-awesome
-export const FontAwesomeIcon = React.forwardRef<
-  SVGSVGElement,
-  FontAwesomeIconProps
->((props, ref) => {
-  const { icon, sx = [], ...otherProps } = props;
+export const FontAwesomeIcon = forwardRef<SVGSVGElement, FontAwesomeIconProps>(
+  (props, ref) => {
+    const { icon, sx = [], ...otherProps } = props;
 
-  const {
-    icon: [width, height, , , svgPathData],
-  } = icon;
+    const {
+      icon: [width, height, , , svgPathData],
+    } = icon;
 
-  return (
-    <SvgIcon
-      ref={ref}
-      viewBox={`0 0 ${width} ${height}`}
-      sx={[
-        {
-          color: "currentColor",
-          width: "1em",
-          height: "1em",
-          fontSize: "16px",
-        },
-        ...(Array.isArray(sx) ? sx : [sx]),
-      ]}
-      {...otherProps}
-    >
-      {typeof svgPathData === "string" ? (
-        <path d={svgPathData} />
-      ) : (
-        /**
-         * A multi-path Font Awesome icon seems to imply a duotune icon. The 0th path seems to
-         * be the faded element (referred to as the "secondary" path in the Font Awesome docs)
-         * of a duotone icon. 40% is the default opacity.
-         *
-         * @see https://fontawesome.com/how-to-use/on-the-web/styling/duotone-icons#changing-opacity
-         */
-        svgPathData.map((pathData: string, i: number) => (
-          <path
-            key={pathData}
-            style={{ opacity: i === 0 ? 0.4 : 1 }}
-            d={pathData}
-          />
-        ))
-      )}
-    </SvgIcon>
-  );
-});
+    return (
+      <SvgIcon
+        ref={ref}
+        viewBox={`0 0 ${width} ${height}`}
+        sx={[
+          {
+            color: "currentColor",
+            width: "1em",
+            height: "1em",
+            fontSize: "16px",
+          },
+          ...(Array.isArray(sx) ? sx : [sx]),
+        ]}
+        {...otherProps}
+      >
+        {typeof svgPathData === "string" ? (
+          <path d={svgPathData} />
+        ) : (
+          /**
+           * A multi-path Font Awesome icon seems to imply a duotune icon. The 0th path seems to
+           * be the faded element (referred to as the "secondary" path in the Font Awesome docs)
+           * of a duotone icon. 40% is the default opacity.
+           *
+           * @see https://fontawesome.com/how-to-use/on-the-web/styling/duotone-icons#changing-opacity
+           */
+          svgPathData.map((pathData: string, i: number) => (
+            <path
+              key={pathData}
+              style={{ opacity: i === 0 ? 0.4 : 1 }}
+              d={pathData}
+            />
+          ))
+        )}
+      </SvgIcon>
+    );
+  },
+);

--- a/packages/hash/frontend/src/shared/icons/hash-icon.tsx
+++ b/packages/hash/frontend/src/shared/icons/hash-icon.tsx
@@ -1,7 +1,7 @@
 import { SvgIcon, SvgIconProps } from "@mui/material";
-import { FC } from "react";
+import { FunctionComponent } from "react";
 
-export const HashIcon: FC<SvgIconProps> = (props) => {
+export const HashIcon: FunctionComponent<SvgIconProps> = (props) => {
   return (
     <SvgIcon {...props} viewBox="0 0 31 30">
       <g opacity="0.9">

--- a/packages/hash/frontend/src/shared/icons/hash-nav-icon.tsx
+++ b/packages/hash/frontend/src/shared/icons/hash-nav-icon.tsx
@@ -1,7 +1,7 @@
-import { FC } from "react";
+import { FunctionComponent } from "react";
 import { SvgIcon, SvgIconProps } from "@mui/material";
 
-export const HashNavIcon: FC<SvgIconProps> = (props) => {
+export const HashNavIcon: FunctionComponent<SvgIconProps> = (props) => {
   return (
     <SvgIcon
       {...props}
@@ -52,7 +52,7 @@ export const HashNavIcon: FC<SvgIconProps> = (props) => {
   );
 };
 
-export const HashAlphaNavIcon: FC<SvgIconProps> = (props) => {
+export const HashAlphaNavIcon: FunctionComponent<SvgIconProps> = (props) => {
   return (
     <SvgIcon
       {...props}

--- a/packages/hash/frontend/src/shared/icons/search-icon.tsx
+++ b/packages/hash/frontend/src/shared/icons/search-icon.tsx
@@ -1,7 +1,7 @@
-import { FC } from "react";
+import { FunctionComponent } from "react";
 import { SvgIcon, SvgIconProps } from "@mui/material";
 
-export const SearchIcon: FC<SvgIconProps> = (props) => {
+export const SearchIcon: FunctionComponent<SvgIconProps> = (props) => {
   return (
     <SvgIcon {...props} width="17" height="16" viewBox="0 0 17 16" fill="none">
       <path

--- a/packages/hash/frontend/src/shared/icons/sidebar-toggle-icon.tsx
+++ b/packages/hash/frontend/src/shared/icons/sidebar-toggle-icon.tsx
@@ -1,7 +1,7 @@
-import { FC } from "react";
+import { FunctionComponent } from "react";
 import { SvgIcon, SvgIconProps } from "@mui/material";
 
-export const SidebarToggleIcon: FC<SvgIconProps> = (props) => {
+export const SidebarToggleIcon: FunctionComponent<SvgIconProps> = (props) => {
   const { sx = [], ...otherProps } = props;
   return (
     <SvgIcon

--- a/packages/hash/frontend/src/shared/icons/warn-icon.tsx
+++ b/packages/hash/frontend/src/shared/icons/warn-icon.tsx
@@ -1,7 +1,7 @@
-import { FC } from "react";
+import { FunctionComponent } from "react";
 import { SvgIcon, SvgIconProps } from "@mui/material";
 
-export const WarnIcon: FC<SvgIconProps> = (props) => {
+export const WarnIcon: FunctionComponent<SvgIconProps> = (props) => {
   return (
     <SvgIcon width="20" height="20" viewBox="0 0 20 20" fill="none" {...props}>
       <path

--- a/packages/hash/frontend/src/shared/layout/layout-with-header.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-header.tsx
@@ -1,8 +1,8 @@
-import { ReactNode, VFC } from "react";
+import { ReactNode, FunctionComponent } from "react";
 import { PageHeader } from "./layout-with-header/page-header";
 import { PlainLayout } from "./plain-layout";
 
-export const LayoutWithHeader: VFC<{
+export const LayoutWithHeader: FunctionComponent<{
   children?: ReactNode;
 }> = ({ children }) => {
   return (

--- a/packages/hash/frontend/src/shared/layout/layout-with-header/account-dropdown.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-header/account-dropdown.tsx
@@ -1,4 +1,4 @@
-import { useMemo, VoidFunctionComponent } from "react";
+import { useMemo, FunctionComponent } from "react";
 import {
   Box,
   Typography,
@@ -24,7 +24,7 @@ type AccountDropdownProps = {
   user: UserFieldsFragment;
 };
 
-export const AccountDropdown: VoidFunctionComponent<AccountDropdownProps> = ({
+export const AccountDropdown: FunctionComponent<AccountDropdownProps> = ({
   avatar,
   logout,
   user,

--- a/packages/hash/frontend/src/shared/layout/layout-with-header/actions-dropdown.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-header/actions-dropdown.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, VFC } from "react";
+import { useState, useCallback, FunctionComponent } from "react";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import {
   Box,
@@ -22,7 +22,7 @@ import { HeaderIconButton } from "./shared/header-icon-button";
 import { useCreatePage } from "../../../components/hooks/useCreatePage";
 import { useRouteAccountInfo } from "../../routing";
 
-export const ActionsDropdownInner: VFC<{
+export const ActionsDropdownInner: FunctionComponent<{
   accountId: string;
 }> = ({ accountId }) => {
   const router = useRouter();
@@ -124,7 +124,7 @@ export const ActionsDropdownInner: VFC<{
   );
 };
 
-export const ActionsDropdown: VFC = () => {
+export const ActionsDropdown: FunctionComponent = () => {
   const { accountId } = useRouteAccountInfo({ allowUndefined: true }) ?? {};
 
   // Don’t render actions if account cannot be derived from URL

--- a/packages/hash/frontend/src/shared/layout/layout-with-header/notifications-dropdown.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-header/notifications-dropdown.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { FunctionComponent, useState } from "react";
 import { faBell } from "@fortawesome/free-solid-svg-icons";
 import { Box, ListItemText, Menu, Typography, useTheme } from "@mui/material";
 import {
@@ -11,7 +11,7 @@ import { FontAwesomeIcon } from "@hashintel/hash-design-system";
 import { MenuItem } from "../../ui";
 import { HeaderIconButton } from "./shared/header-icon-button";
 
-export const NotificationsDropdown: React.FC = () => {
+export const NotificationsDropdown: FunctionComponent = () => {
   const theme = useTheme();
   const [notificationsLength] = useState(3);
   const hasNotifications = !!notificationsLength;

--- a/packages/hash/frontend/src/shared/layout/layout-with-header/page-header.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-header/page-header.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import { FunctionComponent, ReactNode } from "react";
 import { Box, useTheme, useMediaQuery } from "@mui/material";
 
 import { useLogout } from "../../../components/hooks/useLogout";
@@ -9,7 +9,7 @@ import { ActionsDropdown } from "./actions-dropdown";
 import { Button, Link } from "../../ui";
 import { HashAlphaNavIcon } from "../../icons";
 
-const Nav: React.FC<{ children?: ReactNode }> = ({ children }) => (
+const Nav: FunctionComponent<{ children?: ReactNode }> = ({ children }) => (
   <Box
     component="nav"
     sx={{
@@ -25,7 +25,7 @@ const Nav: React.FC<{ children?: ReactNode }> = ({ children }) => (
 
 export const HEADER_HEIGHT = 54;
 
-export const PageHeader: React.VFC = () => {
+export const PageHeader: FunctionComponent = () => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 

--- a/packages/hash/frontend/src/shared/layout/layout-with-header/search-bar.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-header/search-bar.tsx
@@ -1,12 +1,12 @@
 import { useQuery } from "@apollo/client";
 import { PageSearchResult } from "@hashintel/hash-shared/graphql/apiTypes.gen";
 import { escapeRegExp } from "lodash";
-import React, {
+import {
   ReactNode,
   useCallback,
   useEffect,
   useState,
-  VoidFunctionComponent,
+  FunctionComponent,
 } from "react";
 import { useDebounce, useKey, useOutsideClickRef } from "rooks";
 import { Box, Theme, useTheme, useMediaQuery, SxProps } from "@mui/material";
@@ -51,7 +51,7 @@ const toBlockUrl = (searchPage: PageSearchResult): string => {
   return segments.join("");
 };
 
-const ResultList: React.FC<{
+const ResultList: FunctionComponent<{
   isMobile: boolean;
   children?: ReactNode;
 }> = ({ isMobile, ...props }) => (
@@ -73,7 +73,7 @@ const ResultList: React.FC<{
   </Box>
 );
 
-const ResultItem: React.FC<{
+const ResultItem: FunctionComponent<{
   sx?: SxProps<Theme>;
   children?: ReactNode;
 }> = ({ sx = [], ...props }) => {
@@ -143,7 +143,7 @@ const getSearchBarResponsiveStyles = (
   return {};
 };
 
-const SearchBarWhenSearchIsEnabled: React.VFC = () => {
+const SearchBarWhenSearchIsEnabled: FunctionComponent = () => {
   const theme = useTheme();
 
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
@@ -259,7 +259,7 @@ const SearchBarWhenSearchIsEnabled: React.VFC = () => {
   );
 };
 
-const SearchBarWhenSearchIsDisabled: VoidFunctionComponent = () => {
+const SearchBarWhenSearchIsDisabled: FunctionComponent = () => {
   return <div />;
 };
 

--- a/packages/hash/frontend/src/shared/layout/layout-with-header/search-bar/search-input.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-header/search-bar/search-input.tsx
@@ -5,14 +5,14 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
-import { useCallback, useEffect, useRef } from "react";
+import { FunctionComponent, useCallback, useEffect, useRef } from "react";
 import { useKeys } from "rooks";
 import { faXmark } from "@fortawesome/free-solid-svg-icons";
 
 import { FontAwesomeIcon, IconButton } from "@hashintel/hash-design-system";
 import { SearchIcon } from "../../../icons";
 
-const ClearSearchIcon: React.FC<{
+const ClearSearchIcon: FunctionComponent<{
   clearSearch: () => void;
 }> = ({ clearSearch }) => {
   return (
@@ -77,7 +77,7 @@ const ShortcutIcon = () => {
   );
 };
 
-export const SearchInput: React.FC<{
+export const SearchInput: FunctionComponent<{
   displayedQuery: string;
   isMobile: boolean;
   setResultListVisible: (visible: boolean) => void;

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, VFC } from "react";
+import { ReactNode, FunctionComponent } from "react";
 import { Box, Fade, styled, Tooltip } from "@mui/material";
 import { IconButton } from "@hashintel/hash-design-system";
 import { HEADER_HEIGHT } from "./layout-with-header/page-header";
@@ -26,7 +26,7 @@ export type LayoutWithSidebarProps = {
   banner?: ReactNode;
 };
 
-export const LayoutWithSidebar: VFC<LayoutWithSidebarProps> = ({
+export const LayoutWithSidebar: FunctionComponent<LayoutWithSidebarProps> = ({
   children,
   banner,
 }) => {

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list.tsx
@@ -1,4 +1,11 @@
-import { useState, useMemo, useRef, VFC, useEffect, Ref } from "react";
+import {
+  useState,
+  useMemo,
+  useRef,
+  FunctionComponent,
+  useEffect,
+  Ref,
+} from "react";
 import {
   Box,
   Tooltip,
@@ -29,11 +36,12 @@ type SearchInputProps = {
   searchVisible: boolean;
   searchInputRef: Ref<HTMLInputElement>;
   showSearchInput: () => void;
+  // eslint-disable-next-line react/no-unused-prop-types -- @todo remove prop or use it in the component body
   hideSearchInput: () => void;
   onChangeText: (text: string) => void;
 };
 
-const SearchInput: VFC<SearchInputProps> = ({
+const SearchInput: FunctionComponent<SearchInputProps> = ({
   searchVisible,
   searchInputRef,
   showSearchInput,
@@ -116,9 +124,9 @@ type AccountEntityTypeListProps = {
   accountId: string;
 };
 
-export const AccountEntityTypeList: VFC<AccountEntityTypeListProps> = ({
-  accountId,
-}) => {
+export const AccountEntityTypeList: FunctionComponent<
+  AccountEntityTypeListProps
+> = ({ accountId }) => {
   const { data } = useGetAllEntityTypes(accountId);
   const router = useRouter();
 

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list/entity-type-item.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list/entity-type-item.tsx
@@ -1,5 +1,5 @@
 import { Box, BoxProps, styled, Tooltip, Typography } from "@mui/material";
-import { useRef, VFC } from "react";
+import { useRef, FunctionComponent } from "react";
 import { faEllipsis } from "@fortawesome/free-solid-svg-icons";
 import { usePopupState, bindTrigger } from "material-ui-popup-state/hooks";
 
@@ -50,7 +50,7 @@ const Container = styled((props: BoxProps & { selected: boolean }) => (
   },
 }));
 
-export const EntityTypeItem: VFC<EntityTypeItemProps> = ({
+export const EntityTypeItem: FunctionComponent<EntityTypeItemProps> = ({
   accountId,
   entityId,
   title,

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list/entity-type-menu.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list/entity-type-menu.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, VFC } from "react";
+import { useMemo, useState, FunctionComponent } from "react";
 import {
   faLink,
   faAdd,
@@ -24,7 +24,7 @@ type MenuItemType = {
 } & ({ href: string; onClick?: null } | { href?: string; onClick: () => void });
 
 // @todo-mui get free icons that matches the design closely
-export const EntityTypeMenu: VFC<EntityTypeMenuProps> = ({
+export const EntityTypeMenu: FunctionComponent<EntityTypeMenuProps> = ({
   popupState,
   accountId,
   entityId,

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list/sort-actions-dropdown.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list/sort-actions-dropdown.tsx
@@ -1,4 +1,4 @@
-import { VFC } from "react";
+import { FunctionComponent } from "react";
 import { bindMenu, PopupState } from "material-ui-popup-state/hooks";
 import {
   Box,
@@ -60,11 +60,9 @@ const menuItems: {
   // },
 ];
 
-export const SortActionsDropdown: VFC<SortActionsDropdownProps> = ({
-  setSortType,
-  activeSortType,
-  popupState,
-}) => {
+export const SortActionsDropdown: FunctionComponent<
+  SortActionsDropdownProps
+> = ({ setSortType, activeSortType, popupState }) => {
   return (
     <Menu {...bindMenu(popupState)}>
       <Box

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list.tsx
@@ -1,5 +1,5 @@
-import React, {
-  VoidFunctionComponent,
+import {
+  FunctionComponent,
   SyntheticEvent,
   useMemo,
   useState,
@@ -61,7 +61,7 @@ const renderTree = (
   );
 };
 
-export const AccountPageList: VoidFunctionComponent<AccountPageListProps> = ({
+export const AccountPageList: FunctionComponent<AccountPageListProps> = ({
   currentPageEntityId,
   accountId,
 }) => {

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-menu.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-menu.tsx
@@ -1,4 +1,4 @@
-import { VFC, useMemo, useState } from "react";
+import { FunctionComponent, useMemo, useState } from "react";
 import { ListItemIcon, ListItemText, Menu } from "@mui/material";
 import { bindMenu, PopupState } from "material-ui-popup-state/hooks";
 import { faArchive, faLink } from "@fortawesome/free-solid-svg-icons";
@@ -14,7 +14,10 @@ type PageMenuProps = {
   entityId: string;
 };
 
-export const PageMenu: VFC<PageMenuProps> = ({ popupState, entityId }) => {
+export const PageMenu: FunctionComponent<PageMenuProps> = ({
+  popupState,
+  entityId,
+}) => {
   const [copied, setCopied] = useState(false);
   const { accountId } = useRouteAccountInfo();
   const { createSubPage } = useCreatePage(accountId);

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-tree-item.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-tree-item.tsx
@@ -13,7 +13,7 @@ import {
   faFile,
 } from "@fortawesome/free-solid-svg-icons";
 import { IconButton, FontAwesomeIcon } from "@hashintel/hash-design-system";
-import { forwardRef, MouseEvent as ReactMouseEvent, Ref } from "react";
+import { forwardRef, MouseEvent, Ref } from "react";
 import { Link } from "../../../ui";
 import { PageMenu } from "./page-menu";
 
@@ -29,13 +29,13 @@ const CustomContent = forwardRef((props: TreeItemContentProps, ref) => {
     useTreeItem(nodeId);
 
   const handleMouseDown = (
-    event: ReactMouseEvent<HTMLDivElement, MouseEvent>,
+    event: MouseEvent<HTMLDivElement, globalThis.MouseEvent>,
   ) => {
     preventSelection(event);
   };
 
   const handleExpansionClick = (
-    event: ReactMouseEvent<HTMLButtonElement, MouseEvent>,
+    event: MouseEvent<HTMLButtonElement, globalThis.MouseEvent>,
   ) => {
     handleExpansion(event);
   };

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-tree-item.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-tree-item.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import TreeItem, {
   TreeItemProps,
   useTreeItem,
@@ -14,11 +13,12 @@ import {
   faFile,
 } from "@fortawesome/free-solid-svg-icons";
 import { IconButton, FontAwesomeIcon } from "@hashintel/hash-design-system";
+import { forwardRef, MouseEvent as ReactMouseEvent, Ref } from "react";
 import { Link } from "../../../ui";
 import { PageMenu } from "./page-menu";
 
 // tweaked the example at https://mui.com/components/tree-view/#IconExpansionTreeView.tsx
-const CustomContent = React.forwardRef((props: TreeItemContentProps, ref) => {
+const CustomContent = forwardRef((props: TreeItemContentProps, ref) => {
   const { label, nodeId, expandable, url, depth } = props;
   const popupState = usePopupState({
     variant: "popover",
@@ -29,13 +29,13 @@ const CustomContent = React.forwardRef((props: TreeItemContentProps, ref) => {
     useTreeItem(nodeId);
 
   const handleMouseDown = (
-    event: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    event: ReactMouseEvent<HTMLDivElement, MouseEvent>,
   ) => {
     preventSelection(event);
   };
 
   const handleExpansionClick = (
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    event: ReactMouseEvent<HTMLButtonElement, MouseEvent>,
   ) => {
     handleExpansion(event);
   };
@@ -44,7 +44,7 @@ const CustomContent = React.forwardRef((props: TreeItemContentProps, ref) => {
     <Box
       tabIndex={0}
       onMouseDown={handleMouseDown}
-      ref={ref as React.Ref<HTMLDivElement>}
+      ref={ref as Ref<HTMLDivElement>}
       sx={({ palette }) => ({
         display: "flex",
         alignItems: "center",

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/nav-link.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/nav-link.tsx
@@ -1,4 +1,4 @@
-import { useState, FC, ReactNode } from "react";
+import { useState, FunctionComponent, ReactNode } from "react";
 import { faAdd, faChevronRight } from "@fortawesome/free-solid-svg-icons";
 import { Box, Typography, Collapse, Tooltip } from "@mui/material";
 import {
@@ -18,7 +18,7 @@ type NavLinkProps = {
   } & IconButtonProps;
 };
 
-export const NavLink: FC<NavLinkProps> = ({
+export const NavLink: FunctionComponent<NavLinkProps> = ({
   title,
   children,
   endAdornmentProps,

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/sidebar-context.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/sidebar-context.tsx
@@ -1,6 +1,6 @@
 import {
   createContext,
-  FC,
+  FunctionComponent,
   ReactNode,
   useContext,
   useMemo,
@@ -21,9 +21,9 @@ const SidebarContext = createContext<SidebarContextState>({
 
 export const useSidebarContext = () => useContext(SidebarContext);
 
-export const SidebarContextProvider: FC<{ children?: ReactNode }> = ({
-  children,
-}) => {
+export const SidebarContextProvider: FunctionComponent<{
+  children?: ReactNode;
+}> = ({ children }) => {
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(true);
 
   const value = useMemo(

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/sidebar.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/sidebar.tsx
@@ -1,4 +1,4 @@
-import { VoidFunctionComponent } from "react";
+import { FunctionComponent } from "react";
 
 import { useRouter } from "next/router";
 import { Box, Drawer, Tooltip } from "@mui/material";
@@ -16,7 +16,7 @@ import { useRouteAccountInfo, useRoutePageInfo } from "../../routing";
 
 export const SIDEBAR_WIDTH = 260;
 
-export const PageSidebar: VoidFunctionComponent = () => {
+export const PageSidebar: FunctionComponent = () => {
   const router = useRouter();
   const { sidebarOpen, closeSidebar } = useSidebarContext();
   const { accountId } = useRouteAccountInfo();

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/top-nav-link.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/top-nav-link.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FunctionComponent } from "react";
 import { IconDefinition } from "@fortawesome/free-solid-svg-icons";
 import { Typography, Tooltip, typographyClasses } from "@mui/material";
 import { FontAwesomeIcon } from "@hashintel/hash-design-system";
@@ -12,7 +12,7 @@ type NavLinkProps = {
   tooltipTitle: string;
 };
 
-export const TopNavLink: FC<NavLinkProps> = ({
+export const TopNavLink: FunctionComponent<NavLinkProps> = ({
   icon,
   title,
   href,

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/workspace-switcher.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/workspace-switcher.tsx
@@ -1,4 +1,4 @@
-import { VFC, useRef, useMemo } from "react";
+import { FunctionComponent, useRef, useMemo } from "react";
 import {
   Box,
   Typography,
@@ -22,7 +22,9 @@ import { useRouteAccountInfo } from "../../routing";
 
 type WorkspaceSwitcherProps = {};
 
-export const WorkspaceSwitcher: VFC<WorkspaceSwitcherProps> = () => {
+export const WorkspaceSwitcher: FunctionComponent<
+  WorkspaceSwitcherProps
+> = () => {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const popupState = usePopupState({
     variant: "popover",

--- a/packages/hash/frontend/src/shared/layout/plain-layout.tsx
+++ b/packages/hash/frontend/src/shared/layout/plain-layout.tsx
@@ -1,8 +1,8 @@
 import Head from "next/head";
-import { ReactElement, ReactNode, VFC } from "react";
+import { ReactElement, ReactNode, FunctionComponent } from "react";
 import { isProduction } from "../../lib/config";
 
-export const PlainLayout: VFC<{
+export const PlainLayout: FunctionComponent<{
   children?: ReactNode;
 }> = ({ children }) => {
   return (

--- a/packages/hash/frontend/src/shared/routing/route-account-info.tsx
+++ b/packages/hash/frontend/src/shared/routing/route-account-info.tsx
@@ -1,5 +1,11 @@
 import { useRouter } from "next/router";
-import { createContext, VFC, useContext, useMemo, ReactNode } from "react";
+import {
+  createContext,
+  FunctionComponent,
+  useContext,
+  useMemo,
+  ReactNode,
+} from "react";
 
 type RouteAccountInfo = {
   accountId: string;
@@ -14,9 +20,9 @@ const RouteAccountInfoContext = createContext<RouteAccountInfo | undefined>(
  * although this wouldn't work when we switch to using slugs instead of accountIds in the url.
  * When that happens the accountId should be pulled properly in this component
  */
-export const RouteAccountInfoProvider: VFC<{ children?: ReactNode }> = ({
-  children,
-}) => {
+export const RouteAccountInfoProvider: FunctionComponent<{
+  children?: ReactNode;
+}> = ({ children }) => {
   const router = useRouter();
 
   const accountSlug = router.query["account-slug"];

--- a/packages/hash/frontend/src/shared/routing/route-page-info.tsx
+++ b/packages/hash/frontend/src/shared/routing/route-page-info.tsx
@@ -1,5 +1,11 @@
 import { useRouter } from "next/router";
-import { createContext, VFC, useContext, useMemo, ReactNode } from "react";
+import {
+  createContext,
+  FunctionComponent,
+  useContext,
+  useMemo,
+  ReactNode,
+} from "react";
 
 type RoutePageInfo = {
   pageEntityId: string;
@@ -14,9 +20,9 @@ const RoutePageInfoContext = createContext<RoutePageInfo | undefined>(
  * although this wouldn't work when we switch to using slugs instead of pageEntityIds in the url.
  * When that happens the pageEntityId should be pulled properly in this component
  */
-export const RoutePageInfoProvider: VFC<{ children?: ReactNode }> = ({
-  children,
-}) => {
+export const RoutePageInfoProvider: FunctionComponent<{
+  children?: ReactNode;
+}> = ({ children }) => {
   const router = useRouter();
 
   const pageSlug = router.query["page-slug"];

--- a/packages/hash/frontend/src/shared/ui/button.tsx
+++ b/packages/hash/frontend/src/shared/ui/button.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
 import Link from "next/link";
-import { VFC, forwardRef, useMemo, ReactNode } from "react";
+import { FunctionComponent, forwardRef, useMemo, ReactNode } from "react";
 import {
   /* eslint-disable-next-line -- allow import of original button to extend it */
   Button as BaseButton,
@@ -12,7 +12,7 @@ export type ButtonProps = {
   children: ReactNode;
 } & BaseButtonProps; // MUI button renders <a /> when href is provided, but typings miss rel and target
 
-export const Button: VFC<ButtonProps> = forwardRef(
+export const Button: FunctionComponent<ButtonProps> = forwardRef(
   ({ children, href, ...props }, ref) => {
     const linkProps = useMemo(() => {
       if (href && isHrefExternal(href)) {

--- a/packages/hash/frontend/src/shared/ui/link.tsx
+++ b/packages/hash/frontend/src/shared/ui/link.tsx
@@ -3,7 +3,6 @@ import { UrlObject } from "url";
 import { useRouter } from "next/router";
 // eslint-disable-next-line no-restricted-imports
 import NextLink, { LinkProps as NextLinkProps } from "next/link";
-
 import MuiLink, { LinkProps as MuiLinkProps } from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
 import { forwardRef, isValidElement } from "react";

--- a/packages/hash/frontend/src/shared/ui/link.tsx
+++ b/packages/hash/frontend/src/shared/ui/link.tsx
@@ -1,12 +1,12 @@
-import * as React from "react";
 import clsx from "clsx";
 import { UrlObject } from "url";
 import { useRouter } from "next/router";
 // eslint-disable-next-line no-restricted-imports
 import NextLink, { LinkProps as NextLinkProps } from "next/link";
-// eslint-disable-next-line no-restricted-imports
+
 import MuiLink, { LinkProps as MuiLinkProps } from "@mui/material/Link";
 import { styled } from "@mui/material/styles";
+import { forwardRef, isValidElement } from "react";
 import { Button } from "./button";
 import { FRONTEND_URL } from "../../lib/config";
 
@@ -30,7 +30,7 @@ type NextLinkComposedProps = {
 } & Omit<NextLinkProps, "href" | "passHref"> &
   Omit<MuiLinkProps, "href" | "color">;
 
-export const NextLinkComposed = React.forwardRef<
+export const NextLinkComposed = forwardRef<
   HTMLAnchorElement,
   NextLinkComposedProps
 >((props, ref) => {
@@ -61,8 +61,11 @@ export type LinkProps = {
 
 // A styled version of the Next.js Link component:
 // https://nextjs.org/docs/api-reference/next/link
-export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
-  (props, ref) => {
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
+  (
+    props,
+    ref, // https://github.com/prettier/prettier/issues/11923
+  ) => {
     const {
       activeClassName = "active",
       as: linkAs,
@@ -80,7 +83,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
 
     if (process.env.NODE_ENV !== "production") {
       const children = other.children;
-      if (React.isValidElement(children) && children.type === Button) {
+      if (isValidElement(children) && children.type === Button) {
         throw new Error(
           "Please use <Button href='' /> instead of <Link><Button /></Link>",
         );

--- a/packages/hash/frontend/src/shared/ui/menu-item.tsx
+++ b/packages/hash/frontend/src/shared/ui/menu-item.tsx
@@ -1,4 +1,4 @@
-import { VFC, forwardRef, ReactNode } from "react";
+import { FunctionComponent, forwardRef, ReactNode } from "react";
 import {
   MenuItem as BaseMenuItem,
   MenuItemProps as BaseMenuItemProps,
@@ -10,7 +10,7 @@ export type MenuItemProps = {
   href?: string;
 } & BaseMenuItemProps;
 
-export const MenuItem: VFC<MenuItemProps> = forwardRef(
+export const MenuItem: FunctionComponent<MenuItemProps> = forwardRef(
   ({ children, href, ...props }, ref) => {
     const Component = (
       <BaseMenuItem ref={ref} {...props}>

--- a/packages/hash/frontend/src/testUtils/testUtils.tsx
+++ b/packages/hash/frontend/src/testUtils/testUtils.tsx
@@ -1,21 +1,19 @@
 import { MockedProvider, MockedResponse } from "@apollo/client/testing";
 import { ThemeProvider } from "@mui/material";
-// eslint-disable-next-line no-restricted-imports
 import { render, RenderOptions } from "@testing-library/react";
 
 import { theme } from "@hashintel/hash-design-system";
-import { ReactNode } from "react";
+import { FunctionComponent, ReactElement, ReactNode } from "react";
 
 type CustomRenderOptions = RenderOptions & {
   mocks?: Readonly<MockedResponse[]>;
 };
 
-const customRender = (
-  ui: React.ReactElement,
-  options: CustomRenderOptions = {},
-) => {
+const customRender = (ui: ReactElement, options: CustomRenderOptions = {}) => {
   const { mocks = [] } = options;
-  const Wrapper: React.FC<{ children: ReactNode }> = ({ children }) => (
+  const Wrapper: FunctionComponent<{ children: ReactNode }> = ({
+    children,
+  }) => (
     <ThemeProvider theme={theme}>
       <MockedProvider mocks={mocks} addTypename={false}>
         {children}

--- a/packages/hash/task-executor/src/airbyte/temp_io.ts
+++ b/packages/hash/task-executor/src/airbyte/temp_io.ts
@@ -1,13 +1,13 @@
 import { promises as fs } from "fs";
-import { sep } from "path";
+import path from "path";
 import * as os from "os";
 
 export const writeToTempFile = async (
   fileName: string,
   fileContents: string,
 ): Promise<string> => {
-  const tmpDir = await fs.mkdtemp(`${os.tmpdir()}${sep}`);
-  const filePath = `${tmpDir}${sep}${fileName}`;
+  const tmpDir = await fs.mkdtemp(`${os.tmpdir()}${path.sep}`);
+  const filePath = `${tmpDir}${path.sep}${fileName}`;
   await fs.writeFile(filePath, fileContents);
 
   return filePath;

--- a/sites/hashdev/src/_pages/blog/5_build-blocks-in-any-language.mdx
+++ b/sites/hashdev/src/_pages/blog/5_build-blocks-in-any-language.mdx
@@ -10,7 +10,7 @@ date: "2022-06-14"
 
 One of the main motivations behind recent Block Protocol updates has been to enable blocks to be written in a wider variety of languages. To make that possible, the ways in which blocks and embedding applications interact have changed significantly. As of version 0.2 of the specification, Block Protocol requests and responses are handled through DOM `CustomEvents` defined in accordance with JSON Schemas.
 
-It's now a lot easier to create blocks that are not tied to JavaScript, TypeScript, or As long as a block can use browser `Event`s, it can implement the Block Protocol. To show what the changes imply for adventurous block authors, this post will be a technical walk-through of how the Block Protocol can be implemented and used in a language that is not TypeScript. Specifically, we're going to build a block in F#—but the methodology and implementation details are applicable for other languages that support JavaScript as a transpilation target and JavaScript interoperability.
+It's now a lot easier to create blocks that are not tied to JavaScript, TypeScript, or React. As long as a block can use browser `Event`s, it can implement the Block Protocol. To show what the changes imply for adventurous block authors, this post will be a technical walk-through of how the Block Protocol can be implemented and used in a language that is not TypeScript. Specifically, we're going to build a block in F#—but the methodology and implementation details are applicable for other languages that support JavaScript as a transpilation target and JavaScript interoperability.
 
 ## Building blocks with F\#
 

--- a/sites/hashdev/src/_pages/blog/5_build-blocks-in-any-language.mdx
+++ b/sites/hashdev/src/_pages/blog/5_build-blocks-in-any-language.mdx
@@ -10,7 +10,7 @@ date: "2022-06-14"
 
 One of the main motivations behind recent Block Protocol updates has been to enable blocks to be written in a wider variety of languages. To make that possible, the ways in which blocks and embedding applications interact have changed significantly. As of version 0.2 of the specification, Block Protocol requests and responses are handled through DOM `CustomEvents` defined in accordance with JSON Schemas.
 
-It's now a lot easier to create blocks that are not tied to JavaScript, TypeScript, or React. As long as a block can use browser `Event`s, it can implement the Block Protocol. To show what the changes imply for adventurous block authors, this post will be a technical walk-through of how the Block Protocol can be implemented and used in a language that is not TypeScript. Specifically, we're going to build a block in F#—but the methodology and implementation details are applicable for other languages that support JavaScript as a transpilation target and JavaScript interoperability.
+It's now a lot easier to create blocks that are not tied to JavaScript, TypeScript, or As long as a block can use browser `Event`s, it can implement the Block Protocol. To show what the changes imply for adventurous block authors, this post will be a technical walk-through of how the Block Protocol can be implemented and used in a language that is not TypeScript. Specifically, we're going to build a block in F#—but the methodology and implementation details are applicable for other languages that support JavaScript as a transpilation target and JavaScript interoperability.
 
 ## Building blocks with F\#
 

--- a/sites/hashdev/src/components/BlogPost.tsx
+++ b/sites/hashdev/src/components/BlogPost.tsx
@@ -2,7 +2,7 @@ import { Container, Stack, Typography } from "@mui/material";
 import { Box, TypographyProps } from "@mui/system";
 import Head from "next/head";
 import Image from "next/image";
-import { createContext, FC, ReactNode, useContext, VFC } from "react";
+import { createContext, ReactNode, useContext, FunctionComponent } from "react";
 import { format } from "date-fns";
 import { FRONTEND_URL } from "../config";
 import { Link } from "./Link";
@@ -38,7 +38,7 @@ export type BlogPostAuthorProps = TypographyProps & {
   small?: boolean;
 };
 
-export const BlogPostAuthor: FC<BlogPostAuthorProps> = ({
+export const BlogPostAuthor: FunctionComponent<BlogPostAuthorProps> = ({
   children,
   small = false,
   ...props
@@ -52,7 +52,7 @@ export const BlogPostAuthor: FC<BlogPostAuthorProps> = ({
   </Typography>
 );
 
-export const BlogPostHead: VFC<{
+export const BlogPostHead: FunctionComponent<{
   title?: string;
   subtitle?: string;
   author?: string;
@@ -243,7 +243,9 @@ export const BlogPostHead: VFC<{
   );
 };
 
-export const BlogPostContent: FC<{ children?: ReactNode }> = ({ children }) => (
+export const BlogPostContent: FunctionComponent<{ children?: ReactNode }> = ({
+  children,
+}) => (
   <Container>
     <Box
       sx={{

--- a/sites/hashdev/src/components/Button.tsx
+++ b/sites/hashdev/src/components/Button.tsx
@@ -7,7 +7,7 @@ import {
 } from "@mui/material";
 // eslint-disable-next-line no-restricted-imports
 import Link from "next/link";
-import { FC, forwardRef, useMemo, VFC } from "react";
+import { FunctionComponent, forwardRef, useMemo } from "react";
 import { isHrefExternal } from "./Link";
 import { LoadingSpinner } from "./LoadingSpinner";
 
@@ -17,7 +17,7 @@ export type ButtonProps = {
   disabledTooltipText?: string;
 } & MuiButtonProps & { rel?: string; target?: string }; // MUI button renders <a /> when href is provided, but typings miss rel and target
 
-const LoadingContent: VFC<{
+const LoadingContent: FunctionComponent<{
   withText: boolean;
   variant: ButtonProps["variant"];
   size: ButtonProps["size"];
@@ -65,7 +65,7 @@ const LoadingContent: VFC<{
   );
 };
 
-export const Button: FC<ButtonProps> = forwardRef(
+export const Button: FunctionComponent<ButtonProps> = forwardRef(
   ({ children, loading, loadingWithoutText, href, ...props }, ref) => {
     const linkProps = useMemo(() => {
       if (href && isHrefExternal(href)) {

--- a/sites/hashdev/src/components/CalculationBlock.tsx
+++ b/sites/hashdev/src/components/CalculationBlock.tsx
@@ -1,9 +1,9 @@
 import { MockBlockDock } from "mock-block-dock";
-import { VoidFunctionComponent } from "react";
+import { FunctionComponent } from "react";
 
 const CalcBlock = require("calculation-block").default;
 
-export const CalculationBlock: VoidFunctionComponent = () => (
+export const CalculationBlock: FunctionComponent = () => (
   <>
     <div
       style={{

--- a/sites/hashdev/src/components/Footer.tsx
+++ b/sites/hashdev/src/components/Footer.tsx
@@ -1,5 +1,5 @@
 import { Box, Container, Divider, Stack, Typography } from "@mui/material";
-import { ComponentProps, FC, ReactNode } from "react";
+import { ComponentProps, FunctionComponent, ReactNode } from "react";
 import { SITE_DESCRIPTION } from "../config";
 import { DiscordIcon } from "./icons/DiscordIcon";
 import { GithubIcon } from "./icons/GithubIcon";
@@ -8,7 +8,7 @@ import { Link } from "./Link";
 import { Logo } from "./Logo";
 import { Spacer } from "./Spacer";
 
-const FooterLink: FC<
+const FooterLink: FunctionComponent<
   { href: string } & Omit<ComponentProps<typeof Typography>, "variant">
 > = ({ href, sx = [], children, ...props }) => (
   <Link href={href}>
@@ -25,7 +25,7 @@ const FooterLink: FC<
   </Link>
 );
 
-const FooterLinkWithLabel: FC<
+const FooterLinkWithLabel: FunctionComponent<
   ComponentProps<typeof FooterLink> & {
     type: "open" | "fair";
   }
@@ -61,10 +61,10 @@ const FooterLinkWithLabel: FC<
   );
 };
 
-export const FooterSection: FC<{ children?: ReactNode; label: ReactNode }> = ({
-  label,
-  children,
-}) => (
+export const FooterSection: FunctionComponent<{
+  children?: ReactNode;
+  label: ReactNode;
+}> = ({ label, children }) => (
   <Stack spacing={2}>
     <Stack spacing={1}>
       <Typography variant="hashFooterHeading">{label}</Typography>
@@ -74,7 +74,7 @@ export const FooterSection: FC<{ children?: ReactNode; label: ReactNode }> = ({
   </Stack>
 );
 
-export const Footer: FC = () => (
+export const Footer: FunctionComponent = () => (
   <Box
     component="footer"
     sx={{

--- a/sites/hashdev/src/components/GradientContainer.tsx
+++ b/sites/hashdev/src/components/GradientContainer.tsx
@@ -1,8 +1,8 @@
 import { Box } from "@mui/material";
 import { BoxProps } from "@mui/system";
-import { FC } from "react";
+import { FunctionComponent } from "react";
 
-export const GradientContainer: FC<BoxProps> = ({
+export const GradientContainer: FunctionComponent<BoxProps> = ({
   children,
   sx = [],
   ...props

--- a/sites/hashdev/src/components/ImageWithText.tsx
+++ b/sites/hashdev/src/components/ImageWithText.tsx
@@ -1,8 +1,10 @@
 import { Box } from "@mui/material";
-import { FC, ReactNode } from "react";
+import { FunctionComponent, ReactNode } from "react";
 import { mdxImageClasses } from "./MdxImage";
 
-export const ImageWithText: FC<{ children?: ReactNode }> = ({ children }) => (
+export const ImageWithText: FunctionComponent<{ children?: ReactNode }> = ({
+  children,
+}) => (
   <Box
     sx={{
       display: "flex",

--- a/sites/hashdev/src/components/Link.tsx
+++ b/sites/hashdev/src/components/Link.tsx
@@ -5,7 +5,7 @@ import clsx from "clsx";
 // eslint-disable-next-line no-restricted-imports
 import NextLink, { LinkProps as NextLinkProps } from "next/link";
 import { useRouter } from "next/router";
-import * as React from "react";
+import { forwardRef, isValidElement } from "react";
 import { UrlObject } from "url";
 import { FRONTEND_URL } from "../config";
 import { Button } from "./Button";
@@ -72,7 +72,7 @@ type NextLinkComposedProps = {
 } & Omit<NextLinkProps, "href" | "passHref"> &
   Omit<MuiLinkProps, "href" | "color">;
 
-export const NextLinkComposed = React.forwardRef<
+export const NextLinkComposed = forwardRef<
   HTMLAnchorElement,
   NextLinkComposedProps
 >((props, ref) => {
@@ -100,48 +100,46 @@ export type LinkProps = Omit<NextLinkProps, "passHref"> &
 
 // A styled version of the Next.js Link component:
 // https://nextjs.org/docs/api-reference/next/link
-export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
-  (props, ref) => {
-    const { as: linkAs, className: classNameProps, href, ...other } = props;
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
+  const { as: linkAs, className: classNameProps, href, ...other } = props;
 
-    const router = useRouter();
-    const pathname = typeof href === "string" ? href : href.pathname;
-    const className = clsx(classNameProps, {
-      active: router.pathname === pathname,
-    });
+  const router = useRouter();
+  const pathname = typeof href === "string" ? href : href.pathname;
+  const className = clsx(classNameProps, {
+    active: router.pathname === pathname,
+  });
 
-    if (process.env.NODE_ENV !== "production") {
-      const children = other.children;
-      if (React.isValidElement(children) && children.type === Button) {
-        throw new Error(
-          "Please use <Button href='' /> instead of <Link><Button /></Link>",
-        );
-      }
-    }
-
-    if (isHrefExternal(href)) {
-      other.rel = "noopener";
-      other.target = "_blank";
-
-      return (
-        <MuiLink
-          className={className}
-          href={href as string}
-          ref={ref}
-          {...other}
-        />
+  if (process.env.NODE_ENV !== "production") {
+    const children = other.children;
+    if (isValidElement(children) && children.type === Button) {
+      throw new Error(
+        "Please use <Button href='' /> instead of <Link><Button /></Link>",
       );
     }
+  }
+
+  if (isHrefExternal(href)) {
+    other.rel = "noopener";
+    other.target = "_blank";
 
     return (
       <MuiLink
-        component={NextLinkComposed}
-        as={linkAs}
         className={className}
+        href={href as string}
         ref={ref}
-        to={href}
         {...other}
       />
     );
-  },
-);
+  }
+
+  return (
+    <MuiLink
+      component={NextLinkComposed}
+      as={linkAs}
+      className={className}
+      ref={ref}
+      to={href}
+      {...other}
+    />
+  );
+});

--- a/sites/hashdev/src/components/Link.tsx
+++ b/sites/hashdev/src/components/Link.tsx
@@ -100,46 +100,51 @@ export type LinkProps = Omit<NextLinkProps, "passHref"> &
 
 // A styled version of the Next.js Link component:
 // https://nextjs.org/docs/api-reference/next/link
-export const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
-  const { as: linkAs, className: classNameProps, href, ...other } = props;
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
+  (
+    props,
+    ref, // https://github.com/prettier/prettier/issues/11923
+  ) => {
+    const { as: linkAs, className: classNameProps, href, ...other } = props;
 
-  const router = useRouter();
-  const pathname = typeof href === "string" ? href : href.pathname;
-  const className = clsx(classNameProps, {
-    active: router.pathname === pathname,
-  });
+    const router = useRouter();
+    const pathname = typeof href === "string" ? href : href.pathname;
+    const className = clsx(classNameProps, {
+      active: router.pathname === pathname,
+    });
 
-  if (process.env.NODE_ENV !== "production") {
-    const children = other.children;
-    if (isValidElement(children) && children.type === Button) {
-      throw new Error(
-        "Please use <Button href='' /> instead of <Link><Button /></Link>",
+    if (process.env.NODE_ENV !== "production") {
+      const children = other.children;
+      if (isValidElement(children) && children.type === Button) {
+        throw new Error(
+          "Please use <Button href='' /> instead of <Link><Button /></Link>",
+        );
+      }
+    }
+
+    if (isHrefExternal(href)) {
+      other.rel = "noopener";
+      other.target = "_blank";
+
+      return (
+        <MuiLink
+          className={className}
+          href={href as string}
+          ref={ref}
+          {...other}
+        />
       );
     }
-  }
-
-  if (isHrefExternal(href)) {
-    other.rel = "noopener";
-    other.target = "_blank";
 
     return (
       <MuiLink
+        component={NextLinkComposed}
+        as={linkAs}
         className={className}
-        href={href as string}
         ref={ref}
+        to={href}
         {...other}
       />
     );
-  }
-
-  return (
-    <MuiLink
-      component={NextLinkComposed}
-      as={linkAs}
-      className={className}
-      ref={ref}
-      to={href}
-      {...other}
-    />
-  );
-});
+  },
+);

--- a/sites/hashdev/src/components/LoadingSpinner.tsx
+++ b/sites/hashdev/src/components/LoadingSpinner.tsx
@@ -1,5 +1,5 @@
 import { Box, CircularProgress, circularProgressClasses } from "@mui/material";
-import { VFC } from "react";
+import { FunctionComponent } from "react";
 
 const DEFAULT_THICKNESS = 5;
 const DEFAULT_SIZE = 20;
@@ -10,7 +10,7 @@ type LoadingSpinnerProps = {
   color?: string;
 };
 
-export const LoadingSpinner: VFC<LoadingSpinnerProps> = ({
+export const LoadingSpinner: FunctionComponent<LoadingSpinnerProps> = ({
   size = DEFAULT_SIZE,
   thickness = DEFAULT_THICKNESS,
   color = "currentColor",

--- a/sites/hashdev/src/components/Logo.tsx
+++ b/sites/hashdev/src/components/Logo.tsx
@@ -1,11 +1,10 @@
 import Image from "next/image";
-import { ComponentProps, VFC } from "react";
+import { ComponentProps, FunctionComponent } from "react";
 import { Link } from "./Link";
 
-export const Logo: VFC<Omit<ComponentProps<typeof Link>, "href">> = ({
-  sx = [],
-  ...props
-}) => (
+export const Logo: FunctionComponent<
+  Omit<ComponentProps<typeof Link>, "href">
+> = ({ sx = [], ...props }) => (
   <Link
     href="/"
     sx={[

--- a/sites/hashdev/src/components/MdxImage.tsx
+++ b/sites/hashdev/src/components/MdxImage.tsx
@@ -1,12 +1,12 @@
 import { Box } from "@mui/system";
 import { ImageProps } from "next/dist/client/image";
 import Image from "next/image";
-import { HTMLProps, VFC } from "react";
+import { HTMLProps, FunctionComponent } from "react";
 import { useBlogPostPhotos } from "./BlogPost";
 
 export const mdxImageClasses = { root: "MdxImage" };
 
-export const MdxImage: VFC<
+export const MdxImage: FunctionComponent<
   Omit<ImageProps, "src"> & { src: string; style: HTMLProps<HTMLDivElement> }
 > = ({ src, width, height, style, ...props }) => {
   const { body } = useBlogPostPhotos();

--- a/sites/hashdev/src/components/MdxPageContent.tsx
+++ b/sites/hashdev/src/components/MdxPageContent.tsx
@@ -1,13 +1,13 @@
 // @todo update from blockprotocol
 import { MDXRemote, MDXRemoteSerializeResult } from "next-mdx-remote";
-import { VFC } from "react";
+import { FunctionComponent } from "react";
 import { mdxComponents } from "../util/mdxComponents";
 
 type MdxPageContentProps = {
   serializedPage: MDXRemoteSerializeResult<Record<string, unknown>>;
 };
 
-export const MdxPageContent: VFC<MdxPageContentProps> = ({
+export const MdxPageContent: FunctionComponent<MdxPageContentProps> = ({
   serializedPage,
 }) => {
   // @ts-expect-error @todo fix this

--- a/sites/hashdev/src/components/MdxVideo.tsx
+++ b/sites/hashdev/src/components/MdxVideo.tsx
@@ -1,7 +1,7 @@
 import { Box } from "@mui/material";
-import { VoidFunctionComponent } from "react";
+import { FunctionComponent } from "react";
 
-export const MdxVideo: VoidFunctionComponent<{
+export const MdxVideo: FunctionComponent<{
   src: string;
   title: string;
 }> = ({ src, title }) => {

--- a/sites/hashdev/src/components/Navbar.tsx
+++ b/sites/hashdev/src/components/Navbar.tsx
@@ -14,7 +14,7 @@ import {
 import { SxProps, Theme } from "@mui/system";
 import clsx from "clsx";
 import { useRouter } from "next/router";
-import { useState, VFC } from "react";
+import { useState, FunctionComponent } from "react";
 import { Button } from "./Button";
 import { FaIcon } from "./icons/FaIcon";
 import { FontAwesomeIcon } from "./icons/FontAwesomeIcon";
@@ -51,7 +51,7 @@ const NAV_BUTTON_STYLES: SxProps<Theme> = {
   },
 };
 
-const DesktopNav: VFC = () => {
+const DesktopNav: FunctionComponent = () => {
   const router = useRouter();
 
   return (
@@ -122,10 +122,10 @@ const DesktopNav: VFC = () => {
   );
 };
 
-const MobileNavButton: VFC<{ open: boolean; onOpenToggle: () => void }> = ({
-  open,
-  onOpenToggle,
-}) => (
+const MobileNavButton: FunctionComponent<{
+  open: boolean;
+  onOpenToggle: () => void;
+}> = ({ open, onOpenToggle }) => (
   <IconButton
     sx={{
       ml: "auto",
@@ -142,10 +142,10 @@ const MobileNavButton: VFC<{ open: boolean; onOpenToggle: () => void }> = ({
   </IconButton>
 );
 
-const MobileNav: VFC<{ open: boolean; onMenuClose: () => void }> = ({
-  open,
-  onMenuClose,
-}) => {
+const MobileNav: FunctionComponent<{
+  open: boolean;
+  onMenuClose: () => void;
+}> = ({ open, onMenuClose }) => {
   const router = useRouter();
   return (
     <>
@@ -262,7 +262,7 @@ const MobileNav: VFC<{ open: boolean; onMenuClose: () => void }> = ({
   );
 };
 
-export const Navbar: VFC = () => {
+export const Navbar: FunctionComponent = () => {
   const theme = useTheme();
   const mobileNav = useMediaQuery(theme.breakpoints.down("md"));
   const [mobileNavOpen, setMobileNavOpen] = useState(false);

--- a/sites/hashdev/src/components/PageLayout.tsx
+++ b/sites/hashdev/src/components/PageLayout.tsx
@@ -1,6 +1,6 @@
 import { Box } from "@mui/material";
 import { useTheme } from "@mui/system";
-import { FC, ReactNode } from "react";
+import { FunctionComponent, ReactNode } from "react";
 import { Footer } from "./Footer";
 import { HiringBanner } from "./HiringBanner";
 import { Navbar } from "./Navbar";
@@ -8,10 +8,10 @@ import { PreFooter } from "./PreFooter";
 
 // @todo extract NavLink component
 
-export const PageLayout: FC<{ children?: ReactNode; subscribe?: boolean }> = ({
-  children,
-  subscribe = true,
-}) => {
+export const PageLayout: FunctionComponent<{
+  children?: ReactNode;
+  subscribe?: boolean;
+}> = ({ children, subscribe = true }) => {
   const theme = useTheme();
 
   return (

--- a/sites/hashdev/src/components/PreFooter.tsx
+++ b/sites/hashdev/src/components/PreFooter.tsx
@@ -2,7 +2,13 @@ import { Box, Container, Stack, Typography } from "@mui/material";
 import { BoxProps } from "@mui/system";
 import axios from "axios";
 import { useRouter } from "next/router";
-import { useCallback, useEffect, useRef, useState, VFC } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  FunctionComponent,
+} from "react";
 import { unstable_batchedUpdates } from "react-dom";
 import { FRONTEND_URL } from "../config";
 import { Button } from "./Button";
@@ -16,7 +22,7 @@ const EMAIL_REGEX =
 
 const subscribeElmId = "subscribe";
 
-export const Subscribe: VFC<BoxProps> = (props) => {
+export const Subscribe: FunctionComponent<BoxProps> = (props) => {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [userJoined, setUserJoined] = useState<boolean>(false);
@@ -201,7 +207,7 @@ export const Subscribe: VFC<BoxProps> = (props) => {
   );
 };
 
-const Community: VFC = () => {
+const Community: FunctionComponent = () => {
   return (
     <Box
       sx={{
@@ -279,7 +285,7 @@ const Community: VFC = () => {
   );
 };
 
-export const PreFooter: VFC<{ subscribe?: boolean }> = ({
+export const PreFooter: FunctionComponent<{ subscribe?: boolean }> = ({
   subscribe = true,
 }) => (
   <>

--- a/sites/hashdev/src/components/Snippet.tsx
+++ b/sites/hashdev/src/components/Snippet.tsx
@@ -19,14 +19,14 @@ import "prismjs/components/prism-fsharp";
 
 import { Box, BoxProps } from "@mui/material";
 import Prism from "prismjs";
-import React from "react";
+import { FunctionComponent } from "react";
 
 type SnippetProps = {
   source: string;
   language: string;
 } & BoxProps;
 
-export const Snippet: React.VFC<SnippetProps> = ({
+export const Snippet: FunctionComponent<SnippetProps> = ({
   source,
   language,
   ...boxProps

--- a/sites/hashdev/src/components/Spacer.tsx
+++ b/sites/hashdev/src/components/Spacer.tsx
@@ -1,6 +1,6 @@
 import { Box, Breakpoint, Theme } from "@mui/material";
 import { SystemStyleObject } from "@mui/system";
-import { VFC } from "react";
+import { FunctionComponent } from "react";
 
 type FlexProps = { flex: true };
 type InnerNotFlexProps = {
@@ -27,7 +27,7 @@ const spacerStyles = ({
   flexBasis: (theme) => (basis ? theme.spacing(basis) : undefined),
 });
 
-export const Spacer: VFC<SpacerProps> = ({
+export const Spacer: FunctionComponent<SpacerProps> = ({
   x,
   y,
   flex,

--- a/sites/hashdev/src/components/TextField.tsx
+++ b/sites/hashdev/src/components/TextField.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useState, VFC } from "react";
+import { ReactNode, useEffect, useState, FunctionComponent } from "react";
 import {
   Box,
   Collapse,
@@ -14,7 +14,7 @@ type TextFieldProps = {
   displayErrorOnTouched?: boolean;
 } & MuiTextFieldProps;
 
-export const TextField: VFC<TextFieldProps> = ({
+export const TextField: FunctionComponent<TextFieldProps> = ({
   helperText,
   sx,
   ...textFieldProps

--- a/sites/hashdev/src/components/icons/DiscordIcon.tsx
+++ b/sites/hashdev/src/components/icons/DiscordIcon.tsx
@@ -1,7 +1,10 @@
-import { VFC } from "react";
+import { FunctionComponent } from "react";
 import { SvgIcon, SvgIconProps } from "@mui/material";
 
-export const DiscordIcon: VFC<SvgIconProps> = ({ sx = [], ...props }) => (
+export const DiscordIcon: FunctionComponent<SvgIconProps> = ({
+  sx = [],
+  ...props
+}) => (
   <SvgIcon
     {...props}
     viewBox="0 0 18 21"

--- a/sites/hashdev/src/components/icons/FaIcon.tsx
+++ b/sites/hashdev/src/components/icons/FaIcon.tsx
@@ -1,11 +1,11 @@
 import { Box } from "@mui/system";
-import { ComponentProps, VFC } from "react";
+import { ComponentProps, FunctionComponent } from "react";
 
 /**
  * @note A necessary script for this is added in
  *   {@link import("../../theme/MuiProvider").MuiProvider}
  */
-export const FaIcon: VFC<
+export const FaIcon: FunctionComponent<
   { name: string; type: string } & ComponentProps<typeof Box>
 > = ({ name, type, ...props }) => (
   <Box component="span" className={`fa-${name} fa-${type}`} {...props} />

--- a/sites/hashdev/src/components/icons/FontAwesomeIcon.tsx
+++ b/sites/hashdev/src/components/icons/FontAwesomeIcon.tsx
@@ -1,15 +1,15 @@
-import * as React from "react";
 import { SvgIcon, SvgIconProps } from "@mui/material";
 import { IconDefinition } from "@fortawesome/free-solid-svg-icons";
+import { forwardRef } from "react";
 
 type FontAwesomeIconProps = {
   icon: IconDefinition;
 } & SvgIconProps;
 
 // gotten from https://mui.com/components/icons/#font-awesome
-export const FontAwesomeIcon = React.forwardRef<
+export const FontAwesomeIcon = forwardRef<
   SVGSVGElement,
-  FontAwesomeIconProps
+  FontAwesomeIconProps // https://github.com/prettier/prettier/issues/11923
 >((props, ref) => {
   const { icon, sx, ...otherProps } = props;
 

--- a/sites/hashdev/src/components/icons/GithubIcon.tsx
+++ b/sites/hashdev/src/components/icons/GithubIcon.tsx
@@ -1,7 +1,10 @@
-import { VFC } from "react";
+import { FunctionComponent } from "react";
 import { SvgIcon, SvgIconProps } from "@mui/material";
 
-export const GithubIcon: VFC<SvgIconProps> = ({ sx = [], ...props }) => (
+export const GithubIcon: FunctionComponent<SvgIconProps> = ({
+  sx = [],
+  ...props
+}) => (
   <SvgIcon
     {...props}
     viewBox="0 0 20 20"

--- a/sites/hashdev/src/components/icons/TwitterIcon.tsx
+++ b/sites/hashdev/src/components/icons/TwitterIcon.tsx
@@ -1,7 +1,10 @@
-import { VFC } from "react";
+import { FunctionComponent } from "react";
 import { SvgIcon, SvgIconProps } from "@mui/material";
 
-export const TwitterIcon: VFC<SvgIconProps> = ({ sx = [], ...props }) => (
+export const TwitterIcon: FunctionComponent<SvgIconProps> = ({
+  sx = [],
+  ...props
+}) => (
   <SvgIcon
     {...props}
     viewBox="0 0 20 17"

--- a/sites/hashdev/src/pages/_app.page.tsx
+++ b/sites/hashdev/src/pages/_app.page.tsx
@@ -4,7 +4,7 @@ import "../../styles/prism.css";
 import { EmotionCache } from "@emotion/react";
 import type { AppProps } from "next/app";
 import { useRouter } from "next/router";
-import { useEffect, VFC } from "react";
+import { useEffect, FunctionComponent } from "react";
 import "../../styles/globals.css";
 import { PageLayout } from "../components/PageLayout";
 import { theme } from "../theme";
@@ -19,7 +19,11 @@ type MyAppProps = {
   emotionCache?: EmotionCache;
 } & AppPropsWithLayout;
 
-const MyApp: VFC<MyAppProps> = ({ Component, pageProps, emotionCache }) => {
+const MyApp: FunctionComponent<MyAppProps> = ({
+  Component,
+  pageProps,
+  emotionCache,
+}) => {
   const router = useRouter();
 
   // Use the layout defined at the page level, if available

--- a/sites/hashdev/src/pages/_document.page.tsx
+++ b/sites/hashdev/src/pages/_document.page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Document, {
   Html,
   Head,
@@ -7,6 +6,7 @@ import Document, {
   DocumentContext,
 } from "next/document";
 import createEmotionServer from "@emotion/server/create-instance";
+import { Children } from "react";
 import { createEmotionCache } from "../util/createEmotionCache";
 
 class MyDocument extends Document {
@@ -65,10 +65,7 @@ class MyDocument extends Document {
     return {
       ...initialProps,
       // Styles fragment is rendered after the app and page rendering finish.
-      styles: [
-        ...React.Children.toArray(initialProps.styles),
-        ...emotionStyleTags,
-      ],
+      styles: [...Children.toArray(initialProps.styles), ...emotionStyleTags],
     };
   }
 

--- a/sites/hashdev/src/pages/blog/index.page.tsx
+++ b/sites/hashdev/src/pages/blog/index.page.tsx
@@ -9,7 +9,7 @@ import { Box } from "@mui/system";
 import { GetStaticProps } from "next";
 import Head from "next/head";
 import Image from "next/image";
-import { ComponentProps, FC, Fragment, VFC } from "react";
+import { ComponentProps, FunctionComponent, Fragment } from "react";
 import { BlogPostAuthor, BlogPostPagePhoto } from "../../components/BlogPost";
 import { GradientContainer } from "../../components/GradientContainer";
 import { Link } from "../../components/Link";
@@ -79,7 +79,7 @@ export const getStaticProps: GetStaticProps<BlogPageListProps> = async () => {
   }
 };
 
-const BlogPostLink: FC<
+const BlogPostLink: FunctionComponent<
   { page: BlogIndividualPage } & Omit<ComponentProps<typeof Link>, "href">
 > = ({ page, children, ...props }) => (
   <Link
@@ -93,13 +93,16 @@ const BlogPostLink: FC<
   </Link>
 );
 
-const PostCopyContainer: FC<StackProps> = ({ children, ...props }) => (
+const PostCopyContainer: FunctionComponent<StackProps> = ({
+  children,
+  ...props
+}) => (
   <Stack {...props} direction="column" spacing={{ xs: 1, md: 2 }}>
     {children}
   </Stack>
 );
 
-const PostImage: VFC<{
+const PostImage: FunctionComponent<{
   page: BlogIndividualPage;
   fill?: boolean;
   square?: boolean;
@@ -118,7 +121,7 @@ const PostImage: VFC<{
     </BlogPostLink>
   ) : null;
 
-const BigPost: VFC<{ page: BlogIndividualPage }> = ({ page }) => (
+const BigPost: FunctionComponent<{ page: BlogIndividualPage }> = ({ page }) => (
   <Stack direction="column" spacing={{ xs: 3, md: 4 }}>
     <Box position="relative">
       <PostImage page={page} fill={false} />
@@ -141,7 +144,7 @@ const BigPost: VFC<{ page: BlogIndividualPage }> = ({ page }) => (
   </Stack>
 );
 
-const Post: VFC<{
+const Post: FunctionComponent<{
   post: BlogIndividualPage;
   collapsed?: boolean;
   displayPhoto?: boolean;
@@ -189,7 +192,7 @@ const Post: VFC<{
   </Stack>
 );
 
-const FourPostsRow: VFC<{
+const FourPostsRow: FunctionComponent<{
   reverse?: boolean;
   posts: BlogIndividualPage[];
   displayPhotos: boolean;
@@ -223,7 +226,9 @@ const FourPostsRow: VFC<{
   </Stack>
 );
 
-const ThreePostsRow: VFC<{ posts: BlogIndividualPage[] }> = ({ posts }) => (
+const ThreePostsRow: FunctionComponent<{ posts: BlogIndividualPage[] }> = ({
+  posts,
+}) => (
   <Stack direction={{ xs: "column", md: "row" }} spacing={5}>
     {posts.map((post) => (
       <Post post={post} collapsed key={post.fileName} />

--- a/sites/hashdev/src/pages/index.page.tsx
+++ b/sites/hashdev/src/pages/index.page.tsx
@@ -10,14 +10,14 @@ import { useTheme } from "@mui/system";
 import type { NextPage } from "next";
 import Head from "next/head";
 import Image from "next/image";
-import { ComponentProps, FC, ReactNode, VFC } from "react";
+import { ComponentProps, FunctionComponent, ReactNode } from "react";
 import { Button } from "../components/Button";
 import { GradientContainer } from "../components/GradientContainer";
 import { FaIcon } from "../components/icons/FaIcon";
 import { Link } from "../components/Link";
 import { SITE_DESCRIPTION } from "../config";
 
-const StylishDivider: VFC<
+const StylishDivider: FunctionComponent<
   ComponentProps<typeof Stack> & { wide?: boolean }
 > = ({ wide = false, ...props }) => {
   const bgcolor = "orange.400";
@@ -38,7 +38,7 @@ const StylishDivider: VFC<
   );
 };
 
-const Hero: VFC = () => (
+const Hero: FunctionComponent = () => (
   <GradientContainer>
     <Container>
       <Box width={{ xs: 1, md: 873 }}>
@@ -73,7 +73,7 @@ const Hero: VFC = () => (
   </GradientContainer>
 );
 
-const Project: FC<{
+const Project: FunctionComponent<{
   buttons: ReactNode;
   children?: ReactNode;
   image: ReactNode;
@@ -131,7 +131,7 @@ const Project: FC<{
   );
 };
 
-const Projects: VFC<ComponentProps<typeof Stack>> = (props) => {
+const Projects: FunctionComponent<ComponentProps<typeof Stack>> = (props) => {
   return (
     <Container component="section">
       <Stack {...props} direction={{ xs: "column", lg: "row" }} spacing={6}>

--- a/sites/hashdev/src/theme/MuiProvider.tsx
+++ b/sites/hashdev/src/theme/MuiProvider.tsx
@@ -2,12 +2,12 @@ import { CacheProvider, EmotionCache } from "@emotion/react";
 import { ThemeProvider } from "@mui/material";
 import CssBaseline from "@mui/material/CssBaseline";
 import { ThemeProviderProps } from "@mui/material/styles/ThemeProvider";
-import { FC, ReactNode, useEffect } from "react";
+import { FunctionComponent, ReactNode, useEffect } from "react";
 import { createEmotionCache } from "../util/createEmotionCache";
 
 const clientSideEmotionCache = createEmotionCache();
 
-export const MuiProvider: FC<{
+export const MuiProvider: FunctionComponent<{
   children?: ReactNode;
   emotionCache?: EmotionCache;
   theme: ThemeProviderProps["theme"];

--- a/sites/hashdev/theme-override.d.ts
+++ b/sites/hashdev/theme-override.d.ts
@@ -49,37 +49,37 @@ declare module "@mui/material/styles" {
   }
 
   interface TypographyVariants {
-    hashLargeTitle: React.CSSProperties;
-    hashHeading1: React.CSSProperties;
-    hashHeading2: React.CSSProperties;
-    hashHeading3: React.CSSProperties;
-    hashHeading4: React.CSSProperties;
-    hashHeading5: React.CSSProperties;
-    hashBodyCopy: React.CSSProperties;
-    hashLargeText: React.CSSProperties;
-    hashSmallText: React.CSSProperties;
-    hashSmallTextMedium: React.CSSProperties;
-    hashFooterHeading: React.CSSProperties;
-    hashSmallCaps: React.CSSProperties;
-    hashMediumCaps: React.CSSProperties;
-    hashSocialIconLink?: React.CSSProperties;
+    hashLargeTitle: CSSProperties;
+    hashHeading1: CSSProperties;
+    hashHeading2: CSSProperties;
+    hashHeading3: CSSProperties;
+    hashHeading4: CSSProperties;
+    hashHeading5: CSSProperties;
+    hashBodyCopy: CSSProperties;
+    hashLargeText: CSSProperties;
+    hashSmallText: CSSProperties;
+    hashSmallTextMedium: CSSProperties;
+    hashFooterHeading: CSSProperties;
+    hashSmallCaps: CSSProperties;
+    hashMediumCaps: CSSProperties;
+    hashSocialIconLink?: CSSProperties;
   }
 
   interface TypographyVariantsOptions {
-    hashLargeTitle?: React.CSSProperties;
-    hashHeading1?: React.CSSProperties;
-    hashHeading2?: React.CSSProperties;
-    hashHeading3?: React.CSSProperties;
-    hashHeading4?: React.CSSProperties;
-    hashHeading5?: React.CSSProperties;
-    hashBodyCopy?: React.CSSProperties;
-    hashLargeText?: React.CSSProperties;
-    hashSmallText?: React.CSSProperties;
-    hashSmallTextMedium?: React.CSSProperties;
-    hashFooterHeading?: React.CSSProperties;
-    hashSmallCaps?: React.CSSProperties;
-    hashMediumCaps?: React.CSSProperties;
-    hashSocialIconLink?: React.CSSProperties;
+    hashLargeTitle?: CSSProperties;
+    hashHeading1?: CSSProperties;
+    hashHeading2?: CSSProperties;
+    hashHeading3?: CSSProperties;
+    hashHeading4?: CSSProperties;
+    hashHeading5?: CSSProperties;
+    hashBodyCopy?: CSSProperties;
+    hashLargeText?: CSSProperties;
+    hashSmallText?: CSSProperties;
+    hashSmallTextMedium?: CSSProperties;
+    hashFooterHeading?: CSSProperties;
+    hashSmallCaps?: CSSProperties;
+    hashMediumCaps?: CSSProperties;
+    hashSocialIconLink?: CSSProperties;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7880,12 +7880,7 @@ ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
-ci-info@^3.2.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.0.tgz#b4ed1fb6818dea4803a55c623041f9165d2066b2"
-  integrity sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==
-
-ci-info@^3.3.2:
+ci-info@^3.2.0, ci-info@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.2.tgz#6d2967ffa407466481c6c90b6e16b3098f080128"
   integrity sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==
@@ -16234,10 +16229,10 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.x, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
-  version "7.3.5"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
-  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+semver@7.x, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -16245,13 +16240,6 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.3.7:
-  version "7.3.7"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
-  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
-  dependencies:
-    lru-cache "^6.0.0"
 
 send@0.17.1:
   version "0.17.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2217,7 +2217,7 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-validator-identifier@^7.15.7", "@babel/helper-validator-identifier@^7.16.7", "@babel/helper-validator-identifier@^7.18.6":
+"@babel/helper-validator-identifier@^7.16.7", "@babel/helper-validator-identifier@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
   integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
@@ -7880,10 +7880,15 @@ ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
-ci-info@^3.2.0, ci-info@^3.3.0:
+ci-info@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.0.tgz#b4ed1fb6818dea4803a55c623041f9165d2066b2"
   integrity sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==
+
+ci-info@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.2.tgz#6d2967ffa407466481c6c90b6e16b3098f080128"
+  integrity sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==
 
 cjs-module-lexer@^1.0.0:
   version "1.2.2"
@@ -9408,13 +9413,13 @@ eslint-plugin-react@7.29.4:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.6"
 
-eslint-plugin-unicorn@41.0.1:
-  version "41.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-41.0.1.tgz#b49205b38e71e227d21fb5776f8d078a1dc637ca"
-  integrity sha512-gF5vo2dIj0YdNMQ/IMegiBkQdQ22GBFFVpdkJP+0og3w7XD4ypea0xQVRv6iofkLVR2w0phAdikcnU01ybd4Ow==
+eslint-plugin-unicorn@43.0.2:
+  version "43.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-43.0.2.tgz#b189d58494c8a0985a4b89dba5dbfde3ad7575a5"
+  integrity sha512-DtqZ5mf/GMlfWoz1abIjq5jZfaFuHzGBZYIeuJfEoKKGWRHr2JiJR+ea+BF7Wx2N1PPRoT/2fwgiK1NnmNE3Hg==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.15.7"
-    ci-info "^3.3.0"
+    "@babel/helper-validator-identifier" "^7.18.6"
+    ci-info "^3.3.2"
     clean-regexp "^1.0.0"
     eslint-utils "^3.0.0"
     esquery "^1.4.0"
@@ -9425,7 +9430,7 @@ eslint-plugin-unicorn@41.0.1:
     read-pkg-up "^7.0.1"
     regexp-tree "^0.1.24"
     safe-regex "^2.1.1"
-    semver "^7.3.5"
+    semver "^7.3.7"
     strip-indent "^3.0.0"
 
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
@@ -16240,6 +16245,13 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
+  dependencies:
+    lru-cache "^6.0.0"
 
 send@0.17.1:
   version "0.17.1"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The goal of this PR is to reduce the entropy in the codebase by aligning React import style. See similar work in https://github.com/blockprotocol/blockprotocol/pull/441.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202542409311090/1202621858687196/f) _(internal)_

## 🔍 What does this change?

- `FC`, `VFC`, `VoidFunctionComponent` → `FunctionComponent`
- `import React from "react"` & `import * as React from "react"` → `import { ... } from "react"`
- see PR comments

## 📜 Does this require a change to the docs?

No

## ⚠️ Known issues

- See PR comments
- https://github.com/prettier/prettier/issues/11923

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

- Consider removing `FunctionComponent` (possibly via https://github.com/gndelia/codemod-replace-react-fc-typescript)
- Introduce `simple-import-sort` ESLint plugin, similar to how this was done in https://github.com/blockprotocol/blockprotocol/pull/297

## 🛡 What tests cover this?

CI

## ❓ How to test this?

Check CI and diff
