### PR TITLE
Make `VersionId` an implementation detail

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
@@ -187,7 +187,7 @@ async fn inactivate_link<P: GraphPool>(
     })?;
 
     store
-        .inactivate_link(Link::new(source_entity, target_entity, link_type_uri))
+        .inactivate_link(&Link::new(source_entity, target_entity, link_type_uri))
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not inactivate link");

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
@@ -88,11 +88,10 @@ async fn create_link<P: GraphPool>(
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
+    let link = Link::new(source_entity, target_entity, link_type_uri);
+
     store
-        .create_link(
-            Link::new(source_entity, target_entity, link_type_uri),
-            account_id,
-        )
+        .create_link(&link, account_id)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not create link");
@@ -104,8 +103,9 @@ async fn create_link<P: GraphPool>(
 
             // Insertion/update errors are considered internal server errors.
             StatusCode::INTERNAL_SERVER_ERROR
-        })
-        .map(Json)
+        })?;
+
+    Ok(Json(link))
 }
 
 #[utoipa::path(

--- a/packages/graph/hash_graph/lib/graph/src/lib.rs
+++ b/packages/graph/hash_graph/lib/graph/src/lib.rs
@@ -55,7 +55,7 @@
 
 use crate::{
     knowledge::{Entity, EntityId, Links},
-    ontology::types::{uri::VersionedUri, DataType, EntityType, LinkType, Persisted, PropertyType},
+    ontology::types::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType},
     store::{crud::Read, Store, StorePool},
 };
 
@@ -78,9 +78,9 @@ pub trait GraphPool = StorePool + 'static where for<'pool> <Self as StorePool>::
 /// Interface for a [`Store`].
 pub trait Graph = Store
 where
-    for<'i> Self: Read<'i, &'i VersionedUri, DataType, Output = Persisted<DataType>>
-        + Read<'i, &'i VersionedUri, PropertyType, Output = Persisted<PropertyType>>
-        + Read<'i, &'i VersionedUri, LinkType, Output = Persisted<LinkType>>
-        + Read<'i, &'i VersionedUri, EntityType, Output = Persisted<EntityType>>
+    for<'i> Self: Read<'i, &'i VersionedUri, DataType, Output = DataType>
+        + Read<'i, &'i VersionedUri, PropertyType, Output = PropertyType>
+        + Read<'i, &'i VersionedUri, LinkType, Output = LinkType>
+        + Read<'i, &'i VersionedUri, EntityType, Output = EntityType>
         + Read<'i, EntityId, Entity, Output = Entity>
         + Read<'i, EntityId, Links, Output = Links>;

