### PR TITLE
Use `error-stack` by path

### DIFF
--- a/packages/engine/Cargo.lock
+++ b/packages/engine/Cargo.lock
@@ -648,10 +648,11 @@ dependencies = [
 [[package]]
 name = "error-stack"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5975af488b218348f3f183862f88e8699a91a809f0ee2658fcafaa6239d6759e"
 dependencies = [
+ "anyhow",
+ "once_cell",
  "rustc_version",
+ "smallvec",
  "tracing-error",
 ]
 

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -13,7 +13,7 @@ experiment-structure = { path = "lib/experiment-structure", default-features = f
 experiment-control = { path = "lib/experiment-control", default-features = false }
 orchestrator = { path = "lib/orchestrator", default-features = false }
 
-error-stack = { version = "0.1.1", features = ["spantrace"] }
+error-stack = { version = "0.1.1", path = "../libs/error-stack", features = ["spantrace"] }
 
 num_cpus = "1.13.1"
 serde = { version = "1.0.138", features = ["derive"] }

--- a/packages/engine/bin/cli/Cargo.toml
+++ b/packages/engine/bin/cli/Cargo.toml
@@ -11,7 +11,7 @@ experiment-structure = { path = "../../lib/experiment-structure", default-featur
 experiment-control = { path = "../../lib/experiment-control", default-features = false, features = ["clap"] }
 orchestrator = { path = "../../lib/orchestrator", default-features = false, features = ["clap"] }
 
-error-stack = { version = "0.1.1", features = ["spantrace"] }
+error-stack = { version = "0.1.1", path = "../../../libs/error-stack", features = ["spantrace"] }
 
 clap = { version = "=3.0.13", features = ["cargo", "derive", "env"] }
 serde = { version = "1.0.138", features = ["derive"] }

--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -65,7 +65,7 @@ async fn main() -> Result<(), CliError> {
         &format!("cli-{now}"),
         &format!("cli-{now}-texray"),
     )
-    .report()
+    .into_report()
     .attach_printable("Failed to initialize the logger")
     .change_context(CliError)?;
 
@@ -77,7 +77,7 @@ async fn main() -> Result<(), CliError> {
     let absolute_project_path = args
         .project
         .canonicalize()
-        .report()
+        .into_report()
         .attach_printable_lazy(|| {
             format!("Could not canonicalize project path: {:?}", args.project)
         })

--- a/packages/engine/bin/hash_engine/Cargo.toml
+++ b/packages/engine/bin/hash_engine/Cargo.toml
@@ -8,7 +8,7 @@ execution = { path = "../../lib/execution", default-features = false }
 experiment-structure = { path = "../../lib/experiment-structure", default-features = false }
 experiment-control = { path = "../../lib/experiment-control", default-features = false, features = ["clap"] }
 
-error-stack = { version = "0.1.1", features = ["spantrace"] }
+error-stack = { version = "0.1.1", path = "../../../libs/error-stack", features = ["spantrace"] }
 
 tokio = "1.19.2"
 tracing = "0.1.35"

--- a/packages/engine/bin/hash_engine/src/main.rs
+++ b/packages/engine/bin/hash_engine/src/main.rs
@@ -51,13 +51,13 @@ async fn main() -> Result<(), EngineError> {
         &format!("experiment-{}", args.experiment_id),
         &format!("experiment-{}-texray", args.experiment_id),
     )
-    .report()
+    .into_report()
     .attach_printable("Failed to initialize the logger")
     .change_context(EngineError)?;
 
     let mut env = Environment::new(&args)
         .await
-        .report()
+        .into_report()
         .attach_printable("Could not create environment for experiment")
         .change_context(EngineError)?;
     // Fetch all dependencies of the experiment run such as datasets
@@ -77,7 +77,7 @@ async fn main() -> Result<(), EngineError> {
 
     let experiment_result = run_experiment(config, env)
         .await
-        .report()
+        .into_report()
         .attach_printable("Could not run experiment")
         .change_context(EngineError);
 

--- a/packages/engine/lib/experiment-control/Cargo.toml
+++ b/packages/engine/lib/experiment-control/Cargo.toml
@@ -11,7 +11,7 @@ execution = { path = "../execution", default-features = false }
 experiment-structure = { path = "../experiment-structure", default-features = false }
 simulation-control = { path = "../simulation-control", default-features = false }
 
-error-stack = { version = "0.1.1", features = ["spantrace"] }
+error-stack = { version = "0.1.1", path = "../../../libs/error-stack", features = ["spantrace"] }
 
 clap = { version = "=3.0.13", features = ["cargo", "derive", "env"], optional = true }
 num_cpus = "1.13.1"

--- a/packages/engine/lib/experiment-structure/Cargo.toml
+++ b/packages/engine/lib/experiment-structure/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 stateful = { path = "../stateful", default-features = false }
 execution = { path = "../execution", default-features = false }
 
-error-stack = "0.1.1"
+error-stack = { version = "0.1.1", path = "../../../libs/error-stack", features = ["spantrace"] }
 
 async-trait = "0.1.56"
 csv = "1.1.6"

--- a/packages/engine/lib/experiment-structure/src/config/experiment.rs
+++ b/packages/engine/lib/experiment-structure/src/config/experiment.rs
@@ -41,7 +41,7 @@ impl ExperimentConfig {
             })
             .build()?;
         let base_globals: Globals = serde_json::from_str(&simulation.globals_src)
-            .report()
+            .into_report()
             .attach_printable("Could not parse globals JSON")
             .change_context(ConfigError)?;
 

--- a/packages/engine/lib/experiment-structure/src/config/package.rs
+++ b/packages/engine/lib/experiment-structure/src/config/package.rs
@@ -211,7 +211,7 @@ impl PackageConfigBuilder {
         {
             let deps = dependency
                 .get_all_dependencies()
-                .report()
+                .into_report()
                 .attach_printable_lazy(|| format!("Could not get dependencies for {dependency}"))
                 .change_context(ConfigError)?;
             for dep in deps.into_iter_deps() {

--- a/packages/engine/lib/experiment-structure/src/experiment/plan.rs
+++ b/packages/engine/lib/experiment-structure/src/experiment/plan.rs
@@ -53,7 +53,7 @@ fn get_simple_experiment_config(
         .attach_printable("Experiment configuration not found: experiments.json")?;
     let experiments_manifest_comment_remover = StripComments::new(experiments_manifest.as_bytes());
     let parsed = serde_json::from_reader(experiments_manifest_comment_remover)
-        .report()
+        .into_report()
         .change_context(ExperimentPlanError)
         .attach_printable("Could not parse experiment manifest")?;
     let plan = create_experiment_plan(&parsed, &experiment_name)
@@ -133,7 +133,7 @@ fn create_multiparameter_variant(
     }
 
     let var: MultiparameterVariant = serde_json::from_value(selected_experiment.clone())
-        .report()
+        .into_report()
         .change_context(ExperimentPlanError)
         .attach_printable("Could not parse multiparameter variant")?;
     let subplans = var
@@ -190,7 +190,7 @@ fn create_group_variant(
         runs: Vec<ExperimentName>,
     }
     let var: GroupVariant = serde_json::from_value(selected_experiment.clone())
-        .report()
+        .into_report()
         .change_context(ExperimentPlanError)
         .attach_printable("Could not create group variant")?;
     var.runs.iter().try_fold(
@@ -289,37 +289,37 @@ fn create_monte_carlo_variant_plan(
             let distribution = match self.distribution.as_str() {
                 "normal" => Box::new(
                     Normal::new(self.mean.unwrap_or(1.0), self.std.unwrap_or(1.0))
-                        .report()
+                        .into_report()
                         .change_context(ExperimentPlanError)
                         .attach_printable("Unable to create normal distribution")?,
                 ) as Box<dyn DynDistribution<f64>>,
                 "log-normal" => Box::new(
                     LogNormal::new(self.mu.unwrap_or(1.0), self.sigma.unwrap_or(1.0))
-                        .report()
+                        .into_report()
                         .change_context(ExperimentPlanError)
                         .attach_printable("Unable to create log-normal distribution")?,
                 ),
                 "poisson" => Box::new(
                     Poisson::new(self.rate.unwrap_or(1.0))
-                        .report()
+                        .into_report()
                         .change_context(ExperimentPlanError)
                         .attach_printable("Unable to create poisson distribution")?,
                 ),
                 "beta" => Box::new(
                     Beta::new(self.alpha.unwrap_or(1.0), self.beta.unwrap_or(1.0))
-                        .report()
+                        .into_report()
                         .change_context(ExperimentPlanError)
                         .attach_printable("Unable to create beta distribution")?,
                 ),
                 "gamma" => Box::new(
                     Gamma::new(self.shape.unwrap_or(1.0), self.scale.unwrap_or(1.0))
-                        .report()
+                        .into_report()
                         .change_context(ExperimentPlanError)
                         .attach_printable("Unable to create gamma distribution")?,
                 ),
                 _ => Box::new(
                     Normal::new(1.0, 1.0)
-                        .report()
+                        .into_report()
                         .change_context(ExperimentPlanError)
                         .attach_printable("Unable to create normal distribution")?,
                 ),
@@ -332,7 +332,7 @@ fn create_monte_carlo_variant_plan(
     }
 
     let var: MonteCarloVariant = serde_json::from_value(selected_experiment.clone())
-        .report()
+        .into_report()
         .change_context(ExperimentPlanError)
         .attach_printable("Could not create monte carlo distribution")?;
     let values: Vec<_> = (0..var.samples as usize).map(|_| 0.into()).collect();
@@ -357,7 +357,7 @@ fn create_value_variant_plan(
     }
 
     let var: ValueVariant = serde_json::from_value(selected_experiment.clone())
-        .report()
+        .into_report()
         .change_context(ExperimentPlanError)
         .attach_printable("Could not parse value variant")?;
     let mapper: Mapper = Box::new(|val, _index| val);
@@ -383,7 +383,7 @@ fn create_linspace_variant_plan(
         stop: f64,
     }
     let var: LinspaceVariant = serde_json::from_value(selected_experiment.clone())
-        .report()
+        .into_report()
         .change_context(ExperimentPlanError)
         .attach_printable("Could not create linspace variant")?;
     let values: Vec<_> = (0..var.samples as usize).map(|_| 0.into()).collect();
@@ -422,7 +422,7 @@ fn create_arange_variant_plan(
         stop: f64,
     }
     let var: ArangeVariant = serde_json::from_value(selected_experiment.clone())
-        .report()
+        .into_report()
         .change_context(ExperimentPlanError)
         .attach_printable("Could not create arange variant")?;
     let mut values = vec![];
@@ -455,7 +455,7 @@ fn create_meshgrid_variant_plan(
         y: [f64; 3], // [start, stop, num_samples]
     }
     let var: MeshgridVariant = serde_json::from_value(selected_experiment.clone())
-        .report()
+        .into_report()
         .change_context(ExperimentPlanError)
         .attach_printable("Could not create meshgrid variant")?;
 

--- a/packages/engine/lib/experiment-structure/src/manifest.rs
+++ b/packages/engine/lib/experiment-structure/src/manifest.rs
@@ -303,7 +303,7 @@ impl Manifest {
         tracing::debug!("Reading behaviors in {src_folder:?}");
         for entry in src_folder
             .read_dir()
-            .report()
+            .into_report()
             .attach_printable_lazy(|| format!("Could not read behavior directory: {src_folder:?}"))
             .change_context(ManifestError)?
         {
@@ -387,7 +387,7 @@ impl Manifest {
         tracing::debug!("Reading datasets in {src_folder:?}");
         for entry in src_folder
             .read_dir()
-            .report()
+            .into_report()
             .attach_printable_lazy(|| format!("Could not read dataset directory: {src_folder:?}"))
             .change_context(ManifestError)?
         {
@@ -713,7 +713,7 @@ fn _try_read_local_dependencies<P: AsRef<Path>>(dependency_path: P) -> Result<Ve
 
     let mut entries = dependency_path
         .read_dir()
-        .report()
+        .into_report()
         .attach_printable_lazy(|| format!("Could not read dependency directory: {dependency_path:?}"))
         .change_context(ManifestError)?
         .filter_map(|dir_res| {
@@ -729,7 +729,7 @@ fn _try_read_local_dependencies<P: AsRef<Path>>(dependency_path: P) -> Result<Ve
             user_dir
                 .path()
                 .read_dir()
-                .report()
+                .into_report()
                 .attach_printable_lazy(|| {
                     format!("Could not read directory {:?}", user_dir.path())
                 })
@@ -770,7 +770,7 @@ fn file_contents<P: AsRef<Path>>(path: P) -> Result<String> {
     let path = path.as_ref();
     tracing::debug!("Reading contents at path: {path:?}");
     std::fs::read_to_string(path)
-        .report()
+        .into_report()
         .attach_printable_lazy(|| format!("Could not read file: {path:?}"))
         .change_context(ManifestError)
 }
@@ -788,11 +788,11 @@ fn parse_file<T: DeserializeOwned, P: AsRef<Path>>(path: P) -> Result<T> {
     let path = path.as_ref();
     serde_json::from_reader(BufReader::new(
         File::open(path)
-            .report()
+            .into_report()
             .attach_printable_lazy(|| format!("Could not read file {path:?}"))
             .change_context(ManifestError)?,
     ))
-    .report()
+    .into_report()
     .attach_printable_lazy(|| format!("Could not parse {path:?}"))
     .change_context(ManifestError)
 }

--- a/packages/engine/lib/nano/Cargo.toml
+++ b/packages/engine/lib/nano/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-error-stack = { version = "0.1.1", features = ["spantrace"] }
+error-stack = { version = "0.1.1", path = "../../../libs/error-stack", features = ["spantrace"] }
 
 nng = { version = "1.0.1", default-features = false }
 serde = { version = "1.0.138", features = ["derive"] }

--- a/packages/engine/lib/nano/src/server.rs
+++ b/packages/engine/lib/nano/src/server.rs
@@ -56,7 +56,7 @@ impl Worker {
     /// [`Sleep`]: nng::AioResult::Sleep
     fn new(socket: &nng::Socket, sender: MsgSender, url: &str) -> Result<Self, nng::Error> {
         let ctx_orig = nng::Context::new(socket)
-            .report()
+            .into_report()
             .attach_printable("Could not create context")?;
         let ctx = ctx_orig.clone();
 
@@ -89,7 +89,7 @@ impl Worker {
         // Initialize the Aio in the Recv state
         ctx_orig
             .recv(&aio)
-            .report()
+            .into_report()
             .attach_printable("Could not receive message from context")?;
 
         Ok(Self { _aio: aio })
@@ -107,12 +107,12 @@ impl Server {
     /// - the worker could not be created from the provided `url`.
     pub fn new(url: &str) -> Result<Self> {
         let socket = nng::Socket::new(nng::Protocol::Rep0)
-            .report()
+            .into_report()
             .attach_printable("Could not create socket")
             .change_context(ErrorKind::ServerCreation)?;
         socket
             .listen(url)
-            .report()
+            .into_report()
             .attach_printable("Could not listen on socket")
             .change_context(ErrorKind::ServerCreation)?;
 
@@ -152,7 +152,7 @@ impl Server {
     {
         let msg = self.receiver.recv().await.expect(RECV_EXPECT_MESSAGE);
         serde_json::from_slice::<T>(msg.as_slice())
-            .report()
+            .into_report()
             .attach_printable("Could not convert message from JSON")
             .change_context(ErrorKind::Receive)
     }

--- a/packages/engine/lib/orchestrator/Cargo.toml
+++ b/packages/engine/lib/orchestrator/Cargo.toml
@@ -12,7 +12,7 @@ simulation-control = { path = "../simulation-control", default-features = false 
 experiment-control = { path = "../experiment-control", default-features = false }
 hash_engine = { path = "../../bin/hash_engine", default-features = false, artifact = "bin" }
 
-error-stack = { version = "0.1.1", features = ["spantrace"] }
+error-stack = { version = "0.1.1", path = "../../../libs/error-stack", features = ["spantrace"] }
 
 async-trait = "0.1.56"
 clap = { version = "=3.0.13", optional = true }

--- a/packages/engine/lib/orchestrator/src/experiment.rs
+++ b/packages/engine/lib/orchestrator/src/experiment.rs
@@ -212,7 +212,7 @@ impl Experiment {
             engine_handle.recv(),
         )
         .await
-        .report()
+        .into_report()
         .change_context(OrchestratorError::from("engine start timeout"));
         match msg {
             Ok(EngineStatus::Started) => {}

--- a/packages/engine/lib/orchestrator/src/experiment_server.rs
+++ b/packages/engine/lib/orchestrator/src/experiment_server.rs
@@ -91,7 +91,7 @@ impl Handler {
         })?;
         result_rx
             .await
-            .report()
+            .into_report()
             .change_context(OrchestratorError::from("Failed to receive response from"))?
     }
 
@@ -223,7 +223,7 @@ impl Server {
                 // completes before sending de-registering the experiment.
                 Ok(())
             }
-            Some(sender) => sender.send(msg.body).report().attach_printable_lazy(|| {
+            Some(sender) => sender.send(msg.body).into_report().attach_printable_lazy(|| {
                 format!("Routing message for experiment {}", msg.experiment_id)
             }),
         }

--- a/packages/engine/lib/orchestrator/src/experiment_server.rs
+++ b/packages/engine/lib/orchestrator/src/experiment_server.rs
@@ -223,9 +223,12 @@ impl Server {
                 // completes before sending de-registering the experiment.
                 Ok(())
             }
-            Some(sender) => sender.send(msg.body).into_report().attach_printable_lazy(|| {
-                format!("Routing message for experiment {}", msg.experiment_id)
-            }),
+            Some(sender) => sender
+                .send(msg.body)
+                .into_report()
+                .attach_printable_lazy(|| {
+                    format!("Routing message for experiment {}", msg.experiment_id)
+                }),
         }
     }
 

--- a/packages/engine/lib/orchestrator/src/process/local.rs
+++ b/packages/engine/lib/orchestrator/src/process/local.rs
@@ -102,7 +102,7 @@ impl process::Process for LocalProcess {
             .child
             .wait()
             .await
-            .report()
+            .into_report()
             .change_context(OrchestratorError::from(
                 "Could not wait for the process to exit",
             ))?)
@@ -209,7 +209,7 @@ impl process::Command for LocalCommand {
         }
         debug!("Running `{cmd:?}`");
 
-        let child = cmd.spawn().report().change_context_lazy(|| {
+        let child = cmd.spawn().into_report().change_context_lazy(|| {
             OrchestratorError::from(format!("Could not run command: {process_path:?}"))
         })?;
         debug!("Spawned local engine process for experiment");

--- a/packages/engine/tests/experiment/mod.rs
+++ b/packages/engine/tests/experiment/mod.rs
@@ -377,10 +377,10 @@ fn parse_file<T: DeserializeOwned, P: AsRef<Path>>(path: P) -> Result<T, TestErr
     let path = path.as_ref();
     serde_json::from_reader(BufReader::new(
         File::open(path)
-            .report()
+            .into_report()
             .change_context_lazy(|| TestError::parse_error(path))?,
     ))
-    .report()
+    .into_report()
     .change_context_lazy(|| TestError::parse_error(path))
 }
 
@@ -480,7 +480,7 @@ impl ExpectedOutput {
         for (step, expected_states) in json_state {
             let step = step
                 .parse::<usize>()
-                .report()
+                .into_report()
                 .change_context_lazy(|| TestError::invalid_step(step.clone()))?;
             let result_states = agent_states
                 .get(step)

--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -13,13 +13,13 @@ keywords = ["error", "library", "report", "no_std", "stack"]
 categories = ["rust-patterns", "no-std"]
 
 [dependencies]
-tracing-error = { version = "0.2.0", optional = true, default_features = false }
+tracing-error = { version = "0.2", optional = true, default_features = false }
 once_cell = { version = "1.10.0", optional = true, default_features = false }
 pin-project = { version = "1.0.10", optional = true, default_features = false }
-futures-core = { version = "0.3.21", optional = true, default-features = false }
-smallvec = { version = "1.9.0", optional = true, default_features = false, features = ['union'] }
-anyhow = { version = "1.0.58", default-features = false, optional = true }
-eyre = { version = "0.6.8", default-features = false, optional = true }
+futures-core = { version = "0.3", optional = true, default-features = false }
+smallvec = { version = "1", optional = true, default_features = false, features = ['union'] }
+anyhow = { version = "1", default-features = false, optional = true }
+eyre = { version = "0.6", default-features = false, optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0.137", features = ["derive"] }

--- a/packages/libs/error-stack/examples/exit_code.rs
+++ b/packages/libs/error-stack/examples/exit_code.rs
@@ -20,5 +20,5 @@ fn main() -> ExitCode {
         .attach(ExitCode::from(100))
         .attach_printable("This error has an exit code of 100!");
 
-    report.into_report()
+    report.report()
 }

--- a/packages/libs/error-stack/examples/exit_code.rs
+++ b/packages/libs/error-stack/examples/exit_code.rs
@@ -20,5 +20,5 @@ fn main() -> ExitCode {
         .attach(ExitCode::from(100))
         .attach_printable("This error has an exit code of 100!");
 
-    report.report()
+    report.into_report()
 }

--- a/packages/libs/error-stack/tests/test_conversion.rs
+++ b/packages/libs/error-stack/tests/test_conversion.rs
@@ -12,7 +12,7 @@ fn io_error() -> Result<(), io::Error> {
 #[test]
 #[allow(deprecated)]
 fn report() {
-    let report = io_error().report().expect_err("Not an error");
+    let report = io_error().into_report().expect_err("Not an error");
     assert!(report.contains::<io::Error>());
     assert_eq!(report.current_context().kind(), io::ErrorKind::Other);
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In order to bump the toolchain for `hEngine`, it's required to use the latest `error-stack` version available, as `std::error::Error::backtrace` were removed.

## ⚠️ Known issues

Our CI is currently limited to only the same nightly toolchains for different projects, this results in problems with a breaking changes on a nightly feature in `std`. It's not possible to simply bump the toolchain as hEngine would then use an old version of `error-stack` but on a compiler which is not working for `error-stack`. It's also not possible to specify the link to `error-stack` by a git path because it does not yet exist upstream. So this is a temporary fix to use the correct error-stack version until the toolchain was bumped. Afterward, it will be replaced by a git-link instead of a path to avoid breaking hEngine without noticing in the case `error-stack` will have a breaking change (this wouldn't test hEngine).

## 🔗 Related links

- #898 

## 🔍 What does this change?

- Use `error-stack` by path
- Use the new method `into_report` rather than the deprecated `report` method
 
## 🐾 Next steps

1. Bump the toolchain
2. Replace the `path` with the sticked git version, see `known problems`