### PR TITLE
Use test groups for testing `error-stack`

### DIFF
--- a/.github/scripts/rust/Makefile.toml
+++ b/.github/scripts/rust/Makefile.toml
@@ -18,6 +18,10 @@ CARGO_DOC_HACK_FLAGS = "--workspace"
 CARGO_RUSTDOC_FLAGS = "--all-features -Zunstable-options -Zrustdoc-scrape-examples=examples -- -Zunstable-options"
 CARGO_RUSTDOC_HACK_FLAGS = "--workspace"
 CARGO_TEST_FLAGS = ""
+# This needs to be here, as error-stack uses it, and _BASE **needs** to be defined before
+# the variable using it has been defined. This is done per suggestion of
+# https://github.com/sagiegurari/cargo-make/issues/685
+CARGO_TEST_HACK_FLAGS_BASE = ""
 CARGO_TEST_HACK_FLAGS = "--workspace --feature-powerset"
 CARGO_DOC_TEST_FLAGS = "--workspace --all-features"
 CARGO_MIRI_FLAGS = ""

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -209,7 +209,10 @@ jobs:
       matrix:
         directory: ${{ fromJSON(needs.setup.outputs.publish) }}
         toolchain:
+          - stable
           - ${{ needs.setup.outputs.nightly }}
+        profile:
+          - release
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
@@ -221,6 +224,18 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
           override: true
+
+      - name: Install tools
+        shell: bash
+        run: |
+          cargo install cargo-quickinstall
+          cargo quickinstall cargo-make --version 0.35.15
+          cargo quickinstall cargo-hack --version 0.5.15
+          cargo quickinstall cargo-nextest --version 0.9.28
+
+      - name: Run tests
+        working-directory: ${{ matrix.directory }}
+        run: cargo make --profile ${{ matrix.profile }} test --no-fail-fast
 
       - name: Login
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -209,7 +209,6 @@ jobs:
       matrix:
         directory: ${{ fromJSON(needs.setup.outputs.publish) }}
         toolchain:
-          - stable
           - ${{ needs.setup.outputs.nightly }}
         profile:
           - release

--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error-stack"
-version = "0.2.0"
+version = "0.1.1"
 authors = ["HASH"]
 edition = "2021"
 rust-version = "1.61.0"

--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error-stack"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["HASH"]
 edition = "2021"
 rust-version = "1.61.0"

--- a/packages/libs/error-stack/Makefile.toml
+++ b/packages/libs/error-stack/Makefile.toml
@@ -6,7 +6,7 @@ CARGO_TEST_HACK_FLAGS = "--workspace --feature-powerset --exclude-features defau
 CARGO_MIRI_FLAGS = "--tests --lib"
 
 [tasks.test]
-env = { CARGO_TEST_HACK_FLAGS = "${CARGO_TEST_HACK_FLAGS} --group-features anyhow,eyre --group-features std,hook --group-features spantrace,futures,small" }
+env = { CARGO_TEST_HACK_FLAGS = "${CARGO_TEST_HACK_FLAGS} --group-features anyhow,eyre --group-features std,hooks --group-features spantrace,futures,small" }
 
 
 [tasks.test-release]

--- a/packages/libs/error-stack/Makefile.toml
+++ b/packages/libs/error-stack/Makefile.toml
@@ -1,7 +1,37 @@
 extend = { path = "../../../.github/scripts/rust/Makefile.toml" }
 
+env_scripts = [
+'''
+#!@duckscript
+
+# get the groups from CARGO_TEST_HACK_GROUPS and convert them into a list
+groups = get_env CARGO_TEST_HACK_GROUPS
+raw = split ${groups} ;
+release ${groups}
+
+# prepend the list with --group-features and join them
+prefix = array
+for group in ${raw}
+    array_push ${prefix} "--group-features ${group}"
+end
+
+release ${raw}
+groups = array_join ${prefix} " "
+release ${prefix}
+
+# append the value to the existing hack flags
+flags = get_env CARGO_TEST_HACK_FLAGS
+flags = set "${flags} ${groups}"
+set_env CARGO_TEST_HACK_FLAGS ${flags}
+
+release ${flags}
+release ${groups}
+'''
+]
+
 [env]
 CARGO_CLIPPY_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default --optional-deps eyre,anyhow"
+CARGO_TEST_HACK_GROUPS = ["anyhow,eyre", "glyph,serde", "std,hooks", "spantrace,futures,small"]
 CARGO_TEST_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default --optional-deps eyre,anyhow"
 CARGO_MIRI_FLAGS = "--tests --lib"
 

--- a/packages/libs/error-stack/Makefile.toml
+++ b/packages/libs/error-stack/Makefile.toml
@@ -2,18 +2,12 @@ extend = { path = "../../../.github/scripts/rust/Makefile.toml" }
 
 [env]
 CARGO_CLIPPY_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default --optional-deps eyre,anyhow"
-CARGO_TEST_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default --optional-deps eyre,anyhow"
+CARGO_TEST_HACK_FLAGS_BASE = "--workspace --feature-powerset --exclude-features default --optional-deps eyre,anyhow"
+CARGO_TEST_HACK_FLAGS = "${CARGO_TEST_HACK_FLAGS_BASE} --group-features anyhow,eyre --group-features spantrace,futures,small"
 CARGO_MIRI_FLAGS = "--tests --lib"
 
