### PR TITLE
Add hint for autogenerated files

### DIFF
--- a/packages/graph/.gitattributes
+++ b/packages/graph/.gitattributes
@@ -1,5 +1,5 @@
 clients/typescript/api.ts linguist-generated=true
-clients/typescript/common.ts linguist-generated=true
 clients/typescript/base.ts linguist-generated=true
+clients/typescript/common.ts linguist-generated=true
 clients/typescript/configuration.ts linguist-generated=true
 clients/typescript/index.ts linguist-generated=true

--- a/packages/graph/.gitattributes
+++ b/packages/graph/.gitattributes
@@ -1,0 +1,1 @@
+clients/typescript/api.ts linguist-generated=true

--- a/packages/graph/.gitattributes
+++ b/packages/graph/.gitattributes
@@ -1,1 +1,5 @@
 clients/typescript/api.ts linguist-generated=true
+clients/typescript/common.ts linguist-generated=true
+clients/typescript/base.ts linguist-generated=true
+clients/typescript/configuration.ts linguist-generated=true
+clients/typescript/index.ts linguist-generated=true


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `api.ts` file is autogenerated. This hides the file from diffs and excluded it from stats.