### PR TITLE
Pin `cargo quickinstall` versions (dev/graph)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -93,8 +93,8 @@ jobs:
         shell: bash
         run: |
           cargo install cargo-quickinstall
-          cargo quickinstall cargo-make
-          cargo quickinstall cargo-hack
+          cargo quickinstall cargo-make --version 0.35.15
+          cargo quickinstall cargo-hack --version 0.5.15
 
       - name: Check formatting
         working-directory: ${{ matrix.directory }}
@@ -159,9 +159,9 @@ jobs:
         shell: bash
         run: |
           cargo install cargo-quickinstall
-          cargo quickinstall cargo-make
-          cargo quickinstall cargo-hack
-          cargo quickinstall cargo-nextest
+          cargo quickinstall cargo-make --version 0.35.15
+          cargo quickinstall cargo-hack --version 0.5.15
+          cargo quickinstall cargo-nextest --version 0.9.28
 
       - name: Install Python
         if: matrix.directory == 'packages/engine'


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, we always use the latest version for tools in CI. To avoid breaking changes and speed up CI runs in the case the binary is not prebuilt yet, we want to pin the version of the used tools.
