### PR TITLE
Fix OpenAPI Validation errors and serve ontology type meta JSON Schemas

### DIFF
--- a/packages/graph/hash_graph/Cargo.lock
+++ b/packages/graph/hash_graph/Cargo.lock
@@ -398,6 +398,7 @@ dependencies = [
  "bb8-postgres",
  "clap",
  "error-stack",
+ "include_dir",
  "postgres-types",
  "serde",
  "serde_json",
@@ -517,6 +518,25 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "include_dir"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482a2e29200b7eed25d7fdbd14423326760b7f6658d21a4cf12d55a50713c69f"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e074c19deab2501407c91ba1860fa3d6820bfde307db6d8cb851b55a10be89b"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]

--- a/packages/graph/hash_graph/lib/graph/Cargo.toml
+++ b/packages/graph/hash_graph/lib/graph/Cargo.toml
@@ -22,6 +22,7 @@ tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter", "json"] }
 uuid = { version = "1.1.2", features = ["v4", "serde"] }
 utoipa = { git = "https://github.com/juhaku/utoipa", rev = "031073f", features = ["uuid"] }
+include_dir = "0.7.2"
 
 [dev-dependencies]
 tokio = { version = "1.18.2", features = ["rt-multi-thread", "macros"] }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -29,7 +29,7 @@ use crate::{
         get_data_type,
         update_data_type
     ),
-    components(CreateDataTypeRequest, UpdateDataTypeRequest, AccountId, DataType),
+    components(CreateDataTypeRequest, UpdateDataTypeRequest, AccountId),
     tags(
         (name = "DataType", description = "Data Type management API")
     )
