### PR TITLE
Return metadata with ontology types

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -433,6 +433,25 @@ export interface Links {
   outgoing: object;
 }
 /**
+ *
+ * @export
+ * @interface PersistedDataType
+ */
+export interface PersistedDataType {
+  /**
+   *
+   * @type {PersistedOntologyIdentifier}
+   * @memberof PersistedDataType
+   */
+  identifier: PersistedOntologyIdentifier;
+  /**
+   *
+   * @type {DataType}
+   * @memberof PersistedDataType
+   */
+  inner: DataType;
+}
+/**
  * A record of an [`Entity`] that has been persisted in the datastore, with its associated
  * @export
  * @interface PersistedEntity
@@ -481,6 +500,82 @@ export interface PersistedEntityIdentifier {
    * @memberof PersistedEntityIdentifier
    */
   version: string;
+}
+/**
+ *
+ * @export
+ * @interface PersistedEntityType
+ */
+export interface PersistedEntityType {
+  /**
+   *
+   * @type {PersistedOntologyIdentifier}
+   * @memberof PersistedEntityType
+   */
+  identifier: PersistedOntologyIdentifier;
+  /**
+   *
+   * @type {DataType}
+   * @memberof PersistedEntityType
+   */
+  inner: DataType;
+}
+/**
+ *
+ * @export
+ * @interface PersistedLinkType
+ */
+export interface PersistedLinkType {
+  /**
+   *
+   * @type {PersistedOntologyIdentifier}
+   * @memberof PersistedLinkType
+   */
+  identifier: PersistedOntologyIdentifier;
+  /**
+   *
+   * @type {DataType}
+   * @memberof PersistedLinkType
+   */
+  inner: DataType;
+}
+/**
+ * The metadata required to uniquely identify an ontology element that has been persisted in the
+ * @export
+ * @interface PersistedOntologyIdentifier
+ */
+export interface PersistedOntologyIdentifier {
+  /**
+   *
+   * @type {string}
+   * @memberof PersistedOntologyIdentifier
+   */
+  createdBy: string;
+  /**
+   *
+   * @type {VersionedUri}
+   * @memberof PersistedOntologyIdentifier
+   */
+  uri: VersionedUri;
+}
+/**
+ *
+ * @export
+ * @interface PersistedPropertyType
+ */
+export interface PersistedPropertyType {
+  /**
+   *
+   * @type {PersistedOntologyIdentifier}
+   * @memberof PersistedPropertyType
+   */
+  identifier: PersistedOntologyIdentifier;
+  /**
+   *
+   * @type {DataType}
+   * @memberof PersistedPropertyType
+   */
+  inner: DataType;
 }
 /**
  *
@@ -940,7 +1035,10 @@ export const DataTypeApiFp = function (configuration?: Configuration) {
       createDataTypeRequest: CreateDataTypeRequest,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<DataType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedOntologyIdentifier>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.createDataType(
         createDataTypeRequest,
@@ -1008,7 +1106,10 @@ export const DataTypeApiFp = function (configuration?: Configuration) {
       updateDataTypeRequest: UpdateDataTypeRequest,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<DataType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedOntologyIdentifier>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.updateDataType(
         updateDataTypeRequest,
@@ -1044,7 +1145,7 @@ export const DataTypeApiFactory = function (
     createDataType(
       createDataTypeRequest: CreateDataTypeRequest,
       options?: any,
-    ): AxiosPromise<DataType> {
+    ): AxiosPromise<PersistedOntologyIdentifier> {
       return localVarFp
         .createDataType(createDataTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -1079,7 +1180,7 @@ export const DataTypeApiFactory = function (
     updateDataType(
       updateDataTypeRequest: UpdateDataTypeRequest,
       options?: any,
-    ): AxiosPromise<DataType> {
+    ): AxiosPromise<PersistedOntologyIdentifier> {
       return localVarFp
         .updateDataType(updateDataTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -1103,7 +1204,7 @@ export interface DataTypeApiInterface {
   createDataType(
     createDataTypeRequest: CreateDataTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<DataType>;
+  ): AxiosPromise<PersistedOntologyIdentifier>;
 
   /**
    *
@@ -1137,7 +1238,7 @@ export interface DataTypeApiInterface {
   updateDataType(
     updateDataTypeRequest: UpdateDataTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<DataType>;
+  ): AxiosPromise<PersistedOntologyIdentifier>;
 }
 
 /**
@@ -1914,7 +2015,10 @@ export const EntityTypeApiFp = function (configuration?: Configuration) {
       createEntityTypeRequest: CreateEntityTypeRequest,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<EntityType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedOntologyIdentifier>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.createEntityType(
@@ -1983,7 +2087,10 @@ export const EntityTypeApiFp = function (configuration?: Configuration) {
       updateEntityTypeRequest: UpdateEntityTypeRequest,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<EntityType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedOntologyIdentifier>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.updateEntityType(
@@ -2020,7 +2127,7 @@ export const EntityTypeApiFactory = function (
     createEntityType(
       createEntityTypeRequest: CreateEntityTypeRequest,
       options?: any,
-    ): AxiosPromise<EntityType> {
+    ): AxiosPromise<PersistedOntologyIdentifier> {
       return localVarFp
         .createEntityType(createEntityTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -2055,7 +2162,7 @@ export const EntityTypeApiFactory = function (
     updateEntityType(
       updateEntityTypeRequest: UpdateEntityTypeRequest,
       options?: any,
-    ): AxiosPromise<EntityType> {
+    ): AxiosPromise<PersistedOntologyIdentifier> {
       return localVarFp
         .updateEntityType(updateEntityTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -2079,7 +2186,7 @@ export interface EntityTypeApiInterface {
   createEntityType(
     createEntityTypeRequest: CreateEntityTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<EntityType>;
+  ): AxiosPromise<PersistedOntologyIdentifier>;
 
   /**
    *
@@ -2113,7 +2220,7 @@ export interface EntityTypeApiInterface {
   updateEntityType(
     updateEntityTypeRequest: UpdateEntityTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<EntityType>;
+  ): AxiosPromise<PersistedOntologyIdentifier>;
 }
 
 /**
@@ -3315,7 +3422,10 @@ export const GraphApiFp = function (configuration?: Configuration) {
       createDataTypeRequest: CreateDataTypeRequest,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<DataType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedOntologyIdentifier>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.createDataType(
         createDataTypeRequest,
@@ -3364,7 +3474,10 @@ export const GraphApiFp = function (configuration?: Configuration) {
       createEntityTypeRequest: CreateEntityTypeRequest,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<EntityType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedOntologyIdentifier>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.createEntityType(
@@ -3414,7 +3527,10 @@ export const GraphApiFp = function (configuration?: Configuration) {
       createLinkTypeRequest: CreateLinkTypeRequest,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<LinkType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedOntologyIdentifier>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.createLinkType(
         createLinkTypeRequest,
@@ -3437,7 +3553,10 @@ export const GraphApiFp = function (configuration?: Configuration) {
       createPropertyTypeRequest: CreatePropertyTypeRequest,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<PropertyType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedOntologyIdentifier>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.createPropertyType(
@@ -3738,7 +3857,10 @@ export const GraphApiFp = function (configuration?: Configuration) {
       updateDataTypeRequest: UpdateDataTypeRequest,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<DataType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedOntologyIdentifier>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.updateDataType(
         updateDataTypeRequest,
@@ -3787,7 +3909,10 @@ export const GraphApiFp = function (configuration?: Configuration) {
       updateEntityTypeRequest: UpdateEntityTypeRequest,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<EntityType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedOntologyIdentifier>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.updateEntityType(
@@ -3811,7 +3936,10 @@ export const GraphApiFp = function (configuration?: Configuration) {
       updateLinkTypeRequest: UpdateLinkTypeRequest,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<LinkType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedOntologyIdentifier>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.updateLinkType(
         updateLinkTypeRequest,
@@ -3834,7 +3962,10 @@ export const GraphApiFp = function (configuration?: Configuration) {
       updatePropertyTypeRequest: UpdatePropertyTypeRequest,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<PropertyType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedOntologyIdentifier>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.updatePropertyType(
@@ -3871,7 +4002,7 @@ export const GraphApiFactory = function (
     createDataType(
       createDataTypeRequest: CreateDataTypeRequest,
       options?: any,
-    ): AxiosPromise<DataType> {
+    ): AxiosPromise<PersistedOntologyIdentifier> {
       return localVarFp
         .createDataType(createDataTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -3899,7 +4030,7 @@ export const GraphApiFactory = function (
     createEntityType(
       createEntityTypeRequest: CreateEntityTypeRequest,
       options?: any,
-    ): AxiosPromise<EntityType> {
+    ): AxiosPromise<PersistedOntologyIdentifier> {
       return localVarFp
         .createEntityType(createEntityTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -3929,7 +4060,7 @@ export const GraphApiFactory = function (
     createLinkType(
       createLinkTypeRequest: CreateLinkTypeRequest,
       options?: any,
-    ): AxiosPromise<LinkType> {
+    ): AxiosPromise<PersistedOntologyIdentifier> {
       return localVarFp
         .createLinkType(createLinkTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -3943,7 +4074,7 @@ export const GraphApiFactory = function (
     createPropertyType(
       createPropertyTypeRequest: CreatePropertyTypeRequest,
       options?: any,
-    ): AxiosPromise<PropertyType> {
+    ): AxiosPromise<PersistedOntologyIdentifier> {
       return localVarFp
         .createPropertyType(createPropertyTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -4089,7 +4220,7 @@ export const GraphApiFactory = function (
     updateDataType(
       updateDataTypeRequest: UpdateDataTypeRequest,
       options?: any,
-    ): AxiosPromise<DataType> {
+    ): AxiosPromise<PersistedOntologyIdentifier> {
       return localVarFp
         .updateDataType(updateDataTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -4117,7 +4248,7 @@ export const GraphApiFactory = function (
     updateEntityType(
       updateEntityTypeRequest: UpdateEntityTypeRequest,
       options?: any,
-    ): AxiosPromise<EntityType> {
+    ): AxiosPromise<PersistedOntologyIdentifier> {
       return localVarFp
         .updateEntityType(updateEntityTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -4131,7 +4262,7 @@ export const GraphApiFactory = function (
     updateLinkType(
       updateLinkTypeRequest: UpdateLinkTypeRequest,
       options?: any,
-    ): AxiosPromise<LinkType> {
+    ): AxiosPromise<PersistedOntologyIdentifier> {
       return localVarFp
         .updateLinkType(updateLinkTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -4145,7 +4276,7 @@ export const GraphApiFactory = function (
     updatePropertyType(
       updatePropertyTypeRequest: UpdatePropertyTypeRequest,
       options?: any,
-    ): AxiosPromise<PropertyType> {
+    ): AxiosPromise<PersistedOntologyIdentifier> {
       return localVarFp
         .updatePropertyType(updatePropertyTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -4169,7 +4300,7 @@ export interface GraphApiInterface {
   createDataType(
     createDataTypeRequest: CreateDataTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<DataType>;
+  ): AxiosPromise<PersistedOntologyIdentifier>;
 
   /**
    *
@@ -4193,7 +4324,7 @@ export interface GraphApiInterface {
   createEntityType(
     createEntityTypeRequest: CreateEntityTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<EntityType>;
+  ): AxiosPromise<PersistedOntologyIdentifier>;
 
   /**
    *
@@ -4219,7 +4350,7 @@ export interface GraphApiInterface {
   createLinkType(
     createLinkTypeRequest: CreateLinkTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<LinkType>;
+  ): AxiosPromise<PersistedOntologyIdentifier>;
 
   /**
    *
@@ -4231,7 +4362,7 @@ export interface GraphApiInterface {
   createPropertyType(
     createPropertyTypeRequest: CreatePropertyTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PropertyType>;
+  ): AxiosPromise<PersistedOntologyIdentifier>;
 
   /**
    *
@@ -4379,7 +4510,7 @@ export interface GraphApiInterface {
   updateDataType(
     updateDataTypeRequest: UpdateDataTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<DataType>;
+  ): AxiosPromise<PersistedOntologyIdentifier>;
 
   /**
    *
@@ -4403,7 +4534,7 @@ export interface GraphApiInterface {
   updateEntityType(
     updateEntityTypeRequest: UpdateEntityTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<EntityType>;
+  ): AxiosPromise<PersistedOntologyIdentifier>;
 
   /**
    *
@@ -4415,7 +4546,7 @@ export interface GraphApiInterface {
   updateLinkType(
     updateLinkTypeRequest: UpdateLinkTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<LinkType>;
+  ): AxiosPromise<PersistedOntologyIdentifier>;
 
   /**
    *
@@ -4427,7 +4558,7 @@ export interface GraphApiInterface {
   updatePropertyType(
     updatePropertyTypeRequest: UpdatePropertyTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PropertyType>;
+  ): AxiosPromise<PersistedOntologyIdentifier>;
 }
 
 /**
@@ -5407,7 +5538,10 @@ export const LinkTypeApiFp = function (configuration?: Configuration) {
       createLinkTypeRequest: CreateLinkTypeRequest,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<LinkType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedOntologyIdentifier>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.createLinkType(
         createLinkTypeRequest,
@@ -5475,7 +5609,10 @@ export const LinkTypeApiFp = function (configuration?: Configuration) {
       updateLinkTypeRequest: UpdateLinkTypeRequest,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<LinkType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedOntologyIdentifier>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.updateLinkType(
         updateLinkTypeRequest,
@@ -5511,7 +5648,7 @@ export const LinkTypeApiFactory = function (
     createLinkType(
       createLinkTypeRequest: CreateLinkTypeRequest,
       options?: any,
-    ): AxiosPromise<LinkType> {
+    ): AxiosPromise<PersistedOntologyIdentifier> {
       return localVarFp
         .createLinkType(createLinkTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -5546,7 +5683,7 @@ export const LinkTypeApiFactory = function (
     updateLinkType(
       updateLinkTypeRequest: UpdateLinkTypeRequest,
       options?: any,
-    ): AxiosPromise<LinkType> {
+    ): AxiosPromise<PersistedOntologyIdentifier> {
       return localVarFp
         .updateLinkType(updateLinkTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -5570,7 +5707,7 @@ export interface LinkTypeApiInterface {
   createLinkType(
     createLinkTypeRequest: CreateLinkTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<LinkType>;
+  ): AxiosPromise<PersistedOntologyIdentifier>;
 
   /**
    *
@@ -5604,7 +5741,7 @@ export interface LinkTypeApiInterface {
   updateLinkType(
     updateLinkTypeRequest: UpdateLinkTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<LinkType>;
+  ): AxiosPromise<PersistedOntologyIdentifier>;
 }
 
 /**
@@ -5890,7 +6027,10 @@ export const PropertyTypeApiFp = function (configuration?: Configuration) {
       createPropertyTypeRequest: CreatePropertyTypeRequest,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<PropertyType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedOntologyIdentifier>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.createPropertyType(
@@ -5959,7 +6099,10 @@ export const PropertyTypeApiFp = function (configuration?: Configuration) {
       updatePropertyTypeRequest: UpdatePropertyTypeRequest,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<PropertyType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedOntologyIdentifier>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.updatePropertyType(
@@ -5996,7 +6139,7 @@ export const PropertyTypeApiFactory = function (
     createPropertyType(
       createPropertyTypeRequest: CreatePropertyTypeRequest,
       options?: any,
-    ): AxiosPromise<PropertyType> {
+    ): AxiosPromise<PersistedOntologyIdentifier> {
       return localVarFp
         .createPropertyType(createPropertyTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -6031,7 +6174,7 @@ export const PropertyTypeApiFactory = function (
     updatePropertyType(
       updatePropertyTypeRequest: UpdatePropertyTypeRequest,
       options?: any,
-    ): AxiosPromise<PropertyType> {
+    ): AxiosPromise<PersistedOntologyIdentifier> {
       return localVarFp
         .updatePropertyType(updatePropertyTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -6055,7 +6198,7 @@ export interface PropertyTypeApiInterface {
   createPropertyType(
     createPropertyTypeRequest: CreatePropertyTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PropertyType>;
+  ): AxiosPromise<PersistedOntologyIdentifier>;
 
   /**
    *
@@ -6089,7 +6232,7 @@ export interface PropertyTypeApiInterface {
   updatePropertyType(
     updatePropertyTypeRequest: UpdatePropertyTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PropertyType>;
+  ): AxiosPromise<PersistedOntologyIdentifier>;
 }
 
 /**

--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -515,10 +515,10 @@ export interface PersistedEntityType {
   identifier: PersistedOntologyIdentifier;
   /**
    *
-   * @type {DataType}
+   * @type {EntityType}
    * @memberof PersistedEntityType
    */
