### PR TITLE
Assorted tidy up 

### DIFF
--- a/packages/hash/README.md
+++ b/packages/hash/README.md
@@ -147,6 +147,14 @@ See https://blockprotocol.org/docs/developing-blocks
 
 ## Testing
 
+### Debug mode
+
+Some parts of the UI designed to help with development/debugging are hidden. You can display these elements by running the following in your browser console.
+
+```js
+localStorage["hash.internal.debugging"] = "true";
+```
+
 ### Backend integration tests
 
 Backend integration tests are located in [packages/hash/integration](./packages/hash/integration) folder.

--- a/packages/hash/design-system/src/fontawesome-icon.tsx
+++ b/packages/hash/design-system/src/fontawesome-icon.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import { forwardRef } from "react";
 import { SvgIcon, SvgIconProps } from "@mui/material";
 import { IconDefinition } from "@fortawesome/free-solid-svg-icons";
@@ -5,6 +6,10 @@ import { IconDefinition } from "@fortawesome/free-solid-svg-icons";
 type FontAwesomeIconProps = {
   icon: IconDefinition;
 } & SvgIconProps;
+
+export const fontAwesomeIconClasses = {
+  icon: "FontAwesomeIcon",
+};
 
 // gotten from https://mui.com/components/icons/#font-awesome
 export const FontAwesomeIcon = forwardRef<
@@ -31,6 +36,10 @@ export const FontAwesomeIcon = forwardRef<
         ...(Array.isArray(sx) ? sx : [sx]),
       ]}
       {...otherProps}
