### PR TITLE
Fix output of toolchain in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           nightly=$(cat $(find . -name rust-toolchain.toml) | grep channel | cut -d\" -f2)
           echo "::set-output name=nightly::$nightly"
-          echo "use toolchains: $(echo $nightly | jq -r)"
+          echo "use toolchains: $(echo $nightly)"
 
       - name: Determine samples
         id: samples


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When determining the toolchain to use, outputting fails. This was only a bug in displaying the toolchain, the toolchain was picked up correctly.

Thanks for @indietyp for reporting!

## 🔗 Related links

- https://github.com/hashintel/hash/issues/897#issuecomment-1207476945