### PR TITLE
Add structural queries for `EntityType`

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -18,7 +18,7 @@ use crate::{
     ontology::{AccountId, PersistedEntityType, PersistedOntologyIdentifier},
     store::{
         error::{BaseUriAlreadyExists, BaseUriDoesNotExist},
-        query::EntityTypeQuery,
+        query::Expression,
         EntityTypeStore, StorePool,
     },
 };
@@ -131,10 +131,16 @@ async fn create_entity_type<P: StorePool + Send>(
 )]
 async fn get_latest_entity_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
+    mut body: Option<Json<Expression>>,
 ) -> Result<Json<Vec<PersistedEntityType>>, StatusCode> {
-    read_from_store(pool.as_ref(), &EntityTypeQuery::new().by_latest_version())
-        .await
-        .map(Json)
+    read_from_store(
+        pool.as_ref(),
+        &body
+            .take()
+            .map_or_else(Expression::for_latest_version, |json| json.0),
+    )
+    .await
+    .map(Json)
 }
 
 #[utoipa::path(
@@ -156,15 +162,10 @@ async fn get_entity_type<P: StorePool + Send>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,
 ) -> Result<Json<PersistedEntityType>, StatusCode> {
-    read_from_store(
-        pool.as_ref(),
-        &EntityTypeQuery::new()
-            .by_uri(uri.base_uri())
-            .by_version(uri.version()),
-    )
-    .await
-    .and_then(|mut entity_types| entity_types.pop().ok_or(StatusCode::NOT_FOUND))
-    .map(Json)
+    read_from_store(pool.as_ref(), &Expression::for_versioned_uri(&uri.0))
+        .await
+        .and_then(|mut data_types| data_types.pop().ok_or(StatusCode::NOT_FOUND))
+        .map(Json)
 }
 
 #[derive(Component, Serialize, Deserialize)]

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -164,7 +164,7 @@ async fn get_entity_type<P: StorePool + Send>(
 ) -> Result<Json<PersistedEntityType>, StatusCode> {
     read_from_store(pool.as_ref(), &Expression::for_versioned_uri(&uri.0))
         .await
-        .and_then(|mut data_types| data_types.pop().ok_or(StatusCode::NOT_FOUND))
+        .and_then(|mut entity_types| entity_types.pop().ok_or(StatusCode::NOT_FOUND))
         .map(Json)
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     },
     store::{
         error::LinkActivationError,
-        query::{EntityQuery, EntityTypeQuery, Expression, LinkQuery},
+        query::{EntityQuery, Expression, LinkQuery},
     },
 };
 
@@ -286,9 +286,7 @@ pub trait PropertyTypeStore:
 
 /// Describes the API of a store implementation for [`EntityType`]s.
 #[async_trait]
