### PR TITLE
Increase slonik connection timeout

### DIFF
--- a/packages/hash/backend-utils/src/postgres.ts
+++ b/packages/hash/backend-utils/src/postgres.ts
@@ -21,6 +21,7 @@ export const createPostgresConnPool = (
 
   return createPool(connStr, {
     captureStackTrace: true,
+    connectionTimeout: 10_000,
     maximumPoolSize: params.maxPoolSize,
     interceptors: [
       {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Slonik is the library we use to connect to Postgres in the HASH API.

Although this is being replaced by a new Graph API, in the meantime we still want the deployed version of HASH to be somewhat usable, and it crashes on any slow db query (which is many of them).

The primary cause of this seems to be Slonik timing out when waiting for a response from the database, probably owing to an aggressive ([their words](https://github.com/gajus/slonik#default-timeouts)) 5 second timeout.

This PR increases it to 10 second in an attempt to reduce the number of crashes.
