### PR TITLE
Forbid unsafe code in the HASH graph

### DIFF
--- a/packages/graph/hash_graph/Makefile.toml
+++ b/packages/graph/hash_graph/Makefile.toml
@@ -11,9 +11,14 @@ CARGO_MAKE_CARGO_PROFILE = "production"
 
 [tasks.test]
 run_task = [
-    { name = ["test-task", "yarn", "deployment-up", "test-integration", "generate-openapi-client", "deployment-down"], condition = { env_true = ["CARGO_MAKE_CI" ] } },
+    { name = ["test-task", "yarn", "deployment-up", "test-integration", "generate-openapi-client", "deployment-down"], condition = { env_true = ["CARGO_MAKE_CI"] } },
     { name = ["test-task"] }
 ]
+
+[tasks.miri]
+clear = true
+command = "echo"
+args = ["Miri is disabled as unsafe code is forbidden"]
 
 [tasks.test-integration]
 private = false

--- a/packages/graph/hash_graph/bin/hash_graph/src/main.rs
+++ b/packages/graph/hash_graph/bin/hash_graph/src/main.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 mod args;
 
 use std::{collections::HashMap, fmt, net::SocketAddr, sync::Arc};

--- a/packages/graph/hash_graph/lib/graph/src/lib.rs
+++ b/packages/graph/hash_graph/lib/graph/src/lib.rs
@@ -46,6 +46,14 @@
     clippy::use_debug,
     clippy::verbose_file_reads
 )]
+// Until we do optimization work, there should be no reason to use unsafe code. When allowing unsafe
+// again don't forget to enable miri in the `Makefile.toml`. When allowing unsafe code again, we
+// should prefer `#![deny(unsafe_code)]` and only allow it in a few places unless this gets very
+// verbose.
+#![forbid(
+    unsafe_code,
+    reason = "At the current state, unsafe code should be avoided"
+)]
 #![allow(
     clippy::module_name_repetitions,
     reason = "This encourages importing `as` which breaks IDEs"

--- a/packages/graph/hash_graph/lib/graph/src/lib.rs
+++ b/packages/graph/hash_graph/lib/graph/src/lib.rs
@@ -46,13 +46,15 @@
     clippy::use_debug,
     clippy::verbose_file_reads
 )]
-// Until we do optimization work, there should be no reason to use unsafe code. When allowing unsafe
-// again don't forget to enable miri in the `Makefile.toml`. When allowing unsafe code again, we
-// should prefer `#![deny(unsafe_code)]` and only allow it in a few places unless this gets very
-// verbose.
+// Until we do optimization work, there is unlikely to be any reason to use unsafe code. When it
+// becomes necessary/desirable to allow for unsafe code, we should:
+// - enable miri checks in the CI for the relevant code
+// - swap this lint with `#![deny(unsafe_code)]` and only allow it in a few places unless, or until,
+//   it gets very verbose to do so.
 #![forbid(
     unsafe_code,
-    reason = "At the current state, unsafe code should be avoided"
+    reason = "Unsafe code has been disabled until a good argument has been put forward for its \
+              usage"
 )]
 #![allow(
     clippy::module_name_repetitions,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We don't use any unsafe code in the [HASH](https://hash.ai/platform/hash) graph datastore, and we should avoid it if not strictly necessary. Forbidding `unsafe` also implies, that we don't require to run `miri` on CI, which (a) speeds up CI and (b) allows us to use toolchains, where `miri` is not available.

## 🔍 What does this change?

- Forbid unsafe code (`#![deny(...)]` allows further `#![allow]` statements, `#![forbid(...)` does not)
- Disable `miri`

## 📜 Does this require a change to the docs?

Next to the statement, I put a comment on how we want to proceed, if we require `unsafe`: We should prefer `#![deny(...)]` over removing the statement, unless this gets too verbose.

## 📹 Demo

```
error: declaration of an `unsafe` function
  --> lib/graph/src/lib.rs:78:1
   |
78 | unsafe fn test() {}
   | ^^^^^^^^^^^^^^^^^^^
   |
   = note: At the current state, unsafe code should be avoided
note: the lint level is defined here
  --> lib/graph/src/lib.rs:54:5
   |
54 |     unsafe_code,
   |     ^^^^^^^^^^^
```

```
error[E0453]: expect(unsafe_code) incompatible with previous forbid
  --> lib/graph/src/lib.rs:78:10
   |
54 |     unsafe_code,
   |     ----------- `forbid` level set here
...
78 | #[expect(unsafe_code)]
   |          ^^^^^^^^^^^ overruled by previous forbid
   |
   = note: At the current state, unsafe code should be avoided
```
