### PR TITLE
Implement pool logic for the `Store`

### DIFF
--- a/packages/graph/hash_graph/bin/hash_graph/src/main.rs
+++ b/packages/graph/hash_graph/bin/hash_graph/src/main.rs
@@ -2,9 +2,12 @@ mod args;
 
 use std::{fmt, net::SocketAddr, sync::Arc};
 
-use error_stack::{Context, FutureExt, Result};
+use error_stack::{Context, Result, ResultExt};
 use graph::{
-    api::rest::rest_api_router, logging::init_logger, ontology::AccountId, store::PostgresDatabase,
+    api::rest::rest_api_router,
+    logging::init_logger,
+    ontology::AccountId,
+    store::{PostgresDatabasePool, StorePool},
 };
 use uuid::Uuid;
 
@@ -30,9 +33,9 @@ async fn main() -> Result<(), GraphError> {
         &args.log_config.log_file_prefix,
     );
 
-    let store = PostgresDatabase::new(&args.db_info)
-        .change_context(GraphError)
+    let pool = PostgresDatabasePool::new(&args.db_info)
         .await
+        .change_context(GraphError)
         .map_err(|err| {
             tracing::error!("{err:?}");
             err
@@ -41,10 +44,19 @@ async fn main() -> Result<(), GraphError> {
     // TODO: Revisit, once authentication is in place
     let account_id = AccountId::new(Uuid::nil());
 
-    if store
-        .insert_account_id(account_id)
-        .change_context(GraphError)
+    let mut connection = pool
+        .acquire()
         .await
+        .change_context(GraphError)
+        .map_err(|err| {
+            tracing::error!("{err:?}");
+            err
+        })?;
+
+    if connection
+        .insert_account_id(account_id)
+        .await
+        .change_context(GraphError)
         .is_err()
     {
         tracing::info!(%account_id, "account id already exist");
@@ -52,7 +64,7 @@ async fn main() -> Result<(), GraphError> {
         tracing::info!(%account_id, "created account id");
     }
 
-    let rest_router = rest_api_router(Arc::new(store));
+    let rest_router = rest_api_router(Arc::new(pool));
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
 
     tracing::info!("Listening on {addr}");

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/api_resource.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/api_resource.rs
@@ -1,6 +1,6 @@
 use axum::Router;
 
-use crate::store::Store;
+use crate::store::StorePool;
 
 /// With REST, we define resources that can be acted on. These resources are defined through
 /// routes and HTTP methods.
@@ -9,7 +9,7 @@ use crate::store::Store;
 /// through a `Router`, making it explicitly clear we want to provide `OpenApi` specification as
 /// documentation for the routes.
 pub(super) trait RoutedResource: utoipa::OpenApi {
-    fn routes<S: Store + Send + Sync + 'static>() -> Router;
+    fn routes<S: StorePool + 'static>() -> Router;
     fn documentation() -> utoipa::openapi::OpenApi {
         Self::openapi()
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -1,4 +1,5 @@
 pub mod error;
+mod pool;
 mod postgres;
 
 use std::fmt;
@@ -8,7 +9,8 @@ use error_stack::{Context, Result};
 
 pub use self::{
     error::{BaseUriAlreadyExists, BaseUriDoesNotExist, InsertionError, QueryError, UpdateError},
-    postgres::PostgresDatabase,
+    pool::StorePool,
+    postgres::{PostgresDatabase, PostgresDatabasePool},
 };
 use crate::{
     knowledge::{Entity, EntityId},
@@ -176,7 +178,7 @@ pub trait Store {
     /// # Errors:
     ///
     /// - if the entry referred to by `uri` does not exist.
-    async fn version_id_by_uri(&self, uri: &VersionedUri) -> Result<VersionId, QueryError>;
+    async fn version_id_by_uri(&mut self, uri: &VersionedUri) -> Result<VersionId, QueryError>;
     /// Creates a new [`DataType`].
     ///
     /// # Errors:
@@ -186,7 +188,7 @@ pub trait Store {
     ///
     /// [`BaseUri`]: crate::ontology::types::uri::BaseUri
     async fn create_data_type(
-        &self,
+        &mut self,
         data_type: DataType,
         created_by: AccountId,
     ) -> Result<Persisted<DataType>, InsertionError>;
@@ -196,8 +198,10 @@ pub trait Store {
     /// # Errors
     ///
     /// - if the requested [`DataType`] doesn't exist.
-    async fn get_data_type(&self, version_id: VersionId)
-    -> Result<Persisted<DataType>, QueryError>;
+    async fn get_data_type(
+        &mut self,
+        version_id: VersionId,
+    ) -> Result<Persisted<DataType>, QueryError>;
 
     /// Update the definition of an existing [`DataType`].
     ///
@@ -205,7 +209,7 @@ pub trait Store {
     ///
     /// - if the [`DataType`] doesn't exist.
     async fn update_data_type(
-        &self,
+        &mut self,
         data_type: DataType,
         updated_by: AccountId,
     ) -> Result<Persisted<DataType>, UpdateError>;
@@ -219,7 +223,7 @@ pub trait Store {
     ///
     /// [`BaseUri`]: crate::ontology::types::uri::BaseUri
     async fn create_property_type(
-        &self,
+        &mut self,
         property_type: PropertyType,
         created_by: AccountId,
     ) -> Result<Persisted<PropertyType>, InsertionError>;
@@ -230,7 +234,7 @@ pub trait Store {
     ///
     /// - if the requested [`PropertyType`] doesn't exist.
     async fn get_property_type(
-        &self,
+        &mut self,
         version_id: VersionId,
     ) -> Result<Persisted<PropertyType>, QueryError>;
 
@@ -240,7 +244,7 @@ pub trait Store {
     ///
     /// - if the [`PropertyType`] doesn't exist.
     async fn update_property_type(
-        &self,
+        &mut self,
         property_type: PropertyType,
         updated_by: AccountId,
     ) -> Result<Persisted<PropertyType>, UpdateError>;
@@ -254,7 +258,7 @@ pub trait Store {
     ///
     /// [`BaseUri`]: crate::ontology::types::uri::BaseUri
     async fn create_entity_type(
-        &self,
+        &mut self,
         entity_type: EntityType,
         created_by: AccountId,
     ) -> Result<Persisted<EntityType>, InsertionError>;
@@ -265,7 +269,7 @@ pub trait Store {
     ///
     /// - if the requested [`EntityType`] doesn't exist.
     async fn get_entity_type(
-        &self,
+        &mut self,
         version_id: VersionId,
     ) -> Result<Persisted<EntityType>, QueryError>;
 
@@ -275,7 +279,7 @@ pub trait Store {
     ///
     /// - if the [`EntityType`] doesn't exist.
     async fn update_entity_type(
-        &self,
+        &mut self,
         entity_type: EntityType,
         updated_by: AccountId,
     ) -> Result<Persisted<EntityType>, UpdateError>;
@@ -291,7 +295,7 @@ pub trait Store {
     ///
     /// [`BaseUri`]: crate::ontology::types::uri::BaseUri
     async fn create_link_type(
-        &self,
+        &mut self,
         link_type: LinkType,
         created_by: AccountId,
     ) -> Result<Persisted<LinkType>, InsertionError>;
@@ -301,8 +305,10 @@ pub trait Store {
     /// # Errors
     ///
     /// - if the requested [`LinkType`] doesn't exist.
-    async fn get_link_type(&self, version_id: VersionId)
-    -> Result<Persisted<LinkType>, QueryError>;
+    async fn get_link_type(
+        &mut self,
+        version_id: VersionId,
+    ) -> Result<Persisted<LinkType>, QueryError>;
 
     /// Update the definition of an existing [`LinkType`].
     ///
@@ -310,7 +316,7 @@ pub trait Store {
     ///
     /// - if the [`LinkType`] doesn't exist.
     async fn update_link_type(
-        &self,
+        &mut self,
         property_type: LinkType,
         updated_by: AccountId,
     ) -> Result<Persisted<LinkType>, UpdateError>;
@@ -323,7 +329,7 @@ pub trait Store {
     /// - if the [`Entity`] is not valid with respect to the specified [`EntityType`]
     /// - if the account referred to by `created_by` does not exist
     async fn create_entity(
-        &self,
+        &mut self,
         entity: &Entity,
         entity_type_uri: VersionedUri,
         created_by: AccountId,
@@ -334,7 +340,7 @@ pub trait Store {
     /// # Errors
     ///
     /// - if the requested [`Entity`] doesn't exist
-    async fn get_entity(&self, entity_id: EntityId) -> Result<Entity, QueryError>;
+    async fn get_entity(&mut self, entity_id: EntityId) -> Result<Entity, QueryError>;
 
     /// Update an existing [`Entity`].
     ///
@@ -345,7 +351,7 @@ pub trait Store {
     /// - if the [`Entity`] is not valid with respect to its [`EntityType`]
     /// - if the account referred to by `updated_by` does not exist
     async fn update_entity(
-        &self,
+        &mut self,
         entity_id: EntityId,
         entity: &Entity,
         entity_type_uri: VersionedUri,

--- a/packages/graph/hash_graph/lib/graph/src/store/pool.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/pool.rs
@@ -1,0 +1,12 @@
+use async_trait::async_trait;
+use error_stack::Result;
+
+use crate::store::Store;
+
+#[async_trait]
+pub trait StorePool: Send + Sync {
+    type Error;
+    type Store: Store + Send;
+
+    async fn acquire(&self) -> Result<Self::Store, Self::Error>;
+}

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -1,14 +1,13 @@
 mod database_type;
+mod pool;
 
 use async_trait::async_trait;
 use error_stack::{IntoReport, Report, Result, ResultExt};
 use serde::{de::DeserializeOwned, Serialize};
-use sqlx::{
-    postgres::PgConnectOptions, ConnectOptions, Executor, PgPool, Postgres, Row, Transaction,
-};
-use tracing::log::LevelFilter;
+use sqlx::{pool::PoolConnection, Acquire, Executor, Postgres, Row, Transaction};
 use uuid::Uuid;
 
+pub use self::pool::PostgresDatabasePool;
 use crate::{
     knowledge::{Entity, EntityId},
     ontology::{
@@ -22,38 +21,20 @@ use crate::{
     store::{
         error::{EntityDoesNotExist, VersionedUriAlreadyExists},
         postgres::database_type::DatabaseType,
-        BaseUriAlreadyExists, BaseUriDoesNotExist, DatabaseConnectionInfo, InsertionError,
-        QueryError, Store, StoreError, UpdateError,
+        BaseUriAlreadyExists, BaseUriDoesNotExist, InsertionError, QueryError, Store, UpdateError,
     },
 };
 
 /// A Postgres-backed store
 pub struct PostgresDatabase {
-    pub pool: PgPool,
+    connection: PoolConnection<Postgres>,
 }
 
 impl PostgresDatabase {
     /// Creates a new `PostgresDatabase` object.
-    ///
-    /// # Errors
-    ///
-    /// - [`StoreError`], if creating a [`PgPool`] connection returns an error.
-    pub async fn new(db_info: &DatabaseConnectionInfo) -> Result<Self, StoreError> {
-        tracing::debug!("Creating connection pool to Postgres");
-        let mut connection_options = PgConnectOptions::default()
-            .username(db_info.user())
-            .password(db_info.password())
-            .host(db_info.host())
-            .port(db_info.port())
-            .database(db_info.database());
-        connection_options.log_statements(LevelFilter::Trace);
-        Ok(Self {
-            pool: PgPool::connect_with(connection_options)
-                .await
-                .report()
-                .change_context(StoreError)
-                .attach_printable_lazy(|| db_info.clone())?,
-        })
+    #[must_use]
+    pub(crate) const fn new(connection: PoolConnection<Postgres>) -> Self {
+        Self { connection }
     }
 
     /// Inserts the specified [`AccountId`] into the database.
@@ -62,8 +43,8 @@ impl PostgresDatabase {
     ///
     /// - if insertion failed, e.g. because the [`AccountId`] already exists.
     // TODO: Revisit this when having authentication in place
-    pub async fn insert_account_id(&self, account_id: AccountId) -> Result<(), InsertionError> {
-        self.pool
+    pub async fn insert_account_id(&mut self, account_id: AccountId) -> Result<(), InsertionError> {
+        self.connection
             .fetch_one(
                 sqlx::query(
                     r#"
@@ -398,14 +379,14 @@ impl PostgresDatabase {
     ///
     /// - If the specified [`VersionId`] does not already exist.
     // TODO: We can't distinguish between an DB error and a non-existing version currently
-    async fn get_by_version<T>(&self, version_id: VersionId) -> Result<Persisted<T>, QueryError>
+    async fn get_by_version<T>(&mut self, version_id: VersionId) -> Result<Persisted<T>, QueryError>
     where
         T: DatabaseType + DeserializeOwned,
     {
         // SAFETY: We insert a table name here, but `T::table()` is only accessible from within this
         //   module.
         let row = self
-            .pool
+            .connection
             .fetch_one(
                 sqlx::query(&format!(
                     r#"
@@ -719,17 +700,17 @@ impl PostgresDatabase {
 
 #[async_trait]
 impl Store for PostgresDatabase {
-    async fn version_id_by_uri(&self, uri: &VersionedUri) -> Result<VersionId, QueryError> {
-        Self::version_id_by_uri_impl(&self.pool, uri).await
+    async fn version_id_by_uri(&mut self, uri: &VersionedUri) -> Result<VersionId, QueryError> {
+        Self::version_id_by_uri_impl(&mut self.connection, uri).await
     }
 
     async fn create_data_type(
-        &self,
+        &mut self,
         data_type: DataType,
         created_by: AccountId,
     ) -> Result<Persisted<DataType>, InsertionError> {
         let mut transaction = self
-            .pool
+            .connection
             .begin()
             .await
             .report()
@@ -747,19 +728,19 @@ impl Store for PostgresDatabase {
     }
 
     async fn get_data_type(
-        &self,
+        &mut self,
         version_id: VersionId,
     ) -> Result<Persisted<DataType>, QueryError> {
         self.get_by_version(version_id).await
     }
 
     async fn update_data_type(
-        &self,
+        &mut self,
         data_type: DataType,
         updated_by: AccountId,
     ) -> Result<Persisted<DataType>, UpdateError> {
         let mut transaction = self
-            .pool
+            .connection
             .begin()
             .await
             .report()
@@ -777,12 +758,12 @@ impl Store for PostgresDatabase {
     }
 
     async fn create_property_type(
-        &self,
+        &mut self,
         property_type: PropertyType,
         created_by: AccountId,
     ) -> Result<Persisted<PropertyType>, InsertionError> {
         let mut transaction = self
-            .pool
+            .connection
             .begin()
             .await
             .report()
@@ -806,19 +787,19 @@ impl Store for PostgresDatabase {
     }
 
     async fn get_property_type(
-        &self,
+        &mut self,
         version_id: VersionId,
     ) -> Result<Persisted<PropertyType>, QueryError> {
         self.get_by_version(version_id).await
     }
 
     async fn update_property_type(
-        &self,
+        &mut self,
         property_type: PropertyType,
         updated_by: AccountId,
     ) -> Result<Persisted<PropertyType>, UpdateError> {
         let mut transaction = self
-            .pool
+            .connection
             .begin()
             .await
             .report()
@@ -842,12 +823,12 @@ impl Store for PostgresDatabase {
     }
 
     async fn create_entity_type(
-        &self,
+        &mut self,
         entity_type: EntityType,
         created_by: AccountId,
     ) -> Result<Persisted<EntityType>, InsertionError> {
         let mut transaction = self
-            .pool
+            .connection
             .begin()
             .await
             .report()
@@ -871,19 +852,19 @@ impl Store for PostgresDatabase {
     }
 
     async fn get_entity_type(
-        &self,
+        &mut self,
         version_id: VersionId,
     ) -> Result<Persisted<EntityType>, QueryError> {
         self.get_by_version(version_id).await
     }
 
     async fn update_entity_type(
-        &self,
+        &mut self,
         entity_type: EntityType,
         updated_by: AccountId,
     ) -> Result<Persisted<EntityType>, UpdateError> {
         let mut transaction = self
-            .pool
+            .connection
             .begin()
             .await
             .report()
@@ -907,12 +888,12 @@ impl Store for PostgresDatabase {
     }
 
     async fn create_link_type(
-        &self,
+        &mut self,
         link_type: LinkType,
         created_by: AccountId,
     ) -> Result<Persisted<LinkType>, InsertionError> {
         let mut transaction = self
-            .pool
+            .connection
             .begin()
             .await
             .report()
@@ -930,19 +911,19 @@ impl Store for PostgresDatabase {
     }
 
     async fn get_link_type(
-        &self,
+        &mut self,
         version_id: VersionId,
     ) -> Result<Persisted<LinkType>, QueryError> {
         self.get_by_version(version_id).await
     }
 
     async fn update_link_type(
-        &self,
+        &mut self,
         link_type: LinkType,
         updated_by: AccountId,
     ) -> Result<Persisted<LinkType>, UpdateError> {
         let mut transaction = self
-            .pool
+            .connection
             .begin()
             .await
             .report()
@@ -960,13 +941,13 @@ impl Store for PostgresDatabase {
     }
 
     async fn create_entity(
-        &self,
+        &mut self,
         entity: &Entity,
         entity_type_uri: VersionedUri,
         created_by: AccountId,
     ) -> Result<EntityId, InsertionError> {
         let mut transaction = self
-            .pool
+            .connection
             .begin()
             .await
             .report()
@@ -991,9 +972,9 @@ impl Store for PostgresDatabase {
         Ok(entity_id)
     }
 
-    async fn get_entity(&self, entity_id: EntityId) -> Result<Entity, QueryError> {
+    async fn get_entity(&mut self, entity_id: EntityId) -> Result<Entity, QueryError> {
         let row = self
-            .pool
+            .connection
             .fetch_one(
                 sqlx::query(
                     r#"
@@ -1019,14 +1000,14 @@ impl Store for PostgresDatabase {
     }
 
     async fn update_entity(
-        &self,
+        &mut self,
         entity_id: EntityId,
         entity: &Entity,
         entity_type_uri: VersionedUri,
         updated_by: AccountId,
     ) -> Result<(), UpdateError> {
         let mut transaction = self
-            .pool
+            .connection
             .begin()
             .await
             .report()

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/pool.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/pool.rs
@@ -1,0 +1,46 @@
+use async_trait::async_trait;
+use error_stack::{IntoReport, Result, ResultExt};
+use sqlx::{postgres::PgConnectOptions, ConnectOptions, PgPool};
+use tracing::log::LevelFilter;
+
+use crate::store::{DatabaseConnectionInfo, PostgresDatabase, StoreError, StorePool};
+
+pub struct PostgresDatabasePool {
+    pool: PgPool,
+}
+
+impl PostgresDatabasePool {
+    /// Creates a new `PostgresDatabasePool`.
+    ///
+    /// # Errors
+    ///
+    /// - if creating a connection returns an error.
+    pub async fn new(db_info: &DatabaseConnectionInfo) -> Result<Self, StoreError> {
+        tracing::debug!("Creating connection pool to Postgres");
+        let mut connection_options = PgConnectOptions::default()
+            .username(db_info.user())
+            .password(db_info.password())
+            .host(db_info.host())
+            .port(db_info.port())
+            .database(db_info.database());
+        connection_options.log_statements(LevelFilter::Trace);
+
+        Ok(Self {
+            pool: PgPool::connect_with(connection_options)
+                .await
+                .report()
+                .change_context(StoreError)
+                .attach_printable_lazy(|| db_info.clone())?,
+        })
+    }
+}
+
+#[async_trait]
+impl StorePool for PostgresDatabasePool {
+    type Error = sqlx::Error;
+    type Store = PostgresDatabase;
+
+    async fn acquire(&self) -> Result<Self::Store, Self::Error> {
+        Ok(PostgresDatabase::new(self.pool.acquire().await?))
+    }
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In order to get a mutable reference to the store, a pool logic is required. The mutable reference is required to create a transaction in `tokio-postgres`. Additionally, `tokio-postgres` has not the concept of a pool, thus the logic needs to be provided

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1202538466812818/1202660056731614/f) _(internal)_

## 🔍 What does this change?

- Add a `StorePool` trait to acquire a `Store`
- Add a `PostgresDatabasePool` and implement `StorePool` on it
- Change the logic in `Store` to use mutable references (required for using the connections)
- Adjust the REST API, the tests, and the binary to use the store instead

## 🐾 Next steps

Switch to `tokio-postgres`

## 🛡 What tests cover this?

- the integration test suite
- the REST API tests