### PR TITLE
`attach_printable()` attachments now invoke hooks in `error-stack`

### DIFF
--- a/packages/libs/error-stack/src/fmt/mod.rs
+++ b/packages/libs/error-stack/src/fmt/mod.rs
@@ -710,6 +710,18 @@ fn debug_attachments_invoke(
             FrameKind::Attachment(AttachmentKind::Opaque(_)) | FrameKind::Context(_) => {
                 vec![]
             }
+            #[cfg(feature = "std")]
+            FrameKind::Attachment(AttachmentKind::Printable(attachment)) => {
+                Report::get_debug_format_hook(|hooks| hooks.call(frame, ctx));
+                let mut body = ctx.take_body();
+
+                if body.is_empty() {
+                    body.push(attachment.to_string())
+                }
+
+                body
+            }
+            #[cfg(not(feature = "std"))]
             FrameKind::Attachment(AttachmentKind::Printable(attachment)) => {
                 vec![attachment.to_string()]
             }

--- a/packages/libs/error-stack/src/fmt/mod.rs
+++ b/packages/libs/error-stack/src/fmt/mod.rs
@@ -41,10 +41,20 @@
 //! ```rust
 //! # // we only test with Rust 1.65, which means that `render()` is unused on earlier version
 //! # #![cfg_attr(not(rust_1_65), allow(dead_code, unused_variables, unused_imports))]
+//! use std::fmt::{Display, Formatter};
 //! use std::io::{Error, ErrorKind};
 //! use error_stack::Report;
 //!
+//! #[derive(Debug)]
 //! struct ErrorCode(u64);
+//!
+//! impl Display for ErrorCode {
+//!   fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+//!     f.write_str("Error: ")?;
+//!     Display::fmt(&self.0, f)
+//!   }
+//! }
+//!
 //! struct Suggestion(&'static str);
 //! struct Warning(&'static str);
 //!
@@ -64,6 +74,9 @@
 //!     ctx.push_body(format!("Suggestion {idx}: {val}"));
 //! });
 //!
+//! // Even though we used `attach_printable`, we can still use hooks, `Display` of a type attached
+//! // via `attach_printable` is only ever used when no hook was found and the fallback returned
+//! // nothing.
 //! Report::install_debug_hook::<ErrorCode>(|ErrorCode(val), ctx| {
 //!     ctx.push_body(format!("Error ({val})"));
 //! });
@@ -82,7 +95,7 @@
 //!
 //!
 //! let report = Report::new(Error::from(ErrorKind::InvalidInput))
-//!     .attach(ErrorCode(404))
+//!     .attach_printable(ErrorCode(404))
 //!     .attach(Suggestion("Try to be connected to the internet."))
 //!     .attach(Suggestion("Try better next time!"))
 //!     .attach(Warning("Unable to fetch resource"));

--- a/packages/libs/error-stack/src/fmt/mod.rs
+++ b/packages/libs/error-stack/src/fmt/mod.rs
@@ -729,7 +729,7 @@ fn debug_attachments_invoke(
                 let mut body = ctx.take_body();
 
                 if body.is_empty() {
-                    body.push(attachment.to_string())
+                    body.push(attachment.to_string());
                 }
 
                 body

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__doc.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__doc.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/mod.rs:46:14</span>
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/mod.rs:59:14</span>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace with [n] frames (1)
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Error (404)
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion 1: Try to be connected to the internet.

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt_doc_alt.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt_doc_alt.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/mod.rs:46:14</span>
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/mod.rs:59:14</span>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace with [n] frames (1)
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Error (404)
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion 1: Try to be connected to the internet.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In the future, once `specialization` is stabilized, we will remove the `attach_printable()` function and replace it with a specialization.

Hooks currently treat printable attachments differently, as they do not invoke any hooks, if we would merge `attach()` and `attach_printable()`, that behavior would change and cause confusion.

Thanks to @TimDiekmann for spotting this!

## 🔍 What does this change?

Hooks are also invoked for printable attachments, but they will have an additional fallback: their `String` representation.

They will change from:
* `printable.to_string()`

To:
* invoke hooks
* no hook invoked? invoke fallback
* no fallback found? use `printable.to_string()`

## 📜 Does this require a change to the docs?

No, no documentation currently explicitly mentions that `attach_printable` does not invoke hooks. We might add an explicit note that hooks are called for both `attach` and `attach_printable`.

## 🛡 What tests cover this?

Snapshot tests

(I might want to add one in test_debug for this specific use case)