### PR TITLE
Add `EntityModel` class with Graph API CRU operations

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -81,7 +81,6 @@ impl PersistedEntityIdentifier {
 #[serde(rename_all = "camelCase")]
 pub struct PersistedEntity {
     inner: Entity,
-    #[serde(flatten)]
     identifier: PersistedEntityIdentifier,
     #[component(value_type = String)]
     type_versioned_uri: VersionedUri,

--- a/packages/hash/api/src/model/index.ts
+++ b/packages/hash/api/src/model/index.ts
@@ -21,6 +21,7 @@ import DataTypeModel from "./ontology/data-type.model";
 import PropertyTypeModel from "./ontology/property-type.model";
 import LinkTypeModel from "./ontology/link-type.model";
 import EntityTypeModel from "./ontology/entity-type.model";
+import EntityModel from "./knowledge/entity.model";
 
 export * from "./ontology/data-type.model";
 export { DataTypeModel };
@@ -33,6 +34,9 @@ export { LinkTypeModel };
 
 export * from "./ontology/entity-type.model";
 export { EntityTypeModel };
+
+export * from "./knowledge/entity.model";
+export { EntityModel };
 
 /** @todo: deprecate legacy model classes */
 

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -1,0 +1,115 @@
+import { Entity, GraphApi } from "@hashintel/hash-graph-client";
+
+import { EntityModel } from "../index";
+
+type EntityModelArgs = {
+  accountId: string;
+  entityId: string;
+  entityTypeUri: string;
+  entity: Entity;
+};
+
+/**
+ * @class {@link EntityModel}
+ */
+export default class {
+  accountId: string;
+
+  entityId: string;
+  entityTypeUri: string;
+  entity: Entity;
+
+  constructor({ accountId, entityId, entityTypeUri, entity }: EntityModelArgs) {
+    this.accountId = accountId;
+
+    this.entityId = entityId;
+    this.entityTypeUri = entityTypeUri;
+    this.entity = entity;
+  }
+
+  /**
+   * Create an entity.
+   *
+   * @param params.accountId the accountId of the account creating the entity
+   * @param params.schema an `Entity`
+   */
+  static async create(
+    graphApi: GraphApi,
+    params: {
+      accountId: string;
+      entity: Entity;
+      entityTypeUri: string;
+    },
+  ): Promise<EntityModel> {
+    const {
+      data: { entity, entityId },
+    } = await graphApi.createEntity(params);
+
+    return new EntityModel({
+      accountId: params.accountId,
+      entityId,
+      entityTypeUri: params.entityTypeUri,
+      entity,
+    });
+  }
+
+  /**
+   * Get all entities at their latest version.
+   *
+   * @param params.accountId the accountId of the account requesting the entities
+   */
+  static async getAllLatest(
+    graphApi: GraphApi,
+    params: { accountId: string },
+  ): Promise<EntityModel[]> {
+    /** @todo: get all latest entities in specified account */
+    const { data: entities } = await graphApi.getLatestEntities();
+
+    return entities.map(
+      ({ schema }) => new EntityModel({ schema, accountId: params.accountId }),
+    );
+  }
+
+  /**
+   * Get the latest version of an entity by its entity ID.
+   *
+   * @param params.accountId the accountId of the account requesting the entity
+   * @param params.versionedUri the unique versioned URI for an entity.
+   */
+  static async get(
+    graphApi: GraphApi,
+    params: {
+      accountId: string;
+      entityId: string;
+    },
+  ): Promise<EntityModel> {
+    const { accountId, entityId } = params;
+    const { data: qualifiedEntity } = await graphApi.getEntity(entityId);
+
+    return new EntityModel({ schema, accountId });
+  }
+
+  /**
+   * Update an entity.
+   *
+   * @todo revisit entity update
+   * As with entity `create`, this `update` operation is not currently relevant to users
+   * because user defined entities are not fully specified.
+   *
+   * @param params.accountId the accountId of the account making the update
+   * @param params.schema an `Entity`
+   */
+  async update(
+    graphApi: GraphApi,
+    params: {
+      accountId: string;
+      schema: Entity;
+    },
+  ): Promise<EntityModel> {
+    const { accountId } = params;
+
+    const { data: schema } = await graphApi.updateEntity(params);
+
+    return new EntityModel({ schema, accountId });
+  }
+}

--- a/packages/hash/api/src/model/ontology/data-type.model.ts
+++ b/packages/hash/api/src/model/ontology/data-type.model.ts
@@ -1,6 +1,7 @@
 import { DataType, GraphApi } from "@hashintel/hash-graph-client";
 
 import { DataTypeModel } from "../index";
+import { NIL_UUID } from "../util";
 
 type DataTypeModelConstructorArgs = {
   accountId: string;
@@ -68,12 +69,14 @@ export default class {
   static async get(
     graphApi: GraphApi,
     params: {
-      accountId: string;
       versionedUri: string;
     },
   ): Promise<DataTypeModel> {
-    const { accountId, versionedUri } = params;
+    const { versionedUri } = params;
     const { data: schema } = await graphApi.getDataType(versionedUri);
+
+    /** @todo: retrieve accountId from `graphApi.getDataType` response */
+    const accountId = NIL_UUID;
 
     return new DataTypeModel({ schema, accountId });
   }

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -1,9 +1,10 @@
 import { EntityType, GraphApi } from "@hashintel/hash-graph-client";
 
 import { EntityTypeModel, PropertyTypeModel, LinkTypeModel } from "../index";
+import { NIL_UUID } from "../util";
 
 type EntityTypeModelConstructorArgs = {
-  accountId: string;
+  accountId?: string;
   schema: EntityType;
 };
 
@@ -11,7 +12,7 @@ type EntityTypeModelConstructorArgs = {
  * @class {@link EntityTypeModel}
  */
 export default class {
-  accountId: string;
+  accountId?: string;
 
   schema: EntityType;
 
@@ -64,12 +65,14 @@ export default class {
   static async get(
     graphApi: GraphApi,
     params: {
-      accountId: string;
       versionedUri: string;
     },
   ): Promise<EntityTypeModel> {
-    const { accountId, versionedUri } = params;
+    const { versionedUri } = params;
     const { data: schema } = await graphApi.getEntityType(versionedUri);
+
+    /** @todo: retrieve accountId from `graphApi.getEntityType` response */
+    const accountId = NIL_UUID;
 
     return new EntityTypeModel({ schema, accountId });
   }
@@ -103,7 +106,6 @@ export default class {
     return await Promise.all(
       linkTypeVersionedUris.map((versionedUri) =>
         LinkTypeModel.get(graphApi, {
-          accountId: this.accountId,
           versionedUri,
         }),
       ),
@@ -121,7 +123,6 @@ export default class {
     return await Promise.all(
       propertyTypeVersionedUris.map((versionedUri) =>
         PropertyTypeModel.get(graphApi, {
-          accountId: this.accountId,
           versionedUri,
         }),
       ),

--- a/packages/hash/api/src/model/ontology/link-type.model.ts
+++ b/packages/hash/api/src/model/ontology/link-type.model.ts
@@ -1,6 +1,7 @@
 import { LinkType, GraphApi } from "@hashintel/hash-graph-client";
 
 import { LinkTypeModel } from "../index";
+import { NIL_UUID } from "../util";
 
 type LinkTypeModelConstructorArgs = {
   accountId: string;
@@ -64,12 +65,14 @@ export default class {
   static async get(
     graphApi: GraphApi,
     params: {
-      accountId: string;
       versionedUri: string;
     },
   ): Promise<LinkTypeModel> {
-    const { accountId, versionedUri } = params;
+    const { versionedUri } = params;
     const { data: schema } = await graphApi.getLinkType(versionedUri);
+
+    /** @todo: retrieve accountId from `graphApi.getLinkType` response */
+    const accountId = NIL_UUID;
 
     return new LinkTypeModel({ schema, accountId });
   }

--- a/packages/hash/api/src/model/ontology/property-type.model.ts
+++ b/packages/hash/api/src/model/ontology/property-type.model.ts
@@ -1,6 +1,7 @@
 import { PropertyType, GraphApi } from "@hashintel/hash-graph-client";
 
 import { PropertyTypeModel } from "../index";
+import { NIL_UUID } from "../util";
 
 type PropertyTypeModelConstructorArgs = {
   accountId: string;
@@ -65,12 +66,14 @@ export default class {
   static async get(
     graphApi: GraphApi,
     params: {
-      accountId: string;
       versionedUri: string;
     },
   ): Promise<PropertyTypeModel> {
-    const { accountId, versionedUri } = params;
+    const { versionedUri } = params;
     const { data: schema } = await graphApi.getPropertyType(versionedUri);
+
+    /** @todo: retrieve accountId from `graphApi.getPropertyType` response */
+    const accountId = NIL_UUID;
 
     return new PropertyTypeModel({ schema, accountId });
   }

--- a/packages/hash/api/src/model/util.ts
+++ b/packages/hash/api/src/model/util.ts
@@ -50,3 +50,5 @@ export const RESTRICTED_SHORTNAMES = [
   "users",
   "v2",
 ];
+
+export const NIL_UUID = "00000000-0000-0000-0000-000000000000";

--- a/packages/hash/integration/src/tests/model/knowledge/entity.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/entity.model.test.ts
@@ -1,0 +1,139 @@
+import { getRequiredEnv } from "@hashintel/hash-backend-utils/environment";
+import { createGraphClient } from "@hashintel/hash-api/src/graph";
+import { Logger } from "@hashintel/hash-backend-utils/logger";
+
+import {
+  EntityModel,
+  EntityTypeModel,
+  DataTypeModel,
+  PropertyTypeModel,
+} from "@hashintel/hash-api/src/model";
+
+jest.setTimeout(60000);
+
+const logger = new Logger({
+  mode: "dev",
+  level: "debug",
+  serviceName: "integration-tests",
+});
+
+const graphApi = createGraphClient(
+  { basePath: getRequiredEnv("HASH_GRAPH_API_BASE_URL") },
+  logger,
+);
+
+const accountId = "00000000-0000-0000-0000-000000000000";
+
+const textDataType$id = "https://entity~example.com/data-type/v/1";
+
+const textPropertyTypeBaseId = "https://entity~example.com/property-type-text";
+const textPropertyType$id = `${textPropertyTypeBaseId}/v/1`;
+
+const namePropertyTypeBaseId = "https://entity~example.com/property-type-name";
+const namePropertyType$id = `${namePropertyTypeBaseId}/v/1`;
+
+const entityType$id = "https://entity~example.com/entity-type-/v/1";
+
+let entityType: EntityTypeModel;
+
+beforeAll(async () => {
+  await DataTypeModel.create(graphApi, {
+    accountId,
+    schema: {
+      $id: textDataType$id,
+      kind: "dataType",
+      title: "Text",
+      type: "string",
+    },
+  });
+
+  const results = await Promise.all([
+    EntityTypeModel.create(graphApi, {
+      accountId,
+      schema: {
+        $id: entityType$id,
+        kind: "entityType",
+        title: "Text",
+        type: "object",
+        properties: {},
+      },
+    }),
+    PropertyTypeModel.create(graphApi, {
+      accountId,
+      schema: {
+        $id: textPropertyType$id,
+        kind: "propertyType",
+        title: "Text",
+        oneOf: [{ $ref: textDataType$id }],
+      },
+    }),
+    PropertyTypeModel.create(graphApi, {
+      accountId,
+      schema: {
+        $id: namePropertyType$id,
+        kind: "propertyType",
+        title: "Text",
+        oneOf: [{ $ref: textDataType$id }],
+      },
+    }),
+  ]);
+
+  entityType = results[0];
+});
+
+describe("Entity CRU", () => {
+  let createdEntity: EntityModel;
+  it("can create an entity", async () => {
+    createdEntity = await EntityModel.create(graphApi, {
+      accountId,
+      properties: {
+        [namePropertyTypeBaseId]: "Bob",
+        [textPropertyTypeBaseId]: "some text",
+      },
+      entityType,
+    });
+  });
+
+  it("can read an entity", async () => {
+    const fetchedEntity = await EntityModel.getLatest(graphApi, {
+      accountId,
+      entityId: createdEntity.entityId,
+    });
+
+    expect(fetchedEntity.entityId).toEqual(createdEntity.entityId);
+    expect(fetchedEntity.version).toEqual(createdEntity.version);
+  });
+
+  let updatedEntity: EntityModel;
+  it("can update an entity", async () => {
+    updatedEntity = await createdEntity
+      .update(graphApi, {
+        accountId,
+        properties: {
+          [namePropertyTypeBaseId]: "Updated Bob",
+          [textPropertyTypeBaseId]: "Even more text than before",
+        },
+      })
+      .catch((err) => Promise.reject(err.data));
+  });
+
+  it("can read all latest entities", async () => {
+    const allEntities = await EntityModel.getAllLatest(graphApi, {
+      accountId,
+    });
+
+    const newlyUpdated = allEntities.find(
+      (ent) => ent.entityId === updatedEntity.entityId,
+    );
+
+    // Even though we've inserted two entities, they're the different versions
+    // of the same entity. This should only retrieve a single entity.
+    expect(allEntities.length).toEqual(1);
+    expect(newlyUpdated).toBeDefined();
+
+    expect(newlyUpdated!.version).toEqual(updatedEntity.version);
+    expect((newlyUpdated!.properties as any)[namePropertyTypeBaseId]).toEqual(
+      (updatedEntity.properties as any)[namePropertyTypeBaseId],
+    );
+  });
+});

--- a/packages/hash/integration/src/tests/model/knowledge/entity.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/entity.model.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 import { getRequiredEnv } from "@hashintel/hash-backend-utils/environment";
 import { createGraphClient } from "@hashintel/hash-api/src/graph";
 import { Logger } from "@hashintel/hash-backend-utils/logger";
@@ -34,7 +35,7 @@ const namePropertyType$id = `${namePropertyTypeBaseId}/v/1`;
 
 const entityType$id = "https://entity~example.com/entity-type-/v/1";
 
-let entityType: EntityTypeModel;
+let entityTypeModel: EntityTypeModel;
 
 beforeAll(async () => {
   await DataTypeModel.create(graphApi, {
@@ -78,35 +79,35 @@ beforeAll(async () => {
     }),
   ]);
 
-  entityType = results[0];
+  entityTypeModel = results[0];
 });
 
 describe("Entity CRU", () => {
-  let createdEntity: EntityModel;
+  let createdEntityModel: EntityModel;
   it("can create an entity", async () => {
-    createdEntity = await EntityModel.create(graphApi, {
+    createdEntityModel = await EntityModel.create(graphApi, {
       accountId,
       properties: {
         [namePropertyTypeBaseId]: "Bob",
         [textPropertyTypeBaseId]: "some text",
       },
-      entityType,
+      entityTypeModel,
     });
   });
 
   it("can read an entity", async () => {
-    const fetchedEntity = await EntityModel.getLatest(graphApi, {
+    const fetchedEntityModel = await EntityModel.getLatest(graphApi, {
       accountId,
-      entityId: createdEntity.entityId,
+      entityId: createdEntityModel.entityId,
     });
 
-    expect(fetchedEntity.entityId).toEqual(createdEntity.entityId);
-    expect(fetchedEntity.version).toEqual(createdEntity.version);
+    expect(fetchedEntityModel.entityId).toEqual(createdEntityModel.entityId);
+    expect(fetchedEntityModel.version).toEqual(createdEntityModel.version);
   });
 
-  let updatedEntity: EntityModel;
+  let updatedEntityModel: EntityModel;
   it("can update an entity", async () => {
-    updatedEntity = await createdEntity
+    updatedEntityModel = await createdEntityModel
       .update(graphApi, {
         accountId,
         properties: {
@@ -118,22 +119,22 @@ describe("Entity CRU", () => {
   });
 
   it("can read all latest entities", async () => {
-    const allEntities = await EntityModel.getAllLatest(graphApi, {
+    const allEntityModels = await EntityModel.getAllLatest(graphApi, {
       accountId,
     });
 
-    const newlyUpdated = allEntities.find(
-      (ent) => ent.entityId === updatedEntity.entityId,
+    const newlyUpdatedModel = allEntityModels.find(
+      (ent) => ent.entityId === updatedEntityModel.entityId,
     );
 
     // Even though we've inserted two entities, they're the different versions
     // of the same entity. This should only retrieve a single entity.
-    expect(allEntities.length).toEqual(1);
-    expect(newlyUpdated).toBeDefined();
+    expect(allEntityModels.length).toEqual(1);
+    expect(newlyUpdatedModel).toBeDefined();
 
-    expect(newlyUpdated!.version).toEqual(updatedEntity.version);
-    expect((newlyUpdated!.properties as any)[namePropertyTypeBaseId]).toEqual(
-      (updatedEntity.properties as any)[namePropertyTypeBaseId],
-    );
+    expect(newlyUpdatedModel!.version).toEqual(updatedEntityModel.version);
+    expect(
+      (newlyUpdatedModel!.properties as any)[namePropertyTypeBaseId],
+    ).toEqual((updatedEntityModel.properties as any)[namePropertyTypeBaseId]);
   });
 });

--- a/packages/hash/integration/src/tests/model/ontology/data-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/data-type.model.test.ts
@@ -43,7 +43,6 @@ describe("Data type CRU", () => {
 
   it("can read a data type", async () => {
     const fetchedDataType = await DataTypeModel.get(graphApi, {
-      accountId,
       versionedUri: createdDataType$id,
     });
 

--- a/packages/hash/integration/src/tests/model/ontology/entity-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/entity-type.model.test.ts
@@ -131,7 +131,6 @@ describe("Entity type CRU", () => {
 
   it("can read an entity type", async () => {
     const fetchedEntityType = await EntityTypeModel.get(graphApi, {
-      accountId,
       versionedUri: createdEntityType$id,
     });
 

--- a/packages/hash/integration/src/tests/model/ontology/link-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/link-type.model.test.ts
@@ -41,7 +41,6 @@ describe("Link type CRU", () => {
 
   it("can read a link type", async () => {
     const fetchedLinkType = await LinkTypeModel.get(graphApi, {
-      accountId,
       versionedUri: createdLinkType$id,
     });
 

--- a/packages/hash/integration/src/tests/model/ontology/property-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/property-type.model.test.ts
@@ -63,7 +63,6 @@ describe("Property type CRU", () => {
 
   it("can read a property type", async () => {
     const fetchedPropertyType = await PropertyTypeModel.get(graphApi, {
-      accountId,
       versionedUri: createdPropertyType$id,
     });
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
This PR adds the `EntityModel` class for creating, getting and updating `Entities`. 

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1200211978612931/1202731581883433/f) _(internal)_

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Changes PersistedEntity in the rust API to not flatten the `identifier` as Utoipa doesn't support this
- Adds a new `EntityModel` class under `/api/src/models/knowledge/` directory

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->


## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->
- We've added explicit NIL UUID references instead of relying on passed-in `accountId`s for the existing model classes. This needs to change and will allow us to refer to `created_by` workspace accounts in the future.

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->
- Implementing user entities [Asana task](https://app.asana.com/0/1200211978612931/1202693393444197/f) (_internal_)

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- `packages/hash/integration/src/tests/model/knowledge/entity.model.test.ts`

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch / view the deployment
1.  Recreate and migrate DB and run backend
     - From the `packages/graph/hash_graph/bin/hash_graph` path run:
     - `cargo make recreate-db && cargo make migrate-up`
     - `cargo run`
1.  In another terminal, from the `packages/hash/integration` path run `yarn jest "knowledge/*"`
1.  Confirm all tests pass

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
![image](https://user-images.githubusercontent.com/6988668/183693460-ae5bb90a-c731-4b01-ac88-6159549149d6.png)
