### PR TITLE
Support filtering for URIs and versions on ontology types

### DIFF
--- a/packages/graph/Makefile.toml
+++ b/packages/graph/Makefile.toml
@@ -69,7 +69,7 @@ command = "yarn"
 args = ["external-services", "down", "${@}"]
 
 [tasks.test-docker]
-run_task = { name = ["graph-up", "test-rest-api", "graph-down"] }
+run_task = { name = ["yarn", "graph-up", "test-rest-api", "graph-down"] }
 
 [tasks.test-rest-api]
 # This is a temporary solution until we have e2e tests in place

--- a/packages/graph/hash_graph/Cargo.lock
+++ b/packages/graph/hash_graph/Cargo.lock
@@ -273,7 +273,9 @@ version = "0.1.1"
 source = "git+https://github.com/hashintel/hash?rev=5edddb5#5edddb5566f9bd82dcdf9ba3b430759bc6b15dc5"
 dependencies = [
  "anyhow",
+ "futures-core",
  "once_cell",
+ "pin-project",
  "rustc_version",
  "smallvec",
  "tracing-error",

--- a/packages/graph/hash_graph/lib/graph/Cargo.toml
+++ b/packages/graph/hash_graph/lib/graph/Cargo.toml
@@ -13,7 +13,7 @@ bb8-postgres = "0.8.1"
 clap = { version = "3.2.10", features = ["derive", "env"], optional = true }
 chrono = { version = "0.4.19", features = ["serde"] }
 # TODO: Change to `version = "0.2"` as soon as it's released
-error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace"] }
+error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace", "futures"] }
 futures = "0.3.21"
 postgres-types = { version = "0.2.3", default-features = false, features = ["derive", "with-uuid-1", "with-serde_json-1", "with-chrono-0_4"] }
 serde = { version = "1.0.137", features = ["derive"] }

--- a/packages/graph/hash_graph/lib/graph/src/store/error.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/error.rs
@@ -14,7 +14,7 @@ impl fmt::Display for InsertionError {
 
 impl Context for InsertionError {}
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[must_use]
 pub struct QueryError;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#909 only covered ontology types with a specific URI + version or all latest types, but no other combinations. This PR adds a more general approach on filtering.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1200211978612931/1202510174412974/f) _(internal)_

## 🔍 What does this change?

- Change the read interface to the database to return all types or only the latest version
- Apply filters in Rust (optimizations can be added later)  

## 📜 Does this require a change to the docs?

This is an internal-only change
