### PR TITLE
Bump toolchain to `2020-08-08` (`dev/graph`)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           nightly=$(cat $(find . -name rust-toolchain.toml) | grep channel | cut -d\" -f2)
           echo "::set-output name=nightly::$nightly"
-          echo "use toolchains: $(echo $nightly | jq -r)"
+          echo "use toolchains: $(echo $nightly)"
 
       - name: Determine samples
         id: samples

--- a/packages/engine/Cargo.lock
+++ b/packages/engine/Cargo.lock
@@ -649,8 +649,7 @@ dependencies = [
 [[package]]
 name = "error-stack"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5975af488b218348f3f183862f88e8699a91a809f0ee2658fcafaa6239d6759e"
+source = "git+https://github.com/hashintel/hash?rev=5edddb5#5edddb5566f9bd82dcdf9ba3b430759bc6b15dc5"
 dependencies = [
  "rustc_version",
  "tracing-error",

--- a/packages/engine/Cargo.lock
+++ b/packages/engine/Cargo.lock
@@ -651,7 +651,10 @@ name = "error-stack"
 version = "0.1.1"
 source = "git+https://github.com/hashintel/hash?rev=5edddb5#5edddb5566f9bd82dcdf9ba3b430759bc6b15dc5"
 dependencies = [
+ "anyhow",
+ "once_cell",
  "rustc_version",
+ "smallvec",
  "tracing-error",
 ]
 

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -13,7 +13,8 @@ experiment-structure = { path = "lib/experiment-structure", default-features = f
 experiment-control = { path = "lib/experiment-control", default-features = false }
 orchestrator = { path = "lib/orchestrator", default-features = false }
 
-error-stack = { version = "0.1.1", features = ["spantrace"] }
+# TODO: Change to `version = "0.2"` as soon as it's released
+error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace"] }
 
 num_cpus = "1.13.0"
 serde = { version = "1.0.111", features = ["derive"] }

--- a/packages/engine/bin/cli/Cargo.toml
+++ b/packages/engine/bin/cli/Cargo.toml
@@ -11,7 +11,8 @@ experiment-structure = { path = "../../lib/experiment-structure", default-featur
 experiment-control = { path = "../../lib/experiment-control", default-features = false, features = ["clap"] }
 orchestrator = { path = "../../lib/orchestrator", default-features = false, features = ["clap"] }
 
-error-stack = { version = "0.1.1", features = ["spantrace"] }
+# TODO: Change to `version = "0.2"` as soon as it's released
+error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace"] }
 
 clap = { version = "3.0.0", features = ["cargo", "derive", "env"] }
 serde = { version = "1.0.111", features = ["derive"] }

--- a/packages/engine/bin/cli/src/main.rs
+++ b/packages/engine/bin/cli/src/main.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), CliError> {
         &format!("cli-{now}"),
         &format!("cli-{now}-texray"),
     )
-    .report()
+    .into_report()
     .attach_printable("Failed to initialize the logger")
     .change_context(CliError)?;
 
@@ -71,7 +71,7 @@ async fn main() -> Result<(), CliError> {
     let absolute_project_path = args
         .project
         .canonicalize()
-        .report()
+        .into_report()
         .attach_printable_lazy(|| {
             format!("Could not canonicalize project path: {:?}", args.project)
         })

--- a/packages/engine/bin/hash_engine/Cargo.toml
+++ b/packages/engine/bin/hash_engine/Cargo.toml
@@ -8,7 +8,8 @@ execution = { path = "../../lib/execution", default-features = false }
 experiment-structure = { path = "../../lib/experiment-structure", default-features = false }
 experiment-control = { path = "../../lib/experiment-control", default-features = false, features = ["clap"] }
 
-error-stack = { version = "0.1.1", features = ["spantrace"] }
+# TODO: Change to `version = "0.2"` as soon as it's released
+error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace"] }
 
 tokio = "1.18.2"
 tracing = "0.1.29"

--- a/packages/engine/bin/hash_engine/src/main.rs
+++ b/packages/engine/bin/hash_engine/src/main.rs
@@ -44,13 +44,13 @@ async fn main() -> Result<(), EngineError> {
         &format!("experiment-{}", args.experiment_id),
         &format!("experiment-{}-texray", args.experiment_id),
     )
-    .report()
+    .into_report()
     .attach_printable("Failed to initialize the logger")
     .change_context(EngineError)?;
 
     let mut env = Environment::new(&args)
         .await
-        .report()
+        .into_report()
         .attach_printable("Could not create environment for experiment")
         .change_context(EngineError)?;
     // Fetch all dependencies of the experiment run such as datasets
@@ -70,7 +70,7 @@ async fn main() -> Result<(), EngineError> {
 
     let experiment_result = run_experiment(config, env)
         .await
-        .report()
+        .into_report()
         .attach_printable("Could not run experiment")
         .change_context(EngineError);
 

--- a/packages/engine/lib/experiment-control/Cargo.toml
+++ b/packages/engine/lib/experiment-control/Cargo.toml
@@ -11,7 +11,8 @@ execution = { path = "../execution", default-features = false }
 experiment-structure = { path = "../experiment-structure", default-features = false }
 simulation-control = { path = "../simulation-control", default-features = false }
 
-error-stack = { version = "0.1.1", features = ["spantrace"] }
+# TODO: Change to `version = "0.2"` as soon as it's released
+error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace"] }
 
 clap = { version = "3.0.0", features = ["cargo", "derive", "env"], optional = true }
 num_cpus = "1.13.0"

--- a/packages/engine/lib/experiment-structure/Cargo.toml
+++ b/packages/engine/lib/experiment-structure/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 stateful = { path = "../stateful", default-features = false }
 execution = { path = "../execution", default-features = false }
 
-error-stack = "0.1.1"
+# TODO: Change to `version = "0.2"` as soon as it's released
+error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace"] }
 
 async-trait = "0.1.48"
 csv = "1.1.5"

--- a/packages/engine/lib/experiment-structure/src/config/experiment.rs
+++ b/packages/engine/lib/experiment-structure/src/config/experiment.rs
@@ -41,7 +41,7 @@ impl ExperimentConfig {
             })
             .build()?;
         let base_globals: Globals = serde_json::from_str(&simulation.globals_src)
-            .report()
+            .into_report()
             .attach_printable("Could not parse globals JSON")
             .change_context(ConfigError)?;
 

--- a/packages/engine/lib/experiment-structure/src/config/package.rs
+++ b/packages/engine/lib/experiment-structure/src/config/package.rs
@@ -211,7 +211,7 @@ impl PackageConfigBuilder {
         {
             let deps = dependency
                 .get_all_dependencies()
-                .report()
+                .into_report()
                 .attach_printable_lazy(|| format!("Could not get dependencies for {dependency}"))
                 .change_context(ConfigError)?;
             for dep in deps.into_iter_deps() {

--- a/packages/engine/lib/experiment-structure/src/experiment/plan.rs
+++ b/packages/engine/lib/experiment-structure/src/experiment/plan.rs
@@ -51,7 +51,7 @@ fn get_simple_experiment_config(
         .ok_or_else(|| Report::new(ExperimentPlanError))
         .attach_printable("Experiment configuration not found: experiments.json")?;
     let parsed = serde_json::from_str(experiments_manifest)
-        .report()
+        .into_report()
         .change_context(ExperimentPlanError)
         .attach_printable("Could not parse experiment manifest")?;
     let plan = create_experiment_plan(&parsed, &experiment_name)
@@ -131,7 +131,7 @@ fn create_multiparameter_variant(
     }
 
     let var: MultiparameterVariant = serde_json::from_value(selected_experiment.clone())
-        .report()
+        .into_report()
         .change_context(ExperimentPlanError)
         .attach_printable("Could not parse multiparameter variant")?;
     let subplans = var
@@ -188,7 +188,7 @@ fn create_group_variant(
         runs: Vec<ExperimentName>,
     }
     let var: GroupVariant = serde_json::from_value(selected_experiment.clone())
-        .report()
+        .into_report()
         .change_context(ExperimentPlanError)
         .attach_printable("Could not create group variant")?;
     var.runs.iter().try_fold(
@@ -287,37 +287,37 @@ fn create_monte_carlo_variant_plan(
             let distribution = match self.distribution.as_str() {
                 "normal" => Box::new(
                     Normal::new(self.mean.unwrap_or(1.0), self.std.unwrap_or(1.0))
-                        .report()
+                        .into_report()
                         .change_context(ExperimentPlanError)
                         .attach_printable("Unable to create normal distribution")?,
                 ) as Box<dyn DynDistribution<f64>>,
                 "log-normal" => Box::new(
                     LogNormal::new(self.mu.unwrap_or(1.0), self.sigma.unwrap_or(1.0))
-                        .report()
+                        .into_report()
                         .change_context(ExperimentPlanError)
                         .attach_printable("Unable to create log-normal distribution")?,
                 ),
                 "poisson" => Box::new(
                     Poisson::new(self.rate.unwrap_or(1.0))
-                        .report()
+                        .into_report()
                         .change_context(ExperimentPlanError)
                         .attach_printable("Unable to create poisson distribution")?,
                 ),
                 "beta" => Box::new(
                     Beta::new(self.alpha.unwrap_or(1.0), self.beta.unwrap_or(1.0))
-                        .report()
+                        .into_report()
                         .change_context(ExperimentPlanError)
                         .attach_printable("Unable to create beta distribution")?,
                 ),
                 "gamma" => Box::new(
                     Gamma::new(self.shape.unwrap_or(1.0), self.scale.unwrap_or(1.0))
-                        .report()
+                        .into_report()
                         .change_context(ExperimentPlanError)
                         .attach_printable("Unable to create gamma distribution")?,
                 ),
                 _ => Box::new(
                     Normal::new(1.0, 1.0)
-                        .report()
+                        .into_report()
                         .change_context(ExperimentPlanError)
                         .attach_printable("Unable to create normal distribution")?,
                 ),
@@ -330,7 +330,7 @@ fn create_monte_carlo_variant_plan(
     }
 
     let var: MonteCarloVariant = serde_json::from_value(selected_experiment.clone())
-        .report()
+        .into_report()
         .change_context(ExperimentPlanError)
         .attach_printable("Could not create monte carlo distribution")?;
     let values: Vec<_> = (0..var.samples as usize).map(|_| 0.into()).collect();
@@ -355,7 +355,7 @@ fn create_value_variant_plan(
     }
 
     let var: ValueVariant = serde_json::from_value(selected_experiment.clone())
-        .report()
+        .into_report()
         .change_context(ExperimentPlanError)
         .attach_printable("Could not parse value variant")?;
     let mapper: Mapper = Box::new(|val, _index| val);
@@ -381,7 +381,7 @@ fn create_linspace_variant_plan(
         stop: f64,
     }
     let var: LinspaceVariant = serde_json::from_value(selected_experiment.clone())
-        .report()
+        .into_report()
         .change_context(ExperimentPlanError)
         .attach_printable("Could not create linspace variant")?;
     let values: Vec<_> = (0..var.samples as usize).map(|_| 0.into()).collect();
@@ -420,7 +420,7 @@ fn create_arange_variant_plan(
         stop: f64,
     }
     let var: ArangeVariant = serde_json::from_value(selected_experiment.clone())
-        .report()
+        .into_report()
         .change_context(ExperimentPlanError)
         .attach_printable("Could not create arange variant")?;
     let mut values = vec![];
@@ -453,7 +453,7 @@ fn create_meshgrid_variant_plan(
         y: [f64; 3], // [start, stop, num_samples]
     }
     let var: MeshgridVariant = serde_json::from_value(selected_experiment.clone())
-        .report()
+        .into_report()
         .change_context(ExperimentPlanError)
         .attach_printable("Could not create meshgrid variant")?;
 

--- a/packages/engine/lib/experiment-structure/src/manifest.rs
+++ b/packages/engine/lib/experiment-structure/src/manifest.rs
@@ -303,7 +303,7 @@ impl Manifest {
         tracing::debug!("Reading behaviors in {src_folder:?}");
         for entry in src_folder
             .read_dir()
-            .report()
+            .into_report()
             .attach_printable_lazy(|| format!("Could not read behavior directory: {src_folder:?}"))
             .change_context(ManifestError)?
         {
@@ -387,7 +387,7 @@ impl Manifest {
         tracing::debug!("Reading datasets in {src_folder:?}");
         for entry in src_folder
             .read_dir()
-            .report()
+            .into_report()
             .attach_printable_lazy(|| format!("Could not read dataset directory: {src_folder:?}"))
             .change_context(ManifestError)?
         {
@@ -713,7 +713,7 @@ fn _try_read_local_dependencies<P: AsRef<Path>>(dependency_path: P) -> Result<Ve
 
     let mut entries = dependency_path
         .read_dir()
-        .report()
+        .into_report()
         .attach_printable_lazy(|| format!("Could not read dependency directory: {dependency_path:?}"))
         .change_context(ManifestError)?
         .filter_map(|dir_res| {
@@ -729,7 +729,7 @@ fn _try_read_local_dependencies<P: AsRef<Path>>(dependency_path: P) -> Result<Ve
             user_dir
                 .path()
                 .read_dir()
-                .report()
+                .into_report()
                 .attach_printable_lazy(|| {
                     format!("Could not read directory {:?}", user_dir.path())
                 })
@@ -770,7 +770,7 @@ fn file_contents<P: AsRef<Path>>(path: P) -> Result<String> {
     let path = path.as_ref();
     tracing::debug!("Reading contents at path: {path:?}");
     std::fs::read_to_string(path)
-        .report()
+        .into_report()
         .attach_printable_lazy(|| format!("Could not read file: {path:?}"))
         .change_context(ManifestError)
 }
@@ -788,11 +788,11 @@ fn parse_file<T: DeserializeOwned, P: AsRef<Path>>(path: P) -> Result<T> {
     let path = path.as_ref();
     serde_json::from_reader(BufReader::new(
         File::open(path)
-            .report()
+            .into_report()
             .attach_printable_lazy(|| format!("Could not read file {path:?}"))
             .change_context(ManifestError)?,
     ))
-    .report()
+    .into_report()
     .attach_printable_lazy(|| format!("Could not parse {path:?}"))
     .change_context(ManifestError)
 }

--- a/packages/engine/lib/memory/src/arrow/ffi/flush.rs
+++ b/packages/engine/lib/memory/src/arrow/ffi/flush.rs
@@ -41,7 +41,7 @@ unsafe extern "C" fn flush_changes(
     let changes = &*changes;
     // Use this base lifetime for everything
     let static_meta_ref = &*static_meta;
-    let num_changes = (*changes).len;
+    let num_changes = changes.len;
     let indices = std::slice::from_raw_parts(changes.indices, num_changes);
     let arrays = std::slice::from_raw_parts(changes.columns, num_changes);
     let prepared_columns: Vec<PreparedColumn<'_>> = match (0..num_changes)

--- a/packages/engine/lib/memory/src/arrow/ffi/mod.rs
+++ b/packages/engine/lib/memory/src/arrow/ffi/mod.rs
@@ -77,7 +77,7 @@ unsafe extern "C" fn get_static_metadata(schema: usize) -> *const meta::Static {
 #[no_mangle]
 unsafe extern "C" fn free_static_metadata(ptr: *mut meta::Static) {
     if !ptr.is_null() {
-        Box::from_raw(ptr);
+        drop(Box::from_raw(ptr));
     }
 }
 
@@ -136,6 +136,6 @@ unsafe extern "C" fn get_dynamic_metadata(memory_ptr: *const CSegment) -> *const
 #[no_mangle]
 unsafe extern "C" fn free_dynamic_metadata(ptr: *mut meta::Dynamic) {
     if !ptr.is_null() {
-        Box::from_raw(ptr);
+        drop(Box::from_raw(ptr));
     }
 }

--- a/packages/engine/lib/memory/src/shared_memory/ffi.rs
+++ b/packages/engine/lib/memory/src/shared_memory/ffi.rs
@@ -37,7 +37,7 @@ unsafe extern "C" fn load_shmem(id: *const u8, len: u64) -> *mut CSegment {
 #[no_mangle]
 // Free memory and drop Memory object
 unsafe extern "C" fn free_memory(c_memory: *mut CSegment) {
-    Box::from_raw((*c_memory).segment as *mut Segment);
+    drop(Box::from_raw((*c_memory).segment as *mut Segment));
 }
 
 const _: () = assert!(

--- a/packages/engine/lib/memory/src/shared_memory/visitor.rs
+++ b/packages/engine/lib/memory/src/shared_memory/visitor.rs
@@ -5,11 +5,13 @@
 
 use std::ops::{Index, IndexMut};
 
+#[cfg(not(target_vendor = "apple"))]
+use crate::{error::Error, shared_memory::markers::Val};
 use crate::{
-    error::{Error, Result},
+    error::Result,
     shared_memory::{
         continuation::{arrow_continuation, buffer_without_continuation, CONTINUATION},
-        markers::{Buffer, Markers, Val},
+        markers::{Buffer, Markers},
         ptr::MemoryPtr,
         BufferChange, Segment,
     },
@@ -174,7 +176,8 @@ impl<'mem: 'v, 'v> VisitorMut<'mem> {
         self.prepare_buffer_write(&Buffer::Data, size)
     }
 
-    pub fn _shrink_with_data_length(&mut self, size: usize) -> Result<BufferChange> {
+    #[cfg(not(target_vendor = "apple"))]
+    pub fn shrink_with_data_length(&mut self, size: usize) -> Result<BufferChange> {
         let markers = self.markers_mut();
         if size >= markers.data_size() {
             return Err(Error::ExpectedSmallerNewDataSize(self.memory.id().into()));

--- a/packages/engine/lib/memory/src/shared_memory/visitor.rs
+++ b/packages/engine/lib/memory/src/shared_memory/visitor.rs
@@ -174,7 +174,7 @@ impl<'mem: 'v, 'v> VisitorMut<'mem> {
         self.prepare_buffer_write(&Buffer::Data, size)
     }
 
-    pub fn shrink_with_data_length(&mut self, size: usize) -> Result<BufferChange> {
+    pub fn _shrink_with_data_length(&mut self, size: usize) -> Result<BufferChange> {
         let markers = self.markers_mut();
         if size >= markers.data_size() {
             return Err(Error::ExpectedSmallerNewDataSize(self.memory.id().into()));

--- a/packages/engine/lib/nano/Cargo.toml
+++ b/packages/engine/lib/nano/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-error-stack = { version = "0.1.1", features = ["spantrace"] }
+# TODO: Change to `version = "0.2"` as soon as it's released
+error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace"] }
 
 nng = { version = "1.0.1", default-features = false }
 serde = { version = "1.0.111", features = ["derive"] }

--- a/packages/engine/lib/nano/src/server.rs
+++ b/packages/engine/lib/nano/src/server.rs
@@ -56,7 +56,7 @@ impl Worker {
     /// [`Sleep`]: nng::AioResult::Sleep
     fn new(socket: &nng::Socket, sender: MsgSender, url: &str) -> Result<Self, nng::Error> {
         let ctx_orig = nng::Context::new(socket)
-            .report()
+            .into_report()
             .attach_printable("Could not create context")?;
         let ctx = ctx_orig.clone();
 
@@ -89,7 +89,7 @@ impl Worker {
         // Initialize the Aio in the Recv state
         ctx_orig
             .recv(&aio)
-            .report()
+            .into_report()
             .attach_printable("Could not receive message from context")?;
 
         Ok(Self { _aio: aio })
@@ -107,12 +107,12 @@ impl Server {
     /// - the worker could not be created from the provided `url`.
     pub fn new(url: &str) -> Result<Self> {
         let socket = nng::Socket::new(nng::Protocol::Rep0)
-            .report()
+            .into_report()
             .attach_printable("Could not create socket")
             .change_context(ErrorKind::ServerCreation)?;
         socket
             .listen(url)
-            .report()
+            .into_report()
             .attach_printable("Could not listen on socket")
             .change_context(ErrorKind::ServerCreation)?;
 
@@ -152,7 +152,7 @@ impl Server {
     {
         let msg = self.receiver.recv().await.expect(RECV_EXPECT_MESSAGE);
         serde_json::from_slice::<T>(msg.as_slice())
-            .report()
+            .into_report()
             .attach_printable("Could not convert message from JSON")
             .change_context(ErrorKind::Receive)
     }

--- a/packages/engine/lib/orchestrator/Cargo.toml
+++ b/packages/engine/lib/orchestrator/Cargo.toml
@@ -12,7 +12,8 @@ simulation-control = { path = "../simulation-control", default-features = false 
 experiment-control = { path = "../experiment-control", default-features = false }
 hash_engine = { path = "../../bin/hash_engine", default-features = false, artifact = "bin" }
 
-error-stack = { version = "0.1.1", features = ["spantrace"] }
+# TODO: Change to `version = "0.2"` as soon as it's released
+error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace"] }
 
 async-trait = "0.1.48"
 clap = { version = "3.0.13", optional = true }

--- a/packages/engine/lib/orchestrator/src/experiment.rs
+++ b/packages/engine/lib/orchestrator/src/experiment.rs
@@ -212,7 +212,7 @@ impl Experiment {
             engine_handle.recv(),
         )
         .await
-        .report()
+        .into_report()
         .change_context(OrchestratorError::from("engine start timeout"));
         match msg {
             Ok(EngineStatus::Started) => {}

--- a/packages/engine/lib/orchestrator/src/experiment_server.rs
+++ b/packages/engine/lib/orchestrator/src/experiment_server.rs
@@ -91,7 +91,7 @@ impl Handler {
         })?;
         result_rx
             .await
-            .report()
+            .into_report()
             .change_context(OrchestratorError::from("Failed to receive response from"))?
     }
 
@@ -223,9 +223,12 @@ impl Server {
                 // completes before sending de-registering the experiment.
                 Ok(())
             }
-            Some(sender) => sender.send(msg.body).report().attach_printable_lazy(|| {
-                format!("Routing message for experiment {}", msg.experiment_id)
-            }),
+            Some(sender) => sender
+                .send(msg.body)
+                .into_report()
+                .attach_printable_lazy(|| {
+                    format!("Routing message for experiment {}", msg.experiment_id)
+                }),
         }
     }
 

--- a/packages/engine/lib/orchestrator/src/process/local.rs
+++ b/packages/engine/lib/orchestrator/src/process/local.rs
@@ -102,7 +102,7 @@ impl process::Process for LocalProcess {
             .child
             .wait()
             .await
-            .report()
+            .into_report()
             .change_context(OrchestratorError::from(
                 "Could not wait for the process to exit",
             ))?)
@@ -209,7 +209,7 @@ impl process::Command for LocalCommand {
         }
         debug!("Running `{cmd:?}`");
 
-        let child = cmd.spawn().report().change_context_lazy(|| {
+        let child = cmd.spawn().into_report().change_context_lazy(|| {
             OrchestratorError::from(format!("Could not run command: {process_path:?}"))
         })?;
         debug!("Spawned local engine process for experiment");

--- a/packages/engine/lib/simulation-control/src/command/mod.rs
+++ b/packages/engine/lib/simulation-control/src/command/mod.rs
@@ -144,7 +144,7 @@ impl Commands {
 
         let mut refs = Vec::with_capacity(HASH.len());
         for hash_recipient in &HASH {
-            refs.push(message_map.get_msg_refs(*hash_recipient))
+            refs.push(message_map.get_msg_refs(hash_recipient))
         }
 
         let res: Commands = refs

--- a/packages/engine/lib/stateful/src/agent/arrow/array.rs
+++ b/packages/engine/lib/stateful/src/agent/arrow/array.rs
@@ -91,27 +91,27 @@ impl IntoRecordBatch for &[&Agent] {
             // `name` must have static lifetime, like `match` arms.
             // TODO: built-ins should take nullability from the schema
             let col = if name.eq(AgentStateField::AgentId.name()) {
-                agents_to_id_col(*self)?
+                agents_to_id_col(self)?
             } else if name == AgentStateField::AgentName.name() {
                 Arc::new(json_vals_to_utf8(vals, true)?)
             } else if name == AgentStateField::Messages.name() {
                 Arc::new(MessageArray::from_json(vals)?)
             } else if name == AgentStateField::Position.name() {
-                Arc::new(agents_to_position_col(*self)?)
+                Arc::new(agents_to_position_col(self)?)
             } else if name == AgentStateField::Direction.name()
                 || name == AgentStateField::Velocity.name()
             {
-                Arc::new(agents_to_direction_col(*self)?)
+                Arc::new(agents_to_direction_col(self)?)
             } else if name == AgentStateField::Shape.name() {
                 Arc::new(json_vals_to_utf8(vals, true)?)
             } else if name == AgentStateField::Height.name() {
                 Arc::new(json_vals_to_primitive::<Float64Type>(vals, true)?)
             } else if name == AgentStateField::Scale.name() {
-                Arc::new(agents_to_scale_col(*self)?)
+                Arc::new(agents_to_scale_col(self)?)
             } else if name == AgentStateField::Color.name() {
                 Arc::new(json_vals_to_utf8(vals, true)?)
             } else if name == AgentStateField::Rgb.name() {
-                Arc::new(agents_to_rgb_col(*self)?)
+                Arc::new(agents_to_rgb_col(self)?)
             } else if name == AgentStateField::Hidden.name() {
                 Arc::new(json_vals_to_bool(vals)?)
             } else if name == PREVIOUS_INDEX_FIELD_KEY {

--- a/packages/engine/lib/stateful/src/message/outbound.rs
+++ b/packages/engine/lib/stateful/src/message/outbound.rs
@@ -215,12 +215,7 @@ impl Message {
         if let Some(serde_json::Value::String(kind /* is a &String */)) = value.get("type") {
             // since all keys stored inside the system message types are lower case, we should also
             // lowercase the kind here too
-            let kind: &String = &kind.to_ascii_lowercase();
-            // contains needs a &str, our type is a &String, so
-            // 1. *&String -> String
-            // 2. *String -> &str
-            // 3. (wrap in a temp ref, for std::borrow::Borrow), thus &**
-            if is_system_message(&**kind) {
+            if is_system_message(&kind.to_ascii_lowercase()) {
                 return Ok(());
             }
             // otherwise throw an error

--- a/packages/engine/rust-toolchain.toml
+++ b/packages/engine/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2022-06-26"
+channel = "nightly-2022-08-08"

--- a/packages/graph/hash_graph/Cargo.lock
+++ b/packages/graph/hash_graph/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c794e162a5eff65c72ef524dfe393eb923c354e350bb78b9c7383df13f3bc142"
+
+[[package]]
 name = "async-trait"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,11 +270,13 @@ dependencies = [
 [[package]]
 name = "error-stack"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5975af488b218348f3f183862f88e8699a91a809f0ee2658fcafaa6239d6759e"
+source = "git+https://github.com/hashintel/hash?rev=5edddb5#5edddb5566f9bd82dcdf9ba3b430759bc6b15dc5"
 dependencies = [
- "pin-project",
+ "anyhow",
+ "once_cell",
  "rustc_version",
+ "smallvec",
+ "tracing-error",
 ]
 
 [[package]]

--- a/packages/graph/hash_graph/bin/hash_graph/Cargo.toml
+++ b/packages/graph/hash_graph/bin/hash_graph/Cargo.toml
@@ -11,7 +11,8 @@ description = "The entity-graph query-layer for the HASH datastore"
 axum = "0.5.11"
 clap = { version = "3.2.10", features = ["cargo", "derive", "env", "wrap_help"] }
 clap_complete = "3.2.3"
-error-stack = { version = "0.1.1", features = ["futures"] }
+# TODO: Change to `version = "0.2"` as soon as it's released
+error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace"] }
 graph = { path = "../../lib/graph", features = ["clap"] }
 tokio = { version = "1.18.2", features = ["rt-multi-thread", "macros"] }
 tokio-postgres = { version = "0.7.6", default-features = false }

--- a/packages/graph/hash_graph/lib/graph/Cargo.toml
+++ b/packages/graph/hash_graph/lib/graph/Cargo.toml
@@ -12,7 +12,8 @@ axum = "0.5.11"
 bb8-postgres = "0.8.1"
 clap = { version = "3.2.10", features = ["derive", "env"], optional = true }
 chrono = { version = "0.4.19", features = ["serde"] }
-error-stack = "0.1.1"
+# TODO: Change to `version = "0.2"` as soon as it's released
+error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace"] }
 futures = "0.3.21"
 postgres-types = { version = "0.2.3", default-features = false, features = ["derive", "with-uuid-1", "with-serde_json-1", "with-chrono-0_4"] }
 serde = { version = "1.0.137", features = ["derive"] }

--- a/packages/graph/hash_graph/lib/graph/src/ontology/types/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/types/property_type/mod.rs
@@ -360,7 +360,7 @@ mod tests {
 
         #[test]
         fn value() -> Result<(), serde_json::Error> {
-            check(&ValueOrArray::Value("value".to_owned()), json!("value")).report()
+            check(&ValueOrArray::Value("value".to_owned()), json!("value")).into_report()
         }
 
         #[test]
@@ -374,7 +374,7 @@ mod tests {
                     },
                 }),
             )
-            .report()
+            .into_report()
         }
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/ontology/types/uri.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/types/uri.rs
@@ -73,7 +73,10 @@ impl FromStr for VersionedUri {
 
         Ok(Self::new(
             base_uri.to_owned(),
-            version.parse().report().change_context(ParseUriError)?,
+            version
+                .parse()
+                .into_report()
+                .change_context(ParseUriError)?,
         ))
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -27,7 +27,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             self.as_mut_client()
                 .transaction()
                 .await
-                .report()
+                .into_report()
                 .change_context(InsertionError)?,
         );
 
@@ -42,7 +42,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             .client
             .commit()
             .await
-            .report()
+            .into_report()
             .change_context(InsertionError)?;
 
         Ok(identifier)
@@ -59,7 +59,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             self.as_mut_client()
                 .transaction()
                 .await
-                .report()
+                .into_report()
                 .change_context(UpdateError)?,
         );
 
@@ -82,7 +82,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             .client
             .commit()
             .await
-            .report()
+            .into_report()
             .change_context(UpdateError)?;
 
         Ok(identifier)

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -33,12 +33,12 @@ impl<C: AsClient> crud::Read<'_, EntityId, PersistedEntity> for PostgresStore<C>
                 &[&identifier],
             )
             .await
-            .report()
+            .into_report()
             .change_context(QueryError)
             .attach_printable(identifier)?;
 
         let entity = serde_json::from_value(row.get(0))
-            .report()
+            .into_report()
             .change_context(QueryError)?;
 
         let entity_id: EntityId = row.get(1);
@@ -77,14 +77,14 @@ impl<C: AsClient> crud::Read<'_, AllLatest, PersistedEntity> for PostgresStore<C
                 [] as [&(dyn ToSql + Sync); 0],
             )
             .await
-            .report()
+            .into_report()
             .change_context(QueryError)?;
 
         row_stream
             .map(|row_result| {
-                let row = row_result.report().change_context(QueryError)?;
+                let row = row_result.into_report().change_context(QueryError)?;
                 let entity = serde_json::from_value(row.get(0))
-                    .report()
+                    .into_report()
                     .change_context(QueryError)?;
 
                 let entity_id: EntityId = row.get(1);

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/read.rs
@@ -31,7 +31,7 @@ impl<C: AsClient> crud::Read<'_, EntityId, Link> for PostgresStore<C> {
                 &[&identifier],
             )
             .await
-            .report()
+            .into_report()
             .change_context(QueryError)
             .attach_printable(identifier)?
             .into_iter()
@@ -50,7 +50,7 @@ impl<C: AsClient> crud::Read<'_, EntityId, Link> for PostgresStore<C> {
                 &[&identifier],
             )
             .await
-            .report()
+            .into_report()
             .change_context(QueryError)
             .attach_printable(identifier)?
             .into_iter()
@@ -103,7 +103,7 @@ impl<'i, C: AsClient> crud::Read<'i, (EntityId, &'i VersionedUri), Link> for Pos
             &[&source_entity_id, link_type_uri.base_uri(), &version],
         )
         .await
-        .report()
+        .into_report()
         .change_context(QueryError)
         .attach_printable(source_entity_id)
         .attach_printable(link_type_uri.clone())?;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -60,7 +60,7 @@ where
                 &[&account_id],
             )
             .await
-            .report()
+            .into_report()
             .change_context(InsertionError)
             .attach_printable(account_id)?;
 
@@ -89,7 +89,7 @@ where
                 &[&base_uri],
             )
             .await
-            .report()
+            .into_report()
             .change_context(QueryError)
             .attach_printable_lazy(|| base_uri.clone())?
             .get(0))
@@ -116,7 +116,7 @@ where
                 &[uri.base_uri(), &version],
             )
             .await
-            .report()
+            .into_report()
             .change_context(QueryError)
             .attach_printable_lazy(|| uri.clone())?
             .get(0))
@@ -138,7 +138,7 @@ where
                 &[&entity_id],
             )
             .await
-            .report()
+            .into_report()
             .change_context(InsertionError)
             .attach_printable(entity_id)?;
 
@@ -165,7 +165,7 @@ where
                 &[&entity_id],
             )
             .await
-            .report()
+            .into_report()
             .change_context(QueryError)
             .attach_printable(entity_id)?
             .get(0))
@@ -192,7 +192,7 @@ where
                 &[uri.base_uri(), &version, &version_id],
             )
             .await
-            .report()
+            .into_report()
             .change_context(InsertionError)
             .attach_printable_lazy(|| uri.clone())?;
 
@@ -217,7 +217,7 @@ where
                 &[&base_uri],
             )
             .await
-            .report()
+            .into_report()
             .change_context(InsertionError)
             .attach_printable_lazy(|| base_uri.clone())?;
 
@@ -240,7 +240,7 @@ where
                 &[&version_id],
             )
             .await
-            .report()
+            .into_report()
             .change_context(InsertionError)
             .attach_printable(version_id)?;
 
@@ -359,7 +359,7 @@ where
         T: OntologyDatabaseType + Serialize + Sync,
     {
         let value = serde_json::to_value(database_type)
-            .report()
+            .into_report()
             .change_context(InsertionError)?;
         // Generally bad practice to construct a query without preparation, but it's not possible to
         // pass a table name as a parameter and `T::table()` is well-defined, so this is a safe
@@ -377,7 +377,7 @@ where
                 &[&version_id, &value, &created_by],
             )
             .await
-            .report()
+            .into_report()
             .change_context(InsertionError)?;
 
         Ok(())
@@ -404,7 +404,7 @@ where
                     &[&version_id, &target_id],
                 )
                 .await
-                .report()
+                .into_report()
                 .change_context(InsertionError)?;
         }
 
@@ -424,7 +424,7 @@ where
                     &[&version_id, &target_id],
                 )
                 .await
-                .report()
+                .into_report()
                 .change_context(InsertionError)?;
         }
 
@@ -452,7 +452,7 @@ where
                     &[&version_id, &target_id],
                 )
                 .await
-                .report()
+                .into_report()
                 .change_context(InsertionError)?;
         }
 
@@ -477,7 +477,7 @@ where
                     &[&version_id, &target_id],
                 )
                 .await
-                .report()
+                .into_report()
                 .change_context(InsertionError)?;
         }
 
@@ -497,7 +497,7 @@ where
                     &[&version_id, &target_id],
                 )
                 .await
-                .report()
+                .into_report()
                 .change_context(InsertionError)?;
         }
 
@@ -584,7 +584,7 @@ where
         // TODO: Validate entity against entity type
 
         let value = serde_json::to_value(entity)
-            .report()
+            .into_report()
             .change_context(InsertionError)?;
         let version = self.as_client().query_one(
                 r#"
@@ -595,7 +595,7 @@ where
                 &[&entity_id, &entity_type_id, &value, &account_id]
             )
             .await
-            .report()
+            .into_report()
             .change_context(InsertionError)?.get(0);
 
         Ok(PersistedEntityIdentifier::new(
@@ -621,7 +621,7 @@ where
                 &[&active, &source_entity, &target_entity, &link_type_version_id],
             )
             .await
-            .report()
+            .into_report()
             .change_context(LinkActivationError)?;
 
         Ok(())
@@ -646,7 +646,7 @@ where
                 &[uri.base_uri(), &version],
             )
             .await
-            .report()
+            .into_report()
             .change_context(QueryError)
             .attach_printable_lazy(|| uri.clone())?
             .get(0))

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -18,7 +18,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
             self.as_mut_client()
                 .transaction()
                 .await
-                .report()
+                .into_report()
                 .change_context(InsertionError)?,
         );
 
@@ -28,7 +28,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
             .client
             .commit()
             .await
-            .report()
+            .into_report()
             .change_context(InsertionError)?;
 
         Ok(())
@@ -43,7 +43,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
             self.as_mut_client()
                 .transaction()
                 .await
-                .report()
+                .into_report()
                 .change_context(UpdateError)?,
         );
 
@@ -53,7 +53,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
             .client
             .commit()
             .await
-            .report()
+            .into_report()
             .change_context(UpdateError)?;
 
         Ok(())

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
@@ -19,7 +19,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
             self.as_mut_client()
                 .transaction()
                 .await
-                .report()
+                .into_report()
                 .change_context(InsertionError)?,
         );
 
@@ -36,7 +36,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
             .client
             .commit()
             .await
-            .report()
+            .into_report()
             .change_context(InsertionError)?;
 
         Ok(())
@@ -51,7 +51,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
             self.as_mut_client()
                 .transaction()
                 .await
-                .report()
+                .into_report()
                 .change_context(UpdateError)?,
         );
 
@@ -68,7 +68,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
             .client
             .commit()
             .await
-            .report()
+            .into_report()
             .change_context(UpdateError)?;
 
         Ok(())

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
@@ -19,7 +19,7 @@ impl<C: AsClient> LinkTypeStore for PostgresStore<C> {
             self.as_mut_client()
                 .transaction()
                 .await
-                .report()
+                .into_report()
                 .change_context(InsertionError)?,
         );
 
@@ -29,7 +29,7 @@ impl<C: AsClient> LinkTypeStore for PostgresStore<C> {
             .client
             .commit()
             .await
-            .report()
+            .into_report()
             .change_context(InsertionError)?;
 
         Ok(())
@@ -44,7 +44,7 @@ impl<C: AsClient> LinkTypeStore for PostgresStore<C> {
             self.as_mut_client()
                 .transaction()
                 .await
-                .report()
+                .into_report()
                 .change_context(UpdateError)?,
         );
 
@@ -54,7 +54,7 @@ impl<C: AsClient> LinkTypeStore for PostgresStore<C> {
             .client
             .commit()
             .await
-            .report()
+            .into_report()
             .change_context(UpdateError)?;
 
         Ok(())

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -19,7 +19,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
             self.as_mut_client()
                 .transaction()
                 .await
-                .report()
+                .into_report()
                 .change_context(InsertionError)?,
         );
 
@@ -36,7 +36,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
             .client
             .commit()
             .await
-            .report()
+            .into_report()
             .change_context(InsertionError)?;
 
         Ok(())
@@ -51,7 +51,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
             self.as_mut_client()
                 .transaction()
                 .await
-                .report()
+                .into_report()
                 .change_context(UpdateError)?,
         );
 
@@ -68,7 +68,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
             .client
             .commit()
             .await
-            .report()
+            .into_report()
             .change_context(UpdateError)?;
 
         Ok(())

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -43,12 +43,12 @@ where
                 &[uri.base_uri(), &version],
             )
             .await
-            .report()
+            .into_report()
             .change_context(QueryError)
             .attach_printable_lazy(|| uri.clone())?;
 
         serde_json::from_value(row.get(0))
-            .report()
+            .into_report()
             .change_context(QueryError)
     }
 }
@@ -81,14 +81,14 @@ where
                 [] as [&(dyn ToSql + Sync); 0],
             )
             .await
-            .report()
+            .into_report()
             .change_context(QueryError)?;
 
         row_stream
             .map(|row_result| {
-                let row = row_result.report().change_context(QueryError)?;
+                let row = row_result.into_report().change_context(QueryError)?;
                 serde_json::from_value(row.get(0))
-                    .report()
+                    .into_report()
                     .change_context(QueryError)
             })
             .try_collect()

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/pool.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/pool.rs
@@ -60,7 +60,7 @@ where
                 .error_sink(Box::new(ErrorLogger))
                 .build(PostgresConnectionManager::new(config, tls))
                 .await
-                .report()
+                .into_report()
                 .change_context(StoreError)
                 .attach_printable_lazy(|| db_info.clone())?,
         })

--- a/packages/graph/hash_graph/rust-toolchain.toml
+++ b/packages/graph/hash_graph/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2022-06-26"
+channel = "nightly-2022-08-08"

--- a/packages/libs/error-stack/Makefile.toml
+++ b/packages/libs/error-stack/Makefile.toml
@@ -9,6 +9,10 @@ CARGO_MIRI_FLAGS = "--tests --lib"
 [tasks.test-task]
 dependencies = ["install-rust-src"]
 
+# Miri is disabled on `dev/graph`
+[tasks.miri]
+run_task = { name = [] }
+
 # Required for UI tests
 [tasks.install-rust-src]
 private = true

--- a/packages/libs/error-stack/src/context.rs
+++ b/packages/libs/error-stack/src/context.rs
@@ -105,8 +105,6 @@ pub fn temporary_provider(context: &impl Context) -> impl Provider + '_ {
 impl<C: std::error::Error + Send + Sync + 'static> Context for C {
     #[cfg(nightly)]
     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
-        if let Some(backtrace) = self.backtrace() {
-            demand.provide_ref(backtrace);
-        }
+        std::error::Error::provide(self, demand);
     }
 }

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -367,7 +367,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(nightly, feature(provide_any))]
 #![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
-#![cfg_attr(all(nightly, feature = "std"), feature(backtrace))]
+#![cfg_attr(
+    all(nightly, feature = "std"),
+    feature(backtrace, error_generic_member_access)
+)]
 #![warn(
     missing_docs,
     clippy::pedantic,

--- a/packages/libs/error-stack/src/report.rs
+++ b/packages/libs/error-stack/src/report.rs
@@ -185,14 +185,14 @@ impl<C> Report<C> {
         let provider = temporary_provider(&context);
 
         #[cfg(all(nightly, feature = "std"))]
-        let backtrace = if core::any::request_ref::<Backtrace, _>(&provider).is_some() {
+        let backtrace = if core::any::request_ref::<Backtrace>(&provider).is_some() {
             None
         } else {
             Some(Backtrace::capture())
         };
 
         #[cfg(all(nightly, feature = "spantrace"))]
-        let span_trace = if core::any::request_ref::<SpanTrace, _>(&provider).is_some() {
+        let span_trace = if core::any::request_ref::<SpanTrace>(&provider).is_some() {
             None
         } else {
             Some(SpanTrace::capture())


### PR DESCRIPTION
Port of `main` to `dev/graph`, see the linked PRs for a description

## 🔗 Related links

- #901
- #902
- #904
- #908

## ⚠️  Known issues

- Miri got more restrictive in the recent versions. With #774 this was fixed on `main` but not on `dev/graph`. As we don't want to port this over to this branch, `miri` is disabled for `error-stack` on `dev/graph`