### PR TITLE
Make test and docs for `Frames` more readable

### DIFF
--- a/packages/libs/error-stack/src/iter.rs
+++ b/packages/libs/error-stack/src/iter.rs
@@ -24,10 +24,10 @@ use crate::Frame;
 /// ```text
 /// 1) Out: - Stack: [A, G]
 /// 2) Out: A Stack: [G] [B, C]
-/// 3) Out: B Stack: [G] [C] [D, E]
-/// 4) Out: D Stack: [G] [C] [E]
-/// 4) Out: E Stack: [G] [C]
-/// 5) Out: C Stack: [G] [F]
+/// 3) Out: B Stack: [G] [E] [C, D]
+/// 4) Out: C Stack: [G] [E] [D]
+/// 4) Out: D Stack: [G] [E]
+/// 5) Out: E Stack: [G] [F]
 /// 6) Out: F Stack: [G]
 /// 7) Out: G Stack: [H]
 /// 8) Out: H Stack: -
@@ -61,37 +61,17 @@ fn next<I: Iterator<Item = T>, T>(iter: &mut Vec<I>) -> Option<T> {
 /// This shows in numbers the index of the different depths, using this it's possible to linearize
 /// all frames and sort topologically, meaning that this ensures no child ever is before its parent.
 ///
-/// ```text
-///      1
-///     / \
-///    2   6
-///  / | \  \
-/// 3  4  5  7
-/// ```
-///
-///
-/// A reversed stack of the implementation is used. Considering the following tree:
+/// Iterating the following report will return the frames in alphabetical order:
 ///
 /// ```text
-///     A     G
-///    / \    |
-///   B   C   H
-///  / \  |
-/// D   E F
-/// ```
-///
-/// the algorithm will create the following through iteration:
-///
-/// ```text
-/// 1) Out: - Stack: [A, G]
-/// 2) Out: A Stack: [G] [B, C]
-/// 3) Out: B Stack: [G] [C] [D, E]
-/// 4) Out: D Stack: [G] [C] [E]
-/// 4) Out: E Stack: [G] [C]
-/// 5) Out: C Stack: [G] [F]
-/// 6) Out: F Stack: [G]
-/// 7) Out: G Stack: [H]
-/// 8) Out: H Stack: -
+/// A
+/// ╰┬▶ B
+///  │  ╰┬▶ C
+///  │   ╰▶ D
+///  ╰▶ E
+///     ╰─▶ F
+/// G
+/// ╰─▶ H
 /// ```
 ///
 /// [`Report`]: crate::Report

--- a/packages/libs/error-stack/tests/test_iter.rs
+++ b/packages/libs/error-stack/tests/test_iter.rs
@@ -4,7 +4,7 @@
 extern crate alloc;
 extern crate core;
 
-use core::{fmt::Write, iter::zip};
+use core::fmt::Write;
 use std::fmt::{Display, Formatter};
 
 mod common;

--- a/packages/libs/error-stack/tests/test_iter.rs
+++ b/packages/libs/error-stack/tests/test_iter.rs
@@ -2,41 +2,64 @@
 #![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
 
 extern crate alloc;
+extern crate core;
 
-use core::iter::zip;
+use core::{fmt::Write, iter::zip};
 use std::fmt::{Display, Formatter};
 
 mod common;
 use error_stack::{report, Context, Report};
 
 #[derive(Debug)]
-struct Root;
+struct Char(char);
 
-impl Display for Root {
+impl Display for Char {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str("root")
+        f.write_char(self.0)
     }
 }
 
-impl Context for Root {}
+impl Context for Char {}
 
+/// Builds the following tree:
+///
+/// ```text
+///     A     G
+///    / \    |
+///   B   E   H
+///  / \  |
+/// C   D F
+/// ```
+///
+/// which will result in this report:
+///
+/// ```text
+/// A
+/// ╰┬▶ B
+///  │  ╰┬▶ C
+///  │   ╰▶ D
+///  ╰▶ E
+///     ╰─▶ F
+/// G
+/// ╰─▶ H
+/// ```
 #[allow(clippy::many_single_char_names)]
-fn build() -> Report<Root> {
-    let mut d = report!(Root).attach('D');
-    let e = report!(Root).attach('E');
+fn build() -> Report<Char> {
+    let mut c = report!(Char('C'));
+    let d = report!(Char('D'));
 
-    d.extend_one(e);
-    let mut b = d.attach('B');
+    c.extend_one(d);
+    let mut b = c.change_context(Char('B'));
 
-    let f = report!(Root).attach('F');
-    let c = f.attach('C');
+    let f = report!(Char('F'));
+    let e = f.change_context(Char('E'));
 
-    b.extend_one(c);
+    b.extend_one(e);
 
-    let mut a = b.attach('A');
+    let mut a = b.change_context(Char('A'));
 
-    let h = report!(Root).attach('H');
-    let g = h.attach('G');
+    let h = report!(Char('H'));
+    let g = h.change_context(Char('G'));
 
     a.extend_one(g);
     a
@@ -56,28 +79,24 @@ fn build() -> Report<Root> {
 fn iter() {
     let report = build();
 
-    for (lhs, &rhs) in zip(
+    assert_eq!(
         report
             .frames()
-            .filter_map(|frame| frame.downcast_ref::<char>())
-            .copied(),
-        ['A', 'B', 'D', 'E', 'C', 'F', 'G', 'H'].iter(),
-    ) {
-        assert_eq!(lhs, rhs);
-    }
+            .filter_map(|frame| frame.downcast_ref::<Char>().map(|c| c.0))
+            .collect::<Vec<_>>(),
+        ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
+    );
 }
 
 #[test]
 fn iter_mut() {
     let mut report = build();
 
-    for (lhs, &rhs) in zip(
+    assert_eq!(
         report
             .frames_mut()
-            .filter_map(|frame| frame.downcast_ref::<char>())
-            .copied(),
-        ['A', 'B', 'D', 'E', 'C', 'F', 'G', 'H'].iter(),
-    ) {
-        assert_eq!(lhs, rhs);
-    }
+            .filter_map(|frame| frame.downcast_ref::<Char>().map(|c| c.0))
+            .collect::<Vec<_>>(),
+        ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
+    );
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The tests for `Frames` is not really readable.

## 🔍 What does this change?

- Change test to use contexts instead of attachments for prettier prints
- use the printed report in the docs
- remove implementation detail on the docs