### PR TITLE
Disable `PageIcon`, `InsertBlock` & `PageTitle` on readonly mode

### DIFF
--- a/packages/hash/frontend/src/blocks/page/InsertBlock.tsx
+++ b/packages/hash/frontend/src/blocks/page/InsertBlock.tsx
@@ -5,6 +5,7 @@ import { HashBlockMeta } from "@hashintel/hash-shared/blocks";
 import type { BlockVariant } from "@blockprotocol/core";
 import { PlusBoxOutlineIcon } from "../../shared/icons/plus-box-outline-icon";
 import { BlockSuggester } from "./createSuggester/BlockSuggester";
+import { useReadonlyMode } from "../../shared/readonly-mode";
 
 type InsertBlockProps = {
   onBlockSuggesterChange: (
@@ -16,6 +17,7 @@ type InsertBlockProps = {
 export const InsertBlock: FunctionComponent<InsertBlockProps> = ({
   onBlockSuggesterChange,
 }) => {
+  const { readonlyMode } = useReadonlyMode();
   const [contextMenuPosition, setContextMenuPosition] = useState<{
     left: number;
     top: number;
@@ -27,6 +29,10 @@ export const InsertBlock: FunctionComponent<InsertBlockProps> = ({
     onBlockSuggesterChange(variant, blockMeta);
     onCloseSuggester();
   };
+
+  if (readonlyMode) {
+    return null;
+  }
 
   return (
     <>

--- a/packages/hash/frontend/src/blocks/page/PageTitle/PageTitle.tsx
+++ b/packages/hash/frontend/src/blocks/page/PageTitle/PageTitle.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import { useBlockProtocolUpdateEntity } from "../../../components/hooks/blockProtocolFunctions/useBlockProtocolUpdateEntity";
 import { rewriteEntityIdentifier } from "../../../lib/entities";
+import { useReadonlyMode } from "../../../shared/readonly-mode";
 import { usePageContext } from "../PageContext";
 import { cleanUpTitle, focusEditorBeginning } from "./utils";
 
@@ -24,6 +25,7 @@ const StyledTextarea = styled(TextareaAutosize)(({ theme }) =>
     fontSize: PAGE_TITLE_FONT_SIZE,
     lineHeight: PAGE_TITLE_LINE_HEIGHT,
     fontWeight: 500,
+    color: theme.palette.black,
 
     "&::placeholder": {
       color: theme.palette.gray[40],
@@ -31,7 +33,8 @@ const StyledTextarea = styled(TextareaAutosize)(({ theme }) =>
     },
 
     ":disabled": {
-      opacity: 0.5,
+      opacity: 1,
+      background: "transparent",
     },
   }),
 );
@@ -44,13 +47,13 @@ type PageTitleProps = {
 
 export const PAGE_TITLE_PLACEHOLDER = "Untitled";
 
-// TODO: Add read-only mode based on page permissions
 export const PageTitle: FunctionComponent<PageTitleProps> = ({
   accountId,
   entityId,
   value,
 }) => {
   // TODO: Display update error once expected UX is discussed
+  const { readonlyMode } = useReadonlyMode();
   const { updateEntity, updateEntityLoading } =
     useBlockProtocolUpdateEntity(true);
   const [prevValue, setPrevValue] = useState(value);
@@ -107,7 +110,7 @@ export const PageTitle: FunctionComponent<PageTitleProps> = ({
     <StyledTextarea
       ref={pageTitleRef}
       placeholder={PAGE_TITLE_PLACEHOLDER}
-      disabled={updateEntityLoading}
+      disabled={updateEntityLoading || readonlyMode}
       onChange={handleInputChange}
       onKeyDown={handleInputKeyDown}
       onBlur={handleInputBlur}

--- a/packages/hash/frontend/src/pages/[account-slug]/[page-slug].page.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/[page-slug].page.tsx
@@ -34,6 +34,7 @@ import {
 } from "../../graphql/apiTypes.gen";
 import { getLayoutWithSidebar, NextPageWithLayout } from "../../shared/layout";
 import { HEADER_HEIGHT } from "../../shared/layout/layout-with-header/page-header";
+import { useReadonlyMode } from "../../shared/readonly-mode";
 import { useRouteAccountInfo, useRoutePageInfo } from "../../shared/routing";
 import { Button } from "../../shared/ui/button";
 import {
@@ -208,7 +209,7 @@ const Page: NextPageWithLayout<PageProps> = ({ blocks }) => {
     variables: { entityId: pageEntityId, accountId, versionId },
   });
   const pageHeaderRef = useRef<HTMLElement>();
-
+  const { readonlyMode } = useReadonlyMode();
   const collabPositions = useCollabPositions(accountId, pageEntityId);
   const reportPosition = useCollabPositionReporter(accountId, pageEntityId);
   useCollabPositionTracking(reportPosition);
@@ -316,6 +317,7 @@ const Page: NextPageWithLayout<PageProps> = ({ blocks }) => {
               entityId={pageEntityId}
               versionId={versionId}
               sx={{ mr: 3, alignSelf: "flex-start" }}
+              readonly={readonlyMode}
             />
 
             <Box flex={1}>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Disable following elements on pages on `readonly` mode, to prevent the users from seeing editable elements on readonly pages. 

- Page title
- Page icon
- Insert block element (full-width horizontal element between blocks)

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1200211978612931/1202855617846688/f) _(internal)_

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch / view the deployment
1.  Open a page and add `&readonly` as url param
1.  Confirm that elements mentioned above are not available.
