### PR TITLE
Deduplicate `Read` implementation for ontology types

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -1,19 +1,13 @@
 pub mod read;
 
 use async_trait::async_trait;
-use error_stack::{bail, IntoReport, Report, Result, ResultExt};
-use futures::TryStreamExt;
+use error_stack::{IntoReport, Result, ResultExt};
 use tokio_postgres::GenericClient;
 use type_system::DataType;
 
 use crate::{
-    ontology::{AccountId, PersistedDataType, PersistedOntologyIdentifier},
-    store::{
-        crud::Read,
-        postgres::resolve::PostgresContext,
-        query::{Expression, ExpressionError, Literal},
-        AsClient, DataTypeStore, InsertionError, PostgresStore, QueryError, UpdateError,
-    },
+    ontology::{AccountId, PersistedOntologyIdentifier},
+    store::{AsClient, DataTypeStore, InsertionError, PostgresStore, UpdateError},
 };
 
 #[async_trait]
@@ -66,45 +60,5 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
             .change_context(UpdateError)?;
 
         Ok(identifier)
-    }
-}
-
-// TODO: Unify methods for Ontology types using `Expression`s
-//   see https://app.asana.com/0/0/1202884883200959/f
-#[async_trait]
-impl<C: AsClient> Read<PersistedDataType> for PostgresStore<C> {
-    type Query<'q> = Expression;
-
-    async fn read<'query>(
-        &self,
-        expression: &Self::Query<'query>,
-    ) -> Result<Vec<PersistedDataType>, QueryError> {
-        self.read_all_data_types()
-            .await?
-            .try_filter_map(|data_type| async move {
-                if let Literal::Bool(result) = expression
-                    .evaluate(&data_type, self)
-                    .await
-                    .change_context(QueryError)?
-                {
-                    Ok(result.then(|| {
-                        let uri = data_type.record.id();
-                        let identifier =
-                            PersistedOntologyIdentifier::new(uri.clone(), data_type.account_id);
-                        PersistedDataType {
-                            inner: data_type.record,
-                            identifier,
-                        }
-                    }))
-                } else {
-                    bail!(
-                        Report::new(ExpressionError)
-                            .attach_printable("does not result in a boolean value")
-                            .change_context(QueryError)
-                    );
-                }
-            })
-            .try_collect()
-            .await
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
@@ -1,19 +1,13 @@
 mod read;
 
 use async_trait::async_trait;
-use error_stack::{bail, IntoReport, Report, Result, ResultExt};
-use futures::TryStreamExt;
+use error_stack::{IntoReport, Result, ResultExt};
 use tokio_postgres::GenericClient;
 use type_system::EntityType;
 
 use crate::{
-    ontology::{AccountId, PersistedEntityType, PersistedOntologyIdentifier},
-    store::{
-        crud::Read,
-        postgres::resolve::PostgresContext,
-        query::{Expression, ExpressionError, Literal},
-        AsClient, EntityTypeStore, InsertionError, PostgresStore, QueryError, UpdateError,
-    },
+    ontology::{AccountId, PersistedOntologyIdentifier},
+    store::{AsClient, EntityTypeStore, InsertionError, PostgresStore, UpdateError},
 };
 
 #[async_trait]
@@ -86,45 +80,5 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
             .change_context(UpdateError)?;
 
         Ok(identifier)
-    }
-}
-
-// TODO: Unify methods for Ontology types using `Expression`s
-//   see https://app.asana.com/0/0/1202884883200959/f
-#[async_trait]
-impl<C: AsClient> Read<PersistedEntityType> for PostgresStore<C> {
-    type Query<'q> = Expression;
-
-    async fn read<'query>(
-        &self,
-        expression: &Self::Query<'query>,
-    ) -> Result<Vec<PersistedEntityType>, QueryError> {
-        self.read_all_entity_types()
-            .await?
-            .try_filter_map(|entity_type| async move {
-                if let Literal::Bool(result) = expression
-                    .evaluate(&entity_type, self)
-                    .await
-                    .change_context(QueryError)?
-                {
-                    Ok(result.then(|| {
-                        let uri = entity_type.record.id();
-                        let identifier =
-                            PersistedOntologyIdentifier::new(uri.clone(), entity_type.account_id);
-                        PersistedEntityType {
-                            inner: entity_type.record,
-                            identifier,
-                        }
-                    }))
-                } else {
-                    bail!(
-                        Report::new(ExpressionError)
-                            .attach_printable("does not result in a boolean value")
-                            .change_context(QueryError)
-                    );
-                }
-            })
-            .try_collect()
-            .await
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/read.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
 use futures::{stream, StreamExt, TryStreamExt};
-use type_system::{uri::VersionedUri, EntityType};
+use type_system::{uri::VersionedUri, EntityType, PropertyType};
 
 use crate::store::{
     postgres::resolve::{PostgresContext, Record},
@@ -27,7 +27,7 @@ async fn resolve_property_types(
                 stream::iter(entity_type.property_type_references())
                     .then(|property_type_ref| async {
                         context
-                            .read_versioned_property_type(property_type_ref.uri())
+                            .read_versioned_ontology_type::<PropertyType>(property_type_ref.uri())
                             .await
                             .change_context(ResolveError::StoreReadError)?
                             .resolve(tail_path_segments, context)
@@ -60,7 +60,9 @@ async fn resolve_link_types(
                         stream::iter(entity_type.link_type_references())
                             .then(|(_, entity_type_ref)| async {
                                 context
-                                    .read_versioned_entity_type(entity_type_ref.uri())
+                                    .read_versioned_ontology_type::<EntityType>(
+                                        entity_type_ref.uri(),
+                                    )
                                     .await
                                     .change_context(ResolveError::StoreReadError)?
                                     .resolve(tail_path_segments, context)
@@ -78,7 +80,7 @@ async fn resolve_link_types(
                         entity_type.link_type_references().get(&versioned_uri)
                     {
                         context
-                            .read_versioned_entity_type(entity_type_ref.uri())
+                            .read_versioned_ontology_type::<EntityType>(entity_type_ref.uri())
                             .await
                             .change_context(ResolveError::StoreReadError)?
                             .resolve(tail_path_segments, context)

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
@@ -1,19 +1,13 @@
 mod read;
 
 use async_trait::async_trait;
-use error_stack::{bail, IntoReport, Report, Result, ResultExt};
-use futures::TryStreamExt;
+use error_stack::{IntoReport, Result, ResultExt};
 use tokio_postgres::GenericClient;
 use type_system::LinkType;
 
 use crate::{
-    ontology::{AccountId, PersistedLinkType, PersistedOntologyIdentifier},
-    store::{
-        crud::Read,
-        postgres::resolve::PostgresContext,
-        query::{Expression, ExpressionError, Literal},
-        AsClient, InsertionError, LinkTypeStore, PostgresStore, QueryError, UpdateError,
-    },
+    ontology::{AccountId, PersistedOntologyIdentifier},
+    store::{AsClient, InsertionError, LinkTypeStore, PostgresStore, UpdateError},
 };
 
 #[async_trait]
@@ -66,45 +60,5 @@ impl<C: AsClient> LinkTypeStore for PostgresStore<C> {
             .change_context(UpdateError)?;
 
         Ok(identifier)
-    }
-}
-
-// TODO: Unify methods for Ontology types using `Expression`s
-//   see https://app.asana.com/0/0/1202884883200959/f
-#[async_trait]
-impl<C: AsClient> Read<PersistedLinkType> for PostgresStore<C> {
-    type Query<'q> = Expression;
-
-    async fn read<'query>(
-        &self,
-        expression: &Self::Query<'query>,
-    ) -> Result<Vec<PersistedLinkType>, QueryError> {
-        self.read_all_link_types()
-            .await?
-            .try_filter_map(|link_type| async move {
-                if let Literal::Bool(result) = expression
-                    .evaluate(&link_type, self)
-                    .await
-                    .change_context(QueryError)?
-                {
-                    Ok(result.then(|| {
-                        let uri = link_type.record.id();
-                        let identifier =
-                            PersistedOntologyIdentifier::new(uri.clone(), link_type.account_id);
-                        PersistedLinkType {
-                            inner: link_type.record,
-                            identifier,
-                        }
-                    }))
-                } else {
-                    bail!(
-                        Report::new(ExpressionError)
-                            .attach_printable("does not result in a boolean value")
-                            .change_context(QueryError)
-                    );
-                }
-            })
-            .try_collect()
-            .await
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/read.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use error_stack::{Result, ResultExt};
 use futures::stream::{self, StreamExt, TryStreamExt};
-use type_system::PropertyType;
+use type_system::{DataType, PropertyType};
 
 use crate::store::{
     postgres::resolve::{PostgresContext, Record},
@@ -43,7 +43,9 @@ where
                                 stream::iter(self.record.data_type_references())
                                     .then(|data_type_ref| async {
                                         context
-                                            .read_versioned_data_type(data_type_ref.uri())
+                                            .read_versioned_ontology_type::<DataType>(
+                                                data_type_ref.uri(),
+                                            )
                                             .await
                                             .change_context(ResolveError::StoreReadError)?
                                             .resolve(data_type_segments, context)
@@ -69,7 +71,9 @@ where
                                 stream::iter(self.record.property_type_references())
                                     .then(|property_type_ref| async {
                                         context
-                                            .read_versioned_property_type(property_type_ref.uri())
+                                            .read_versioned_ontology_type::<PropertyType>(
+                                                property_type_ref.uri(),
+                                            )
                                             .await
                                             .change_context(ResolveError::StoreReadError)?
                                             .resolve(property_type_segments, context)

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -1,14 +1,16 @@
 use async_trait::async_trait;
-use error_stack::{Context, IntoReport, Result, ResultExt, StreamExt as _};
-use futures::{StreamExt, TryStreamExt};
-use tokio_postgres::{GenericClient, RowStream};
+use error_stack::{bail, Context, Report, Result, ResultExt};
+use futures::TryStreamExt;
 
 use crate::{
-    ontology::{AccountId, PersistedOntologyIdentifier},
+    ontology::PersistedOntologyIdentifier,
     store::{
         crud::Read,
-        postgres::{ontology::OntologyDatabaseType, parameter_list},
-        query::{OntologyQuery, OntologyVersion},
+        postgres::{
+            ontology::OntologyDatabaseType,
+            resolve::{PostgresContext, Record},
+        },
+        query::{Expression, ExpressionError, Literal, Resolve},
         AsClient, PostgresStore, QueryError,
     },
 };
@@ -19,97 +21,38 @@ pub trait PersistedOntologyType {
     fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self;
 }
 
-async fn all<T: OntologyDatabaseType>(
-    client: &(impl GenericClient + Sync),
-) -> Result<RowStream, QueryError> {
-    client
-        .query_raw(
-            &format!(
-                r#"
-                SELECT schema, created_by
-                FROM {};
-                "#,
-                T::table()
-            ),
-            parameter_list([]),
-        )
-        .await
-        .into_report()
-        .change_context(QueryError)
-}
-
-async fn by_latest_version<T: OntologyDatabaseType>(
-    client: &(impl GenericClient + Sync),
-) -> Result<RowStream, QueryError> {
-    client
-        .query_raw(
-            &format!(
-                r#"
-                SELECT DISTINCT ON(base_uri) schema, created_by
-                FROM {table}
-                INNER JOIN ids ON ids.version_id = {table}.version_id
-                ORDER BY base_uri, version DESC;
-                "#,
-                table = T::table()
-            ),
-            parameter_list([]),
-        )
-        .await
-        .into_report()
-        .change_context(QueryError)
-}
-
-fn apply_filter<T: OntologyDatabaseType>(element: T, query: &OntologyQuery<'_, T>) -> Option<T> {
-    let uri = element.versioned_uri();
-
-    if let Some(base_uri) = query.uri() {
-        if uri.base_uri() != base_uri {
-            return None;
-        }
-    }
-
-    if let Some(OntologyVersion::Exact(version)) = query.version() {
-        if uri.version() != version {
-            return None;
-        }
-    }
-
-    Some(element)
-}
-
-// TODO: Unify methods for Ontology types using `Expression`s
-//   see https://app.asana.com/0/0/1202884883200959/f
 #[async_trait]
 impl<C: AsClient, T> Read<T> for PostgresStore<C>
 where
     T: PersistedOntologyType + Send,
-    T::Inner: OntologyDatabaseType + TryFrom<serde_json::Value>,
-    <<T as PersistedOntologyType>::Inner as TryFrom<serde_json::Value>>::Error: Context,
+    T::Inner: OntologyDatabaseType + TryFrom<serde_json::Value> + Send,
+    <T::Inner as TryFrom<serde_json::Value>>::Error: Context,
+    Record<T::Inner>: Resolve<Self> + Sync,
 {
-    type Query<'q> = OntologyQuery<'q, T::Inner>;
+    type Query<'q> = Expression;
 
     async fn read<'query>(&self, query: &Self::Query<'query>) -> Result<Vec<T>, QueryError> {
-        let row_stream = if let Some(OntologyVersion::Latest) = query.version() {
-            by_latest_version::<T::Inner>(self.as_client()).await?
-        } else {
-            all::<T::Inner>(self.as_client()).await?
-        };
-
-        row_stream
-            .map(IntoReport::into_report)
-            .change_context(QueryError)
-            .try_filter_map(|row| async move {
-                let element: T::Inner = T::Inner::try_from(row.get(0))
-                    .into_report()
-                    .change_context(QueryError)?;
-
-                let account_id: AccountId = row.get(1);
-
-                Ok(apply_filter(element, query).map(|element| {
-                    let uri = element.versioned_uri();
-                    let identifier = PersistedOntologyIdentifier::new(uri.clone(), account_id);
-                    T::new(element, identifier)
-                }))
+        self.read_all_ontology_types::<T::Inner>()
+            .await?
+            .try_filter_map(|ontology_type| async move {
+                if let Literal::Bool(result) = query
+                    .evaluate(&ontology_type, self)
+                    .await
+                    .change_context(QueryError)?
+                {
+                    Ok(result.then(|| {
+                        let uri = ontology_type.record.versioned_uri();
+                        let identifier =
+                            PersistedOntologyIdentifier::new(uri.clone(), ontology_type.account_id);
+                        T::new(ontology_type.record, identifier)
+                    }))
+                } else {
+                    bail!(
+                        Report::new(ExpressionError)
+                            .attach_printable("does not result in a boolean value")
+                            .change_context(QueryError)
+                    );
+                }
             })
             .try_collect()
             .await

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -1,9 +1,13 @@
 use async_trait::async_trait;
 use error_stack::{bail, Context, Report, Result, ResultExt};
 use futures::TryStreamExt;
+use type_system::{DataType, EntityType, LinkType, PropertyType};
 
 use crate::{
-    ontology::PersistedOntologyIdentifier,
+    ontology::{
+        PersistedDataType, PersistedEntityType, PersistedLinkType, PersistedOntologyIdentifier,
+        PersistedPropertyType,
+    },
     store::{
         crud::Read,
         postgres::{
@@ -19,6 +23,38 @@ pub trait PersistedOntologyType {
     type Inner;
 
     fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self;
+}
+
+impl PersistedOntologyType for PersistedDataType {
+    type Inner = DataType;
+
+    fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self {
+        Self { inner, identifier }
+    }
+}
+
+impl PersistedOntologyType for PersistedPropertyType {
+    type Inner = PropertyType;
+
+    fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self {
+        Self { inner, identifier }
+    }
+}
+
+impl PersistedOntologyType for PersistedLinkType {
+    type Inner = LinkType;
+
+    fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self {
+        Self { inner, identifier }
+    }
+}
+
+impl PersistedOntologyType for PersistedEntityType {
+    type Inner = EntityType;
+
+    fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self {
+        Self { inner, identifier }
+    }
 }
 
 #[async_trait]

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use error_stack::{Context, IntoReport, Result, ResultExt};
 use futures::{Stream, StreamExt};
 use tokio_postgres::{GenericClient, RowStream};
-use type_system::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType};
+use type_system::uri::VersionedUri;
 
 use crate::{
     ontology::AccountId,
@@ -40,26 +40,6 @@ pub trait PostgresContext {
     where
         T: OntologyDatabaseType + TryFrom<serde_json::Value>,
         <T as TryFrom<serde_json::Value>>::Error: Context;
-
-    async fn read_versioned_data_type(
-        &self,
-        uri: &VersionedUri,
-    ) -> Result<Record<DataType>, QueryError>;
-
-    async fn read_versioned_property_type(
-        &self,
-        uri: &VersionedUri,
-    ) -> Result<Record<PropertyType>, QueryError>;
-
-    async fn read_versioned_link_type(
-        &self,
-        uri: &VersionedUri,
-    ) -> Result<Record<LinkType>, QueryError>;
-
-    async fn read_versioned_entity_type(
-        &self,
-        uri: &VersionedUri,
-    ) -> Result<Record<EntityType>, QueryError>;
 }
 
 /// Associates a database entry with the information about the latest version of the corresponding
@@ -180,41 +160,5 @@ impl<C: AsClient> PostgresContext for PostgresStore<C> {
         read_versioned_type(&self.client, T::table(), uri)
             .await
             .attach_printable("could not read ontology type")
-    }
-
-    async fn read_versioned_data_type(
-        &self,
-        uri: &VersionedUri,
-    ) -> Result<Record<DataType>, QueryError> {
-        read_versioned_type(&self.client, "data_types", uri)
-            .await
-            .attach_printable("could not read data type")
-    }
-
-    async fn read_versioned_property_type(
-        &self,
-        uri: &VersionedUri,
-    ) -> Result<Record<PropertyType>, QueryError> {
-        read_versioned_type(&self.client, "property_types", uri)
-            .await
-            .attach_printable("could not read property type")
-    }
-
-    async fn read_versioned_link_type(
-        &self,
-        uri: &VersionedUri,
-    ) -> Result<Record<LinkType>, QueryError> {
-        read_versioned_type(&self.client, "link_types", uri)
-            .await
-            .attach_printable("could not read link type")
-    }
-
-    async fn read_versioned_entity_type(
-        &self,
-        uri: &VersionedUri,
-    ) -> Result<Record<EntityType>, QueryError> {
-        read_versioned_type(&self.client, "entity_types", uri)
-            .await
-            .attach_printable("could not read entity type")
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

For all ontology type, more or less the same `Read` method is implemented. This deduplicates this.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/0/1202884883200959/f) _(internal)_