### PR TITLE
Escape less-thans in entities glossary mdx

### DIFF
--- a/sites/hashai/resources/glossary/entities.mdx
+++ b/sites/hashai/resources/glossary/entities.mdx
@@ -28,7 +28,7 @@ In the real world, entities are often connected to other entities -- often by so
 
 Sometimes these connections take the form of social relationships (e.g. “Mother", "Child”, or “Friend") occurring between entities of the same [entity type] (in this case `Person`).
 
-However, entities of completely different entity types can also be linked. For example, connections between entities may sometimes be legal or procedural, such as “Employee <> Employer” or “Politician <> Political Party”, which may both link a `Person` with an `Organization`.
+However, entities of completely different entity types can also be linked. For example, connections between entities may sometimes be legal or procedural, such as “Employee \<> Employer” or “Politician \<> Political Party”, which may both link a `Person` with an `Organization`.
 
 A network of entities which are connected to other entities is sometimes called a [graph](https://hash.ai/glossary/graphs). We call these entities with links ‘linked entities’.
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `<>` in the copy for the Entities glossary entry was being interpreted as an opening tag for an MDX component, causing a crash when there was no corresponding closing tag.

This PR escapes the `<`s.