### PR TITLE
Bump `rustc_version` to `v0.4`

### DIFF
--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -31,7 +31,7 @@ tracing-subscriber = "0.3.14"
 once_cell = "1.13.0"
 
 [build-dependencies]
-rustc_version = "0.2.3"
+rustc_version = "0.4"
 
 [features]
 default = ["std", "small"]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`rustc_version` does not have any new features we require, but as `error-stack` is a library, it's good practice to keep them update. This implies, that downstream crates don't need to depend on multiple version on the same dependency (assuming they are updating their dependencies as well).