### PR TITLE
Replace `"uri"` with `"baseUri"` and `"versionedUri"` in queries

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/resolve.rs
@@ -61,7 +61,8 @@ where
                 // TODO: Avoid cloning on literals
                 //   see https://app.asana.com/0/0/1202884883200947/f
                 let literal = match segment.identifier.as_str() {
-                    "uri" => Literal::String(self.record.id().base_uri().to_string()),
+                    "baseUri" => Literal::String(self.record.id().base_uri().to_string()),
+                    "versionedUri" => Literal::String(self.record.id().to_string()),
                     "version" => Literal::Version(
                         Version::Ontology(self.record.id().version()),
                         self.is_latest,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/resolve.rs
@@ -19,7 +19,8 @@ where
                 // TODO: Avoid cloning on literals
                 //   see https://app.asana.com/0/0/1202884883200947/f
                 let literal = match head_path_segment.identifier.as_str() {
-                    "uri" => Literal::String(self.record.id().base_uri().to_string()),
+                    "baseUri" => Literal::String(self.record.id().base_uri().to_string()),
+                    "versionedUri" => Literal::String(self.record.id().to_string()),
                     "version" => Literal::Version(
                         Version::Ontology(self.record.id().version()),
                         self.is_latest,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/resolve.rs
@@ -75,7 +75,8 @@ where
                 // TODO: Avoid cloning on literals
                 //   see https://app.asana.com/0/0/1202884883200947/f
                 let literal = match segment.identifier.as_str() {
-                    "uri" => Literal::String(self.record.id().base_uri().to_string()),
+                    "baseUri" => Literal::String(self.record.id().base_uri().to_string()),
+                    "versionedUri" => Literal::String(self.record.id().to_string()),
                     "version" => Literal::Version(
                         Version::Ontology(self.record.id().version()),
                         self.is_latest,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/resolve.rs
@@ -63,7 +63,8 @@ where
                 // TODO: Avoid cloning on literals
                 //   see https://app.asana.com/0/0/1202884883200947/f
                 let literal = match head_path_segment.identifier.as_str() {
-                    "uri" => Literal::String(self.record.id().base_uri().to_string()),
+                    "baseUri" => Literal::String(self.record.id().base_uri().to_string()),
+                    "versionedUri" => Literal::String(self.record.id().to_string()),
                     "version" => Literal::Version(
                         Version::Ontology(self.record.id().version()),
                         self.is_latest,

--- a/packages/graph/hash_graph/lib/graph/src/store/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query.rs
@@ -188,23 +188,13 @@ impl Default for Expression {
 impl Expression {
     #[must_use]
     pub fn for_versioned_uri(uri: &VersionedUri) -> Self {
-        Self::All(vec![
-            Self::Eq(vec![
-                Self::Path(Path {
-                    segments: vec![PathSegment {
-                        identifier: "version".to_owned(),
-                    }],
-                }),
-                Self::Literal(Literal::Float(f64::from(uri.version()))),
-            ]),
-            Self::Eq(vec![
-                Self::Path(Path {
-                    segments: vec![PathSegment {
-                        identifier: "uri".to_owned(),
-                    }],
-                }),
-                Self::Literal(Literal::String(uri.base_uri().to_string())),
-            ]),
+        Self::Eq(vec![
+            Self::Path(Path {
+                segments: vec![PathSegment {
+                    identifier: "versionedUri".to_owned(),
+                }],
+            }),
+            Self::Literal(Literal::String(uri.to_string())),
         ])
     }
 

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -336,7 +336,7 @@ impl DatabaseApi<'_> {
                                 identifier: "type".to_owned(),
                             },
                             PathSegment {
-                                identifier: "uri".to_owned(),
+                                identifier: "baseUri".to_owned(),
                             },
                         ],
                     }),

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -15,11 +15,7 @@ import {
   UserModel,
   DataTypeModel,
 } from "../index";
-import {
-  generateSchemaUri,
-  splitVersionedUri,
-  workspaceAccountId,
-} from "../util";
+import { generateSchemaUri, workspaceAccountId } from "../util";
 import dataTypeModel from "./data-type.model";
 import linkTypeModel from "./link-type.model";
 
@@ -249,7 +245,6 @@ export default class {
     referencedLinkTypes: LinkTypeModel[];
     referencedEntityTypes: EntityTypeModel[];
   }> {
-    const { baseUri, version } = splitVersionedUri(params.versionedUri);
     const { data: propertyTypeRootedSubgraphs } =
       await graphApi.getEntityTypesByQuery({
         dataTypeQueryDepth: params.dataTypeQueryDepth,
@@ -257,10 +252,7 @@ export default class {
         linkTypeQueryDepth: params.linkTypeQueryDepth,
         entityTypeQueryDepth: params.entityTypeQueryDepth,
         query: {
-          all: [
-            { eq: [{ path: ["uri"] }, { literal: baseUri }] },
-            { eq: [{ path: ["version"] }, { literal: version }] },
-          ],
+          eq: [{ path: ["versionedUri"] }, { literal: params.versionedUri }],
         },
       });
     const entityTypeRootedSubgraph = propertyTypeRootedSubgraphs.pop();

--- a/packages/hash/api/src/model/ontology/property-type.model.ts
+++ b/packages/hash/api/src/model/ontology/property-type.model.ts
@@ -9,12 +9,7 @@ import {
 import { WORKSPACE_ACCOUNT_SHORTNAME } from "@hashintel/hash-backend-utils/system";
 
 import { DataTypeModel, PropertyTypeModel, UserModel } from "../index";
-import {
-  extractBaseUri,
-  generateSchemaUri,
-  workspaceAccountId,
-  splitVersionedUri,
-} from "../util";
+import { extractBaseUri, generateSchemaUri, workspaceAccountId } from "../util";
 
 type PropertyTypeModelConstructorParams = {
   accountId: string;
@@ -217,16 +212,12 @@ export default class {
     referencedDataTypes: DataTypeModel[];
     referencedPropertyTypes: PropertyTypeModel[];
   }> {
-    const { baseUri, version } = splitVersionedUri(params.versionedUri);
     const { data: propertyTypeRootedSubgraphs } =
       await graphApi.getPropertyTypesByQuery({
         dataTypeQueryDepth: params.dataTypeQueryDepth,
         propertyTypeQueryDepth: params.propertyTypeQueryDepth,
         query: {
-          all: [
-            { eq: [{ path: ["uri"] }, { literal: baseUri }] },
-            { eq: [{ path: ["version"] }, { literal: version }] },
-          ],
+          eq: [{ path: ["versionedUri"] }, { literal: params.versionedUri }],
         },
       });
     const propertyTypeRootedSubgraph = propertyTypeRootedSubgraphs.pop();


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, structured queries only support `"uri"`, which is misleading as it is not clear, if a base URI or a versioned URI is expected. This removes `"uri"` and adds `"baseUri"` and `"versionedUri"` instead.

## 🔗  Related links

- [Slack discussion](https://hashintel.slack.com/archives/C03F7V6DU9M/p1663254240476059) (_internal_)