### PR TITLE
Bump toolchain to `nightly-2022-09-15`

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
@@ -146,17 +146,18 @@ pub fn rest_api_router<P: StorePool + Send + 'static>(
 async fn serve_static_schema(Path(path): Path<String>) -> Result<Response, StatusCode> {
     let path = path.trim_start_matches('/');
 
-    match STATIC_SCHEMAS.get_file(path) {
-        None => Err(StatusCode::NOT_FOUND),
-        Some(file) => Ok((
-            [(
-                axum::http::header::CONTENT_TYPE,
-                axum::http::HeaderValue::from_static("application/json"),
-            )],
-            file.contents(),
-        )
-            .into_response()),
-    }
+    STATIC_SCHEMAS
+        .get_file(path)
+        .map_or(Err(StatusCode::NOT_FOUND), |file| {
+            Ok((
+                [(
+                    axum::http::header::CONTENT_TYPE,
+                    axum::http::HeaderValue::from_static("application/json"),
+                )],
+                file.contents(),
+            )
+                .into_response())
+        })
 }
 
 #[derive(OpenApi)]

--- a/packages/graph/hash_graph/lib/graph/src/lib.rs
+++ b/packages/graph/hash_graph/lib/graph/src/lib.rs
@@ -4,8 +4,6 @@
 #![feature(lint_reasons)]
 // Not required, reason: Use `std` feature rather than external crate
 #![feature(once_cell)]
-// Not required, reason: Easier than having a separated trait with lifetime bounds
-#![feature(generic_associated_types)]
 // Not required, reason: Simpler than using blanket implementations
 #![feature(trait_alias)]
 // Not required, reason: much more simple bounds

--- a/packages/graph/hash_graph/lib/graph/src/logging/init.rs
+++ b/packages/graph/hash_graph/lib/graph/src/logging/init.rs
@@ -60,12 +60,17 @@ pub fn init_logger<P: AsRef<Path>>(
     let log_folder = log_folder.as_ref();
 
     let filter = log_level.map_or_else(
-        || match std::env::var("RUST_LOG") {
-            Ok(env) => EnvFilter::new(env),
-            #[cfg(debug_assertions)]
-            _ => EnvFilter::default().add_directive(Directive::from(LevelFilter::DEBUG)),
-            #[cfg(not(debug_assertions))]
-            _ => EnvFilter::default().add_directive(Directive::from(LevelFilter::WARN)),
+        || {
+            std::env::var("RUST_LOG").map_or_else(
+                |_| {
+                    if cfg!(debug_assertions) {
+                        EnvFilter::default().add_directive(Directive::from(LevelFilter::DEBUG))
+                    } else {
+                        EnvFilter::default().add_directive(Directive::from(LevelFilter::WARN))
+                    }
+                },
+                EnvFilter::new,
+            )
         },
         |log_level| EnvFilter::default().add_directive(Directive::from(log_level)),
     );

--- a/packages/graph/hash_graph/lib/graph/src/store/pool.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/pool.rs
@@ -10,9 +10,7 @@ pub trait StorePool: Sync {
     type Error;
 
     /// The store returned when acquiring.
-    type Store<'pool>: Store + Send
-    where
-        Self: 'pool;
+    type Store<'pool>: Store + Send;
 
     /// Retrieves a [`Store`] from the pool.
     async fn acquire(&self) -> Result<Self::Store<'_>, Self::Error>;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/context/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/context/entity.rs
@@ -21,7 +21,9 @@ pub struct EntityRecord {
 
 pub type RecordStream = impl Stream<Item = Result<EntityRecord, QueryError>>;
 
-fn row_stream_to_record_stream(row_stream: RowStream) -> RecordStream {
+fn row_stream_to_record_stream(
+    row_stream: RowStream,
+) -> impl Stream<Item = Result<EntityRecord, QueryError>> {
     row_stream.map(|row_result| {
         let row = row_result.into_report().change_context(QueryError)?;
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/context/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/context/entity.rs
@@ -42,7 +42,7 @@ fn row_stream_to_record_stream(
 }
 
 pub async fn read_all_entities(client: &impl AsClient) -> Result<RecordStream, QueryError> {
-    let row_stream= client
+    let row_stream = client
         .as_client()
         .query_raw(
             r#"
@@ -55,7 +55,8 @@ pub async fn read_all_entities(client: &impl AsClient) -> Result<RecordStream, Q
             parameter_list([]),
         )
         .await
-        .into_report().change_context(QueryError)?;
+        .into_report()
+        .change_context(QueryError)?;
     Ok(row_stream_to_record_stream(row_stream))
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/context/links.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/context/links.rs
@@ -18,7 +18,9 @@ pub struct LinkRecord {
 
 pub type RecordStream = impl Stream<Item = Result<LinkRecord, QueryError>>;
 
-fn row_stream_to_record_stream(row_stream: RowStream) -> RecordStream {
+fn row_stream_to_record_stream(
+    row_stream: RowStream,
+) -> impl Stream<Item = Result<LinkRecord, QueryError>> {
     row_stream.map(|row_result| {
         let row = row_result.into_report().change_context(QueryError)?;
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/context/ontology.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/context/ontology.rs
@@ -27,7 +27,9 @@ pub struct OntologyRecord<T> {
     pub is_latest: bool,
 }
 
-fn row_stream_to_record_stream<T>(row_stream: RowStream) -> RecordStream<T>
+fn row_stream_to_record_stream<T>(
+    row_stream: RowStream,
+) -> impl Stream<Item = Result<OntologyRecord<T>, QueryError>>
 where
     T: TryFrom<serde_json::Value, Error: Context>,
 {

--- a/packages/graph/hash_graph/rust-toolchain.toml
+++ b/packages/graph/hash_graph/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "nightly-2022-08-08"
+channel = "nightly-2022-09-15"
+components = ['rust-src', 'clippy', 'rustfmt']


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Generic associated types got stabilized, so we should use the stabilized feature.

This also applies suggestions from clippy introduced since our last toolchain bump.

## 🔗 Related links

- Because of https://github.com/hashintel/hash/pull/1064, we don't require the `miri` component.