### PR TITLE
Change `get` methods to take a shared reference

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -115,7 +115,7 @@ async fn get_data_type<S: StorePool>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<S>>,
 ) -> Result<Json<Persisted<DataType>>, impl IntoResponse> {
-    let mut store = pool.acquire().await.map_err(|report| {
+    let store = pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -125,7 +125,7 @@ async fn get_entity<S: StorePool>(
 ) -> Result<Json<QualifiedEntity>, impl IntoResponse> {
     let Path(entity_id) = entity_id;
 
-    let mut store = pool.acquire().await.map_err(|report| {
+    let store = pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -121,7 +121,7 @@ async fn get_entity_type<S: StorePool>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<S>>,
 ) -> Result<Json<Persisted<EntityType>>, impl IntoResponse> {
-    let mut store = pool.acquire().await.map_err(|report| {
+    let store = pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -115,7 +115,7 @@ async fn get_link_type<S: StorePool>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<S>>,
 ) -> Result<Json<Persisted<LinkType>>, impl IntoResponse> {
-    let mut store = pool.acquire().await.map_err(|report| {
+    let store = pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -118,7 +118,7 @@ async fn get_property_type<S: StorePool>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<S>>,
 ) -> Result<Json<Persisted<PropertyType>>, impl IntoResponse> {
-    let mut store = pool.acquire().await.map_err(|report| {
+    let store = pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -198,10 +198,8 @@ pub trait Store {
     /// # Errors
     ///
     /// - if the requested [`DataType`] doesn't exist.
-    async fn get_data_type(
-        &mut self,
-        version_id: VersionId,
-    ) -> Result<Persisted<DataType>, QueryError>;
+    async fn get_data_type(&self, version_id: VersionId)
+    -> Result<Persisted<DataType>, QueryError>;
 
     /// Update the definition of an existing [`DataType`].
     ///
@@ -234,7 +232,7 @@ pub trait Store {
     ///
     /// - if the requested [`PropertyType`] doesn't exist.
     async fn get_property_type(
-        &mut self,
+        &self,
         version_id: VersionId,
     ) -> Result<Persisted<PropertyType>, QueryError>;
 
@@ -269,7 +267,7 @@ pub trait Store {
     ///
     /// - if the requested [`EntityType`] doesn't exist.
     async fn get_entity_type(
-        &mut self,
+        &self,
         version_id: VersionId,
     ) -> Result<Persisted<EntityType>, QueryError>;
 
@@ -305,10 +303,8 @@ pub trait Store {
     /// # Errors
     ///
     /// - if the requested [`LinkType`] doesn't exist.
-    async fn get_link_type(
-        &mut self,
-        version_id: VersionId,
-    ) -> Result<Persisted<LinkType>, QueryError>;
+    async fn get_link_type(&self, version_id: VersionId)
+    -> Result<Persisted<LinkType>, QueryError>;
 
     /// Update the definition of an existing [`LinkType`].
     ///
@@ -340,7 +336,7 @@ pub trait Store {
     /// # Errors
     ///
     /// - if the requested [`Entity`] doesn't exist
-    async fn get_entity(&mut self, entity_id: EntityId) -> Result<Entity, QueryError>;
+    async fn get_entity(&self, entity_id: EntityId) -> Result<Entity, QueryError>;
 
     /// Update an existing [`Entity`].
     ///

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -696,7 +696,7 @@ where
     }
 
     async fn get_data_type(
-        &mut self,
+        &self,
         version_id: VersionId,
     ) -> Result<Persisted<DataType>, QueryError> {
         self.get_by_version(version_id).await
@@ -760,7 +760,7 @@ where
     }
 
     async fn get_property_type(
-        &mut self,
+        &self,
         version_id: VersionId,
     ) -> Result<Persisted<PropertyType>, QueryError> {
         self.get_by_version(version_id).await
@@ -831,7 +831,7 @@ where
     }
 
     async fn get_entity_type(
-        &mut self,
+        &self,
         version_id: VersionId,
     ) -> Result<Persisted<EntityType>, QueryError> {
         self.get_by_version(version_id).await
@@ -895,7 +895,7 @@ where
     }
 
     async fn get_link_type(
-        &mut self,
+        &self,
         version_id: VersionId,
     ) -> Result<Persisted<LinkType>, QueryError> {
         self.get_by_version(version_id).await
@@ -957,7 +957,7 @@ where
         Ok(entity_id)
     }
 
-    async fn get_entity(&mut self, entity_id: EntityId) -> Result<Entity, QueryError> {
+    async fn get_entity(&self, entity_id: EntityId) -> Result<Entity, QueryError> {
         let row = self
             .client
             .as_client()


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Changes the `Store` signature to only take a shared reference, as a mutable reference is not needed anymore using `tokio-postgres`

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201095311341924/1202652453922927/f) _(internal)_
- #851 
- #855 