### PR TITLE
Change Graph tests to use transactions rather than cascade deletion

### DIFF
--- a/packages/graph/hash_graph/.config/nextest.toml
+++ b/packages/graph/hash_graph/.config/nextest.toml
@@ -1,4 +1,1 @@
 [profile.integration]
-# TODO: Remove this. Currently, it's required as the integration tests requires a set of data to be present. Currently,
-#   we seed the database before any test. This means multiple threads could pollute each test cases and may break them.
-test-threads = 1

--- a/packages/graph/hash_graph/lib/graph/Cargo.toml
+++ b/packages/graph/hash_graph/lib/graph/Cargo.toml
@@ -24,7 +24,7 @@ uuid = { version = "1.1.2", features = ["v4", "serde"] }
 utoipa = { git = "https://github.com/juhaku/utoipa", rev = "031073f", features = ["uuid"] }
 
 [dev-dependencies]
-tokio = { version = "1.18.2", features = ["rt-multi-thread"] }
+tokio = { version = "1.18.2", features = ["rt-multi-thread", "macros"] }
 
 [build-dependencies]
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -632,7 +632,7 @@ where
         self.as_client().query_one(
                 r#"
                     INSERT INTO entities (entity_id, version, entity_type_version_id, properties, created_by) 
-                    VALUES ($1, CURRENT_TIMESTAMP, $2, $3, $4)
+                    VALUES ($1, clock_timestamp(), $2, $3, $4)
                     RETURNING entity_id;
                 "#,
                 &[&entity_id, &entity_type_id, &value, &account_id]

--- a/packages/graph/hash_graph/tests/integration/postgres/data_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/data_type.rs
@@ -1,49 +1,66 @@
 use crate::postgres::DatabaseTestWrapper;
 
-#[test]
-fn insert() {
+#[tokio::test]
+async fn insert() {
     let boolean_dt = serde_json::from_str(crate::test_data::data_type::BOOLEAN_V1)
         .expect("could not parse data type");
 
-    let mut database = DatabaseTestWrapper::new();
-    database
-        .create_data_type(boolean_dt)
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = database
+        .seed([], [], [], [])
+        .await
+        .expect("Could not seed database");
+
+    api.create_data_type(boolean_dt)
+        .await
         .expect("could not create data type");
 }
 
-#[test]
-fn query() {
+#[tokio::test]
+async fn query() {
     let empty_list_dt = serde_json::from_str(crate::test_data::data_type::EMPTY_LIST_V1)
         .expect("could not parse data type");
 
-    let mut database = DatabaseTestWrapper::new();
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = database
+        .seed([], [], [], [])
+        .await
+        .expect("Could not seed database");
 
-    let created_data_type = database
+    let created_data_type = api
         .create_data_type(empty_list_dt)
+        .await
         .expect("could not create data type");
 
-    let data_type = database
+    let data_type = api
         .get_data_type(created_data_type.version_id())
+        .await
         .expect("could not query data type");
 
     assert_eq!(data_type.inner(), created_data_type.inner());
 }
 
-#[test]
-fn update() {
+#[tokio::test]
+async fn update() {
     let object_dt_v1 = serde_json::from_str(crate::test_data::data_type::OBJECT_V1)
         .expect("could not parse data type");
     let object_dt_v2 = serde_json::from_str(crate::test_data::data_type::OBJECT_V2)
         .expect("could not parse data type");
 
-    let mut database = DatabaseTestWrapper::new();
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = database
+        .seed([], [], [], [])
+        .await
+        .expect("Could not seed database");
 
-    let created_data_type = database
+    let created_data_type = api
         .create_data_type(object_dt_v1)
+        .await
         .expect("could not create data type");
 
-    let updated_data_type = database
+    let updated_data_type = api
         .update_data_type(object_dt_v2)
+        .await
         .expect("could not update data type");
 
     assert_ne!(created_data_type.inner(), updated_data_type.inner());

--- a/packages/graph/hash_graph/tests/integration/postgres/entity.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/entity.rs
@@ -5,21 +5,22 @@ use crate::{
     test_data::{data_type, entity, entity_type, link_type, property_type},
 };
 
-#[test]
-fn insert() {
+#[tokio::test]
+async fn insert() {
     let person = serde_json::from_str(entity::PERSON_V1).expect("could not parse entity");
 
-    let mut database = DatabaseTestWrapper::new();
-    database
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = database
         .seed(
             [data_type::TEXT_V1],
             [property_type::NAME_V1],
             [link_type::FRIEND_OF_V1],
             [entity_type::PERSON_V1],
         )
+        .await
         .expect("Could not seed database");
 
-    let entity_id = database
+    let entity_id = api
         .create_entity(
             &person,
             VersionedUri::new(
@@ -27,28 +28,31 @@ fn insert() {
                 1,
             ),
         )
+        .await
         .expect("could not create entity");
 
-    let entity = database
+    let entity = api
         .get_entity(entity_id)
+        .await
         .expect("Could not query entity");
 
     assert_eq!(entity, person);
 }
 
-#[test]
-fn query() {
+#[tokio::test]
+async fn query() {
     let organization =
         serde_json::from_str(entity::ORGANIZATION_V1).expect("could not parse entity");
 
-    let mut database = DatabaseTestWrapper::new();
-    database
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = database
         .seed([data_type::TEXT_V1], [property_type::NAME_V1], [], [
             entity_type::ORGANIZATION_V1,
         ])
+        .await
         .expect("Could not seed database");
 
-    let entity_id = database
+    let entity_id = api
         .create_entity(
             &organization,
             VersionedUri::new(
@@ -56,27 +60,30 @@ fn query() {
                 1,
             ),
         )
+        .await
         .expect("could not create entity");
 
-    let queried_organization = database
+    let queried_organization = api
         .get_entity(entity_id)
+        .await
         .expect("Could not query entity");
     assert_eq!(organization, queried_organization);
 }
 
-#[test]
-fn update() {
+#[tokio::test]
+async fn update() {
     let page_v1 = serde_json::from_str(entity::PAGE_V1).expect("could not parse entity");
     let page_v2 = serde_json::from_str(entity::PAGE_V2).expect("could not parse entity");
 
-    let mut database = DatabaseTestWrapper::new();
-    database
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = database
         .seed([data_type::TEXT_V1], [property_type::TEXT_V1], [], [
             entity_type::PAGE_V1,
         ])
+        .await
         .expect("Could not seed database:");
 
-    let created_entity_id = database
+    let created_entity_id = api
         .create_entity(
             &page_v1,
             VersionedUri::new(
@@ -84,21 +91,23 @@ fn update() {
                 1,
             ),
         )
+        .await
         .expect("could not create entity");
 
-    database
-        .update_entity(
-            created_entity_id,
-            &page_v2,
-            VersionedUri::new(
-                "https://blockprotocol.org/@alice/types/entity-type/page".to_owned(),
-                1,
-            ),
-        )
-        .expect("could not update entity");
+    api.update_entity(
+        created_entity_id,
+        &page_v2,
+        VersionedUri::new(
+            "https://blockprotocol.org/@alice/types/entity-type/page".to_owned(),
+            1,
+        ),
+    )
+    .await
+    .expect("could not update entity");
 
-    let entity = database
+    let entity = api
         .get_entity(created_entity_id)
+        .await
         .expect("Could not query entity");
 
     assert_eq!(entity, page_v2);

--- a/packages/graph/hash_graph/tests/integration/postgres/entity_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/entity_type.rs
@@ -3,56 +3,60 @@ use crate::{
     test_data::{data_type, entity_type, link_type, property_type},
 };
 
-#[test]
-fn insert() {
+#[tokio::test]
+async fn insert() {
     let person_et =
         serde_json::from_str(entity_type::PERSON_V1).expect("could not parse entity type");
 
-    let mut database = DatabaseTestWrapper::new();
-    database
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = database
         .seed(
             [data_type::TEXT_V1],
             [property_type::NAME_V1],
             [link_type::FRIEND_OF_V1],
             [],
         )
+        .await
         .expect("Could not seed database");
 
-    database
-        .create_entity_type(person_et)
+    api.create_entity_type(person_et)
+        .await
         .expect("could not create entity type");
 }
 
-#[test]
-fn query() {
+#[tokio::test]
+async fn query() {
     let organization_et =
         serde_json::from_str(entity_type::ORGANIZATION_V1).expect("could not parse entity type");
 
-    let mut database = DatabaseTestWrapper::new();
-    database
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = database
         .seed([data_type::TEXT_V1], [property_type::NAME_V1], [], [])
+        .await
         .expect("Could not seed database");
 
-    let created_entity_type = database
+    let created_entity_type = api
         .create_entity_type(organization_et)
+        .await
         .expect("could not create entity type");
 
-    let entity_type = database
+    let entity_type = api
         .get_entity_type(created_entity_type.version_id())
+        .await
         .expect("could not query entity type");
 
     assert_eq!(entity_type.inner(), created_entity_type.inner());
 }
 
-#[test]
-fn update() {
+#[tokio::test]
+async fn update() {
     let page_et_v1 =
         serde_json::from_str(entity_type::PAGE_V1).expect("could not parse entity type");
     let page_et_v2 =
         serde_json::from_str(entity_type::PAGE_V2).expect("could not parse entity type");
 
-    let mut database = DatabaseTestWrapper::new();
-    database
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = database
         .seed(
             [data_type::TEXT_V1],
             [property_type::TEXT_V1, property_type::NAME_V1],
@@ -63,14 +67,17 @@ fn update() {
             ],
             [entity_type::PERSON_V1, entity_type::BLOCK_V1],
         )
+        .await
         .expect("Could not seed database:");
 
-    let created_entity_type = database
+    let created_entity_type = api
         .create_entity_type(page_et_v1)
+        .await
         .expect("could not create entity type");
 
-    let updated_entity_type = database
+    let updated_entity_type = api
         .update_entity_type(page_et_v2)
+        .await
         .expect("could not update entity type");
 
     assert_ne!(created_entity_type.inner(), updated_entity_type.inner());

--- a/packages/graph/hash_graph/tests/integration/postgres/link_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/link_type.rs
@@ -1,49 +1,66 @@
 use crate::postgres::DatabaseTestWrapper;
 
-#[test]
-fn insert() {
+#[tokio::test]
+async fn insert() {
     let owns_lt = serde_json::from_str(crate::test_data::link_type::OWNS_V1)
         .expect("could not parse link type");
 
-    let mut database = DatabaseTestWrapper::new();
-    database
-        .create_link_type(owns_lt)
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = database
+        .seed([], [], [], [])
+        .await
+        .expect("Could not seed database");
+
+    api.create_link_type(owns_lt)
+        .await
         .expect("could not create link type");
 }
 
-#[test]
-fn query() {
+#[tokio::test]
+async fn query() {
     let submitted_by_lt = serde_json::from_str(crate::test_data::link_type::SUBMITTED_BY_V1)
         .expect("could not parse link type");
 
-    let mut database = DatabaseTestWrapper::new();
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = database
+        .seed([], [], [], [])
+        .await
+        .expect("Could not seed database");
 
-    let created_link_type = database
+    let created_link_type = api
         .create_link_type(submitted_by_lt)
+        .await
         .expect("could not create link type");
 
-    let link_type = database
+    let link_type = api
         .get_link_type(created_link_type.version_id())
+        .await
         .expect("could not query link type");
 
     assert_eq!(link_type.inner(), created_link_type.inner());
 }
 
-#[test]
-fn update() {
+#[tokio::test]
+async fn update() {
     let owns_lt_v1 = serde_json::from_str(crate::test_data::link_type::OWNS_V1)
         .expect("could not parse link type");
     let owns_lt_v2 = serde_json::from_str(crate::test_data::link_type::OWNS_V2)
         .expect("could not parse link type");
 
-    let mut database = DatabaseTestWrapper::new();
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = database
+        .seed([], [], [], [])
+        .await
+        .expect("Could not seed database");
 
-    let created_link_type = database
+    let created_link_type = api
         .create_link_type(owns_lt_v1)
+        .await
         .expect("could not create link type");
 
-    let updated_link_type = database
+    let updated_link_type = api
         .update_link_type(owns_lt_v2)
+        .await
         .expect("could not update link type");
 
     assert_ne!(created_link_type.inner(), updated_link_type.inner());

--- a/packages/graph/hash_graph/tests/integration/postgres/property_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/property_type.rs
@@ -3,60 +3,67 @@ use crate::{
     test_data::{data_type, property_type},
 };
 
-#[test]
-fn insert() {
+#[tokio::test]
+async fn insert() {
     let age_pt =
         serde_json::from_str(property_type::AGE_V1).expect("could not parse property type");
 
-    let mut database = DatabaseTestWrapper::new();
-    database
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = database
         .seed([data_type::NUMBER_V1], [], [], [])
+        .await
         .expect("Could not seed database");
 
-    database
-        .create_property_type(age_pt)
+    api.create_property_type(age_pt)
+        .await
         .expect("could not create property type");
 }
 
-#[test]
-fn query() {
+#[tokio::test]
+async fn query() {
     let favorite_quote_pt = serde_json::from_str(property_type::FAVORITE_QUOTE_V1)
         .expect("could not parse property type");
 
-    let mut database = DatabaseTestWrapper::new();
-    database
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = database
         .seed([data_type::TEXT_V1], [], [], [])
+        .await
         .expect("Could not seed database");
 
-    let created_property_type = database
+    let created_property_type = api
         .create_property_type(favorite_quote_pt)
+        .await
         .expect("could not create property type");
 
-    let property_type = database
+    let property_type = api
         .get_property_type(created_property_type.version_id())
+        .await
         .expect("could not query property type");
 
     assert_eq!(property_type.inner(), created_property_type.inner());
 }
 
-#[test]
-fn update() {
+#[tokio::test]
+async fn update() {
     let user_id_pt_v1 =
         serde_json::from_str(property_type::USER_ID_V1).expect("could not parse property type");
     let user_id_pt_v2 =
         serde_json::from_str(property_type::USER_ID_V2).expect("could not parse property type");
 
-    let mut database = DatabaseTestWrapper::new();
-    database
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = database
         .seed([data_type::NUMBER_V1, data_type::TEXT_V1], [], [], [])
+        .await
         .expect("Could not seed database");
 
-    let created_property_type = database
+    let created_property_type = api
         .create_property_type(user_id_pt_v1)
+        .await
         .expect("could not create property type");
 
-    let updated_property_type = database
+    let updated_property_type = api
         .update_property_type(user_id_pt_v2)
+        .await
         .expect("could not update property type");
 
     assert_ne!(created_property_type.inner(), updated_property_type.inner());

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -53,7 +53,6 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         type: "TEXT",
         notNull: true,
         references: "base_uris",
-        onDelete: "CASCADE",
       },
       version: {
         type: "BIGINT",
@@ -61,7 +60,6 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       },
       version_id: {
         type: "UUID",
-        onDelete: "CASCADE",
         references: "version_ids",
       },
     },
@@ -84,7 +82,6 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         type: "UUID",
         primaryKey: true,
         references: "version_ids",
-        onDelete: "CASCADE",
       },
       schema: {
         type: "JSONB",
@@ -108,7 +105,6 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         type: "UUID",
         primaryKey: true,
         references: "version_ids",
-        onDelete: "CASCADE",
       },
       schema: {
         type: "JSONB",
@@ -131,7 +127,6 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         type: "UUID",
         primaryKey: true,
         references: "version_ids",
-        onDelete: "CASCADE",
       },
       schema: {
         type: "JSONB",
@@ -155,7 +150,6 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         type: "UUID",
         primaryKey: true,
         references: "version_ids",
-        onDelete: "CASCADE",
       },
       schema: {
         type: "JSONB",
@@ -179,13 +173,11 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         type: "UUID",
         notNull: true,
         references: "property_types",
-        onDelete: "CASCADE",
       },
       target_property_type_version_id: {
         type: "UUID",
         notNull: true,
         references: "property_types",
-        onDelete: "CASCADE",
       },
     },
     {
@@ -200,13 +192,11 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         type: "UUID",
         notNull: true,
         references: "property_types",
-        onDelete: "CASCADE",
       },
       target_data_type_version_id: {
         type: "UUID",
         notNull: true,
         references: "data_types",
-        onDelete: "CASCADE",
       },
     },
     {
@@ -221,13 +211,11 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         type: "UUID",
         notNull: true,
         references: "entity_types",
-        onDelete: "CASCADE",
       },
       target_property_type_version_id: {
         type: "UUID",
         notNull: true,
         references: "property_types",
-        onDelete: "CASCADE",
       },
     },
     {
@@ -242,13 +230,11 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         type: "UUID",
         notNull: true,
         references: "entity_types",
-        onDelete: "CASCADE",
       },
       target_link_type_version_id: {
         type: "UUID",
         notNull: true,
         references: "link_types",
-        onDelete: "CASCADE",
       },
     },
     {
@@ -263,13 +249,11 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         type: "UUID",
         notNull: true,
         references: "entity_types",
-        onDelete: "CASCADE",
       },
       target_entity_type_version_id: {
         type: "UUID",
         notNull: true,
         references: "entity_types",
-        onDelete: "CASCADE",
       },
     },
     {
@@ -296,7 +280,6 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       entity_id: {
         type: "UUID",
         references: "entity_ids",
-        onDelete: "CASCADE",
         notNull: true,
       },
       version: {
@@ -307,7 +290,6 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         type: "UUID",
         notNull: true,
         references: "entity_types",
-        onDelete: "CASCADE",
       },
       properties: {
         type: "JSONB",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, we clean up the database after every test. This has two implications: No tests can run in parallel, as they would affect each other. Also, we need deletion logic only for running the tests.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202538466812818/1202660056731620/f) _(internal)_

## 🔍 What does this change?

- Use transactions instead of cascade deletion in tests
- Use `clock_timestamp()` instead of `CURRENT_TIMESTAMP` to also use the correct timestamp when inside of a transaction
- **Remove `ON DELETE CASCADE`** cc @Alfred-Mountfield 
- Remove limit on parallel tests to run

## 📜 Does this require a change to the docs?

This is an internal change
