### PR TITLE
Test 1.65-beta channel

### DIFF
--- a/.github/scripts/rust/setup.py
+++ b/.github/scripts/rust/setup.py
@@ -23,7 +23,7 @@ ALWAYS_RUN_PATTERNS = [".github/**"]
 # Toolchains used for the specified crates in addition to the toolchain which is defined in
 # rust-toolchain.toml
 TOOLCHAINS = {
-    "packages/libs/error-stack": ["1.63"],
+    "packages/libs/error-stack": ["1.63", "beta-2022-09-25"],
 }
 
 # Try and publish these crates when their version is changed in Cargo.toml

--- a/packages/libs/error-stack/CHANGELOG.md
+++ b/packages/libs/error-stack/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Change Log
+~~# Change Log
 
 All notable changes to `error-stack` will be documented in this file.
 
@@ -18,37 +18,26 @@ All notable changes to `error-stack` will be documented in this file.
 
 ### Features
 
-- Support backtraces on non-nightly channels starting with
-  1.65.0-beta ([#1098](https://github.com/hashintel/hash/pull/1098))
-- Implement [`Termination`](https://doc.rust-lang.org/stable/std/process/trait.Termination.html)
-  for `Report` ([#671](https://github.com/hashintel/hash/pull/671))
-- Add support for [`core::error::Error`](https://doc.rust-lang.org/nightly/core/error/trait.Error.html) on
-  nightly ([#1038](https://github.com/hashintel/hash/pull/1038))
-- Add support
-  for [`Error::provide()`](https://doc.rust-lang.org/nightly/core/error/trait.Error.html#method.provide) ([#904](https://github.com/hashintel/hash/pull/904))
-- Add compatibility for `anyhow` and `eyre` to convert their types
-  into `Report` ([#763](https://github.com/hashintel/hash/pull/763))
+- Support backtraces on non-nightly channels starting with 1.65.0-beta ([#1098](https://github.com/hashintel/hash/pull/1098))
+- Implement [`Termination`](https://doc.rust-lang.org/stable/std/process/trait.Termination.html) for `Report` ([#671](https://github.com/hashintel/hash/pull/671))
+- Add support for [`core::error::Error`](https://doc.rust-lang.org/nightly/core/error/trait.Error.html) on nightly ([#1038](https://github.com/hashintel/hash/pull/1038))
+- Add support for [`Error::provide()`](https://doc.rust-lang.org/nightly/core/error/trait.Error.html#method.provide) ([#904](https://github.com/hashintel/hash/pull/904))
+- Add compatibility for `anyhow` and `eyre` to convert their types into `Report` ([#763](https://github.com/hashintel/hash/pull/763))
 - Add support for related errors and multiple error sources ([#747](https://github.com/hashintel/hash/pull/747))
-- New output
-  for [Debug](https://doc.rust-lang.org/nightly/core/fmt/trait.Debug.html) ([#794](https://github.com/hashintel/hash/pull/794))
-- New hook interface
-  for [Debug](https://doc.rust-lang.org/nightly/core/fmt/trait.Debug.html) ([#794](https://github.com/hashintel/hash/pull/794))
-- `Report::set_debug_hook` and `Report::set_display_hook` no longer return an
-  error ([#794](https://github.com/hashintel/hash/pull/794))
+- New output for [Debug](https://doc.rust-lang.org/nightly/core/fmt/trait.Debug.html) ([#794](https://github.com/hashintel/hash/pull/794))
+- New hook interface for [Debug](https://doc.rust-lang.org/nightly/core/fmt/trait.Debug.html) ([#794](https://github.com/hashintel/hash/pull/794))
+- `Report::set_debug_hook` and `Report::set_display_hook` no longer return an error ([#794](https://github.com/hashintel/hash/pull/794))
 
 ### Deprecations
 
 - `IntoReport::report`: Use `IntoReport::into_report` instead ([#698](https://github.com/hashintel/hash/pull/698))
 - `Report::source`: Use `Report::sources` instead ([#747](https://github.com/hashintel/hash/pull/747))
 - `Report::source_mut`: Use `Report::sources_mut` instead ([#747](https://github.com/hashintel/hash/pull/747))
-- `Report::backtrace`: Use `Report::downcast_ref::<Backtrace>` (non-nightly), `Report::requested_ref::<Backtrace>` (
-  nightly) instead ([#747](https://github.com/hashintel/hash/pull/747))
-- `Report::span_trace`: Use `Report::downcast_ref::<SpanTrace>` (non-nightly), `Report::requested_ref::<SpanTrace>` (
-  nightly) instead ([#747](https://github.com/hashintel/hash/pull/747))
+- `Report::backtrace`: Use `Report::downcast_ref::<Backtrace>` (non-nightly), `Report::requested_ref::<Backtrace>` (nightly) instead ([#747](https://github.com/hashintel/hash/pull/747))
+- `Report::span_trace`: Use `Report::downcast_ref::<SpanTrace>` (non-nightly), `Report::requested_ref::<SpanTrace>` (nightly) instead ([#747](https://github.com/hashintel/hash/pull/747))
 - `Frame::source`: Use `Frame::sources` instead ([#747](https://github.com/hashintel/hash/pull/747))
 - `Frame::source_mut`: Use `Frame::sources_mut` instead ([#747](https://github.com/hashintel/hash/pull/747))
-- `Report::set_debug_hook`: Use `Report::install_debug_hook`
-  instead ([#794](https://github.com/hashintel/hash/pull/794))
+- `Report::set_debug_hook`: Use `Report::install_debug_hook` instead ([#794](https://github.com/hashintel/hash/pull/794))
 - `Report::set_display_hook`([#794](https://github.com/hashintel/hash/pull/794))
 
 ### Internal improvements
@@ -57,4 +46,4 @@ All notable changes to `error-stack` will be documented in this file.
 
 ## [0.1.0](https://github.com/hashintel/hash/tree/d14efbc38559fc38d36e03ebdd499b44cb80c668/packages/libs/error-stack) - 2022-06-10
 
-- Initial release
+- Initial release~~

--- a/packages/libs/error-stack/CHANGELOG.md
+++ b/packages/libs/error-stack/CHANGELOG.md
@@ -46,4 +46,4 @@ All notable changes to `error-stack` will be documented in this file.
 
 ## [0.1.0](https://github.com/hashintel/hash/tree/d14efbc38559fc38d36e03ebdd499b44cb80c668/packages/libs/error-stack) - 2022-06-10
 
-- Initial release~~
+- Initial release

--- a/packages/libs/error-stack/CHANGELOG.md
+++ b/packages/libs/error-stack/CHANGELOG.md
@@ -1,4 +1,4 @@
-~~# Change Log
+# Change Log
 
 All notable changes to `error-stack` will be documented in this file.
 

--- a/packages/libs/error-stack/CHANGELOG.md
+++ b/packages/libs/error-stack/CHANGELOG.md
@@ -18,25 +18,37 @@ All notable changes to `error-stack` will be documented in this file.
 
 ### Features
 
-- Implement [`Termination`](https://doc.rust-lang.org/stable/std/process/trait.Termination.html) for `Report` ([#671](https://github.com/hashintel/hash/pull/671))
-- Add support for [`core::error::Error`](https://doc.rust-lang.org/nightly/core/error/trait.Error.html) on nightly ([#1038](https://github.com/hashintel/hash/pull/1038))
-- Add support for [`Error::provide()`](https://doc.rust-lang.org/nightly/core/error/trait.Error.html#method.provide) ([#904](https://github.com/hashintel/hash/pull/904))
-- Add compatibility for `anyhow` and `eyre` to convert their types into `Report` ([#763](https://github.com/hashintel/hash/pull/763))
+- Support backtraces on non-nightly channels starting with
+  1.65.0-beta ([#1098](https://github.com/hashintel/hash/pull/1098))
+- Implement [`Termination`](https://doc.rust-lang.org/stable/std/process/trait.Termination.html)
+  for `Report` ([#671](https://github.com/hashintel/hash/pull/671))
+- Add support for [`core::error::Error`](https://doc.rust-lang.org/nightly/core/error/trait.Error.html) on
+  nightly ([#1038](https://github.com/hashintel/hash/pull/1038))
+- Add support
+  for [`Error::provide()`](https://doc.rust-lang.org/nightly/core/error/trait.Error.html#method.provide) ([#904](https://github.com/hashintel/hash/pull/904))
+- Add compatibility for `anyhow` and `eyre` to convert their types
+  into `Report` ([#763](https://github.com/hashintel/hash/pull/763))
 - Add support for related errors and multiple error sources ([#747](https://github.com/hashintel/hash/pull/747))
-- New output for [Debug](https://doc.rust-lang.org/nightly/core/fmt/trait.Debug.html) ([#794](https://github.com/hashintel/hash/pull/794))
-- New hook interface for [Debug](https://doc.rust-lang.org/nightly/core/fmt/trait.Debug.html) ([#794](https://github.com/hashintel/hash/pull/794))
-- `Report::set_debug_hook` and `Report::set_display_hook` no longer return an error ([#794](https://github.com/hashintel/hash/pull/794))
+- New output
+  for [Debug](https://doc.rust-lang.org/nightly/core/fmt/trait.Debug.html) ([#794](https://github.com/hashintel/hash/pull/794))
+- New hook interface
+  for [Debug](https://doc.rust-lang.org/nightly/core/fmt/trait.Debug.html) ([#794](https://github.com/hashintel/hash/pull/794))
+- `Report::set_debug_hook` and `Report::set_display_hook` no longer return an
+  error ([#794](https://github.com/hashintel/hash/pull/794))
 
 ### Deprecations
 
 - `IntoReport::report`: Use `IntoReport::into_report` instead ([#698](https://github.com/hashintel/hash/pull/698))
 - `Report::source`: Use `Report::sources` instead ([#747](https://github.com/hashintel/hash/pull/747))
 - `Report::source_mut`: Use `Report::sources_mut` instead ([#747](https://github.com/hashintel/hash/pull/747))
-- `Report::backtrace`: Use `Report::downcast_ref::<Backtrace>` (non-nightly), `Report::requested_ref::<Backtrace>` (nightly) instead ([#747](https://github.com/hashintel/hash/pull/747))
-- `Report::span_trace`: Use `Report::downcast_ref::<SpanTrace>` (non-nightly), `Report::requested_ref::<SpanTrace>` (nightly) instead ([#747](https://github.com/hashintel/hash/pull/747))
+- `Report::backtrace`: Use `Report::downcast_ref::<Backtrace>` (non-nightly), `Report::requested_ref::<Backtrace>` (
+  nightly) instead ([#747](https://github.com/hashintel/hash/pull/747))
+- `Report::span_trace`: Use `Report::downcast_ref::<SpanTrace>` (non-nightly), `Report::requested_ref::<SpanTrace>` (
+  nightly) instead ([#747](https://github.com/hashintel/hash/pull/747))
 - `Frame::source`: Use `Frame::sources` instead ([#747](https://github.com/hashintel/hash/pull/747))
 - `Frame::source_mut`: Use `Frame::sources_mut` instead ([#747](https://github.com/hashintel/hash/pull/747))
-- `Report::set_debug_hook`: Use `Report::install_debug_hook` instead ([#794](https://github.com/hashintel/hash/pull/794))
+- `Report::set_debug_hook`: Use `Report::install_debug_hook`
+  instead ([#794](https://github.com/hashintel/hash/pull/794))
 - `Report::set_display_hook`([#794](https://github.com/hashintel/hash/pull/794))
 
 ### Internal improvements

--- a/packages/libs/error-stack/src/fmt/hook.rs
+++ b/packages/libs/error-stack/src/fmt/hook.rs
@@ -162,10 +162,10 @@ impl HookContextInner {
 /// # owo_colors::set_override(true);
 /// # fn render(value: String) -> String {
 /// #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
-/// #     let backtrace_info = regex::Regex::new(r"backtrace with (\d+) frames \((\d+)\)").unwrap();
+/// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
 /// #
 /// #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
-/// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace with [n] frames ($2)");
+/// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
 /// #
 /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
 /// # }
@@ -242,10 +242,10 @@ impl HookContextInner {
 /// # owo_colors::set_override(true);
 /// # fn render(value: String) -> String {
 /// #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
-/// #     let backtrace_info = regex::Regex::new(r"backtrace with (\d+) frames \((\d+)\)").unwrap();
+/// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
 /// #
 /// #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
-/// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace with [n] frames ($2)");
+/// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
 /// #
 /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
 /// # }
@@ -323,10 +323,10 @@ impl<T> HookContext<T> {
     /// # owo_colors::set_override(true);
     /// # fn render(value: String) -> String {
     /// #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
-    /// #     let backtrace_info = regex::Regex::new(r"backtrace with (\d+) frames \((\d+)\)").unwrap();
+    /// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
     /// #
     /// #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
-    /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace with [n] frames ($2)");
+    /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
     /// #
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
     /// # }
@@ -370,10 +370,10 @@ impl<T> HookContext<T> {
     /// # owo_colors::set_override(true);
     /// # fn render(value: String) -> String {
     /// #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
-    /// #     let backtrace_info = regex::Regex::new(r"backtrace with (\d+) frames \((\d+)\)").unwrap();
+    /// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
     /// #
     /// #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
-    /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace with [n] frames ($2)");
+    /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
     /// #
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
     /// # }
@@ -437,10 +437,10 @@ impl<T> HookContext<T> {
     /// # owo_colors::set_override(true);
     /// # fn render(value: String) -> String {
     /// #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
-    /// #     let backtrace_info = regex::Regex::new(r"backtrace with (\d+) frames \((\d+)\)").unwrap();
+    /// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
     /// #
     /// #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
-    /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace with [n] frames ($2)");
+    /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
     /// #
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
     /// # }
@@ -563,10 +563,10 @@ impl<T: 'static> HookContext<T> {
     /// # owo_colors::set_override(true);
     /// # fn render(value: String) -> String {
     /// #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
-    /// #     let backtrace_info = regex::Regex::new(r"backtrace with (\d+) frames \((\d+)\)").unwrap();
+    /// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
     /// #
     /// #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
-    /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace with [n] frames ($2)");
+    /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
     /// #
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
     /// # }
@@ -628,10 +628,10 @@ impl<T: 'static> HookContext<T> {
     /// # owo_colors::set_override(true);
     /// # fn render(value: String) -> String {
     /// #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
-    /// #     let backtrace_info = regex::Regex::new(r"backtrace with (\d+) frames \((\d+)\)").unwrap();
+    /// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
     /// #
     /// #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
-    /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace with [n] frames ($2)");
+    /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
     /// #
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
     /// # }

--- a/packages/libs/error-stack/src/fmt/hook.rs
+++ b/packages/libs/error-stack/src/fmt/hook.rs
@@ -818,11 +818,14 @@ mod default {
         let idx = ctx.increment_counter();
 
         ctx.push_appendix(format!("Backtrace No. {}\n{}", idx + 1, backtrace));
+        #[cfg(nightly)]
         ctx.push_body(format!(
             "backtrace with {} frames ({})",
             backtrace.frames().len(),
             idx + 1
         ));
+        #[cfg(not(nightly))]
+        ctx.push_body(format!("backtrace ({})", idx + 1));
     }
 
     #[cfg(feature = "spantrace")]

--- a/packages/libs/error-stack/src/fmt/mod.rs
+++ b/packages/libs/error-stack/src/fmt/mod.rs
@@ -103,10 +103,10 @@
 //! # owo_colors::set_override(true);
 //! # fn render(value: String) -> String {
 //! #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
-//! #     let backtrace_info = regex::Regex::new(r"backtrace with (\d+) frames \((\d+)\)").unwrap();
+//! #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
 //! #
 //! #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
-//! #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace with [n] frames ($2)");
+//! #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
 //! #
 //! #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
 //! # }

--- a/packages/libs/error-stack/src/hook.rs
+++ b/packages/libs/error-stack/src/hook.rs
@@ -67,10 +67,10 @@ impl Report<()> {
     /// # owo_colors::set_override(true);
     /// # fn render(value: String) -> String {
     /// #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
-    /// #     let backtrace_info = regex::Regex::new(r"backtrace with (\d+) frames \((\d+)\)").unwrap();
+    /// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
     /// #
     /// #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
-    /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace with [n] frames ($2)");
+    /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
     /// #
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
     /// # }
@@ -142,10 +142,10 @@ impl Report<()> {
     /// # owo_colors::set_override(true);
     /// # fn render(value: String) -> String {
     /// #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
-    /// #     let backtrace_info = regex::Regex::new(r"backtrace with (\d+) frames \((\d+)\)").unwrap();
+    /// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
     /// #
     /// #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
-    /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace with [n] frames ($2)");
+    /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
     /// #
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
     /// # }
@@ -206,10 +206,10 @@ impl Report<()> {
     /// # owo_colors::set_override(true);
     /// # fn render(value: String) -> String {
     /// #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
-    /// #     let backtrace_info = regex::Regex::new(r"backtrace with (\d+) frames \((\d+)\)").unwrap();
+    /// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
     /// #
     /// #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
-    /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace with [n] frames ($2)");
+    /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
     /// #
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
     /// # }
@@ -273,10 +273,10 @@ impl Report<()> {
     /// # owo_colors::set_override(true);
     /// # fn render(value: String) -> String {
     /// #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
-    /// #     let backtrace_info = regex::Regex::new(r"backtrace with (\d+) frames \((\d+)\)").unwrap();
+    /// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
     /// #
     /// #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
-    /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace with [n] frames ($2)");
+    /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
     /// #
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
     /// # }

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -190,10 +190,10 @@
 //! # owo_colors::set_override(true);
 //! # fn render(value: String) -> String {
 //! #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
-//! #     let backtrace_info = regex::Regex::new(r"backtrace with (\d+) frames \((\d+)\)").unwrap();
+//! #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
 //! #
 //! #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
-//! #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace with [n] frames ($2)");
+//! #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
 //! #
 //! #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
 //! # }

--- a/packages/libs/error-stack/tests/common.rs
+++ b/packages/libs/error-stack/tests/common.rs
@@ -107,7 +107,7 @@ impl fmt::Display for ErrorB {
     }
 }
 
-#[cfg(all(rust_1_65, feature = "std"))]
+#[cfg(all(nightly, feature = "std"))]
 impl std::error::Error for ErrorB {
     fn provide<'a>(&'a self, demand: &mut core::any::Demand<'a>) {
         demand.provide_ref(&self.1);

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__diagnostics_add.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__diagnostics_add.snap
@@ -1,6 +1,6 @@
 <b>invalid input parameter</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/hook.rs:19:14</span>
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace with [n] frames (1)
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion: Try better next time
 <span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>Sorry for the inconvenience!
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__doc.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__doc.snap
@@ -1,6 +1,6 @@
 <b>invalid input parameter</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/mod.rs:59:14</span>
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace with [n] frames (1)
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Error (404)
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion 1: Try to be connected to the internet.
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion 2: Try better next time!

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__emit.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__emit.snap
@@ -1,6 +1,6 @@
 <b>invalid input parameter</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/hook.rs:49:14</span>
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace with [n] frames (1)
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Error code: 404
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion (0)
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Error code: 405

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__emit_alt.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__emit_alt.snap
@@ -1,6 +1,6 @@
 <b>invalid input parameter</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/hook.rs:49:14</span>
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace with [n] frames (1)
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Error code: 404
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion 0:
 <span style='color:#a00'>│</span><span style='color:#a00'> </span>  Do you have a connection to the internet?

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_cast.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_cast.snap
@@ -1,6 +1,6 @@
 <b>invalid input parameter</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/hook.rs:27:14</span>
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace with [n] frames (1)
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>[1] [ERROR] Unable to reach remote host
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>[2] [WARN] Disk nearly full
 <span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>[3] [ERROR] Cannot resolve example.com: Unknown host

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_decrement.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_decrement.snap
@@ -1,6 +1,6 @@
 <b>invalid input parameter</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/hook.rs:17:14</span>
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace with [n] frames (1)
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion -1: Use a file you can read next time!
 <span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>Suggestion -2: Don&#39;t press any random keys!
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_emit.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_emit.snap
@@ -1,6 +1,6 @@
 <b>invalid input parameter</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/hook.rs:24:14</span>
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace with [n] frames (1)
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Error 404
 <span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>Error 405
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_increment.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_increment.snap
@@ -1,6 +1,6 @@
 <b>invalid input parameter</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/hook.rs:17:14</span>
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace with [n] frames (1)
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion 0: Use a file you can read next time!
 <span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>Suggestion 1: Don&#39;t press any random keys!
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_storage.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_storage.snap
@@ -1,6 +1,6 @@
 <b>invalid input parameter</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/hook.rs:31:14</span>
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace with [n] frames (1)
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Computation for 2 (acc = 2, div = 0.5)
 <span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>Computation for 3 (acc = 5, div = 0.16666667)
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt_doc_alt.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt_doc_alt.snap
@@ -1,6 +1,6 @@
 <b>invalid input parameter</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/mod.rs:59:14</span>
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace with [n] frames (1)
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Error (404)
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion 1: Try to be connected to the internet.
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion 2: Try better next time!

--- a/packages/libs/error-stack/tests/snapshots/doc/hook__debug_hook.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/hook__debug_hook.snap
@@ -1,6 +1,6 @@
 <b>invalid input parameter</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/hook.rs:19:5</span>
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace with [n] frames (1)
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
 <span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>Suggestion: O no, try again
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/packages/libs/error-stack/tests/snapshots/doc/hook__debug_hook_provide.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/hook__debug_hook_provide.snap
@@ -2,7 +2,7 @@
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/hook.rs:49:14</span>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion: Try better next time!
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Error Code: 420
-<span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>backtrace with [n] frames (1)
+<span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>backtrace (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/doc/hook__fallback.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/hook__fallback.snap
@@ -1,7 +1,7 @@
 <b>invalid input parameter</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/hook.rs:16:5</span>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>unknown
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace with [n] frames (1)
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
 <span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>unknown
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/packages/libs/error-stack/tests/snapshots/doc/hook__fallback_context.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/hook__fallback_context.snap
@@ -1,7 +1,7 @@
 <b>Invalid user input</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/hook.rs:42:14</span>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Error Code: 404
-<span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>backtrace with [n] frames (1)
+<span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>backtrace (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/doc/lib__suggestion.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/lib__suggestion.snap
@@ -5,7 +5,7 @@
 <span style='color:#a00'>│</span>
 <span style='color:#a00'>╰</span><span style='color:#a00'>─</span><span style='color:#a00'>▶</span><span style='color:#a00'> </span><b>No such file or directory (os error 2)</b>
 <span style='color:#a00'> </span><span style='color:#a00'> </span><span style='color:#a00'> </span><span style='color:#a00'> </span><span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/lib.rs:24:10</span>
-<span style='color:#a00'> </span><span style='color:#a00'> </span><span style='color:#a00'> </span><span style='color:#a00'> </span><span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>backtrace with [n] frames (1)
+<span style='color:#a00'> </span><span style='color:#a00'> </span><span style='color:#a00'> </span><span style='color:#a00'> </span><span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>backtrace (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__alt.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__alt.snap
@@ -4,7 +4,7 @@ expression: "format!(\"{report:#?}\")"
 ---
 Root error
 ├╴tests/common.rs:147:5
-├╴backtrace with [n] frames (1)
+├╴backtrace (1)
 ├╴spantrace with 2 frames (1)
 ╰╴Empty
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__complex.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__complex.snap
@@ -8,13 +8,13 @@ Context A
 │
 ╰┬▶ Root error
  │  ├╴tests/common.rs:147:5
- │  ├╴backtrace with [n] frames (1)
+ │  ├╴backtrace (1)
  │  ├╴spantrace with 2 frames (1)
  │  ╰╴Printable A
  │
  ├▶ Root error
  │  ├╴tests/common.rs:147:5
- │  ├╴backtrace with [n] frames (2)
+ │  ├╴backtrace (2)
  │  ├╴spantrace with 2 frames (2)
  │  ├╴Printable B
  │  ├╴Test
@@ -22,7 +22,7 @@ Context A
  │
  ╰▶ Root error
     ├╴tests/common.rs:147:5
-    ├╴backtrace with [n] frames (3)
+    ├╴backtrace (3)
     ├╴spantrace with 2 frames (3)
     ├╴Printable B
     ├╴Test

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook.snap
@@ -4,7 +4,7 @@ expression: "format!(\"{report:?}\")"
 ---
 Root error
 ├╴tests/common.rs:147:5
-├╴backtrace with [n] frames (1)
+├╴backtrace (1)
 ├╴spantrace with 2 frames (1)
 ╰╴unsigned 32bit integer
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_context.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_context.snap
@@ -4,7 +4,7 @@ expression: "format!(\"{report:?}\")"
 ---
 Root error
 ├╴tests/common.rs:147:5
-├╴backtrace with [n] frames (1)
+├╴backtrace (1)
 ├╴spantrace with 2 frames (1)
 ╰╴unsigned 32bit integer (No. 0)
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_decr.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_decr.snap
@@ -4,7 +4,7 @@ expression: "format!(\"{report:?}\")"
 ---
 Root error
 ├╴tests/common.rs:147:5
-├╴backtrace with [n] frames (1)
+├╴backtrace (1)
 ├╴spantrace with 2 frames (1)
 ├╴-1
 ├╴-2

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_fallback.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_fallback.snap
@@ -5,7 +5,7 @@ expression: "format!(\"{report:?}\")"
 Root error
 ├╴tests/common.rs:147:5
 ├╴unknown
-├╴backtrace with [n] frames (1)
+├╴backtrace (1)
 ├╴spantrace with 2 frames (1)
 ╰╴unknown
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_incr.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_incr.snap
@@ -4,7 +4,7 @@ expression: "format!(\"{report:?}\")"
 ---
 Root error
 ├╴tests/common.rs:147:5
-├╴backtrace with [n] frames (1)
+├╴backtrace (1)
 ├╴spantrace with 2 frames (1)
 ├╴0
 ├╴1

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_multiple.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_multiple.snap
@@ -4,7 +4,7 @@ expression: "format!(\"{report:?}\")"
 ---
 Root error
 ├╴tests/common.rs:147:5
-├╴backtrace with [n] frames (1)
+├╴backtrace (1)
 ├╴spantrace with 2 frames (1)
 ├╴unsigned 32bit integer
 ╰╴unsigned 64bit integer

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_provider.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_provider.snap
@@ -9,7 +9,7 @@ Context D
 │
 ╰─▶ Root error
     ├╴tests/common.rs:147:5
-    ├╴backtrace with [n] frames (1)
+    ├╴backtrace (1)
     ╰╴spantrace with 2 frames (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__linear.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__linear.snap
@@ -13,7 +13,7 @@ Context B
 │
 ╰─▶ Root error
     ├╴tests/common.rs:147:5
-    ├╴backtrace with [n] frames (1)
+    ├╴backtrace (1)
     ├╴spantrace with 2 frames (1)
     ├╴Printable A
     ╰╴2 additional opaque attachments

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__linear_ext.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__linear_ext.snap
@@ -13,7 +13,7 @@ Context B
 │
 ╰─▶ Root error
     ├╴tests/common.rs:147:5
-    ├╴backtrace with [n] frames (1)
+    ├╴backtrace (1)
     ├╴spantrace with 2 frames (1)
     ├╴Printable A
     ╰╴2 additional opaque attachments

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__multiline.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__multiline.snap
@@ -4,7 +4,7 @@ expression: "format!(\"{report:#?}\")"
 ---
 Root error
 ├╴tests/common.rs:147:5
-├╴backtrace with [n] frames (1)
+├╴backtrace (1)
 ├╴spantrace with 2 frames (1)
 ╰╴A multiline
   attachment

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__multiline_ctx.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__multiline_ctx.snap
@@ -15,7 +15,7 @@ Context B
 │
 ╰─▶ Root error
     ├╴tests/common.rs:147:5
-    ├╴backtrace with [n] frames (1)
+    ├╴backtrace (1)
     ╰╴spantrace with 2 frames (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__norm.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__norm.snap
@@ -4,7 +4,7 @@ expression: "format!(\"{report:?}\")"
 ---
 Root error
 ├╴tests/common.rs:147:5
-├╴backtrace with [n] frames (1)
+├╴backtrace (1)
 ├╴spantrace with 2 frames (1)
 ╰╴Empty
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__sources.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__sources.snap
@@ -8,21 +8,21 @@ Context A
 │
 ╰┬▶ Root error
  │  ├╴tests/common.rs:147:5
- │  ├╴backtrace with [n] frames (1)
+ │  ├╴backtrace (1)
  │  ├╴spantrace with 2 frames (1)
  │  ├╴Printable A
  │  ╰╴1 additional opaque attachment
  │
  ├▶ Root error
  │  ├╴tests/common.rs:147:5
- │  ├╴backtrace with [n] frames (2)
+ │  ├╴backtrace (2)
  │  ├╴spantrace with 2 frames (2)
  │  ├╴Printable B
  │  ╰╴1 additional opaque attachment
  │
  ╰▶ Root error
     ├╴tests/common.rs:147:5
-    ├╴backtrace with [n] frames (3)
+    ├╴backtrace (3)
     ├╴spantrace with 2 frames (3)
     ├╴Printable B
     ╰╴1 additional opaque attachment

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__sources_transparent.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__sources_transparent.snap
@@ -8,14 +8,14 @@ Context A
 │
 ╰┬▶ Root error
  │  ├╴tests/common.rs:147:5
- │  ├╴backtrace with [n] frames (1)
+ │  ├╴backtrace (1)
  │  ├╴spantrace with 2 frames (1)
  │  ├╴Printable A
  │  ╰╴1 additional opaque attachment
  │
  ├▶ Root error
  │  ├╴tests/common.rs:147:5
- │  ├╴backtrace with [n] frames (2)
+ │  ├╴backtrace (2)
  │  ├╴spantrace with 2 frames (2)
  │  ├╴Printable B
  │  ├╴Printable A
@@ -23,7 +23,7 @@ Context A
  │
  ╰▶ Root error
     ├╴tests/common.rs:147:5
-    ├╴backtrace with [n] frames (3)
+    ├╴backtrace (3)
     ├╴spantrace with 2 frames (3)
     ├╴Printable B
     ├╴Printable A

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@backtrace-pretty-print.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@backtrace-pretty-print.snap
@@ -14,7 +14,7 @@ Context A
  │  │
  │  ╰─▶ Root error
  │      ├╴tests/common.rs:147:5
- │      ├╴backtrace with [n] frames (1)
+ │      ├╴backtrace (1)
  │      ╰╴6
  │
  ╰▶ Context A
@@ -33,7 +33,7 @@ Context A
      │  │
      │  ╰─▶ Root error
      │      ├╴tests/common.rs:147:5
-     │      ╰╴backtrace with [n] frames (2)
+     │      ╰╴backtrace (2)
      │
      ├▶ Context A
      │  ├╴tests/test_debug.rs:186:10
@@ -45,7 +45,7 @@ Context A
      │  │
      │  ╰─▶ Root error
      │      ├╴tests/common.rs:147:5
-     │      ╰╴backtrace with [n] frames (3)
+     │      ╰╴backtrace (3)
      │
      ├▶ Context A
      │  ├╴tests/test_debug.rs:172:10
@@ -58,7 +58,7 @@ Context A
      │  │
      │  ╰─▶ Root error
      │      ├╴tests/common.rs:147:5
-     │      ╰╴backtrace with [n] frames (4)
+     │      ╰╴backtrace (4)
      │
      ├▶ Context A
      │  ├╴tests/test_debug.rs:182:10
@@ -68,7 +68,7 @@ Context A
      │  │
      │  ╰─▶ Root error
      │      ├╴tests/common.rs:147:5
-     │      ╰╴backtrace with [n] frames (5)
+     │      ╰╴backtrace (5)
      │
      ╰▶ Context A
         ├╴tests/test_debug.rs:178:10
@@ -81,7 +81,7 @@ Context A
         │
         ╰─▶ Root error
             ├╴tests/common.rs:147:5
-            ╰╴backtrace with [n] frames (6)
+            ╰╴backtrace (6)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@backtrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@backtrace.snap
@@ -14,7 +14,7 @@ Context A
  |  |
  |  |-> Root error
  |      |-at tests/common.rs:147:5
- |      |-backtrace with [n] frames (1)
+ |      |-backtrace (1)
  |      |-6
  |
  |> Context A
@@ -33,7 +33,7 @@ Context A
      |  |
      |  |-> Root error
      |      |-at tests/common.rs:147:5
-     |      |-backtrace with [n] frames (2)
+     |      |-backtrace (2)
      |
      |> Context A
      |  |-at tests/test_debug.rs:186:10
@@ -45,7 +45,7 @@ Context A
      |  |
      |  |-> Root error
      |      |-at tests/common.rs:147:5
-     |      |-backtrace with [n] frames (3)
+     |      |-backtrace (3)
      |
      |> Context A
      |  |-at tests/test_debug.rs:172:10
@@ -58,7 +58,7 @@ Context A
      |  |
      |  |-> Root error
      |      |-at tests/common.rs:147:5
-     |      |-backtrace with [n] frames (4)
+     |      |-backtrace (4)
      |
      |> Context A
      |  |-at tests/test_debug.rs:182:10
@@ -68,7 +68,7 @@ Context A
      |  |
      |  |-> Root error
      |      |-at tests/common.rs:147:5
-     |      |-backtrace with [n] frames (5)
+     |      |-backtrace (5)
      |
      |> Context A
         |-at tests/test_debug.rs:178:10
@@ -81,7 +81,7 @@ Context A
         |
         |-> Root error
             |-at tests/common.rs:147:5
-            |-backtrace with [n] frames (6)
+            |-backtrace (6)
 
 ========================================
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace-backtrace-pretty-print.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace-backtrace-pretty-print.snap
@@ -14,7 +14,7 @@ Context A
  │  │
  │  ╰─▶ Root error
  │      ├╴tests/common.rs:147:5
- │      ├╴backtrace with [n] frames (1)
+ │      ├╴backtrace (1)
  │      ├╴spantrace with 2 frames (1)
  │      ╰╴6
  │
@@ -34,7 +34,7 @@ Context A
      │  │
      │  ╰─▶ Root error
      │      ├╴tests/common.rs:147:5
-     │      ├╴backtrace with [n] frames (2)
+     │      ├╴backtrace (2)
      │      ╰╴spantrace with 2 frames (2)
      │
      ├▶ Context A
@@ -47,7 +47,7 @@ Context A
      │  │
      │  ╰─▶ Root error
      │      ├╴tests/common.rs:147:5
-     │      ├╴backtrace with [n] frames (3)
+     │      ├╴backtrace (3)
      │      ╰╴spantrace with 2 frames (3)
      │
      ├▶ Context A
@@ -61,7 +61,7 @@ Context A
      │  │
      │  ╰─▶ Root error
      │      ├╴tests/common.rs:147:5
-     │      ├╴backtrace with [n] frames (4)
+     │      ├╴backtrace (4)
      │      ╰╴spantrace with 2 frames (4)
      │
      ├▶ Context A
@@ -72,7 +72,7 @@ Context A
      │  │
      │  ╰─▶ Root error
      │      ├╴tests/common.rs:147:5
-     │      ├╴backtrace with [n] frames (5)
+     │      ├╴backtrace (5)
      │      ╰╴spantrace with 2 frames (5)
      │
      ╰▶ Context A
@@ -86,7 +86,7 @@ Context A
         │
         ╰─▶ Root error
             ├╴tests/common.rs:147:5
-            ├╴backtrace with [n] frames (6)
+            ├╴backtrace (6)
             ╰╴spantrace with 2 frames (6)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace-backtrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace-backtrace.snap
@@ -14,7 +14,7 @@ Context A
  |  |
  |  |-> Root error
  |      |-at tests/common.rs:147:5
- |      |-backtrace with [n] frames (1)
+ |      |-backtrace (1)
  |      |-spantrace with 2 frames (1)
  |      |-6
  |
@@ -34,7 +34,7 @@ Context A
      |  |
      |  |-> Root error
      |      |-at tests/common.rs:147:5
-     |      |-backtrace with [n] frames (2)
+     |      |-backtrace (2)
      |      |-spantrace with 2 frames (2)
      |
      |> Context A
@@ -47,7 +47,7 @@ Context A
      |  |
      |  |-> Root error
      |      |-at tests/common.rs:147:5
-     |      |-backtrace with [n] frames (3)
+     |      |-backtrace (3)
      |      |-spantrace with 2 frames (3)
      |
      |> Context A
@@ -61,7 +61,7 @@ Context A
      |  |
      |  |-> Root error
      |      |-at tests/common.rs:147:5
-     |      |-backtrace with [n] frames (4)
+     |      |-backtrace (4)
      |      |-spantrace with 2 frames (4)
      |
      |> Context A
@@ -72,7 +72,7 @@ Context A
      |  |
      |  |-> Root error
      |      |-at tests/common.rs:147:5
-     |      |-backtrace with [n] frames (5)
+     |      |-backtrace (5)
      |      |-spantrace with 2 frames (5)
      |
      |> Context A
@@ -86,7 +86,7 @@ Context A
         |
         |-> Root error
             |-at tests/common.rs:147:5
-            |-backtrace with [n] frames (6)
+            |-backtrace (6)
             |-spantrace with 2 frames (6)
 
 ========================================

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@backtrace-pretty-print.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@backtrace-pretty-print.snap
@@ -14,7 +14,7 @@ Context A
  │  │
  │  ╰─▶ Root error
  │      ├╴tests/common.rs:147:5
- │      ├╴backtrace with [n] frames (1)
+ │      ├╴backtrace (1)
  │      ╰╴6
  │
  ╰▶ Context A
@@ -33,7 +33,7 @@ Context A
      │  │
      │  ╰─▶ Root error
      │      ├╴tests/common.rs:147:5
-     │      ╰╴backtrace with [n] frames (2)
+     │      ╰╴backtrace (2)
      │
      ├▶ Context A
      │  ├╴tests/test_debug.rs:186:10
@@ -45,7 +45,7 @@ Context A
      │  │
      │  ╰─▶ Root error
      │      ├╴tests/common.rs:147:5
-     │      ╰╴backtrace with [n] frames (3)
+     │      ╰╴backtrace (3)
      │
      ├▶ Context A
      │  ├╴tests/test_debug.rs:172:10
@@ -58,7 +58,7 @@ Context A
      │  │
      │  ╰─▶ Root error
      │      ├╴tests/common.rs:147:5
-     │      ╰╴backtrace with [n] frames (4)
+     │      ╰╴backtrace (4)
      │
      ├▶ Context A
      │  ├╴tests/test_debug.rs:182:10
@@ -68,7 +68,7 @@ Context A
      │  │
      │  ╰─▶ Root error
      │      ├╴tests/common.rs:147:5
-     │      ╰╴backtrace with [n] frames (5)
+     │      ╰╴backtrace (5)
      │
      ╰▶ Context A
         ├╴tests/test_debug.rs:178:10
@@ -81,7 +81,7 @@ Context A
         │
         ╰─▶ Root error
             ├╴tests/common.rs:147:5
-            ╰╴backtrace with [n] frames (6)
+            ╰╴backtrace (6)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@backtrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@backtrace.snap
@@ -14,7 +14,7 @@ Context A
  |  |
  |  |-> Root error
  |      |-at tests/common.rs:147:5
- |      |-backtrace with [n] frames (1)
+ |      |-backtrace (1)
  |      |-6
  |
  |> Context A
@@ -33,7 +33,7 @@ Context A
      |  |
      |  |-> Root error
      |      |-at tests/common.rs:147:5
-     |      |-backtrace with [n] frames (2)
+     |      |-backtrace (2)
      |
      |> Context A
      |  |-at tests/test_debug.rs:186:10
@@ -45,7 +45,7 @@ Context A
      |  |
      |  |-> Root error
      |      |-at tests/common.rs:147:5
-     |      |-backtrace with [n] frames (3)
+     |      |-backtrace (3)
      |
      |> Context A
      |  |-at tests/test_debug.rs:172:10
@@ -58,7 +58,7 @@ Context A
      |  |
      |  |-> Root error
      |      |-at tests/common.rs:147:5
-     |      |-backtrace with [n] frames (4)
+     |      |-backtrace (4)
      |
      |> Context A
      |  |-at tests/test_debug.rs:182:10
@@ -68,7 +68,7 @@ Context A
      |  |
      |  |-> Root error
      |      |-at tests/common.rs:147:5
-     |      |-backtrace with [n] frames (5)
+     |      |-backtrace (5)
      |
      |> Context A
         |-at tests/test_debug.rs:178:10
@@ -81,7 +81,7 @@ Context A
         |
         |-> Root error
             |-at tests/common.rs:147:5
-            |-backtrace with [n] frames (6)
+            |-backtrace (6)
 
 ========================================
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace-backtrace-pretty-print.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace-backtrace-pretty-print.snap
@@ -14,7 +14,7 @@ Context A
  │  │
  │  ╰─▶ Root error
  │      ├╴tests/common.rs:147:5
- │      ├╴backtrace with [n] frames (1)
+ │      ├╴backtrace (1)
  │      ├╴spantrace with 2 frames (1)
  │      ╰╴6
  │
@@ -34,7 +34,7 @@ Context A
      │  │
      │  ╰─▶ Root error
      │      ├╴tests/common.rs:147:5
-     │      ├╴backtrace with [n] frames (2)
+     │      ├╴backtrace (2)
      │      ╰╴spantrace with 2 frames (2)
      │
      ├▶ Context A
@@ -47,7 +47,7 @@ Context A
      │  │
      │  ╰─▶ Root error
      │      ├╴tests/common.rs:147:5
-     │      ├╴backtrace with [n] frames (3)
+     │      ├╴backtrace (3)
      │      ╰╴spantrace with 2 frames (3)
      │
      ├▶ Context A
@@ -61,7 +61,7 @@ Context A
      │  │
      │  ╰─▶ Root error
      │      ├╴tests/common.rs:147:5
-     │      ├╴backtrace with [n] frames (4)
+     │      ├╴backtrace (4)
      │      ╰╴spantrace with 2 frames (4)
      │
      ├▶ Context A
@@ -72,7 +72,7 @@ Context A
      │  │
      │  ╰─▶ Root error
      │      ├╴tests/common.rs:147:5
-     │      ├╴backtrace with [n] frames (5)
+     │      ├╴backtrace (5)
      │      ╰╴spantrace with 2 frames (5)
      │
      ╰▶ Context A
@@ -86,7 +86,7 @@ Context A
         │
         ╰─▶ Root error
             ├╴tests/common.rs:147:5
-            ├╴backtrace with [n] frames (6)
+            ├╴backtrace (6)
             ╰╴spantrace with 2 frames (6)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace-backtrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace-backtrace.snap
@@ -14,7 +14,7 @@ Context A
  |  |
  |  |-> Root error
  |      |-at tests/common.rs:147:5
- |      |-backtrace with [n] frames (1)
+ |      |-backtrace (1)
  |      |-spantrace with 2 frames (1)
  |      |-6
  |
@@ -34,7 +34,7 @@ Context A
      |  |
      |  |-> Root error
      |      |-at tests/common.rs:147:5
-     |      |-backtrace with [n] frames (2)
+     |      |-backtrace (2)
      |      |-spantrace with 2 frames (2)
      |
      |> Context A
@@ -47,7 +47,7 @@ Context A
      |  |
      |  |-> Root error
      |      |-at tests/common.rs:147:5
-     |      |-backtrace with [n] frames (3)
+     |      |-backtrace (3)
      |      |-spantrace with 2 frames (3)
      |
      |> Context A
@@ -61,7 +61,7 @@ Context A
      |  |
      |  |-> Root error
      |      |-at tests/common.rs:147:5
-     |      |-backtrace with [n] frames (4)
+     |      |-backtrace (4)
      |      |-spantrace with 2 frames (4)
      |
      |> Context A
@@ -72,7 +72,7 @@ Context A
      |  |
      |  |-> Root error
      |      |-at tests/common.rs:147:5
-     |      |-backtrace with [n] frames (5)
+     |      |-backtrace (5)
      |      |-spantrace with 2 frames (5)
      |
      |> Context A
@@ -86,7 +86,7 @@ Context A
         |
         |-> Root error
             |-at tests/common.rs:147:5
-            |-backtrace with [n] frames (6)
+            |-backtrace (6)
             |-spantrace with 2 frames (6)
 
 ========================================

--- a/packages/libs/error-stack/tests/test_backtrace.rs
+++ b/packages/libs/error-stack/tests/test_backtrace.rs
@@ -9,6 +9,7 @@ mod common;
 use std::backtrace::Backtrace;
 
 use common::*;
+#[cfg(nightly)]
 use error_stack::Report;
 
 #[test]
@@ -17,15 +18,25 @@ fn captured() {
 
     let report = create_report();
     #[cfg(nightly)]
-    assert_eq!(report.request_ref::<Backtrace>().count(), 1);
-    let backtrace = report
-        .request_ref::<Backtrace>()
-        .next()
-        .expect("No backtrace captured");
-    assert!(!backtrace.frames().is_empty());
+    {
+        assert_eq!(report.request_ref::<Backtrace>().count(), 1);
+        let backtrace = report
+            .request_ref::<Backtrace>()
+            .next()
+            .expect("No backtrace captured");
+        assert!(!backtrace.frames().is_empty());
+    }
+    #[cfg(not(nightly))]
+    {
+        assert!(
+            report.downcast_ref::<Backtrace>().is_some(),
+            "No backtrace captured"
+        );
+    }
 }
 
 #[test]
+#[cfg(nightly)]
 fn captured_deprecated() {
     std::env::set_var("RUST_LIB_BACKTRACE", "1");
 

--- a/packages/libs/error-stack/tests/test_debug.rs
+++ b/packages/libs/error-stack/tests/test_debug.rs
@@ -28,12 +28,12 @@ fn setup_tracing() {
 #[cfg(not(feature = "spantrace"))]
 fn setup_tracing() {}
 
-#[cfg(not(all(nightly, feature = "std")))]
+#[cfg(not(all(rust_1_65, feature = "std")))]
 fn setup_backtrace() {
     std::env::set_var("RUST_LIB_BACKTRACE", "0");
 }
 
-#[cfg(all(nightly, feature = "std"))]
+#[cfg(all(rust_1_65, feature = "std"))]
 fn setup_backtrace() {
     std::env::set_var("RUST_LIB_BACKTRACE", "1");
 }
@@ -61,7 +61,7 @@ fn snap_suffix() -> String {
         suffix.push("spantrace");
     }
 
-    #[cfg(all(nightly, feature = "std"))]
+    #[cfg(all(rust_1_65, feature = "std"))]
     if supports_backtrace() {
         suffix.push("backtrace");
     }
@@ -107,8 +107,8 @@ fn prepare(suffix: bool) -> impl Drop {
         "Span Trace No. $1\n  [redacted]",
     );
     settings.add_filter(
-        r"backtrace with (\d+) frames \((\d+)\)",
-        "backtrace with [n] frames ($2)",
+        r"backtrace with( (\d+) frames)? \((\d+)\)",
+        "backtrace ($3)",
     );
 
     settings.bind_to_scope()


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

With 1.65, backtrace support is added, so it's possible to use it without a nightly toolchain. In order to properly support it, we need to test that release in CI as well.

## 🔗 Related links

- Fixes #1094 

## 🔍 What does this change?

- Add beta channel to CI (current beta is `1.65.0-beta.2`)
- Fix usage of a nightly feature to read the number of frames in a backtrace, it's now omitted in non-nightly channels
- Adjust documentation to show the non-nightly output

## 🛡 What tests cover this?

- All tests, which are running at 1.63 will also be tested on 1.65 (which are all tests which are not using the Provider API)