### PR TITLE
Bump `error-stack` toolchain to `2022-08-19`

### DIFF
--- a/.github/scripts/rust/setup.py
+++ b/.github/scripts/rust/setup.py
@@ -18,7 +18,7 @@ from pygit2 import Repository, Commit
 CWD = Path.cwd()
 
 # All jobs for all crates will run if any of these paths change
-ALWAYS_RUN_PATTERNS = ["**/rust-toolchain.toml", ".github/**"]
+ALWAYS_RUN_PATTERNS = [".github/**"]
 
 # Toolchains used for the specified crates in addition to the toolchain which is defined in
 # rust-toolchain.toml

--- a/.github/scripts/rust/setup.py
+++ b/.github/scripts/rust/setup.py
@@ -132,17 +132,17 @@ def output_matrix(name, crates, **kwargs):
     :param crates: a list of paths to crates
     """
 
-    available_toolchains = []
+    available_toolchains = set()
     for crate in crates:
         with open(
             crate / "rust-toolchain.toml", "r", encoding="UTF-8"
         ) as toolchain_toml:
-            available_toolchains.append(
+            available_toolchains.add(
                 toml.loads(toolchain_toml.read())["toolchain"]["channel"]
             )
         for pattern, additional_toolchains in TOOLCHAINS.items():
             for additional_toolchain in additional_toolchains:
-                available_toolchains.append(additional_toolchain)
+                available_toolchains.add(additional_toolchain)
 
     used_toolchain_combinations = []
     for crate in crates:
@@ -168,7 +168,7 @@ def output_matrix(name, crates, **kwargs):
 
     matrix = dict(
         directory=[str(crate) for crate in crates],
-        toolchain=available_toolchains,
+        toolchain=list(available_toolchains),
         **kwargs,
         exclude=[
             dict(directory=str(elem[0]), toolchain=elem[1])

--- a/packages/libs/error-stack/README.md
+++ b/packages/libs/error-stack/README.md
@@ -8,7 +8,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/error-stack)][crates.io]
 [![libs.rs](https://img.shields.io/badge/libs.rs-error--stack-orange)][libs.rs]
-[![rust-version](https://img.shields.io/badge/Rust-1.63.0/nightly--2022--08--08-blue)][rust-version]
+[![rust-version](https://img.shields.io/badge/Rust-1.63.0/nightly--2022--08--19-blue)][rust-version]
 [![documentation](https://img.shields.io/docsrs/error-stack)][documentation]
 [![license](https://img.shields.io/crates/l/error-stack)][license]
 [![discord](https://img.shields.io/discord/840573247803097118)][discord]

--- a/packages/libs/error-stack/rust-toolchain.toml
+++ b/packages/libs/error-stack/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 # Please also update the badges in `README.md` and `src/lib.rs`
-channel = "nightly-2022-08-08"
+channel = "nightly-2022-08-19"

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! [![crates.io](https://img.shields.io/crates/v/error-stack)][crates.io]
 //! [![libs.rs](https://img.shields.io/badge/libs.rs-error--stack-orange)][libs.rs]
-//! [![rust-version](https://img.shields.io/badge/Rust-1.63.0/nightly--2022--08--08-blue)][rust-version]
+//! [![rust-version](https://img.shields.io/badge/Rust-1.63.0/nightly--2022--08--19-blue)][rust-version]
 //! [![discord](https://img.shields.io/discord/840573247803097118)][discord]
 //!
 //! [crates.io]: https://crates.io/crates/error-stack

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -445,7 +445,7 @@
 #![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
 #![cfg_attr(
     all(nightly, feature = "std"),
-    feature(backtrace, backtrace_frames, error_generic_member_access)
+    feature(backtrace_frames, error_generic_member_access)
 )]
 #![warn(
     missing_docs,

--- a/packages/libs/error-stack/src/report.rs
+++ b/packages/libs/error-stack/src/report.rs
@@ -159,11 +159,9 @@ use crate::{
 /// }
 /// ```
 ///
-/// Get the attached backtrace and spantrace:
+/// Get the attached [`Backtrace`] and [`SpanTrace`]:
 ///
 /// ```should_panic
-/// # #![cfg_attr(nightly, feature(backtrace))]
-///
 /// use error_stack::{IntoReport, ResultExt, Result};
 ///
 /// # #[allow(unused_variables)]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__complex.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__complex.snap
@@ -3,7 +3,7 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 Context A
-├╴tests/test_debug.rs:492:14
+├╴tests/test_debug.rs:489:14
 ├╴Printable A
 │
 ╰┬▶ Root error

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__linear.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__linear.snap
@@ -3,11 +3,11 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 Context B
-├╴tests/test_debug.rs:338:14
+├╴tests/test_debug.rs:335:14
 ├╴Printable C
 │
 ├─▶ Context A
-│   ├╴tests/test_debug.rs:335:14
+│   ├╴tests/test_debug.rs:332:14
 │   ├╴Printable B
 │   ╰╴1 additional opaque attachment
 │

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__linear_ext.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__linear_ext.snap
@@ -3,11 +3,11 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 Context B
-├╴tests/test_debug.rs:355:14
+├╴tests/test_debug.rs:352:14
 ├╴Printable C
 │
 ├─▶ Context A
-│   ├╴tests/test_debug.rs:352:14
+│   ├╴tests/test_debug.rs:349:14
 │   ├╴Printable B
 │   ╰╴1 additional opaque attachment
 │

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__multiline_ctx.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__multiline_ctx.snap
@@ -3,13 +3,13 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 Context B
-├╴tests/test_debug.rs:380:14
+├╴tests/test_debug.rs:377:14
 ├╴Printable C
 │
 ├─▶ A multiline
 │   context that might have
 │   a bit more info
-│   ├╴tests/test_debug.rs:377:14
+│   ├╴tests/test_debug.rs:374:14
 │   ├╴Printable B
 │   ╰╴1 additional opaque attachment
 │

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__sources.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__sources.snap
@@ -3,7 +3,7 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 Context A
-├╴tests/test_debug.rs:424:14
+├╴tests/test_debug.rs:421:14
 ├╴1 additional opaque attachment
 │
 ╰┬▶ Root error

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__sources_transparent.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__sources_transparent.snap
@@ -3,7 +3,7 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 Context A
-├╴tests/test_debug.rs:465:18
+├╴tests/test_debug.rs:462:18
 ├╴1 additional opaque attachment
 │
 ╰┬▶ Root error

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 Context A
-|-at tests/test_debug.rs:217:10
+|-at tests/test_debug.rs:214:10
 |-2
 |-1
 |
 |-> Context A
- |  |-at tests/test_debug.rs:211:10
+ |  |-at tests/test_debug.rs:208:10
  |  |-4
  |  |-3
  |  |
@@ -17,16 +17,16 @@ Context A
  |      |-6
  |
  |> Context A
-    |-at tests/test_debug.rs:206:10
+    |-at tests/test_debug.rs:203:10
     |-5
     |-3
     |
     |-> Context A
-    |   |-at tests/test_debug.rs:204:10
+    |   |-at tests/test_debug.rs:201:10
     |   |-7
     |
     |-> Context A
-     |  |-at tests/test_debug.rs:195:34
+     |  |-at tests/test_debug.rs:192:34
      |  |-9
      |  |-8
      |  |
@@ -34,7 +34,7 @@ Context A
      |      |-at tests/common.rs:147:5
      |
      |> Context A
-     |  |-at tests/test_debug.rs:189:10
+     |  |-at tests/test_debug.rs:186:10
      |  |-13
      |  |-10
      |  |-16
@@ -45,7 +45,7 @@ Context A
      |      |-at tests/common.rs:147:5
      |
      |> Context A
-     |  |-at tests/test_debug.rs:175:10
+     |  |-at tests/test_debug.rs:172:10
      |  |-15
      |  |-14
      |  |-10
@@ -57,7 +57,7 @@ Context A
      |      |-at tests/common.rs:147:5
      |
      |> Context A
-     |  |-at tests/test_debug.rs:185:10
+     |  |-at tests/test_debug.rs:182:10
      |  |-11
      |  |-9
      |  |-8
@@ -66,13 +66,13 @@ Context A
      |      |-at tests/common.rs:147:5
      |
      |> Context A
-        |-at tests/test_debug.rs:181:10
+        |-at tests/test_debug.rs:178:10
         |-12
         |-9
         |-8
         |
         |-> Context A
-        |   |-at tests/test_debug.rs:180:10
+        |   |-at tests/test_debug.rs:177:10
         |
         |-> Root error
             |-at tests/common.rs:147:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@backtrace-pretty-print.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@backtrace-pretty-print.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 Context A
-├╴tests/test_debug.rs:217:10
+├╴tests/test_debug.rs:214:10
 ├╴2
 ├╴1
 │
 ╰┬▶ Context A
- │  ├╴tests/test_debug.rs:211:10
+ │  ├╴tests/test_debug.rs:208:10
  │  ├╴4
  │  ├╴3
  │  │
@@ -18,16 +18,16 @@ Context A
  │      ╰╴backtrace with [n] frames (1)
  │
  ╰▶ Context A
-    ├╴tests/test_debug.rs:206:10
+    ├╴tests/test_debug.rs:203:10
     ├╴5
     ├╴3
     │
     ├─▶ Context A
-    │   ├╴tests/test_debug.rs:204:10
+    │   ├╴tests/test_debug.rs:201:10
     │   ╰╴7
     │
     ╰┬▶ Context A
-     │  ├╴tests/test_debug.rs:195:34
+     │  ├╴tests/test_debug.rs:192:34
      │  ├╴9
      │  ├╴8
      │  │
@@ -36,7 +36,7 @@ Context A
      │      ╰╴backtrace with [n] frames (2)
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:189:10
+     │  ├╴tests/test_debug.rs:186:10
      │  ├╴13
      │  ├╴10
      │  ├╴16
@@ -48,7 +48,7 @@ Context A
      │      ╰╴backtrace with [n] frames (3)
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:175:10
+     │  ├╴tests/test_debug.rs:172:10
      │  ├╴15
      │  ├╴14
      │  ├╴10
@@ -61,7 +61,7 @@ Context A
      │      ╰╴backtrace with [n] frames (4)
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:185:10
+     │  ├╴tests/test_debug.rs:182:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
@@ -71,13 +71,13 @@ Context A
      │      ╰╴backtrace with [n] frames (5)
      │
      ╰▶ Context A
-        ├╴tests/test_debug.rs:181:10
+        ├╴tests/test_debug.rs:178:10
         ├╴12
         ├╴9
         ├╴8
         │
         ├─▶ Context A
-        │   ╰╴tests/test_debug.rs:180:10
+        │   ╰╴tests/test_debug.rs:177:10
         │
         ╰─▶ Root error
             ├╴tests/common.rs:147:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@backtrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@backtrace.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 Context A
-|-at tests/test_debug.rs:217:10
+|-at tests/test_debug.rs:214:10
 |-2
 |-1
 |
 |-> Context A
- |  |-at tests/test_debug.rs:211:10
+ |  |-at tests/test_debug.rs:208:10
  |  |-4
  |  |-3
  |  |
@@ -18,16 +18,16 @@ Context A
  |      |-backtrace with [n] frames (1)
  |
  |> Context A
-    |-at tests/test_debug.rs:206:10
+    |-at tests/test_debug.rs:203:10
     |-5
     |-3
     |
     |-> Context A
-    |   |-at tests/test_debug.rs:204:10
+    |   |-at tests/test_debug.rs:201:10
     |   |-7
     |
     |-> Context A
-     |  |-at tests/test_debug.rs:195:34
+     |  |-at tests/test_debug.rs:192:34
      |  |-9
      |  |-8
      |  |
@@ -36,7 +36,7 @@ Context A
      |      |-backtrace with [n] frames (2)
      |
      |> Context A
-     |  |-at tests/test_debug.rs:189:10
+     |  |-at tests/test_debug.rs:186:10
      |  |-13
      |  |-10
      |  |-16
@@ -48,7 +48,7 @@ Context A
      |      |-backtrace with [n] frames (3)
      |
      |> Context A
-     |  |-at tests/test_debug.rs:175:10
+     |  |-at tests/test_debug.rs:172:10
      |  |-15
      |  |-14
      |  |-10
@@ -61,7 +61,7 @@ Context A
      |      |-backtrace with [n] frames (4)
      |
      |> Context A
-     |  |-at tests/test_debug.rs:185:10
+     |  |-at tests/test_debug.rs:182:10
      |  |-11
      |  |-9
      |  |-8
@@ -71,13 +71,13 @@ Context A
      |      |-backtrace with [n] frames (5)
      |
      |> Context A
-        |-at tests/test_debug.rs:181:10
+        |-at tests/test_debug.rs:178:10
         |-12
         |-9
         |-8
         |
         |-> Context A
-        |   |-at tests/test_debug.rs:180:10
+        |   |-at tests/test_debug.rs:177:10
         |
         |-> Root error
             |-at tests/common.rs:147:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@pretty-print.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@pretty-print.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 Context A
-├╴tests/test_debug.rs:217:10
+├╴tests/test_debug.rs:214:10
 ├╴2
 ├╴1
 │
 ╰┬▶ Context A
- │  ├╴tests/test_debug.rs:211:10
+ │  ├╴tests/test_debug.rs:208:10
  │  ├╴4
  │  ├╴3
  │  │
@@ -17,16 +17,16 @@ Context A
  │      ╰╴6
  │
  ╰▶ Context A
-    ├╴tests/test_debug.rs:206:10
+    ├╴tests/test_debug.rs:203:10
     ├╴5
     ├╴3
     │
     ├─▶ Context A
-    │   ├╴tests/test_debug.rs:204:10
+    │   ├╴tests/test_debug.rs:201:10
     │   ╰╴7
     │
     ╰┬▶ Context A
-     │  ├╴tests/test_debug.rs:195:34
+     │  ├╴tests/test_debug.rs:192:34
      │  ├╴9
      │  ├╴8
      │  │
@@ -34,7 +34,7 @@ Context A
      │      ╰╴tests/common.rs:147:5
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:189:10
+     │  ├╴tests/test_debug.rs:186:10
      │  ├╴13
      │  ├╴10
      │  ├╴16
@@ -45,7 +45,7 @@ Context A
      │      ╰╴tests/common.rs:147:5
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:175:10
+     │  ├╴tests/test_debug.rs:172:10
      │  ├╴15
      │  ├╴14
      │  ├╴10
@@ -57,7 +57,7 @@ Context A
      │      ╰╴tests/common.rs:147:5
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:185:10
+     │  ├╴tests/test_debug.rs:182:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
@@ -66,13 +66,13 @@ Context A
      │      ╰╴tests/common.rs:147:5
      │
      ╰▶ Context A
-        ├╴tests/test_debug.rs:181:10
+        ├╴tests/test_debug.rs:178:10
         ├╴12
         ├╴9
         ├╴8
         │
         ├─▶ Context A
-        │   ╰╴tests/test_debug.rs:180:10
+        │   ╰╴tests/test_debug.rs:177:10
         │
         ╰─▶ Root error
             ╰╴tests/common.rs:147:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace-backtrace-pretty-print.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace-backtrace-pretty-print.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 Context A
-├╴tests/test_debug.rs:217:10
+├╴tests/test_debug.rs:214:10
 ├╴2
 ├╴1
 │
 ╰┬▶ Context A
- │  ├╴tests/test_debug.rs:211:10
+ │  ├╴tests/test_debug.rs:208:10
  │  ├╴4
  │  ├╴3
  │  │
@@ -19,16 +19,16 @@ Context A
  │      ╰╴backtrace with [n] frames (1)
  │
  ╰▶ Context A
-    ├╴tests/test_debug.rs:206:10
+    ├╴tests/test_debug.rs:203:10
     ├╴5
     ├╴3
     │
     ├─▶ Context A
-    │   ├╴tests/test_debug.rs:204:10
+    │   ├╴tests/test_debug.rs:201:10
     │   ╰╴7
     │
     ╰┬▶ Context A
-     │  ├╴tests/test_debug.rs:195:34
+     │  ├╴tests/test_debug.rs:192:34
      │  ├╴9
      │  ├╴8
      │  │
@@ -38,7 +38,7 @@ Context A
      │      ╰╴backtrace with [n] frames (2)
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:189:10
+     │  ├╴tests/test_debug.rs:186:10
      │  ├╴13
      │  ├╴10
      │  ├╴16
@@ -51,7 +51,7 @@ Context A
      │      ╰╴backtrace with [n] frames (3)
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:175:10
+     │  ├╴tests/test_debug.rs:172:10
      │  ├╴15
      │  ├╴14
      │  ├╴10
@@ -65,7 +65,7 @@ Context A
      │      ╰╴backtrace with [n] frames (4)
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:185:10
+     │  ├╴tests/test_debug.rs:182:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
@@ -76,13 +76,13 @@ Context A
      │      ╰╴backtrace with [n] frames (5)
      │
      ╰▶ Context A
-        ├╴tests/test_debug.rs:181:10
+        ├╴tests/test_debug.rs:178:10
         ├╴12
         ├╴9
         ├╴8
         │
         ├─▶ Context A
-        │   ╰╴tests/test_debug.rs:180:10
+        │   ╰╴tests/test_debug.rs:177:10
         │
         ╰─▶ Root error
             ├╴tests/common.rs:147:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace-backtrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace-backtrace.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 Context A
-|-at tests/test_debug.rs:217:10
+|-at tests/test_debug.rs:214:10
 |-2
 |-1
 |
 |-> Context A
- |  |-at tests/test_debug.rs:211:10
+ |  |-at tests/test_debug.rs:208:10
  |  |-4
  |  |-3
  |  |
@@ -19,16 +19,16 @@ Context A
  |      |-backtrace with [n] frames (1)
  |
  |> Context A
-    |-at tests/test_debug.rs:206:10
+    |-at tests/test_debug.rs:203:10
     |-5
     |-3
     |
     |-> Context A
-    |   |-at tests/test_debug.rs:204:10
+    |   |-at tests/test_debug.rs:201:10
     |   |-7
     |
     |-> Context A
-     |  |-at tests/test_debug.rs:195:34
+     |  |-at tests/test_debug.rs:192:34
      |  |-9
      |  |-8
      |  |
@@ -38,7 +38,7 @@ Context A
      |      |-backtrace with [n] frames (2)
      |
      |> Context A
-     |  |-at tests/test_debug.rs:189:10
+     |  |-at tests/test_debug.rs:186:10
      |  |-13
      |  |-10
      |  |-16
@@ -51,7 +51,7 @@ Context A
      |      |-backtrace with [n] frames (3)
      |
      |> Context A
-     |  |-at tests/test_debug.rs:175:10
+     |  |-at tests/test_debug.rs:172:10
      |  |-15
      |  |-14
      |  |-10
@@ -65,7 +65,7 @@ Context A
      |      |-backtrace with [n] frames (4)
      |
      |> Context A
-     |  |-at tests/test_debug.rs:185:10
+     |  |-at tests/test_debug.rs:182:10
      |  |-11
      |  |-9
      |  |-8
@@ -76,13 +76,13 @@ Context A
      |      |-backtrace with [n] frames (5)
      |
      |> Context A
-        |-at tests/test_debug.rs:181:10
+        |-at tests/test_debug.rs:178:10
         |-12
         |-9
         |-8
         |
         |-> Context A
-        |   |-at tests/test_debug.rs:180:10
+        |   |-at tests/test_debug.rs:177:10
         |
         |-> Root error
             |-at tests/common.rs:147:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace-pretty-print.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace-pretty-print.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 Context A
-├╴tests/test_debug.rs:217:10
+├╴tests/test_debug.rs:214:10
 ├╴2
 ├╴1
 │
 ╰┬▶ Context A
- │  ├╴tests/test_debug.rs:211:10
+ │  ├╴tests/test_debug.rs:208:10
  │  ├╴4
  │  ├╴3
  │  │
@@ -18,16 +18,16 @@ Context A
  │      ╰╴spantrace with 2 frames (1)
  │
  ╰▶ Context A
-    ├╴tests/test_debug.rs:206:10
+    ├╴tests/test_debug.rs:203:10
     ├╴5
     ├╴3
     │
     ├─▶ Context A
-    │   ├╴tests/test_debug.rs:204:10
+    │   ├╴tests/test_debug.rs:201:10
     │   ╰╴7
     │
     ╰┬▶ Context A
-     │  ├╴tests/test_debug.rs:195:34
+     │  ├╴tests/test_debug.rs:192:34
      │  ├╴9
      │  ├╴8
      │  │
@@ -36,7 +36,7 @@ Context A
      │      ╰╴spantrace with 2 frames (2)
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:189:10
+     │  ├╴tests/test_debug.rs:186:10
      │  ├╴13
      │  ├╴10
      │  ├╴16
@@ -48,7 +48,7 @@ Context A
      │      ╰╴spantrace with 2 frames (3)
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:175:10
+     │  ├╴tests/test_debug.rs:172:10
      │  ├╴15
      │  ├╴14
      │  ├╴10
@@ -61,7 +61,7 @@ Context A
      │      ╰╴spantrace with 2 frames (4)
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:185:10
+     │  ├╴tests/test_debug.rs:182:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
@@ -71,13 +71,13 @@ Context A
      │      ╰╴spantrace with 2 frames (5)
      │
      ╰▶ Context A
-        ├╴tests/test_debug.rs:181:10
+        ├╴tests/test_debug.rs:178:10
         ├╴12
         ├╴9
         ├╴8
         │
         ├─▶ Context A
-        │   ╰╴tests/test_debug.rs:180:10
+        │   ╰╴tests/test_debug.rs:177:10
         │
         ╰─▶ Root error
             ├╴tests/common.rs:147:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 Context A
-|-at tests/test_debug.rs:217:10
+|-at tests/test_debug.rs:214:10
 |-2
 |-1
 |
 |-> Context A
- |  |-at tests/test_debug.rs:211:10
+ |  |-at tests/test_debug.rs:208:10
  |  |-4
  |  |-3
  |  |
@@ -18,16 +18,16 @@ Context A
  |      |-spantrace with 2 frames (1)
  |
  |> Context A
-    |-at tests/test_debug.rs:206:10
+    |-at tests/test_debug.rs:203:10
     |-5
     |-3
     |
     |-> Context A
-    |   |-at tests/test_debug.rs:204:10
+    |   |-at tests/test_debug.rs:201:10
     |   |-7
     |
     |-> Context A
-     |  |-at tests/test_debug.rs:195:34
+     |  |-at tests/test_debug.rs:192:34
      |  |-9
      |  |-8
      |  |
@@ -36,7 +36,7 @@ Context A
      |      |-spantrace with 2 frames (2)
      |
      |> Context A
-     |  |-at tests/test_debug.rs:189:10
+     |  |-at tests/test_debug.rs:186:10
      |  |-13
      |  |-10
      |  |-16
@@ -48,7 +48,7 @@ Context A
      |      |-spantrace with 2 frames (3)
      |
      |> Context A
-     |  |-at tests/test_debug.rs:175:10
+     |  |-at tests/test_debug.rs:172:10
      |  |-15
      |  |-14
      |  |-10
@@ -61,7 +61,7 @@ Context A
      |      |-spantrace with 2 frames (4)
      |
      |> Context A
-     |  |-at tests/test_debug.rs:185:10
+     |  |-at tests/test_debug.rs:182:10
      |  |-11
      |  |-9
      |  |-8
@@ -71,13 +71,13 @@ Context A
      |      |-spantrace with 2 frames (5)
      |
      |> Context A
-        |-at tests/test_debug.rs:181:10
+        |-at tests/test_debug.rs:178:10
         |-12
         |-9
         |-8
         |
         |-> Context A
-        |   |-at tests/test_debug.rs:180:10
+        |   |-at tests/test_debug.rs:177:10
         |
         |-> Root error
             |-at tests/common.rs:147:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 Context A
-|-at tests/test_debug.rs:217:10
+|-at tests/test_debug.rs:214:10
 |-2
 |-1
 |
 |-> Context A
- |  |-at tests/test_debug.rs:211:10
+ |  |-at tests/test_debug.rs:208:10
  |  |-4
  |  |-3
  |  |
@@ -17,16 +17,16 @@ Context A
  |      |-6
  |
  |> Context A
-    |-at tests/test_debug.rs:206:10
+    |-at tests/test_debug.rs:203:10
     |-5
     |-3
     |
     |-> Context A
-    |   |-at tests/test_debug.rs:204:10
+    |   |-at tests/test_debug.rs:201:10
     |   |-7
     |
     |-> Context A
-     |  |-at tests/test_debug.rs:195:34
+     |  |-at tests/test_debug.rs:192:34
      |  |-9
      |  |-8
      |  |
@@ -34,7 +34,7 @@ Context A
      |      |-at tests/common.rs:147:5
      |
      |> Context A
-     |  |-at tests/test_debug.rs:189:10
+     |  |-at tests/test_debug.rs:186:10
      |  |-13
      |  |-10
      |  |-16
@@ -45,7 +45,7 @@ Context A
      |      |-at tests/common.rs:147:5
      |
      |> Context A
-     |  |-at tests/test_debug.rs:175:10
+     |  |-at tests/test_debug.rs:172:10
      |  |-15
      |  |-14
      |  |-10
@@ -57,7 +57,7 @@ Context A
      |      |-at tests/common.rs:147:5
      |
      |> Context A
-     |  |-at tests/test_debug.rs:185:10
+     |  |-at tests/test_debug.rs:182:10
      |  |-11
      |  |-9
      |  |-8
@@ -66,13 +66,13 @@ Context A
      |      |-at tests/common.rs:147:5
      |
      |> Context A
-        |-at tests/test_debug.rs:181:10
+        |-at tests/test_debug.rs:178:10
         |-12
         |-9
         |-8
         |
         |-> Context A
-        |   |-at tests/test_debug.rs:180:10
+        |   |-at tests/test_debug.rs:177:10
         |
         |-> Root error
             |-at tests/common.rs:147:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@backtrace-pretty-print.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@backtrace-pretty-print.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 Context A
-├╴tests/test_debug.rs:217:10
+├╴tests/test_debug.rs:214:10
 ├╴2
 ├╴1
 │
 ╰┬▶ Context A
- │  ├╴tests/test_debug.rs:211:10
+ │  ├╴tests/test_debug.rs:208:10
  │  ├╴4
  │  ├╴3
  │  │
@@ -18,16 +18,16 @@ Context A
  │      ╰╴backtrace with [n] frames (1)
  │
  ╰▶ Context A
-    ├╴tests/test_debug.rs:206:10
+    ├╴tests/test_debug.rs:203:10
     ├╴5
     ├╴3
     │
     ├─▶ Context A
-    │   ├╴tests/test_debug.rs:204:10
+    │   ├╴tests/test_debug.rs:201:10
     │   ╰╴7
     │
     ╰┬▶ Context A
-     │  ├╴tests/test_debug.rs:195:34
+     │  ├╴tests/test_debug.rs:192:34
      │  ├╴9
      │  ├╴8
      │  │
@@ -36,7 +36,7 @@ Context A
      │      ╰╴backtrace with [n] frames (2)
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:189:10
+     │  ├╴tests/test_debug.rs:186:10
      │  ├╴13
      │  ├╴10
      │  ├╴16
@@ -48,7 +48,7 @@ Context A
      │      ╰╴backtrace with [n] frames (3)
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:175:10
+     │  ├╴tests/test_debug.rs:172:10
      │  ├╴15
      │  ├╴14
      │  ├╴10
@@ -61,7 +61,7 @@ Context A
      │      ╰╴backtrace with [n] frames (4)
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:185:10
+     │  ├╴tests/test_debug.rs:182:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
@@ -71,13 +71,13 @@ Context A
      │      ╰╴backtrace with [n] frames (5)
      │
      ╰▶ Context A
-        ├╴tests/test_debug.rs:181:10
+        ├╴tests/test_debug.rs:178:10
         ├╴12
         ├╴9
         ├╴8
         │
         ├─▶ Context A
-        │   ╰╴tests/test_debug.rs:180:10
+        │   ╰╴tests/test_debug.rs:177:10
         │
         ╰─▶ Root error
             ├╴tests/common.rs:147:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@backtrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@backtrace.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 Context A
-|-at tests/test_debug.rs:217:10
+|-at tests/test_debug.rs:214:10
 |-2
 |-1
 |
 |-> Context A
- |  |-at tests/test_debug.rs:211:10
+ |  |-at tests/test_debug.rs:208:10
  |  |-4
  |  |-3
  |  |
@@ -18,16 +18,16 @@ Context A
  |      |-backtrace with [n] frames (1)
  |
  |> Context A
-    |-at tests/test_debug.rs:206:10
+    |-at tests/test_debug.rs:203:10
     |-5
     |-3
     |
     |-> Context A
-    |   |-at tests/test_debug.rs:204:10
+    |   |-at tests/test_debug.rs:201:10
     |   |-7
     |
     |-> Context A
-     |  |-at tests/test_debug.rs:195:34
+     |  |-at tests/test_debug.rs:192:34
      |  |-9
      |  |-8
      |  |
@@ -36,7 +36,7 @@ Context A
      |      |-backtrace with [n] frames (2)
      |
      |> Context A
-     |  |-at tests/test_debug.rs:189:10
+     |  |-at tests/test_debug.rs:186:10
      |  |-13
      |  |-10
      |  |-16
@@ -48,7 +48,7 @@ Context A
      |      |-backtrace with [n] frames (3)
      |
      |> Context A
-     |  |-at tests/test_debug.rs:175:10
+     |  |-at tests/test_debug.rs:172:10
      |  |-15
      |  |-14
      |  |-10
@@ -61,7 +61,7 @@ Context A
      |      |-backtrace with [n] frames (4)
      |
      |> Context A
-     |  |-at tests/test_debug.rs:185:10
+     |  |-at tests/test_debug.rs:182:10
      |  |-11
      |  |-9
      |  |-8
@@ -71,13 +71,13 @@ Context A
      |      |-backtrace with [n] frames (5)
      |
      |> Context A
-        |-at tests/test_debug.rs:181:10
+        |-at tests/test_debug.rs:178:10
         |-12
         |-9
         |-8
         |
         |-> Context A
-        |   |-at tests/test_debug.rs:180:10
+        |   |-at tests/test_debug.rs:177:10
         |
         |-> Root error
             |-at tests/common.rs:147:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@pretty-print.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@pretty-print.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 Context A
-├╴tests/test_debug.rs:217:10
+├╴tests/test_debug.rs:214:10
 ├╴2
 ├╴1
 │
 ╰┬▶ Context A
- │  ├╴tests/test_debug.rs:211:10
+ │  ├╴tests/test_debug.rs:208:10
  │  ├╴4
  │  ├╴3
  │  │
@@ -17,16 +17,16 @@ Context A
  │      ╰╴6
  │
  ╰▶ Context A
-    ├╴tests/test_debug.rs:206:10
+    ├╴tests/test_debug.rs:203:10
     ├╴5
     ├╴3
     │
     ├─▶ Context A
-    │   ├╴tests/test_debug.rs:204:10
+    │   ├╴tests/test_debug.rs:201:10
     │   ╰╴7
     │
     ╰┬▶ Context A
-     │  ├╴tests/test_debug.rs:195:34
+     │  ├╴tests/test_debug.rs:192:34
      │  ├╴9
      │  ├╴8
      │  │
@@ -34,7 +34,7 @@ Context A
      │      ╰╴tests/common.rs:147:5
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:189:10
+     │  ├╴tests/test_debug.rs:186:10
      │  ├╴13
      │  ├╴10
      │  ├╴16
@@ -45,7 +45,7 @@ Context A
      │      ╰╴tests/common.rs:147:5
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:175:10
+     │  ├╴tests/test_debug.rs:172:10
      │  ├╴15
      │  ├╴14
      │  ├╴10
@@ -57,7 +57,7 @@ Context A
      │      ╰╴tests/common.rs:147:5
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:185:10
+     │  ├╴tests/test_debug.rs:182:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
@@ -66,13 +66,13 @@ Context A
      │      ╰╴tests/common.rs:147:5
      │
      ╰▶ Context A
-        ├╴tests/test_debug.rs:181:10
+        ├╴tests/test_debug.rs:178:10
         ├╴12
         ├╴9
         ├╴8
         │
         ├─▶ Context A
-        │   ╰╴tests/test_debug.rs:180:10
+        │   ╰╴tests/test_debug.rs:177:10
         │
         ╰─▶ Root error
             ╰╴tests/common.rs:147:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace-backtrace-pretty-print.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace-backtrace-pretty-print.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 Context A
-├╴tests/test_debug.rs:217:10
+├╴tests/test_debug.rs:214:10
 ├╴2
 ├╴1
 │
 ╰┬▶ Context A
- │  ├╴tests/test_debug.rs:211:10
+ │  ├╴tests/test_debug.rs:208:10
  │  ├╴4
  │  ├╴3
  │  │
@@ -19,16 +19,16 @@ Context A
  │      ╰╴backtrace with [n] frames (1)
  │
  ╰▶ Context A
-    ├╴tests/test_debug.rs:206:10
+    ├╴tests/test_debug.rs:203:10
     ├╴5
     ├╴3
     │
     ├─▶ Context A
-    │   ├╴tests/test_debug.rs:204:10
+    │   ├╴tests/test_debug.rs:201:10
     │   ╰╴7
     │
     ╰┬▶ Context A
-     │  ├╴tests/test_debug.rs:195:34
+     │  ├╴tests/test_debug.rs:192:34
      │  ├╴9
      │  ├╴8
      │  │
@@ -38,7 +38,7 @@ Context A
      │      ╰╴backtrace with [n] frames (2)
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:189:10
+     │  ├╴tests/test_debug.rs:186:10
      │  ├╴13
      │  ├╴10
      │  ├╴16
@@ -51,7 +51,7 @@ Context A
      │      ╰╴backtrace with [n] frames (3)
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:175:10
+     │  ├╴tests/test_debug.rs:172:10
      │  ├╴15
      │  ├╴14
      │  ├╴10
@@ -65,7 +65,7 @@ Context A
      │      ╰╴backtrace with [n] frames (4)
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:185:10
+     │  ├╴tests/test_debug.rs:182:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
@@ -76,13 +76,13 @@ Context A
      │      ╰╴backtrace with [n] frames (5)
      │
      ╰▶ Context A
-        ├╴tests/test_debug.rs:181:10
+        ├╴tests/test_debug.rs:178:10
         ├╴12
         ├╴9
         ├╴8
         │
         ├─▶ Context A
-        │   ╰╴tests/test_debug.rs:180:10
+        │   ╰╴tests/test_debug.rs:177:10
         │
         ╰─▶ Root error
             ├╴tests/common.rs:147:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace-backtrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace-backtrace.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 Context A
-|-at tests/test_debug.rs:217:10
+|-at tests/test_debug.rs:214:10
 |-2
 |-1
 |
 |-> Context A
- |  |-at tests/test_debug.rs:211:10
+ |  |-at tests/test_debug.rs:208:10
  |  |-4
  |  |-3
  |  |
@@ -19,16 +19,16 @@ Context A
  |      |-backtrace with [n] frames (1)
  |
  |> Context A
-    |-at tests/test_debug.rs:206:10
+    |-at tests/test_debug.rs:203:10
     |-5
     |-3
     |
     |-> Context A
-    |   |-at tests/test_debug.rs:204:10
+    |   |-at tests/test_debug.rs:201:10
     |   |-7
     |
     |-> Context A
-     |  |-at tests/test_debug.rs:195:34
+     |  |-at tests/test_debug.rs:192:34
      |  |-9
      |  |-8
      |  |
@@ -38,7 +38,7 @@ Context A
      |      |-backtrace with [n] frames (2)
      |
      |> Context A
-     |  |-at tests/test_debug.rs:189:10
+     |  |-at tests/test_debug.rs:186:10
      |  |-13
      |  |-10
      |  |-16
@@ -51,7 +51,7 @@ Context A
      |      |-backtrace with [n] frames (3)
      |
      |> Context A
-     |  |-at tests/test_debug.rs:175:10
+     |  |-at tests/test_debug.rs:172:10
      |  |-15
      |  |-14
      |  |-10
@@ -65,7 +65,7 @@ Context A
      |      |-backtrace with [n] frames (4)
      |
      |> Context A
-     |  |-at tests/test_debug.rs:185:10
+     |  |-at tests/test_debug.rs:182:10
      |  |-11
      |  |-9
      |  |-8
@@ -76,13 +76,13 @@ Context A
      |      |-backtrace with [n] frames (5)
      |
      |> Context A
-        |-at tests/test_debug.rs:181:10
+        |-at tests/test_debug.rs:178:10
         |-12
         |-9
         |-8
         |
         |-> Context A
-        |   |-at tests/test_debug.rs:180:10
+        |   |-at tests/test_debug.rs:177:10
         |
         |-> Root error
             |-at tests/common.rs:147:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace-pretty-print.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace-pretty-print.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 Context A
-├╴tests/test_debug.rs:217:10
+├╴tests/test_debug.rs:214:10
 ├╴2
 ├╴1
 │
 ╰┬▶ Context A
- │  ├╴tests/test_debug.rs:211:10
+ │  ├╴tests/test_debug.rs:208:10
  │  ├╴4
  │  ├╴3
  │  │
@@ -18,16 +18,16 @@ Context A
  │      ╰╴spantrace with 2 frames (1)
  │
  ╰▶ Context A
-    ├╴tests/test_debug.rs:206:10
+    ├╴tests/test_debug.rs:203:10
     ├╴5
     ├╴3
     │
     ├─▶ Context A
-    │   ├╴tests/test_debug.rs:204:10
+    │   ├╴tests/test_debug.rs:201:10
     │   ╰╴7
     │
     ╰┬▶ Context A
-     │  ├╴tests/test_debug.rs:195:34
+     │  ├╴tests/test_debug.rs:192:34
      │  ├╴9
      │  ├╴8
      │  │
@@ -36,7 +36,7 @@ Context A
      │      ╰╴spantrace with 2 frames (2)
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:189:10
+     │  ├╴tests/test_debug.rs:186:10
      │  ├╴13
      │  ├╴10
      │  ├╴16
@@ -48,7 +48,7 @@ Context A
      │      ╰╴spantrace with 2 frames (3)
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:175:10
+     │  ├╴tests/test_debug.rs:172:10
      │  ├╴15
      │  ├╴14
      │  ├╴10
@@ -61,7 +61,7 @@ Context A
      │      ╰╴spantrace with 2 frames (4)
      │
      ├▶ Context A
-     │  ├╴tests/test_debug.rs:185:10
+     │  ├╴tests/test_debug.rs:182:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
@@ -71,13 +71,13 @@ Context A
      │      ╰╴spantrace with 2 frames (5)
      │
      ╰▶ Context A
-        ├╴tests/test_debug.rs:181:10
+        ├╴tests/test_debug.rs:178:10
         ├╴12
         ├╴9
         ├╴8
         │
         ├─▶ Context A
-        │   ╰╴tests/test_debug.rs:180:10
+        │   ╰╴tests/test_debug.rs:177:10
         │
         ╰─▶ Root error
             ├╴tests/common.rs:147:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 Context A
-|-at tests/test_debug.rs:217:10
+|-at tests/test_debug.rs:214:10
 |-2
 |-1
 |
 |-> Context A
- |  |-at tests/test_debug.rs:211:10
+ |  |-at tests/test_debug.rs:208:10
  |  |-4
  |  |-3
  |  |
@@ -18,16 +18,16 @@ Context A
  |      |-spantrace with 2 frames (1)
  |
  |> Context A
-    |-at tests/test_debug.rs:206:10
+    |-at tests/test_debug.rs:203:10
     |-5
     |-3
     |
     |-> Context A
-    |   |-at tests/test_debug.rs:204:10
+    |   |-at tests/test_debug.rs:201:10
     |   |-7
     |
     |-> Context A
-     |  |-at tests/test_debug.rs:195:34
+     |  |-at tests/test_debug.rs:192:34
      |  |-9
      |  |-8
      |  |
@@ -36,7 +36,7 @@ Context A
      |      |-spantrace with 2 frames (2)
      |
      |> Context A
-     |  |-at tests/test_debug.rs:189:10
+     |  |-at tests/test_debug.rs:186:10
      |  |-13
      |  |-10
      |  |-16
@@ -48,7 +48,7 @@ Context A
      |      |-spantrace with 2 frames (3)
      |
      |> Context A
-     |  |-at tests/test_debug.rs:175:10
+     |  |-at tests/test_debug.rs:172:10
      |  |-15
      |  |-14
      |  |-10
@@ -61,7 +61,7 @@ Context A
      |      |-spantrace with 2 frames (4)
      |
      |> Context A
-     |  |-at tests/test_debug.rs:185:10
+     |  |-at tests/test_debug.rs:182:10
      |  |-11
      |  |-9
      |  |-8
@@ -71,13 +71,13 @@ Context A
      |      |-spantrace with 2 frames (5)
      |
      |> Context A
-        |-at tests/test_debug.rs:181:10
+        |-at tests/test_debug.rs:178:10
         |-12
         |-9
         |-8
         |
         |-> Context A
-        |   |-at tests/test_debug.rs:180:10
+        |   |-at tests/test_debug.rs:177:10
         |
         |-> Root error
             |-at tests/common.rs:147:5

--- a/packages/libs/error-stack/tests/test_attach.rs
+++ b/packages/libs/error-stack/tests/test_attach.rs
@@ -1,8 +1,5 @@
 #![cfg_attr(nightly, feature(provide_any))]
-#![cfg_attr(
-    all(nightly, feature = "std"),
-    feature(backtrace, error_generic_member_access)
-)]
+#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
 
 #[macro_use]
 mod common;

--- a/packages/libs/error-stack/tests/test_attach_printable.rs
+++ b/packages/libs/error-stack/tests/test_attach_printable.rs
@@ -1,8 +1,5 @@
 #![cfg_attr(nightly, feature(provide_any))]
-#![cfg_attr(
-    all(nightly, feature = "std"),
-    feature(backtrace, error_generic_member_access)
-)]
+#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
 
 #[macro_use]
 mod common;

--- a/packages/libs/error-stack/tests/test_backtrace.rs
+++ b/packages/libs/error-stack/tests/test_backtrace.rs
@@ -1,5 +1,5 @@
 #![cfg(all(feature = "std", nightly))]
-#![feature(provide_any, backtrace, backtrace_frames, error_generic_member_access)]
+#![feature(provide_any, backtrace_frames, error_generic_member_access)]
 
 mod common;
 

--- a/packages/libs/error-stack/tests/test_change_context.rs
+++ b/packages/libs/error-stack/tests/test_change_context.rs
@@ -1,8 +1,5 @@
 #![cfg_attr(nightly, feature(provide_any))]
-#![cfg_attr(
-    all(nightly, feature = "std"),
-    feature(backtrace, error_generic_member_access)
-)]
+#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
 
 #[macro_use]
 mod common;

--- a/packages/libs/error-stack/tests/test_compatibility.rs
+++ b/packages/libs/error-stack/tests/test_compatibility.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(nightly, feature(provide_any))]
 #![cfg_attr(
     all(nightly, feature = "std"),
-    feature(backtrace, backtrace_frames, error_generic_member_access)
+    feature(backtrace_frames, error_generic_member_access)
 )]
 #![cfg(any(feature = "eyre", feature = "anyhow"))]
 

--- a/packages/libs/error-stack/tests/test_conversion.rs
+++ b/packages/libs/error-stack/tests/test_conversion.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "std")]
-#![cfg_attr(nightly, feature(provide_any, backtrace, error_generic_member_access))]
+#![cfg_attr(nightly, feature(provide_any, error_generic_member_access))]
 
 use std::io;
 

--- a/packages/libs/error-stack/tests/test_debug.rs
+++ b/packages/libs/error-stack/tests/test_debug.rs
@@ -2,10 +2,7 @@
 // can be considered safe, because we only check the output, which in itself does not use **any**
 // unsafe code.
 #![cfg(not(miri))]
-#![cfg_attr(
-    all(nightly, feature = "std"),
-    feature(backtrace, error_generic_member_access)
-)]
+#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
 
 mod common;
 use common::*;

--- a/packages/libs/error-stack/tests/test_display.rs
+++ b/packages/libs/error-stack/tests/test_display.rs
@@ -1,8 +1,5 @@
 #![cfg_attr(nightly, feature(provide_any))]
-#![cfg_attr(
-    all(nightly, feature = "std"),
-    feature(backtrace, error_generic_member_access)
-)]
+#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
 
 mod common;
 

--- a/packages/libs/error-stack/tests/test_downcast.rs
+++ b/packages/libs/error-stack/tests/test_downcast.rs
@@ -1,8 +1,5 @@
 #![cfg_attr(nightly, feature(provide_any))]
-#![cfg_attr(
-    all(nightly, feature = "std"),
-    feature(backtrace, error_generic_member_access)
-)]
+#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
 
 mod common;
 

--- a/packages/libs/error-stack/tests/test_extend.rs
+++ b/packages/libs/error-stack/tests/test_extend.rs
@@ -1,8 +1,5 @@
 #![cfg_attr(nightly, feature(provide_any))]
-#![cfg_attr(
-    all(nightly, feature = "std"),
-    feature(backtrace, error_generic_member_access)
-)]
+#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
 
 mod common;
 use core::fmt::{Display, Formatter};

--- a/packages/libs/error-stack/tests/test_frame.rs
+++ b/packages/libs/error-stack/tests/test_frame.rs
@@ -1,6 +1,6 @@
 #![cfg(nightly)]
 #![feature(provide_any)]
-#![cfg_attr(feature = "std", feature(backtrace, error_generic_member_access))]
+#![cfg_attr(feature = "std", feature(error_generic_member_access))]
 
 mod common;
 

--- a/packages/libs/error-stack/tests/test_hooks.rs
+++ b/packages/libs/error-stack/tests/test_hooks.rs
@@ -1,9 +1,6 @@
 #![cfg(feature = "std")]
 #![cfg_attr(nightly, feature(provide_any))]
-#![cfg_attr(
-    all(nightly, feature = "std"),
-    feature(backtrace, error_generic_member_access)
-)]
+#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
 
 mod common;
 

--- a/packages/libs/error-stack/tests/test_iter.rs
+++ b/packages/libs/error-stack/tests/test_iter.rs
@@ -1,8 +1,5 @@
 #![cfg_attr(nightly, feature(provide_any))]
-#![cfg_attr(
-    all(nightly, feature = "std"),
-    feature(backtrace, error_generic_member_access)
-)]
+#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
 
 extern crate alloc;
 

--- a/packages/libs/error-stack/tests/test_macros.rs
+++ b/packages/libs/error-stack/tests/test_macros.rs
@@ -1,8 +1,5 @@
 #![cfg_attr(nightly, feature(provide_any))]
-#![cfg_attr(
-    all(nightly, feature = "std"),
-    feature(backtrace, error_generic_member_access)
-)]
+#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
 
 mod common;
 

--- a/packages/libs/error-stack/tests/test_provision.rs
+++ b/packages/libs/error-stack/tests/test_provision.rs
@@ -1,6 +1,6 @@
 #![cfg(nightly)]
 #![feature(provide_any)]
-#![cfg_attr(feature = "std", feature(backtrace, error_generic_member_access))]
+#![cfg_attr(feature = "std", feature(error_generic_member_access))]
 
 mod common;
 

--- a/packages/libs/error-stack/tests/test_span_trace.rs
+++ b/packages/libs/error-stack/tests/test_span_trace.rs
@@ -1,9 +1,6 @@
 #![cfg(feature = "spantrace")]
 #![cfg_attr(nightly, feature(provide_any))]
-#![cfg_attr(
-    all(nightly, feature = "std"),
-    feature(backtrace, error_generic_member_access)
-)]
+#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
 
 mod common;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In a recent toolchain `backtrace` was stabilized. To avoid warnings on no longer required attributes we compile the crate with a more recent version.

## 🔍 What does this change?

- Bump toolchain to `nightly-2022-08-19`
- Remove the `backtrace` feature
- Drive-by: Fix duplicated toolchains
- Drive-by: Don't run all packages on toolchain changes, since we #943 it's not needed anymore