### PR TITLE
Rename database columns

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -124,13 +124,13 @@ export interface CreateLinkRequest {
    * @type {string}
    * @memberof CreateLinkRequest
    */
-  ownedById: string;
+  linkTypeUri: string;
   /**
    *
    * @type {string}
    * @memberof CreateLinkRequest
    */
-  linkTypeUri: string;
+  ownedById: string;
   /**
    *
    * @type {string}
@@ -605,13 +605,13 @@ export interface PersistedEntityIdentifier {
    * @type {string}
    * @memberof PersistedEntityIdentifier
    */
-  ownedById: string;
+  entityId: string;
   /**
    *
    * @type {string}
    * @memberof PersistedEntityIdentifier
    */
-  entityId: string;
+  ownedById: string;
   /**
    *
    * @type {string}

--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -962,7 +962,7 @@ export interface RemoveLinkRequest {
    * @type {string}
    * @memberof RemoveLinkRequest
    */
-  removedBy: string;
+  removedById: string;
   /**
    *
    * @type {string}

--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -124,7 +124,7 @@ export interface CreateLinkRequest {
    * @type {string}
    * @memberof CreateLinkRequest
    */
-  createdBy: string;
+  ownedById: string;
   /**
    *
    * @type {string}
@@ -605,7 +605,7 @@ export interface PersistedEntityIdentifier {
    * @type {string}
    * @memberof PersistedEntityIdentifier
    */
-  createdBy: string;
+  ownedById: string;
   /**
    *
    * @type {string}
@@ -668,7 +668,7 @@ export interface PersistedOntologyIdentifier {
    * @type {string}
    * @memberof PersistedOntologyIdentifier
    */
-  createdBy: string;
+  ownedById: string;
   /**
    *
    * @type {string}

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
@@ -54,7 +54,7 @@ struct CreateLinkRequest {
     target_entity_id: EntityId,
     #[component(value_type = String)]
     link_type_uri: VersionedUri,
-    created_by: AccountId,
+    owned_by_id: AccountId,
 }
 
 #[utoipa::path(
@@ -82,7 +82,7 @@ async fn create_link<P: StorePool + Send>(
     let Json(CreateLinkRequest {
         target_entity_id,
         link_type_uri,
-        created_by,
+        owned_by_id,
     }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
@@ -93,7 +93,7 @@ async fn create_link<P: StorePool + Send>(
     let link = Link::new(source_entity_id, target_entity_id, link_type_uri);
 
     store
-        .create_link(&link, created_by)
+        .create_link(&link, owned_by_id)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not create link");

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
@@ -162,7 +162,7 @@ struct RemoveLinkRequest {
     target_entity_id: EntityId,
     #[component(value_type = String)]
     link_type_uri: VersionedUri,
-    removed_by: AccountId,
+    removed_by_id: AccountId,
 }
 
 #[utoipa::path(
@@ -190,7 +190,7 @@ async fn remove_link<P: StorePool + Send>(
     let Json(RemoveLinkRequest {
         target_entity_id,
         link_type_uri,
-        removed_by,
+        removed_by_id,
     }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
@@ -201,7 +201,7 @@ async fn remove_link<P: StorePool + Send>(
     store
         .remove_link(
             &Link::new(source_entity_id, target_entity_id, link_type_uri),
-            removed_by,
+            removed_by_id,
         )
         .await
         .map_err(|report| {

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -48,16 +48,16 @@ pub struct PersistedEntityIdentifier {
     entity_id: EntityId,
     #[component(value_type = String)]
     version: DateTime<Utc>,
-    created_by: AccountId,
+    owned_by_id: AccountId,
 }
 
 impl PersistedEntityIdentifier {
     #[must_use]
-    pub const fn new(entity_id: EntityId, version: DateTime<Utc>, created_by: AccountId) -> Self {
+    pub const fn new(entity_id: EntityId, version: DateTime<Utc>, owned_by_id: AccountId) -> Self {
         Self {
             entity_id,
             version,
-            created_by,
+            owned_by_id,
         }
     }
 
@@ -72,8 +72,8 @@ impl PersistedEntityIdentifier {
     }
 
     #[must_use]
-    pub const fn created_by(&self) -> AccountId {
-        self.created_by
+    pub const fn owned_by_id(&self) -> AccountId {
+        self.owned_by_id
     }
 }
 
@@ -95,11 +95,11 @@ impl PersistedEntity {
         entity_id: EntityId,
         version: DateTime<Utc>,
         type_versioned_uri: VersionedUri,
-        created_by: AccountId,
+        owned_by_id: AccountId,
     ) -> Self {
         Self {
             inner,
-            identifier: PersistedEntityIdentifier::new(entity_id, version, created_by),
+            identifier: PersistedEntityIdentifier::new(entity_id, version, owned_by_id),
             type_versioned_uri,
         }
     }

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -41,13 +41,13 @@ impl fmt::Display for AccountId {
 pub struct PersistedOntologyIdentifier {
     #[component(value_type = String)]
     uri: VersionedUri,
-    created_by: AccountId,
+    owned_by_id: AccountId,
 }
 
 impl PersistedOntologyIdentifier {
     #[must_use]
-    pub const fn new(uri: VersionedUri, created_by: AccountId) -> Self {
-        Self { uri, created_by }
+    pub const fn new(uri: VersionedUri, owned_by_id: AccountId) -> Self {
+        Self { uri, owned_by_id }
     }
 
     #[must_use]
@@ -56,8 +56,8 @@ impl PersistedOntologyIdentifier {
     }
 
     #[must_use]
-    pub const fn created_by(&self) -> AccountId {
-        self.created_by
+    pub const fn owned_by_id(&self) -> AccountId {
+        self.owned_by_id
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -204,14 +204,14 @@ pub trait DataTypeStore: for<'q> crud::Read<PersistedDataType, Query<'q> = Expre
     ///
     /// # Errors:
     ///
-    /// - if the account referred to by `created_by` does not exist.
+    /// - if the account referred to by `owned_by_id` does not exist.
     /// - if the [`BaseUri`] of the `data_type` already exist.
     ///
     /// [`BaseUri`]: type_system::uri::BaseUri
     async fn create_data_type(
         &mut self,
         data_type: DataType,
-        created_by: AccountId,
+        owned_by_id: AccountId,
     ) -> Result<PersistedOntologyIdentifier, InsertionError>;
 
     /// Get the [`DataType`]s specified by the [`Expression`].
@@ -245,14 +245,14 @@ pub trait PropertyTypeStore:
     ///
     /// # Errors:
     ///
-    /// - if the account referred to by `created_by` does not exist.
+    /// - if the account referred to by `owned_by_id` does not exist.
     /// - if the [`BaseUri`] of the `property_type` already exists.
     ///
     /// [`BaseUri`]: type_system::uri::BaseUri
     async fn create_property_type(
         &mut self,
         property_type: PropertyType,
-        created_by: AccountId,
+        owned_by_id: AccountId,
     ) -> Result<PersistedOntologyIdentifier, InsertionError>;
 
     /// Get the [`PropertyType`]s specified by the [`Expression`].
@@ -284,14 +284,14 @@ pub trait EntityTypeStore: for<'q> crud::Read<PersistedEntityType, Query<'q> = E
     ///
     /// # Errors:
     ///
-    /// - if the account referred to by `created_by` does not exist.
+    /// - if the account referred to by `owned_by_id` does not exist.
     /// - if the [`BaseUri`] of the `entity_type` already exist.
     ///
     /// [`BaseUri`]: type_system::uri::BaseUri
     async fn create_entity_type(
         &mut self,
         entity_type: EntityType,
-        created_by: AccountId,
+        owned_by_id: AccountId,
     ) -> Result<PersistedOntologyIdentifier, InsertionError>;
 
     /// Get the [`EntityType`]s specified by the [`Expression`].
@@ -323,14 +323,14 @@ pub trait LinkTypeStore: for<'q> crud::Read<PersistedLinkType, Query<'q> = Expre
     ///
     /// # Errors:
     ///
-    /// - if the account referred to by `created_by` does not exist.
+    /// - if the account referred to by `owned_by_id` does not exist.
     /// - if the [`BaseUri`] of the `property_type` already exists.
     ///
     /// [`BaseUri`]: type_system::uri::BaseUri
     async fn create_link_type(
         &mut self,
         link_type: LinkType,
-        created_by: AccountId,
+        owned_by_id: AccountId,
     ) -> Result<PersistedOntologyIdentifier, InsertionError>;
 
     /// Get the [`LinkType`]s specified by the [`Expression`].
@@ -364,13 +364,13 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Expressio
     ///
     /// - if the [`EntityType`] doesn't exist
     /// - if the [`Entity`] is not valid with respect to the specified [`EntityType`]
-    /// - if the account referred to by `created_by` does not exist
+    /// - if the account referred to by `owned_by_id` does not exist
     /// - if an [`EntityId`] was supplied and already exists in the store
     async fn create_entity(
         &mut self,
         entity: Entity,
         entity_type_uri: VersionedUri,
-        created_by: AccountId,
+        owned_by_id: AccountId,
         entity_id: Option<EntityId>,
     ) -> Result<PersistedEntityIdentifier, InsertionError>;
 
@@ -409,11 +409,11 @@ pub trait LinkStore: for<'q> crud::Read<Link, Query<'q> = Expression> {
     ///
     /// - if the [`Link`] exists already
     /// - if the [`Link`]s [`LinkType`] doesn't exist
-    /// - if the account referred to by `created_by` does not exist
+    /// - if the account referred to by `owned_by_id` does not exist
     async fn create_link(
         &mut self,
         link: &Link,
-        created_by: AccountId,
+        owned_by_id: AccountId,
     ) -> Result<(), InsertionError>;
 
     /// Get the [`Link`]s specified by the [`Expression`].
@@ -431,7 +431,7 @@ pub trait LinkStore: for<'q> crud::Read<Link, Query<'q> = Expression> {
     ///
     /// - if the [`Link`] doesn't exist
     /// - if the[`Link`]s [`LinkType`] doesn't exist
-    /// - if the account referred to by `created_by` does not exist
+    /// - if the account referred to by `owned_by_id` does not exist
     async fn remove_link(
         &mut self,
         link: &Link,

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -435,6 +435,6 @@ pub trait LinkStore: for<'q> crud::Read<Link, Query<'q> = Expression> {
     async fn remove_link(
         &mut self,
         link: &Link,
-        removed_by: AccountId,
+        removed_by_id: AccountId,
     ) -> Result<(), LinkRemovalError>;
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/context/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/context/entity.rs
@@ -44,10 +44,10 @@ pub async fn read_all_entities(client: &impl AsClient) -> Result<RecordStream, Q
         .as_client()
         .query_raw(
             r#"
-            SELECT properties, entity_id, entities.version, ids.base_uri, ids.version, created_by, MAX(entities.version) OVER (PARTITION by entity_id) = entities.version as latest
+            SELECT properties, entity_id, entities.version, type_ids.base_uri, type_ids.version, created_by, MAX(entities.version) OVER (PARTITION by entity_id) = entities.version as latest
             FROM entities
-            INNER JOIN ids
-            ON ids.version_id = entities.entity_type_version_id
+            INNER JOIN type_ids
+            ON type_ids.version_id = entities.entity_type_version_id
             ORDER BY entity_id, entities.version DESC;
             "#,
             parameter_list([]),
@@ -65,9 +65,9 @@ pub async fn read_latest_entity_by_id(
         .as_client()
         .query_one(
             r#"
-            SELECT properties, entity_id, entities.version, ids.base_uri, ids.version, created_by
+            SELECT properties, entity_id, entities.version, type_ids.base_uri, type_ids.version, created_by
             FROM entities
-            INNER JOIN ids ON ids.version_id = entities.entity_type_version_id
+            INNER JOIN type_ids ON type_ids.version_id = entities.entity_type_version_id
             WHERE entity_id = $1 AND entities.version = (
                 SELECT MAX("version")
                 FROM entities

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/context/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/context/entity.rs
@@ -44,7 +44,7 @@ pub async fn read_all_entities(client: &impl AsClient) -> Result<RecordStream, Q
         .as_client()
         .query_raw(
             r#"
-            SELECT properties, entity_id, entities.version, type_ids.base_uri, type_ids.version, created_by, MAX(entities.version) OVER (PARTITION by entity_id) = entities.version as latest
+            SELECT properties, entity_id, entities.version, type_ids.base_uri, type_ids.version, owned_by_id, MAX(entities.version) OVER (PARTITION by entity_id) = entities.version as latest
             FROM entities
             INNER JOIN type_ids
             ON type_ids.version_id = entities.entity_type_version_id
@@ -65,7 +65,7 @@ pub async fn read_latest_entity_by_id(
         .as_client()
         .query_one(
             r#"
-            SELECT properties, entity_id, entities.version, type_ids.base_uri, type_ids.version, created_by
+            SELECT properties, entity_id, entities.version, type_ids.base_uri, type_ids.version, owned_by_id
             FROM entities
             INNER JOIN type_ids ON type_ids.version_id = entities.entity_type_version_id
             WHERE entity_id = $1 AND entities.version = (

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/context/links.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/context/links.rs
@@ -39,7 +39,7 @@ pub async fn read_all_links(client: &impl AsClient) -> Result<RecordStream, Quer
         .as_client()
         .query_raw(
             r#"
-            SELECT base_uri, version, source_entity_id, target_entity_id, created_by
+            SELECT base_uri, version, source_entity_id, target_entity_id, owned_by_id
             FROM links
             JOIN type_ids ON version_id = link_type_version_id
             -- Nulls will be last with default ascending order (default is ASC NULLS LAST)
@@ -61,7 +61,7 @@ pub async fn read_links_by_source(
         .as_client()
         .query_raw(
             r#"
-            SELECT base_uri, version, source_entity_id, target_entity_id, created_by
+            SELECT base_uri, version, source_entity_id, target_entity_id, owned_by_id
             FROM links
             JOIN type_ids ON version_id = link_type_version_id
             WHERE source_entity_id = $1
@@ -84,7 +84,7 @@ pub async fn read_links_by_target(
         .as_client()
         .query_raw(
             r#"
-            SELECT base_uri, version, source_entity_id, target_entity_id, created_by
+            SELECT base_uri, version, source_entity_id, target_entity_id, owned_by_id
             FROM links
             JOIN type_ids ON version_id = link_type_version_id
             WHERE target_entity_id = $1

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/context/links.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/context/links.rs
@@ -41,7 +41,7 @@ pub async fn read_all_links(client: &impl AsClient) -> Result<RecordStream, Quer
             r#"
             SELECT base_uri, version, source_entity_id, target_entity_id, created_by
             FROM links
-            JOIN ids ON version_id = link_type_version_id
+            JOIN type_ids ON version_id = link_type_version_id
             -- Nulls will be last with default ascending order (default is ASC NULLS LAST)
             ORDER BY link_order ASC
             "#,
@@ -63,7 +63,7 @@ pub async fn read_links_by_source(
             r#"
             SELECT base_uri, version, source_entity_id, target_entity_id, created_by
             FROM links
-            JOIN ids ON version_id = link_type_version_id
+            JOIN type_ids ON version_id = link_type_version_id
             WHERE source_entity_id = $1
             -- Nulls will be last with default ascending order (default is ASC NULLS LAST)
             ORDER BY link_order ASC
@@ -86,7 +86,7 @@ pub async fn read_links_by_target(
             r#"
             SELECT base_uri, version, source_entity_id, target_entity_id, created_by
             FROM links
-            JOIN ids ON version_id = link_type_version_id
+            JOIN type_ids ON version_id = link_type_version_id
             WHERE target_entity_id = $1
             "#,
             parameter_list([&entity_id]),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/context/ontology.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/context/ontology.rs
@@ -57,7 +57,7 @@ where
         .query_raw(
             &format!(
                 r#"
-                SELECT schema, created_by, MAX(version) OVER (PARTITION by base_uri) = version as latest
+                SELECT schema, owned_by_id, MAX(version) OVER (PARTITION by base_uri) = version as latest
                 FROM {table} type_table
                 INNER JOIN type_ids
                 ON type_table.version_id = type_ids.version_id
@@ -83,7 +83,7 @@ where
         .query_one(
             &format!(
                 r#"
-                SELECT schema, created_by, (
+                SELECT schema, owned_by_id, (
                     SELECT MAX(version) as latest
                     FROM type_ids
                     WHERE base_uri = $1

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/context/ontology.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/context/ontology.rs
@@ -59,8 +59,8 @@ where
                 r#"
                 SELECT schema, created_by, MAX(version) OVER (PARTITION by base_uri) = version as latest
                 FROM {table} type_table
-                INNER JOIN ids
-                ON type_table.version_id = ids.version_id
+                INNER JOIN type_ids
+                ON type_table.version_id = type_ids.version_id
                 ORDER BY base_uri, version DESC;
                 "#,
             ),
@@ -85,12 +85,12 @@ where
                 r#"
                 SELECT schema, created_by, (
                     SELECT MAX(version) as latest
-                    FROM ids
+                    FROM type_ids
                     WHERE base_uri = $1
                 )
                 FROM {} type_table
-                INNER JOIN ids
-                ON type_table.version_id = ids.version_id
+                INNER JOIN type_ids
+                ON type_table.version_id = type_ids.version_id
                 WHERE base_uri = $1 AND version = $2;
                 "#,
                 T::table()

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -22,7 +22,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         &mut self,
         entity: Entity,
         entity_type_uri: VersionedUri,
-        created_by: AccountId,
+        owned_by_id: AccountId,
         entity_id: Option<EntityId>,
     ) -> Result<PersistedEntityIdentifier, InsertionError> {
         let transaction = PostgresStore::new(
@@ -39,7 +39,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         //   https://app.asana.com/0/1200211978612931/1202574350052904/f
         transaction.insert_entity_id(entity_id).await?;
         let identifier = transaction
-            .insert_entity(entity_id, entity, entity_type_uri, created_by)
+            .insert_entity(entity_id, entity, entity_type_uri, owned_by_id)
             .await?;
 
         transaction

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/mod.rs
@@ -16,7 +16,7 @@ impl<C: AsClient> LinkStore for PostgresStore<C> {
     async fn create_link(
         &mut self,
         link: &Link,
-        created_by: AccountId,
+        owned_by_id: AccountId,
     ) -> Result<(), InsertionError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
@@ -26,7 +26,7 @@ impl<C: AsClient> LinkStore for PostgresStore<C> {
                 .change_context(InsertionError)?,
         );
 
-        transaction.insert_link(link, created_by).await?;
+        transaction.insert_link(link, owned_by_id).await?;
 
         transaction
             .client

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/mod.rs
@@ -41,7 +41,7 @@ impl<C: AsClient> LinkStore for PostgresStore<C> {
     async fn remove_link(
         &mut self,
         link: &Link,
-        removed_by: AccountId,
+        removed_by_id: AccountId,
     ) -> Result<(), LinkRemovalError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
@@ -51,7 +51,9 @@ impl<C: AsClient> LinkStore for PostgresStore<C> {
                 .change_context(LinkRemovalError)?,
         );
 
-        transaction.move_link_to_history(link, removed_by).await?;
+        transaction
+            .move_link_to_history(link, removed_by_id)
+            .await?;
 
         transaction
             .client

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -167,7 +167,7 @@ where
                 r#"
                     SELECT EXISTS(
                         SELECT 1
-                        FROM ids
+                        FROM type_ids
                         WHERE base_uri = $1 AND version = $2
                     );
                 "#,
@@ -243,7 +243,7 @@ where
         self.as_client()
             .query_one(
                 r#"
-                    INSERT INTO ids (base_uri, version, version_id)
+                    INSERT INTO type_ids (base_uri, version, version_id)
                     VALUES ($1, $2, $3)
                     RETURNING version_id;
                 "#,
@@ -680,7 +680,7 @@ where
             .query_one(
                 r#"
                 SELECT version_id
-                FROM ids
+                FROM type_ids
                 WHERE base_uri = $1 AND version = $2;
                 "#,
                 &[&uri.base_uri().as_str(), &version],

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -738,7 +738,7 @@ where
     async fn move_link_to_history(
         &self,
         link: &Link,
-        removed_by: AccountId,
+        removed_by_id: AccountId,
     ) -> Result<(), LinkRemovalError> {
         let link_type_version_id = self
             .version_id_by_uri(link.link_type_uri())
@@ -761,8 +761,8 @@ where
                     link_order, owned_by_id, created_at
                 )
                 INSERT INTO link_histories(source_entity_id, target_entity_id, link_type_version_id,
-                    link_order, owned_by_id, created_at, removed_by, removed_at)
-                -- When inserting into `link_histories`, `removed_by` and `removed_at` are provided
+                    link_order, owned_by_id, created_at, removed_by_id, removed_at)
+                -- When inserting into `link_histories`, `removed_by_id` and `removed_at` are provided
                 SELECT *, $4, clock_timestamp() FROM removed
                 RETURNING source_entity_id, target_entity_id, link_type_version_id;
                 "#,
@@ -770,7 +770,7 @@ where
                     &link.source_entity(),
                     &link.target_entity(),
                     &link_type_version_id,
-                    &removed_by,
+                    &removed_by_id,
                 ],
             )
             .await

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -56,7 +56,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
     async fn create_data_type(
         &mut self,
         data_type: DataType,
-        created_by: AccountId,
+        owned_by_id: AccountId,
     ) -> Result<PersistedOntologyIdentifier, InsertionError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
@@ -66,7 +66,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
                 .change_context(InsertionError)?,
         );
 
-        let (_, identifier) = transaction.create(data_type, created_by).await?;
+        let (_, identifier) = transaction.create(data_type, owned_by_id).await?;
 
         transaction
             .client

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
@@ -139,7 +139,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
     async fn create_entity_type(
         &mut self,
         entity_type: EntityType,
-        created_by: AccountId,
+        owned_by_id: AccountId,
     ) -> Result<PersistedOntologyIdentifier, InsertionError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
@@ -152,7 +152,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         // This clone is currently necessary because we extract the references as we insert them.
         // We can only insert them after the type has been created, and so we currently extract them
         // after as well. See `insert_entity_type_references` taking `&entity_type`
-        let (version_id, identifier) = transaction.create(entity_type.clone(), created_by).await?;
+        let (version_id, identifier) = transaction.create(entity_type.clone(), owned_by_id).await?;
 
         transaction
             .insert_entity_type_references(&entity_type, version_id)

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
@@ -55,7 +55,7 @@ impl<C: AsClient> LinkTypeStore for PostgresStore<C> {
     async fn create_link_type(
         &mut self,
         link_type: LinkType,
-        created_by: AccountId,
+        owned_by_id: AccountId,
     ) -> Result<PersistedOntologyIdentifier, InsertionError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
@@ -65,7 +65,7 @@ impl<C: AsClient> LinkTypeStore for PostgresStore<C> {
                 .change_context(InsertionError)?,
         );
 
-        let (_, identifier) = transaction.create(link_type, created_by).await?;
+        let (_, identifier) = transaction.create(link_type, owned_by_id).await?;
 
         transaction
             .client

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -108,7 +108,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
     async fn create_property_type(
         &mut self,
         property_type: PropertyType,
-        created_by: AccountId,
+        owned_by_id: AccountId,
     ) -> Result<PersistedOntologyIdentifier, InsertionError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
@@ -122,7 +122,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         // We can only insert them after the type has been created, and so we currently extract them
         // after as well. See `insert_property_type_references` taking `&property_type`
         let (version_id, identifier) = transaction
-            .create(property_type.clone(), created_by)
+            .create(property_type.clone(), owned_by_id)
             .await?;
 
         transaction

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -383,7 +383,7 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "createdBy": "{{account_id}}",
+  "ownedById": "{{account_id}}",
   "targetEntityId": "{{person_b_entity_id}}",
   "linkTypeUri": "{{friend_of_link_type_uri_raw}}"
 }

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -416,7 +416,7 @@ Accept: application/json
 {
   "targetEntityId": "{{person_b_entity_id}}",
   "linkTypeUri": "{{friend_of_link_type_uri_raw}}",
-  "removedBy": "{{account_id}}"
+  "removedById": "{{account_id}}"
 }
 
 > {%

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -389,7 +389,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         type: "TIMESTAMP WITH TIME ZONE",
         notNull: true,
       },
-      removed_by: {
+      removed_by_id: {
         type: "UUID",
         notNull: true,
         references: "accounts",

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -10,8 +10,6 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       account_id: {
         type: "UUID",
         primaryKey: true,
-        comment:
-          "Accounts are undecided and just here for satisfying the future schema",
       },
     },
     {
@@ -45,9 +43,8 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     },
   );
 
-  // TODO: rename ids to type_ids
   pgm.createTable(
-    "ids",
+    "type_ids",
     {
       base_uri: {
         type: "TEXT",
@@ -71,7 +68,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         `),
     },
   );
-  pgm.addConstraint("ids", "ids_primary_key", {
+  pgm.addConstraint("type_ids", "type_ids_primary_key", {
     primaryKey: ["base_uri", "version"],
   });
 

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -72,7 +72,6 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     primaryKey: ["base_uri", "version"],
   });
 
-  // TODO: consider changing `created_by` to `author` or something in all tables : https://app.asana.com/0/1201095311341924/1202769355319303/f
   pgm.createTable(
     "data_types",
     {
@@ -85,7 +84,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         type: "JSONB",
         notNull: true,
       },
-      created_by: {
+      owned_by_id: {
         type: "UUID",
         notNull: true,
         references: "accounts",
@@ -108,7 +107,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         type: "JSONB",
         notNull: true,
       },
-      created_by: {
+      owned_by_id: {
         type: "UUID",
         notNull: true,
         references: "accounts",
@@ -130,7 +129,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         type: "JSONB",
         notNull: true,
       },
-      created_by: {
+      owned_by_id: {
         type: "UUID",
         notNull: true,
         references: "accounts",
@@ -153,7 +152,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         type: "JSONB",
         notNull: true,
       },
-      created_by: {
+      owned_by_id: {
         type: "UUID",
         notNull: true,
         references: "accounts",
@@ -293,7 +292,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         type: "JSONB",
         notNull: true,
       },
-      created_by: {
+      owned_by_id: {
         type: "UUID",
         notNull: true,
         references: "accounts",
@@ -331,7 +330,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         type: "integer",
         notNull: false,
       },
-      created_by: {
+      owned_by_id: {
         type: "UUID",
         notNull: true,
         references: "accounts",
@@ -381,7 +380,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         type: "integer",
         notNull: false,
       },
-      created_by: {
+      owned_by_id: {
         type: "UUID",
         notNull: true,
         references: "accounts",

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -54,7 +54,7 @@ export default class {
     { identifier, inner, typeVersionedUri }: PersistedEntity,
     cachedEntityTypeModels?: Map<string, EntityTypeModel>,
   ): Promise<EntityModel> {
-    const { createdBy: accountId, version } = identifier;
+    const { ownedById: accountId, version } = identifier;
     const cachedEntityTypeModel = cachedEntityTypeModels?.get(typeVersionedUri);
 
     let entityTypeModel: EntityTypeModel;

--- a/packages/hash/api/src/model/knowledge/link.model.ts
+++ b/packages/hash/api/src/model/knowledge/link.model.ts
@@ -60,7 +60,7 @@ export default class {
     const {
       data: { sourceEntityId, linkTypeUri, targetEntityId },
     } = await graphApi.createLink(sourceEntityModel.entityId, {
-      createdBy,
+      ownedById: createdBy,
       linkTypeUri: linkTypeModel.schema.$id,
       targetEntityId: targetEntityModel.entityId,
     });
@@ -95,7 +95,7 @@ export default class {
     await graphApi.removeLink(this.sourceEntityModel.entityId, {
       linkTypeUri: this.linkTypeModel.schema.$id,
       targetEntityId: this.targetEntityModel.entityId,
-      removedBy,
+      removedById: removedBy,
     });
   }
 

--- a/packages/hash/api/src/model/ontology/data-type.model.ts
+++ b/packages/hash/api/src/model/ontology/data-type.model.ts
@@ -46,7 +46,7 @@ export default class {
      */
     return new DataTypeModel({
       schema: inner as DataType,
-      accountId: identifier.createdBy,
+      accountId: identifier.ownedById,
     });
   }
 
