### PR TITLE
Upgrade @blockprotocol dependencies

### DIFF
--- a/packages/blocks/callout/package.json
+++ b/packages/blocks/callout/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@blockprotocol/graph": "0.0.16",
-    "@blockprotocol/hook": "0.0.1"
+    "@blockprotocol/hook": "0.0.4"
   },
   "devDependencies": {
     "block-scripts": "0.0.14",

--- a/packages/blocks/header/package.json
+++ b/packages/blocks/header/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@blockprotocol/graph": "0.0.16",
-    "@blockprotocol/hook": "0.0.1",
+    "@blockprotocol/hook": "0.0.4",
     "@rooks/use-fork-ref": "4.11.2"
   },
   "devDependencies": {

--- a/packages/blocks/paragraph/package.json
+++ b/packages/blocks/paragraph/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@blockprotocol/graph": "0.0.16",
-    "@blockprotocol/hook": "0.0.1"
+    "@blockprotocol/hook": "0.0.4"
   },
   "devDependencies": {
     "block-scripts": "0.0.14",

--- a/packages/hash/api/package.json
+++ b/packages/hash/api/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/credential-provider-node": "3.41.0",
     "@aws-sdk/s3-presigned-post": "3.38.0",
     "@aws-sdk/s3-request-presigner": "3.38.0",
-    "@blockprotocol/core": "0.0.8",
+    "@blockprotocol/core": "0.0.11",
     "@graphql-tools/schema": "8.5.0",
     "@hashintel/hash-backend-utils": "0.0.0",
     "@hashintel/hash-shared": "0.0.0",

--- a/packages/hash/backend-utils/package.json
+++ b/packages/hash/backend-utils/package.json
@@ -21,7 +21,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@blockprotocol/core": "0.0.8",
+    "@blockprotocol/core": "0.0.11",
     "@opensearch-project/opensearch": "1.1.0",
     "apollo-datasource": "3.3.2",
     "dotenv-flow": "3.2.0",

--- a/packages/hash/frontend/package.json
+++ b/packages/hash/frontend/package.json
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@apollo/client": "3.6.9",
-    "@blockprotocol/core": "0.0.8",
+    "@blockprotocol/core": "0.0.11",
     "@blockprotocol/graph": "0.0.16",
-    "@blockprotocol/hook": "0.0.1",
+    "@blockprotocol/hook": "0.0.4",
     "@dnd-kit/core": "6.0.5",
     "@dnd-kit/modifiers": "6.0.0",
     "@dnd-kit/sortable": "7.0.1",

--- a/packages/hash/shared/package.json
+++ b/packages/hash/shared/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@apollo/client": "3.6.9",
-    "@blockprotocol/core": "0.0.8",
+    "@blockprotocol/core": "0.0.11",
     "@sentry/browser": "7.10.0",
     "graphql-tag": "2.12.5",
     "immer": "9.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3088,14 +3088,6 @@
   dependencies:
     uuid "^8.3.2"
 
-"@blockprotocol/core@0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@blockprotocol/core/-/core-0.0.8.tgz#21924dfd24315120427d3ccef4f3c836eaf6a782"
-  integrity sha512-Xy9litxz1gn6192zgXIPTg7vRdFGLANDtXfC70JlA7375H3voW15+SZnYvo/8UARyIcBMhm4d/0XZDa+uqE2Kw==
-  dependencies:
-    es-module-lexer "^0.10.5"
-    uuid "^8.3.2"
-
 "@blockprotocol/graph@0.0.16":
   version "0.0.16"
   resolved "https://registry.yarnpkg.com/@blockprotocol/graph/-/graph-0.0.16.tgz#1a1026633df9ea8bfdf2f763cb124441d392cb3e"
@@ -3104,12 +3096,12 @@
     "@blockprotocol/core" "0.0.11"
     lit "^2.2.5"
 
-"@blockprotocol/hook@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@blockprotocol/hook/-/hook-0.0.1.tgz#e98e0ec0453d64891cebaf9721369b7405a04b8e"
-  integrity sha512-t2g0cImU3Tt5HgjLc8VSvxWKE/F6uCsAmtgY8yevwFHIF+QiLZoP3URiILL97QxH1QIrk7kid5hsJlw0wzHVRQ==
+"@blockprotocol/hook@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@blockprotocol/hook/-/hook-0.0.4.tgz#da1f64bb87c805ad1681efb65abd58bfff769a54"
+  integrity sha512-SCWyp/6BopRFkwHckVUrAo7Vxx/NRclJsNl3GLdrGLX0awzUIDoMBfdarVc8aIZaMocXDN/Rp4wZf/iV3FoY6w==
   dependencies:
-    "@blockprotocol/core" "0.0.8"
+    "@blockprotocol/core" "0.0.11"
 
 "@cspotcode/source-map-consumer@0.8.0":
   version "0.8.0"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We currently require a single version of `@blockprotocol/core` to be relied on by the other `@blockprotocol/*` packages, because they are designed to share a map of element:core handlers.

`@blockprotocol/hook` had fallen behind, and was using a different version to `@blockprotocol/graph`, meaning that blocks did not work.

This PR fixes that by upgrading `@blockprotocol/hook`.
