### PR TITLE
Identify paragraph block by its componentId, not name

### DIFF
--- a/packages/blocks/callout/README.md
+++ b/packages/blocks/callout/README.md
@@ -1,3 +1,3 @@
 # Callout block
 
-https://blockprotocol.org/@hash/callout
+A block to call attention to text.

--- a/packages/blocks/embed/README.md
+++ b/packages/blocks/embed/README.md
@@ -1,3 +1,3 @@
 # Embed block
 
-https://blockprotocol.org/@hash/embed
+A block to embed content from third-party sites.

--- a/packages/blocks/header/README.md
+++ b/packages/blocks/header/README.md
@@ -1,3 +1,3 @@
 # Header block
 
-https://blockprotocol.org/@hash/header
+A block to display heading text.

--- a/packages/blocks/paragraph/README.md
+++ b/packages/blocks/paragraph/README.md
@@ -1,3 +1,3 @@
 # Paragraph block
 
-https://blockprotocol.org/@hash/paragraph
+A block to display a paragraph of text.

--- a/packages/hash/frontend/src/blocks/page/createEditorView.ts
+++ b/packages/hash/frontend/src/blocks/page/createEditorView.ts
@@ -148,7 +148,9 @@ export const createEditorView = (
   const blocksArray = Object.values(blocks);
 
   const paragraphBlock = blocksArray.find(
-    (block) => block.meta.name === "@hashintel/block-paragraph",
+    (block) =>
+      block.meta.componentId ===
+      "https://blockprotocol.org/blocks/@hash/paragraph",
   );
 
   if (!paragraphBlock) {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

There's one place in the HASH code where we find the paragraph block by the `name` property in its metadata returned by the API, which at the moment is its `name` in its original source location, i.e. its yarn workspace name (`@hashintel/block-code`).

[This PR](https://github.com/blockprotocol/blockprotocol/pull/509) in `blockprotocol` is setting `name` to be a block's `name` in the Block Protocol hub, not whatever was its `name` in its original package.json, which might be completely unrelated.

We were previously matching the paragraph block based on its name in the original package.json, we will no longer be what is exposed via the BP API. This PR updates it to something that will remain consistent (the `componentId`).

## 🔗 Related links

- https://github.com/blockprotocol/blockprotocol/pull/509
