### PR TITLE
Fix OpenAPI spec type mismatch

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -1061,7 +1061,10 @@ export const DataTypeApiFp = function (configuration?: Configuration) {
       uri: string,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<DataType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedDataType>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getDataType(
         uri,
@@ -1085,7 +1088,7 @@ export const DataTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<DataType>>
+      ) => AxiosPromise<Array<PersistedDataType>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getLatestDataTypes(options);
@@ -1156,7 +1159,7 @@ export const DataTypeApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getDataType(uri: string, options?: any): AxiosPromise<DataType> {
+    getDataType(uri: string, options?: any): AxiosPromise<PersistedDataType> {
       return localVarFp
         .getDataType(uri, options)
         .then((request) => request(axios, basePath));
@@ -1166,7 +1169,7 @@ export const DataTypeApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getLatestDataTypes(options?: any): AxiosPromise<Array<DataType>> {
+    getLatestDataTypes(options?: any): AxiosPromise<Array<PersistedDataType>> {
       return localVarFp
         .getLatestDataTypes(options)
         .then((request) => request(axios, basePath));
@@ -1216,7 +1219,7 @@ export interface DataTypeApiInterface {
   getDataType(
     uri: string,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<DataType>;
+  ): AxiosPromise<PersistedDataType>;
 
   /**
    *
@@ -1226,7 +1229,7 @@ export interface DataTypeApiInterface {
    */
   getLatestDataTypes(
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<DataType>>;
+  ): AxiosPromise<Array<PersistedDataType>>;
 
   /**
    *
@@ -2042,7 +2045,10 @@ export const EntityTypeApiFp = function (configuration?: Configuration) {
       uri: string,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<EntityType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedEntityType>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getEntityType(
         uri,
@@ -2066,7 +2072,7 @@ export const EntityTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<EntityType>>
+      ) => AxiosPromise<Array<PersistedEntityType>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getLatestEntityTypes(options);
@@ -2138,7 +2144,10 @@ export const EntityTypeApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getEntityType(uri: string, options?: any): AxiosPromise<EntityType> {
+    getEntityType(
+      uri: string,
+      options?: any,
+    ): AxiosPromise<PersistedEntityType> {
       return localVarFp
         .getEntityType(uri, options)
         .then((request) => request(axios, basePath));
@@ -2148,7 +2157,9 @@ export const EntityTypeApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getLatestEntityTypes(options?: any): AxiosPromise<Array<EntityType>> {
+    getLatestEntityTypes(
+      options?: any,
+    ): AxiosPromise<Array<PersistedEntityType>> {
       return localVarFp
         .getLatestEntityTypes(options)
         .then((request) => request(axios, basePath));
@@ -2198,7 +2209,7 @@ export interface EntityTypeApiInterface {
   getEntityType(
     uri: string,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<EntityType>;
+  ): AxiosPromise<PersistedEntityType>;
 
   /**
    *
@@ -2208,7 +2219,7 @@ export interface EntityTypeApiInterface {
    */
   getLatestEntityTypes(
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<EntityType>>;
+  ): AxiosPromise<Array<PersistedEntityType>>;
 
   /**
    *
@@ -3580,7 +3591,10 @@ export const GraphApiFp = function (configuration?: Configuration) {
       uri: string,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<DataType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedDataType>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getDataType(
         uri,
@@ -3652,7 +3666,10 @@ export const GraphApiFp = function (configuration?: Configuration) {
       uri: string,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<EntityType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedEntityType>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getEntityType(
         uri,
@@ -3676,7 +3693,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<DataType>>
+      ) => AxiosPromise<Array<PersistedDataType>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getLatestDataTypes(options);
@@ -3720,7 +3737,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<EntityType>>
+      ) => AxiosPromise<Array<PersistedEntityType>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getLatestEntityTypes(options);
@@ -3742,7 +3759,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<LinkType>>
+      ) => AxiosPromise<Array<PersistedLinkType>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getLatestLinkTypes(options);
@@ -3764,7 +3781,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<PropertyType>>
+      ) => AxiosPromise<Array<PersistedPropertyType>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getLatestPropertyTypes(options);
@@ -3785,7 +3802,10 @@ export const GraphApiFp = function (configuration?: Configuration) {
       uri: string,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<LinkType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedLinkType>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getLinkType(
         uri,
@@ -3808,7 +3828,10 @@ export const GraphApiFp = function (configuration?: Configuration) {
       uri: string,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<PropertyType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedPropertyType>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getPropertyType(
         uri,
@@ -4085,7 +4108,7 @@ export const GraphApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getDataType(uri: string, options?: any): AxiosPromise<DataType> {
+    getDataType(uri: string, options?: any): AxiosPromise<PersistedDataType> {
       return localVarFp
         .getDataType(uri, options)
         .then((request) => request(axios, basePath));
@@ -4118,7 +4141,10 @@ export const GraphApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getEntityType(uri: string, options?: any): AxiosPromise<EntityType> {
+    getEntityType(
+      uri: string,
+      options?: any,
+    ): AxiosPromise<PersistedEntityType> {
       return localVarFp
         .getEntityType(uri, options)
         .then((request) => request(axios, basePath));
@@ -4128,7 +4154,7 @@ export const GraphApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getLatestDataTypes(options?: any): AxiosPromise<Array<DataType>> {
+    getLatestDataTypes(options?: any): AxiosPromise<Array<PersistedDataType>> {
       return localVarFp
         .getLatestDataTypes(options)
         .then((request) => request(axios, basePath));
@@ -4148,7 +4174,9 @@ export const GraphApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getLatestEntityTypes(options?: any): AxiosPromise<Array<EntityType>> {
+    getLatestEntityTypes(
+      options?: any,
+    ): AxiosPromise<Array<PersistedEntityType>> {
       return localVarFp
         .getLatestEntityTypes(options)
         .then((request) => request(axios, basePath));
@@ -4158,7 +4186,7 @@ export const GraphApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getLatestLinkTypes(options?: any): AxiosPromise<Array<LinkType>> {
+    getLatestLinkTypes(options?: any): AxiosPromise<Array<PersistedLinkType>> {
       return localVarFp
         .getLatestLinkTypes(options)
         .then((request) => request(axios, basePath));
@@ -4168,7 +4196,9 @@ export const GraphApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getLatestPropertyTypes(options?: any): AxiosPromise<Array<PropertyType>> {
+    getLatestPropertyTypes(
+      options?: any,
+    ): AxiosPromise<Array<PersistedPropertyType>> {
       return localVarFp
         .getLatestPropertyTypes(options)
         .then((request) => request(axios, basePath));
@@ -4179,7 +4209,7 @@ export const GraphApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getLinkType(uri: string, options?: any): AxiosPromise<LinkType> {
+    getLinkType(uri: string, options?: any): AxiosPromise<PersistedLinkType> {
       return localVarFp
         .getLinkType(uri, options)
         .then((request) => request(axios, basePath));
@@ -4190,7 +4220,10 @@ export const GraphApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getPropertyType(uri: string, options?: any): AxiosPromise<PropertyType> {
+    getPropertyType(
+      uri: string,
+      options?: any,
+    ): AxiosPromise<PersistedPropertyType> {
       return localVarFp
         .getPropertyType(uri, options)
         .then((request) => request(axios, basePath));
@@ -4374,7 +4407,7 @@ export interface GraphApiInterface {
   getDataType(
     uri: string,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<DataType>;
+  ): AxiosPromise<PersistedDataType>;
 
   /**
    *
@@ -4410,7 +4443,7 @@ export interface GraphApiInterface {
   getEntityType(
     uri: string,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<EntityType>;
+  ): AxiosPromise<PersistedEntityType>;
 
   /**
    *
@@ -4420,7 +4453,7 @@ export interface GraphApiInterface {
    */
   getLatestDataTypes(
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<DataType>>;
+  ): AxiosPromise<Array<PersistedDataType>>;
 
   /**
    *
@@ -4440,7 +4473,7 @@ export interface GraphApiInterface {
    */
   getLatestEntityTypes(
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<EntityType>>;
+  ): AxiosPromise<Array<PersistedEntityType>>;
 
   /**
    *
@@ -4450,7 +4483,7 @@ export interface GraphApiInterface {
    */
   getLatestLinkTypes(
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<LinkType>>;
+  ): AxiosPromise<Array<PersistedLinkType>>;
 
   /**
    *
@@ -4460,7 +4493,7 @@ export interface GraphApiInterface {
    */
   getLatestPropertyTypes(
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PropertyType>>;
+  ): AxiosPromise<Array<PersistedPropertyType>>;
 
   /**
    *
@@ -4472,7 +4505,7 @@ export interface GraphApiInterface {
   getLinkType(
     uri: string,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<LinkType>;
+  ): AxiosPromise<PersistedLinkType>;
 
   /**
    *
@@ -4484,7 +4517,7 @@ export interface GraphApiInterface {
   getPropertyType(
     uri: string,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PropertyType>;
+  ): AxiosPromise<PersistedPropertyType>;
 
   /**
    *
@@ -5565,7 +5598,7 @@ export const LinkTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<LinkType>>
+      ) => AxiosPromise<Array<PersistedLinkType>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getLatestLinkTypes(options);
@@ -5586,7 +5619,10 @@ export const LinkTypeApiFp = function (configuration?: Configuration) {
       uri: string,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<LinkType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedLinkType>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getLinkType(
         uri,
@@ -5658,7 +5694,7 @@ export const LinkTypeApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getLatestLinkTypes(options?: any): AxiosPromise<Array<LinkType>> {
+    getLatestLinkTypes(options?: any): AxiosPromise<Array<PersistedLinkType>> {
       return localVarFp
         .getLatestLinkTypes(options)
         .then((request) => request(axios, basePath));
@@ -5669,7 +5705,7 @@ export const LinkTypeApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getLinkType(uri: string, options?: any): AxiosPromise<LinkType> {
+    getLinkType(uri: string, options?: any): AxiosPromise<PersistedLinkType> {
       return localVarFp
         .getLinkType(uri, options)
         .then((request) => request(axios, basePath));
@@ -5717,7 +5753,7 @@ export interface LinkTypeApiInterface {
    */
   getLatestLinkTypes(
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<LinkType>>;
+  ): AxiosPromise<Array<PersistedLinkType>>;
 
   /**
    *
@@ -5729,7 +5765,7 @@ export interface LinkTypeApiInterface {
   getLinkType(
     uri: string,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<LinkType>;
+  ): AxiosPromise<PersistedLinkType>;
 
   /**
    *
@@ -6055,7 +6091,7 @@ export const PropertyTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<PropertyType>>
+      ) => AxiosPromise<Array<PersistedPropertyType>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getLatestPropertyTypes(options);
@@ -6076,7 +6112,10 @@ export const PropertyTypeApiFp = function (configuration?: Configuration) {
       uri: string,
       options?: AxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<PropertyType>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PersistedPropertyType>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getPropertyType(
         uri,
@@ -6149,7 +6188,9 @@ export const PropertyTypeApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getLatestPropertyTypes(options?: any): AxiosPromise<Array<PropertyType>> {
+    getLatestPropertyTypes(
+      options?: any,
+    ): AxiosPromise<Array<PersistedPropertyType>> {
       return localVarFp
         .getLatestPropertyTypes(options)
         .then((request) => request(axios, basePath));
@@ -6160,7 +6201,10 @@ export const PropertyTypeApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getPropertyType(uri: string, options?: any): AxiosPromise<PropertyType> {
+    getPropertyType(
+      uri: string,
+      options?: any,
+    ): AxiosPromise<PersistedPropertyType> {
       return localVarFp
         .getPropertyType(uri, options)
         .then((request) => request(axios, basePath));
@@ -6208,7 +6252,7 @@ export interface PropertyTypeApiInterface {
    */
   getLatestPropertyTypes(
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PropertyType>>;
+  ): AxiosPromise<Array<PersistedPropertyType>>;
 
   /**
    *
@@ -6220,7 +6264,7 @@ export interface PropertyTypeApiInterface {
   getPropertyType(
     uri: string,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PropertyType>;
+  ): AxiosPromise<PersistedPropertyType>;
 
   /**
    *

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -117,7 +117,7 @@ async fn create_data_type<P: StorePool + Send>(
     path = "/data-types",
     tag = "DataType",
     responses(
-        (status = 200, content_type = "application/json", description = "List of all data types at their latest versions", body = [VAR_DATA_TYPE]),
+        (status = 200, content_type = "application/json", description = "List of all data types at their latest versions", body = [PersistedDataType]),
 
         (status = 500, description = "Store error occurred"),
     )
@@ -135,7 +135,7 @@ async fn get_latest_data_types<P: StorePool + Send>(
     path = "/data-types/{uri}",
     tag = "DataType",
     responses(
-        (status = 200, content_type = "application/json", description = "The schema of the requested data type", body = VAR_DATA_TYPE),
+        (status = 200, content_type = "application/json", description = "The schema of the requested data type", body = PersistedDataType),
         (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 404, description = "Data type was not found"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -117,7 +117,7 @@ async fn create_entity_type<P: StorePool + Send>(
     path = "/entity-types",
     tag = "EntityType",
     responses(
-        (status = 200, content_type = "application/json", description = "List of all entity types at their latest versions", body = [VAR_ENTITY_TYPE]),
+        (status = 200, content_type = "application/json", description = "List of all entity types at their latest versions", body = [PersistedEntityType]),
 
         (status = 500, description = "Datastore error occurred"),
     )
@@ -135,7 +135,7 @@ async fn get_latest_entity_types<P: StorePool + Send>(
     path = "/entity-types/{uri}",
     tag = "EntityType",
     responses(
-        (status = 200, content_type = "application/json", description = "The schema of the requested entity type", body = VAR_ENTITY_TYPE),
+        (status = 200, content_type = "application/json", description = "The schema of the requested entity type", body = PersistedEntityType),
         (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 404, description = "Entity type was not found"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -116,7 +116,7 @@ async fn create_link_type<P: StorePool + Send>(
     path = "/link-types",
     tag = "LinkType",
     responses(
-        (status = 200, content_type = "application/json", description = "List of all link types at their latest versions", body = [VAR_LINK_TYPE]),
+        (status = 200, content_type = "application/json", description = "List of all link types at their latest versions", body = [PersistedLinkType]),
 
         (status = 500, description = "Store error occurred"),
     )
@@ -134,7 +134,7 @@ async fn get_latest_link_types<P: StorePool + Send>(
     path = "/link-types/{uri}",
     tag = "LinkType",
     responses(
-        (status = 200, content_type = "application/json", description = "The schema of the requested link type", body = VAR_LINK_TYPE),
+        (status = 200, content_type = "application/json", description = "The schema of the requested link type", body = PersistedLinkType),
         (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 404, description = "Link type was not found"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -117,7 +117,7 @@ async fn create_property_type<P: StorePool + Send>(
     path = "/property-types",
     tag = "PropertyType",
     responses(
-        (status = 200, content_type = "application/json", description = "List of all property types at their latest versions", body = [VAR_PROPERTY_TYPE]),
+        (status = 200, content_type = "application/json", description = "List of all property types at their latest versions", body = [PersistedPropertyType]),
 
         (status = 500, description = "Store error occurred"),
     )
@@ -135,7 +135,7 @@ async fn get_latest_property_types<P: StorePool + Send>(
     path = "/property-types/{uri}",
     tag = "PropertyType",
     responses(
-        (status = 200, content_type = "application/json", description = "The schema of the requested property type", body = VAR_PROPERTY_TYPE),
+        (status = 200, content_type = "application/json", description = "The schema of the requested property type", body = PersistedPropertyType),
         (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 404, description = "Property type was not found"),

--- a/packages/hash/api/src/model/ontology/data-type.model.ts
+++ b/packages/hash/api/src/model/ontology/data-type.model.ts
@@ -1,7 +1,6 @@
 import { DataType, GraphApi } from "@hashintel/hash-graph-client";
 
 import { DataTypeModel } from "../index";
-import { NIL_UUID } from "../util";
 
 type DataTypeModelConstructorArgs = {
   accountId: string;
@@ -53,13 +52,17 @@ export default class {
    */
   static async getAllLatest(
     graphApi: GraphApi,
-    params: { accountId: string },
+    _params: { accountId: string },
   ): Promise<DataTypeModel[]> {
     /** @todo: get all latest data types in specified account */
-    const { data: schemas } = await graphApi.getLatestDataTypes();
+    const { data: identifiedDataTypes } = await graphApi.getLatestDataTypes();
 
-    return schemas.map(
-      (schema) => new DataTypeModel({ schema, accountId: params.accountId }),
+    return identifiedDataTypes.map(
+      (identifiedDataType) =>
+        new DataTypeModel({
+          schema: identifiedDataType.inner,
+          accountId: identifiedDataType.identifier.createdBy,
+        }),
     );
   }
 
@@ -76,12 +79,14 @@ export default class {
     },
   ): Promise<DataTypeModel> {
     const { versionedUri } = params;
-    const { data: schema } = await graphApi.getDataType(versionedUri);
+    const { data: identifiedDataType } = await graphApi.getDataType(
+      versionedUri,
+    );
 
-    /** @todo: retrieve accountId from `graphApi.getDataType` response */
-    const accountId = NIL_UUID;
-
-    return new DataTypeModel({ schema, accountId });
+    return new DataTypeModel({
+      schema: identifiedDataType.inner,
+      accountId: identifiedDataType.identifier.createdBy,
+    });
   }
 
   /**

--- a/packages/hash/api/src/model/ontology/data-type.model.ts
+++ b/packages/hash/api/src/model/ontology/data-type.model.ts
@@ -55,13 +55,13 @@ export default class {
     _params: { accountId: string },
   ): Promise<DataTypeModel[]> {
     /** @todo: get all latest data types in specified account */
-    const { data: identifiedDataTypes } = await graphApi.getLatestDataTypes();
+    const { data: persistedDataTypes } = await graphApi.getLatestDataTypes();
 
-    return identifiedDataTypes.map(
-      (identifiedDataType) =>
+    return persistedDataTypes.map(
+      (persistedDataType) =>
         new DataTypeModel({
-          schema: identifiedDataType.inner,
-          accountId: identifiedDataType.identifier.createdBy,
+          schema: persistedDataType.inner,
+          accountId: persistedDataType.identifier.createdBy,
         }),
     );
   }
@@ -79,13 +79,13 @@ export default class {
     },
   ): Promise<DataTypeModel> {
     const { versionedUri } = params;
-    const { data: identifiedDataType } = await graphApi.getDataType(
+    const { data: persistedDataType } = await graphApi.getDataType(
       versionedUri,
     );
 
     return new DataTypeModel({
-      schema: identifiedDataType.inner,
-      accountId: identifiedDataType.identifier.createdBy,
+      schema: persistedDataType.inner,
+      accountId: persistedDataType.identifier.createdBy,
     });
   }
 

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -1,7 +1,6 @@
 import { EntityType, GraphApi } from "@hashintel/hash-graph-client";
 
 import { EntityTypeModel, PropertyTypeModel, LinkTypeModel } from "../index";
-import { NIL_UUID } from "../util";
 
 type EntityTypeModelConstructorArgs = {
   accountId?: string;
@@ -49,13 +48,18 @@ export default class {
    */
   static async getAllLatest(
     graphApi: GraphApi,
-    params: { accountId: string },
+    _params: { accountId: string },
   ): Promise<EntityTypeModel[]> {
     /** @todo: get all latest entity types in specified account */
-    const { data: schemas } = await graphApi.getLatestEntityTypes();
+    const { data: identifiedEntityTypes } =
+      await graphApi.getLatestEntityTypes();
 
-    return schemas.map(
-      (schema) => new EntityTypeModel({ schema, accountId: params.accountId }),
+    return identifiedEntityTypes.map(
+      (identifiedEntityType) =>
+        new EntityTypeModel({
+          schema: identifiedEntityType.inner,
+          accountId: identifiedEntityType.identifier.createdBy,
+        }),
     );
   }
 
@@ -72,12 +76,14 @@ export default class {
     },
   ): Promise<EntityTypeModel> {
     const { versionedUri } = params;
-    const { data: schema } = await graphApi.getEntityType(versionedUri);
+    const { data: identifiedEntityType } = await graphApi.getEntityType(
+      versionedUri,
+    );
 
-    /** @todo: retrieve accountId from `graphApi.getEntityType` response */
-    const accountId = NIL_UUID;
-
-    return new EntityTypeModel({ schema, accountId });
+    return new EntityTypeModel({
+      schema: identifiedEntityType.inner,
+      accountId: identifiedEntityType.identifier.createdBy,
+    });
   }
 
   /**

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -51,14 +51,14 @@ export default class {
     _params: { accountId: string },
   ): Promise<EntityTypeModel[]> {
     /** @todo: get all latest entity types in specified account */
-    const { data: identifiedEntityTypes } =
+    const { data: persistedEntityTypes } =
       await graphApi.getLatestEntityTypes();
 
-    return identifiedEntityTypes.map(
-      (identifiedEntityType) =>
+    return persistedEntityTypes.map(
+      (persistedEntityType) =>
         new EntityTypeModel({
-          schema: identifiedEntityType.inner,
-          accountId: identifiedEntityType.identifier.createdBy,
+          schema: persistedEntityType.inner,
+          accountId: persistedEntityType.identifier.createdBy,
         }),
     );
   }
@@ -76,13 +76,13 @@ export default class {
     },
   ): Promise<EntityTypeModel> {
     const { versionedUri } = params;
-    const { data: identifiedEntityType } = await graphApi.getEntityType(
+    const { data: persistedEntityType } = await graphApi.getEntityType(
       versionedUri,
     );
 
     return new EntityTypeModel({
-      schema: identifiedEntityType.inner,
-      accountId: identifiedEntityType.identifier.createdBy,
+      schema: persistedEntityType.inner,
+      accountId: persistedEntityType.identifier.createdBy,
     });
   }
 

--- a/packages/hash/api/src/model/ontology/link-type.model.ts
+++ b/packages/hash/api/src/model/ontology/link-type.model.ts
@@ -51,13 +51,13 @@ export default class {
     _params: { accountId: string },
   ): Promise<LinkTypeModel[]> {
     /** @todo: get all latest link types in specified account */
-    const { data: identifiedLinkTypes } = await graphApi.getLatestLinkTypes();
+    const { data: persistedLinkTypes } = await graphApi.getLatestLinkTypes();
 
-    return identifiedLinkTypes.map(
-      (identifiedLinkType) =>
+    return persistedLinkTypes.map(
+      (persistedLinkType) =>
         new LinkTypeModel({
-          schema: identifiedLinkType.inner,
-          accountId: identifiedLinkType.identifier.createdBy,
+          schema: persistedLinkType.inner,
+          accountId: persistedLinkType.identifier.createdBy,
         }),
     );
   }
@@ -75,13 +75,13 @@ export default class {
     },
   ): Promise<LinkTypeModel> {
     const { versionedUri } = params;
-    const { data: identifiedLinkType } = await graphApi.getLinkType(
+    const { data: persistedLinkType } = await graphApi.getLinkType(
       versionedUri,
     );
 
     return new LinkTypeModel({
-      schema: identifiedLinkType.inner,
-      accountId: identifiedLinkType.identifier.createdBy,
+      schema: persistedLinkType.inner,
+      accountId: persistedLinkType.identifier.createdBy,
     });
   }
 

--- a/packages/hash/api/src/model/ontology/link-type.model.ts
+++ b/packages/hash/api/src/model/ontology/link-type.model.ts
@@ -1,7 +1,6 @@
 import { LinkType, GraphApi } from "@hashintel/hash-graph-client";
 
 import { LinkTypeModel } from "../index";
-import { NIL_UUID } from "../util";
 
 type LinkTypeModelConstructorArgs = {
   accountId: string;
@@ -49,13 +48,17 @@ export default class {
    */
   static async getAllLatest(
     graphApi: GraphApi,
-    params: { accountId: string },
+    _params: { accountId: string },
   ): Promise<LinkTypeModel[]> {
     /** @todo: get all latest link types in specified account */
-    const { data: schemas } = await graphApi.getLatestLinkTypes();
+    const { data: identifiedLinkTypes } = await graphApi.getLatestLinkTypes();
 
-    return schemas.map(
-      (schema) => new LinkTypeModel({ schema, accountId: params.accountId }),
+    return identifiedLinkTypes.map(
+      (identifiedLinkType) =>
+        new LinkTypeModel({
+          schema: identifiedLinkType.inner,
+          accountId: identifiedLinkType.identifier.createdBy,
+        }),
     );
   }
 
@@ -72,12 +75,14 @@ export default class {
     },
   ): Promise<LinkTypeModel> {
     const { versionedUri } = params;
-    const { data: schema } = await graphApi.getLinkType(versionedUri);
+    const { data: identifiedLinkType } = await graphApi.getLinkType(
+      versionedUri,
+    );
 
-    /** @todo: retrieve accountId from `graphApi.getLinkType` response */
-    const accountId = NIL_UUID;
-
-    return new LinkTypeModel({ schema, accountId });
+    return new LinkTypeModel({
+      schema: identifiedLinkType.inner,
+      accountId: identifiedLinkType.identifier.createdBy,
+    });
   }
 
   /**

--- a/packages/hash/api/src/model/ontology/property-type.model.ts
+++ b/packages/hash/api/src/model/ontology/property-type.model.ts
@@ -51,14 +51,14 @@ export default class {
     _params: { accountId: string },
   ): Promise<PropertyTypeModel[]> {
     /** @todo: get all latest property types in specified account */
-    const { data: identifiedPropertyTypes } =
+    const { data: persistedPropertyTypes } =
       await graphApi.getLatestPropertyTypes();
 
-    return identifiedPropertyTypes.map(
-      (identifiedPropertyType) =>
+    return persistedPropertyTypes.map(
+      (persistedPropertyType) =>
         new PropertyTypeModel({
-          schema: identifiedPropertyType.inner,
-          accountId: identifiedPropertyType.identifier.createdBy,
+          schema: persistedPropertyType.inner,
+          accountId: persistedPropertyType.identifier.createdBy,
         }),
     );
   }
@@ -76,13 +76,13 @@ export default class {
     },
   ): Promise<PropertyTypeModel> {
     const { versionedUri } = params;
-    const { data: identifiedPropertyType } = await graphApi.getPropertyType(
+    const { data: persistedPropertyType } = await graphApi.getPropertyType(
       versionedUri,
     );
 
     return new PropertyTypeModel({
-      schema: identifiedPropertyType.inner,
-      accountId: identifiedPropertyType.identifier.createdBy,
+      schema: persistedPropertyType.inner,
+      accountId: persistedPropertyType.identifier.createdBy,
     });
   }
 

--- a/packages/hash/api/src/model/ontology/property-type.model.ts
+++ b/packages/hash/api/src/model/ontology/property-type.model.ts
@@ -1,7 +1,6 @@
 import { PropertyType, GraphApi } from "@hashintel/hash-graph-client";
 
 import { PropertyTypeModel } from "../index";
-import { NIL_UUID } from "../util";
 
 type PropertyTypeModelConstructorArgs = {
   accountId: string;
@@ -49,14 +48,18 @@ export default class {
    */
   static async getAllLatest(
     graphApi: GraphApi,
-    params: { accountId: string },
+    _params: { accountId: string },
   ): Promise<PropertyTypeModel[]> {
     /** @todo: get all latest property types in specified account */
-    const { data: schemas } = await graphApi.getLatestPropertyTypes();
+    const { data: identifiedPropertyTypes } =
+      await graphApi.getLatestPropertyTypes();
 
-    return schemas.map(
-      (schema) =>
-        new PropertyTypeModel({ schema, accountId: params.accountId }),
+    return identifiedPropertyTypes.map(
+      (identifiedPropertyType) =>
+        new PropertyTypeModel({
+          schema: identifiedPropertyType.inner,
+          accountId: identifiedPropertyType.identifier.createdBy,
+        }),
     );
   }
 
@@ -73,12 +76,14 @@ export default class {
     },
   ): Promise<PropertyTypeModel> {
     const { versionedUri } = params;
-    const { data: schema } = await graphApi.getPropertyType(versionedUri);
+    const { data: identifiedPropertyType } = await graphApi.getPropertyType(
+      versionedUri,
+    );
 
-    /** @todo: retrieve accountId from `graphApi.getPropertyType` response */
-    const accountId = NIL_UUID;
-
-    return new PropertyTypeModel({ schema, accountId });
+    return new PropertyTypeModel({
+      schema: identifiedPropertyType.inner,
+      accountId: identifiedPropertyType.identifier.createdBy,
+    });
   }
 
   /**

--- a/packages/hash/frontend/sentry.properties
+++ b/packages/hash/frontend/sentry.properties
@@ -1,3 +1,3 @@
 defaults.url=https://sentry.io/
 defaults.org=hashintel
-defaults.project=hashdev-frontend
+defaults.project=hash-frontend


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

As a follow up to #912 we missed updating the GET operations' OpenAPI annotations to return `Persisted*Type` instead of the raw schemas

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- Follow up to #912 

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->


## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Changed from `VAR_*_TYPE` to `Persisted*Type` in GET operations on the rust side
- Update model classes to make use of the new structures

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->



## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- Ontology integration tests

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch / view the deployment
1.  Recreate and migrate DB and run backend
     - From the `packages/graph/hash_graph/bin/hash_graph` path run:
     - `cargo make recreate-db && cargo make migrate-up`
     - `cargo run`
1.  In another terminal, from the `packages/hash/integration` path run `yarn jest "ontology/*"`
1.  Confirm all tests pass

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
![image](https://user-images.githubusercontent.com/6988668/184102571-18e315d3-d5ad-42ff-af37-299c4510afcc.png)