@@ -62,11 +62,11 @@ struct CreateDataTypeRequest {
     request_body = CreateDataTypeRequest,
     tag = "DataType",
     responses(
-      (status = 201, content_type = "application/json", description = "Data type created successfully", body = DataType),
-      (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
+        (status = 201, content_type = "application/json", description = "Data type created successfully", body = EXTERNAL_DataType),
+        (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
-      (status = 409, description = "Unable to create data type in the store as the base data type ID already exists"),
-      (status = 500, description = "Store error occurred"),
+        (status = 409, description = "Unable to create data type in the store as the base data type ID already exists"),
+        (status = 500, description = "Store error occurred"),
     ),
     request_body = CreateDataTypeRequest,
 )]
@@ -103,7 +103,7 @@ async fn create_data_type<P: GraphPool>(
     path = "/data-types/{uri}",
     tag = "DataType",
     responses(
-        (status = 200, content_type = "application/json", description = "Data type found", body = DataType),
+        (status = 200, content_type = "application/json", description = "Data type found", body = EXTERNAL_DataType),
         (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 404, description = "Data type was not found"),
@@ -150,7 +150,7 @@ struct UpdateDataTypeRequest {
     path = "/data-types",
     tag = "DataType",
     responses(
-        (status = 200, content_type = "application/json", description = "Data type updated successfully", body = DataType),
+        (status = 200, content_type = "application/json", description = "Data type updated successfully", body = EXTERNAL_DataType),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Base data type ID was not found"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -33,7 +33,7 @@ struct QualifiedEntity {
         get_entity,
         update_entity
     ),
-    components(CreateEntityRequest, UpdateEntityRequest, EntityId, QualifiedEntity),
+    components(CreateEntityRequest, UpdateEntityRequest, EntityId, QualifiedEntity, Entity),
     tags(
         (name = "Entity", description = "entity management API")
     )
@@ -57,6 +57,7 @@ impl RoutedResource for EntityResource {
 struct CreateEntityRequest {
     #[component(value_type = Any)]
     entity: Entity,
+    #[component(value_type = String)]
     entity_type_uri: VersionedUri,
     account_id: AccountId,
 }
@@ -67,11 +68,11 @@ struct CreateEntityRequest {
     request_body = CreateEntityRequest,
     tag = "Entity",
     responses(
-      (status = 201, content_type = "application/json", description = "entity created successfully", body = QualifiedEntity),
-      (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
+        (status = 201, content_type = "application/json", description = "entity created successfully", body = QualifiedEntity),
+        (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
-      (status = 404, description = "Entity Type URI was not found"),
-      (status = 500, description = "Datastore error occurred"),
+        (status = 404, description = "Entity Type URI was not found"),
+        (status = 500, description = "Datastore error occurred"),
     ),
     request_body = CreateEntityRequest,
 )]
@@ -149,6 +150,7 @@ struct UpdateEntityRequest {
     #[component(value_type = Any)]
     entity: Entity,
     entity_id: EntityId,
+    #[component(value_type = String)]
     entity_type_uri: VersionedUri,
     account_id: AccountId,
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -29,7 +29,7 @@ use crate::{
         get_entity_type,
         update_entity_type
     ),
-    components(CreateEntityTypeRequest, UpdateEntityTypeRequest, AccountId, EntityType),
+    components(CreateEntityTypeRequest, UpdateEntityTypeRequest, AccountId),
     tags(
         (name = "EntityType", description = "Entity type management API")
     )
@@ -65,11 +65,11 @@ struct CreateEntityTypeRequest {
     request_body = CreateEntityTypeRequest,
     tag = "EntityType",
     responses(
-      (status = 201, content_type = "application/json", description = "Entity type created successfully", body = EntityType),
-      (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
+        (status = 201, content_type = "application/json", description = "Entity type created successfully", body = EXTERNAL_EntityType),
+        (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
-      (status = 409, description = "Unable to create entity type in the datastore as the base entity type ID already exists"),
-      (status = 500, description = "Datastore error occurred"),
+        (status = 409, description = "Unable to create entity type in the datastore as the base entity type ID already exists"),
+        (status = 500, description = "Datastore error occurred"),
     ),
     request_body = CreateEntityTypeRequest,
 )]
@@ -106,7 +106,7 @@ async fn create_entity_type<P: GraphPool>(
     path = "/entity-types/{uri}",
     tag = "EntityType",
     responses(
-        (status = 200, content_type = "application/json", description = "Entity type found", body = EntityType),
+        (status = 200, content_type = "application/json", description = "Entity type found", body = EXTERNAL_EntityType),
         (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 404, description = "Entity type was not found"),
@@ -153,7 +153,7 @@ struct UpdateEntityTypeRequest {
     path = "/entity-types",
     tag = "EntityType",
     responses(
-        (status = 200, content_type = "application/json", description = "Entity type updated successfully", body = EntityType),
+        (status = 200, content_type = "application/json", description = "Entity type updated successfully", body = EXTERNAL_EntityType),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Base entity type ID was not found"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/json_schemas/DataType.json
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/json_schemas/DataType.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://blockprotocol.org/type-system/0.2/schema/meta/data-type",
+  "description": "Specifies the structure of a Data Type",
+  "type": "object",
+  "properties": {
+    "kind": {
+      "const": "dataType"
+    },
+    "$id": { "type": "string", "format": "uri" },
+    "title": { "type": "string" },
+    "description": { "type": "string" },
+    "type": { "type": "string" }
+  },
+  "required": ["kind", "$id", "title", "type"]
+}

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/json_schemas/EntityType.json
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/json_schemas/EntityType.json
@@ -1,0 +1,154 @@
+{
+  "$id": "https://blockprotocol.org/type-system/0.2/schema/meta/entity-type",
+  "description": "Specifies the structure of an Entity Type",
+  "type": "object",
+  "properties": {
+    "kind": {
+      "const": "entityType"
+    },
+    "$id": {
+      "type": "string",
+      "format": "uri"
+    },
+    "title": { "type": "string" },
+    "description": { "type": "string" },
+    "default": {
+      "$comment": "Default Entity instance",
+      "type": "object",
+      "propertyNames": {
+        "$comment": "Property names must be a valid URI to a Property Type",
+        "type": "string",
+        "format": "uri"
+      }
+    },
+    "examples": {
+      "$comment": "Example Entity instances",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "propertyNames": {
+          "$comment": "Property names must be a valid URI to a Property Type",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "properties": { "$ref": "#/$defs/propertyTypeObject" },
+    "required": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "uri"
+      }
+    },
+    "requiredLinks": {
+      "$comment": "A list of link-types which are required. This is a separate field to 'required' to avoid breaking standard JSON schema validation",
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "links": {
+      "type": "object",
+      "propertyNames": {
+        "$comment": "Property names must be a valid URI to a link-type",
+        "type": "string",
+        "format": "uri"
+      },
+      "patternProperties": {
+        ".*": {
+          "type": "object",
+          "oneOf": [
+            {
+              "properties": {
+                "ordered": { "type": "boolean", "default": false },
+                "type": { "const": "array" },
+                "minItems": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "maxItems": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "required": ["ordered", "type"]
+            },
+            {}
+          ],
+          "additionalProperties": false
+        }
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": ["kind", "$id", "title", "properties"],
+  "$defs": {
+    "propertyTypeObject": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "object"
+        },
+        "properties": {
+          "type": "object",
+          "propertyNames": {
+            "$comment": "Property names must be a valid URI to a Property Type",
+            "type": "string",
+            "format": "uri"
+          },
+          "patternProperties": {
+            ".*": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/propertyTypeReference"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "const": "array"
+                    },
+                    "items": {
+                      "$ref": "#/$defs/propertyTypeReference"
+                    },
+                    "minItems": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "maxItems": {
+                      "type": "integer",
+                      "minimum": 0
+                    }
+                  },
+                  "required": ["type", "items"],
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "minimumProperties": 1
+        },
+        "required": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      },
+      "required": ["type", "properties"],
+      "additionalProperties": false
+    },
+    "propertyTypeReference": {
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "$comment": "Property Object values must be defined through references to the same valid URI to a Property Type",
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "required": ["$ref"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/json_schemas/LinkType.json
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/json_schemas/LinkType.json
@@ -1,0 +1,21 @@
+{
+  "$id": "https://blockprotocol.org/type-system/0.2/schema/meta/link-type",
+  "description": "Specifies the structure of a Link Type",
+  "properties": {
+    "kind": {
+      "const": "linkType"
+    },
+    "$id": {
+      "type": "string",
+      "format": "uri"
+    },
+    "title": { "type": "string" },
+    "description": { "type": "string" },
+    "relatedKeywords": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "additionalProperties": false,
+  "required": ["kind", "$id", "title", "description"]
+}

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/json_schemas/PropertyType.json
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/json_schemas/PropertyType.json
@@ -1,0 +1,150 @@
+{
+  "$id": "https://blockprotocol.org/type-system/0.2/schema/meta/property-type",
+  "description": "Specifies the structure of a Property Type",
+  "type": "object",
+  "properties": {
+    "kind": {
+      "const": "propertyType"
+    },
+    "$id": {
+      "type": "string",
+      "format": "uri"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "oneOf": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/propertyValues"
+      }
+    }
+  },
+  "required": ["kind", "$id", "title", "oneOf"],
+  "$defs": {
+    "propertyValues": {
+      "$comment": "The definition of potential property values, made up of a `oneOf` keyword which has a list of options of either references to Data Types, or objects made up of more Property Types",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/propertyTypeObject"
+        },
+        {
+          "$ref": "#/$defs/dataTypeReference"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "array"
+            },
+            "items": {
+              "type": "object",
+              "properties": {
+                "oneOf": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/propertyValues"
+                  },
+                  "minItems": 1
+                }
+              },
+              "required": ["oneOf"],
+              "additionalProperties": false
+            },
+            "minItems": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "maxItems": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "required": ["type", "items"]
+        }
+      ]
+    },
+    "propertyTypeObject": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "object"
+        },
+        "properties": {
+          "type": "object",
+          "propertyNames": {
+            "$comment": "Property names must be a valid URI to a Property Type",
+            "type": "string",
+            "format": "uri"
+          },
+          "patternProperties": {
+            ".*": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/propertyTypeReference"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "const": "array"
+                    },
+                    "items": {
+                      "$ref": "#/$defs/propertyTypeReference"
+                    },
+                    "minItems": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "maxItems": {
+                      "type": "integer",
+                      "minimum": 0
+                    }
+                  },
+                  "required": ["type", "items"],
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "minimumProperties": 1
+        },
+        "required": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      },
+      "required": ["type", "properties"],
+      "additionalProperties": false
+    },
+    "propertyTypeReference": {
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "$comment": "Property Object values must be defined through references to the same valid URI to a Property Type",
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["$ref"]
+    },
+    "dataTypeReference": {
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["$ref"]
+    }
+  }
+}

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
@@ -23,7 +23,7 @@ use crate::{
         get_entity_links,
         inactivate_link
     ),
-    components(AccountId, Link, InactivateLinkRequest),
+    components(AccountId, Link, Links, CreateLinkRequest, InactivateLinkRequest),
     tags(
         (name = "Link", description = "link management API")
     )
@@ -61,11 +61,11 @@ struct CreateLinkRequest {
     request_body = CreateLinkRequest,
     tag = "Link",
     responses(
-      (status = 201, content_type = "application/json", description = "link created successfully", body = Link),
-      (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
+        (status = 201, content_type = "application/json", description = "link created successfully", body = Link),
+        (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
-      (status = 404, description = "Source entity, target entity or link type URI was not found"),
-      (status = 500, description = "Datastore error occurred"),
+        (status = 404, description = "Source entity, target entity or link type URI was not found"),
+        (status = 500, description = "Datastore error occurred"),
     ),
     params(
         ("entity_id" = Uuid, Path, description = "The ID of the source entity"),
@@ -113,7 +113,7 @@ async fn create_link<P: GraphPool>(
     path = "/entities/{entity_id}/links",
     tag = "Link",
     responses(
-        (status = 200, content_type = "application/json", description = "all active links from the source entity", body = QualifiedLink),
+        (status = 200, content_type = "application/json", description = "all active links from the source entity", body = Links),
         (status = 422, content_type = "text/plain", description = "Provided source entity id is invalid"),
 
         (status = 404, description = "No links were found"),
@@ -168,7 +168,10 @@ struct InactivateLinkRequest {
         (status = 404, description = "Source entity, target entity or link type URI was not found"),
         (status = 500, description = "Datastore error occurred"),
     ),
-    request_body = UpdateLinkRequest,
+    request_body = InactivateLinkRequest,
+    params(
+        ("entity_id" = Uuid, Path, description = "The ID of the source entity"),
+    ),
 )]
 async fn inactivate_link<P: GraphPool>(
     source_entity: Path<EntityId>,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -29,7 +29,7 @@ use crate::{
         get_link_type,
         update_link_type
     ),
-    components(CreateLinkTypeRequest, UpdateLinkTypeRequest, AccountId, LinkType),
+    components(CreateLinkTypeRequest, UpdateLinkTypeRequest, AccountId),
     tags(
         (name = "LinkType", description = "Link type management API")
     )
@@ -62,11 +62,11 @@ struct CreateLinkTypeRequest {
     request_body = CreateLinkTypeRequest,
     tag = "LinkType",
     responses(
-      (status = 201, content_type = "application/json", description = "Link type created successfully", body = LinkType),
-      (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
+        (status = 201, content_type = "application/json", description = "Link type created successfully", body = EXTERNAL_LinkType),
+        (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
-      (status = 409, description = "Unable to create link type in the store as the base link type ID already exists"),
-      (status = 500, description = "Store error occurred"),
+        (status = 409, description = "Unable to create link type in the store as the base link type ID already exists"),
+        (status = 500, description = "Store error occurred"),
     ),
     request_body = CreateLinkTypeRequest,
 )]
@@ -103,7 +103,7 @@ async fn create_link_type<P: GraphPool>(
     path = "/link-types/{uri}",
     tag = "LinkType",
     responses(
-        (status = 200, content_type = "application/json", description = "Link type found", body = LinkType),
+        (status = 200, content_type = "application/json", description = "Link type found", body = EXTERNAL_LinkType),
         (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 404, description = "Link type was not found"),
@@ -150,7 +150,7 @@ struct UpdateLinkTypeRequest {
     path = "/link-types",
     tag = "LinkType",
     responses(
-        (status = 200, content_type = "application/json", description = "Link type updated successfully", body = LinkType),
+        (status = 200, content_type = "application/json", description = "Link type updated successfully", body = EXTERNAL_LinkType),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Base link type ID was not found"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -29,7 +29,7 @@ use crate::{
         get_property_type,
         update_property_type
     ),
-    components(CreatePropertyTypeRequest, UpdatePropertyTypeRequest, AccountId, PropertyType),
+    components(CreatePropertyTypeRequest, UpdatePropertyTypeRequest, AccountId),
     tags(
         (name = "PropertyType", description = "Property type management API")
     )
@@ -65,11 +65,11 @@ struct CreatePropertyTypeRequest {
     request_body = CreatePropertyTypeRequest,
     tag = "PropertyType",
     responses(
-      (status = 201, content_type = "application/json", description = "Property type created successfully", body = PropertyType),
-      (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
+        (status = 201, content_type = "application/json", description = "Property type created successfully", body = EXTERNAL_PropertyType),
+        (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
-      (status = 409, description = "Unable to create property type in the store as the base property type ID already exists"),
-      (status = 500, description = "Store error occurred"),
+        (status = 409, description = "Unable to create property type in the store as the base property type ID already exists"),
+        (status = 500, description = "Store error occurred"),
     ),
     request_body = CreatePropertyTypeRequest,
 )]
@@ -106,7 +106,7 @@ async fn create_property_type<P: GraphPool>(
     path = "/property-types/{uri}",
     tag = "PropertyType",
     responses(
-        (status = 200, content_type = "application/json", description = "Property type found", body = PropertyType),
+        (status = 200, content_type = "application/json", description = "Property type found", body = EXTERNAL_PropertyType),
         (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 404, description = "Property type was not found"),
@@ -153,7 +153,7 @@ struct UpdatePropertyTypeRequest {
     path = "/property-types",
     tag = "PropertyType",
     responses(
-        (status = 200, content_type = "application/json", description = "Property type updated successfully", body = PropertyType),
+        (status = 200, content_type = "application/json", description = "Property type updated successfully", body = EXTERNAL_PropertyType),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Base property type ID was not found"),

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -25,7 +25,7 @@ impl fmt::Display for EntityId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
 pub struct Entity {
     #[serde(flatten)]
     properties: HashMap<BaseUri, serde_json::Value>,

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/link/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/link/mod.rs
@@ -64,7 +64,7 @@ pub enum Outgoing {
 }
 
 /// A collection of links that originate from the same source entity.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
 pub struct Links {
     #[serde(flatten)]
     outgoing: HashMap<VersionedUri, Outgoing>,

--- a/packages/graph/hash_graph/lib/graph/src/ontology/types/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/types/data_type/mod.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use error_stack::{ensure, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use utoipa::Component;
 
 use crate::ontology::types::{
     error::ValidationError,
@@ -53,7 +52,7 @@ enum DataTypeTag {
     DataType,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DataType {
     kind: DataTypeTag,

--- a/packages/graph/hash_graph/lib/graph/src/ontology/types/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/types/entity_type/mod.rs
@@ -4,7 +4,6 @@ use std::collections::{HashMap, HashSet};
 
 use error_stack::{ensure, Result};
 use serde::{Deserialize, Serialize};
-use utoipa::Component;
 
 use crate::ontology::types::{
     entity_type::links::{Links, ValueOrMaybeOrderedArray},
@@ -58,7 +57,7 @@ pub enum EntityTypeTag {
 }
 
 /// Intermediate representation used during deserialization.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EntityType {
     kind: EntityTypeTag,

--- a/packages/graph/hash_graph/lib/graph/src/ontology/types/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/types/link_type/mod.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use utoipa::Component;
 
 use crate::ontology::types::{uri::VersionedUri, OntologyType};
 
@@ -10,7 +9,7 @@ enum LinkTypeTag {
     LinkType,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LinkType {
     kind: LinkTypeTag,

--- a/packages/graph/hash_graph/lib/graph/src/ontology/types/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/types/property_type/mod.rs
@@ -2,7 +2,6 @@ use std::collections::HashSet;
 
 use error_stack::{ensure, Result};
 use serde::{Deserialize, Serialize};
-use utoipa::Component;
 
 use crate::ontology::types::{
     data_type::DataTypeReference,
@@ -120,7 +119,7 @@ enum PropertyTypeTag {
     PropertyType,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropertyType {
     kind: PropertyTypeTag,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
This PR makes the OpenAPI generator validate correctly, allowing us to properly generate clients.
## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1200211978612931/1202697418861671/f) _(internal)_

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->
## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Removes `Component` derive from ontology types that are too complex for compile-time reflection (all `*Type` models)
- Statically serve JSON Schemas for these ontology types
    - Added new "json_schemas` folder in the REST API with the different meta JSON Schemas
- Add mechanism for externally referring to JSON schemas from Utoipa for all models starting with `EXTERNAL_`
- Had to add anchor to PropertyType's `propertyValues` to make the resolver happy :)

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

- This PR changes documentation for the API, hopefully for the better

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->
- These added JSON Schemas are taken directly from the RFC, we have a known set of changes that need to be applied, though.
- The OpenAPI generator I've been testing against uses 

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->
- Generate Client API based on OpenAPI Spec and make use of it :tada: 

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- None yet. I treid running [`dredd`](https://dredd.org/en/latest/) but it does not support external references.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch / view the deployment
1.  Start the backend and head to http://localhost:3000/api-doc/openapi.json
1.  Try to validate with `openapi-generator-cli` or other OpenAPI tool.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
![image](https://user-images.githubusercontent.com/6988668/182172581-7e6fa058-fbb8-4870-8380-d55148e6a607.png)
