### PR TITLE
Add badges to crate documentation

### DIFF
--- a/packages/libs/error-stack/README.md
+++ b/packages/libs/error-stack/README.md
@@ -8,7 +8,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/error-stack)][crates.io]
 [![libs.rs](https://img.shields.io/badge/libs.rs-error--stack-orange)][libs.rs]
-[![rust-version](https://img.shields.io/badge/Rust-1.63.0-orange)][rust-version]
+[![rust-version](https://img.shields.io/badge/Rust-1.63.0/nightly--2022--08--08-blue)][rust-version]
 [![documentation](https://img.shields.io/docsrs/error-stack)][documentation]
 [![license](https://img.shields.io/crates/l/error-stack)][license]
 [![discord](https://img.shields.io/discord/840573247803097118)][discord]

--- a/packages/libs/error-stack/rust-toolchain.toml
+++ b/packages/libs/error-stack/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
+# Please also update the badges in `README.md` and `src/lib.rs`
 channel = "nightly-2022-08-08"

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -1,5 +1,15 @@
 //! A context-aware error library with arbitrary attached user data.
 //!
+//! [![crates.io](https://img.shields.io/crates/v/error-stack)][crates.io]
+//! [![libs.rs](https://img.shields.io/badge/libs.rs-error--stack-orange)][libs.rs]
+//! [![rust-version](https://img.shields.io/badge/Rust-1.63.0/nightly--2022--08--08-blue)][rust-version]
+//! [![discord](https://img.shields.io/discord/840573247803097118)][discord]
+//!
+//! [crates.io]: https://crates.io/crates/error-stack
+//! [libs.rs]: https://lib.rs/crates/error-stack
+//! [rust-version]: https://www.rust-lang.org
+//! [discord]: https://hash.ai/discord?utm_medium=organic&utm_source=github_readme_hash-repo_error-stack
+//!
 //! # Overview
 //!
 //! `error-stack` is an error-handling library centered around the idea of building a [`Report`] of


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

With `error-stack` v0.1 our MSRV is `1.61`, but with v0.2 it will be bumped to `1.63`. When looking at the [documentation](https://docs.rs/error-stack/latest/error_stack) it's not possible to determine the MSRV for the current version. Looking at the repository is misleading because it only captures the most recent MSRV.

## 🔗 Related links

[Asana Task](https://app.asana.com/0/1200211978612931/1202829737531477/f) (_internal_)

## 🔍 What does this change?

- Extend MSRV badge by the current nightly version we use for testing
- Add badges to crate-level documentation

## 🎥  Demo

<img width="978" alt="image" src="https://user-images.githubusercontent.com/21277928/185743093-e9ab9bfa-45d0-4371-8ce5-0d857ab1175a.png">
