### PR TITLE
Remove intermediate context for compatibility module

### DIFF
--- a/packages/libs/error-stack/src/compat/anyhow.rs
+++ b/packages/libs/error-stack/src/compat/anyhow.rs
@@ -1,55 +1,15 @@
-#[cfg(nightly)]
-use core::any::Demand;
-use core::fmt;
+use core::panic::Location;
 
 use anyhow::Error as AnyhowError;
 
-use crate::{compat::IntoReportCompat, Context, Report, Result};
-
-/// A [`Context`] wrapper for [`anyhow::Error`].
-///
-/// It provides the [`anyhow::Error`] and forwards the [`Demand`] to [`Error::provide`].
-///
-/// [`Error::provide`]: core::error::Error::provide
-#[repr(transparent)]
-pub struct AnyhowContext(AnyhowError);
-
-impl AnyhowContext {
-    /// Returns a reference to the underlying [`anyhow::Error`].
-    #[must_use]
-    pub const fn as_anyhow(&self) -> &AnyhowError {
-        &self.0
-    }
-}
-
-impl fmt::Debug for AnyhowContext {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&self.0, fmt)
-    }
-}
-
-impl fmt::Display for AnyhowContext {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.0, fmt)
-    }
-}
-
-impl Context for AnyhowContext {
-    #[cfg(nightly)]
-    fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
-        demand.provide_ref(&self.0);
-
-        #[cfg(feature = "std")]
-        self.0.provide(demand);
-    }
-}
+use crate::{Frame, IntoReportCompat, Report, Result};
 
 impl<T> IntoReportCompat for core::result::Result<T, AnyhowError> {
-    type Err = AnyhowContext;
+    type Err = AnyhowError;
     type Ok = T;
 
     #[track_caller]
-    fn into_report(self) -> Result<T, AnyhowContext> {
+    fn into_report(self) -> Result<T, AnyhowError> {
         match self {
             Ok(t) => Ok(t),
             Err(anyhow) => {
@@ -61,7 +21,11 @@ impl<T> IntoReportCompat for core::result::Result<T, AnyhowError> {
                     .collect::<alloc::vec::Vec<_>>();
 
                 #[cfg_attr(not(feature = "std"), allow(unused_mut))]
-                let mut report = Report::new(AnyhowContext(anyhow));
+                let mut report = Report::from_frame(Frame::from_anyhow(
+                    anyhow,
+                    Location::caller(),
+                    alloc::boxed::Box::new([]),
+                ));
 
                 #[cfg(feature = "std")]
                 for source in sources {

--- a/packages/libs/error-stack/src/compat/eyre.rs
+++ b/packages/libs/error-stack/src/compat/eyre.rs
@@ -1,53 +1,15 @@
-#[cfg(nightly)]
-use core::any::Demand;
-use core::fmt;
+use core::panic::Location;
 
 use eyre::Report as EyreReport;
 
-use crate::{compat::IntoReportCompat, Context, Report, Result};
-
-/// A [`Context`] wrapper for [`eyre::Report`].
-///
-/// It provides the [`eyre::Report`] and forwards the [`Demand`] to [`Error::provide`].
-///
-/// [`Error::provide`]: core::error::Error::provide
-#[repr(transparent)]
-pub struct EyreContext(EyreReport);
-
-impl EyreContext {
-    /// Returns a reference to the underlying [`anyhow::Error`].
-    pub const fn as_eyre(&self) -> &EyreReport {
-        &self.0
-    }
-}
-
-impl fmt::Debug for EyreContext {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&self.0, fmt)
-    }
-}
-
-impl fmt::Display for EyreContext {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.0, fmt)
-    }
-}
-
-impl Context for EyreContext {
-    #[cfg(nightly)]
-    fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
-        demand.provide_ref(&self.0);
-
-        self.0.provide(demand);
-    }
-}
+use crate::{Frame, IntoReportCompat, Report, Result};
 
 impl<T> IntoReportCompat for core::result::Result<T, EyreReport> {
-    type Err = EyreContext;
+    type Err = EyreReport;
     type Ok = T;
 
     #[track_caller]
-    fn into_report(self) -> Result<T, EyreContext> {
+    fn into_report(self) -> Result<T, EyreReport> {
         match self {
             Ok(t) => Ok(t),
             Err(eyre) => {
@@ -58,7 +20,8 @@ impl<T> IntoReportCompat for core::result::Result<T, EyreReport> {
                     .collect::<alloc::vec::Vec<_>>();
 
                 #[cfg_attr(not(feature = "std"), allow(unused_mut))]
-                let mut report = Report::new(EyreContext(eyre));
+                let mut report =
+                    Report::from_frame(Frame::from_eyre(eyre, Location::caller(), Box::new([])));
 
                 for source in sources {
                     report = report.attach_printable(source);

--- a/packages/libs/error-stack/src/compat/mod.rs
+++ b/packages/libs/error-stack/src/compat/mod.rs
@@ -7,11 +7,6 @@ mod anyhow;
 #[cfg(feature = "eyre")]
 mod eyre;
 
-#[cfg(feature = "anyhow")]
-pub use self::anyhow::AnyhowContext;
-#[cfg(feature = "eyre")]
-pub use self::eyre::EyreContext;
-
 /// Compatibility trait to convert from external libraries to [`Report`].
 ///
 /// *Note*: It's not possible to implement [`IntoReport`] or [`Context`] on other error libraries'

--- a/packages/libs/error-stack/src/frame/frame_impl.rs
+++ b/packages/libs/error-stack/src/frame/frame_impl.rs
@@ -122,7 +122,7 @@ impl Context for AnyhowContext {
     #[cfg(all(nightly, feature = "std"))]
     #[inline]
     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
-        self.0.provide(demand);
+        core::any::Provider::provide(&self.0, demand);
     }
 }
 
@@ -167,7 +167,7 @@ impl Context for EyreContext {
     #[cfg(nightly)]
     #[inline]
     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
-        self.0.provide(demand);
+        // `eyre::Report` does not implement `Provider`
     }
 }
 

--- a/packages/libs/error-stack/src/frame/frame_impl.rs
+++ b/packages/libs/error-stack/src/frame/frame_impl.rs
@@ -166,7 +166,7 @@ impl fmt::Display for EyreContext {
 impl Context for EyreContext {
     #[cfg(nightly)]
     #[inline]
-    fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
+    fn provide<'a>(&'a self, _demand: &mut Demand<'a>) {
         // `eyre::Report` does not implement `Provider`
     }
 }

--- a/packages/libs/error-stack/src/frame/frame_impl.rs
+++ b/packages/libs/error-stack/src/frame/frame_impl.rs
@@ -119,7 +119,7 @@ impl fmt::Display for AnyhowContext {
 
 #[cfg(feature = "anyhow")]
 impl Context for AnyhowContext {
-    #[cfg(all(nightly, feature = "std"))]
+    #[cfg(nightly)]
     #[inline]
     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
         core::any::Provider::provide(&self.0, demand);

--- a/packages/libs/error-stack/src/frame/frame_impl.rs
+++ b/packages/libs/error-stack/src/frame/frame_impl.rs
@@ -119,9 +119,11 @@ impl fmt::Display for AnyhowContext {
 
 #[cfg(feature = "anyhow")]
 impl Context for AnyhowContext {
-    #[cfg(all(nightly, feature = "std"))]
+    #[cfg(nightly)]
     #[inline]
     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
+        // `Provider` is only implemented for `anyhow::Error` on `std`
+        #[cfg(feature = "std")]
         core::any::Provider::provide(&self.0, demand);
     }
 }

--- a/packages/libs/error-stack/src/frame/frame_impl.rs
+++ b/packages/libs/error-stack/src/frame/frame_impl.rs
@@ -1,6 +1,8 @@
 use alloc::boxed::Box;
 #[cfg(nightly)]
 use core::any::Demand;
+#[cfg(any(feature = "anyhow", feature = "eyre"))]
+use core::fmt;
 use core::{
     any::TypeId,
     fmt::{Debug, Display},
@@ -97,6 +99,96 @@ unsafe impl<A: 'static + Debug + Display + Send + Sync> FrameImpl for PrintableA
     }
 }
 
+#[repr(transparent)]
+#[cfg(feature = "anyhow")]
+struct AnyhowContext(anyhow::Error);
+
+#[cfg(feature = "anyhow")]
+impl fmt::Debug for AnyhowContext {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, fmt)
+    }
+}
+
+#[cfg(feature = "anyhow")]
+impl fmt::Display for AnyhowContext {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, fmt)
+    }
+}
+
+#[cfg(feature = "anyhow")]
+impl Context for AnyhowContext {
+    #[cfg(all(nightly, feature = "std"))]
+    #[inline]
+    fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
+        self.0.provide(demand);
+    }
+}
+
+#[cfg(feature = "anyhow")]
+// SAFETY: `type_id` returns `anyhow::Error` and `AnyhowContext` is `#[repr(transparent)]`
+unsafe impl FrameImpl for AnyhowContext {
+    fn kind(&self) -> FrameKind<'_> {
+        FrameKind::Context(self)
+    }
+
+    fn type_id(&self) -> TypeId {
+        TypeId::of::<anyhow::Error>()
+    }
+
+    #[cfg(nightly)]
+    #[inline]
+    fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
+        Context::provide(self, demand);
+    }
+}
+
+#[repr(transparent)]
+#[cfg(feature = "eyre")]
+struct EyreContext(eyre::Report);
+
+#[cfg(feature = "eyre")]
+impl fmt::Debug for EyreContext {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, fmt)
+    }
+}
+
+#[cfg(feature = "eyre")]
+impl fmt::Display for EyreContext {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, fmt)
+    }
+}
+
+#[cfg(feature = "eyre")]
+impl Context for EyreContext {
+    #[cfg(nightly)]
+    #[inline]
+    fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
+        self.0.provide(demand);
+    }
+}
+
+#[cfg(feature = "eyre")]
+// SAFETY: `type_id` returns `eyre::Report` and `EyreContext` is `#[repr(transparent)]`
+unsafe impl FrameImpl for EyreContext {
+    fn kind(&self) -> FrameKind<'_> {
+        FrameKind::Context(self)
+    }
+
+    fn type_id(&self) -> TypeId {
+        TypeId::of::<eyre::Report>()
+    }
+
+    #[cfg(nightly)]
+    #[inline]
+    fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
+        Context::provide(self, demand);
+    }
+}
+
 impl Frame {
     /// Creates a frame from a [`Context`].
     pub(crate) fn from_context<C>(
@@ -125,6 +217,34 @@ impl Frame {
     {
         Self {
             frame: Box::new(AttachmentFrame { attachment }),
+            location,
+            sources,
+        }
+    }
+
+    /// Creates a frame from a [`anyhow::Error`].
+    #[cfg(feature = "anyhow")]
+    pub(crate) fn from_anyhow(
+        error: anyhow::Error,
+        location: &'static Location<'static>,
+        sources: Box<[Self]>,
+    ) -> Self {
+        Self {
+            frame: Box::new(AnyhowContext(error)),
+            location,
+            sources,
+        }
+    }
+
+    /// Creates a frame from a [`eyre::Report`].
+    #[cfg(feature = "eyre")]
+    pub(crate) fn from_eyre(
+        report: eyre::Report,
+        location: &'static Location<'static>,
+        sources: Box<[Self]>,
+    ) -> Self {
+        Self {
+            frame: Box::new(EyreContext(report)),
             location,
             sources,
         }

--- a/packages/libs/error-stack/src/frame/frame_impl.rs
+++ b/packages/libs/error-stack/src/frame/frame_impl.rs
@@ -119,11 +119,10 @@ impl fmt::Display for AnyhowContext {
 
 #[cfg(feature = "anyhow")]
 impl Context for AnyhowContext {
-    #[cfg(nightly)]
+    // `Provider` is only implemented for `anyhow::Error` on `std`
+    #[cfg(all(nightly, feature = "std"))]
     #[inline]
     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
-        // `Provider` is only implemented for `anyhow::Error` on `std`
-        #[cfg(feature = "std")]
         core::any::Provider::provide(&self.0, demand);
     }
 }

--- a/packages/libs/error-stack/src/frame/frame_impl.rs
+++ b/packages/libs/error-stack/src/frame/frame_impl.rs
@@ -119,7 +119,7 @@ impl fmt::Display for AnyhowContext {
 
 #[cfg(feature = "anyhow")]
 impl Context for AnyhowContext {
-    #[cfg(nightly)]
+    #[cfg(all(nightly, feature = "std"))]
     #[inline]
     fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
         core::any::Provider::provide(&self.0, demand);

--- a/packages/libs/error-stack/src/frame/frame_impl.rs
+++ b/packages/libs/error-stack/src/frame/frame_impl.rs
@@ -222,7 +222,7 @@ impl Frame {
         }
     }
 
-    /// Creates a frame from a [`anyhow::Error`].
+    /// Creates a frame from an [`anyhow::Error`].
     #[cfg(feature = "anyhow")]
     pub(crate) fn from_anyhow(
         error: anyhow::Error,

--- a/packages/libs/error-stack/src/frame/frame_impl.rs
+++ b/packages/libs/error-stack/src/frame/frame_impl.rs
@@ -236,7 +236,7 @@ impl Frame {
         }
     }
 
-    /// Creates a frame from a [`eyre::Report`].
+    /// Creates a frame from an [`eyre::Report`].
     #[cfg(feature = "eyre")]
     pub(crate) fn from_eyre(
         report: eyre::Report,

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -458,8 +458,9 @@
 )]
 
 extern crate alloc;
+extern crate core;
 
-pub mod compat;
+mod compat;
 mod frame;
 pub mod iter;
 mod macros;
@@ -476,13 +477,16 @@ mod fmt;
 mod hook;
 
 #[doc(inline)]
-pub use self::ext::result::{IntoReport, ResultExt};
+pub use self::ext::{
+    future::FutureExt,
+    result::{IntoReport, ResultExt},
+};
 #[cfg(feature = "std")]
 #[allow(deprecated, unreachable_pub)]
 pub use self::hook::HookAlreadySet;
 pub use self::{
+    compat::IntoReportCompat,
     context::Context,
-    ext::future::FutureExt,
     frame::{AttachmentKind, Frame, FrameKind},
     macros::*,
     report::Report,

--- a/packages/libs/error-stack/src/report.rs
+++ b/packages/libs/error-stack/src/report.rs
@@ -1,5 +1,5 @@
 use alloc::{boxed::Box, vec, vec::Vec};
-use core::{fmt, marker::PhantomData, mem, panic::Location};
+use core::{any::TypeId, fmt, fmt::Display, marker::PhantomData, mem, panic::Location};
 #[cfg(all(rust_1_65, feature = "std"))]
 use std::backtrace::{Backtrace, BacktraceStatus};
 #[cfg(feature = "std")]
@@ -211,13 +211,21 @@ impl<C> Report<C> {
     /// documentation for more information.
     ///
     /// [`Backtrace` and `SpanTrace` section]: #backtrace-and-spantrace
+    #[inline]
     #[track_caller]
     pub fn new(context: C) -> Self
     where
         C: Context,
     {
-        let frame = Frame::from_context(context, Location::caller(), Box::new([]));
+        Self::from_frame(Frame::from_context(
+            context,
+            Location::caller(),
+            Box::new([]),
+        ))
+    }
 
+    #[track_caller]
+    pub(crate) fn from_frame(frame: Frame) -> Self {
         #[cfg(all(nightly, feature = "std"))]
         let backtrace = core::any::request_ref::<Backtrace>(&frame)
             .filter(|backtrace| backtrace.status() == BacktraceStatus::Captured)
@@ -557,9 +565,7 @@ impl<C> Report<C> {
     pub fn downcast_mut<T: Send + Sync + 'static>(&mut self) -> Option<&mut T> {
         self.frames_mut().find_map(Frame::downcast_mut::<T>)
     }
-}
 
-impl<T: Context> Report<T> {
     /// Returns the current context of the `Report`.
     ///
     /// If the user want to get the latest context, `current_context` can be called. If the user
@@ -590,8 +596,12 @@ impl<T: Context> Report<T> {
     /// assert_eq!(io_error.kind(), io::ErrorKind::NotFound);
     /// # }
     /// ```
+    // TODO: Remove `Display` bound when `set_debug_hook` and `set_display_hook` are removed
     #[must_use]
-    pub fn current_context(&self) -> &T {
+    pub fn current_context(&self) -> &C
+    where
+        C: Display + Send + Sync + 'static,
+    {
         self.downcast_ref().unwrap_or_else(|| {
             // Panics if there isn't an attached context which matches `T`. As it's not possible to
             // create a `Report` without a valid context and this method can only be called when `T`

--- a/packages/libs/error-stack/src/report.rs
+++ b/packages/libs/error-stack/src/report.rs
@@ -1,5 +1,5 @@
 use alloc::{boxed::Box, vec, vec::Vec};
-use core::{any::TypeId, fmt, fmt::Display, marker::PhantomData, mem, panic::Location};
+use core::{fmt, fmt::Display, marker::PhantomData, mem, panic::Location};
 #[cfg(all(rust_1_65, feature = "std"))]
 use std::backtrace::{Backtrace, BacktraceStatus};
 #[cfg(feature = "std")]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, the compatibility layer has an intermediate context (`AnyhowContext`/`EyreContext`). This PR removes the required additional context, so `anyhow::Error`/`eyre::Report` are directly captured in a `Report`

## 🔗 Related links

- #1113 

## 🔍 What does this change?

- Make `AnyhowContext`/`EyreContext` an implementation detail by making it private to frame implementation
- Implement `FrameImpl` for those contexts and support constructing a frame from the underlying error directly
- Properly test backtrace capturing of `anyhow` and `eyre`

## 📹 Demo

Before:

```rust
let anyhow_error: anyhow::Error = anyhow!(...);
let anyhow_report: Report<AnyhowContext> = Err(anyhow_error).into_report().unwrap_err();
let anyhow_context: &AnyhowContext = anyhow_report.current_context();
let anyhow_error_ref: &anyhow::Error = anyhow_context.as_anyhow();
```

now:

```rust
let anyhow_error: anyhow::Error = anyhow!(...);
let anyhow_report: Report<anyhow::Error> = Err(anyhow_error).into_report().unwrap_err();
let anyhow_error_ref: &anyhow::Error = anyhow_report.current_context();
```