+      classes={{
+        ...(otherProps.classes ?? {}),
+        root: clsx(fontAwesomeIconClasses.icon, otherProps.classes?.root),
+      }}
     >
       {typeof svgPathData === "string" ? (
         <path d={svgPathData} />

--- a/packages/hash/frontend/package.json
+++ b/packages/hash/frontend/package.json
@@ -37,6 +37,7 @@
     "@mui/icons-material": "5.4.2",
     "@mui/lab": "5.0.0-alpha.71",
     "@mui/material": "5.4.3",
+    "@mui/system": "5.5.1",
     "@rjsf/core": "4.1.1",
     "@rjsf/material-ui": "4.1.1",
     "@sentry/nextjs": "7.10.0",

--- a/packages/hash/frontend/src/blocks/page/PageBlock.tsx
+++ b/packages/hash/frontend/src/blocks/page/PageBlock.tsx
@@ -33,7 +33,7 @@ export const PageBlock: FunctionComponent<PageBlockProps> = ({
   entityId,
 }) => {
   const root = useRef<HTMLDivElement>(null);
-  const [portals, renderPortal] = usePortals();
+  const [portals, renderPortal, clearPortals] = usePortals();
   const [debugging] = useLocalstorageState<
     { restartCollabButton?: boolean } | boolean
   >("hash.internal.debugging", false);
@@ -76,16 +76,16 @@ export const PageBlock: FunctionComponent<PageBlockProps> = ({
     };
 
     if (readonlyMode) {
-      prosemirrorSetup.current.manager.setReadonlyMode();
+      manager.setReadonlyMode();
     }
 
     return () => {
-      // @todo how does this work with portals?
-      node.innerHTML = "";
+      clearPortals();
+      view.destroy();
+      connection.close();
       prosemirrorSetup.current = null;
-      connection?.close();
     };
-  }, [accountId, blocks, entityId, renderPortal, readonlyMode]);
+  }, [accountId, blocks, entityId, renderPortal, readonlyMode, clearPortals]);
 
   return (
     <UserBlocksProvider value={blocks}>

--- a/packages/hash/frontend/src/components/EmojiPicker/EmojiPicker.tsx
+++ b/packages/hash/frontend/src/components/EmojiPicker/EmojiPicker.tsx
@@ -1,16 +1,28 @@
 import Picker from "@emoji-mart/react";
 import { Popover } from "@hashintel/hash-design-system";
+import { PopoverProps } from "@mui/material";
 import { BaseEmoji } from "emoji-mart";
 import { bindPopover, PopupState } from "material-ui-popup-state/core";
+
+export type EmojiPickerPopoverProps = Omit<
+  PopoverProps,
+  | keyof ReturnType<typeof bindPopover>
+  | "anchorOrigin"
+  | "transformOrigin"
+  | "elevation"
+  | "sx"
+>;
 
 interface EmojiPickerProps {
   onEmojiSelect: (emoji: BaseEmoji) => void;
   popupState: PopupState;
+  popoverProps?: EmojiPickerPopoverProps;
 }
 
 export const EmojiPicker = ({
   onEmojiSelect,
   popupState,
+  popoverProps,
 }: EmojiPickerProps) => {
   return (
     <Popover
@@ -25,10 +37,7 @@ export const EmojiPicker = ({
       }}
       elevation={4}
       sx={{ mt: 1 }}
-      onClick={(evt) => {
-        evt.preventDefault();
-        evt.stopPropagation();
-      }}
+      {...(popoverProps ?? {})}
     >
       <Picker
         autoFocus

--- a/packages/hash/frontend/src/components/EmojiPicker/EmojiPicker.tsx
+++ b/packages/hash/frontend/src/components/EmojiPicker/EmojiPicker.tsx
@@ -25,6 +25,10 @@ export const EmojiPicker = ({
       }}
       elevation={4}
       sx={{ mt: 1 }}
+      onClick={(evt) => {
+        evt.preventDefault();
+        evt.stopPropagation();
+      }}
     >
       <Picker
         autoFocus

--- a/packages/hash/frontend/src/components/PageIcon.tsx
+++ b/packages/hash/frontend/src/components/PageIcon.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@apollo/client";
 import { faFile } from "@fortawesome/free-regular-svg-icons";
-import { FontAwesomeIcon } from "@hashintel/hash-design-system/fontawesome-icon";
+import { FontAwesomeIcon } from "@hashintel/hash-design-system";
 import { getPageInfoQuery } from "@hashintel/hash-shared/queries/page.queries";
 import { Box } from "@mui/material";
 import {

--- a/packages/hash/frontend/src/components/PageIcon.tsx
+++ b/packages/hash/frontend/src/components/PageIcon.tsx
@@ -1,19 +1,14 @@
 import { useQuery } from "@apollo/client";
 import { faFile } from "@fortawesome/free-regular-svg-icons";
-import { FontAwesomeIcon, IconButton } from "@hashintel/hash-design-system";
+import { FontAwesomeIcon } from "@hashintel/hash-design-system/fontawesome-icon";
 import { getPageInfoQuery } from "@hashintel/hash-shared/queries/page.queries";
-import { iconButtonClasses, Tooltip } from "@mui/material";
-import { bindTrigger, usePopupState } from "material-ui-popup-state/hooks";
+import { Box } from "@mui/material";
 import {
   GetPageInfoQuery,
   GetPageInfoQueryVariables,
 } from "../graphql/apiTypes.gen";
-import { rewriteEntityIdentifier } from "../lib/entities";
 
-import { EmojiPicker } from "./EmojiPicker/EmojiPicker";
-import { useBlockProtocolUpdateEntity } from "./hooks/blockProtocolFunctions/useBlockProtocolUpdateEntity";
-
-type SizeVariant = "small" | "medium";
+export type SizeVariant = "small" | "medium";
 
 const variantSizes: Record<SizeVariant, { container: number; font: number }> = {
   small: { container: 20, font: 14 },
@@ -24,27 +19,15 @@ interface PageIconProps {
   accountId: string;
   entityId: string;
   versionId?: string;
-  readonly?: boolean;
   size?: SizeVariant;
-  hasDarkBg?: boolean;
 }
 
 export const PageIcon = ({
   accountId,
   entityId,
   versionId,
-  readonly,
   size = "medium",
-  hasDarkBg,
 }: PageIconProps) => {
-  const popupState = usePopupState({
-    variant: "popover",
-    popupId: "emoji-picker",
-  });
-
-  const { updateEntity, updateEntityLoading } =
-    useBlockProtocolUpdateEntity(true);
-
   const { data } = useQuery<GetPageInfoQuery, GetPageInfoQueryVariables>(
     getPageInfoQuery,
     {
@@ -55,53 +38,25 @@ export const PageIcon = ({
   const sizes = variantSizes[size];
 
   return (
-    <>
-      <Tooltip title="Change icon" placement="bottom">
-        <IconButton
-          {...bindTrigger(popupState)}
-          sx={({ palette }) => {
-            const background = hasDarkBg ? palette.gray[40] : palette.gray[30];
-
-            return {
-              width: sizes.container,
-              height: sizes.container,
-              fontSize: sizes.font,
-              ...(popupState.isOpen && {
-                background,
-              }),
-              "&:focus-visible, &:hover": {
-                background,
-              },
-              [`&.${iconButtonClasses.disabled}`]: { color: "unset" },
-            };
-          }}
-          disabled={readonly || updateEntityLoading}
-        >
-          {data?.page?.properties?.icon || (
-            <FontAwesomeIcon
-              icon={faFile}
-              sx={(theme) => ({
-                fontSize: `${sizes.font}px !important`,
-                color: theme.palette.gray[40],
-              })}
-            />
-          )}
-        </IconButton>
-      </Tooltip>
-      <EmojiPicker
-        popupState={popupState}
-        onEmojiSelect={(emoji) => {
-          void updateEntity({
-            data: {
-              entityId: rewriteEntityIdentifier({
-                accountId,
-                entityId,
-              }),
-              properties: { icon: emoji.native },
-            },
-          });
-        }}
-      />
-    </>
+    <Box
+      sx={{
+        width: sizes.container,
+        height: sizes.container,
+        fontSize: sizes.font,
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
+      {data?.page?.properties?.icon || (
+        <FontAwesomeIcon
+          icon={faFile}
+          sx={(theme) => ({
+            fontSize: `${sizes.font}px !important`,
+            color: theme.palette.gray[40],
+          })}
+        />
+      )}
+    </Box>
   );
 };

--- a/packages/hash/frontend/src/components/PageIconButton.tsx
+++ b/packages/hash/frontend/src/components/PageIconButton.tsx
@@ -1,6 +1,7 @@
 import { IconButton } from "@hashintel/hash-design-system";
 import { iconButtonClasses, Tooltip } from "@mui/material";
 import { bindTrigger, usePopupState } from "material-ui-popup-state/hooks";
+import { MouseEventHandler } from "react";
 import { rewriteEntityIdentifier } from "../lib/entities";
 
 import { EmojiPicker } from "./EmojiPicker/EmojiPicker";
@@ -14,6 +15,7 @@ interface PageIconButtonProps {
   readonly?: boolean;
   size?: SizeVariant;
   hasDarkBg?: boolean;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
 export const PageIconButton = ({
@@ -23,6 +25,7 @@ export const PageIconButton = ({
   readonly,
   size = "medium",
   hasDarkBg,
+  onClick,
 }: PageIconButtonProps) => {
   const popupState = usePopupState({
     variant: "popover",
@@ -32,11 +35,17 @@ export const PageIconButton = ({
   const { updateEntity, updateEntityLoading } =
     useBlockProtocolUpdateEntity(true);
 
+  const trigger = bindTrigger(popupState);
+
   return (
     <>
       <Tooltip title="Change icon" placement="bottom">
         <IconButton
-          {...bindTrigger(popupState)}
+          {...trigger}
+          onClick={(event) => {
+            onClick?.(event);
+            trigger.onClick(event);
+          }}
           sx={({ palette }) => {
             const background = hasDarkBg ? palette.gray[40] : palette.gray[30];
 

--- a/packages/hash/frontend/src/components/PageIconButton.tsx
+++ b/packages/hash/frontend/src/components/PageIconButton.tsx
@@ -8,7 +8,10 @@ import { bindTrigger, usePopupState } from "material-ui-popup-state/hooks";
 import { MouseEventHandler } from "react";
 import { rewriteEntityIdentifier } from "../lib/entities";
 
-import { EmojiPicker } from "./EmojiPicker/EmojiPicker";
+import {
+  EmojiPicker,
+  EmojiPickerPopoverProps,
+} from "./EmojiPicker/EmojiPicker";
 import { useBlockProtocolUpdateEntity } from "./hooks/blockProtocolFunctions/useBlockProtocolUpdateEntity";
 import { PageIcon, SizeVariant } from "./PageIcon";
 
@@ -20,6 +23,7 @@ interface PageIconButtonProps {
   size?: SizeVariant;
   hasDarkBg?: boolean;
   onClick?: MouseEventHandler<HTMLButtonElement>;
+  popoverProps?: EmojiPickerPopoverProps;
 }
 
 export const PageIconButton = ({
@@ -30,6 +34,7 @@ export const PageIconButton = ({
   size = "medium",
   hasDarkBg,
   onClick,
+  popoverProps,
 }: PageIconButtonProps) => {
   const popupState = usePopupState({
     variant: "popover",
@@ -81,6 +86,7 @@ export const PageIconButton = ({
         </IconButton>
       </Tooltip>
       <EmojiPicker
+        popoverProps={popoverProps}
         popupState={popupState}
         onEmojiSelect={(emoji) => {
           void updateEntity({

--- a/packages/hash/frontend/src/components/PageIconButton.tsx
+++ b/packages/hash/frontend/src/components/PageIconButton.tsx
@@ -3,7 +3,7 @@ import {
   IconButton,
 } from "@hashintel/hash-design-system";
 import { iconButtonClasses, Tooltip } from "@mui/material";
-import { SystemStyleObject } from "@mui/system/styleFunctionSx/styleFunctionSx";
+import { SystemStyleObject } from "@mui/system";
 import { bindTrigger, usePopupState } from "material-ui-popup-state/hooks";
 import { MouseEventHandler } from "react";
 import { rewriteEntityIdentifier } from "../lib/entities";

--- a/packages/hash/frontend/src/components/PageIconButton.tsx
+++ b/packages/hash/frontend/src/components/PageIconButton.tsx
@@ -1,0 +1,80 @@
+import { IconButton } from "@hashintel/hash-design-system";
+import { iconButtonClasses, Tooltip } from "@mui/material";
+import { bindTrigger, usePopupState } from "material-ui-popup-state/hooks";
+import { rewriteEntityIdentifier } from "../lib/entities";
+
+import { EmojiPicker } from "./EmojiPicker/EmojiPicker";
+import { useBlockProtocolUpdateEntity } from "./hooks/blockProtocolFunctions/useBlockProtocolUpdateEntity";
+import { PageIcon, SizeVariant } from "./PageIcon";
+
+interface PageIconButtonProps {
+  accountId: string;
+  entityId: string;
+  versionId?: string;
+  readonly?: boolean;
+  size?: SizeVariant;
+  hasDarkBg?: boolean;
+}
+
+export const PageIconButton = ({
+  accountId,
+  entityId,
+  versionId,
+  readonly,
+  size = "medium",
+  hasDarkBg,
+}: PageIconButtonProps) => {
+  const popupState = usePopupState({
+    variant: "popover",
+    popupId: "emoji-picker",
+  });
+
+  const { updateEntity, updateEntityLoading } =
+    useBlockProtocolUpdateEntity(true);
+
+  return (
+    <>
+      <Tooltip title="Change icon" placement="bottom">
+        <IconButton
+          {...bindTrigger(popupState)}
+          sx={({ palette }) => {
+            const background = hasDarkBg ? palette.gray[40] : palette.gray[30];
+
+            return {
+              p: 0,
+              ...(popupState.isOpen && {
+                background,
+              }),
+              "&:focus-visible, &:hover": {
+                background,
+              },
+              [`&.${iconButtonClasses.disabled}`]: { color: "unset" },
+            };
+          }}
+          disabled={readonly || updateEntityLoading}
+        >
+          <PageIcon
+            accountId={accountId}
+            entityId={entityId}
+            versionId={versionId}
+            size={size}
+          />
+        </IconButton>
+      </Tooltip>
+      <EmojiPicker
+        popupState={popupState}
+        onEmojiSelect={(emoji) => {
+          void updateEntity({
+            data: {
+              entityId: rewriteEntityIdentifier({
+                accountId,
+                entityId,
+              }),
+              properties: { icon: emoji.native },
+            },
+          });
+        }}
+      />
+    </>
+  );
+};

--- a/packages/hash/frontend/src/components/PageIconButton.tsx
+++ b/packages/hash/frontend/src/components/PageIconButton.tsx
@@ -1,5 +1,9 @@
-import { IconButton } from "@hashintel/hash-design-system";
+import {
+  fontAwesomeIconClasses,
+  IconButton,
+} from "@hashintel/hash-design-system";
 import { iconButtonClasses, Tooltip } from "@mui/material";
+import { SystemStyleObject } from "@mui/system/styleFunctionSx/styleFunctionSx";
 import { bindTrigger, usePopupState } from "material-ui-popup-state/hooks";
 import { MouseEventHandler } from "react";
 import { rewriteEntityIdentifier } from "../lib/entities";
@@ -49,14 +53,20 @@ export const PageIconButton = ({
           sx={({ palette }) => {
             const background = hasDarkBg ? palette.gray[40] : palette.gray[30];
 
+            const hoverState: SystemStyleObject = {
+              background,
+              ...(hasDarkBg && {
+                [`.${fontAwesomeIconClasses.icon}`]: {
+                  color: palette.gray[50],
+                },
+              }),
+
+              // ""
+            };
             return {
               p: 0,
-              ...(popupState.isOpen && {
-                background,
-              }),
-              "&:focus-visible, &:hover": {
-                background,
-              },
+              ...(popupState.isOpen && hoverState),
+              "&:focus-visible, &:hover": hoverState,
               [`&.${iconButtonClasses.disabled}`]: { color: "unset" },
             };
           }}

--- a/packages/hash/frontend/src/pages/[account-slug]/[page-slug].page.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/[page-slug].page.tsx
@@ -24,6 +24,7 @@ import {
 } from "../../components/hooks/useAccountPages";
 import { useArchivePage } from "../../components/hooks/useArchivePage";
 import { PageIcon } from "../../components/PageIcon";
+import { PageIconButton } from "../../components/PageIconButton";
 import { CollabPositionProvider } from "../../contexts/CollabPositionContext";
 import {
   GetPageInfoQuery,
@@ -309,7 +310,7 @@ const Page: NextPageWithLayout<PageProps> = ({ blocks }) => {
             scrollMarginTop: HEADER_HEIGHT + TOP_CONTEXT_BAR_HEIGHT,
           }}
         >
-          <PageIcon
+          <PageIconButton
             accountId={accountId}
             entityId={pageEntityId}
             versionId={versionId}

--- a/packages/hash/frontend/src/pages/[account-slug]/entities/[entity-id].page.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/entities/[entity-id].page.tsx
@@ -8,7 +8,7 @@ import { useMemo, useRef } from "react";
 
 import { getEntity } from "@hashintel/hash-shared/queries/entity.queries";
 import { Box, styled } from "@mui/material";
-import { FontAwesomeIcon } from "@hashintel/hash-design-system/fontawesome-icon";
+import { FontAwesomeIcon } from "@hashintel/hash-design-system";
 import { faAsterisk } from "@fortawesome/free-solid-svg-icons";
 import { SimpleEntityEditor } from "./shared/simple-entity-editor";
 

--- a/packages/hash/frontend/src/pages/shared/top-context-bar.tsx
+++ b/packages/hash/frontend/src/pages/shared/top-context-bar.tsx
@@ -34,40 +34,6 @@ export const TopContextBar = ({
           scrollToTop={scrollToTop}
         />
       </Box>
-
-      {/*<Box*/}
-      {/*  ml="auto"*/}
-      {/*  alignItems="center"*/}
-      {/*  sx={({ palette }) => ({*/}
-      {/*    display: readonlyMode ? "none" : "flex",*/}
-      {/*    "& > *": {*/}
-      {/*      color: palette.gray[50],*/}
-      {/*      "&:hover": {*/}
-      {/*        color: palette.gray[70],*/}
-      {/*      },*/}
-      {/*    },*/}
-      {/*  })}*/}
-      {/*>*/}
-      {/*  <Button variant="tertiary_quiet" size="xs">*/}
-      {/*    <Typography variant="smallTextLabels" whiteSpace="nowrap">*/}
-      {/*      <Box component="strong">0</Box> comments*/}
-      {/*    </Typography>*/}
-      {/*  </Button>*/}
-
-      {/*  <Button variant="tertiary_quiet" size="xs">*/}
-      {/*    Share*/}
-      {/*  </Button>*/}
-      {/*  <Button*/}
-      {/*    variant="tertiary_quiet"*/}
-      {/*    size="xs"*/}
-      {/*    startIcon={<FontAwesomeIcon icon={faClockRotateLeft} />}*/}
-      {/*  >*/}
-      {/*    v2.3.1*/}
-      {/*  </Button>*/}
-      {/*  <IconButton>*/}
-      {/*    <FontAwesomeIcon icon={faEllipsisVertical} />*/}
-      {/*  </IconButton>*/}
-      {/*</Box>*/}
     </Box>
   );
 };

--- a/packages/hash/frontend/src/pages/shared/top-context-bar.tsx
+++ b/packages/hash/frontend/src/pages/shared/top-context-bar.tsx
@@ -1,14 +1,8 @@
-import {
-  faClockRotateLeft,
-  faEllipsisVertical,
-  faFile,
-} from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon, IconButton } from "@hashintel/hash-design-system";
-import { Box, Typography } from "@mui/material";
+import { faFile } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@hashintel/hash-design-system";
+import { Box } from "@mui/material";
 import { ReactNode } from "react";
 import { useSidebarContext } from "../../shared/layout/layout-with-sidebar";
-import { useReadonlyMode } from "../../shared/readonly-mode";
-import { Button } from "../../shared/ui";
 import { Breadcrumbs, BreadcrumbsProps } from "./breadcrumbs";
 
 type Props = {
@@ -24,7 +18,6 @@ export const TopContextBar = ({
   defaultCrumbIcon = <FontAwesomeIcon icon={faFile} />,
   scrollToTop = () => {},
 }: Props) => {
-  const { readonlyMode } = useReadonlyMode();
   const { sidebarOpen } = useSidebarContext();
   return (
     <Box
@@ -42,39 +35,39 @@ export const TopContextBar = ({
         />
       </Box>
 
-      <Box
-        ml="auto"
-        alignItems="center"
-        sx={({ palette }) => ({
-          display: readonlyMode ? "none" : "flex",
-          "& > *": {
-            color: palette.gray[50],
-            "&:hover": {
-              color: palette.gray[70],
-            },
-          },
-        })}
-      >
-        <Button variant="tertiary_quiet" size="xs">
-          <Typography variant="smallTextLabels" whiteSpace="nowrap">
-            <Box component="strong">0</Box> comments
-          </Typography>
-        </Button>
+      {/*<Box*/}
+      {/*  ml="auto"*/}
+      {/*  alignItems="center"*/}
+      {/*  sx={({ palette }) => ({*/}
+      {/*    display: readonlyMode ? "none" : "flex",*/}
+      {/*    "& > *": {*/}
+      {/*      color: palette.gray[50],*/}
+      {/*      "&:hover": {*/}
+      {/*        color: palette.gray[70],*/}
+      {/*      },*/}
+      {/*    },*/}
+      {/*  })}*/}
+      {/*>*/}
+      {/*  <Button variant="tertiary_quiet" size="xs">*/}
+      {/*    <Typography variant="smallTextLabels" whiteSpace="nowrap">*/}
+      {/*      <Box component="strong">0</Box> comments*/}
+      {/*    </Typography>*/}
+      {/*  </Button>*/}
 
-        <Button variant="tertiary_quiet" size="xs">
-          Share
-        </Button>
-        <Button
-          variant="tertiary_quiet"
-          size="xs"
-          startIcon={<FontAwesomeIcon icon={faClockRotateLeft} />}
-        >
-          v2.3.1
-        </Button>
-        <IconButton>
-          <FontAwesomeIcon icon={faEllipsisVertical} />
-        </IconButton>
-      </Box>
+      {/*  <Button variant="tertiary_quiet" size="xs">*/}
+      {/*    Share*/}
+      {/*  </Button>*/}
+      {/*  <Button*/}
+      {/*    variant="tertiary_quiet"*/}
+      {/*    size="xs"*/}
+      {/*    startIcon={<FontAwesomeIcon icon={faClockRotateLeft} />}*/}
+      {/*  >*/}
+      {/*    v2.3.1*/}
+      {/*  </Button>*/}
+      {/*  <IconButton>*/}
+      {/*    <FontAwesomeIcon icon={faEllipsisVertical} />*/}
+      {/*  </IconButton>*/}
+      {/*</Box>*/}
     </Box>
   );
 };

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list.tsx
@@ -126,7 +126,7 @@ export const AccountPageList: FunctionComponent<AccountPageListProps> = ({
         sx={{
           mx: 0.75,
         }}
-        {...(currentPageEntityId && { selected: currentPageEntityId })}
+        selected={currentPageEntityId ?? ""}
         expanded={expanded}
         onNodeToggle={handleToggle}
         onNodeSelect={handleSelect}

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-tree-item.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-tree-item.tsx
@@ -10,7 +10,7 @@ import { usePopupState, bindTrigger } from "material-ui-popup-state/hooks";
 import { faChevronRight, faEllipsis } from "@fortawesome/free-solid-svg-icons";
 import { IconButton, FontAwesomeIcon } from "@hashintel/hash-design-system";
 import { forwardRef, MouseEvent, Ref } from "react";
-import { PageIcon } from "../../../../components/PageIcon";
+import { PageIconButton } from "../../../../components/PageIconButton";
 import { Link } from "../../../ui";
 import { PageMenu } from "./page-menu";
 import { useRouteAccountInfo } from "../../../routing";
@@ -92,7 +92,7 @@ const CustomContent = forwardRef((props: TreeItemContentProps, ref) => {
         <FontAwesomeIcon icon={faChevronRight} />
       </IconButton>
 
-      <PageIcon
+      <PageIconButton
         hasDarkBg={selected}
         accountId={accountId}
         entityId={nodeId}

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-tree-item.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-tree-item.tsx
@@ -41,6 +41,9 @@ const CustomContent = forwardRef((props: TreeItemContentProps, ref) => {
 
   return (
     <Box
+      component={Link}
+      noLinkStyle
+      href={url}
       tabIndex={0}
       onMouseDown={handleMouseDown}
       ref={ref as Ref<HTMLDivElement>}
@@ -91,40 +94,32 @@ const CustomContent = forwardRef((props: TreeItemContentProps, ref) => {
       >
         <FontAwesomeIcon icon={faChevronRight} />
       </IconButton>
-
       <PageIconButton
         hasDarkBg={selected}
         accountId={accountId}
         entityId={nodeId}
         size="small"
       />
-
-      <Link
-        noLinkStyle
-        tabIndex={-1}
-        sx={{
-          flex: 1,
+      <Typography
+        variant="smallTextLabels"
+        className="page-title"
+        sx={({ palette }) => ({
           ml: "6px",
-        }}
-        href={url}
+          display: "block",
+          color: palette.gray[70],
+          fontWeight: 400,
+          py: 1,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          flex: 1,
+          ...(selected && {
+            color: palette.gray[90],
+          }),
+        })}
       >
-        <Typography
-          variant="smallTextLabels"
-          className="page-title"
-          sx={({ palette }) => ({
-            display: "block",
-            color: palette.gray[70],
-            fontWeight: 400,
-            py: 1,
-
-            ...(selected && {
-              color: palette.gray[90],
-            }),
-          })}
-        >
-          {label}
-        </Typography>
-      </Link>
+        {label}
+      </Typography>
       <Tooltip
         title="Add subpages, delete, duplicate and more"
         componentsProps={{
@@ -141,6 +136,7 @@ const CustomContent = forwardRef((props: TreeItemContentProps, ref) => {
           unpadded
           className="page-menu-trigger"
           sx={({ palette }) => ({
+            ml: "auto",
             color: [selected ? palette.gray[40] : "transparent"],
             "&:focus-visible, &:hover": {
               backgroundColor: palette.gray[selected ? 40 : 30],

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-tree-item.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-tree-item.tsx
@@ -1,156 +1,170 @@
+import { faChevronRight, faEllipsis } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon, IconButton } from "@hashintel/hash-design-system";
 import TreeItem, {
+  treeItemClasses,
+  TreeItemContentProps,
   TreeItemProps,
   useTreeItem,
-  TreeItemContentProps,
-  treeItemClasses,
 } from "@mui/lab/TreeItem";
 // import clsx from "clsx";
-import { Box, Tooltip, Typography } from "@mui/material";
-import { usePopupState, bindTrigger } from "material-ui-popup-state/hooks";
-import { faChevronRight, faEllipsis } from "@fortawesome/free-solid-svg-icons";
-import { IconButton, FontAwesomeIcon } from "@hashintel/hash-design-system";
-import { forwardRef, MouseEvent, Ref } from "react";
+import { Tooltip, Typography } from "@mui/material";
+import { bindTrigger, usePopupState } from "material-ui-popup-state/hooks";
+import { forwardRef, MouseEvent, ReactElement, Ref } from "react";
 import { PageIconButton } from "../../../../components/PageIconButton";
+import { useRouteAccountInfo } from "../../../routing";
 import { Link } from "../../../ui";
 import { PageMenu } from "./page-menu";
-import { useRouteAccountInfo } from "../../../routing";
 
 // tweaked the example at https://mui.com/components/tree-view/#IconExpansionTreeView.tsx
-const CustomContent = forwardRef((props: TreeItemContentProps, ref) => {
-  const { label, nodeId, expandable, url, depth } = props;
-  const { accountId } = useRouteAccountInfo();
-  const popupState = usePopupState({
-    variant: "popover",
-    popupId: "page-menu",
-  });
+const CustomContent = forwardRef(
+  (props: TreeItemContentProps, ref): ReactElement => {
+    const { label, nodeId, expandable, url, depth } = props;
+    const { accountId } = useRouteAccountInfo();
+    const popupState = usePopupState({
+      variant: "popover",
+      popupId: "page-menu",
+    });
 
-  const { expanded, selected, handleExpansion, preventSelection } =
-    useTreeItem(nodeId);
+    const { expanded, selected, handleExpansion, preventSelection } =
+      useTreeItem(nodeId);
 
-  const handleMouseDown = (
-    event: MouseEvent<HTMLDivElement, globalThis.MouseEvent>,
-  ) => {
-    preventSelection(event);
-  };
+    const handleMouseDown = (
+      event: MouseEvent<HTMLAnchorElement, globalThis.MouseEvent>,
+    ) => {
+      preventSelection(event);
+    };
 
-  const handleExpansionClick = (
-    event: MouseEvent<HTMLButtonElement, globalThis.MouseEvent>,
-  ) => {
-    handleExpansion(event);
-  };
+    const handleExpansionClick = (
+      event: MouseEvent<HTMLButtonElement, globalThis.MouseEvent>,
+    ) => {
+      event.stopPropagation();
+      event.preventDefault();
+      handleExpansion(event);
+    };
 
-  return (
-    <Box
-      component={Link}
-      noLinkStyle
-      href={url}
-      tabIndex={0}
-      onMouseDown={handleMouseDown}
-      ref={ref as Ref<HTMLDivElement>}
-      sx={({ palette }) => ({
-        display: "flex",
-        alignItems: "center",
-        borderRadius: "4px",
+    const trigger = bindTrigger(popupState);
 
-        pl: `${depth * 16 + 8}px`,
-        pr: 0.5,
-
-        ...(!selected && {}),
-
-        "&:hover": {
-          ...(!selected && { backgroundColor: palette.gray[20] }),
-
-          "& .page-title": {
-            color: palette.gray[80],
-          },
-
-          "& .page-menu-trigger": {
-            color: palette.gray[40],
-          },
-        },
-
-        ...(selected && {
-          backgroundColor: palette.gray[30],
-        }),
-      })}
-    >
-      <IconButton
-        onClick={handleExpansionClick}
-        size="xs"
-        unpadded
-        rounded
-        sx={({ transitions }) => ({
-          visibility: "hidden",
-          pointerEvents: "none",
-          mr: 0.5,
-
-          ...(expandable && {
-            visibility: "visible",
-            pointerEvents: "auto",
-            transform: expanded ? `rotate(90deg)` : "none",
-            transition: transitions.create("transform", { duration: 300 }),
-          }),
-        })}
-      >
-        <FontAwesomeIcon icon={faChevronRight} />
-      </IconButton>
-      <PageIconButton
-        hasDarkBg={selected}
-        accountId={accountId}
-        entityId={nodeId}
-        size="small"
-      />
-      <Typography
-        variant="smallTextLabels"
-        className="page-title"
+    return (
+      <Link
+        noLinkStyle
+        href={url}
+        tabIndex={0}
+        onMouseDown={handleMouseDown}
+        ref={ref as Ref<HTMLAnchorElement>}
         sx={({ palette }) => ({
-          ml: "6px",
-          display: "block",
-          color: palette.gray[70],
-          fontWeight: 400,
-          py: 1,
-          overflow: "hidden",
-          textOverflow: "ellipsis",
-          whiteSpace: "nowrap",
-          flex: 1,
-          ...(selected && {
-            color: palette.gray[90],
-          }),
-        })}
-      >
-        {label}
-      </Typography>
-      <Tooltip
-        title="Add subpages, delete, duplicate and more"
-        componentsProps={{
-          tooltip: {
-            sx: {
-              width: 175,
+          display: "flex",
+          alignItems: "center",
+          borderRadius: "4px",
+
+          pl: `${depth * 16 + 8}px`,
+          pr: 0.5,
+
+          ...(!selected && {}),
+
+          "&:hover": {
+            ...(!selected && { backgroundColor: palette.gray[20] }),
+
+            "& .page-title": {
+              color: palette.gray[80],
+            },
+
+            "& .page-menu-trigger": {
+              color: palette.gray[40],
             },
           },
-        }}
+
+          ...(selected && {
+            backgroundColor: palette.gray[30],
+          }),
+        })}
       >
         <IconButton
-          {...bindTrigger(popupState)}
-          size="medium"
+          onClick={handleExpansionClick}
+          size="xs"
           unpadded
-          className="page-menu-trigger"
-          sx={({ palette }) => ({
-            ml: "auto",
-            color: [selected ? palette.gray[40] : "transparent"],
-            "&:focus-visible, &:hover": {
-              backgroundColor: palette.gray[selected ? 40 : 30],
-              color: `${palette.gray[selected ? 50 : 40]} !important`,
-            },
+          rounded
+          sx={({ transitions }) => ({
+            visibility: "hidden",
+            pointerEvents: "none",
+            mr: 0.5,
+
+            ...(expandable && {
+              visibility: "visible",
+              pointerEvents: "auto",
+              transform: expanded ? `rotate(90deg)` : "none",
+              transition: transitions.create("transform", { duration: 300 }),
+            }),
           })}
         >
-          <FontAwesomeIcon icon={faEllipsis} />
+          <FontAwesomeIcon icon={faChevronRight} />
         </IconButton>
-      </Tooltip>
-      <PageMenu popupState={popupState} entityId={nodeId} />
-    </Box>
-  );
-});
+        <PageIconButton
+          hasDarkBg={selected}
+          accountId={accountId}
+          entityId={nodeId}
+          size="small"
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+          }}
+        />
+        <Typography
+          variant="smallTextLabels"
+          className="page-title"
+          sx={({ palette }) => ({
+            ml: "6px",
+            display: "block",
+            color: palette.gray[70],
+            fontWeight: 400,
+            py: 1,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            flex: 1,
+            ...(selected && {
+              color: palette.gray[90],
+            }),
+          })}
+        >
+          {label}
+        </Typography>
+        <Tooltip
+          title="Add subpages, delete, duplicate and more"
+          componentsProps={{
+            tooltip: {
+              sx: {
+                width: 175,
+              },
+            },
+          }}
+        >
+          <IconButton
+            {...trigger}
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              trigger.onClick(event);
+            }}
+            size="medium"
+            unpadded
+            className="page-menu-trigger"
+            sx={({ palette }) => ({
+              ml: "auto",
+              color: [selected ? palette.gray[40] : "transparent"],
+              "&:focus-visible, &:hover": {
+                backgroundColor: palette.gray[selected ? 40 : 30],
+                color: `${palette.gray[selected ? 50 : 40]} !important`,
+              },
+            })}
+          >
+            <FontAwesomeIcon icon={faEllipsis} />
+          </IconButton>
+        </Tooltip>
+        <PageMenu popupState={popupState} entityId={nodeId} />
+      </Link>
+    );
+  },
+);
 
 export const PageTreeItem = ({
   sx = [],

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-tree-item.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-tree-item.tsx
@@ -15,6 +15,11 @@ import { useRouteAccountInfo } from "../../../routing";
 import { Link } from "../../../ui";
 import { PageMenu } from "./page-menu";
 
+const stopEvent = (event: MouseEvent) => {
+  event.preventDefault();
+  event.stopPropagation();
+};
+
 // tweaked the example at https://mui.com/components/tree-view/#IconExpansionTreeView.tsx
 const CustomContent = forwardRef(
   (props: TreeItemContentProps, ref): ReactElement => {
@@ -37,8 +42,7 @@ const CustomContent = forwardRef(
     const handleExpansionClick = (
       event: MouseEvent<HTMLButtonElement, globalThis.MouseEvent>,
     ) => {
-      event.stopPropagation();
-      event.preventDefault();
+      stopEvent(event);
       handleExpansion(event);
     };
 
@@ -103,10 +107,8 @@ const CustomContent = forwardRef(
           accountId={accountId}
           entityId={nodeId}
           size="small"
-          onClick={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-          }}
+          onClick={stopEvent}
+          popoverProps={{ onClick: stopEvent }}
         />
         <Typography
           variant="smallTextLabels"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This addresses a few things that needed tidying up. Read below for more information. 

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

**Asana Links**: (_internal_)

- [Add instructions on enabling debug mode to HASH project README](https://app.asana.com/0/1200211978612931/1202796290628210/f)
- [Comment out non-functional context bar buttons](https://app.asana.com/0/1200211978612931/1202819146709794/f)
- [Sidebar Pages should have text-overflow](https://app.asana.com/0/1201095311341924/1202847510363966)
- [Error crashing blocks – Failed to execute 'removeChild' on 'Node'](https://app.asana.com/0/1201095311341924/1202838927575313/f)
- [TreeView changing between controlled/not controlled warning](https://app.asana.com/0/1201095311341924/1202849277774018/f)
- [validateDOMNesting(...): <button> cannot appear as a descendant of <button>.](https://app.asana.com/0/1201095311341924/1202847066895806/f)
- [Default page icon invisible in sidebar when hovering on the button ](https://app.asana.com/0/1201095311341924/1202854720761260/f)

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

N/A

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Add instructions on turning on debug mode
- Clear portals properly on effect teardown in order to try to prevent React crashing with "removeChild", and destroy view properly
- Ensure sidebar pages overflow with an ellipsis, and make the whole "hoverable" section clickable instead of just the text
- Hide the not yet implemented buttons in the context bar
- Remove a warning about the sidebar tree view changing between controlled/not controlled when switching between the home page and a page
- Remove the emoji picker from the breadcrumb temporarily to fix DOM structure error
- Overwrite default icon cover when button is setup to have a dark hover background (i.e, when page is selected) 

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

No

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

N/A

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

- We may implement new UX for picking the page emoji from breadcrumbs

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

N/A

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Visual verification 