### PR TITLE
Change `error-stack` `pub(crate)` lints

### DIFF
--- a/packages/libs/error-stack/src/context.rs
+++ b/packages/libs/error-stack/src/context.rs
@@ -90,7 +90,7 @@ where
 // be implemented on `Error`. For `request`ing a type from `Context`, we need a `Provider`
 // implementation however.
 #[cfg(all(nightly, any(feature = "std", feature = "spantrace")))]
-pub fn temporary_provider(context: &impl Context) -> impl Provider + '_ {
+pub(crate) fn temporary_provider(context: &impl Context) -> impl Provider + '_ {
     struct ProviderImpl<'a, C>(&'a C);
     impl<C: Context> Provider for ProviderImpl<'_, C> {
         fn provide<'a>(&'a self, demand: &mut Demand<'a>) {

--- a/packages/libs/error-stack/src/ext/mod.rs
+++ b/packages/libs/error-stack/src/ext/mod.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "futures")]
 pub mod future;
+// false positive, is imported in `lib.rs`
+#[allow(unreachable_pub)]
 pub mod iter;
 mod result;
 #[cfg(feature = "futures")]

--- a/packages/libs/error-stack/src/fmt/hook.rs
+++ b/packages/libs/error-stack/src/fmt/hook.rs
@@ -1,7 +1,7 @@
 // We allow dead-code here, because some of the functions are only exposed when `feature = "hooks"`
 // we could do cfg for everything, but that gets very messy, instead we only use a subset
 // and enable deadcode on `feature = "std"`.
-#![cfg_attr(not(feature = "std"), allow(dead_code))]
+#![cfg_attr(not(feature = "std"), allow(dead_code, unreachable_pub))]
 
 use alloc::{boxed::Box, collections::BTreeMap, string::String, vec::Vec};
 use core::{

--- a/packages/libs/error-stack/src/fmt/hook.rs
+++ b/packages/libs/error-stack/src/fmt/hook.rs
@@ -14,7 +14,7 @@ pub use default::builtin_debug_hook_fallback;
 use crate::fmt::{Emit, Frame};
 
 #[derive(Default)]
-pub struct HookContextImpl {
+pub(crate) struct HookContextImpl {
     pub(crate) snippets: Vec<String>,
     alternate: bool,
 

--- a/packages/libs/error-stack/src/fmt/hook.rs
+++ b/packages/libs/error-stack/src/fmt/hook.rs
@@ -4,7 +4,7 @@
 #![cfg_attr(not(feature = "std"), allow(dead_code))]
 // We allow `unreachable_pub` on no-std, because in that case we do not export (`pub`) the
 // structures contained in here, but still use them, otherwise we would need to have two redundant
-// implementation: `pub(crate)` and `pub`, which is silly.
+// implementation: `pub(crate)` and `pub`.
 #![cfg_attr(not(feature = "std"), allow(unreachable_pub))]
 
 use alloc::{boxed::Box, collections::BTreeMap, string::String, vec::Vec};

--- a/packages/libs/error-stack/src/fmt/hook.rs
+++ b/packages/libs/error-stack/src/fmt/hook.rs
@@ -1,7 +1,11 @@
 // We allow dead-code here, because some of the functions are only exposed when `feature = "hooks"`
 // we could do cfg for everything, but that gets very messy, instead we only use a subset
 // and enable deadcode on `feature = "std"`.
-#![cfg_attr(not(feature = "std"), allow(dead_code, unreachable_pub))]
+#![cfg_attr(not(feature = "std"), allow(dead_code))]
+// We allow `unreachable_pub` on no-std, because in that case we do not export (`pub`) the
+// structures contained in here, but still use them, otherwise we would need to have two redundant
+// implementation: `pub(crate)` and `pub`, which is silly.
+#![cfg_attr(not(feature = "std"), allow(unreachable_pub))]
 
 use alloc::{boxed::Box, collections::BTreeMap, string::String, vec::Vec};
 use core::{

--- a/packages/libs/error-stack/src/fmt/mod.rs
+++ b/packages/libs/error-stack/src/fmt/mod.rs
@@ -128,7 +128,7 @@
 //! [`atomic`]: std::sync::atomic
 // This makes sure that `Emit` isn't regarded as dead-code even though it isn't exported on no-std.
 // This just simplifies maintenance, as otherwise we would be in cfg hell.
-#![cfg_attr(not(feature = "std"), allow(dead_code))]
+#![cfg_attr(not(feature = "std"), allow(dead_code, unreachable_pub))]
 
 mod hook;
 #[cfg(feature = "unstable")]

--- a/packages/libs/error-stack/src/fmt/mod.rs
+++ b/packages/libs/error-stack/src/fmt/mod.rs
@@ -128,7 +128,10 @@
 //! [`atomic`]: std::sync::atomic
 // This makes sure that `Emit` isn't regarded as dead-code even though it isn't exported on no-std.
 // This just simplifies maintenance, as otherwise we would be in cfg hell.
-#![cfg_attr(not(feature = "std"), allow(dead_code, unreachable_pub))]
+#![cfg_attr(not(feature = "std"), allow(dead_code))]
+// Makes sure that `Emit` isn't regarded as unreachable even though it isn't exported on no-std.
+// Simplifies maintenance as we don't need to special case the visibility modifier.
+#![cfg_attr(not(feature = "std"), allow(unreachable_pub))]
 
 mod hook;
 #[cfg(feature = "unstable")]

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -449,10 +449,12 @@
 )]
 #![warn(
     missing_docs,
+    unreachable_pub,
     clippy::pedantic,
     clippy::nursery,
     clippy::undocumented_unsafe_blocks
 )]
+#![allow(clippy::redundant_pub_crate)] // This would otherwise clash with `unreachable_pub`
 #![allow(clippy::missing_errors_doc)] // This is an error handling library producing Results, not Errors
 #![allow(clippy::module_name_repetitions)]
 #![cfg_attr(

--- a/packages/libs/error-stack/src/macros.rs
+++ b/packages/libs/error-stack/src/macros.rs
@@ -60,6 +60,8 @@ pub mod __private {
         }
     }
 
+    // false-positive lint
+    #[allow(unreachable_pub)]
     // Import anonymously to allow calling `__kind` but forbid implementing the tag-traits.
     pub use self::specialization::{ContextTag as _, ReportTag as _};
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This is a continuation of https://github.com/hashintel/hash/pull/794#discussion_r950169256, which enables the `unreachable_pub` lint and disables the [`redundant_pub_crate`](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pub_crate) clippy lint.

## 🔗 Related links

* Initial discussion: https://github.com/hashintel/hash/pull/794#discussion_r950169256

## 🔍 What does this change?

This changes which lints we make use of for visibility modifiers in `error-stack`.

## 📜 Does this require a change to the docs?

No

## ⚠️ Known issues

<img width="572" alt="image" src="https://user-images.githubusercontent.com/7252775/185786448-348aa002-7b67-46a5-83c6-c6f1abfb0039.png">

This is a bit weird. As we export those, this could very well be a false positive.

## 🛡 What tests cover this?

`cargo make lint`
