### PR TITLE
Add Entity Type CRU resolvers

### DIFF
--- a/packages/hash/api/src/collab/graphql/queries/entityType.queries.ts
+++ b/packages/hash/api/src/collab/graphql/queries/entityType.queries.ts
@@ -1,16 +1,16 @@
 import gql from "graphql-tag";
 
-export const getTextEntityType = gql`
-  query getTextEntityType {
-    getEntityType(choice: { systemTypeName: Text }) {
+export const deprecatedGetTextEntityType = gql`
+  query deprecatedGetTextEntityType {
+    deprecatedGetEntityType(choice: { systemTypeName: Text }) {
       entityId
     }
   }
 `;
 
-export const getComponentEntityType = gql`
-  query getComponentEntityType($componentId: ID!) {
-    getEntityType(choice: { componentId: $componentId }) {
+export const deprecatedGetComponentEntityType = gql`
+  query deprecatedGetComponentEntityType($componentId: ID!) {
+    deprecatedGetEntityType(choice: { componentId: $componentId }) {
       entityId
     }
   }

--- a/packages/hash/api/src/collab/save.ts
+++ b/packages/hash/api/src/collab/save.ts
@@ -18,12 +18,12 @@ import { ProsemirrorNode, Schema } from "prosemirror-model";
 import { v4 as uuid } from "uuid";
 import {
   EntityTypeChoice,
-  GetComponentEntityTypeQuery,
-  GetComponentEntityTypeQueryVariables,
+  DeprecatedGetComponentEntityTypeQuery,
+  DeprecatedGetComponentEntityTypeQueryVariables,
   GetPageQuery,
   GetPageQueryVariables,
-  GetTextEntityTypeQuery,
-  GetTextEntityTypeQueryVariables,
+  DeprecatedGetTextEntityTypeQuery,
+  DeprecatedGetTextEntityTypeQueryVariables,
   SystemTypeName,
   Text,
   UpdatePageAction,
@@ -33,8 +33,8 @@ import {
 } from "../graphql/apiTypes.gen";
 import { capitalizeComponentName } from "../util";
 import {
-  getComponentEntityType,
-  getTextEntityType,
+  deprecatedGetComponentEntityType,
+  deprecatedGetTextEntityType,
 } from "./graphql/queries/entityType.queries";
 import {
   getPageQuery,
@@ -60,13 +60,14 @@ const ensureEntityTypeForComponent = async (
 
   if (!desiredEntityTypeId) {
     desiredEntityTypeId = await apolloClient
-      .query<GetComponentEntityTypeQuery, GetComponentEntityTypeQueryVariables>(
-        {
-          query: getComponentEntityType,
-          variables: { componentId },
-        },
-      )
-      .then((res) => res.data.getEntityType.entityId)
+      .query<
+        DeprecatedGetComponentEntityTypeQuery,
+        DeprecatedGetComponentEntityTypeQueryVariables
+      >({
+        query: deprecatedGetComponentEntityType,
+        variables: { componentId },
+      })
+      .then((res) => res.data.deprecatedGetEntityType.entityId)
       .catch((err) => {
         if (
           err instanceof ApolloError &&
@@ -520,10 +521,13 @@ export const save = async (
       })
       .then((res) => res.data.page.contents),
     apolloClient
-      .query<GetTextEntityTypeQuery, GetTextEntityTypeQueryVariables>({
-        query: getTextEntityType,
+      .query<
+        DeprecatedGetTextEntityTypeQuery,
+        DeprecatedGetTextEntityTypeQueryVariables
+      >({
+        query: deprecatedGetTextEntityType,
       })
-      .then((res) => res.data.getEntityType.entityId)
+      .then((res) => res.data.deprecatedGetEntityType.entityId)
       .catch(() => {
         throw new Error("Cannot find text entity type id");
       }),

--- a/packages/hash/api/src/graphql/resolvers/entityType/createEntityType.ts
+++ b/packages/hash/api/src/graphql/resolvers/entityType/createEntityType.ts
@@ -1,12 +1,15 @@
-import { MutationCreateEntityTypeArgs, ResolverFn } from "../../apiTypes.gen";
+import {
+  MutationDeprecatedCreateEntityTypeArgs,
+  ResolverFn,
+} from "../../apiTypes.gen";
 import { LoggedInGraphQLContext } from "../../context";
 import { EntityType, UnresolvedGQLEntityType } from "../../../model";
 
-export const createEntityType: ResolverFn<
+export const deprecatedCreateEntityType: ResolverFn<
   Promise<UnresolvedGQLEntityType>,
   {},
   LoggedInGraphQLContext,
-  MutationCreateEntityTypeArgs
+  MutationDeprecatedCreateEntityTypeArgs
 > = async (
   _,
   { accountId, description, name, schema },

--- a/packages/hash/api/src/graphql/resolvers/entityType/entityTypeInheritance.ts
+++ b/packages/hash/api/src/graphql/resolvers/entityType/entityTypeInheritance.ts
@@ -1,14 +1,13 @@
 import { ApolloError } from "apollo-server-express";
 
-import { ResolverFn, EntityType as GQLEntityType } from "../../apiTypes.gen";
+import { ResolverFn, DeprecatedEntityType } from "../../apiTypes.gen";
 import { GraphQLContext } from "../../context";
 import { EntityType, UnresolvedGQLEntityType } from "../../../model";
 
 const children: ResolverFn<
   Promise<UnresolvedGQLEntityType[]>,
-  GQLEntityType,
-  GraphQLContext,
-  {}
+  DeprecatedEntityType,
+  GraphQLContext
 > = async (params, _, { dataSources: { db } }) => {
   const { entityId: entityTypeId } = params;
 
@@ -31,9 +30,8 @@ const children: ResolverFn<
 
 const parents: ResolverFn<
   Promise<UnresolvedGQLEntityType[]>,
-  GQLEntityType,
-  GraphQLContext,
-  {}
+  DeprecatedEntityType,
+  GraphQLContext
 > = async (params, _, { dataSources: { db } }) => {
   const { entityId: entityTypeId } = params;
 
@@ -56,9 +54,8 @@ const parents: ResolverFn<
 
 const ancestors: ResolverFn<
   Promise<UnresolvedGQLEntityType[]>,
-  GQLEntityType,
-  GraphQLContext,
-  {}
+  DeprecatedEntityType,
+  GraphQLContext
 > = async (params, _, { dataSources: { db } }) => {
   const { entityId: entityTypeId } = params;
 

--- a/packages/hash/api/src/graphql/resolvers/entityType/entityTypeInheritance.ts
+++ b/packages/hash/api/src/graphql/resolvers/entityType/entityTypeInheritance.ts
@@ -7,7 +7,8 @@ import { EntityType, UnresolvedGQLEntityType } from "../../../model";
 const children: ResolverFn<
   Promise<UnresolvedGQLEntityType[]>,
   DeprecatedEntityType,
-  GraphQLContext
+  GraphQLContext,
+  {}
 > = async (params, _, { dataSources: { db } }) => {
   const { entityId: entityTypeId } = params;
 
@@ -31,7 +32,8 @@ const children: ResolverFn<
 const parents: ResolverFn<
   Promise<UnresolvedGQLEntityType[]>,
   DeprecatedEntityType,
-  GraphQLContext
+  GraphQLContext,
+  {}
 > = async (params, _, { dataSources: { db } }) => {
   const { entityId: entityTypeId } = params;
 
@@ -55,7 +57,8 @@ const parents: ResolverFn<
 const ancestors: ResolverFn<
   Promise<UnresolvedGQLEntityType[]>,
   DeprecatedEntityType,
-  GraphQLContext
+  GraphQLContext,
+  {}
 > = async (params, _, { dataSources: { db } }) => {
   const { entityId: entityTypeId } = params;
 

--- a/packages/hash/api/src/graphql/resolvers/entityType/entityTypeTypeFields.ts
+++ b/packages/hash/api/src/graphql/resolvers/entityType/entityTypeTypeFields.ts
@@ -1,14 +1,14 @@
 import { ApolloError } from "apollo-server-express";
-import { ResolverFn, EntityType as GQLEntityType } from "../../apiTypes.gen";
+import { ResolverFn, DeprecatedEntityType } from "../../apiTypes.gen";
 import { GraphQLContext } from "../../context";
 import { EntityType, UnresolvedGQLEntityType } from "../../../model";
 import { EntityTypeTypeFields } from "../../../db/adapter";
 
 type EntityTypeMaybeTypeFields = UnresolvedGQLEntityType & {
-  entityType?: GQLEntityType["entityType"];
-  entityTypeId?: GQLEntityType["entityTypeId"];
-  entityTypeVersionId?: GQLEntityType["entityTypeVersionId"];
-  entityTypeName?: GQLEntityType["entityTypeName"];
+  entityType?: DeprecatedEntityType["entityType"];
+  entityTypeId?: DeprecatedEntityType["entityTypeId"];
+  entityTypeVersionId?: DeprecatedEntityType["entityTypeVersionId"];
+  entityTypeName?: DeprecatedEntityType["entityTypeName"];
 };
 
 /**
@@ -24,7 +24,7 @@ const getEntityTypeType = async (dataSources: GraphQLContext["dataSources"]) =>
  */
 const entityType: ResolverFn<
   Omit<
-    GQLEntityType["entityType"],
+    DeprecatedEntityType["entityType"],
     | EntityTypeTypeFields
     | "linkGroups"
     | "linkedEntities"
@@ -44,7 +44,7 @@ const entityType: ResolverFn<
  * Get the entityTypeId of an EntityType, i.e. the entityId of the "EntityType" EntityType.
  */
 const entityTypeId: ResolverFn<
-  GQLEntityType["entityTypeId"],
+  DeprecatedEntityType["entityTypeId"],
   EntityTypeMaybeTypeFields,
   GraphQLContext,
   {}
@@ -62,7 +62,7 @@ const entityTypeId: ResolverFn<
  * Get the entityTypeName of an EntityType, i.e. the name of the "EntityType" EntityType.
  */
 const entityTypeName: ResolverFn<
-  GQLEntityType["entityTypeName"],
+  DeprecatedEntityType["entityTypeName"],
   EntityTypeMaybeTypeFields,
   GraphQLContext,
   {}
@@ -82,7 +82,7 @@ const entityTypeName: ResolverFn<
  * Get the entityTypeVersionId of an EntityType, i.e. the entityVersionId of the "EntityType" EntityType.
  */
 const entityTypeVersionId: ResolverFn<
-  GQLEntityType["entityTypeVersionId"],
+  DeprecatedEntityType["entityTypeVersionId"],
   EntityTypeMaybeTypeFields,
   GraphQLContext,
   {}

--- a/packages/hash/api/src/graphql/resolvers/entityType/getAccountEntityTypes.ts
+++ b/packages/hash/api/src/graphql/resolvers/entityType/getAccountEntityTypes.ts
@@ -1,14 +1,17 @@
-import { QueryGetAccountEntityTypesArgs, ResolverFn } from "../../apiTypes.gen";
+import {
+  QueryDeprecatedGetAccountEntityTypesArgs,
+  ResolverFn,
+} from "../../apiTypes.gen";
 import { GraphQLContext } from "../../context";
 import EntityType, {
   UnresolvedGQLEntityType,
 } from "../../../model/entityType.model";
 
-export const getAccountEntityTypes: ResolverFn<
+export const deprecatedGetAccountEntityTypes: ResolverFn<
   Promise<UnresolvedGQLEntityType[]>,
   {},
   GraphQLContext,
-  QueryGetAccountEntityTypesArgs
+  QueryDeprecatedGetAccountEntityTypesArgs
 > = async (
   _,
   { accountId, includeAllTypes, includeOtherTypesInUse },

--- a/packages/hash/api/src/graphql/resolvers/entityType/getEntityType.ts
+++ b/packages/hash/api/src/graphql/resolvers/entityType/getEntityType.ts
@@ -2,15 +2,18 @@ import { UserInputError } from "apollo-server-errors";
 import { ApolloError } from "apollo-server-express";
 import { exactlyOne, validateEntityTypeChoice } from "../../../util";
 
-import { QueryGetEntityTypeArgs, ResolverFn } from "../../apiTypes.gen";
+import {
+  QueryDeprecatedGetEntityTypeArgs,
+  ResolverFn,
+} from "../../apiTypes.gen";
 import { GraphQLContext } from "../../context";
 import { UnresolvedGQLEntityType, EntityType } from "../../../model";
 
-export const getEntityType: ResolverFn<
+export const deprecatedGetEntityType: ResolverFn<
   Promise<UnresolvedGQLEntityType>,
   {},
   GraphQLContext,
-  QueryGetEntityTypeArgs
+  QueryDeprecatedGetEntityTypeArgs
 > = async (_, { entityTypeId, choice }, { dataSources }) => {
   let filter;
 

--- a/packages/hash/api/src/graphql/resolvers/entityType/updateEntityType.ts
+++ b/packages/hash/api/src/graphql/resolvers/entityType/updateEntityType.ts
@@ -12,11 +12,7 @@ export const deprecatedUpdateEntityType: ResolverFn<
   {},
   LoggedInGraphQLContext,
   MutationDeprecatedUpdateEntityTypeArgs
-> = async (
-  _,
-  { accountId, entityId, schema },
-  { dataSources: { db }, user },
-) => {
+> = async (_, { entityId, schema }, { dataSources: { db }, user }) => {
   return await db.transaction(async (conn) => {
     const entityType = await EntityType.getEntityType(conn, {
       entityTypeId: entityId,

--- a/packages/hash/api/src/graphql/resolvers/entityType/updateEntityType.ts
+++ b/packages/hash/api/src/graphql/resolvers/entityType/updateEntityType.ts
@@ -1,15 +1,22 @@
 import { ApolloError } from "apollo-server-express";
 
-import { MutationUpdateEntityTypeArgs, ResolverFn } from "../../apiTypes.gen";
+import {
+  MutationDeprecatedUpdateEntityTypeArgs,
+  ResolverFn,
+} from "../../apiTypes.gen";
 import { LoggedInGraphQLContext } from "../../context";
 import { EntityType, UnresolvedGQLEntityType } from "../../../model";
 
-export const updateEntityType: ResolverFn<
+export const deprecatedUpdateEntityType: ResolverFn<
   Promise<UnresolvedGQLEntityType>,
   {},
   LoggedInGraphQLContext,
-  MutationUpdateEntityTypeArgs
-> = async (_, { entityId, schema }, { dataSources: { db }, user }) => {
+  MutationDeprecatedUpdateEntityTypeArgs
+> = async (
+  _,
+  { accountId, entityId, schema },
+  { dataSources: { db }, user },
+) => {
   return await db.transaction(async (conn) => {
     const entityType = await EntityType.getEntityType(conn, {
       entityTypeId: entityId,

--- a/packages/hash/api/src/graphql/resolvers/index.ts
+++ b/packages/hash/api/src/graphql/resolvers/index.ts
@@ -59,7 +59,7 @@ import { createFileFromLink } from "./file/createFileFromLink";
 import { loggedIn } from "./middlewares/loggedIn";
 import { loggedInAndSignedUp } from "./middlewares/loggedInAndSignedUp";
 import { canAccessAccount } from "./middlewares/canAccessAccount";
-import { updateEntityType } from "./entityType/updateEntityType";
+import { deprecatedUpdateEntityType } from "./entityType/updateEntityType";
 import { deleteLinkedAggregation } from "./linkedAggregation/deleteLinkedAggregation";
 import { updateLinkedAggregationOperation } from "./linkedAggregation/updateLinkedAggregationOperation";
 import { createLinkedAggregation } from "./linkedAggregation/createLinkedAggregation";
@@ -145,7 +145,7 @@ export const resolvers = {
     createOrgEmailInvitation: loggedInAndSignedUp(createOrgEmailInvitation),
     transferEntity: loggedInAndSignedUp(transferEntity),
     updateEntity: loggedInAndSignedUp(updateEntity),
-    updateEntityType: loggedInAndSignedUp(updateEntityType),
+    deprecatedUpdateEntityType: loggedInAndSignedUp(deprecatedUpdateEntityType),
     updatePage: loggedInAndSignedUp(updatePage),
     updatePageContents: loggedInAndSignedUp(updatePageContents),
     joinOrg: loggedInAndSignedUp(joinOrg),

--- a/packages/hash/api/src/graphql/resolvers/index.ts
+++ b/packages/hash/api/src/graphql/resolvers/index.ts
@@ -241,7 +241,7 @@ export const resolvers = {
     results: linkedAggregationResults,
   },
 
-  EntityType: {
+  DeprecatedEntityType: {
     entityType: entityTypeTypeFields.entityType,
     entityTypeId: entityTypeTypeFields.entityTypeId,
     entityTypeName: entityTypeTypeFields.entityTypeName,

--- a/packages/hash/api/src/graphql/resolvers/index.ts
+++ b/packages/hash/api/src/graphql/resolvers/index.ts
@@ -48,7 +48,7 @@ import { SYSTEM_TYPES, SystemType } from "../../types/entityTypes";
 import { entityTypeTypeFields } from "./entityType/entityTypeTypeFields";
 import { entityTypeInheritance } from "./entityType/entityTypeInheritance";
 import { getAccountEntityTypes } from "./entityType/getAccountEntityTypes";
-import { getEntityType } from "./entityType/getEntityType";
+import { deprecatedGetEntityType } from "./entityType/getEntityType";
 import { createOrgEmailInvitation } from "./org/createOrgEmailInvitation";
 import { getOrgEmailInvitation } from "./org/getOrgEmailInvitation";
 import { getOrgInvitationLink } from "./org/getOrgInvitationLink";
@@ -103,7 +103,7 @@ export const resolvers = {
     getAccountEntityTypes: loggedInAndSignedUp(getAccountEntityTypes),
     entity: loggedInAndSignedUp(entity),
     entities: loggedInAndSignedUp(canAccessAccount(entities)),
-    getEntityType: loggedInAndSignedUp(getEntityType),
+    deprecatedGetEntityType: loggedInAndSignedUp(deprecatedGetEntityType),
     getLink: loggedInAndSignedUp(getLink),
     getLinkedAggregation: loggedInAndSignedUp(getLinkedAggregation),
     page: canAccessAccount(page),

--- a/packages/hash/api/src/graphql/resolvers/index.ts
+++ b/packages/hash/api/src/graphql/resolvers/index.ts
@@ -90,6 +90,13 @@ import {
   updateLinkType,
 } from "./ontology/link-type";
 
+import {
+  createEntityType,
+  getAllLatestEntityTypes,
+  getEntityType,
+  updateEntityType,
+} from "./ontology/entity-type";
+
 export const resolvers = {
   Query: {
     // Logged in and signed up users only
@@ -128,6 +135,8 @@ export const resolvers = {
     getPropertyType,
     getAllLatestLinkTypes,
     getLinkType,
+    getAllLatestEntityTypes,
+    getEntityType,
   },
 
   Mutation: {
@@ -171,6 +180,8 @@ export const resolvers = {
     updatePropertyType,
     createLinkType,
     updateLinkType,
+    createEntityType,
+    updateEntityType,
   },
 
   JSONObject: JSONObjectResolver,

--- a/packages/hash/api/src/graphql/resolvers/index.ts
+++ b/packages/hash/api/src/graphql/resolvers/index.ts
@@ -43,7 +43,7 @@ import {
 
 import { me } from "./user/me";
 import { isShortnameTaken } from "./user/isShortnameTaken";
-import { createEntityType } from "./entityType/createEntityType";
+import { deprecatedCreateEntityType } from "./entityType/createEntityType";
 import { SYSTEM_TYPES, SystemType } from "../../types/entityTypes";
 import { entityTypeTypeFields } from "./entityType/entityTypeTypeFields";
 import { entityTypeInheritance } from "./entityType/entityTypeInheritance";
@@ -138,7 +138,7 @@ export const resolvers = {
       updateLinkedAggregationOperation,
     ),
     deleteLinkedAggregation: loggedInAndSignedUp(deleteLinkedAggregation),
-    createEntityType: loggedInAndSignedUp(createEntityType),
+    deprecatedCreateEntityType: loggedInAndSignedUp(deprecatedCreateEntityType),
     createFileFromLink: loggedInAndSignedUp(createFileFromLink),
     createPage: loggedInAndSignedUp(createPage),
     createOrg: loggedInAndSignedUp(createOrg),

--- a/packages/hash/api/src/graphql/resolvers/index.ts
+++ b/packages/hash/api/src/graphql/resolvers/index.ts
@@ -47,7 +47,7 @@ import { deprecatedCreateEntityType } from "./entityType/createEntityType";
 import { SYSTEM_TYPES, SystemType } from "../../types/entityTypes";
 import { entityTypeTypeFields } from "./entityType/entityTypeTypeFields";
 import { entityTypeInheritance } from "./entityType/entityTypeInheritance";
-import { getAccountEntityTypes } from "./entityType/getAccountEntityTypes";
+import { deprecatedGetAccountEntityTypes } from "./entityType/getAccountEntityTypes";
 import { deprecatedGetEntityType } from "./entityType/getEntityType";
 import { createOrgEmailInvitation } from "./org/createOrgEmailInvitation";
 import { getOrgEmailInvitation } from "./org/getOrgEmailInvitation";
@@ -100,7 +100,9 @@ export const resolvers = {
       ) /** @todo: make accessible to admins only (or deprecate) */,
     aggregateEntity: loggedInAndSignedUp(aggregateEntity),
     blocks: loggedInAndSignedUp(blocks),
-    getAccountEntityTypes: loggedInAndSignedUp(getAccountEntityTypes),
+    deprecatedGetAccountEntityTypes: loggedInAndSignedUp(
+      deprecatedGetAccountEntityTypes,
+    ),
     entity: loggedInAndSignedUp(entity),
     entities: loggedInAndSignedUp(canAccessAccount(entities)),
     deprecatedGetEntityType: loggedInAndSignedUp(deprecatedGetEntityType),

--- a/packages/hash/api/src/graphql/resolvers/ontology/data-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/data-type.ts
@@ -27,9 +27,7 @@ export const getAllLatestDataTypes: ResolverFn<
     );
   });
 
-  return allLatestDataTypeModels.map((dataTypeModel) =>
-    dataTypeModelToGQL(dataTypeModel),
-  );
+  return allLatestDataTypeModels.map(dataTypeModelToGQL);
 };
 
 export const getDataType: ResolverFn<

--- a/packages/hash/api/src/graphql/resolvers/ontology/entity-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/entity-type.ts
@@ -25,14 +25,12 @@ export const createEntityType: ResolverFn<
     accountId: accountId ?? user.getAccountId(),
     schema: entityType,
   }).catch((err: AxiosError) => {
-    if (err.response?.status === 409) {
-      throw new ApolloError(
-        `Entity type with the same URI already exists. [URI=${entityType.$id}]`,
-        "CREATION_ERROR",
-      );
-    }
+    const msg =
+      err.response?.status === 409
+        ? `Entity type with the same URI already exists. [URI=${entityType.$id}]`
+        : `Couldn't create entity type.`;
 
-    throw new ApolloError(`Couldn't create entity type.`, "CREATION_ERROR");
+    throw new ApolloError(msg, "CREATION_ERROR");
   });
 
   return entityTypeModelToGQL(createdEntityTypeModel);
