### PR TITLE
Improve usages of streams by using `StreamExt`

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/lib.rs
+++ b/packages/graph/hash_graph/lib/graph/src/lib.rs
@@ -9,6 +9,7 @@
 // Not required, reason: Simpler than using blanket implementations
 #![feature(trait_alias)]
 #![feature(try_find)]
+#![feature(type_alias_impl_trait)]
 #![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
 #![cfg_attr(not(miri), doc(test(attr(deny(warnings, clippy::all)))))]
 #![warn(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -2,7 +2,7 @@ pub mod read;
 
 use async_trait::async_trait;
 use error_stack::{bail, IntoReport, Report, Result, ResultExt};
-use futures::{StreamExt, TryStreamExt};
+use futures::TryStreamExt;
 use tokio_postgres::GenericClient;
 use type_system::DataType;
 
@@ -10,7 +10,7 @@ use crate::{
     ontology::{AccountId, PersistedDataType, PersistedOntologyIdentifier},
     store::{
         crud::Read,
-        postgres::resolve::{PostgresContext, Record},
+        postgres::resolve::PostgresContext,
         query::{Expression, ExpressionError, Literal},
         AsClient, DataTypeStore, InsertionError, PostgresStore, QueryError, UpdateError,
     },
@@ -81,28 +81,18 @@ impl<C: AsClient> Read<PersistedDataType> for PostgresStore<C> {
     ) -> Result<Vec<PersistedDataType>, QueryError> {
         self.read_all_data_types()
             .await?
-            .map(|row_result| row_result.into_report().change_context(QueryError))
-            .try_filter_map(|row| async move {
-                let data_type: DataType = serde_json::from_value(row.get(0))
-                    .into_report()
-                    .change_context(QueryError)?;
-
-                let versioned_data_type = Record {
-                    record: data_type,
-                    is_latest: row.get(2),
-                };
-
+            .try_filter_map(|data_type| async move {
                 if let Literal::Bool(result) = expression
-                    .evaluate(&versioned_data_type, self)
+                    .evaluate(&data_type, self)
                     .await
                     .change_context(QueryError)?
                 {
                     Ok(result.then(|| {
-                        let uri = versioned_data_type.record.id();
-                        let account_id: AccountId = row.get(1);
-                        let identifier = PersistedOntologyIdentifier::new(uri.clone(), account_id);
+                        let uri = data_type.record.id();
+                        let identifier =
+                            PersistedOntologyIdentifier::new(uri.clone(), data_type.account_id);
                         PersistedDataType {
-                            inner: versioned_data_type.record,
+                            inner: data_type.record,
                             identifier,
                         }
                     }))

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -2,7 +2,7 @@ mod read;
 
 use async_trait::async_trait;
 use error_stack::{bail, IntoReport, Report, Result, ResultExt};
-use futures::{StreamExt, TryStreamExt};
+use futures::TryStreamExt;
 use tokio_postgres::GenericClient;
 use type_system::PropertyType;
 
@@ -10,7 +10,7 @@ use crate::{
     ontology::{AccountId, PersistedOntologyIdentifier, PersistedPropertyType},
     store::{
         crud::Read,
-        postgres::resolve::{PostgresContext, Record},
+        postgres::resolve::PostgresContext,
         query::{Expression, ExpressionError, Literal},
         AsClient, InsertionError, PostgresStore, PropertyTypeStore, QueryError, UpdateError,
     },
@@ -95,28 +95,18 @@ impl<C: AsClient> Read<PersistedPropertyType> for PostgresStore<C> {
     ) -> Result<Vec<PersistedPropertyType>, QueryError> {
         self.read_all_property_types()
             .await?
-            .map(|row_result| row_result.into_report().change_context(QueryError))
-            .try_filter_map(|row| async move {
-                let property_type: PropertyType = serde_json::from_value(row.get(0))
-                    .into_report()
-                    .change_context(QueryError)?;
-
-                let versioned_property_type = Record {
-                    record: property_type,
-                    is_latest: row.get(2),
-                };
-
+            .try_filter_map(|property_type| async move {
                 if let Literal::Bool(result) = expression
-                    .evaluate(&versioned_property_type, self)
+                    .evaluate(&property_type, self)
                     .await
                     .change_context(QueryError)?
                 {
                     Ok(result.then(|| {
-                        let uri = versioned_property_type.record.id();
-                        let account_id: AccountId = row.get(1);
-                        let identifier = PersistedOntologyIdentifier::new(uri.clone(), account_id);
+                        let uri = property_type.record.id();
+                        let identifier =
+                            PersistedOntologyIdentifier::new(uri.clone(), property_type.account_id);
                         PersistedPropertyType {
-                            inner: versioned_property_type.record,
+                            inner: property_type.record,
                             identifier,
                         }
                     }))

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve.rs
@@ -1,9 +1,16 @@
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
+use futures::{Stream, StreamExt};
+use serde::Deserialize;
 use tokio_postgres::{GenericClient, Row, RowStream};
 use type_system::{uri::VersionedUri, DataType, PropertyType};
 
-use crate::store::{postgres::parameter_list, AsClient, PostgresStore, QueryError};
+use crate::{
+    ontology::AccountId,
+    store::{postgres::parameter_list, AsClient, PostgresStore, QueryError},
+};
+
+type RecordStream<T: for<'de> Deserialize<'de>> = impl Stream<Item = Result<Record<T>, QueryError>>;
 
 /// Context used for [`Resolve`].
 ///
@@ -15,14 +22,14 @@ use crate::store::{postgres::parameter_list, AsClient, PostgresStore, QueryError
 //   see https://app.asana.com/0/0/1202884883200946/f
 #[async_trait]
 pub trait PostgresContext {
-    async fn read_all_data_types(&self) -> Result<RowStream, QueryError>;
+    async fn read_all_data_types(&self) -> Result<RecordStream<DataType>, QueryError>;
 
     async fn read_versioned_data_type(
         &self,
         uri: &VersionedUri,
     ) -> Result<Record<DataType>, QueryError>;
 
-    async fn read_all_property_types(&self) -> Result<RowStream, QueryError>;
+    async fn read_all_property_types(&self) -> Result<RecordStream<PropertyType>, QueryError>;
 
     async fn read_versioned_property_type(
         &self,
@@ -37,7 +44,24 @@ pub trait PostgresContext {
 #[derive(Debug)]
 pub struct Record<T> {
     pub record: T,
+    pub account_id: AccountId,
     pub is_latest: bool,
+}
+
+fn row_stream_to_record_stream<T: for<'de> Deserialize<'de>>(
+    row_stream: RowStream,
+) -> RecordStream<T> {
+    row_stream.map(|row| {
+        let row = row.into_report().change_context(QueryError)?;
+
+        Ok(Record {
+            record: serde_json::from_value(row.get(0))
+                .into_report()
+                .change_context(QueryError)?,
+            account_id: row.get(1),
+            is_latest: row.get(2),
+        })
+    })
 }
 
 async fn read_all_types(client: &impl AsClient, table: &str) -> Result<RowStream, QueryError> {
@@ -56,8 +80,7 @@ async fn read_all_types(client: &impl AsClient, table: &str) -> Result<RowStream
             parameter_list([]),
         )
         .await
-        .into_report()
-        .change_context(QueryError)
+        .into_report().change_context(QueryError)
 }
 
 async fn read_versioned_type(
@@ -87,26 +110,32 @@ async fn read_versioned_type(
         .into_report()
         .change_context(QueryError)?;
 
+    let account_id = row.get(1);
     let latest: i64 = row.get(2);
     Ok(Record {
         record: row,
+        account_id,
         is_latest: latest as u32 == uri.version(),
     })
 }
 
 #[async_trait]
 impl<C: AsClient> PostgresContext for PostgresStore<C> {
-    async fn read_all_data_types(&self) -> Result<RowStream, QueryError> {
-        read_all_types(&self.client, "data_types")
-            .await
-            .attach_printable("could not read data types")
+    async fn read_all_data_types(&self) -> Result<RecordStream<DataType>, QueryError> {
+        Ok(row_stream_to_record_stream(
+            read_all_types(&self.client, "data_types").await?,
+        ))
     }
 
     async fn read_versioned_data_type(
         &self,
         uri: &VersionedUri,
     ) -> Result<Record<DataType>, QueryError> {
-        let Record { record, is_latest } = read_versioned_type(&self.client, "data_types", uri)
+        let Record {
+            record,
+            account_id,
+            is_latest,
+        } = read_versioned_type(&self.client, "data_types", uri)
             .await
             .attach_printable("could not read data type")?;
 
@@ -114,21 +143,26 @@ impl<C: AsClient> PostgresContext for PostgresStore<C> {
             record: serde_json::from_value(record.get(0))
                 .into_report()
                 .change_context(QueryError)?,
+            account_id,
             is_latest,
         })
     }
 
-    async fn read_all_property_types(&self) -> Result<RowStream, QueryError> {
-        read_all_types(&self.client, "property_types")
-            .await
-            .attach_printable("could not read property types")
+    async fn read_all_property_types(&self) -> Result<RecordStream<PropertyType>, QueryError> {
+        Ok(row_stream_to_record_stream(
+            read_all_types(&self.client, "property_types").await?,
+        ))
     }
 
     async fn read_versioned_property_type(
         &self,
         uri: &VersionedUri,
     ) -> Result<Record<PropertyType>, QueryError> {
-        let Record { record, is_latest } = read_versioned_type(&self.client, "property_types", uri)
+        let Record {
+            record,
+            account_id,
+            is_latest,
+        } = read_versioned_type(&self.client, "property_types", uri)
             .await
             .attach_printable("could not read property type")?;
 
@@ -136,6 +170,7 @@ impl<C: AsClient> PostgresContext for PostgresStore<C> {
             record: serde_json::from_value(record.get(0))
                 .into_report()
                 .change_context(QueryError)?,
+            account_id,
             is_latest,
         })
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A few small improvements when dealing with streams

## 🔍 What does this change?

- Change `PostgresContext` to return `impl Stream<Item = Result<Record<T>, QueryObject>>` instead of `RowStream`. For this, `account_id` was added to `Record`.
- Use stream combinators for building `Literal::List` instead of constructing the `Vec` by hand

## 🚫  Blocked on

- #1016 