@@ -111,7 +111,7 @@ export default class {
 
     return new DataTypeModel({
       schema: fullDataType,
-      accountId: identifier.createdBy,
+      accountId: identifier.ownedById,
     });
   }
 
@@ -190,7 +190,7 @@ export default class {
 
     return new DataTypeModel({
       schema: { ...schema, $id: identifier.uri },
-      accountId: identifier.createdBy,
+      accountId: identifier.ownedById,
     });
   }
 }

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -86,7 +86,7 @@ export default class {
 
     return new EntityTypeModel({
       schema: fullEntityType,
-      accountId: identifier.createdBy,
+      accountId: identifier.ownedById,
     });
   }
 
@@ -123,7 +123,7 @@ export default class {
            *   https://app.asana.com/0/1202805690238892/1202892835843657/f
            */
           schema: persistedEntityType.inner as EntityType,
-          accountId: persistedEntityType.identifier.createdBy,
+          accountId: persistedEntityType.identifier.ownedById,
         }),
     );
   }
@@ -158,7 +158,7 @@ export default class {
        *   https://app.asana.com/0/1202805690238892/1202892835843657/f
        */
       schema: persistedEntityType.inner as EntityType,
-      accountId: persistedEntityType.identifier.createdBy,
+      accountId: persistedEntityType.identifier.ownedById,
     });
   }
 