@@ -105,13 +103,12 @@ export const updateEntityType: ResolverFn<
       schema: updatedEntityType,
     })
     .catch((err: AxiosError) => {
-      if (err.response?.status === 409) {
-        throw new ApolloError(
-          `Entity type URI doesn't exist, unable to update. [URI=${entityTypeVersionedUri}]`,
-          "CREATION_ERROR",
-        );
-      }
-      throw new ApolloError(`Couldn't update entity type.`, "CREATION_ERROR");
+      const msg =
+        err.response?.status === 409
+          ? `Entity type URI doesn't exist, unable to update. [URI=${entityTypeVersionedUri}]`
+          : `Couldn't update entity type.`;
+
+      throw new ApolloError(msg, "CREATION_ERROR");
     });
 
   return entityTypeModelToGQL(updatedEntityTypeModel);

--- a/packages/hash/api/src/graphql/resolvers/ontology/entity-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/entity-type.ts
@@ -1,0 +1,122 @@
+import { ApolloError } from "apollo-server-express";
+import { AxiosError } from "axios";
+
+import {
+  PersistedEntityType,
+  MutationCreateEntityTypeArgs,
+  MutationUpdateEntityTypeArgs,
+  QueryGetEntityTypeArgs,
+  Resolver,
+} from "../../apiTypes.gen";
+import { GraphQLContext } from "../../context";
+import { EntityTypeModel } from "../../../model";
+import { nilUuid } from "../../../model/util";
+import { entityTypeModelToGQL } from "./model-mapping";
+
+export const createEntityType: Resolver<
+  Promise<PersistedEntityType>,
+  {},
+  GraphQLContext,
+  MutationCreateEntityTypeArgs
+> = async (_, params, { dataSources }) => {
+  const { graphApi } = dataSources;
+  const { accountId, entityType } = params;
+
+  const createdEntityTypeModel = await EntityTypeModel.create(graphApi, {
+    accountId,
+    schema: entityType,
+  }).catch((err: AxiosError) => {
+    if (err.response?.status === 409) {
+      throw new ApolloError(
+        `Entity type with the same URI already exists. [URI=${entityType.$id}]`,
+        "CREATION_ERROR",
+      );
+    }
+
+    throw new ApolloError(`Couldn't create entity type.`, "CREATION_ERROR");
+  });
+
+  return entityTypeModelToGQL(createdEntityTypeModel);
+};
+
+export const getAllLatestEntityTypes: Resolver<
+  Promise<PersistedEntityType[]>,
+  {},
+  GraphQLContext,
+  {}
+> = async (_, __, { dataSources }) => {
+  const { graphApi } = dataSources;
+
+  const allLatestEntityTypeModels = await EntityTypeModel.getAllLatest(
+    graphApi,
+    {
+      /** @todo Replace with User from the request */
+      accountId: nilUuid,
+    },
+  ).catch((err: AxiosError) => {
+    throw new ApolloError(
+      `Unable to retrieve all latest entity types. ${err.response?.data}`,
+      "GET_ALL_ERROR",
+    );
+  });
+
+  return allLatestEntityTypeModels.map((entityTypeModel) =>
+    entityTypeModelToGQL(entityTypeModel),
+  );
+};
+
+export const getEntityType: Resolver<
+  Promise<PersistedEntityType>,
+  {},
+  GraphQLContext,
+  QueryGetEntityTypeArgs
+> = async (_, { entityTypeVersionedUri }, { dataSources }) => {
+  const { graphApi } = dataSources;
+
+  const entityTypeModel = await EntityTypeModel.get(graphApi, {
+    versionedUri: entityTypeVersionedUri,
+  }).catch((err: AxiosError) => {
+    throw new ApolloError(
+      `Unable to retrieve entity type. ${err.response?.data}`,
+      "GET_ERROR",
+    );
+  });
+
+  return entityTypeModelToGQL(entityTypeModel);
+};
+
+export const updateEntityType: Resolver<
+  Promise<PersistedEntityType>,
+  {},
+  GraphQLContext,
+  MutationUpdateEntityTypeArgs
+> = async (_, params, { dataSources }) => {
+  const { graphApi } = dataSources;
+  const { accountId, entityTypeVersionedUri, updatedEntityType } = params;
+
+  const entityTypeModel = await EntityTypeModel.get(graphApi, {
+    versionedUri: entityTypeVersionedUri,
+  }).catch((err: AxiosError) => {
+    throw new ApolloError(
+      `Unable to retrieve entity type. ${err.response?.data} [URI=${entityTypeVersionedUri}]`,
+      "GET_ERROR",
+    );
+  });
+
+  const updatedEntityTypeModel = await entityTypeModel
+    .update(graphApi, {
+      accountId,
+      schema: updatedEntityType,
+    })
+    .catch((err: AxiosError) => {
+      if (err.response?.status === 409) {
+        throw new ApolloError(
+          `Entity type URI doesn't exist, unable to update. [URI=${entityTypeVersionedUri}]`,
+          "CREATION_ERROR",
+        );
+      }
+      throw new ApolloError(`Couldn't update entity type.`, "CREATION_ERROR");
+    });
+
+  return entityTypeModelToGQL(updatedEntityTypeModel);
+};

