### PR TITLE
Proxy get Block Protocol blocks request via Workspace API

### DIFF
--- a/packages/hash/README.md
+++ b/packages/hash/README.md
@@ -400,7 +400,7 @@ If the service should report metrics to a StatsD server, the following variables
 - `NEXT_PUBLIC_API_ORIGIN`: The origin that the API service can be reached on (default: `http://localhost:5001`)
 - `SESSION_SECRET`: The secret used to sign login sessions (default: `secret`)
 - `LOG_LEVEL`: the level of runtime logs that should be omitted, either set to `debug`, `info`, `warn`, `error` (default: `info`)
-- `NEXT_PUBLIC_BLOCK_PROTOCOL_API_KEY`: the api key for fetching blocks from [BP Hub](https://blockprotocol.org/hub).
+- `BLOCK_PROTOCOL_API_KEY`: the api key for fetching blocks from [BP Hub](https://blockprotocol.org/hub).
 
 ## Contributors
 

--- a/packages/hash/api/src/graphql/resolvers/blockprotocol/getBlock.ts
+++ b/packages/hash/api/src/graphql/resolvers/blockprotocol/getBlock.ts
@@ -8,7 +8,11 @@ export const getBlockProtocolBlocks: ResolverFn<
   GraphQLContext,
   {}
 > = async () => {
-  const apiKey = process.env.BLOCK_PROTOCOL_API_KEY as string;
+  const apiKey = process.env.BLOCK_PROTOCOL_API_KEY;
+
+  if (!apiKey) {
+    throw new Error("BLOCK_PROTOCOL_API_KEY env variable is missing!");
+  }
 
   const res = await fetch("https://blockprotocol.org/api/blocks", {
     headers: { "x-api-key": apiKey },

--- a/packages/hash/api/src/graphql/resolvers/blockprotocol/getBlock.ts
+++ b/packages/hash/api/src/graphql/resolvers/blockprotocol/getBlock.ts
@@ -1,0 +1,20 @@
+import fetch from "node-fetch";
+import { ResolverFn, BlockProtocolBlock } from "../../apiTypes.gen";
+import { GraphQLContext } from "../../context";
+
+export const getBlockProtocolBlocks: ResolverFn<
+  Promise<BlockProtocolBlock[]>,
+  {},
+  GraphQLContext,
+  {}
+> = async () => {
+  const apiKey = process.env.NEXT_PUBLIC_BLOCK_PROTOCOL_API_KEY as string;
+
+  const res = await fetch("https://blockprotocol.org/api/blocks", {
+    headers: { "x-api-key": apiKey },
+  });
+
+  const { results } = await res.json();
+
+  return results as BlockProtocolBlock[];
+};

--- a/packages/hash/api/src/graphql/resolvers/blockprotocol/getBlock.ts
+++ b/packages/hash/api/src/graphql/resolvers/blockprotocol/getBlock.ts
@@ -8,7 +8,7 @@ export const getBlockProtocolBlocks: ResolverFn<
   GraphQLContext,
   {}
 > = async () => {
-  const apiKey = process.env.NEXT_PUBLIC_BLOCK_PROTOCOL_API_KEY as string;
+  const apiKey = process.env.BLOCK_PROTOCOL_API_KEY as string;
 
   const res = await fetch("https://blockprotocol.org/api/blocks", {
     headers: { "x-api-key": apiKey },

--- a/packages/hash/api/src/graphql/resolvers/index.ts
+++ b/packages/hash/api/src/graphql/resolvers/index.ts
@@ -79,6 +79,7 @@ import {
 } from "./taskExecutor";
 import { getLink } from "./link/getLink";
 import { getLinkedAggregation } from "./linkedAggregation/getLinkedAggregation";
+import { getBlockProtocolBlocks } from "./blockprotocol/getBlock";
 
 export const resolvers = {
   Query: {
@@ -90,6 +91,7 @@ export const resolvers = {
       ) /** @todo: make accessible to admins only (or deprecate) */,
     aggregateEntity: loggedInAndSignedUp(aggregateEntity),
     blocks: loggedInAndSignedUp(blocks),
+    getBlockProtocolBlocks,
     getAccountEntityTypes: loggedInAndSignedUp(getAccountEntityTypes),
     entity: loggedInAndSignedUp(entity),
     entities: loggedInAndSignedUp(canAccessAccount(entities)),

--- a/packages/hash/api/src/graphql/typeDefs/blockprotocol.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/blockprotocol.typedef.ts
@@ -11,16 +11,15 @@ export const blockprotocolTypedef = gql`
     icon: String
     name: String
     properties: JSONObject
-    examples: [JSONObject]
+    examples: [JSONObject!]
   }
 
   type BlockProtocolBlock {
     blockType: BlockType!
     default: JSONObject
     description: String
-    devReloadEndpoint: String
     displayName: String
-    examples: [JSONObject]
+    examples: [JSONObject!]
     externals: JSONObject
     icon: String
     image: String

--- a/packages/hash/api/src/graphql/typeDefs/blockprotocol.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/blockprotocol.typedef.ts
@@ -1,0 +1,48 @@
+import { gql } from "apollo-server-express";
+
+export const blockprotocolTypedef = gql`
+  type BlockType {
+    entryPoint: String!
+    tagName: String
+  }
+
+  type BlockVariant {
+    description: String
+    icon: String
+    name: String
+    properties: JSONObject
+    examples: [JSONObject]
+  }
+
+  type BlockProtocolBlock {
+    blockType: BlockType!
+    default: JSONObject
+    description: String
+    devReloadEndpoint: String
+    displayName: String
+    examples: [JSONObject]
+    externals: JSONObject
+    icon: String
+    image: String
+    license: String
+    name: String!
+    protocol: String
+    source: String!
+    variants: [BlockVariant!]
+    version: String!
+    author: String!
+    createdAt: String
+    blockSitePath: String!
+    componentId: String!
+    exampleGraph: String
+    lastUpdated: String
+    npmPackageName: String
+    pathWithNamespace: String!
+    repository: String
+    schema: String
+  }
+
+  extend type Query {
+    getBlockProtocolBlocks: [BlockProtocolBlock!]!
+  }
+`;

--- a/packages/hash/api/src/graphql/typeDefs/index.ts
+++ b/packages/hash/api/src/graphql/typeDefs/index.ts
@@ -18,6 +18,7 @@ import { orgMembershipTypedef } from "./orgMembership.typedef";
 import { aggregationTypedef } from "./aggregation.typedef";
 import { pagePaginationTypedef } from "./paginationConnections.typedef";
 import { executeTaskTypedef } from "./taskExecution.typedef";
+import { blockprotocolTypedef } from "./blockprotocol.typedef";
 
 const baseSchema = gql`
   scalar Date
@@ -45,6 +46,7 @@ export const schema = [
   accountTypedef,
   baseSchema,
   blockTypedef,
+  blockprotocolTypedef,
   embedTypeDef,
   entityTypedef,
   linkTypedef,

--- a/packages/hash/frontend/src/blocks/userBlocks.tsx
+++ b/packages/hash/frontend/src/blocks/userBlocks.tsx
@@ -39,16 +39,16 @@ export const UserBlocksProvider: FunctionComponent<{
 
   useEffect(() => {
     const setInitialBlocks = async () => {
-      if (process.env.NEXT_PUBLIC_BLOCK_PROTOCOL_API_KEY && data) {
-        const apiProvidedBlocksMap: BlocksMap = {};
-        for (const { componentId } of data.getBlockProtocolBlocks) {
-          apiProvidedBlocksMap[componentId] = await fetchBlock(componentId);
-        }
+      if (!data) return;
 
-        setValue((prevValue) => {
-          return { ...prevValue, ...apiProvidedBlocksMap };
-        });
+      const apiProvidedBlocksMap: BlocksMap = {};
+      for (const { componentId } of data.getBlockProtocolBlocks) {
+        apiProvidedBlocksMap[componentId] = await fetchBlock(componentId);
       }
+
+      setValue((prevValue) => {
+        return { ...prevValue, ...apiProvidedBlocksMap };
+      });
     };
 
     void setInitialBlocks();

--- a/packages/hash/frontend/src/components/hooks/useGetBlockProtocolBlocks.ts
+++ b/packages/hash/frontend/src/components/hooks/useGetBlockProtocolBlocks.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@apollo/client";
+import { GetBlockProtocolBlocksQuery } from "../../graphql/apiTypes.gen";
+import { getBlockProtocolBlocksQuery } from "../../graphql/queries/block.queries";
+
+export const useGetBlockProtocolBlocks = () => {
+  const { data, error } = useQuery<GetBlockProtocolBlocksQuery>(
+    getBlockProtocolBlocksQuery,
+    {},
+  );
+
+  return { data, error };
+};

--- a/packages/hash/frontend/src/graphql/queries/block.queries.ts
+++ b/packages/hash/frontend/src/graphql/queries/block.queries.ts
@@ -1,0 +1,42 @@
+import { gql } from "@apollo/client";
+
+export const getBlockProtocolBlocksQuery = gql`
+  query getBlockProtocolBlocks {
+    getBlockProtocolBlocks {
+      blockType {
+        entryPoint
+        tagName
+      }
+      default
+      description
+      devReloadEndpoint
+      displayName
+      examples
+      externals
+      icon
+      image
+      license
+      name
+      protocol
+      source
+      variants {
+        description
+        examples
+        icon
+        name
+        properties
+      }
+      version
+      author
+      createdAt
+      blockSitePath
+      componentId
+      exampleGraph
+      lastUpdated
+      npmPackageName
+      pathWithNamespace
+      repository
+      schema
+    }
+  }
+`;

--- a/packages/hash/frontend/src/graphql/queries/block.queries.ts
+++ b/packages/hash/frontend/src/graphql/queries/block.queries.ts
@@ -9,7 +9,6 @@ export const getBlockProtocolBlocksQuery = gql`
       }
       default
       description
-      devReloadEndpoint
       displayName
       examples
       externals


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR requests the `Available Block List` from `BP API` over `Workspace API` , instead of directly making a call to `BP API` from frontend. So this PR will prevent avoid leaking the API key in the frontend client, which is a security flaw.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1200211978612931/1202720005996068/f) _(internal)_

## 🔍 What does this change?

- Create a new graphql query to make a call to `BP API` from `Workspace API`. And use the new query instead of calling `BP API` from client
