### PR TITLE
Support `core::error::Error`

### DIFF
--- a/packages/libs/error-stack/src/context.rs
+++ b/packages/libs/error-stack/src/context.rs
@@ -1,15 +1,19 @@
 #[cfg(nightly)]
 use core::any::Demand;
+#[cfg(nightly)]
+use core::error::Error;
 use core::fmt;
+#[cfg(all(not(nightly), feature = "std"))]
+use std::error::Error;
 
 use crate::Report;
 
 /// Defines the current context of a [`Report`].
 ///
-/// When in a `std` environment, every [`Error`] is a valid `Context`. This trait is not limited to
-/// [`Error`]s and can also be manually implemented for custom objects.
+/// When in a `std` environment or on a nightly toolchain, every [`Error`] is a valid `Context`.
+/// This trait is not limited to [`Error`]s and can also be manually implemented for custom objects.
 ///
-/// [`Error`]: std::error::Error
+/// [`Error`]: core::error::Error
 ///
 /// ## Example
 ///
@@ -80,10 +84,10 @@ where
     }
 }
 
-#[cfg(feature = "std")]
-impl<C: std::error::Error + Send + Sync + 'static> Context for C {
+#[cfg(any(nightly, feature = "std"))]
+impl<C: Error + Send + Sync + 'static> Context for C {
     #[cfg(nightly)]
     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
-        std::error::Error::provide(self, demand);
+        Error::provide(self, demand);
     }
 }

--- a/packages/libs/error-stack/src/context.rs
+++ b/packages/libs/error-stack/src/context.rs
@@ -11,7 +11,7 @@ use crate::Report;
 /// Defines the current context of a [`Report`].
 ///
 /// When in a `std` environment or on a nightly toolchain, every [`Error`] is a valid `Context`.
-/// This trait is not limited to [`Error`]s and can also be manually implemented for custom objects.
+/// This trait is not limited to [`Error`]s and can also be manually implemented on a type.
 ///
 /// [`Error`]: core::error::Error
 ///

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -438,7 +438,7 @@
 //! [`SpanTrace`]: tracing_error::SpanTrace
 //! [`smallvec`]: https://docs.rs/smallvec
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(nightly, feature(provide_any))]
+#![cfg_attr(nightly, feature(provide_any, error_in_core))]
 #![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
 #![cfg_attr(
     all(nightly, feature = "std"),

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -438,12 +438,12 @@
 //! [`SpanTrace`]: tracing_error::SpanTrace
 //! [`smallvec`]: https://docs.rs/smallvec
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(nightly, feature(provide_any, error_in_core))]
-#![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
 #![cfg_attr(
-    all(nightly, feature = "std"),
-    feature(backtrace_frames, error_generic_member_access)
+    nightly,
+    feature(provide_any, error_in_core, error_generic_member_access)
 )]
+#![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
+#![cfg_attr(all(nightly, feature = "std"), feature(backtrace_frames))]
 #![warn(
     missing_docs,
     unreachable_pub,

--- a/packages/libs/error-stack/src/macros.rs
+++ b/packages/libs/error-stack/src/macros.rs
@@ -73,7 +73,7 @@ pub mod __private {
 ///
 /// [`Report`]: crate::Report
 /// [`Context`]: crate::Context
-/// [`Error`]: std::error::Error
+/// [`Error`]: core::error::Error
 ///
 /// # Examples
 ///
@@ -144,7 +144,7 @@ macro_rules! report {
 ///
 /// Create a [`Report`] from [`Error`]:
 ///
-/// [`Error`]: std::error::Error
+/// [`Error`]: core::error::Error
 ///
 /// ```
 /// # #[cfg(all(not(miri), feature = "std"))] {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`Error` was moved to `core`, we should support it

## 🔗 Related links

- https://github.com/rust-lang/rust/pull/99917
- https://github.com/rust-lang/project-error-handling/issues/3

## 🚫 Blocked by

- #1037

## 🔍 What does this change?

- Support `core::error::Error` on nightly builds

## 🎥  Demo

<img width="583" alt="image" src="https://user-images.githubusercontent.com/21277928/188815112-869ab750-cf90-434b-8a66-a187d743aeb9.png">
