### PR TITLE
fix BlockContextMenu focus outline issue

### DIFF
--- a/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockContextMenuItem.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockContextMenu/BlockContextMenuItem.tsx
@@ -1,5 +1,5 @@
 import { faChevronRight } from "@fortawesome/free-solid-svg-icons";
-import { ListItemIcon, ListItemText } from "@mui/material";
+import { ListItemIcon, ListItemText, menuItemClasses } from "@mui/material";
 import {
   bindPopover,
   bindHover,
@@ -65,6 +65,14 @@ export const BlockContextMenuItem = forwardRef<
           })}
       sx={{
         position: "relative",
+
+        [`&.${menuItemClasses.focusVisible}`]: {
+          boxShadow: "none",
+        },
+
+        ...(subMenuPopupState.isOpen && {
+          backgroundColor: ({ palette }) => `${palette.gray[20]} !important`,
+        }),
       }}
     >
       <ListItemIcon>{icon}</ListItemIcon>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Removes weird looking outlines from `BlockContextMenuItem`'s with submenus. The outline was visible on hover. It was confusing & looking bad.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1200211978612931/1202765662321769/f) _(internal)_

## 🔍 What does this change?

- Remove blue outline from `BlockContextMenuItem` on focus and set the background color properly while submenu is open.

## 🐾 Next steps

- We should implement a better way for nested menu items, also handle keyboard navigation & focus properly.
- https://github.com/steviebaa/mui-nested-menu This library might worth have a look at to get some inspiration, or implement.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch / view the deployment
1.  Open a page
2. Try the behavior showed in the demo below

## 📹 Demo

### Before
<img width="516" alt="before" src="https://user-images.githubusercontent.com/39553853/187931433-99668938-458c-4b5e-a851-63bf74c23318.png">

### After
<img width="516" alt="after" src="https://user-images.githubusercontent.com/39553853/187931449-a62ab416-4efb-4ff5-8ae3-b2a0a7336fd4.png">

