### PR TITLE
Bump toolchain to `2022-08-27`

### DIFF
--- a/packages/libs/error-stack/README.md
+++ b/packages/libs/error-stack/README.md
@@ -8,7 +8,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/error-stack)][crates.io]
 [![libs.rs](https://img.shields.io/badge/libs.rs-error--stack-orange)][libs.rs]
-[![rust-version](https://img.shields.io/badge/Rust-1.63.0/nightly--2022--08--19-blue)][rust-version]
+[![rust-version](https://img.shields.io/badge/Rust-1.63.0/nightly--2022--08--27-blue)][rust-version]
 [![documentation](https://img.shields.io/docsrs/error-stack)][documentation]
 [![license](https://img.shields.io/crates/l/error-stack)][license]
 [![discord](https://img.shields.io/discord/840573247803097118)][discord]

--- a/packages/libs/error-stack/macros/rust-toolchain.toml
+++ b/packages/libs/error-stack/macros/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2022-08-19"
+channel = "nightly-2022-08-27"

--- a/packages/libs/error-stack/rust-toolchain.toml
+++ b/packages/libs/error-stack/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 # Please also update the badges in `README.md`, `src/lib.rs`, and `macros/`
-channel = "nightly-2022-08-19"
+channel = "nightly-2022-08-27"

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! [![crates.io](https://img.shields.io/crates/v/error-stack)][crates.io]
 //! [![libs.rs](https://img.shields.io/badge/libs.rs-error--stack-orange)][libs.rs]
-//! [![rust-version](https://img.shields.io/badge/Rust-1.63.0/nightly--2022--08--19-blue)][rust-version]
+//! [![rust-version](https://img.shields.io/badge/Rust-1.63.0/nightly--2022--08--27-blue)][rust-version]
 //! [![discord](https://img.shields.io/discord/840573247803097118)][discord]
 //!
 //! [crates.io]: https://crates.io/crates/error-stack


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Wtith the`2022-08-27` toolchain, `Error` was moved into `core.

## ⚠️ Known issues

`2022-08-27` is currently the latest toolchain with miri support

## 🐾 Next steps

- #1038