--- a/packages/hash/api/src/graphql/resolvers/ontology/entity-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/entity-type.ts
@@ -58,9 +58,7 @@ export const getAllLatestEntityTypes: ResolverFn<
     );
   });
 
-  return allLatestEntityTypeModels.map((entityTypeModel) =>
-    entityTypeModelToGQL(entityTypeModel),
-  );
+  return allLatestEntityTypeModels.map(entityTypeModelToGQL);
 };
 
 export const getEntityType: ResolverFn<

--- a/packages/hash/api/src/graphql/resolvers/ontology/link-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/link-type.ts
@@ -25,13 +25,12 @@ export const createLinkType: ResolverFn<
     accountId: accountId ?? user.getAccountId(),
     schema: linkType,
   }).catch((err: AxiosError) => {
-    if (err.response?.status === 409) {
-      throw new ApolloError(
-        `Link type with the same URI already exists. [URI=${linkType.$id}]`,
-        "CREATION_ERROR",
-      );
-    }
-    throw new ApolloError(`Couldn't create link type`, "CREATION_ERROR");
+    const msg =
+      err.response?.status === 409
+        ? `Link type with the same URI already exists. [URI=${linkType.$id}]`
+        : `Couldn't create link type.`;
+
+    throw new ApolloError(msg, "CREATION_ERROR");
   });
 
   return linkTypeModelToGQL(createdLinkTypeModel);
@@ -103,13 +102,12 @@ export const updateLinkType: ResolverFn<
       schema: newLinkType,
     })
     .catch((err: AxiosError) => {
-      if (err.response?.status === 409) {
-        throw new ApolloError(
-          `Link type URI doesn't exist, unable to update. [URI=${linkTypeVersionedUri}]`,
-          "CREATION_ERROR",
-        );
-      }
-      throw new ApolloError(`Couldn't update link type.`, "CREATION_ERROR");
+      const msg =
+        err.response?.status === 409
+          ? `Link type URI doesn't exist, unable to update. [URI=${linkTypeVersionedUri}]`
+          : `Couldn't update link type.`;
+
+      throw new ApolloError(msg, "CREATION_ERROR");
     });
 
   return linkTypeModelToGQL(updatedLinkTypeModel);

--- a/packages/hash/api/src/graphql/resolvers/ontology/model-mapping.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/model-mapping.ts
@@ -1,10 +1,12 @@
 import {
   DataTypeModel,
+  EntityTypeModel,
   LinkTypeModel,
   PropertyTypeModel,
 } from "../../../model";
 import {
   PersistedDataType,
+  PersistedEntityType,
   PersistedLinkType,
   PersistedPropertyType,
 } from "../../apiTypes.gen";
@@ -31,4 +33,12 @@ export const linkTypeModelToGQL = (
   createdBy: linkType.accountId,
   linkTypeVersionedUri: linkType.schema.$id,
   schema: linkType.schema,
+});
+
+export const entityTypeModelToGQL = (
+  entityType: EntityTypeModel,
+): PersistedEntityType => ({
+  createdBy: entityType.accountId,
+  entityTypeVersionedUri: entityType.schema.$id,
+  schema: entityType.schema,
 });

--- a/packages/hash/api/src/graphql/resolvers/ontology/model-mapping.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/model-mapping.ts
@@ -14,31 +14,31 @@ import {
 export const dataTypeModelToGQL = (
   dataType: DataTypeModel,
 ): PersistedDataType => ({
-  createdBy: dataType.accountId,
+  accountId: dataType.accountId,
   dataTypeVersionedUri: dataType.schema.$id,
-  schema: dataType.schema,
+  dataType: dataType.schema,
 });
 
 export const propertyTypeModelToGQL = (
   propertyType: PropertyTypeModel,
 ): PersistedPropertyType => ({
-  createdBy: propertyType.accountId,
+  accountId: propertyType.accountId,
   propertyTypeVersionedUri: propertyType.schema.$id,
-  schema: propertyType.schema,
+  propertyType: propertyType.schema,
 });
 
 export const linkTypeModelToGQL = (
   linkType: LinkTypeModel,
 ): PersistedLinkType => ({
-  createdBy: linkType.accountId,
+  accountId: linkType.accountId,
   linkTypeVersionedUri: linkType.schema.$id,
-  schema: linkType.schema,
+  linkType: linkType.schema,
 });
 
 export const entityTypeModelToGQL = (
   entityType: EntityTypeModel,
 ): PersistedEntityType => ({
-  createdBy: entityType.accountId,
+  accountId: entityType.accountId,
   entityTypeVersionedUri: entityType.schema.$id,
-  schema: entityType.schema,
+  entityType: entityType.schema,
 });

--- a/packages/hash/api/src/graphql/resolvers/ontology/property-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/property-type.ts
@@ -25,14 +25,12 @@ export const createPropertyType: ResolverFn<
     accountId: accountId ?? user.getAccountId(),
     schema: propertyType,
   }).catch((err: AxiosError) => {
-    if (err.response?.status === 409) {
-      throw new ApolloError(
-        `Property type with the same URI already exists. [URI=${propertyType.$id}]`,
-        "CREATION_ERROR",
-      );
-    }
+    const msg =
+      err.response?.status === 409
+        ? `Property type with the same URI already exists. [URI=${propertyType.$id}]`
+        : `Couldn't create property type.`;
 
-    throw new ApolloError(`Couldn't create property type.`, "CREATION_ERROR");
+    throw new ApolloError(msg, "CREATION_ERROR");
   });
 
   return propertyTypeModelToGQL(createdPropertyTypeModel);
@@ -105,13 +103,12 @@ export const updatePropertyType: ResolverFn<
       schema: updatedPropertyType,
     })
     .catch((err: AxiosError) => {
-      if (err.response?.status === 409) {
-        throw new ApolloError(
-          `Property type URI doesn't exist, unable to update. [URI=${propertyTypeVersionedUri}]`,
-          "CREATION_ERROR",
-        );
-      }
-      throw new ApolloError(`Couldn't update property type.`, "CREATION_ERROR");
+      const msg =
+        err.response?.status === 409
+          ? `Property type URI doesn't exist, unable to update. [URI=${propertyTypeVersionedUri}]`
+          : `Couldn't update property type.`;
+
+      throw new ApolloError(msg, "CREATION_ERROR");
     });
 
   return propertyTypeModelToGQL(updatedPropertyTypeModel);

--- a/packages/hash/api/src/graphql/resolvers/ontology/property-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/property-type.ts
@@ -58,9 +58,7 @@ export const getAllLatestPropertyTypes: ResolverFn<
     );
   });
 
