### PR TITLE
Consolidate entityId and accountId for Users/Orgs

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -86,6 +86,12 @@ export interface CreateEntityRequest {
    * @type {string}
    * @memberof CreateEntityRequest
    */
+  entityId?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof CreateEntityRequest
+   */
   entityTypeUri: string;
 }
 /**

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -65,6 +65,7 @@ struct CreateEntityRequest {
     #[component(value_type = String)]
     entity_type_uri: VersionedUri,
     account_id: AccountId,
+    entity_id: Option<EntityId>,
 }
 
 #[utoipa::path(
@@ -89,6 +90,7 @@ async fn create_entity<P: StorePool + Send>(
         entity,
         entity_type_uri,
         account_id,
+        entity_id,
     }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
@@ -97,7 +99,7 @@ async fn create_entity<P: StorePool + Send>(
     })?;
 
     store
-        .create_entity(entity, entity_type_uri, account_id)
+        .create_entity(entity, entity_type_uri, account_id, entity_id)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not create entity");

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -365,11 +365,13 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Expressio
     /// - if the [`EntityType`] doesn't exist
     /// - if the [`Entity`] is not valid with respect to the specified [`EntityType`]
     /// - if the account referred to by `created_by` does not exist
+    /// - if an [`EntityId`] was supplied and already exists in the store
     async fn create_entity(
         &mut self,
         entity: Entity,
         entity_type_uri: VersionedUri,
         created_by: AccountId,
+        entity_id: Option<EntityId>,
     ) -> Result<PersistedEntityIdentifier, InsertionError>;
 
     /// Get the [`PersistedEntity`] specified by the [`Expression`].

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -23,6 +23,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         entity: Entity,
         entity_type_uri: VersionedUri,
         created_by: AccountId,
+        entity_id: Option<EntityId>,
     ) -> Result<PersistedEntityIdentifier, InsertionError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
@@ -32,8 +33,9 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 .change_context(InsertionError)?,
         );
 
-        let entity_id = EntityId::new(Uuid::new_v4());
+        let entity_id = entity_id.unwrap_or_else(|| EntityId::new(Uuid::new_v4()));
 
+        // TODO: return a better error if the ID already exists
         transaction.insert_entity_id(entity_id).await?;
         let identifier = transaction
             .insert_entity(entity_id, entity, entity_type_uri, created_by)

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -35,7 +35,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
 
         let entity_id = entity_id.unwrap_or_else(|| EntityId::new(Uuid::new_v4()));
 
-        // TODO: return a better error if the ID already exists
+        // TODO: match on and return the relevant error
+        //   https://app.asana.com/0/1200211978612931/1202574350052904/f
         transaction.insert_entity_id(entity_id).await?;
         let identifier = transaction
             .insert_entity(entity_id, entity, entity_type_uri, created_by)

--- a/packages/graph/hash_graph/tests/integration/postgres/entity.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/entity.rs
@@ -31,6 +31,7 @@ async fn insert() {
                 .expect("couldn't construct Base URI"),
                 1,
             ),
+            None,
         )
         .await
         .expect("could not create entity");
@@ -66,6 +67,7 @@ async fn query() {
                 .expect("couldn't construct Base URI"),
                 1,
             ),
+            None,
         )
         .await
         .expect("could not create entity");
@@ -98,6 +100,7 @@ async fn update() {
                     .expect("couldn't construct Base URI"),
                 1,
             ),
+            None,
         )
         .await
         .expect("could not create entity");

--- a/packages/graph/hash_graph/tests/integration/postgres/links.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/links.rs
@@ -34,12 +34,12 @@ async fn insert() {
     );
 
     let person_a_identifier = api
-        .create_entity(person_a, person_type_uri.clone())
+        .create_entity(person_a, person_type_uri.clone(), None)
         .await
         .expect("could not create entity");
 
     let person_b_identifier = api
-        .create_entity(person_b, person_type_uri.clone())
+        .create_entity(person_b, person_type_uri.clone(), None)
         .await
         .expect("could not create entity");
 
@@ -97,17 +97,17 @@ async fn get_entity_links() {
     );
 
     let person_a_identifier = api
-        .create_entity(person_a, person_type_uri.clone())
+        .create_entity(person_a, person_type_uri.clone(), None)
         .await
         .expect("could not create entity");
 
     let person_b_identifier = api
-        .create_entity(person_b, person_type_uri.clone())
+        .create_entity(person_b, person_type_uri.clone(), None)
         .await
         .expect("could not create entity");
 
     let person_c_identifier = api
-        .create_entity(person_c, person_type_uri.clone())
+        .create_entity(person_c, person_type_uri.clone(), None)
         .await
         .expect("could not create entity");
 
@@ -177,12 +177,12 @@ async fn remove_link() {
     );
 
     let person_a_identifier = api
-        .create_entity(person_a, person_type_uri.clone())
+        .create_entity(person_a, person_type_uri.clone(), None)
         .await
         .expect("could not create entity");
 
     let person_b_identifier = api
-        .create_entity(person_b, person_type_uri.clone())
+        .create_entity(person_b, person_type_uri.clone(), None)
         .await
         .expect("could not create entity");
 

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -283,9 +283,10 @@ impl DatabaseApi<'_> {
         &mut self,
         entity: Entity,
         entity_type_uri: VersionedUri,
+        entity_id: Option<EntityId>,
     ) -> Result<PersistedEntityIdentifier, InsertionError> {
         self.store
-            .create_entity(entity, entity_type_uri, self.account_id)
+            .create_entity(entity, entity_type_uri, self.account_id, entity_id)
             .await
     }
 

--- a/packages/hash/api/src/graph/workspace-types.ts
+++ b/packages/hash/api/src/graph/workspace-types.ts
@@ -11,7 +11,6 @@ export let WORKSPACE_TYPES: {
   dataType: {};
   propertyType: {
     // General account related
-    accountId: PropertyTypeModel;
     shortName: PropertyTypeModel;
 
     // User-related
@@ -62,9 +61,6 @@ export const orgEntityTypeInitializer = async (graphApi: GraphApi) => {
   const shortnamePropertyTypeModel =
     await WORKSPACE_TYPES_INITIALIZERS.propertyType.shortName(graphApi);
 
-  const accountIdPropertyTypeModel =
-    await WORKSPACE_TYPES_INITIALIZERS.propertyType.accountId(graphApi);
-
   const orgNamePropertyTypeModel =
     await WORKSPACE_TYPES_INITIALIZERS.propertyType.orgName(graphApi);
 
@@ -82,11 +78,6 @@ export const orgEntityTypeInitializer = async (graphApi: GraphApi) => {
         required: true,
       },
       {
-        baseUri: accountIdPropertyTypeModel.baseUri,
-        versionedUri: accountIdPropertyTypeModel.schema.$id,
-        required: true,
-      },
-      {
         baseUri: orgNamePropertyTypeModel.baseUri,
         versionedUri: orgNamePropertyTypeModel.schema.$id,
         required: true,
@@ -99,12 +90,6 @@ export const orgEntityTypeInitializer = async (graphApi: GraphApi) => {
     ],
   })(graphApi);
 };
-
-const accountIdPropertyTypeInitializer = propertyTypeInitializer({
-  namespace: WORKSPACE_ACCOUNT_SHORTNAME,
-  title: "Account ID",
-  possibleValues: [{ primitiveDataType: "Text" }],
-});
 
 const shortnamePropertyTypeInitializer = propertyTypeInitializer({
   namespace: WORKSPACE_ACCOUNT_SHORTNAME,
@@ -152,8 +137,6 @@ const userEntityTypeInitializer = async (graphApi: GraphApi) => {
 
   const kratosIdentityIdPropertyTypeModel =
     await WORKSPACE_TYPES_INITIALIZERS.propertyType.kratosIdentityId(graphApi);
-  const accountIdPropertyTypeModel =
-    await WORKSPACE_TYPES_INITIALIZERS.propertyType.accountId(graphApi);
 
   const preferredNamePropertyTypeModel =
     await WORKSPACE_TYPES_INITIALIZERS.propertyType.preferredName(graphApi);
@@ -179,11 +162,6 @@ const userEntityTypeInitializer = async (graphApi: GraphApi) => {
         required: true,
       },
       {
-        baseUri: accountIdPropertyTypeModel.baseUri,
-        versionedUri: accountIdPropertyTypeModel.schema.$id,
-        required: true,
-      },
-      {
         baseUri: preferredNamePropertyTypeModel.baseUri,
         versionedUri: preferredNamePropertyTypeModel.schema.$id,
         required: true,
@@ -205,7 +183,6 @@ export const WORKSPACE_TYPES_INITIALIZERS: FlattenAndPromisify<
 > = {
   dataType: {},
   propertyType: {
-    accountId: accountIdPropertyTypeInitializer,
     shortName: shortnamePropertyTypeInitializer,
 
     email: emailPropertyTypeInitializer,

--- a/packages/hash/api/src/graphql/resolvers/ontology/data-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/data-type.ts
@@ -19,7 +19,7 @@ export const getAllLatestDataTypes: ResolverFn<
   const { graphApi } = dataSources;
 
   const allLatestDataTypeModels = await DataTypeModel.getAllLatest(graphApi, {
-    accountId: user.getAccountId(),
+    accountId: user.entityId,
   }).catch((err: AxiosError) => {
     throw new ApolloError(
       `Unable to retrieve all latest data types. ${err.response?.data}`,

--- a/packages/hash/api/src/graphql/resolvers/ontology/entity-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/entity-type.ts
@@ -22,7 +22,7 @@ export const createEntityType: ResolverFn<
   const { accountId, entityType } = params;
 
   const createdEntityTypeModel = await EntityTypeModel.create(graphApi, {
-    accountId: accountId ?? user.getAccountId(),
+    accountId: accountId ?? user.entityId,
     schema: entityType,
   }).catch((err) => {
     throw new ApolloError(err, "CREATION_ERROR");
@@ -42,7 +42,7 @@ export const getAllLatestEntityTypes: ResolverFn<
   const allLatestEntityTypeModels = await EntityTypeModel.getAllLatest(
     graphApi,
     {
-      accountId: user.getAccountId(),
+      accountId: user.entityId,
     },
   ).catch((err: AxiosError) => {
     throw new ApolloError(
@@ -94,7 +94,7 @@ export const updateEntityType: ResolverFn<
 
   const updatedEntityTypeModel = await entityTypeModel
     .update(graphApi, {
-      accountId: accountId ?? user.getAccountId(),
+      accountId: accountId ?? user.entityId,
       schema: updatedEntityType,
     })
     .catch((err: AxiosError) => {

--- a/packages/hash/api/src/graphql/resolvers/ontology/link-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/link-type.ts
@@ -22,7 +22,7 @@ export const createLinkType: ResolverFn<
   const { accountId, linkType } = params;
 
   const createdLinkTypeModel = await LinkTypeModel.create(graphApi, {
-    accountId: accountId ?? user.getAccountId(),
+    accountId: accountId ?? user.entityId,
     schema: linkType,
   }).catch((err) => {
     throw new ApolloError(err, "CREATION_ERROR");
@@ -40,7 +40,7 @@ export const getAllLatestLinkTypes: ResolverFn<
   const { graphApi } = dataSources;
 
   const allLatestLinkTypeModels = await LinkTypeModel.getAllLatest(graphApi, {
-    accountId: user.getAccountId(),
+    accountId: user.entityId,
   }).catch((err: AxiosError) => {
     throw new ApolloError(
       `Unable to retrieve all latest link types. ${err.response?.data}`,
@@ -93,7 +93,7 @@ export const updateLinkType: ResolverFn<
 
   const updatedLinkTypeModel = await linkTypeModel
     .update(graphApi, {
-      accountId: accountId ?? user.getAccountId(),
+      accountId: accountId ?? user.entityId,
       schema: updatedLinkType,
     })
     .catch((err: AxiosError) => {

--- a/packages/hash/api/src/graphql/resolvers/ontology/property-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/property-type.ts
@@ -27,7 +27,7 @@ export const createPropertyType: ResolverFn<
   const { accountId, propertyType } = params;
 
   const createdPropertyTypeModel = await PropertyTypeModel.create(graphApi, {
-    accountId: accountId ?? user.getAccountId(),
+    accountId: accountId ?? user.entityId,
     schema: propertyType,
   }).catch((err) => {
     throw new ApolloError(err, "CREATION_ERROR");
@@ -47,7 +47,7 @@ export const getAllLatestPropertyTypes: ResolverFn<
   const propertyTypeSubgraphs = await PropertyTypeModel.getAllLatestResolved(
     graphApi,
     {
-      accountId: user.getAccountId(),
+      accountId: user.entityId,
       dataTypeQueryDepth: dataTypeQueryDepth(info),
       propertyTypeQueryDepth: propertyTypeQueryDepth(info),
     },
@@ -103,7 +103,7 @@ export const updatePropertyType: ResolverFn<
 
   const updatedPropertyTypeModel = await propertyTypeModel
     .update(graphApi, {
-      accountId: accountId ?? user.getAccountId(),
+      accountId: accountId ?? user.entityId,
       schema: updatedPropertyType,
     })
     .catch((err: AxiosError) => {

--- a/packages/hash/api/src/graphql/resolvers/user/util.ts
+++ b/packages/hash/api/src/graphql/resolvers/user/util.ts
@@ -17,7 +17,7 @@ export const mapUserModelToGQL = async (
   user: UserModel,
 ): Promise<UnresolvedGQLUser> => {
   return {
-    accountId: user.getAccountId(),
+    accountId: user.entityId,
     id: user.entityId,
     entityId: user.entityId,
     entityVersionId: user.version,

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -20,6 +20,7 @@ export type EntityModelCreateParams = {
   accountId: string;
   properties: object;
   entityTypeModel: EntityTypeModel;
+  entityId?: string;
 };
 
 /**
@@ -86,7 +87,12 @@ export default class {
    */
   static async create(
     graphApi: GraphApi,
-    { accountId, entityTypeModel, properties }: EntityModelCreateParams,
+    {
+      accountId,
+      entityTypeModel,
+      properties,
+      entityId: overrideEntityId,
+    }: EntityModelCreateParams,
   ): Promise<EntityModel> {
     const {
       data: { entityId, version },
@@ -94,6 +100,7 @@ export default class {
       accountId,
       entityTypeUri: entityTypeModel.schema.$id,
       entity: properties,
+      entityId: overrideEntityId,
     });
 
     return new EntityModel({

--- a/packages/hash/api/src/model/knowledge/org.model.ts
+++ b/packages/hash/api/src/model/knowledge/org.model.ts
@@ -51,7 +51,6 @@ export default class extends EntityModel {
     const { data: orgAccountId } = await graphApi.createAccountId();
 
     const properties: object = {
-      [WORKSPACE_TYPES.propertyType.accountId.baseUri]: orgAccountId,
       [WORKSPACE_TYPES.propertyType.shortName.baseUri]: shortname,
       [WORKSPACE_TYPES.propertyType.orgName.baseUri]: name,
       [WORKSPACE_TYPES.propertyType.orgProvidedInfo.baseUri]: providedInfo
@@ -70,6 +69,7 @@ export default class extends EntityModel {
       accountId: workspaceAccountId,
       properties,
       entityTypeModel,
+      entityId: orgAccountId,
     });
 
     return new OrgModel({
@@ -116,12 +116,6 @@ export default class extends EntityModel {
       .find((org) => org.getShortname() === params.shortname);
 
     return matchingOrg ?? null;
-  }
-
-  getAccountId(): string {
-    return (this.properties as any)[
-      WORKSPACE_TYPES.propertyType.accountId.baseUri
-    ];
   }
 
   getShortname(): string {

--- a/packages/hash/api/src/model/knowledge/user.model.ts
+++ b/packages/hash/api/src/model/knowledge/user.model.ts
@@ -48,7 +48,7 @@ export default class extends EntityModel {
           WORKSPACE_TYPES.entityType.user.schema.$id,
       )
       .map((entityModel) => new UserModel(entityModel))
-      .find((user) => user.getAccountId() === params.accountId);
+      .find((user) => user.entityId === params.accountId);
 
     return matchingUser ?? null;
   }
@@ -171,7 +171,6 @@ export default class extends EntityModel {
     const properties: object = {
       [WORKSPACE_TYPES.propertyType.email.baseUri]: emails,
       [WORKSPACE_TYPES.propertyType.kratosIdentityId.baseUri]: kratosIdentityId,
-      [WORKSPACE_TYPES.propertyType.accountId.baseUri]: userAccountId,
       [WORKSPACE_TYPES.propertyType.shortName.baseUri]: undefined,
       [WORKSPACE_TYPES.propertyType.preferredName.baseUri]: undefined,
     };
@@ -184,6 +183,7 @@ export default class extends EntityModel {
       accountId: workspaceAccountId,
       properties,
       entityTypeModel,
+      entityId: userAccountId,
     });
 
     return new UserModel({
@@ -367,12 +367,6 @@ export default class extends EntityModel {
   getKratosIdentityId(): string {
     return (this.properties as any)[
       WORKSPACE_TYPES.propertyType.kratosIdentityId.baseUri
-    ];
-  }
-
-  getAccountId(): string {
-    return (this.properties as any)[
-      WORKSPACE_TYPES.propertyType.accountId.baseUri
     ];
   }
 

--- a/packages/hash/integration/src/tests/model/knowledge/org.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/org.model.test.ts
@@ -38,20 +38,20 @@ describe("Org model class", () => {
   });
 
   it("can get the account id", () => {
-    expect(createdOrg.getAccountId()).toBeDefined();
+    expect(createdOrg.entityId).toBeDefined();
   });
 
   it("can update the shortname of an org", async () => {
     shortname = "test-org-updated";
     createdOrg = await createdOrg.updateShortname(graphApi, {
-      updatedByAccountId: createdOrg.getAccountId(),
+      updatedByAccountId: createdOrg.entityId,
       updatedShortname: shortname,
     });
   });
 
   it("can update the preferred name of an org", async () => {
     createdOrg = await createdOrg.updateOrgName(graphApi, {
-      updatedByAccountId: createdOrg.getAccountId(),
+      updatedByAccountId: createdOrg.entityId,
       updatedOrgName: "The testing org",
     });
   });

--- a/packages/hash/integration/src/tests/model/knowledge/user.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/user.model.test.ts
@@ -58,19 +58,19 @@ describe("User model class", () => {
   });
 
   it("can get the account id", () => {
-    expect(createdUser.getAccountId()).toBeDefined();
+    expect(createdUser.entityId).toBeDefined();
   });
 
   it("can update the shortname of a user", async () => {
     createdUser = await createdUser.updateShortname(graphApi, {
-      updatedByAccountId: createdUser.getAccountId(),
+      updatedByAccountId: createdUser.entityId,
       updatedShortname: shortname,
     });
   });
 
   it("can update the preferred name of a user", async () => {
     createdUser = await createdUser.updatePreferredName(graphApi, {
-      updatedByAccountId: createdUser.getAccountId(),
+      updatedByAccountId: createdUser.entityId,
       updatedPreferredName: "Alice",
     });
   });

--- a/packages/hash/integration/src/tests/util.ts
+++ b/packages/hash/integration/src/tests/util.ts
@@ -143,7 +143,7 @@ export const createTestUser = async (
       throw err;
     });
 
-  return updatedUser.getAccountId();
+  return updatedUser.entityId;
 };
 
 export class ApiClient {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Users and Orgs had the following IDs:
- Kratos Identifier ID
- Entity ID
- Account ID (stored inside the properties blob)

The last two were deemed duplicative (and confusing) and as such the Account ID inside the properties blob (and its associated property types and accessors) has been removed.

Doing so required us to extend the create_entity endpoint to allow the caller to pass in an `entityId`. This seems a little strange but it could allow the workspace to implement custom ID generation in the future.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1200211978612931/1202937382769276/f) _(internal)_

## 🔍 What does this change?

- Adds an optional `EntityId` parameter on the create entity methods.
- Removes the `accountId` property type and accessors from the User and Org types and Model classes
- Replaces usages of `getAccountId` with `.entityId` for `UserModel` and `OrgModel`

## 📜 Does this require a change to the docs?

- Not to my knowledge

## ⚠️ Known issues

- I don't think we're providing a nice error if the entity ID already exists

## 🐾 Next steps

- Clean-up the tables and fields on things. We want to rename a number of them, for instance `owned_by_id`

## 🛡 What tests cover this?

- The Rust unit tests
- The Rust integration tests
- The HTTP tests
- The "ontology" tests of the workspace
- The "knowledge" integration tests of the workspace

## ❓ How to test this?

1.  Checkout the branch / view the deployment
2. Try running the Graph tests according to the readme.
3. Ensure you take down the docker deployment and clear all volumes.
4. Run `external-services up --build` in the repo root
5. Inside `packages/hash/integration` in another terminal run
  a.  `LOG_LEVEL="debug" yarn jest "ontology" --maxWorkers 1`  
  b.  `LOG_LEVEL="debug" yarn jest "knowledge" --maxWorkers 1`
6. Also try `yarn dev` and check that login works, and that the `/type-editor` route is not broken.
