### PR TITLE
Fix `anyhow` test to support backtraces

### DIFF
--- a/packages/libs/error-stack/tests/test_compatibility.rs
+++ b/packages/libs/error-stack/tests/test_compatibility.rs
@@ -52,7 +52,9 @@ fn anyhow() {
 
     // Backtrace is provided through `anyhow::Error` by `Error::provide`
     #[cfg(all(rust_1_65, feature = "std"))]
-    remove_backtrace_context(&mut report_messages);
+    if has_backtrace(&anyhow) {
+        remove_backtrace_context(&mut report_messages);
+    }
 
     let anyhow_report = anyhow.into_report().unwrap_err();
 

--- a/packages/libs/error-stack/tests/test_compatibility.rs
+++ b/packages/libs/error-stack/tests/test_compatibility.rs
@@ -50,9 +50,7 @@ fn anyhow() {
     #[allow(unused_mut)]
     let mut report_messages = messages(&report);
 
-    // Backtrace from anyhow cannot be captured currently until `Error::provide` is implemented.
-    // Previously, `backtrace` was a function on `Error`, but this was removed, so it has to be
-    // provided by the Provider API.
+    // Backtrace is provided through `anyhow::Error` by `Error::provide`
     #[cfg(all(rust_1_65, feature = "std"))]
     remove_backtrace_context(&mut report_messages);
 
@@ -60,9 +58,6 @@ fn anyhow() {
 
     #[allow(unused_mut)]
     let mut anyhow_messages = messages(&anyhow_report);
-
-    #[cfg(all(rust_1_65, feature = "std"))]
-    remove_backtrace_context(&mut anyhow_messages);
 
     for (anyhow, error_stack) in anyhow_messages.into_iter().rev().zip(report_messages) {
         assert_eq!(anyhow, error_stack);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`anyhow` was released today in a new version that allows `Backtrace` to be provided using `Error::provide`. The test assumed that `anyhow` does not currently support retrieving backtraces, but this has been fixed upstream.

## 🔗 Related links

- https://github.com/dtolnay/anyhow/pull/266