-  return allLatestPropertyTypeModels.map((propertyTypeModel) =>
-    propertyTypeModelToGQL(propertyTypeModel),
-  );
+  return allLatestPropertyTypeModels.map(propertyTypeModelToGQL);
 };
 
 export const getPropertyType: ResolverFn<

--- a/packages/hash/api/src/graphql/typeDefs/block.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/block.typedef.ts
@@ -59,7 +59,7 @@ export const blockTypedef = gql`
     """
     The full entityType definition
     """
-    entityType: EntityType!
+    entityType: DeprecatedEntityType!
     """
     The version timeline of the entity.
     """

--- a/packages/hash/api/src/graphql/typeDefs/entity.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/entity.typedef.ts
@@ -1,6 +1,6 @@
 import { gql } from "apollo-server-express";
 
-export const entityTypedef = gql`
+export const deprecatedEntityTypedef = gql`
   interface Entity {
     # These fields are repeated everywhere they're used because
     # (a) GQL requires it - https://github.com/graphql/graphql-spec/issues/533

--- a/packages/hash/api/src/graphql/typeDefs/entity.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/entity.typedef.ts
@@ -213,7 +213,7 @@ export const entityTypedef = gql`
     """
     componentId: ID
     """
-    A fixed entity type ID. This may be a reference to a placeholder set using a previous CreateEntityTypeAction
+    A fixed entity type ID. This may be a reference to a placeholder set using a previous createEntityTypeAction
     """
     entityTypeId: ID
     """

--- a/packages/hash/api/src/graphql/typeDefs/entity.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/entity.typedef.ts
@@ -62,7 +62,7 @@ export const entityTypedef = gql`
     """
     The full entityType definition.
     """
-    entityType: EntityType
+    entityType: DeprecatedEntityType
     """
     The version timeline of the entity.
     """
@@ -168,7 +168,7 @@ export const entityTypedef = gql`
     """
     The full entityType definition
     """
-    entityType: EntityType!
+    entityType: DeprecatedEntityType!
     """
     The version timeline of the entity.
     """

--- a/packages/hash/api/src/graphql/typeDefs/entity.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/entity.typedef.ts
@@ -1,6 +1,6 @@
 import { gql } from "apollo-server-express";
 
-export const deprecatedEntityTypedef = gql`
+export const entityTypedef = gql`
   interface Entity {
     # These fields are repeated everywhere they're used because
     # (a) GQL requires it - https://github.com/graphql/graphql-spec/issues/533

--- a/packages/hash/api/src/graphql/typeDefs/entityType.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/entityType.typedef.ts
@@ -36,7 +36,7 @@ export const entityTypeTypedef = gql`
     """
     Create an entity type
     """
-    createEntityType(
+    deprecatedCreateEntityType(
       accountId: ID!
       """
       The name for the type. Must be unique in the given account.

--- a/packages/hash/api/src/graphql/typeDefs/entityType.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/entityType.typedef.ts
@@ -8,7 +8,7 @@ export const entityTypeTypedef = gql`
     - entityTypeId on an Entity of its type)
     Or, by EntityTypeChoice
     """
-    getEntityType(
+    deprecatedGetEntityType(
       entityTypeId: ID
         @deprecated(
           reason: """

--- a/packages/hash/api/src/graphql/typeDefs/entityType.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/entityType.typedef.ts
@@ -55,7 +55,7 @@ export const entityTypeTypedef = gql`
     """
     Update an entity type
     """
-    updateEntityType(
+    deprecatedUpdateEntityType(
       """
       The fixed id of the entityType to update, i.e. its entityId
       """

--- a/packages/hash/api/src/graphql/typeDefs/entityType.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/entityType.typedef.ts
@@ -1,6 +1,6 @@
 import { gql } from "apollo-server-express";
 
-export const entityTypeTypedef = gql`
+export const deprecatedEntityTypeTypedef = gql`
   extend type Query {
     """
     Get an entity type by its fixed id, which is:

--- a/packages/hash/api/src/graphql/typeDefs/entityType.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/entityType.typedef.ts
@@ -16,8 +16,7 @@ export const entityTypeTypedef = gql`
           """
         )
       choice: EntityTypeChoice
-    ): EntityType!
-
+    ): DeprecatedEntityType!
     """
     Get all EntityTypes belonging to an account.
     Optionally include:
@@ -29,7 +28,7 @@ export const entityTypeTypedef = gql`
       accountId: ID!
       includeAllTypes: Boolean = false
       includeOtherTypesInUse: Boolean = false
-    ): [EntityType!]!
+    ): [DeprecatedEntityType!]!
   }
 
   extend type Mutation {
@@ -50,7 +49,7 @@ export const entityTypeTypedef = gql`
       The schema definition for the entity type, in JSON Schema.
       """
       schema: JSONObject
-    ): EntityType!
+    ): DeprecatedEntityType!
 
     """
     Update an entity type
@@ -64,7 +63,7 @@ export const entityTypeTypedef = gql`
       The schema definition for the entity type, in JSON Schema format.
       """
       schema: JSONObject!
-    ): EntityType!
+    ): DeprecatedEntityType!
   }
 
   enum SystemTypeName {
@@ -83,7 +82,7 @@ export const entityTypeTypedef = gql`
   """
   A schema describing and validating a specific type of entity
   """
