### PR TITLE
Implement GET all entities

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -111,7 +111,6 @@ async fn create_data_type<P: GraphPool>(
     tag = "DataType",
     responses(
         (status = 200, content_type = "application/json", description = "List of all data types at their latest versions", body = [VAR_DATA_TYPE]),
-        (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 500, description = "Store error occurred"),
     )

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -135,13 +135,13 @@ async fn get_entity<P: GraphPool>(
 }
 
 #[utoipa::path(
-get,
-path = "/entities",
-tag = "Entity",
-responses(
-(status = 200, content_type = "application/json", description = "List of all entities", body = [Entity]),
-(status = 500, description = "Store error occurred"),
-)
+    get,
+    path = "/entities",
+    tag = "Entity",
+    responses(
+        (status = 200, content_type = "application/json", description = "List of all entities", body = [Entity]),
+        (status = 500, description = "Store error occurred"),
+    )
 )]
 async fn get_latest_entities<P: GraphPool>(
     pool: Extension<Arc<P>>,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -15,7 +15,10 @@ use crate::{
     api::rest::{api_resource::RoutedResource, read_from_store},
     knowledge::{Entity, EntityId},
     ontology::{types::uri::VersionedUri, AccountId},
-    store::error::{EntityDoesNotExist, QueryError},
+    store::{
+        crud::AllLatest,
+        error::{EntityDoesNotExist, QueryError},
+    },
     GraphPool,
 };
 
@@ -30,6 +33,7 @@ struct QualifiedEntity {
     handlers(
         create_entity,
         get_entity,
+        get_latest_entities,
         update_entity
     ),
     components(CreateEntityRequest, UpdateEntityRequest, EntityId, QualifiedEntity, Entity),
@@ -46,7 +50,12 @@ impl RoutedResource for EntityResource {
         Router::new().nest(
             "/entities",
             Router::new()
-                .route("/", post(create_entity::<P>).put(update_entity::<P>))
+                .route(
+                    "/",
+                    post(create_entity::<P>)
+                        .get(get_latest_entities::<P>)
+                        .put(update_entity::<P>),
+                )
                 .route("/:entity_id", get(get_entity::<P>)),
         )
     }
@@ -121,6 +130,23 @@ async fn get_entity<P: GraphPool>(
     Extension(pool): Extension<Arc<P>>,
 ) -> Result<Json<Entity>, StatusCode> {
     read_from_store::<Entity, _, _, _>(pool.as_ref(), entity_id)
+        .await
+        .map(Json)
+}
+
+#[utoipa::path(
+get,
+path = "/entities",
+tag = "Entity",
+responses(
+(status = 200, content_type = "application/json", description = "List of all entities", body = [Entity]),
+(status = 500, description = "Store error occurred"),
+)
+)]
+async fn get_latest_entities<P: GraphPool>(
+    pool: Extension<Arc<P>>,
+) -> Result<Json<Vec<Entity>>, StatusCode> {
+    read_from_store::<Entity, _, _, _>(pool.as_ref(), AllLatest)
         .await
         .map(Json)
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -112,7 +112,6 @@ async fn create_entity_type<P: GraphPool>(
     tag = "EntityType",
     responses(
         (status = 200, content_type = "application/json", description = "List of all entity types at their latest versions", body = [VAR_ENTITY_TYPE]),
-        (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 500, description = "Datastore error occurred"),
     )

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -110,7 +110,6 @@ async fn create_link_type<P: GraphPool>(
     tag = "LinkType",
     responses(
         (status = 200, content_type = "application/json", description = "List of all link types at their latest versions", body = [VAR_LINK_TYPE]),
-        (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 500, description = "Store error occurred"),
     )

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -110,7 +110,6 @@ async fn create_property_type<P: GraphPool>(
     tag = "PropertyType",
     responses(
         (status = 200, content_type = "application/json", description = "List of all property types at their latest versions", body = [VAR_PROPERTY_TYPE]),
-        (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 500, description = "Store error occurred"),
     )

--- a/packages/graph/hash_graph/lib/graph/src/lib.rs
+++ b/packages/graph/hash_graph/lib/graph/src/lib.rs
@@ -85,6 +85,7 @@ pub trait Graph = where
         + Read<'i, AllLatest, PropertyType, Output = Vec<PropertyType>>
         + Read<'i, AllLatest, LinkType, Output = Vec<LinkType>>
         + Read<'i, AllLatest, EntityType, Output = Vec<EntityType>>
+        + Read<'i, AllLatest, Entity, Output = Vec<Entity>>
         + Read<'i, &'i VersionedUri, DataType, Output = DataType>
         + Read<'i, &'i VersionedUri, PropertyType, Output = PropertyType>
         + Read<'i, &'i VersionedUri, LinkType, Output = LinkType>

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/entity/read.rs
@@ -1,10 +1,13 @@
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
+use futures::{StreamExt, TryStreamExt};
+use postgres_types::ToSql;
 use tokio_postgres::GenericClient;
 
 use crate::{
     knowledge::{Entity, EntityId},
     store::{crud, AsClient, PostgresStore, QueryError},
+    AllLatest,
 };
 
 #[async_trait]
@@ -34,5 +37,38 @@ impl<C: AsClient> crud::Read<'_, EntityId, Entity> for PostgresStore<C> {
         Ok(serde_json::from_value(row.get(0))
             .report()
             .change_context(QueryError)?)
+    }
+}
+
+#[async_trait]
+impl<C: AsClient> crud::Read<'_, AllLatest, Entity> for PostgresStore<C> {
+    type Output = Vec<Entity>;
+
+    async fn get(&self, _: AllLatest) -> Result<Self::Output, QueryError> {
+        let row_stream = self
+            .as_client()
+            .query_raw(
+                r#"
+                    SELECT DISTINCT ON(entity_id) properties
+                    FROM entities
+                    ORDER BY entity_id, version DESC;
+                    "#,
+                // Requires a concrete type, which implements
+                // `IntoIterator<Item = impl BorrowToSql>`
+                [] as [&(dyn ToSql + Sync); 0],
+            )
+            .await
+            .report()
+            .change_context(QueryError)?;
+
+        row_stream
+            .map(|row_result| {
+                let row = row_result.report().change_context(QueryError)?;
+                serde_json::from_value(row.get(0))
+                    .report()
+                    .change_context(QueryError)
+            })
+            .try_collect()
+            .await
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/entity/read.rs
@@ -49,10 +49,10 @@ impl<C: AsClient> crud::Read<'_, AllLatest, Entity> for PostgresStore<C> {
             .as_client()
             .query_raw(
                 r#"
-                    SELECT DISTINCT ON(entity_id) properties
-                    FROM entities
-                    ORDER BY entity_id, version DESC;
-                    "#,
+                SELECT DISTINCT ON(entity_id) properties
+                FROM entities
+                ORDER BY entity_id, version DESC;
+                "#,
                 // Requires a concrete type, which implements
                 // `IntoIterator<Item = impl BorrowToSql>`
                 [] as [&(dyn ToSql + Sync); 0],

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -351,6 +351,16 @@ Accept: application/json
     client.global.set("person_b_entity_id", encodeURIComponent(response.body.entity_id));
 %}
 
+### Get all entities
+GET http://127.0.0.1:3000/entities
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(response.body.length === 2, "Unexpected number of entities");
+    });
+%}
+
 ### Insert link between entities
 POST http://127.0.0.1:3000/entities/{{person_a_entity_id}}/links
 Content-Type: application/json


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Extends the API to support getting all available entities

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1202621375435411/1202682556665582/f) _(internal)_

## 🔍 What does this change?

- Adds a REST endpoint for getting all entities, and the required backend code
- Driveby on some incorrect status codes on other endpoints

## 📜 Does this require a change to the docs?

The OpenAPI is generated from the REST endpoints

## 🐾 Next steps

- Make the entities filterable by `AccountId`
- Make the entities filterable by a given Entity Type's Base URI

## 🛡 What tests cover this?

The newly added functions has been added to the REST endpoint test