### PR TITLE
Support `ownedById` in queries

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/context/ontology.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/context/ontology.rs
@@ -23,7 +23,7 @@ where
 #[derive(Debug)]
 pub struct OntologyRecord<T> {
     pub record: T,
-    pub account_id: AccountId,
+    pub account_id: AccountId, // TODO - rename to owned_by_id
     pub is_latest: bool,
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/resolve.rs
@@ -25,6 +25,7 @@ where
                 // TODO: Avoid cloning on literals
                 //   see https://app.asana.com/0/0/1202884883200947/f
                 let literal = match head_path_segment.identifier.as_str() {
+                    "ownedById" => Literal::String(self.account_id.to_string()),
                     "id" => Literal::String(self.id.to_string()),
                     "version" => Literal::Version(Version::Entity(self.version), self.is_latest),
                     "type" => {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/resolve.rs
@@ -17,6 +17,7 @@ where
             [] => todo!("{}", UNIMPLEMENTED_LITERAL_OBJECT),
             [head_path_segment, tail_path_segments @ ..] => {
                 let literal = match head_path_segment.identifier.as_str() {
+                    "ownedById" => Literal::String(self.account_id.to_string()),
                     "type" => {
                         return context
                             .read_versioned_ontology_type::<LinkType>(&self.link_type_id)

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/resolve.rs
@@ -61,6 +61,7 @@ where
                 // TODO: Avoid cloning on literals
                 //   see https://app.asana.com/0/0/1202884883200947/f
                 let literal = match segment.identifier.as_str() {
+                    "ownedById" => Literal::String(self.account_id.to_string()),
                     "baseUri" => Literal::String(self.record.id().base_uri().to_string()),
                     "versionedUri" => Literal::String(self.record.id().to_string()),
                     "version" => Literal::Version(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/resolve.rs
@@ -19,6 +19,7 @@ where
                 // TODO: Avoid cloning on literals
                 //   see https://app.asana.com/0/0/1202884883200947/f
                 let literal = match head_path_segment.identifier.as_str() {
+                    "ownedById" => Literal::String(self.account_id.to_string()),
                     "baseUri" => Literal::String(self.record.id().base_uri().to_string()),
                     "versionedUri" => Literal::String(self.record.id().to_string()),
                     "version" => Literal::Version(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/resolve.rs
@@ -75,6 +75,7 @@ where
                 // TODO: Avoid cloning on literals
                 //   see https://app.asana.com/0/0/1202884883200947/f
                 let literal = match segment.identifier.as_str() {
+                    "ownedById" => Literal::String(self.account_id.to_string()),
                     "baseUri" => Literal::String(self.record.id().base_uri().to_string()),
                     "versionedUri" => Literal::String(self.record.id().to_string()),
                     "version" => Literal::Version(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/resolve.rs
@@ -63,6 +63,7 @@ where
                 // TODO: Avoid cloning on literals
                 //   see https://app.asana.com/0/0/1202884883200947/f
                 let literal = match head_path_segment.identifier.as_str() {
+                    "ownedById" => Literal::String(self.account_id.to_string()),
                     "baseUri" => Literal::String(self.record.id().base_uri().to_string()),
                     "versionedUri" => Literal::String(self.record.id().to_string()),
                     "version" => Literal::Version(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

For some use cases we want to filter queries by their owner id.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1200211978612931/1203015527055374/f) _(internal)_

## 🔍 What does this change?

- add `ownedById` filter to queries

## 🛡 What tests cover this?

Currently, this is not tested, but this will be used soon in the backend, which then will be tested as part of the backend integration tests

## 📹 Demo

```http
POST http://127.0.0.1:4000/entities/query
Content-Type: application/json

{
  "query": {
    "eq": [
      {
        "path": [
          "ownedById"
        ]
      },
      {
        "literal": "f13ef0fb-fcfd-44c8-b652-a47824b95596"
      }
    ]
  },
  "dataTypeQueryDepth": 0,
  "propertyTypeQueryDepth": 0,
  "linkTypeQueryDepth": 0,
  "entityTypeQueryDepth": 0,
  "linkTargetEntityQueryDepth": 0,
  "linkQueryDepth": 0
}
```