### PR TITLE
Determine whether link is `ordered` using its source entity type schema

### DIFF
--- a/packages/hash/api/src/model/knowledge/link.model.ts
+++ b/packages/hash/api/src/model/knowledge/link.model.ts
@@ -166,7 +166,7 @@ export default class {
     });
 
     /**
-     * @todo: rely on Graph API validation instead of manually checking whether sibling links are ordered
+     * @todo: rely on Graph API validation instead of performing this check here
      * @see https://app.asana.com/0/1200211978612931/1203031430417465/f
      */
     const isOrdered = sourceEntityModel.entityTypeModel.isOutgoingLinkOrdered({
@@ -180,9 +180,9 @@ export default class {
     }
 
     const index = isOrdered
-      ? // if link is ordered and an index is provided, use the provided index
+      ? // if the link is ordered and an index is provided, use the provided index
         params.index ??
-        // if link is ordered and no index is provided, default to the end of the list of links
+        // if the link is ordered and no index is provided, default to the end of the list of links
         siblingLinks.length
       : undefined;
 
@@ -273,7 +273,7 @@ export default class {
     const { index: previousIndex, linkTypeModel } = this;
 
     /**
-     * @todo: rely on Graph API validation instead of manually checking whether sibling links are ordered
+     * @todo: rely on Graph API validation instead of performing this check here
      * @see https://app.asana.com/0/1200211978612931/1203031430417465/f
      */
     const isOrdered =
@@ -367,7 +367,7 @@ export default class {
     });
 
     /**
-     * @todo: rely on Graph API validation instead of manually checking whether sibling links are ordered
+     * @todo: rely on Graph API validation instead of performing this check here
      * @see https://app.asana.com/0/1200211978612931/1203031430417465/f
      */
     const isOrdered =

--- a/packages/hash/api/src/model/knowledge/user.model.ts
+++ b/packages/hash/api/src/model/knowledge/user.model.ts
@@ -434,7 +434,7 @@ export default class extends EntityModel {
     );
 
     await this.createOutgoingLink(graphApi, {
-      linkTypeModel: WORKSPACE_TYPES.linkType.ofOrg,
+      linkTypeModel: WORKSPACE_TYPES.linkType.hasMembership,
       targetEntityModel: orgMembership,
       createdById: workspaceAccountId,
     });
@@ -452,7 +452,7 @@ export default class extends EntityModel {
               eq: [
                 { path: ["type", "versionedUri"] },
                 {
-                  literal: WORKSPACE_TYPES.linkType.ofOrg.schema.$id,
+                  literal: WORKSPACE_TYPES.linkType.hasMembership.schema.$id,
                 },
               ],
             },

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -326,6 +326,36 @@ export default class {
   }
 
   /**
+   * Whether an outgoing link is ordered or not.
+   *
+   * @todo: deprecreate this method when the Graph API can be relied upon for schema validation
+   * @see https://app.asana.com/0/1200211978612931/1203031430417465/f
+   *
+   * @param params.outgoingLinkType - the outgoing link type for which to check whether it is ordered
+   */
+  isOutgoingLinkOrdered(params: { outgoingLinkType: LinkTypeModel }) {
+    const { outgoingLinkType } = params;
+
+    const outgoingLinkDefinition = Object.entries(this.schema.links ?? {}).find(
+      ([linkTypeId]) => linkTypeId === outgoingLinkType.schema.$id,
+    )?.[1];
+
+    if (!outgoingLinkDefinition) {
+      throw new Error("Link is not an outgoing link on this entity");
+    }
+
+    if (
+      typeof outgoingLinkDefinition === "object" &&
+      "type" in outgoingLinkDefinition &&
+      outgoingLinkDefinition.type === "array"
+    ) {
+      return outgoingLinkDefinition.ordered ?? false;
+    }
+
+    return false;
+  }
+
+  /**
    * Get all property types of the entity type.
    */
   async getPropertyTypes(graphApi: GraphApi): Promise<PropertyTypeModel[]> {

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -328,7 +328,7 @@ export default class {
   /**
    * Whether an outgoing link is ordered or not.
    *
-   * @todo: deprecreate this method when the Graph API can be relied upon for schema validation
+   * @todo: deprecate this method when the Graph API can be relied upon for schema validation
    * @see https://app.asana.com/0/1200211978612931/1203031430417465/f
    *
    * @param params.outgoingLinkType - the outgoing link type for which to check whether it is ordered

--- a/packages/hash/api/src/model/util.ts
+++ b/packages/hash/api/src/model/util.ts
@@ -272,6 +272,7 @@ export const propertyTypeInitializer = (
 export type EntityTypeCreatorParams = {
   namespace: string;
   title: string;
+  pluralTitle?: string;
   properties: {
     propertyTypeModel: PropertyTypeModel;
     required?: boolean;
@@ -329,7 +330,12 @@ export const generateWorkspaceEntityTypeSchema = (
       ? params.outgoingLinks.reduce<EntityType["links"]>(
           (
             prev,
-            { linkTypeModel, destinationEntityTypeModels, array, ordered },
+            {
+              linkTypeModel,
+              destinationEntityTypeModels,
+              array,
+              ordered = false,
+            },
           ) => {
             const oneOf = {
               oneOf: destinationEntityTypeModels.map(
@@ -365,7 +371,7 @@ export const generateWorkspaceEntityTypeSchema = (
   return {
     $id,
     title: params.title,
-    pluralTitle: params.title,
+    pluralTitle: params.pluralTitle ?? params.title,
     type: "object",
     kind: "entityType",
     properties,

--- a/packages/hash/integration/src/tests/model/knowledge/entity.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/entity.model.test.ts
@@ -9,6 +9,7 @@ import {
   PropertyTypeModel,
   LinkTypeModel,
 } from "@hashintel/hash-api/src/model";
+import { generateWorkspaceEntityTypeSchema } from "@hashintel/hash-api/src/model/util";
 import { createTestUser } from "../../util";
 
 jest.setTimeout(60000);
@@ -53,23 +54,6 @@ describe("Entity CRU", () => {
     });
 
     await Promise.all([
-      EntityTypeModel.create(graphApi, {
-        accountId,
-        schema: {
-          kind: "entityType",
-          title: "Person",
-          pluralTitle: "People",
-          type: "object",
-          properties: {},
-        },
-      })
-        .then((val) => {
-          entityTypeModel = val;
-        })
-        .catch((err) => {
-          logger.error(`Something went wrong making Person: ${err}`);
-          throw err;
-        }),
       LinkTypeModel.create(graphApi, {
         accountId,
         schema: {
@@ -120,6 +104,26 @@ describe("Entity CRU", () => {
           throw err;
         }),
     ]);
+
+    entityTypeModel = await EntityTypeModel.create(graphApi, {
+      accountId,
+      schema: generateWorkspaceEntityTypeSchema({
+        namespace: testUser.getShortname()!,
+        title: "Person",
+        pluralTitle: "People",
+        properties: [
+          { propertyTypeModel: favoriteBookPropertyTypeModel },
+          { propertyTypeModel: namePropertyTypeModel },
+        ],
+        outgoingLinks: [
+          {
+            linkTypeModel: linkTypeFriend,
+            destinationEntityTypeModels: ["SELF_REFERENCE"],
+            array: true,
+          },
+        ],
+      }),
+    });
   });
 
   let createdEntityModel: EntityModel;

--- a/packages/hash/integration/src/tests/model/ontology/entity-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/entity-type.model.test.ts
@@ -139,24 +139,14 @@ beforeAll(async () => {
       [knowsLinkTypeModel.schema.$id]: {
         type: "array",
         items: {
-          oneOf: [
-            // When adding links in entity type definitions the `$ref` is
-            // expected to be another entity type. That other entity type needs
-            // to exist in the DB beforehand.
-            { $ref: workerEntityTypeModel.schema.$id },
-          ],
+          oneOf: [{ $ref: workerEntityTypeModel.schema.$id }],
         },
         ordered: false,
       },
       [previousAddressLinkTypeModel.schema.$id]: {
         type: "array",
         items: {
-          oneOf: [
-            // When adding links in entity type definitions the `$ref` is
-            // expected to be another entity type. That other entity type needs
-            // to exist in the DB beforehand.
-            { $ref: addressEntityTypeModel.schema.$id },
-          ],
+          oneOf: [{ $ref: addressEntityTypeModel.schema.$id }],
         },
         ordered: true,
       },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR improves how the `LinkModel` class determines whether a link is ordered. Previously it inspected the sibling links for the presence of an `index`. Now it inspects the source entity type schema to see if `ordered` is set to `true` for the outgoing link.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202805690238892/1203045927094838/f) _(internal)_


## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

See commits.

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

- The docs for x need updating to explain that y

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

The existing integration tests, and an additional `EntityTypeModel` test for the `isOutgoingLinkOrdered` method.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Check backend integration tests in CI

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