-  type EntityType implements Entity {
+  type DeprecatedEntityType implements Entity {
     """
     The shape of the entity, expressed as a JSON Schema
     https://json-schema.org/
@@ -143,7 +142,7 @@ export const entityTypeTypedef = gql`
     """
     The full entityType definition
     """
-    entityType: EntityType!
+    entityType: DeprecatedEntityType!
     """
     The version timeline of the entity.
     """
@@ -166,16 +165,16 @@ export const entityTypeTypedef = gql`
     Retrieve all EntityTypes that are children of
     the current EntityType.
     """
-    children: [EntityType!]
+    children: [DeprecatedEntityType!]
     """
     Retrieve all EntityTypes that are parents of
     the current EntityType.
     """
-    parents: [EntityType!]
+    parents: [DeprecatedEntityType!]
 
     """
     Retrieve all ancestors of the current Entity Type (resolving the parents, parents' parents and so forth)
     """
-    ancestors: [EntityType!]
+    ancestors: [DeprecatedEntityType!]
   }
 `;

--- a/packages/hash/api/src/graphql/typeDefs/entityType.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/entityType.typedef.ts
@@ -25,7 +25,7 @@ export const entityTypeTypedef = gql`
     - ALL types.
     TODO: replace this with a new aggregateEntityTypes query instead
     """
-    getAccountEntityTypes(
+    deprecatedGetAccountEntityTypes(
       accountId: ID!
       includeAllTypes: Boolean = false
       includeOtherTypesInUse: Boolean = false

--- a/packages/hash/api/src/graphql/typeDefs/file.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/file.typedef.ts
@@ -65,7 +65,7 @@ export const fileTypedef = gql`
     """
     The full entityType definition
     """
-    entityType: EntityType!
+    entityType: DeprecatedEntityType!
     """
     The version timeline of the entity.
     """

--- a/packages/hash/api/src/graphql/typeDefs/index.ts
+++ b/packages/hash/api/src/graphql/typeDefs/index.ts
@@ -2,9 +2,9 @@ import { gql } from "apollo-server-express";
 
 import { accountTypedef } from "./account.typedef";
 import { blockTypedef } from "./block.typedef";
-import { deprecatedEntityTypedef } from "./entity.typedef";
+import { entityTypedef } from "./entity.typedef";
 import { linkTypedef } from "./link.typedef";
-import { entityTypeTypedef } from "./entityType.typedef";
+import { deprecatedEntityTypeTypedef } from "./entityType.typedef";
 import { orgEmailInvitationTypedef } from "./orgEmailInvitation.typedef";
 import { orgInvitationLinkTypedef } from "./orgInvitationLink.typedef";
 import { orgTypedef } from "./org.typedef";
@@ -21,6 +21,7 @@ import { executeTaskTypedef } from "./taskExecution.typedef";
 import { dataTypeTypedef } from "./ontology/data-type.typedef";
 import { propertyTypeTypedef } from "./ontology/property-type.typedef";
 import { linkTypeTypedef } from "./ontology/link-type.typedef";
+import { entityTypeTypedef } from "./ontology/entity-type.typedef";
 
 const baseSchema = gql`
   scalar Date
@@ -56,10 +57,10 @@ export const schema = [
   baseSchema,
   blockTypedef,
   embedTypeDef,
-  deprecatedEntityTypedef,
+  entityTypedef,
   linkTypedef,
   aggregationTypedef,
-  entityTypeTypedef,
+  deprecatedEntityTypeTypedef,
   impliedHistoryTypedef,
   orgEmailInvitationTypedef,
   orgInvitationLinkTypedef,

--- a/packages/hash/api/src/graphql/typeDefs/index.ts
+++ b/packages/hash/api/src/graphql/typeDefs/index.ts
@@ -2,7 +2,7 @@ import { gql } from "apollo-server-express";
 
 import { accountTypedef } from "./account.typedef";
 import { blockTypedef } from "./block.typedef";
-import { entityTypedef } from "./entity.typedef";
+import { deprecatedEntityTypedef } from "./entity.typedef";
 import { linkTypedef } from "./link.typedef";
 import { entityTypeTypedef } from "./entityType.typedef";
 import { orgEmailInvitationTypedef } from "./orgEmailInvitation.typedef";
@@ -42,7 +42,12 @@ const baseSchema = gql`
   }
 `;
 
-const ontology = [dataTypeTypedef, propertyTypeTypedef, linkTypeTypedef];
+const ontology = [
+  dataTypeTypedef,
+  propertyTypeTypedef,
+  linkTypeTypedef,
+  entityTypeTypedef,
+];
 
 // This needs to be called 'schema' to be picked up by codegen -
 // It could alternatively be a default export.
@@ -51,7 +56,7 @@ export const schema = [
   baseSchema,
   blockTypedef,
   embedTypeDef,
-  entityTypedef,
+  deprecatedEntityTypedef,
   linkTypedef,
   aggregationTypedef,
   entityTypeTypedef,

--- a/packages/hash/api/src/graphql/typeDefs/ontology/data-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/data-type.typedef.ts
@@ -11,11 +11,11 @@ export const dataTypeTypedef = gql`
     """
     The user who created the data type
     """
-    createdBy: ID!
+    accountId: ID!
     """
     The data type
     """
-    schema: DataType!
+    dataType: DataType!
   }
 
   extend type Query {

--- a/packages/hash/api/src/graphql/typeDefs/ontology/data-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/data-type.typedef.ts
@@ -4,8 +4,17 @@ export const dataTypeTypedef = gql`
   scalar DataType
 
   type PersistedDataType {
+    """
+    The specific versioned URI of the data type
+    """
     dataTypeVersionedUri: String!
+    """
+    The user who created the data type
+    """
     createdBy: ID!
+    """
+    The data type
+    """
     schema: DataType!
   }
 

--- a/packages/hash/api/src/graphql/typeDefs/ontology/entity-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/entity-type.typedef.ts
@@ -1,0 +1,56 @@
+import { gql } from "apollo-server-express";
+
+export const entityTypeTypedef = gql`
+  scalar EntityType
+
+  type PersistedEntityType {
+    entityTypeVersionedUri: String!
+    createdBy: ID!
+    schema: EntityType!
+    # TODO: we might need something like
+    # "referencedPropertyTypes: [PersistedPropertyType!]"
+  }
+
+  extend type Query {
+    """
+    Get all entity types at their latest version.
+    """
+    getAllLatestEntityTypes: [PersistedEntityType!]!
+
+    """
+    Get a entity type by its versioned URI.
+    """
+    getEntityType(entityTypeVersionedUri: String!): PersistedEntityType!
+  }
+
+  extend type Mutation {
+    """
+    Create a entity type.
+    """
+    createEntityType(
+      """
+      accountId refers to the account to create the entity type in.
+      """
+      accountId: ID!
+      entityType: EntityType!
+    ): PersistedEntityType!
+
+    """
+    Update a entity type.
+    """
+    updateEntityType(
+      """
+      accountId refers to the account to update the entity type in.
+      """
+      accountId: ID!
+      """
+      The entity type versioned $id to update.
+      """
+      entityTypeVersionedUri: String!
+      """
+      New entity type schema contents to be used.
+      """
+      updatedEntityType: EntityType!
+    ): PersistedEntityType!
+  }
+`;

--- a/packages/hash/api/src/graphql/typeDefs/ontology/entity-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/entity-type.typedef.ts
@@ -51,7 +51,7 @@ export const entityTypeTypedef = gql`
       """
       accountId refers to the account to update the entity type in.
       """
-      accountId: ID!
+      accountId: ID
       """
       The entity type versioned $id to update.
       """

--- a/packages/hash/api/src/graphql/typeDefs/ontology/entity-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/entity-type.typedef.ts
@@ -4,8 +4,17 @@ export const entityTypeTypedef = gql`
   scalar EntityType
 
   type PersistedEntityType {
+    """
+    The specific versioned URI of the entity type
+    """
     entityTypeVersionedUri: String!
+    """
+    The user who created the entity type
+    """
     createdBy: ID!
+    """
+    The entity type
+    """
     schema: EntityType!
     # TODO: we might need something like
     # "referencedPropertyTypes: [PersistedPropertyType!]"

--- a/packages/hash/api/src/graphql/typeDefs/ontology/entity-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/entity-type.typedef.ts
@@ -11,11 +11,11 @@ export const entityTypeTypedef = gql`
     """
     The user who created the entity type
     """
-    createdBy: ID!
+    accountId: ID!
     """
     The entity type
     """
-    schema: EntityType!
+    entityType: EntityType!
     # TODO: we might need something like
     # "referencedPropertyTypes: [PersistedPropertyType!]"
   }

--- a/packages/hash/api/src/graphql/typeDefs/ontology/link-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/link-type.typedef.ts
@@ -4,8 +4,17 @@ export const linkTypeTypedef = gql`
   scalar LinkType
 
   type PersistedLinkType {
+    """
+    The specific versioned URI of the link type
+    """
     linkTypeVersionedUri: String!
+    """
+    The user who created the link type
+    """
     createdBy: ID!
+    """
+    The link type
+    """
     schema: LinkType!
   }
 

--- a/packages/hash/api/src/graphql/typeDefs/ontology/link-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/link-type.typedef.ts
@@ -11,11 +11,11 @@ export const linkTypeTypedef = gql`
     """
     The user who created the link type
     """
-    createdBy: ID!
+    accountId: ID!
     """
     The link type
     """
-    schema: LinkType!
+    linkType: LinkType!
   }
 
   extend type Query {

--- a/packages/hash/api/src/graphql/typeDefs/ontology/property-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/property-type.typedef.ts
@@ -11,11 +11,11 @@ export const propertyTypeTypedef = gql`
     """
     The user who created the property type
     """
-    createdBy: ID!
+    accountId: ID!
     """
     The property type
     """
-    schema: PropertyType!
+    propertyType: PropertyType!
     # TODO: we might need something like
     # "referencedDataTypes: [PersistedDataType!]"
     # for us to retrieve all referenced data types, and one for referenced property types as well.

--- a/packages/hash/api/src/graphql/typeDefs/ontology/property-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/property-type.typedef.ts
@@ -4,8 +4,17 @@ export const propertyTypeTypedef = gql`
   scalar PropertyType
 
   type PersistedPropertyType {
+    """
+    The specific versioned URI of the property type
+    """
     propertyTypeVersionedUri: String!
+    """
+    The user who created the property type
+    """
     createdBy: ID!
+    """
+    The property type
+    """
     schema: PropertyType!
     # TODO: we might need something like
     # "referencedDataTypes: [PersistedDataType!]"

--- a/packages/hash/api/src/graphql/typeDefs/org.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/org.typedef.ts
@@ -63,7 +63,7 @@ export const orgTypedef = gql`
     """
     The full entityType definition
     """
-    entityType: EntityType!
+    entityType: DeprecatedEntityType!
     """
     The version timeline of the entity.
     """

--- a/packages/hash/api/src/graphql/typeDefs/orgEmailInvitation.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/orgEmailInvitation.typedef.ts
@@ -65,7 +65,7 @@ export const orgEmailInvitationTypedef = gql`
     """
     The full entityType definition
     """
-    entityType: EntityType!
+    entityType: DeprecatedEntityType!
     """
     The version timeline of the entity.
     """

--- a/packages/hash/api/src/graphql/typeDefs/orgInvitationLink.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/orgInvitationLink.typedef.ts
@@ -63,7 +63,7 @@ export const orgInvitationLinkTypedef = gql`
     """
     The full entityType definition
     """
-    entityType: EntityType!
+    entityType: DeprecatedEntityType!
     """
     The version timeline of the entity.
     """

--- a/packages/hash/api/src/graphql/typeDefs/orgMembership.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/orgMembership.typedef.ts
@@ -65,7 +65,7 @@ export const orgMembershipTypedef = gql`
     """
     The full entityType definition
     """
-    entityType: EntityType!
+    entityType: DeprecatedEntityType!
     """
     The version timeline of the entity.
     """

--- a/packages/hash/api/src/graphql/typeDefs/page.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/page.typedef.ts
@@ -59,7 +59,7 @@ export const pageTypedef = gql`
     """
     The full entityType definition
     """
-    entityType: EntityType!
+    entityType: DeprecatedEntityType!
     """
     The version timeline of the entity.
     """

--- a/packages/hash/api/src/graphql/typeDefs/text.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/text.typedef.ts
@@ -57,7 +57,7 @@ export const textTypedef = gql`
     """
     The full entityType definition
     """
-    entityType: EntityType!
+    entityType: DeprecatedEntityType!
     """
     The version timeline of the entity.
     """

--- a/packages/hash/api/src/graphql/typeDefs/user.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/user.typedef.ts
@@ -62,7 +62,7 @@ export const userTypedef = gql`
     """
     The full entityType definition
     """
-    entityType: EntityType!
+    entityType: DeprecatedEntityType!
     """
     The version timeline of the entity.
     """

--- a/packages/hash/api/src/model/entityType.model.ts
+++ b/packages/hash/api/src/model/entityType.model.ts
@@ -7,10 +7,7 @@ import { JSONSchema7 } from "json-schema";
 
 import { EntityExternalResolvers, EntityType } from ".";
 import { DbClient } from "../db";
-import {
-  EntityType as GQLEntityType,
-  Visibility,
-} from "../graphql/apiTypes.gen";
+import { DeprecatedEntityType, Visibility } from "../graphql/apiTypes.gen";
 import { EntityTypeMeta, EntityTypeTypeFields } from "../db/adapter";
 import { SystemType } from "../types/entityTypes";
 import {
@@ -29,7 +26,10 @@ export type JSONSchema = JSONSchema7;
  * We handle the various entityType fields for an entityType in separate field resolvers,
  * to allow consumers to recursively request the entityType of an entityType, and so on.
  */
-type EntityTypeWithoutTypeFields = Omit<GQLEntityType, EntityTypeTypeFields>;
+type EntityTypeWithoutTypeFields = Omit<
+  DeprecatedEntityType,
+  EntityTypeTypeFields
+>;
 
 export type UnresolvedGQLEntityType = Omit<
   EntityTypeWithoutTypeFields,

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -8,7 +8,7 @@ import { EntityTypeModel, PropertyTypeModel, LinkTypeModel } from "../index";
 import { incrementVersionedId } from "../util";
 
 export type EntityTypeModelConstructorParams = {
-  accountId?: string;
+  accountId: string;
   schema: EntityType;
 };
 
@@ -21,7 +21,7 @@ export type EntityTypeModelCreateParams = {
  * @class {@link EntityTypeModel}
  */
 export default class {
-  accountId?: string;
+  accountId: string;
 
   schema: EntityType;
 

--- a/packages/hash/frontend/src/components/BlockLoader/BlockLoader.tsx
+++ b/packages/hash/frontend/src/components/BlockLoader/BlockLoader.tsx
@@ -45,7 +45,7 @@ import { useBlockProtocolUpdateEntity } from "../hooks/blockProtocolFunctions/us
 import { useBlockProtocolUpdateEntityType } from "../hooks/blockProtocolFunctions/useBlockProtocolUpdateEntityType";
 import { useBlockProtocolUpdateLink } from "../hooks/blockProtocolFunctions/useBlockProtocolUpdateLink";
 import { useBlockProtocolUpdateLinkedAggregation } from "../hooks/blockProtocolFunctions/useBlockProtocolUpdateLinkedAggregation";
-import { EntityType as ApiEntityType } from "../../graphql/apiTypes.gen";
+import { DeprecatedEntityType as ApiEntityType } from "../../graphql/apiTypes.gen";
 import { useReadonlyMode } from "../../shared/readonly-mode";
 import { DataMapEditor } from "./data-map-editor";
 import { mapData, SchemaMap } from "./shared";

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolAggregateEntityTypes.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolAggregateEntityTypes.ts
@@ -3,10 +3,10 @@ import { useLazyQuery } from "@apollo/client";
 import { EmbedderGraphMessageCallbacks } from "@blockprotocol/graph";
 import { useCallback } from "react";
 import {
-  GetAccountEntityTypesQuery,
-  GetAccountEntityTypesQueryVariables,
+  DeprecatedGetAccountEntityTypesQuery,
+  DeprecatedGetAccountEntityTypesQueryVariables,
 } from "../../../graphql/apiTypes.gen";
-import { getAccountEntityTypes } from "../../../graphql/queries/account.queries";
+import { deprecatedGetAccountEntityTypes } from "../../../graphql/queries/account.queries";
 import { convertApiEntityTypeToBpEntityType } from "../../../lib/entities";
 
 export const useBlockProtocolAggregateEntityTypes = (
@@ -15,9 +15,9 @@ export const useBlockProtocolAggregateEntityTypes = (
   aggregateEntityTypes: EmbedderGraphMessageCallbacks["aggregateEntityTypes"];
 } => {
   const [aggregateEntityTypesInDb] = useLazyQuery<
-    GetAccountEntityTypesQuery,
-    GetAccountEntityTypesQueryVariables
-  >(getAccountEntityTypes);
+    DeprecatedGetAccountEntityTypesQuery,
+    DeprecatedGetAccountEntityTypesQueryVariables
+  >(deprecatedGetAccountEntityTypes);
 
   const aggregateEntityTypes = useCallback<
     EmbedderGraphMessageCallbacks["aggregateEntityTypes"]
@@ -34,7 +34,7 @@ export const useBlockProtocolAggregateEntityTypes = (
         };
       }
       const response = await aggregateEntityTypesInDb({
-        query: getAccountEntityTypes,
+        query: deprecatedGetAccountEntityTypes,
         variables: {
           accountId,
           /**

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolAggregateEntityTypes.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolAggregateEntityTypes.ts
@@ -33,6 +33,7 @@ export const useBlockProtocolAggregateEntityTypes = (
           ],
         };
       }
+
       const response = await aggregateEntityTypesInDb({
         query: deprecatedGetAccountEntityTypes,
         variables: {
@@ -57,7 +58,7 @@ export const useBlockProtocolAggregateEntityTypes = (
         };
       }
 
-      const responseData = response.data.getAccountEntityTypes;
+      const responseData = response.data.deprecatedGetAccountEntityTypes;
 
       return {
         data: {

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolCreateEntityType.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolCreateEntityType.ts
@@ -68,7 +68,7 @@ export const useBlockProtocolCreateEntityType = (
 
         return {
           data: convertApiEntityTypeToBpEntityType(
-            responseData.createEntityType,
+            responseData.deprecatedCreateEntityType,
           ),
         };
       },

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolCreateEntityType.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolCreateEntityType.ts
@@ -3,10 +3,10 @@ import { useMutation } from "@apollo/client";
 import { EmbedderGraphMessageCallbacks } from "@blockprotocol/graph";
 import { useCallback } from "react";
 import {
-  CreateEntityTypeMutation,
-  CreateEntityTypeMutationVariables,
+  DeprecatedCreateEntityTypeMutation,
+  DeprecatedCreateEntityTypeMutationVariables,
 } from "../../../graphql/apiTypes.gen";
-import { createEntityTypeMutation } from "../../../graphql/queries/entityType.queries";
+import { deprecatedCreateEntityTypeMutation } from "../../../graphql/queries/entityType.queries";
 import { convertApiEntityTypeToBpEntityType } from "../../../lib/entities";
 
 export const useBlockProtocolCreateEntityType = (
@@ -16,9 +16,9 @@ export const useBlockProtocolCreateEntityType = (
   createEntityType: EmbedderGraphMessageCallbacks["createEntityType"];
 } => {
   const [createFn] = useMutation<
-    CreateEntityTypeMutation,
-    CreateEntityTypeMutationVariables
-  >(createEntityTypeMutation);
+    DeprecatedCreateEntityTypeMutation,
+    DeprecatedCreateEntityTypeMutationVariables
+  >(deprecatedCreateEntityTypeMutation);
 
   const createEntityType: EmbedderGraphMessageCallbacks["createEntityType"] =
     useCallback(

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolUpdateEntityType.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolUpdateEntityType.ts
@@ -62,7 +62,7 @@ export const useBlockProtocolUpdateEntityType = (
         }
         return {
           data: convertApiEntityTypeToBpEntityType(
-            responseData.updateEntityType,
+            responseData.deprecatedUpdateEntityType,
           ),
         };
       },

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolUpdateEntityType.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/useBlockProtocolUpdateEntityType.ts
@@ -3,10 +3,10 @@ import { useMutation } from "@apollo/client";
 import { EmbedderGraphMessageCallbacks } from "@blockprotocol/graph";
 import { useCallback } from "react";
 import {
-  UpdateEntityTypeMutation,
-  UpdateEntityTypeMutationVariables,
+  DeprecatedUpdateEntityTypeMutation,
+  DeprecatedUpdateEntityTypeMutationVariables,
 } from "../../../graphql/apiTypes.gen";
-import { updateEntityTypeMutation } from "../../../graphql/queries/entityType.queries";
+import { deprecatedUpdateEntityTypeMutation } from "../../../graphql/queries/entityType.queries";
 import { convertApiEntityTypeToBpEntityType } from "../../../lib/entities";
 
 export const useBlockProtocolUpdateEntityType = (
@@ -15,9 +15,9 @@ export const useBlockProtocolUpdateEntityType = (
   updateEntityType: EmbedderGraphMessageCallbacks["updateEntityType"];
 } => {
   const [runUpdateEntityTypeMutation] = useMutation<
-    UpdateEntityTypeMutation,
-    UpdateEntityTypeMutationVariables
-  >(updateEntityTypeMutation);
+    DeprecatedUpdateEntityTypeMutation,
+    DeprecatedUpdateEntityTypeMutationVariables
+  >(deprecatedUpdateEntityTypeMutation);
 
   const updateEntityType: EmbedderGraphMessageCallbacks["updateEntityType"] =
     useCallback(

--- a/packages/hash/frontend/src/components/hooks/useGetAllEntityTypes.ts
+++ b/packages/hash/frontend/src/components/hooks/useGetAllEntityTypes.ts
@@ -1,18 +1,18 @@
 import { useQuery } from "@apollo/client";
 import {
-  GetAccountEntityTypesQuery,
-  GetAccountEntityTypesQueryVariables,
+  DeprecatedGetAccountEntityTypesQuery,
+  DeprecatedGetAccountEntityTypesQueryVariables,
 } from "../../graphql/apiTypes.gen";
-import { getAccountEntityTypes } from "../../graphql/queries/account.queries";
+import { deprecatedGetAccountEntityTypes } from "../../graphql/queries/account.queries";
 
 /**
  * @todo consolidate this and useBlockProtocolAggregateEntityTypes
  */
 export const useGetAllEntityTypes = (accountId: string) => {
   const { data } = useQuery<
-    GetAccountEntityTypesQuery,
-    GetAccountEntityTypesQueryVariables
-  >(getAccountEntityTypes, {
+    DeprecatedGetAccountEntityTypesQuery,
+    DeprecatedGetAccountEntityTypesQueryVariables
+  >(deprecatedGetAccountEntityTypes, {
     variables: {
       accountId,
       includeAllTypes: true,

--- a/packages/hash/frontend/src/graphql/queries/account.queries.ts
+++ b/packages/hash/frontend/src/graphql/queries/account.queries.ts
@@ -62,13 +62,13 @@ export const getAccountPagesTree = gql`
   }
 `;
 
-export const getAccountEntityTypes = gql`
-  query getAccountEntityTypes(
+export const deprecatedGetAccountEntityTypes = gql`
+  query deprecatedGetAccountEntityTypes(
     $accountId: ID!
     $includeAllTypes: Boolean = false
     $includeOtherTypesInUse: Boolean = false
   ) {
-    getAccountEntityTypes(
+    deprecatedGetAccountEntityTypes(
       accountId: $accountId
       includeAllTypes: $includeAllTypes
       includeOtherTypesInUse: $includeOtherTypesInUse

--- a/packages/hash/frontend/src/graphql/queries/entityType.queries.ts
+++ b/packages/hash/frontend/src/graphql/queries/entityType.queries.ts
@@ -46,9 +46,9 @@ export const deprecatedCreateEntityTypeMutation = gql`
   }
 `;
 
-export const updateEntityTypeMutation = gql`
-  mutation updateEntityType($entityId: ID!, $schema: JSONObject!) {
-    updateEntityType(entityId: $entityId, schema: $schema) {
+export const deprecatedUpdateEntityTypeMutation = gql`
+  mutation deprecatedUpdateEntityType($entityId: ID!, $schema: JSONObject!) {
+    deprecatedUpdateEntityType(entityId: $entityId, schema: $schema) {
       ...EntityTypeFields
     }
   }

--- a/packages/hash/frontend/src/graphql/queries/entityType.queries.ts
+++ b/packages/hash/frontend/src/graphql/queries/entityType.queries.ts
@@ -1,7 +1,7 @@
 import { gql } from "@apollo/client";
 
 const entityTypeFieldsFragment = gql`
-  fragment EntityTypeFields on EntityType {
+  fragment EntityTypeFields on DeprecatedEntityType {
     accountId
     createdByAccountId
     createdAt

--- a/packages/hash/frontend/src/graphql/queries/entityType.queries.ts
+++ b/packages/hash/frontend/src/graphql/queries/entityType.queries.ts
@@ -24,14 +24,14 @@ export const getEntityTypeQuery = gql`
     }
   }
 `;
-export const createEntityTypeMutation = gql`
-  mutation createEntityType(
+export const deprecatedCreateEntityTypeMutation = gql`
+  mutation deprecatedCreateEntityType(
     $accountId: ID!
     $description: String
     $name: String!
     $schema: JSONObject
   ) {
-    createEntityType(
+    deprecatedCreateEntityType(
       accountId: $accountId
       description: $description
       name: $name

--- a/packages/hash/frontend/src/graphql/queries/entityType.queries.ts
+++ b/packages/hash/frontend/src/graphql/queries/entityType.queries.ts
@@ -16,9 +16,9 @@ const entityTypeFieldsFragment = gql`
   }
 `;
 
-export const getEntityTypeQuery = gql`
-  query getEntityType($entityTypeId: ID!) {
-    getEntityType(entityTypeId: $entityTypeId) {
+export const deprecatedGetEntityTypeQuery = gql`
+  query deprecatedGetEntityType($entityTypeId: ID!) {
+    deprecatedGetEntityType(entityTypeId: $entityTypeId) {
       entityId
       properties
     }

--- a/packages/hash/frontend/src/lib/entities.ts
+++ b/packages/hash/frontend/src/lib/entities.ts
@@ -12,7 +12,7 @@ import { isParsedJsonObject } from "@hashintel/hash-shared/json-utils";
 
 import {
   UnknownEntity as ApiEntity,
-  EntityType as ApiEntityType,
+  DeprecatedEntityType as ApiEntityType,
   Link as ApiLink,
   LinkGroup as ApiLinkGroup,
   LinkedAggregation as ApiLinkedAggregation,

--- a/packages/hash/frontend/src/pages/[account-slug]/entities/new.page.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/entities/new.page.tsx
@@ -64,7 +64,7 @@ const Page: NextPageWithLayout = () => {
 
   const { data } = useGetAllEntityTypes(accountId);
 
-  const typeOptions = data?.getAccountEntityTypes;
+  const typeOptions = data?.deprecatedGetAccountEntityTypes;
   const selectedType = useMemo(() => {
     return (typeOptions ?? []).find(
       (option) => option.entityId === selectedTypeId,

--- a/packages/hash/frontend/src/pages/[account-slug]/types/[type-id].page.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/[type-id].page.tsx
@@ -7,10 +7,10 @@ import { Box, styled } from "@mui/material";
 import { faAsterisk } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@hashintel/hash-design-system";
 import {
-  GetEntityTypeQuery,
-  GetEntityTypeQueryVariables,
+  DeprecatedGetEntityTypeQuery,
+  DeprecatedGetEntityTypeQueryVariables,
 } from "../../../graphql/apiTypes.gen";
-import { getEntityTypeQuery } from "../../../graphql/queries/entityType.queries";
+import { deprecatedGetEntityTypeQuery } from "../../../graphql/queries/entityType.queries";
 import {
   SchemaEditor,
   SchemaSelectElementType,
@@ -58,15 +58,15 @@ const Page: NextPageWithLayout = () => {
       ? decodeURIComponent(window.location.hash)
       : undefined;
 
-  const { data } = useQuery<GetEntityTypeQuery, GetEntityTypeQueryVariables>(
-    getEntityTypeQuery,
-    {
-      variables: { entityTypeId: typeId },
-      pollInterval: 5000,
-    },
-  );
+  const { data } = useQuery<
+    DeprecatedGetEntityTypeQuery,
+    DeprecatedGetEntityTypeQueryVariables
+  >(deprecatedGetEntityTypeQuery, {
+    variables: { entityTypeId: typeId },
+    pollInterval: 5000,
+  });
 
-  const schema = data?.getEntityType.properties;
+  const schema = data?.deprecatedGetEntityType.properties;
 
   const schema$id: string = schema?.$id;
 
@@ -195,7 +195,7 @@ const Page: NextPageWithLayout = () => {
         </Box>
         <SchemaEditor
           aggregateEntityTypes={aggregateEntityTypes}
-          entityTypeId={data.getEntityType.entityId}
+          entityTypeId={data.deprecatedGetEntityType.entityId}
           schema={schema}
           GoToSchemaElement={schemaSelectElement}
           subSchemaReference={subSchemaReference}

--- a/packages/hash/frontend/src/pages/[account-slug]/types/new.page.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/new.page.tsx
@@ -6,11 +6,11 @@ import { useRouter } from "next/router";
 import { FormEvent, useState } from "react";
 import { tw } from "twind";
 import {
-  CreateEntityTypeMutation,
-  CreateEntityTypeMutationVariables,
+  DeprecatedCreateEntityTypeMutation,
+  DeprecatedCreateEntityTypeMutationVariables,
 } from "../../../graphql/apiTypes.gen";
 import { getAccountEntityTypes } from "../../../graphql/queries/account.queries";
-import { createEntityTypeMutation } from "../../../graphql/queries/entityType.queries";
+import { deprecatedCreateEntityTypeMutation } from "../../../graphql/queries/entityType.queries";
 import {
   getLayoutWithSidebar,
   NextPageWithLayout,
@@ -26,10 +26,10 @@ const Page: NextPageWithLayout = () => {
   const [description, setDescription] = useState("");
 
   const [createEntityType, { loading, error }] = useMutation<
-    CreateEntityTypeMutation,
-    CreateEntityTypeMutationVariables
-  >(createEntityTypeMutation, {
-    onCompleted: ({ createEntityType: entityType }) =>
+    DeprecatedCreateEntityTypeMutation,
+    DeprecatedCreateEntityTypeMutationVariables
+  >(deprecatedCreateEntityTypeMutation, {
+    onCompleted: ({ deprecatedCreateEntityType: entityType }) =>
       router.push(`/${accountId}/types/${entityType.entityId}`),
     refetchQueries: [
       { query: getAccountEntityTypes, variables: { accountId } },

--- a/packages/hash/frontend/src/pages/[account-slug]/types/new.page.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/new.page.tsx
@@ -9,7 +9,7 @@ import {
   DeprecatedCreateEntityTypeMutation,
   DeprecatedCreateEntityTypeMutationVariables,
 } from "../../../graphql/apiTypes.gen";
-import { getAccountEntityTypes } from "../../../graphql/queries/account.queries";
+import { deprecatedGetAccountEntityTypes } from "../../../graphql/queries/account.queries";
 import { deprecatedCreateEntityTypeMutation } from "../../../graphql/queries/entityType.queries";
 import {
   getLayoutWithSidebar,
@@ -32,7 +32,7 @@ const Page: NextPageWithLayout = () => {
     onCompleted: ({ deprecatedCreateEntityType: entityType }) =>
       router.push(`/${accountId}/types/${entityType.entityId}`),
     refetchQueries: [
-      { query: getAccountEntityTypes, variables: { accountId } },
+      { query: deprecatedGetAccountEntityTypes, variables: { accountId } },
     ],
   });
 

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list.tsx
@@ -147,7 +147,7 @@ export const AccountEntityTypeList: FunctionComponent<
 
   // todo: handle search server side
   const filteredData = useMemo(() => {
-    let entityTypes = data?.getAccountEntityTypes ?? [];
+    let entityTypes = data?.deprecatedGetAccountEntityTypes ?? [];
 
     if (searchQuery) {
       entityTypes = entityTypes.filter(({ properties }) =>

--- a/packages/hash/integration/src/graphql/queries/entity.queries.ts
+++ b/packages/hash/integration/src/graphql/queries/entity.queries.ts
@@ -34,9 +34,9 @@ export const createEntity = gql`
   }
 `;
 
-export const getEntityType = gql`
-  query getEntityType($entityTypeId: ID!) {
-    getEntityType(entityTypeId: $entityTypeId) {
+export const deprecatedGetEntityType = gql`
+  query deprecatedGetEntityType($entityTypeId: ID!) {
+    deprecatedGetEntityType(entityTypeId: $entityTypeId) {
       entityId
       entityVersionId
       properties
@@ -54,9 +54,9 @@ export const getEntityType = gql`
   }
 `;
 
-export const getEntityTypeAllParents = gql`
-  query getEntityTypeAllParents($entityTypeId: ID!) {
-    getEntityType(entityTypeId: $entityTypeId) {
+export const deprecatedGetEntityTypeAllParents = gql`
+  query deprecatedGetEntityTypeAllParents($entityTypeId: ID!) {
+    deprecatedGetEntityType(entityTypeId: $entityTypeId) {
       entityId
       entityVersionId
       properties

--- a/packages/hash/integration/src/graphql/queries/entity.queries.ts
+++ b/packages/hash/integration/src/graphql/queries/entity.queries.ts
@@ -69,14 +69,14 @@ export const getEntityTypeAllParents = gql`
   }
 `;
 
-export const createEntityType = gql`
-  mutation createEntityType(
+export const deprecatedCreateEntityType = gql`
+  mutation deprecatedCreateEntityType(
     $accountId: ID!
     $description: String
     $name: String!
     $schema: JSONObject!
   ) {
-    createEntityType(
+    deprecatedCreateEntityType(
       accountId: $accountId
       description: $description
       name: $name

--- a/packages/hash/integration/src/graphql/queries/entity.queries.ts
+++ b/packages/hash/integration/src/graphql/queries/entity.queries.ts
@@ -89,9 +89,9 @@ export const deprecatedCreateEntityType = gql`
   }
 `;
 
-export const updateEntityType = gql`
-  mutation updateEntityType($entityId: ID!, $schema: JSONObject!) {
-    updateEntityType(entityId: $entityId, schema: $schema) {
+export const deprecatedUpdateEntityType = gql`
+  mutation deprecatedUpdateEntityType($entityId: ID!, $schema: JSONObject!) {
+    deprecatedUpdateEntityType(entityId: $entityId, schema: $schema) {
       entityId
       entityTypeName
       properties

--- a/packages/hash/integration/src/tests/integration.test.ts
+++ b/packages/hash/integration/src/tests/integration.test.ts
@@ -23,7 +23,7 @@ import {
   PageFieldsFragment,
   SystemTypeName,
   WayToUseHash,
-  EntityType as GQLEntityType,
+  DeprecatedEntityType,
 } from "../graphql/apiTypes.gen";
 
 const logger = new Logger({
@@ -781,7 +781,7 @@ describe("logged in user ", () => {
 
   describe("can create EntityType inheritance relations", () => {
     let superType: Pick<
-      GQLEntityType,
+      DeprecatedEntityType,
       "entityId" | "properties" | "entityTypeName"
     >;
     beforeAll(async () => {
@@ -793,7 +793,7 @@ describe("logged in user ", () => {
     });
 
     let subType1: Pick<
-      GQLEntityType,
+      DeprecatedEntityType,
       "entityId" | "properties" | "entityTypeName"
     >;
     it("can inherit from SuperType", async () => {
@@ -1178,7 +1178,7 @@ describe("logged in user ", () => {
     };
 
     let testEntityType!: Pick<
-      GQLEntityType,
+      DeprecatedEntityType,
       "entityId" | "properties" | "entityTypeName"
     >;
     it("can create an entity type with a valid schema", async () => {
@@ -1259,7 +1259,7 @@ describe("logged in user ", () => {
     });
 
     let subType!: Pick<
-      GQLEntityType,
+      DeprecatedEntityType,
       "entityId" | "properties" | "entityTypeName"
     >;
     it("allows schema that inherits with compatible property types", async () => {

--- a/packages/hash/integration/src/tests/integration.test.ts
+++ b/packages/hash/integration/src/tests/integration.test.ts
@@ -693,7 +693,7 @@ describe("logged in user ", () => {
       entityTypeComponentId = newBlock.data.entityTypeId;
 
       // Get the EntitType that has been created because of the ComponentId
-      const componentIdType = await client.getEntityType({
+      const componentIdType = await client.deprecatedGetEntityType({
         entityTypeId: entityTypeComponentId,
       });
 
@@ -756,7 +756,7 @@ describe("logged in user ", () => {
       const entityId = newBlock.data.entityId;
 
       // Get the EntitType that has been created _previously_ because of the ComponentId
-      const componentIdType = await client.getEntityType({
+      const componentIdType = await client.deprecatedGetEntityType({
         entityTypeId: entityTypeComponentId,
       });
 
@@ -804,7 +804,7 @@ describe("logged in user ", () => {
       });
 
       const subTypeParent = await client
-        .getEntityType({
+        .deprecatedGetEntityType({
           entityTypeId: subType1.entityId,
         })
         .then((entyp) => entyp.parents);
@@ -823,7 +823,7 @@ describe("logged in user ", () => {
       });
 
       const superTypeChldren = await client
-        .getEntityType({
+        .deprecatedGetEntityType({
           entityTypeId: superType.entityId,
         })
         .then((entyp) => entyp.children);

--- a/packages/hash/integration/src/tests/integration.test.ts
+++ b/packages/hash/integration/src/tests/integration.test.ts
@@ -785,7 +785,7 @@ describe("logged in user ", () => {
       "entityId" | "properties" | "entityTypeName"
     >;
     beforeAll(async () => {
-      superType = await client.createEntityType({
+      superType = await client.deprecatedCreateEntityType({
         accountId: existingUser.accountId,
         name: "Supertype",
         schema: {},
@@ -797,7 +797,7 @@ describe("logged in user ", () => {
       "entityId" | "properties" | "entityTypeName"
     >;
     it("can inherit from SuperType", async () => {
-      subType1 = await client.createEntityType({
+      subType1 = await client.deprecatedCreateEntityType({
         accountId: existingUser.accountId,
         name: "Subtype1",
         schema: { allOf: [{ $ref: superType.properties.$id }] },
@@ -816,7 +816,7 @@ describe("logged in user ", () => {
 
     it("can get all children of supertype", async () => {
       // new subType
-      const subType2 = await client.createEntityType({
+      const subType2 = await client.deprecatedCreateEntityType({
         accountId: existingUser.accountId,
         name: "Subtype2",
         schema: { allOf: [{ $ref: superType.properties.$id }] },
@@ -1182,7 +1182,7 @@ describe("logged in user ", () => {
       "entityId" | "properties" | "entityTypeName"
     >;
     it("can create an entity type with a valid schema", async () => {
-      testEntityType = await client.createEntityType({
+      testEntityType = await client.deprecatedCreateEntityType({
         accountId: existingUser.accountId,
         ...validSchemaInput,
       });
@@ -1194,7 +1194,7 @@ describe("logged in user ", () => {
 
     it("enforces uniqueness of schema name in account", async () => {
       await expect(
-        client.createEntityType({
+        client.deprecatedCreateEntityType({
           accountId: existingUser.accountId,
           ...validSchemaInput,
         }),
@@ -1204,7 +1204,7 @@ describe("logged in user ", () => {
     it("rejects entity types with invalid JSON schemas", async () => {
       const schemaName = "Invalid schema entity type";
       await expect(
-        client.createEntityType({
+        client.deprecatedCreateEntityType({
           accountId: existingUser.accountId,
           schema: {
             properties: [],
@@ -1214,7 +1214,7 @@ describe("logged in user ", () => {
       ).rejects.toThrowError(/properties must be object/);
 
       await expect(
-        client.createEntityType({
+        client.deprecatedCreateEntityType({
           accountId: existingUser.accountId,
           schema: {
             properties: {
@@ -1226,7 +1226,7 @@ describe("logged in user ", () => {
       ).rejects.toThrowError(/testField must be object,boolean/);
 
       await expect(
-        client.createEntityType({
+        client.deprecatedCreateEntityType({
           accountId: existingUser.accountId,
           schema: {
             invalidKeyword: true,
@@ -1239,7 +1239,7 @@ describe("logged in user ", () => {
     it("rejects schema that inherits with incompatible property types", async () => {
       const schemaName = "Schema invalid property inheritance";
       await expect(
-        client.createEntityType({
+        client.deprecatedCreateEntityType({
           accountId: existingUser.accountId,
           schema: {
             allOf: [
@@ -1265,7 +1265,7 @@ describe("logged in user ", () => {
     it("allows schema that inherits with compatible property types", async () => {
       const schemaName = "Schema valid property inheritance";
 
-      subType = await client.createEntityType({
+      subType = await client.deprecatedCreateEntityType({
         accountId: existingUser.accountId,
         schema: {
           allOf: [
@@ -1285,7 +1285,7 @@ describe("logged in user ", () => {
     it("rejects schema that inherits with incompatible property types deeper than top level", async () => {
       const schemaName = "Schema invalid property inheritance";
       await expect(
-        client.createEntityType({
+        client.deprecatedCreateEntityType({
           accountId: existingUser.accountId,
           schema: {
             allOf: [
@@ -1307,7 +1307,7 @@ describe("logged in user ", () => {
     it("can get inheritance chain of a EntityType", async () => {
       const schemaName = "ThreeLayerType";
 
-      const entityType = await client.createEntityType({
+      const entityType = await client.deprecatedCreateEntityType({
         accountId: existingUser.accountId,
         schema: {
           allOf: [
@@ -1348,7 +1348,7 @@ describe("logged in user ", () => {
     };
 
     it("can update an entity type's schema", async () => {
-      const entityType = await client.createEntityType({
+      const entityType = await client.deprecatedCreateEntityType({
         accountId: existingUser.accountId,
         ...validSchemaInput,
       });
@@ -1358,7 +1358,7 @@ describe("logged in user ", () => {
 
       const newDescription = "Now this is updated";
 
-      const updatedEntityType = await client.updateEntityType({
+      const updatedEntityType = await client.deprecatedUpdateEntityType({
         entityId: entityType.entityId,
         schema: {
           ...validSchemaInput.schema,

--- a/packages/hash/integration/src/tests/util.ts
+++ b/packages/hash/integration/src/tests/util.ts
@@ -275,7 +275,9 @@ export class ApiClient {
     ).getEntityType;
   }
 
-  async createEntityType(vars: DeprecatedCreateEntityTypeMutationVariables) {
+  async deprecatedCreateEntityType(
+    vars: DeprecatedCreateEntityTypeMutationVariables,
+  ) {
     return (
       await this.client.request<
         DeprecatedCreateEntityTypeMutation,
@@ -284,7 +286,9 @@ export class ApiClient {
     ).deprecatedCreateEntityType;
   }
 
-  async updateEntityType(vars: DeprecatedUpdateEntityTypeMutationVariables) {
+  async deprecatedUpdateEntityType(
+    vars: DeprecatedUpdateEntityTypeMutationVariables,
+  ) {
     return (
       await this.client.request<
         DeprecatedUpdateEntityTypeMutation,

--- a/packages/hash/integration/src/tests/util.ts
+++ b/packages/hash/integration/src/tests/util.ts
@@ -29,8 +29,8 @@ import {
   UpdatePageContentsMutationVariables,
   DeprecatedCreateEntityTypeMutation,
   DeprecatedCreateEntityTypeMutationVariables,
-  UpdateEntityTypeMutation,
-  UpdateEntityTypeMutationVariables,
+  DeprecatedUpdateEntityTypeMutation,
+  DeprecatedUpdateEntityTypeMutationVariables,
   CreateOrgEmailInvitationMutationVariables,
   CreateOrgEmailInvitationMutation,
   CreateUserWithOrgEmailInvitationMutationVariables,
@@ -66,7 +66,7 @@ import {
   getUnknownEntity,
   getEntities,
   updateEntity,
-  updateEntityType,
+  deprecatedUpdateEntityType,
   getEntityAndLinks,
 } from "../graphql/queries/entity.queries";
 import {
@@ -284,13 +284,13 @@ export class ApiClient {
     ).deprecatedCreateEntityType;
   }
 
-  async updateEntityType(vars: UpdateEntityTypeMutationVariables) {
+  async updateEntityType(vars: DeprecatedUpdateEntityTypeMutationVariables) {
     return (
       await this.client.request<
-        UpdateEntityTypeMutation,
-        UpdateEntityTypeMutationVariables
-      >(updateEntityType, vars)
-    ).updateEntityType;
+        DeprecatedUpdateEntityTypeMutation,
+        DeprecatedUpdateEntityTypeMutationVariables
+      >(deprecatedUpdateEntityType, vars)
+    ).deprecatedUpdateEntityType;
   }
 
   getPage = async (vars: GetPageQueryVariables) =>

--- a/packages/hash/integration/src/tests/util.ts
+++ b/packages/hash/integration/src/tests/util.ts
@@ -47,7 +47,7 @@ import {
   UpdateLinkedAggregationOperationMutationVariables,
   DeleteLinkedAggregationMutation,
   DeleteLinkedAggregationMutationVariables,
-  QueryGetEntityTypeArgs,
+  QueryDeprecatedGetEntityTypeArgs,
   Query,
   GetEntitiesQuery,
   GetEntitiesQueryVariables,
@@ -61,8 +61,8 @@ import {
 import {
   createEntity,
   deprecatedCreateEntityType,
-  getEntityType,
-  getEntityTypeAllParents,
+  deprecatedGetEntityType,
+  deprecatedGetEntityTypeAllParents,
   getUnknownEntity,
   getEntities,
   updateEntity,
@@ -257,22 +257,22 @@ export class ApiClient {
     ).setParentPage;
   }
 
-  async getEntityType(vars: QueryGetEntityTypeArgs) {
+  async deprecatedGetEntityType(vars: QueryDeprecatedGetEntityTypeArgs) {
     return (
       await this.client.request<
-        Pick<Query, "getEntityType">,
-        QueryGetEntityTypeArgs
-      >(getEntityType, vars)
-    ).getEntityType;
+        Pick<Query, "deprecatedGetEntityType">,
+        QueryDeprecatedGetEntityTypeArgs
+      >(deprecatedGetEntityType, vars)
+    ).deprecatedGetEntityType;
   }
 
-  async getEntityTypeAllParents(vars: QueryGetEntityTypeArgs) {
+  async getEntityTypeAllParents(vars: QueryDeprecatedGetEntityTypeArgs) {
     return (
       await this.client.request<
-        Pick<Query, "getEntityType">,
-        QueryGetEntityTypeArgs
-      >(getEntityTypeAllParents, vars)
-    ).getEntityType;
+        Pick<Query, "deprecatedGetEntityType">,
+        QueryDeprecatedGetEntityTypeArgs
+      >(deprecatedGetEntityTypeAllParents, vars)
+    ).deprecatedGetEntityType;
   }
 
   async deprecatedCreateEntityType(

--- a/packages/hash/integration/src/tests/util.ts
+++ b/packages/hash/integration/src/tests/util.ts
@@ -27,8 +27,8 @@ import {
   GetPageQuery,
   UpdatePageContentsMutation,
   UpdatePageContentsMutationVariables,
-  CreateEntityTypeMutation,
-  CreateEntityTypeMutationVariables,
+  DeprecatedCreateEntityTypeMutation,
+  DeprecatedCreateEntityTypeMutationVariables,
   UpdateEntityTypeMutation,
   UpdateEntityTypeMutationVariables,
   CreateOrgEmailInvitationMutationVariables,
@@ -60,7 +60,7 @@ import {
 } from "../graphql/apiTypes.gen";
 import {
   createEntity,
-  createEntityType,
+  deprecatedCreateEntityType,
   getEntityType,
   getEntityTypeAllParents,
   getUnknownEntity,
@@ -275,13 +275,13 @@ export class ApiClient {
     ).getEntityType;
   }
 
-  async createEntityType(vars: CreateEntityTypeMutationVariables) {
+  async createEntityType(vars: DeprecatedCreateEntityTypeMutationVariables) {
     return (
       await this.client.request<
-        CreateEntityTypeMutation,
-        CreateEntityTypeMutationVariables
-      >(createEntityType, vars)
-    ).createEntityType;
+        DeprecatedCreateEntityTypeMutation,
+        DeprecatedCreateEntityTypeMutationVariables
+      >(deprecatedCreateEntityType, vars)
+    ).deprecatedCreateEntityType;
   }
 
   async updateEntityType(vars: UpdateEntityTypeMutationVariables) {

--- a/packages/hash/shared/src/queries/entity.queries.ts
+++ b/packages/hash/shared/src/queries/entity.queries.ts
@@ -2,7 +2,7 @@ import gql from "graphql-tag";
 import { linkFieldsFragment } from "./link.queries";
 
 const minimalEntityTypeFieldsFragment = gql`
-  fragment MinimalEntityTypeFields on EntityType {
+  fragment MinimalEntityTypeFields on DeprecatedEntityType {
     entityId
     properties
   }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
This PR is a follow-up to #924, in order to introduce Entity Types the same way the other Ontology types are defined the old resolvers had to be renamed (I chose the `deprecated` prefix for each resolver).

Commits a8446abaa7d04538b5efa6a067e1a4028def0b20..2509414deb2501024f42da8dd509702d40b09b54 are about deprecating the previous entity type fields, while 5053549c72d2f3d5cd7525acde75748af4a805be is the actual new CRU resolvers

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/0/1202790003697058/f) _(internal)_

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->


## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Deprecates queries/mutations related to the "old" entity types in the system
   - transiently touches on any frontend and integration test that used these old resolvers
- Add new Entity Type CRU resolvers similarly to those in #924

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

- GraphQL resolvers have auto-generated docs

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- None currently, just manual tests

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch / view the deployment
1.  Start the HASH graph 
     - From the `packages/graph/hash_graph/bin/hash_graph` path run:
     - `cargo make recreate-db && cargo make migrate-up`
     - `cargo run`
1. Run the HASH workspace
     - From the root, run `yarn dev:backend:api`
1. Head to `http://localhost:5001/graphql` and try some of the queries/mutations
     - Example query: ` query { getAllLatestLinkTypes{ linkTypeVersionedUri createdBy schema } }`


GQL queries:
<details>
<summary>Create Entity type</summary>

**Query**:

```gql
mutation($schema: EntityType!) {
  createEntityType(accountId: "00000000-0000-0000-0000-000000000000", 
    entityType: $schema) {
    entityTypeVersionedUri
    createdBy
    schema 
  }
}
```
**Params**:
```json
{
  "schema":  {
    "kind": "entityType",
    "$id": "https://blockprotocol.org/@alice/types/entity-type/page/v/1",
    "type": "object",
    "title": "Page",
    "properties": {
      "https://example.com/@example/types/property-type/account-id": {
        "$ref": "https://example.com/@example/types/property-type/account-id/v/1"
      }
    }
  }
}
```
</details>

<details>
<summary>Get created entity type</summary>

```gql
query {
  getEntityType(entityTypeVersionedUri: "https://blockprotocol.org/@alice/types/entity-type/page/v/1") {
    entityTypeVersionedUri
    schema
  }
}
```
</details>

<details>
<summary>Update Entity type</summary>

**Query**:

```gql
mutation($schema: EntityType!, $id:String!) {
  updateEntityType(accountId: "00000000-0000-0000-0000-000000000000", 
    entityTypeVersionedUri:$id
    updatedEntityType: $schema) {
    entityTypeVersionedUri
    createdBy
    schema 
  }
}
```
**Params**:
```json
{
  "id": "https://blockprotocol.org/@alice/types/entity-type/page/v/1",
  "schema": {
    "kind": "entityType",
    "$id": "https://blockprotocol.org/@alice/types/entity-type/page/v/1",
    "type": "object",
    "title": "Page",
    "properties": {
      "https://example.com/@example/types/property-type/account-id": {
        "$ref": "https://example.com/@example/types/property-type/account-id/v/1"
      },
      "https://example.com/@example/types/property-type/email": {
        "$ref": "https://example.com/@example/types/property-type/email/v/1"
      }
    }
  }
}
```
</details>

<details>
<summary>Get all Entity types</summary>

```gql
query {
  getAllLatestEntityTypes {
    entityTypeVersionedUri
    schema
  }
}
```
</details>