-[tasks.test]
-env = { CARGO_TEST_HACK_FLAGS = "${CARGO_TEST_HACK_FLAGS} --group-features anyhow,eyre --group-features std,hooks --group-features spantrace,futures,small" }
-
-
-[tasks.test-release]
-category = "Test"
-description = "Runs the complete test suite with all permutations"
-extend = "test"
-env = { CARGO_TEST_HACK_FLAGS = { source = "CARGO_TEST_HACK_FLAGS" } }
+[env.release]
+CARGO_TEST_HACK_FLAGS = "${CARGO_TEST_HACK_FLAGS_BASE}"
 
 [tasks.test-task]
 dependencies = ["install-rust-src"]

--- a/packages/libs/error-stack/Makefile.toml
+++ b/packages/libs/error-stack/Makefile.toml
@@ -1,44 +1,19 @@
 extend = { path = "../../../.github/scripts/rust/Makefile.toml" }
 
-env_scripts = [
-'''
-#!@duckscript
-
-# get the groups from CARGO_TEST_HACK_GROUPS and convert them into a list
-groups = get_env CARGO_TEST_HACK_GROUPS
-raw = split ${groups} ;
-release ${groups}
-
-# prepend the list with --group-features and join them
-prefix = array
-for group in ${raw}
-    if not is_empty ${group}
-        array_push ${prefix} "--group-features ${group}"
-    end
-end
-
-release ${raw}
-groups = array_join ${prefix} " "
-release ${prefix}
-
-# append the value to the existing hack flags
-flags = get_env CARGO_TEST_HACK_FLAGS
-if not is_empty ${groups}
-    flags = set "${flags} ${groups}"
-end
-set_env CARGO_TEST_HACK_FLAGS ${flags}
-
-release ${flags}
-release ${groups}
-'''
-]
-
 [env]
 CARGO_CLIPPY_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default --optional-deps eyre,anyhow"
-CARGO_TEST_HACK_GROUPS = ["anyhow,eyre", "std,hooks", "spantrace,futures,small"]
 CARGO_TEST_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default --optional-deps eyre,anyhow"
 CARGO_MIRI_FLAGS = "--tests --lib"
 
+[tasks.test]
+env = { CARGO_TEST_HACK_FLAGS = "${CARGO_TEST_HACK_FLAGS} --group-features anyhow,eyre --group-features std,hook --group-features spantrace,futures,small" }
+
+
+[tasks.test-release]
+category = "Test"
+description = "Runs the complete test suite with all permutations"
+extend = "test"
+env = { CARGO_TEST_HACK_FLAGS = { source = "CARGO_TEST_HACK_FLAGS" } }
 
 [tasks.test-task]
 dependencies = ["install-rust-src"]

--- a/packages/libs/error-stack/Makefile.toml
+++ b/packages/libs/error-stack/Makefile.toml
@@ -35,7 +35,7 @@ release ${groups}
 
 [env]
 CARGO_CLIPPY_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default --optional-deps eyre,anyhow"
-CARGO_TEST_HACK_GROUPS = ["anyhow,eyre", "glyph,serde", "std,hooks", "spantrace,futures,small"]
+CARGO_TEST_HACK_GROUPS = ["anyhow,eyre", "std,hooks", "spantrace,futures,small"]
 CARGO_TEST_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default --optional-deps eyre,anyhow"
 CARGO_MIRI_FLAGS = "--tests --lib"
 

--- a/packages/libs/error-stack/Makefile.toml
+++ b/packages/libs/error-stack/Makefile.toml
@@ -12,7 +12,9 @@ release ${groups}
 # prepend the list with --group-features and join them
 prefix = array
 for group in ${raw}
-    array_push ${prefix} "--group-features ${group}"
+    if not is_empty ${group}
+        array_push ${prefix} "--group-features ${group}"
+    end
 end
 
 release ${raw}
@@ -21,7 +23,9 @@ release ${prefix}
 
 # append the value to the existing hack flags
 flags = get_env CARGO_TEST_HACK_FLAGS
-flags = set "${flags} ${groups}"
+if not is_empty ${groups}
+    flags = set "${flags} ${groups}"
+end
 set_env CARGO_TEST_HACK_FLAGS ${flags}
 
 release ${flags}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

error-stack recently gained new capabilities (#794, #793, #747), combined with the newly introduced extensive test suite, which has been implemented in #777, results in multiple new `feature` flags, which we need to test against. These circumstances have led to testing times up to ~5h, which - with new features - will only get exponentially longer.

This PR tries to find a compromise by introducing feature groups of features that are unlikely to influence each other. Discussion #877 outlines the worst-case math and potential improvements this change adds.

> **Note:** This change adds a new environmental flag, `CARGO_TEST_HACK_GROUPS`, which we append to the actual `cargo-hack` command. For the complete pre-release test, needs to set `CARGO_TEST_HACK_GROUPS = ""`, the env_script will pick it up and not emit any groups, running the full powerset.

> **Note:** I am unsure of the location for the env_scripts. Should this be in the main `Makefile`, then we only set `CARGO_TEST_HACK_GROUPS` in the `Makefile.toml` in the `error-stack` file?

> **Note:** I decided on an env_script approach because it got very unwieldy and confusing/unclear[^1] with such a long command (and makes the release test harder to realize). I think the current process will be better for maintainability.

## 🔗 Related links

- #877 

## 🚫 Blocked by

- https://github.com/sagiegurari/cargo-make/issues/685

## 🔍 What does this change?

* CI tests are run against a group of features
* pre-release tests are run against the full powerset of features

## 📜 Does this require a change to the docs?

- this is only internally used

## ⚠️ Known issues

## 🐾 Next steps

* change GitHub CI (I believe I do not have the permissions to do that) to be able to test on release

## 🛡 What tests cover this?
## ❓ How to test this?
## 📹 Demo

[^1]: German: unübersichtlich. I cannot find a 100% fitting word equivalent for the English language.