### PR TITLE
Bump the Minimal Supported Rust Version to 1.63

### DIFF
--- a/.github/scripts/rust/setup.py
+++ b/.github/scripts/rust/setup.py
@@ -23,7 +23,7 @@ ALWAYS_RUN_PATTERNS = ["**/rust-toolchain.toml", ".github/**"]
 # Toolchains used for the specified crates in addition to the toolchain which is defined in
 # rust-toolchain.toml
 TOOLCHAINS = {
-    "packages/libs/error-stack": ["1.61"],
+    "packages/libs/error-stack": ["1.63"],
 }
 
 # Try and publish these crates when their version is changed in Cargo.toml

--- a/packages/libs/error-stack/CHANGELOG.md
+++ b/packages/libs/error-stack/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to `error-stack` will be documented in this file.
 
 - Use `Provider` API from `core::any` ([#697](https://github.com/hashintel/hash/pull/697))
 - Hide `futures-core` feature ([#695](https://github.com/hashintel/hash/pull/695))
+- Set the MSRV to 1.63 ([#944](https://github.com/hashintel/hash/pull/944))
 
 ### Features
 

--- a/packages/libs/error-stack/README.md
+++ b/packages/libs/error-stack/README.md
@@ -8,7 +8,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/error-stack)][crates.io]
 [![libs.rs](https://img.shields.io/badge/libs.rs-error--stack-orange)][libs.rs]
-[![rust-version](https://img.shields.io/badge/Rust-1.61.0-orange)][rust-version]
+[![rust-version](https://img.shields.io/badge/Rust-1.63.0-orange)][rust-version]
 [![documentation](https://img.shields.io/docsrs/error-stack)][documentation]
 [![license](https://img.shields.io/crates/l/error-stack)][license]
 [![discord](https://img.shields.io/discord/840573247803097118)][discord]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We have agreed on bumping the Minimum Supported Rust Version to 1.63 as this will reduce the maintenance of multiple branches in the upcoming hook logic

## 🔗 Related links

- Closes #930 
- #794 

## 🚫  Blocked on

- #943 
