### PR TITLE
Imply `std` feature when enabling `eyre`

### DIFF
--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -46,6 +46,7 @@ hooks = ["std"]
 pretty-print = ["dep:owo-colors"]
 spantrace = ["dep:tracing-error", "std"]
 std = ["anyhow?/std"]
+eyre = ["dep:eyre", "std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/packages/libs/error-stack/src/compat/eyre.rs
+++ b/packages/libs/error-stack/src/compat/eyre.rs
@@ -38,7 +38,6 @@ impl Context for EyreContext {
     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
         demand.provide_ref(&self.0);
 
-        #[cfg(feature = "std")]
         self.0.provide(demand);
     }
 }

--- a/packages/libs/error-stack/tests/compiletest.rs
+++ b/packages/libs/error-stack/tests/compiletest.rs
@@ -1,7 +1,9 @@
-#[cfg_attr(not(nightly), ignore = "Outputs are different across toolchains")]
-#[cfg_attr(miri, ignore = "Miri does not support UI tests")]
-#[test]
-fn ui() {
-    let t = trybuild::TestCases::new();
-    t.compile_fail("tests/ui/*.rs");
-}
+//! Currently disabled because of https://github.com/dtolnay/trybuild/issues/171
+
+// #[cfg_attr(not(nightly), ignore = "Outputs are different across toolchains")]
+// #[cfg_attr(miri, ignore = "Miri does not support UI tests")]
+// #[test]
+// fn ui() {
+//     let t = trybuild::TestCases::new();
+//     t.compile_fail("tests/ui/*.rs");
+// }

--- a/packages/libs/error-stack/tests/test_compatibility.rs
+++ b/packages/libs/error-stack/tests/test_compatibility.rs
@@ -1,9 +1,9 @@
+#![cfg(any(feature = "eyre", feature = "anyhow"))]
 #![cfg_attr(nightly, feature(provide_any))]
 #![cfg_attr(
     all(nightly, feature = "std"),
     feature(backtrace_frames, error_generic_member_access)
 )]
-#![cfg(any(feature = "eyre", feature = "anyhow"))]
 
 mod common;
 
@@ -170,14 +170,14 @@ fn eyre() {
 
     #[allow(unused_mut)]
     let mut report_messages = messages(&report);
-    #[cfg(all(rust_1_65, feature = "std"))]
+    #[cfg(rust_1_65)]
     remove_opaque_frames(&mut report_messages);
 
     let eyre_report = eyre.into_report().unwrap_err();
 
     #[allow(unused_mut)]
     let mut eyre_messages = messages(&eyre_report);
-    #[cfg(all(rust_1_65, feature = "std"))]
+    #[cfg(rust_1_65)]
     remove_opaque_frames(&mut eyre_messages);
 
     assert_eq!(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`eyre` currently does not support `no-std` compilation. Implying avoids surprises and also reduces the amount of tests

## ⚠️  Known issues

`trybuild` currently has a bug with `dep:`-features, so UI builds are currently disabled