### PR TITLE
Generalize GET method bodies

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use axum::{
     extract::Path,
     http::StatusCode,
-    response::IntoResponse,
     routing::{get, post},
     Extension, Json, Router,
 };
@@ -14,11 +13,12 @@ use utoipa::{Component, OpenApi};
 
 use super::api_resource::RoutedResource;
 use crate::{
+    api::rest::read_from_store,
     ontology::{
         types::{uri::VersionedUri, DataType},
         AccountId,
     },
-    store::{BaseUriAlreadyExists, BaseUriDoesNotExist, QueryError},
+    store::{BaseUriAlreadyExists, BaseUriDoesNotExist},
     GraphPool,
 };
 
@@ -116,25 +116,9 @@ async fn create_data_type<P: GraphPool>(
 async fn get_data_type<P: GraphPool>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<DataType>, impl IntoResponse> {
-    let store = pool.acquire().await.map_err(|report| {
-        tracing::error!(error=?report, "Could not acquire store");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
-    store
-        .get_data_type(&uri.0)
+) -> Result<Json<DataType>, StatusCode> {
+    read_from_store::<DataType, _, _, _>(pool.as_ref(), &uri.0)
         .await
-        .map_err(|report| {
-            tracing::error!(error=?report, "Could not query data type");
-
-            if report.contains::<QueryError>() {
-                return StatusCode::NOT_FOUND;
-            }
-
-            // Store errors such as connection failure are considered internal server errors.
-            StatusCode::INTERNAL_SERVER_ERROR
-        })
         .map(Json)
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -114,10 +114,10 @@ async fn create_data_type<P: GraphPool>(
     )
 )]
 async fn get_data_type<P: GraphPool>(
-    uri: Path<VersionedUri>,
-    pool: Extension<Arc<P>>,
+    Path(uri): Path<VersionedUri>,
+    Extension(pool): Extension<Arc<P>>,
 ) -> Result<Json<DataType>, StatusCode> {
-    read_from_store::<DataType, _, _, _>(pool.as_ref(), &uri.0)
+    read_from_store::<DataType, _, _, _>(pool.as_ref(), &uri)
         .await
         .map(Json)
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use axum::{
     extract::Path,
     http::StatusCode,
-    response::IntoResponse,
     routing::{get, post},
     Extension, Json, Router,
 };
@@ -13,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::{Component, OpenApi};
 
 use crate::{
-    api::rest::api_resource::RoutedResource,
+    api::rest::{api_resource::RoutedResource, read_from_store},
     knowledge::{Entity, EntityId},
     ontology::{types::uri::VersionedUri, AccountId},
     store::error::{EntityDoesNotExist, QueryError},
@@ -120,28 +119,11 @@ async fn create_entity<P: GraphPool>(
 async fn get_entity<P: GraphPool>(
     entity_id: Path<EntityId>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<QualifiedEntity>, impl IntoResponse> {
-    let Path(entity_id) = entity_id;
-
-    let store = pool.acquire().await.map_err(|report| {
-        tracing::error!(error=?report, "Could not acquire store");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
-    store
-        .get_entity(entity_id)
-        .await
-        .map_err(|report| {
-            tracing::error!(error=?report, "Could not query entity");
-
-            if report.contains::<QueryError>() {
-                return StatusCode::NOT_FOUND;
-            }
-
-            // Datastore errors such as connection failure are considered internal server errors.
-            StatusCode::INTERNAL_SERVER_ERROR
-        })
-        .map(|entity| Json(QualifiedEntity { entity_id, entity }))
+) -> Result<Json<QualifiedEntity>, StatusCode> {
+    Ok(Json(QualifiedEntity {
+        entity_id: entity_id.0,
+        entity: read_from_store::<Entity, _, _, _>(pool.as_ref(), entity_id.0).await?,
+    }))
 }
 
 #[derive(Component, Serialize, Deserialize)]

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -106,7 +106,7 @@ async fn create_entity<P: GraphPool>(
     path = "/entities/{entity_id}",
     tag = "Entity",
     responses(
-        (status = 200, content_type = "application/json", description = "entity found", body = QualifiedEntity),
+        (status = 200, content_type = "application/json", description = "entity found", body = Entity),
         (status = 422, content_type = "text/plain", description = "Provided entity id is invalid"),
 
         (status = 404, description = "entity was not found"),
@@ -117,13 +117,12 @@ async fn create_entity<P: GraphPool>(
     )
 )]
 async fn get_entity<P: GraphPool>(
-    entity_id: Path<EntityId>,
-    pool: Extension<Arc<P>>,
-) -> Result<Json<QualifiedEntity>, StatusCode> {
-    Ok(Json(QualifiedEntity {
-        entity_id: entity_id.0,
-        entity: read_from_store::<Entity, _, _, _>(pool.as_ref(), entity_id.0).await?,
-    }))
+    Path(entity_id): Path<EntityId>,
+    Extension(pool): Extension<Arc<P>>,
+) -> Result<Json<Entity>, StatusCode> {
+    read_from_store::<Entity, _, _, _>(pool.as_ref(), entity_id)
+        .await
+        .map(Json)
 }
 
 #[derive(Component, Serialize, Deserialize)]

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use axum::{
     extract::Path,
     http::StatusCode,
-    response::IntoResponse,
     routing::{get, post},
     Extension, Json, Router,
 };
@@ -13,12 +12,12 @@ use serde::{Deserialize, Serialize};
 use utoipa::{Component, OpenApi};
 
 use crate::{
-    api::rest::api_resource::RoutedResource,
+    api::rest::{api_resource::RoutedResource, read_from_store},
     ontology::{
         types::{uri::VersionedUri, EntityType},
         AccountId,
     },
-    store::error::{BaseUriAlreadyExists, BaseUriDoesNotExist, QueryError},
+    store::error::{BaseUriAlreadyExists, BaseUriDoesNotExist},
     GraphPool,
 };
 
@@ -119,25 +118,9 @@ async fn create_entity_type<P: GraphPool>(
 async fn get_entity_type<P: GraphPool>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<EntityType>, impl IntoResponse> {
-    let store = pool.acquire().await.map_err(|report| {
-        tracing::error!(error=?report, "Could not acquire store");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
-    store
-        .get_entity_type(&uri.0)
+) -> Result<Json<EntityType>, StatusCode> {
+    read_from_store::<EntityType, _, _, _>(pool.as_ref(), &uri.0)
         .await
-        .map_err(|report| {
-            tracing::error!(error=?report, "Could not query entity type");
-
-            if report.contains::<QueryError>() {
-                return StatusCode::NOT_FOUND;
-            }
-
-            // Datastore errors such as connection failure are considered internal server errors.
-            StatusCode::INTERNAL_SERVER_ERROR
-        })
         .map(Json)
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -116,10 +116,10 @@ async fn create_entity_type<P: GraphPool>(
     )
 )]
 async fn get_entity_type<P: GraphPool>(
-    uri: Path<VersionedUri>,
-    pool: Extension<Arc<P>>,
+    Path(uri): Path<VersionedUri>,
+    Extension(pool): Extension<Arc<P>>,
 ) -> Result<Json<EntityType>, StatusCode> {
-    read_from_store::<EntityType, _, _, _>(pool.as_ref(), &uri.0)
+    read_from_store::<EntityType, _, _, _>(pool.as_ref(), &uri)
         .await
         .map(Json)
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
@@ -2,14 +2,12 @@
 
 use std::sync::Arc;
 
-use axum::{
-    extract::Path, http::StatusCode, response::IntoResponse, routing::post, Extension, Json, Router,
-};
+use axum::{extract::Path, http::StatusCode, routing::post, Extension, Json, Router};
 use serde::{Deserialize, Serialize};
 use utoipa::{Component, OpenApi};
 
 use crate::{
-    api::rest::api_resource::RoutedResource,
+    api::rest::{api_resource::RoutedResource, read_from_store},
     knowledge::{EntityId, Link, Links},
     ontology::{types::uri::VersionedUri, AccountId},
     store::error::QueryError,
@@ -126,27 +124,9 @@ async fn create_link<P: GraphPool>(
 async fn get_entity_links<P: GraphPool>(
     source_entity_id: Path<EntityId>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<Links>, impl IntoResponse> {
-    let Path(source_entity_id) = source_entity_id;
-
-    let store = pool.acquire().await.map_err(|report| {
-        tracing::error!(error=?report, "Could not acquire store");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
-    store
-        .get_entity_links(source_entity_id)
+) -> Result<Json<Links>, StatusCode> {
+    read_from_store::<Link, _, _, _>(pool.as_ref(), source_entity_id.0)
         .await
-        .map_err(|report| {
-            tracing::error!(error=?report, "Could not query link");
-
-            if report.contains::<QueryError>() {
-                return StatusCode::NOT_FOUND;
-            }
-
-            // Datastore errors such as connection failure are considered internal server errors.
-            StatusCode::INTERNAL_SERVER_ERROR
-        })
         .map(Json)
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
@@ -122,10 +122,10 @@ async fn create_link<P: GraphPool>(
     )
 )]
 async fn get_entity_links<P: GraphPool>(
-    source_entity_id: Path<EntityId>,
-    pool: Extension<Arc<P>>,
+    Path(source_entity_id): Path<EntityId>,
+    Extension(pool): Extension<Arc<P>>,
 ) -> Result<Json<Links>, StatusCode> {
-    read_from_store::<Link, _, _, _>(pool.as_ref(), source_entity_id.0)
+    read_from_store::<Link, _, _, _>(pool.as_ref(), source_entity_id)
         .await
         .map(Json)
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -114,10 +114,10 @@ async fn create_link_type<P: GraphPool>(
     )
 )]
 async fn get_link_type<P: GraphPool>(
-    uri: Path<VersionedUri>,
-    pool: Extension<Arc<P>>,
+    Path(uri): Path<VersionedUri>,
+    Extension(pool): Extension<Arc<P>>,
 ) -> Result<Json<LinkType>, StatusCode> {
-    read_from_store::<LinkType, _, _, _>(pool.as_ref(), &uri.0)
+    read_from_store::<LinkType, _, _, _>(pool.as_ref(), &uri)
         .await
         .map(Json)
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use axum::{
     extract::Path,
     http::StatusCode,
-    response::IntoResponse,
     routing::{get, post},
     Extension, Json, Router,
 };
@@ -14,11 +13,12 @@ use utoipa::{Component, OpenApi};
 
 use super::api_resource::RoutedResource;
 use crate::{
+    api::rest::read_from_store,
     ontology::{
         types::{uri::VersionedUri, LinkType},
         AccountId,
     },
-    store::{BaseUriAlreadyExists, BaseUriDoesNotExist, QueryError},
+    store::{BaseUriAlreadyExists, BaseUriDoesNotExist},
     GraphPool,
 };
 
@@ -116,25 +116,9 @@ async fn create_link_type<P: GraphPool>(
 async fn get_link_type<P: GraphPool>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<LinkType>, impl IntoResponse> {
-    let store = pool.acquire().await.map_err(|report| {
-        tracing::error!(error=?report, "Could not acquire store");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
-    store
-        .get_link_type(&uri.0)
+) -> Result<Json<LinkType>, StatusCode> {
+    read_from_store::<LinkType, _, _, _>(pool.as_ref(), &uri.0)
         .await
-        .map_err(|report| {
-            tracing::error!(error=?report, "Could not query link type");
-
-            if report.contains::<QueryError>() {
-                return StatusCode::NOT_FOUND;
-            }
-
-            // Store errors such as connection failure are considered internal server errors.
-            StatusCode::INTERNAL_SERVER_ERROR
-        })
         .map(Json)
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
@@ -12,11 +12,14 @@ mod property_type;
 
 use std::sync::Arc;
 
-use axum::{routing::get, Extension, Json, Router};
+use axum::{http::StatusCode, routing::get, Extension, Json, Router};
 use utoipa::{openapi, Modify, OpenApi};
 
 use self::api_resource::RoutedResource;
-use crate::GraphPool;
+use crate::{
+    store::{crud, QueryError},
+    GraphPool, StorePool,
+};
 
 fn api_resources<P: GraphPool>() -> Vec<Router> {
     vec![
@@ -38,6 +41,34 @@ fn api_documentation() -> Vec<openapi::OpenApi> {
         entity::EntityResource::documentation(),
         link::LinkResource::documentation(),
     ]
+}
+
+async fn read_from_store<'pool, 'id: 'pool, T, O, P, I>(
+    pool: &'pool P,
+    identifier: I,
+) -> Result<O, StatusCode>
+where
+    P: StorePool,
+    P::Store<'pool>: crud::Read<'id, I, T, Output = O>,
+    I: Send + 'id,
+{
+    let store = pool.acquire().await.map_err(|report| {
+        tracing::error!(error=?report, "Could not acquire store");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    crud::Read::<I, T>::get(&store, identifier)
+        .await
+        .map_err(|report| {
+            tracing::error!(error=?report, "Could not query from store");
+
+            if report.contains::<QueryError>() {
+                return StatusCode::NOT_FOUND;
+            }
+
+            // Store errors such as connection failure are considered internal server errors.
+            StatusCode::INTERNAL_SERVER_ERROR
+        })
 }
 
 pub fn rest_api_router<P: GraphPool>(store: Arc<P>) -> Router {

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
@@ -43,7 +43,7 @@ fn api_documentation() -> Vec<openapi::OpenApi> {
     ]
 }
 
-async fn read_from_store<'pool, 'id: 'pool, T, O, P, I>(
+async fn read_from_store<'pool, 'id: 'pool, T, P, I, O>(
     pool: &'pool P,
     identifier: I,
 ) -> Result<O, StatusCode>

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
@@ -53,14 +53,14 @@ where
     I: Send + 'id,
 {
     let store = pool.acquire().await.map_err(|report| {
-        tracing::error!(error=?report, "Could not acquire store");
+        tracing::error!(error=?report, "Could not acquire access to the store");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
     crud::Read::<I, T>::get(&store, identifier)
         .await
         .map_err(|report| {
-            tracing::error!(error=?report, "Could not query from store");
+            tracing::error!(error=?report, "Could not read from the store");
 
             if report.contains::<QueryError>() {
                 return StatusCode::NOT_FOUND;

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use axum::{
     extract::Path,
     http::StatusCode,
-    response::IntoResponse,
     routing::{get, post},
     Extension, Json, Router,
 };
@@ -14,11 +13,12 @@ use utoipa::{Component, OpenApi};
 
 use super::api_resource::RoutedResource;
 use crate::{
+    api::rest::read_from_store,
     ontology::{
         types::{uri::VersionedUri, PropertyType},
         AccountId,
     },
-    store::{BaseUriAlreadyExists, BaseUriDoesNotExist, QueryError},
+    store::{BaseUriAlreadyExists, BaseUriDoesNotExist},
     GraphPool,
 };
 
@@ -119,25 +119,9 @@ async fn create_property_type<P: GraphPool>(
 async fn get_property_type<P: GraphPool>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<PropertyType>, impl IntoResponse> {
-    let store = pool.acquire().await.map_err(|report| {
-        tracing::error!(error=?report, "Could not acquire store");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
-    store
-        .get_property_type(&uri.0)
+) -> Result<Json<PropertyType>, StatusCode> {
+    read_from_store::<PropertyType, _, _, _>(pool.as_ref(), &uri.0)
         .await
-        .map_err(|report| {
-            tracing::error!(error=?report, "Could not query property type");
-
-            if report.contains::<QueryError>() {
-                return StatusCode::NOT_FOUND;
-            }
-
-            // Store errors such as connection failure are considered internal server errors.
-            StatusCode::INTERNAL_SERVER_ERROR
-        })
         .map(Json)
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -117,10 +117,10 @@ async fn create_property_type<P: GraphPool>(
     )
 )]
 async fn get_property_type<P: GraphPool>(
-    uri: Path<VersionedUri>,
-    pool: Extension<Arc<P>>,
+    Path(uri): Path<VersionedUri>,
+    Extension(pool): Extension<Arc<P>>,
 ) -> Result<Json<PropertyType>, StatusCode> {
-    read_from_store::<PropertyType, _, _, _>(pool.as_ref(), &uri.0)
+    read_from_store::<PropertyType, _, _, _>(pool.as_ref(), &uri)
         .await
         .map(Json)
 }

--- a/packages/graph/hash_graph/lib/graph/src/lib.rs
+++ b/packages/graph/hash_graph/lib/graph/src/lib.rs
@@ -54,11 +54,10 @@
 )]
 
 use crate::{
-    knowledge::{Entity, EntityId, Links},
+    knowledge::{Entity, EntityId, Link, Links},
     ontology::types::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType},
     store::{crud::Read, Store, StorePool},
 };
-use crate::knowledge::Link;
 
 pub mod api;
 

--- a/packages/graph/hash_graph/lib/graph/src/lib.rs
+++ b/packages/graph/hash_graph/lib/graph/src/lib.rs
@@ -58,6 +58,7 @@ use crate::{
     ontology::types::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType},
     store::{crud::Read, Store, StorePool},
 };
+use crate::knowledge::Link;
 
 pub mod api;
 
@@ -83,4 +84,4 @@ pub trait Graph = where
         + Read<'i, &'i VersionedUri, LinkType, Output = LinkType>
         + Read<'i, &'i VersionedUri, EntityType, Output = EntityType>
         + Read<'i, EntityId, Entity, Output = Entity>
-        + Read<'i, EntityId, Links, Output = Links>;
+        + Read<'i, EntityId, Link, Output = Links>;

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -16,7 +16,7 @@ pub use self::{
     postgres::{AsClient, PostgresStore, PostgresStorePool},
 };
 use crate::{
-    knowledge::{Entity, EntityId, Link, Links},
+    knowledge::{Entity, EntityId, Link},
     ontology::{
         types::{uri::VersionedUri, EntityType, LinkType, PropertyType},
         AccountId,
@@ -417,7 +417,7 @@ pub trait LinkStore {
     /// - if the requested [`Entity`] doesn't exist
     async fn get_entity_links<'i, I: Send>(&self, identifier: I) -> Result<Self::Output, QueryError>
     where
-        Self: Read<'i, I, Links>,
+        Self: Read<'i, I, Link>,
     {
         self.get(identifier).await
     }
@@ -433,7 +433,7 @@ pub trait LinkStore {
         link_type: L,
     ) -> Result<Self::Output, QueryError>
     where
-        Self: Read<'i, (E, L), Links>,
+        Self: Read<'i, (E, L), Link>,
     {
         self.get((source_entity, link_type)).await
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -410,7 +410,9 @@ pub trait LinkStore {
         created_by: AccountId,
     ) -> Result<(), InsertionError>;
 
-    /// Get [`Links`] of an [`Entity`] identified by an [`EntityId`].
+    /// Get one or multiple [`Link`]s of an [`Entity`] specified by `identifier`.
+    ///
+    /// Depending on the `identifier` the output is specified by [`Read::Output`].
     ///
     /// # Errors
     ///

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/link/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/link/read.rs
@@ -3,13 +3,13 @@ use error_stack::{IntoReport, Report, Result, ResultExt};
 use tokio_postgres::GenericClient;
 
 use crate::{
-    knowledge::{EntityId, Links, Outgoing},
+    knowledge::{EntityId, Link, Links, Outgoing},
     ontology::types::uri::VersionedUri,
     store::{crud, AsClient, PostgresStore, QueryError},
 };
 
 #[async_trait]
-impl<C: AsClient> crud::Read<'_, EntityId, Links> for PostgresStore<C> {
+impl<C: AsClient> crud::Read<'_, EntityId, Link> for PostgresStore<C> {
     type Output = Links;
 
     async fn get(&self, identifier: EntityId) -> Result<Self::Output, QueryError> {
@@ -65,7 +65,7 @@ impl<C: AsClient> crud::Read<'_, EntityId, Links> for PostgresStore<C> {
 }
 
 #[async_trait]
-impl<'i, C: AsClient> crud::Read<'i, (EntityId, &'i VersionedUri), Links> for PostgresStore<C> {
+impl<'i, C: AsClient> crud::Read<'i, (EntityId, &'i VersionedUri), Link> for PostgresStore<C> {
     type Output = Outgoing;
 
     async fn get(

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -14,7 +14,7 @@ use graph::{
     },
     store::{
         error::LinkActivationError, AsClient, DatabaseConnectionInfo, DatabaseType, InsertionError,
-        PostgresStore, PostgresStorePool, QueryError, Store, StorePool, UpdateError,
+        LinkStore, PostgresStore, PostgresStorePool, QueryError, Store, StorePool, UpdateError,
     },
 };
 use tokio_postgres::{NoTls, Transaction};


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

With the recent changes, it's now possible to generalize the GET methods for the REST endpoints to avoid code duplication

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201095311341924/1202668708596541/f) _(internal)_

## 🔍 What does this change?

- Generalize the GET method bodides
- Drive-by: Make `T` for links in `Read` trait singular (for consistency)