### PR TITLE
Test optional dependencies from `cargo make`

### DIFF
--- a/packages/libs/error-stack/Makefile.toml
+++ b/packages/libs/error-stack/Makefile.toml
@@ -1,15 +1,15 @@
 extend = { path = "../../../.github/scripts/rust/Makefile.toml" }
 
 [env]
-CARGO_CLIPPY_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default,hooks,futures"
-CARGO_TEST_HACK_FLAGS = "--workspace --feature-powerset --exclude-features default,hooks,futures"
+CARGO_CLIPPY_HACK_FLAGS = "--workspace --optional-deps --feature-powerset --exclude-features default,hooks,futures"
+CARGO_TEST_HACK_FLAGS = "--workspace --optional-deps --feature-powerset --exclude-features default,hooks,futures"
 CARGO_MIRI_FLAGS = "--tests --lib"
 CARGO_INSTA_TEST_FLAGS = "--no-fail-fast"
 CARGO_RUSTDOC_HACK_FLAGS = ""
 CARGO_DOC_HACK_FLAGS = ""
 # The only features that are of relevance are: spantrace, pretty-print, std
 # all others do not change the output
-CARGO_INSTA_TEST_HACK_FLAGS = "--keep-going --feature-powerset --include-features spantrace,pretty-print,std --ignore-unknown-features"
+CARGO_INSTA_TEST_HACK_FLAGS = "--keep-going --feature-powerset --include-features spantrace,pretty-print,std"
 
 
 [tasks.test]

--- a/packages/libs/error-stack/tests/common.rs
+++ b/packages/libs/error-stack/tests/common.rs
@@ -189,6 +189,11 @@ pub fn supports_backtrace() -> bool {
     *STATE
 }
 
