### PR TITLE
Implement a store-reader to read types from URIs directly

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -121,19 +121,8 @@ async fn get_data_type<P: GraphPool>(
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let version_id = store.version_id_by_uri(&uri).await.map_err(|report| {
-        tracing::error!(error=?report, "Could not resolve URI");
-
-        if report.contains::<QueryError>() {
-            return StatusCode::NOT_FOUND;
-        }
-
-        // Datastore errors such as connection failure are considered internal server errors.
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
     store
-        .get_data_type(version_id)
+        .get_data_type(&uri.0)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not query data type");

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -124,19 +124,8 @@ async fn get_entity_type<P: GraphPool>(
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let version_id = store.version_id_by_uri(&uri).await.map_err(|report| {
-        tracing::error!(error=?report, "Could not resolve URI");
-
-        if report.contains::<QueryError>() {
-            return StatusCode::NOT_FOUND;
-        }
-
-        // Datastore errors such as connection failure are considered internal server errors.
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
     store
-        .get_entity_type(version_id)
+        .get_entity_type(&uri.0)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not query entity type");

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -121,19 +121,8 @@ async fn get_link_type<P: GraphPool>(
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let version_id = store.version_id_by_uri(&uri).await.map_err(|report| {
-        tracing::error!(error=?report, "Could not resolve URI");
-
-        if report.contains::<QueryError>() {
-            return StatusCode::NOT_FOUND;
-        }
-
-        // Datastore errors such as connection failure are considered internal server errors.
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
     store
-        .get_link_type(version_id)
+        .get_link_type(&uri.0)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not query link type");

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -124,19 +124,8 @@ async fn get_property_type<P: GraphPool>(
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let version_id = store.version_id_by_uri(&uri).await.map_err(|report| {
-        tracing::error!(error=?report, "Could not resolve URI");
-
-        if report.contains::<QueryError>() {
-            return StatusCode::NOT_FOUND;
-        }
-
-        // Datastore errors such as connection failure are considered internal server errors.
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
     store
-        .get_property_type(version_id)
+        .get_property_type(&uri.0)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not query property type");

--- a/packages/graph/hash_graph/lib/graph/src/lib.rs
+++ b/packages/graph/hash_graph/lib/graph/src/lib.rs
@@ -55,10 +55,7 @@
 
 use crate::{
     knowledge::{Entity, EntityId, Links},
-    ontology::{
-        types::{DataType, EntityType, LinkType, Persisted, PropertyType},
-        VersionId,
-    },
+    ontology::types::{uri::VersionedUri, DataType, EntityType, LinkType, Persisted, PropertyType},
     store::{crud::Read, Store, StorePool},
 };
 
@@ -81,9 +78,9 @@ pub trait GraphPool = StorePool + 'static where for<'pool> <Self as StorePool>::
 /// Interface for a [`Store`].
 pub trait Graph = Store
 where
-    for<'i> Self: Read<'i, VersionId, DataType, Output = Persisted<DataType>>
-        + Read<'i, VersionId, PropertyType, Output = Persisted<PropertyType>>
-        + Read<'i, VersionId, LinkType, Output = Persisted<LinkType>>
-        + Read<'i, VersionId, EntityType, Output = Persisted<EntityType>>
+    for<'i> Self: Read<'i, &'i VersionedUri, DataType, Output = Persisted<DataType>>
+        + Read<'i, &'i VersionedUri, PropertyType, Output = Persisted<PropertyType>>
+        + Read<'i, &'i VersionedUri, LinkType, Output = Persisted<LinkType>>
+        + Read<'i, &'i VersionedUri, EntityType, Output = Persisted<EntityType>>
         + Read<'i, EntityId, Entity, Output = Entity>
         + Read<'i, EntityId, Links, Output = Links>;

--- a/packages/graph/hash_graph/tests/integration/postgres/data_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/data_type.rs
@@ -33,7 +33,7 @@ async fn query() {
         .expect("could not create data type");
 
     let data_type = api
-        .get_data_type(created_data_type.version_id())
+        .get_data_type(created_data_type.inner().id())
         .await
         .expect("could not query data type");
 

--- a/packages/graph/hash_graph/tests/integration/postgres/entity_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/entity_type.rs
@@ -41,7 +41,7 @@ async fn query() {
         .expect("could not create entity type");
 
     let entity_type = api
-        .get_entity_type(created_entity_type.version_id())
+        .get_entity_type(created_entity_type.inner().id())
         .await
         .expect("could not query entity type");
 

--- a/packages/graph/hash_graph/tests/integration/postgres/link_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/link_type.rs
@@ -33,7 +33,7 @@ async fn query() {
         .expect("could not create link type");
 
     let link_type = api
-        .get_link_type(created_link_type.version_id())
+        .get_link_type(created_link_type.inner().id())
         .await
         .expect("could not query link type");
 

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -10,7 +10,7 @@ use graph::{
     knowledge::{Entity, EntityId, Link, Links, Outgoing},
     ontology::{
         types::{uri::VersionedUri, DataType, EntityType, LinkType, Persisted, PropertyType},
-        AccountId, VersionId,
+        AccountId,
     },
     store::{
         error::LinkActivationError, AsClient, DatabaseConnectionInfo, DatabaseType, InsertionError,
@@ -142,9 +142,9 @@ impl DatabaseApi<'_> {
 
     pub async fn get_data_type(
         &mut self,
-        version_id: VersionId,
+        uri: &VersionedUri,
     ) -> Result<Persisted<DataType>, QueryError> {
-        self.store.get_data_type(version_id).await
+        self.store.get_data_type(uri).await
     }
 
     pub async fn update_data_type(
@@ -167,9 +167,9 @@ impl DatabaseApi<'_> {
 
     pub async fn get_property_type(
         &mut self,
-        version_id: VersionId,
+        uri: &VersionedUri,
     ) -> Result<Persisted<PropertyType>, QueryError> {
-        self.store.get_property_type(version_id).await
+        self.store.get_property_type(uri).await
     }
 
     pub async fn update_property_type(
@@ -192,9 +192,9 @@ impl DatabaseApi<'_> {
 
     pub async fn get_entity_type(
         &mut self,
-        version_id: VersionId,
+        uri: &VersionedUri,
     ) -> Result<Persisted<EntityType>, QueryError> {
-        self.store.get_entity_type(version_id).await
+        self.store.get_entity_type(uri).await
     }
 
     pub async fn update_entity_type(
@@ -217,9 +217,9 @@ impl DatabaseApi<'_> {
 
     pub async fn get_link_type(
         &mut self,
-        version_id: VersionId,
+        uri: &VersionedUri,
     ) -> Result<Persisted<LinkType>, QueryError> {
-        self.store.get_link_type(version_id).await
+        self.store.get_link_type(uri).await
     }
 
     pub async fn update_link_type(

--- a/packages/graph/hash_graph/tests/integration/postgres/property_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/property_type.rs
@@ -36,7 +36,7 @@ async fn query() {
         .expect("could not create property type");
 
     let property_type = api
-        .get_property_type(created_property_type.version_id())
+        .get_property_type(created_property_type.inner().id())
         .await
         .expect("could not query property type");
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The public-facing interface is not using `VersionId` but `VersionedUri`. This adds the read-method for the store to support reading by URI directly

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202538466812818/1202675758696580/f) _(internal)_

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

- #864

## 🔍 What does this change?

- Add `Read<VersionedUri, T> for PostgresStore`
- Use `VersionedUri` in tests and the REST API