### PR TITLE
`error-stack` conditionally disable `backtrace` feature in `1.65`

### DIFF
--- a/packages/libs/error-stack/build.rs
+++ b/packages/libs/error-stack/build.rs
@@ -1,7 +1,16 @@
-use rustc_version::{version_meta, Channel};
+use rustc_version::{version_meta, Channel, Version};
 
 fn main() {
     if version_meta().unwrap().channel == Channel::Nightly {
         println!("cargo:rustc-cfg=nightly")
+    }
+
+    let mut version = version_meta().unwrap().semver;
+    // remove the suffix (like nightly)
+    version.pre = vec![];
+    version.build = vec![];
+
+    if version >= Version::new(1, 65, 0) {
+        println!("cargo:rustc-cfg=rust_1_65")
     }
 }

--- a/packages/libs/error-stack/build.rs
+++ b/packages/libs/error-stack/build.rs
@@ -16,7 +16,6 @@ fn main() {
         let month: usize = build_date.next().unwrap().parse().unwrap();
         let day: usize = build_date.next().unwrap().parse().unwrap();
 
-        eprintln!("{} {} {}", year, month, day);
         if year >= 2022 && month >= 8 && day >= 10 {
             println!("cargo:rustc-cfg=nightly_2022_08_10")
         }

--- a/packages/libs/error-stack/build.rs
+++ b/packages/libs/error-stack/build.rs
@@ -10,6 +10,18 @@ fn main() {
     version.pre = vec![];
     version.build = vec![];
 
+    if let Some(build_date) = version_meta().unwrap().commit_date {
+        let mut build_date = build_date.split('-');
+        let year: usize = build_date.next().unwrap().parse().unwrap();
+        let month: usize = build_date.next().unwrap().parse().unwrap();
+        let day: usize = build_date.next().unwrap().parse().unwrap();
+
+        eprintln!("{} {} {}", year, month, day);
+        if year >= 2022 && month >= 8 && day >= 10 {
+            println!("cargo:rustc-cfg=nightly_2022_08_10")
+        }
+    }
+
     if version >= Version::new(1, 65, 0) {
         println!("cargo:rustc-cfg=rust_1_65")
     }

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -418,7 +418,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(nightly, feature(provide_any))]
 #![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
-#![cfg_attr(all(nightly, not(rust_1_65), feature = "std"), feature(backtrace))]
+#![cfg_attr(
+    all(nightly, not(all(rust_1_65, nightly_2022_08_10)), feature = "std"),
+    feature(backtrace)
+)]
 #![cfg_attr(
     all(nightly, feature = "std"),
     feature(backtrace_frames, error_generic_member_access)

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -418,9 +418,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(nightly, feature(provide_any))]
 #![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
+#![cfg_attr(all(nightly, not(rust_1_65), feature = "std"), feature(backtrace))]
 #![cfg_attr(
     all(nightly, feature = "std"),
-    feature(backtrace, backtrace_frames, error_generic_member_access)
+    feature(backtrace_frames, error_generic_member_access)
 )]
 #![warn(
     missing_docs,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `backtrace` feature is scheduled for stabilization in rust 1.65, which means that the newest nightly versions will throw warnings, which will fail in CI.

This PR solves the issue by creating a new flag, `rust_1_65`, which will enable backtrace only if not present.

I completely understand if this PR is not going to get merged, this is quite a bit early, but something similar will need to be implemented sooner or later. (I think?)

## 🔗 Related links

## 🚫 Blocked by

## 🔍 What does this change?

Create a new `cfg` for `error-stack`

## 📜 Does this require a change to the docs?

No.

## ⚠️ Known issues

## 🐾 Next steps

## 🛡 What tests cover this?

* CI on the newest nightly should not error out

## ❓ How to test this?

Does CI work where the backtrace feature has been stabilized and before that? `2022-08-14` is likely to work. Nightlies before `2022-08-10` will not work because of a stabilization oopsie.

## 📹 Demo
