### PR TITLE
[SPIKE] First hook service proof of concept

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "packages/hash/design-system",
     "packages/hash/eslint-config",
     "packages/hash/frontend",
+    "packages/hash/frontend/tmp/hook",
     "packages/hash/integration",
     "packages/hash/playwright",
     "packages/hash/realtime",

--- a/packages/blocks/header/package.json
+++ b/packages/blocks/header/package.json
@@ -19,7 +19,8 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "blockprotocol": "0.0.10"
+    "blockprotocol": "0.0.10",
+    "react-merge-refs": "2.0.1"
   },
   "devDependencies": {
     "block-scripts": "0.0.13",
@@ -30,6 +31,7 @@
     "typescript": "4.6.3"
   },
   "peerDependencies": {
+    "@blockprotocol/hook": "0.0.0-next.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/packages/blocks/header/src/app.tsx
+++ b/packages/blocks/header/src/app.tsx
@@ -1,5 +1,7 @@
 import { BlockComponent } from "blockprotocol/react";
-import React, { RefCallback } from "react";
+import React, { RefCallback, useRef } from "react";
+import { useHookRef, useHookBlockService } from "@blockprotocol/hook";
+import { mergeRefs } from "react-merge-refs";
 
 type BlockEntityProperties = {
   color?: string;
@@ -11,22 +13,19 @@ type BlockEntityProperties = {
 export const App: BlockComponent<BlockEntityProperties> = ({
   color,
   level = 1,
-  editableRef,
   text,
 }) => {
   // @todo set type correctly
   const Header = `h${level}` as any;
 
-  return editableRef ? (
+  const headingRef = useRef<HTMLHeadingElement>(null);
+  const { hookService } = useHookBlockService(headingRef);
+  const hookRef = useHookRef(hookService, text);
+
+  return (
     <Header
       style={{ fontFamily: "Arial", color: color ?? "black", marginBottom: 0 }}
-      ref={editableRef}
+      ref={mergeRefs([headingRef, hookRef])}
     />
-  ) : (
-    <Header
-      style={{ fontFamily: "Arial", color: color ?? "black", marginBottom: 0 }}
-    >
-      {text}
-    </Header>
   );
 };

--- a/packages/hash/frontend/block.dependencies.ts
+++ b/packages/hash/frontend/block.dependencies.ts
@@ -5,4 +5,5 @@ export const blockDependencies: Record<string, any> = {
   "react-dom": require("react-dom"),
   twind: require("twind"),
   lodash: require("lodash"),
+  "@blockprotocol/hook": require("@blockprotocol/hook"),
 };

--- a/packages/hash/frontend/next.config.js
+++ b/packages/hash/frontend/next.config.js
@@ -3,6 +3,7 @@ const path = require("path");
 const withTM = require("next-transpile-modules")([
   "@hashintel/hash-shared",
   "@hashintel/hash-design-system",
+  "@blockprotocol/hook",
 ]); // pass the modules you would like to see transpiled
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const withBundleAnalyzer = require("@next/bundle-analyzer")({

--- a/packages/hash/frontend/src/blocks/page/createEditorView.ts
+++ b/packages/hash/frontend/src/blocks/page/createEditorView.ts
@@ -116,7 +116,14 @@ export const createEditorView = (
         throw new Error("Invalid config for nodeview");
       }
 
-      return new ComponentView(node, editorView, getPos, renderPortal, meta);
+      return new ComponentView(
+        node,
+        editorView,
+        getPos,
+        renderPortal,
+        meta,
+        manager,
+      );
     },
   );
 

--- a/packages/hash/frontend/src/blocks/page/createSuggester/createSuggester.tsx
+++ b/packages/hash/frontend/src/blocks/page/createSuggester/createSuggester.tsx
@@ -1,9 +1,6 @@
-import type { BlockVariant } from "blockprotocol";
-import {
-  blockComponentRequiresText,
-  BlockMeta,
-} from "@hashintel/hash-shared/blockMeta";
+import { BlockMeta } from "@hashintel/hash-shared/blockMeta";
 import { ProsemirrorSchemaManager } from "@hashintel/hash-shared/ProsemirrorSchemaManager";
+import type { BlockVariant } from "blockprotocol";
 import { Schema } from "prosemirror-model";
 import {
   EditorState,
@@ -12,8 +9,8 @@ import {
   TextSelection,
 } from "prosemirror-state";
 import React, { CSSProperties } from "react";
-import { RenderPortal } from "../usePortals";
 import { ensureMounted } from "../../../lib/dom";
+import { RenderPortal } from "../usePortals";
 import { BlockSuggester } from "./BlockSuggester";
 import { MentionSuggester } from "./MentionSuggester";
 
@@ -93,12 +90,12 @@ const key = new PluginKey<SuggesterState, Schema>("suggester");
  * Suggester plugin factory
  *
  * Behaviour:
- * Typing one of the trigger characters followed by any number of non-whitespace characters will
- * activate the plugin and open a popup right under the "textual trigger".
- * Moving the cursor outside the trigger will close the popup. Pressing the
- * Escape-key while inside the trigger will disable the plugin until a trigger
- * is newly encountered (e.g. by leaving/deleting and reentering/retyping a
- * trigger).
+ * Typing one of the trigger characters followed by any number of
+ * non-whitespace characters will activate the plugin and open a popup right
+ * under the "textual trigger". Moving the cursor outside the trigger will
+ * close the popup. Pressing the Escape-key while inside the trigger will
+ * disable the plugin until a trigger is newly encountered (e.g. by
+ * leaving/deleting and reentering/retyping a trigger).
  */
 export const createSuggester = (
   renderPortal: RenderPortal,
@@ -184,7 +181,9 @@ export const createSuggester = (
                 const endPosition = $end.end(1);
                 tr.insert(endPosition, node);
 
-                if (blockComponentRequiresText(meta.componentSchema)) {
+                // @todo need to consider what happens when inserting for
+                //  first time and block is upgradedd
+                if (node.type.isTextblock) {
                   tr.setSelection(
                     TextSelection.create<Schema>(tr.doc, endPosition),
                   );

--- a/packages/hash/frontend/src/components/RemoteBlock/RemoteBlock.tsx
+++ b/packages/hash/frontend/src/components/RemoteBlock/RemoteBlock.tsx
@@ -1,6 +1,7 @@
 import { BlockProtocolFunctions, BlockProtocolProps } from "blockprotocol";
-import React from "react";
+import React, { useRef } from "react";
 
+import { useHookEmbedderService } from "@blockprotocol/hook";
 import { HtmlBlock } from "../HtmlBlock/HtmlBlock";
 import { useRemoteBlock } from "./useRemoteBlock";
 
@@ -8,7 +9,7 @@ type RemoteBlockProps = {
   blockFunctions: BlockProtocolFunctions;
   blockProperties: Omit<BlockProtocolProps, keyof BlockProtocolFunctions>;
   crossFrame?: boolean;
-  editableRef?: unknown;
+  editableRef?: (node: HTMLElement | null) => void;
   onBlockLoaded?: () => void;
   sourceUrl: string;
 };
@@ -31,6 +32,18 @@ export const RemoteBlock: React.VFC<RemoteBlockProps> = ({
     crossFrame,
     onBlockLoaded,
   );
+
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useHookEmbedderService(wrapperRef, {
+    callbacks: {
+      node(msg) {
+        if (msg.data) {
+          editableRef?.(msg.data.node);
+        }
+      },
+    },
+  });
 
   if (loading) {
     return <BlockLoadingIndicator />;
@@ -60,10 +73,12 @@ export const RemoteBlock: React.VFC<RemoteBlockProps> = ({
   }
 
   return (
-    <Component
-      {...blockFunctions}
-      {...blockProperties}
-      editableRef={editableRef}
-    />
+    <div ref={wrapperRef}>
+      <Component
+        {...blockFunctions}
+        {...blockProperties}
+        editableRef={editableRef}
+      />
+    </div>
   );
 };

--- a/packages/hash/frontend/tmp/hook/README.md
+++ b/packages/hash/frontend/tmp/hook/README.md
@@ -1,0 +1,3 @@
+## Block Protocol – Hook service
+
+This is a proof of concept ahead of an RFC.

--- a/packages/hash/frontend/tmp/hook/package.json
+++ b/packages/hash/frontend/tmp/hook/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@blockprotocol/hook",
+  "version": "0.0.0-next.0",
+  "description": "Implementation of the Block Protocol Hook service specification for blocks and embedding applications",
+  "keywords": [
+    "blockprotocol",
+    "blocks",
+    "hook"
+  ],
+  "homepage": "https://blockprotocol.org",
+  "bugs": {
+    "url": "https://github.com/blockprotocol/blockprotocol/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:blockprotocol/blockprotocol.git",
+    "directory": "packages/@blockprotocol/graph"
+  },
+  "license": "MIT",
+  "author": {
+    "name": "HASH",
+    "url": "https://hash.ai"
+  },
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts"
+  },
+  "scripts": {
+    "build": "yarn clean && yarn build:cjs && yarn build:esm",
+    "build:cjs": "tsc --module commonjs --outDir dist/cjs ",
+    "build:esm": "tsc",
+    "clean": "rimraf ./dist/",
+    "lint:tsc": "tsc --noEmit",
+    "prepare": "yarn build"
+  },
+  "dependencies": {
+    "@blockprotocol/core": "0.0.7",
+    "react": "^17.0.2"
+  },
+  "devDependencies": {
+    "rimraf": "^3.0.2",
+    "typescript": "4.7.2"
+  },
+  "peerDependencies": {
+    "react": "^17.0.2"
+  }
+}

--- a/packages/hash/frontend/tmp/hook/src/custom-element.ts
+++ b/packages/hash/frontend/tmp/hook/src/custom-element.ts
@@ -1,0 +1,73 @@
+import { LitElement } from "lit";
+
+import {
+  BlockHookProperties,
+  HookBlockHandler,
+  UpdateEntityData,
+} from "./index";
+
+export interface BlockElementBase<
+  _BlockEntityProperties extends Record<string, unknown> | null,
+> extends LitElement,
+    BlockHookProperties<_BlockEntityProperties> {}
+
+export abstract class BlockElementBase<
+  _BlockEntityProperties extends Record<string, unknown> | null,
+> extends LitElement {
+  protected hookService?: HookBlockHandler;
+
+  static properties = {
+    hook: { type: Object },
+  };
+
+  connectedCallback() {
+    super.connectedCallback();
+    if (!this.hookService || this.hookService.destroyed) {
+      this.hookService = new HookBlockHandler({ element: this });
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this.hookService && !this.hookService.destroyed) {
+      this.hookService.destroy();
+    }
+  }
+
+  // /**
+  //  * Alias for this.hook.blockEntity
+  //  */
+  // protected get blockEntity():
+  //   | BlockHookProperties<BlockEntityProperties>["hook"]["blockEntity"]
+  //   | undefined {
+  //   return this.hook?.blockEntity;
+  // }
+
+  /**
+   * Update the properties of the entity loaded into the block, i.e. this.hook.blockEntity
+   * @param _properties the properties to update, which will be merged with any others
+   */
+  protected updateSelf(_properties: UpdateEntityData["properties"]) {
+    if (!this.hookService) {
+      throw new Error("Cannot updateSelf – hookService not yet connected.");
+    }
+    if (!this.hook) {
+      throw new Error(
+        "Cannot update self: no 'hook' property object passed to block.",
+      );
+    }
+    /* else if (!this.hook.blockEntity) {
+      throw new Error(
+        "Cannot update self: no 'blockEntity' on 'hook' object passed to block",
+      );
+    } else if (!this.hook.blockEntity.entityId) {
+      throw new Error(
+        "Cannot update self: no 'entityId' on hook.blockEntity passed to block",
+      );
+    }
+
+    return this.hookService.updateEntity({
+      data: { entityId: this.hook.blockEntity.entityId, properties },
+    }); */
+  }
+}

--- a/packages/hash/frontend/tmp/hook/src/hook-block-handler.ts
+++ b/packages/hash/frontend/tmp/hook/src/hook-block-handler.ts
@@ -1,0 +1,280 @@
+import { ServiceHandler } from "@blockprotocol/core";
+
+import serviceJsonDefinition from "./hook-service.json";
+import { BlockHookMessageCallbacks, BlockHookMessages } from "./types";
+/**
+ * Creates a handler for the graph service for the block.
+ * Register callbacks in the constructor or afterwards using the 'on' method to react to messages from the embedder.
+ * Call the relevant methods to send messages to the embedder.
+ */
+export class HookBlockHandler
+  extends ServiceHandler
+  implements BlockHookMessages
+{
+  constructor({
+    callbacks,
+    element,
+  }: {
+    callbacks?: Partial<BlockHookMessageCallbacks>;
+    element: HTMLElement;
+  }) {
+    super({ element, serviceName: "hook", sourceType: "block" });
+    if (callbacks) {
+      this.registerCallbacks(callbacks);
+    }
+    this.coreHandler.initialize();
+  }
+
+  getInitPayload(): Record<string, any> {
+    // there are no block messages which are sentOnInitialization in the hook service
+    return {};
+  }
+
+  // @todo what is this for
+  on<K extends keyof BlockHookMessageCallbacks>(
+    this: HookBlockHandler,
+    messageName: K,
+    handlerFunction: BlockHookMessageCallbacks[K],
+  ) {
+    const expectedMessageSource = "embedder";
+    const messageJsonDefinition = serviceJsonDefinition.messages.find(
+      (message) =>
+        message.messageName === messageName &&
+        message.source === expectedMessageSource,
+    );
+    if (!messageJsonDefinition) {
+      throw new Error(
+        `No message with name '${messageName}' expected from ${expectedMessageSource}.`,
+      );
+    }
+    this.registerCallback({
+      callback: handlerFunction,
+      messageName,
+    });
+  }
+
+  async node(value: unknown, node: HTMLElement | null) {
+    if (node) {
+      await this.sendMessage({
+        message: {
+          messageName: "node",
+          data: { node, value },
+        },
+      });
+    }
+  }
+
+  async render(value: unknown) {
+    const result = await this.sendMessage({
+      message: {
+        messageName: "render",
+        data: { value },
+      },
+      respondedToBy: "renderResponse",
+    });
+
+    return result.data;
+  }
+
+  // @todo automate creation of these methods from graph-service.json and types.ts
+  //
+  // createEntity({ data }: { data?: CreateEntityData }) {
+  //   return this.sendMessage<Entity, CreateResourceError>({
+  //     message: {
+  //       messageName: "createEntity",
+  //       data,
+  //     },
+  //     respondedToBy: "createEntityResponse", // @todo get these from graph-service.json
+  //   });
+  // }
+  //
+  // updateEntity({ data }: { data?: UpdateEntityData }) {
+  //   return this.sendMessage<Entity, ReadOrModifyResourceError>({
+  //     message: {
+  //       messageName: "updateEntity",
+  //       data,
+  //     },
+  //     respondedToBy: "updateEntityResponse",
+  //   });
+  // }
+  //
+  // deleteEntity({ data }: { data?: DeleteEntityData }) {
+  //   // @todo fix this 'any'
+  //   return this.sendMessage<any, ReadOrModifyResourceError>({
+  //     message: {
+  //       messageName: "deleteEntity",
+  //       data,
+  //     },
+  //     respondedToBy: "deleteEntityResponse",
+  //   });
+  // }
+  //
+  // getEntity({ data }: { data?: GetEntityData }) {
+  //   return this.sendMessage<Entity, ReadOrModifyResourceError>({
+  //     message: {
+  //       messageName: "getEntity",
+  //       data,
+  //     },
+  //     respondedToBy: "getEntityResponse",
+  //   });
+  // }
+  //
+  // aggregateEntities({ data }: { data?: AggregateEntitiesData }) {
+  //   return this.sendMessage<
+  //     AggregateEntitiesResult<Entity>,
+  //     ReadOrModifyResourceError
+  //   >({
+  //     message: {
+  //       messageName: "aggregateEntities",
+  //       data,
+  //     },
+  //     respondedToBy: "aggregateEntitiesResponse",
+  //   });
+  // }
+  //
+  // createEntityType({ data }: { data?: CreateEntityTypeData }) {
+  //   return this.sendMessage<EntityType, CreateResourceError>({
+  //     message: {
+  //       messageName: "createEntityType",
+  //       data,
+  //     },
+  //     respondedToBy: "createEntityTypeResponse", // @todo get this from graph-service.json
+  //   });
+  // }
+  //
+  // updateEntityType({ data }: { data?: UpdateEntityTypeData }) {
+  //   return this.sendMessage<EntityType, ReadOrModifyResourceError>({
+  //     message: {
+  //       messageName: "updateEntityType",
+  //       data,
+  //     },
+  //     respondedToBy: "updateEntityTypeResponse",
+  //   });
+  // }
+  //
+  // deleteEntityType({ data }: { data?: DeleteEntityTypeData }) {
+  //   // @todo fix this 'any'
+  //   return this.sendMessage<any, ReadOrModifyResourceError>({
+  //     message: {
+  //       messageName: "deleteEntityType",
+  //       data,
+  //     },
+  //     respondedToBy: "deleteEntityTypeResponse",
+  //   });
+  // }
+  //
+  // getEntityType({ data }: { data?: GetEntityTypeData }) {
+  //   return this.sendMessage<EntityType, ReadOrModifyResourceError>({
+  //     message: {
+  //       messageName: "getEntityType",
+  //       data,
+  //     },
+  //     respondedToBy: "getEntityTypeResponse",
+  //   });
+  // }
+  //
+  // aggregateEntityTypes({ data }: { data?: AggregateEntityTypesData }) {
+  //   return this.sendMessage<
+  //     AggregateEntitiesResult<EntityType>,
+  //     ReadOrModifyResourceError
+  //   >({
+  //     message: {
+  //       messageName: "aggregateEntityTypes",
+  //       data,
+  //     },
+  //     respondedToBy: "aggregateEntityTypesResponse",
+  //   });
+  // }
+  //
+  // createLink({ data }: { data?: CreateLinkData }) {
+  //   return this.sendMessage<Link, CreateResourceError>({
+  //     message: {
+  //       messageName: "createLink",
+  //       data,
+  //     },
+  //     respondedToBy: "createLinkResponse",
+  //   });
+  // }
+  //
+  // updateLink({ data }: { data?: UpdateLinkData }) {
+  //   return this.sendMessage<Link, ReadOrModifyResourceError>({
+  //     message: {
+  //       messageName: "updateLink",
+  //       data,
+  //     },
+  //     respondedToBy: "updateLinkResponse",
+  //   });
+  // }
+  //
+  // deleteLink({ data }: { data?: DeleteLinkData }) {
+  //   // @todo fix this 'any'
+  //   return this.sendMessage<any, ReadOrModifyResourceError>({
+  //     message: {
+  //       messageName: "deleteLink",
+  //       data,
+  //     },
+  //     respondedToBy: "deleteLinkResponse",
+  //   });
+  // }
+  //
+  // getLink({ data }: { data?: GetLinkData }) {
+  //   return this.sendMessage<Link, ReadOrModifyResourceError>({
+  //     message: {
+  //       messageName: "getLink",
+  //       data,
+  //     },
+  //     respondedToBy: "getLinkResponse",
+  //   });
+  // }
+  //
+  // createLinkedAggregation({ data }: { data?: CreateLinkedAggregationData }) {
+  //   return this.sendMessage<LinkedAggregation, CreateResourceError>({
+  //     message: {
+  //       messageName: "createLinkedAggregation",
+  //       data,
+  //     },
+  //     respondedToBy: "createLinkedAggregationResponse",
+  //   });
+  // }
+  //
+  // updateLinkedAggregation({ data }: { data?: UpdateLinkedAggregationData }) {
+  //   return this.sendMessage<LinkedAggregation, ReadOrModifyResourceError>({
+  //     message: {
+  //       messageName: "updateLinkedAggregation",
+  //       data,
+  //     },
+  //     respondedToBy: "updateLinkedAggregationResponse",
+  //   });
+  // }
+  //
+  // deleteLinkedAggregation({ data }: { data?: DeleteLinkedAggregationData }) {
+  //   // @todo fix this 'any'
+  //   return this.sendMessage<any, ReadOrModifyResourceError>({
+  //     message: {
+  //       messageName: "deleteLinkedAggregation",
+  //       data,
+  //     },
+  //     respondedToBy: "deleteLinkedAggregationResponse",
+  //   });
+  // }
+  //
+  // getLinkedAggregation({ data }: { data?: GetLinkedAggregationData }) {
+  //   return this.sendMessage<LinkedAggregation, ReadOrModifyResourceError>({
+  //     message: {
+  //       messageName: "getLinkedAggregation",
+  //       data,
+  //     },
+  //     respondedToBy: "getLinkedAggregationResponse",
+  //   });
+  // }
+  //
+  // uploadFile({ data }: { data?: UploadFileData }) {
+  //   return this.sendMessage<UploadFileReturn, CreateResourceError>({
+  //     message: {
+  //       messageName: "uploadFile",
+  //       data,
+  //     },
+  //     respondedToBy: "uploadFileResponse",
+  //   });
+  // }
+}

--- a/packages/hash/frontend/tmp/hook/src/hook-embedder-handler.ts
+++ b/packages/hash/frontend/tmp/hook/src/hook-embedder-handler.ts
@@ -1,0 +1,71 @@
+import { ServiceHandler } from "@blockprotocol/core";
+
+import serviceJsonDefinition from "./hook-service.json";
+import { EmbedderHookMessageCallbacks, EmbedderHookMessages } from "./types";
+
+/**
+ * Creates a handler for the graph service for the embedder.
+ * Register callbacks in the constructor or afterwards using the 'on' method to react to messages from the block.
+ * Call the relevant methods to send messages to the block.
+ */
+export class HookEmbedderHandler
+  extends ServiceHandler
+  implements EmbedderHookMessages
+{
+  constructor({
+    callbacks,
+    element,
+  }: {
+    callbacks?: Partial<EmbedderHookMessageCallbacks>;
+    element: HTMLElement;
+  }) {
+    super({ element, serviceName: "hook", sourceType: "embedder" });
+    if (callbacks) {
+      this.registerCallbacks(callbacks);
+    }
+  }
+
+  // @todo what is this for
+
+  /**
+   * Call the provided function when the named message is received, passing the data/errors object from the message.
+   * If the named message expects a response, the callback should provide the expected data/errors object as the return.
+   * @param messageName the message name to listen for
+   * @param handlerFunction the function to call when the message is received, with the message data / errors
+   */
+  on<K extends keyof EmbedderHookMessageCallbacks>(
+    this: HookEmbedderHandler,
+    messageName: K,
+    handlerFunction: NonNullable<EmbedderHookMessageCallbacks[K]>,
+  ) {
+    const expectedMessageSource = "block";
+    const messageJsonDefinition = serviceJsonDefinition.messages.find(
+      (message) =>
+        message.messageName === messageName &&
+        message.source === expectedMessageSource,
+    );
+    if (!messageJsonDefinition) {
+      throw new Error(
+        `No message with name '${messageName}' expected from ${expectedMessageSource}.`,
+      );
+    }
+    this.registerCallback({
+      callback: handlerFunction,
+      messageName,
+    });
+  }
+
+  getInitPayload(this: HookEmbedderHandler): Record<string, any> {
+    return {};
+  }
+
+  // blockEntity({ data }: { data?: Entity }) {
+  //   this._blockEntity = data;
+  //   this.sendMessage({
+  //     message: {
+  //       messageName: "blockEntity",
+  //       data: this._blockEntity,
+  //     },
+  //   });
+  // }
+}

--- a/packages/hash/frontend/tmp/hook/src/hook-service.json
+++ b/packages/hash/frontend/tmp/hook/src/hook-service.json
@@ -1,0 +1,826 @@
+{
+  "name": "hook",
+  "version": "0.1",
+  "coreVersion": "0.2",
+  "messages": [
+    {
+      "messageName": "createEntity",
+      "description": "Request to create an entity",
+      "source": "block",
+      "respondedToBy": "createEntityResponse",
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "entityTypeId": {
+            "description": "The entityTypeId of the type of the entity to create",
+            "type": "string"
+          },
+          "properties": {
+            "description": "The properties of the entity to create",
+            "type": "object"
+          },
+          "links": {
+            "description": "Links to create along with the entity",
+            "type": "array",
+            "items": {
+              "$ref": "https://blockprotocol.org/types/services/graph/link"
+            }
+          }
+        },
+        "required": ["entityTypeId", "properties"]
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "createEntityResponse",
+      "description": "The response to a request to create an entity",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "entity": {
+            "description": "The newly created entity",
+            "$ref": "https://blockprotocol.org/types/services/graph/entity"
+          }
+        },
+        "required": ["entity"]
+      },
+      "errorCodes": ["FORBIDDEN", "INVALID_INPUT"]
+    },
+    {
+      "messageName": "updateEntity",
+      "description": "Request to update an entity, with the properties to update",
+      "source": "block",
+      "respondedToBy": "updateEntityResponse",
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "entityId": {
+            "description": "The entityId of the entity to update",
+            "type": "string"
+          },
+          "properties": {
+            "description": "The properties of the entity to update, which will be merged with any other properties on the entity",
+            "type": "object"
+          }
+        },
+        "required": ["entityId", "properties"]
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "updateEntityResponse",
+      "description": "The response to a request to update an entity",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "entity": {
+            "description": "The updated entity",
+            "$ref": "https://blockprotocol.org/types/services/graph/entity"
+          }
+        },
+        "required": ["entity"]
+      },
+      "errorCodes": ["FORBIDDEN", "INVALID_INPUT", "NOT_FOUND"]
+    },
+    {
+      "messageName": "deleteEntity",
+      "description": "Request to delete an entity, expecting 'true' in response if the operation succeeds.",
+      "source": "block",
+      "respondedToBy": "deleteEntityResponse",
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "entityId": {
+            "description": "The entityId of the entity to delete",
+            "type": "string"
+          }
+        },
+        "required": ["entityId"]
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "deleteEntityResponse",
+      "description": "The response to a request to delete an entity",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": false,
+      "data": {
+        "description": "'true' if the operation succeeded. Otherwise, errors should be returned.",
+        "type": "boolean"
+      },
+      "errorCodes": ["FORBIDDEN", "INVALID_INPUT", "NOT_FOUND"]
+    },
+    {
+      "messageName": "getEntity",
+      "description": "Request to retrieve an entity, expecting the entity in response.",
+      "source": "block",
+      "respondedToBy": "getEntityResponse",
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "entityId": {
+            "description": "The entityId of the entity to retrieve",
+            "type": "string"
+          }
+        },
+        "required": ["entityId"]
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "getEntityResponse",
+      "description": "The response to a request to get an entity",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "entity": {
+            "description": "The retrieved entity",
+            "$ref": "https://blockprotocol.org/types/services/graph/entity"
+          }
+        },
+        "required": ["entity"]
+      },
+      "errorCodes": ["FORBIDDEN", "INVALID_INPUT", "NOT_FOUND"]
+    },
+    {
+      "messageName": "aggregateEntities",
+      "description": "Request to retrieve an aggregation of entities.",
+      "source": "block",
+      "respondedToBy": "aggregateEntitiesResponse",
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "description": "The aggregation operation to apply",
+            "$ref": "https://blockprotocol.org/types/services/graph/aggregation-operation"
+          }
+        },
+        "required": ["operation"]
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "aggregateEntitiesResponse",
+      "description": "The response to a request to retrieve an aggregation of entities",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "description": "The aggregation operation that was applied to generate the results, including any defaults set by the application.",
+            "$ref": "https://blockprotocol.org/types/services/graph/aggregation-operation"
+          },
+          "results": {
+            "description": "The entities returned by the aggregation operation",
+            "type": "array",
+            "items": {
+              "$ref": "https://blockprotocol.org/types/services/graph/entity"
+            }
+          }
+        },
+        "required": ["operation", "results"]
+      },
+      "errorCodes": ["FORBIDDEN", "INVALID_INPUT"]
+    },
+    {
+      "messageName": "createEntityType",
+      "description": "Request to create an entity type, expecting the created entity type in response.",
+      "source": "block",
+      "respondedToBy": "createEntityTypeResponse",
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "schema": {
+            "description": "The schema of the entity type to create",
+            "type": "object"
+          }
+        },
+        "required": ["schema"]
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "createEntityTypeResponse",
+      "description": "The response to a request to create an entityType",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "entityType": {
+            "description": "The created entity type",
+            "$ref": "https://blockprotocol.org/types/services/graph/entity-type"
+          }
+        },
+        "required": ["entityType"]
+      },
+      "errorCodes": ["FORBIDDEN", "INVALID_INPUT"]
+    },
+    {
+      "messageName": "updateEntityType",
+      "description": "Request to update an entityType, expecting the updated entityType in response.",
+      "source": "block",
+      "respondedToBy": "updateEntityTypeResponse",
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "entityTypeId": {
+            "description": "The entityTypeId of the entity to update",
+            "type": "string"
+          },
+          "schema": {
+            "description": "A partial schema to apply as an update, which will be merged with any other properties on the schema",
+            "type": "object"
+          }
+        },
+        "required": ["entityTypeId", "schema"]
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "updateEntityTypeResponse",
+      "description": "The response to a request to update an entity type",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "entityType": {
+            "description": "The updated entity type",
+            "$ref": "https://blockprotocol.org/types/services/graph/entity-type"
+          }
+        },
+        "required": ["entityType"]
+      },
+      "errorCodes": ["FORBIDDEN", "INVALID_INPUT", "NOT_FOUND"]
+    },
+    {
+      "messageName": "deleteEntityType",
+      "description": "Request to delete an entityType, expecting a boolean in response.",
+      "source": "block",
+      "respondedToBy": "deleteEntityTypeResponse",
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "entityTypeId": {
+            "description": "The entityTypeId of the entityType to delete",
+            "type": "string"
+          }
+        },
+        "required": ["entityTypeId"]
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "deleteEntityTypeResponse",
+      "description": "The response to a request to delete an entity type",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": false,
+      "data": {
+        "description": "'true' if the operation succeeded. Otherwise, 'errors' will be returned.",
+        "type": "boolean"
+      },
+      "errorCodes": ["FORBIDDEN", "INVALID_INPUT", "NOT_FOUND"]
+    },
+    {
+      "messageName": "getEntityType",
+      "description": "Request to retrieve an entity type, expecting the entity type in response.",
+      "source": "block",
+      "respondedToBy": "getEntityTypeResponse",
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "entityTypeId": {
+            "description": "The entityTypeId of the entity type to retrieve",
+            "type": "string"
+          }
+        },
+        "required": ["entityTypeId"]
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "getEntityTypeResponse",
+      "description": "The response to a request to get an entity type",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "entityType": {
+            "description": "The retrieved entity type",
+            "$ref": "https://blockprotocol.org/types/services/graph/entity-type"
+          }
+        },
+        "required": ["entityType"]
+      },
+      "errorCodes": ["FORBIDDEN", "INVALID_INPUT", "NOT_FOUND"]
+    },
+    {
+      "messageName": "aggregateEntityTypes",
+      "description": "Request to retrieve an aggregation of entity types.",
+      "source": "block",
+      "respondedToBy": "aggregateEntityTypesResponse",
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "description": "The aggregation operation to apply",
+            "$ref": "https://blockprotocol.org/types/services/graph/aggregation-operation"
+          }
+        },
+        "required": ["operation"]
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "aggregateEntityTypesResponse",
+      "description": "The response to a request to retrieve an aggregation of entity types",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "description": "The aggregation operation that was applied to generate the results, including any defaults set by the application.",
+            "$ref": "https://blockprotocol.org/types/services/graph/aggregation-operation"
+          },
+          "results": {
+            "description": "The entity types returned by the aggregation operation",
+            "type": "array",
+            "items": {
+              "$ref": "https://blockprotocol.org/types/services/graph/entity-type"
+            }
+          }
+        },
+        "required": ["operation", "results"]
+      },
+      "errorCodes": ["FORBIDDEN", "INVALID_INPUT"]
+    },
+    {
+      "messageName": "createLink",
+      "description": "Request to create a link, expecting the created link in response.",
+      "source": "block",
+      "respondedToBy": "createLinkResponse",
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "sourceEntityId": {
+            "description": "The entityId of the source entity for the link",
+            "type": "string"
+          },
+          "destinationEntityId": {
+            "description": "The entityId of the destination entity for the link",
+            "type": "string"
+          },
+          "index": {
+            "description": "The position of this link in an ordered list of links, where ordering is important. An index of 0 represents the first position in the list.",
+            "type": "number"
+          },
+          "path": {
+            "description": "The path or field on the entity where this link is made (e.g. 'friend', 'employer')",
+            "type": "string"
+          }
+        },
+        "required": ["sourceEntityId", "destinationEntityId", "path"]
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "createLinkResponse",
+      "description": "The response to a request to create a link",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "link": {
+            "description": "The created link",
+            "$ref": "https://blockprotocol.org/types/services/graph/link"
+          }
+        },
+        "required": ["link"]
+      },
+      "errorCodes": ["FORBIDDEN", "INVALID_INPUT"]
+    },
+    {
+      "messageName": "updateLink",
+      "description": "Request to update a link, expecting the updated link in response.",
+      "source": "block",
+      "respondedToBy": "updateLinkResponse",
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "linkId": {
+            "description": "The linkId of the entity to update",
+            "type": "string"
+          },
+          "index": {
+            "description": "The new index the link should occupy in an ordered list of links",
+            "type": "number"
+          }
+        },
+        "required": ["linkId", "index"]
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "updateLinkResponse",
+      "description": "The response to a request to update a link",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "link": {
+            "description": "The updated link",
+            "$ref": "https://blockprotocol.org/types/services/graph/link"
+          }
+        },
+        "required": ["link"]
+      },
+      "errorCodes": ["FORBIDDEN", "INVALID_INPUT", "NOT_FOUND"]
+    },
+    {
+      "messageName": "deleteLink",
+      "description": "Request to delete a link, expecting a boolean in response.",
+      "source": "block",
+      "respondedToBy": "deleteLinkResponse",
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "linkId": {
+            "description": "The linkId of the link to delete",
+            "type": "string"
+          }
+        },
+        "required": ["linkId"]
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "deleteLinkResponse",
+      "description": "The response to a request to delete a link",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": false,
+      "data": {
+        "description": "'true' if the operation succeeded. Otherwise, 'errors' should be returned.",
+        "type": "boolean"
+      },
+      "errorCodes": ["FORBIDDEN", "INVALID_INPUT", "NOT_FOUND"]
+    },
+    {
+      "messageName": "getLink",
+      "description": "Request to retrieve a link, expecting the link in response.",
+      "source": "block",
+      "respondedToBy": "getLinkResponse",
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "linkId": {
+            "description": "The linkId of the link to retrieve",
+            "type": "string"
+          }
+        },
+        "required": ["linkId"]
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "getLinkResponse",
+      "description": "The response to a request to get a link",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "link": {
+            "description": "The retrieved link",
+            "$ref": "https://blockprotocol.org/types/services/graph/link"
+          }
+        },
+        "required": ["link"]
+      },
+      "errorCodes": ["FORBIDDEN", "INVALID_INPUT", "NOT_FOUND"]
+    },
+    {
+      "messageName": "createLinkedAggregation",
+      "description": "Request to create a linked aggregation, expecting the created linked aggregation in response.",
+      "source": "block",
+      "respondedToBy": "createLinkedAggregationResponse",
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "sourceEntityId": {
+            "description": "The entityId of the source entity of this linked aggregation",
+            "type": "string"
+          },
+          "operation": {
+            "description": "The aggregation operation to apply",
+            "$ref": "https://blockprotocol.org/types/services/graph/aggregation-operation"
+          },
+          "path": {
+            "description": "The path or field on the entity where this linked aggregation is made (e.g. 'rows')",
+            "type": "string"
+          }
+        },
+        "required": ["sourceEntityId", "operation", "path"]
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "createLinkedAggregationResponse",
+      "description": "The response to a request to create a linkedAggregation",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "linkedAggregation": {
+            "description": "The created linked aggregation",
+            "$ref": "https://blockprotocol.org/types/services/graph/linked-aggregation-definition"
+          }
+        },
+        "required": ["linkedAggregation"]
+      },
+      "errorCodes": ["FORBIDDEN", "INVALID_INPUT"]
+    },
+    {
+      "messageName": "updateLinkedAggregation",
+      "description": "Request to update a linked aggregation, expecting the updated linked aggregation in response.",
+      "source": "block",
+      "respondedToBy": "updateLinkedAggregationResponse",
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "aggregationId": {
+            "description": "The aggregationId of the linked aggregation to update",
+            "type": "string"
+          },
+          "operation": {
+            "description": "The new aggregation operation",
+            "$ref": "https://blockprotocol.org/types/services/graph/aggregation-operation"
+          }
+        },
+        "required": ["aggregationId", "operation"]
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "updateLinkedAggregationResponse",
+      "description": "The response to a request to update a linked aggregation",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "linkedAggregation": {
+            "description": "The updated linked aggregation definition",
+            "$ref": "https://blockprotocol.org/types/services/graph/linked-aggregation-definition"
+          }
+        },
+        "required": ["linkedAggregation"]
+      },
+      "errorCodes": ["FORBIDDEN", "INVALID_INPUT", "NOT_FOUND"]
+    },
+    {
+      "messageName": "deleteLinkedAggregation",
+      "description": "Request to delete a linked aggregation, expecting a boolean in response.",
+      "source": "block",
+      "respondedToBy": "deleteLinkedAggregationResponse",
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "aggregationId": {
+            "description": "The aggregationId of the linked aggregation to delete",
+            "type": "string"
+          }
+        },
+        "required": ["aggregationId"]
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "deleteLinkedAggregationResponse",
+      "description": "The response to a request to delete a linked aggregation",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": false,
+      "data": {
+        "type": "boolean"
+      },
+      "errorCodes": ["FORBIDDEN", "INVALID_INPUT", "NOT_FOUND"]
+    },
+    {
+      "messageName": "getLinkedAggregation",
+      "description": "Request to retrieve a linked aggregation, expecting the linked aggregation in response.",
+      "source": "block",
+      "respondedToBy": "getLinkedAggregationResponse",
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "aggregationId": {
+            "description": "The aggregationId of the linkedAggregation to retrieve",
+            "type": "string"
+          }
+        },
+        "required": ["aggregationId"]
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "getLinkedAggregationResponse",
+      "description": "The response to a request to get a linkedAggregation",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "linkedAggregation": {
+            "description": "The retrieved linked aggregation",
+            "$ref": "https://blockprotocol.org/types/services/graph/linked-aggregation"
+          }
+        },
+        "required": ["linkedAggregation"]
+      },
+      "errorCodes": ["FORBIDDEN", "INVALID_INPUT", "NOT_FOUND"]
+    },
+    {
+      "messageName": "uploadFile",
+      "description": "Request to upload a file and create an entity to store metadata about it.",
+      "source": "block",
+      "respondedToBy": "uploadFileResponse",
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "file": {
+            "description": "The file blob, if being uploaded directly. Either 'url' or 'file' is required."
+          },
+          "url": {
+            "description": "The URL to take the file from, if not being uploaded directly. Either 'url' or 'file' is required.",
+            "type": "string"
+          },
+          "mediaType": {
+            "description": "The type of media file this is",
+            "type": "string",
+            "enum": ["image", "video"]
+          }
+        },
+        "required": ["mediaType"]
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "uploadFileResponse",
+      "description": "The response to a request to create an entity storing metadata about an uploaded file.",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": false,
+      "data": {
+        "type": "object",
+        "properties": {
+          "entityId": {
+            "description": "The entityId of the entity storing metadata about the file."
+          },
+          "url": {
+            "description": "The URL the file is now being served from.",
+            "type": "string"
+          },
+          "mediaType": {
+            "description": "The type of media file this is",
+            "type": "string",
+            "enum": ["image", "video"]
+          }
+        },
+        "required": ["entityId", "mediaType", "url"]
+      },
+      "errorCodes": ["FORBIDDEN", "INVALID_INPUT", "NOT_FOUND"]
+    },
+    {
+      "messageName": "blockEntity",
+      "description": "The entity associated with the block",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": true,
+      "data": {
+        "$ref": "https://blockprotocol.org/types/services/graph/entity"
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "blockGraph",
+      "description": "A graph of entities with the block entity at the root, resolved to the specified depth.",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": true,
+      "data": {
+        "type": "object",
+        "properties": {
+          "linkedEntities": {
+            "description": "The entities linked from the block entity, and potentially entities linked from them, and so on, depending on depth.",
+            "type": "array",
+            "items": {
+              "$ref": "https://blockprotocol.org/types/services/graph/entity"
+            }
+          },
+          "linkGroups": {
+            "description": "The links attached to the block or the entities provided in linkedEntities, grouped by entity and path.",
+            "type": "array",
+            "items": {
+              "$ref": "https://blockprotocol.org/types/services/graph/link-group"
+            }
+          },
+          "depth": {
+            "description": "The number of links that will be followed from the block when resolving the graph.",
+            "type": "integer",
+            "inclusiveMinimum": 0
+          }
+        },
+        "required": ["linkedEntities", "linkGroups", "depth"]
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "entityTypes",
+      "description": "The entity types for any entities provided to the block as part of other messages.",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": true,
+      "data": {
+        "type": "array",
+        "items": {
+          "$ref": "https://blockprotocol.org/types/services/graph/entity-type"
+        }
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "linkedAggregations",
+      "description": "Aggregations which are linked to from the block entity.",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": true,
+      "data": {
+        "type": "array",
+        "items": {
+          "$ref": "https://blockprotocol.org/types/services/graph/linked-aggregation-definition"
+        }
+      },
+      "errorCodes": []
+    },
+    {
+      "messageName": "readonly",
+      "description": "Indicates if the block should display in 'readonly' mode, i.e. without editing controls.",
+      "source": "embedder",
+      "respondedToBy": null,
+      "sentOnInitialization": true,
+      "data": {
+        "type": "boolean"
+      },
+      "errorCodes": []
+    }
+  ]
+}

--- a/packages/hash/frontend/tmp/hook/src/index.ts
+++ b/packages/hash/frontend/tmp/hook/src/index.ts
@@ -1,0 +1,10 @@
+export { BlockElementBase } from "./custom-element";
+export { HookBlockHandler } from "./hook-block-handler";
+export { HookEmbedderHandler } from "./hook-embedder-handler";
+export type { BlockComponent } from "./react";
+export {
+  useHookBlockService,
+  useHookEmbedderService,
+  useHookRef,
+} from "./react";
+export * from "./types";

--- a/packages/hash/frontend/tmp/hook/src/index.ts
+++ b/packages/hash/frontend/tmp/hook/src/index.ts
@@ -1,4 +1,3 @@
-export { BlockElementBase } from "./custom-element";
 export { HookBlockHandler } from "./hook-block-handler";
 export { HookEmbedderHandler } from "./hook-embedder-handler";
 export type { BlockComponent } from "./react";

--- a/packages/hash/frontend/tmp/hook/src/react.ts
+++ b/packages/hash/frontend/tmp/hook/src/react.ts
@@ -1,0 +1,132 @@
+import {
+  RefObject,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  VoidFunctionComponent,
+} from "react";
+
+import {
+  BlockHookProperties,
+  HookBlockHandler,
+  HookEmbedderHandler,
+} from "./index";
+
+export type BlockComponent<
+  Properties extends Record<string, unknown> | null = null,
+> = VoidFunctionComponent<BlockHookProperties<Properties>>;
+
+const useHookServiceConstructor = <
+  T extends typeof HookBlockHandler | typeof HookEmbedderHandler,
+>({
+  Handler,
+  constructorArgs,
+  ref,
+}: {
+  Handler: T;
+  constructorArgs?: Omit<ConstructorParameters<T>[0], "element">;
+  ref: RefObject<HTMLElement>;
+}) => {
+  const previousRef = useRef<HTMLElement | null>(null);
+
+  const [hookService, setHookService] = useState<
+    | (T extends typeof HookBlockHandler
+        ? HookBlockHandler
+        : HookEmbedderHandler)
+    | null
+  >(null);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- will not loop & we don't want to reconstruct on other args
+  useEffect(() => {
+    if (ref.current === previousRef.current) {
+      return;
+    }
+
+    if (previousRef.current) {
+      hookService?.destroy();
+    }
+
+    previousRef.current = ref.current;
+
+    if (ref.current) {
+      setHookService(
+        new Handler({
+          element: ref.current,
+          ...(constructorArgs as unknown as ConstructorParameters<T>), // @todo fix these casts
+        }) as T extends typeof HookBlockHandler // @todo fix these casts
+          ? HookBlockHandler
+          : HookEmbedderHandler,
+      );
+    }
+  });
+
+  return { hookService };
+};
+
+/**
+ * Create a HookBlockHandler instance, using a reference to an element in the block.
+ *
+ * The hookService will only be reconstructed if the element reference changes.
+ * Updates to any callbacks after first constructing should be made by calling hookService.on("messageName", callback);
+ */
+export const useHookBlockService = (
+  ref: RefObject<HTMLElement>,
+  constructorArgs?: Omit<
+    ConstructorParameters<typeof HookBlockHandler>[0],
+    "element"
+  >,
+): { hookService: HookBlockHandler | null } => {
+  return useHookServiceConstructor({
+    Handler: HookBlockHandler,
+    constructorArgs,
+    ref,
+  });
+};
+
+export const useHookRef = (
+  handler: HookBlockHandler | null,
+  value?: unknown,
+  onError?: (...args: any[]) => unknown,
+) => {
+  const currentValue = useRef(value);
+  const currentOnError = useRef(onError);
+  const currentNode = useRef<HTMLElement>(null);
+
+  useLayoutEffect(() => {
+    currentValue.current = value;
+    currentOnError.current = onError;
+  });
+
+  useLayoutEffect(() => {
+    const node = currentNode.current;
+
+    if (node && handler) {
+      handler.node(currentValue.current, node).catch((err) => {
+        currentOnError.current?.(err);
+      });
+    }
+  }, [handler, value]);
+
+  return currentNode;
+};
+
+/**
+ * Create a HookBlockHandler instance, using a reference to an element in the block.
+ *
+ * The hookService will only be reconstructed if the element reference changes.
+ * Updates to any callbacks after first constructing should be made by calling hookService.on("messageName", callback);
+ */
+export const useHookEmbedderService = (
+  ref: RefObject<HTMLElement>,
+  constructorArgs?: Omit<
+    ConstructorParameters<typeof HookEmbedderHandler>[0],
+    "element"
+  >,
+): { hookService: HookEmbedderHandler | null } => {
+  return useHookServiceConstructor({
+    Handler: HookEmbedderHandler,
+    ref,
+    constructorArgs,
+  });
+};

--- a/packages/hash/frontend/tmp/hook/src/types.ts
+++ b/packages/hash/frontend/tmp/hook/src/types.ts
@@ -1,0 +1,291 @@
+import { MessageCallback, UnknownRecord } from "@blockprotocol/core";
+
+// ----------------------------- ENTITIES ----------------------------- //
+
+export type Entity<
+  Properties extends Record<string, unknown> | null = Record<string, unknown>,
+> = {
+  entityId: string;
+  entityTypeId?: string;
+} & (Properties extends null ? {} : { properties: Properties });
+
+export type UpdateEntityData = {
+  entityId: string;
+  properties: UnknownRecord;
+};
+
+export type FilterOperatorType =
+  | FilterOperatorRequiringValue
+  | FilterOperatorWithoutValue;
+
+export type FilterOperatorWithoutValue = "IS_EMPTY" | "IS_NOT_EMPTY";
+
+export type FilterOperatorRequiringValue =
+  | "CONTAINS"
+  | "DOES_NOT_CONTAIN"
+  | "IS"
+  | "IS_NOT"
+  | "STARTS_WITH"
+  | "ENDS_WITH";
+
+export type MultiFilterOperatorType = "AND" | "OR";
+
+export type MultiFilter = {
+  filters: (
+    | {
+        field: string;
+        operator: FilterOperatorRequiringValue;
+        value: string;
+      }
+    | { field: string; operator: FilterOperatorWithoutValue }
+  )[];
+  operator: MultiFilterOperatorType;
+};
+
+export type Sort = {
+  field: string;
+  desc?: boolean | undefined | null;
+};
+
+export type MultiSort = Sort[];
+
+export type AggregateOperationInput = {
+  entityTypeId?: string | null;
+  pageNumber?: number | null;
+  itemsPerPage?: number | null;
+  multiSort?: MultiSort | null;
+  multiFilter?: MultiFilter | null;
+};
+
+export type AggregateEntitiesData = {
+  operation: AggregateOperationInput;
+};
+
+export type AggregateEntitiesResult<T extends Entity | EntityType> = {
+  results: T[];
+  operation: AggregateOperationInput &
+    Required<Pick<AggregateOperationInput, "pageNumber" | "itemsPerPage">> & {
+      pageCount?: number | null;
+      totalCount?: number | null;
+    };
+};
+
+// ------------------------ OTHER FUNCTIONS --------------------------- //
+
+// ----------------------------- LINKS -------------------------------- //
+
+export type Link = {
+  linkId: string;
+  sourceEntityId: string;
+  destinationEntityId: string;
+  index?: number | null;
+  path: string;
+};
+
+export type LinkGroup = {
+  sourceEntityId: string;
+  path: string;
+  links: Link[];
+};
+
+// ---------------------- LINKED AGGREGATIONS ------------------------- //
+
+export type LinkedAggregationDefinition = {
+  aggregationId: string;
+  sourceEntityId: string;
+  path: string;
+  operation: AggregateOperationInput;
+};
+
+export type LinkedAggregation = Omit<LinkedAggregationDefinition, "operation"> &
+  AggregateEntitiesResult<Entity>;
+
+// ------------------------- ENTITY TYPES ----------------------------- //
+
+export type EntityType = {
+  entityTypeId: string; // @todo consider removing this and just using $id, the URI
+  schema: {
+    $id: string;
+    $schema: string;
+    title: string;
+    type: string;
+    [key: string]: unknown;
+  };
+};
+
+export type AggregateEntityTypesData = {
+  // @todo mention in spec or remove
+  // include entities that are used by, but don't belong to, the specified account
+  includeOtherTypesInUse?: boolean | null;
+  operation?: Omit<AggregateOperationInput, "entityTypeId"> | null;
+};
+
+// -------------------------- BLOCK GRAPH -------------------------- //
+
+export type LinkedAggregations = LinkedAggregation[];
+export type LinkedEntities = Entity[];
+export type LinkGroups = LinkGroup[];
+
+export type BlockGraph = {
+  depth: number;
+  linkedEntities: LinkedEntities;
+  linkGroups: LinkGroups;
+};
+
+export type BlockHookProperties<
+  _BlockEntityProperties extends Record<string, unknown> | null,
+> = {
+  hook: {};
+  // hook: {
+  //   blockGraph?: BlockGraph;
+  //   entityTypes?: EntityType[];
+  //   linkedAggregations?: LinkedAggregations;
+  // } & (BlockEntityProperties extends null
+  //   ? { blockEntity?: Entity }
+  //   : { blockEntity: Entity<BlockEntityProperties> });
+};
+
+export type BlockHookMessageCallbacks = {
+  // blockEntity: MessageCallback<Entity, null>;
+  // blockGraph: MessageCallback<BlockGraph, null>;
+  // entityTypes: MessageCallback<EntityType[], null>;
+  // linkedAggregations: MessageCallback<LinkedAggregations, null>;
+};
+
+export type EmbedderHookMessages<
+  _Key extends keyof BlockHookMessageCallbacks = keyof BlockHookMessageCallbacks,
+> = {
+  // [key in Key]: ({
+  //   data,
+  //   errors,
+  // }: Parameters<BlockHookMessageCallbacks[key]>[0]) => ReturnType<
+  //   BlockHookMessageCallbacks[key]
+  // >;
+};
+
+export type RenderData = unknown;
+
+/**
+ * @todo Generate these types from the JSON definition, to avoid manually keeping the JSON and types in sync
+ */
+export type EmbedderHookMessageCallbacks = {
+  render: MessageCallback<RenderData, null, HTMLElement, null>;
+  node: MessageCallback<{ node: HTMLElement; value: RenderData }, null>;
+
+  // @todo type the error here
+  // createEntity: MessageCallback<
+  //   CreateEntityData,
+  //   null,
+  //   Entity,
+  //   CreateResourceError
+  // >;
+  // updateEntity: MessageCallback<
+  //   UpdateEntityData,
+  //   null,
+  //   Entity,
+  //   ReadOrModifyResourceError
+  // >;
+  // deleteEntity: MessageCallback<
+  //   DeleteEntityData,
+  //   null,
+  //   true,
+  //   ReadOrModifyResourceError
+  // >;
+  // getEntity: MessageCallback<
+  //   GetEntityData,
+  //   null,
+  //   Entity,
+  //   ReadOrModifyResourceError
+  // >;
+  // aggregateEntities: MessageCallback<
+  //   AggregateEntitiesData,
+  //   null,
+  //   AggregateEntitiesResult<Entity>,
+  //   ReadOrModifyResourceError
+  // >;
+  // createEntityType: MessageCallback<
+  //   CreateEntityTypeData,
+  //   null,
+  //   EntityType,
+  //   CreateResourceError
+  // >;
+  // updateEntityType: MessageCallback<
+  //   UpdateEntityTypeData,
+  //   null,
+  //   EntityType,
+  //   ReadOrModifyResourceError
+  // >;
+  // deleteEntityType: MessageCallback<
+  //   DeleteEntityTypeData,
+  //   null,
+  //   true,
+  //   ReadOrModifyResourceError
+  // >;
+  // getEntityType: MessageCallback<
+  //   GetEntityTypeData,
+  //   null,
+  //   EntityType,
+  //   ReadOrModifyResourceError
+  // >;
+  // aggregateEntityTypes: MessageCallback<
+  //   AggregateEntityTypesData,
+  //   null,
+  //   AggregateEntitiesResult<EntityType>,
+  //   ReadOrModifyResourceError
+  // >;
+  // createLink: MessageCallback<CreateLinkData, null, Link, CreateResourceError>;
+  // updateLink: MessageCallback<
+  //   UpdateLinkData,
+  //   null,
+  //   Link,
+  //   ReadOrModifyResourceError
+  // >;
+  // deleteLink: MessageCallback<
+  //   DeleteLinkData,
+  //   null,
+  //   true,
+  //   ReadOrModifyResourceError
+  // >;
+  // getLink: MessageCallback<GetLinkData, null, Link, ReadOrModifyResourceError>;
+  // createLinkedAggregation: MessageCallback<
+  //   CreateLinkedAggregationData,
+  //   null,
+  //   LinkedAggregationDefinition,
+  //   CreateResourceError
+  // >;
+  // updateLinkedAggregation: MessageCallback<
+  //   UpdateLinkedAggregationData,
+  //   null,
+  //   LinkedAggregationDefinition,
+  //   ReadOrModifyResourceError
+  // >;
+  // deleteLinkedAggregation: MessageCallback<
+  //   DeleteLinkedAggregationData,
+  //   null,
+  //   true,
+  //   ReadOrModifyResourceError
+  // >;
+  // getLinkedAggregation: MessageCallback<
+  //   GetLinkedAggregationData,
+  //   null,
+  //   LinkedAggregationDefinition,
+  //   ReadOrModifyResourceError
+  // >;
+  // uploadFile: MessageCallback<
+  //   UploadFileData,
+  //   null,
+  //   UploadFileReturn,
+  //   CreateResourceError
+  // >;
+};
+
+export type BlockHookMessages<
+  _Key extends keyof EmbedderHookMessageCallbacks = keyof EmbedderHookMessageCallbacks,
+> = {
+  // [key in Key]: ({
+  //   data,
+  //   errors,
+  // }: Parameters<EmbedderHookMessageCallbacks[key]>[0]) => ReturnType<
+  //   EmbedderHookMessageCallbacks[key]
+  // >;
+};

--- a/packages/hash/frontend/tmp/hook/tsconfig.json
+++ b/packages/hash/frontend/tmp/hook/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "allowJs": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "module": "esnext",
+    "moduleResolution": "node",
+    "outDir": "dist/esm",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "es6"
+  },
+  "include": ["./src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/hash/shared/src/blockMeta.ts
+++ b/packages/hash/shared/src/blockMeta.ts
@@ -1,5 +1,5 @@
-import { BlockMetadata, BlockVariant } from "blockprotocol";
 import { JsonSchema } from "@hashintel/hash-shared/json-utils";
+import { BlockMetadata, BlockVariant } from "blockprotocol";
 
 /** @todo: might need refactor: https://github.com/hashintel/dev/pull/206#discussion_r723210329 */
 // eslint-disable-next-line global-require
@@ -234,15 +234,4 @@ export const fetchBlockMeta = async (
   }
 
   return await promise;
-};
-
-// @todo remove this
-export const blockComponentRequiresText = (
-  componentSchema: BlockMeta["componentSchema"],
-) => {
-  return false;
-
-  return (
-    !!componentSchema.properties && "editableRef" in componentSchema.properties
-  );
 };

