### PR TITLE
Show tooltip with full page title on hover in sidebar

### DIFF
--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-tree-item.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-page-list/page-tree-item.tsx
@@ -144,22 +144,35 @@ export const PageTreeItem = forwardRef<HTMLAnchorElement, PageTreeItemProps>(
             popoverProps={{ onClick: stopEvent }}
           />
 
-          <Typography
-            variant="smallTextLabels"
-            sx={({ palette }) => ({
-              display: "block",
-              fontWeight: 400,
-              marginLeft: 0.75,
-              py: 1,
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-              flex: 1,
-              color: palette.gray[selected || hovered ? 90 : 70],
-            })}
+          <Tooltip
+            title={title || PAGE_TITLE_PLACEHOLDER}
+            placement="right"
+            disableInteractive
+            enterDelay={500}
+            enterNextDelay={300}
+            componentsProps={{
+              tooltip: {
+                sx: { ml: "32px !important" },
+              },
+            }}
           >
-            {title || PAGE_TITLE_PLACEHOLDER}
-          </Typography>
+            <Typography
+              variant="smallTextLabels"
+              sx={({ palette }) => ({
+                display: "block",
+                fontWeight: 400,
+                marginLeft: 0.75,
+                py: 1,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                flex: 1,
+                color: palette.gray[selected || hovered ? 90 : 70],
+              })}
+            >
+              {title || PAGE_TITLE_PLACEHOLDER}
+            </Typography>
+          </Tooltip>
 
           <Tooltip
             title="Add subpages, delete, duplicate and more"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR shows a tooltip when page titles on the left sidebar are hovered, to improve the UX.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1200211978612931/1202861224066305/f) _(internal)_

## 📹 Demo

<img width="500" alt="Screen Shot 2022-09-27 at 14 41 17" src="https://user-images.githubusercontent.com/39553853/192518924-92772d77-a7af-4d5d-a307-23c1932347bd.png">
