### PR TITLE
Implement recursive lookup for ontology types

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -220,6 +220,25 @@ export type DataTypeKindEnum =
 /**
  *
  * @export
+ * @interface DataTypeQuery
+ */
+export interface DataTypeQuery {
+  /**
+   *
+   * @type {number}
+   * @memberof DataTypeQuery
+   */
+  dataTypeQueryDepth: number;
+  /**
+   *
+   * @type {object}
+   * @memberof DataTypeQuery
+   */
+  query: object;
+}
+/**
+ *
+ * @export
  * @interface DataTypeReference
  */
 export interface DataTypeReference {
@@ -242,6 +261,19 @@ export interface DataTypeReferenceUpdate {
    * @memberof DataTypeReferenceUpdate
    */
   $ref: string;
+}
+/**
+ *
+ * @export
+ * @interface DataTypeTree
+ */
+export interface DataTypeTree {
+  /**
+   *
+   * @type {PersistedDataType}
+   * @memberof DataTypeTree
+   */
+  dataType: PersistedDataType;
 }
 /**
  * Specifies the structure of an Entity Type
@@ -337,6 +369,74 @@ export type EntityTypeTypeEnum =
   typeof EntityTypeTypeEnum[keyof typeof EntityTypeTypeEnum];
 
 /**
+ *
+ * @export
+ * @interface EntityTypeQuery
+ */
+export interface EntityTypeQuery {
+  /**
+   *
+   * @type {number}
+   * @memberof EntityTypeQuery
+   */
+  dataTypeQueryDepth: number;
+  /**
+   *
+   * @type {number}
+   * @memberof EntityTypeQuery
+   */
+  entityLinkQueryDepth: number;
+  /**
+   *
+   * @type {number}
+   * @memberof EntityTypeQuery
+   */
+  propertyTypeQueryDepth: number;
+  /**
+   *
+   * @type {object}
+   * @memberof EntityTypeQuery
+   */
+  query: object;
+}
+/**
+ *
+ * @export
+ * @interface EntityTypeTree
+ */
+export interface EntityTypeTree {
+  /**
+   *
+   * @type {Array<PersistedDataType>}
+   * @memberof EntityTypeTree
+   */
+  dataTypeReferences: Array<PersistedDataType>;
+  /**
+   *
+   * @type {PersistedEntityType}
+   * @memberof EntityTypeTree
+   */
+  entityType: PersistedEntityType;
+  /**
+   *
+   * @type {Array<PersistedEntityType>}
+   * @memberof EntityTypeTree
+   */
+  entityTypeReferences: Array<PersistedEntityType>;
+  /**
+   *
+   * @type {Array<PersistedLinkType>}
+   * @memberof EntityTypeTree
+   */
+  linkTypeReferences: Array<PersistedLinkType>;
+  /**
+   *
+   * @type {Array<PersistedPropertyType>}
+   * @memberof EntityTypeTree
+   */
+  propertyTypeReferences: Array<PersistedPropertyType>;
+}
+/**
  * A Link between a source and a target entity identified by [`EntityId`]s.
  * @export
  * @interface Link
@@ -412,6 +512,32 @@ export const LinkTypeKindEnum = {
 export type LinkTypeKindEnum =
   typeof LinkTypeKindEnum[keyof typeof LinkTypeKindEnum];
 
+/**
+ *
+ * @export
+ * @interface LinkTypeQuery
+ */
+export interface LinkTypeQuery {
+  /**
+   *
+   * @type {object}
+   * @memberof LinkTypeQuery
+   */
+  query: object;
+}
+/**
+ *
+ * @export
+ * @interface LinkTypeTree
+ */
+export interface LinkTypeTree {
+  /**
+   *
+   * @type {PersistedLinkType}
+   * @memberof LinkTypeTree
+   */
+  linkType: PersistedLinkType;
+}
 /**
  *
  * @export
@@ -739,6 +865,56 @@ export const PropertyTypeKindEnum = {
 export type PropertyTypeKindEnum =
   typeof PropertyTypeKindEnum[keyof typeof PropertyTypeKindEnum];
 
+/**
+ *
+ * @export
+ * @interface PropertyTypeQuery
+ */
+export interface PropertyTypeQuery {
+  /**
+   *
+   * @type {number}
+   * @memberof PropertyTypeQuery
+   */
+  dataTypeQueryDepth: number;
+  /**
+   *
+   * @type {number}
+   * @memberof PropertyTypeQuery
+   */
+  propertyTypeQueryDepth: number;
+  /**
+   *
+   * @type {object}
+   * @memberof PropertyTypeQuery
+   */
+  query: object;
+}
+/**
+ *
+ * @export
+ * @interface PropertyTypeTree
+ */
+export interface PropertyTypeTree {
+  /**
+   *
+   * @type {Array<PersistedDataType>}
+   * @memberof PropertyTypeTree
+   */
+  dataTypeReferences: Array<PersistedDataType>;
+  /**
+   *
+   * @type {PersistedPropertyType}
+   * @memberof PropertyTypeTree
+   */
+  propertyType: PersistedPropertyType;
+  /**
+   *
+   * @type {Array<PersistedPropertyType>}
+   * @memberof PropertyTypeTree
+   */
+  propertyTypeReferences: Array<PersistedPropertyType>;
+}
 /**
  * @type PropertyValues
  * @export
@@ -2584,16 +2760,20 @@ export const EntityTypeApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {object} body
+     * @param {EntityTypeQuery} entityTypeQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getEntityTypesByQuery: async (
-      body: object,
+      entityTypeQuery: EntityTypeQuery,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'body' is not null or undefined
-      assertParamExists("getEntityTypesByQuery", "body", body);
+      // verify required parameter 'entityTypeQuery' is not null or undefined
+      assertParamExists(
+        "getEntityTypesByQuery",
+        "entityTypeQuery",
+        entityTypeQuery,
+      );
       const localVarPath = `/entity-types/query`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -2621,7 +2801,7 @@ export const EntityTypeApiAxiosParamCreator = function (
         ...options.headers,
       };
       localVarRequestOptions.data = serializeDataIfNeeded(
-        body,
+        entityTypeQuery,
         localVarRequestOptions,
         configuration,
       );
@@ -2788,21 +2968,24 @@ export const EntityTypeApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {object} body
+     * @param {EntityTypeQuery} entityTypeQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getEntityTypesByQuery(
-      body: object,
+      entityTypeQuery: EntityTypeQuery,
       options?: AxiosRequestConfig,
     ): Promise<
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<PersistedEntityType>>
+      ) => AxiosPromise<Array<EntityTypeTree>>
     > {
       const localVarAxiosArgs =
-        await localVarAxiosParamCreator.getEntityTypesByQuery(body, options);
+        await localVarAxiosParamCreator.getEntityTypesByQuery(
+          entityTypeQuery,
+          options,
+        );
       return createRequestFunction(
         localVarAxiosArgs,
         globalAxios,
@@ -2903,16 +3086,16 @@ export const EntityTypeApiFactory = function (
     },
     /**
      *
-     * @param {object} body
+     * @param {EntityTypeQuery} entityTypeQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getEntityTypesByQuery(
-      body: object,
+      entityTypeQuery: EntityTypeQuery,
       options?: any,
-    ): AxiosPromise<Array<PersistedEntityType>> {
+    ): AxiosPromise<Array<EntityTypeTree>> {
       return localVarFp
-        .getEntityTypesByQuery(body, options)
+        .getEntityTypesByQuery(entityTypeQuery, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -2976,15 +3159,15 @@ export interface EntityTypeApiInterface {
 
   /**
    *
-   * @param {object} body
+   * @param {EntityTypeQuery} entityTypeQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof EntityTypeApiInterface
    */
   getEntityTypesByQuery(
-    body: object,
+    entityTypeQuery: EntityTypeQuery,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PersistedEntityType>>;
+  ): AxiosPromise<Array<EntityTypeTree>>;
 
   /**
    *
@@ -3047,14 +3230,17 @@ export class EntityTypeApi extends BaseAPI implements EntityTypeApiInterface {
 
   /**
    *
-   * @param {object} body
+   * @param {EntityTypeQuery} entityTypeQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof EntityTypeApi
    */
-  public getEntityTypesByQuery(body: object, options?: AxiosRequestConfig) {
+  public getEntityTypesByQuery(
+    entityTypeQuery: EntityTypeQuery,
+    options?: AxiosRequestConfig,
+  ) {
     return EntityTypeApiFp(this.configuration)
-      .getEntityTypesByQuery(body, options)
+      .getEntityTypesByQuery(entityTypeQuery, options)
       .then((request) => request(this.axios, this.basePath));
   }
 
@@ -3734,16 +3920,20 @@ export const GraphApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {object} body
+     * @param {EntityTypeQuery} entityTypeQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getEntityTypesByQuery: async (
-      body: object,
+      entityTypeQuery: EntityTypeQuery,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'body' is not null or undefined
-      assertParamExists("getEntityTypesByQuery", "body", body);
+      // verify required parameter 'entityTypeQuery' is not null or undefined
+      assertParamExists(
+        "getEntityTypesByQuery",
+        "entityTypeQuery",
+        entityTypeQuery,
+      );
       const localVarPath = `/entity-types/query`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -3771,7 +3961,7 @@ export const GraphApiAxiosParamCreator = function (
         ...options.headers,
       };
       localVarRequestOptions.data = serializeDataIfNeeded(
-        body,
+        entityTypeQuery,
         localVarRequestOptions,
         configuration,
       );
@@ -4018,16 +4208,16 @@ export const GraphApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {object} body
+     * @param {LinkTypeQuery} linkTypeQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getLinkTypesByQuery: async (
-      body: object,
+      linkTypeQuery: LinkTypeQuery,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'body' is not null or undefined
-      assertParamExists("getLinkTypesByQuery", "body", body);
+      // verify required parameter 'linkTypeQuery' is not null or undefined
+      assertParamExists("getLinkTypesByQuery", "linkTypeQuery", linkTypeQuery);
       const localVarPath = `/link-types/query`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -4055,7 +4245,7 @@ export const GraphApiAxiosParamCreator = function (
         ...options.headers,
       };
       localVarRequestOptions.data = serializeDataIfNeeded(
-        body,
+        linkTypeQuery,
         localVarRequestOptions,
         configuration,
       );
@@ -4161,16 +4351,20 @@ export const GraphApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {object} body
+     * @param {PropertyTypeQuery} propertyTypeQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getPropertyTypesByQuery: async (
-      body: object,
+      propertyTypeQuery: PropertyTypeQuery,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'body' is not null or undefined
-      assertParamExists("getPropertyTypesByQuery", "body", body);
+      // verify required parameter 'propertyTypeQuery' is not null or undefined
+      assertParamExists(
+        "getPropertyTypesByQuery",
+        "propertyTypeQuery",
+        propertyTypeQuery,
+      );
       const localVarPath = `/property-types/query`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -4198,7 +4392,7 @@ export const GraphApiAxiosParamCreator = function (
         ...options.headers,
       };
       localVarRequestOptions.data = serializeDataIfNeeded(
-        body,
+        propertyTypeQuery,
         localVarRequestOptions,
         configuration,
       );
@@ -4868,21 +5062,24 @@ export const GraphApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {object} body
+     * @param {EntityTypeQuery} entityTypeQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getEntityTypesByQuery(
-      body: object,
+      entityTypeQuery: EntityTypeQuery,
       options?: AxiosRequestConfig,
     ): Promise<
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<PersistedEntityType>>
+      ) => AxiosPromise<Array<EntityTypeTree>>
     > {
       const localVarAxiosArgs =
-        await localVarAxiosParamCreator.getEntityTypesByQuery(body, options);
+        await localVarAxiosParamCreator.getEntityTypesByQuery(
+          entityTypeQuery,
+          options,
+        );
       return createRequestFunction(
         localVarAxiosArgs,
         globalAxios,
@@ -5028,21 +5225,24 @@ export const GraphApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {object} body
+     * @param {LinkTypeQuery} linkTypeQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getLinkTypesByQuery(
-      body: object,
+      linkTypeQuery: LinkTypeQuery,
       options?: AxiosRequestConfig,
     ): Promise<
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<PersistedLinkType>>
+      ) => AxiosPromise<Array<LinkTypeTree>>
     > {
       const localVarAxiosArgs =
-        await localVarAxiosParamCreator.getLinkTypesByQuery(body, options);
+        await localVarAxiosParamCreator.getLinkTypesByQuery(
+          linkTypeQuery,
+          options,
+        );
       return createRequestFunction(
         localVarAxiosArgs,
         globalAxios,
@@ -5101,21 +5301,24 @@ export const GraphApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {object} body
+     * @param {PropertyTypeQuery} propertyTypeQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getPropertyTypesByQuery(
-      body: object,
+      propertyTypeQuery: PropertyTypeQuery,
       options?: AxiosRequestConfig,
     ): Promise<
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<PersistedPropertyType>>
+      ) => AxiosPromise<Array<PropertyTypeTree>>
     > {
       const localVarAxiosArgs =
-        await localVarAxiosParamCreator.getPropertyTypesByQuery(body, options);
+        await localVarAxiosParamCreator.getPropertyTypesByQuery(
+          propertyTypeQuery,
+          options,
+        );
       return createRequestFunction(
         localVarAxiosArgs,
         globalAxios,
@@ -5468,16 +5671,16 @@ export const GraphApiFactory = function (
     },
     /**
      *
-     * @param {object} body
+     * @param {EntityTypeQuery} entityTypeQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getEntityTypesByQuery(
-      body: object,
+      entityTypeQuery: EntityTypeQuery,
       options?: any,
-    ): AxiosPromise<Array<PersistedEntityType>> {
+    ): AxiosPromise<Array<EntityTypeTree>> {
       return localVarFp
-        .getEntityTypesByQuery(body, options)
+        .getEntityTypesByQuery(entityTypeQuery, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -5547,16 +5750,16 @@ export const GraphApiFactory = function (
     },
     /**
      *
-     * @param {object} body
+     * @param {LinkTypeQuery} linkTypeQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getLinkTypesByQuery(
-      body: object,
+      linkTypeQuery: LinkTypeQuery,
       options?: any,
-    ): AxiosPromise<Array<PersistedLinkType>> {
+    ): AxiosPromise<Array<LinkTypeTree>> {
       return localVarFp
-        .getLinkTypesByQuery(body, options)
+        .getLinkTypesByQuery(linkTypeQuery, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -5586,16 +5789,16 @@ export const GraphApiFactory = function (
     },
     /**
      *
-     * @param {object} body
+     * @param {PropertyTypeQuery} propertyTypeQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getPropertyTypesByQuery(
-      body: object,
+      propertyTypeQuery: PropertyTypeQuery,
       options?: any,
-    ): AxiosPromise<Array<PersistedPropertyType>> {
+    ): AxiosPromise<Array<PropertyTypeTree>> {
       return localVarFp
-        .getPropertyTypesByQuery(body, options)
+        .getPropertyTypesByQuery(propertyTypeQuery, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -5849,15 +6052,15 @@ export interface GraphApiInterface {
 
   /**
    *
-   * @param {object} body
+   * @param {EntityTypeQuery} entityTypeQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof GraphApiInterface
    */
   getEntityTypesByQuery(
-    body: object,
+    entityTypeQuery: EntityTypeQuery,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PersistedEntityType>>;
+  ): AxiosPromise<Array<EntityTypeTree>>;
 
   /**
    *
@@ -5923,15 +6126,15 @@ export interface GraphApiInterface {
 
   /**
    *
-   * @param {object} body
+   * @param {LinkTypeQuery} linkTypeQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof GraphApiInterface
    */
   getLinkTypesByQuery(
-    body: object,
+    linkTypeQuery: LinkTypeQuery,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PersistedLinkType>>;
+  ): AxiosPromise<Array<LinkTypeTree>>;
 
   /**
    *
@@ -5959,15 +6162,15 @@ export interface GraphApiInterface {
 
   /**
    *
-   * @param {object} body
+   * @param {PropertyTypeQuery} propertyTypeQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof GraphApiInterface
    */
   getPropertyTypesByQuery(
-    body: object,
+    propertyTypeQuery: PropertyTypeQuery,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PersistedPropertyType>>;
+  ): AxiosPromise<Array<PropertyTypeTree>>;
 
   /**
    *
@@ -6241,14 +6444,17 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
 
   /**
    *
-   * @param {object} body
+   * @param {EntityTypeQuery} entityTypeQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof GraphApi
    */
-  public getEntityTypesByQuery(body: object, options?: AxiosRequestConfig) {
+  public getEntityTypesByQuery(
+    entityTypeQuery: EntityTypeQuery,
+    options?: AxiosRequestConfig,
+  ) {
     return GraphApiFp(this.configuration)
-      .getEntityTypesByQuery(body, options)
+      .getEntityTypesByQuery(entityTypeQuery, options)
       .then((request) => request(this.axios, this.basePath));
   }
 
@@ -6327,14 +6533,17 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
 
   /**
    *
-   * @param {object} body
+   * @param {LinkTypeQuery} linkTypeQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof GraphApi
    */
-  public getLinkTypesByQuery(body: object, options?: AxiosRequestConfig) {
+  public getLinkTypesByQuery(
+    linkTypeQuery: LinkTypeQuery,
+    options?: AxiosRequestConfig,
+  ) {
     return GraphApiFp(this.configuration)
-      .getLinkTypesByQuery(body, options)
+      .getLinkTypesByQuery(linkTypeQuery, options)
       .then((request) => request(this.axios, this.basePath));
   }
 
@@ -6366,14 +6575,17 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
 
   /**
    *
-   * @param {object} body
+   * @param {PropertyTypeQuery} propertyTypeQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof GraphApi
    */
-  public getPropertyTypesByQuery(body: object, options?: AxiosRequestConfig) {
+  public getPropertyTypesByQuery(
+    propertyTypeQuery: PropertyTypeQuery,
+    options?: AxiosRequestConfig,
+  ) {
     return GraphApiFp(this.configuration)
-      .getPropertyTypesByQuery(body, options)
+      .getPropertyTypesByQuery(propertyTypeQuery, options)
       .then((request) => request(this.axios, this.basePath));
   }
 
@@ -7144,16 +7356,16 @@ export const LinkTypeApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {object} body
+     * @param {LinkTypeQuery} linkTypeQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getLinkTypesByQuery: async (
-      body: object,
+      linkTypeQuery: LinkTypeQuery,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'body' is not null or undefined
-      assertParamExists("getLinkTypesByQuery", "body", body);
+      // verify required parameter 'linkTypeQuery' is not null or undefined
+      assertParamExists("getLinkTypesByQuery", "linkTypeQuery", linkTypeQuery);
       const localVarPath = `/link-types/query`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -7181,7 +7393,7 @@ export const LinkTypeApiAxiosParamCreator = function (
         ...options.headers,
       };
       localVarRequestOptions.data = serializeDataIfNeeded(
-        body,
+        linkTypeQuery,
         localVarRequestOptions,
         configuration,
       );
@@ -7330,21 +7542,24 @@ export const LinkTypeApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {object} body
+     * @param {LinkTypeQuery} linkTypeQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getLinkTypesByQuery(
-      body: object,
+      linkTypeQuery: LinkTypeQuery,
       options?: AxiosRequestConfig,
     ): Promise<
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<PersistedLinkType>>
+      ) => AxiosPromise<Array<LinkTypeTree>>
     > {
       const localVarAxiosArgs =
-        await localVarAxiosParamCreator.getLinkTypesByQuery(body, options);
+        await localVarAxiosParamCreator.getLinkTypesByQuery(
+          linkTypeQuery,
+          options,
+        );
       return createRequestFunction(
         localVarAxiosArgs,
         globalAxios,
@@ -7429,16 +7644,16 @@ export const LinkTypeApiFactory = function (
     },
     /**
      *
-     * @param {object} body
+     * @param {LinkTypeQuery} linkTypeQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getLinkTypesByQuery(
-      body: object,
+      linkTypeQuery: LinkTypeQuery,
       options?: any,
-    ): AxiosPromise<Array<PersistedLinkType>> {
+    ): AxiosPromise<Array<LinkTypeTree>> {
       return localVarFp
-        .getLinkTypesByQuery(body, options)
+        .getLinkTypesByQuery(linkTypeQuery, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -7500,15 +7715,15 @@ export interface LinkTypeApiInterface {
 
   /**
    *
-   * @param {object} body
+   * @param {LinkTypeQuery} linkTypeQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof LinkTypeApiInterface
    */
   getLinkTypesByQuery(
-    body: object,
+    linkTypeQuery: LinkTypeQuery,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PersistedLinkType>>;
+  ): AxiosPromise<Array<LinkTypeTree>>;
 
   /**
    *
@@ -7573,14 +7788,17 @@ export class LinkTypeApi extends BaseAPI implements LinkTypeApiInterface {
 
   /**
    *
-   * @param {object} body
+   * @param {LinkTypeQuery} linkTypeQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof LinkTypeApi
    */
-  public getLinkTypesByQuery(body: object, options?: AxiosRequestConfig) {
+  public getLinkTypesByQuery(
+    linkTypeQuery: LinkTypeQuery,
+    options?: AxiosRequestConfig,
+  ) {
     return LinkTypeApiFp(this.configuration)
-      .getLinkTypesByQuery(body, options)
+      .getLinkTypesByQuery(linkTypeQuery, options)
       .then((request) => request(this.axios, this.basePath));
   }
 
@@ -7747,16 +7965,20 @@ export const PropertyTypeApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {object} body
+     * @param {PropertyTypeQuery} propertyTypeQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getPropertyTypesByQuery: async (
-      body: object,
+      propertyTypeQuery: PropertyTypeQuery,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'body' is not null or undefined
-      assertParamExists("getPropertyTypesByQuery", "body", body);
+      // verify required parameter 'propertyTypeQuery' is not null or undefined
+      assertParamExists(
+        "getPropertyTypesByQuery",
+        "propertyTypeQuery",
+        propertyTypeQuery,
+      );
       const localVarPath = `/property-types/query`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -7784,7 +8006,7 @@ export const PropertyTypeApiAxiosParamCreator = function (
         ...options.headers,
       };
       localVarRequestOptions.data = serializeDataIfNeeded(
-        body,
+        propertyTypeQuery,
         localVarRequestOptions,
         configuration,
       );
@@ -7935,21 +8157,24 @@ export const PropertyTypeApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {object} body
+     * @param {PropertyTypeQuery} propertyTypeQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getPropertyTypesByQuery(
-      body: object,
+      propertyTypeQuery: PropertyTypeQuery,
       options?: AxiosRequestConfig,
     ): Promise<
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<PersistedPropertyType>>
+      ) => AxiosPromise<Array<PropertyTypeTree>>
     > {
       const localVarAxiosArgs =
-        await localVarAxiosParamCreator.getPropertyTypesByQuery(body, options);
+        await localVarAxiosParamCreator.getPropertyTypesByQuery(
+          propertyTypeQuery,
+          options,
+        );
       return createRequestFunction(
         localVarAxiosArgs,
         globalAxios,
@@ -8040,16 +8265,16 @@ export const PropertyTypeApiFactory = function (
     },
     /**
      *
-     * @param {object} body
+     * @param {PropertyTypeQuery} propertyTypeQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getPropertyTypesByQuery(
-      body: object,
+      propertyTypeQuery: PropertyTypeQuery,
       options?: any,
-    ): AxiosPromise<Array<PersistedPropertyType>> {
+    ): AxiosPromise<Array<PropertyTypeTree>> {
       return localVarFp
-        .getPropertyTypesByQuery(body, options)
+        .getPropertyTypesByQuery(propertyTypeQuery, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -8111,15 +8336,15 @@ export interface PropertyTypeApiInterface {
 
   /**
    *
-   * @param {object} body
+   * @param {PropertyTypeQuery} propertyTypeQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof PropertyTypeApiInterface
    */
   getPropertyTypesByQuery(
-    body: object,
+    propertyTypeQuery: PropertyTypeQuery,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PersistedPropertyType>>;
+  ): AxiosPromise<Array<PropertyTypeTree>>;
 
   /**
    *
@@ -8187,14 +8412,17 @@ export class PropertyTypeApi
 
   /**
    *
-   * @param {object} body
+   * @param {PropertyTypeQuery} propertyTypeQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof PropertyTypeApi
    */
-  public getPropertyTypesByQuery(body: object, options?: AxiosRequestConfig) {
+  public getPropertyTypesByQuery(
+    propertyTypeQuery: PropertyTypeQuery,
+    options?: AxiosRequestConfig,
+  ) {
     return PropertyTypeApiFp(this.configuration)
-      .getPropertyTypesByQuery(body, options)
+      .getPropertyTypesByQuery(propertyTypeQuery, options)
       .then((request) => request(this.axios, this.basePath));
   }
 

--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -1773,7 +1773,7 @@ export const DataTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<PersistedDataType>>
+      ) => AxiosPromise<Array<DataTypeTree>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getDataTypesByQuery(body, options);
@@ -1880,7 +1880,7 @@ export const DataTypeApiFactory = function (
     getDataTypesByQuery(
       body: object,
       options?: any,
-    ): AxiosPromise<Array<PersistedDataType>> {
+    ): AxiosPromise<Array<DataTypeTree>> {
       return localVarFp
         .getDataTypesByQuery(body, options)
         .then((request) => request(axios, basePath));
@@ -1952,7 +1952,7 @@ export interface DataTypeApiInterface {
   getDataTypesByQuery(
     body: object,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PersistedDataType>>;
+  ): AxiosPromise<Array<DataTypeTree>>;
 
   /**
    *
@@ -4956,7 +4956,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<PersistedDataType>>
+      ) => AxiosPromise<Array<DataTypeTree>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getDataTypesByQuery(body, options);
@@ -5620,7 +5620,7 @@ export const GraphApiFactory = function (
     getDataTypesByQuery(
       body: object,
       options?: any,
-    ): AxiosPromise<Array<PersistedDataType>> {
+    ): AxiosPromise<Array<DataTypeTree>> {
       return localVarFp
         .getDataTypesByQuery(body, options)
         .then((request) => request(axios, basePath));
@@ -6006,7 +6006,7 @@ export interface GraphApiInterface {
   getDataTypesByQuery(
     body: object,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PersistedDataType>>;
+  ): AxiosPromise<Array<DataTypeTree>>;
 
   /**
    *

--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -265,13 +265,13 @@ export interface DataTypeReferenceUpdate {
 /**
  *
  * @export
- * @interface DataTypeTree
+ * @interface DataTypeRootedSubgraph
  */
-export interface DataTypeTree {
+export interface DataTypeRootedSubgraph {
   /**
    *
    * @type {PersistedDataType}
-   * @memberof DataTypeTree
+   * @memberof DataTypeRootedSubgraph
    */
   dataType: PersistedDataType;
 }
@@ -408,39 +408,39 @@ export interface EntityTypeQuery {
 /**
  *
  * @export
- * @interface EntityTypeTree
+ * @interface EntityTypeRootedSubgraph
  */
-export interface EntityTypeTree {
-  /**
-   *
-   * @type {Array<PersistedDataType>}
-   * @memberof EntityTypeTree
-   */
-  dataTypeReferences: Array<PersistedDataType>;
+export interface EntityTypeRootedSubgraph {
   /**
    *
    * @type {PersistedEntityType}
-   * @memberof EntityTypeTree
+   * @memberof EntityTypeRootedSubgraph
    */
   entityType: PersistedEntityType;
   /**
    *
-   * @type {Array<PersistedEntityType>}
-   * @memberof EntityTypeTree
+   * @type {Array<PersistedDataType>}
+   * @memberof EntityTypeRootedSubgraph
    */
-  entityTypeReferences: Array<PersistedEntityType>;
+  referencedDataTypes: Array<PersistedDataType>;
+  /**
+   *
+   * @type {Array<PersistedEntityType>}
+   * @memberof EntityTypeRootedSubgraph
+   */
+  referencedEntityTypes: Array<PersistedEntityType>;
   /**
    *
    * @type {Array<PersistedLinkType>}
-   * @memberof EntityTypeTree
+   * @memberof EntityTypeRootedSubgraph
    */
-  linkTypeReferences: Array<PersistedLinkType>;
+  referencedLinkTypes: Array<PersistedLinkType>;
   /**
    *
    * @type {Array<PersistedPropertyType>}
-   * @memberof EntityTypeTree
+   * @memberof EntityTypeRootedSubgraph
    */
-  propertyTypeReferences: Array<PersistedPropertyType>;
+  referencedPropertyTypes: Array<PersistedPropertyType>;
 }
 /**
  * A Link between a source and a target entity identified by [`EntityId`]s.
@@ -534,13 +534,13 @@ export interface LinkTypeQuery {
 /**
  *
  * @export
- * @interface LinkTypeTree
+ * @interface LinkTypeRootedSubgraph
  */
-export interface LinkTypeTree {
+export interface LinkTypeRootedSubgraph {
   /**
    *
    * @type {PersistedLinkType}
-   * @memberof LinkTypeTree
+   * @memberof LinkTypeRootedSubgraph
    */
   linkType: PersistedLinkType;
 }
@@ -899,27 +899,27 @@ export interface PropertyTypeQuery {
 /**
  *
  * @export
- * @interface PropertyTypeTree
+ * @interface PropertyTypeRootedSubgraph
  */
-export interface PropertyTypeTree {
-  /**
-   *
-   * @type {Array<PersistedDataType>}
-   * @memberof PropertyTypeTree
-   */
-  dataTypeReferences: Array<PersistedDataType>;
+export interface PropertyTypeRootedSubgraph {
   /**
    *
    * @type {PersistedPropertyType}
-   * @memberof PropertyTypeTree
+   * @memberof PropertyTypeRootedSubgraph
    */
   propertyType: PersistedPropertyType;
   /**
    *
-   * @type {Array<PersistedPropertyType>}
-   * @memberof PropertyTypeTree
+   * @type {Array<PersistedDataType>}
+   * @memberof PropertyTypeRootedSubgraph
    */
-  propertyTypeReferences: Array<PersistedPropertyType>;
+  referencedDataTypes: Array<PersistedDataType>;
+  /**
+   *
+   * @type {Array<PersistedPropertyType>}
+   * @memberof PropertyTypeRootedSubgraph
+   */
+  referencedPropertyTypes: Array<PersistedPropertyType>;
 }
 /**
  * @type PropertyValues
@@ -1773,7 +1773,7 @@ export const DataTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<DataTypeTree>>
+      ) => AxiosPromise<Array<DataTypeRootedSubgraph>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getDataTypesByQuery(body, options);
@@ -1880,7 +1880,7 @@ export const DataTypeApiFactory = function (
     getDataTypesByQuery(
       body: object,
       options?: any,
-    ): AxiosPromise<Array<DataTypeTree>> {
+    ): AxiosPromise<Array<DataTypeRootedSubgraph>> {
       return localVarFp
         .getDataTypesByQuery(body, options)
         .then((request) => request(axios, basePath));
@@ -1952,7 +1952,7 @@ export interface DataTypeApiInterface {
   getDataTypesByQuery(
     body: object,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<DataTypeTree>>;
+  ): AxiosPromise<Array<DataTypeRootedSubgraph>>;
 
   /**
    *
@@ -2985,7 +2985,7 @@ export const EntityTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<EntityTypeTree>>
+      ) => AxiosPromise<Array<EntityTypeRootedSubgraph>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getEntityTypesByQuery(
@@ -3099,7 +3099,7 @@ export const EntityTypeApiFactory = function (
     getEntityTypesByQuery(
       entityTypeQuery: EntityTypeQuery,
       options?: any,
-    ): AxiosPromise<Array<EntityTypeTree>> {
+    ): AxiosPromise<Array<EntityTypeRootedSubgraph>> {
       return localVarFp
         .getEntityTypesByQuery(entityTypeQuery, options)
         .then((request) => request(axios, basePath));
@@ -3173,7 +3173,7 @@ export interface EntityTypeApiInterface {
   getEntityTypesByQuery(
     entityTypeQuery: EntityTypeQuery,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<EntityTypeTree>>;
+  ): AxiosPromise<Array<EntityTypeRootedSubgraph>>;
 
   /**
    *
@@ -4956,7 +4956,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<DataTypeTree>>
+      ) => AxiosPromise<Array<DataTypeRootedSubgraph>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getDataTypesByQuery(body, options);
@@ -5079,7 +5079,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<EntityTypeTree>>
+      ) => AxiosPromise<Array<EntityTypeRootedSubgraph>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getEntityTypesByQuery(
@@ -5242,7 +5242,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<LinkTypeTree>>
+      ) => AxiosPromise<Array<LinkTypeRootedSubgraph>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getLinkTypesByQuery(
@@ -5318,7 +5318,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<PropertyTypeTree>>
+      ) => AxiosPromise<Array<PropertyTypeRootedSubgraph>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getPropertyTypesByQuery(
@@ -5620,7 +5620,7 @@ export const GraphApiFactory = function (
     getDataTypesByQuery(
       body: object,
       options?: any,
-    ): AxiosPromise<Array<DataTypeTree>> {
+    ): AxiosPromise<Array<DataTypeRootedSubgraph>> {
       return localVarFp
         .getDataTypesByQuery(body, options)
         .then((request) => request(axios, basePath));
@@ -5684,7 +5684,7 @@ export const GraphApiFactory = function (
     getEntityTypesByQuery(
       entityTypeQuery: EntityTypeQuery,
       options?: any,
-    ): AxiosPromise<Array<EntityTypeTree>> {
+    ): AxiosPromise<Array<EntityTypeRootedSubgraph>> {
       return localVarFp
         .getEntityTypesByQuery(entityTypeQuery, options)
         .then((request) => request(axios, basePath));
@@ -5763,7 +5763,7 @@ export const GraphApiFactory = function (
     getLinkTypesByQuery(
       linkTypeQuery: LinkTypeQuery,
       options?: any,
-    ): AxiosPromise<Array<LinkTypeTree>> {
+    ): AxiosPromise<Array<LinkTypeRootedSubgraph>> {
       return localVarFp
         .getLinkTypesByQuery(linkTypeQuery, options)
         .then((request) => request(axios, basePath));
@@ -5802,7 +5802,7 @@ export const GraphApiFactory = function (
     getPropertyTypesByQuery(
       propertyTypeQuery: PropertyTypeQuery,
       options?: any,
-    ): AxiosPromise<Array<PropertyTypeTree>> {
+    ): AxiosPromise<Array<PropertyTypeRootedSubgraph>> {
       return localVarFp
         .getPropertyTypesByQuery(propertyTypeQuery, options)
         .then((request) => request(axios, basePath));
@@ -6006,7 +6006,7 @@ export interface GraphApiInterface {
   getDataTypesByQuery(
     body: object,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<DataTypeTree>>;
+  ): AxiosPromise<Array<DataTypeRootedSubgraph>>;
 
   /**
    *
@@ -6066,7 +6066,7 @@ export interface GraphApiInterface {
   getEntityTypesByQuery(
     entityTypeQuery: EntityTypeQuery,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<EntityTypeTree>>;
+  ): AxiosPromise<Array<EntityTypeRootedSubgraph>>;
 
   /**
    *
@@ -6140,7 +6140,7 @@ export interface GraphApiInterface {
   getLinkTypesByQuery(
     linkTypeQuery: LinkTypeQuery,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<LinkTypeTree>>;
+  ): AxiosPromise<Array<LinkTypeRootedSubgraph>>;
 
   /**
    *
@@ -6176,7 +6176,7 @@ export interface GraphApiInterface {
   getPropertyTypesByQuery(
     propertyTypeQuery: PropertyTypeQuery,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PropertyTypeTree>>;
+  ): AxiosPromise<Array<PropertyTypeRootedSubgraph>>;
 
   /**
    *
@@ -7559,7 +7559,7 @@ export const LinkTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<LinkTypeTree>>
+      ) => AxiosPromise<Array<LinkTypeRootedSubgraph>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getLinkTypesByQuery(
@@ -7657,7 +7657,7 @@ export const LinkTypeApiFactory = function (
     getLinkTypesByQuery(
       linkTypeQuery: LinkTypeQuery,
       options?: any,
-    ): AxiosPromise<Array<LinkTypeTree>> {
+    ): AxiosPromise<Array<LinkTypeRootedSubgraph>> {
       return localVarFp
         .getLinkTypesByQuery(linkTypeQuery, options)
         .then((request) => request(axios, basePath));
@@ -7729,7 +7729,7 @@ export interface LinkTypeApiInterface {
   getLinkTypesByQuery(
     linkTypeQuery: LinkTypeQuery,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<LinkTypeTree>>;
+  ): AxiosPromise<Array<LinkTypeRootedSubgraph>>;
 
   /**
    *
@@ -8174,7 +8174,7 @@ export const PropertyTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<PropertyTypeTree>>
+      ) => AxiosPromise<Array<PropertyTypeRootedSubgraph>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getPropertyTypesByQuery(
@@ -8278,7 +8278,7 @@ export const PropertyTypeApiFactory = function (
     getPropertyTypesByQuery(
       propertyTypeQuery: PropertyTypeQuery,
       options?: any,
-    ): AxiosPromise<Array<PropertyTypeTree>> {
+    ): AxiosPromise<Array<PropertyTypeRootedSubgraph>> {
       return localVarFp
         .getPropertyTypesByQuery(propertyTypeQuery, options)
         .then((request) => request(axios, basePath));
@@ -8350,7 +8350,7 @@ export interface PropertyTypeApiInterface {
   getPropertyTypesByQuery(
     propertyTypeQuery: PropertyTypeQuery,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PropertyTypeTree>>;
+  ): AxiosPromise<Array<PropertyTypeRootedSubgraph>>;
 
   /**
    *

--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -218,7 +218,7 @@ export type DataTypeKindEnum =
   typeof DataTypeKindEnum[keyof typeof DataTypeKindEnum];
 
 /**
- *
+ * Query to read [`DataType`]s, which are matching the [`Expression`].
  * @export
  * @interface DataTypeQuery
  */
@@ -369,7 +369,7 @@ export type EntityTypeTypeEnum =
   typeof EntityTypeTypeEnum[keyof typeof EntityTypeTypeEnum];
 
 /**
- *
+ * Query to read [`EntityType`]s, which are matching the [`Expression`].
  * @export
  * @interface EntityTypeQuery
  */
@@ -519,7 +519,7 @@ export type LinkTypeKindEnum =
   typeof LinkTypeKindEnum[keyof typeof LinkTypeKindEnum];
 
 /**
- *
+ * Query to read [`LinkType`]s, which are matching the [`Expression`].
  * @export
  * @interface LinkTypeQuery
  */
@@ -872,7 +872,7 @@ export type PropertyTypeKindEnum =
   typeof PropertyTypeKindEnum[keyof typeof PropertyTypeKindEnum];
 
 /**
- *
+ * Query to read [`PropertyType`]s, which are matching the [`Expression`].
  * @export
  * @interface PropertyTypeQuery
  */

--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -385,7 +385,13 @@ export interface EntityTypeQuery {
    * @type {number}
    * @memberof EntityTypeQuery
    */
-  entityLinkQueryDepth: number;
+  entityTypeQueryDepth: number;
+  /**
+   *
+   * @type {number}
+   * @memberof EntityTypeQuery
+   */
+  linkTypeQueryDepth: number;
   /**
    *
    * @type {number}

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -134,7 +134,7 @@ async fn create_data_type<P: StorePool + Send>(
 }
 
 #[derive(Deserialize, Component)]
-#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 struct DataTypeQuery {
     query: Expression,
     #[serde(default)]

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -137,7 +137,6 @@ async fn create_data_type<P: StorePool + Send>(
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 struct DataTypeQuery {
     query: Expression,
-    #[serde(default)]
     data_type_query_depth: u8,
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -19,7 +19,7 @@ use crate::{
     api::rest::{read_from_store, report_to_status_code},
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
-        patch_id_and_parse, AccountId, DataTypeQuery, DataTypeTree, PersistedDataType,
+        patch_id_and_parse, AccountId, DataTypeQuery, DataTypeRootedSubgraph, PersistedDataType,
         PersistedOntologyIdentifier,
     },
     store::{
@@ -43,7 +43,7 @@ use crate::{
         PersistedOntologyIdentifier,
         PersistedDataType,
         DataTypeQuery,
-        DataTypeTree,
+        DataTypeRootedSubgraph,
     ),
     tags(
         (name = "DataType", description = "Data Type management API")
@@ -139,7 +139,7 @@ async fn create_data_type<P: StorePool + Send>(
     request_body = Expression,
     tag = "DataType",
     responses(
-        (status = 200, content_type = "application/json", body = [DataTypeTree], description = "A list of subgraphs rooted at data types that satisfy the given query each resolved to the requested depth."),
+        (status = 200, content_type = "application/json", body = [DataTypeRootedSubgraph], description = "A list of subgraphs rooted at data types that satisfy the given query each resolved to the requested depth."),
 
         (status = 422, content_type = "text/plain", description = "Provided query is invalid"),
         (status = 500, description = "Store error occurred"),
@@ -148,7 +148,7 @@ async fn create_data_type<P: StorePool + Send>(
 async fn get_data_types_by_query<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
     Json(query): Json<DataTypeQuery>,
-) -> Result<Json<Vec<DataTypeTree>>, StatusCode> {
+) -> Result<Json<Vec<DataTypeRootedSubgraph>>, StatusCode> {
     pool.acquire()
         .map_err(|error| {
             tracing::error!(?error, "Could not acquire access to the store");

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -139,7 +139,7 @@ async fn create_data_type<P: StorePool + Send>(
     request_body = Expression,
     tag = "DataType",
     responses(
-        (status = 200, content_type = "application/json", body = [DataTypeRootedSubgraph], description = "A list of subgraphs rooted at data types that satisfy the given query each resolved to the requested depth."),
+        (status = 200, content_type = "application/json", body = [DataTypeRootedSubgraph], description = "A list of subgraphs rooted at data types that satisfy the given query, each resolved to the requested depth."),
 
         (status = 422, content_type = "text/plain", description = "Provided query is invalid"),
         (status = 500, description = "Store error occurred"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -139,7 +139,7 @@ async fn create_data_type<P: StorePool + Send>(
     request_body = Expression,
     tag = "DataType",
     responses(
-        (status = 200, content_type = "application/json", description = "List of all data types matching the provided query", body = [DataTypeTree]),
+        (status = 200, content_type = "application/json", body = [DataTypeTree], description = "A list of subgraphs rooted at data types that satisfy the given query each resolved to the requested depth."),
 
         (status = 422, content_type = "text/plain", description = "Provided query is invalid"),
         (status = 500, description = "Store error occurred"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -146,7 +146,7 @@ struct DataTypeQuery {
     request_body = Expression,
     tag = "DataType",
     responses(
-        (status = 200, content_type = "application/json", description = "List of all data types matching the provided query", body = [PersistedDataType]),
+        (status = 200, content_type = "application/json", description = "List of all data types matching the provided query", body = [DataTypeTree]),
 
         (status = 422, content_type = "text/plain", description = "Provided query is invalid"),
         (status = 500, description = "Store error occurred"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -135,7 +135,7 @@ async fn create_entity_type<P: StorePool + Send>(
 }
 
 #[derive(Deserialize, Component)]
-#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 struct EntityTypeQuery {
     query: Expression,
     #[serde(default)]

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -9,15 +9,17 @@ use axum::{
     Extension, Json, Router,
 };
 use error_stack::IntoReport;
+use futures::TryFutureExt;
 use serde::{Deserialize, Serialize};
 use type_system::{uri::VersionedUri, EntityType};
 use utoipa::{Component, OpenApi};
 
 use crate::{
-    api::rest::{api_resource::RoutedResource, read_from_store},
+    api::rest::{api_resource::RoutedResource, read_from_store, report_to_status_code},
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
-        patch_id_and_parse, AccountId, PersistedEntityType, PersistedOntologyIdentifier,
+        patch_id_and_parse, AccountId, EntityTypeTree, PersistedEntityType,
+        PersistedOntologyIdentifier,
     },
     store::{
         error::{BaseUriAlreadyExists, BaseUriDoesNotExist},
@@ -40,7 +42,9 @@ use crate::{
         UpdateEntityTypeRequest,
         AccountId,
         PersistedOntologyIdentifier,
-        PersistedEntityType
+        PersistedEntityType,
+        EntityTypeQuery,
+        EntityTypeTree,
     ),
     tags(
         (name = "EntityType", description = "Entity type management API")
@@ -130,13 +134,25 @@ async fn create_entity_type<P: StorePool + Send>(
         .map(Json)
 }
 
+#[derive(Deserialize, Component)]
+#[serde(rename_all = "camelCase")]
+struct EntityTypeQuery {
+    query: Expression,
+    #[serde(default)]
+    data_type_query_depth: u8,
+    #[serde(default)]
+    property_type_query_depth: u8,
+    #[serde(default)]
+    entity_link_query_depth: u8,
+}
+
 #[utoipa::path(
     post,
     path = "/entity-types/query",
-    request_body = Expression,
+    request_body = EntityTypeQuery,
     tag = "EntityType",
     responses(
-        (status = 200, content_type = "application/json", description = "List of all entity types matching the provided query", body = [PersistedEntityType]),
+        (status = 200, content_type = "application/json", description = "List of all entity types matching the provided query", body = [EntityTypeTree]),
 
         (status = 422, content_type = "text/plain", description = "Provided query is invalid"),
         (status = 500, description = "Store error occurred"),
@@ -144,9 +160,36 @@ async fn create_entity_type<P: StorePool + Send>(
 )]
 async fn get_entity_types_by_query<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
-    Json(expression): Json<Expression>,
-) -> Result<Json<Vec<PersistedEntityType>>, StatusCode> {
-    read_from_store(pool.as_ref(), &expression).await.map(Json)
+    query: Json<EntityTypeQuery>,
+) -> Result<Json<Vec<EntityTypeTree>>, StatusCode> {
+    let EntityTypeQuery {
+        query,
+        data_type_query_depth,
+        property_type_query_depth,
+        entity_link_query_depth,
+    } = query.0;
+
+    pool.acquire()
+        .map_err(|error| {
+            tracing::error!(?error, "Could not acquire access to the store");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })
+        .and_then(|store| async move {
+            store
+                .get_entity_type(
+                    &query,
+                    data_type_query_depth,
+                    property_type_query_depth,
+                    entity_link_query_depth,
+                )
+                .await
+                .map_err(|report| {
+                    tracing::error!(error=?report, ?query, "Could not read entity type from the store");
+                    report_to_status_code(&report)
+                })
+        })
+        .await
+        .map(Json)
 }
 
 #[utoipa::path(

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -30,25 +30,25 @@ use crate::{
 
 #[derive(OpenApi)]
 #[openapi(
-handlers(
-create_entity_type,
-get_entity_types_by_query,
-get_entity_type,
-get_latest_entity_types,
-update_entity_type
-),
-components(
-CreateEntityTypeRequest,
-UpdateEntityTypeRequest,
-AccountId,
-PersistedOntologyIdentifier,
-PersistedEntityType,
-EntityTypeQuery,
-EntityTypeTree,
-),
-tags(
-(name = "EntityType", description = "Entity type management API")
-)
+    handlers(
+        create_entity_type,
+        get_entity_types_by_query,
+        get_entity_type,
+        get_latest_entity_types,
+        update_entity_type
+    ),
+    components(
+        CreateEntityTypeRequest,
+        UpdateEntityTypeRequest,
+        AccountId,
+        PersistedOntologyIdentifier,
+        PersistedEntityType,
+        EntityTypeQuery,
+        EntityTypeTree,
+    ),
+    tags(
+        (name = "EntityType", description = "Entity type management API")
+    )
 )]
 pub struct EntityTypeResource;
 
@@ -80,18 +80,18 @@ struct CreateEntityTypeRequest {
 }
 
 #[utoipa::path(
-post,
-path = "/entity-types",
-request_body = CreateEntityTypeRequest,
-tag = "EntityType",
-responses(
-(status = 201, content_type = "application/json", description = "The schema of the created entity type", body = PersistedOntologyIdentifier),
-(status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
+    post,
+    path = "/entity-types",
+    request_body = CreateEntityTypeRequest,
+    tag = "EntityType",
+    responses(
+        (status = 201, content_type = "application/json", description = "The schema of the created entity type", body = PersistedOntologyIdentifier),
+        (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
-(status = 409, description = "Unable to create entity type in the datastore as the base entity type ID already exists"),
-(status = 500, description = "Store error occurred"),
-),
-request_body = CreateEntityTypeRequest,
+        (status = 409, description = "Unable to create entity type in the datastore as the base entity type ID already exists"),
+        (status = 500, description = "Store error occurred"),
+    ),
+    request_body = CreateEntityTypeRequest,
 )]
 async fn create_entity_type<P: StorePool + Send>(
     body: Json<CreateEntityTypeRequest>,
@@ -149,15 +149,15 @@ struct EntityTypeQuery {
 }
 
 #[utoipa::path(
-post,
-path = "/entity-types/query",
-request_body = EntityTypeQuery,
-tag = "EntityType",
-responses(
-(status = 200, content_type = "application/json", description = "List of all entity types matching the provided query", body = [EntityTypeTree]),
-(status = 422, content_type = "text/plain", description = "Provided query is invalid"),
-(status = 500, description = "Store error occurred"),
-)
+    post,
+    path = "/entity-types/query",
+    request_body = EntityTypeQuery,
+    tag = "EntityType",
+    responses(
+        (status = 200, content_type = "application/json", description = "List of all entity types matching the provided query", body = [EntityTypeTree]),
+        (status = 422, content_type = "text/plain", description = "Provided query is invalid"),
+        (status = 500, description = "Store error occurred"),
+    )
 )]
 async fn get_entity_types_by_query<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
@@ -196,14 +196,14 @@ async fn get_entity_types_by_query<P: StorePool + Send>(
 }
 
 #[utoipa::path(
-get,
-path = "/entity-types",
-tag = "EntityType",
-responses(
-(status = 200, content_type = "application/json", description = "List of all entity types at their latest versions", body = [PersistedEntityType]),
+    get,
+    path = "/entity-types",
+    tag = "EntityType",
+    responses(
+        (status = 200, content_type = "application/json", description = "List of all entity types at their latest versions", body = [PersistedEntityType]),
 
-(status = 500, description = "Store error occurred"),
-)
+        (status = 500, description = "Store error occurred"),
+    )
 )]
 async fn get_latest_entity_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
@@ -214,19 +214,19 @@ async fn get_latest_entity_types<P: StorePool + Send>(
 }
 
 #[utoipa::path(
-get,
-path = "/entity-types/{uri}",
-tag = "EntityType",
-responses(
-(status = 200, content_type = "application/json", description = "The schema of the requested entity type", body = PersistedEntityType),
-(status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
+    get,
+    path = "/entity-types/{uri}",
+    tag = "EntityType",
+    responses(
+        (status = 200, content_type = "application/json", description = "The schema of the requested entity type", body = PersistedEntityType),
+        (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
-(status = 404, description = "Entity type was not found"),
-(status = 500, description = "Store error occurred"),
-),
-params(
-("uri" = String, Path, description = "The URI of the entity type"),
-)
+        (status = 404, description = "Entity type was not found"),
+        (status = 500, description = "Store error occurred"),
+    ),
+    params(
+        ("uri" = String, Path, description = "The URI of the entity type"),
+    )
 )]
 async fn get_entity_type<P: StorePool + Send>(
     uri: Path<VersionedUri>,
@@ -249,17 +249,17 @@ struct UpdateEntityTypeRequest {
 }
 
 #[utoipa::path(
-put,
-path = "/entity-types",
-tag = "EntityType",
-responses(
-(status = 200, content_type = "application/json", description = "The schema of the updated entity type", body = PersistedOntologyIdentifier),
-(status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
+    put,
+    path = "/entity-types",
+    tag = "EntityType",
+    responses(
+        (status = 200, content_type = "application/json", description = "The schema of the updated entity type", body = PersistedOntologyIdentifier),
+        (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
-(status = 404, description = "Base entity type ID was not found"),
-(status = 500, description = "Store error occurred"),
-),
-request_body = UpdateEntityTypeRequest,
+        (status = 404, description = "Base entity type ID was not found"),
+        (status = 500, description = "Store error occurred"),
+    ),
+    request_body = UpdateEntityTypeRequest,
 )]
 async fn update_entity_type<P: StorePool + Send>(
     body: Json<UpdateEntityTypeRequest>,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -151,6 +151,7 @@ struct EntityTypeQuery {
     tag = "EntityType",
     responses(
         (status = 200, content_type = "application/json", description = "List of all entity types matching the provided query", body = [EntityTypeTree]),
+
         (status = 422, content_type = "text/plain", description = "Provided query is invalid"),
         (status = 500, description = "Store error occurred"),
     )

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -18,8 +18,8 @@ use crate::{
     api::rest::{api_resource::RoutedResource, read_from_store, report_to_status_code},
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
-        patch_id_and_parse, AccountId, EntityTypeQuery, EntityTypeTree, PersistedEntityType,
-        PersistedOntologyIdentifier,
+        patch_id_and_parse, AccountId, EntityTypeQuery, EntityTypeRootedSubgraph,
+        PersistedEntityType, PersistedOntologyIdentifier,
     },
     store::{
         error::{BaseUriAlreadyExists, BaseUriDoesNotExist},
@@ -44,7 +44,7 @@ use crate::{
         PersistedOntologyIdentifier,
         PersistedEntityType,
         EntityTypeQuery,
-        EntityTypeTree,
+        EntityTypeRootedSubgraph,
     ),
     tags(
         (name = "EntityType", description = "Entity type management API")
@@ -140,7 +140,7 @@ async fn create_entity_type<P: StorePool + Send>(
     request_body = EntityTypeQuery,
     tag = "EntityType",
     responses(
-        (status = 200, content_type = "application/json", body = [EntityTypeTree], description = "A list of subgraphs rooted at entity types that satisfy the given query each resolved to the requested depth."),
+        (status = 200, content_type = "application/json", body = [EntityTypeRootedSubgraph], description = "A list of subgraphs rooted at entity types that satisfy the given query each resolved to the requested depth."),
 
         (status = 422, content_type = "text/plain", description = "Provided query is invalid"),
         (status = 500, description = "Store error occurred"),
@@ -149,7 +149,7 @@ async fn create_entity_type<P: StorePool + Send>(
 async fn get_entity_types_by_query<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
     Json(query): Json<EntityTypeQuery>,
-) -> Result<Json<Vec<EntityTypeTree>>, StatusCode> {
+) -> Result<Json<Vec<EntityTypeRootedSubgraph>>, StatusCode> {
     pool.acquire()
         .map_err(|error| {
             tracing::error!(?error, "Could not acquire access to the store");

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -140,7 +140,7 @@ async fn create_entity_type<P: StorePool + Send>(
     request_body = EntityTypeQuery,
     tag = "EntityType",
     responses(
-        (status = 200, content_type = "application/json", body = [EntityTypeRootedSubgraph], description = "A list of subgraphs rooted at entity types that satisfy the given query each resolved to the requested depth."),
+        (status = 200, content_type = "application/json", body = [EntityTypeRootedSubgraph], description = "A list of subgraphs rooted at entity types that satisfy the given query, each resolved to the requested depth."),
 
         (status = 422, content_type = "text/plain", description = "Provided query is invalid"),
         (status = 500, description = "Store error occurred"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -30,25 +30,25 @@ use crate::{
 
 #[derive(OpenApi)]
 #[openapi(
-    handlers(
-        create_entity_type,
-        get_entity_types_by_query,
-        get_entity_type,
-        get_latest_entity_types,
-        update_entity_type
-    ),
-    components(
-        CreateEntityTypeRequest,
-        UpdateEntityTypeRequest,
-        AccountId,
-        PersistedOntologyIdentifier,
-        PersistedEntityType,
-        EntityTypeQuery,
-        EntityTypeTree,
-    ),
-    tags(
-        (name = "EntityType", description = "Entity type management API")
-    )
+handlers(
+create_entity_type,
+get_entity_types_by_query,
+get_entity_type,
+get_latest_entity_types,
+update_entity_type
+),
+components(
+CreateEntityTypeRequest,
+UpdateEntityTypeRequest,
+AccountId,
+PersistedOntologyIdentifier,
+PersistedEntityType,
+EntityTypeQuery,
+EntityTypeTree,
+),
+tags(
+(name = "EntityType", description = "Entity type management API")
+)
 )]
 pub struct EntityTypeResource;
 
@@ -80,18 +80,18 @@ struct CreateEntityTypeRequest {
 }
 
 #[utoipa::path(
-    post,
-    path = "/entity-types",
-    request_body = CreateEntityTypeRequest,
-    tag = "EntityType",
-    responses(
-        (status = 201, content_type = "application/json", description = "The schema of the created entity type", body = PersistedOntologyIdentifier),
-        (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
+post,
+path = "/entity-types",
+request_body = CreateEntityTypeRequest,
+tag = "EntityType",
+responses(
+(status = 201, content_type = "application/json", description = "The schema of the created entity type", body = PersistedOntologyIdentifier),
+(status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
-        (status = 409, description = "Unable to create entity type in the datastore as the base entity type ID already exists"),
-        (status = 500, description = "Store error occurred"),
-    ),
-    request_body = CreateEntityTypeRequest,
+(status = 409, description = "Unable to create entity type in the datastore as the base entity type ID already exists"),
+(status = 500, description = "Store error occurred"),
+),
+request_body = CreateEntityTypeRequest,
 )]
 async fn create_entity_type<P: StorePool + Send>(
     body: Json<CreateEntityTypeRequest>,
@@ -143,19 +143,20 @@ struct EntityTypeQuery {
     #[serde(default)]
     property_type_query_depth: u8,
     #[serde(default)]
-    entity_link_query_depth: u8,
+    link_type_query_depth: u8,
+    #[serde(default)]
+    entity_type_query_depth: u8,
 }
 
 #[utoipa::path(
-    post,
-    path = "/entity-types/query",
-    request_body = EntityTypeQuery,
-    tag = "EntityType",
-    responses(
-        (status = 200, content_type = "application/json", description = "List of all entity types matching the provided query", body = [EntityTypeTree]),
-
-        (status = 422, content_type = "text/plain", description = "Provided query is invalid"),
-        (status = 500, description = "Store error occurred"),
+post,
+path = "/entity-types/query",
+request_body = EntityTypeQuery,
+tag = "EntityType",
+responses(
+(status = 200, content_type = "application/json", description = "List of all entity types matching the provided query", body = [EntityTypeTree]),
+(status = 422, content_type = "text/plain", description = "Provided query is invalid"),
+(status = 500, description = "Store error occurred"),
 )
 )]
 async fn get_entity_types_by_query<P: StorePool + Send>(
@@ -166,7 +167,8 @@ async fn get_entity_types_by_query<P: StorePool + Send>(
         query,
         data_type_query_depth,
         property_type_query_depth,
-        entity_link_query_depth,
+        link_type_query_depth,
+        entity_type_query_depth,
     } = query.0;
 
     pool.acquire()
@@ -180,7 +182,8 @@ async fn get_entity_types_by_query<P: StorePool + Send>(
                     &query,
                     data_type_query_depth,
                     property_type_query_depth,
-                    entity_link_query_depth,
+                    link_type_query_depth,
+                    entity_type_query_depth,
                 )
                 .await
                 .map_err(|report| {
@@ -193,14 +196,14 @@ async fn get_entity_types_by_query<P: StorePool + Send>(
 }
 
 #[utoipa::path(
-    get,
-    path = "/entity-types",
-    tag = "EntityType",
-    responses(
-        (status = 200, content_type = "application/json", description = "List of all entity types at their latest versions", body = [PersistedEntityType]),
+get,
+path = "/entity-types",
+tag = "EntityType",
+responses(
+(status = 200, content_type = "application/json", description = "List of all entity types at their latest versions", body = [PersistedEntityType]),
 
-        (status = 500, description = "Store error occurred"),
-    )
+(status = 500, description = "Store error occurred"),
+)
 )]
 async fn get_latest_entity_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
@@ -211,19 +214,19 @@ async fn get_latest_entity_types<P: StorePool + Send>(
 }
 
 #[utoipa::path(
-    get,
-    path = "/entity-types/{uri}",
-    tag = "EntityType",
-    responses(
-        (status = 200, content_type = "application/json", description = "The schema of the requested entity type", body = PersistedEntityType),
-        (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
+get,
+path = "/entity-types/{uri}",
+tag = "EntityType",
+responses(
+(status = 200, content_type = "application/json", description = "The schema of the requested entity type", body = PersistedEntityType),
+(status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
-        (status = 404, description = "Entity type was not found"),
-        (status = 500, description = "Store error occurred"),
-    ),
-    params(
-        ("uri" = String, Path, description = "The URI of the entity type"),
-    )
+(status = 404, description = "Entity type was not found"),
+(status = 500, description = "Store error occurred"),
+),
+params(
+("uri" = String, Path, description = "The URI of the entity type"),
+)
 )]
 async fn get_entity_type<P: StorePool + Send>(
     uri: Path<VersionedUri>,
@@ -246,17 +249,17 @@ struct UpdateEntityTypeRequest {
 }
 
 #[utoipa::path(
-    put,
-    path = "/entity-types",
-    tag = "EntityType",
-    responses(
-        (status = 200, content_type = "application/json", description = "The schema of the updated entity type", body = PersistedOntologyIdentifier),
-        (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
+put,
+path = "/entity-types",
+tag = "EntityType",
+responses(
+(status = 200, content_type = "application/json", description = "The schema of the updated entity type", body = PersistedOntologyIdentifier),
+(status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
-        (status = 404, description = "Base entity type ID was not found"),
-        (status = 500, description = "Store error occurred"),
-    ),
-    request_body = UpdateEntityTypeRequest,
+(status = 404, description = "Base entity type ID was not found"),
+(status = 500, description = "Store error occurred"),
+),
+request_body = UpdateEntityTypeRequest,
 )]
 async fn update_entity_type<P: StorePool + Send>(
     body: Json<UpdateEntityTypeRequest>,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -138,13 +138,9 @@ async fn create_entity_type<P: StorePool + Send>(
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 struct EntityTypeQuery {
     query: Expression,
-    #[serde(default)]
     data_type_query_depth: u8,
-    #[serde(default)]
     property_type_query_depth: u8,
-    #[serde(default)]
     link_type_query_depth: u8,
-    #[serde(default)]
     entity_type_query_depth: u8,
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -140,7 +140,7 @@ async fn create_entity_type<P: StorePool + Send>(
     request_body = EntityTypeQuery,
     tag = "EntityType",
     responses(
-        (status = 200, content_type = "application/json", description = "List of all entity types matching the provided query", body = [EntityTypeTree]),
+        (status = 200, content_type = "application/json", body = [EntityTypeTree], description = "A list of subgraphs rooted at entity types that satisfy the given query each resolved to the requested depth."),
 
         (status = 422, content_type = "text/plain", description = "Provided query is invalid"),
         (status = 500, description = "Store error occurred"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -133,7 +133,7 @@ async fn create_link_type<P: StorePool + Send>(
 }
 
 #[derive(Deserialize, Component)]
-#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 struct LinkTypeQuery {
     query: Expression,
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -138,7 +138,7 @@ async fn create_link_type<P: StorePool + Send>(
     request_body = LinkTypeQuery,
     tag = "LinkType",
     responses(
-        (status = 200, content_type = "application/json", description = "List of all link types matching the provided query", body = [LinkTypeRootedSubgraph]),
+        (status = 200, content_type = "application/json", description = "A list of subgraphs rooted at link types that satisfy the given query, each resolved to the requested depth.", body = [LinkTypeRootedSubgraph]),
 
         (status = 422, content_type = "text/plain", description = "Provided query is invalid"),
         (status = 500, description = "Store error occurred"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -19,7 +19,7 @@ use crate::{
     api::rest::{read_from_store, report_to_status_code},
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
-        patch_id_and_parse, AccountId, LinkTypeQuery, LinkTypeTree, PersistedLinkType,
+        patch_id_and_parse, AccountId, LinkTypeQuery, LinkTypeRootedSubgraph, PersistedLinkType,
         PersistedOntologyIdentifier,
     },
     store::{
@@ -43,7 +43,7 @@ use crate::{
         PersistedOntologyIdentifier,
         PersistedLinkType,
         LinkTypeQuery,
-        LinkTypeTree,
+        LinkTypeRootedSubgraph,
     ),
     tags(
         (name = "LinkType", description = "Link type management API")
@@ -138,7 +138,7 @@ async fn create_link_type<P: StorePool + Send>(
     request_body = LinkTypeQuery,
     tag = "LinkType",
     responses(
-        (status = 200, content_type = "application/json", description = "List of all link types matching the provided query", body = [LinkTypeTree]),
+        (status = 200, content_type = "application/json", description = "List of all link types matching the provided query", body = [LinkTypeRootedSubgraph]),
 
         (status = 422, content_type = "text/plain", description = "Provided query is invalid"),
         (status = 500, description = "Store error occurred"),
@@ -147,7 +147,7 @@ async fn create_link_type<P: StorePool + Send>(
 async fn get_link_types_by_query<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
     Json(query): Json<LinkTypeQuery>,
-) -> Result<Json<Vec<LinkTypeTree>>, StatusCode> {
+) -> Result<Json<Vec<LinkTypeRootedSubgraph>>, StatusCode> {
     pool.acquire()
         .map_err(|error| {
             tracing::error!(?error, "Could not acquire access to the store");

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -29,25 +29,25 @@ use crate::{
 
 #[derive(OpenApi)]
 #[openapi(
-handlers(
-create_link_type,
-get_link_types_by_query,
-get_link_type,
-get_latest_link_types,
-update_link_type
-),
-components(
-CreateLinkTypeRequest,
-UpdateLinkTypeRequest,
-AccountId,
-PersistedOntologyIdentifier,
-PersistedLinkType,
-LinkTypeQuery,
-LinkTypeTree,
-),
-tags(
-(name = "LinkType", description = "Link type management API")
-)
+    handlers(
+        create_link_type,
+        get_link_types_by_query,
+        get_link_type,
+        get_latest_link_types,
+        update_link_type
+    ),
+    components(
+        CreateLinkTypeRequest,
+        UpdateLinkTypeRequest,
+        AccountId,
+        PersistedOntologyIdentifier,
+        PersistedLinkType,
+        LinkTypeQuery,
+        LinkTypeTree,
+    ),
+    tags(
+        (name = "LinkType", description = "Link type management API")
+    )
 )]
 pub struct LinkTypeResource;
 
@@ -79,17 +79,18 @@ struct CreateLinkTypeRequest {
 }
 
 #[utoipa::path(
-post,
-path = "/link-types",
-request_body = CreateLinkTypeRequest,
-tag = "LinkType",
-responses(
-(status = 201, content_type = "application/json", description = "The schema of the created link type", body = PersistedOntologyIdentifier),
-(status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
-(status = 409, description = "Unable to create link type in the store as the base link type ID already exists"),
-(status = 500, description = "Store error occurred"),
-),
-request_body = CreateLinkTypeRequest,
+    post,
+    path = "/link-types",
+    request_body = CreateLinkTypeRequest,
+    tag = "LinkType",
+    responses(
+        (status = 201, content_type = "application/json", description = "The schema of the created link type", body = PersistedOntologyIdentifier),
+
+        (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
+        (status = 409, description = "Unable to create link type in the store as the base link type ID already exists"),
+        (status = 500, description = "Store error occurred"),
+    ),
+    request_body = CreateLinkTypeRequest,
 )]
 async fn create_link_type<P: StorePool + Send>(
     body: Json<CreateLinkTypeRequest>,
@@ -132,15 +133,16 @@ async fn create_link_type<P: StorePool + Send>(
 }
 
 #[utoipa::path(
-post,
-path = "/link-types/query",
-request_body = LinkTypeQuery,
-tag = "LinkType",
-responses(
-(status = 200, content_type = "application/json", description = "List of all link types matching the provided query", body = [LinkTypeTree]),
-(status = 422, content_type = "text/plain", description = "Provided query is invalid"),
-(status = 500, description = "Store error occurred"),
-)
+    post,
+    path = "/link-types/query",
+    request_body = LinkTypeQuery,
+    tag = "LinkType",
+    responses(
+        (status = 200, content_type = "application/json", description = "List of all link types matching the provided query", body = [LinkTypeTree]),
+
+        (status = 422, content_type = "text/plain", description = "Provided query is invalid"),
+        (status = 500, description = "Store error occurred"),
+    )
 )]
 async fn get_link_types_by_query<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
@@ -162,13 +164,14 @@ async fn get_link_types_by_query<P: StorePool + Send>(
 }
 
 #[utoipa::path(
-get,
-path = "/link-types",
-tag = "LinkType",
-responses(
-(status = 200, content_type = "application/json", description = "List of all link types at their latest versions", body = [PersistedLinkType]),
-(status = 500, description = "Store error occurred"),
-)
+    get,
+    path = "/link-types",
+    tag = "LinkType",
+    responses(
+        (status = 200, content_type = "application/json", description = "List of all link types at their latest versions", body = [PersistedLinkType]),
+
+        (status = 500, description = "Store error occurred"),
+    )
 )]
 async fn get_latest_link_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
@@ -179,18 +182,19 @@ async fn get_latest_link_types<P: StorePool + Send>(
 }
 
 #[utoipa::path(
-get,
-path = "/link-types/{uri}",
-tag = "LinkType",
-responses(
-(status = 200, content_type = "application/json", description = "The schema of the requested link type", body = PersistedLinkType),
-(status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
-(status = 404, description = "Link type was not found"),
-(status = 500, description = "Store error occurred"),
-),
-params(
-("uri" = String, Path, description = "The URI of the link type"),
-)
+    get,
+    path = "/link-types/{uri}",
+    tag = "LinkType",
+    responses(
+        (status = 200, content_type = "application/json", description = "The schema of the requested link type", body = PersistedLinkType),
+
+        (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
+        (status = 404, description = "Link type was not found"),
+        (status = 500, description = "Store error occurred"),
+    ),
+    params(
+        ("uri" = String, Path, description = "The URI of the link type"),
+    )
 )]
 async fn get_link_type<P: StorePool + Send>(
     uri: Path<VersionedUri>,
@@ -213,16 +217,17 @@ struct UpdateLinkTypeRequest {
 }
 
 #[utoipa::path(
-put,
-path = "/link-types",
-tag = "LinkType",
-responses(
-(status = 200, content_type = "application/json", description = "The schema of the updated link type", body = PersistedOntologyIdentifier),
-(status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
-(status = 404, description = "Base link type ID was not found"),
-(status = 500, description = "Store error occurred"),
-),
-request_body = UpdateLinkTypeRequest,
+    put,
+    path = "/link-types",
+    tag = "LinkType",
+    responses(
+        (status = 200, content_type = "application/json", description = "The schema of the updated link type", body = PersistedOntologyIdentifier),
+
+        (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
+        (status = 404, description = "Base link type ID was not found"),
+        (status = 500, description = "Store error occurred"),
+    ),
+    request_body = UpdateLinkTypeRequest,
 )]
 async fn update_link_type<P: StorePool + Send>(
     body: Json<UpdateLinkTypeRequest>,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
@@ -94,7 +94,7 @@ where
         })
         .and_then(|store| async move {
             // TODO: Closure is taking reference of `store` to `read()`, so the read operation
-            //       needs to be awaited on. By passing through a steam we could avoid awaiting and
+            //       needs to be awaited on. By passing through a stream we could avoid awaiting and
             //       remove the `async move` closure
             //   see https://app.asana.com/0/1202805690238892/1202923536131158/f
             Read::read(&store, query)

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
@@ -20,6 +20,8 @@ use axum::{
     routing::get,
     Extension, Json, Router,
 };
+use error_stack::Report;
+use futures::TryFutureExt;
 use include_dir::{include_dir, Dir};
 use utoipa::{
     openapi::{self, schema, ObjectBuilder},
@@ -62,6 +64,21 @@ fn api_documentation() -> Vec<openapi::OpenApi> {
     ]
 }
 
+fn report_to_status_code<C>(report: &Report<C>) -> StatusCode {
+    let mut status_code = StatusCode::INTERNAL_SERVER_ERROR;
+
+    if let Some(error) = report.downcast_ref::<ExpressionError>() {
+        tracing::error!(%error, "Could not evaluate expression");
+        status_code = StatusCode::UNPROCESSABLE_ENTITY;
+    }
+
+    if let Some(error) = report.downcast_ref::<ResolveError>() {
+        tracing::error!(%error, "Unable to resolve query");
+        status_code = StatusCode::UNPROCESSABLE_ENTITY;
+    }
+    status_code
+}
+
 async fn read_from_store<'pool, P, T>(
     pool: &'pool P,
     query: &<P::Store<'pool> as Read<T>>::Query<'_>,
@@ -70,28 +87,25 @@ where
     P: StorePool<Store<'pool>: Read<T>>,
     T: Send,
 {
-    let store = pool.acquire().await.map_err(|report| {
-        tracing::error!(error=?report, "Could not acquire access to the store");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
-    // TODO: Implement `Valuable` for queries and print them here
-    store.read(query).await.map_err(|report| {
-        let mut status_code = StatusCode::INTERNAL_SERVER_ERROR;
-
-        if let Some(error) = report.downcast_ref::<ExpressionError>() {
-            tracing::error!(%error, "Could not evaluate expression");
-            status_code = StatusCode::UNPROCESSABLE_ENTITY;
-        }
-
-        if let Some(error) = report.downcast_ref::<ResolveError>() {
-            tracing::error!(%error, "Unable to resolve query");
-            status_code = StatusCode::UNPROCESSABLE_ENTITY;
-        }
-
-        tracing::error!(error=?report, ?query, "Could not read from the store");
-        status_code
-    })
+    pool.acquire()
+        .map_err(|report| {
+            tracing::error!(error=?report, "Could not acquire access to the store");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })
+        .and_then(|store| async move {
+            // TODO: Closure is taking reference of `store` to `read()`, so the read operation
+            //       needs to be awaited on. By passing through a steam we could avoid awaiting and
+            //       remove the `async move` closure
+            //   see https://app.asana.com/0/1202805690238892/1202923536131158/f
+            Read::read(&store, query)
+                .map_err(|report| {
+                    // TODO: Implement `Valuable` for queries and print them here
+                    tracing::error!(error=?report, ?query, "Could not read from the store");
+                    report_to_status_code(&report)
+                })
+                .await
+        })
+        .await
 }
 
 pub fn rest_api_router<P: StorePool + Send + 'static>(

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -138,9 +138,7 @@ async fn create_property_type<P: StorePool + Send>(
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 struct PropertyTypeQuery {
     query: Expression,
-    #[serde(default)]
     data_type_query_depth: u8,
-    #[serde(default)]
     property_type_query_depth: u8,
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -140,7 +140,7 @@ async fn create_property_type<P: StorePool + Send>(
     request_body = PropertyTypeQuery,
     tag = "PropertyType",
     responses(
-        (status = 200, content_type = "application/json", body = [PropertyTypeRootedSubgraph], description = "A list of subgraphs rooted at property types that satisfy the given query each resolved to the requested depth."),
+        (status = 200, content_type = "application/json", body = [PropertyTypeRootedSubgraph], description = "A list of subgraphs rooted at property types that satisfy the given query, each resolved to the requested depth."),
 
         (status = 422, content_type = "text/plain", description = "Provided query is invalid"),
         (status = 500, description = "Store error occurred"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -20,7 +20,7 @@ use crate::{
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
         patch_id_and_parse, AccountId, PersistedOntologyIdentifier, PersistedPropertyType,
-        PropertyTypeQuery, PropertyTypeTree,
+        PropertyTypeQuery, PropertyTypeRootedSubgraph,
     },
     store::{
         query::Expression, BaseUriAlreadyExists, BaseUriDoesNotExist, PropertyTypeStore, StorePool,
@@ -43,7 +43,7 @@ use crate::{
         PersistedOntologyIdentifier,
         PersistedPropertyType,
         PropertyTypeQuery,
-        PropertyTypeTree,
+        PropertyTypeRootedSubgraph,
     ),
     tags(
         (name = "PropertyType", description = "Property type management API")
@@ -140,7 +140,7 @@ async fn create_property_type<P: StorePool + Send>(
     request_body = PropertyTypeQuery,
     tag = "PropertyType",
     responses(
-        (status = 200, content_type = "application/json", body = [PropertyTypeTree], description = "A list of subgraphs rooted at property types that satisfy the given query each resolved to the requested depth."),
+        (status = 200, content_type = "application/json", body = [PropertyTypeRootedSubgraph], description = "A list of subgraphs rooted at property types that satisfy the given query each resolved to the requested depth."),
 
         (status = 422, content_type = "text/plain", description = "Provided query is invalid"),
         (status = 500, description = "Store error occurred"),
@@ -149,7 +149,7 @@ async fn create_property_type<P: StorePool + Send>(
 async fn get_property_types_by_query<P>(
     pool: Extension<Arc<P>>,
     Json(query): Json<PropertyTypeQuery>,
-) -> Result<Json<Vec<PropertyTypeTree>>, StatusCode>
+) -> Result<Json<Vec<PropertyTypeRootedSubgraph>>, StatusCode>
 where
     for<'pool> P: StorePool<Store<'pool>: PropertyTypeStore> + Send,
 {

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -140,7 +140,7 @@ async fn create_property_type<P: StorePool + Send>(
     request_body = PropertyTypeQuery,
     tag = "PropertyType",
     responses(
-        (status = 200, content_type = "application/json", description = "List of all property types matching the provided query", body = [PropertyTypeTree]),
+        (status = 200, content_type = "application/json", body = [PropertyTypeTree], description = "A list of subgraphs rooted at property types that satisfy the given query each resolved to the requested depth."),
 
         (status = 422, content_type = "text/plain", description = "Provided query is invalid"),
         (status = 500, description = "Store error occurred"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -135,7 +135,7 @@ async fn create_property_type<P: StorePool + Send>(
 }
 
 #[derive(Deserialize, Component)]
-#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 struct PropertyTypeQuery {
     query: Expression,
     #[serde(default)]

--- a/packages/graph/hash_graph/lib/graph/src/lib.rs
+++ b/packages/graph/hash_graph/lib/graph/src/lib.rs
@@ -12,6 +12,7 @@
 #![feature(associated_type_bounds)]
 #![feature(try_find)]
 #![feature(type_alias_impl_trait)]
+#![feature(hash_raw_entry)]
 #![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
 #![cfg_attr(not(miri), doc(test(attr(deny(warnings, clippy::all)))))]
 #![warn(

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -63,6 +63,7 @@ impl PersistedOntologyIdentifier {
 
 #[derive(Debug)]
 pub struct PatchAndParseError;
+
 impl Context for PatchAndParseError {}
 
 impl fmt::Display for PatchAndParseError {
@@ -135,11 +136,17 @@ pub struct PersistedDataType {
     pub identifier: PersistedOntologyIdentifier,
 }
 
+/// Query to read [`DataType`]s, which are matching the [`Expression`].
 #[derive(Debug, Deserialize, Component)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct DataTypeQuery {
     #[serde(rename = "query")]
     pub expression: Expression,
+    /// Depth used to read nested [`DataType`]s.
+    // TODO: `data_type_query_depth` currently does nothing, in the future it will most probably be
+    //       used to resolve user defined data types.
+    //   see https://app.asana.com/0/1200211978612931/1202464168422955/f
+    /// **Note**: Currently, this parameter is unused.
     pub data_type_query_depth: u8,
 }
 
@@ -157,12 +164,24 @@ pub struct PersistedPropertyType {
     pub identifier: PersistedOntologyIdentifier,
 }
 
+/// Query to read [`PropertyType`]s, which are matching the [`Expression`].
 #[derive(Debug, Deserialize, Component)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct PropertyTypeQuery {
     #[serde(rename = "query")]
     pub expression: Expression,
+    /// Depth used to read directly or indirectly referenced [`DataType`]s.
+    ///
+    /// [`DataType`]s resolved by [`property_type_query_depth`] are also take into account. This
+    /// means that a for a [`PropertyType`] referring to another [`PropertyType`], which itself
+    /// refers to a [`DataType`] will also resolve the [`DataType`] if both depth-parameter are at
+    /// least set to `1`.
+    ///
+    /// [`property_type_query_depth`]: Self::property_type_query_depth
+    // TODO: https://app.asana.com/0/1200211978612931/1202464168422955/f
+    /// **Note**: A value greater than `1` currently does not have any effect
     pub data_type_query_depth: u8,
+    /// Depth used to read nested [`PropertyType`]s.
     pub property_type_query_depth: u8,
 }
 
@@ -182,6 +201,7 @@ pub struct PersistedLinkType {
     pub identifier: PersistedOntologyIdentifier,
 }
 
+/// Query to read [`LinkType`]s, which are matching the [`Expression`].
 #[derive(Debug, Deserialize, Component)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct LinkTypeQuery {
@@ -203,14 +223,23 @@ pub struct PersistedEntityType {
     pub identifier: PersistedOntologyIdentifier,
 }
 
+/// Query to read [`EntityType`]s, which are matching the [`Expression`].
 #[derive(Debug, Deserialize, Component)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct EntityTypeQuery {
     #[serde(rename = "query")]
     pub expression: Expression,
+    /// Depth used to read indirectly referenced [`DataType`]s.
+    // TODO: https://app.asana.com/0/1200211978612931/1202464168422955/f
+    /// **Note**: A value greater than `1` currently does not have any effect
     pub data_type_query_depth: u8,
+    /// Depth used to read directly or indirectly referenced [`PropertyType`]s.
     pub property_type_query_depth: u8,
+    /// Depth used to read directly or indirectly referenced [`LinkType`]s.
+    ///
+    /// **Note**: A value greater than `1` does not have any effect
     pub link_type_query_depth: u8,
+    /// Depth used to read directly or indirectly referenced [`PropertyType`]s.
     pub entity_type_query_depth: u8,
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -12,7 +12,7 @@ use type_system::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyTyp
 use utoipa::Component;
 use uuid::Uuid;
 
-use crate::store::query::Expression;
+use crate::store::{crud::QueryDepth, query::Expression};
 
 // TODO - find a good place for AccountId, perhaps it will become redundant in a future design
 
@@ -142,12 +142,10 @@ pub struct PersistedDataType {
 pub struct DataTypeQuery {
     #[serde(rename = "query")]
     pub expression: Expression,
-    /// Depth used to read nested [`DataType`]s.
     // TODO: `data_type_query_depth` currently does nothing, in the future it will most probably be
     //       used to resolve user defined data types.
     //   see https://app.asana.com/0/1200211978612931/1202464168422955/f
-    /// **Note**: Currently, this parameter is unused.
-    pub data_type_query_depth: u8,
+    pub data_type_query_depth: QueryDepth,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
@@ -170,19 +168,10 @@ pub struct PersistedPropertyType {
 pub struct PropertyTypeQuery {
     #[serde(rename = "query")]
     pub expression: Expression,
-    /// Depth used to read directly or indirectly referenced [`DataType`]s.
-    ///
-    /// [`DataType`]s resolved by [`property_type_query_depth`] are also take into account. This
-    /// means that a for a [`PropertyType`] referring to another [`PropertyType`], which itself
-    /// refers to a [`DataType`] will also resolve the [`DataType`] if both depth-parameter are at
-    /// least set to `1`.
-    ///
-    /// [`property_type_query_depth`]: Self::property_type_query_depth
-    // TODO: https://app.asana.com/0/1200211978612931/1202464168422955/f
-    /// **Note**: A value greater than `1` currently does not have any effect.
-    pub data_type_query_depth: u8,
-    /// Depth used to read nested [`PropertyType`]s.
-    pub property_type_query_depth: u8,
+    // TODO: A value greater than `1` currently does not have any effect.
+    //   see https://app.asana.com/0/1200211978612931/1202464168422955/f
+    pub data_type_query_depth: QueryDepth,
+    pub property_type_query_depth: QueryDepth,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
@@ -229,18 +218,12 @@ pub struct PersistedEntityType {
 pub struct EntityTypeQuery {
     #[serde(rename = "query")]
     pub expression: Expression,
-    /// Depth used to read indirectly referenced [`DataType`]s.
-    // TODO: https://app.asana.com/0/1200211978612931/1202464168422955/f
-    /// **Note**: A value greater than `1` currently does not have any effect.
-    pub data_type_query_depth: u8,
-    /// Depth used to read directly or indirectly referenced [`PropertyType`]s.
-    pub property_type_query_depth: u8,
-    /// Depth used to read directly or indirectly referenced [`LinkType`]s.
-    ///
-    /// **Note**: A value greater than `1` does not have any effect.
-    pub link_type_query_depth: u8,
-    /// Depth used to read directly or indirectly referenced [`PropertyType`]s.
-    pub entity_type_query_depth: u8,
+    // TODO: A value greater than `1` currently does not have any effect.
+    //   see https://app.asana.com/0/1200211978612931/1202464168422955/f
+    pub data_type_query_depth: QueryDepth,
+    pub property_type_query_depth: QueryDepth,
+    pub link_type_query_depth: QueryDepth,
+    pub entity_type_query_depth: QueryDepth,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -12,7 +12,7 @@ use type_system::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyTyp
 use utoipa::Component;
 use uuid::Uuid;
 
-use crate::store::{crud::QueryDepth, query::Expression};
+use crate::store::query::Expression;
 
 // TODO - find a good place for AccountId, perhaps it will become redundant in a future design
 
@@ -127,6 +127,25 @@ where
     //  even though we only use it in places where we could move
     serde_json::Value::from(ontology_type.clone()).serialize(serializer)
 }
+
+/// Depth used to read referenced ontology types when querying a rooted subgraph.
+///
+/// Records may have references to other types, e.g. a [`PropertyType`] may reference other
+/// [`PropertyType`]s or [`DataType`]s. When a type is requested, a depth for each referenced
+/// type has to be provided. The depth specify, how far references are resolved when returning a
+/// rooted subgraph, a depth of `0` means, that no further references are returned.
+///
+/// # Example
+///
+/// When reading a [`PropertyType`], `data_type_query_depth` and `property_type_query_depth` needs
+/// to be specified. For a give [`PropertyType`], which is referring to another [`PropertyType`],
+/// which itself refers to a [`DataType`], referenced [`PropertyType`] will be returned as well if
+/// `property_type_query_depth` is at least `1`. If in addition `data_type_query_depth` is at least
+/// `1`, the [`DataType`] will be returned as well.
+///
+/// If `property_type_query_depth` is set to `0`, this will not return any referenced record,
+/// regardless of the `data_type_query_depth`.
+pub type QueryDepth = u8;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
 pub struct PersistedDataType {

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -170,8 +170,8 @@ pub struct PropertyTypeQuery {
 #[serde(rename_all = "camelCase")]
 pub struct PropertyTypeRootedSubgraph {
     pub property_type: PersistedPropertyType,
-    pub data_type_references: Vec<PersistedDataType>,
-    pub property_type_references: Vec<PersistedPropertyType>,
+    pub referenced_data_types: Vec<PersistedDataType>,
+    pub referenced_property_types: Vec<PersistedPropertyType>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
@@ -218,8 +218,8 @@ pub struct EntityTypeQuery {
 #[serde(rename_all = "camelCase")]
 pub struct EntityTypeRootedSubgraph {
     pub entity_type: PersistedEntityType,
-    pub data_type_references: Vec<PersistedDataType>,
-    pub property_type_references: Vec<PersistedPropertyType>,
-    pub link_type_references: Vec<PersistedLinkType>,
-    pub entity_type_references: Vec<PersistedEntityType>,
+    pub referenced_data_types: Vec<PersistedDataType>,
+    pub referenced_property_types: Vec<PersistedPropertyType>,
+    pub referenced_link_types: Vec<PersistedLinkType>,
+    pub referenced_entity_types: Vec<PersistedEntityType>,
 }

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -145,7 +145,7 @@ pub struct DataTypeQuery {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
 #[serde(rename_all = "camelCase")]
-pub struct DataTypeTree {
+pub struct DataTypeRootedSubgraph {
     pub data_type: PersistedDataType,
 }
 
@@ -168,7 +168,7 @@ pub struct PropertyTypeQuery {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
 #[serde(rename_all = "camelCase")]
-pub struct PropertyTypeTree {
+pub struct PropertyTypeRootedSubgraph {
     pub property_type: PersistedPropertyType,
     pub data_type_references: Vec<PersistedDataType>,
     pub property_type_references: Vec<PersistedPropertyType>,
@@ -191,7 +191,7 @@ pub struct LinkTypeQuery {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
 #[serde(rename_all = "camelCase")]
-pub struct LinkTypeTree {
+pub struct LinkTypeRootedSubgraph {
     pub link_type: PersistedLinkType,
 }
 
@@ -216,7 +216,7 @@ pub struct EntityTypeQuery {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
 #[serde(rename_all = "camelCase")]
-pub struct EntityTypeTree {
+pub struct EntityTypeRootedSubgraph {
     pub entity_type: PersistedEntityType,
     pub data_type_references: Vec<PersistedDataType>,
     pub property_type_references: Vec<PersistedPropertyType>,

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -184,6 +184,7 @@ pub struct DataTypeQuery {
     // TODO: `data_type_query_depth` currently does nothing, in the future it will most probably be
     //       used to resolve user defined data types.
     //   see https://app.asana.com/0/1200211978612931/1202464168422955/f
+    #[component(value_type = number)]
     pub data_type_query_depth: QueryDepth,
 }
 
@@ -209,7 +210,9 @@ pub struct PropertyTypeQuery {
     pub expression: Expression,
     // TODO: A value greater than `1` currently does not have any effect.
     //   see https://app.asana.com/0/1200211978612931/1202464168422955/f
+    #[component(value_type = number)]
     pub data_type_query_depth: QueryDepth,
+    #[component(value_type = number)]
     pub property_type_query_depth: QueryDepth,
 }
 
@@ -259,9 +262,13 @@ pub struct EntityTypeQuery {
     pub expression: Expression,
     // TODO: A value greater than `1` currently does not have any effect.
     //   see https://app.asana.com/0/1200211978612931/1202464168422955/f
+    #[component(value_type = number)]
     pub data_type_query_depth: QueryDepth,
+    #[component(value_type = number)]
     pub property_type_query_depth: QueryDepth,
+    #[component(value_type = number)]
     pub link_type_query_depth: QueryDepth,
+    #[component(value_type = number)]
     pub entity_type_query_depth: QueryDepth,
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -179,7 +179,7 @@ pub struct PropertyTypeQuery {
     ///
     /// [`property_type_query_depth`]: Self::property_type_query_depth
     // TODO: https://app.asana.com/0/1200211978612931/1202464168422955/f
-    /// **Note**: A value greater than `1` currently does not have any effect
+    /// **Note**: A value greater than `1` currently does not have any effect.
     pub data_type_query_depth: u8,
     /// Depth used to read nested [`PropertyType`]s.
     pub property_type_query_depth: u8,
@@ -231,13 +231,13 @@ pub struct EntityTypeQuery {
     pub expression: Expression,
     /// Depth used to read indirectly referenced [`DataType`]s.
     // TODO: https://app.asana.com/0/1200211978612931/1202464168422955/f
-    /// **Note**: A value greater than `1` currently does not have any effect
+    /// **Note**: A value greater than `1` currently does not have any effect.
     pub data_type_query_depth: u8,
     /// Depth used to read directly or indirectly referenced [`PropertyType`]s.
     pub property_type_query_depth: u8,
     /// Depth used to read directly or indirectly referenced [`LinkType`]s.
     ///
-    /// **Note**: A value greater than `1` does not have any effect
+    /// **Note**: A value greater than `1` does not have any effect.
     pub link_type_query_depth: u8,
     /// Depth used to read directly or indirectly referenced [`PropertyType`]s.
     pub entity_type_query_depth: u8,

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -122,8 +122,7 @@ where
 {
     // This clone is necessary because `Serialize` requires us to take the param by reference here
     //  even though we only use it in places where we could move
-    let value: serde_json::Value = ontology_type.clone().into();
-    value.serialize(serializer)
+    serde_json::Value::from(ontology_type.clone()).serialize(serializer)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
@@ -135,11 +134,25 @@ pub struct PersistedDataType {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
+#[serde(rename_all = "camelCase")]
+pub struct DataTypeTree {
+    pub data_type: PersistedDataType,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
 pub struct PersistedPropertyType {
     #[component(value_type = VAR_PROPERTY_TYPE)]
     #[serde(serialize_with = "serialize_ontology_type")]
     pub inner: PropertyType,
     pub identifier: PersistedOntologyIdentifier,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
+#[serde(rename_all = "camelCase")]
+pub struct PropertyTypeTree {
+    pub property_type: PersistedPropertyType,
+    pub data_type_references: Vec<PersistedDataType>,
+    pub property_type_references: Vec<PersistedPropertyType>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
@@ -151,9 +164,25 @@ pub struct PersistedLinkType {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
+#[serde(rename_all = "camelCase")]
+pub struct LinkTypeTree {
+    pub link_type: PersistedLinkType,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
 pub struct PersistedEntityType {
     #[component(value_type = VAR_ENTITY_TYPE)]
     #[serde(serialize_with = "serialize_ontology_type")]
     pub inner: EntityType,
     pub identifier: PersistedOntologyIdentifier,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityTypeTree {
+    pub entity_type: PersistedEntityType,
+    pub data_type_references: Vec<PersistedDataType>,
+    pub property_type_references: Vec<PersistedPropertyType>,
+    pub link_type_references: Vec<PersistedLinkType>,
+    pub entity_type_references: Vec<PersistedEntityType>,
 }

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -12,6 +12,8 @@ use type_system::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyTyp
 use utoipa::Component;
 use uuid::Uuid;
 
+use crate::store::query::Expression;
+
 // TODO - find a good place for AccountId, perhaps it will become redundant in a future design
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Component, FromSql, ToSql)]
@@ -133,6 +135,14 @@ pub struct PersistedDataType {
     pub identifier: PersistedOntologyIdentifier,
 }
 
+#[derive(Debug, Deserialize, Component)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct DataTypeQuery {
+    #[serde(rename = "query")]
+    pub expression: Expression,
+    pub data_type_query_depth: u8,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
 #[serde(rename_all = "camelCase")]
 pub struct DataTypeTree {
@@ -145,6 +155,15 @@ pub struct PersistedPropertyType {
     #[serde(serialize_with = "serialize_ontology_type")]
     pub inner: PropertyType,
     pub identifier: PersistedOntologyIdentifier,
+}
+
+#[derive(Debug, Deserialize, Component)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct PropertyTypeQuery {
+    #[serde(rename = "query")]
+    pub expression: Expression,
+    pub data_type_query_depth: u8,
+    pub property_type_query_depth: u8,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
@@ -163,6 +182,13 @@ pub struct PersistedLinkType {
     pub identifier: PersistedOntologyIdentifier,
 }
 
+#[derive(Debug, Deserialize, Component)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct LinkTypeQuery {
+    #[serde(rename = "query")]
+    pub expression: Expression,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
 #[serde(rename_all = "camelCase")]
 pub struct LinkTypeTree {
@@ -175,6 +201,17 @@ pub struct PersistedEntityType {
     #[serde(serialize_with = "serialize_ontology_type")]
     pub inner: EntityType,
     pub identifier: PersistedOntologyIdentifier,
+}
+
+#[derive(Debug, Deserialize, Component)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct EntityTypeQuery {
+    #[serde(rename = "query")]
+    pub expression: Expression,
+    pub data_type_query_depth: u8,
+    pub property_type_query_depth: u8,
+    pub link_type_query_depth: u8,
+    pub entity_type_query_depth: u8,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -127,6 +127,7 @@ where
     //  even though we only use it in places where we could move
     serde_json::Value::from(ontology_type.clone()).serialize(serializer)
 }
+
 /// Distance to explore when querying a rooted subgraph in the ontology.
 ///
 /// Ontology records may have references to other records, e.g. a [`PropertyType`] may reference

--- a/packages/graph/hash_graph/lib/graph/src/store/crud.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/crud.rs
@@ -21,6 +21,8 @@ pub trait Read<T: Send>: Sync {
     // TODO: Implement `Valuable` for queries and use them directly
     type Query<'q>: Debug + Sync;
 
+    // TODO: Return a stream of `T` instead
+    //   see https://app.asana.com/0/1202805690238892/1202923536131158/f
     /// Returns a value from the [`Store`] specified by the passed `query`.
     ///
     /// [`Store`]: crate::store::Store

--- a/packages/graph/hash_graph/lib/graph/src/store/crud.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/crud.rs
@@ -13,28 +13,6 @@ use error_stack::Result;
 
 use crate::store::QueryError;
 
-/// Depth used to read referenced records when querying a rooted subgraph.
-///
-/// Records may have references to other records, e.g. a [`PropertyType`] may reference other
-/// [`PropertyType`]s or [`DataType`]s. When a record is requested, a depth for each referenced
-/// record has to be provided. The depth specify, how far references are resolved when returning a
-/// rooted subgraph, a depth of `0` means, that no further references are returned.
-///
-/// # Example
-///
-/// When reading a [`PropertyType`], `data_type_query_depth` and `property_type_query_depth` needs
-/// to be specified. For a give [`PropertyType`], which is referring to another [`PropertyType`],
-/// which itself refers to a [`DataType`], referenced [`PropertyType`] will be returned as well if
-/// `property_type_query_depth` is at least `1`. If in addition `data_type_query_depth` is at least
-/// `1`, the [`DataType`] will be returned as well.
-///
-/// If `property_type_query_depth` is set to `0`, this will not return any referenced record,
-/// regardless of the `data_type_query_depth`.
-///
-/// [`DataType`]: type_system::DataType
-/// [`PropertyType`]: type_system::PropertyType
-pub type QueryDepth = u8;
-
 /// Read access to a [`Store`].
 ///
 /// [`Store`]: crate::store::Store

--- a/packages/graph/hash_graph/lib/graph/src/store/crud.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/crud.rs
@@ -13,9 +13,33 @@ use error_stack::Result;
 
 use crate::store::QueryError;
 
+/// Depth used to read referenced records when querying a rooted subgraph.
+///
+/// Records may have references to other records, e.g. a [`PropertyType`] may reference other
+/// [`PropertyType`]s or [`DataType`]s. When a record is requested, a depth for each referenced
+/// record has to be provided. The depth specify, how far references are resolved when returning a
+/// rooted subgraph, a depth of `0` means, that no further references are returned.
+///
+/// # Example
+///
+/// When reading a [`PropertyType`], `data_type_query_depth` and `property_type_query_depth` needs
+/// to be specified. For a give [`PropertyType`], which is referring to another [`PropertyType`],
+/// which itself refers to a [`DataType`], referenced [`PropertyType`] will be returned as well if
+/// `property_type_query_depth` is at least `1`. If in addition `data_type_query_depth` is at least
+/// `1`, the [`DataType`] will be returned as well.
+///
+/// If `property_type_query_depth` is set to `0`, this will not return any referenced record,
+/// regardless of the `data_type_query_depth`.
+///
+/// [`DataType`]: type_system::DataType
+/// [`PropertyType`]: type_system::PropertyType
+pub type QueryDepth = u8;
+
 /// Read access to a [`Store`].
 ///
 /// [`Store`]: crate::store::Store
+// TODO: Use queries, which are passed to the query-endpoint
+//   see https://app.asana.com/0/1202805690238892/1202979057056097/f
 #[async_trait]
 pub trait Read<T: Send>: Sync {
     // TODO: Implement `Valuable` for queries and use them directly

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -306,7 +306,8 @@ pub trait EntityTypeStore: for<'q> crud::Read<PersistedEntityType, Query<'q> = E
         query: &Expression,
         data_type_resolve_depth: u8,
         property_type_resolve_depth: u8,
-        entity_link_query_depth: u8,
+        link_type_query_depth: u8,
+        entity_type_query_depth: u8,
     ) -> Result<Vec<EntityTypeTree>, QueryError>;
 
     /// Update the definition of an existing [`EntityType`].

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -19,9 +19,10 @@ pub use self::{
 use crate::{
     knowledge::{Entity, EntityId, Link, PersistedEntity, PersistedEntityIdentifier},
     ontology::{
-        AccountId, DataTypeQuery, DataTypeTree, EntityTypeQuery, EntityTypeTree, LinkTypeQuery,
-        LinkTypeTree, PersistedDataType, PersistedEntityType, PersistedLinkType,
-        PersistedOntologyIdentifier, PersistedPropertyType, PropertyTypeQuery, PropertyTypeTree,
+        AccountId, DataTypeQuery, DataTypeRootedSubgraph, EntityTypeQuery,
+        EntityTypeRootedSubgraph, LinkTypeQuery, LinkTypeRootedSubgraph, PersistedDataType,
+        PersistedEntityType, PersistedLinkType, PersistedOntologyIdentifier, PersistedPropertyType,
+        PropertyTypeQuery, PropertyTypeRootedSubgraph,
     },
     store::{error::LinkRemovalError, query::Expression},
 };
@@ -218,7 +219,10 @@ pub trait DataTypeStore: for<'q> crud::Read<PersistedDataType, Query<'q> = Expre
     /// # Errors
     ///
     /// - if the requested [`DataType`] doesn't exist.
-    async fn get_data_type(&self, query: &DataTypeQuery) -> Result<Vec<DataTypeTree>, QueryError>;
+    async fn get_data_type(
+        &self,
+        query: &DataTypeQuery,
+    ) -> Result<Vec<DataTypeRootedSubgraph>, QueryError>;
 
     /// Update the definition of an existing [`DataType`].
     ///
@@ -259,7 +263,7 @@ pub trait PropertyTypeStore:
     async fn get_property_type(
         &self,
         query: &PropertyTypeQuery,
-    ) -> Result<Vec<PropertyTypeTree>, QueryError>;
+    ) -> Result<Vec<PropertyTypeRootedSubgraph>, QueryError>;
 
     /// Update the definition of an existing [`PropertyType`].
     ///
@@ -298,7 +302,7 @@ pub trait EntityTypeStore: for<'q> crud::Read<PersistedEntityType, Query<'q> = E
     async fn get_entity_type(
         &self,
         query: &EntityTypeQuery,
-    ) -> Result<Vec<EntityTypeTree>, QueryError>;
+    ) -> Result<Vec<EntityTypeRootedSubgraph>, QueryError>;
 
     /// Update the definition of an existing [`EntityType`].
     ///
@@ -334,7 +338,10 @@ pub trait LinkTypeStore: for<'q> crud::Read<PersistedLinkType, Query<'q> = Expre
     /// # Errors
     ///
     /// - if the requested [`LinkType`] doesn't exist.
-    async fn get_link_type(&self, query: &LinkTypeQuery) -> Result<Vec<LinkTypeTree>, QueryError>;
+    async fn get_link_type(
+        &self,
+        query: &LinkTypeQuery,
+    ) -> Result<Vec<LinkTypeRootedSubgraph>, QueryError>;
 
     /// Update the definition of an existing [`LinkType`].
     ///

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -19,9 +19,9 @@ pub use self::{
 use crate::{
     knowledge::{Entity, EntityId, Link, PersistedEntity, PersistedEntityIdentifier},
     ontology::{
-        AccountId, DataTypeTree, EntityTypeTree, LinkTypeTree, PersistedDataType,
-        PersistedEntityType, PersistedLinkType, PersistedOntologyIdentifier, PersistedPropertyType,
-        PropertyTypeTree,
+        AccountId, DataTypeQuery, DataTypeTree, EntityTypeQuery, EntityTypeTree, LinkTypeQuery,
+        LinkTypeTree, PersistedDataType, PersistedEntityType, PersistedLinkType,
+        PersistedOntologyIdentifier, PersistedPropertyType, PropertyTypeQuery, PropertyTypeTree,
     },
     store::{error::LinkRemovalError, query::Expression},
 };
@@ -218,11 +218,7 @@ pub trait DataTypeStore: for<'q> crud::Read<PersistedDataType, Query<'q> = Expre
     /// # Errors
     ///
     /// - if the requested [`DataType`] doesn't exist.
-    async fn get_data_type(
-        &self,
-        query: &Expression,
-        data_type_resolve_depth: u8,
-    ) -> Result<Vec<DataTypeTree>, QueryError>;
+    async fn get_data_type(&self, query: &DataTypeQuery) -> Result<Vec<DataTypeTree>, QueryError>;
 
     /// Update the definition of an existing [`DataType`].
     ///
@@ -262,9 +258,7 @@ pub trait PropertyTypeStore:
     /// - if the requested [`PropertyType`] doesn't exist.
     async fn get_property_type(
         &self,
-        query: &Expression,
-        data_type_resolve_depth: u8,
-        property_type_resolve_depth: u8,
+        query: &PropertyTypeQuery,
     ) -> Result<Vec<PropertyTypeTree>, QueryError>;
 
     /// Update the definition of an existing [`PropertyType`].
@@ -303,11 +297,7 @@ pub trait EntityTypeStore: for<'q> crud::Read<PersistedEntityType, Query<'q> = E
     /// - if the requested [`EntityType`] doesn't exist.
     async fn get_entity_type(
         &self,
-        query: &Expression,
-        data_type_resolve_depth: u8,
-        property_type_resolve_depth: u8,
-        link_type_query_depth: u8,
-        entity_type_query_depth: u8,
+        query: &EntityTypeQuery,
     ) -> Result<Vec<EntityTypeTree>, QueryError>;
 
     /// Update the definition of an existing [`EntityType`].
@@ -344,7 +334,7 @@ pub trait LinkTypeStore: for<'q> crud::Read<PersistedLinkType, Query<'q> = Expre
     /// # Errors
     ///
     /// - if the requested [`LinkType`] doesn't exist.
-    async fn get_link_type(&self, query: &Expression) -> Result<Vec<LinkTypeTree>, QueryError>;
+    async fn get_link_type(&self, query: &LinkTypeQuery) -> Result<Vec<LinkTypeTree>, QueryError>;
 
     /// Update the definition of an existing [`LinkType`].
     ///

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -19,8 +19,9 @@ pub use self::{
 use crate::{
     knowledge::{Entity, EntityId, Link, PersistedEntity, PersistedEntityIdentifier},
     ontology::{
-        AccountId, PersistedDataType, PersistedEntityType, PersistedLinkType,
-        PersistedOntologyIdentifier, PersistedPropertyType,
+        AccountId, DataTypeTree, EntityTypeTree, LinkTypeTree, PersistedDataType,
+        PersistedEntityType, PersistedLinkType, PersistedOntologyIdentifier, PersistedPropertyType,
+        PropertyTypeTree,
     },
     store::{error::LinkRemovalError, query::Expression},
 };
@@ -220,9 +221,8 @@ pub trait DataTypeStore: for<'q> crud::Read<PersistedDataType, Query<'q> = Expre
     async fn get_data_type(
         &self,
         query: &Expression,
-    ) -> Result<Vec<PersistedDataType>, QueryError> {
-        self.read(query).await
-    }
+        data_type_resolve_depth: u8,
+    ) -> Result<Vec<DataTypeTree>, QueryError>;
 
     /// Update the definition of an existing [`DataType`].
     ///
@@ -263,9 +263,9 @@ pub trait PropertyTypeStore:
     async fn get_property_type(
         &self,
         query: &Expression,
-    ) -> Result<Vec<PersistedPropertyType>, QueryError> {
-        self.read(query).await
-    }
+        data_type_resolve_depth: u8,
+        property_type_resolve_depth: u8,
+    ) -> Result<Vec<PropertyTypeTree>, QueryError>;
 
     /// Update the definition of an existing [`PropertyType`].
     ///
@@ -304,9 +304,10 @@ pub trait EntityTypeStore: for<'q> crud::Read<PersistedEntityType, Query<'q> = E
     async fn get_entity_type(
         &self,
         query: &Expression,
-    ) -> Result<Vec<PersistedEntityType>, QueryError> {
-        self.read(query).await
-    }
+        data_type_resolve_depth: u8,
+        property_type_resolve_depth: u8,
+        entity_link_query_depth: u8,
+    ) -> Result<Vec<EntityTypeTree>, QueryError>;
 
     /// Update the definition of an existing [`EntityType`].
     ///
@@ -342,12 +343,7 @@ pub trait LinkTypeStore: for<'q> crud::Read<PersistedLinkType, Query<'q> = Expre
     /// # Errors
     ///
     /// - if the requested [`LinkType`] doesn't exist.
-    async fn get_link_type(
-        &self,
-        query: &Expression,
-    ) -> Result<Vec<PersistedLinkType>, QueryError> {
-        self.read(query).await
-    }
+    async fn get_link_type(&self, query: &Expression) -> Result<Vec<LinkTypeTree>, QueryError>;
 
     /// Update the definition of an existing [`LinkType`].
     ///

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/context/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/context/mod.rs
@@ -73,7 +73,7 @@ impl<C: AsClient> PostgresContext for PostgresStore<C> {
     {
         ontology::read_versioned_type(&self.client, uri)
             .await
-            .attach_printable("could not read ontology type")
+            .attach_printable_lazy(|| format!("could not read ontology type: {uri}"))
     }
 
     async fn read_all_entities(&self) -> Result<entity::RecordStream, QueryError> {
@@ -88,7 +88,7 @@ impl<C: AsClient> PostgresContext for PostgresStore<C> {
     ) -> Result<EntityRecord, QueryError> {
         entity::read_latest_entity_by_id(&self.client, entity_id)
             .await
-            .attach_printable("could not read entity")
+            .attach_printable_lazy(|| format!("could not read entity: {entity_id}"))
     }
 
     async fn read_all_links(&self) -> Result<links::RecordStream, QueryError> {
@@ -103,8 +103,7 @@ impl<C: AsClient> PostgresContext for PostgresStore<C> {
     ) -> Result<links::RecordStream, QueryError> {
         links::read_links_by_source(&self.client, entity_id)
             .await
-            .attach_printable("could not read outgoing links")
-            .attach_printable_lazy(|| format!("source entity: {entity_id}"))
+            .attach_printable_lazy(|| format!("could not read outgoing links: {entity_id}"))
     }
 
     async fn read_links_by_target(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/context/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/context/mod.rs
@@ -73,7 +73,8 @@ impl<C: AsClient> PostgresContext for PostgresStore<C> {
     {
         ontology::read_versioned_type(&self.client, uri)
             .await
-            .attach_printable_lazy(|| format!("could not read ontology type: {uri}"))
+            .attach_printable("could not read ontology type")
+            .attach_printable_lazy(|| uri.clone())
     }
 
     async fn read_all_entities(&self) -> Result<entity::RecordStream, QueryError> {
@@ -88,7 +89,8 @@ impl<C: AsClient> PostgresContext for PostgresStore<C> {
     ) -> Result<EntityRecord, QueryError> {
         entity::read_latest_entity_by_id(&self.client, entity_id)
             .await
-            .attach_printable_lazy(|| format!("could not read entity: {entity_id}"))
+            .attach_printable("could not read entity")
+            .attach_printable(entity_id)
     }
 
     async fn read_all_links(&self) -> Result<links::RecordStream, QueryError> {
@@ -103,7 +105,8 @@ impl<C: AsClient> PostgresContext for PostgresStore<C> {
     ) -> Result<links::RecordStream, QueryError> {
         links::read_links_by_source(&self.client, entity_id)
             .await
-            .attach_printable_lazy(|| format!("could not read outgoing links: {entity_id}"))
+            .attach_printable("could not read outgoing links")
+            .attach_printable(entity_id)
     }
 
     async fn read_links_by_target(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -62,12 +62,12 @@ where
 {
     /// Inserts a dependency into the map.
     ///
-    /// If the dependency does not already exist in the dependency map, it will be inserted
-    /// with the provided `depth` and a reference to this dependency will be returned in order
-    /// to continue resolving it. In the case, that the dependency already exists, the `depth`
-    /// will be compared with depth used when inserting it before:
-    /// - If the new depth is higher, the depth will be updated and a reference to the
-    /// dependency will be returned in order to keep resolving it
+    /// If the dependency does not already exist in the dependency map, it will be inserted with the
+    /// provided `depth` and a reference to this dependency will be returned in order to continue
+    /// resolving it. In the case, that the dependency already exists, the `depth` will be compared
+    /// with depth used when inserting it before:
+    /// - If the new depth is higher, the depth will be updated and a reference to the dependency
+    ///   will be returned in order to keep resolving it
     /// - Otherwise, `None` will be returned as no further resolution is needed
     pub async fn insert<F, R>(
         &mut self,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -15,7 +15,10 @@ use type_system::{
 };
 use uuid::Uuid;
 
-pub use self::pool::{AsClient, PostgresStorePool};
+pub use self::{
+    ontology::PersistedOntologyType,
+    pool::{AsClient, PostgresStorePool},
+};
 use super::error::LinkRemovalError;
 use crate::{
     knowledge::{Entity, EntityId, Link, PersistedEntityIdentifier},

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -62,11 +62,13 @@ where
 {
     /// Inserts a dependency into the map.
     ///
-    /// If the dependency does not already exists in the dependency map, it will be inserted with
-    /// the provided `depth` and a reference to this dependency will be returned. In the case, that
-    /// the dependency already exist, the `depth` will be compared with depth used when inserting
-    /// it before. If the new depth is higher, the depth will be updated and a reference to the
-    /// dependency will be returned, otherwise `None` will be returned.
+    /// If the dependency does not already exist in the dependency map, it will be inserted
+    /// with the provided `depth` and a reference to this dependency will be returned in order
+    /// to continue resolving it. In the case, that the dependency already exists, the `depth`
+    /// will be compared with depth used when inserting it before:
+    /// - If the new depth is higher, the depth will be updated and a reference to the
+    /// dependency will be returned in order to keep resolving it
+    /// - Otherwise, `None` will be returned as no further resolution is needed
     pub async fn insert<F, R>(
         &mut self,
         identifier: &V,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -5,6 +5,12 @@ mod context;
 mod pool;
 mod version_id;
 
+use std::{
+    collections::{hash_map::RawEntryMut, HashMap},
+    future::Future,
+    hash::Hash,
+};
+
 use async_trait::async_trait;
 use error_stack::{IntoReport, Report, Result, ResultExt};
 use postgres_types::ToSql;
@@ -22,7 +28,7 @@ pub use self::{
 use super::error::LinkRemovalError;
 use crate::{
     knowledge::{Entity, EntityId, Link, PersistedEntityIdentifier},
-    ontology::{AccountId, PersistedOntologyIdentifier},
+    ontology::{AccountId, PersistedOntologyIdentifier, QueryDepth},
     store::{
         error::VersionedUriAlreadyExists,
         postgres::{ontology::OntologyDatabaseType, version_id::VersionId},
@@ -30,6 +36,69 @@ use crate::{
         UpdateError,
     },
 };
+
+pub struct DependencyMap<V, T> {
+    resolved: HashMap<V, (T, QueryDepth)>,
+}
+
+impl<V, T> Default for DependencyMap<V, T> {
+    fn default() -> Self {
+        Self {
+            resolved: HashMap::default(),
+        }
+    }
+}
+
+impl<V, T> DependencyMap<V, T> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<V, T> DependencyMap<V, T>
+where
+    V: Eq + Hash + Clone + Send + Sync,
+    T: Send,
+{
+    /// Inserts a dependency into the map.
+    ///
+    /// If the dependency does not already exists in the dependency map, it will be inserted with
+    /// the provided `depth` and a reference to this dependency will be returned. In the case, that
+    /// the dependency already exist, the `depth` will be compared with depth used when inserting
+    /// it before. If the new depth is higher, the depth will be updated and a reference to the
+    /// dependency will be returned, otherwise `None` will be returned.
+    pub async fn insert<F, R>(
+        &mut self,
+        identifier: &V,
+        depth: QueryDepth,
+        resolver: F,
+    ) -> Result<Option<&T>, QueryError>
+    where
+        F: Fn() -> R + Send + Sync,
+        R: Future<Output = Result<T, QueryError>> + Send,
+    {
+        Ok(match self.resolved.raw_entry_mut().from_key(identifier) {
+            RawEntryMut::Vacant(entry) => {
+                let value = resolver().await?;
+                let (_id, (value, _depth)) = entry.insert(identifier.clone(), (value, depth));
+                Some(value)
+            }
+            RawEntryMut::Occupied(entry) => {
+                let (value, used_depth) = entry.into_mut();
+                if *used_depth < depth {
+                    *used_depth = depth;
+                    Some(value)
+                } else {
+                    None
+                }
+            }
+        })
+    }
+
+    pub fn into_vec(self) -> Vec<T> {
+        self.resolved.into_values().map(|value| value.0).collect()
+    }
+}
 
 /// Utility function used for [`GenericClient::query_raw`] to infer the parameter as
 /// [`dyn ToSql`][ToSql].

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -11,10 +11,10 @@ use type_system::{uri::VersionedUri, DataType};
 use crate::{
     ontology::{
         AccountId, DataTypeQuery, DataTypeRootedSubgraph, PersistedDataType,
-        PersistedOntologyIdentifier,
+        PersistedOntologyIdentifier, QueryDepth,
     },
     store::{
-        crud::{QueryDepth, Read},
+        crud::Read,
         postgres::{context::PostgresContext, PersistedOntologyType},
         AsClient, DataTypeStore, InsertionError, PostgresStore, QueryError, UpdateError,
     },

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -20,6 +20,8 @@ use crate::{
 };
 
 impl<C: AsClient> PostgresStore<C> {
+    // TODO: `_data_type_query_depth` is unused until data types can reference other data types
+    //   see https://app.asana.com/0/1200211978612931/1202464168422955/f
     /// Internal method to read a [`PersistedDataType`] into a [`HashMap`].
     ///
     /// This is used to recursively resolve a type, so the result can be reused.

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -26,7 +26,7 @@ pub struct DataTypeDependencyContext<'a> {
 }
 
 impl<C: AsClient> PostgresStore<C> {
-    /// Internal method to read a [`PersistedDataType`] into a [`HashMap`].
+    /// Internal method to read a [`PersistedDataType`] into a [`DependencyMap`].
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
     pub(crate) async fn get_data_type_as_dependency(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -10,7 +10,8 @@ use type_system::{uri::VersionedUri, DataType};
 
 use crate::{
     ontology::{
-        AccountId, DataTypeQuery, DataTypeTree, PersistedDataType, PersistedOntologyIdentifier,
+        AccountId, DataTypeQuery, DataTypeRootedSubgraph, PersistedDataType,
+        PersistedOntologyIdentifier,
     },
     store::{
         crud::Read,
@@ -78,14 +79,17 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
         Ok(identifier)
     }
 
-    async fn get_data_type(&self, query: &DataTypeQuery) -> Result<Vec<DataTypeTree>, QueryError> {
+    async fn get_data_type(
+        &self,
+        query: &DataTypeQuery,
+    ) -> Result<Vec<DataTypeRootedSubgraph>, QueryError> {
         let DataTypeQuery {
             ref expression,
             data_type_query_depth: _,
         } = *query;
 
         stream::iter(Read::<PersistedDataType>::read(self, expression).await?)
-            .then(|data_type: PersistedDataType| async { Ok(DataTypeTree { data_type }) })
+            .then(|data_type: PersistedDataType| async { Ok(DataTypeRootedSubgraph { data_type }) })
             .try_collect()
             .await
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -14,7 +14,7 @@ use crate::{
         PersistedOntologyIdentifier,
     },
     store::{
-        crud::Read,
+        crud::{QueryDepth, Read},
         postgres::{context::PostgresContext, PersistedOntologyType},
         AsClient, DataTypeStore, InsertionError, PostgresStore, QueryError, UpdateError,
     },
@@ -24,7 +24,7 @@ pub struct DataTypeDependencyContext<'a> {
     pub data_type_references: &'a mut HashMap<VersionedUri, PersistedDataType>,
     // TODO: `_data_type_query_depth` is unused until data types can reference other data types
     //   see https://app.asana.com/0/1200211978612931/1202464168422955/f
-    pub _data_type_query_depth: u8,
+    pub _data_type_query_depth: QueryDepth,
 }
 
 impl<C: AsClient> PostgresStore<C> {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
@@ -14,8 +14,8 @@ use type_system::{uri::VersionedUri, EntityType};
 
 use crate::{
     ontology::{
-        AccountId, EntityTypeQuery, EntityTypeTree, PersistedDataType, PersistedEntityType,
-        PersistedLinkType, PersistedOntologyIdentifier, PersistedPropertyType,
+        AccountId, EntityTypeQuery, EntityTypeRootedSubgraph, PersistedDataType,
+        PersistedEntityType, PersistedLinkType, PersistedOntologyIdentifier, PersistedPropertyType,
     },
     store::{
         crud::Read,
@@ -177,7 +177,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
     async fn get_entity_type(
         &self,
         query: &EntityTypeQuery,
-    ) -> Result<Vec<EntityTypeTree>, QueryError> {
+    ) -> Result<Vec<EntityTypeRootedSubgraph>, QueryError> {
         let EntityTypeQuery {
             ref expression,
             data_type_query_depth,
@@ -242,7 +242,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
                     }
                 }
 
-                Ok(EntityTypeTree {
+                Ok(EntityTypeRootedSubgraph {
                     entity_type,
                     data_type_references: data_type_references.into_values().collect(),
                     property_type_references: property_type_references.into_values().collect(),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
@@ -45,7 +45,7 @@ impl<C: AsClient> PostgresStore<C> {
         entity_type_query_depth: u8,
     ) -> Pin<Box<dyn Future<Output = Result<(), QueryError>> + Send + 'a>> {
         async move {
-            // URI is cloned due to limitations of Entry API, see 
+            // URI is cloned due to limitations of Entry API, see
             // https://stackoverflow.com/questions/51542024
             if let Entry::Vacant(entry) = entity_type_references.entry(entity_type_uri) {
                 let entity_type = PersistedEntityType::from_record(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
@@ -16,9 +16,10 @@ use crate::{
     ontology::{
         AccountId, EntityTypeQuery, EntityTypeRootedSubgraph, PersistedDataType,
         PersistedEntityType, PersistedLinkType, PersistedOntologyIdentifier, PersistedPropertyType,
+        QueryDepth,
     },
     store::{
-        crud::{QueryDepth, Read},
+        crud::Read,
         postgres::{
             context::PostgresContext,
             ontology::{

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
@@ -39,7 +39,7 @@ pub struct EntityTypeDependencyContext<'a> {
 }
 
 impl<C: AsClient> PostgresStore<C> {
-    /// Internal method to read a [`PersistedEntityType`] into a [`HashMap`].
+    /// Internal method to read a [`PersistedEntityType`] into four [`DependencyMap`]s.
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
     pub(crate) fn get_entity_type_as_dependency<'a>(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
@@ -244,10 +244,10 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
 
                 Ok(EntityTypeRootedSubgraph {
                     entity_type,
-                    data_type_references: data_type_references.into_values().collect(),
-                    property_type_references: property_type_references.into_values().collect(),
-                    link_type_references: link_type_references.into_values().collect(),
-                    entity_type_references: entity_type_references.into_values().collect(),
+                    referenced_data_types: data_type_references.into_values().collect(),
+                    referenced_property_types: property_type_references.into_values().collect(),
+                    referenced_link_types: link_type_references.into_values().collect(),
+                    referenced_entity_types: entity_type_references.into_values().collect(),
                 })
             })
             .try_collect()

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
@@ -46,8 +46,8 @@ impl<C: AsClient> PostgresStore<C> {
         entity_type_query_depth: u8,
     ) -> Pin<Box<dyn Future<Output = Result<(), QueryError>> + Send + 'a>> {
         async move {
-            // TODO: Avoid cloning of URI
-            //   see https://stackoverflow.com/questions/51542024
+            // URI is cloned due to limitations of Entry API, see 
+            // https://stackoverflow.com/questions/51542024
             if let Entry::Vacant(entry) = entity_type_references.entry(entity_type_uri) {
                 let entity_type = PersistedEntityType::from_record(
                     self.read_versioned_ontology_type::<EntityType>(entry.key())

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
@@ -9,11 +9,12 @@ use tokio_postgres::GenericClient;
 use type_system::{uri::VersionedUri, LinkType};
 
 use crate::{
-    ontology::{AccountId, LinkTypeTree, PersistedLinkType, PersistedOntologyIdentifier},
+    ontology::{
+        AccountId, LinkTypeQuery, LinkTypeTree, PersistedLinkType, PersistedOntologyIdentifier,
+    },
     store::{
         crud::Read,
         postgres::{context::PostgresContext, PersistedOntologyType},
-        query::Expression,
         AsClient, InsertionError, LinkTypeStore, PostgresStore, QueryError, UpdateError,
     },
 };
@@ -68,8 +69,8 @@ impl<C: AsClient> LinkTypeStore for PostgresStore<C> {
         Ok(identifier)
     }
 
-    async fn get_link_type(&self, query: &Expression) -> Result<Vec<LinkTypeTree>, QueryError> {
-        stream::iter(Read::<PersistedLinkType>::read(self, query).await?)
+    async fn get_link_type(&self, query: &LinkTypeQuery) -> Result<Vec<LinkTypeTree>, QueryError> {
+        stream::iter(Read::<PersistedLinkType>::read(self, &query.expression).await?)
             .then(|link_type: PersistedLinkType| async { Ok(LinkTypeTree { link_type }) })
             .try_collect()
             .await

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 impl<C: AsClient> PostgresStore<C> {
-    /// Internal method to read a [`PersistedDataType`] into a [`HashMap`].
+    /// Internal method to read a [`PersistedLinkType`] into a [`HashMap`].
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
     pub(crate) async fn get_link_type_as_dependency(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
@@ -25,7 +25,7 @@ pub struct LinkTypeDependencyContext<'a> {
 }
 
 impl<C: AsClient> PostgresStore<C> {
-    /// Internal method to read a [`PersistedLinkType`] into a [`HashMap`].
+    /// Internal method to read a [`PersistedLinkType`] into a [`DependencyMap`].
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
     pub(crate) async fn get_link_type_as_dependency(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
@@ -1,14 +1,44 @@
 mod resolve;
 
+use std::collections::{hash_map::Entry, HashMap};
+
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
+use futures::{stream, StreamExt, TryStreamExt};
 use tokio_postgres::GenericClient;
-use type_system::LinkType;
+use type_system::{uri::VersionedUri, LinkType};
 
 use crate::{
-    ontology::{AccountId, PersistedOntologyIdentifier},
-    store::{AsClient, InsertionError, LinkTypeStore, PostgresStore, UpdateError},
+    ontology::{AccountId, LinkTypeTree, PersistedLinkType, PersistedOntologyIdentifier},
+    store::{
+        crud::Read,
+        postgres::{context::PostgresContext, PersistedOntologyType},
+        query::Expression,
+        AsClient, InsertionError, LinkTypeStore, PostgresStore, QueryError, UpdateError,
+    },
 };
+
+impl<C: AsClient> PostgresStore<C> {
+    /// Internal method to read a [`PersistedDataType`] into a [`HashMap`].
+    ///
+    /// This is used to recursively resolve a type, so the result can be reused.
+    pub(crate) async fn get_link_type_as_dependency(
+        &self,
+        link_type_uri: VersionedUri,
+        link_types: &mut HashMap<VersionedUri, PersistedLinkType>,
+    ) -> Result<(), QueryError> {
+        // TODO: Use relation tables
+        //   see https://app.asana.com/0/0/1202884883200942/f
+        if let Entry::Vacant(entry) = link_types.entry(link_type_uri) {
+            let link_type = PersistedLinkType::from_record(
+                self.read_versioned_ontology_type::<LinkType>(entry.key())
+                    .await?,
+            );
+            entry.insert(link_type);
+        }
+        Ok(())
+    }
+}
 
 #[async_trait]
 impl<C: AsClient> LinkTypeStore for PostgresStore<C> {
@@ -35,6 +65,13 @@ impl<C: AsClient> LinkTypeStore for PostgresStore<C> {
             .change_context(InsertionError)?;
 
         Ok(identifier)
+    }
+
+    async fn get_link_type(&self, query: &Expression) -> Result<Vec<LinkTypeTree>, QueryError> {
+        stream::iter(Read::<PersistedLinkType>::read(self, query).await?)
+            .then(|link_type: PersistedLinkType| async { Ok(LinkTypeTree { link_type }) })
+            .try_collect()
+            .await
     }
 
     async fn update_link_type(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
@@ -28,7 +28,7 @@ impl<C: AsClient> PostgresStore<C> {
     /// Internal method to read a [`PersistedLinkType`] into a [`HashMap`].
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
-    pub(crate) async fn get_link_type_as_dependency<'a>(
+    pub(crate) async fn get_link_type_as_dependency(
         &self,
         link_type_uri: &VersionedUri,
         context: LinkTypeDependencyContext<'_>,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
@@ -11,15 +11,14 @@ use type_system::{uri::VersionedUri, LinkType};
 use crate::{
     ontology::{
         AccountId, LinkTypeQuery, LinkTypeRootedSubgraph, PersistedLinkType,
-        PersistedOntologyIdentifier,
+        PersistedOntologyIdentifier, QueryDepth,
     },
     store::{
-        crud::{QueryDepth, Read},
+        crud::Read,
         postgres::{context::PostgresContext, PersistedOntologyType},
         AsClient, InsertionError, LinkTypeStore, PostgresStore, QueryError, UpdateError,
     },
 };
-
 pub struct LinkTypeDependencyContext<'a> {
     pub link_type_references: &'a mut HashMap<VersionedUri, PersistedLinkType>,
     // `_link_type_query_depth` is unused as link types do not reference other link types

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
@@ -26,6 +26,7 @@ impl<C: AsClient> PostgresStore<C> {
         &self,
         link_type_uri: VersionedUri,
         link_types: &mut HashMap<VersionedUri, PersistedLinkType>,
+        _link_type_resolve_depth: u8,
     ) -> Result<(), QueryError> {
         // TODO: Use relation tables
         //   see https://app.asana.com/0/0/1202884883200942/f

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
@@ -14,7 +14,7 @@ use crate::{
         PersistedOntologyIdentifier,
     },
     store::{
-        crud::Read,
+        crud::{QueryDepth, Read},
         postgres::{context::PostgresContext, PersistedOntologyType},
         AsClient, InsertionError, LinkTypeStore, PostgresStore, QueryError, UpdateError,
     },
@@ -23,7 +23,7 @@ use crate::{
 pub struct LinkTypeDependencyContext<'a> {
     pub link_type_references: &'a mut HashMap<VersionedUri, PersistedLinkType>,
     // `_link_type_query_depth` is unused as link types do not reference other link types
-    pub _link_type_query_depth: u8,
+    pub _link_type_query_depth: QueryDepth,
 }
 
 impl<C: AsClient> PostgresStore<C> {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
@@ -10,7 +10,8 @@ use type_system::{uri::VersionedUri, LinkType};
 
 use crate::{
     ontology::{
-        AccountId, LinkTypeQuery, LinkTypeTree, PersistedLinkType, PersistedOntologyIdentifier,
+        AccountId, LinkTypeQuery, LinkTypeRootedSubgraph, PersistedLinkType,
+        PersistedOntologyIdentifier,
     },
     store::{
         crud::Read,
@@ -79,11 +80,14 @@ impl<C: AsClient> LinkTypeStore for PostgresStore<C> {
         Ok(identifier)
     }
 
-    async fn get_link_type(&self, query: &LinkTypeQuery) -> Result<Vec<LinkTypeTree>, QueryError> {
+    async fn get_link_type(
+        &self,
+        query: &LinkTypeQuery,
+    ) -> Result<Vec<LinkTypeRootedSubgraph>, QueryError> {
         let LinkTypeQuery { ref expression } = *query;
 
         stream::iter(Read::<PersistedLinkType>::read(self, expression).await?)
-            .then(|link_type: PersistedLinkType| async { Ok(LinkTypeTree { link_type }) })
+            .then(|link_type: PersistedLinkType| async { Ok(LinkTypeRootedSubgraph { link_type }) })
             .try_collect()
             .await
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/mod.rs
@@ -6,6 +6,8 @@ mod read;
 
 use type_system::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType};
 
+pub use self::read::PersistedOntologyType;
+
 /// Provides an abstraction over elements of the Type System stored in the Database.
 ///
 /// [`PostgresDatabase`]: crate::store::PostgresDatabase

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -15,10 +15,10 @@ use type_system::{uri::VersionedUri, PropertyType, PropertyTypeReference};
 use crate::{
     ontology::{
         AccountId, PersistedDataType, PersistedOntologyIdentifier, PersistedPropertyType,
-        PropertyTypeQuery, PropertyTypeRootedSubgraph,
+        PropertyTypeQuery, PropertyTypeRootedSubgraph, QueryDepth,
     },
     store::{
-        crud::{QueryDepth, Read},
+        crud::Read,
         postgres::{
             context::PostgresContext, ontology::data_type::DataTypeDependencyContext,
             PersistedOntologyType,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -15,7 +15,7 @@ use type_system::{uri::VersionedUri, PropertyType, PropertyTypeReference};
 use crate::{
     ontology::{
         AccountId, PersistedDataType, PersistedOntologyIdentifier, PersistedPropertyType,
-        PropertyTypeQuery, PropertyTypeTree,
+        PropertyTypeQuery, PropertyTypeRootedSubgraph,
     },
     store::{
         crud::Read,
@@ -141,7 +141,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
     async fn get_property_type(
         &self,
         query: &PropertyTypeQuery,
-    ) -> Result<Vec<PropertyTypeTree>, QueryError> {
+    ) -> Result<Vec<PropertyTypeRootedSubgraph>, QueryError> {
         let PropertyTypeQuery {
             ref expression,
             data_type_query_depth,
@@ -183,7 +183,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                     }
                 }
 
-                Ok(PropertyTypeTree {
+                Ok(PropertyTypeRootedSubgraph {
                     property_type,
                     data_type_references: data_type_references.into_values().collect(),
                     property_type_references: property_type_references.into_values().collect(),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -31,7 +31,7 @@ pub struct PropertyTypeDependencyContext<'a> {
 }
 
 impl<C: AsClient> PostgresStore<C> {
-    /// Internal method to read a [`PersistedPropertyType`] into a [`HashMap`].
+    /// Internal method to read a [`PersistedPropertyType`] into two [`DependencyMap`]s.
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
     pub(crate) fn get_property_type_as_dependency<'a>(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -46,20 +46,20 @@ impl<C: AsClient> PostgresStore<C> {
                 );
                 let property_type = entry.insert(property_type);
 
-                if let Some(new_depth) = data_type_query_depth.checked_sub(1) {
+                if data_type_query_depth > 0 {
                     // TODO: Use relation tables
                     //   see https://app.asana.com/0/0/1202884883200942/f
                     for data_type_ref in property_type.inner.data_type_references() {
                         self.get_data_type_as_dependency(
                             data_type_ref.uri().clone(),
                             data_type_references,
-                            new_depth,
+                            data_type_query_depth - 1,
                         )
                         .await?;
                     }
                 }
 
-                if let Some(new_depth) = property_type_query_depth.checked_sub(1) {
+                if property_type_query_depth > 0 {
                     // TODO: Use relation tables
                     //   see https://app.asana.com/0/0/1202884883200942/f
                     let property_type_uris = property_type
@@ -76,7 +76,7 @@ impl<C: AsClient> PostgresStore<C> {
                             data_type_references,
                             property_type_references,
                             data_type_query_depth,
-                            new_depth,
+                            property_type_query_depth - 1,
                         )
                         .await?;
                     }
@@ -142,20 +142,20 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                 let mut data_type_references = HashMap::new();
                 let mut property_type_references = HashMap::new();
 
-                if let Some(new_depth) = query.data_type_query_depth.checked_sub(1) {
+                if query.data_type_query_depth > 0 {
                     // TODO: Use relation tables
                     //   see https://app.asana.com/0/0/1202884883200942/f
                     for data_type_ref in property_type.inner.data_type_references() {
                         self.get_data_type_as_dependency(
                             data_type_ref.uri().clone(),
                             &mut data_type_references,
-                            new_depth,
+                            query.data_type_query_depth - 1,
                         )
                         .await?;
                     }
                 }
 
-                if let Some(new_depth) = query.property_type_query_depth.checked_sub(1) {
+                if query.property_type_query_depth > 0 {
                     // TODO: Use relation tables
                     //   see https://app.asana.com/0/0/1202884883200942/f
                     for property_type_ref in property_type.inner.property_type_references() {
@@ -164,7 +164,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                             &mut data_type_references,
                             &mut property_type_references,
                             query.data_type_query_depth,
-                            new_depth,
+                            query.property_type_query_depth - 1,
                         )
                         .await?;
                     }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -161,7 +161,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                 if let Some(new_depth) = property_type_resolve_depth.checked_sub(1) {
                     // TODO: Use relation tables
                     //   see https://app.asana.com/0/0/1202884883200942/f
-                    for property_type_ref in property_type.inner.data_type_references() {
+                    for property_type_ref in property_type.inner.property_type_references() {
                         self.get_property_type_as_dependency(
                             property_type_ref.uri().clone(),
                             &mut data_type_references,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -185,8 +185,8 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
 
                 Ok(PropertyTypeRootedSubgraph {
                     property_type,
-                    data_type_references: data_type_references.into_values().collect(),
-                    property_type_references: property_type_references.into_values().collect(),
+                    referenced_data_types: data_type_references.into_values().collect(),
+                    referenced_property_types: property_type_references.into_values().collect(),
                 })
             })
             .try_collect()

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -22,38 +22,62 @@ use crate::{
 pub trait PersistedOntologyType {
     type Inner;
 
-    fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self;
+    fn from_record(record: OntologyRecord<Self::Inner>) -> Self;
 }
 
 impl PersistedOntologyType for PersistedDataType {
     type Inner = DataType;
 
-    fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self {
-        Self { inner, identifier }
+    fn from_record(data_type: OntologyRecord<Self::Inner>) -> Self {
+        let identifier =
+            PersistedOntologyIdentifier::new(data_type.record.id().clone(), data_type.account_id);
+        Self {
+            inner: data_type.record,
+            identifier,
+        }
     }
 }
 
 impl PersistedOntologyType for PersistedPropertyType {
     type Inner = PropertyType;
 
-    fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self {
-        Self { inner, identifier }
+    fn from_record(property_type: OntologyRecord<Self::Inner>) -> Self {
+        let identifier = PersistedOntologyIdentifier::new(
+            property_type.record.id().clone(),
+            property_type.account_id,
+        );
+        Self {
+            inner: property_type.record,
+            identifier,
+        }
     }
 }
 
 impl PersistedOntologyType for PersistedLinkType {
     type Inner = LinkType;
 
-    fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self {
-        Self { inner, identifier }
+    fn from_record(link_type: OntologyRecord<Self::Inner>) -> Self {
+        let identifier =
+            PersistedOntologyIdentifier::new(link_type.record.id().clone(), link_type.account_id);
+        Self {
+            inner: link_type.record,
+            identifier,
+        }
     }
 }
 
 impl PersistedOntologyType for PersistedEntityType {
     type Inner = EntityType;
 
-    fn new(inner: Self::Inner, identifier: PersistedOntologyIdentifier) -> Self {
-        Self { inner, identifier }
+    fn from_record(entity_type: OntologyRecord<Self::Inner>) -> Self {
+        let identifier = PersistedOntologyIdentifier::new(
+            entity_type.record.id().clone(),
+            entity_type.account_id,
+        );
+        Self {
+            inner: entity_type.record,
+            identifier,
+        }
     }
 }
 
@@ -75,12 +99,7 @@ where
                     .await
                     .change_context(QueryError)?
                 {
-                    Ok(result.then(|| {
-                        let uri = ontology_type.record.versioned_uri();
-                        let identifier =
-                            PersistedOntologyIdentifier::new(uri.clone(), ontology_type.account_id);
-                        T::new(ontology_type.record, identifier)
-                    }))
+                    Ok(result.then(|| T::from_record(ontology_type)))
                 } else {
                     bail!(
                         Report::new(ExpressionError)

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -216,7 +216,7 @@ impl DatabaseApi<'_> {
     ) -> Result<PersistedEntityType, QueryError> {
         Ok(self
             .store
-            .get_entity_type(&Expression::for_versioned_uri(uri), 0, 0, 0)
+            .get_entity_type(&Expression::for_versioned_uri(uri), 0, 0, 0, 0)
             .await?
             .pop()
             .expect("no entity type found")

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -11,8 +11,9 @@ use error_stack::{Report, Result};
 use graph::{
     knowledge::{Entity, EntityId, Link, PersistedEntity, PersistedEntityIdentifier},
     ontology::{
-        AccountId, PersistedDataType, PersistedEntityType, PersistedLinkType,
-        PersistedOntologyIdentifier, PersistedPropertyType,
+        AccountId, DataTypeQuery, EntityTypeQuery, LinkTypeQuery, PersistedDataType,
+        PersistedEntityType, PersistedLinkType, PersistedOntologyIdentifier, PersistedPropertyType,
+        PropertyTypeQuery,
     },
     store::{
         error::LinkRemovalError,
@@ -154,7 +155,10 @@ impl DatabaseApi<'_> {
     ) -> Result<PersistedDataType, QueryError> {
         Ok(self
             .store
-            .get_data_type(&Expression::for_versioned_uri(uri), 0)
+            .get_data_type(&DataTypeQuery {
+                expression: Expression::for_versioned_uri(uri),
+                data_type_query_depth: 0,
+            })
             .await?
             .pop()
             .expect("no data type found")
@@ -185,7 +189,11 @@ impl DatabaseApi<'_> {
     ) -> Result<PersistedPropertyType, QueryError> {
         Ok(self
             .store
-            .get_property_type(&Expression::for_versioned_uri(uri), 0, 0)
+            .get_property_type(&PropertyTypeQuery {
+                expression: Expression::for_versioned_uri(uri),
+                data_type_query_depth: 0,
+                property_type_query_depth: 0,
+            })
             .await?
             .pop()
             .expect("no property type found")
@@ -216,7 +224,13 @@ impl DatabaseApi<'_> {
     ) -> Result<PersistedEntityType, QueryError> {
         Ok(self
             .store
-            .get_entity_type(&Expression::for_versioned_uri(uri), 0, 0, 0, 0)
+            .get_entity_type(&EntityTypeQuery {
+                expression: Expression::for_versioned_uri(uri),
+                data_type_query_depth: 0,
+                property_type_query_depth: 0,
+                link_type_query_depth: 0,
+                entity_type_query_depth: 0,
+            })
             .await?
             .pop()
             .expect("no entity type found")
@@ -247,7 +261,9 @@ impl DatabaseApi<'_> {
     ) -> Result<PersistedLinkType, QueryError> {
         Ok(self
             .store
-            .get_link_type(&Expression::for_versioned_uri(uri))
+            .get_link_type(&LinkTypeQuery {
+                expression: Expression::for_versioned_uri(uri),
+            })
             .await?
             .pop()
             .expect("no link type found")

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -154,10 +154,11 @@ impl DatabaseApi<'_> {
     ) -> Result<PersistedDataType, QueryError> {
         Ok(self
             .store
-            .get_data_type(&Expression::for_versioned_uri(uri))
+            .get_data_type(&Expression::for_versioned_uri(uri), 0)
             .await?
             .pop()
-            .expect("no data type found"))
+            .expect("no data type found")
+            .data_type)
     }
 
     pub async fn update_data_type(
@@ -184,10 +185,11 @@ impl DatabaseApi<'_> {
     ) -> Result<PersistedPropertyType, QueryError> {
         Ok(self
             .store
-            .get_property_type(&Expression::for_versioned_uri(uri))
+            .get_property_type(&Expression::for_versioned_uri(uri), 0, 0)
             .await?
             .pop()
-            .expect("no property type found"))
+            .expect("no property type found")
+            .property_type)
     }
 
     pub async fn update_property_type(
@@ -214,10 +216,11 @@ impl DatabaseApi<'_> {
     ) -> Result<PersistedEntityType, QueryError> {
         Ok(self
             .store
-            .get_entity_type(&Expression::for_versioned_uri(uri))
+            .get_entity_type(&Expression::for_versioned_uri(uri), 0, 0, 0)
             .await?
             .pop()
-            .expect("no entity type found"))
+            .expect("no entity type found")
+            .entity_type)
     }
 
     pub async fn update_entity_type(
@@ -247,7 +250,8 @@ impl DatabaseApi<'_> {
             .get_link_type(&Expression::for_versioned_uri(uri))
             .await?
             .pop()
-            .expect("no link type found"))
+            .expect("no link type found")
+            .link_type)
     }
 
     pub async fn update_link_type(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This moves out the Rust implementation from #1051. It cleans up the linked implementation and also adds implementations for `DataType`, `EntityType` and `LinkType`.

This PR enhances the query REST endpoints to require additional depth parameters. When passing a depth > 0, all referenced types up to a certain depth will also be returned. The depth specifies how deep the recursive lookup will be. E.g. having a property type `A`, which references a property type `B`, which references a property type `C`, which references a data type `D`:
- a `propertyTypeQueryDepth=0` will not return any references
- a `propertyTypeQueryDepth=1` will include `B` in the referenced property types
- a `propertyTypeQueryDepth=2` will return `B` and `C` in the referenced property types
- a `propertyTypeQueryDepth=2` *and* `dataTypeQueryDepth=1` will return `B` and `C` in the referenced property types, and `D` in the referenced data types
- a `propertyTypeQueryDepth < 2` *and* `dataTypeQueryDepth=1` will *not* return `D` because `C` is not returned

See "What does this change" for all added parameters


## 🔗 Related links

- #1051

## 🔍 What does this change?

- For the query endpoints, this adds a `*Query` struct as input and a `*Tree` struct as output
    - `DataTypeQuery` contains the `dataTypeQueryDepth` parameter, which may be used at a later point (currently unused).
    - `PropertyTypeQuery` contains `dataTypeQueryDepth` and `propertyTypeQueryDepth`, see above for an example. Note, that a `dataTypeQueryDepth>1` has no special meaning currently as `DataType`s currently cannot reference other `DataType`s.
    - `EntityTypeQuery` contains `dataTypeQueryDepth`, `propertyTypeQueryDepth`, `linkTypeQueryDepth`, and `entityTypeQueryDepth`. `linkTypeQueryDepth>1` does (currently?) not have any other meaning than `linkTypeQueryDepth=1` as `LinkType`s does not refer to other types.
    - `LinkTypeQuery` has no further parameters and was introduced for persistency 
- Implement logic to resolve the above queries into the flattened trees
- Adjust query endpoints to use these parameters
- generate the OpenAPI client

## 📜 Does this require a change to the docs?

The OpenAPI generator was adjusted to include all types

## ⚠️ Known issues

There currently is a bunch of code duplication between the old endpoints and the query endpoints. This will be resolved as soon as the old endpoints are removed

## 🐾 Next steps

- Support recursive queries in GraphQL (see #1051 for property types)

## 🛡 What tests cover this?

Currently, this is only tested manually

## 📹 Demo

```http
POST http://127.0.0.1:4000/entity-types/query
Content-Type: application/json

{
  "query": {
    "eq": [{ "path": ["version"] }, { "literal": "latest" }]
  },
  "dataTypeQueryDepth": 255,
  "propertyTypeQueryDepth": 255,
  "linkTypeQueryDepth": 255,
  "entityTypeQueryDepth": 255
}
```

```json
[
  {
    "entityType": {
      "inner": {
        "$id": "http://localhost:3000/@alice/types/entity-type/person/v/2",
        "kind": "entityType",
        "links": {
          "http://localhost:3000/@alice/types/link-type/friend-of/v/2": {
            "items": {
              "$ref": "http://localhost:3000/@alice/types/entity-type/person/v/2"
            },
            "ordered": false,
            "type": "array"
          }
        },
        "pluralTitle": "People",
        "properties": {
          "http://localhost:3000/@alice/types/property-type/name/": {
            "$ref": "http://localhost:3000/@alice/types/property-type/name/v/2"
          }
        },
        "title": "Person",
        "type": "object"
      },
      "identifier": {
        "uri": "http://localhost:3000/@alice/types/entity-type/person/v/2",
        "createdBy": "4e8edb0b-6133-4e29-810c-b9a3633accde"
      }
    },
    "dataTypeReferences": [
      {
        "inner": {
          "$id": "http://localhost:3000/@alice/types/data-type/text/v/2",
          "description": "An ordered sequence of characters",
          "kind": "dataType",
          "title": "Text",
          "type": "string"
        },
        "identifier": {
          "uri": "http://localhost:3000/@alice/types/data-type/text/v/2",
          "createdBy": "4e8edb0b-6133-4e29-810c-b9a3633accde"
        }
      }
    ],
    "propertyTypeReferences": [
      {
        "inner": {
          "$id": "http://localhost:3000/@alice/types/property-type/name/v/2",
          "kind": "propertyType",
          "oneOf": [
            {
              "$ref": "http://localhost:3000/@alice/types/data-type/text/v/2"
            }
          ],
          "pluralTitle": "Names",
          "title": "Name"
        },
        "identifier": {
          "uri": "http://localhost:3000/@alice/types/property-type/name/v/2",
          "createdBy": "4e8edb0b-6133-4e29-810c-b9a3633accde"
        }
      }
    ],
    "linkTypeReferences": [
      {
        "inner": {
          "$id": "http://localhost:3000/@alice/types/link-type/friend-of/v/2",
          "description": "Someone who has a shared bond of mutual affection",
          "kind": "linkType",
          "pluralTitle": "Friends Of",
          "relatedKeywords": [
            "social"
          ],
          "title": "Friend Of"
        },
        "identifier": {
          "uri": "http://localhost:3000/@alice/types/link-type/friend-of/v/2",
          "createdBy": "4e8edb0b-6133-4e29-810c-b9a3633accde"
        }
      }
    ],
    "entityTypeReferences": [
      {
        "inner": {
          "$id": "http://localhost:3000/@alice/types/entity-type/person/v/2",
          "kind": "entityType",
          "links": {
            "http://localhost:3000/@alice/types/link-type/friend-of/v/2": {
              "items": {
                "$ref": "http://localhost:3000/@alice/types/entity-type/person/v/2"
              },
              "ordered": false,
              "type": "array"
            }
          },
          "pluralTitle": "People",
          "properties": {
            "http://localhost:3000/@alice/types/property-type/name/": {
              "$ref": "http://localhost:3000/@alice/types/property-type/name/v/2"
            }
          },
          "title": "Person",
          "type": "object"
        },
        "identifier": {
          "uri": "http://localhost:3000/@alice/types/entity-type/person/v/2",
          "createdBy": "4e8edb0b-6133-4e29-810c-b9a3633accde"
        }
      }
    ]
  }
]
```
