### PR TITLE
Fix refs in publish job and prepare `error-stack-macros` release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -199,6 +199,7 @@ jobs:
           override: true
 
       - name: Install tools
+        if: github.event_name == 'pull_request'
         shell: bash
         run: |
           cargo install cargo-quickinstall
@@ -207,10 +208,12 @@ jobs:
           cargo quickinstall cargo-nextest --version 0.9.28
 
       - name: Run lints
+        if: github.event_name == 'pull_request'
         working-directory: ${{ matrix.directory }}
         run: cargo +${{ matrix.toolchain }} make --profile ${{ matrix.profile }} lint
 
       - name: Run tests
+        if: github.event_name == 'pull_request'
         working-directory: ${{ matrix.directory }}
         run: cargo +${{ matrix.toolchain }} make --profile ${{ matrix.profile }} test --no-fail-fast
 
@@ -225,9 +228,9 @@ jobs:
         run: cargo +${{ matrix.toolchain }} publish --all-features --dry-run
 
       - name: Publish
-        if: github.event_name == 'push' && github.ref == 'ref/head/main'
+        if: github.event_name == 'push' && github.ref == 'refs/head/main'
         working-directory: ${{ matrix.directory }}
-        run: cargo +${{ matrix.toolchain }} publish --all-features
+        run: cargo +${{ matrix.toolchain }} publish --all-features --dry-run
 
   merging-enabled:
     name: merging enabled

--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -23,7 +23,6 @@ futures-core = { version = "0.3", optional = true, default-features = false }
 smallvec = { version = "1", optional = true, default_features = false, features = ['union'] }
 anyhow = { version = "1", default-features = false, optional = true }
 eyre = { version = "0.6", default-features = false, optional = true }
-error-stack-macros = { path = "macros" }
 
 owo-colors = { version = "3.4.0", default-features = false, optional = true, features = ['supports-colors'] }
 

--- a/packages/libs/error-stack/macros/Cargo.toml
+++ b/packages/libs/error-stack/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error-stack-macros"
-version = "0.0.1"
+version = "0.0.0-draft"
 authors = ["HASH"]
 edition = "2021"
 rust-version = "1.63.0"

--- a/packages/libs/error-stack/macros/Cargo.toml
+++ b/packages/libs/error-stack/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error-stack-macros"
-version = "0.0.0"
+version = "0.0.1"
 authors = ["HASH"]
 edition = "2021"
 rust-version = "1.63.0"
@@ -18,4 +18,4 @@ proc-macro = true
 [dependencies]
 
 [dev-dependencies]
-error-stack = { path = ".." }
+error-stack = { version = "0.1.1", default-features = false }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

With #982 we attempted to publish `error-stack-crates` but it failed because instead of `refs/head/main` we specified `ref/head/main`. Also, this fixes an issue in `Cargo.toml`

## 🔗 Related links

- #982

## 🔍 What does this change?

- Fix publish job CI
- Only run tests on pull requests, not on push. There is no point in testing it after the tests have passed again. First, it will take quite a while (about 30 minutes), and secondly, it might fail spuriously (we didn't have that issue yet but who knows...)
- Fix Cargo.toml
- Temporarily (will be reverted in follow-up):
  - Bump version to test it on CI (needs to be merged)
  - Do a dry-run on push to ensure it's working without publishing the version

## 🐾 Next steps

- Revert the mentioned changes and publish the crate