+#[cfg(all(not(rust_1_65), feature = "std"))]
+pub fn supports_backtrace() -> bool {
+    false
+}
+
 #[cfg(feature = "spantrace")]
 pub fn supports_spantrace() -> bool {
     static STATE: Lazy<bool> = Lazy::new(|| {

--- a/packages/libs/error-stack/tests/common.rs
+++ b/packages/libs/error-stack/tests/common.rs
@@ -189,11 +189,6 @@ pub fn supports_backtrace() -> bool {
     *STATE
 }
 
-#[cfg(all(not(rust_1_65), feature = "std"))]
-pub fn supports_backtrace() -> bool {
-    false
-}
-
 #[cfg(feature = "spantrace")]
 pub fn supports_spantrace() -> bool {
     static STATE: Lazy<bool> = Lazy::new(|| {

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__complex.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__complex.snap
@@ -3,7 +3,7 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 Context A
-├╴tests/test_debug.rs:442:14
+├╴tests/test_debug.rs:440:14
 ├╴Printable A
 │
 ╰┬▶ Root error

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_provider.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_provider.snap
@@ -3,7 +3,7 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 Context D
-├╴tests/test_debug.rs:578:38
+├╴tests/test_debug.rs:580:38
 ├╴usize: 420
 ├╴&'static str: Invalid User Input
 │

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__linear.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__linear.snap
@@ -3,11 +3,11 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 Context B
-├╴tests/test_debug.rs:288:14
+├╴tests/test_debug.rs:286:14
 ├╴Printable C
 │
 ├─▶ Context A
-│   ├╴tests/test_debug.rs:285:14
+│   ├╴tests/test_debug.rs:283:14
 │   ├╴Printable B
 │   ╰╴1 additional opaque attachment
 │

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__linear_ext.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__linear_ext.snap
@@ -3,11 +3,11 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 Context B
-├╴tests/test_debug.rs:305:14
+├╴tests/test_debug.rs:303:14
 ├╴Printable C
 │
 ├─▶ Context A
-│   ├╴tests/test_debug.rs:302:14
+│   ├╴tests/test_debug.rs:300:14
 │   ├╴Printable B
 │   ╰╴1 additional opaque attachment
 │

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__multiline_ctx.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__multiline_ctx.snap
@@ -3,13 +3,13 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 Context B
-├╴tests/test_debug.rs:330:14
+├╴tests/test_debug.rs:328:14
 ├╴Printable C
 │
 ├─▶ A multiline
 │   context that might have
 │   a bit more info
-│   ├╴tests/test_debug.rs:327:14
+│   ├╴tests/test_debug.rs:325:14
 │   ├╴Printable B
 │   ╰╴1 additional opaque attachment
 │

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__sources.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__sources.snap
@@ -3,7 +3,7 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 Context A
-├╴tests/test_debug.rs:374:14
+├╴tests/test_debug.rs:372:14
 ├╴1 additional opaque attachment
 │
 ╰┬▶ Root error

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__sources_transparent.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__sources_transparent.snap
@@ -3,7 +3,7 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 Context A
-├╴tests/test_debug.rs:415:18
+├╴tests/test_debug.rs:413:18
 ├╴1 additional opaque attachment
 │
 ╰┬▶ Root error

--- a/packages/libs/error-stack/tests/test_compatibility.rs
+++ b/packages/libs/error-stack/tests/test_compatibility.rs
@@ -10,12 +10,14 @@ mod common;
 use common::*;
 use error_stack::compat::IntoReportCompat;
 
+// All frames except backtraces in this file are printable (either a printable attachment or a
+// context), so only backtraces are "Opaque". Depending on how the backtrace is generated, it will
+// appear at different locations. To simplify the general tests, we remove backtraces, they are
+// tested explicitly in other tests. On nightly, anyhow/eyre will capture the backtrace and provide
+// it by `Error::provide`. On non-nightly toolchains since 1.65 the backtrace will be captured by
+// `Report.
 #[cfg(all(rust_1_65, feature = "std"))]
 fn remove_opaque_frames(messages: &mut Vec<String>) {
-    /// Depending on how the backtrace is generated, it will appear at different locations. To
-    /// simplify the general tests, we remove backtraces, they are tested explicitly in other tests.
-    /// On nightly, anyhow/eyre will capture the backtrace and provide it by `Error::provide`. On
-    /// non-nightly toolchains since 1.65 the backtrace will be captured by `Report.
     messages.retain(|message| message != "Opaque")
 }
 

--- a/packages/libs/error-stack/tests/test_compatibility.rs
+++ b/packages/libs/error-stack/tests/test_compatibility.rs
@@ -11,7 +11,7 @@ use common::*;
 use error_stack::compat::IntoReportCompat;
 
 #[cfg(all(rust_1_65, feature = "std"))]
-fn remove_opaque_attachment(messages: &mut Vec<String>) {
+fn remove_opaque_frames(messages: &mut Vec<String>) {
     /// Depending on how the backtrace is generated, it will appear at different locations. To
     /// simplify the general tests, we remove backtraces, they are tested explicitly in other tests.
     /// On nightly, anyhow/eyre will capture the backtrace and provide it by `Error::provide`. On
@@ -33,14 +33,14 @@ fn anyhow() {
     #[allow(unused_mut)]
     let mut report_messages = messages(&report);
     #[cfg(rust_1_65)]
-    remove_opaque_attachment(&mut report_messages);
+    remove_opaque_frames(&mut report_messages);
 
     let anyhow_report = anyhow.into_report().unwrap_err();
 
     #[allow(unused_mut)]
     let mut anyhow_messages = messages(&anyhow_report);
     #[cfg(rust_1_65)]
-    remove_opaque_attachment(&mut anyhow_messages);
+    remove_opaque_frames(&mut anyhow_messages);
 
     assert_eq!(
         anyhow_messages.into_iter().rev().collect::<Vec<_>>(),
@@ -169,14 +169,14 @@ fn eyre() {
     #[allow(unused_mut)]
     let mut report_messages = messages(&report);
     #[cfg(all(rust_1_65, feature = "std"))]
-    remove_opaque_attachment(&mut report_messages);
+    remove_opaque_frames(&mut report_messages);
 
     let eyre_report = eyre.into_report().unwrap_err();
 
     #[allow(unused_mut)]
     let mut eyre_messages = messages(&eyre_report);
     #[cfg(all(rust_1_65, feature = "std"))]
-    remove_opaque_attachment(&mut eyre_messages);
+    remove_opaque_frames(&mut eyre_messages);
 
     assert_eq!(
         eyre_messages.into_iter().rev().collect::<Vec<_>>(),

--- a/packages/libs/error-stack/tests/test_compatibility.rs
+++ b/packages/libs/error-stack/tests/test_compatibility.rs
@@ -7,11 +7,14 @@
 
 mod common;
 
-#[cfg(all(nightly, feature = "std"))]
-use std::backtrace::{Backtrace, BacktraceStatus};
 #[cfg(feature = "eyre")]
 use std::sync::Once;
-use std::{error::Error, ops::Deref};
+#[cfg(all(nightly, feature = "std"))]
+use std::{
+    backtrace::{Backtrace, BacktraceStatus},
+    error::Error,
+    ops::Deref,
+};
 
 use common::*;
 use error_stack::compat::IntoReportCompat;
@@ -51,17 +54,18 @@ fn anyhow() {
 
     let mut swap = false;
 
+    #[cfg(nightly)]
     if has_provided_backtrace(&anyhow) {
         // Backtrace is provided through `anyhow::Error` by `Error::provide`
-        #[cfg(nightly)]
         remove_backtrace_context(&mut report_messages);
-    } else if supports_backtrace() {
+    }
+
+    if !cfg!(nightly) && supports_backtrace() {
         swap = true;
     }
 
     let anyhow_report = anyhow.into_report().unwrap_err();
 
-    #[allow(unused_mut)]
     let mut anyhow_messages = messages(&anyhow_report);
 
     if swap {
@@ -205,6 +209,7 @@ fn eyre() {
     }
 
     let eyre_report = eyre.into_report().unwrap_err();
+    #[allow(unused_mut)]
     let mut eyre_messages = messages(&eyre_report);
 
     #[cfg(feature = "std")]

--- a/packages/libs/error-stack/tests/test_compatibility.rs
+++ b/packages/libs/error-stack/tests/test_compatibility.rs
@@ -11,13 +11,13 @@ mod common;
 use std::backtrace::Backtrace;
 #[cfg(feature = "eyre")]
 use std::sync::Once;
-#[cfg(all(rust_1_65, feature = "std", feature = "eyre"))]
+#[cfg(all(rust_1_65, feature = "std", any(feature = "eyre", feature = "anyhow")))]
 use std::{backtrace::BacktraceStatus, error::Error, ops::Deref};
 
 use common::*;
 use error_stack::compat::IntoReportCompat;
 
-#[cfg(all(rust_1_65, feature = "std", feature = "eyre"))]
+#[cfg(all(nightly, feature = "std", any(feature = "eyre", feature = "anyhow")))]
 fn has_backtrace<E: Deref<Target = dyn Error + Send + Sync>>(err: &Result<(), E>) -> bool {
     err.as_ref()
         .unwrap_err()
@@ -51,7 +51,7 @@ fn anyhow() {
     let mut report_messages = messages(&report);
 
     // Backtrace is provided through `anyhow::Error` by `Error::provide`
-    #[cfg(all(rust_1_65, feature = "std"))]
+    #[cfg(all(nightly, feature = "std"))]
     if has_backtrace(&anyhow) {
         remove_backtrace_context(&mut report_messages);
     }
@@ -94,7 +94,7 @@ fn anyhow_provider() {
 }
 
 #[test]
-#[cfg(all(rust_1_65, feature = "std", feature = "anyhow"))]
+#[cfg(all(nightly, feature = "std", feature = "anyhow"))]
 fn anyhow_backtrace() {
     let error = ErrorB::new(0);
     let error_backtrace = error.backtrace().expect("No backtrace captured");
@@ -188,7 +188,7 @@ fn eyre() {
     #[allow(unused_mut)]
     let mut swap = false;
 
-    #[cfg(all(rust_1_65, feature = "std"))]
+    #[cfg(all(nightly, feature = "std"))]
     {
         if has_backtrace(&eyre) {
             remove_backtrace_context(&mut report_messages);

--- a/packages/libs/error-stack/tests/test_debug.rs
+++ b/packages/libs/error-stack/tests/test_debug.rs
@@ -237,7 +237,7 @@ fn sources_nested_alternate() {
 }
 
 #[cfg(all(
-    nightly,
+    rust_1_65,
     feature = "std",
     feature = "spantrace",
     feature = "pretty-print"
@@ -263,14 +263,12 @@ mod full {
     //!
     //! There are still some big snapshot tests, which are used evaluate all of the above.
 
+    #[cfg(nightly)]
+    use std::any::Demand;
     use std::{
-        any::Demand,
         error::Error,
         fmt::{Display, Formatter},
     };
-
-    #[cfg(all(nightly, feature = "unstable"))]
-    use error_stack::fmt::DebugDiagnostic;
 
     use super::*;
 
@@ -552,18 +550,21 @@ mod full {
         assert_snapshot!("alt", format!("{report:#?}"));
     }
 
+    #[cfg(nightly)]
     #[derive(Debug)]
     struct ContextD {
         code: usize,
         reason: &'static str,
     }
 
+    #[cfg(nightly)]
     impl Display for ContextD {
         fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
             f.write_str("Context D")
         }
     }
 
+    #[cfg(nightly)]
     impl Error for ContextD {
         fn provide<'a>(&'a self, req: &mut Demand<'a>) {
             req.provide_ref(&self.code);
@@ -572,6 +573,7 @@ mod full {
     }
 
     #[test]
+    #[cfg(nightly)]
     fn hook_provider() {
         let _guard = prepare(false);
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In CI, we currently do not test `test_compatibility`. This is because optional dependencies (`eyre`/`anyhow`) are not included by `cargo hack` by default.

## 🚫 Blocked by

- #1098 

## 🔍 What does this change?

- Enable optional dependencies in `cargo make`
- Fix `test_compatibility` (was outdated as it was not tested)