### PR TITLE
Implement recursive lookups for entities

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -310,6 +310,12 @@ export interface EntityQuery {
    * @type {number}
    * @memberof EntityQuery
    */
+  linkedEntityQueryDepth: number;
+  /**
+   *
+   * @type {number}
+   * @memberof EntityQuery
+   */
   propertyTypeQueryDepth: number;
   /**
    *
@@ -330,6 +336,12 @@ export interface EntityRootedSubgraph {
    * @memberof EntityRootedSubgraph
    */
   entity: PersistedEntity;
+  /**
+   *
+   * @type {Array<PersistedEntity>}
+   * @memberof EntityRootedSubgraph
+   */
+  linkedEntities: Array<PersistedEntity>;
   /**
    *
    * @type {Array<PersistedDataType>}

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -9,7 +9,9 @@ use uuid::Uuid;
 
 use crate::ontology::AccountId;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Component, FromSql, ToSql)]
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Component, FromSql, ToSql,
+)]
 #[repr(transparent)]
 #[postgres(transparent)]
 pub struct EntityId(Uuid);

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/mod.rs
@@ -35,6 +35,8 @@ pub struct EntityQuery {
     pub link_type_query_depth: QueryDepth,
     #[component(value_type = number)]
     pub entity_type_query_depth: QueryDepth,
+    #[component(value_type = number)]
+    pub linked_entity_query_depth: QueryDepth,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
@@ -45,4 +47,5 @@ pub struct EntityRootedSubgraph {
     pub referenced_property_types: Vec<PersistedPropertyType>,
     pub referenced_link_types: Vec<PersistedLinkType>,
     pub referenced_entity_types: Vec<PersistedEntityType>,
+    pub linked_entities: Vec<PersistedEntity>,
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -377,7 +377,7 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Expressio
         entity_id: Option<EntityId>,
     ) -> Result<PersistedEntityIdentifier, InsertionError>;
 
-    /// Get the [`EntityRootedSubgraph`] specified by the [`EntityQuery`].
+    /// Get the [`EntityRootedSubgraph`]s specified by the [`EntityQuery`].
     ///
     /// # Errors
     ///

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/context/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/context/entity.rs
@@ -5,7 +5,7 @@ use tokio_postgres::{GenericClient, RowStream};
 use type_system::uri::{BaseUri, VersionedUri};
 
 use crate::{
-    knowledge::{Entity, EntityId},
+    knowledge::{Entity, EntityId, PersistedEntity},
     ontology::AccountId,
     store::{postgres::parameter_list, AsClient, QueryError},
 };
@@ -17,6 +17,18 @@ pub struct EntityRecord {
     pub type_uri: VersionedUri,
     pub account_id: AccountId,
     pub is_latest: bool,
+}
+
+impl From<EntityRecord> for PersistedEntity {
+    fn from(record: EntityRecord) -> Self {
+        Self::new(
+            record.entity,
+            record.id,
+            record.version,
+            record.type_uri,
+            record.account_id,
+        )
+    }
 }
 
 pub type RecordStream = impl Stream<Item = Result<EntityRecord, QueryError>>;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -1,11 +1,13 @@
 mod read;
 mod resolve;
 
+use std::{future::Future, pin::Pin};
+
 use async_trait::async_trait;
 use error_stack::{IntoReport, Report, Result, ResultExt};
-use futures::{stream, StreamExt, TryStreamExt};
+use futures::{stream, FutureExt, StreamExt, TryStreamExt};
 use tokio_postgres::GenericClient;
-use type_system::uri::VersionedUri;
+use type_system::uri::{BaseUri, VersionedUri};
 use uuid::Uuid;
 
 use crate::{
@@ -13,14 +15,165 @@ use crate::{
         Entity, EntityId, EntityQuery, EntityRootedSubgraph, PersistedEntity,
         PersistedEntityIdentifier,
     },
-    ontology::AccountId,
+    ontology::{
+        AccountId, PersistedDataType, PersistedEntityType, PersistedLinkType,
+        PersistedPropertyType, QueryDepth,
+    },
     store::{
         crud::Read,
         error::EntityDoesNotExist,
-        postgres::{ontology::EntityTypeDependencyContext, DependencyMap},
+        postgres::{
+            context::PostgresContext,
+            ontology::{EntityTypeDependencyContext, LinkTypeDependencyContext},
+            parameter_list, DependencyMap,
+        },
         AsClient, EntityStore, InsertionError, PostgresStore, QueryError, UpdateError,
     },
 };
+
+pub struct EntityDependencyContext<'a> {
+    pub referenced_data_types: &'a mut DependencyMap<VersionedUri, PersistedDataType>,
+    pub referenced_property_types: &'a mut DependencyMap<VersionedUri, PersistedPropertyType>,
+    pub referenced_link_types: &'a mut DependencyMap<VersionedUri, PersistedLinkType>,
+    pub referenced_entity_types: &'a mut DependencyMap<VersionedUri, PersistedEntityType>,
+    pub linked_entities: &'a mut DependencyMap<EntityId, PersistedEntity>,
+    pub data_type_query_depth: QueryDepth,
+    pub property_type_query_depth: QueryDepth,
+    pub link_type_query_depth: QueryDepth,
+    pub entity_type_query_depth: QueryDepth,
+    pub linked_entity_query_depth: QueryDepth,
+}
+
+impl<C: AsClient> PostgresStore<C> {
+    /// Returns the linked [`EntityId`]s and the corresponding [`LinkType`] with the provided
+    /// `entity_id` as source entity.
+    ///
+    /// [`LinkType`]: type_system::LinkType
+    async fn get_linked_entities(
+        &self,
+        entity_id: EntityId,
+    ) -> Result<Vec<(EntityId, VersionedUri)>, QueryError> {
+        self.as_client()
+            .query_raw(
+                r#"
+                SELECT target_entity_id, type_ids.base_uri, type_ids.version
+                FROM links
+                INNER JOIN type_ids ON type_ids.version_id = link_type_version_id
+                WHERE source_entity_id = $1;
+                "#,
+                parameter_list([&entity_id]),
+            )
+            .await
+            .into_report()
+            .change_context(QueryError)?
+            .map_err(|error| Report::new(error).change_context(QueryError))
+            .map_ok(|row| {
+                let entity_id: EntityId = row.get(0);
+                let link_type_base_uri: String = row.get(1);
+                let link_type_version: i64 = row.get(2);
+
+                (
+                    entity_id,
+                    VersionedUri::new(
+                        BaseUri::new(link_type_base_uri).expect("invalid base URI for link type"),
+                        link_type_version as u32,
+                    ),
+                )
+            })
+            .try_collect()
+            .await
+    }
+
+    /// Internal method to read a [`PersistedDataType`] into a [`DependencyMap`].
+    ///
+    /// This is used to recursively resolve a type, so the result can be reused.
+    pub(crate) fn get_entity_as_dependency<'a>(
+        &'a self,
+        entity_id: EntityId,
+        context: EntityDependencyContext<'a>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), QueryError>> + Send + 'a>> {
+        let EntityDependencyContext {
+            referenced_data_types,
+            referenced_property_types,
+            referenced_link_types,
+            referenced_entity_types,
+            linked_entities,
+            data_type_query_depth,
+            property_type_query_depth,
+            link_type_query_depth,
+            entity_type_query_depth,
+            linked_entity_query_depth,
+        } = context;
+
+        async move {
+            let unresolved_entity = linked_entities
+                .insert(&entity_id, entity_type_query_depth, || async {
+                    Ok(PersistedEntity::from(
+                        self.read_latest_entity_by_id(entity_id).await?,
+                    ))
+                })
+                .await?;
+
+            if let Some(entity) = unresolved_entity {
+                if entity_type_query_depth > 0 {
+                    self.get_entity_type_as_dependency(
+                        entity.type_versioned_uri(),
+                        EntityTypeDependencyContext {
+                            referenced_data_types,
+                            referenced_property_types,
+                            referenced_link_types,
+                            referenced_entity_types,
+                            data_type_query_depth,
+                            property_type_query_depth,
+                            link_type_query_depth,
+                            entity_type_query_depth: entity_type_query_depth - 1,
+                        },
+                    )
+                    .await?;
+                }
+
+                if linked_entity_query_depth > 0 || link_type_query_depth > 0 {
+                    for (source_entity_id, link_type_uri) in
+                        self.get_linked_entities(entity_id).await?
+                    {
+                        if linked_entity_query_depth > 0 {
+                            self.get_entity_as_dependency(
+                                source_entity_id,
+                                EntityDependencyContext {
+                                    referenced_data_types,
+                                    referenced_property_types,
+                                    referenced_link_types,
+                                    referenced_entity_types,
+                                    linked_entities,
+                                    data_type_query_depth,
+                                    property_type_query_depth,
+                                    link_type_query_depth,
+                                    entity_type_query_depth,
+                                    linked_entity_query_depth: linked_entity_query_depth - 1,
+                                },
+                            )
+                            .await?;
+                        }
+
+                        if link_type_query_depth > 0 {
+                            self.get_link_type_as_dependency(
+                                &link_type_uri,
+                                LinkTypeDependencyContext {
+                                    referenced_link_types,
+                                    link_type_query_depth: link_type_query_depth - 1,
+                                },
+                            )
+                            .await?;
+                        }
+                    }
+                }
+            }
+
+            Ok(())
+        }
+        .boxed()
+    }
+}
 
 #[async_trait]
 impl<C: AsClient> EntityStore for PostgresStore<C> {
@@ -68,6 +221,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             property_type_query_depth,
             link_type_query_depth,
             entity_type_query_depth,
+            linked_entity_query_depth,
         } = *query;
 
         stream::iter(Read::<PersistedEntity>::read(self, expression).await?)
@@ -76,6 +230,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 let mut referenced_property_types = DependencyMap::new();
                 let mut referenced_link_types = DependencyMap::new();
                 let mut referenced_entity_types = DependencyMap::new();
+                let mut linked_entities = DependencyMap::new();
 
                 if entity_type_query_depth > 0 {
                     self.get_entity_type_as_dependency(
@@ -94,12 +249,50 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                     .await?;
                 }
 
+                if linked_entity_query_depth > 0 || link_type_query_depth > 0 {
+                    for (source_entity_id, link_type_uri) in self
+                        .get_linked_entities(entity.identifier().entity_id())
+                        .await?
+                    {
+                        if linked_entity_query_depth > 0 {
+                            self.get_entity_as_dependency(
+                                source_entity_id,
+                                EntityDependencyContext {
+                                    referenced_data_types: &mut referenced_data_types,
+                                    referenced_property_types: &mut referenced_property_types,
+                                    referenced_link_types: &mut referenced_link_types,
+                                    referenced_entity_types: &mut referenced_entity_types,
+                                    linked_entities: &mut linked_entities,
+                                    data_type_query_depth,
+                                    property_type_query_depth,
+                                    link_type_query_depth,
+                                    entity_type_query_depth,
+                                    linked_entity_query_depth: linked_entity_query_depth - 1,
+                                },
+                            )
+                            .await?;
+                        }
+
+                        if link_type_query_depth > 0 {
+                            self.get_link_type_as_dependency(
+                                &link_type_uri,
+                                LinkTypeDependencyContext {
+                                    referenced_link_types: &mut referenced_link_types,
+                                    link_type_query_depth: link_type_query_depth - 1,
+                                },
+                            )
+                            .await?;
+                        }
+                    }
+                }
+
                 Ok(EntityRootedSubgraph {
                     entity,
                     referenced_data_types: referenced_data_types.into_vec(),
                     referenced_property_types: referenced_property_types.into_vec(),
                     referenced_link_types: referenced_link_types.into_vec(),
                     referenced_entity_types: referenced_entity_types.into_vec(),
+                    linked_entities: linked_entities.into_vec(),
                 })
             })
             .try_collect()

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -286,6 +286,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                     }
                 }
 
+                linked_entities.remove(&entity.identifier().entity_id());
+
                 Ok(EntityRootedSubgraph {
                     entity,
                     referenced_data_types: referenced_data_types.into_vec(),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -100,6 +100,10 @@ where
     pub fn into_vec(self) -> Vec<T> {
         self.resolved.into_values().map(|value| value.0).collect()
     }
+
+    pub fn remove(&mut self, identifier: &V) -> Option<T> {
+        self.resolved.remove(identifier).map(|(value, _)| value)
+    }
 }
 
 /// Utility function used for [`GenericClient::query_raw`] to infer the parameter as

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
@@ -246,6 +246,8 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
                     }
                 }
 
+                referenced_entity_types.remove(entity_type.identifier.uri());
+
                 Ok(EntityTypeRootedSubgraph {
                     entity_type,
                     referenced_data_types: referenced_data_types.into_vec(),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -194,6 +194,8 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                     }
                 }
 
+                referenced_property_types.remove(property_type.identifier.uri());
+
                 Ok(PropertyTypeRootedSubgraph {
                     property_type,
                     referenced_data_types: referenced_data_types.into_vec(),

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -299,6 +299,7 @@ impl DatabaseApi<'_> {
                 property_type_query_depth: 0,
                 link_type_query_depth: 0,
                 entity_type_query_depth: 0,
+                linked_entity_query_depth: 0,
             })
             .await?
             .pop()

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -394,10 +394,11 @@ Content-Type: application/json
       }
     ]
   },
-  "dataTypeQueryDepth": 255,
-  "propertyTypeQueryDepth": 255,
-  "linkTypeQueryDepth": 255,
-  "entityTypeQueryDepth": 255
+  "dataTypeQueryDepth": 0,
+  "propertyTypeQueryDepth": 0,
+  "linkTypeQueryDepth": 1,
+  "entityTypeQueryDepth": 0,
+  "linkedEntityQueryDepth": 10
 }
 
 > {%


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds a depth field to read linked entities when querying enttities.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1200211978612931/1202682556665585/f) _(internal)_

## 🔍 What does this change?

- This is a follow-up of #1066
- Look up linked entity ids and it's corresponding link type by a given entity id
- Recursively resolve the linked entities up to the specified 

## 📜 Does this require a change to the docs?

- The OpenAPI client was updated

## 🐾 Next steps

- Support returning Links
- Add a similar functionality for `Link`s: [Asana Task](https://app.asana.com/0/1202882583267702/1202986163519979/f) (_internal_)

## 🛡 What tests cover this?

The query itself is used in a REST endpoint test, but the result is not read yet

## ❓ How to test this?

Run the query as shown in `rest-test.http` and validate the results

## 📹 Demo

```http
POST http://127.0.0.1:4000/entities/query
Content-Type: application/json

{
  "query": {
    "eq": [
      {
        "path": [
          "version"
        ]
      },
      {
        "literal": "latest"
      }
    ]
  },
  "dataTypeQueryDepth": 0,
  "propertyTypeQueryDepth": 0,
  "linkTypeQueryDepth": 1,
  "entityTypeQueryDepth": 0,
  "linkedEntityQueryDepth": 1
}
```

```json
[
  {
    "entity": {
      "inner": {
        "http://localhost:3000/@alice/types/property-type/name/": "Alice Allison"
      },
      "identifier": {
        "entityId": "0335be0b-26a1-475f-81de-aabcb3bf0676",
        "version": "2022-09-16T10:21:38.140412Z",
        "ownedById": "74014335-79d2-4a66-8533-5a9165538497"
      },
      "typeVersionedUri": "http://localhost:3000/@alice/types/entity-type/person/v/2"
    },
    "referencedDataTypes": [],
    "referencedPropertyTypes": [],
    "referencedLinkTypes": [
      {
        "inner": {
          "$id": "http://localhost:3000/@alice/types/link-type/friend-of/v/1",
          "description": "Someone who has a shared bond of mutual affection",
          "kind": "linkType",
          "pluralTitle": "Friends Of",
          "title": "Friend Of"
        },
        "identifier": {
          "uri": "http://localhost:3000/@alice/types/link-type/friend-of/v/1",
          "ownedById": "74014335-79d2-4a66-8533-5a9165538497"
        }
      }
    ],
    "referencedEntityTypes": [],
    "linkedEntities": [
      {
        "inner": {
          "http://localhost:3000/@alice/types/property-type/name/": "Bob"
        },
        "identifier": {
          "entityId": "c0950d7e-68ee-41c8-a9bd-e1e2dddd5a2d",
          "version": "2022-09-16T10:21:38.254749Z",
          "ownedById": "74014335-79d2-4a66-8533-5a9165538497"
        },
        "typeVersionedUri": "http://localhost:3000/@alice/types/entity-type/person/v/1"
      }
    ]
  },
  {
    "entity": {
      "inner": {
        "http://localhost:3000/@alice/types/property-type/name/": "Bob"
      },
      "identifier": {
        "entityId": "c0950d7e-68ee-41c8-a9bd-e1e2dddd5a2d",
        "version": "2022-09-16T10:21:38.254749Z",
        "ownedById": "74014335-79d2-4a66-8533-5a9165538497"
      },
      "typeVersionedUri": "http://localhost:3000/@alice/types/entity-type/person/v/1"
    },
    "referencedDataTypes": [],
    "referencedPropertyTypes": [],
    "referencedLinkTypes": [],
    "referencedEntityTypes": [],
    "linkedEntities": []
  }
]
```