### PR TITLE
Fix hook behavior on non-nightly channels

### DIFF
--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_for_context.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_for_context.snap
@@ -2,15 +2,11 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-Context D
-├╴tests/test_debug.rs:595:38
-├╴usize: 420
-├╴&'static str: Invalid User Input
-│
-╰─▶ Root error
-    ├╴tests/common.rs:147:5
-    ├╴backtrace (1)
-    ╰╴spantrace with 2 frames (1)
+Root error
+├╴tests/common.rs:147:5
+├╴backtrace (1)
+├╴spantrace with 2 frames (1)
+╰╴1 additional opaque attachment
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/test_debug.rs
+++ b/packages/libs/error-stack/tests/test_debug.rs
@@ -471,6 +471,21 @@ mod full {
     }
 
     #[test]
+    fn hook_for_context() {
+        let _guard = prepare(false);
+
+        let report = create_report().attach(2u32);
+
+        Report::install_debug_hook::<RootError>(|_, _| {
+            // This should not be displayed as `RootError` is only used as `Context`, never as
+            // attachment.
+            unreachable!("A context should never be used as hook");
+        });
+
+        assert_snapshot!(format!("{report:?}"));
+    }
+
+    #[test]
     fn hook_multiple() {
         let _guard = prepare(false);
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The hooks are supposed to be invoked on:
- Attachments
- values provided by `Context::provide`

On non-nightly channels, the latter is not available, but the hooks are invoked for `Context` as well. This PR changes the behavior on non-nightly channels to match the behavior on nightly channels (as far as possible).

## 🔗 Related links

- Fixes https://github.com/hashintel/hash/issues/1092

## 🚫 Blocked by

- #1099 

## 🔍 What does this change?

- Hook behavior on stable channels

## 🛡 What tests cover this?

A new test was added to test this behavior