-pub trait EntityTypeStore:
-    for<'q> crud::Read<PersistedEntityType, Query<'q> = EntityTypeQuery<'q>>
-{
+pub trait EntityTypeStore: for<'q> crud::Read<PersistedEntityType, Query<'q> = Expression> {
     /// Creates a new [`EntityType`].
     ///
     /// # Errors:
@@ -310,7 +308,7 @@ pub trait EntityTypeStore:
     /// - if the requested [`EntityType`] doesn't exist.
     async fn get_entity_type(
         &self,
-        query: &EntityTypeQuery<'_>,
+        query: &Expression,
     ) -> Result<Vec<PersistedEntityType>, QueryError> {
         self.read(query).await
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -301,7 +301,7 @@ pub trait EntityTypeStore: for<'q> crud::Read<PersistedEntityType, Query<'q> = E
         created_by: AccountId,
     ) -> Result<PersistedOntologyIdentifier, InsertionError>;
 
-    /// Get the [`EntityType`]s specified by the [`EntityTypeQuery`].
+    /// Get the [`EntityType`]s specified by the [`Expression`].
     ///
     /// # Errors
     ///

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
@@ -1,3 +1,5 @@
+mod read;
+
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
 use tokio_postgres::GenericClient;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
@@ -1,13 +1,19 @@
 mod read;
 
 use async_trait::async_trait;
-use error_stack::{IntoReport, Result, ResultExt};
+use error_stack::{bail, IntoReport, Report, Result, ResultExt};
+use futures::TryStreamExt;
 use tokio_postgres::GenericClient;
 use type_system::EntityType;
 
 use crate::{
-    ontology::{AccountId, PersistedOntologyIdentifier},
-    store::{AsClient, EntityTypeStore, InsertionError, PostgresStore, UpdateError},
+    ontology::{AccountId, PersistedEntityType, PersistedOntologyIdentifier},
+    store::{
+        crud::Read,
+        postgres::resolve::PostgresContext,
+        query::{Expression, ExpressionError, Literal},
+        AsClient, EntityTypeStore, InsertionError, PostgresStore, QueryError, UpdateError,
+    },
 };
 
 #[async_trait]
@@ -80,5 +86,45 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
             .change_context(UpdateError)?;
 
         Ok(identifier)
+    }
+}
+
+// TODO: Unify methods for Ontology types using `Expression`s
+//   see https://app.asana.com/0/0/1202884883200959/f
+#[async_trait]
+impl<C: AsClient> Read<PersistedEntityType> for PostgresStore<C> {
+    type Query<'q> = Expression;
+
+    async fn read<'query>(
+        &self,
+        expression: &Self::Query<'query>,
+    ) -> Result<Vec<PersistedEntityType>, QueryError> {
+        self.read_all_entity_types()
+            .await?
+            .try_filter_map(|entity_type| async move {
+                if let Literal::Bool(result) = expression
+                    .evaluate(&entity_type, self)
+                    .await
+                    .change_context(QueryError)?
+                {
+                    Ok(result.then(|| {
+                        let uri = entity_type.record.id();
+                        let identifier =
+                            PersistedOntologyIdentifier::new(uri.clone(), entity_type.account_id);
+                        PersistedEntityType {
+                            inner: entity_type.record,
+                            identifier,
+                        }
+                    }))
+                } else {
+                    bail!(
+                        Report::new(ExpressionError)
+                            .attach_printable("does not result in a boolean value")
+                            .change_context(QueryError)
+                    );
+                }
+            })
+            .try_collect()
+            .await
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/read.rs
@@ -1,0 +1,142 @@
+use std::str::FromStr;
+
+use async_trait::async_trait;
+use error_stack::{IntoReport, Result, ResultExt};
+use futures::{stream, StreamExt, TryStreamExt};
+use type_system::{uri::VersionedUri, EntityType};
+
+use crate::store::{
+    postgres::resolve::{PostgresContext, Record},
+    query::{
+        Literal, PathSegment, Resolve, ResolveError, UNIMPLEMENTED_LITERAL_OBJECT,
+        UNIMPLEMENTED_WILDCARDS,
+    },
+};
+
+async fn resolve_entity_type(
+    uri: &VersionedUri,
+    path: &[PathSegment],
+    context: &(impl PostgresContext + Sync),
+) -> Result<Literal, ResolveError> {
+    context
+        .read_versioned_entity_type(uri)
+        .await
+        .change_context(ResolveError::StoreReadError)?
+        .resolve(path, context)
+        .await
+}
+
+#[async_trait]
+impl<C> Resolve<C> for Record<EntityType>
+where
+    C: PostgresContext + Sync,
+{
+    async fn resolve(&self, path: &[PathSegment], context: &C) -> Result<Literal, ResolveError> {
+        match path {
+            [] => todo!("{}", UNIMPLEMENTED_LITERAL_OBJECT),
+            [segment, segments @ ..] => {
+                // TODO: Avoid cloning on literals
+                //   see https://app.asana.com/0/0/1202884883200947/f
+                let literal = match segment.identifier.as_str() {
+                    "uri" => Literal::String(self.record.id().base_uri().to_string()),
+                    "version" => Literal::Version(self.record.id().version(), self.is_latest),
+                    "title" => Literal::String(self.record.title().to_owned()),
+                    "description" => self
+                        .record
+                        .description()
+                        .map_or(Literal::Null, |description| {
+                            Literal::String(description.to_owned())
+                        }),
+                    "default" | "examples" => todo!("{}", UNIMPLEMENTED_LITERAL_OBJECT),
+                    "properties" => match segments {
+                        [] => todo!("{}", UNIMPLEMENTED_LITERAL_OBJECT),
+                        [property_type_segment, property_type_segments @ ..]
+                            if property_type_segment.identifier == "**" =>
+                        {
+                            // TODO: Use relation tables
+                            //   see https://app.asana.com/0/0/1202884883200942/f
+                            return Ok(Literal::List(
+                                stream::iter(self.record.property_type_references())
+                                    .then(|property_type_ref| async {
+                                        context
+                                            .read_versioned_property_type(property_type_ref.uri())
+                                            .await
+                                            .change_context(ResolveError::StoreReadError)?
+                                            .resolve(property_type_segments, context)
+                                            .await
+                                    })
+                                    .try_collect()
+                                    .await?,
+                            ));
+                        }
+                        [property_type_segment, ..] if property_type_segment.identifier == "*" => {
+                            todo!("{}", UNIMPLEMENTED_WILDCARDS)
+                        }
+                        _ => todo!("{}", UNIMPLEMENTED_LITERAL_OBJECT),
+                    },
+                    "required" => Literal::List(
+                        self.record
+                            .required()
+                            .iter()
+                            .map(|base_uri| Literal::String(base_uri.to_string()))
+                            .collect(),
+                    ),
+                    "links" => match segments {
+                        [] => todo!("{}", UNIMPLEMENTED_LITERAL_OBJECT),
+                        [entity_type_segment, entity_type_segments @ ..] => {
+                            match entity_type_segment.identifier.as_str() {
+                                "*" => {
+                                    // TODO: Use relation tables,
+                                    //   see https://app.asana.com/0/0/1202884883200942/f
+                                    return Ok(Literal::List(
+                                        stream::iter(self.record.link_type_references())
+                                            .then(|(_, entity_type_ref)| async {
+                                                resolve_entity_type(
+                                                    entity_type_ref.uri(),
+                                                    entity_type_segments,
+                                                    context,
+                                                )
+                                                .await
+                                            })
+                                            .try_collect()
+                                            .await?,
+                                    ));
+                                }
+                                link_type_uri => {
+                                    let versioned_uri = VersionedUri::from_str(link_type_uri)
+                                        .into_report()
+                                        .change_context(ResolveError::StoreReadError)?;
+                                    if let Some(entity_type_ref) =
+                                        self.record.link_type_references().get(&versioned_uri)
+                                    {
+                                        return resolve_entity_type(
+                                            entity_type_ref.uri(),
+                                            entity_type_segments,
+                                            context,
+                                        )
+                                        .await;
+                                    }
+                                    Literal::Null
+                                }
+                            }
+                        }
+                    },
+                    "requiredLinks" => Literal::List(
+                        self.record
+                            .required_links()
+                            .iter()
+                            .map(|uri| Literal::String(uri.to_string()))
+                            .collect(),
+                    ),
+                    _ => Literal::Null,
+                };
+
+                if segments.is_empty() {
+                    Ok(literal)
+                } else {
+                    literal.resolve(segments, context).await
+                }
+            }
+        }
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -2,10 +2,9 @@ use async_trait::async_trait;
 use error_stack::{Context, IntoReport, Result, ResultExt, StreamExt as _};
 use futures::{StreamExt, TryStreamExt};
 use tokio_postgres::{GenericClient, RowStream};
-use type_system::EntityType;
 
 use crate::{
-    ontology::{AccountId, PersistedEntityType, PersistedOntologyIdentifier},
+    ontology::{AccountId, PersistedOntologyIdentifier},
     store::{
         crud::Read,
         postgres::{ontology::OntologyDatabaseType, parameter_list},
@@ -18,14 +17,6 @@ pub trait PersistedOntologyType {
     type Inner;
 
     fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self;
-}
-
-impl PersistedOntologyType for PersistedEntityType {
-    type Inner = EntityType;
-
-    fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self {
-        Self { inner, identifier }
-    }
 }
 
 async fn all<T: OntologyDatabaseType>(

--- a/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
@@ -11,7 +11,7 @@ use type_system::uri::VersionedUri;
 
 pub use self::{
     knowledge::{EntityQuery, EntityVersion, LinkQuery},
-    ontology::{EntityTypeQuery, LinkTypeQuery, OntologyQuery, OntologyVersion},
+    ontology::{LinkTypeQuery, OntologyQuery, OntologyVersion},
 };
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/packages/graph/hash_graph/lib/graph/src/store/query/ontology.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/ontology.rs
@@ -1,9 +1,8 @@
 use std::{fmt, fmt::Formatter, marker::PhantomData};
 
-use type_system::{uri::BaseUri, EntityType, LinkType};
+use type_system::{uri::BaseUri, LinkType};
 
 pub type LinkTypeQuery<'q> = OntologyQuery<'q, LinkType>;
-pub type EntityTypeQuery<'q> = OntologyQuery<'q, EntityType>;
 
 #[derive(Debug, Copy, Clone)]
 pub enum OntologyVersion {

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -19,7 +19,7 @@ use graph::{
     },
     store::{
         error::LinkActivationError,
-        query::{EntityQuery, EntityTypeQuery, Expression, LinkQuery},
+        query::{EntityQuery, Expression, LinkQuery},
         AccountStore, AsClient, DataTypeStore, DatabaseConnectionInfo, DatabaseType, EntityStore,
         EntityTypeStore, InsertionError, LinkStore, LinkTypeStore, PostgresStore,
         PostgresStorePool, PropertyTypeStore, QueryError, StorePool, UpdateError,
@@ -217,11 +217,7 @@ impl DatabaseApi<'_> {
     ) -> Result<PersistedEntityType, QueryError> {
         Ok(self
             .store
-            .get_entity_type(
-                &EntityTypeQuery::new()
-                    .by_uri(uri.base_uri())
-                    .by_version(uri.version()),
-            )
+            .get_entity_type(&Expression::for_versioned_uri(uri))
             .await?
             .pop()
             .expect("no entity type found"))


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Similar to #1021 this adds structural queries for `EntityType`s

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/0/1202884883200955/f) _(internal)_

## 🚫 Blocked by

- #1021 
- #1023

## 🔍 What does this change?

- Add `EntityType` to `PostgresContext`
- Implement resolving for `EntityType`
- Implement `Read` for `EntityType` with `Expression` as `Read::Query`
- Use the new implementation in the REST endpoints
- Adjust tests

## 🐾 Next steps

- This is the last ontology type where structural queries had to be adjusted. All four ontology types share a similar `Read` implementation, this will be unified: [Asana Task](https://app.asana.com/0/0/1202884883200959/f) (_internal_)

## 🛡 What tests cover this?

Currently, only basic expressions are tested. Currently, these are manually tested, a [follow-up task](https://app.asana.com/0/0/1202884883200974/f) (_internal_) will cover more extensive testing of the API.

## ❓ How to test this?

Pass arbitrary expressions to the REST endpoint, for an example see the demo below

## 📹 Demo

> Give me all entity types in it’s latest version, which contains a `friend-of@v2` link, where the linked entity type has a property of `.../name/`
```http
GET http://127.0.0.1:4000/entity-types
Content-Type: application/json

{
  "all": [
    {
      "eq": [
        {
          "path": [
            "version"
          ]
        },
        {
          "literal": "latest"
        }
      ]
    },
    {
      "eq": [
        {
          "path": [
            "links",
            "https://blockprotocol.org/@alice/types/link-type/friend-of/v/2",
            "properties",
            "**",
            "uri"
          ]
        },
        {
          "literal": "https://blockprotocol.org/@alice/types/property-type/name/"
        }
      ]
    }
  ]
}
```