-  inner: DataType;
+  inner: EntityType;
 }
 /**
  *
@@ -534,10 +534,10 @@ export interface PersistedLinkType {
   identifier: PersistedOntologyIdentifier;
   /**
    *
-   * @type {DataType}
+   * @type {LinkType}
    * @memberof PersistedLinkType
    */
-  inner: DataType;
+  inner: LinkType;
 }
 /**
  * The metadata required to uniquely identify an ontology element that has been persisted in the
@@ -553,10 +553,10 @@ export interface PersistedOntologyIdentifier {
   createdBy: string;
   /**
    *
-   * @type {VersionedUri}
+   * @type {string}
    * @memberof PersistedOntologyIdentifier
    */
-  uri: VersionedUri;
+  uri: string;
 }
 /**
  *
@@ -572,10 +572,10 @@ export interface PersistedPropertyType {
   identifier: PersistedOntologyIdentifier;
   /**
    *
-   * @type {DataType}
+   * @type {PropertyType}
    * @memberof PersistedPropertyType
    */
-  inner: DataType;
+  inner: PropertyType;
 }
 /**
  *

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -70,7 +70,7 @@ struct CreateDataTypeRequest {
     request_body = CreateDataTypeRequest,
     tag = "DataType",
     responses(
-        (status = 201, content_type = "application/json", description = "The schema of the created data type", body = VAR_DATA_TYPE),
+        (status = 201, content_type = "application/json", description = "The schema of the created data type", body = PersistedOntologyIdentifier),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 409, description = "Unable to create data type in the store as the base data type URI already exists"),
@@ -167,7 +167,7 @@ struct UpdateDataTypeRequest {
     path = "/data-types",
     tag = "DataType",
     responses(
-        (status = 200, content_type = "application/json", description = "The schema of the updated data type", body = VAR_DATA_TYPE),
+        (status = 200, content_type = "application/json", description = "The schema of the updated data type", body = PersistedOntologyIdentifier),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Base data type ID was not found"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -16,7 +16,7 @@ use crate::{
     api::rest::read_from_store,
     ontology::{
         types::{uri::VersionedUri, DataType},
-        AccountId,
+        AccountId, PersistedDataType,
     },
     store::{
         query::DataTypeQuery, BaseUriAlreadyExists, BaseUriDoesNotExist, DataTypeStore, StorePool,
@@ -119,7 +119,7 @@ async fn create_data_type<P: StorePool + Send>(
 )]
 async fn get_latest_data_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
-) -> Result<Json<Vec<DataType>>, StatusCode> {
+) -> Result<Json<Vec<PersistedDataType>>, StatusCode> {
     read_from_store(pool.as_ref(), &DataTypeQuery::new().by_latest_version())
         .await
         .map(Json)
@@ -143,7 +143,7 @@ async fn get_latest_data_types<P: StorePool + Send>(
 async fn get_data_type<P: StorePool + Send>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<DataType>, StatusCode> {
+) -> Result<Json<PersistedDataType>, StatusCode> {
     read_from_store(
         pool.as_ref(),
         &DataTypeQuery::new()

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -31,7 +31,13 @@ use crate::{
         get_latest_data_types,
         update_data_type
     ),
-    components(CreateDataTypeRequest, UpdateDataTypeRequest, AccountId),
+    components(
+        CreateDataTypeRequest,
+        UpdateDataTypeRequest,
+        AccountId,
+        PersistedOntologyIdentifier,
+        PersistedDataType
+    ),
     tags(
         (name = "DataType", description = "Data Type management API")
     )

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -16,7 +16,7 @@ use crate::{
     api::rest::read_from_store,
     ontology::{
         types::{uri::VersionedUri, DataType},
-        AccountId, PersistedDataType,
+        AccountId, PersistedDataType, PersistedOntologyIdentifier,
     },
     store::{
         query::DataTypeQuery, BaseUriAlreadyExists, BaseUriDoesNotExist, DataTypeStore, StorePool,
@@ -81,7 +81,7 @@ struct CreateDataTypeRequest {
 async fn create_data_type<P: StorePool + Send>(
     body: Json<CreateDataTypeRequest>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<DataType>, StatusCode> {
+) -> Result<Json<PersistedOntologyIdentifier>, StatusCode> {
     let Json(CreateDataTypeRequest { schema, account_id }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
@@ -102,9 +102,8 @@ async fn create_data_type<P: StorePool + Send>(
 
             // Insertion/update errors are considered internal server errors.
             StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-
-    Ok(Json(schema))
+        })
+        .map(Json)
 }
 
 #[utoipa::path(
@@ -179,7 +178,7 @@ struct UpdateDataTypeRequest {
 async fn update_data_type<P: StorePool + Send>(
     body: Json<UpdateDataTypeRequest>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<DataType>, StatusCode> {
+) -> Result<Json<PersistedOntologyIdentifier>, StatusCode> {
     let Json(UpdateDataTypeRequest { schema, account_id }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
@@ -199,7 +198,6 @@ async fn update_data_type<P: StorePool + Send>(
 
             // Insertion/update errors are considered internal server errors.
             StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-
-    Ok(Json(schema))
+        })
+        .map(Json)
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -15,7 +15,7 @@ use crate::{
     api::rest::{api_resource::RoutedResource, read_from_store},
     ontology::{
         types::{uri::VersionedUri, EntityType},
-        AccountId,
+        AccountId, PersistedEntityType,
     },
     store::{
         error::{BaseUriAlreadyExists, BaseUriDoesNotExist},
@@ -119,7 +119,7 @@ async fn create_entity_type<P: StorePool + Send>(
 )]
 async fn get_latest_entity_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
-) -> Result<Json<Vec<EntityType>>, StatusCode> {
+) -> Result<Json<Vec<PersistedEntityType>>, StatusCode> {
     read_from_store(pool.as_ref(), &EntityTypeQuery::new().by_latest_version())
         .await
         .map(Json)
@@ -143,7 +143,7 @@ async fn get_latest_entity_types<P: StorePool + Send>(
 async fn get_entity_type<P: StorePool + Send>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<EntityType>, StatusCode> {
+) -> Result<Json<PersistedEntityType>, StatusCode> {
     read_from_store(
         pool.as_ref(),
         &EntityTypeQuery::new()

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -32,7 +32,13 @@ use crate::{
         get_latest_entity_types,
         update_entity_type
     ),
-    components(CreateEntityTypeRequest, UpdateEntityTypeRequest, AccountId),
+    components(
+        CreateEntityTypeRequest,
+        UpdateEntityTypeRequest,
+        AccountId,
+        PersistedOntologyIdentifier,
+        PersistedEntityType
+    ),
     tags(
         (name = "EntityType", description = "Entity type management API")
     )

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -15,7 +15,7 @@ use crate::{
     api::rest::{api_resource::RoutedResource, read_from_store},
     ontology::{
         types::{uri::VersionedUri, EntityType},
-        AccountId, PersistedEntityType,
+        AccountId, PersistedEntityType, PersistedOntologyIdentifier,
     },
     store::{
         error::{BaseUriAlreadyExists, BaseUriDoesNotExist},
@@ -82,7 +82,7 @@ struct CreateEntityTypeRequest {
 async fn create_entity_type<P: StorePool + Send>(
     body: Json<CreateEntityTypeRequest>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<EntityType>, StatusCode> {
+) -> Result<Json<PersistedOntologyIdentifier>, StatusCode> {
     let Json(CreateEntityTypeRequest { schema, account_id }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
@@ -102,9 +102,8 @@ async fn create_entity_type<P: StorePool + Send>(
 
             // Insertion/update errors are considered internal server errors.
             StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-
-    Ok(Json(schema))
+        })
+        .map(Json)
 }
 
 #[utoipa::path(
@@ -179,7 +178,7 @@ struct UpdateEntityTypeRequest {
 async fn update_entity_type<P: StorePool + Send>(
     body: Json<UpdateEntityTypeRequest>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<EntityType>, StatusCode> {
+) -> Result<Json<PersistedOntologyIdentifier>, StatusCode> {
     let Json(UpdateEntityTypeRequest { schema, account_id }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
@@ -199,7 +198,6 @@ async fn update_entity_type<P: StorePool + Send>(
 
             // Insertion/update errors are considered internal server errors.
             StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-
-    Ok(Json(schema))
+        })
+        .map(Json)
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -71,7 +71,7 @@ struct CreateEntityTypeRequest {
     request_body = CreateEntityTypeRequest,
     tag = "EntityType",
     responses(
-        (status = 201, content_type = "application/json", description = "The schema of the created entity type", body = VAR_ENTITY_TYPE),
+        (status = 201, content_type = "application/json", description = "The schema of the created entity type", body = PersistedOntologyIdentifier),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 409, description = "Unable to create entity type in the datastore as the base entity type ID already exists"),
@@ -167,7 +167,7 @@ struct UpdateEntityTypeRequest {
     path = "/entity-types",
     tag = "EntityType",
     responses(
-        (status = 200, content_type = "application/json", description = "The schema of the updated entity type", body = VAR_ENTITY_TYPE),
+        (status = 200, content_type = "application/json", description = "The schema of the updated entity type", body = PersistedOntologyIdentifier),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Base entity type ID was not found"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -16,7 +16,7 @@ use crate::{
     api::rest::read_from_store,
     ontology::{
         types::{uri::VersionedUri, LinkType},
-        AccountId, PersistedLinkType,
+        AccountId, PersistedLinkType, PersistedOntologyIdentifier,
     },
     store::{
         query::LinkTypeQuery, BaseUriAlreadyExists, BaseUriDoesNotExist, LinkTypeStore, StorePool,
@@ -81,7 +81,7 @@ struct CreateLinkTypeRequest {
 async fn create_link_type<P: StorePool + Send>(
     body: Json<CreateLinkTypeRequest>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<LinkType>, StatusCode> {
+) -> Result<Json<PersistedOntologyIdentifier>, StatusCode> {
     let Json(CreateLinkTypeRequest { schema, account_id }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
@@ -101,9 +101,8 @@ async fn create_link_type<P: StorePool + Send>(
 
             // Insertion/update errors are considered internal server errors.
             StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-
-    Ok(Json(schema))
+        })
+        .map(Json)
 }
 
 #[utoipa::path(
@@ -178,7 +177,7 @@ struct UpdateLinkTypeRequest {
 async fn update_link_type<P: StorePool + Send>(
     body: Json<UpdateLinkTypeRequest>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<LinkType>, StatusCode> {
+) -> Result<Json<PersistedOntologyIdentifier>, StatusCode> {
     let Json(UpdateLinkTypeRequest { schema, account_id }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
@@ -198,7 +197,6 @@ async fn update_link_type<P: StorePool + Send>(
 
             // Insertion/update errors are considered internal server errors.
             StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-
-    Ok(Json(schema))
+        })
+        .map(Json)
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -31,7 +31,13 @@ use crate::{
         get_latest_link_types,
         update_link_type
     ),
-    components(CreateLinkTypeRequest, UpdateLinkTypeRequest, AccountId),
+    components(
+        CreateLinkTypeRequest,
+        UpdateLinkTypeRequest,
+        AccountId,
+        PersistedOntologyIdentifier,
+        PersistedLinkType
+    ),
     tags(
         (name = "LinkType", description = "Link type management API")
     )

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -70,7 +70,7 @@ struct CreateLinkTypeRequest {
     request_body = CreateLinkTypeRequest,
     tag = "LinkType",
     responses(
-        (status = 201, content_type = "application/json", description = "The schema of the created link type", body = VAR_LINK_TYPE),
+        (status = 201, content_type = "application/json", description = "The schema of the created link type", body = PersistedOntologyIdentifier),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 409, description = "Unable to create link type in the store as the base link type ID already exists"),
@@ -166,7 +166,7 @@ struct UpdateLinkTypeRequest {
     path = "/link-types",
     tag = "LinkType",
     responses(
-        (status = 200, content_type = "application/json", description = "The schema of the updated link type", body = VAR_LINK_TYPE),
+        (status = 200, content_type = "application/json", description = "The schema of the updated link type", body = PersistedOntologyIdentifier),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Base link type ID was not found"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -16,7 +16,7 @@ use crate::{
     api::rest::read_from_store,
     ontology::{
         types::{uri::VersionedUri, LinkType},
-        AccountId,
+        AccountId, PersistedLinkType,
     },
     store::{
         query::LinkTypeQuery, BaseUriAlreadyExists, BaseUriDoesNotExist, LinkTypeStore, StorePool,
@@ -118,7 +118,7 @@ async fn create_link_type<P: StorePool + Send>(
 )]
 async fn get_latest_link_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
-) -> Result<Json<Vec<LinkType>>, StatusCode> {
+) -> Result<Json<Vec<PersistedLinkType>>, StatusCode> {
     read_from_store(pool.as_ref(), &LinkTypeQuery::new().by_latest_version())
         .await
         .map(Json)
@@ -142,7 +142,7 @@ async fn get_latest_link_types<P: StorePool + Send>(
 async fn get_link_type<P: StorePool + Send>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<LinkType>, StatusCode> {
+) -> Result<Json<PersistedLinkType>, StatusCode> {
     read_from_store(
         pool.as_ref(),
         &LinkTypeQuery::new()

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -16,7 +16,7 @@ use crate::{
     api::rest::read_from_store,
     ontology::{
         types::{uri::VersionedUri, PropertyType},
-        AccountId,
+        AccountId, PersistedPropertyType,
     },
     store::{
         query::PropertyTypeQuery, BaseUriAlreadyExists, BaseUriDoesNotExist, PropertyTypeStore,
@@ -119,7 +119,7 @@ async fn create_property_type<P: StorePool + Send>(
 )]
 async fn get_latest_property_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
-) -> Result<Json<Vec<PropertyType>>, StatusCode> {
+) -> Result<Json<Vec<PersistedPropertyType>>, StatusCode> {
     read_from_store(pool.as_ref(), &PropertyTypeQuery::new().by_latest_version())
         .await
         .map(Json)
@@ -143,7 +143,7 @@ async fn get_latest_property_types<P: StorePool + Send>(
 async fn get_property_type<P: StorePool + Send>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<PropertyType>, StatusCode> {
+) -> Result<Json<PersistedPropertyType>, StatusCode> {
     read_from_store(
         pool.as_ref(),
         &PropertyTypeQuery::new()

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -32,7 +32,13 @@ use crate::{
         get_latest_property_types,
         update_property_type
     ),
-    components(CreatePropertyTypeRequest, UpdatePropertyTypeRequest, AccountId),
+    components(
+        CreatePropertyTypeRequest,
+        UpdatePropertyTypeRequest,
+        AccountId,
+        PersistedOntologyIdentifier,
+        PersistedPropertyType
+    ),
     tags(
         (name = "PropertyType", description = "Property type management API")
     )

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -16,7 +16,7 @@ use crate::{
     api::rest::read_from_store,
     ontology::{
         types::{uri::VersionedUri, PropertyType},
-        AccountId, PersistedPropertyType,
+        AccountId, PersistedOntologyIdentifier, PersistedPropertyType,
     },
     store::{
         query::PropertyTypeQuery, BaseUriAlreadyExists, BaseUriDoesNotExist, PropertyTypeStore,
@@ -82,7 +82,7 @@ struct CreatePropertyTypeRequest {
 async fn create_property_type<P: StorePool + Send>(
     body: Json<CreatePropertyTypeRequest>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<PropertyType>, StatusCode> {
+) -> Result<Json<PersistedOntologyIdentifier>, StatusCode> {
     let Json(CreatePropertyTypeRequest { schema, account_id }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
@@ -102,9 +102,8 @@ async fn create_property_type<P: StorePool + Send>(
 
             // Insertion/update errors are considered internal server errors.
             StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-
-    Ok(Json(schema))
+        })
+        .map(Json)
 }
 
 #[utoipa::path(
@@ -179,7 +178,7 @@ struct UpdatePropertyTypeRequest {
 async fn update_property_type<P: StorePool + Send>(
     body: Json<UpdatePropertyTypeRequest>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<PropertyType>, StatusCode> {
+) -> Result<Json<PersistedOntologyIdentifier>, StatusCode> {
     let Json(UpdatePropertyTypeRequest { schema, account_id }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
@@ -199,7 +198,6 @@ async fn update_property_type<P: StorePool + Send>(
 
             // Insertion/update errors are considered internal server errors.
             StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-
-    Ok(Json(schema))
+        })
+        .map(Json)
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -71,7 +71,7 @@ struct CreatePropertyTypeRequest {
     request_body = CreatePropertyTypeRequest,
     tag = "PropertyType",
     responses(
-        (status = 201, content_type = "application/json", description = "The schema of the created property type", body = VAR_PROPERTY_TYPE),
+        (status = 201, content_type = "application/json", description = "The schema of the created property type", body = PersistedOntologyIdentifier),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 409, description = "Unable to create property type in the store as the base property type ID already exists"),
@@ -167,7 +167,7 @@ struct UpdatePropertyTypeRequest {
     path = "/property-types",
     tag = "PropertyType",
     responses(
-        (status = 200, content_type = "application/json", description = "The schema of the updated property type", body = VAR_PROPERTY_TYPE),
+        (status = 200, content_type = "application/json", description = "The schema of the updated property type", body = PersistedOntologyIdentifier),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Base property type ID was not found"),

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -45,6 +45,7 @@ pub struct Entity {
 #[serde(rename_all = "camelCase")]
 pub struct PersistedEntityIdentifier {
     entity_id: EntityId,
+    #[component(value_type = String)]
     version: DateTime<Utc>,
     created_by: AccountId,
 }

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -9,6 +9,8 @@ use tokio_postgres::types::{FromSql, ToSql};
 use utoipa::Component;
 use uuid::Uuid;
 
+use crate::ontology::types::{DataType, EntityType, LinkType, PropertyType};
+
 // TODO - find a good place for AccountId, perhaps it will become redundant in a future design
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Component, FromSql, ToSql)]
@@ -73,3 +75,8 @@ impl<T> PersistedOntologyType<T> {
         &self.identifier
     }
 }
+
+pub type PersistedDataType = PersistedOntologyType<DataType>;
+pub type PersistedPropertyType = PersistedOntologyType<PropertyType>;
+pub type PersistedLinkType = PersistedOntologyType<LinkType>;
+pub type PersistedEntityType = PersistedOntologyType<EntityType>;

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -66,21 +66,21 @@ pub struct PersistedDataType {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
 pub struct PersistedPropertyType {
-    #[component(value_type = VAR_DATA_TYPE)]
+    #[component(value_type = VAR_PROPERTY_TYPE)]
     pub inner: PropertyType,
     pub identifier: PersistedOntologyIdentifier,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
 pub struct PersistedLinkType {
-    #[component(value_type = VAR_DATA_TYPE)]
+    #[component(value_type = VAR_LINK_TYPE)]
     pub inner: LinkType,
     pub identifier: PersistedOntologyIdentifier,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
 pub struct PersistedEntityType {
-    #[component(value_type = VAR_DATA_TYPE)]
+    #[component(value_type = VAR_ENTITY_TYPE)]
     pub inner: EntityType,
     pub identifier: PersistedOntologyIdentifier,
 }

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -51,6 +51,7 @@ impl PersistedOntologyIdentifier {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
 pub struct PersistedOntologyType<T> {
     inner: T,
     identifier: PersistedOntologyIdentifier,

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -28,3 +28,48 @@ impl fmt::Display for AccountId {
         write!(fmt, "{}", &self.0)
     }
 }
+
+/// The metadata required to uniquely identify an ontology element that has been persisted in the
+/// datastore.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
+#[serde(rename_all = "camelCase")]
+pub struct PersistedOntologyIdentifier {
+    created_by: AccountId,
+}
+
+impl PersistedOntologyIdentifier {
+    #[must_use]
+    pub const fn new(created_by: AccountId) -> Self {
+        Self { created_by }
+    }
+
+    #[must_use]
+    pub const fn created_by(&self) -> AccountId {
+        self.created_by
+    }
+}
+
+pub struct PersistedOntologyType<T> {
+    inner: T,
+    identifier: PersistedOntologyIdentifier,
+}
+
+impl<T> PersistedOntologyType<T> {
+    #[must_use]
+    pub const fn new(inner: T, created_by: AccountId) -> Self {
+        Self {
+            inner,
+            identifier: PersistedOntologyIdentifier::new(created_by),
+        }
+    }
+
+    #[must_use]
+    pub const fn inner(&self) -> &T {
+        &self.inner
+    }
+
+    #[must_use]
+    pub const fn identifier(&self) -> &PersistedOntologyIdentifier {
+        &self.identifier
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -9,7 +9,7 @@ use tokio_postgres::types::{FromSql, ToSql};
 use utoipa::Component;
 use uuid::Uuid;
 
-use crate::ontology::types::{DataType, EntityType, LinkType, PropertyType};
+use crate::ontology::types::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType};
 
 // TODO - find a good place for AccountId, perhaps it will become redundant in a future design
 
@@ -36,13 +36,19 @@ impl fmt::Display for AccountId {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
 #[serde(rename_all = "camelCase")]
 pub struct PersistedOntologyIdentifier {
+    uri: VersionedUri,
     created_by: AccountId,
 }
 
 impl PersistedOntologyIdentifier {
     #[must_use]
-    pub const fn new(created_by: AccountId) -> Self {
-        Self { created_by }
+    pub const fn new(uri: VersionedUri, created_by: AccountId) -> Self {
+        Self { uri, created_by }
+    }
+
+    #[must_use]
+    pub const fn uri(&self) -> &VersionedUri {
+        &self.uri
     }
 
     #[must_use]
@@ -52,32 +58,29 @@ impl PersistedOntologyIdentifier {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
-pub struct PersistedOntologyType<T> {
-    inner: T,
-    identifier: PersistedOntologyIdentifier,
+pub struct PersistedDataType {
+    #[component(value_type = VAR_DATA_TYPE)]
+    pub inner: DataType,
+    pub identifier: PersistedOntologyIdentifier,
 }
 
-impl<T> PersistedOntologyType<T> {
-    #[must_use]
-    pub const fn new(inner: T, created_by: AccountId) -> Self {
-        Self {
-            inner,
-            identifier: PersistedOntologyIdentifier::new(created_by),
-        }
-    }
-
-    #[must_use]
-    pub const fn inner(&self) -> &T {
-        &self.inner
-    }
-
-    #[must_use]
-    pub const fn identifier(&self) -> &PersistedOntologyIdentifier {
-        &self.identifier
-    }
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
+pub struct PersistedPropertyType {
+    #[component(value_type = VAR_DATA_TYPE)]
+    pub inner: PropertyType,
+    pub identifier: PersistedOntologyIdentifier,
 }
 
-pub type PersistedDataType = PersistedOntologyType<DataType>;
-pub type PersistedPropertyType = PersistedOntologyType<PropertyType>;
-pub type PersistedLinkType = PersistedOntologyType<LinkType>;
-pub type PersistedEntityType = PersistedOntologyType<EntityType>;
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
+pub struct PersistedLinkType {
+    #[component(value_type = VAR_DATA_TYPE)]
+    pub inner: LinkType,
+    pub identifier: PersistedOntologyIdentifier,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
+pub struct PersistedEntityType {
+    #[component(value_type = VAR_DATA_TYPE)]
+    pub inner: EntityType,
+    pub identifier: PersistedOntologyIdentifier,
+}

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -36,6 +36,7 @@ impl fmt::Display for AccountId {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
 #[serde(rename_all = "camelCase")]
 pub struct PersistedOntologyIdentifier {
+    #[component(value_type = String)]
     uri: VersionedUri,
     created_by: AccountId,
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -19,7 +19,8 @@ use crate::{
     knowledge::{Entity, EntityId, Link, Links, PersistedEntity, PersistedEntityIdentifier},
     ontology::{
         types::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType},
-        AccountId,
+        AccountId, PersistedDataType, PersistedEntityType, PersistedLinkType,
+        PersistedPropertyType,
     },
     store::{
         error::LinkActivationError,
@@ -186,7 +187,9 @@ pub trait Store =
 
 /// Describes the API of a store implementation for [`DataType`]s.
 #[async_trait]
-pub trait DataTypeStore: for<'q> crud::Read<DataType, Query<'q> = DataTypeQuery<'q>> {
+pub trait DataTypeStore:
+    for<'q> crud::Read<PersistedDataType, Query<'q> = DataTypeQuery<'q>>
+{
     /// Creates a new [`DataType`].
     ///
     /// # Errors:
@@ -206,7 +209,10 @@ pub trait DataTypeStore: for<'q> crud::Read<DataType, Query<'q> = DataTypeQuery<
     /// # Errors
     ///
     /// - if the requested [`DataType`] doesn't exist.
-    async fn get_data_type(&self, query: &DataTypeQuery<'_>) -> Result<Vec<DataType>, QueryError> {
+    async fn get_data_type(
+        &self,
+        query: &DataTypeQuery<'_>,
+    ) -> Result<Vec<PersistedDataType>, QueryError> {
         self.read(query).await
     }
 
@@ -225,7 +231,7 @@ pub trait DataTypeStore: for<'q> crud::Read<DataType, Query<'q> = DataTypeQuery<
 /// Describes the API of a store implementation for [`PropertyType`]s.
 #[async_trait]
 pub trait PropertyTypeStore:
-    for<'q> crud::Read<PropertyType, Query<'q> = PropertyTypeQuery<'q>>
+    for<'q> crud::Read<PersistedPropertyType, Query<'q> = PropertyTypeQuery<'q>>
 {
     /// Creates a new [`PropertyType`].
     ///
@@ -249,7 +255,7 @@ pub trait PropertyTypeStore:
     async fn get_property_type(
         &self,
         query: &PropertyTypeQuery<'_>,
-    ) -> Result<Vec<PropertyType>, QueryError> {
+    ) -> Result<Vec<PersistedPropertyType>, QueryError> {
         self.read(query).await
     }
 
@@ -267,7 +273,9 @@ pub trait PropertyTypeStore:
 
 /// Describes the API of a store implementation for [`EntityType`]s.
 #[async_trait]
-pub trait EntityTypeStore: for<'q> crud::Read<EntityType, Query<'q> = EntityTypeQuery<'q>> {
+pub trait EntityTypeStore:
+    for<'q> crud::Read<PersistedEntityType, Query<'q> = EntityTypeQuery<'q>>
+{
     /// Creates a new [`EntityType`].
     ///
     /// # Errors:
@@ -290,7 +298,7 @@ pub trait EntityTypeStore: for<'q> crud::Read<EntityType, Query<'q> = EntityType
     async fn get_entity_type(
         &self,
         query: &EntityTypeQuery<'_>,
-    ) -> Result<Vec<EntityType>, QueryError> {
+    ) -> Result<Vec<PersistedEntityType>, QueryError> {
         self.read(query).await
     }
 
@@ -308,7 +316,9 @@ pub trait EntityTypeStore: for<'q> crud::Read<EntityType, Query<'q> = EntityType
 
 /// Describes the API of a store implementation for [`LinkType`]s.
 #[async_trait]
-pub trait LinkTypeStore: for<'q> crud::Read<LinkType, Query<'q> = LinkTypeQuery<'q>> {
+pub trait LinkTypeStore:
+    for<'q> crud::Read<PersistedLinkType, Query<'q> = LinkTypeQuery<'q>>
+{
     /// Creates a new [`LinkType`].
     ///
     /// # Errors:
@@ -328,7 +338,10 @@ pub trait LinkTypeStore: for<'q> crud::Read<LinkType, Query<'q> = LinkTypeQuery<
     /// # Errors
     ///
     /// - if the requested [`LinkType`] doesn't exist.
-    async fn get_link_type(&self, query: &LinkTypeQuery<'_>) -> Result<Vec<LinkType>, QueryError> {
+    async fn get_link_type(
+        &self,
+        query: &LinkTypeQuery<'_>,
+    ) -> Result<Vec<PersistedLinkType>, QueryError> {
         self.read(query).await
     }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     ontology::{
         types::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType},
         AccountId, PersistedDataType, PersistedEntityType, PersistedLinkType,
-        PersistedPropertyType,
+        PersistedOntologyIdentifier, PersistedPropertyType,
     },
     store::{
         error::LinkActivationError,
@@ -202,7 +202,7 @@ pub trait DataTypeStore:
         &mut self,
         data_type: &DataType,
         created_by: AccountId,
-    ) -> Result<(), InsertionError>;
+    ) -> Result<PersistedOntologyIdentifier, InsertionError>;
 
     /// Get the [`DataType`]s specified by the [`DataTypeQuery`].
     ///
@@ -225,7 +225,7 @@ pub trait DataTypeStore:
         &mut self,
         data_type: &DataType,
         updated_by: AccountId,
-    ) -> Result<(), UpdateError>;
+    ) -> Result<PersistedOntologyIdentifier, UpdateError>;
 }
 
 /// Describes the API of a store implementation for [`PropertyType`]s.
@@ -245,7 +245,7 @@ pub trait PropertyTypeStore:
         &mut self,
         property_type: &PropertyType,
         created_by: AccountId,
-    ) -> Result<(), InsertionError>;
+    ) -> Result<PersistedOntologyIdentifier, InsertionError>;
 
     /// Get the [`PropertyType`]s specified by the [`PropertyTypeQuery`].
     ///
@@ -268,7 +268,7 @@ pub trait PropertyTypeStore:
         &mut self,
         property_type: &PropertyType,
         updated_by: AccountId,
-    ) -> Result<(), UpdateError>;
+    ) -> Result<PersistedOntologyIdentifier, UpdateError>;
 }
 
 /// Describes the API of a store implementation for [`EntityType`]s.
@@ -288,7 +288,7 @@ pub trait EntityTypeStore:
         &mut self,
         entity_type: &EntityType,
         created_by: AccountId,
-    ) -> Result<(), InsertionError>;
+    ) -> Result<PersistedOntologyIdentifier, InsertionError>;
 
     /// Get the [`EntityType`]s specified by the [`EntityTypeQuery`].
     ///
@@ -311,7 +311,7 @@ pub trait EntityTypeStore:
         &mut self,
         entity_type: &EntityType,
         updated_by: AccountId,
-    ) -> Result<(), UpdateError>;
+    ) -> Result<PersistedOntologyIdentifier, UpdateError>;
 }
 
 /// Describes the API of a store implementation for [`LinkType`]s.
@@ -331,7 +331,7 @@ pub trait LinkTypeStore:
         &mut self,
         link_type: &LinkType,
         created_by: AccountId,
-    ) -> Result<(), InsertionError>;
+    ) -> Result<PersistedOntologyIdentifier, InsertionError>;
 
     /// Get the [`LinkType`]s specified by the [`LinkTypeQuery`].
     ///
@@ -354,7 +354,7 @@ pub trait LinkTypeStore:
         &mut self,
         property_type: &LinkType,
         updated_by: AccountId,
-    ) -> Result<(), UpdateError>;
+    ) -> Result<PersistedOntologyIdentifier, UpdateError>;
 }
 
 /// Describes the API of a store implementation for Entities.

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -20,7 +20,7 @@ use crate::{
             DataTypeReference, EntityType, EntityTypeReference, PropertyType,
             PropertyTypeReference,
         },
-        AccountId,
+        AccountId, PersistedOntologyIdentifier,
     },
     store::{
         error::VersionedUriAlreadyExists,
@@ -271,7 +271,7 @@ where
         &self,
         database_type: &T,
         created_by: AccountId,
-    ) -> Result<VersionId, InsertionError>
+    ) -> Result<(VersionId, PersistedOntologyIdentifier), InsertionError>
     where
         T: OntologyDatabaseType + Serialize + Send + Sync,
     {
@@ -305,7 +305,7 @@ where
         self.insert_with_id(version_id, database_type, created_by)
             .await?;
 
-        Ok(version_id)
+        Ok((version_id, PersistedOntologyIdentifier::new(created_by)))
     }
 
     /// Updates the specified [`OntologyDatabaseType`].
@@ -322,7 +322,7 @@ where
         &self,
         database_type: &T,
         updated_by: AccountId,
-    ) -> Result<VersionId, UpdateError>
+    ) -> Result<(VersionId, PersistedOntologyIdentifier), UpdateError>
     where
         T: OntologyDatabaseType + Serialize + Send + Sync,
     {
@@ -349,7 +349,7 @@ where
             .await
             .change_context(UpdateError)?;
 
-        Ok(version_id)
+        Ok((version_id, PersistedOntologyIdentifier::new(updated_by)))
     }
 
     /// Inserts an [`OntologyDatabaseType`] identified by [`VersionId`], and associated with an

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -305,7 +305,10 @@ where
         self.insert_with_id(version_id, database_type, created_by)
             .await?;
 
-        Ok((version_id, PersistedOntologyIdentifier::new(created_by)))
+        Ok((
+            version_id,
+            PersistedOntologyIdentifier::new(uri.clone(), created_by),
+        ))
     }
 
     /// Updates the specified [`OntologyDatabaseType`].
@@ -349,7 +352,10 @@ where
             .await
             .change_context(UpdateError)?;
 
-        Ok((version_id, PersistedOntologyIdentifier::new(updated_by)))
+        Ok((
+            version_id,
+            PersistedOntologyIdentifier::new(uri.clone(), updated_by),
+        ))
     }
 
     /// Inserts an [`OntologyDatabaseType`] identified by [`VersionId`], and associated with an

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -3,7 +3,7 @@ use error_stack::{IntoReport, Result, ResultExt};
 use tokio_postgres::GenericClient;
 
 use crate::{
-    ontology::{types::DataType, AccountId},
+    ontology::{types::DataType, AccountId, PersistedOntologyIdentifier},
     store::{AsClient, DataTypeStore, InsertionError, PostgresStore, UpdateError},
 };
 
@@ -13,7 +13,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
         &mut self,
         data_type: &DataType,
         created_by: AccountId,
-    ) -> Result<(), InsertionError> {
+    ) -> Result<PersistedOntologyIdentifier, InsertionError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
                 .transaction()
@@ -22,7 +22,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
                 .change_context(InsertionError)?,
         );
 
-        transaction.create(data_type, created_by).await?;
+        let (_, identifier) = transaction.create(data_type, created_by).await?;
 
         transaction
             .client
@@ -31,14 +31,14 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
             .into_report()
             .change_context(InsertionError)?;
 
-        Ok(())
+        Ok(identifier)
     }
 
     async fn update_data_type(
         &mut self,
         data_type: &DataType,
         updated_by: AccountId,
-    ) -> Result<(), UpdateError> {
+    ) -> Result<PersistedOntologyIdentifier, UpdateError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
                 .transaction()
@@ -47,7 +47,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
                 .change_context(UpdateError)?,
         );
 
-        transaction.update(data_type, updated_by).await?;
+        let (_, identifier) = transaction.update(data_type, updated_by).await?;
 
         transaction
             .client
@@ -56,6 +56,6 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
             .into_report()
             .change_context(UpdateError)?;
 
-        Ok(())
+        Ok(identifier)
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -3,7 +3,7 @@ use error_stack::{IntoReport, Result, ResultExt};
 use tokio_postgres::GenericClient;
 
 use crate::{
-    ontology::{types::PropertyType, AccountId},
+    ontology::{types::PropertyType, AccountId, PersistedOntologyIdentifier},
     store::{AsClient, InsertionError, PostgresStore, PropertyTypeStore, UpdateError},
 };
 
@@ -13,7 +13,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         &mut self,
         property_type: &PropertyType,
         created_by: AccountId,
-    ) -> Result<(), InsertionError> {
+    ) -> Result<PersistedOntologyIdentifier, InsertionError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
                 .transaction()
@@ -22,7 +22,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                 .change_context(InsertionError)?,
         );
 
-        let version_id = transaction.create(property_type, created_by).await?;
+        let (version_id, identifier) = transaction.create(property_type, created_by).await?;
 
         transaction
             .insert_property_type_references(property_type, version_id)
@@ -38,14 +38,14 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
             .into_report()
             .change_context(InsertionError)?;
 
-        Ok(())
+        Ok(identifier)
     }
 
     async fn update_property_type(
         &mut self,
         property_type: &PropertyType,
         updated_by: AccountId,
-    ) -> Result<(), UpdateError> {
+    ) -> Result<PersistedOntologyIdentifier, UpdateError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
                 .transaction()
@@ -54,7 +54,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                 .change_context(UpdateError)?,
         );
 
-        let version_id = transaction.update(property_type, updated_by).await?;
+        let (version_id, identifier) = transaction.update(property_type, updated_by).await?;
 
         transaction
             .insert_property_type_references(property_type, version_id)
@@ -70,6 +70,6 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
             .into_report()
             .change_context(UpdateError)?;
 
-        Ok(())
+        Ok(identifier)
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -2,11 +2,11 @@ use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
 use futures::{StreamExt, TryStreamExt};
 use serde::Deserialize;
-use tokio_postgres::GenericClient;
+use tokio_postgres::{GenericClient, RowStream};
 
 use crate::{
     ontology::{
-        types::{DataType, EntityType, LinkType, PropertyType},
+        types::{uri::BaseUri, DataType, EntityType, LinkType, PropertyType},
         AccountId, PersistedDataType, PersistedEntityType, PersistedLinkType,
         PersistedOntologyIdentifier, PersistedPropertyType,
     },
@@ -56,6 +56,53 @@ impl PersistedOntologyType for PersistedEntityType {
     }
 }
 
+async fn by_uri_by_version<T: OntologyDatabaseType>(
+    client: &(impl GenericClient + Sync),
+    uri: &BaseUri,
+    version: u32,
+) -> Result<RowStream, QueryError> {
+    client
+        .query_raw(
+            &format!(
+                r#"
+                SELECT schema, created_by
+                FROM {}
+                WHERE version_id = (
+                    SELECT version_id
+                    FROM ids
+                    WHERE base_uri = $1 AND version = $2
+                )
+                "#,
+                T::table()
+            ),
+            parameter_list([uri, &i64::from(version)]),
+        )
+        .await
+        .into_report()
+        .change_context(QueryError)
+}
+
+async fn by_latest_version<T: OntologyDatabaseType>(
+    client: &(impl GenericClient + Sync),
+) -> Result<RowStream, QueryError> {
+    client
+        .query_raw(
+            &format!(
+                r#"
+                SELECT DISTINCT ON(base_uri) schema, created_by
+                FROM {table}
+                INNER JOIN ids ON ids.version_id = {table}.version_id
+                ORDER BY base_uri, version DESC;
+                "#,
+                table = T::table()
+            ),
+            parameter_list([]),
+        )
+        .await
+        .into_report()
+        .change_context(QueryError)
+}
+
 #[async_trait]
 impl<C: AsClient, T> Read<T> for PostgresStore<C>
 where
@@ -67,55 +114,24 @@ where
     async fn read<'query>(&self, query: &Self::Query<'query>) -> Result<Vec<T>, QueryError> {
         let row_stream = match (query.uri(), query.version()) {
             (Some(uri), Some(OntologyVersion::Exact(version))) => {
-                self.as_client()
-                    .query_raw(
-                        &format!(
-                            r#"
-                            SELECT schema, created_by
-                            FROM {}
-                            WHERE version_id = (
-                                SELECT version_id
-                                FROM ids
-                                WHERE base_uri = $1 AND version = $2
-                            )
-                            "#,
-                            <T::Inner as OntologyDatabaseType>::table()
-                        ),
-                        parameter_list([uri, &i64::from(version)]),
-                    )
-                    .await
+                by_uri_by_version::<T::Inner>(self.as_client(), uri, version).await?
             }
             (None, Some(OntologyVersion::Latest)) => {
-                self.as_client()
-                    .query_raw(
-                        &format!(
-                            r#"
-                            SELECT DISTINCT ON(base_uri) schema, created_by
-                            FROM {table}
-                            INNER JOIN ids ON ids.version_id = {table}.version_id
-                            ORDER BY base_uri, version DESC;
-                            "#,
-                            table = <T::Inner as OntologyDatabaseType>::table()
-                        ),
-                        parameter_list([]),
-                    )
-                    .await
+                by_latest_version::<T::Inner>(self.as_client()).await?
             }
             _ => todo!(),
         };
 
         row_stream
-            .into_report()
-            .change_context(QueryError)?
             .map(|row_result| {
                 let row = row_result.into_report().change_context(QueryError)?;
 
                 let element: T::Inner = serde_json::from_value(row.get(0))
                     .into_report()
                     .change_context(QueryError)?;
-                let account_id: AccountId = row.get(1);
 
                 let uri = element.versioned_uri().clone();
+                let account_id: AccountId = row.get(1);
 
                 Ok(T::new(
                     element,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -6,7 +6,11 @@ use serde::Deserialize;
 use tokio_postgres::GenericClient;
 
 use crate::{
-    ontology::{AccountId, PersistedOntologyType},
+    ontology::{
+        types::{DataType, EntityType, LinkType, PropertyType},
+        AccountId, PersistedDataType, PersistedEntityType, PersistedLinkType,
+        PersistedOntologyIdentifier, PersistedPropertyType,
+    },
     store::{
         crud::Read,
         postgres::ontology::OntologyDatabaseType,
@@ -19,17 +23,53 @@ fn parameter_list<const N: usize>(list: [&(dyn ToSql + Sync); N]) -> [&(dyn ToSq
     list
 }
 
-#[async_trait]
-impl<C: AsClient, T> Read<PersistedOntologyType<T>> for PostgresStore<C>
-where
-    for<'de> T: OntologyDatabaseType + Deserialize<'de> + Send,
-{
-    type Query<'q> = OntologyQuery<'q, T>;
+pub trait PersistedOntologyType {
+    type Inner;
 
-    async fn read<'query>(
-        &self,
-        query: &Self::Query<'query>,
-    ) -> Result<Vec<PersistedOntologyType<T>>, QueryError> {
+    fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self;
+}
+
+impl PersistedOntologyType for PersistedDataType {
+    type Inner = DataType;
+
+    fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self {
+        Self { inner, identifier }
+    }
+}
+
+impl PersistedOntologyType for PersistedPropertyType {
+    type Inner = PropertyType;
+
+    fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self {
+        Self { inner, identifier }
+    }
+}
+
+impl PersistedOntologyType for PersistedLinkType {
+    type Inner = LinkType;
+
+    fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self {
+        Self { inner, identifier }
+    }
+}
+
+impl PersistedOntologyType for PersistedEntityType {
+    type Inner = EntityType;
+
+    fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self {
+        Self { inner, identifier }
+    }
+}
+
+#[async_trait]
+impl<C: AsClient, T> Read<T> for PostgresStore<C>
+where
+    T: PersistedOntologyType + Send,
+    for<'de> T::Inner: OntologyDatabaseType + Deserialize<'de>,
+{
+    type Query<'q> = OntologyQuery<'q, T::Inner>;
+
+    async fn read<'query>(&self, query: &Self::Query<'query>) -> Result<Vec<T>, QueryError> {
         let row_stream = match (query.uri(), query.version()) {
             (Some(uri), Some(OntologyVersion::Exact(version))) => {
                 self.as_client()
@@ -44,7 +84,7 @@ where
                                 WHERE base_uri = $1 AND version = $2
                             )
                             "#,
-                            T::table()
+                            <T::Inner as OntologyDatabaseType>::table()
                         ),
                         parameter_list([uri, &i64::from(version)]),
                     )
@@ -60,7 +100,7 @@ where
                             INNER JOIN ids ON ids.version_id = {table}.version_id
                             ORDER BY base_uri, version DESC;
                             "#,
-                            table = T::table()
+                            table = <T::Inner as OntologyDatabaseType>::table()
                         ),
                         parameter_list([]),
                     )
@@ -75,12 +115,17 @@ where
             .map(|row_result| {
                 let row = row_result.into_report().change_context(QueryError)?;
 
-                let element: T = serde_json::from_value(row.get(0))
+                let element: T::Inner = serde_json::from_value(row.get(0))
                     .into_report()
                     .change_context(QueryError)?;
                 let account_id: AccountId = row.get(1);
 
-                Ok(PersistedOntologyType::new(element, account_id))
+                let uri = element.versioned_uri().clone();
+
+                Ok(T::new(
+                    element,
+                    PersistedOntologyIdentifier::new(uri, account_id),
+                ))
             })
             .try_collect()
             .await

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
 use futures::{StreamExt, TryStreamExt};
-use postgres_types::ToSql;
 use serde::Deserialize;
 use tokio_postgres::GenericClient;
 
@@ -13,15 +12,11 @@ use crate::{
     },
     store::{
         crud::Read,
-        postgres::ontology::OntologyDatabaseType,
+        postgres::{ontology::OntologyDatabaseType, parameter_list},
         query::{OntologyQuery, OntologyVersion},
         AsClient, PostgresStore, QueryError,
     },
 };
-
-fn parameter_list<const N: usize>(list: [&(dyn ToSql + Sync); N]) -> [&(dyn ToSql + Sync); N] {
-    list
-}
 
 pub trait PersistedOntologyType {
     type Inner;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -1,90 +1,86 @@
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
 use futures::{StreamExt, TryStreamExt};
+use postgres_types::ToSql;
 use serde::Deserialize;
-use tokio_postgres::{GenericClient, RowStream};
+use tokio_postgres::GenericClient;
 
 use crate::{
-    ontology::types::uri::BaseUri,
+    ontology::{AccountId, PersistedOntologyType},
     store::{
         crud::Read,
-        postgres::{ontology::OntologyDatabaseType, parameter_list},
+        postgres::ontology::OntologyDatabaseType,
         query::{OntologyQuery, OntologyVersion},
         AsClient, PostgresStore, QueryError,
     },
 };
 
-async fn by_uri_by_version<T: OntologyDatabaseType>(
-    client: &(impl GenericClient + Sync),
-    uri: &BaseUri,
-    version: u32,
-) -> Result<RowStream, QueryError> {
-    client
-        .query_raw(
-            &format!(
-                r#"
-                SELECT schema
-                FROM {}
-                WHERE version_id = (
-                    SELECT version_id
-                    FROM ids
-                    WHERE base_uri = $1 AND version = $2
-                )
-                "#,
-                T::table()
-            ),
-            parameter_list([uri, &i64::from(version)]),
-        )
-        .await
-        .into_report()
-        .change_context(QueryError)
-}
-
-async fn by_latest_version<T: OntologyDatabaseType>(
-    client: &(impl GenericClient + Sync),
-) -> Result<RowStream, QueryError> {
-    client
-        .query_raw(
-            &format!(
-                r#"
-                SELECT DISTINCT ON(base_uri) schema
-                FROM {table}
-                INNER JOIN ids ON ids.version_id = {table}.version_id
-                ORDER BY base_uri, version DESC;
-                "#,
-                table = T::table()
-            ),
-            parameter_list([]),
-        )
-        .await
-        .into_report()
-        .change_context(QueryError)
+fn parameter_list<const N: usize>(list: [&(dyn ToSql + Sync); N]) -> [&(dyn ToSql + Sync); N] {
+    list
 }
 
 #[async_trait]
-impl<C: AsClient, T> Read<T> for PostgresStore<C>
+impl<C: AsClient, T> Read<PersistedOntologyType<T>> for PostgresStore<C>
 where
     for<'de> T: OntologyDatabaseType + Deserialize<'de> + Send,
 {
     type Query<'q> = OntologyQuery<'q, T>;
 
-    async fn read<'query>(&self, query: &Self::Query<'query>) -> Result<Vec<T>, QueryError> {
+    async fn read<'query>(
+        &self,
+        query: &Self::Query<'query>,
+    ) -> Result<Vec<PersistedOntologyType<T>>, QueryError> {
         let row_stream = match (query.uri(), query.version()) {
             (Some(uri), Some(OntologyVersion::Exact(version))) => {
-                by_uri_by_version::<T>(self.as_client(), uri, version).await?
+                self.as_client()
+                    .query_raw(
+                        &format!(
+                            r#"
+                            SELECT schema, created_by
+                            FROM {}
+                            WHERE version_id = (
+                                SELECT version_id
+                                FROM ids
+                                WHERE base_uri = $1 AND version = $2
+                            )
+                            "#,
+                            T::table()
+                        ),
+                        parameter_list([uri, &i64::from(version)]),
+                    )
+                    .await
             }
             (None, Some(OntologyVersion::Latest)) => {
-                by_latest_version::<T>(self.as_client()).await?
+                self.as_client()
+                    .query_raw(
+                        &format!(
+                            r#"
+                            SELECT DISTINCT ON(base_uri) schema, created_by
+                            FROM {table}
+                            INNER JOIN ids ON ids.version_id = {table}.version_id
+                            ORDER BY base_uri, version DESC;
+                            "#,
+                            table = T::table()
+                        ),
+                        parameter_list([]),
+                    )
+                    .await
             }
             _ => todo!(),
         };
 
         row_stream
+            .into_report()
+            .change_context(QueryError)?
             .map(|row_result| {
                 let row = row_result.into_report().change_context(QueryError)?;
-                serde_json::from_value(row.get(0))
+
+                let element: T = serde_json::from_value(row.get(0))
                     .into_report()
-                    .change_context(QueryError)
+                    .change_context(QueryError)?;
+                let account_id: AccountId = row.get(1);
+
+                Ok(PersistedOntologyType::new(element, account_id))
             })
             .try_collect()
             .await

--- a/packages/graph/hash_graph/tests/integration/postgres/data_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/data_type.rs
@@ -36,7 +36,7 @@ async fn query() {
         .await
         .expect("could not get data type");
 
-    assert_eq!(data_type.inner(), &empty_list_dt);
+    assert_eq!(data_type.inner, empty_list_dt);
 }
 
 #[tokio::test]

--- a/packages/graph/hash_graph/tests/integration/postgres/data_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/data_type.rs
@@ -36,7 +36,7 @@ async fn query() {
         .await
         .expect("could not get data type");
 
-    assert_eq!(data_type, empty_list_dt);
+    assert_eq!(data_type.inner(), &empty_list_dt);
 }
 
 #[tokio::test]

--- a/packages/graph/hash_graph/tests/integration/postgres/entity_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/entity_type.rs
@@ -44,7 +44,7 @@ async fn query() {
         .await
         .expect("could not get entity type");
 
-    assert_eq!(entity_type.inner(), &organization_et);
+    assert_eq!(entity_type.inner, organization_et);
 }
 
 #[tokio::test]

--- a/packages/graph/hash_graph/tests/integration/postgres/entity_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/entity_type.rs
@@ -44,7 +44,7 @@ async fn query() {
         .await
         .expect("could not get entity type");
 
-    assert_eq!(entity_type, organization_et);
+    assert_eq!(entity_type.inner(), &organization_et);
 }
 
 #[tokio::test]

--- a/packages/graph/hash_graph/tests/integration/postgres/link_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/link_type.rs
@@ -36,7 +36,7 @@ async fn query() {
         .await
         .expect("could not get link type");
 
-    assert_eq!(link_type.inner(), &submitted_by_lt);
+    assert_eq!(link_type.inner, submitted_by_lt);
 }
 
 #[tokio::test]

--- a/packages/graph/hash_graph/tests/integration/postgres/link_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/link_type.rs
@@ -36,7 +36,7 @@ async fn query() {
         .await
         .expect("could not get link type");
 
-    assert_eq!(link_type, submitted_by_lt);
+    assert_eq!(link_type.inner(), &submitted_by_lt);
 }
 
 #[tokio::test]

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -13,7 +13,7 @@ use graph::{
     ontology::{
         types::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType},
         AccountId, PersistedDataType, PersistedEntityType, PersistedLinkType,
-        PersistedPropertyType,
+        PersistedOntologyIdentifier, PersistedPropertyType,
     },
     store::{
         error::LinkActivationError,
@@ -142,7 +142,10 @@ impl DatabaseTestWrapper {
 
 // TODO: Add get_all_* methods
 impl DatabaseApi<'_> {
-    pub async fn create_data_type(&mut self, data_type: &DataType) -> Result<(), InsertionError> {
+    pub async fn create_data_type(
+        &mut self,
+        data_type: &DataType,
+    ) -> Result<PersistedOntologyIdentifier, InsertionError> {
         self.store
             .create_data_type(data_type, self.account_id)
             .await
@@ -164,7 +167,10 @@ impl DatabaseApi<'_> {
             .expect("No data type found"))
     }
 
-    pub async fn update_data_type(&mut self, data_type: &DataType) -> Result<(), UpdateError> {
+    pub async fn update_data_type(
+        &mut self,
+        data_type: &DataType,
+    ) -> Result<PersistedOntologyIdentifier, UpdateError> {
         self.store
             .update_data_type(data_type, self.account_id)
             .await
@@ -173,7 +179,7 @@ impl DatabaseApi<'_> {
     pub async fn create_property_type(
         &mut self,
         property_type: &PropertyType,
-    ) -> Result<(), InsertionError> {
+    ) -> Result<PersistedOntologyIdentifier, InsertionError> {
         self.store
             .create_property_type(property_type, self.account_id)
             .await
@@ -198,7 +204,7 @@ impl DatabaseApi<'_> {
     pub async fn update_property_type(
         &mut self,
         property_type: &PropertyType,
-    ) -> Result<(), UpdateError> {
+    ) -> Result<PersistedOntologyIdentifier, UpdateError> {
         self.store
             .update_property_type(property_type, self.account_id)
             .await
@@ -207,7 +213,7 @@ impl DatabaseApi<'_> {
     pub async fn create_entity_type(
         &mut self,
         entity_type: &EntityType,
-    ) -> Result<(), InsertionError> {
+    ) -> Result<PersistedOntologyIdentifier, InsertionError> {
         self.store
             .create_entity_type(entity_type, self.account_id)
             .await
@@ -232,13 +238,16 @@ impl DatabaseApi<'_> {
     pub async fn update_entity_type(
         &mut self,
         entity_type: &EntityType,
-    ) -> Result<(), UpdateError> {
+    ) -> Result<PersistedOntologyIdentifier, UpdateError> {
         self.store
             .update_entity_type(entity_type, self.account_id)
             .await
     }
 
-    pub async fn create_link_type(&mut self, link_type: &LinkType) -> Result<(), InsertionError> {
+    pub async fn create_link_type(
+        &mut self,
+        link_type: &LinkType,
+    ) -> Result<PersistedOntologyIdentifier, InsertionError> {
         self.store
             .create_link_type(link_type, self.account_id)
             .await
@@ -260,7 +269,10 @@ impl DatabaseApi<'_> {
             .expect("No link type found"))
     }
 
-    pub async fn update_link_type(&mut self, link_type: &LinkType) -> Result<(), UpdateError> {
+    pub async fn update_link_type(
+        &mut self,
+        link_type: &LinkType,
+    ) -> Result<PersistedOntologyIdentifier, UpdateError> {
         self.store
             .update_link_type(link_type, self.account_id)
             .await

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -12,7 +12,8 @@ use graph::{
     },
     ontology::{
         types::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType},
-        AccountId,
+        AccountId, PersistedDataType, PersistedEntityType, PersistedLinkType,
+        PersistedPropertyType,
     },
     store::{
         error::LinkActivationError,
@@ -147,7 +148,10 @@ impl DatabaseApi<'_> {
             .await
     }
 
-    pub async fn get_data_type(&mut self, uri: &VersionedUri) -> Result<DataType, QueryError> {
+    pub async fn get_data_type(
+        &mut self,
+        uri: &VersionedUri,
+    ) -> Result<PersistedDataType, QueryError> {
         Ok(self
             .store
             .get_data_type(
@@ -178,7 +182,7 @@ impl DatabaseApi<'_> {
     pub async fn get_property_type(
         &mut self,
         uri: &VersionedUri,
-    ) -> Result<PropertyType, QueryError> {
+    ) -> Result<PersistedPropertyType, QueryError> {
         Ok(self
             .store
             .get_property_type(
@@ -209,7 +213,10 @@ impl DatabaseApi<'_> {
             .await
     }
 
-    pub async fn get_entity_type(&mut self, uri: &VersionedUri) -> Result<EntityType, QueryError> {
+    pub async fn get_entity_type(
+        &mut self,
+        uri: &VersionedUri,
+    ) -> Result<PersistedEntityType, QueryError> {
         Ok(self
             .store
             .get_entity_type(
@@ -237,7 +244,10 @@ impl DatabaseApi<'_> {
             .await
     }
 
-    pub async fn get_link_type(&mut self, uri: &VersionedUri) -> Result<LinkType, QueryError> {
+    pub async fn get_link_type(
+        &mut self,
+        uri: &VersionedUri,
+    ) -> Result<PersistedLinkType, QueryError> {
         Ok(self
             .store
             .get_link_type(

--- a/packages/graph/hash_graph/tests/integration/postgres/property_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/property_type.rs
@@ -39,7 +39,7 @@ async fn query() {
         .await
         .expect("could not get property type");
 
-    assert_eq!(property_type.inner(), &favorite_quote_pt);
+    assert_eq!(property_type.inner, favorite_quote_pt);
 }
 
 #[tokio::test]

--- a/packages/graph/hash_graph/tests/integration/postgres/property_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/property_type.rs
@@ -39,7 +39,7 @@ async fn query() {
         .await
         .expect("could not get property type");
 
-    assert_eq!(property_type, favorite_quote_pt);
+    assert_eq!(property_type.inner(), &favorite_quote_pt);
 }
 
 #[tokio::test]

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -29,7 +29,7 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("text_data_type_uri", encodeURIComponent(response.body["$id"]));
+    client.global.set("text_data_type_uri", encodeURIComponent("https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"));
 %}
 
 ### Get Text data type
@@ -86,7 +86,7 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("person_property_type_uri", encodeURIComponent(response.body["$id"]));
+    client.global.set("person_property_type_uri", encodeURIComponent("https://blockprotocol.org/@alice/types/property-type/name/v/1"));
 %}
 
 ### Get Name property type
@@ -153,8 +153,8 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("friend_of_link_type_uri", encodeURIComponent(response.body["$id"]));
-    client.global.set("friend_of_link_type_uri_raw", response.body["$id"]);
+    client.global.set("friend_of_link_type_uri", encodeURIComponent("https://blockprotocol.org/@alice/types/link-type/friend-of/v/1"));
+    client.global.set("friend_of_link_type_uri_raw", "https://blockprotocol.org/@alice/types/link-type/friend-of/v/1");
 %}
 
 ### Get FriendOf link type
@@ -224,7 +224,7 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("person_entity_type_uri", encodeURIComponent(response.body["$id"]));
+    client.global.set("person_entity_type_uri", encodeURIComponent("https://blockprotocol.org/@alice/types/entity-type/person/v/1"));
 %}
 
 ### Get Person entity type

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -29,7 +29,7 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("text_data_type_uri", encodeURIComponent("https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"));
+    client.global.set("text_data_type_uri", encodeURIComponent(response.body.uri));
 %}
 
 ### Get Text data type
@@ -86,7 +86,7 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("person_property_type_uri", encodeURIComponent("https://blockprotocol.org/@alice/types/property-type/name/v/1"));
+    client.global.set("person_property_type_uri", encodeURIComponent(response.body.uri));
 %}
 
 ### Get Name property type
@@ -153,8 +153,8 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("friend_of_link_type_uri", encodeURIComponent("https://blockprotocol.org/@alice/types/link-type/friend-of/v/1"));
-    client.global.set("friend_of_link_type_uri_raw", "https://blockprotocol.org/@alice/types/link-type/friend-of/v/1");
+    client.global.set("friend_of_link_type_uri", encodeURIComponent(response.body.uri));
+    client.global.set("friend_of_link_type_uri_raw", response.body.uri);
 %}
 
 ### Get FriendOf link type
@@ -224,7 +224,7 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("person_entity_type_uri", encodeURIComponent("https://blockprotocol.org/@alice/types/entity-type/person/v/1"));
+    client.global.set("person_entity_type_uri", encodeURIComponent(response.body.uri));
 %}
 
 ### Get Person entity type

--- a/packages/hash/api/src/model/ontology/data-type.model.ts
+++ b/packages/hash/api/src/model/ontology/data-type.model.ts
@@ -37,9 +37,12 @@ export default class {
       schema: DataType;
     },
   ): Promise<DataTypeModel> {
-    const { data: schema } = await graphApi.createDataType(params);
+    const { data: identifier } = await graphApi.createDataType(params);
 
-    return new DataTypeModel({ schema, accountId: params.accountId });
+    return new DataTypeModel({
+      schema: params.schema,
+      accountId: identifier.createdBy,
+    });
   }
 
   /**
@@ -95,10 +98,11 @@ export default class {
       schema: DataType;
     },
   ): Promise<DataTypeModel> {
-    const { accountId } = params;
+    const { data: identifier } = await graphApi.updateDataType(params);
 
-    const { data: schema } = await graphApi.updateDataType(params);
-
-    return new DataTypeModel({ schema, accountId });
+    return new DataTypeModel({
+      schema: params.schema,
+      accountId: identifier.createdBy,
+    });
   }
 }

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -33,9 +33,12 @@ export default class {
       schema: EntityType;
     },
   ): Promise<EntityTypeModel> {
-    const { data: schema } = await graphApi.createEntityType(params);
+    const { data: identifier } = await graphApi.createEntityType(params);
 
-    return new EntityTypeModel({ schema, accountId: params.accountId });
+    return new EntityTypeModel({
+      schema: params.schema,
+      accountId: identifier.createdBy,
+    });
   }
 
   /**
@@ -87,11 +90,12 @@ export default class {
       schema: EntityType;
     },
   ): Promise<EntityTypeModel> {
-    const { accountId } = params;
+    const { data: identifier } = await graphApi.updateEntityType(params);
 
-    const { data: schema } = await graphApi.updateEntityType(params);
-
-    return new EntityTypeModel({ schema, accountId });
+    return new EntityTypeModel({
+      schema: params.schema,
+      accountId: identifier.createdBy,
+    });
   }
 
   /**

--- a/packages/hash/api/src/model/ontology/link-type.model.ts
+++ b/packages/hash/api/src/model/ontology/link-type.model.ts
@@ -33,9 +33,12 @@ export default class {
       schema: LinkType;
     },
   ): Promise<LinkTypeModel> {
-    const { data: schema } = await graphApi.createLinkType(params);
+    const { data: identifier } = await graphApi.createLinkType(params);
 
-    return new LinkTypeModel({ schema, accountId: params.accountId });
+    return new LinkTypeModel({
+      schema: params.schema,
+      accountId: identifier.createdBy,
+    });
   }
 
   /**
@@ -87,10 +90,11 @@ export default class {
       schema: LinkType;
     },
   ): Promise<LinkTypeModel> {
-    const { accountId } = params;
+    const { data: identifier } = await graphApi.updateLinkType(params);
 
-    const { data: schema } = await graphApi.updateLinkType(params);
-
-    return new LinkTypeModel({ schema, accountId });
+    return new LinkTypeModel({
+      schema: params.schema,
+      accountId: identifier.createdBy,
+    });
   }
 }

--- a/packages/hash/api/src/model/ontology/property-type.model.ts
+++ b/packages/hash/api/src/model/ontology/property-type.model.ts
@@ -33,9 +33,12 @@ export default class {
       schema: PropertyType;
     },
   ): Promise<PropertyTypeModel> {
-    const { data: schema } = await graphApi.createPropertyType(params);
+    const { data: identifier } = await graphApi.createPropertyType(params);
 
-    return new PropertyTypeModel({ schema, accountId: params.accountId });
+    return new PropertyTypeModel({
+      schema: params.schema,
+      accountId: identifier.createdBy,
+    });
   }
 
   /**
@@ -88,10 +91,11 @@ export default class {
       schema: PropertyType;
     },
   ): Promise<PropertyTypeModel> {
-    const { accountId } = params;
+    const { data: identifier } = await graphApi.updatePropertyType(params);
 
-    const { data: schema } = await graphApi.updatePropertyType(params);
-
-    return new PropertyTypeModel({ schema, accountId });
+    return new PropertyTypeModel({
+      schema: params.schema,
+      accountId: identifier.createdBy,
+    });
   }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Similar to #905, this returns metadata from ontology types

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201095311341924/1202770062090893/f) _(internal)_

## 🚫  Blocked on

- #909 

## 🔍 What does this change?

- Add `PersistedOntologyIdentifier` containing a `created_by` field
- Add `PersistedOntologyType<T>` containing the identifier from above and `T`
  - Add aliases for `PersistedOntologType<DataType>`, `PersistedOntologType<PropertyType>`, etc.
- Change return type for creating/updating to `PersistedOntologyIdentifier`
- Change return type for reading to `PersistedOntologyType`
