### PR TITLE
Load any child entity into a block + remove feature flag

### DIFF
--- a/packages/hash/api/src/collab/save.ts
+++ b/packages/hash/api/src/collab/save.ts
@@ -112,7 +112,7 @@ const ensureEntityTypeForComponent = async (
 };
 
 /**
- * Given the entity 'store', the 'blocks' persisted to the database, and hte PromiseMirror 'doc',
+ * Given the entity 'store', the 'blocks' persisted to the database, and the PromiseMirror 'doc',
  * determines what changes are needed to persist changes to the database.
  */
 const calculateSaveActions = async (

--- a/packages/hash/api/src/collab/save.ts
+++ b/packages/hash/api/src/collab/save.ts
@@ -111,6 +111,10 @@ const ensureEntityTypeForComponent = async (
   return [desiredEntityTypeId, actions];
 };
 
+/**
+ * Given the entity 'store', the 'blocks' persisted to the database, and hte PromiseMirror 'doc',
+ * determines what changes are needed to persist changes to the database.
+ */
 const calculateSaveActions = async (
   store: EntityStore,
   accountId: string,
@@ -161,8 +165,10 @@ const calculateSaveActions = async (
     };
   };
 
+  // Check the entities in the draft entity store against their representation (if any) in the database
   for (const draftEntity of Object.values(store.draft)) {
     if (isDraftBlockEntity(draftEntity)) {
+      // Draft blocks are checked for updates separately, after this loop
       draftIdToBlockEntities.set(draftEntity.draftId, draftEntity);
       continue;
     }
@@ -313,6 +319,9 @@ const calculateSaveActions = async (
     }
   }
 
+  // Having dealt with non-block entities, now we check for changes in the blocks themselves
+  // Block entities are wrappers which point to (a) a component and (b) a child entity
+  // First, gather the ids of the blocks as they appear in the db-persisted page
   const beforeBlockDraftIds = blocks.map((block) => {
     const draftEntity = getDraftEntityByEntityId(store.draft, block.entityId);
 
@@ -325,6 +334,7 @@ const calculateSaveActions = async (
 
   const afterBlockDraftIds: string[] = [];
 
+  // Check nodes in the ProseMirror document to gather the ids of the blocks as they appear in the latest page
   doc.descendants((node) => {
     if (isEntityNode(node)) {
       if (!node.attrs.draftId) {
@@ -346,6 +356,7 @@ const calculateSaveActions = async (
     return true;
   });
 
+  // Check the blocks from the db-persisted page against the latest version of the page
   let position = 0;
   let itCount = 0;
   while (
@@ -366,15 +377,63 @@ const calculateSaveActions = async (
     }
 
     if (afterDraftId === beforeDraftId) {
+      // the block id has not changed – but its child entity may have done, so we need to compare them
+
+      const draftEntity = draftIdToBlockEntities.get(afterDraftId!); // asserted because we've just checked they're not both falsy
+      if (!draftEntity) {
+        throw new Error("missing draft block entity");
+      }
+
+      if (!draftEntity.entityId) {
+        // The block has not yet been saved to the database, and therefore there is no saved block to compare it with
+        // It's probably been inserted as part of this loop and spliced into the before ids – no further action required
+        position += 1;
+        continue;
+      }
+
+      const savedEntity = store.saved[draftEntity.entityId];
+      if (!savedEntity) {
+        throw new Error("missing saved block entity");
+      }
+
+      // extract the children for comparison
+      const newChildEntityForBlock = draftEntity.properties.entity;
+      if (!("entity" in savedEntity.properties)) {
+        throw new Error("Missing child entity in saved block entity");
+      }
+
+      const oldChildEntityForBlock = savedEntity.properties.entity;
+
+      if (oldChildEntityForBlock.entityId !== newChildEntityForBlock.entityId) {
+        if (!newChildEntityForBlock.entityId) {
+          // this should never happen because users select new child entities from API-provided entities.
+          // if this errors in future, it's because users are choosing locally-created but not yet db-persisted entities
+          throw new Error("New child entity for block has not yet been saved");
+        }
+
+        actions.push({
+          swapBlockData: {
+            accountId: draftEntity.accountId,
+            entityId: savedEntity.entityId,
+            newEntityEntityId: newChildEntityForBlock.entityId,
+            newEntityAccountId: newChildEntityForBlock.accountId,
+          },
+        });
+      }
+
       position += 1;
       continue;
     }
 
+    // the before draft id isn't the same as the after draft id, so this block shouldn't be in this position any more
     if (beforeDraftId) {
       actions.push({ removeBlock: { position } });
+
+      // delete this block from the 'before' series so that we're comparing subsequent blocks in the correct position
       beforeBlockDraftIds.splice(position, 1);
     }
 
+    // this block wasn't in this position before – it needs inserting there
     if (afterDraftId) {
       const draftEntity = draftIdToBlockEntities.get(afterDraftId);
 
@@ -419,6 +478,8 @@ const calculateSaveActions = async (
               }),
         },
       });
+
+      // insert this new block into the 'before' series so that we compare subsequent blocks in the current position
       beforeBlockDraftIds.splice(position, 0, afterDraftId);
     }
   }

--- a/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockListMenuContent.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockListMenuContent.tsx
@@ -9,38 +9,35 @@ import {
   Typography,
 } from "@mui/material";
 import { PopupState } from "material-ui-popup-state/core";
-import { useRef, useState, FunctionComponent } from "react";
+import { useRef, useState, FunctionComponent, useEffect } from "react";
 import { TextField, FontAwesomeIcon } from "@hashintel/hash-design-system";
-import { BlockSuggesterProps } from "../createSuggester/BlockSuggester";
 import { useFilteredBlocks } from "../createSuggester/useFilteredBlocks";
 import { MenuItem } from "../../../shared/ui";
+import { useBlockView } from "../BlockViewContext";
 
 type BlockListMenuContentProps = {
   popupState?: PopupState;
-  blockSuggesterProps: BlockSuggesterProps;
   compatibleBlocks: HashBlock[];
 };
 
 export const BlockListMenuContent: FunctionComponent<
   BlockListMenuContentProps
-> = ({ blockSuggesterProps, popupState, compatibleBlocks }) => {
+> = ({ compatibleBlocks, popupState }) => {
   const [searchQuery, setSearchQuery] = useState("");
   const searchInputRef = useRef<HTMLInputElement>(null);
   const blocks = useFilteredBlocks(searchQuery, compatibleBlocks);
+  const blockView = useBlockView();
 
-  // The essence of this is to autoFocus the input when
-  // the blocklist menu comes up. We have a listener for
-  // character "/". Once that is clicked the MenuItem that has this submenu
-  // is focused and as a result the submenu becomes visible.
-  // Currently this flow introduces a bug where it is difficult to switch to certain blocks
-  // e.g Embed;
-  // @see https://github.com/hashintel/hash/pull/480#discussion_r849594184
-  // Commenting this out till a fix is made
-  // useEffect(() => {
-  // if (popupState?.isOpen) {
-  //   searchInputRef.current?.focus();
-  // }
-  // }, [popupState]);
+  const popupWasOpen = useRef<boolean>(false);
+
+  useEffect(() => {
+    if (popupState?.isOpen && !popupWasOpen.current) {
+      searchInputRef.current?.focus();
+      popupWasOpen.current = true;
+    } else if (!popupState?.isOpen) {
+      popupWasOpen.current = false;
+    }
+  }, [popupState]);
 
   return (
     <MenuList>
@@ -81,10 +78,7 @@ export const BlockListMenuContent: FunctionComponent<
       )}
       {blocks.map((option) => (
         <MenuItem
-          onClick={() => {
-            blockSuggesterProps.onChange(option.variant, option.meta);
-            popupState?.close();
-          }}
+          onClick={() => blockView.onBlockChange(option.variant, option.meta)}
           key={`${option.meta.componentId}/${option.variant.name}`}
         >
           <ListItemIcon>

--- a/packages/hash/frontend/src/blocks/page/BlockContextMenu/LoadEntityMenuContent.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockContextMenu/LoadEntityMenuContent.tsx
@@ -148,7 +148,6 @@ export const LoadEntityMenuContent: FunctionComponent<
             key={entity.entityId}
             onClick={() => {
               swapEntity(entity);
-
               closeParentContextMenu();
             }}
           >

--- a/packages/hash/frontend/src/blocks/page/BlockHandle.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockHandle.tsx
@@ -4,20 +4,18 @@ import { EntityStore, isBlockEntity } from "@hashintel/hash-shared/entityStore";
 import { Box } from "@mui/material";
 import { bindTrigger } from "material-ui-popup-state";
 import { usePopupState } from "material-ui-popup-state/hooks";
-import { ForwardRefRenderFunction, useMemo, forwardRef } from "react";
+import { ForwardRefRenderFunction, forwardRef } from "react";
 import { IconButton, FontAwesomeIcon } from "@hashintel/hash-design-system";
 import { useUserBlocks } from "../userBlocks";
 import { BlockConfigMenu } from "./BlockConfigMenu/BlockConfigMenu";
 import { BlockContextMenu } from "./BlockContextMenu/BlockContextMenu";
 import { useBlockView } from "./BlockViewContext";
 import { useBlockContext } from "./BlockContext";
-import { BlockSuggesterProps } from "./createSuggester/BlockSuggester";
 
 type BlockHandleProps = {
   deleteBlock: () => void;
   draftId: string | null;
   entityStore: EntityStore;
-  onTypeChange: BlockSuggesterProps["onChange"];
   onMouseDown: () => void;
   onClick: () => void;
 };
@@ -25,10 +23,7 @@ type BlockHandleProps = {
 const BlockHandle: ForwardRefRenderFunction<
   HTMLDivElement,
   BlockHandleProps
-> = (
-  { deleteBlock, draftId, entityStore, onTypeChange, onMouseDown, onClick },
-  ref,
-) => {
+> = ({ deleteBlock, draftId, entityStore, onMouseDown, onClick }, ref) => {
   const contextMenuPopupState = usePopupState({
     variant: "popover",
     popupId: "block-context-menu",
@@ -38,16 +33,6 @@ const BlockHandle: ForwardRefRenderFunction<
     variant: "popover",
     popupId: "block-config-menu",
   });
-
-  const blockSuggesterProps: BlockSuggesterProps = useMemo(
-    () => ({
-      onChange: (variant, block) => {
-        onTypeChange(variant, block);
-        contextMenuPopupState.close();
-      },
-    }),
-    [onTypeChange, contextMenuPopupState],
-  );
 
   const { value: blocksMap } = useUserBlocks();
 
@@ -103,7 +88,6 @@ const BlockHandle: ForwardRefRenderFunction<
 
       <BlockContextMenu
         blockEntity={blockEntity}
-        blockSuggesterProps={blockSuggesterProps}
         deleteBlock={deleteBlock}
         openConfigMenu={configMenuPopupState.open}
         popupState={contextMenuPopupState}

--- a/packages/hash/frontend/src/blocks/page/BlockView.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockView.tsx
@@ -189,7 +189,6 @@ export class BlockView implements NodeView<Schema> {
           deleteBlock={this.deleteBlock}
           entityStore={this.store}
           draftId={blockDraftId}
-          onTypeChange={this.onBlockChange}
           ref={this.blockHandleRef}
           onMouseDown={() => {
             /**

--- a/packages/hash/frontend/src/components/hooks/useAccountEntities.ts
+++ b/packages/hash/frontend/src/components/hooks/useAccountEntities.ts
@@ -13,7 +13,7 @@ export const useAccountEntities = ({
   skip,
 }: {
   accountId: string;
-  entityTypeFilter: EntityTypeChoice;
+  entityTypeFilter?: EntityTypeChoice;
   skip: boolean;
 }) => {
   const { data, loading } = useQuery<

--- a/packages/hash/integration/src/mockData/index.ts
+++ b/packages/hash/integration/src/mockData/index.ts
@@ -389,12 +389,6 @@ void (async () => {
           properties: {
             email: "alice@example.com",
             name: "Alice Alison",
-            employer: {
-              __linkedData: {
-                entityTypeId: newTypeIds.Company!,
-                entityId: results.get("c1")!.entityId,
-              },
-            },
           },
           accountId: user.accountId,
           createdByAccountId: user.entityId,
@@ -407,12 +401,6 @@ void (async () => {
           properties: {
             email: "bob@example.com",
             name: "Bob Bobson",
-            employer: {
-              __linkedData: {
-                entityTypeId: newTypeIds.Company!,
-                entityId: results.get("c1")!.entityId,
-              },
-            },
           },
           entityTypeId: newTypeIds.Person!,
           accountId: user.accountId,

--- a/packages/hash/shared/src/ProsemirrorManager.ts
+++ b/packages/hash/shared/src/ProsemirrorManager.ts
@@ -454,13 +454,12 @@ export class ProsemirrorManager {
    *
    * @todo this does not work within text blocks
    */
-  swapBlockData(
-    entityId: string,
+  replaceBlockChildEntity(
+    blockEntityId: string,
     targetChildEntity: EntityStoreType,
-    pos: number,
   ) {
     if (!this.view) {
-      throw new Error("Cannot trigger updateBlock without view");
+      throw new Error("Cannot trigger replaceBlockChildEntity without view");
     }
 
     const { tr } = this.view.state;
@@ -469,18 +468,17 @@ export class ProsemirrorManager {
       this.view.state,
     ).store;
 
-    const blockEntity = entityId ? entityStore.saved[entityId] : null;
-    const blockData = isBlockEntity(blockEntity)
-      ? blockEntity.properties.entity
-      : null;
+    const blockEntity = blockEntityId ? entityStore.saved[blockEntityId] : null;
 
-    if (!isBlockEntity(blockEntity) || !blockData) {
-      throw new Error("Can only update data of a BlockEntity");
+    if (!isBlockEntity(blockEntity)) {
+      throw new Error("Can only update child of a BlockEntity");
     }
+
+    const childEntity = blockEntity.properties.entity;
 
     // If the target entity is the same as the block's child entity
     // we don't need to do anything
-    if (targetChildEntity.entityId === blockData.entityId) {
+    if (targetChildEntity.entityId === childEntity.entityId) {
       return;
     }
 
@@ -490,25 +488,13 @@ export class ProsemirrorManager {
     ).draftId;
 
     addEntityStoreAction(this.view.state, tr, {
-      type: "updateBlockEntityProperties",
+      type: "setBlockChildEntity",
       payload: {
         targetEntity: targetChildEntity,
         blockEntityDraftId,
       },
     });
 
-    const updatedStore = entityStorePluginStateFromTransaction(
-      tr,
-      this.view.state,
-    ).store;
-
-    const newBlockNode = this.renderBlock(
-      blockEntity.properties.componentId,
-      updatedStore,
-      blockEntityDraftId,
-    );
-
-    tr.replaceRangeWith(pos, pos + newBlockNode.nodeSize, newBlockNode);
     this.view.dispatch(tr);
   }
 

--- a/packages/hash/shared/src/entityStorePlugin.ts
+++ b/packages/hash/shared/src/entityStorePlugin.ts
@@ -77,7 +77,7 @@ export type EntityStorePluginAction = { received?: boolean } & (
       };
     }
   | {
-      type: "updateBlockEntityProperties";
+      type: "setBlockChildEntity";
       payload: { blockEntityDraftId: string; targetEntity: EntityStoreType };
     }
 );
@@ -182,7 +182,7 @@ const updateEntitiesByDraftId = (
  * @param blockEntityDraftId draft id of the Block Entity whose child entity should be changed
  * @param targetEntity entity to be changed to
  */
-const swapBlockData = (
+const setBlockChildEntity = (
   draftEntityStore: Draft<EntityStore["draft"]>,
   blockEntityDraftId: string,
   targetEntity: EntityStoreType,
@@ -280,7 +280,7 @@ const entityStoreReducer = (
       });
     }
 
-    case "updateBlockEntityProperties": {
+    case "setBlockChildEntity": {
       if (!state.store.draft[action.payload.blockEntityDraftId]) {
         throw new Error(
           `Block missing to merge entity properties -> ${action.payload.blockEntityDraftId}`,
@@ -296,7 +296,7 @@ const entityStoreReducer = (
           draftState.trackedActions.push({ action, id: uuid() });
         }
 
-        swapBlockData(
+        setBlockChildEntity(
           draftState.store.draft,
           action.payload.blockEntityDraftId,
           action.payload.targetEntity,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We have a feature whereby users can choose an entity to load into a block, rather than relying on the block itself being able to generate a new entity, and swap existing entities for new ones. This previously:
- only allowed users to swap to another _block_ entity of an identical type (i.e. a block that referenced the same `componentId`, e.g. `blockprotocol.org/.../table` – a "block entity" in this context is the entity that wraps a block, and references the child / data entity and the component that loads it)
- was behind a feature flag

This PR is part of the groundwork for being able to choose any entity to load into a block, even if isn't compatible, by:
a. allowing users to pick from any data entity to load into a block, i.e. not the _block_entity, but any child / data entity
b. removes the feature flag

This does mean that users are able to pick data entities which have a structure that is incompatible with a block, but we will address that by allowing users to map from entity properties to block properties in a follow-up PR.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1200211978612931/1202712725488218/f) _(internal)_

## 🔍 What does this change?

- in the collab `save` process, detect if a block's child entity has been changed. add some comments throughout
- Remove feature flag on entity add / swap feature
- fix a bug whereby the search input in the swap entity menu was focused when clicking on entities below the initial viewable list (i.e. if you scrolled down the entity list and clicked on something, it would focus the input rather than switching entity). restored input autofocus in the block swap menu
- add loading indicator to entity swap menu
- removed prop drilling passing the `onBlockChange` function down through the block handle
- consistently close the context menu when items in it are clicked
- remove `__linkedData` from the mock `Person` entities (it isn't doing anything)

## 🐾 Next steps

- Follow up PR to introduce basic "data mapping", i.e. transforming a data entity into a structure compatible with the block's expected properties.

## Known issues

- This doesn't work with text blocks, because they have a wrapping entity that needs to be taken account of (an existing issue with the feature)

## ❓ How to test this?

1. Try swapping between entities on the Person block, i.e. from Alice to Bob on the 'my awesome page' demo page

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

https://user-images.githubusercontent.com/37743469/182656586-e4f1bfb7-5e0e-4d55-88be-3e35904ed165.mp4


