### PR TITLE
Implement GET for all stored ontology types

### DIFF
--- a/packages/graph/hash_graph/Cargo.lock
+++ b/packages/graph/hash_graph/Cargo.lock
@@ -398,6 +398,7 @@ dependencies = [
  "bb8-postgres",
  "clap",
  "error-stack",
+ "futures",
  "postgres-types",
  "serde",
  "serde_json",

--- a/packages/graph/hash_graph/lib/graph/Cargo.toml
+++ b/packages/graph/hash_graph/lib/graph/Cargo.toml
@@ -12,6 +12,7 @@ axum = "0.5.11"
 bb8-postgres = "0.8.1"
 clap = { version = "3.2.10", features = ["derive", "env"], optional = true }
 error-stack = "0.1.1"
+futures = "0.3.21"
 postgres-types = { version = "0.2.3", default-features = false, features = ["derive", "with-uuid-1", "with-serde_json-1"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -109,7 +109,7 @@ async fn create_data_type<P: GraphPool>(
     path = "/data-types",
     tag = "DataType",
     responses(
-        (status = 200, content_type = "application/json", description = "List of the latest version of all data types", body = [DataType]),
+        (status = 200, content_type = "application/json", description = "List of all data types at their latest versions", body = [DataType]),
         (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 500, description = "Store error occurred"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -27,6 +27,7 @@ use crate::{
     handlers(
         create_data_type,
         get_data_type,
+        get_data_type_unfiltered,
         update_data_type
     ),
     components(CreateDataTypeRequest, UpdateDataTypeRequest, AccountId, DataType),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -109,7 +109,7 @@ async fn create_data_type<P: GraphPool>(
     path = "/data-types",
     tag = "DataType",
     responses(
-        (status = 200, content_type = "application/json", description = "Data type found", body = [DataType]),
+        (status = 200, content_type = "application/json", description = "List of the latest version of all data types", body = [DataType]),
         (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 500, description = "Store error occurred"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -18,7 +18,7 @@ use crate::{
         types::{uri::VersionedUri, DataType},
         AccountId,
     },
-    store::{BaseUriAlreadyExists, BaseUriDoesNotExist},
+    store::{crud::AllLatest, BaseUriAlreadyExists, BaseUriDoesNotExist},
     GraphPool,
 };
 
@@ -118,7 +118,7 @@ async fn create_data_type<P: GraphPool>(
 async fn get_latest_data_types<P: GraphPool>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<DataType>>, StatusCode> {
-    read_from_store::<DataType, _, _, _>(pool.as_ref(), ())
+    read_from_store::<DataType, _, _, _>(pool.as_ref(), AllLatest)
         .await
         .map(Json)
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -27,7 +27,7 @@ use crate::{
     handlers(
         create_data_type,
         get_data_type,
-        get_data_type_unfiltered,
+        get_latest_data_types,
         update_data_type
     ),
     components(CreateDataTypeRequest, UpdateDataTypeRequest, AccountId, DataType),
@@ -47,7 +47,7 @@ impl RoutedResource for DataTypeResource {
                 .route(
                     "/",
                     post(create_data_type::<P>)
-                        .get(get_data_type_unfiltered::<P>)
+                        .get(get_latest_data_types::<P>)
                         .put(update_data_type::<P>),
                 )
                 .route("/:version_id", get(get_data_type::<P>)),
@@ -115,7 +115,7 @@ async fn create_data_type<P: GraphPool>(
         (status = 500, description = "Store error occurred"),
     )
 )]
-async fn get_data_type_unfiltered<P: GraphPool>(
+async fn get_latest_data_types<P: GraphPool>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<DataType>>, StatusCode> {
     read_from_store::<DataType, _, _, _>(pool.as_ref(), ())

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -111,7 +111,7 @@ async fn create_entity_type<P: GraphPool>(
     path = "/entity-types",
     tag = "EntityType",
     responses(
-        (status = 200, content_type = "application/json", description = "List of the latest version of all entity types", body = [EntityType]),
+        (status = 200, content_type = "application/json", description = "List of all entity types at their latest versions", body = [EntityType]),
         (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 500, description = "Datastore error occurred"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -26,6 +26,7 @@ use crate::{
     handlers(
         create_entity_type,
         get_entity_type,
+        get_entity_type_unfiltered,
         update_entity_type
     ),
     components(CreateEntityTypeRequest, UpdateEntityTypeRequest, AccountId, EntityType),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -26,7 +26,7 @@ use crate::{
     handlers(
         create_entity_type,
         get_entity_type,
-        get_entity_type_unfiltered,
+        get_latest_entity_types,
         update_entity_type
     ),
     components(CreateEntityTypeRequest, UpdateEntityTypeRequest, AccountId, EntityType),
@@ -46,7 +46,7 @@ impl RoutedResource for EntityTypeResource {
                 .route(
                     "/",
                     post(create_entity_type::<P>)
-                        .get(get_entity_type_unfiltered::<P>)
+                        .get(get_latest_entity_types::<P>)
                         .put(update_entity_type::<P>),
                 )
                 .route("/:version_id", get(get_entity_type::<P>)),
@@ -114,7 +114,7 @@ async fn create_entity_type<P: GraphPool>(
         (status = 500, description = "Datastore error occurred"),
     )
 )]
-async fn get_entity_type_unfiltered<P: GraphPool>(
+async fn get_latest_entity_types<P: GraphPool>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<EntityType>>, StatusCode> {
     read_from_store::<EntityType, _, _, _>(pool.as_ref(), ())

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -17,7 +17,10 @@ use crate::{
         types::{uri::VersionedUri, EntityType},
         AccountId,
     },
-    store::error::{BaseUriAlreadyExists, BaseUriDoesNotExist},
+    store::{
+        crud::AllLatest,
+        error::{BaseUriAlreadyExists, BaseUriDoesNotExist},
+    },
     GraphPool,
 };
 
@@ -117,7 +120,7 @@ async fn create_entity_type<P: GraphPool>(
 async fn get_latest_entity_types<P: GraphPool>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<EntityType>>, StatusCode> {
-    read_from_store::<EntityType, _, _, _>(pool.as_ref(), ())
+    read_from_store::<EntityType, _, _, _>(pool.as_ref(), AllLatest)
         .await
         .map(Json)
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -108,7 +108,7 @@ async fn create_entity_type<P: GraphPool>(
     path = "/entity-types",
     tag = "EntityType",
     responses(
-        (status = 200, content_type = "application/json", description = "Entity type found", body = [EntityType]),
+        (status = 200, content_type = "application/json", description = "List of the latest version of all entity types", body = [EntityType]),
         (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 500, description = "Datastore error occurred"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -27,6 +27,7 @@ use crate::{
     handlers(
         create_link_type,
         get_link_type,
+        get_link_type_unfiltered,
         update_link_type
     ),
     components(CreateLinkTypeRequest, UpdateLinkTypeRequest, AccountId, LinkType),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -18,7 +18,7 @@ use crate::{
         types::{uri::VersionedUri, LinkType},
         AccountId,
     },
-    store::{BaseUriAlreadyExists, BaseUriDoesNotExist},
+    store::{crud::AllLatest, BaseUriAlreadyExists, BaseUriDoesNotExist},
     GraphPool,
 };
 
@@ -118,7 +118,7 @@ async fn create_link_type<P: GraphPool>(
 async fn get_latest_link_types<P: GraphPool>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<LinkType>>, StatusCode> {
-    read_from_store::<LinkType, _, _, _>(pool.as_ref(), ())
+    read_from_store::<LinkType, _, _, _>(pool.as_ref(), AllLatest)
         .await
         .map(Json)
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -27,7 +27,7 @@ use crate::{
     handlers(
         create_link_type,
         get_link_type,
-        get_link_type_unfiltered,
+        get_latest_link_types,
         update_link_type
     ),
     components(CreateLinkTypeRequest, UpdateLinkTypeRequest, AccountId, LinkType),
@@ -47,7 +47,7 @@ impl RoutedResource for LinkTypeResource {
                 .route(
                     "/",
                     post(create_link_type::<P>)
-                        .get(get_link_type_unfiltered::<P>)
+                        .get(get_latest_link_types::<P>)
                         .put(update_link_type::<P>),
                 )
                 .route("/:version_id", get(get_link_type::<P>)),
@@ -115,7 +115,7 @@ async fn create_link_type<P: GraphPool>(
         (status = 500, description = "Store error occurred"),
     )
 )]
-async fn get_link_type_unfiltered<P: GraphPool>(
+async fn get_latest_link_types<P: GraphPool>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<LinkType>>, StatusCode> {
     read_from_store::<LinkType, _, _, _>(pool.as_ref(), ())

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -109,7 +109,7 @@ async fn create_link_type<P: GraphPool>(
     path = "/link-types",
     tag = "LinkType",
     responses(
-        (status = 200, content_type = "application/json", description = "Link type found", body = [LinkType]),
+        (status = 200, content_type = "application/json", description = "List of the latest version of all link types", body = [LinkType]),
         (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 500, description = "Store error occurred"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -109,7 +109,7 @@ async fn create_link_type<P: GraphPool>(
     path = "/link-types",
     tag = "LinkType",
     responses(
-        (status = 200, content_type = "application/json", description = "List of the latest version of all link types", body = [LinkType]),
+        (status = 200, content_type = "application/json", description = "List of all link types at their latest versions", body = [LinkType]),
         (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 500, description = "Store error occurred"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -18,7 +18,7 @@ use crate::{
         types::{uri::VersionedUri, PropertyType},
         AccountId,
     },
-    store::{BaseUriAlreadyExists, BaseUriDoesNotExist},
+    store::{crud::AllLatest, BaseUriAlreadyExists, BaseUriDoesNotExist},
     GraphPool,
 };
 
@@ -118,7 +118,7 @@ async fn create_property_type<P: GraphPool>(
 async fn get_latest_property_types<P: GraphPool>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<PropertyType>>, StatusCode> {
-    read_from_store::<PropertyType, _, _, _>(pool.as_ref(), ())
+    read_from_store::<PropertyType, _, _, _>(pool.as_ref(), AllLatest)
         .await
         .map(Json)
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -27,6 +27,7 @@ use crate::{
     handlers(
         create_property_type,
         get_property_type,
+        get_property_type_unfiltered,
         update_property_type
     ),
     components(CreatePropertyTypeRequest, UpdatePropertyTypeRequest, AccountId, PropertyType),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -109,7 +109,7 @@ async fn create_property_type<P: GraphPool>(
     path = "/property-types",
     tag = "PropertyType",
     responses(
-        (status = 200, content_type = "application/json", description = "Property type found", body = [PropertyType]),
+        (status = 200, content_type = "application/json", description = "List of the latest version of all property types", body = [PropertyType]),
         (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 500, description = "Store error occurred"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -27,7 +27,7 @@ use crate::{
     handlers(
         create_property_type,
         get_property_type,
-        get_property_type_unfiltered,
+        get_latest_property_types,
         update_property_type
     ),
     components(CreatePropertyTypeRequest, UpdatePropertyTypeRequest, AccountId, PropertyType),
@@ -47,7 +47,7 @@ impl RoutedResource for PropertyTypeResource {
                 .route(
                     "/",
                     post(create_property_type::<P>)
-                        .get(get_property_type_unfiltered::<P>)
+                        .get(get_latest_property_types::<P>)
                         .put(update_property_type::<P>),
                 )
                 .route("/:version_id", get(get_property_type::<P>)),
@@ -115,7 +115,7 @@ async fn create_property_type<P: GraphPool>(
         (status = 500, description = "Store error occurred"),
     )
 )]
-async fn get_property_type_unfiltered<P: GraphPool>(
+async fn get_latest_property_types<P: GraphPool>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<PropertyType>>, StatusCode> {
     read_from_store::<PropertyType, _, _, _>(pool.as_ref(), ())

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -109,7 +109,7 @@ async fn create_property_type<P: GraphPool>(
     path = "/property-types",
     tag = "PropertyType",
     responses(
-        (status = 200, content_type = "application/json", description = "List of the latest version of all property types", body = [PropertyType]),
+        (status = 200, content_type = "application/json", description = "List of all property types at their latest versions", body = [PropertyType]),
         (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 500, description = "Store error occurred"),

--- a/packages/graph/hash_graph/lib/graph/src/lib.rs
+++ b/packages/graph/hash_graph/lib/graph/src/lib.rs
@@ -56,7 +56,10 @@
 use crate::{
     knowledge::{Entity, EntityId, Link, Links},
     ontology::types::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType},
-    store::{crud::Read, Store, StorePool},
+    store::{
+        crud::{AllLatest, Read},
+        Store, StorePool,
+    },
 };
 
 pub mod api;
@@ -78,10 +81,10 @@ pub trait GraphPool = StorePool + 'static where for<'pool> <Self as StorePool>::
 /// Interface for a [`Store`].
 pub trait Graph = where
     for<'i> Self: Store
-        + Read<'i, (), DataType, Output = Vec<DataType>>
-        + Read<'i, (), PropertyType, Output = Vec<PropertyType>>
-        + Read<'i, (), LinkType, Output = Vec<LinkType>>
-        + Read<'i, (), EntityType, Output = Vec<EntityType>>
+        + Read<'i, AllLatest, DataType, Output = Vec<DataType>>
+        + Read<'i, AllLatest, PropertyType, Output = Vec<PropertyType>>
+        + Read<'i, AllLatest, LinkType, Output = Vec<LinkType>>
+        + Read<'i, AllLatest, EntityType, Output = Vec<EntityType>>
         + Read<'i, &'i VersionedUri, DataType, Output = DataType>
         + Read<'i, &'i VersionedUri, PropertyType, Output = PropertyType>
         + Read<'i, &'i VersionedUri, LinkType, Output = LinkType>

--- a/packages/graph/hash_graph/lib/graph/src/lib.rs
+++ b/packages/graph/hash_graph/lib/graph/src/lib.rs
@@ -78,6 +78,10 @@ pub trait GraphPool = StorePool + 'static where for<'pool> <Self as StorePool>::
 /// Interface for a [`Store`].
 pub trait Graph = where
     for<'i> Self: Store
+        + Read<'i, (), DataType, Output = Vec<DataType>>
+        + Read<'i, (), PropertyType, Output = Vec<PropertyType>>
+        + Read<'i, (), LinkType, Output = Vec<LinkType>>
+        + Read<'i, (), EntityType, Output = Vec<EntityType>>
         + Read<'i, &'i VersionedUri, DataType, Output = DataType>
         + Read<'i, &'i VersionedUri, PropertyType, Output = PropertyType>
         + Read<'i, &'i VersionedUri, LinkType, Output = LinkType>

--- a/packages/graph/hash_graph/lib/graph/src/store/crud.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/crud.rs
@@ -14,6 +14,15 @@ use crate::store::{QueryError, Store};
 pub struct AllLatest;
 
 /// Read access to a [`Store`].
+// TODO: Change the way we are interacting with this trait (or change the trait).
+//   With our current design we need to specify a marker, what exactly we want to extract. For some
+//   things this is intuitive like a `&VersionedUri`, which will return exactly one type, but for
+//   other types, like `&BaseUri` this does not convey the meaning well enough. This could return
+//   only the latest version of a type or all types with this URI. This would imply, that we need
+//   a marker struct for each meaning, i.e. `Latest<'i, BaseUri>(&'i BaseUri)`. In addition to that,
+//   we want to extend our interface to structural querying, so something like an `AST` needs to be
+//   aware of the types.
+//   As an example why this is bad see the `AllLatest` marker struct.
 #[async_trait]
 pub trait Read<'i, I: Send + 'i, T>: Store {
     /// Output returned when getting the value by the identifier `I`.

--- a/packages/graph/hash_graph/lib/graph/src/store/crud.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/crud.rs
@@ -9,6 +9,10 @@ use error_stack::Result;
 
 use crate::store::{QueryError, Store};
 
+/// Marker to return the latest version of all records.
+#[derive(Copy, Clone, Debug)]
+pub struct AllLatest;
+
 /// Read access to a [`Store`].
 #[async_trait]
 pub trait Read<'i, I: Send + 'i, T>: Store {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -367,8 +367,9 @@ where
         let value = serde_json::to_value(database_type)
             .report()
             .change_context(InsertionError)?;
-        // SAFETY: We insert a table name here, but `T::table()` is only accessible from within this
-        //   module.
+        // Generally bad practice to construct a query without preparation, but it's not possible to
+        // pass a table name as a parameter and `T::table()` is well-defined, so this is a safe
+        // usage.
         self.as_client()
             .query_one(
                 &format!(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -22,8 +22,9 @@ where
 
     async fn get(&self, uri: &'i VersionedUri) -> Result<Self::Output, QueryError> {
         let version = i64::from(uri.version());
-        // SAFETY: We insert a table name here, but `T::table()` is only accessible from within this
-        //   module.
+        // Generally bad practice to construct a query without preparation, but it's not possible to
+        // pass a table name as a parameter and `T::table()` is well-defined, so this is a safe
+        // usage.
         let row = self
             .as_client()
             .query_one(
@@ -60,8 +61,9 @@ where
     type Output = Vec<T>;
 
     async fn get(&self, _: AllLatest) -> Result<Self::Output, QueryError> {
-        // SAFETY: We insert a table name here, but `T::table()` is only accessible from within this
-        //   module.
+        // Generally bad practice to construct a query without preparation, but it's not possible to
+        // pass a table name as a parameter and `T::table()` is well-defined, so this is a safe
+        // usage.
         let row_stream = self
             .as_client()
             .query_raw(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -64,10 +64,12 @@ where
             .query_raw(
                 &format!(
                     r#"
-                    SELECT schema
-                    FROM {};
+                    SELECT DISTINCT ON(base_uri) schema
+                    FROM {table}
+                    INNER JOIN ids ON ids.version_id = {table}.version_id
+                    ORDER BY base_uri, version DESC;
                     "#,
-                    T::table()
+                    table = T::table()
                 ),
                 [] as [&(dyn ToSql + Sync); 0],
             )

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -76,7 +76,7 @@ where
                     "#,
                     table = T::table()
                 ),
-                // Requires a concrete types, which implements
+                // Requires a concrete type, which implements
                 // `IntoIterator<Item = impl BorrowToSql>`
                 [] as [&(dyn ToSql + Sync); 0],
             )

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
+use futures::{StreamExt, TryStreamExt};
+use postgres_types::ToSql;
 use serde::Deserialize;
 use tokio_postgres::GenericClient;
 
@@ -44,5 +46,43 @@ where
         serde_json::from_value(row.get(0))
             .report()
             .change_context(QueryError)
+    }
+}
+
+#[async_trait]
+impl<C: AsClient, T> crud::Read<'_, (), T> for PostgresStore<C>
+where
+    for<'de> T: OntologyDatabaseType + Deserialize<'de> + Send,
+{
+    type Output = Vec<T>;
+
+    async fn get(&self, _: ()) -> Result<Self::Output, QueryError> {
+        // SAFETY: We insert a table name here, but `T::table()` is only accessible from within this
+        //   module.
+        let row_stream = self
+            .as_client()
+            .query_raw(
+                &format!(
+                    r#"
+                    SELECT schema
+                    FROM {};
+                    "#,
+                    T::table()
+                ),
+                [] as [&(dyn ToSql + Sync); 0],
+            )
+            .await
+            .report()
+            .change_context(QueryError)?;
+
+        row_stream
+            .map(|row_result| {
+                let row = row_result.report().change_context(QueryError)?;
+                serde_json::from_value(row.get(0))
+                    .report()
+                    .change_context(QueryError)
+            })
+            .try_collect()
+            .await
     }
 }

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -59,7 +59,7 @@ GET http://127.0.0.1:3000/data-types
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
-        client.assert(response.body.length === 2, "Unexpected number of data types");
+        client.assert(response.body.length === 1, "Unexpected number of data types");
     });
 %}
 
@@ -129,7 +129,7 @@ GET http://127.0.0.1:3000/property-types
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
-        client.assert(response.body.length === 2, "Unexpected number of property types");
+        client.assert(response.body.length === 1, "Unexpected number of property types");
     });
 %}
 
@@ -195,7 +195,7 @@ GET http://127.0.0.1:3000/link-types
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
-        client.assert(response.body.length === 2, "Unexpected number of link types");
+        client.assert(response.body.length === 1, "Unexpected number of link types");
     });
 %}
 
@@ -277,7 +277,7 @@ GET http://127.0.0.1:3000/entity-types
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
-        client.assert(response.body.length === 2, "Unexpected number of entity types");
+        client.assert(response.body.length === 1, "Unexpected number of entity types");
     });
 %}
 

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -53,6 +53,16 @@ Accept: application/json
     });
 %}
 
+### Get all data types
+GET http://127.0.0.1:3000/data-types
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(response.body.length === 2, "Unexpected number of data types");
+    });
+%}
+
 ### Insert Name property type
 POST http://127.0.0.1:3000/property-types
 Content-Type: application/json
@@ -113,6 +123,16 @@ Accept: application/json
     });
 %}
 
+### Get all property types
+GET http://127.0.0.1:3000/property-types
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(response.body.length === 2, "Unexpected number of property types");
+    });
+%}
+
 ### Insert FriendOf link type
 POST http://127.0.0.1:3000/link-types
 Content-Type: application/json
@@ -166,6 +186,16 @@ Accept: application/json
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
+    });
+%}
+
+### Get all link types
+GET http://127.0.0.1:3000/link-types
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(response.body.length === 2, "Unexpected number of link types");
     });
 %}
 
@@ -238,6 +268,16 @@ Accept: application/json
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
+    });
+%}
+
+### Get all entity types
+GET http://127.0.0.1:3000/entity-types
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(response.body.length === 2, "Unexpected number of entity types");
     });
 %}
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Enhances the API to support getting all available data/property/link/entity-types

## 🚫 Blocked by

- #878 

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202538466812818/1202682556665567/f) _(internal)_

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Implement the logic in the backend: dac951c6d032628e80260048ad56182d97f9bcad
- Make the logic usable in the REST endpoint: 75761a64575025db1a3531ddc2e8f93ad3852891
- Add methods to the REST endpoints: a027b3bdc0d4deff16022ebb90b9c0bebadb0fe6
- Add tests for the newly added functionality: 419312004eb61220188ef512999e2b2f0690bb29

## 📜 Does this require a change to the docs?

The OpenAPI is generated from the REST endpoints

## 🐾 Next steps

- Make the types filterable by `AccountId`

## 🛡 What tests cover this?

The newly added functions has been added to the REST endpoint test