### PR TITLE
Implement `BlockModel` class

### DIFF
--- a/packages/hash/api/src/graph/workspace-types.ts
+++ b/packages/hash/api/src/graph/workspace-types.ts
@@ -38,7 +38,10 @@ export let WORKSPACE_TYPES: {
     org: EntityTypeModel;
     orgMembership: EntityTypeModel;
     block: EntityTypeModel;
-    /** @todo: deprecate all uses of this dummy entity type */
+    /**
+     * @todo: deprecate all uses of this dummy entity type
+     * @see https://app.asana.com/0/1202805690238892/1203015527055368/f
+     */
     dummy: EntityTypeModel;
   };
   linkType: {

--- a/packages/hash/api/src/graph/workspace-types.ts
+++ b/packages/hash/api/src/graph/workspace-types.ts
@@ -38,6 +38,8 @@ export let WORKSPACE_TYPES: {
     org: EntityTypeModel;
     orgMembership: EntityTypeModel;
     block: EntityTypeModel;
+    /** @todo: deprecate all uses of this dummy entity type */
+    dummy: EntityTypeModel;
   };
   linkType: {
     // User-related
@@ -280,10 +282,8 @@ const blockEntityTypeInitializer = async (graphApi: GraphApi) => {
   const blockDataLinkTypeModel =
     await WORKSPACE_TYPES_INITIALIZERS.linkType.blockData(graphApi);
 
-  /** @todo: unset this when the destination entity type can be undefined */
-  const blockDataTypeModel = await WORKSPACE_TYPES_INITIALIZERS.entityType.org(
-    graphApi,
-  );
+  const dummyEntityTypeModel =
+    await WORKSPACE_TYPES_INITIALIZERS.entityType.dummy(graphApi);
 
   /* eslint-enable @typescript-eslint/no-use-before-define */
 
@@ -300,10 +300,21 @@ const blockEntityTypeInitializer = async (graphApi: GraphApi) => {
     outgoingLinks: [
       {
         linkTypeVersionedUri: blockDataLinkTypeModel.schema.$id,
-        destinationEntityTypeVersionedUri: blockDataTypeModel.schema.$id,
+        /** @todo: unset this when the destination entity type can be undefined */
+        destinationEntityTypeVersionedUri: dummyEntityTypeModel.schema.$id,
         required: true,
       },
     ],
+  })(graphApi);
+};
+
+/** @todo: remove this dummy entity type once we are able to define the block data link type without it */
+const dummyEntityTypeInitializer = async (graphApi: GraphApi) => {
+  return entityTypeInitializer({
+    namespace: WORKSPACE_ACCOUNT_SHORTNAME,
+    title: "Dummy",
+    properties: [],
+    outgoingLinks: [],
   })(graphApi);
 };
 
@@ -339,6 +350,7 @@ export const WORKSPACE_TYPES_INITIALIZERS: FlattenAndPromisify<
     org: orgEntityTypeInitializer,
     orgMembership: orgMembershipEntityTypeInitializer,
     block: blockEntityTypeInitializer,
+    dummy: dummyEntityTypeInitializer,
   },
   linkType: {
     ofOrg: ofOrgLinkTypeInitializer,

--- a/packages/hash/api/src/graph/workspace-types.ts
+++ b/packages/hash/api/src/graph/workspace-types.ts
@@ -300,7 +300,10 @@ const blockEntityTypeInitializer = async (graphApi: GraphApi) => {
     outgoingLinks: [
       {
         linkTypeVersionedUri: blockDataLinkTypeModel.schema.$id,
-        /** @todo: unset this when the destination entity type can be undefined */
+        /**
+         * @todo: unset this when the destination entity type can be undefined
+         * @see https://app.asana.com/0/1202805690238892/1203015527055368/f
+         */
         destinationEntityTypeVersionedUri: dummyEntityTypeModel.schema.$id,
         required: true,
       },
@@ -308,7 +311,10 @@ const blockEntityTypeInitializer = async (graphApi: GraphApi) => {
   })(graphApi);
 };
 
-/** @todo: remove this dummy entity type once we are able to define the block data link type without it */
+/**
+ * @todo: remove this dummy entity type once we are able to define the block data link type without it
+ * @see https://app.asana.com/0/1202805690238892/1203015527055368/f
+ */
 const dummyEntityTypeInitializer = async (graphApi: GraphApi) => {
   return entityTypeInitializer({
     namespace: WORKSPACE_ACCOUNT_SHORTNAME,

--- a/packages/hash/api/src/model/index.ts
+++ b/packages/hash/api/src/model/index.ts
@@ -44,8 +44,11 @@ export { default as UserModel } from "./knowledge/user.model";
 export * from "./knowledge/org.model";
 export { default as OrgModel } from "./knowledge/org.model";
 
-export * from "./knowledge/org.model";
+export * from "./knowledge/orgMembership.model";
 export { default as OrgMembershipModel } from "./knowledge/orgMembership.model";
+
+export * from "./knowledge/block.model";
+export { default as BlockModel } from "./knowledge/block.model";
 
 /** @todo: deprecate legacy model classes */
 

--- a/packages/hash/api/src/model/knowledge/block.model.ts
+++ b/packages/hash/api/src/model/knowledge/block.model.ts
@@ -45,6 +45,7 @@ export default class extends EntityModel {
    * Create a workspace block entity.
    *
    * @param params.componentId - the component id of the block
+   * @param params.blockData - the linked block data entity
    */
   static async createBlock(
     graphApi: GraphApi,

--- a/packages/hash/api/src/model/knowledge/block.model.ts
+++ b/packages/hash/api/src/model/knowledge/block.model.ts
@@ -37,11 +37,7 @@ export default class extends EntityModel {
     graphApi: GraphApi,
     params: { entityId: string },
   ): Promise<BlockModel> {
-    const entity = await EntityModel.getLatest(graphApi, {
-      // assumption: `accountId` of block is always the workspace account id
-      accountId: workspaceAccountId,
-      entityId: params.entityId,
-    });
+    const entity = await EntityModel.getLatest(graphApi, params);
 
     return BlockModel.fromEntityModel(entity);
   }

--- a/packages/hash/api/src/model/knowledge/block.model.ts
+++ b/packages/hash/api/src/model/knowledge/block.model.ts
@@ -1,0 +1,182 @@
+import { GraphApi } from "@hashintel/hash-graph-client";
+import { EntityModel, BlockModel, EntityModelCreateParams } from "..";
+import { WORKSPACE_TYPES } from "../../graph/workspace-types";
+import { workspaceAccountId } from "../util";
+
+type BlockModelCreateParams = Omit<
+  EntityModelCreateParams,
+  "properties" | "entityTypeModel"
+> & {
+  componentId: string;
+  blockData: EntityModel;
+};
+
+/**
+ * @class {@link BlockModel}
+ */
+export default class extends EntityModel {
+  static fromEntityModel(entity: EntityModel): BlockModel {
+    if (
+      entity.entityTypeModel.schema.$id !==
+      WORKSPACE_TYPES.entityType.block.schema.$id
+    ) {
+      throw new Error(
+        `Entity with id ${entity.entityId} is not a workspace block`,
+      );
+    }
+
+    return new BlockModel(entity);
+  }
+
+  /**
+   * Get a workspace block entity by its entity id.
+   *
+   * @param params.entityId - the entity id of the block
+   */
+  static async getBlockById(
+    graphApi: GraphApi,
+    params: { entityId: string },
+  ): Promise<BlockModel> {
+    const entity = await EntityModel.getLatest(graphApi, {
+      // assumption: `accountId` of block is always the workspace account id
+      accountId: workspaceAccountId,
+      entityId: params.entityId,
+    });
+
+    return BlockModel.fromEntityModel(entity);
+  }
+
+  /**
+   * Get a workspace block entity by its component id.
+   *
+   * @param params.componentId - the component id
+   */
+  static async getBlockByComponentId(
+    graphApi: GraphApi,
+    params: { componentId: string },
+  ): Promise<BlockModel | null> {
+    /**
+     * @todo: use upcoming Graph API method to filter entities in the datastore
+     *   https://app.asana.com/0/1202805690238892/1202890614880643/f
+     */
+    const allEntities = await EntityModel.getAllLatest(graphApi, {
+      accountId: workspaceAccountId,
+    });
+
+    const matchingBlock = allEntities
+      .filter(
+        ({ entityTypeModel }) =>
+          entityTypeModel.schema.$id ===
+          WORKSPACE_TYPES.entityType.block.schema.$id,
+      )
+      .map((entityModel) => new BlockModel(entityModel))
+      .find((block) => block.getComponentId() === params.componentId);
+
+    return matchingBlock ?? null;
+  }
+
+  /**
+   * Create a workspace block entity.
+   *
+   * @param params.componentId - the component id of the block
+   */
+  static async createBlock(
+    graphApi: GraphApi,
+    params: BlockModelCreateParams,
+  ): Promise<BlockModel> {
+    const { componentId, blockData, accountId } = params;
+
+    const properties: object = {
+      [WORKSPACE_TYPES.propertyType.componentId.baseUri]: componentId,
+    };
+
+    const entityTypeModel = WORKSPACE_TYPES.entityType.block;
+
+    const entity = await EntityModel.create(graphApi, {
+      accountId,
+      properties,
+      entityTypeModel,
+    });
+
+    await entity.createOutgoingLink(graphApi, {
+      linkTypeModel: WORKSPACE_TYPES.linkType.blockData,
+      targetEntityModel: blockData,
+    });
+
+    return BlockModel.fromEntityModel(entity);
+  }
+
+  /**
+   * Get the component id of the block.
+   */
+  getComponentId(): string {
+    return (this.properties as any)[
+      WORKSPACE_TYPES.propertyType.componentId.baseUri
+    ];
+  }
+
+  /**
+   * Get the linked block data entity of the block.
+   */
+  async getBlockData(graphApi: GraphApi): Promise<EntityModel> {
+    const outgoingBlockDataLinks = await this.getOutgoingLink(graphApi, {
+      linkTypeModel: WORKSPACE_TYPES.linkType.blockData,
+    });
+
+    const outgoingBlockDataLink = outgoingBlockDataLinks[0];
+
+    if (!outgoingBlockDataLink) {
+      throw new Error(
+        `Block with entityId ${this.entityId} does not have an outgoing blockData link`,
+      );
+    }
+
+    return outgoingBlockDataLink.targetEntityModel;
+  }
+
+  /**
+   * Update the linked block data entity of a block.
+   *
+   * @param params.updatedByAccountId - the account id of the user that updated the
+   * @param params.newBlockDataEntity - the new block data entity
+   */
+  async updateBlockDataEntity(
+    graphApi: GraphApi,
+    params: {
+      /** @todo: rename this argument to something that doesn't include `accountId` */
+      updatedByAccountId: string;
+      newBlockDataEntity: EntityModel;
+    },
+  ): Promise<void> {
+    const { updatedByAccountId, newBlockDataEntity } = params;
+    const outgoingBlockDataLinks = await this.getOutgoingLink(graphApi, {
+      linkTypeModel: WORKSPACE_TYPES.linkType.blockData,
+    });
+
+    const outgoingBlockDataLink = outgoingBlockDataLinks[0];
+
+    if (!outgoingBlockDataLink) {
+      throw new Error(
+        `Block with entityId ${this.entityId} does not have an outgoing block data link`,
+      );
+    }
+
+    if (
+      outgoingBlockDataLink.targetEntityModel.entityId ===
+      newBlockDataEntity.entityId
+    ) {
+      throw new Error(
+        `The block with entity id ${this.entityId} already has a linked block data entity with entity id ${newBlockDataEntity.entityId}`,
+      );
+    }
+
+    await outgoingBlockDataLink.remove(graphApi, {
+      removedBy: updatedByAccountId,
+    });
+
+    await this.createOutgoingLink(graphApi, {
+      linkTypeModel: WORKSPACE_TYPES.linkType.blockData,
+      targetEntityModel: newBlockDataEntity,
+    });
+  }
+}

--- a/packages/hash/api/src/model/knowledge/block.model.ts
+++ b/packages/hash/api/src/model/knowledge/block.model.ts
@@ -1,7 +1,6 @@
 import { GraphApi } from "@hashintel/hash-graph-client";
 import { EntityModel, BlockModel, EntityModelCreateParams } from "..";
 import { WORKSPACE_TYPES } from "../../graph/workspace-types";
-import { workspaceAccountId } from "../util";
 
 type BlockModelCreateParams = Omit<
   EntityModelCreateParams,
@@ -40,35 +39,6 @@ export default class extends EntityModel {
     const entity = await EntityModel.getLatest(graphApi, params);
 
     return BlockModel.fromEntityModel(entity);
-  }
-
-  /**
-   * Get a workspace block entity by its component id.
-   *
-   * @param params.componentId - the component id
-   */
-  static async getBlockByComponentId(
-    graphApi: GraphApi,
-    params: { componentId: string },
-  ): Promise<BlockModel | null> {
-    /**
-     * @todo: use upcoming Graph API method to filter entities in the datastore
-     *   https://app.asana.com/0/1202805690238892/1202890614880643/f
-     */
-    const allEntities = await EntityModel.getAllLatest(graphApi, {
-      accountId: workspaceAccountId,
-    });
-
-    const matchingBlock = allEntities
-      .filter(
-        ({ entityTypeModel }) =>
-          entityTypeModel.schema.$id ===
-          WORKSPACE_TYPES.entityType.block.schema.$id,
-      )
-      .map((entityModel) => new BlockModel(entityModel))
-      .find((block) => block.getComponentId() === params.componentId);
-
-    return matchingBlock ?? null;
   }
 
   /**

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -6,7 +6,7 @@ import {
   LinkModel,
   LinkModelCreateParams,
   LinkTypeModel,
-} from "../index";
+} from "..";
 
 export type EntityModelConstructorParams = {
   accountId: string;

--- a/packages/hash/integration/src/tests/model/knowledge/block.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/block.model.test.ts
@@ -1,0 +1,115 @@
+import { getRequiredEnv } from "@hashintel/hash-backend-utils/environment";
+import { createGraphClient } from "@hashintel/hash-api/src/graph";
+import { ensureWorkspaceTypesExist } from "@hashintel/hash-api/src/graph/workspace-types";
+import {
+  BlockModel,
+  EntityModel,
+  EntityTypeModel,
+  UserModel,
+} from "@hashintel/hash-api/src/model";
+import { generateWorkspaceEntityTypeSchema } from "@hashintel/hash-api/src/model/util";
+import { Logger } from "@hashintel/hash-backend-utils/logger";
+import { createTestUser } from "../../util";
+
+jest.setTimeout(60000);
+
+const logger = new Logger({
+  mode: "dev",
+  level: "debug",
+  serviceName: "integration-tests",
+});
+
+const graphApiHost = getRequiredEnv("HASH_GRAPH_API_HOST");
+const graphApiPort = parseInt(getRequiredEnv("HASH_GRAPH_API_PORT"), 10);
+
+const graphApi = createGraphClient(logger, {
+  host: graphApiHost,
+  port: graphApiPort,
+});
+
+describe("Block model class", () => {
+  let testUser: UserModel;
+
+  let testBlock: BlockModel;
+
+  const testBlockComponentId = "test-component-id";
+
+  let testBlockDataEntity: EntityModel;
+
+  let dummyEntityType: EntityTypeModel;
+
+  beforeAll(async () => {
+    await ensureWorkspaceTypesExist({ graphApi, logger });
+
+    testUser = await createTestUser(graphApi, "blockModelTest", logger);
+
+    dummyEntityType = await EntityTypeModel.create(graphApi, {
+      accountId: testUser.entityId,
+      schema: generateWorkspaceEntityTypeSchema({
+        namespace: testUser.getShortname()!,
+        title: "Dummy",
+        properties: [],
+        outgoingLinks: [],
+      }),
+    });
+
+    testBlockDataEntity = await EntityModel.create(graphApi, {
+      accountId: testUser.entityId,
+      properties: {},
+      entityTypeModel: dummyEntityType,
+    });
+  });
+
+  it("can create a Block", async () => {
+    testBlock = await BlockModel.createBlock(graphApi, {
+      accountId: testUser.entityId,
+      componentId: testBlockComponentId,
+      blockData: testBlockDataEntity,
+    });
+  });
+
+  it("can get a block by its entity id", async () => {
+    const fetchedBlock = await BlockModel.getBlockById(graphApi, {
+      entityId: testBlock.entityId,
+    });
+
+    expect(fetchedBlock).not.toBeNull();
+
+    expect(fetchedBlock).toEqual(testBlock);
+  });
+
+  it("can get the block's data entity", async () => {
+    const fetchedBlockData = await testBlock.getBlockData(graphApi);
+
+    expect(fetchedBlockData).toEqual(testBlockDataEntity);
+  });
+
+  it("can update the block data entity", async () => {
+    const newBlockDataEntity = await EntityModel.create(graphApi, {
+      accountId: testUser.entityId,
+      properties: {},
+      entityTypeModel: dummyEntityType,
+    });
+
+    expect(testBlockDataEntity).not.toEqual(newBlockDataEntity);
+    expect(await testBlock.getBlockData(graphApi)).toEqual(testBlockDataEntity);
+
+    await testBlock.updateBlockDataEntity(graphApi, {
+      updatedByAccountId: testUser.entityId,
+      newBlockDataEntity,
+    });
+
+    expect(await testBlock.getBlockData(graphApi)).toEqual(newBlockDataEntity);
+  });
+
+  it("cannot update the block data entity to the same data entity", async () => {
+    const currentDataEntity = await testBlock.getBlockData(graphApi);
+
+    await expect(
+      testBlock.updateBlockDataEntity(graphApi, {
+        updatedByAccountId: testUser.entityId,
+        newBlockDataEntity: currentDataEntity,
+      }),
+    ).rejects.toThrow(/already has a linked block data entity with entity id/);
+  });
+});

--- a/packages/hash/integration/src/tests/model/knowledge/block.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/block.model.test.ts
@@ -43,6 +43,10 @@ describe("Block model class", () => {
 
     testUser = await createTestUser(graphApi, "blockModelTest", logger);
 
+    /**
+     * @todo: rename to something more representative of a real-world use-case,
+     * once the exact role of the block data entity's entity type is known.
+     */
     dummyEntityType = await EntityTypeModel.create(graphApi, {
       accountId: testUser.entityId,
       schema: generateWorkspaceEntityTypeSchema({


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR adds the `BlockModel` class, and its corresponding workspace types:
- the `componentId` property type
- the `blockData` link type
- the `block` entity type

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202882583267702/1202606867065365/f) _(internal)_

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

- [ ] merging https://github.com/hashintel/hash/pull/1074

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- adds workspace types blocks depend on
- adds `BlockModel` class

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

No.

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

- currently the destination entity type of a link type has to be specified when adding an outgoing link to an entity type. For the outgoing block data link of a block model class, any entity type could be a possible destination for the link. As a temporary solution, a "dummy" entity type has been added to the workspace types so that the block entity type satisfies the current constraints of the Graph API.

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

- [Stop requiring outgoing links to specifying a destination entity type, and deprecate `Dummy` entity type](https://hashintel.slack.com/archives/C03F7V6DU9M/p1663685733315319)

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- `knowledge/block.model.test.ts`

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Inspect CI, or run the integration tests locally to verify the `Block` model class behaves as expected

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
<img width="543" alt="image" src="https://user-images.githubusercontent.com/42802102/191281928-773810b1-967a-49e8-854f-92ea039b65a6.png">


