### PR TITLE
Authenticate type GQL resolvers

### DIFF
--- a/packages/hash/api/src/graphql/resolvers/index.ts
+++ b/packages/hash/api/src/graphql/resolvers/index.ts
@@ -119,13 +119,12 @@ export const resolvers = {
     embedCode,
     pageSearchResultConnection,
     // Ontology
-    /** @todo add auth gate for the following endpoints. */
-    getAllLatestDataTypes,
-    getDataType,
-    getAllLatestPropertyTypes,
-    getPropertyType,
-    getAllLatestLinkTypes,
-    getLinkType,
+    getAllLatestDataTypes: loggedInAndSignedUp(getAllLatestDataTypes),
+    getDataType: loggedInAndSignedUp(getDataType),
+    getAllLatestPropertyTypes: loggedInAndSignedUp(getAllLatestPropertyTypes),
+    getPropertyType: loggedInAndSignedUp(getPropertyType),
+    getAllLatestLinkTypes: loggedInAndSignedUp(getAllLatestLinkTypes),
+    getLinkType: loggedInAndSignedUp(getLinkType),
   },
 
   Mutation: {
@@ -164,11 +163,10 @@ export const resolvers = {
     executeGithubDiscoverTask: loggedInAndSignedUp(executeGithubDiscoverTask),
     executeGithubReadTask: loggedInAndSignedUp(executeGithubReadTask),
     // Ontology
-    /** @todo add auth gate for the following endpoints. */
-    createPropertyType,
-    updatePropertyType,
-    createLinkType,
-    updateLinkType,
+    createPropertyType: loggedInAndSignedUp(createPropertyType),
+    updatePropertyType: loggedInAndSignedUp(updatePropertyType),
+    createLinkType: loggedInAndSignedUp(createLinkType),
+    updateLinkType: loggedInAndSignedUp(updateLinkType),
   },
 
   JSONObject: JSONObjectResolver,

--- a/packages/hash/api/src/graphql/resolvers/ontology/data-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/data-type.ts
@@ -4,24 +4,22 @@ import { AxiosError } from "axios";
 import {
   PersistedDataType,
   QueryGetDataTypeArgs,
-  Resolver,
+  ResolverFn,
 } from "../../apiTypes.gen";
-import { GraphQLContext } from "../../context";
+import { GraphQLContext, LoggedInGraphQLContext } from "../../context";
 import { DataTypeModel } from "../../../model";
-import { nilUuid } from "../../../model/util";
 import { dataTypeModelToGQL } from "./model-mapping";
 
-export const getAllLatestDataTypes: Resolver<
+export const getAllLatestDataTypes: ResolverFn<
   Promise<PersistedDataType[]>,
   {},
-  GraphQLContext,
+  LoggedInGraphQLContext,
   {}
-> = async (_, __, { dataSources }) => {
+> = async (_, __, { dataSources, user }) => {
   const { graphApi } = dataSources;
 
   const allLatestDataTypeModels = await DataTypeModel.getAllLatest(graphApi, {
-    /** @todo Replace with User from the request */
-    accountId: nilUuid,
+    accountId: user.getAccountId(),
   }).catch((err: AxiosError) => {
     throw new ApolloError(
       `Unable to retrieve all latest data types. ${err.response?.data}`,
@@ -34,7 +32,7 @@ export const getAllLatestDataTypes: Resolver<
   );
 };
 
-export const getDataType: Resolver<
+export const getDataType: ResolverFn<
   Promise<PersistedDataType>,
   {},
   GraphQLContext,

--- a/packages/hash/api/src/graphql/typeDefs/ontology/link-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/link-type.typedef.ts
@@ -27,9 +27,9 @@ export const linkTypeTypedef = gql`
     """
     createLinkType(
       """
-      accountId refers to the account to create the link type in.
+      The id of the account where to create the link type in. Defaults to the account id of the current user.
       """
-      accountId: ID!
+      accountId: ID
       linkType: LinkType!
     ): PersistedLinkType!
 
@@ -38,9 +38,9 @@ export const linkTypeTypedef = gql`
     """
     updateLinkType(
       """
-      accountId refers to the account to update the link type in.
+      The id of the account where to create the updated link type in. Defaults to the account id of the current user.
       """
-      accountId: ID!
+      accountId: ID
       """
       The link type versioned $id to update.
       """

--- a/packages/hash/api/src/graphql/typeDefs/ontology/property-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/property-type.typedef.ts
@@ -31,9 +31,9 @@ export const propertyTypeTypedef = gql`
     """
     createPropertyType(
       """
-      accountId refers to the account to create the property type in.
+      The id of the account where to create the property type in. Defaults to the account id of the current user.
       """
-      accountId: ID!
+      accountId: ID
       propertyType: PropertyType!
     ): PersistedPropertyType!
 
@@ -42,9 +42,9 @@ export const propertyTypeTypedef = gql`
     """
     updatePropertyType(
       """
-      accountId refers to the account to update the property type in.
+      The id of the account where to create the updated property type in. Defaults to the account id of the current user.
       """
-      accountId: ID!
+      accountId: ID
       """
       The property type versioned $id to update.
       """


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR adds authentication middleware to the recently added type resolvers in the GQL API.

Additionally it makes the `accountId` parameter for the `createLinkType`/`createPropertyType` methods optional, defaulting to the `accountId` of the currently authenticated user.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publically accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202621375435417/1202829711398832/f) _(internal)_

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

No.

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Checkout the branch / view the deployment
2. Run the hash workspace using `yarn external-services up` and `yarn dev`
3. Go to the GraphQL playground at `http://localhost:5001/graphql` and try to call a type query/mutation such as `getAllLatestDataTypes` (you can use the query attached below). You should get an authentication error.
4. Login to the hash workspace at `http://localhost:3000/login`
5. Re-run the mutation in the GQL playground, you should now get the correct response.


<details>
<summary>Get all data types query</summary>

```gql
query {
  getAllLatestDataTypes {
    dataTypeVersionedUri
  }
}
```
</details>