### PR TITLE
Show block handles only on mouse hover

### DIFF
--- a/packages/hash/frontend/src/blocks/page/BlockHandle.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockHandle.tsx
@@ -75,9 +75,11 @@ const BlockHandle: ForwardRefRenderFunction<
   return (
     <Box
       ref={ref}
-      sx={{
+      sx={(theme) => ({
         display: readonlyMode ? "none" : "block",
-      }}
+        opacity: blockView.hovered || contextMenuPopupState.isOpen ? 1 : 0,
+        transition: theme.transitions.create("opacity"),
+      })}
       data-testid="block-handle"
     >
       <IconButton

--- a/packages/hash/frontend/src/blocks/page/BlockView.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockView.tsx
@@ -136,7 +136,7 @@ export class BlockView implements NodeView<Schema> {
    * destroyed and/or updated. Here we're instructing PM to ignore changes
    * made by us
    *
-   * @todo find a more generalised alternative
+   * @todo find a more generalized alternative
    */
   ignoreMutation(
     record: Parameters<NonNullable<NodeView<Schema>["ignoreMutation"]>>[0],

--- a/packages/hash/frontend/src/blocks/page/BlockView.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockView.tsx
@@ -250,8 +250,8 @@ export class BlockView implements NodeView<Schema> {
     this.renderPortal(null, this.selectContainer);
     this.dom.remove();
     document.removeEventListener("dragend", this.onDragEnd);
-    document.removeEventListener("mouseenter", this.onMouseEnter);
-    document.removeEventListener("mouseleave", this.onMouseLeave);
+    this.dom.removeEventListener("mouseenter", this.onMouseEnter);
+    this.dom.removeEventListener("mouseleave", this.onMouseLeave);
   }
 
   deleteBlock = () => {

--- a/packages/hash/frontend/src/blocks/page/BlockView.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockView.tsx
@@ -33,6 +33,7 @@ export class BlockView implements NodeView<Schema> {
 
   allowDragging = false;
   dragging = false;
+  hovered = false;
 
   /** used to hide node-view specific events from prosemirror */
   blockHandleRef = createRef<HTMLDivElement>();
@@ -66,6 +67,13 @@ export class BlockView implements NodeView<Schema> {
     return blockEntityNode.attrs.draftId ?? null;
   }
 
+  private createHoverHandler = (hovered: boolean) => {
+    return () => {
+      this.hovered = hovered;
+      this.update(this.node);
+    };
+  };
+
   constructor(
     public node: ProsemirrorNode<Schema>,
     public editorView: EditorView<Schema>,
@@ -76,6 +84,8 @@ export class BlockView implements NodeView<Schema> {
     this.dom = document.createElement("div");
     this.dom.classList.add(styles.Block!);
     this.dom.setAttribute("data-testid", "block");
+    this.dom.addEventListener("mouseenter", this.onMouseEnter);
+    this.dom.addEventListener("mouseleave", this.onMouseLeave);
 
     this.selectContainer = document.createElement("div");
     this.selectContainer.classList.add(styles.Block__UI!);
@@ -96,6 +106,9 @@ export class BlockView implements NodeView<Schema> {
 
     this.update(node);
   }
+
+  onMouseEnter = this.createHoverHandler(true);
+  onMouseLeave = this.createHoverHandler(false);
 
   onDragEnd = () => {
     (document.activeElement as HTMLElement | null)?.blur();
@@ -237,6 +250,8 @@ export class BlockView implements NodeView<Schema> {
     this.renderPortal(null, this.selectContainer);
     this.dom.remove();
     document.removeEventListener("dragend", this.onDragEnd);
+    document.removeEventListener("mouseenter", this.onMouseEnter);
+    document.removeEventListener("mouseleave", this.onMouseLeave);
   }
 
   deleteBlock = () => {

--- a/packages/hash/frontend/src/blocks/page/style.module.css
+++ b/packages/hash/frontend/src/blocks/page/style.module.css
@@ -41,6 +41,15 @@
   align-items: center;
 }
 
+.Block__UI {
+  transition: opacity 0.3s;
+  opacity: 0;
+}
+
+.Block:hover .Block__UI {
+  opacity: 1;
+}
+
 .Block__Content {
   flex: 1;
   height: 100%;

--- a/packages/hash/frontend/src/blocks/page/style.module.css
+++ b/packages/hash/frontend/src/blocks/page/style.module.css
@@ -41,15 +41,6 @@
   align-items: center;
 }
 
-.Block__UI {
-  transition: opacity 0.3s;
-  opacity: 0;
-}
-
-.Block:hover .Block__UI {
-  opacity: 1;
-}
-
 .Block__Content {
   flex: 1;
   height: 100%;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

- Hides the `BlockHandle` by default, and display it only when the mouse cursor hovers over a block.
- Changes a spelling to American English within a comment


## 🔗 Related links
[Asana task](https://app.asana.com/0/1200211978612931/1202700524579036/f) (internal)


## ❓ How to test this?

1.  Checkout the branch / view the deployment
1.  Try hovering on a Block inside a page
1.  Confirm that `BlockHandle` is visible on hover.

## 📹 Demo

https://user-images.githubusercontent.com/39553853/183638037-1045618b-1127-412b-ab4b-c0ea40881a13.mov
