### PR TITLE
Support links in `Entity` queries

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve/context.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve/context.rs
@@ -104,7 +104,7 @@ impl<C: AsClient> PostgresContext for PostgresStore<C> {
     ) -> Result<links::RecordStream, QueryError> {
         Ok(links::read_active_links_by_source(&self.client, entity_id)
             .await
-            .attach_printable("could not read links")?)
+            .attach_printable("could not read outgoing links")?)
     }
 
     async fn read_active_links_by_target(
@@ -113,6 +113,6 @@ impl<C: AsClient> PostgresContext for PostgresStore<C> {
     ) -> Result<links::RecordStream, QueryError> {
         Ok(links::read_active_links_by_target(&self.client, entity_id)
             .await
-            .attach_printable("could not read links")?)
+            .attach_printable("could not read incoming links")?)
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve/context.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve/context.rs
@@ -42,6 +42,16 @@ pub trait PostgresContext {
     ) -> Result<EntityRecord, QueryError>;
 
     async fn read_all_active_links(&self) -> Result<links::RecordStream, QueryError>;
+
+    async fn read_active_links_by_source(
+        &self,
+        entity_id: EntityId,
+    ) -> Result<links::RecordStream, QueryError>;
+
+    async fn read_active_links_by_target(
+        &self,
+        entity_id: EntityId,
+    ) -> Result<links::RecordStream, QueryError>;
 }
 
 #[async_trait]
