### PR TITLE
Pin `error-stack` version to 5edddb5 in hEngine

### DIFF
--- a/packages/engine/Cargo.lock
+++ b/packages/engine/Cargo.lock
@@ -648,6 +648,7 @@ dependencies = [
 [[package]]
 name = "error-stack"
 version = "0.1.1"
+source = "git+https://github.com/hashintel/hash?rev=5edddb5#5edddb5566f9bd82dcdf9ba3b430759bc6b15dc5"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -13,7 +13,7 @@ experiment-structure = { path = "lib/experiment-structure", default-features = f
 experiment-control = { path = "lib/experiment-control", default-features = false }
 orchestrator = { path = "lib/orchestrator", default-features = false }
 
-error-stack = { version = "0.1.1", path = "../libs/error-stack", features = ["spantrace"] }
+error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace"] }
 
 num_cpus = "1.13.1"
 serde = { version = "1.0.138", features = ["derive"] }

--- a/packages/engine/bin/cli/Cargo.toml
+++ b/packages/engine/bin/cli/Cargo.toml
@@ -11,7 +11,7 @@ experiment-structure = { path = "../../lib/experiment-structure", default-featur
 experiment-control = { path = "../../lib/experiment-control", default-features = false, features = ["clap"] }
 orchestrator = { path = "../../lib/orchestrator", default-features = false, features = ["clap"] }
 
-error-stack = { version = "0.1.1", path = "../../../libs/error-stack", features = ["spantrace"] }
+error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace"] }
 
 clap = { version = "=3.0.13", features = ["cargo", "derive", "env"] }
 serde = { version = "1.0.138", features = ["derive"] }

--- a/packages/engine/bin/hash_engine/Cargo.toml
+++ b/packages/engine/bin/hash_engine/Cargo.toml
@@ -8,7 +8,7 @@ execution = { path = "../../lib/execution", default-features = false }
 experiment-structure = { path = "../../lib/experiment-structure", default-features = false }
 experiment-control = { path = "../../lib/experiment-control", default-features = false, features = ["clap"] }
 
-error-stack = { version = "0.1.1", path = "../../../libs/error-stack", features = ["spantrace"] }
+error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace"] }
 
 tokio = "1.19.2"
 tracing = "0.1.35"

--- a/packages/engine/lib/experiment-control/Cargo.toml
+++ b/packages/engine/lib/experiment-control/Cargo.toml
@@ -11,7 +11,7 @@ execution = { path = "../execution", default-features = false }
 experiment-structure = { path = "../experiment-structure", default-features = false }
 simulation-control = { path = "../simulation-control", default-features = false }
 
-error-stack = { version = "0.1.1", path = "../../../libs/error-stack", features = ["spantrace"] }
+error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace"] }
 
 clap = { version = "=3.0.13", features = ["cargo", "derive", "env"], optional = true }
 num_cpus = "1.13.1"

--- a/packages/engine/lib/experiment-structure/Cargo.toml
+++ b/packages/engine/lib/experiment-structure/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 stateful = { path = "../stateful", default-features = false }
 execution = { path = "../execution", default-features = false }
 
-error-stack = { version = "0.1.1", path = "../../../libs/error-stack", features = ["spantrace"] }
+error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace"] }
 
 async-trait = "0.1.56"
 csv = "1.1.6"

--- a/packages/engine/lib/nano/Cargo.toml
+++ b/packages/engine/lib/nano/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-error-stack = { version = "0.1.1", path = "../../../libs/error-stack", features = ["spantrace"] }
+error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace"] }
 
 nng = { version = "1.0.1", default-features = false }
 serde = { version = "1.0.138", features = ["derive"] }

--- a/packages/engine/lib/orchestrator/Cargo.toml
+++ b/packages/engine/lib/orchestrator/Cargo.toml
@@ -12,7 +12,7 @@ simulation-control = { path = "../simulation-control", default-features = false 
 experiment-control = { path = "../experiment-control", default-features = false }
 hash_engine = { path = "../../bin/hash_engine", default-features = false, artifact = "bin" }
 
-error-stack = { version = "0.1.1", path = "../../../libs/error-stack", features = ["spantrace"] }
+error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace"] }
 
 async-trait = "0.1.56"
 clap = { version = "=3.0.13", optional = true }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#904 required using the latest version of `error-stack`. In order to use the nightly version of `error-stack` in hEngine in the future, this PR pins to the current version.

## 🔗 Related links

- #904 

## 🔍 What does this change?

Change the resolving for `error-stack` from `path` to `git + rev`
