### PR TITLE
Rename sentry project

### DIFF
--- a/packages/hash/frontend/sentry.properties
+++ b/packages/hash/frontend/sentry.properties
@@ -1,3 +1,3 @@
 defaults.url=https://sentry.io/
 defaults.org=hashintel
-defaults.project=hashdev-frontend
+defaults.project=hash-frontend


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Renames the Sentry project for the HASH frontend from `hashdev-frontend` to `hash-frontend`. 

`hashdev` was an early/inaccurate name for the project which is now confusing since we also have a hash.dev website.

The one reference to the project name is in `sentry.properties`, which sets the options for the Sentry CLI, which is used to upload source maps to Sentry. The destination for errors logged at runtime is set by the DSN variable, which does not change.

**I have renamed the project in Sentry, because otherwise this branch will not build. We need to merge this to make other branches build again, since they will now contain a project name that doesn't exist.**

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1200211978612931/1202579651285689/f) _(internal)_