@@ -84,6 +94,24 @@ impl<C: AsClient> PostgresContext for PostgresStore<C> {
 
     async fn read_all_active_links(&self) -> Result<links::RecordStream, QueryError> {
         Ok(links::read_all_active_links(&self.client)
+            .await
+            .attach_printable("could not read links")?)
+    }
+
+    async fn read_active_links_by_source(
+        &self,
+        entity_id: EntityId,
+    ) -> Result<links::RecordStream, QueryError> {
+        Ok(links::read_active_links_by_source(&self.client, entity_id)
+            .await
+            .attach_printable("could not read links")?)
+    }
+
+    async fn read_active_links_by_target(
+        &self,
+        entity_id: EntityId,
+    ) -> Result<links::RecordStream, QueryError> {
+        Ok(links::read_active_links_by_target(&self.client, entity_id)
             .await
             .attach_printable("could not read links")?)
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve/context.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve/context.rs
@@ -60,9 +60,9 @@ impl<C: AsClient> PostgresContext for PostgresStore<C> {
     where
         T: OntologyDatabaseType + TryFrom<serde_json::Value, Error: Context>,
     {
-        Ok(ontology::read_all_types(&self.client, T::table())
+        ontology::read_all_types(&self.client, T::table())
             .await
-            .attach_printable("could not read ontology types")?)
+            .attach_printable("could not read ontology types")
     }
 
     async fn read_versioned_ontology_type<T>(
@@ -78,41 +78,43 @@ impl<C: AsClient> PostgresContext for PostgresStore<C> {
     }
 
     async fn read_all_entities(&self) -> Result<entity::RecordStream, QueryError> {
-        Ok(entity::read_all_entities(&self.client)
+        entity::read_all_entities(&self.client)
             .await
-            .attach_printable("could not read entities")?)
+            .attach_printable("could not read entities")
     }
 
     async fn read_latest_entity_by_id(
         &self,
         entity_id: EntityId,
     ) -> Result<EntityRecord, QueryError> {
-        Ok(entity::read_latest_entity_by_id(&self.client, entity_id)
+        entity::read_latest_entity_by_id(&self.client, entity_id)
             .await
-            .attach_printable("could not read entity")?)
+            .attach_printable("could not read entity")
     }
 
     async fn read_all_active_links(&self) -> Result<links::RecordStream, QueryError> {
-        Ok(links::read_all_active_links(&self.client)
+        links::read_all_active_links(&self.client)
             .await
-            .attach_printable("could not read links")?)
+            .attach_printable("could not read links")
     }
 
     async fn read_active_links_by_source(
         &self,
         entity_id: EntityId,
     ) -> Result<links::RecordStream, QueryError> {
-        Ok(links::read_active_links_by_source(&self.client, entity_id)
+        links::read_active_links_by_source(&self.client, entity_id)
             .await
-            .attach_printable("could not read outgoing links")?)
+            .attach_printable("could not read outgoing links")
+            .attach_printable_lazy(|| format!("source entity: {entity_id}"))
     }
 
     async fn read_active_links_by_target(
         &self,
         entity_id: EntityId,
     ) -> Result<links::RecordStream, QueryError> {
-        Ok(links::read_active_links_by_target(&self.client, entity_id)
+        links::read_active_links_by_target(&self.client, entity_id)
             .await
-            .attach_printable("could not read incoming links")?)
+            .attach_printable("could not read incoming links")
+            .attach_printable_lazy(|| format!("target entity: {entity_id}"))
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve/links.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/resolve/links.rs
@@ -53,3 +53,45 @@ pub async fn read_all_active_links(client: &impl AsClient) -> Result<RecordStrea
         .change_context(QueryError)?;
     Ok(row_stream_to_record_stream(row_stream))
 }
+
+pub async fn read_active_links_by_source(
+    client: &impl AsClient,
+    entity_id: EntityId,
+) -> Result<RecordStream, QueryError> {
+    let row_stream = client
+        .as_client()
+        .query_raw(
+            r#"
+            SELECT base_uri, version, source_entity_id, target_entity_id, created_by, active
+            FROM links
+            JOIN ids ON version_id = link_type_version_id
+            WHERE active AND source_entity_id = $1
+            "#,
+            parameter_list([&entity_id]),
+        )
+        .await
+        .into_report()
+        .change_context(QueryError)?;
+    Ok(row_stream_to_record_stream(row_stream))
+}
+
+pub async fn read_active_links_by_target(
+    client: &impl AsClient,
+    entity_id: EntityId,
+) -> Result<RecordStream, QueryError> {
+    let row_stream = client
+        .as_client()
+        .query_raw(
+            r#"
+            SELECT base_uri, version, source_entity_id, target_entity_id, created_by, active
+            FROM links
+            JOIN ids ON version_id = link_type_version_id
+            WHERE active AND target_entity_id = $1
+            "#,
+            parameter_list([&entity_id]),
+        )
+        .await
+        .into_report()
+        .change_context(QueryError)?;
+    Ok(row_stream_to_record_stream(row_stream))
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#1027 added support for basic `Entity` queries, but did not implement queries across entities as `Links` were added in #1028. This combines these functionalities and adds a query for `Entity` to filter by `"outgoingLinks"` and `"incomingLinks"`.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/0/1202912966917505/f) _(internal)_

## 🚫 Blocked by

- #1027 
- #1028

## 🔍 What does this change?

- Add functions to read links by source/target entity ids from the context
- Resolve the source/target entity queries 

## 🐾 Next steps

- Add tests for Structural Querying: [Asana Task](https://app.asana.com/0/0/1202884883200974/f) (_internal_)

## 🛡 What tests cover this?

Currently, only basic expressions are tested. Currently, these are manually tested, a [follow-up task](https://app.asana.com/0/0/1202884883200974/f) (_internal_) will cover more extensive testing of the API.

## ❓ How to test this?

Pass arbitrary expressions to the REST endpoint, for an example see the demo below

## 📹 Demo

> Give me all entities where a friend of the entity is called "Bob"

```http
GET http://127.0.0.1:4000/entities
Content-Type: application/json

{
  "all": [
    {
      "eq": [
        {
          "path": [
            "outgoingLinks",
            "type",
            "uri"
          ]
        },
        {
          "literal": "https://blockprotocol.org/@alice/types/link-type/friend-of/"
        }
      ]
    },
    {
      "eq": [
        {
          "path": [
            "outgoingLinks",
            "target",
            "properties",
            "https://blockprotocol.org/@alice/types/property-type/name/"
          ]
        },
        {
          "literal": "Bob"
        }
      ]
    }
  ]
}
```