### PR TITLE
Rename REST endpoints to plural names

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -41,7 +41,7 @@ impl RoutedResource for DataTypeResource {
     fn routes<P: GraphPool>() -> Router {
         // TODO: The URL format here is preliminary and will have to change.
         Router::new().nest(
-            "/data-type",
+            "/data-types",
             Router::new()
                 .route("/", post(create_data_type::<P>).put(update_data_type::<P>))
                 .route("/:version_id", get(get_data_type::<P>)),
@@ -58,7 +58,7 @@ struct CreateDataTypeRequest {
 
 #[utoipa::path(
     post,
-    path = "/data-type",
+    path = "/data-types",
     request_body = CreateDataTypeRequest,
     tag = "DataType",
     responses(
@@ -100,7 +100,7 @@ async fn create_data_type<P: GraphPool>(
 
 #[utoipa::path(
     get,
-    path = "/data-type/{uri}",
+    path = "/data-types/{uri}",
     tag = "DataType",
     responses(
         (status = 200, content_type = "application/json", description = "Data type found", body = DataType),
@@ -147,7 +147,7 @@ struct UpdateDataTypeRequest {
 
 #[utoipa::path(
     put,
-    path = "/data-type",
+    path = "/data-types",
     tag = "DataType",
     responses(
         (status = 200, content_type = "application/json", description = "Data type updated successfully", body = DataType),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -45,7 +45,7 @@ impl RoutedResource for EntityResource {
     fn routes<P: GraphPool>() -> Router {
         // TODO: The URL format here is preliminary and will have to change.
         Router::new().nest(
-            "/entity",
+            "/entities",
             Router::new()
                 .route("/", post(create_entity::<P>).put(update_entity::<P>))
                 .route("/:entity_id", get(get_entity::<P>)),
@@ -63,7 +63,7 @@ struct CreateEntityRequest {
 
 #[utoipa::path(
     post,
-    path = "/entity",
+    path = "/entities",
     request_body = CreateEntityRequest,
     tag = "Entity",
     responses(
@@ -104,7 +104,7 @@ async fn create_entity<P: GraphPool>(
 
 #[utoipa::path(
     get,
-    path = "/entity/{entity_id}",
+    path = "/entities/{entity_id}",
     tag = "Entity",
     responses(
         (status = 200, content_type = "application/json", description = "entity found", body = QualifiedEntity),
@@ -155,7 +155,7 @@ struct UpdateEntityRequest {
 
 #[utoipa::path(
     put,
-    path = "/entity",
+    path = "/entities",
     tag = "Entity",
     responses(
         (status = 200, content_type = "application/json", description = "entity updated successfully", body = QualifiedEntity),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -41,7 +41,7 @@ impl RoutedResource for EntityTypeResource {
     fn routes<P: GraphPool>() -> Router {
         // TODO: The URL format here is preliminary and will have to change.
         Router::new().nest(
-            "/entity-type",
+            "/entity-types",
             Router::new()
                 .route(
                     "/",
@@ -61,7 +61,7 @@ struct CreateEntityTypeRequest {
 
 #[utoipa::path(
     post,
-    path = "/entity-type",
+    path = "/entity-types",
     request_body = CreateEntityTypeRequest,
     tag = "EntityType",
     responses(
@@ -103,7 +103,7 @@ async fn create_entity_type<P: GraphPool>(
 
 #[utoipa::path(
     get,
-    path = "/entity-type/{uri}",
+    path = "/entity-types/{uri}",
     tag = "EntityType",
     responses(
         (status = 200, content_type = "application/json", description = "Entity type found", body = EntityType),
@@ -150,7 +150,7 @@ struct UpdateEntityTypeRequest {
 
 #[utoipa::path(
     put,
-    path = "/entity-type",
+    path = "/entity-types",
     tag = "EntityType",
     responses(
         (status = 200, content_type = "application/json", description = "Entity type updated successfully", body = EntityType),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
@@ -36,7 +36,7 @@ impl RoutedResource for LinkResource {
         // TODO: The URL format here is preliminary and will have to change.
         //   for links specifically, we are stacking on top of the existing `/entity/` routes.
         Router::new().nest(
-            "/entity/:entity_id/link",
+            "/entities/:entity_id/links",
             Router::new().route(
                 "/",
                 post(create_link::<P>)
@@ -57,7 +57,7 @@ struct CreateLinkRequest {
 
 #[utoipa::path(
     post,
-    path = "/entity/{entity_id}/link",
+    path = "/entities/{entity_id}/links",
     request_body = CreateLinkRequest,
     tag = "Link",
     responses(
@@ -110,7 +110,7 @@ async fn create_link<P: GraphPool>(
 
 #[utoipa::path(
     get,
-    path = "/entity/{entity_id}/link",
+    path = "/entities/{entity_id}/links",
     tag = "Link",
     responses(
         (status = 200, content_type = "application/json", description = "all active links from the source entity", body = QualifiedLink),
@@ -159,7 +159,7 @@ struct InactivateLinkRequest {
 
 #[utoipa::path(
     delete,
-    path = "/entity/{entity_id}/link",
+    path = "/entities/{entity_id}/links",
     tag = "Link",
     responses(
         (status = 204, content_type = "application/json", description = "link updated successfully"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -41,7 +41,7 @@ impl RoutedResource for LinkTypeResource {
     fn routes<P: GraphPool>() -> Router {
         // TODO: The URL format here is preliminary and will have to change.
         Router::new().nest(
-            "/link-type",
+            "/link-types",
             Router::new()
                 .route("/", post(create_link_type::<P>).put(update_link_type::<P>))
                 .route("/:version_id", get(get_link_type::<P>)),
@@ -58,7 +58,7 @@ struct CreateLinkTypeRequest {
 
 #[utoipa::path(
     post,
-    path = "/link-type",
+    path = "/link-types",
     request_body = CreateLinkTypeRequest,
     tag = "LinkType",
     responses(
@@ -100,7 +100,7 @@ async fn create_link_type<P: GraphPool>(
 
 #[utoipa::path(
     get,
-    path = "/link-type/{uri}",
+    path = "/link-types/{uri}",
     tag = "LinkType",
     responses(
         (status = 200, content_type = "application/json", description = "Link type found", body = LinkType),
@@ -147,7 +147,7 @@ struct UpdateLinkTypeRequest {
 
 #[utoipa::path(
     put,
-    path = "/link-type",
+    path = "/link-types",
     tag = "LinkType",
     responses(
         (status = 200, content_type = "application/json", description = "Link type updated successfully", body = LinkType),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -41,7 +41,7 @@ impl RoutedResource for PropertyTypeResource {
     fn routes<P: GraphPool>() -> Router {
         // TODO: The URL format here is preliminary and will have to change.
         Router::new().nest(
-            "/property-type",
+            "/property-types",
             Router::new()
                 .route(
                     "/",
@@ -61,7 +61,7 @@ struct CreatePropertyTypeRequest {
 
 #[utoipa::path(
     post,
-    path = "/property-type",
+    path = "/property-types",
     request_body = CreatePropertyTypeRequest,
     tag = "PropertyType",
     responses(
@@ -103,7 +103,7 @@ async fn create_property_type<P: GraphPool>(
 
 #[utoipa::path(
     get,
-    path = "/property-type/{uri}",
+    path = "/property-types/{uri}",
     tag = "PropertyType",
     responses(
         (status = 200, content_type = "application/json", description = "Property type found", body = PropertyType),
@@ -150,7 +150,7 @@ struct UpdatePropertyTypeRequest {
 
 #[utoipa::path(
     put,
-    path = "/property-type",
+    path = "/property-types",
     tag = "PropertyType",
     responses(
         (status = 200, content_type = "application/json", description = "Property type updated successfully", body = PropertyType),

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -1,7 +1,7 @@
 # This file either runs with JetBrains' http requests or using httpYac (https://httpyac.github.io).
 
 ### Insert Text data type
-POST http://127.0.0.1:3000/data-type
+POST http://127.0.0.1:3000/data-types
 Content-Type: application/json
 Accept: application/json
 
@@ -23,7 +23,7 @@ Accept: application/json
 %}
 
 ### Get Text data type
-GET http://127.0.0.1:3000/data-type/{{text_data_type_uri}}
+GET http://127.0.0.1:3000/data-types/{{text_data_type_uri}}
 
 > {%
     client.test("status", function() {
@@ -32,7 +32,7 @@ GET http://127.0.0.1:3000/data-type/{{text_data_type_uri}}
 %}
 
 ### Update Text data type
-PUT http://127.0.0.1:3000/data-type
+PUT http://127.0.0.1:3000/data-types
 Content-Type: application/json
 Accept: application/json
 
@@ -54,7 +54,7 @@ Accept: application/json
 %}
 
 ### Insert Name property type
-POST http://127.0.0.1:3000/property-type
+POST http://127.0.0.1:3000/property-types
 Content-Type: application/json
 Accept: application/json
 
@@ -80,7 +80,7 @@ Accept: application/json
 %}
 
 ### Get Name property type
-GET http://127.0.0.1:3000/property-type/{{person_property_type_uri}}
+GET http://127.0.0.1:3000/property-types/{{person_property_type_uri}}
 
 > {%
     client.test("status", function() {
@@ -89,7 +89,7 @@ GET http://127.0.0.1:3000/property-type/{{person_property_type_uri}}
 %}
 
 ### Update Name property type
-PUT http://127.0.0.1:3000/property-type
+PUT http://127.0.0.1:3000/property-types
 Content-Type: application/json
 Accept: application/json
 
@@ -114,7 +114,7 @@ Accept: application/json
 %}
 
 ### Insert FriendOf link type
-POST http://127.0.0.1:3000/link-type
+POST http://127.0.0.1:3000/link-types
 Content-Type: application/json
 Accept: application/json
 
@@ -138,7 +138,7 @@ Accept: application/json
 %}
 
 ### Get FriendOf link type
-GET http://127.0.0.1:3000/link-type/{{friend_of_link_type_uri}}
+GET http://127.0.0.1:3000/link-types/{{friend_of_link_type_uri}}
 
 > {%
     client.test("status", function() {
@@ -147,7 +147,7 @@ GET http://127.0.0.1:3000/link-type/{{friend_of_link_type_uri}}
 %}
 
 ### Update FriendOf link type
-PUT http://127.0.0.1:3000/link-type
+PUT http://127.0.0.1:3000/link-types
 Content-Type: application/json
 Accept: application/json
 
@@ -171,7 +171,7 @@ Accept: application/json
 
 
 ### Insert Person entity type
-POST http://127.0.0.1:3000/entity-type
+POST http://127.0.0.1:3000/entity-types
 Content-Type: application/json
 Accept: application/json
 
@@ -198,7 +198,7 @@ Accept: application/json
 %}
 
 ### Get Person entity type
-GET http://127.0.0.1:3000/entity-type/{{person_entity_type_uri}}
+GET http://127.0.0.1:3000/entity-types/{{person_entity_type_uri}}
 
 > {%
     client.test("status", function() {
@@ -207,7 +207,7 @@ GET http://127.0.0.1:3000/entity-type/{{person_entity_type_uri}}
 %}
 
 ### Update Person entity type
-PUT http://127.0.0.1:3000/entity-type
+PUT http://127.0.0.1:3000/entity-types
 Content-Type: application/json
 Accept: application/json
 
@@ -243,7 +243,7 @@ Accept: application/json
 
 
 ### Insert Person entity
-POST http://127.0.0.1:3000/entity
+POST http://127.0.0.1:3000/entities
 Content-Type: application/json
 Accept: application/json
 
@@ -263,7 +263,7 @@ Accept: application/json
 %}
 
 ### Get Person entity
-GET http://127.0.0.1:3000/entity/{{person_a_entity_id}}
+GET http://127.0.0.1:3000/entities/{{person_a_entity_id}}
 
 > {%
     client.test("status", function() {
@@ -272,7 +272,7 @@ GET http://127.0.0.1:3000/entity/{{person_a_entity_id}}
 %}
 
 ### Update Person entity
-PUT http://127.0.0.1:3000/entity
+PUT http://127.0.0.1:3000/entities
 Content-Type: application/json
 Accept: application/json
 
@@ -292,7 +292,7 @@ Accept: application/json
 %}
 
 ### Insert another Person entity
-POST http://127.0.0.1:3000/entity
+POST http://127.0.0.1:3000/entities
 Content-Type: application/json
 Accept: application/json
 
@@ -312,7 +312,7 @@ Accept: application/json
 %}
 
 ### Insert link between entities
-POST http://127.0.0.1:3000/entity/{{person_a_entity_id}}/link
+POST http://127.0.0.1:3000/entities/{{person_a_entity_id}}/links
 Content-Type: application/json
 Accept: application/json
 
@@ -329,7 +329,7 @@ Accept: application/json
 %}
 
 ### Get person "a" links
-GET http://127.0.0.1:3000/entity/{{person_a_entity_id}}/link
+GET http://127.0.0.1:3000/entities/{{person_a_entity_id}}/links
 Content-Type: application/json
 Accept: application/json
 
@@ -343,7 +343,7 @@ Accept: application/json
 %}
 
 ### Inactivate person "a" to person "b" link
-DELETE http://127.0.0.1:3000/entity/{{person_a_entity_id}}/link
+DELETE http://127.0.0.1:3000/entities/{{person_a_entity_id}}/links
 Content-Type: application/json
 Accept: application/json
 
@@ -359,7 +359,7 @@ Accept: application/json
 %}
 
 ### Check inactivated person "a" to person "b" link
-GET http://127.0.0.1:3000/entity/{{person_a_entity_id}}/link
+GET http://127.0.0.1:3000/entities/{{person_a_entity_id}}/links
 Content-Type: application/json
 Accept: application/json
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, all endpoints are singular. Normally, REST endpoints are plural, to play well with getting multiple things as well, e.g.
- `/api/data-types/` to get all data-types
- `/api/data-types/{data-type-uri}` to get a specific data-type

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202538466812818/1202682556665557/f) _(internal)_

## 🔍 What does this change?

- Make the endpoints plural
- Adjust the tests

## 📜 Does this require a change to the docs?

The OpenAPI attributes also has been adjusted

## 🐾 Next steps

- Implement read-many endpoints

## 🛡 What tests cover this?

The REST endpoint tests were adjusted