@@ -188,7 +188,7 @@ export default class {
 
     return new EntityTypeModel({
       schema: { ...schema, $id: identifier.uri },
-      accountId: identifier.createdBy,
+      accountId: identifier.ownedById,
     });
   }
 

--- a/packages/hash/api/src/model/ontology/link-type.model.ts
+++ b/packages/hash/api/src/model/ontology/link-type.model.ts
@@ -76,7 +76,7 @@ export default class {
 
     return new LinkTypeModel({
       schema: fullLinkType,
-      accountId: identifier.createdBy,
+      accountId: identifier.ownedById,
     });
   }
 
@@ -101,7 +101,7 @@ export default class {
       (persistedLinkType) =>
         new LinkTypeModel({
           schema: persistedLinkType.inner,
-          accountId: persistedLinkType.identifier.createdBy,
+          accountId: persistedLinkType.identifier.ownedById,
         }),
     );
   }
@@ -125,7 +125,7 @@ export default class {
 
     return new LinkTypeModel({
       schema: persistedLinkType.inner,
-      accountId: persistedLinkType.identifier.createdBy,
+      accountId: persistedLinkType.identifier.ownedById,
     });
   }
 
@@ -153,7 +153,7 @@ export default class {
 
     return new LinkTypeModel({
       schema: { ...schema, $id: identifier.uri },
-      accountId: identifier.createdBy,
+      accountId: identifier.ownedById,
     });
   }
 }