--- a/packages/hash/shared/src/blockMeta.ts
+++ b/packages/hash/shared/src/blockMeta.ts
@@ -236,7 +236,13 @@ export const fetchBlockMeta = async (
   return await promise;
 };
 
+// @todo remove this
 export const blockComponentRequiresText = (
   componentSchema: BlockMeta["componentSchema"],
-) =>
-  !!componentSchema.properties && "editableRef" in componentSchema.properties;
+) => {
+  return false;
+
+  return (
+    !!componentSchema.properties && "editableRef" in componentSchema.properties
+  );
+};

--- a/packages/hash/shared/src/defaultBlocks.ts
+++ b/packages/hash/shared/src/defaultBlocks.ts
@@ -8,7 +8,6 @@
  */
 export const defaultBlocks = [
   "https://blockprotocol.org/blocks/@hash/paragraph",
-  "https://blockprotocol.org/blocks/@hash/header",
   "https://blockprotocol.org/blocks/@hash/callout",
   "https://blockprotocol.org/blocks/@hash/person",
   "https://blockprotocol.org/blocks/@hash/image",

--- a/packages/hash/shared/src/defaultBlocks.ts
+++ b/packages/hash/shared/src/defaultBlocks.ts
@@ -16,4 +16,5 @@ export const defaultBlocks = [
   "https://blockprotocol.org/blocks/@hash/embed",
   "https://blockprotocol.org/blocks/@hash/code",
   "https://blockprotocol.org/blocks/@hash/video",
+  "http://localhost:63282",
 ];

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,6 +14,7 @@
     "baseUrl": ".",
     "paths": {
       "@hashintel/hash-shared/*": ["./packages/hash/shared/src/*"],
+      "@blockprotocol/hook/*": ["./packages/hash/frontend/tmp/hook/src/*"],
       "@hashintel/hash-backend-utils/*": [
         "./packages/hash/backend-utils/src/*"
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3041,6 +3041,13 @@
   dependencies:
     uuid "^8.3.2"
 
+"@blockprotocol/core@0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@blockprotocol/core/-/core-0.0.7.tgz#22f42a7aa4792c0ff9668cbabf20953df5eab5b3"
+  integrity sha512-7i6gogO6fNXGXqxLeUdDTZFmnHyfZPZvjwYOuNMT5coOI1gsZqdCWjpT6lV4B3HwZTdJY651JhQvM4CsegoDZw==
+  dependencies:
+    uuid "^8.3.2"
+
 "@blockprotocol/graph@0.0.8":
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/@blockprotocol/graph/-/graph-0.0.8.tgz#27b28c6cb18168fc02b71df7b6a24b3fb494b413"
@@ -15650,6 +15657,11 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-merge-refs@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-2.0.1.tgz#a1f8c2dadefa635333e9b91ec59f30b65228b006"
+  integrity sha512-pywF6oouJWuqL26xV3OruRSIqai31R9SdJX/I3gP2q8jLxUnA1IwXcLW8werUHLZOrp4N7YOeQNZrh/BKrHI4A==
 
 react-modal-hook@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This PR represents a proof of concept of replacing `editableRef` with a previous iteration of the hook service.

Creating this PR for prosperity, as the hook service has changed quite dramatically since this spike, and this has since been replaced by https://github.com/hashintel/hash/pull/936 

Some of the same ideas about upgrading a block to being editable are present in https://github.com/hashintel/hash/pull/937 which was replaced by https://github.com/hashintel/hash/pull/872