### PR TITLE
Fix failing broken integration tests due to timeout

### DIFF
--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list/account-page-list.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list/account-page-list.tsx
@@ -317,7 +317,7 @@ export const AccountPageList: FunctionComponent<AccountPageListProps> = ({
           {pagesLoading ? (
             <PagesLoadingState />
           ) : (
-            <Box sx={{ marginX: 0.75 }}>
+            <Box sx={{ marginX: 0.75 }} data-testid="pages-tree">
               {renderPageTree(treeItems)}
 
               <DragOverlay dropAnimation={null} />

--- a/packages/hash/playwright/tests/page-creation.spec.ts
+++ b/packages/hash/playwright/tests/page-creation.spec.ts
@@ -8,13 +8,10 @@ const pageNameFallback = "Untitled";
 
 const listOfPagesSelector = '[data-testid="pages-tree"]';
 const pageTitleInputSelector = '[placeholder="Untitled"]';
+const createPageButtonSelector = '[data-testid="create-page-btn"]';
 
 const modifierKey = process.platform === "darwin" ? "Meta" : "Control";
 
-/**
- * not calling resetDb in beforeEach
- * because "user can rename page" uses the page created at "user can create page"
- */
 test.beforeEach(async () => {
   await resetDb();
 });
@@ -31,8 +28,9 @@ test("user can create page", async ({ page }) => {
   // TODO: Check URL contains own login once we have replaced uuids implemented
   await page.waitForURL((url) => !!url.pathname.match(/^\/[\w-]+$/));
 
-  // Create the new page
-  await page.locator('[data-testid="create-page-btn"]').click();
+  // TODO: investigate why delay is required for create page button to work
+  await sleep(500);
+  await page.locator(createPageButtonSelector).click();
 
   await page.waitForURL((url) => !!url.pathname.match(/^\/[\w-]+\/[\w-]+$/));
 
@@ -172,7 +170,9 @@ test("user can rename page", async ({ page }) => {
 
   await loginUsingUi({ page, accountShortName: "alice" });
 
-  await page.locator('[data-testid="create-page-btn"]').click();
+  // TODO: investigate why delay is required for create page button to work
+  await sleep(500);
+  await page.locator(createPageButtonSelector).click();
 
   await page.waitForURL((url) => !!url.pathname.match(/^\/[\w-]+\/[\w-]+$/));
 

--- a/packages/hash/playwright/tests/page-creation.spec.ts
+++ b/packages/hash/playwright/tests/page-creation.spec.ts
@@ -15,7 +15,7 @@ const modifierKey = process.platform === "darwin" ? "Meta" : "Control";
  * not calling resetDb in beforeEach
  * because "user can rename page" uses the page created at "user can create page"
  */
-test.beforeAll(async () => {
+test.beforeEach(async () => {
   await resetDb();
 });
 
@@ -171,7 +171,9 @@ test("user can rename page", async ({ page }) => {
   const pageName2 = `Page 2 ${pageNameSuffix}`;
 
   await loginUsingUi({ page, accountShortName: "alice" });
-  await page.click(`text=${pageNameFallback}`);
+
+  await page.locator('[data-testid="create-page-btn"]').click();
+
   await page.waitForURL((url) => !!url.pathname.match(/^\/[\w-]+\/[\w-]+$/));
 
   const listOfPagesLocator = page.locator(listOfPagesSelector);

--- a/packages/hash/playwright/tests/page-readonly-mode.spec.ts
+++ b/packages/hash/playwright/tests/page-readonly-mode.spec.ts
@@ -1,3 +1,4 @@
+import { sleep } from "@hashintel/hash-shared/sleep";
 import { test, expect } from "@playwright/test";
 import { loginUsingUi } from "./utils/login-using-ui";
 import { resetDb } from "./utils/reset-db";
@@ -14,7 +15,8 @@ test("user can view page in read-only mode but not update", async ({
     accountShortName: "alice",
   });
 
-  // Create the new page
+  // TODO: investigate why delay is required for create page button to work
+  await sleep(500);
   await page.locator('[data-testid="create-page-btn"]').click();
 
   await page.waitForURL((url) => !!url.pathname.match(/^\/[\w-]+\/[\w-]+$/));


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes integration tests failing due to timeout

## 🔍 What does this change?

- Adds `sleep(500)` before clicking `create new page` button
- Fixes a page selector