### PR TITLE
Add initial query builders

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/api/rest/api_resource.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/api_resource.rs
@@ -1,6 +1,6 @@
 use axum::Router;
 
-use crate::GraphPool;
+use crate::store::StorePool;
 
 /// With REST, we define resources that can be acted on. These resources are defined through
 /// routes and HTTP methods.
@@ -9,7 +9,7 @@ use crate::GraphPool;
 /// through a `Router`, making it explicitly clear we want to provide `OpenApi` specification as
 /// documentation for the routes.
 pub(super) trait RoutedResource: utoipa::OpenApi {
-    fn routes<P: GraphPool>() -> Router;
+    fn routes<P: StorePool + Send + Sync + 'static>() -> Router;
     fn documentation() -> utoipa::openapi::OpenApi {
         Self::openapi()
     }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/api_resource.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/api_resource.rs
@@ -9,7 +9,7 @@ use crate::store::StorePool;
 /// through a `Router`, making it explicitly clear we want to provide `OpenApi` specification as
 /// documentation for the routes.
 pub(super) trait RoutedResource: utoipa::OpenApi {
-    fn routes<P: StorePool + Send + Sync + 'static>() -> Router;
+    fn routes<P: StorePool + Send + 'static>() -> Router;
     fn documentation() -> utoipa::openapi::OpenApi {
         Self::openapi()
     }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -120,7 +120,7 @@ async fn create_data_type<P: StorePool + Send>(
 async fn get_latest_data_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<DataType>>, StatusCode> {
-    read_from_store(pool.as_ref(), &DataTypeQuery::new().with_latest_version())
+    read_from_store(pool.as_ref(), &DataTypeQuery::new().by_latest_version())
         .await
         .map(Json)
 }
@@ -147,8 +147,8 @@ async fn get_data_type<P: StorePool + Send>(
     read_from_store(
         pool.as_ref(),
         &DataTypeQuery::new()
-            .with_uri(uri.base_uri())
-            .with_version(uri.version()),
+            .by_uri(uri.base_uri())
+            .by_version(uri.version()),
     )
     .await
     .and_then(|mut data_types| data_types.pop().ok_or(StatusCode::NOT_FOUND))

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -18,8 +18,9 @@ use crate::{
         types::{uri::VersionedUri, DataType},
         AccountId,
     },
-    store::{crud::AllLatest, BaseUriAlreadyExists, BaseUriDoesNotExist},
-    GraphPool,
+    store::{
+        query::DataTypeQuery, BaseUriAlreadyExists, BaseUriDoesNotExist, DataTypeStore, StorePool,
+    },
 };
 
 #[derive(OpenApi)]
@@ -39,7 +40,7 @@ pub struct DataTypeResource;
 
 impl RoutedResource for DataTypeResource {
     /// Create routes for interacting with data types.
-    fn routes<P: GraphPool>() -> Router {
+    fn routes<P: StorePool + Send + 'static>() -> Router {
         // TODO: The URL format here is preliminary and will have to change.
         Router::new().nest(
             "/data-types",
@@ -77,7 +78,7 @@ struct CreateDataTypeRequest {
     ),
     request_body = CreateDataTypeRequest,
 )]
-async fn create_data_type<P: GraphPool>(
+async fn create_data_type<P: StorePool + Send>(
     body: Json<CreateDataTypeRequest>,
     pool: Extension<Arc<P>>,
 ) -> Result<Json<DataType>, StatusCode> {
@@ -116,10 +117,10 @@ async fn create_data_type<P: GraphPool>(
         (status = 500, description = "Store error occurred"),
     )
 )]
-async fn get_latest_data_types<P: GraphPool>(
+async fn get_latest_data_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<DataType>>, StatusCode> {
-    read_from_store::<DataType, _, _, _>(pool.as_ref(), AllLatest)
+    read_from_store(pool.as_ref(), &DataTypeQuery::new().with_latest_version())
         .await
         .map(Json)
 }
@@ -139,13 +140,19 @@ async fn get_latest_data_types<P: GraphPool>(
         ("uri" = String, Path, description = "The URI of the data type"),
     )
 )]
-async fn get_data_type<P: GraphPool>(
-    Path(uri): Path<VersionedUri>,
-    Extension(pool): Extension<Arc<P>>,
+async fn get_data_type<P: StorePool + Send>(
+    uri: Path<VersionedUri>,
+    pool: Extension<Arc<P>>,
 ) -> Result<Json<DataType>, StatusCode> {
-    read_from_store::<DataType, _, _, _>(pool.as_ref(), &uri)
-        .await
-        .map(Json)
+    read_from_store(
+        pool.as_ref(),
+        &DataTypeQuery::new()
+            .with_uri(uri.base_uri())
+            .with_version(uri.version()),
+    )
+    .await
+    .and_then(|mut data_types| data_types.pop().ok_or(StatusCode::NOT_FOUND))
+    .map(Json)
 }
 
 #[derive(Component, Serialize, Deserialize)]
@@ -169,7 +176,7 @@ struct UpdateDataTypeRequest {
     ),
     request_body = UpdateDataTypeRequest,
 )]
-async fn update_data_type<P: GraphPool>(
+async fn update_data_type<P: StorePool + Send>(
     body: Json<UpdateDataTypeRequest>,
     pool: Extension<Arc<P>>,
 ) -> Result<Json<DataType>, StatusCode> {

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -13,13 +13,13 @@ use utoipa::{Component, OpenApi};
 
 use crate::{
     api::rest::{api_resource::RoutedResource, read_from_store},
-    knowledge::{Entity, EntityId, PersistedEntityIdentifier},
+    knowledge::{Entity, EntityId, PersistedEntity, PersistedEntityIdentifier},
     ontology::{types::uri::VersionedUri, AccountId},
     store::{
-        crud::AllLatest,
         error::{EntityDoesNotExist, QueryError},
+        query::EntityQuery,
+        EntityStore, StorePool,
     },
-    GraphPool, PersistedEntity,
 };
 
 #[derive(OpenApi)]
@@ -39,7 +39,7 @@ pub struct EntityResource;
 
 impl RoutedResource for EntityResource {
     /// Create routes for interacting with entities.
-    fn routes<P: GraphPool>() -> Router {
+    fn routes<P: StorePool + Send + 'static>() -> Router {
         // TODO: The URL format here is preliminary and will have to change.
         Router::new().nest(
             "/entities",
@@ -78,7 +78,7 @@ struct CreateEntityRequest {
     ),
     request_body = CreateEntityRequest,
 )]
-async fn create_entity<P: GraphPool>(
+async fn create_entity<P: StorePool + Send>(
     body: Json<CreateEntityRequest>,
     pool: Extension<Arc<P>>,
 ) -> Result<Json<PersistedEntityIdentifier>, StatusCode> {
@@ -120,13 +120,17 @@ async fn create_entity<P: GraphPool>(
         ("entityId" = Uuid, Path, description = "The ID of the entity"),
     )
 )]
-async fn get_entity<P: GraphPool>(
+async fn get_entity<P: StorePool + Send>(
     Path(entity_id): Path<EntityId>,
-    Extension(pool): Extension<Arc<P>>,
+    pool: Extension<Arc<P>>,
 ) -> Result<Json<PersistedEntity>, StatusCode> {
-    read_from_store::<PersistedEntity, _, _, _>(pool.as_ref(), entity_id)
-        .await
-        .map(Json)
+    read_from_store(
+        pool.as_ref(),
+        &EntityQuery::new().with_id(entity_id).with_latest_version(),
+    )
+    .await
+    .and_then(|mut entities| entities.pop().ok_or(StatusCode::NOT_FOUND))
+    .map(Json)
 }
 
 #[utoipa::path(
@@ -138,10 +142,10 @@ async fn get_entity<P: GraphPool>(
         (status = 500, description = "Store error occurred"),
     )
 )]
-async fn get_latest_entities<P: GraphPool>(
+async fn get_latest_entities<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<PersistedEntity>>, StatusCode> {
-    read_from_store::<PersistedEntity, _, _, _>(pool.as_ref(), AllLatest)
+    read_from_store(pool.as_ref(), &EntityQuery::new().with_latest_version())
         .await
         .map(Json)
 }
@@ -169,7 +173,7 @@ struct UpdateEntityRequest {
     ),
     request_body = UpdateEntityRequest,
 )]
-async fn update_entity<P: GraphPool>(
+async fn update_entity<P: StorePool + Send>(
     body: Json<UpdateEntityRequest>,
     pool: Extension<Arc<P>>,
 ) -> Result<Json<PersistedEntityIdentifier>, StatusCode> {

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -126,7 +126,7 @@ async fn get_entity<P: StorePool + Send>(
 ) -> Result<Json<PersistedEntity>, StatusCode> {
     read_from_store(
         pool.as_ref(),
-        &EntityQuery::new().with_id(entity_id).with_latest_version(),
+        &EntityQuery::new().by_id(entity_id).by_latest_version(),
     )
     .await
     .and_then(|mut entities| entities.pop().ok_or(StatusCode::NOT_FOUND))
@@ -145,7 +145,7 @@ async fn get_entity<P: StorePool + Send>(
 async fn get_latest_entities<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<PersistedEntity>>, StatusCode> {
-    read_from_store(pool.as_ref(), &EntityQuery::new().with_latest_version())
+    read_from_store(pool.as_ref(), &EntityQuery::new().by_latest_version())
         .await
         .map(Json)
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -120,7 +120,7 @@ async fn create_entity_type<P: StorePool + Send>(
 async fn get_latest_entity_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<EntityType>>, StatusCode> {
-    read_from_store(pool.as_ref(), &EntityTypeQuery::new().with_latest_version())
+    read_from_store(pool.as_ref(), &EntityTypeQuery::new().by_latest_version())
         .await
         .map(Json)
 }
@@ -147,8 +147,8 @@ async fn get_entity_type<P: StorePool + Send>(
     read_from_store(
         pool.as_ref(),
         &EntityTypeQuery::new()
-            .with_uri(uri.base_uri())
-            .with_version(uri.version()),
+            .by_uri(uri.base_uri())
+            .by_version(uri.version()),
     )
     .await
     .and_then(|mut entity_types| entity_types.pop().ok_or(StatusCode::NOT_FOUND))

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -18,10 +18,10 @@ use crate::{
         AccountId,
     },
     store::{
-        crud::AllLatest,
         error::{BaseUriAlreadyExists, BaseUriDoesNotExist},
+        query::EntityTypeQuery,
+        EntityTypeStore, StorePool,
     },
-    GraphPool,
 };
 
 #[derive(OpenApi)]
@@ -41,7 +41,7 @@ pub struct EntityTypeResource;
 
 impl RoutedResource for EntityTypeResource {
     /// Create routes for interacting with entity types.
-    fn routes<P: GraphPool>() -> Router {
+    fn routes<P: StorePool + Send + 'static>() -> Router {
         // TODO: The URL format here is preliminary and will have to change.
         Router::new().nest(
             "/entity-types",
@@ -79,7 +79,7 @@ struct CreateEntityTypeRequest {
     ),
     request_body = CreateEntityTypeRequest,
 )]
-async fn create_entity_type<P: GraphPool>(
+async fn create_entity_type<P: StorePool + Send>(
     body: Json<CreateEntityTypeRequest>,
     pool: Extension<Arc<P>>,
 ) -> Result<Json<EntityType>, StatusCode> {
@@ -117,10 +117,10 @@ async fn create_entity_type<P: GraphPool>(
         (status = 500, description = "Datastore error occurred"),
     )
 )]
-async fn get_latest_entity_types<P: GraphPool>(
+async fn get_latest_entity_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<EntityType>>, StatusCode> {
-    read_from_store::<EntityType, _, _, _>(pool.as_ref(), AllLatest)
+    read_from_store(pool.as_ref(), &EntityTypeQuery::new().with_latest_version())
         .await
         .map(Json)
 }
@@ -140,13 +140,19 @@ async fn get_latest_entity_types<P: GraphPool>(
         ("uri" = String, Path, description = "The URI of the entity type"),
     )
 )]
-async fn get_entity_type<P: GraphPool>(
-    Path(uri): Path<VersionedUri>,
-    Extension(pool): Extension<Arc<P>>,
+async fn get_entity_type<P: StorePool + Send>(
+    uri: Path<VersionedUri>,
+    pool: Extension<Arc<P>>,
 ) -> Result<Json<EntityType>, StatusCode> {
-    read_from_store::<EntityType, _, _, _>(pool.as_ref(), &uri)
-        .await
-        .map(Json)
+    read_from_store(
+        pool.as_ref(),
+        &EntityTypeQuery::new()
+            .with_uri(uri.base_uri())
+            .with_version(uri.version()),
+    )
+    .await
+    .and_then(|mut entity_types| entity_types.pop().ok_or(StatusCode::NOT_FOUND))
+    .map(Json)
 }
 
 #[derive(Component, Serialize, Deserialize)]
@@ -170,7 +176,7 @@ struct UpdateEntityTypeRequest {
     ),
     request_body = UpdateEntityTypeRequest,
 )]
-async fn update_entity_type<P: GraphPool>(
+async fn update_entity_type<P: StorePool + Send>(
     body: Json<UpdateEntityTypeRequest>,
     pool: Extension<Arc<P>>,
 ) -> Result<Json<EntityType>, StatusCode> {

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
@@ -127,7 +127,7 @@ async fn get_entity_links<P: StorePool + Send>(
 ) -> Result<Json<Links>, StatusCode> {
     read_from_store(
         pool.as_ref(),
-        &LinkQuery::new().with_source_entity_id(source_entity_id),
+        &LinkQuery::new().by_source_entity_id(source_entity_id),
     )
     .await
     .and_then(|mut links| links.pop().ok_or(StatusCode::NOT_FOUND))

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -18,8 +18,9 @@ use crate::{
         types::{uri::VersionedUri, LinkType},
         AccountId,
     },
-    store::{crud::AllLatest, BaseUriAlreadyExists, BaseUriDoesNotExist},
-    GraphPool,
+    store::{
+        query::LinkTypeQuery, BaseUriAlreadyExists, BaseUriDoesNotExist, LinkTypeStore, StorePool,
+    },
 };
 
 #[derive(OpenApi)]
@@ -39,7 +40,7 @@ pub struct LinkTypeResource;
 
 impl RoutedResource for LinkTypeResource {
     /// Create routes for interacting with link types.
-    fn routes<P: GraphPool>() -> Router {
+    fn routes<P: StorePool + Send + 'static>() -> Router {
         // TODO: The URL format here is preliminary and will have to change.
         Router::new().nest(
             "/link-types",
@@ -77,7 +78,7 @@ struct CreateLinkTypeRequest {
     ),
     request_body = CreateLinkTypeRequest,
 )]
-async fn create_link_type<P: GraphPool>(
+async fn create_link_type<P: StorePool + Send>(
     body: Json<CreateLinkTypeRequest>,
     pool: Extension<Arc<P>>,
 ) -> Result<Json<LinkType>, StatusCode> {
@@ -115,10 +116,10 @@ async fn create_link_type<P: GraphPool>(
         (status = 500, description = "Store error occurred"),
     )
 )]
-async fn get_latest_link_types<P: GraphPool>(
+async fn get_latest_link_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<LinkType>>, StatusCode> {
-    read_from_store::<LinkType, _, _, _>(pool.as_ref(), AllLatest)
+    read_from_store(pool.as_ref(), &LinkTypeQuery::new().with_latest_version())
         .await
         .map(Json)
 }
@@ -138,13 +139,19 @@ async fn get_latest_link_types<P: GraphPool>(
         ("uri" = String, Path, description = "The URI of the link type"),
     )
 )]
-async fn get_link_type<P: GraphPool>(
-    Path(uri): Path<VersionedUri>,
-    Extension(pool): Extension<Arc<P>>,
+async fn get_link_type<P: StorePool + Send>(
+    uri: Path<VersionedUri>,
+    pool: Extension<Arc<P>>,
 ) -> Result<Json<LinkType>, StatusCode> {
-    read_from_store::<LinkType, _, _, _>(pool.as_ref(), &uri)
-        .await
-        .map(Json)
+    read_from_store(
+        pool.as_ref(),
+        &LinkTypeQuery::new()
+            .with_uri(uri.base_uri())
+            .with_version(uri.version()),
+    )
+    .await
+    .and_then(|mut link_types| link_types.pop().ok_or(StatusCode::NOT_FOUND))
+    .map(Json)
 }
 
 #[derive(Component, Serialize, Deserialize)]
@@ -168,7 +175,7 @@ struct UpdateLinkTypeRequest {
     ),
     request_body = UpdateLinkTypeRequest,
 )]
-async fn update_link_type<P: GraphPool>(
+async fn update_link_type<P: StorePool + Send>(
     body: Json<UpdateLinkTypeRequest>,
     pool: Extension<Arc<P>>,
 ) -> Result<Json<LinkType>, StatusCode> {

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -119,7 +119,7 @@ async fn create_link_type<P: StorePool + Send>(
 async fn get_latest_link_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<LinkType>>, StatusCode> {
-    read_from_store(pool.as_ref(), &LinkTypeQuery::new().with_latest_version())
+    read_from_store(pool.as_ref(), &LinkTypeQuery::new().by_latest_version())
         .await
         .map(Json)
 }
@@ -146,8 +146,8 @@ async fn get_link_type<P: StorePool + Send>(
     read_from_store(
         pool.as_ref(),
         &LinkTypeQuery::new()
-            .with_uri(uri.base_uri())
-            .with_version(uri.version()),
+            .by_uri(uri.base_uri())
+            .by_version(uri.version()),
     )
     .await
     .and_then(|mut link_types| link_types.pop().ok_or(StatusCode::NOT_FOUND))

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -120,12 +120,9 @@ async fn create_property_type<P: StorePool + Send>(
 async fn get_latest_property_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<PropertyType>>, StatusCode> {
-    read_from_store(
-        pool.as_ref(),
-        &PropertyTypeQuery::new().by_latest_version(),
-    )
-    .await
-    .map(Json)
+    read_from_store(pool.as_ref(), &PropertyTypeQuery::new().by_latest_version())
+        .await
+        .map(Json)
 }
 
 #[utoipa::path(

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -18,8 +18,10 @@ use crate::{
         types::{uri::VersionedUri, PropertyType},
         AccountId,
     },
-    store::{crud::AllLatest, BaseUriAlreadyExists, BaseUriDoesNotExist},
-    GraphPool,
+    store::{
+        query::PropertyTypeQuery, BaseUriAlreadyExists, BaseUriDoesNotExist, PropertyTypeStore,
+        StorePool,
+    },
 };
 
 #[derive(OpenApi)]
@@ -39,7 +41,7 @@ pub struct PropertyTypeResource;
 
 impl RoutedResource for PropertyTypeResource {
     /// Create routes for interacting with property types.
-    fn routes<P: GraphPool>() -> Router {
+    fn routes<P: StorePool + Send + 'static>() -> Router {
         // TODO: The URL format here is preliminary and will have to change.
         Router::new().nest(
             "/property-types",
@@ -77,7 +79,7 @@ struct CreatePropertyTypeRequest {
     ),
     request_body = CreatePropertyTypeRequest,
 )]
-async fn create_property_type<P: GraphPool>(
+async fn create_property_type<P: StorePool + Send>(
     body: Json<CreatePropertyTypeRequest>,
     pool: Extension<Arc<P>>,
 ) -> Result<Json<PropertyType>, StatusCode> {
@@ -115,12 +117,15 @@ async fn create_property_type<P: GraphPool>(
         (status = 500, description = "Store error occurred"),
     )
 )]
-async fn get_latest_property_types<P: GraphPool>(
+async fn get_latest_property_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<PropertyType>>, StatusCode> {
-    read_from_store::<PropertyType, _, _, _>(pool.as_ref(), AllLatest)
-        .await
-        .map(Json)
+    read_from_store(
+        pool.as_ref(),
+        &PropertyTypeQuery::new().with_latest_version(),
+    )
+    .await
+    .map(Json)
 }
 
 #[utoipa::path(
@@ -138,13 +143,19 @@ async fn get_latest_property_types<P: GraphPool>(
         ("uri" = String, Path, description = "The URI of the property type"),
     )
 )]
-async fn get_property_type<P: GraphPool>(
-    Path(uri): Path<VersionedUri>,
-    Extension(pool): Extension<Arc<P>>,
+async fn get_property_type<P: StorePool + Send>(
+    uri: Path<VersionedUri>,
+    pool: Extension<Arc<P>>,
 ) -> Result<Json<PropertyType>, StatusCode> {
-    read_from_store::<PropertyType, _, _, _>(pool.as_ref(), &uri)
-        .await
-        .map(Json)
+    read_from_store(
+        pool.as_ref(),
+        &PropertyTypeQuery::new()
+            .with_uri(uri.base_uri())
+            .with_version(uri.version()),
+    )
+    .await
+    .and_then(|mut property_types| property_types.pop().ok_or(StatusCode::NOT_FOUND))
+    .map(Json)
 }
 
 #[derive(Component, Serialize, Deserialize)]
@@ -168,7 +179,7 @@ struct UpdatePropertyTypeRequest {
     ),
     request_body = UpdatePropertyTypeRequest,
 )]
-async fn update_property_type<P: GraphPool>(
+async fn update_property_type<P: StorePool + Send>(
     body: Json<UpdatePropertyTypeRequest>,
     pool: Extension<Arc<P>>,
 ) -> Result<Json<PropertyType>, StatusCode> {

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -122,7 +122,7 @@ async fn get_latest_property_types<P: StorePool + Send>(
 ) -> Result<Json<Vec<PropertyType>>, StatusCode> {
     read_from_store(
         pool.as_ref(),
-        &PropertyTypeQuery::new().with_latest_version(),
+        &PropertyTypeQuery::new().by_latest_version(),
     )
     .await
     .map(Json)
@@ -150,8 +150,8 @@ async fn get_property_type<P: StorePool + Send>(
     read_from_store(
         pool.as_ref(),
         &PropertyTypeQuery::new()
-            .with_uri(uri.base_uri())
-            .with_version(uri.version()),
+            .by_uri(uri.base_uri())
+            .by_version(uri.version()),
     )
     .await
     .and_then(|mut property_types| property_types.pop().ok_or(StatusCode::NOT_FOUND))

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -6,9 +6,9 @@ use tokio_postgres::types::{FromSql, ToSql};
 use utoipa::Component;
 use uuid::Uuid;
 
-use crate::{
-    ontology::{types::uri::BaseUri, AccountId},
-    VersionedUri,
+use crate::ontology::{
+    types::uri::{BaseUri, VersionedUri},
+    AccountId,
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Component, FromSql, ToSql)]

--- a/packages/graph/hash_graph/lib/graph/src/lib.rs
+++ b/packages/graph/hash_graph/lib/graph/src/lib.rs
@@ -53,15 +53,6 @@
               the negative part, though"
 )]
 
-use crate::{
-    knowledge::{Entity, EntityId, Link, Links, PersistedEntity},
-    ontology::types::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType},
-    store::{
-        crud::{AllLatest, Read},
-        Store, StorePool,
-    },
-};
-
 pub mod api;
 
 pub mod knowledge;
@@ -74,21 +65,3 @@ pub mod logging;
 #[cfg(test)]
 #[path = "../../../tests/test_data/lib.rs"]
 mod test_data;
-
-/// Abstraction over [`StorePool`] for [`Graph`]s.
-pub trait GraphPool = StorePool + 'static where for<'pool> <Self as StorePool>::Store<'pool>: Graph;
-
-/// Interface for a [`Store`].
-pub trait Graph = where
-    for<'i> Self: Store
-        + Read<'i, AllLatest, DataType, Output = Vec<DataType>>
-        + Read<'i, AllLatest, PropertyType, Output = Vec<PropertyType>>
-        + Read<'i, AllLatest, LinkType, Output = Vec<LinkType>>
-        + Read<'i, AllLatest, EntityType, Output = Vec<EntityType>>
-        + Read<'i, AllLatest, PersistedEntity, Output = Vec<PersistedEntity>>
-        + Read<'i, &'i VersionedUri, DataType, Output = DataType>
-        + Read<'i, &'i VersionedUri, PropertyType, Output = PropertyType>
-        + Read<'i, &'i VersionedUri, LinkType, Output = LinkType>
-        + Read<'i, &'i VersionedUri, EntityType, Output = EntityType>
-        + Read<'i, EntityId, PersistedEntity, Output = PersistedEntity>
-        + Read<'i, EntityId, Link, Output = Links>;

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -9,8 +9,7 @@ use tokio_postgres::types::{FromSql, ToSql};
 use utoipa::Component;
 use uuid::Uuid;
 
-// TODO - find a good place for AccountId and VersionId, perhaps they will become redundant in a
-//  future design
+// TODO - find a good place for AccountId, perhaps it will become redundant in a future design
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Component, FromSql, ToSql)]
 #[repr(transparent)]

--- a/packages/graph/hash_graph/lib/graph/src/ontology/types/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/types/data_type/mod.rs
@@ -8,7 +8,6 @@ use crate::ontology::types::{
     error::ValidationError,
     serde_shared::object::ValidateUri,
     uri::{BaseUri, VersionedUri},
-    OntologyType,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -69,12 +68,6 @@ pub struct DataType {
     /// catch-all field to store all non-typed data.
     #[serde(flatten)]
     additional_properties: HashMap<String, serde_json::Value>,
-}
-
-impl OntologyType for DataType {
-    fn uri(&self) -> &VersionedUri {
-        self.id()
-    }
 }
 
 impl DataType {

--- a/packages/graph/hash_graph/lib/graph/src/ontology/types/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/types/entity_type/mod.rs
@@ -11,7 +11,6 @@ use crate::ontology::types::{
     property_type::PropertyTypeReference,
     serde_shared::object::{Object, ValidateUri},
     uri::{BaseUri, VersionedUri},
-    OntologyType,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -74,12 +73,6 @@ pub struct EntityType {
     property_object: Object<PropertyTypeReference>,
     #[serde(flatten)]
     links: Links,
-}
-
-impl OntologyType for EntityType {
-    fn uri(&self) -> &VersionedUri {
-        self.id()
-    }
 }
 
 impl EntityType {

--- a/packages/graph/hash_graph/lib/graph/src/ontology/types/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/types/link_type/mod.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::ontology::types::{uri::VersionedUri, OntologyType};
+use crate::ontology::types::uri::VersionedUri;
 
 /// Will serialize as a constant value `"linkType"`
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -19,12 +19,6 @@ pub struct LinkType {
     description: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     related_keywords: Vec<String>,
-}
-
-impl OntologyType for LinkType {
-    fn uri(&self) -> &VersionedUri {
-        self.id()
-    }
 }
 
 impl LinkType {

--- a/packages/graph/hash_graph/lib/graph/src/ontology/types/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/types/mod.rs
@@ -15,7 +15,6 @@ mod entity_type;
 mod link_type;
 mod property_type;
 
-use crate::ontology::types::uri::VersionedUri;
 pub use crate::ontology::types::{
     data_type::{DataType, DataTypeReference},
     entity_type::{EntityType, EntityTypeReference},
@@ -26,8 +25,3 @@ pub use crate::ontology::types::{
 pub mod error;
 
 mod serde_shared;
-
-pub trait OntologyType {
-    /// Returns the unique versioned URI used to identify this instance of a type.
-    fn uri(&self) -> &VersionedUri;
-}

--- a/packages/graph/hash_graph/lib/graph/src/ontology/types/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/types/property_type/mod.rs
@@ -12,7 +12,6 @@ use crate::ontology::types::{
         one_of::OneOf,
     },
     uri::{BaseUri, VersionedUri},
-    OntologyType,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -130,12 +129,6 @@ pub struct PropertyType {
     description: Option<String>,
     #[serde(flatten)]
     one_of: OneOf<PropertyValues>,
-}
-
-impl OntologyType for PropertyType {
-    fn uri(&self) -> &VersionedUri {
-        self.id()
-    }
 }
 
 impl PropertyType {

--- a/packages/graph/hash_graph/lib/graph/src/store/crud.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/crud.rs
@@ -5,6 +5,7 @@
 //! [`Store`] without changing the [`Store`] implementation.
 
 use std::fmt::Debug;
+
 use async_trait::async_trait;
 use error_stack::Result;
 

--- a/packages/graph/hash_graph/lib/graph/src/store/crud.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/crud.rs
@@ -3,6 +3,8 @@
 //! The traits defined in this module are used in [`Store`] to create, read, update, and delete
 //! entries. They form a unified access to the [`Store`], so it's possible to add operations to the
 //! [`Store`] without changing the [`Store`] implementation.
+//!
+//! [`Store`]: crate::store::Store
 
 use std::fmt::Debug;
 
@@ -12,12 +14,16 @@ use error_stack::Result;
 use crate::store::QueryError;
 
 /// Read access to a [`Store`].
+///
+/// [`Store`]: crate::store::Store
 #[async_trait]
 pub trait Read<T: Send>: Sync {
     // TODO: Implement `Valuable` for queries and use them directly
     type Query<'q>: Debug + Sync;
 
     /// Returns a value from the [`Store`] specified by `identifier`.
+    ///
+    /// [`Store`]: crate::store::Store
     async fn read<'query>(&self, query: &Self::Query<'query>) -> Result<Vec<T>, QueryError>;
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/crud.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/crud.rs
@@ -4,34 +4,20 @@
 //! entries. They form a unified access to the [`Store`], so it's possible to add operations to the
 //! [`Store`] without changing the [`Store`] implementation.
 
+use std::fmt::Debug;
 use async_trait::async_trait;
 use error_stack::Result;
 
-use crate::store::{QueryError, Store};
-
-/// Marker to return the latest version of all records.
-#[derive(Copy, Clone, Debug)]
-pub struct AllLatest;
+use crate::store::QueryError;
 
 /// Read access to a [`Store`].
-// TODO: Change the way we are interacting with this trait (or change the trait).
-//   With our current design we need to specify a marker, what exactly we want to extract. For some
-//   things this is intuitive like a `&VersionedUri`, which will return exactly one type, but for
-//   other types, like `&BaseUri` this does not convey the meaning well enough. This could return
-//   only the latest version of a type or all types with this URI. This would imply, that we need
-//   a marker struct for each meaning, i.e. `Latest<'i, BaseUri>(&'i BaseUri)`. In addition to that,
-//   we want to extend our interface to structural querying, so something like an `AST` needs to be
-//   aware of the types.
-//   As an example why this is bad see the `AllLatest` marker struct.
 #[async_trait]
-pub trait Read<'i, I: Send + 'i, T>: Store {
-    /// Output returned when getting the value by the identifier `I`.
-    type Output;
+pub trait Read<T: Send>: Sync {
+    // TODO: Implement `Valuable` for queries and use them directly
+    type Query<'q>: Debug + Sync;
 
     /// Returns a value from the [`Store`] specified by `identifier`.
-    async fn get(&self, identifier: I) -> Result<Self::Output, QueryError>
-    where
-        'i: 'async_trait;
+    async fn read<'query>(&self, query: &Self::Query<'query>) -> Result<Vec<T>, QueryError>;
 }
 
 // TODO: Add remaining CRUD traits (but probably don't implement the `D`-part)

--- a/packages/graph/hash_graph/lib/graph/src/store/crud.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/crud.rs
@@ -25,6 +25,8 @@ pub trait Read<T: Send>: Sync {
     ///
     /// [`Store`]: crate::store::Store
     async fn read<'query>(&self, query: &Self::Query<'query>) -> Result<Vec<T>, QueryError>;
+
+    // TODO: Consider adding additional methods, which defaults to `read` e.g. reading exactly one
 }
 
 // TODO: Add remaining CRUD traits (but probably don't implement the `D`-part)

--- a/packages/graph/hash_graph/lib/graph/src/store/crud.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/crud.rs
@@ -21,7 +21,7 @@ pub trait Read<T: Send>: Sync {
     // TODO: Implement `Valuable` for queries and use them directly
     type Query<'q>: Debug + Sync;
 
-    /// Returns a value from the [`Store`] specified by `identifier`.
+    /// Returns a value from the [`Store`] specified by the passed `query`.
     ///
     /// [`Store`]: crate::store::Store
     async fn read<'query>(&self, query: &Self::Query<'query>) -> Result<Vec<T>, QueryError>;

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -201,7 +201,7 @@ pub trait DataTypeStore: for<'q> crud::Read<DataType, Query<'q> = DataTypeQuery<
         created_by: AccountId,
     ) -> Result<(), InsertionError>;
 
-    /// Get the [`DataType`] by the specified [`DataTypeQuery`].
+    /// Get the [`DataType`]s specified by the [`DataTypeQuery`].
     ///
     /// # Errors
     ///
@@ -241,7 +241,7 @@ pub trait PropertyTypeStore:
         created_by: AccountId,
     ) -> Result<(), InsertionError>;
 
-    /// Get the [`PropertyType`] specified by `identifier`.
+    /// Get the [`PropertyType`]s specified by the [`PropertyTypeQuery`].
     ///
     /// # Errors
     ///
@@ -282,7 +282,7 @@ pub trait EntityTypeStore: for<'q> crud::Read<EntityType, Query<'q> = EntityType
         created_by: AccountId,
     ) -> Result<(), InsertionError>;
 
-    /// Get the [`EntityType`] specified by `identifier`.
+    /// Get the [`EntityType`]s specified by the [`EntityTypeQuery`].
     ///
     /// # Errors
     ///
@@ -323,7 +323,7 @@ pub trait LinkTypeStore: for<'q> crud::Read<LinkType, Query<'q> = LinkTypeQuery<
         created_by: AccountId,
     ) -> Result<(), InsertionError>;
 
-    /// Get the [`LinkType`] specified by `identifier`.
+    /// Get the [`LinkType`]s specified by the [`LinkTypeQuery`].
     ///
     /// # Errors
     ///
@@ -361,7 +361,7 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = EntityQue
         created_by: AccountId,
     ) -> Result<PersistedEntityIdentifier, InsertionError>;
 
-    /// Get the [`PersistedEntity`] specified by `identifier`.
+    /// Get the [`PersistedEntity`] specified by the [`EntityQuery`].
     ///
     /// # Errors
     ///

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -16,7 +16,7 @@ pub use self::{
     postgres::{AsClient, PostgresStore, PostgresStorePool},
 };
 use crate::{
-    knowledge::{Entity, EntityId, Link, Links, PersistedEntityIdentifier},
+    knowledge::{Entity, EntityId, Link, Links, PersistedEntity, PersistedEntityIdentifier},
     ontology::{
         types::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType},
         AccountId,
@@ -29,7 +29,6 @@ use crate::{
         },
     },
 };
-use crate::knowledge::PersistedEntity;
 
 #[derive(Debug)]
 pub struct StoreError;

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -1,5 +1,6 @@
 pub mod crud;
 pub mod error;
+pub mod query;
 
 mod pool;
 mod postgres;
@@ -9,21 +10,26 @@ use std::fmt;
 use async_trait::async_trait;
 use error_stack::{Context, Result};
 
-use self::error::LinkActivationError;
 pub use self::{
     error::{BaseUriAlreadyExists, BaseUriDoesNotExist, InsertionError, QueryError, UpdateError},
     pool::StorePool,
     postgres::{AsClient, PostgresStore, PostgresStorePool},
 };
 use crate::{
-    knowledge::{Entity, EntityId, Link, PersistedEntityIdentifier},
+    knowledge::{Entity, EntityId, Link, Links, PersistedEntityIdentifier},
     ontology::{
-        types::{uri::VersionedUri, EntityType, LinkType, PropertyType},
+        types::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType},
         AccountId,
     },
-    store::crud::Read,
-    DataType, PersistedEntity,
+    store::{
+        error::LinkActivationError,
+        query::{
+            DataTypeQuery, EntityQuery, EntityTypeQuery, LinkQuery, LinkTypeQuery,
+            PropertyTypeQuery,
+        },
+    },
 };
+use crate::knowledge::PersistedEntity;
 
 #[derive(Debug)]
 pub struct StoreError;
@@ -181,7 +187,7 @@ pub trait Store =
 
 /// Describes the API of a store implementation for [`DataType`]s.
 #[async_trait]
-pub trait DataTypeStore {
+pub trait DataTypeStore: for<'q> crud::Read<DataType, Query<'q> = DataTypeQuery<'q>> {
     /// Creates a new [`DataType`].
     ///
     /// # Errors:
@@ -196,16 +202,13 @@ pub trait DataTypeStore {
         created_by: AccountId,
     ) -> Result<(), InsertionError>;
 
-    /// Get the [`DataType`] specified by `identifier`.
+    /// Get the [`DataType`] by the specified [`OntologyQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`DataType`] doesn't exist.
-    async fn get_data_type<'i, I: Send>(&self, identifier: I) -> Result<Self::Output, QueryError>
-    where
-        Self: Read<'i, I, DataType>,
-    {
-        self.get(identifier).await
+    async fn get_data_type(&self, query: &DataTypeQuery<'_>) -> Result<Vec<DataType>, QueryError> {
+        self.read(query).await
     }
 
     /// Update the definition of an existing [`DataType`].
@@ -222,7 +225,9 @@ pub trait DataTypeStore {
 
 /// Describes the API of a store implementation for [`PropertyType`]s.
 #[async_trait]
-pub trait PropertyTypeStore {
+pub trait PropertyTypeStore:
+    for<'q> crud::Read<PropertyType, Query<'q> = PropertyTypeQuery<'q>>
+{
     /// Creates a new [`PropertyType`].
     ///
     /// # Errors:
@@ -242,14 +247,11 @@ pub trait PropertyTypeStore {
     /// # Errors
     ///
     /// - if the requested [`PropertyType`] doesn't exist.
-    async fn get_property_type<'i, I: Send>(
+    async fn get_property_type(
         &self,
-        identifier: I,
-    ) -> Result<Self::Output, QueryError>
-    where
-        Self: Read<'i, I, PropertyType>,
-    {
-        self.get(identifier).await
+        query: &PropertyTypeQuery<'_>,
+    ) -> Result<Vec<PropertyType>, QueryError> {
+        self.read(query).await
     }
 
     /// Update the definition of an existing [`PropertyType`].
@@ -266,7 +268,7 @@ pub trait PropertyTypeStore {
 
 /// Describes the API of a store implementation for [`EntityType`]s.
 #[async_trait]
-pub trait EntityTypeStore {
+pub trait EntityTypeStore: for<'q> crud::Read<EntityType, Query<'q> = EntityTypeQuery<'q>> {
     /// Creates a new [`EntityType`].
     ///
     /// # Errors:
@@ -286,11 +288,11 @@ pub trait EntityTypeStore {
     /// # Errors
     ///
     /// - if the requested [`EntityType`] doesn't exist.
-    async fn get_entity_type<'i, I: Send>(&self, identifier: I) -> Result<Self::Output, QueryError>
-    where
-        Self: Read<'i, I, EntityType>,
-    {
-        self.get(identifier).await
+    async fn get_entity_type(
+        &self,
+        query: &EntityTypeQuery<'_>,
+    ) -> Result<Vec<EntityType>, QueryError> {
+        self.read(query).await
     }
 
     /// Update the definition of an existing [`EntityType`].
@@ -307,7 +309,7 @@ pub trait EntityTypeStore {
 
 /// Describes the API of a store implementation for [`LinkType`]s.
 #[async_trait]
-pub trait LinkTypeStore {
+pub trait LinkTypeStore: for<'q> crud::Read<LinkType, Query<'q> = LinkTypeQuery<'q>> {
     /// Creates a new [`LinkType`].
     ///
     /// # Errors:
@@ -327,11 +329,8 @@ pub trait LinkTypeStore {
     /// # Errors
     ///
     /// - if the requested [`LinkType`] doesn't exist.
-    async fn get_link_type<'i, I: Send>(&self, identifier: I) -> Result<Self::Output, QueryError>
-    where
-        Self: Read<'i, I, LinkType>,
-    {
-        self.get(identifier).await
+    async fn get_link_type(&self, query: &LinkTypeQuery<'_>) -> Result<Vec<LinkType>, QueryError> {
+        self.read(query).await
     }
 
     /// Update the definition of an existing [`LinkType`].
@@ -348,7 +347,7 @@ pub trait LinkTypeStore {
 
 /// Describes the API of a store implementation for Entities.
 #[async_trait]
-pub trait EntityStore {
+pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = EntityQuery> {
     /// Creates a new [`Entity`].
     ///
     /// # Errors:
@@ -370,11 +369,8 @@ pub trait EntityStore {
     /// # Errors
     ///
     /// - if the requested [`Entity`] doesn't exist
-    async fn get_entity<'i, I: Send>(&self, identifier: I) -> Result<Self::Output, QueryError>
-    where
-        Self: Read<'i, I, PersistedEntity>,
-    {
-        self.get(identifier).await
+    async fn get_entity(&self, query: &EntityQuery) -> Result<Vec<PersistedEntity>, QueryError> {
+        self.read(query).await
     }
 
     /// Update an existing [`Entity`].
@@ -396,7 +392,7 @@ pub trait EntityStore {
 
 /// Describes the API of a store implementation for [`Link`]s.
 #[async_trait]
-pub trait LinkStore {
+pub trait LinkStore: for<'q> crud::Read<Links, Query<'q> = LinkQuery<'q>> {
     /// Creates a new [`Link`].
     ///
     /// # Errors:
@@ -410,34 +406,13 @@ pub trait LinkStore {
         created_by: AccountId,
     ) -> Result<(), InsertionError>;
 
-    /// Get one or multiple [`Link`]s of an [`Entity`] specified by `identifier`.
-    ///
-    /// Depending on the `identifier` the output is specified by [`Read::Output`].
+    /// Get the [`Links`] specified by the [`LinkQuery`].
     ///
     /// # Errors
     ///
-    /// - if the requested [`Entity`] doesn't exist
-    async fn get_entity_links<'i, I: Send>(&self, identifier: I) -> Result<Self::Output, QueryError>
-    where
-        Self: Read<'i, I, Link>,
-    {
-        self.get(identifier).await
-    }
-
-    /// Get a [`Link`] target identified by an [`EntityId`] and a Link Type [`VersionedUri`].
-    ///
-    /// # Errors
-    ///
-    /// - if the requested [`Entity`] doesn't exist
-    async fn get_link_target<'i, E: Send, L: Send>(
-        &self,
-        source_entity: E,
-        link_type: L,
-    ) -> Result<Self::Output, QueryError>
-    where
-        Self: Read<'i, (E, L), Link>,
-    {
-        self.get((source_entity, link_type)).await
+    /// - if the requested [`Links`] don't exist.
+    async fn get_links(&self, query: &LinkQuery<'_>) -> Result<Vec<Links>, QueryError> {
+        self.read(query).await
     }
 
     /// Inactivates a [`Link`] between a source and target [`Entity`].

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -201,7 +201,7 @@ pub trait DataTypeStore: for<'q> crud::Read<DataType, Query<'q> = DataTypeQuery<
         created_by: AccountId,
     ) -> Result<(), InsertionError>;
 
-    /// Get the [`DataType`] by the specified [`OntologyQuery`].
+    /// Get the [`DataType`] by the specified [`DataTypeQuery`].
     ///
     /// # Errors
     ///
@@ -362,8 +362,6 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = EntityQue
     ) -> Result<PersistedEntityIdentifier, InsertionError>;
 
     /// Get the [`PersistedEntity`] specified by `identifier`.
-    ///
-    /// Depending on the `identifier` the output is specified by [`Read::Output`].
     ///
     /// # Errors
     ///

--- a/packages/graph/hash_graph/lib/graph/src/store/pool.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/pool.rs
@@ -5,12 +5,12 @@ use crate::store::Store;
 
 /// Managed pool to keep track about [`Store`]s.
 #[async_trait]
-pub trait StorePool: Send + Sync {
+pub trait StorePool: Sync {
     /// The error returned when acquiring a [`Store`].
     type Error;
 
     /// The store returned when acquiring.
-    type Store<'pool>: Store + Send + Sync
+    type Store<'pool>: Store + Send
     where
         Self: 'pool;
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -6,14 +6,13 @@ use tokio_postgres::GenericClient;
 use uuid::Uuid;
 
 use crate::{
-    knowledge::{Entity, EntityId},
+    knowledge::{Entity, EntityId, PersistedEntityIdentifier},
     ontology::{types::uri::VersionedUri, AccountId},
     store::{
         error::EntityDoesNotExist, AsClient, EntityStore, InsertionError, PostgresStore,
         UpdateError,
     },
 };
-use crate::knowledge::PersistedEntityIdentifier;
 
 #[async_trait]
 impl<C: AsClient> EntityStore for PostgresStore<C> {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -6,14 +6,14 @@ use tokio_postgres::GenericClient;
 use uuid::Uuid;
 
 use crate::{
-    knowledge::PersistedEntityIdentifier,
-    ontology::AccountId,
+    knowledge::{Entity, EntityId},
+    ontology::{types::uri::VersionedUri, AccountId},
     store::{
         error::EntityDoesNotExist, AsClient, EntityStore, InsertionError, PostgresStore,
         UpdateError,
     },
-    Entity, EntityId, VersionedUri,
 };
+use crate::knowledge::PersistedEntityIdentifier;
 
 #[async_trait]
 impl<C: AsClient> EntityStore for PostgresStore<C> {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -6,81 +6,62 @@ use postgres_types::ToSql;
 use tokio_postgres::GenericClient;
 
 use crate::{
-    knowledge::EntityId,
-    ontology::AccountId,
-    store::{crud, AsClient, PostgresStore, QueryError},
-    AllLatest, PersistedEntity, VersionedUri,
+    knowledge::{EntityId, PersistedEntity},
+    ontology::{types::uri::VersionedUri, AccountId},
+    store::{
+        crud,
+        query::{EntityQuery, EntityVersion},
+        AsClient, PostgresStore, QueryError,
+    },
 };
 
 #[async_trait]
-impl<C: AsClient> crud::Read<'_, EntityId, PersistedEntity> for PostgresStore<C> {
-    type Output = PersistedEntity;
+impl<C: AsClient> crud::Read<PersistedEntity> for PostgresStore<C> {
+    type Query<'q> = EntityQuery;
 
-    async fn get(&self, identifier: EntityId) -> Result<Self::Output, QueryError> {
-        let row = self
-            .as_client()
-            .query_one(
-                r#"
-                SELECT properties, entity_id, entities.version, ids.base_uri, ids.version, created_by
-                FROM entities
-                INNER JOIN ids ON ids.version_id = entities.entity_type_version_id
-                WHERE entity_id = $1 AND entities.version = (
-                    SELECT MAX("version")
-                    FROM entities
-                    WHERE entity_id = $1
-                );
-                "#,
-                &[&identifier],
-            )
-            .await
-            .report()
-            .change_context(QueryError)
-            .attach_printable(identifier)?;
-
-        let entity = serde_json::from_value(row.get(0))
-            .report()
-            .change_context(QueryError)?;
-
-        let entity_id: EntityId = row.get(1);
-        let entity_version: DateTime<Utc> = row.get(2);
-        let type_base_uri: String = row.get(3);
-        let type_version: i64 = row.get(4);
-        let created_by: AccountId = row.get(5);
-
-        let type_versioned_uri = VersionedUri::new(type_base_uri, type_version as u32);
-        Ok(PersistedEntity::new(
-            entity,
-            entity_id,
-            entity_version,
-            type_versioned_uri,
-            created_by,
-        ))
-    }
-}
-
-#[async_trait]
-impl<C: AsClient> crud::Read<'_, AllLatest, PersistedEntity> for PostgresStore<C> {
-    type Output = Vec<PersistedEntity>;
-
-    async fn get(&self, _: AllLatest) -> Result<Self::Output, QueryError> {
-        let row_stream = self
-            .as_client()
-            .query_raw(
-                r#"
-                SELECT DISTINCT ON(entity_id) properties, entity_id, entities.version, ids.base_uri, ids.version, created_by
-                FROM entities
-                INNER JOIN ids ON ids.version_id = entities.entity_type_version_id
-                ORDER BY entity_id, entities.version DESC;
-                "#,
-                // Requires a concrete type, which implements
-                // `IntoIterator<Item = impl BorrowToSql>`
-                [] as [&(dyn ToSql + Sync); 0],
-            )
-            .await
-            .report()
-            .change_context(QueryError)?;
+    async fn read<'query>(
+        &self,
+        query: &Self::Query<'query>,
+    ) -> Result<Vec<PersistedEntity>, QueryError> {
+        let row_stream = match (query.id(), query.version()) {
+            (Some(entity_id), Some(EntityVersion::Latest)) => {
+                self.as_client()
+                    .query_raw(
+                        r#"
+                        SELECT properties, entity_id, entities.version, ids.base_uri, ids.version, created_by
+                        FROM entities
+                        INNER JOIN ids ON ids.version_id = entities.entity_type_version_id
+                        WHERE entity_id = $1 AND entities.version = (
+                            SELECT MAX("version")
+                            FROM entities
+                            WHERE entity_id = $1
+                        );
+                        "#,
+                        &[&entity_id],
+                    )
+                    .await
+            }
+            (None, Some(EntityVersion::Latest)) => {
+                self.as_client()
+                    .query_raw(
+                        r#"
+                        SELECT DISTINCT ON(entity_id) properties, entity_id, entities.version, ids.base_uri, ids.version, created_by
+                        FROM entities
+                        INNER JOIN ids ON ids.version_id = entities.entity_type_version_id
+                        ORDER BY entity_id, entities.version DESC;
+                        "#,
+                        // Requires a concrete type, which implements
+                        // `IntoIterator<Item = impl BorrowToSql>`
+                        [] as [&(dyn ToSql + Sync); 0],
+                    )
+                    .await
+            }
+            _ => todo!(),
+        };
 
         row_stream
+            .report()
+            .change_context(QueryError)?
             .map(|row_result| {
                 let row = row_result.report().change_context(QueryError)?;
                 let entity = serde_json::from_value(row.get(0))

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use error_stack::{IntoReport, Result, ResultExt};
 use futures::{StreamExt, TryStreamExt};
 use postgres_types::ToSql;
-use tokio_postgres::GenericClient;
+use tokio_postgres::{GenericClient, RowStream};
 
 use crate::{
     knowledge::{EntityId, PersistedEntity},
@@ -15,6 +15,45 @@ use crate::{
     },
 };
 
+async fn by_id_by_latest_version(
+    client: &(impl GenericClient + Sync),
+    entity_id: EntityId,
+) -> Result<RowStream, QueryError> {
+    client
+        .query_raw(
+            r#"
+            SELECT properties, entity_id, entities.version, ids.base_uri, ids.version, created_by
+            FROM entities
+            INNER JOIN ids ON ids.version_id = entities.entity_type_version_id
+            WHERE entity_id = $1 AND entities.version = (
+                SELECT MAX("version")
+                FROM entities
+                WHERE entity_id = $1
+            );
+            "#,
+            &[&entity_id],
+        )
+        .await
+        .into_report()
+        .change_context(QueryError)
+}
+
+async fn by_latest_version(client: &(impl GenericClient + Sync)) -> Result<RowStream, QueryError> {
+    client
+        .query_raw(
+            r#"
+            SELECT DISTINCT ON(entity_id) properties, entity_id, entities.version, ids.base_uri, ids.version, created_by
+            FROM entities
+            INNER JOIN ids ON ids.version_id = entities.entity_type_version_id
+            ORDER BY entity_id, entities.version DESC;
+            "#,
+            // Requires a concrete type, which implements `IntoIterator<Item = impl BorrowToSql>`
+            [] as [&(dyn ToSql + Sync); 0],
+        ).await
+        .into_report()
+        .change_context(QueryError)
+}
+
 #[async_trait]
 impl<C: AsClient> crud::Read<PersistedEntity> for PostgresStore<C> {
     type Query<'q> = EntityQuery;
@@ -25,43 +64,13 @@ impl<C: AsClient> crud::Read<PersistedEntity> for PostgresStore<C> {
     ) -> Result<Vec<PersistedEntity>, QueryError> {
         let row_stream = match (query.id(), query.version()) {
             (Some(entity_id), Some(EntityVersion::Latest)) => {
-                self.as_client()
-                    .query_raw(
-                        r#"
-                        SELECT properties, entity_id, entities.version, ids.base_uri, ids.version, created_by
-                        FROM entities
-                        INNER JOIN ids ON ids.version_id = entities.entity_type_version_id
-                        WHERE entity_id = $1 AND entities.version = (
-                            SELECT MAX("version")
-                            FROM entities
-                            WHERE entity_id = $1
-                        );
-                        "#,
-                        &[&entity_id],
-                    )
-                    .await
+                by_id_by_latest_version(self.as_client(), entity_id).await?
             }
-            (None, Some(EntityVersion::Latest)) => {
-                self.as_client()
-                    .query_raw(
-                        r#"
-                        SELECT DISTINCT ON(entity_id) properties, entity_id, entities.version, ids.base_uri, ids.version, created_by
-                        FROM entities
-                        INNER JOIN ids ON ids.version_id = entities.entity_type_version_id
-                        ORDER BY entity_id, entities.version DESC;
-                        "#,
-                        // Requires a concrete type, which implements
-                        // `IntoIterator<Item = impl BorrowToSql>`
-                        [] as [&(dyn ToSql + Sync); 0],
-                    )
-                    .await
-            }
+            (None, Some(EntityVersion::Latest)) => by_latest_version(self.as_client()).await?,
             _ => todo!(),
         };
 
         row_stream
-            .into_report()
-            .change_context(QueryError)?
             .map(|row_result| {
                 let row = row_result.into_report().change_context(QueryError)?;
                 let entity = serde_json::from_value(row.get(0))

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -10,6 +10,7 @@ use crate::{
     ontology::{types::uri::VersionedUri, AccountId},
     store::{
         crud,
+        postgres::parameter_list,
         query::{EntityQuery, EntityVersion},
         AsClient, PostgresStore, QueryError,
     },
@@ -31,7 +32,7 @@ async fn by_id_by_latest_version(
                 WHERE entity_id = $1
             );
             "#,
-            &[&entity_id],
+            parameter_list([&entity_id]),
         )
         .await
         .into_report()
@@ -47,8 +48,7 @@ async fn by_latest_version(client: &(impl GenericClient + Sync)) -> Result<RowSt
             INNER JOIN ids ON ids.version_id = entities.entity_type_version_id
             ORDER BY entity_id, entities.version DESC;
             "#,
-            // Requires a concrete type, which implements `IntoIterator<Item = impl BorrowToSql>`
-            [] as [&(dyn ToSql + Sync); 0],
+            parameter_list([]),
         ).await
         .into_report()
         .change_context(QueryError)

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -2,7 +2,6 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use error_stack::{IntoReport, Result, ResultExt};
 use futures::{StreamExt, TryStreamExt};
-use postgres_types::ToSql;
 use tokio_postgres::{GenericClient, RowStream};
 
 use crate::{

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/read.rs
@@ -4,7 +4,7 @@ use tokio_postgres::GenericClient;
 
 use crate::{
     knowledge::{EntityId, Links, Outgoing},
-    ontology::types::uri::VersionedUri,
+    ontology::types::uri::{BaseUri, VersionedUri},
     store::{
         crud,
         query::{LinkQuery, OntologyVersion},
@@ -12,123 +12,149 @@ use crate::{
     },
 };
 
+async fn single_by_source_entity_id(
+    client: &(impl GenericClient + Sync),
+    source_entity_id: EntityId,
+) -> Result<impl Iterator<Item = (VersionedUri, Outgoing)> + Send, QueryError> {
+    Ok(client
+        .query(
+            r#"
+            SELECT base_uri, "version", target_entity_id
+            FROM links
+            INNER JOIN ids ON ids.version_id = links.link_type_version_id
+            WHERE active AND NOT multi and source_entity_id = $1
+            "#,
+            &[&source_entity_id],
+        )
+        .await
+        .into_report()
+        .change_context(QueryError)
+        .attach_printable(source_entity_id)?
+        .into_iter()
+        .map(|row| {
+            (
+                VersionedUri::new(row.get(0), row.get::<_, i64>(1) as u32),
+                Outgoing::Single(row.get(2)),
+            )
+        }))
+}
+
+async fn multi_by_source_entity_id(
+    client: &(impl GenericClient + Sync),
+    source_entity_id: EntityId,
+) -> Result<impl Iterator<Item = (VersionedUri, Outgoing)> + Send, QueryError> {
+    Ok(client
+        .query(
+            r#"
+            WITH aggregated as (
+                SELECT link_type_version_id, ARRAY_AGG(target_entity_id ORDER BY multi_order ASC) as links
+                FROM links
+                WHERE active AND multi and source_entity_id = $1
+                GROUP BY link_type_version_id
+            )
+            SELECT base_uri, "version", links FROM aggregated
+            INNER JOIN ids ON ids.version_id = aggregated.link_type_version_id
+            "#,
+            &[&source_entity_id],
+        )
+        .await
+        .into_report()
+        .change_context(QueryError)
+        .attach_printable(source_entity_id)?
+        .into_iter()
+        .map(|row| (
+            VersionedUri::new(row.get(0), row.get::<_, i64>(1) as u32),
+            Outgoing::Multiple(row.get(2))
+        )))
+}
+
+async fn by_source_entity_id(
+    client: &(impl GenericClient + Sync),
+    source_entity_id: EntityId,
+) -> Result<Vec<Links>, QueryError> {
+    let single_links = single_by_source_entity_id(client, source_entity_id).await?;
+    let multi_links = multi_by_source_entity_id(client, source_entity_id).await?;
+    Ok(vec![Links::new(single_links.chain(multi_links).collect())])
+}
+
+async fn by_link_type_by_source_entity_id(
+    client: &(impl GenericClient + Sync),
+    link_type_uri: &BaseUri,
+    link_type_version: u32,
+    source_entity_id: EntityId,
+) -> Result<Vec<Links>, QueryError> {
+    let link =
+        client
+        .query_one(
+            r#"
+            -- Gather all single-links
+            WITH single_links AS (
+                SELECT link_type_version_id, target_entity_id
+                FROM links
+                INNER JOIN ids ON ids.version_id = links.link_type_version_id
+                WHERE active AND NOT multi AND source_entity_id = $1 AND base_uri = $2 AND "version" = $3
+            ),
+            -- Gather all multi-links
+            multi_links AS (
+                SELECT link_type_version_id, ARRAY_AGG(target_entity_id ORDER BY multi_order ASC) AS target_entity_ids
+                FROM links
+                INNER JOIN ids ON ids.version_id = links.link_type_version_id
+                WHERE active AND multi AND source_entity_id = $1 AND base_uri = $2 AND "version" = $3 GROUP BY link_type_version_id
+            )
+            -- Combine single and multi links with null values in rows where the other doesn't exist
+            SELECT link_type_version_id, target_entity_id AS single_link, NULL AS multi_link
+            FROM single_links
+            UNION
+            SELECT link_type_version_id, NULL AS single_link, target_entity_ids AS multi_link
+            FROM multi_links
+            "#,
+            &[&source_entity_id, link_type_uri, &i64::from(link_type_version)],
+        )
+        .await
+        .into_report()
+        .change_context(QueryError)
+        .attach_printable(source_entity_id)
+        .attach_printable(link_type_uri.clone())?;
+
+    let val: (Option<EntityId>, Option<Vec<EntityId>>) = (link.get(1), link.get(2));
+    let outgoing = match val {
+        (Some(entity_id), None) => Outgoing::Single(entity_id),
+        (None, Some(entity_ids)) => Outgoing::Multiple(entity_ids),
+        _ => {
+            return Err(Report::new(QueryError)
+                .attach_printable(source_entity_id)
+                .attach_printable(link_type_uri.clone()));
+        }
+    };
+    Ok(vec![Links::new(
+        [(
+            VersionedUri::new(link_type_uri.to_string(), link_type_version),
+            outgoing,
+        )]
+        .into(),
+    )])
+}
+
 // TODO: we should probably support taking PersistedEntityIdentifier here as well as an EntityId
 #[async_trait]
 impl<C: AsClient> crud::Read<Links> for PostgresStore<C> {
     type Query<'q> = LinkQuery<'q>;
 
-    #[expect(
-        clippy::too_many_lines,
-        reason = "TODO: Function needs to be split into smaller parts"
-    )]
     async fn read<'query>(&self, query: &Self::Query<'query>) -> Result<Vec<Links>, QueryError> {
         match (query.link_type_query(), query.source_entity_id()) {
             (None, Some(source_entity_id)) => {
-                let multi_links = self
-                    .as_client()
-                    .query(
-                        r#"
-                        WITH aggregated as (
-                            SELECT link_type_version_id, ARRAY_AGG(target_entity_id ORDER BY multi_order ASC) as links 
-                            FROM links
-                            WHERE active AND multi and source_entity_id = $1
-                            GROUP BY link_type_version_id
-                        )
-                        SELECT base_uri, "version", links FROM aggregated
-                        INNER JOIN ids ON ids.version_id = aggregated.link_type_version_id
-                        "#,
-                        &[&source_entity_id],
-                    )
-                    .await
-                    .into_report()
-                    .change_context(QueryError)
-                    .attach_printable(source_entity_id)?
-                    .into_iter()
-                    .map(|row| (
-                        VersionedUri::new(row.get(0), row.get::<_, i64>(1) as u32),
-                        Outgoing::Multiple(row.get(2))
-                    ));
-
-                let single_links = self
-                    .client
-                    .as_client()
-                    .query(
-                        r#"
-                        SELECT base_uri, "version", target_entity_id
-                        FROM links
-                        INNER JOIN ids ON ids.version_id = links.link_type_version_id
-                        WHERE active AND NOT multi and source_entity_id = $1
-                        "#,
-                        &[&source_entity_id],
-                    )
-                    .await
-                    .into_report()
-                    .change_context(QueryError)
-                    .attach_printable(source_entity_id)?
-                    .into_iter()
-                    .map(|row| {
-                        (
-                            VersionedUri::new(row.get(0), row.get::<_, i64>(1) as u32),
-                            Outgoing::Single(row.get(2)),
-                        )
-                    });
-                Ok(vec![Links::new(multi_links.chain(single_links).collect())])
+                by_source_entity_id(self.as_client(), source_entity_id).await
             }
             (Some(link_type_query), Some(source_entity_id)) => {
                 match (link_type_query.uri(), link_type_query.version()) {
                     (Some(link_type_uri), Some(OntologyVersion::Exact(link_type_version))) => {
-                        let link = self
-                            .client
-                            .as_client()
-                            .query_one(
-                                r#"
-                                -- Gather all single-links
-                                WITH single_links AS (
-                                    SELECT link_type_version_id, target_entity_id
-                                    FROM links
-                                    INNER JOIN ids ON ids.version_id = links.link_type_version_id
-                                    WHERE active AND NOT multi AND source_entity_id = $1 AND base_uri = $2 AND "version" = $3
-                                ),
-                                -- Gather all multi-links
-                                multi_links AS (
-                                    SELECT link_type_version_id, ARRAY_AGG(target_entity_id ORDER BY multi_order ASC) AS target_entity_ids
-                                    FROM links
-                                    INNER JOIN ids ON ids.version_id = links.link_type_version_id
-                                    WHERE active AND multi AND source_entity_id = $1 AND base_uri = $2 AND "version" = $3 GROUP BY link_type_version_id
-                                )
-                                -- Combine single and multi links with null values in rows where the other doesn't exist
-                                SELECT link_type_version_id, target_entity_id AS single_link, NULL AS multi_link 
-                                FROM single_links
-                                UNION
-                                SELECT link_type_version_id, NULL AS single_link, target_entity_ids AS multi_link
-                                FROM multi_links
-                                "#,
-                                &[&source_entity_id, link_type_uri, &i64::from(link_type_version)],
-                            )
-                            .await
-                            .into_report()
-                            .change_context(QueryError)
-                            .attach_printable(source_entity_id)
-                            .attach_printable(link_type_uri.clone())?;
-
-                        let val: (Option<EntityId>, Option<Vec<EntityId>>) =
-                            (link.get(1), link.get(2));
-                        let outgoing = match val {
-                            (Some(entity_id), None) => Outgoing::Single(entity_id),
-                            (None, Some(entity_ids)) => Outgoing::Multiple(entity_ids),
-                            _ => {
-                                return Err(Report::new(QueryError)
-                                    .attach_printable(source_entity_id)
-                                    .attach_printable(link_type_uri.clone()));
-                            }
-                        };
-                        Ok(vec![Links::new(
-                            [(
-                                VersionedUri::new(link_type_uri.to_string(), link_type_version),
-                                outgoing,
-                            )]
-                            .into(),
-                        )])
+                        by_link_type_by_source_entity_id(
+                            self.as_client(),
+                            link_type_uri,
+                            link_type_version,
+                            source_entity_id,
+                        )
+                        .await
                     }
                     _ => todo!(),
                 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/read.rs
@@ -17,7 +17,10 @@ use crate::{
 impl<C: AsClient> crud::Read<Links> for PostgresStore<C> {
     type Query<'q> = LinkQuery<'q>;
 
-    #[expect(clippy::too_many_lines, reason = "TODO: Function needs to be split into smaller parts")]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "TODO: Function needs to be split into smaller parts"
+    )]
     async fn read<'query>(&self, query: &Self::Query<'query>) -> Result<Vec<Links>, QueryError> {
         match (query.link_type_query(), query.source_entity_id()) {
             (None, Some(source_entity_id)) => {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/read.rs
@@ -3,118 +3,134 @@ use error_stack::{IntoReport, Report, Result, ResultExt};
 use tokio_postgres::GenericClient;
 
 use crate::{
-    knowledge::{EntityId, Link, Links, Outgoing},
+    knowledge::{EntityId, Links, Outgoing},
     ontology::types::uri::VersionedUri,
-    store::{crud, AsClient, PostgresStore, QueryError},
+    store::{
+        crud,
+        query::{LinkQuery, OntologyVersion},
+        AsClient, PostgresStore, QueryError,
+    },
 };
 
 // TODO: we should probably support taking PersistedEntityIdentifier here as well as an EntityId
 #[async_trait]
-impl<C: AsClient> crud::Read<'_, EntityId, Link> for PostgresStore<C> {
-    type Output = Links;
+impl<C: AsClient> crud::Read<Links> for PostgresStore<C> {
+    type Query<'q> = LinkQuery<'q>;
 
-    async fn get(&self, identifier: EntityId) -> Result<Self::Output, QueryError> {
-        let multi_links = self
-            .client
-            .as_client()
-            .query(
-                r#"
-                WITH aggregated as (
-                    SELECT link_type_version_id, ARRAY_AGG(target_entity_id ORDER BY multi_order ASC) as links
-                    FROM links
-                    WHERE active AND multi and source_entity_id = $1
-                    GROUP BY link_type_version_id
-                )
-                SELECT base_uri, "version", links FROM aggregated
-                INNER JOIN ids ON ids.version_id = aggregated.link_type_version_id
-                "#,
-                &[&identifier],
-            )
-            .await
-            .report()
-            .change_context(QueryError)
-            .attach_printable(identifier)?
-            .into_iter()
-            .map(|row| (VersionedUri::new(row.get(0), row.get::<_, i64>(1) as u32), Outgoing::Multiple(row.get(2))));
+    #[expect(clippy::too_many_lines, reason = "TODO: Function needs to be split into smaller parts")]
+    async fn read<'query>(&self, query: &Self::Query<'query>) -> Result<Vec<Links>, QueryError> {
+        match (query.link_type_query(), query.source_entity_id()) {
+            (None, Some(source_entity_id)) => {
+                let multi_links = self
+                    .as_client()
+                    .query(
+                        r#"
+                        WITH aggregated as (
+                            SELECT link_type_version_id, ARRAY_AGG(target_entity_id ORDER BY multi_order ASC) as links 
+                            FROM links
+                            WHERE active AND multi and source_entity_id = $1
+                            GROUP BY link_type_version_id
+                        )
+                        SELECT base_uri, "version", links FROM aggregated
+                        INNER JOIN ids ON ids.version_id = aggregated.link_type_version_id
+                        "#,
+                        &[&source_entity_id],
+                    )
+                    .await
+                    .report()
+                    .change_context(QueryError)
+                    .attach_printable(source_entity_id)?
+                    .into_iter()
+                    .map(|row| (
+                        VersionedUri::new(row.get(0), row.get::<_, i64>(1) as u32),
+                        Outgoing::Multiple(row.get(2))
+                    ));
 
-        let single_links = self
-            .client
-            .as_client()
-            .query(
-                r#"
-                SELECT base_uri, "version", target_entity_id
-                FROM links
-                INNER JOIN ids ON ids.version_id = links.link_type_version_id
-                WHERE active AND NOT multi and source_entity_id = $1
-                "#,
-                &[&identifier],
-            )
-            .await
-            .report()
-            .change_context(QueryError)
-            .attach_printable(identifier)?
-            .into_iter()
-            .map(|row| {
-                (
-                    VersionedUri::new(row.get(0), row.get::<_, i64>(1) as u32),
-                    Outgoing::Single(row.get(2)),
-                )
-            });
+                let single_links = self
+                    .client
+                    .as_client()
+                    .query(
+                        r#"
+                        SELECT base_uri, "version", target_entity_id
+                        FROM links
+                        INNER JOIN ids ON ids.version_id = links.link_type_version_id
+                        WHERE active AND NOT multi and source_entity_id = $1
+                        "#,
+                        &[&source_entity_id],
+                    )
+                    .await
+                    .report()
+                    .change_context(QueryError)
+                    .attach_printable(source_entity_id)?
+                    .into_iter()
+                    .map(|row| {
+                        (
+                            VersionedUri::new(row.get(0), row.get::<_, i64>(1) as u32),
+                            Outgoing::Single(row.get(2)),
+                        )
+                    });
+                Ok(vec![Links::new(multi_links.chain(single_links).collect())])
+            }
+            (Some(link_type_query), Some(source_entity_id)) => {
+                match (link_type_query.uri(), link_type_query.version()) {
+                    (Some(link_type_uri), Some(OntologyVersion::Exact(link_type_version))) => {
+                        let link = self
+                            .client
+                            .as_client()
+                            .query_one(
+                                r#"
+                                -- Gather all single-links
+                                WITH single_links AS (
+                                    SELECT link_type_version_id, target_entity_id
+                                    FROM links
+                                    INNER JOIN ids ON ids.version_id = links.link_type_version_id
+                                    WHERE active AND NOT multi AND source_entity_id = $1 AND base_uri = $2 AND "version" = $3
+                                ),
+                                -- Gather all multi-links
+                                multi_links AS (
+                                    SELECT link_type_version_id, ARRAY_AGG(target_entity_id ORDER BY multi_order ASC) AS target_entity_ids
+                                    FROM links
+                                    INNER JOIN ids ON ids.version_id = links.link_type_version_id
+                                    WHERE active AND multi AND source_entity_id = $1 AND base_uri = $2 AND "version" = $3 GROUP BY link_type_version_id
+                                )
+                                -- Combine single and multi links with null values in rows where the other doesn't exist
+                                SELECT link_type_version_id, target_entity_id AS single_link, NULL AS multi_link 
+                                FROM single_links
+                                UNION
+                                SELECT link_type_version_id, NULL AS single_link, target_entity_ids AS multi_link
+                                FROM multi_links
+                                "#,
+                                &[&source_entity_id, link_type_uri, &i64::from(link_type_version)],
+                            )
+                            .await
+                            .report()
+                            .change_context(QueryError)
+                            .attach_printable(source_entity_id)
+                            .attach_printable(link_type_uri.clone())?;
 
-        Ok(Links::new(multi_links.chain(single_links).collect()))
-    }
-}
-
-#[async_trait]
-impl<'i, C: AsClient> crud::Read<'i, (EntityId, &'i VersionedUri), Link> for PostgresStore<C> {
-    type Output = Outgoing;
-
-    async fn get(
-        &self,
-        identifier: (EntityId, &'i VersionedUri),
-    ) -> Result<Self::Output, QueryError> {
-        let (source_entity_id, link_type_uri) = identifier;
-        let version = i64::from(link_type_uri.version());
-        let link = self
-        .client
-        .as_client()
-        .query_one(
-            r#"
-                -- Gather all single-links
-                WITH single_links AS (
-                    SELECT link_type_version_id, target_entity_id
-                    FROM links
-                    INNER JOIN ids ON ids.version_id = links.link_type_version_id
-                    WHERE active AND NOT multi AND source_entity_id = $1 AND base_uri = $2 AND "version" = $3
-                ),
-                -- Gather all multi-links
-                multi_links AS (
-                    SELECT link_type_version_id, ARRAY_AGG(target_entity_id ORDER BY multi_order ASC) AS target_entity_ids
-                    FROM links
-                    INNER JOIN ids ON ids.version_id = links.link_type_version_id
-                    WHERE active AND multi AND source_entity_id = $1 AND base_uri = $2 AND "version" = $3
-                    GROUP BY link_type_version_id
-                )
-                -- Combine single and multi links with null values in rows where the other doesn't exist
-                SELECT link_type_version_id, target_entity_id AS single_link, NULL AS multi_link FROM single_links 
-                UNION 
-                SELECT link_type_version_id, NULL AS single_link, target_entity_ids AS multi_link from multi_links
-                "#,
-            &[&source_entity_id, link_type_uri.base_uri(), &version],
-        )
-        .await
-        .report()
-        .change_context(QueryError)
-        .attach_printable(source_entity_id)
-        .attach_printable(link_type_uri.clone())?;
-
-        let val: (Option<EntityId>, Option<Vec<EntityId>>) = (link.get(1), link.get(2));
-        match val {
-            (Some(entity_id), None) => Ok(Outgoing::Single(entity_id)),
-            (None, Some(entity_ids)) => Ok(Outgoing::Multiple(entity_ids)),
-            _ => Err(Report::new(QueryError)
-                .attach_printable(source_entity_id)
-                .attach_printable(link_type_uri.clone())),
+                        let val: (Option<EntityId>, Option<Vec<EntityId>>) =
+                            (link.get(1), link.get(2));
+                        let outgoing = match val {
+                            (Some(entity_id), None) => Outgoing::Single(entity_id),
+                            (None, Some(entity_ids)) => Outgoing::Multiple(entity_ids),
+                            _ => {
+                                return Err(Report::new(QueryError)
+                                    .attach_printable(source_entity_id)
+                                    .attach_printable(link_type_uri.clone()));
+                            }
+                        };
+                        Ok(vec![Links::new(
+                            [(
+                                VersionedUri::new(link_type_uri.to_string(), link_type_version),
+                                outgoing,
+                            )]
+                            .into(),
+                        )])
+                    }
+                    _ => todo!(),
+                }
+            }
+            _ => todo!(),
         }
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -5,6 +5,7 @@ mod pool;
 mod version_id;
 
 use error_stack::{IntoReport, Report, Result, ResultExt};
+use postgres_types::ToSql;
 use serde::Serialize;
 use tokio_postgres::GenericClient;
 use uuid::Uuid;
@@ -27,6 +28,14 @@ use crate::{
         BaseUriAlreadyExists, BaseUriDoesNotExist, InsertionError, QueryError, UpdateError,
     },
 };
+
+/// Utility function used for [`GenericClient::query_raw`] to infer the parameter as
+/// [`dyn ToSql`][ToSql].
+///
+/// [`GenericClient::query_raw`]: tokio_postgres::GenericClient::query_raw
+fn parameter_list<const N: usize>(list: [&(dyn ToSql + Sync); N]) -> [&(dyn ToSql + Sync); N] {
+    list
+}
 
 /// A Postgres-backed store
 pub struct PostgresStore<C> {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -266,7 +266,7 @@ where
     where
         T: OntologyDatabaseType + Serialize + Send + Sync,
     {
-        let uri = database_type.uri();
+        let uri = database_type.versioned_uri();
 
         if self
             .contains_base_uri(uri.base_uri())
@@ -317,7 +317,7 @@ where
     where
         T: OntologyDatabaseType + Serialize + Send + Sync,
     {
-        let uri = database_type.uri();
+        let uri = database_type.versioned_uri();
 
         if !self
             .contains_base_uri(uri.base_uri())

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
@@ -3,9 +3,8 @@ use error_stack::{IntoReport, Result, ResultExt};
 use tokio_postgres::GenericClient;
 
 use crate::{
-    ontology::AccountId,
+    ontology::{types::EntityType, AccountId},
     store::{AsClient, EntityTypeStore, InsertionError, PostgresStore, UpdateError},
-    EntityType,
 };
 
 #[async_trait]

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
@@ -3,9 +3,8 @@ use error_stack::{IntoReport, Result, ResultExt};
 use tokio_postgres::GenericClient;
 
 use crate::{
-    ontology::AccountId,
+    ontology::{types::LinkType, AccountId},
     store::{AsClient, InsertionError, LinkTypeStore, PostgresStore, UpdateError},
-    LinkType,
 };
 
 #[async_trait]

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/mod.rs
@@ -4,19 +4,25 @@ mod link_type;
 mod property_type;
 mod read;
 
-use crate::ontology::types::{DataType, EntityType, LinkType, OntologyType, PropertyType};
+use crate::ontology::types::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType};
 
 /// Provides an abstraction over elements of the Type System stored in the Database.
 ///
 /// [`PostgresDatabase`]: crate::store::PostgresDatabase
-pub trait OntologyDatabaseType: OntologyType {
+pub trait OntologyDatabaseType {
     /// Returns the name of the table where this type is stored.
     fn table() -> &'static str;
+
+    fn versioned_uri(&self) -> &VersionedUri;
 }
 
 impl OntologyDatabaseType for DataType {
     fn table() -> &'static str {
         "data_types"
+    }
+
+    fn versioned_uri(&self) -> &VersionedUri {
+        self.id()
     }
 }
 
@@ -24,16 +30,28 @@ impl OntologyDatabaseType for PropertyType {
     fn table() -> &'static str {
         "property_types"
     }
+
+    fn versioned_uri(&self) -> &VersionedUri {
+        self.id()
+    }
 }
 
 impl OntologyDatabaseType for EntityType {
     fn table() -> &'static str {
         "entity_types"
     }
+
+    fn versioned_uri(&self) -> &VersionedUri {
+        self.id()
+    }
 }
 
 impl OntologyDatabaseType for LinkType {
     fn table() -> &'static str {
         "link_types"
+    }
+
+    fn versioned_uri(&self) -> &VersionedUri {
+        self.id()
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -3,9 +3,8 @@ use error_stack::{IntoReport, Result, ResultExt};
 use tokio_postgres::GenericClient;
 
 use crate::{
-    ontology::AccountId,
+    ontology::{types::PropertyType, AccountId},
     store::{AsClient, InsertionError, PostgresStore, PropertyTypeStore, UpdateError},
-    PropertyType,
 };
 
 #[async_trait]

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
 use futures::{StreamExt, TryStreamExt};
-use postgres_types::ToSql;
 use serde::Deserialize;
 use tokio_postgres::{GenericClient, RowStream};
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -5,86 +5,67 @@ use postgres_types::ToSql;
 use serde::Deserialize;
 use tokio_postgres::GenericClient;
 
-use crate::{
-    ontology::types::uri::VersionedUri,
-    store::{
-        crud, crud::AllLatest, postgres::ontology::OntologyDatabaseType, AsClient, PostgresStore,
-        QueryError,
-    },
+use crate::store::{
+    crud::Read,
+    postgres::ontology::OntologyDatabaseType,
+    query::{OntologyQuery, OntologyVersion},
+    AsClient, PostgresStore, QueryError,
 };
 
-#[async_trait]
-impl<'i, C: AsClient, T> crud::Read<'i, &'i VersionedUri, T> for PostgresStore<C>
-where
-    for<'de> T: OntologyDatabaseType + Deserialize<'de>,
-{
-    type Output = T;
-
-    async fn get(&self, uri: &'i VersionedUri) -> Result<Self::Output, QueryError> {
-        let version = i64::from(uri.version());
-        // Generally bad practice to construct a query without preparation, but it's not possible to
-        // pass a table name as a parameter and `T::table()` is well-defined, so this is a safe
-        // usage.
-        let row = self
-            .as_client()
-            .query_one(
-                &format!(
-                    r#"
-                    SELECT schema
-                    FROM {}
-                    WHERE version_id = (
-                        SELECT version_id
-                        FROM ids
-                        WHERE base_uri = $1 AND version = $2
-                    )
-                    "#,
-                    T::table()
-                ),
-                &[uri.base_uri(), &version],
-            )
-            .await
-            .report()
-            .change_context(QueryError)
-            .attach_printable_lazy(|| uri.clone())?;
-
-        serde_json::from_value(row.get(0))
-            .report()
-            .change_context(QueryError)
-    }
+fn parameter_list<const N: usize>(list: [&(dyn ToSql + Sync); N]) -> [&(dyn ToSql + Sync); N] {
+    list
 }
 
 #[async_trait]
-impl<C: AsClient, T> crud::Read<'_, AllLatest, T> for PostgresStore<C>
+impl<C: AsClient, T> Read<T> for PostgresStore<C>
 where
     for<'de> T: OntologyDatabaseType + Deserialize<'de> + Send,
 {
-    type Output = Vec<T>;
+    type Query<'q> = OntologyQuery<'q, T>;
 
-    async fn get(&self, _: AllLatest) -> Result<Self::Output, QueryError> {
-        // Generally bad practice to construct a query without preparation, but it's not possible to
-        // pass a table name as a parameter and `T::table()` is well-defined, so this is a safe
-        // usage.
-        let row_stream = self
-            .as_client()
-            .query_raw(
-                &format!(
-                    r#"
-                    SELECT DISTINCT ON(base_uri) schema
-                    FROM {table}
-                    INNER JOIN ids ON ids.version_id = {table}.version_id
-                    ORDER BY base_uri, version DESC;
-                    "#,
-                    table = T::table()
-                ),
-                // Requires a concrete type, which implements
-                // `IntoIterator<Item = impl BorrowToSql>`
-                [] as [&(dyn ToSql + Sync); 0],
-            )
-            .await
-            .report()
-            .change_context(QueryError)?;
+    async fn read<'query>(&self, query: &Self::Query<'query>) -> Result<Vec<T>, QueryError> {
+        let row_stream = match (query.uri(), query.version()) {
+            (Some(uri), Some(OntologyVersion::Exact(version))) => {
+                self.as_client()
+                    .query_raw(
+                        &format!(
+                            r#"
+                            SELECT schema
+                            FROM {}
+                            WHERE version_id = (
+                                SELECT version_id
+                                FROM ids
+                                WHERE base_uri = $1 AND version = $2
+                            )
+                            "#,
+                            T::table()
+                        ),
+                        parameter_list([uri, &i64::from(version)]),
+                    )
+                    .await
+            }
+            (None, Some(OntologyVersion::Latest)) => {
+                self.as_client()
+                    .query_raw(
+                        &format!(
+                            r#"
+                            SELECT DISTINCT ON(base_uri) schema
+                            FROM {table}
+                            INNER JOIN ids ON ids.version_id = {table}.version_id
+                            ORDER BY base_uri, version DESC;
+                            "#,
+                            table = T::table()
+                        ),
+                        parameter_list([]),
+                    )
+                    .await
+            }
+            _ => todo!(),
+        };
 
         row_stream
+            .report()
+            .change_context(QueryError)?
             .map(|row_result| {
                 let row = row_result.report().change_context(QueryError)?;
                 serde_json::from_value(row.get(0))

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -9,15 +9,11 @@ use crate::{
     ontology::types::uri::BaseUri,
     store::{
         crud::Read,
-        postgres::ontology::OntologyDatabaseType,
+        postgres::{ontology::OntologyDatabaseType, parameter_list},
         query::{OntologyQuery, OntologyVersion},
         AsClient, PostgresStore, QueryError,
     },
 };
-
-fn parameter_list<const N: usize>(list: [&(dyn ToSql + Sync); N]) -> [&(dyn ToSql + Sync); N] {
-    list
-}
 
 async fn by_uri_by_version<T: OntologyDatabaseType>(
     client: &(impl GenericClient + Sync),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -3,17 +3,67 @@ use error_stack::{IntoReport, Result, ResultExt};
 use futures::{StreamExt, TryStreamExt};
 use postgres_types::ToSql;
 use serde::Deserialize;
-use tokio_postgres::GenericClient;
+use tokio_postgres::{GenericClient, RowStream};
 
-use crate::store::{
-    crud::Read,
-    postgres::ontology::OntologyDatabaseType,
-    query::{OntologyQuery, OntologyVersion},
-    AsClient, PostgresStore, QueryError,
+use crate::{
+    ontology::types::uri::BaseUri,
+    store::{
+        crud::Read,
+        postgres::ontology::OntologyDatabaseType,
+        query::{OntologyQuery, OntologyVersion},
+        AsClient, PostgresStore, QueryError,
+    },
 };
 
 fn parameter_list<const N: usize>(list: [&(dyn ToSql + Sync); N]) -> [&(dyn ToSql + Sync); N] {
     list
+}
+
+async fn by_uri_by_version<T: OntologyDatabaseType>(
+    client: &(impl GenericClient + Sync),
+    uri: &BaseUri,
+    version: u32,
+) -> Result<RowStream, QueryError> {
+    client
+        .query_raw(
+            &format!(
+                r#"
+                SELECT schema
+                FROM {}
+                WHERE version_id = (
+                    SELECT version_id
+                    FROM ids
+                    WHERE base_uri = $1 AND version = $2
+                )
+                "#,
+                T::table()
+            ),
+            parameter_list([uri, &i64::from(version)]),
+        )
+        .await
+        .into_report()
+        .change_context(QueryError)
+}
+
+async fn by_latest_version<T: OntologyDatabaseType>(
+    client: &(impl GenericClient + Sync),
+) -> Result<RowStream, QueryError> {
+    client
+        .query_raw(
+            &format!(
+                r#"
+                SELECT DISTINCT ON(base_uri) schema
+                FROM {table}
+                INNER JOIN ids ON ids.version_id = {table}.version_id
+                ORDER BY base_uri, version DESC;
+                "#,
+                table = T::table()
+            ),
+            parameter_list([]),
+        )
+        .await
+        .into_report()
+        .change_context(QueryError)
 }
 
 #[async_trait]
@@ -26,46 +76,15 @@ where
     async fn read<'query>(&self, query: &Self::Query<'query>) -> Result<Vec<T>, QueryError> {
         let row_stream = match (query.uri(), query.version()) {
             (Some(uri), Some(OntologyVersion::Exact(version))) => {
-                self.as_client()
-                    .query_raw(
-                        &format!(
-                            r#"
-                            SELECT schema
-                            FROM {}
-                            WHERE version_id = (
-                                SELECT version_id
-                                FROM ids
-                                WHERE base_uri = $1 AND version = $2
-                            )
-                            "#,
-                            T::table()
-                        ),
-                        parameter_list([uri, &i64::from(version)]),
-                    )
-                    .await
+                by_uri_by_version::<T>(self.as_client(), uri, version).await?
             }
             (None, Some(OntologyVersion::Latest)) => {
-                self.as_client()
-                    .query_raw(
-                        &format!(
-                            r#"
-                            SELECT DISTINCT ON(base_uri) schema
-                            FROM {table}
-                            INNER JOIN ids ON ids.version_id = {table}.version_id
-                            ORDER BY base_uri, version DESC;
-                            "#,
-                            table = T::table()
-                        ),
-                        parameter_list([]),
-                    )
-                    .await
+                by_latest_version::<T>(self.as_client()).await?
             }
             _ => todo!(),
         };
 
         row_stream
-            .into_report()
-            .change_context(QueryError)?
             .map(|row_result| {
                 let row = row_result.into_report().change_context(QueryError)?;
                 serde_json::from_value(row.get(0))

--- a/packages/graph/hash_graph/lib/graph/src/store/query/knowledge/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/knowledge/entity.rs
@@ -24,13 +24,13 @@ impl EntityQuery {
 /// Methods for building up a query.
 impl EntityQuery {
     #[must_use]
-    pub const fn with_id(mut self, id: EntityId) -> Self {
+    pub const fn by_id(mut self, id: EntityId) -> Self {
         self.id = Some(id);
         self
     }
 
     #[must_use]
-    pub const fn with_latest_version(mut self) -> Self {
+    pub const fn by_latest_version(mut self) -> Self {
         self.version = Some(EntityVersion::Latest);
         self
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/query/knowledge/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/knowledge/entity.rs
@@ -1,0 +1,50 @@
+use crate::knowledge::EntityId;
+
+#[derive(Debug, Copy, Clone)]
+pub enum EntityVersion {
+    Latest,
+}
+
+#[derive(Debug, Default)]
+pub struct EntityQuery {
+    id: Option<EntityId>,
+    version: Option<EntityVersion>,
+}
+
+impl EntityQuery {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            id: None,
+            version: None,
+        }
+    }
+}
+
+/// Methods for building up a query.
+impl EntityQuery {
+    #[must_use]
+    pub const fn with_id(mut self, id: EntityId) -> Self {
+        self.id = Some(id);
+        self
+    }
+
+    #[must_use]
+    pub const fn with_latest_version(mut self) -> Self {
+        self.version = Some(EntityVersion::Latest);
+        self
+    }
+}
+
+/// Parameters specified in the query.
+impl EntityQuery {
+    #[must_use]
+    pub const fn id(&self) -> Option<EntityId> {
+        self.id
+    }
+
+    #[must_use]
+    pub const fn version(&self) -> Option<EntityVersion> {
+        self.version
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/store/query/knowledge/link.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/knowledge/link.rs
@@ -1,0 +1,48 @@
+use crate::{knowledge::EntityId, store::query::LinkTypeQuery};
+
+#[derive(Debug, Default)]
+pub struct LinkQuery<'q> {
+    link_type_query: Option<LinkTypeQuery<'q>>,
+    source_entity_id: Option<EntityId>,
+}
+
+impl LinkQuery<'_> {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            link_type_query: None,
+            source_entity_id: None,
+        }
+    }
+}
+
+/// Methods for building up a query.
+impl<'q> LinkQuery<'q> {
+    #[must_use]
+    pub fn with_link_types<Q>(mut self, link_type_query: Q) -> Self
+    where
+        Q: FnOnce(LinkTypeQuery<'q>) -> LinkTypeQuery<'q>,
+    {
+        self.link_type_query = Some(link_type_query(LinkTypeQuery::new()));
+        self
+    }
+
+    #[must_use]
+    pub const fn with_source_entity_id(mut self, source_entity_id: EntityId) -> Self {
+        self.source_entity_id = Some(source_entity_id);
+        self
+    }
+}
+
+/// Parameters specified in the query.
+impl<'q> LinkQuery<'q> {
+    #[must_use]
+    pub const fn link_type_query(&self) -> Option<&LinkTypeQuery<'q>> {
+        self.link_type_query.as_ref()
+    }
+
+    #[must_use]
+    pub const fn source_entity_id(&self) -> Option<EntityId> {
+        self.source_entity_id
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/store/query/knowledge/link.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/knowledge/link.rs
@@ -19,7 +19,7 @@ impl LinkQuery<'_> {
 /// Methods for building up a query.
 impl<'q> LinkQuery<'q> {
     #[must_use]
-    pub fn with_link_types<Q>(mut self, link_type_query: Q) -> Self
+    pub fn by_link_types<Q>(mut self, link_type_query: Q) -> Self
     where
         Q: FnOnce(LinkTypeQuery<'q>) -> LinkTypeQuery<'q>,
     {
@@ -28,7 +28,7 @@ impl<'q> LinkQuery<'q> {
     }
 
     #[must_use]
-    pub const fn with_source_entity_id(mut self, source_entity_id: EntityId) -> Self {
+    pub const fn by_source_entity_id(mut self, source_entity_id: EntityId) -> Self {
         self.source_entity_id = Some(source_entity_id);
         self
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/query/knowledge/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/knowledge/mod.rs
@@ -1,0 +1,7 @@
+mod entity;
+mod link;
+
+pub use self::{
+    entity::{EntityQuery, EntityVersion},
+    link::LinkQuery,
+};

--- a/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
@@ -1,0 +1,10 @@
+mod knowledge;
+mod ontology;
+
+pub use self::{
+    knowledge::{EntityQuery, EntityVersion, LinkQuery},
+    ontology::{
+        DataTypeQuery, EntityTypeQuery, LinkTypeQuery, OntologyQuery, OntologyVersion,
+        PropertyTypeQuery,
+    },
+};

--- a/packages/graph/hash_graph/lib/graph/src/store/query/ontology.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/ontology.rs
@@ -1,6 +1,4 @@
-use std::fmt;
-use std::fmt::Formatter;
-use std::marker::PhantomData;
+use std::{fmt, fmt::Formatter, marker::PhantomData};
 
 use crate::ontology::types::{uri::BaseUri, DataType, EntityType, LinkType, PropertyType};
 
@@ -23,7 +21,10 @@ pub struct OntologyQuery<'q, T> {
 
 impl<T> fmt::Debug for OntologyQuery<'_, T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("OntologyQuery").field("uri", &self.uri()).field("version", &self.version()).finish()
+        f.debug_struct("OntologyQuery")
+            .field("uri", &self.uri())
+            .field("version", &self.version())
+            .finish()
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/query/ontology.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/ontology.rs
@@ -1,0 +1,73 @@
+use std::fmt;
+use std::fmt::Formatter;
+use std::marker::PhantomData;
+
+use crate::ontology::types::{uri::BaseUri, DataType, EntityType, LinkType, PropertyType};
+
+pub type DataTypeQuery<'q> = OntologyQuery<'q, DataType>;
+pub type PropertyTypeQuery<'q> = OntologyQuery<'q, PropertyType>;
+pub type LinkTypeQuery<'q> = OntologyQuery<'q, LinkType>;
+pub type EntityTypeQuery<'q> = OntologyQuery<'q, EntityType>;
+
+#[derive(Debug, Copy, Clone)]
+pub enum OntologyVersion {
+    Exact(u32),
+    Latest,
+}
+
+pub struct OntologyQuery<'q, T> {
+    _marker: PhantomData<fn() -> T>,
+    uri: Option<&'q BaseUri>,
+    version: Option<OntologyVersion>,
+}
+
+impl<T> fmt::Debug for OntologyQuery<'_, T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OntologyQuery").field("uri", &self.uri()).field("version", &self.version()).finish()
+    }
+}
+
+impl<T> OntologyQuery<'_, T> {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            _marker: PhantomData,
+            uri: None,
+            version: None,
+        }
+    }
+}
+
+/// Methods for building up a query.
+impl<'q, T> OntologyQuery<'q, T> {
+    #[must_use]
+    pub const fn with_uri(mut self, uri: &'q BaseUri) -> Self {
+        self.uri = Some(uri);
+        self
+    }
+
+    #[must_use]
+    pub const fn with_version(mut self, version: u32) -> Self {
+        self.version = Some(OntologyVersion::Exact(version));
+        self
+    }
+
+    #[must_use]
+    pub const fn with_latest_version(mut self) -> Self {
+        self.version = Some(OntologyVersion::Latest);
+        self
+    }
+}
+
+/// Parameters specified in the query.
+impl<'q, T> OntologyQuery<'q, T> {
+    #[must_use]
+    pub const fn uri(&self) -> Option<&BaseUri> {
+        self.uri
+    }
+
+    #[must_use]
+    pub const fn version(&self) -> Option<OntologyVersion> {
+        self.version
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/store/query/ontology.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/ontology.rs
@@ -42,19 +42,19 @@ impl<T> OntologyQuery<'_, T> {
 /// Methods for building up a query.
 impl<'q, T> OntologyQuery<'q, T> {
     #[must_use]
-    pub const fn with_uri(mut self, uri: &'q BaseUri) -> Self {
+    pub const fn by_uri(mut self, uri: &'q BaseUri) -> Self {
         self.uri = Some(uri);
         self
     }
 
     #[must_use]
-    pub const fn with_version(mut self, version: u32) -> Self {
+    pub const fn by_version(mut self, version: u32) -> Self {
         self.version = Some(OntologyVersion::Exact(version));
         self
     }
 
     #[must_use]
-    pub const fn with_latest_version(mut self) -> Self {
+    pub const fn by_latest_version(mut self) -> Self {
         self.version = Some(OntologyVersion::Latest);
         self
     }

--- a/packages/graph/hash_graph/tests/integration/postgres/data_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/data_type.rs
@@ -1,5 +1,3 @@
-use graph::ontology::types::OntologyType;
-
 use crate::postgres::DatabaseTestWrapper;
 
 #[tokio::test]
@@ -63,5 +61,5 @@ async fn update() {
         .expect("could not update data type");
 
     assert_ne!(object_dt_v1, object_dt_v2);
-    assert_ne!(object_dt_v1.uri(), object_dt_v2.uri());
+    assert_ne!(object_dt_v1.id(), object_dt_v2.id());
 }

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -314,7 +314,7 @@ impl DatabaseApi<'_> {
             )
             .await?
             .pop()
-            .expect("No links found")
+            .expect("No link found")
             .outgoing()[&link_type_uri]
             .clone())
     }

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -152,8 +152,8 @@ impl DatabaseApi<'_> {
             .store
             .get_data_type(
                 &DataTypeQuery::new()
-                    .with_uri(uri.base_uri())
-                    .with_version(uri.version()),
+                    .by_uri(uri.base_uri())
+                    .by_version(uri.version()),
             )
             .await?
             .pop()
@@ -183,8 +183,8 @@ impl DatabaseApi<'_> {
             .store
             .get_property_type(
                 &PropertyTypeQuery::new()
-                    .with_uri(uri.base_uri())
-                    .with_version(uri.version()),
+                    .by_uri(uri.base_uri())
+                    .by_version(uri.version()),
             )
             .await?
             .pop()
@@ -214,8 +214,8 @@ impl DatabaseApi<'_> {
             .store
             .get_entity_type(
                 &EntityTypeQuery::new()
-                    .with_uri(uri.base_uri())
-                    .with_version(uri.version()),
+                    .by_uri(uri.base_uri())
+                    .by_version(uri.version()),
             )
             .await?
             .pop()
@@ -242,8 +242,8 @@ impl DatabaseApi<'_> {
             .store
             .get_link_type(
                 &LinkTypeQuery::new()
-                    .with_uri(uri.base_uri())
-                    .with_version(uri.version()),
+                    .by_uri(uri.base_uri())
+                    .by_version(uri.version()),
             )
             .await?
             .pop()
@@ -269,7 +269,7 @@ impl DatabaseApi<'_> {
     pub async fn get_entity(&mut self, entity_id: EntityId) -> Result<PersistedEntity, QueryError> {
         Ok(self
             .store
-            .get_entity(&EntityQuery::new().with_id(entity_id).with_latest_version())
+            .get_entity(&EntityQuery::new().by_id(entity_id).by_latest_version())
             .await?
             .pop()
             .expect("No entity found"))
@@ -305,11 +305,11 @@ impl DatabaseApi<'_> {
             .store
             .get_links(
                 &LinkQuery::new()
-                    .with_source_entity_id(source_entity)
-                    .with_link_types(|link_types| {
+                    .by_source_entity_id(source_entity)
+                    .by_link_types(|link_types| {
                         link_types
-                            .with_uri(link_type_uri.base_uri())
-                            .with_version(link_type_uri.version())
+                            .by_uri(link_type_uri.base_uri())
+                            .by_version(link_type_uri.version())
                     }),
             )
             .await?
@@ -322,7 +322,7 @@ impl DatabaseApi<'_> {
     pub async fn get_entity_links(&self, source_entity: EntityId) -> Result<Links, QueryError> {
         Ok(self
             .store
-            .get_links(&LinkQuery::new().with_source_entity_id(source_entity))
+            .get_links(&LinkQuery::new().by_source_entity_id(source_entity))
             .await?
             .pop()
             .expect("No links found"))


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In order to implement structured querying for the Graph API we chose to use a query builder approach to build our queries on the Rust side. We had a few requirements for our builders: They should be composable and deserializable, so it's possible to pass a full query from e.g. the REST API and directly translate it to Rust. This is the reason, why builders implemented in this PR do not contain a generic state argument.

This PR only adds very basic builders, which are able to specify the same functionality we had before.

## 🔗 Related links

- [Notion draft on structural querying](https://www.notion.so/hashintel/What-is-Structural-Querying-and-why-does-everyone-talk-about-it-9acbcd334c7f4d8d857b36e6ea81d89c) (_internal_)
- [Asana task](https://app.asana.com/0/0/1202770062090891/f) _(internal)_

## 🔍 What does this change?

- Add basic queries for
  - Ontology types (`DataType`, `PropertyType`, `LinkType`, `EntityType`)
  - `PersistedEntity`
  - `Links`
- Change the `Read` trait to use the queries
  - Currently, queries only need to be `Debug` (for logging) and `Sync`, there is no `Query` trait
  - `Read` is not bound to a lifetime anymore, `Query` will be passed by reference in any case (even though, the current queries could implement `Copy`, but this may change later and I chose to be conservative here)
  - `Read<T>::read` will *always* return `Vec<T>`
    - If we need different outputs, we can add this as a generic later
- Add the `Read` bound on the stores directly, e.g. `DataTypeStore: Read<DataType>` or `EntityStore: Read<PersistedEntity>`
- Remove the trait alias on `Graph` (which was only used to alias `Store` and the `Read` bounds)
- Only the previously implemented queries are implemented on queries, this means, that the graph will panic if an unsupported query is used (e.g. `DataType::with_version(10)`, this would read *all* `DataType`s with a version of `10`, but without specifying the URI).

## 📜 Does this require a change to the docs?

The external API does not change

## ⚠️ Known issues

- Queries always has the same output. This has two issues:
  - This is annoying when having queries like "give me entity with ID X and version Y", this will at most return one entity, but the `Read` trait returns a `Vec`. This could be resolved by adding a `read_one` method on the trait, which reuses the `read` method by default, but this is not required for now, so this was left out.
  - It will always return the most generic type, e.g. `PersistedEntity`. If only an account id ("Give me the account id for entity X") is required, the full entity is returned. This can be avoided later on by adding an additional generic to the `Read` trait, but to avoid overengineering now, this was left out. It's possible to add this functionality later.
- ~~Currently, the implementation of `Read` are pretty big because all the functionality is in one function, this should be moved out to dedicated functions in a follow-up.~~

## 🛡 What tests cover this?

The external API did not change, so the REST endpoint tests and the integration tests covers this. The integration test suite was slightly adjusted to create the queries in the API wrapper.

## ❓ How to test this?

Run the usual test suites.
I can highly recommend reviewing this offline, e.g. with CLion, as the diff-viewer is smarter there.