--- a/packages/graph/hash_graph/lib/graph/src/ontology/types/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/types/data_type/mod.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use error_stack::{ensure, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use utoipa::Component;
 
 use crate::ontology::types::{
     error::ValidationError,
@@ -52,7 +53,7 @@ enum DataTypeTag {
     DataType,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
 #[serde(rename_all = "camelCase")]
 pub struct DataType {
     kind: DataTypeTag,

--- a/packages/graph/hash_graph/lib/graph/src/ontology/types/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/types/entity_type/mod.rs
@@ -4,6 +4,7 @@ use std::collections::{HashMap, HashSet};
 
 use error_stack::{ensure, Result};
 use serde::{Deserialize, Serialize};
+use utoipa::Component;
 
 use crate::ontology::types::{
     entity_type::links::{Links, ValueOrMaybeOrderedArray},
@@ -57,7 +58,7 @@ pub enum EntityTypeTag {
 }
 
 /// Intermediate representation used during deserialization.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EntityType {
     kind: EntityTypeTag,

--- a/packages/graph/hash_graph/lib/graph/src/ontology/types/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/types/link_type/mod.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use utoipa::Component;
 
 use crate::ontology::types::{uri::VersionedUri, OntologyType};
 
@@ -9,7 +10,7 @@ enum LinkTypeTag {
     LinkType,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
 #[serde(rename_all = "camelCase")]
 pub struct LinkType {
     kind: LinkTypeTag,

--- a/packages/graph/hash_graph/lib/graph/src/ontology/types/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/types/mod.rs
@@ -7,10 +7,6 @@
 //! submodules.
 //!
 //! [`store`]: crate::store
-use serde::{Deserialize, Serialize};
-use utoipa::Component;
-
-use crate::ontology::{AccountId, VersionId};
 
 pub mod uri;
 
@@ -34,45 +30,4 @@ mod serde_shared;
 pub trait OntologyType {
     /// Returns the unique versioned URI used to identify this instance of a type.
     fn uri(&self) -> &VersionedUri;
-}
-
-/// A representation of an [`OntologyType`] that exists (has been `Persisted`) in a backing store.
-#[derive(Clone, Debug, Serialize, Deserialize, Component)]
-#[aliases(
-    PersistedDataType = Persisted<DataType>,
-    PersistedPropertyType = Persisted<PropertyType>,
-    PersistedLinkType = Persisted<LinkType>,
-    PersistedEntityType = Persisted<EntityType>
-)]
-pub struct Persisted<T: OntologyType> {
-    version_id: VersionId,
-    // TODO: we would want the inner types to be represented in the OpenAPI components list. This
-    //   means that any generic instance used by the web API needs to have an alias above, and all
-    //   subsequent inner types need to implement utoipa's `Component` trait.
-    #[component(value_type = Any)]
-    inner: T,
-    created_by: AccountId,
-}
-
-impl<T: OntologyType> Persisted<T> {
-    #[must_use]
-    pub const fn new(version_id: VersionId, inner: T, created_by: AccountId) -> Self {
-        Self {
-            version_id,
-            inner,
-            created_by,
-        }
-    }
-
-    pub const fn version_id(&self) -> VersionId {
-        self.version_id
-    }
-
-    pub const fn inner(&self) -> &T {
-        &self.inner
-    }
-
-    pub const fn account_id(&self) -> &AccountId {
-        &self.created_by
-    }
 }

--- a/packages/graph/hash_graph/lib/graph/src/ontology/types/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/types/property_type/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use error_stack::{ensure, Result};
 use serde::{Deserialize, Serialize};
+use utoipa::Component;
 
 use crate::ontology::types::{
     data_type::DataTypeReference,
@@ -119,7 +120,7 @@ enum PropertyTypeTag {
     PropertyType,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropertyType {
     kind: PropertyTypeTag,

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -382,9 +382,9 @@ pub trait Store {
     /// - if the account referred to by `created_by` does not exist
     async fn create_link(
         &mut self,
-        link: Link,
+        link: &Link,
         created_by: AccountId,
-    ) -> Result<Link, InsertionError>;
+    ) -> Result<(), InsertionError>;
 
     /// Get [`Links`] of an [`Entity`] identified by an [`EntityId`].
     ///

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -420,5 +420,5 @@ pub trait Store {
     ///
     /// - if the [`Link`] doesn't exist
     /// - if the account referred to by `created_by` does not exist
-    async fn inactivate_link(&mut self, link: Link) -> Result<(), LinkActivationError>;
+    async fn inactivate_link(&mut self, link: &Link) -> Result<(), LinkActivationError>;
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -17,8 +17,8 @@ pub use self::{
 use crate::{
     knowledge::{Entity, EntityId, Link, Links},
     ontology::{
-        types::{uri::VersionedUri, DataType, EntityType, LinkType, Persisted, PropertyType},
-        AccountId, VersionId,
+        types::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType},
+        AccountId,
     },
     store::crud::Read,
 };
@@ -176,13 +176,6 @@ impl fmt::Display for DatabaseConnectionInfo {
 /// raised depending on the implementation, e.g. connection issues.
 #[async_trait]
 pub trait Store {
-    /// Fetches the [`VersionId`] of the specified [`VersionedUri`].
-    ///
-    /// # Errors:
-    ///
-    /// - if the entry referred to by `uri` does not exist.
-    async fn version_id_by_uri(&self, uri: &VersionedUri) -> Result<VersionId, QueryError>;
-
     /// Creates a new [`DataType`].
     ///
     /// # Errors:
@@ -193,9 +186,9 @@ pub trait Store {
     /// [`BaseUri`]: crate::ontology::types::uri::BaseUri
     async fn create_data_type(
         &mut self,
-        data_type: DataType,
+        data_type: &DataType,
         created_by: AccountId,
-    ) -> Result<Persisted<DataType>, InsertionError>;
+    ) -> Result<(), InsertionError>;
 
     /// Get the [`DataType`] specified by `identifier`.
     ///
@@ -216,9 +209,9 @@ pub trait Store {
     /// - if the [`DataType`] doesn't exist.
     async fn update_data_type(
         &mut self,
-        data_type: DataType,
+        data_type: &DataType,
         updated_by: AccountId,
-    ) -> Result<Persisted<DataType>, UpdateError>;
+    ) -> Result<(), UpdateError>;
 
     /// Creates a new [`PropertyType`].
     ///
@@ -230,9 +223,9 @@ pub trait Store {
     /// [`BaseUri`]: crate::ontology::types::uri::BaseUri
     async fn create_property_type(
         &mut self,
-        property_type: PropertyType,
+        property_type: &PropertyType,
         created_by: AccountId,
-    ) -> Result<Persisted<PropertyType>, InsertionError>;
+    ) -> Result<(), InsertionError>;
 
     /// Get the [`PropertyType`] specified by `identifier`.
     ///
@@ -256,9 +249,9 @@ pub trait Store {
     /// - if the [`PropertyType`] doesn't exist.
     async fn update_property_type(
         &mut self,
-        property_type: PropertyType,
+        property_type: &PropertyType,
         updated_by: AccountId,
-    ) -> Result<Persisted<PropertyType>, UpdateError>;
+    ) -> Result<(), UpdateError>;
 
     /// Creates a new [`EntityType`].
     ///
@@ -270,9 +263,9 @@ pub trait Store {
     /// [`BaseUri`]: crate::ontology::types::uri::BaseUri
     async fn create_entity_type(
         &mut self,
-        entity_type: EntityType,
+        entity_type: &EntityType,
         created_by: AccountId,
-    ) -> Result<Persisted<EntityType>, InsertionError>;
+    ) -> Result<(), InsertionError>;
 
     /// Get the [`EntityType`] specified by `identifier`.
     ///
@@ -293,9 +286,9 @@ pub trait Store {
     /// - if the [`EntityType`] doesn't exist.
     async fn update_entity_type(
         &mut self,
-        entity_type: EntityType,
+        entity_type: &EntityType,
         updated_by: AccountId,
-    ) -> Result<Persisted<EntityType>, UpdateError>;
+    ) -> Result<(), UpdateError>;
 
     // TODO - perhaps we want to separate the store into the Type Graph and the Data Graph
 
@@ -309,9 +302,9 @@ pub trait Store {
     /// [`BaseUri`]: crate::ontology::types::uri::BaseUri
     async fn create_link_type(
         &mut self,
-        link_type: LinkType,
+        link_type: &LinkType,
         created_by: AccountId,
-    ) -> Result<Persisted<LinkType>, InsertionError>;
+    ) -> Result<(), InsertionError>;
 
     /// Get the [`LinkType`] specified by `identifier`.
     ///
@@ -332,9 +325,9 @@ pub trait Store {
     /// - if the [`LinkType`] doesn't exist.
     async fn update_link_type(
         &mut self,
-        property_type: LinkType,
+        property_type: &LinkType,
         updated_by: AccountId,
-    ) -> Result<Persisted<LinkType>, UpdateError>;
+    ) -> Result<(), UpdateError>;
 
     /// Creates a new [`Entity`].
     ///

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -994,7 +994,7 @@ where
         Ok(())
     }
 
-    async fn inactivate_link(&mut self, link: Link) -> Result<(), LinkActivationError> {
+    async fn inactivate_link(&mut self, link: &Link) -> Result<(), LinkActivationError> {
         let link_type_version_id = self
             .version_id_by_uri(link.link_type_uri())
             .await

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -956,9 +956,9 @@ where
 
     async fn create_link(
         &mut self,
-        link: Link,
+        link: &Link,
         created_by: AccountId,
-    ) -> Result<Link, InsertionError> {
+    ) -> Result<(), InsertionError> {
         let link_type_version_id = self
             .version_id_by_uri(link.link_type_uri())
             .await
@@ -991,7 +991,7 @@ where
             .attach_lazy(|| link.clone())?;
         }
 
-        Ok(link)
+        Ok(())
     }
 
     async fn inactivate_link(&mut self, link: Link) -> Result<(), LinkActivationError> {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/version_id.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/version_id.rs
@@ -1,30 +1,23 @@
-//! Model types that describe the elements of the HASH Ontology.
+use std::fmt;
 
-pub mod types;
-
-use core::fmt;
-
+use postgres_types::{FromSql, ToSql};
 use serde::{Deserialize, Serialize};
-use tokio_postgres::types::{FromSql, ToSql};
 use utoipa::Component;
 use uuid::Uuid;
-
-// TODO - find a good place for AccountId and VersionId, perhaps they will become redundant in a
-//  future design
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Component, FromSql, ToSql)]
 #[repr(transparent)]
 #[postgres(transparent)]
-pub struct AccountId(Uuid);
+pub struct VersionId(Uuid);
 
-impl AccountId {
+impl VersionId {
     #[must_use]
     pub const fn new(uuid: Uuid) -> Self {
         Self(uuid)
     }
 }
 
-impl fmt::Display for AccountId {
+impl fmt::Display for VersionId {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "{}", &self.0)
     }

--- a/packages/graph/hash_graph/tests/integration/postgres/data_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/data_type.rs
@@ -1,3 +1,5 @@
+use graph::ontology::types::OntologyType;
+
 use crate::postgres::DatabaseTestWrapper;
 
 #[tokio::test]
@@ -11,7 +13,7 @@ async fn insert() {
         .await
         .expect("Could not seed database");
 
-    api.create_data_type(boolean_dt)
+    api.create_data_type(&boolean_dt)
         .await
         .expect("could not create data type");
 }
@@ -27,17 +29,16 @@ async fn query() {
         .await
         .expect("Could not seed database");
 
-    let created_data_type = api
-        .create_data_type(empty_list_dt)
+    api.create_data_type(&empty_list_dt)
         .await
         .expect("could not create data type");
 
     let data_type = api
-        .get_data_type(created_data_type.inner().id())
+        .get_data_type(empty_list_dt.id())
         .await
         .expect("could not query data type");
 
-    assert_eq!(data_type.inner(), created_data_type.inner());
+    assert_eq!(data_type, empty_list_dt);
 }
 
 #[tokio::test]
@@ -53,19 +54,14 @@ async fn update() {
         .await
         .expect("Could not seed database");
 
-    let created_data_type = api
-        .create_data_type(object_dt_v1)
+    api.create_data_type(&object_dt_v1)
         .await
         .expect("could not create data type");
 
-    let updated_data_type = api
-        .update_data_type(object_dt_v2)
+    api.update_data_type(&object_dt_v2)
         .await
         .expect("could not update data type");
 
-    assert_ne!(created_data_type.inner(), updated_data_type.inner());
-    assert_ne!(
-        created_data_type.version_id(),
-        updated_data_type.version_id()
-    );
+    assert_ne!(object_dt_v1, object_dt_v2);
+    assert_ne!(object_dt_v1.uri(), object_dt_v2.uri());
 }

--- a/packages/graph/hash_graph/tests/integration/postgres/entity_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/entity_type.rs
@@ -19,7 +19,7 @@ async fn insert() {
         .await
         .expect("Could not seed database");
 
-    api.create_entity_type(person_et)
+    api.create_entity_type(&person_et)
         .await
         .expect("could not create entity type");
 }
@@ -35,17 +35,16 @@ async fn query() {
         .await
         .expect("Could not seed database");
 
-    let created_entity_type = api
-        .create_entity_type(organization_et)
+    api.create_entity_type(&organization_et)
         .await
         .expect("could not create entity type");
 
     let entity_type = api
-        .get_entity_type(created_entity_type.inner().id())
+        .get_entity_type(organization_et.id())
         .await
         .expect("could not query entity type");
 
-    assert_eq!(entity_type.inner(), created_entity_type.inner());
+    assert_eq!(entity_type, organization_et);
 }
 
 #[tokio::test]
@@ -70,19 +69,14 @@ async fn update() {
         .await
         .expect("Could not seed database:");
 
-    let created_entity_type = api
-        .create_entity_type(page_et_v1)
+    api.create_entity_type(&page_et_v1)
         .await
         .expect("could not create entity type");
 
-    let updated_entity_type = api
-        .update_entity_type(page_et_v2)
+    api.update_entity_type(&page_et_v2)
         .await
         .expect("could not update entity type");
 
-    assert_ne!(created_entity_type.inner(), updated_entity_type.inner());
-    assert_ne!(
-        created_entity_type.version_id(),
-        updated_entity_type.version_id()
-    );
+    assert_ne!(page_et_v1, page_et_v2);
+    assert_ne!(page_et_v1.id(), page_et_v2.id());
 }

--- a/packages/graph/hash_graph/tests/integration/postgres/link_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/link_type.rs
@@ -11,7 +11,7 @@ async fn insert() {
         .await
         .expect("Could not seed database");
 
-    api.create_link_type(owns_lt)
+    api.create_link_type(&owns_lt)
         .await
         .expect("could not create link type");
 }
@@ -27,17 +27,16 @@ async fn query() {
         .await
         .expect("Could not seed database");
 
-    let created_link_type = api
-        .create_link_type(submitted_by_lt)
+    api.create_link_type(&submitted_by_lt)
         .await
         .expect("could not create link type");
 
     let link_type = api
-        .get_link_type(created_link_type.inner().id())
+        .get_link_type(submitted_by_lt.id())
         .await
         .expect("could not query link type");
 
-    assert_eq!(link_type.inner(), created_link_type.inner());
+    assert_eq!(link_type, submitted_by_lt);
 }
 
 #[tokio::test]
@@ -53,19 +52,14 @@ async fn update() {
         .await
         .expect("Could not seed database");
 
-    let created_link_type = api
-        .create_link_type(owns_lt_v1)
+    api.create_link_type(&owns_lt_v1)
         .await
         .expect("could not create link type");
 
-    let updated_link_type = api
-        .update_link_type(owns_lt_v2)
+    api.update_link_type(&owns_lt_v2)
         .await
         .expect("could not update link type");
 
-    assert_ne!(created_link_type.inner(), updated_link_type.inner());
-    assert_ne!(
-        created_link_type.version_id(),
-        updated_link_type.version_id()
-    );
+    assert_ne!(owns_lt_v1, owns_lt_v2);
+    assert_ne!(owns_lt_v1.id(), owns_lt_v2.id());
 }

--- a/packages/graph/hash_graph/tests/integration/postgres/links.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/links.rs
@@ -41,23 +41,19 @@ async fn insert() {
         .await
         .expect("could not create entity");
 
-    let created_link = api
-        .create_link(
-            person_a_entity_id,
-            person_b_entity_id,
-            link_type_uri.clone(),
-        )
-        .await
-        .expect("coud not create link");
+    api.create_link(
+        person_a_entity_id,
+        person_b_entity_id,
+        link_type_uri.clone(),
+    )
+    .await
+    .expect("coud not create link");
 
     let link_target = api
         .get_link_target(person_a_entity_id, link_type_uri.clone())
         .await
         .expect("could not fetch link");
 
-    assert_eq!(created_link.source_entity(), person_a_entity_id);
-    assert_eq!(created_link.target_entity(), person_b_entity_id);
-    assert_eq!(created_link.link_type_uri(), &link_type_uri);
     assert_eq!(link_target, Outgoing::Single(person_b_entity_id));
 }
 

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -240,9 +240,9 @@ impl DatabaseApi<'_> {
         source_entity: EntityId,
         target_entity: EntityId,
         link_type_uri: VersionedUri,
-    ) -> Result<Link, InsertionError> {
+    ) -> Result<(), InsertionError> {
         let link = Link::new(source_entity, target_entity, link_type_uri);
-        self.store.create_link(link, self.account_id).await
+        self.store.create_link(&link, self.account_id).await
     }
 
     pub async fn get_link_target(
@@ -266,7 +266,7 @@ impl DatabaseApi<'_> {
         link_type_uri: VersionedUri,
     ) -> Result<(), LinkActivationError> {
         let link = Link::new(source_entity, target_entity, link_type_uri);
-        self.store.inactivate_link(link).await
+        self.store.inactivate_link(&link).await
     }
 }
 

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -9,7 +9,7 @@ use error_stack::Result;
 use graph::{
     knowledge::{Entity, EntityId, Link, Links, Outgoing},
     ontology::{
-        types::{uri::VersionedUri, DataType, EntityType, LinkType, Persisted, PropertyType},
+        types::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType},
         AccountId,
     },
     store::{
@@ -93,7 +93,7 @@ impl DatabaseTestWrapper {
         for data_type in data_types {
             store
                 .create_data_type(
-                    serde_json::from_str(data_type).expect("could not parse data type"),
+                    &serde_json::from_str(data_type).expect("could not parse data type"),
                     account_id,
                 )
                 .await?;
@@ -102,7 +102,7 @@ impl DatabaseTestWrapper {
         for property_type in property_types {
             store
                 .create_property_type(
-                    serde_json::from_str(property_type).expect("could not parse data type"),
+                    &serde_json::from_str(property_type).expect("could not parse data type"),
                     account_id,
                 )
                 .await?;
@@ -112,7 +112,7 @@ impl DatabaseTestWrapper {
         for link_type in link_types {
             store
                 .create_link_type(
-                    serde_json::from_str(link_type).expect("could not parse link type"),
+                    &serde_json::from_str(link_type).expect("could not parse link type"),
                     account_id,
                 )
                 .await?;
@@ -121,7 +121,7 @@ impl DatabaseTestWrapper {
         for entity_type in entity_types {
             store
                 .create_entity_type(
-                    serde_json::from_str(entity_type).expect("could not parse entity type"),
+                    &serde_json::from_str(entity_type).expect("could not parse entity type"),
                     account_id,
                 )
                 .await?;
@@ -131,26 +131,17 @@ impl DatabaseTestWrapper {
     }
 }
 impl DatabaseApi<'_> {
-    pub async fn create_data_type(
-        &mut self,
-        data_type: DataType,
-    ) -> Result<Persisted<DataType>, InsertionError> {
+    pub async fn create_data_type(&mut self, data_type: &DataType) -> Result<(), InsertionError> {
         self.store
             .create_data_type(data_type, self.account_id)
             .await
     }
 
-    pub async fn get_data_type(
-        &mut self,
-        uri: &VersionedUri,
-    ) -> Result<Persisted<DataType>, QueryError> {
+    pub async fn get_data_type(&mut self, uri: &VersionedUri) -> Result<DataType, QueryError> {
         self.store.get_data_type(uri).await
     }
 
-    pub async fn update_data_type(
-        &mut self,
-        data_type: DataType,
-    ) -> Result<Persisted<DataType>, UpdateError> {
+    pub async fn update_data_type(&mut self, data_type: &DataType) -> Result<(), UpdateError> {
         self.store
             .update_data_type(data_type, self.account_id)
             .await
@@ -158,8 +149,8 @@ impl DatabaseApi<'_> {
 
     pub async fn create_property_type(
         &mut self,
-        property_type: PropertyType,
-    ) -> Result<Persisted<PropertyType>, InsertionError> {
+        property_type: &PropertyType,
+    ) -> Result<(), InsertionError> {
         self.store
             .create_property_type(property_type, self.account_id)
             .await
@@ -168,14 +159,14 @@ impl DatabaseApi<'_> {
     pub async fn get_property_type(
         &mut self,
         uri: &VersionedUri,
-    ) -> Result<Persisted<PropertyType>, QueryError> {
+    ) -> Result<PropertyType, QueryError> {
         self.store.get_property_type(uri).await
     }
 
     pub async fn update_property_type(
         &mut self,
-        property_type: PropertyType,
-    ) -> Result<Persisted<PropertyType>, UpdateError> {
+        property_type: &PropertyType,
+    ) -> Result<(), UpdateError> {
         self.store
             .update_property_type(property_type, self.account_id)
             .await
@@ -183,49 +174,37 @@ impl DatabaseApi<'_> {
 
     pub async fn create_entity_type(
         &mut self,
-        entity_type: EntityType,
-    ) -> Result<Persisted<EntityType>, InsertionError> {
+        entity_type: &EntityType,
+    ) -> Result<(), InsertionError> {
         self.store
             .create_entity_type(entity_type, self.account_id)
             .await
     }
 
-    pub async fn get_entity_type(
-        &mut self,
-        uri: &VersionedUri,
-    ) -> Result<Persisted<EntityType>, QueryError> {
+    pub async fn get_entity_type(&mut self, uri: &VersionedUri) -> Result<EntityType, QueryError> {
         self.store.get_entity_type(uri).await
     }
 
     pub async fn update_entity_type(
         &mut self,
-        entity_type: EntityType,
-    ) -> Result<Persisted<EntityType>, UpdateError> {
+        entity_type: &EntityType,
+    ) -> Result<(), UpdateError> {
         self.store
             .update_entity_type(entity_type, self.account_id)
             .await
     }
 
-    pub async fn create_link_type(
-        &mut self,
-        link_type: LinkType,
-    ) -> Result<Persisted<LinkType>, InsertionError> {
+    pub async fn create_link_type(&mut self, link_type: &LinkType) -> Result<(), InsertionError> {
         self.store
             .create_link_type(link_type, self.account_id)
             .await
     }
 
-    pub async fn get_link_type(
-        &mut self,
-        uri: &VersionedUri,
-    ) -> Result<Persisted<LinkType>, QueryError> {
+    pub async fn get_link_type(&mut self, uri: &VersionedUri) -> Result<LinkType, QueryError> {
         self.store.get_link_type(uri).await
     }
 
-    pub async fn update_link_type(
-        &mut self,
-        link_type: LinkType,
-    ) -> Result<Persisted<LinkType>, UpdateError> {
+    pub async fn update_link_type(&mut self, link_type: &LinkType) -> Result<(), UpdateError> {
         self.store
             .update_link_type(link_type, self.account_id)
             .await

--- a/packages/graph/hash_graph/tests/integration/postgres/property_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/property_type.rs
@@ -14,7 +14,7 @@ async fn insert() {
         .await
         .expect("Could not seed database");
 
-    api.create_property_type(age_pt)
+    api.create_property_type(&age_pt)
         .await
         .expect("could not create property type");
 }
@@ -30,17 +30,16 @@ async fn query() {
         .await
         .expect("Could not seed database");
 
-    let created_property_type = api
-        .create_property_type(favorite_quote_pt)
+    api.create_property_type(&favorite_quote_pt)
         .await
         .expect("could not create property type");
 
     let property_type = api
-        .get_property_type(created_property_type.inner().id())
+        .get_property_type(favorite_quote_pt.id())
         .await
         .expect("could not query property type");
 
-    assert_eq!(property_type.inner(), created_property_type.inner());
+    assert_eq!(property_type, favorite_quote_pt);
 }
 
 #[tokio::test]
@@ -56,19 +55,14 @@ async fn update() {
         .await
         .expect("Could not seed database");
 
-    let created_property_type = api
-        .create_property_type(user_id_pt_v1)
+    api.create_property_type(&user_id_pt_v1)
         .await
         .expect("could not create property type");
 
-    let updated_property_type = api
-        .update_property_type(user_id_pt_v2)
+    api.update_property_type(&user_id_pt_v2)
         .await
         .expect("could not update property type");
 
-    assert_ne!(created_property_type.inner(), updated_property_type.inner());
-    assert_ne!(
-        created_property_type.version_id(),
-        updated_property_type.version_id()
-    );
+    assert_ne!(user_id_pt_v1, user_id_pt_v2);
+    assert_ne!(user_id_pt_v1.id(), user_id_pt_v2.id());
 }

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -19,7 +19,7 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("text_data_type_uri", encodeURIComponent(response.body.inner["$id"]));
+    client.global.set("text_data_type_uri", encodeURIComponent(response.body["$id"]));
 %}
 
 ### Get Text data type
@@ -76,7 +76,7 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("person_property_type_uri", encodeURIComponent(response.body.inner["$id"]));
+    client.global.set("person_property_type_uri", encodeURIComponent(response.body["$id"]));
 %}
 
 ### Get Name property type
@@ -133,8 +133,8 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("friend_of_link_type_uri", encodeURIComponent(response.body.inner["$id"]));
-    client.global.set("friend_of_link_type_uri_raw", response.body.inner["$id"]);
+    client.global.set("friend_of_link_type_uri", encodeURIComponent(response.body["$id"]));
+    client.global.set("friend_of_link_type_uri_raw", response.body["$id"]);
 %}
 
 ### Get FriendOf link type
@@ -194,7 +194,7 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("person_entity_type_uri", encodeURIComponent(response.body.inner["$id"]));
+    client.global.set("person_entity_type_uri", encodeURIComponent(response.body["$id"]));
 %}
 
 ### Get Person entity type


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `VersionId` was never designed to be exposed, this removes all references to the `VersionId` outside of the `postgres` module

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/0/1202675758696584/f) _(internal)_

## 🔍 What does this change?

- Don't return `Persisted` from the REST API
- Don't return `Persisted` from the `Store` anymore (but create/update it by reference)
- Move `VersionId` to `store::postgres`

## 🛡 What tests cover this?

- Integration tests
- REST endpoint tests