### PR TITLE
Shuffle block improvements

### DIFF
--- a/packages/blocks/shuffle/package.json
+++ b/packages/blocks/shuffle/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hashintel/shuffle",
+  "name": "@hashintel/block-shuffle",
   "version": "0.0.0",
   "description": "Create a list and set it into a random order",
   "keywords": [
@@ -56,11 +56,13 @@
     },
     "displayName": "shuffle",
     "examples": [
-      [
-        "Alice",
-        "Bob",
-        "Charlie"
-      ]
+      {
+        "items": [
+          "Alice",
+          "Bob",
+          "Charlie"
+        ]
+      }
     ],
     "icon": "public/shuffle.svg",
     "image": "public/preview.png",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The Shuffle block workspace name does not follow the normal pattern and the examples in the block's `package.json` are incorrect.

## 🔍 What does this change?

- Changed workspace name from `@hashintel/shuffle` to `@hashintel/block-shuffle`
- Changed examples from: 
 ```   
"examples": [
      [
        "Alice",
        "Bob",
        "Charlie"
      ]
    ]
```

to:
```
"examples": [
      {
        "items": [
          "Alice",
          "Bob",
          "Charlie"
        ]
      }
    ],
```
