### PR TITLE
Fix suggester scrolling with arrow keys

### DIFF
--- a/packages/hash/frontend/src/blocks/page/createSuggester/Suggester.tsx
+++ b/packages/hash/frontend/src/blocks/page/createSuggester/Suggester.tsx
@@ -1,5 +1,5 @@
 import { Box, SxProps, Theme, Typography } from "@mui/material";
-import { ReactElement, useState } from "react";
+import { ReactElement, useEffect, useRef, useState } from "react";
 import { useKey } from "rooks";
 import { tw } from "twind";
 import { SpinnerIcon } from "../../../shared/icons";
@@ -32,6 +32,13 @@ export const Suggester = <T,>({
   if (selectedIndex >= options.length) {
     setSelectedIndex(options.length - 1);
   }
+
+  // scroll the selected option into view
+  const selectedRef = useRef<HTMLLIElement>(null);
+  useEffect(
+    () => selectedRef.current?.scrollIntoView({ block: "nearest" }),
+    [selectedIndex],
+  );
 
   // enable cyclic arrow-key navigation
   useKey(["ArrowUp", "ArrowDown"], (event) => {
@@ -89,6 +96,7 @@ export const Suggester = <T,>({
         {options.map((option, index) => (
           <Box
             component="li"
+            ref={index === selectedIndex ? selectedRef : undefined}
             key={itemKey(option)}
             sx={({ palette }) => ({
               backgroundColor:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#896 inserted a bug where the suggester won't automatically scroll when navigating the list with the up and down arrow keys. This PR adds back the code that scrolls the selected item into the view.

## 📹 Demo

Before: 
![before](https://user-images.githubusercontent.com/37453800/191874403-d146be19-400d-438a-bcca-d72097d20e95.gif)


After:
![after](https://user-images.githubusercontent.com/37453800/191874412-c5a55714-0196-4d78-8afd-39e12f5705e4.gif)

