### PR TITLE
Add feature groups for linting

### DIFF
--- a/.github/scripts/rust/Makefile.toml
+++ b/.github/scripts/rust/Makefile.toml
@@ -12,6 +12,10 @@ CARGO_RUN_FLAGS = ""
 CARGO_FORMAT_FLAGS = ""
 CARGO_FORMAT_HACK_FLAGS = "--workspace"
 CARGO_CLIPPY_FLAGS = "--no-deps --tests"
+# This needs to be here, as error-stack uses it, and _BASE **needs** to be defined before
+# the variable using it has been defined. This is done per suggestion of
+# https://github.com/sagiegurari/cargo-make/issues/685
+CARGO_CLIPPY_HACK_FLAGS_BASE = ""
 CARGO_CLIPPY_HACK_FLAGS = "--workspace --feature-powerset"
 CARGO_DOC_FLAGS = "--no-deps --all-features -Zunstable-options -Zrustdoc-scrape-examples=examples"
 CARGO_DOC_HACK_FLAGS = "--workspace"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -212,7 +212,7 @@ jobs:
       
       - name: Run lints
         working-directory: ${{ matrix.directory }}
-        run: cargo +${{ matrix.toolchain }} make --profile ${{ matrix.profile }} lint -- -D warnings
+        run: cargo +${{ matrix.toolchain }} make --profile ${{ matrix.profile }} clippy -- -D warnings
 
 
       - name: Login

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -209,6 +209,11 @@ jobs:
       - name: Run tests
         working-directory: ${{ matrix.directory }}
         run: cargo +${{ matrix.toolchain }} make --profile ${{ matrix.profile }} test --no-fail-fast
+      
+      - name: Run lints
+        working-directory: ${{ matrix.directory }}
+        run: cargo +${{ matrix.toolchain }} make --profile ${{ matrix.profile }} lint -- -D warnings
+
 
       - name: Login
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -206,14 +206,13 @@ jobs:
           cargo quickinstall cargo-hack --version 0.5.15
           cargo quickinstall cargo-nextest --version 0.9.28
 
-      - name: Run tests
-        working-directory: ${{ matrix.directory }}
-        run: cargo +${{ matrix.toolchain }} make --profile ${{ matrix.profile }} test --no-fail-fast
-      
       - name: Run lints
         working-directory: ${{ matrix.directory }}
         run: cargo +${{ matrix.toolchain }} make --profile ${{ matrix.profile }} clippy -- -D warnings
 
+      - name: Run tests
+        working-directory: ${{ matrix.directory }}
+        run: cargo +${{ matrix.toolchain }} make --profile ${{ matrix.profile }} test --no-fail-fast
 
       - name: Login
         run: |

--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error-stack"
-version = "0.2.0"
+version = "0.1.1"
 authors = ["HASH"]
 edition = "2021"
 rust-version = "1.61.0"

--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error-stack"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["HASH"]
 edition = "2021"
 rust-version = "1.61.0"

--- a/packages/libs/error-stack/Makefile.toml
+++ b/packages/libs/error-stack/Makefile.toml
@@ -1,12 +1,14 @@
 extend = { path = "../../../.github/scripts/rust/Makefile.toml" }
 
 [env]
-CARGO_CLIPPY_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default --optional-deps eyre,anyhow"
+CARGO_CLIPPY_HACK_FLAGS_BASE = "--workspace --feature-powerset --exclude-features default --optional-deps eyre,anyhow"
+CARGO_CLIPPY_HACK_FLAGS = "${CARGO_CLIPPY_HACK_FLAGS_BASE} --group-features anyhow,eyre --group-features spantrace,futures,small"
 CARGO_TEST_HACK_FLAGS_BASE = "--workspace --feature-powerset --exclude-features default --optional-deps eyre,anyhow"
 CARGO_TEST_HACK_FLAGS = "${CARGO_TEST_HACK_FLAGS_BASE} --group-features anyhow,eyre --group-features spantrace,futures,small"
 CARGO_MIRI_FLAGS = "--tests --lib"
 
 [env.release]
+CARGO_CLIPPY_HACK_FLAGS = "${CARGO_CLIPPY_HACK_FLAGS_BASE}"
 CARGO_TEST_HACK_FLAGS = "${CARGO_TEST_HACK_FLAGS_BASE}"
 
 [tasks.test-task]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This implements the same optimizations outlined in #877, which have been applied in #892 for tests. We forgot Clippy in the initial PR, which has been applied in this PR after being pointed out by https://github.com/hashintel/hash/pull/794#discussion_r949698353.

## 🔗 Related links

* Discussion about time complexity and motivation: #877 
* Initial PR: #892 

## 🔍 What does this change?

`cargo make clippy` will only run for a fraction of feature sets on PRs, but with all permutations on release.

## 📜 Does this require a change to the docs?

Not user-facing, just CI.