### PR TITLE
Introduce structural queries

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use axum::{
+    extract::Path,
     http::StatusCode,
     routing::{get, post},
     Extension, Json, Router,
@@ -149,7 +150,7 @@ async fn get_latest_data_types<P: StorePool + Send>(
     )
 )]
 async fn get_data_type<P: StorePool + Send>(
-    uri: axum::extract::Path<VersionedUri>,
+    uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,
 ) -> Result<Json<PersistedDataType>, StatusCode> {
     read_from_store(pool.as_ref(), &Expression::for_versioned_uri(&uri.0))

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -3,7 +3,6 @@
 use std::sync::Arc;
 
 use axum::{
-    extract::Path,
     http::StatusCode,
     routing::{get, post},
     Extension, Json, Router,
@@ -16,8 +15,11 @@ use super::api_resource::RoutedResource;
 use crate::{
     api::rest::read_from_store,
     ontology::{AccountId, PersistedDataType, PersistedOntologyIdentifier},
-    store::{BaseUriAlreadyExists, BaseUriDoesNotExist, DataTypeStore, StorePool},
+    store::{
+        query::Expression, BaseUriAlreadyExists, BaseUriDoesNotExist, DataTypeStore, StorePool,
+    },
 };
+
 #[derive(OpenApi)]
 #[openapi(
     handlers(
@@ -119,19 +121,16 @@ async fn create_data_type<P: StorePool + Send>(
 )]
 async fn get_latest_data_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
+    mut body: Option<Json<Expression>>,
 ) -> Result<Json<Vec<PersistedDataType>>, StatusCode> {
-    use crate::store::query::{Expression, Literal, Path, PathSegment};
-
-    let query = Expression::Eq(vec![
-        Expression::Path(Path {
-            segments: vec![PathSegment {
-                identifier: "version".to_owned(),
-            }],
-        }),
-        Expression::Literal(Literal::String("latest".to_owned())),
-    ]);
-    tracing::debug!("query: {}", serde_json::to_string_pretty(&query).unwrap());
-    read_from_store(pool.as_ref(), &query).await.map(Json)
+    read_from_store(
+        pool.as_ref(),
+        &body
+            .take()
+            .map_or_else(Expression::for_latest_version, |json| json.0),
+    )
+    .await
+    .map(Json)
 }
 
 #[utoipa::path(
@@ -150,31 +149,10 @@ async fn get_latest_data_types<P: StorePool + Send>(
     )
 )]
 async fn get_data_type<P: StorePool + Send>(
-    uri: Path<VersionedUri>,
+    uri: axum::extract::Path<VersionedUri>,
     pool: Extension<Arc<P>>,
 ) -> Result<Json<PersistedDataType>, StatusCode> {
-    use crate::store::query::{Expression, Literal, Path, PathSegment};
-
-    let query = Expression::All(vec![
-        Expression::Eq(vec![
-            Expression::Path(Path {
-                segments: vec![PathSegment {
-                    identifier: "version".to_owned(),
-                }],
-            }),
-            Expression::Literal(Literal::Float(f64::from(uri.version()))),
-        ]),
-        Expression::Eq(vec![
-            Expression::Path(Path {
-                segments: vec![PathSegment {
-                    identifier: "uri".to_owned(),
-                }],
-            }),
-            Expression::Literal(Literal::String(uri.base_uri().to_string())),
-        ]),
-    ]);
-    tracing::debug!("query: {}", serde_json::to_string_pretty(&query).unwrap());
-    read_from_store(pool.as_ref(), &query)
+    read_from_store(pool.as_ref(), &Expression::for_versioned_uri(&uri.0))
         .await
         .and_then(|mut data_types| data_types.pop().ok_or(StatusCode::NOT_FOUND))
         .map(Json)

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -16,9 +16,7 @@ use super::api_resource::RoutedResource;
 use crate::{
     api::rest::read_from_store,
     ontology::{AccountId, PersistedDataType, PersistedOntologyIdentifier},
-    store::{
-        query::DataTypeQuery, BaseUriAlreadyExists, BaseUriDoesNotExist, DataTypeStore, StorePool,
-    },
+    store::{BaseUriAlreadyExists, BaseUriDoesNotExist, DataTypeStore, StorePool},
 };
 #[derive(OpenApi)]
 #[openapi(
@@ -122,9 +120,18 @@ async fn create_data_type<P: StorePool + Send>(
 async fn get_latest_data_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<PersistedDataType>>, StatusCode> {
-    read_from_store(pool.as_ref(), &DataTypeQuery::new().by_latest_version())
-        .await
-        .map(Json)
+    use crate::store::query::{Expression, Literal, Path, PathSegment};
+
+    let query = Expression::Eq(vec![
+        Expression::Path(Path {
+            segments: vec![PathSegment {
+                identifier: "version".to_owned(),
+            }],
+        }),
+        Expression::Literal(Literal::String("latest".to_owned())),
+    ]);
+    tracing::debug!("query: {}", serde_json::to_string_pretty(&query).unwrap());
+    read_from_store(pool.as_ref(), &query).await.map(Json)
 }
 
 #[utoipa::path(
@@ -146,15 +153,31 @@ async fn get_data_type<P: StorePool + Send>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,
 ) -> Result<Json<PersistedDataType>, StatusCode> {
-    read_from_store(
-        pool.as_ref(),
-        &DataTypeQuery::new()
-            .by_uri(uri.base_uri())
-            .by_version(uri.version()),
-    )
-    .await
-    .and_then(|mut data_types| data_types.pop().ok_or(StatusCode::NOT_FOUND))
-    .map(Json)
+    use crate::store::query::{Expression, Literal, Path, PathSegment};
+
+    let query = Expression::All(vec![
+        Expression::Eq(vec![
+            Expression::Path(Path {
+                segments: vec![PathSegment {
+                    identifier: "version".to_owned(),
+                }],
+            }),
+            Expression::Literal(Literal::Float(f64::from(uri.version()))),
+        ]),
+        Expression::Eq(vec![
+            Expression::Path(Path {
+                segments: vec![PathSegment {
+                    identifier: "uri".to_owned(),
+                }],
+            }),
+            Expression::Literal(Literal::String(uri.base_uri().to_string())),
+        ]),
+    ]);
+    tracing::debug!("query: {}", serde_json::to_string_pretty(&query).unwrap());
+    read_from_store(pool.as_ref(), &query)
+        .await
+        .and_then(|mut data_types| data_types.pop().ok_or(StatusCode::NOT_FOUND))
+        .map(Json)
 }
 
 #[derive(Component, Serialize, Deserialize)]

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use axum::{
+    extract::Path,
     http::StatusCode,
     routing::{get, post},
     Extension, Json, Router,
@@ -148,7 +149,7 @@ async fn get_latest_property_types<P: StorePool + Send>(
     )
 )]
 async fn get_property_type<P: StorePool + Send>(
-    uri: axum::extract::Path<VersionedUri>,
+    uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,
 ) -> Result<Json<PersistedPropertyType>, StatusCode> {
     read_from_store(pool.as_ref(), &Expression::for_versioned_uri(&uri.0))

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -154,7 +154,7 @@ async fn get_property_type<P: StorePool + Send>(
 ) -> Result<Json<PersistedPropertyType>, StatusCode> {
     read_from_store(pool.as_ref(), &Expression::for_versioned_uri(&uri.0))
         .await
-        .and_then(|mut data_types| data_types.pop().ok_or(StatusCode::NOT_FOUND))
+        .and_then(|mut property_types| property_types.pop().ok_or(StatusCode::NOT_FOUND))
         .map(Json)
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -25,9 +25,7 @@ use crate::{
     },
     store::{
         error::LinkActivationError,
-        query::{
-            EntityQuery, EntityTypeQuery, Expression, LinkQuery, LinkTypeQuery, PropertyTypeQuery,
-        },
+        query::{EntityQuery, EntityTypeQuery, Expression, LinkQuery, LinkTypeQuery},
     },
 };
 
@@ -245,7 +243,7 @@ pub trait DataTypeStore: for<'q> crud::Read<PersistedDataType, Query<'q> = Expre
 /// Describes the API of a store implementation for [`PropertyType`]s.
 #[async_trait]
 pub trait PropertyTypeStore:
-    for<'q> crud::Read<PersistedPropertyType, Query<'q> = PropertyTypeQuery<'q>>
+    for<'q> crud::Read<PersistedPropertyType, Query<'q> = Expression>
 {
     /// Creates a new [`PropertyType`].
     ///
@@ -268,7 +266,7 @@ pub trait PropertyTypeStore:
     /// - if the requested [`PropertyType`] doesn't exist.
     async fn get_property_type(
         &self,
-        query: &PropertyTypeQuery<'_>,
+        query: &Expression,
     ) -> Result<Vec<PersistedPropertyType>, QueryError> {
         self.read(query).await
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -26,8 +26,7 @@ use crate::{
     store::{
         error::LinkActivationError,
         query::{
-            DataTypeQuery, EntityQuery, EntityTypeQuery, LinkQuery, LinkTypeQuery,
-            PropertyTypeQuery,
+            EntityQuery, EntityTypeQuery, Expression, LinkQuery, LinkTypeQuery, PropertyTypeQuery,
         },
     },
 };
@@ -204,9 +203,7 @@ pub trait AccountStore {
 
 /// Describes the API of a store implementation for [`DataType`]s.
 #[async_trait]
-pub trait DataTypeStore:
-    for<'q> crud::Read<PersistedDataType, Query<'q> = DataTypeQuery<'q>>
-{
+pub trait DataTypeStore: for<'q> crud::Read<PersistedDataType, Query<'q> = Expression> {
     /// Creates a new [`DataType`].
     ///
     /// # Errors:
@@ -228,7 +225,7 @@ pub trait DataTypeStore:
     /// - if the requested [`DataType`] doesn't exist.
     async fn get_data_type(
         &self,
-        query: &DataTypeQuery<'_>,
+        query: &Expression,
     ) -> Result<Vec<PersistedDataType>, QueryError> {
         self.read(query).await
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -216,7 +216,7 @@ pub trait DataTypeStore: for<'q> crud::Read<PersistedDataType, Query<'q> = Expre
         created_by: AccountId,
     ) -> Result<PersistedOntologyIdentifier, InsertionError>;
 
-    /// Get the [`DataType`]s specified by the [`DataTypeQuery`].
+    /// Get the [`DataType`]s specified by the [`Expression`].
     ///
     /// # Errors
     ///
@@ -259,7 +259,7 @@ pub trait PropertyTypeStore:
         created_by: AccountId,
     ) -> Result<PersistedOntologyIdentifier, InsertionError>;
 
-    /// Get the [`PropertyType`]s specified by the [`PropertyTypeQuery`].
+    /// Get the [`PropertyType`]s specified by the [`Expression`].
     ///
     /// # Errors
     ///

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -1,8 +1,8 @@
-use async_trait::async_trait;
 mod knowledge;
 mod ontology;
 
 mod pool;
+mod resolve;
 mod version_id;
 
 use error_stack::{IntoReport, Report, Result, ResultExt};

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -5,6 +5,7 @@ mod pool;
 mod resolve;
 mod version_id;
 
+use async_trait::async_trait;
 use error_stack::{IntoReport, Report, Result, ResultExt};
 use postgres_types::ToSql;
 use serde::Serialize;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -1,22 +1,16 @@
 mod read;
 
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
-use futures::{StreamExt, TryStreamExt};
-use tokio_postgres::{GenericClient, RowStream};
+use tokio_postgres::GenericClient;
 use type_system::DataType;
 
 use crate::{
     ontology::{AccountId, PersistedDataType, PersistedOntologyIdentifier},
     store::{
         crud::Read,
-        postgres::{
-            ontology::{data_type::read::PostgresDataTypeResolver, OntologyDatabaseType},
-            parameter_list,
-        },
-        query::{Expression, ExpressionResolver, Literal, Path},
+        postgres::ontology::data_type::read::PostgresDataTypeResolver,
+        query::{Expression, ExpressionResolver},
         AsClient, DataTypeStore, InsertionError, PostgresStore, QueryError, UpdateError,
     },
 };
@@ -74,23 +68,6 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
     }
 }
 
-async fn read_data_types(client: &(impl GenericClient + Sync)) -> Result<RowStream, QueryError> {
-    client
-        .query_raw(
-            r#"
-            SELECT schema, created_by, MAX(version) OVER (PARTITION by base_uri) = version as latest
-            FROM data_types
-            INNER JOIN ids
-	        ON data_types.version_id = ids.version_id
-            ORDER BY base_uri, version DESC;
-            "#,
-            parameter_list([]),
-        )
-        .await
-        .into_report()
-        .change_context(QueryError)
-}
-
 #[async_trait]
 impl<C: AsClient> Read<PersistedDataType> for PostgresStore<C> {
     type Query<'q> = Expression;
@@ -99,7 +76,7 @@ impl<C: AsClient> Read<PersistedDataType> for PostgresStore<C> {
         &self,
         query: &Self::Query<'query>,
     ) -> Result<Vec<PersistedDataType>, QueryError> {
-        let mut resolver = Arc::new(PostgresDataTypeResolver::new(self.as_client()));
+        let mut resolver = PostgresDataTypeResolver::new(self.as_client());
         resolver.resolve(query).await
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -79,47 +79,37 @@ impl<C: AsClient> Read<PersistedDataType> for PostgresStore<C> {
         &self,
         expression: &Self::Query<'query>,
     ) -> Result<Vec<PersistedDataType>, QueryError> {
-        let mut output = Vec::new();
         self.read_all_data_types()
             .await?
             .map(|row_result| row_result.into_report().change_context(QueryError))
-            .try_fold(
-                (self, &mut output),
-                |(mut context, output), row| async move {
-                    let data_type: DataType = serde_json::from_value(row.get(0))
-                        .into_report()
-                        .change_context(QueryError)?;
+            .try_filter_map(|row| async move {
+                let data_type: DataType = serde_json::from_value(row.get(0))
+                    .into_report()
+                    .change_context(QueryError)?;
 
-                    let versioned_data_type = Record {
-                        record: data_type,
-                        is_latest: row.get(2),
-                    };
+                let versioned_data_type = Record {
+                    record: data_type,
+                    is_latest: row.get(2),
+                };
 
-                    if let Literal::Bool(result) = expression
-                        .evaluate(&versioned_data_type, &mut context)
-                        .await
-                    {
-                        if result {
-                            let uri = versioned_data_type.record.id();
-                            let account_id: AccountId = row.get(1);
-                            let identifier =
-                                PersistedOntologyIdentifier::new(uri.clone(), account_id);
-                            output.push(PersistedDataType {
-                                inner: versioned_data_type.record,
-                                identifier,
-                            });
+                if let Literal::Bool(result) = expression.evaluate(&versioned_data_type, self).await
+                {
+                    Ok(result.then(|| {
+                        let uri = versioned_data_type.record.id();
+                        let account_id: AccountId = row.get(1);
+                        let identifier = PersistedOntologyIdentifier::new(uri.clone(), account_id);
+                        PersistedDataType {
+                            inner: versioned_data_type.record,
+                            identifier,
                         }
-                    } else {
-                        // TODO: Implement error handling
-                        //   see https://app.asana.com/0/0/1202884883200968/f
-                        panic!("Expression does not result in a boolean value")
-                    }
-
-                    Ok((context, output))
-                },
-            )
-            .await?;
-
-        Ok(output)
+                    }))
+                } else {
+                    // TODO: Implement error handling
+                    //   see https://app.asana.com/0/0/1202884883200968/f
+                    panic!("Expression does not result in a boolean value")
+                }
+            })
+            .try_collect()
+            .await
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -69,6 +69,8 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
     }
 }
 
+// TODO: Unify methods for Ontology types using `Expression`s
+//   see https://app.asana.com/0/0/1202884883200959/f
 #[async_trait]
 impl<C: AsClient> Read<PersistedDataType> for PostgresStore<C> {
     type Query<'q> = Expression;
@@ -108,6 +110,8 @@ impl<C: AsClient> Read<PersistedDataType> for PostgresStore<C> {
                             });
                         }
                     } else {
+                        // TODO: Implement error handling
+                        //   see https://app.asana.com/0/0/1202884883200968/f
                         panic!("Expression does not result in a boolean value")
                     }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -1,11 +1,17 @@
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
-use tokio_postgres::GenericClient;
+use futures::{StreamExt, TryStreamExt};
+use tokio_postgres::{GenericClient, RowStream};
 use type_system::DataType;
 
 use crate::{
-    ontology::{AccountId, PersistedOntologyIdentifier},
-    store::{AsClient, DataTypeStore, InsertionError, PostgresStore, UpdateError},
+    ontology::{AccountId, PersistedDataType, PersistedOntologyIdentifier},
+    store::{
+        crud::Read,
+        postgres::{ontology::OntologyDatabaseType, parameter_list},
+        query::{resolve, Expression, Literal, Path, Resolve},
+        AsClient, DataTypeStore, InsertionError, PostgresStore, QueryError, UpdateError,
+    },
 };
 
 #[async_trait]
@@ -58,5 +64,105 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
             .change_context(UpdateError)?;
 
         Ok(identifier)
+    }
+}
+
+async fn read_data_types(client: &(impl GenericClient + Sync)) -> Result<RowStream, QueryError> {
+    client
+        .query_raw(
+            r#"
+            SELECT schema, created_by, MAX(version) OVER (PARTITION by base_uri) = version as latest
+            FROM data_types
+            INNER JOIN ids
+	        ON data_types.version_id = ids.version_id
+            ORDER BY base_uri, version DESC;
+            "#,
+            parameter_list([]),
+        )
+        .await
+        .into_report()
+        .change_context(QueryError)
+}
+
+// TODO: Make this stateful
+//   A stateless filter is not able to reason about previous values or caches. Also, for more
+//   complex queries it's not possible to query more data on demand
+impl Resolve for (DataType, bool) {
+    fn resolve_path(&self, path: &Path) -> Literal {
+        match path.segments.as_slice() {
+            [] => panic!("Path is empty"),
+            [segment] => match segment.identifier.as_str() {
+                "uri" => Literal::String(self.0.id().base_uri().to_string()),
+                "version" => Literal::Version(self.0.id().version(), self.1),
+                "title" => Literal::String(self.0.title().to_owned()),
+                "description" => self
+                    .0
+                    .description()
+                    .map_or(Literal::Null, |desc| Literal::String(desc.to_owned())),
+                "type" => Literal::String(self.0.json_type().to_owned()),
+                key => self
+                    .0
+                    .additional_properties()
+                    .get(key)
+                    .unwrap_or_else(|| panic!("Invalid data type key {key}"))
+                    .clone()
+                    .try_into()
+                    .expect("Could not convert value into literal"),
+            },
+            [segment, segments @ ..] => {
+                let value = self
+                    .0
+                    .additional_properties()
+                    .get(&segment.identifier)
+                    .unwrap_or_else(|| panic!("Invalid data type key {}", segment.identifier));
+                Literal::try_from(value.clone())
+                    .expect("Could not convert value into literal")
+                    .resolve_path(&Path {
+                        segments: segments.to_vec(),
+                    })
+            }
+        }
+    }
+}
+
+fn apply_filter(element: (DataType, bool), query: &Expression) -> Option<DataType> {
+    let mut path = vec![];
+    if let Literal::Bool(result) = resolve(query, &element, &mut path) {
+        result.then_some(element.0)
+    } else {
+        panic!("Expression does not result in a boolean value")
+    }
+}
+
+#[async_trait]
+impl<C: AsClient> Read<PersistedDataType> for PostgresStore<C> {
+    type Query<'q> = Expression;
+
+    async fn read<'query>(
+        &self,
+        query: &Self::Query<'query>,
+    ) -> Result<Vec<PersistedDataType>, QueryError> {
+        let row_stream = read_data_types(self.as_client()).await?;
+
+        row_stream
+            .map(|row_result| row_result.into_report().change_context(QueryError))
+            .try_filter_map(|row| async move {
+                let element: DataType = serde_json::from_value(row.get(0))
+                    .into_report()
+                    .change_context(QueryError)?;
+
+                let account_id: AccountId = row.get(1);
+
+                Ok(apply_filter((element, row.get(2)), query).map(|element| {
+                    let uri = element.versioned_uri();
+                    let identifier = PersistedOntologyIdentifier::new(uri.clone(), account_id);
+                    PersistedDataType {
+                        inner: element,
+                        identifier,
+                    }
+                }))
+            })
+            .try_collect()
+            .await
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -80,7 +80,7 @@ impl<C: AsClient> Read<PersistedDataType> for PostgresStore<C> {
         expression: &Self::Query<'query>,
     ) -> Result<Vec<PersistedDataType>, QueryError> {
         let mut output = Vec::new();
-        self.read_data_types()
+        self.read_all_data_types()
             .await?
             .map(|row_result| row_result.into_report().change_context(QueryError))
             .try_fold(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -1,3 +1,7 @@
+mod read;
+
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
 use futures::{StreamExt, TryStreamExt};
@@ -8,8 +12,11 @@ use crate::{
     ontology::{AccountId, PersistedDataType, PersistedOntologyIdentifier},
     store::{
         crud::Read,
-        postgres::{ontology::OntologyDatabaseType, parameter_list},
-        query::{resolve, Expression, Literal, Path, Resolve},
+        postgres::{
+            ontology::{data_type::read::PostgresDataTypeResolver, OntologyDatabaseType},
+            parameter_list,
+        },
+        query::{Expression, ExpressionResolver, Literal, Path},
         AsClient, DataTypeStore, InsertionError, PostgresStore, QueryError, UpdateError,
     },
 };
@@ -84,56 +91,6 @@ async fn read_data_types(client: &(impl GenericClient + Sync)) -> Result<RowStre
         .change_context(QueryError)
 }
 
-// TODO: Make this stateful
-//   A stateless filter is not able to reason about previous values or caches. Also, for more
-//   complex queries it's not possible to query more data on demand
-impl Resolve for (DataType, bool) {
-    fn resolve_path(&self, path: &Path) -> Literal {
-        match path.segments.as_slice() {
-            [] => panic!("Path is empty"),
-            [segment] => match segment.identifier.as_str() {
-                "uri" => Literal::String(self.0.id().base_uri().to_string()),
-                "version" => Literal::Version(self.0.id().version(), self.1),
-                "title" => Literal::String(self.0.title().to_owned()),
-                "description" => self
-                    .0
-                    .description()
-                    .map_or(Literal::Null, |desc| Literal::String(desc.to_owned())),
-                "type" => Literal::String(self.0.json_type().to_owned()),
-                key => self
-                    .0
-                    .additional_properties()
-                    .get(key)
-                    .unwrap_or_else(|| panic!("Invalid data type key {key}"))
-                    .clone()
-                    .try_into()
-                    .expect("Could not convert value into literal"),
-            },
-            [segment, segments @ ..] => {
-                let value = self
-                    .0
-                    .additional_properties()
-                    .get(&segment.identifier)
-                    .unwrap_or_else(|| panic!("Invalid data type key {}", segment.identifier));
-                Literal::try_from(value.clone())
-                    .expect("Could not convert value into literal")
-                    .resolve_path(&Path {
-                        segments: segments.to_vec(),
-                    })
-            }
-        }
-    }
-}
-
-fn apply_filter(element: (DataType, bool), query: &Expression) -> Option<DataType> {
-    let mut path = vec![];
-    if let Literal::Bool(result) = resolve(query, &element, &mut path) {
-        result.then_some(element.0)
-    } else {
-        panic!("Expression does not result in a boolean value")
-    }
-}
-
 #[async_trait]
 impl<C: AsClient> Read<PersistedDataType> for PostgresStore<C> {
     type Query<'q> = Expression;
@@ -142,27 +99,7 @@ impl<C: AsClient> Read<PersistedDataType> for PostgresStore<C> {
         &self,
         query: &Self::Query<'query>,
     ) -> Result<Vec<PersistedDataType>, QueryError> {
-        let row_stream = read_data_types(self.as_client()).await?;
-
-        row_stream
-            .map(|row_result| row_result.into_report().change_context(QueryError))
-            .try_filter_map(|row| async move {
-                let element: DataType = serde_json::from_value(row.get(0))
-                    .into_report()
-                    .change_context(QueryError)?;
-
-                let account_id: AccountId = row.get(1);
-
-                Ok(apply_filter((element, row.get(2)), query).map(|element| {
-                    let uri = element.versioned_uri();
-                    let identifier = PersistedOntologyIdentifier::new(uri.clone(), account_id);
-                    PersistedDataType {
-                        inner: element,
-                        identifier,
-                    }
-                }))
-            })
-            .try_collect()
-            .await
+        let mut resolver = Arc::new(PostgresDataTypeResolver::new(self.as_client()));
+        resolver.resolve(query).await
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/read.rs
@@ -1,129 +1,50 @@
 use async_trait::async_trait;
-use error_stack::{IntoReport, Result, ResultExt};
-use futures::{StreamExt, TryStreamExt};
-use tokio_postgres::{GenericClient, RowStream};
 use type_system::DataType;
 
-use crate::{
-    ontology::{AccountId, PersistedDataType, PersistedOntologyIdentifier},
-    store::{
-        postgres::parameter_list,
-        query::{Expression, ExpressionResolver, Literal, Path, PathResolver},
-        QueryError,
-    },
+use crate::store::{
+    postgres::resolve::Record,
+    query::{Literal, PathSegment, Resolve},
 };
 
-pub struct PostgresDataTypeResolver<'con, C> {
-    client: &'con C,
-}
-
-impl<'con, C> PostgresDataTypeResolver<'con, C> {
-    #[must_use]
-    pub const fn new(client: &'con C) -> Self {
-        Self { client }
-    }
-}
-
-pub struct DataTypeRecordResolver<'record, 'con, C> {
-    data_type: &'record DataType,
-    is_latest: bool,
-    client: &'con C,
-}
-
 #[async_trait]
-impl<C: Sync> PathResolver for DataTypeRecordResolver<'_, '_, C> {
-    async fn resolve(&self, path: &Path) -> Literal {
-        match path.segments.as_slice() {
-            [] => panic!("Path is empty"),
-            [segment] => match segment.identifier.as_str() {
-                "uri" => Literal::String(self.data_type.id().base_uri().to_string()),
-                "version" => Literal::Version(self.data_type.id().version(), self.is_latest),
-                "title" => Literal::String(self.data_type.title().to_owned()),
-                "description" => self
-                    .data_type
-                    .description()
-                    .map_or(Literal::Null, |desc| Literal::String(desc.to_owned())),
-                "type" => Literal::String(self.data_type.json_type().to_owned()),
-                key => self
-                    .data_type
-                    .additional_properties()
-                    .get(key)
-                    .unwrap_or_else(|| panic!("Invalid data type key {key}"))
-                    .clone()
-                    .try_into()
-                    .expect("Could not convert value into literal"),
-            },
+impl<Ctx> Resolve<Ctx> for Record<DataType>
+where
+    Ctx: Send,
+{
+    async fn resolve(&self, path: &[PathSegment], context: &mut Ctx) -> Literal {
+        match path {
+            [] => {
+                // see https://app.asana.com/0/0/1202884883200943/f"
+                todo!("`Literal::Object`")
+            }
             [segment, segments @ ..] => {
-                let value = self
-                    .data_type
-                    .additional_properties()
-                    .get(&segment.identifier)
-                    .unwrap_or_else(|| panic!("Invalid data type key {}", segment.identifier));
-                Literal::try_from(value.clone())
-                    .expect("Could not convert value into literal")
-                    .resolve(&Path {
-                        segments: segments.to_vec(),
-                    })
-                    .await
+                let literal = match segment.identifier.as_str() {
+                    "uri" => Literal::String(self.record.id().base_uri().to_string()),
+                    "version" => Literal::Version(self.record.id().version(), self.is_latest),
+                    "title" => Literal::String(self.record.title().to_owned()),
+                    "description" => self
+                        .record
+                        .description()
+                        .map_or(Literal::Null, |description| {
+                            Literal::String(description.to_owned())
+                        }),
+                    "type" => Literal::String(self.record.json_type().to_owned()),
+                    key => self
+                        .record
+                        .additional_properties()
+                        .get(key)
+                        .cloned()
+                        .map(TryFrom::try_from)
+                        .transpose()
+                        .expect("Could not convert value into literal")
+                        .unwrap_or(Literal::Null),
+                };
+                if segments.is_empty() {
+                    literal
+                } else {
+                    literal.resolve(segments, context).await
+                }
             }
         }
-    }
-}
-
-impl<'con, C: GenericClient + Sync> PostgresDataTypeResolver<'con, C> {
-    pub async fn read_data_types(&self) -> Result<RowStream, QueryError> {
-        self.client
-            .query_raw(
-                r#"
-                SELECT schema, created_by, MAX(version) OVER (PARTITION by base_uri) = version as latest
-                FROM data_types
-                INNER JOIN ids
-                ON data_types.version_id = ids.version_id
-                ORDER BY base_uri, version DESC;
-                "#,
-                parameter_list([]),
-            )
-            .await
-            .into_report()
-            .change_context(QueryError)
-    }
-}
-
-#[async_trait]
-impl<C: GenericClient + Sync> ExpressionResolver for PostgresDataTypeResolver<'_, C> {
-    type Record = PersistedDataType;
-
-    async fn resolve(&mut self, expression: &Expression) -> Result<Vec<Self::Record>, QueryError> {
-        let client = &self.client;
-        self.read_data_types()
-            .await?
-            .map(|row_result| row_result.into_report().change_context(QueryError))
-            .try_filter_map(|row| async move {
-                let element: DataType = serde_json::from_value(row.get(0))
-                    .into_report()
-                    .change_context(QueryError)?;
-
-                let mut resolver = DataTypeRecordResolver {
-                    data_type: &element,
-                    is_latest: row.get(2),
-                    client,
-                };
-
-                if let Literal::Bool(result) = expression.evaluate(&mut resolver).await {
-                    Ok(result.then(|| {
-                        let uri = element.id();
-                        let account_id: AccountId = row.get(1);
-                        let identifier = PersistedOntologyIdentifier::new(uri.clone(), account_id);
-                        PersistedDataType {
-                            inner: element,
-                            identifier,
-                        }
-                    }))
-                } else {
-                    panic!("Expression does not result in a boolean value")
-                }
-            })
-            .try_collect()
-            .await
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/read.rs
@@ -1,17 +1,15 @@
-use std::{collections::HashMap, sync::Arc};
-
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
 use futures::{StreamExt, TryStreamExt};
 use tokio_postgres::{GenericClient, RowStream};
-use type_system::{uri::BaseUri, DataType};
+use type_system::DataType;
 
 use crate::{
     ontology::{AccountId, PersistedDataType, PersistedOntologyIdentifier},
     store::{
         postgres::parameter_list,
         query::{Expression, ExpressionResolver, Literal, Path, PathResolver},
-        AsClient, PostgresStore, QueryError,
+        QueryError,
     },
 };
 
@@ -95,10 +93,7 @@ impl<'con, C: GenericClient + Sync> PostgresDataTypeResolver<'con, C> {
 impl<C: GenericClient + Sync> ExpressionResolver for PostgresDataTypeResolver<'_, C> {
     type Record = PersistedDataType;
 
-    async fn resolve(
-        self: Arc<Self>,
-        expression: &Expression,
-    ) -> Result<Vec<Self::Record>, QueryError> {
+    async fn resolve(&mut self, expression: &Expression) -> Result<Vec<Self::Record>, QueryError> {
         let client = &self.client;
         self.read_data_types()
             .await?

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/read.rs
@@ -18,6 +18,8 @@ where
                 todo!("`Literal::Object`")
             }
             [segment, segments @ ..] => {
+                // TODO: Avoid cloning on literals
+                //   see https://app.asana.com/0/0/1202884883200947/f
                 let literal = match segment.identifier.as_str() {
                     "uri" => Literal::String(self.record.id().base_uri().to_string()),
                     "version" => Literal::Version(self.record.id().version(), self.is_latest),
@@ -34,10 +36,7 @@ where
                         .additional_properties()
                         .get(key)
                         .cloned()
-                        .map(TryFrom::try_from)
-                        .transpose()
-                        .expect("Could not convert value into literal")
-                        .unwrap_or(Literal::Null),
+                        .map_or(Literal::Null, From::from),
                 };
                 if segments.is_empty() {
                     literal

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/read.rs
@@ -7,11 +7,11 @@ use crate::store::{
 };
 
 #[async_trait]
-impl<Ctx> Resolve<Ctx> for Record<DataType>
+impl<C> Resolve<C> for Record<DataType>
 where
-    Ctx: Send,
+    C: Sync,
 {
-    async fn resolve(&self, path: &[PathSegment], context: &mut Ctx) -> Literal {
+    async fn resolve(&self, path: &[PathSegment], context: &C) -> Literal {
         match path {
             [] => {
                 // see https://app.asana.com/0/0/1202884883200943/f"

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/read.rs
@@ -1,0 +1,134 @@
+use std::{collections::HashMap, sync::Arc};
+
+use async_trait::async_trait;
+use error_stack::{IntoReport, Result, ResultExt};
+use futures::{StreamExt, TryStreamExt};
+use tokio_postgres::{GenericClient, RowStream};
+use type_system::{uri::BaseUri, DataType};
+
+use crate::{
+    ontology::{AccountId, PersistedDataType, PersistedOntologyIdentifier},
+    store::{
+        postgres::parameter_list,
+        query::{Expression, ExpressionResolver, Literal, Path, PathResolver},
+        AsClient, PostgresStore, QueryError,
+    },
+};
+
+pub struct PostgresDataTypeResolver<'con, C> {
+    client: &'con C,
+}
+
+impl<'con, C> PostgresDataTypeResolver<'con, C> {
+    #[must_use]
+    pub const fn new(client: &'con C) -> Self {
+        Self { client }
+    }
+}
+
+pub struct DataTypeRecordResolver<'record, 'con, C> {
+    data_type: &'record DataType,
+    is_latest: bool,
+    client: &'con C,
+}
+
+#[async_trait]
+impl<C: Sync> PathResolver for DataTypeRecordResolver<'_, '_, C> {
+    async fn resolve(&self, path: &Path) -> Literal {
+        match path.segments.as_slice() {
+            [] => panic!("Path is empty"),
+            [segment] => match segment.identifier.as_str() {
+                "uri" => Literal::String(self.data_type.id().base_uri().to_string()),
+                "version" => Literal::Version(self.data_type.id().version(), self.is_latest),
+                "title" => Literal::String(self.data_type.title().to_owned()),
+                "description" => self
+                    .data_type
+                    .description()
+                    .map_or(Literal::Null, |desc| Literal::String(desc.to_owned())),
+                "type" => Literal::String(self.data_type.json_type().to_owned()),
+                key => self
+                    .data_type
+                    .additional_properties()
+                    .get(key)
+                    .unwrap_or_else(|| panic!("Invalid data type key {key}"))
+                    .clone()
+                    .try_into()
+                    .expect("Could not convert value into literal"),
+            },
+            [segment, segments @ ..] => {
+                let value = self
+                    .data_type
+                    .additional_properties()
+                    .get(&segment.identifier)
+                    .unwrap_or_else(|| panic!("Invalid data type key {}", segment.identifier));
+                Literal::try_from(value.clone())
+                    .expect("Could not convert value into literal")
+                    .resolve(&Path {
+                        segments: segments.to_vec(),
+                    })
+                    .await
+            }
+        }
+    }
+}
+
+impl<'con, C: GenericClient + Sync> PostgresDataTypeResolver<'con, C> {
+    pub async fn read_data_types(&self) -> Result<RowStream, QueryError> {
+        self.client
+            .query_raw(
+                r#"
+                SELECT schema, created_by, MAX(version) OVER (PARTITION by base_uri) = version as latest
+                FROM data_types
+                INNER JOIN ids
+                ON data_types.version_id = ids.version_id
+                ORDER BY base_uri, version DESC;
+                "#,
+                parameter_list([]),
+            )
+            .await
+            .into_report()
+            .change_context(QueryError)
+    }
+}
+
+#[async_trait]
+impl<C: GenericClient + Sync> ExpressionResolver for PostgresDataTypeResolver<'_, C> {
+    type Record = PersistedDataType;
+
+    async fn resolve(
+        self: Arc<Self>,
+        expression: &Expression,
+    ) -> Result<Vec<Self::Record>, QueryError> {
+        let client = &self.client;
+        self.read_data_types()
+            .await?
+            .map(|row_result| row_result.into_report().change_context(QueryError))
+            .try_filter_map(|row| async move {
+                let element: DataType = serde_json::from_value(row.get(0))
+                    .into_report()
+                    .change_context(QueryError)?;
+
+                let mut resolver = DataTypeRecordResolver {
+                    data_type: &element,
+                    is_latest: row.get(2),
+                    client,
+                };
+
+                if let Literal::Bool(result) = expression.evaluate(&mut resolver).await {
+                    Ok(result.then(|| {
+                        let uri = element.id();
+                        let account_id: AccountId = row.get(1);
+                        let identifier = PersistedOntologyIdentifier::new(uri.clone(), account_id);
+                        PersistedDataType {
+                            inner: element,
+                            identifier,
+                        }
+                    }))
+                } else {
+                    panic!("Expression does not result in a boolean value")
+                }
+            })
+            .try_collect()
+            .await
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -94,7 +94,7 @@ impl<C: AsClient> Read<PersistedPropertyType> for PostgresStore<C> {
         expression: &Self::Query<'query>,
     ) -> Result<Vec<PersistedPropertyType>, QueryError> {
         let mut output = Vec::new();
-        self.read_property_types()
+        self.read_all_property_types()
             .await?
             .map(|row_result| row_result.into_report().change_context(QueryError))
             .try_fold(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -83,6 +83,8 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
     }
 }
 
+// TODO: Unify methods for Ontology types using `Expression`s
+//   see https://app.asana.com/0/0/1202884883200959/f
 #[async_trait]
 impl<C: AsClient> Read<PersistedPropertyType> for PostgresStore<C> {
     type Query<'q> = Expression;
@@ -122,6 +124,8 @@ impl<C: AsClient> Read<PersistedPropertyType> for PostgresStore<C> {
                             });
                         }
                     } else {
+                        // TODO: Implement error handling
+                        //   see https://app.asana.com/0/0/1202884883200968/f
                         panic!("Expression does not result in a boolean value")
                     }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/read.rs
@@ -1,0 +1,113 @@
+use async_trait::async_trait;
+use error_stack::{IntoReport, Result, ResultExt};
+use futures::{StreamExt, TryStreamExt};
+use tokio_postgres::{GenericClient, RowStream};
+use type_system::PropertyType;
+
+use crate::{
+    ontology::{AccountId, PersistedOntologyIdentifier, PersistedPropertyType},
+    store::{
+        postgres::parameter_list,
+        query::{Expression, ExpressionResolver, Literal, Path, PathResolver},
+        QueryError,
+    },
+};
+
+pub struct PostgresPropertyTypeResolver<'con, C> {
+    client: &'con C,
+}
+
+impl<'con, C> PostgresPropertyTypeResolver<'con, C> {
+    #[must_use]
+    pub const fn new(client: &'con C) -> Self {
+        Self { client }
+    }
+}
+
+impl<'con, C: GenericClient + Sync> PostgresPropertyTypeResolver<'con, C> {
+    pub async fn read_property_types(&self) -> Result<RowStream, QueryError> {
+        self.client
+            .query_raw(
+                r#"
+                SELECT schema, created_by, MAX(version) OVER (PARTITION by base_uri) = version as latest
+                FROM property_types
+                INNER JOIN ids
+                ON property_types.version_id = ids.version_id
+                ORDER BY base_uri, version DESC;
+                "#,
+                parameter_list([]),
+            )
+            .await
+            .into_report()
+            .change_context(QueryError)
+    }
+}
+
+pub struct PropertyTypeRecordResolver<'record, 'con, C> {
+    property_type: &'record PropertyType,
+    is_latest: bool,
+    client: &'con C,
+}
+
+#[async_trait]
+impl<C: Sync> PathResolver for PropertyTypeRecordResolver<'_, '_, C> {
+    async fn resolve(&self, path: &Path) -> Literal {
+        match path.segments.as_slice() {
+            [] => panic!("Path is empty"),
+            [segment] => match segment.identifier.as_str() {
+                "uri" => Literal::String(self.property_type.id().base_uri().to_string()),
+                "version" => Literal::Version(self.property_type.id().version(), self.is_latest),
+                "title" => Literal::String(self.property_type.title().to_owned()),
+                "description" => self
+                    .property_type
+                    .description()
+                    .map_or(Literal::Null, |desc| Literal::String(desc.to_owned())),
+                key => panic!("{key} is not a valid property type key"),
+            },
+            [segment, segments @ ..] => match segment.identifier.as_str() {
+                "dataTypes" => todo!("Implement data types for {segments:?}"),
+                "propertyTypes" => todo!("Implement property types for {segments:?}"),
+                key => panic!("{key} is not a valid property type key"),
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl<C: GenericClient + Sync> ExpressionResolver for PostgresPropertyTypeResolver<'_, C> {
+    type Record = PersistedPropertyType;
+
+    async fn resolve(&mut self, expression: &Expression) -> Result<Vec<Self::Record>, QueryError> {
+        let client = &self.client;
+        self.read_property_types()
+            .await?
+            .map(|row_result| row_result.into_report().change_context(QueryError))
+            .try_filter_map(|row| async move {
+                let element: PropertyType = serde_json::from_value(row.get(0))
+                    .into_report()
+                    .change_context(QueryError)?;
+
+                let mut resolver = PropertyTypeRecordResolver {
+                    property_type: &element,
+                    is_latest: row.get(2),
+                    client,
+                };
+
+                if let Literal::Bool(result) = expression.evaluate(&mut resolver).await {
+                    Ok(result.then(|| {
+                        let uri = element.id();
+                        let account_id: AccountId = row.get(1);
+                        let identifier = PersistedOntologyIdentifier::new(uri.clone(), account_id);
+                        PersistedPropertyType {
+                            inner: element,
+                            identifier,
+                        }
+                    }))
+                } else {
+                    panic!("Expression does not result in a boolean value")
+                }
+            })
+            .try_collect()
+            .await
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/read.rs
@@ -1,113 +1,96 @@
 use async_trait::async_trait;
-use error_stack::{IntoReport, Result, ResultExt};
-use futures::{StreamExt, TryStreamExt};
-use tokio_postgres::{GenericClient, RowStream};
 use type_system::PropertyType;
 
-use crate::{
-    ontology::{AccountId, PersistedOntologyIdentifier, PersistedPropertyType},
-    store::{
-        postgres::parameter_list,
-        query::{Expression, ExpressionResolver, Literal, Path, PathResolver},
-        QueryError,
-    },
+use crate::store::{
+    postgres::resolve::{PostgresContext, Record},
+    query::{Literal, PathSegment, Resolve},
 };
 
-pub struct PostgresPropertyTypeResolver<'con, C> {
-    client: &'con C,
-}
-
-impl<'con, C> PostgresPropertyTypeResolver<'con, C> {
-    #[must_use]
-    pub const fn new(client: &'con C) -> Self {
-        Self { client }
-    }
-}
-
-impl<'con, C: GenericClient + Sync> PostgresPropertyTypeResolver<'con, C> {
-    pub async fn read_property_types(&self) -> Result<RowStream, QueryError> {
-        self.client
-            .query_raw(
-                r#"
-                SELECT schema, created_by, MAX(version) OVER (PARTITION by base_uri) = version as latest
-                FROM property_types
-                INNER JOIN ids
-                ON property_types.version_id = ids.version_id
-                ORDER BY base_uri, version DESC;
-                "#,
-                parameter_list([]),
-            )
-            .await
-            .into_report()
-            .change_context(QueryError)
-    }
-}
-
-pub struct PropertyTypeRecordResolver<'record, 'con, C> {
-    property_type: &'record PropertyType,
-    is_latest: bool,
-    client: &'con C,
-}
-
 #[async_trait]
-impl<C: Sync> PathResolver for PropertyTypeRecordResolver<'_, '_, C> {
-    async fn resolve(&self, path: &Path) -> Literal {
-        match path.segments.as_slice() {
-            [] => panic!("Path is empty"),
-            [segment] => match segment.identifier.as_str() {
-                "uri" => Literal::String(self.property_type.id().base_uri().to_string()),
-                "version" => Literal::Version(self.property_type.id().version(), self.is_latest),
-                "title" => Literal::String(self.property_type.title().to_owned()),
-                "description" => self
-                    .property_type
-                    .description()
-                    .map_or(Literal::Null, |desc| Literal::String(desc.to_owned())),
-                key => panic!("{key} is not a valid property type key"),
-            },
-            [segment, segments @ ..] => match segment.identifier.as_str() {
-                "dataTypes" => todo!("Implement data types for {segments:?}"),
-                "propertyTypes" => todo!("Implement property types for {segments:?}"),
-                key => panic!("{key} is not a valid property type key"),
-            },
-        }
-    }
-}
-
-#[async_trait]
-impl<C: GenericClient + Sync> ExpressionResolver for PostgresPropertyTypeResolver<'_, C> {
-    type Record = PersistedPropertyType;
-
-    async fn resolve(&mut self, expression: &Expression) -> Result<Vec<Self::Record>, QueryError> {
-        let client = &self.client;
-        self.read_property_types()
-            .await?
-            .map(|row_result| row_result.into_report().change_context(QueryError))
-            .try_filter_map(|row| async move {
-                let element: PropertyType = serde_json::from_value(row.get(0))
-                    .into_report()
-                    .change_context(QueryError)?;
-
-                let mut resolver = PropertyTypeRecordResolver {
-                    property_type: &element,
-                    is_latest: row.get(2),
-                    client,
+impl<Ctx> Resolve<Ctx> for Record<PropertyType>
+where
+    Ctx: PostgresContext + Send + Sync,
+{
+    async fn resolve(&self, path: &[PathSegment], context: &mut Ctx) -> Literal {
+        match path {
+            [] => {
+                // see https://app.asana.com/0/0/1202884883200943/f"
+                todo!("`Literal::Object`")
+            }
+            [segment, segments @ ..] => {
+                let literal = match segment.identifier.as_str() {
+                    "uri" => Literal::String(self.record.id().base_uri().to_string()),
+                    "version" => Literal::Version(self.record.id().version(), self.is_latest),
+                    "title" => Literal::String(self.record.title().to_owned()),
+                    "description" => self
+                        .record
+                        .description()
+                        .map_or(Literal::Null, |description| {
+                            Literal::String(description.to_owned())
+                        }),
+                    "dataTypes" => match segments {
+                        [] => {
+                            // see https://app.asana.com/0/0/1202884883200943/f"
+                            todo!("`Literal::Object`")
+                        }
+                        [data_type_segment, data_type_segments @ ..]
+                            if data_type_segment.identifier == "**" =>
+                        {
+                            // TODO: Use relation tables
+                            //   see https://app.asana.com/0/0/1202884883200942/f
+                            let data_type_set = self.record.data_type_references();
+                            let mut data_types = Vec::with_capacity(data_type_set.len());
+                            for data_type_ref in data_type_set {
+                                let data_type = context
+                                    .read_versioned_data_type(data_type_ref.uri())
+                                    .await
+                                    .expect("Could not read data type");
+                                data_types
+                                    .push(data_type.resolve(data_type_segments, context).await);
+                            }
+                            return Literal::List(data_types);
+                        }
+                        _ => {
+                            // see https://app.asana.com/0/0/1202884883200970/f
+                            todo!("Non-wildcard queries on data types")
+                        }
+                    },
+                    "propertyTypes" => match segments {
+                        [] => {
+                            // see https://app.asana.com/0/0/1202884883200943/f"
+                            todo!("`Literal::Object`")
+                        }
+                        [property_type_segment, property_type_segments @ ..]
+                            if property_type_segment.identifier == "**" =>
+                        {
+                            // TODO: Use relation tables
+                            //   see https://app.asana.com/0/0/1202884883200942/f
+                            let property_type_set = self.record.data_type_references();
+                            let mut data_types = Vec::with_capacity(property_type_set.len());
+                            for data_type_ref in property_type_set {
+                                let data_type = context
+                                    .read_versioned_data_type(data_type_ref.uri())
+                                    .await
+                                    .expect("Could not read data type");
+                                data_types
+                                    .push(data_type.resolve(property_type_segments, context).await);
+                            }
+                            return Literal::List(data_types);
+                        }
+                        _ => {
+                            // see https://app.asana.com/0/0/1202884883200970/f
+                            todo!("Non-wildcard queries on data types")
+                        }
+                    },
+                    _ => Literal::Null,
                 };
 
-                if let Literal::Bool(result) = expression.evaluate(&mut resolver).await {
-                    Ok(result.then(|| {
-                        let uri = element.id();
-                        let account_id: AccountId = row.get(1);
-                        let identifier = PersistedOntologyIdentifier::new(uri.clone(), account_id);
-                        PersistedPropertyType {
-                            inner: element,
-                            identifier,
-                        }
-                    }))
+                if segments.is_empty() {
+                    literal
                 } else {
-                    panic!("Expression does not result in a boolean value")
+                    literal.resolve(segments, context).await
                 }
-            })
-            .try_collect()
-            .await
+            }
+        }
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/read.rs
@@ -59,7 +59,7 @@ where
                     },
                     "propertyTypes" => match segments {
                         [] => {
-                            // see https://app.asana.com/0/0/1202884883200943/f"
+                            // see https://app.asana.com/0/0/1202884883200943/f
                             todo!("`Literal::Object`")
                         }
                         [property_type_segment, property_type_segments @ ..]

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/read.rs
@@ -18,6 +18,8 @@ where
                 todo!("`Literal::Object`")
             }
             [segment, segments @ ..] => {
+                // TODO: Avoid cloning on literals
+                //   see https://app.asana.com/0/0/1202884883200947/f
                 let literal = match segment.identifier.as_str() {
                     "uri" => Literal::String(self.record.id().base_uri().to_string()),
                     "version" => Literal::Version(self.record.id().version(), self.is_latest),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/read.rs
@@ -67,21 +67,22 @@ where
                         {
                             // TODO: Use relation tables
                             //   see https://app.asana.com/0/0/1202884883200942/f
-                            let property_type_set = self.record.data_type_references();
-                            let mut data_types = Vec::with_capacity(property_type_set.len());
-                            for data_type_ref in property_type_set {
-                                let data_type = context
-                                    .read_versioned_data_type(data_type_ref.uri())
+                            let property_type_set = self.record.property_type_references();
+                            let mut property_types = Vec::with_capacity(property_type_set.len());
+                            for property_type_ref in property_type_set {
+                                let property_type = context
+                                    .read_versioned_property_type(property_type_ref.uri())
                                     .await
-                                    .expect("Could not read data type");
-                                data_types
-                                    .push(data_type.resolve(property_type_segments, context).await);
+                                    .expect("Could not read property type");
+                                property_types.push(
+                                    property_type.resolve(property_type_segments, context).await,
+                                );
                             }
-                            return Literal::List(data_types);
+                            return Literal::List(property_types);
                         }
                         _ => {
                             // see https://app.asana.com/0/0/1202884883200970/f
-                            todo!("Non-wildcard queries on data types")
+                            todo!("Non-wildcard queries on property types")
                         }
                     },
                     _ => Literal::Null,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/read.rs
@@ -7,11 +7,11 @@ use crate::store::{
 };
 
 #[async_trait]
-impl<Ctx> Resolve<Ctx> for Record<PropertyType>
+impl<C> Resolve<C> for Record<PropertyType>
 where
-    Ctx: PostgresContext + Send + Sync,
+    C: PostgresContext + Sync,
 {
-    async fn resolve(&self, path: &[PathSegment], context: &mut Ctx) -> Literal {
+    async fn resolve(&self, path: &[PathSegment], context: &C) -> Literal {
         match path {
             [] => {
                 // see https://app.asana.com/0/0/1202884883200943/f"

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -23,22 +23,6 @@ pub trait PersistedOntologyType {
     fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self;
 }
 
-// impl PersistedOntologyType for PersistedDataType {
-//     type Inner = DataType;
-//
-//     fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self {
-//         Self { inner, identifier }
-//     }
-// }
-//
-// impl PersistedOntologyType for PersistedPropertyType {
-//     type Inner = PropertyType;
-//
-//     fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self {
-//         Self { inner, identifier }
-//     }
-// }
-
 impl PersistedOntologyType for PersistedLinkType {
     type Inner = LinkType;
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -3,13 +3,13 @@ use error_stack::{IntoReport, Result, ResultExt, StreamExt as _};
 use futures::{StreamExt, TryStreamExt};
 use serde::Deserialize;
 use tokio_postgres::{GenericClient, RowStream};
-use type_system::{DataType, PropertyType};
+use type_system::PropertyType;
 
 use crate::{
     ontology::{
         types::{EntityType, LinkType},
-        AccountId, PersistedDataType, PersistedEntityType, PersistedLinkType,
-        PersistedOntologyIdentifier, PersistedPropertyType,
+        AccountId, PersistedEntityType, PersistedLinkType, PersistedOntologyIdentifier,
+        PersistedPropertyType,
     },
     store::{
         crud::Read,
@@ -25,13 +25,13 @@ pub trait PersistedOntologyType {
     fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self;
 }
 
-impl PersistedOntologyType for PersistedDataType {
-    type Inner = DataType;
-
-    fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self {
-        Self { inner, identifier }
-    }
-}
+// impl PersistedOntologyType for PersistedDataType {
+//     type Inner = DataType;
+//
+//     fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self {
+//         Self { inner, identifier }
+//     }
+// }
 
 impl PersistedOntologyType for PersistedPropertyType {
     type Inner = PropertyType;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -3,13 +3,11 @@ use error_stack::{IntoReport, Result, ResultExt, StreamExt as _};
 use futures::{StreamExt, TryStreamExt};
 use serde::Deserialize;
 use tokio_postgres::{GenericClient, RowStream};
-use type_system::PropertyType;
 
 use crate::{
     ontology::{
         types::{EntityType, LinkType},
         AccountId, PersistedEntityType, PersistedLinkType, PersistedOntologyIdentifier,
-        PersistedPropertyType,
     },
     store::{
         crud::Read,
@@ -32,14 +30,14 @@ pub trait PersistedOntologyType {
 //         Self { inner, identifier }
 //     }
 // }
-
-impl PersistedOntologyType for PersistedPropertyType {
-    type Inner = PropertyType;
-
-    fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self {
-        Self { inner, identifier }
-    }
-}
+//
+// impl PersistedOntologyType for PersistedPropertyType {
+//     type Inner = PropertyType;
+//
+//     fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self {
+//         Self { inner, identifier }
+//     }
+// }
 
 impl PersistedOntologyType for PersistedLinkType {
     type Inner = LinkType;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -97,6 +97,8 @@ fn apply_filter<T: OntologyDatabaseType>(element: T, query: &OntologyQuery<'_, T
     Some(element)
 }
 
+// TODO: Unify methods for Ontology types using `Expression`s
+//   see https://app.asana.com/0/0/1202884883200959/f
 #[async_trait]
 impl<C: AsClient, T> Read<T> for PostgresStore<C>
 where

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve.rs
@@ -1,0 +1,125 @@
+use async_trait::async_trait;
+use error_stack::{IntoReport, Result, ResultExt};
+use tokio_postgres::{GenericClient, RowStream};
+use type_system::{uri::VersionedUri, DataType};
+
+use crate::store::{postgres::parameter_list, AsClient, PostgresStore, QueryError};
+
+#[async_trait]
+pub trait PostgresContext {
+    async fn read_data_types(&self) -> Result<RowStream, QueryError>;
+    async fn read_versioned_data_type(
+        &self,
+        uri: &VersionedUri,
+    ) -> Result<Record<DataType>, QueryError>;
+    async fn read_property_types(&self) -> Result<RowStream, QueryError>;
+}
+
+#[async_trait]
+impl<T> PostgresContext for &T
+where
+    T: PostgresContext + Sync,
+{
+    async fn read_data_types(&self) -> Result<RowStream, QueryError> {
+        PostgresContext::read_data_types(*self).await
+    }
+
+    async fn read_versioned_data_type(
+        &self,
+        uri: &VersionedUri,
+    ) -> Result<Record<DataType>, QueryError> {
+        PostgresContext::read_versioned_data_type(*self, uri).await
+    }
+
+    async fn read_property_types(&self) -> Result<RowStream, QueryError> {
+        PostgresContext::read_property_types(*self).await
+    }
+}
+
+#[derive(Debug)]
+pub struct Record<T> {
+    pub record: T,
+    pub is_latest: bool,
+}
+
+#[async_trait]
+impl<C: AsClient> PostgresContext for PostgresStore<C> {
+    async fn read_data_types(&self) -> Result<RowStream, QueryError> {
+        self.client.as_client()
+            .query_raw(
+                r#"
+                SELECT schema, created_by, MAX(version) OVER (PARTITION by base_uri) = version as latest
+                FROM data_types
+                INNER JOIN ids
+                ON data_types.version_id = ids.version_id
+                ORDER BY base_uri, version DESC;
+                "#,
+                parameter_list([]),
+            )
+            .await
+            .into_report()
+            .change_context(QueryError)
+    }
+
+    async fn read_versioned_data_type(
+        &self,
+        uri: &VersionedUri,
+    ) -> Result<Record<DataType>, QueryError> {
+        let row = self
+            .client
+            .as_client()
+            .query_one(
+                r#"
+                SELECT schema, created_by
+                FROM data_types
+                INNER JOIN ids
+                ON data_types.version_id = ids.version_id
+                WHERE base_uri = $1 AND version = $2;
+                "#,
+                &[&uri.base_uri().as_str(), &i64::from(uri.version())],
+            )
+            .await
+            .into_report()
+            .change_context(QueryError)?;
+        let data_type: DataType = serde_json::from_value(row.get(0))
+            .into_report()
+            .change_context(QueryError)?;
+
+        let row = self
+            .client
+            .as_client()
+            .query_one(
+                r#"
+                SELECT MAX(version) as latest
+                FROM ids
+                WHERE base_uri = $1
+                "#,
+                &[&uri.base_uri().as_str()],
+            )
+            .await
+            .into_report()
+            .change_context(QueryError)?;
+        let latest: i64 = row.get(0);
+        Ok(Record {
+            record: data_type,
+            is_latest: latest as u32 == uri.version(),
+        })
+    }
+
+    async fn read_property_types(&self) -> Result<RowStream, QueryError> {
+        self.client.as_client()
+            .query_raw(
+                r#"
+                SELECT schema, created_by, MAX(version) OVER (PARTITION by base_uri) = version as latest
+                FROM property_types
+                INNER JOIN ids
+                ON property_types.version_id = ids.version_id
+                ORDER BY base_uri, version DESC;
+                "#,
+                parameter_list([]),
+            )
+            .await
+            .into_report()
+            .change_context(QueryError)
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve.rs
@@ -3,12 +3,13 @@ use error_stack::{IntoReport, Result, ResultExt};
 use tokio_postgres::{GenericClient, Row, RowStream};
 use type_system::{uri::VersionedUri, DataType, PropertyType};
 
-use crate::store::{postgres::parameter_list, AsClient, PostgresStore, QueryError};
+use crate::store::{postgres::parameter_list, query::Resolve, AsClient, PostgresStore, QueryError};
 
 /// Context used to for [`Resolve`].
 ///
 /// This is only used as an implementation detail inside of the [`postgres`] module.
 ///
+/// [`Resolve`]: crate::store::query::Resolve
 /// [`postgres`]: crate::store::postgres
 // TODO: Use the context to hold query data
 //   see https://app.asana.com/0/0/1202884883200946/f

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve.rs
@@ -58,7 +58,7 @@ where
     }
 }
 
-/// Associates a database entry with the information about the latest version if the corresponding
+/// Associates a database entry with the information about the latest version of the corresponding
 /// entry.
 ///
 /// This is used for filtering by the latest version.

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve.rs
@@ -5,6 +5,13 @@ use type_system::{uri::VersionedUri, DataType, PropertyType};
 
 use crate::store::{postgres::parameter_list, AsClient, PostgresStore, QueryError};
 
+/// Context used to for [`Resolve`].
+///
+/// This is only used as an implementation detail inside of the [`postgres`] module.
+///
+/// [`postgres`]: crate::store::postgres
+// TODO: Use the context to hold query data
+//   see https://app.asana.com/0/0/1202884883200946/f
 #[async_trait]
 pub trait PostgresContext {
     async fn read_all_data_types(&self) -> Result<RowStream, QueryError>;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve.rs
@@ -30,34 +30,6 @@ pub trait PostgresContext {
     ) -> Result<Record<PropertyType>, QueryError>;
 }
 
-#[async_trait]
-impl<T> PostgresContext for &T
-where
-    T: PostgresContext + Sync,
-{
-    async fn read_all_data_types(&self) -> Result<RowStream, QueryError> {
-        PostgresContext::read_all_data_types(*self).await
-    }
-
-    async fn read_versioned_data_type(
-        &self,
-        uri: &VersionedUri,
-    ) -> Result<Record<DataType>, QueryError> {
-        PostgresContext::read_versioned_data_type(*self, uri).await
-    }
-
-    async fn read_all_property_types(&self) -> Result<RowStream, QueryError> {
-        PostgresContext::read_all_property_types(*self).await
-    }
-
-    async fn read_versioned_property_type(
-        &self,
-        uri: &VersionedUri,
-    ) -> Result<Record<PropertyType>, QueryError> {
-        PostgresContext::read_versioned_property_type(*self, uri).await
-    }
-}
-
 /// Associates a database entry with the information about the latest version of the corresponding
 /// entry.
 ///

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve.rs
@@ -58,6 +58,10 @@ where
     }
 }
 
+/// Associates a database entry with the information about the latest version if the corresponding
+/// entry.
+///
+/// This is used for filtering by the latest version.
 #[derive(Debug)]
 pub struct Record<T> {
     pub record: T,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve.rs
@@ -5,7 +5,7 @@ use type_system::{uri::VersionedUri, DataType, PropertyType};
 
 use crate::store::{postgres::parameter_list, AsClient, PostgresStore, QueryError};
 
-/// Context used to for [`Resolve`].
+/// Context used for [`Resolve`].
 ///
 /// This is only used as an implementation detail inside of the [`postgres`] module.
 ///

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve.rs
@@ -10,7 +10,7 @@ use crate::store::{postgres::parameter_list, AsClient, PostgresStore, QueryError
 /// This is only used as an implementation detail inside of the [`postgres`] module.
 ///
 /// [`Resolve`]: crate::store::query::Resolve
-/// [`postgres`]: crate::store::postgres
+/// [`postgres`]: super
 // TODO: Use the context to hold query data
 //   see https://app.asana.com/0/0/1202884883200946/f
 #[async_trait]

--- a/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
@@ -245,7 +245,7 @@ where
                         .identifier
                         .parse()
                         .expect("path needs to be an unsigned integer");
-                    let literal = values.get(index).expect("Index out of bounds");
+                    let literal = values.get(index).expect("index out of bounds");
                     if segments.is_empty() {
                         literal.clone()
                     } else {

--- a/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
@@ -219,6 +219,9 @@ impl Expression {
     }
 }
 
+/// Resolves this types into a [`Literal`].
+// TODO: DOC
+//   see https://app.asana.com/0/0/1202884883200976/f
 #[async_trait]
 pub trait Resolve<Ctx> {
     // TODO: Implement error handling

--- a/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
@@ -132,6 +132,7 @@ impl Expression {
                 Expression::All(expressions) => {
                     for expression in expressions {
                         match expression.evaluate(resolver).await {
+                            Literal::Bool(true) => continue,
                             literal @ Literal::Bool(false) => return literal,
                             literal => panic!("Not a boolean: {literal:?}"),
                         }
@@ -141,6 +142,7 @@ impl Expression {
                 Expression::Any(expressions) => {
                     for expression in expressions {
                         match expression.evaluate(resolver).await {
+                            Literal::Bool(false) => continue,
                             literal @ Literal::Bool(true) => return literal,
                             literal => panic!("Not a boolean: {literal:?}"),
                         }

--- a/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
@@ -150,7 +150,7 @@ impl Expression {
 impl Expression {
     // TODO: Implement error handling
     //   see https://app.asana.com/0/0/1202884883200968/f
-    #[allow(clippy::missing_panics_doc, reason = "Error handling not applied yet")]
+    #[expect(clippy::missing_panics_doc, reason = "Error handling not applied yet")]
     pub fn evaluate<'t, 'resolver, 'context, 'r, R, C>(
         &'t self,
         resolver: &'resolver R,

--- a/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
@@ -154,11 +154,11 @@ impl Expression {
     pub fn evaluate<'t, 'resolver, 'context, 'r, R, C>(
         &'t self,
         resolver: &'resolver R,
-        context: &'context mut C,
+        context: &'context C,
     ) -> BoxFuture<'t, Literal>
     where
         for<'rec> R: Resolve<C> + Send + Sync + 'resolver,
-        C: Send + 'context,
+        C: Sync + 'context,
         'context: 't,
         'resolver: 't,
         Self: 't,
@@ -223,18 +223,18 @@ impl Expression {
 // TODO: DOC
 //   see https://app.asana.com/0/0/1202884883200976/f
 #[async_trait]
-pub trait Resolve<Ctx> {
+pub trait Resolve<C> {
     // TODO: Implement error handling
     //   see https://app.asana.com/0/0/1202884883200968/f
-    async fn resolve(&self, path: &[PathSegment], context: &mut Ctx) -> Literal;
+    async fn resolve(&self, path: &[PathSegment], context: &C) -> Literal;
 }
 
 #[async_trait]
-impl<Ctx> Resolve<Ctx> for Literal
+impl<C> Resolve<C> for Literal
 where
-    Ctx: Send,
+    C: Sync,
 {
-    async fn resolve(&self, path: &[PathSegment], context: &mut Ctx) -> Literal {
+    async fn resolve(&self, path: &[PathSegment], context: &C) -> Literal {
         // TODO: Support `Literal::Object`
         //   see https://app.asana.com/0/0/1202884883200943/f
         match self {

--- a/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
@@ -1,6 +1,8 @@
 mod knowledge;
 mod ontology;
 
+use serde::{Deserialize, Serialize};
+
 pub use self::{
     knowledge::{EntityQuery, EntityVersion, LinkQuery},
     ontology::{
@@ -8,3 +10,153 @@ pub use self::{
         PropertyTypeQuery,
     },
 };
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Literal {
+    String(String),
+    Float(f64),
+    Bool(bool),
+    Null,
+    List(Vec<Self>),
+    /// Internal representation for a version
+    #[serde(skip)]
+    Version(u32, bool),
+}
+
+fn compare(lhs: &Literal, rhs: &Literal) -> bool {
+    match (lhs, rhs) {
+        (Literal::String(lhs), Literal::String(rhs)) => lhs == rhs,
+        (Literal::Float(lhs), Literal::Float(rhs)) => (lhs - rhs).abs() < f64::EPSILON,
+        (Literal::Bool(lhs), Literal::Bool(rhs)) => lhs == rhs,
+        (Literal::Null, Literal::Null) => true,
+        (Literal::List(lhs), Literal::List(rhs)) => {
+            lhs.len() == rhs.len() && lhs.iter().zip(rhs).all(|(lhs, rhs)| compare(lhs, rhs))
+        }
+        (Literal::Version(lhs, _), Literal::Float(rhs)) => *lhs == *rhs as u32,
+        (Literal::Float(lhs), Literal::Version(rhs, _)) => *lhs as u32 == *rhs,
+        (Literal::String(lhs), Literal::Version(_, latest)) if lhs == "latest" => *latest,
+        (Literal::Version(_, latest), Literal::String(rhs)) if rhs == "latest" => *latest,
+        (lhs, rhs) => {
+            tracing::warn!("unsupported operation: {lhs:?} == {rhs:?}");
+            false
+        }
+    }
+}
+
+impl TryFrom<serde_json::Value> for Literal {
+    type Error = ();
+
+    fn try_from(value: serde_json::Value) -> Result<Self, Self::Error> {
+        use serde_json::Value;
+
+        Ok(match value {
+            Value::Null => Self::Null,
+            Value::Bool(bool) => Self::Bool(bool),
+            Value::Number(number) => number.as_f64().map_or_else(
+                || panic!("Could not parse {number} as literal"),
+                Self::Float,
+            ),
+            Value::String(string) => Self::String(string),
+            Value::Array(values) => Self::List(
+                values
+                    .into_iter()
+                    .map(TryFrom::try_from)
+                    .collect::<Result<Vec<_>, _>>()?,
+            ),
+            Value::Object(_) => todo!(),
+        })
+    }
+}
+
+type Identifier = String;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct PathSegment {
+    pub identifier: Identifier,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Path {
+    pub segments: Vec<PathSegment>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Expression {
+    Eq(Vec<Expression>),
+    Ne(Vec<Expression>),
+    All(Vec<Expression>),
+    Any(Vec<Expression>),
+    Literal(Literal),
+    Path(Path),
+    Field(Identifier),
+}
+
+pub trait Resolve {
+    fn resolve_path(&self, path: &Path) -> Literal;
+}
+
+#[allow(clippy::missing_panics_doc, reason = "Error handling needs to be done")]
+pub fn resolve(
+    expr: &Expression,
+    resolver: &impl Resolve,
+    current_path: &mut Vec<PathSegment>,
+) -> Literal {
+    match expr {
+        Expression::Eq(expressions) => Literal::Bool(expressions.windows(2).all(|expression| {
+            compare(
+                &resolve(&expression[0], resolver, current_path),
+                &resolve(&expression[1], resolver, current_path),
+            )
+        })),
+        Expression::Ne(expressions) => Literal::Bool(expressions.windows(2).any(|expression| {
+            !compare(
+                &resolve(&expression[0], resolver, current_path),
+                &resolve(&expression[1], resolver, current_path),
+            )
+        })),
+        Expression::All(expressions) => Literal::Bool(expressions.iter().all(|expression| {
+            match resolve(expression, resolver, current_path) {
+                Literal::Bool(bool) => bool,
+                literal => panic!("Not a boolean: {literal:?}"),
+            }
+        })),
+        Expression::Any(expressions) => Literal::Bool(expressions.iter().any(|expression| {
+            match resolve(expression, resolver, current_path) {
+                Literal::Bool(bool) => bool,
+                literal => panic!("Not a boolean: {literal:?}"),
+            }
+        })),
+        Expression::Literal(literal) => literal.clone(),
+        Expression::Path(path) => resolver.resolve_path(path),
+        Expression::Field(_identifier) => todo!(),
+    }
+}
+
+impl Resolve for Literal {
+    fn resolve_path(&self, path: &Path) -> Literal {
+        match self {
+            Literal::List(values) => match path.segments.as_slice() {
+                [] => panic!("Path is empty"),
+                [segment, segments @ ..] => {
+                    let index: usize = segment
+                        .identifier
+                        .parse()
+                        .expect("path needs to be an unsigned integer");
+                    let literal = values.get(index).expect("Index out of bounds");
+                    if segments.is_empty() {
+                        literal.clone()
+                    } else {
+                        literal.resolve_path(&Path {
+                            segments: segments.to_vec(),
+                        })
+                    }
+                }
+            },
+            literal => panic!("Cannot index a {literal:?}"),
+        }
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
@@ -1,11 +1,9 @@
 mod knowledge;
 mod ontology;
 
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use error_stack::Result;
-use futures::{future::BoxFuture, stream::iter, FutureExt, StreamExt};
+use futures::{future::BoxFuture, FutureExt};
 use serde::{Deserialize, Serialize};
 
 pub use self::{
@@ -102,6 +100,7 @@ pub enum Expression {
 }
 
 impl Expression {
+    #[allow(clippy::missing_panics_doc, reason = "TODO: Apply error handling")]
     pub fn evaluate<'a, R>(&'a self, resolver: &'a mut R) -> BoxFuture<Literal>
     where
         R: PathResolver + Send + Sync,
@@ -161,10 +160,7 @@ impl Expression {
 pub trait ExpressionResolver {
     type Record;
 
-    async fn resolve(
-        self: Arc<Self>,
-        expression: &Expression,
-    ) -> Result<Vec<Self::Record>, QueryError>;
+    async fn resolve(&mut self, expression: &Expression) -> Result<Vec<Self::Record>, QueryError>;
 }
 
 #[async_trait]

--- a/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
@@ -151,17 +151,10 @@ impl Expression {
     // TODO: Implement error handling
     //   see https://app.asana.com/0/0/1202884883200968/f
     #[expect(clippy::missing_panics_doc, reason = "Error handling not applied yet")]
-    pub fn evaluate<'t, 'resolver, 'context, 'r, R, C>(
-        &'t self,
-        resolver: &'resolver R,
-        context: &'context C,
-    ) -> BoxFuture<'t, Literal>
+    pub fn evaluate<'a, R, C>(&'a self, resolver: &'a R, context: &'a C) -> BoxFuture<Literal>
     where
-        for<'rec> R: Resolve<C> + Send + Sync + 'resolver,
-        C: Sync + 'context,
-        'context: 't,
-        'resolver: 't,
-        Self: 't,
+        R: Resolve<C> + Sync,
+        C: Sync,
     {
         async move {
             match self {

--- a/packages/graph/hash_graph/lib/graph/src/store/query/ontology.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/ontology.rs
@@ -1,11 +1,9 @@
 use std::{fmt, fmt::Formatter, marker::PhantomData};
 
-use type_system::{uri::BaseUri, DataType, PropertyType};
+use type_system::uri::BaseUri;
 
 use crate::ontology::types::{EntityType, LinkType};
 
-pub type DataTypeQuery<'q> = OntologyQuery<'q, DataType>;
-pub type PropertyTypeQuery<'q> = OntologyQuery<'q, PropertyType>;
 pub type LinkTypeQuery<'q> = OntologyQuery<'q, LinkType>;
 pub type EntityTypeQuery<'q> = OntologyQuery<'q, EntityType>;
 

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -17,10 +17,7 @@ use graph::{
     },
     store::{
         error::LinkActivationError,
-        query::{
-            DataTypeQuery, EntityQuery, EntityTypeQuery, LinkQuery, LinkTypeQuery,
-            PropertyTypeQuery,
-        },
+        query::{EntityQuery, EntityTypeQuery, Expression, LinkQuery, LinkTypeQuery},
         AccountStore, AsClient, DataTypeStore, DatabaseConnectionInfo, DatabaseType, EntityStore,
         EntityTypeStore, InsertionError, LinkStore, LinkTypeStore, PostgresStore,
         PostgresStorePool, PropertyTypeStore, QueryError, StorePool, UpdateError,
@@ -158,11 +155,7 @@ impl DatabaseApi<'_> {
     ) -> Result<PersistedDataType, QueryError> {
         Ok(self
             .store
-            .get_data_type(
-                &DataTypeQuery::new()
-                    .by_uri(uri.base_uri())
-                    .by_version(uri.version()),
-            )
+            .get_data_type(&Expression::for_versioned_uri(uri))
             .await?
             .pop()
             .expect("no data type found"))
@@ -192,11 +185,7 @@ impl DatabaseApi<'_> {
     ) -> Result<PersistedPropertyType, QueryError> {
         Ok(self
             .store
-            .get_property_type(
-                &PropertyTypeQuery::new()
-                    .by_uri(uri.base_uri())
-                    .by_version(uri.version()),
-            )
+            .get_property_type(&Expression::for_versioned_uri(uri))
             .await?
             .pop()
             .expect("no property type found"))


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This is the initial PR to support basic structural queries. "basic" in this context means, that the queries do not have a syntax, but only an AST. Also, only a small set of query parameters are supported.

## 🔗 Related links

- [Asana task for data types](https://app.asana.com/0/0/1202884883200952/f) _(internal)_
- [Asana task for property types](https://app.asana.com/0/0/1202884883200953/f) _(internal)_

## 🔍 What does this change?

- Add a `Literal` enumeration, which is similar to `serde_json::Value`. `Value` is not used as we require some special handling for e.g. versioning and subsets. 
- Add a `Resolve` trait, which resolves a struct into a `Literal`
- Add a `PostgresContext` trait used as the resolver context. Currently, this is implemented by the `PostgresStore` itself, but in the future it will be used to store query information.
- Add the `Expression` enumeration, which resolves to a boolean Literal used for filtering. It will resolve to a `Literal` as needed.
- Change the REST Endpoints for `ProeprtyType` and `DataType` to use `Expressions`. Optionally, an expression can be passed as JSON.

## 📜 Does this require a change to the docs?

- Will be done in a follow-up: [Asana Task](https://app.asana.com/0/0/1202884883200976/f) (_internal_). This was not done in this PR as I expect to change the syntax in follow-ups and keeping the documentation up-to-date will be an annoying step.
- In one of the next follow-ups, we will also add more tests for the queries ([Asana Task](https://app.asana.com/0/0/1202884883200974/f) (_internal_)), this is going to be the source of truth until the queries are fully documentad

## ⚠️ Known issues

Currently, each time a record is required for a query, the database is invoked. All filtering happens at Rust and this is suboptimal. However, we need a working version sooner than later, so this can/will be optimized later.
There are other things, which needs to be solved. For a list please see the subtasks of [the structural queries task](https://app.asana.com/0/1200211978612931/1202510174412974/f) (_internal_)

## 🐾 Next steps

- Please see the subtasks of [the structural queries task](https://app.asana.com/0/1200211978612931/1202510174412974/f) (_internal_)

## 🛡 What tests cover this?

Only a subset of expressions is currently tested through the integration test suite and the REST endpoint tests. These need to be expanded later, for tracking please see [the corresponding task](https://app.asana.com/0/0/1202884883200974/f) (_internal_)

## ❓ How to test this?

Pass arbitrary queries to the REST API

## 📹 Demo


### Get all latest data types
```http
GET localhost/data-types
Content-Type: application/json

{
  "eq": [
    {
      "path": [
        "version"
      ]
    },
    {
      "literal": "latest"
    }
  ]
}
```

### Get all data types with type "string"
```http
GET localhost/data-types
Content-Type: application/json

{
  "eq": [
    {
      "path": [
        "type"
      ]
    },
    {
      "literal": "string"
    }
  ]
}
```

### Get all data types with type "string" *and* the latest version
```http
GET localhost/data-types
Content-Type: application/json

{
  "all": [
    {
      "eq": [
        {
          "path": [
            "type"
          ]
        },
        {
          "literal": "string"
        }
      ]
    },
    {
      "eq": [
        {
          "path": [
            "version"
          ]
        },
        {
          "literal": "latest"
        }
      ]
    }
  ]
}
```

### Get all latest property types
```http
GET localhost/property-types
Content-Type: application/json

{
  "eq": [
    {
      "path": [
        "version"
      ]
    },
    {
      "literal": "latest"
    }
  ]
}
```

### Get all `name` property types
```http
GET localhost/property-types
Content-Type: application/json

{
  "eq": [
    {
      "path": [
        "uri"
      ]
    },
    {
      "literal": "https://blockprotocol.org/@alice/types/property-type/name/"
    }
  ]
}
```


### Get all property types with a `string`-type data type, but only if the property type is the latest version
```http
GET localhost/property-types
Content-Type: application/json

{
  "all": [
    {
      "eq": [
        {
          "path": [
            "version"
          ]
        },
        {
          "literal": "latest"
        }
      ]
    },
    {
      "eq": [
        {
          "path": [
            "dataTypes",
            "**",
            "type"
          ]
        },
        {
          "literal": "string"
        }
      ]
    }
  ]
}
```