### PR TITLE
Lb/insert block button

### DIFF
--- a/packages/hash/frontend/src/blocks/page/ComponentView.tsx
+++ b/packages/hash/frontend/src/blocks/page/ComponentView.tsx
@@ -22,6 +22,7 @@ import { EditorView, NodeView } from "prosemirror-view";
 import { BlockLoader } from "../../components/BlockLoader/BlockLoader";
 import { ErrorBlock } from "../../components/ErrorBlock/ErrorBlock";
 import { BlockContext } from "./BlockContext";
+import { InsertBlock } from "./InsertBlock";
 import { RenderPortal } from "./usePortals";
 
 /**
@@ -183,6 +184,7 @@ export class ComponentView implements NodeView<Schema> {
                 linkedEntities={childEntity?.linkedEntities ?? []}
                 linkedAggregations={childEntity?.linkedAggregations ?? []}
               />
+              <InsertBlock />
             </Sentry.ErrorBoundary>
           )}
         </BlockContext.Consumer>,

--- a/packages/hash/frontend/src/blocks/page/ComponentView.tsx
+++ b/packages/hash/frontend/src/blocks/page/ComponentView.tsx
@@ -22,7 +22,6 @@ import { EditorView, NodeView } from "prosemirror-view";
 import { BlockLoader } from "../../components/BlockLoader/BlockLoader";
 import { ErrorBlock } from "../../components/ErrorBlock/ErrorBlock";
 import { BlockContext } from "./BlockContext";
-import { InsertBlock } from "./InsertBlock";
 import { RenderPortal } from "./usePortals";
 
 /**
@@ -184,7 +183,6 @@ export class ComponentView implements NodeView<Schema> {
                 linkedEntities={childEntity?.linkedEntities ?? []}
                 linkedAggregations={childEntity?.linkedAggregations ?? []}
               />
-              <InsertBlock />
             </Sentry.ErrorBoundary>
           )}
         </BlockContext.Consumer>,

--- a/packages/hash/frontend/src/blocks/page/InsertBlock.tsx
+++ b/packages/hash/frontend/src/blocks/page/InsertBlock.tsx
@@ -1,0 +1,65 @@
+import { FunctionComponent, useState } from "react";
+import { Box } from "@mui/material";
+import { Menu } from "@hashintel/hash-design-system/menu";
+import { PlusBoxOutlineIcon } from "../../shared/icons/plus-box-outline-icon";
+
+type InsertBlockProps = {};
+
+export const InsertBlock: FunctionComponent<InsertBlockProps> = () => {
+  const [contextMenu, setContextMenu] = useState<{
+    mouseX: number;
+    mouseY: number;
+  } | null>(null);
+
+  return (
+    <>
+      <Box
+        onClick={(event) => {
+          setContextMenu(
+            contextMenu === null
+              ? {
+                  mouseX: event.clientX + 2,
+                  mouseY: event.clientY - 6,
+                }
+              : null,
+          );
+        }}
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          opacity: 0,
+          height: 30,
+          cursor: "pointer",
+          transition: ({ transitions }) => transitions.create("opacity"),
+          "&:hover": {
+            opacity: 1,
+          },
+        }}
+      >
+        <Box
+          sx={{
+            width: 1,
+            height: "1px",
+            background:
+              "linear-gradient(90deg, #DDE7F0 41.42%, #FFFFFF 50.26%, #DDE7F0 59.11%)",
+          }}
+        />
+        <PlusBoxOutlineIcon sx={{ position: "absolute" }} />
+      </Box>
+
+      <Menu
+        open={contextMenu !== null}
+        onClose={() => setContextMenu(null)}
+        anchorReference="anchorPosition"
+        anchorPosition={
+          contextMenu !== null
+            ? { top: contextMenu.mouseY, left: contextMenu.mouseX }
+            : undefined
+        }
+      >
+        test
+      </Menu>
+    </>
+  );
+};

--- a/packages/hash/frontend/src/blocks/page/InsertBlock.tsx
+++ b/packages/hash/frontend/src/blocks/page/InsertBlock.tsx
@@ -75,6 +75,8 @@ export const InsertBlock: FunctionComponent<InsertBlockProps> = ({
         anchorPosition={contextMenu ?? undefined}
         sx={{
           [`& .${popoverClasses.paper}`]: {
+            width: 340,
+            height: 400,
             overflow: "visible",
           },
         }}

--- a/packages/hash/frontend/src/blocks/page/InsertBlock.tsx
+++ b/packages/hash/frontend/src/blocks/page/InsertBlock.tsx
@@ -1,25 +1,45 @@
-import { FunctionComponent, useState } from "react";
-import { Box } from "@mui/material";
-import { Menu } from "@hashintel/hash-design-system/menu";
+import { useState, FunctionComponent } from "react";
+import { Box, popoverClasses } from "@mui/material";
+import { Popover } from "@hashintel/hash-design-system/popover";
+import { BlockMeta } from "@hashintel/hash-shared/blockMeta";
+import type { BlockVariant } from "@blockprotocol/core";
 import { PlusBoxOutlineIcon } from "../../shared/icons/plus-box-outline-icon";
+import { BlockSuggester } from "./createSuggester/BlockSuggester";
 
-type InsertBlockProps = {};
+type InsertBlockProps = {
+  onBlockSuggesterChange: (
+    variant: BlockVariant,
+    blockMeta: BlockMeta["componentMetadata"],
+  ) => void;
+};
 
-export const InsertBlock: FunctionComponent<InsertBlockProps> = () => {
+export const InsertBlock: FunctionComponent<InsertBlockProps> = ({
+  onBlockSuggesterChange,
+}) => {
   const [contextMenu, setContextMenu] = useState<{
-    mouseX: number;
-    mouseY: number;
+    left: number;
+    top: number;
   } | null>(null);
+
+  const onCloseSuggester = () => setContextMenu(null);
+
+  const onChange = (
+    variant: BlockVariant,
+    block: BlockMeta["componentMetadata"],
+  ) => {
+    onBlockSuggesterChange(variant, block);
+    onCloseSuggester();
+  };
 
   return (
     <>
       <Box
-        onClick={(event) => {
+        onClick={({ clientX, clientY }) => {
           setContextMenu(
             contextMenu === null
               ? {
-                  mouseX: event.clientX + 2,
-                  mouseY: event.clientY - 6,
+                  left: clientX,
+                  top: clientY,
                 }
               : null,
           );
@@ -28,7 +48,7 @@ export const InsertBlock: FunctionComponent<InsertBlockProps> = () => {
           display: "flex",
           justifyContent: "center",
           alignItems: "center",
-          opacity: 0,
+          opacity: contextMenu !== null ? 1 : 0,
           height: 30,
           cursor: "pointer",
           transition: ({ transitions }) => transitions.create("opacity"),
@@ -48,18 +68,19 @@ export const InsertBlock: FunctionComponent<InsertBlockProps> = () => {
         <PlusBoxOutlineIcon sx={{ position: "absolute" }} />
       </Box>
 
-      <Menu
+      <Popover
         open={contextMenu !== null}
-        onClose={() => setContextMenu(null)}
+        onClose={onCloseSuggester}
         anchorReference="anchorPosition"
-        anchorPosition={
-          contextMenu !== null
-            ? { top: contextMenu.mouseY, left: contextMenu.mouseX }
-            : undefined
-        }
+        anchorPosition={contextMenu ?? undefined}
+        sx={{
+          [`& .${popoverClasses.paper}`]: {
+            overflow: "visible",
+          },
+        }}
       >
-        test
-      </Menu>
+        <BlockSuggester onChange={onChange} />
+      </Popover>
     </>
   );
 };

--- a/packages/hash/frontend/src/blocks/page/style.module.css
+++ b/packages/hash/frontend/src/blocks/page/style.module.css
@@ -23,6 +23,7 @@
   word-break: break-word;
   white-space: pre-wrap;
   outline: none !important;
+  position: relative;
 }
 
 /**
@@ -62,4 +63,13 @@
   height: 100%;
   max-width: 1200px;
   overflow-x: auto;
+}
+
+.Block__InsertBlock {
+  top: 100%;
+  width: 100%;
+  max-width: 1200px;
+  position: absolute;
+  height: 30px;
+  margin-left: 32px;
 }

--- a/packages/hash/frontend/src/shared/icons/plus-box-outline-icon.tsx
+++ b/packages/hash/frontend/src/shared/icons/plus-box-outline-icon.tsx
@@ -1,0 +1,13 @@
+import { FunctionComponent } from "react";
+import { SvgIcon, SvgIconProps } from "@mui/material";
+
+export const PlusBoxOutlineIcon: FunctionComponent<SvgIconProps> = (props) => {
+  return (
+    <SvgIcon {...props} width="24" height="24" viewBox="0 0 24 24" fill="none">
+      <path
+        d="M17.25 5.25C18.078 5.25 18.75 5.922 18.75 6.75V17.25C18.75 18.0787 18.078 18.75 17.25 18.75H6.75C5.922 18.75 5.25 18.0787 5.25 17.25V6.75C5.25 5.922 5.922 5.25 6.75 5.25H17.25ZM17.2501 17.25V6.75H6.75007V17.2507L17.2501 17.25ZM12.7506 8.25143H11.2506V11.2514H8.2506V12.7514H11.2506V15.7514H12.7506V12.7514H15.7506V11.2514H12.7506V8.25143Z"
+        fill="#C1CFDE"
+      />
+    </SvgIcon>
+  );
+};


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR adds a block insertion button between blocks.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1200211978612931/1202500568584719/f) _(internal)_
- [Design](https://www.figma.com/file/gydVGka9FjNEg9E2STwhi2/HASH-App?node-id=3635%3A177743)

## 🔍 What does this change?

- Adds a button after each block;
- Clicking on it opens a block list (reusing `BlockSuggester`);
- Selecting a block on this list inserts a it below the block the button belongs to.

## 📹 Demo

![demo](https://user-images.githubusercontent.com/37453800/182439483-be666a47-9bb8-4f15-837f-9905358ef3d5.gif)