--- a/packages/hash/api/src/model/ontology/property-type.model.ts
+++ b/packages/hash/api/src/model/ontology/property-type.model.ts
@@ -51,7 +51,7 @@ export default class {
      */
     return new PropertyTypeModel({
       schema: inner as PropertyType,
-      accountId: identifier.createdBy,
+      accountId: identifier.ownedById,
     });
   }
 
@@ -106,7 +106,7 @@ export default class {
 
     return new PropertyTypeModel({
       schema: fullPropertyType,
-      accountId: identifier.createdBy,
+      accountId: identifier.ownedById,
     });
   }
 
@@ -274,7 +274,7 @@ export default class {
 
     return new PropertyTypeModel({
       schema: { ...schema, $id: identifier.uri },
-      accountId: identifier.createdBy,
+      accountId: identifier.ownedById,
     });
   }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

There were a few confusing / non-ideal column names in the database. This PR simply updates them and the relevant usages in the Graph. It does not propagate those renames through the workspace code, as that is a larger task ([tracked in this](https://app.asana.com/0/0/1202986802899184/f))

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1202882583267702/1202986802899183/f) _(internal)_

## 🔍 What does this change?

- Completes a TODO to rename `ids` to `type_ids`
- Renames `created_by` to `owned_by_id`
- Renames `removed_by` to `removed_by_id`

## 📜 Does this require a change to the docs?

- Not to my knowledge

## ⚠️ Known issues

This introduces some inconsistency whereby the workspace now has `accountId`, and `ownedByAccountId` and other things throughout its code. We will want to unify the naming.

## 🐾 Next steps

Refactor the Workspace backend (and possibly frontend) code to be consistent with the naming. This will likely be done post merge into main.

## 🛡 What tests cover this?

- The Rust unit tests
- The Rust integration tests
- The HTTP tests
- The "ontology" tests of the workspace
- The "knowledge" integration tests of the workspace

## ❓ How to test this?

1.  Checkout the branch / view the deployment
2. Try running the Graph tests according to the readme.
3. Ensure you take down the docker deployment and clear all volumes.
4. Run `external-services up --build` in the repo root
5. Inside `packages/hash/integration` in another terminal run
  a.  `LOG_LEVEL="debug" yarn jest "ontology" --maxWorkers 1`  
  b.  `LOG_LEVEL="debug" yarn jest "knowledge" --maxWorkers 1`
6. Also try `yarn dev` and check that login works, and that the `/type-editor` route is not broken.
