### PR TITLE
Bump type-system dependency to latest revision

### DIFF
--- a/packages/graph/hash_graph/Cargo.lock
+++ b/packages/graph/hash_graph/Cargo.lock
@@ -1590,7 +1590,7 @@ dependencies = [
 [[package]]
 name = "type-system"
 version = "0.0.0"
-source = "git+https://github.com/blockprotocol/blockprotocol?rev=d33a4ec#d33a4ecc214cfdcf97dd115442ef00cb6b3f6636"
+source = "git+https://github.com/blockprotocol/blockprotocol?rev=57f64ce#57f64cec6c8e7ff022d1da02c7eb549925e604f0"
 dependencies = [
  "console_error_panic_hook",
  "regex",

--- a/packages/graph/hash_graph/bin/hash_graph/Cargo.toml
+++ b/packages/graph/hash_graph/bin/hash_graph/Cargo.toml
@@ -18,5 +18,5 @@ serde_json = "1.0.83"
 tokio = { version = "1.18.2", features = ["rt-multi-thread", "macros"] }
 tokio-postgres = { version = "0.7.6", default-features = false }
 tracing = "0.1.35"
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "d33a4ec" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "57f64ce" }
 uuid = "1.1.2"

--- a/packages/graph/hash_graph/lib/graph/Cargo.toml
+++ b/packages/graph/hash_graph/lib/graph/Cargo.toml
@@ -23,7 +23,7 @@ tracing = "0.1.35"
 tracing-appender = "0.2.2"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.14", features = ["env-filter", "json"] }
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "d33a4ec" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "57f64ce" }
 uuid = { version = "1.1.2", features = ["v4", "serde"] }
 utoipa = { git = "https://github.com/juhaku/utoipa", rev = "031073f", features = ["uuid"] }
 include_dir = "0.7.2"

--- a/packages/hash/api/package.json
+++ b/packages/hash/api/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/s3-presigned-post": "3.38.0",
     "@aws-sdk/s3-request-presigner": "3.38.0",
     "@blockprotocol/core": "0.0.8",
-    "@blockprotocol/type-system-web": "https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?d33a4ec",
+    "@blockprotocol/type-system-web": "https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?57f64ce",
     "@graphql-tools/schema": "8.5.0",
     "@hashintel/hash-backend-utils": "0.0.0",
     "@hashintel/hash-graph-client": "0.0.0",

--- a/packages/hash/frontend/package.json
+++ b/packages/hash/frontend/package.json
@@ -20,7 +20,7 @@
     "@blockprotocol/core": "0.0.8",
     "@blockprotocol/graph": "0.0.12",
     "@blockprotocol/hook": "0.0.1",
-    "@blockprotocol/type-system-web": "https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?d33a4ec",
+    "@blockprotocol/type-system-web": "https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?57f64ce",
     "@emoji-mart/data": "1.0.5",
     "@emoji-mart/react": "1.0.1",
     "@emotion/cache": "11.7.1",

--- a/packages/hash/integration/package.json
+++ b/packages/hash/integration/package.json
@@ -14,7 +14,7 @@
     "test": "jest --runInBand"
   },
   "dependencies": {
-    "@blockprotocol/type-system-web": "https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?d33a4ec",
+    "@blockprotocol/type-system-web": "https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?57f64ce",
     "@hashintel/hash-api": "0.0.0",
     "@hashintel/hash-backend-utils": "0.0.0",
     "@hashintel/hash-graph-client": "0.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3110,10 +3110,10 @@
   dependencies:
     "@blockprotocol/core" "0.0.8"
 
-"@blockprotocol/type-system-web@https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?d33a4ec":
+"@blockprotocol/type-system-web@https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?57f64ce":
   version "0.0.1"
-  uid "446c6dd608b34721bc1a4f72d81891b05cf5a894"
-  resolved "https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?d33a4ec#446c6dd608b34721bc1a4f72d81891b05cf5a894"
+  uid "310049e0e60a79e0844673af397d006b6d0e764e"
+  resolved "https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?57f64ce#310049e0e60a79e0844673af397d006b6d0e764e"
 
 "@cloudamqp/amqp-client@^2.0.3":
   version "2.0.3"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The latest changes are required in order to use `error-stack`.

## 🔗 Related links

- https://github.com/blockprotocol/blockprotocol/pull/563