### PR TITLE
Decrease the memory footprint of `Report` to a third

### DIFF
--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -500,6 +500,8 @@ pub use self::{
 mod tests {
     #![allow(dead_code)]
 
+    use core::mem;
+
     use crate::Report;
 
     const fn test_send<T: Send>() {}
@@ -510,5 +512,10 @@ mod tests {
         test_send::<Report<()>>();
         test_sync::<Report<()>>();
         test_static::<Report<()>>();
+    }
+
+    #[test]
+    fn test_size() {
+        assert_eq!(mem::size_of::<Report<()>>(), mem::size_of::<*const ()>())
     }
 }

--- a/packages/libs/error-stack/src/report.rs
+++ b/packages/libs/error-stack/src/report.rs
@@ -193,10 +193,11 @@ use crate::{
 #[must_use]
 #[repr(transparent)]
 pub struct Report<C> {
-    // reason: This implies a memory footprint equal to a single pointer size instead of three
-    //         pointer sizes. `Report` is unlikely to be used in the happy path, but it's almost
-    //         always used in `Result::Err`, so for small `Result::Ok` variants, this would
-    //         increase the size of the `Result` to 24 bytes (on 64 bit) instead of 8 bytes.
+    // The vector is boxed as this implies a memory footprint equal to a single pointer size
+    // instead of three pointer sizes. Even for small `Result::Ok` variants, the `Result` would
+    // still have at least the size of `Report`, even at the happy path. It's unexpected, that
+    // creating or traversing a report will happen in the hot path, so a double indirection is
+    // a good trade-off.
     #[allow(clippy::box_collection)]
     pub(super) frames: Box<Vec<Frame>>,
     _context: PhantomData<fn() -> *const C>,

--- a/packages/libs/error-stack/src/report.rs
+++ b/packages/libs/error-stack/src/report.rs
@@ -1,5 +1,5 @@
 use alloc::{boxed::Box, vec, vec::Vec};
-use core::{fmt, marker::PhantomData, panic::Location};
+use core::{fmt, marker::PhantomData, mem, panic::Location};
 #[cfg(all(rust_1_65, feature = "std"))]
 use std::backtrace::{Backtrace, BacktraceStatus};
 #[cfg(feature = "std")]
@@ -193,18 +193,16 @@ use crate::{
 #[must_use]
 #[repr(transparent)]
 pub struct Report<C> {
-    pub(super) frames: Vec<Frame>,
+    // reason: This implies a memory footprint equal to a single pointer size instead of three
+    //         pointer sizes. `Report` is unlikely to be used in the happy path, but it's almost
+    //         always used in `Result::Err`, so for small `Result::Ok` variants, this would
+    //         increase the size of the `Result` to 24 bytes (on 64 bit) instead of 8 bytes.
+    #[allow(clippy::box_collection)]
+    pub(super) frames: Box<Vec<Frame>>,
     _context: PhantomData<fn() -> *const C>,
 }
 
 impl<C> Report<C> {
-    pub(crate) fn from_frame(frame: Frame) -> Self {
-        Self {
-            frames: vec![frame],
-            _context: PhantomData,
-        }
-    }
-
     /// Creates a new `Report<Context>` from a provided scope.
     ///
     /// If `context` does not provide [`Backtrace`]/[`SpanTrace`] then this attempts to capture
@@ -238,7 +236,10 @@ impl<C> Report<C> {
         let span_trace = Some(SpanTrace::capture());
 
         #[allow(unused_mut)]
-        let mut report = Self::from_frame(frame);
+        let mut report = Self {
+            frames: Box::new(vec![frame]),
+            _context: PhantomData,
+        };
 
         #[cfg(all(rust_1_65, feature = "std"))]
         if let Some(backtrace) =
@@ -359,15 +360,17 @@ impl<C> Report<C> {
     /// [`Debug`]: core::fmt::Debug
     /// [`attach_printable()`]: Self::attach_printable
     #[track_caller]
-    pub fn attach<A>(self, attachment: A) -> Self
+    pub fn attach<A>(mut self, attachment: A) -> Self
     where
         A: Send + Sync + 'static,
     {
-        Self::from_frame(Frame::from_attachment(
+        let old_frames = mem::replace(self.frames.as_mut(), Vec::with_capacity(1));
+        self.frames.push(Frame::from_attachment(
             attachment,
             Location::caller(),
-            self.frames.into_boxed_slice(),
-        ))
+            old_frames.into_boxed_slice(),
+        ));
+        self
     }
 
     /// Adds additional (printable) information to the [`Frame`] stack.
@@ -409,15 +412,17 @@ impl<C> Report<C> {
     /// assert_eq!(suggestion.0, "Better use a file which exists next time!");
     /// # }
     #[track_caller]
-    pub fn attach_printable<A>(self, attachment: A) -> Self
+    pub fn attach_printable<A>(mut self, attachment: A) -> Self
     where
         A: fmt::Display + fmt::Debug + Send + Sync + 'static,
     {
-        Self::from_frame(Frame::from_printable_attachment(
+        let old_frames = mem::replace(self.frames.as_mut(), Vec::with_capacity(1));
+        self.frames.push(Frame::from_printable_attachment(
             attachment,
             Location::caller(),
-            self.frames.into_boxed_slice(),
-        ))
+            old_frames.into_boxed_slice(),
+        ));
+        self
     }
 
     /// Add a new [`Context`] object to the top of the [`Frame`] stack, changing the type of the
@@ -425,15 +430,20 @@ impl<C> Report<C> {
     ///
     /// Please see the [`Context`] documentation for more information.
     #[track_caller]
-    pub fn change_context<T>(self, context: T) -> Report<T>
+    pub fn change_context<T>(mut self, context: T) -> Report<T>
     where
         T: Context,
     {
-        Report::from_frame(Frame::from_context(
+        let old_frames = mem::replace(self.frames.as_mut(), Vec::with_capacity(1));
+        self.frames.push(Frame::from_context(
             context,
             Location::caller(),
-            self.frames.into_boxed_slice(),
-        ))
+            old_frames.into_boxed_slice(),
+        ));
+        Report {
+            frames: self.frames,
+            _context: PhantomData,
+        }
     }
 
     /// Return the direct current frames of this report,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Boxing the collection of Frames implies a memory footprint equal to a single pointer size instead of three pointer sizes. `Report` is unlikely to be used in the happy path, but it's almost always used in `Result::Err`, so for small `Result::Ok` variants, this would increase the size of the `Result` to 24 bytes (on 64 bit) instead of 8 bytes.

## 🚫 Blocked by

- #1054 

## 🔍 What does this change?

- Box the vector of Frames in `Report`

## 📜 Does this require a change to the docs?

No

## 🛡 What tests cover this?

A test was added, which ensures, that a `Report` always has the same memory footprint as a pointer