### PR TITLE
Remove `Store` bounds

### DIFF
--- a/packages/graph/hash_graph/bin/hash_graph/src/main.rs
+++ b/packages/graph/hash_graph/bin/hash_graph/src/main.rs
@@ -1,6 +1,6 @@
 mod args;
 
-use std::{fmt, net::SocketAddr};
+use std::{fmt, net::SocketAddr, sync::Arc};
 
 use error_stack::{Context, FutureExt, Result};
 use graph::{
@@ -52,7 +52,7 @@ async fn main() -> Result<(), GraphError> {
         tracing::info!(%account_id, "created account id");
     }
 
-    let rest_router = rest_api_router(store);
+    let rest_router = rest_api_router(Arc::new(store));
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
 
     tracing::info!("Listening on {addr}");

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/api_resource.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/api_resource.rs
@@ -9,7 +9,7 @@ use crate::store::Store;
 /// through a `Router`, making it explicitly clear we want to provide `OpenApi` specification as
 /// documentation for the routes.
 pub(super) trait RoutedResource: utoipa::OpenApi {
-    fn routes<S: Store>() -> Router;
+    fn routes<S: Store + Send + Sync + 'static>() -> Router;
     fn documentation() -> utoipa::openapi::OpenApi {
         Self::openapi()
     }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
@@ -9,13 +9,15 @@ mod entity_type;
 mod link_type;
 mod property_type;
 
+use std::sync::Arc;
+
 use axum::{routing::get, Extension, Json, Router};
 use utoipa::{openapi, Modify, OpenApi};
 
 use self::api_resource::RoutedResource;
 use crate::store::Store;
 
-fn api_resources<T: Store>() -> Vec<Router> {
+fn api_resources<T: Store + Send + Sync + 'static>() -> Vec<Router> {
     vec![
         data_type::DataTypeResource::routes::<T>(),
         property_type::PropertyTypeResource::routes::<T>(),
@@ -35,7 +37,7 @@ fn api_documentation() -> Vec<openapi::OpenApi> {
     ]
 }
 
-pub fn rest_api_router<T: Store>(store: T) -> Router {
+pub fn rest_api_router<T: Store + Send + Sync + 'static>(store: Arc<T>) -> Router {
     // All api resources are merged together into a super-router.
     let merged_routes = api_resources::<T>()
         .into_iter()

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -170,7 +170,7 @@ impl fmt::Display for DatabaseConnectionInfo {
 /// In addition to the errors described in the methods of this trait, further errors might also be
 /// raised depending on the implementation, e.g. connection issues.
 #[async_trait]
-pub trait Store: Clone + Send + Sync + 'static {
+pub trait Store {
     /// Fetches the [`VersionId`] of the specified [`VersionedUri`].
     ///
     /// # Errors:

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -28,7 +28,6 @@ use crate::{
 };
 
 /// A Postgres-backed store
-#[derive(Clone)]
 pub struct PostgresDatabase {
     pub pool: PgPool,
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We are going to split the pooling and the connection logic of the `Store`, this implies, that the `Store` itself is not necessarily `Clone` anymore. `Send` + `Sync` + `'static` are not necessarily required for a store.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1202538466812818/1202660056731614/f) _(internal)_


## 🔍 What does this change?

- Remove the `Clone` bound by using `Arc` instead
- Remove `Send` + `Sync` + `'static` bounds by moving them to the REST API. `Send` + `'static` are required to use the `Store` inside of a router, the `Sync` bound is required because `Arc<T>` implements `Send` when `T: Send + Sync`
- Drive-by: Reduce boilerplate in REST API methods

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

Split the pooling logic from the connection logic

## 🛡 What tests cover this?

- REST API tests
