### PR TITLE
Create log directory if it does not exist

### DIFF
--- a/packages/engine/lib/experiment-control/src/environment/logging.rs
+++ b/packages/engine/lib/experiment-control/src/environment/logging.rs
@@ -269,17 +269,15 @@ pub fn init_logger<P: AsRef<Path>>(
             );
             std::process::exit(1);
         }
-    } else {
-        if let Err(e) = fs::create_dir(log_folder) {
-            eprintln!(
-                "Could not create the log folder. Please try creating the folder `{}` in the \
-                 directory from which you are running the engine.
-                 Note: the specific error the engine encountered is `{:?}`",
-                log_folder.display(),
-                e
-            );
-            std::process::exit(1)
-        }
+    } else if let Err(e) = fs::create_dir(log_folder) {
+        eprintln!(
+            "Could not create the log folder. Please try creating the folder `{}` in the \
+             directory from which you are running the engine.
+             Note: the specific error the engine encountered is `{:?}`",
+            log_folder.display(),
+            e
+        );
+        std::process::exit(1)
     }
 
     let json_file_appender =


### PR DESCRIPTION
Also raise an error if the log directory is a file.

## 🌟 What is the purpose of this PR?

- Better error message for an admittedly niche case (though I did, unintentionally, run into it and the previous error message - which came from tracing was pretty opaque)

## ⚠️ Known issues

- Should we create directories on the user's behalf, or ask them to create the directory themselves?