### PR TITLE
Fix generic arguments when requesting from a `Provider`

### DIFF
--- a/packages/libs/error-stack/src/report.rs
+++ b/packages/libs/error-stack/src/report.rs
@@ -233,8 +233,8 @@ impl<C> Report<C> {
         let provider = temporary_provider(&context);
 
         #[cfg(all(nightly, feature = "std"))]
-        let backtrace = if core::any::request_ref::<Backtrace, _>(&provider)
-            .filter(|backtrace| backtrace.status() == BacktraceStatus::Captured)
+        let backtrace = if core::any::request_ref(&provider)
+            .filter(|backtrace: &&Backtrace| backtrace.status() == BacktraceStatus::Captured)
             .is_some()
         {
             None
@@ -243,8 +243,8 @@ impl<C> Report<C> {
         };
 
         #[cfg(all(nightly, feature = "spantrace"))]
-        let span_trace = if core::any::request_ref::<SpanTrace, _>(&provider)
-            .filter(|span_trace| span_trace.status() == SpanTraceStatus::CAPTURED)
+        let span_trace = if core::any::request_ref(&provider)
+            .filter(|span_trace: &&SpanTrace| span_trace.status() == SpanTraceStatus::CAPTURED)
             .is_some()
         {
             None


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

[#98912 ](https://github.com/rust-lang/rust/pull/98912) in the newest nightly changed how the generics for `core::any::request_ref` are. Instead of specifying the value requested via the generic, we explicitly annotate the filter method. Circumventing the issue.

## 🔗 Related links

* [#98912 ](https://github.com/rust-lang/rust/pull/98912)
* https://github.com/rust-lang/rust/issues/96024
* #873

## 🚫 Blocked by

## 🔍 What does this change?

changes `core::any::request_ref<T, _>().filter(|x| ...)` to `core::any::request_ref().filter(|x: &&T| ...)`

## 📜 Does this require a change to the docs?

Nope.

## ⚠️ Known issues


## 🐾 Next steps

## 🛡 What tests cover this?

## ❓ How to test this?

Does it compile on the old nightly and the new nightly?

## 📹 Demo
