### PR TITLE
Make variables and string casing more consistent in whole crate

### DIFF
--- a/packages/libs/error-stack/README.md
+++ b/packages/libs/error-stack/README.md
@@ -69,17 +69,17 @@ fn start_experiments(
         .map(|exp_id| {
             let description = experiment_descriptions.get(*exp_id).ok_or_else(|| {
                 Report::new(ExperimentError)
-                    .attach_printable(format!("Experiment {exp_id} has no valid description"))
+                    .attach_printable(format!("experiment {exp_id} has no valid description"))
             })?;
 
             let experiment = parse_experiment(description)
-                .attach_printable(format!("Experiment {exp_id} could not be parsed"))
+                .attach_printable(format!("experiment {exp_id} could not be parsed"))
                 .change_context(ExperimentError)?;
 
             Ok(move || experiment.0 * experiment.1)
         })
         .collect::<Result<Vec<_>, ExperimentError>>()
-        .attach_printable("Unable to set up experiments")?;
+        .attach_printable("unable to set up experiments")?;
 
     Ok(experiments.iter().map(|experiment| experiment()).collect())
 }

--- a/packages/libs/error-stack/examples/demo.rs
+++ b/packages/libs/error-stack/examples/demo.rs
@@ -65,11 +65,11 @@ fn start_experiments(
         .map(|exp_id| {
             let description = experiment_descriptions.get(*exp_id).ok_or_else(|| {
                 Report::new(ExperimentError)
-                    .attach_printable(format!("Experiment {exp_id} has no valid description"))
+                    .attach_printable(format!("experiment {exp_id} has no valid description"))
             })?;
 
             let experiments = parse_experiment(description)
-                .attach_printable(format!("Experiment {exp_id} could not be parsed"))
+                .attach_printable(format!("experiment {exp_id} could not be parsed"))
                 .change_context(ExperimentError)?;
 
             let experiments = experiments
@@ -96,7 +96,7 @@ fn start_experiments(
                 }
             },
         )
-        .attach_printable("Unable to set up experiments")?;
+        .attach_printable("unable to set up experiments")?;
 
     Ok(experiments.iter().map(|experiment| experiment()).collect())
 }

--- a/packages/libs/error-stack/examples/exit_code.rs
+++ b/packages/libs/error-stack/examples/exit_code.rs
@@ -18,7 +18,7 @@ impl std::fmt::Display for CustomError {
 fn main() -> ExitCode {
     let report = Report::new(CustomError)
         .attach(ExitCode::from(100))
-        .attach_printable("This error has an exit code of 100!");
+        .attach_printable("this error has an exit code of 100!");
 
     report.report()
 }

--- a/packages/libs/error-stack/examples/parse_config.rs
+++ b/packages/libs/error-stack/examples/parse_config.rs
@@ -32,8 +32,8 @@ fn parse_config(path: impl AsRef<Path>) -> Result<Config, Report<ParseConfigErro
     let content = fs::read_to_string(path)
         .into_report()
         .change_context(ParseConfigError::new())
-        .attach(Suggestion("Use a file you can read next time!"))
-        .attach_printable_lazy(|| format!("Could not read file {path:?}"))?;
+        .attach(Suggestion("use a file you can read next time!"))
+        .attach_printable_lazy(|| format!("could not read file {path:?}"))?;
 
     Ok(content)
 }

--- a/packages/libs/error-stack/src/fmt/hook.rs
+++ b/packages/libs/error-stack/src/fmt/hook.rs
@@ -119,11 +119,11 @@ impl HookContextInner {
 ///     // Create a new appendix, which is going to be displayed when someone requests the alternate
 ///     // version (`:#?`) of the report.
 ///     if ctx.alternate() {
-///         ctx.push_appendix(format!("Error {val}: {} Error", if *val < 500 {"Client"} else {"Server"}))
+///         ctx.push_appendix(format!("error {val}: {} error", if *val < 500 {"client"} else {"server"}))
 ///     }
 ///
 ///     // This will push a new entry onto the body with the specified value
-///     ctx.push_body(format!("Error code: {val}"));
+///     ctx.push_body(format!("error code: {val}"));
 /// });
 ///
 /// Report::install_debug_hook::<Suggestion>(|Suggestion(val), ctx| {
@@ -132,17 +132,17 @@ impl HookContextInner {
 ///     // Create a new appendix, which is going to be displayed when someone requests the alternate
 ///     // version (`:#?`) of the report.
 ///     if ctx.alternate() {
-///         ctx.push_body(format!("Suggestion {idx}:\n  {val}"));
+///         ctx.push_body(format!("suggestion {idx}:\n  {val}"));
 ///     }
 ///
 ///     // This will push a new entry onto the body with the specified value
-///     ctx.push_body(format!("Suggestion ({idx})"));
+///     ctx.push_body(format!("suggestion ({idx})"));
 /// });
 ///
 /// Report::install_debug_hook::<Warning>(|Warning(val), ctx| {
 ///     // You can add multiples entries to the body (and appendix) in the same hook.
-///     ctx.push_body("Abnormal program execution detected");
-///     ctx.push_body(format!("Warning: {val}"));
+///     ctx.push_body("abnormal program execution detected");
+///     ctx.push_body(format!("warning: {val}"));
 /// });
 ///
 /// // By not adding anything you are able to hide an attachment
@@ -151,20 +151,20 @@ impl HookContextInner {
 ///
 /// let report = Report::new(Error::from(ErrorKind::InvalidInput))
 ///     .attach(HttpResponseStatusCode(404))
-///     .attach(Suggestion("Do you have a connection to the internet?"))
+///     .attach(Suggestion("do you have a connection to the internet?"))
 ///     .attach(HttpResponseStatusCode(405))
-///     .attach(Warning("Unable to determine environment"))
+///     .attach(Warning("unable to determine environment"))
 ///     .attach(Secret("pssst, don't tell anyone else c;"))
-///     .attach(Suggestion("Execute the program from the fish shell"))
+///     .attach(Suggestion("execute the program from the fish shell"))
 ///     .attach(HttpResponseStatusCode(501))
-///     .attach(Suggestion("Try better next time!"));
+///     .attach(Suggestion("try better next time!"));
 ///
 /// # owo_colors::set_override(true);
 /// # fn render(value: String) -> String {
-/// #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
+/// #     let backtrace = regex::Regex::new(r"backtrace no\. (\d+)\n(?:  .*\n)*  .*").unwrap();
 /// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
 /// #
-/// #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
+/// #     let value = backtrace.replace_all(&value, "backtrace no. $1\n  [redacted]");
 /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
 /// #
 /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
@@ -231,7 +231,7 @@ impl HookContextInner {
 ///     ctx.insert(div);
 ///
 ///     ctx.push_body(format!(
-///         "Computation for {val} (acc = {acc}, div = {div})"
+///         "computation for {val} (acc = {acc}, div = {div})"
 ///     ));
 /// });
 ///
@@ -241,10 +241,10 @@ impl HookContextInner {
 ///
 /// # owo_colors::set_override(true);
 /// # fn render(value: String) -> String {
-/// #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
+/// #     let backtrace = regex::Regex::new(r"backtrace no\. (\d+)\n(?:  .*\n)*  .*").unwrap();
 /// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
 /// #
-/// #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
+/// #     let value = backtrace.replace_all(&value, "backtrace no. $1\n  [redacted]");
 /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
 /// #
 /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
@@ -304,28 +304,28 @@ impl<T> HookContext<T> {
     /// Report::install_debug_hook::<Error>(|Error { code, reason }, ctx| {
     ///     if ctx.alternate() {
     ///         // Add an entry to the appendix
-    ///         ctx.push_appendix(format!("Error {code}:\n  {reason}"));
+    ///         ctx.push_appendix(format!("error {code}:\n  {reason}"));
     ///     }
     ///
-    ///     ctx.push_body(format!("Error {code}"));
+    ///     ctx.push_body(format!("error {code}"));
     /// });
     ///
     /// let report = Report::new(std::io::Error::from(ErrorKind::InvalidInput))
     ///     .attach(Error {
     ///         code: 404,
-    ///         reason: "Not Found - Server cannot find requested resource",
+    ///         reason: "not found - server cannot find requested resource",
     ///     })
     ///     .attach(Error {
     ///         code: 405,
-    ///         reason: "Bad Request - Server cannot or will not process request",
+    ///         reason: "bad request - server cannot or will not process request",
     ///     });
     ///
     /// # owo_colors::set_override(true);
     /// # fn render(value: String) -> String {
-    /// #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
+    /// #     let backtrace = regex::Regex::new(r"backtrace no\. (\d+)\n(?:  .*\n)*  .*").unwrap();
     /// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
     /// #
-    /// #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
+    /// #     let value = backtrace.replace_all(&value, "backtrace no. $1\n  [redacted]");
     /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
     /// #
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
@@ -358,21 +358,21 @@ impl<T> HookContext<T> {
     /// struct Suggestion(&'static str);
     ///
     /// Report::install_debug_hook::<Suggestion>(|Suggestion(val), ctx| {
-    ///     ctx.push_body(format!("Suggestion: {val}"));
+    ///     ctx.push_body(format!("suggestion: {val}"));
     ///     // We can push multiples entries in a single hook, these lines will be added one after
     ///     // another.
-    ///     ctx.push_body("Sorry for the inconvenience!");
+    ///     ctx.push_body("sorry for the inconvenience!");
     /// });
     ///
     /// let report = Report::new(io::Error::from(io::ErrorKind::InvalidInput))
-    ///     .attach(Suggestion("Try better next time"));
+    ///     .attach(Suggestion("try better next time"));
     ///
     /// # owo_colors::set_override(true);
     /// # fn render(value: String) -> String {
-    /// #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
+    /// #     let backtrace = regex::Regex::new(r"backtrace no\. (\d+)\n(?:  .*\n)*  .*").unwrap();
     /// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
     /// #
-    /// #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
+    /// #     let value = backtrace.replace_all(&value, "backtrace no. $1\n  [redacted]");
     /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
     /// #
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
@@ -428,16 +428,16 @@ impl<T> HookContext<T> {
     /// });
     ///
     /// let report = Report::new(std::io::Error::from(ErrorKind::InvalidInput))
-    ///     .attach(Error("Unable to reach remote host"))
-    ///     .attach(Warning("Disk nearly full"))
-    ///     .attach(Error("Cannot resolve example.com: Unknown host"));
+    ///     .attach(Error("unable to reach remote host"))
+    ///     .attach(Warning("disk nearly full"))
+    ///     .attach(Error("cannot resolve example.com: unknown host"));
     ///
     /// # owo_colors::set_override(true);
     /// # fn render(value: String) -> String {
-    /// #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
+    /// #     let backtrace = regex::Regex::new(r"backtrace no\. (\d+)\n(?:  .*\n)*  .*").unwrap();
     /// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
     /// #
-    /// #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
+    /// #     let value = backtrace.replace_all(&value, "backtrace no. $1\n  [redacted]");
     /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
     /// #
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
@@ -554,19 +554,19 @@ impl<T: 'static> HookContext<T> {
     ///
     /// Report::install_debug_hook::<Suggestion>(|Suggestion(val), ctx| {
     ///     let idx = ctx.increment_counter();
-    ///     ctx.push_body(format!("Suggestion {idx}: {val}"));
+    ///     ctx.push_body(format!("suggestion {idx}: {val}"));
     /// });
     ///
     /// let report = Report::new(std::io::Error::from(ErrorKind::InvalidInput))
-    ///     .attach(Suggestion("Use a file you can read next time!"))
-    ///     .attach(Suggestion("Don't press any random keys!"));
+    ///     .attach(Suggestion("use a file you can read next time!"))
+    ///     .attach(Suggestion("don't press any random keys!"));
     ///
     /// # owo_colors::set_override(true);
     /// # fn render(value: String) -> String {
-    /// #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
+    /// #     let backtrace = regex::Regex::new(r"backtrace no\. (\d+)\n(?:  .*\n)*  .*").unwrap();
     /// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
     /// #
-    /// #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
+    /// #     let value = backtrace.replace_all(&value, "backtrace no. $1\n  [redacted]");
     /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
     /// #
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
@@ -621,19 +621,19 @@ impl<T: 'static> HookContext<T> {
     ///
     /// Report::install_debug_hook::<Suggestion>(|Suggestion(val), ctx| {
     ///     let idx = ctx.decrement_counter();
-    ///     ctx.push_body(format!("Suggestion {idx}: {val}"));
+    ///     ctx.push_body(format!("suggestion {idx}: {val}"));
     /// });
     ///
     /// let report = Report::new(std::io::Error::from(ErrorKind::InvalidInput))
-    ///     .attach(Suggestion("Use a file you can read next time!"))
-    ///     .attach(Suggestion("Don't press any random keys!"));
+    ///     .attach(Suggestion("use a file you can read next time!"))
+    ///     .attach(Suggestion("don't press any random keys!"));
     ///
     /// # owo_colors::set_override(true);
     /// # fn render(value: String) -> String {
-    /// #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
+    /// #     let backtrace = regex::Regex::new(r"backtrace no\. (\d+)\n(?:  .*\n)*  .*").unwrap();
     /// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
     /// #
-    /// #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
+    /// #     let value = backtrace.replace_all(&value, "backtrace no. $1\n  [redacted]");
     /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
     /// #
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
@@ -803,7 +803,7 @@ mod default {
     fn backtrace(backtrace: &Backtrace, ctx: &mut HookContext<Backtrace>) {
         let idx = ctx.increment_counter();
 
-        ctx.push_appendix(format!("Backtrace No. {}\n{}", idx + 1, backtrace));
+        ctx.push_appendix(format!("backtrace no. {}\n{}", idx + 1, backtrace));
         #[cfg(nightly)]
         ctx.push_body(format!(
             "backtrace with {} frames ({})",
@@ -824,7 +824,7 @@ mod default {
             true
         });
 
-        ctx.push_appendix(format!("Span Trace No. {}\n{}", idx + 1, spantrace));
-        ctx.push_body(format!("spantrace with {span} frames ({})", idx + 1));
+        ctx.push_appendix(format!("span trace No. {}\n{}", idx + 1, spantrace));
+        ctx.push_body(format!("span trace with {span} frames ({})", idx + 1));
     }
 }

--- a/packages/libs/error-stack/src/fmt/hook.rs
+++ b/packages/libs/error-stack/src/fmt/hook.rs
@@ -115,34 +115,34 @@ impl HookContextInner {
 /// struct Suggestion(&'static str);
 /// struct Secret(&'static str);
 ///
-/// Report::install_debug_hook::<HttpResponseStatusCode>(|HttpResponseStatusCode(val), ctx| {
+/// Report::install_debug_hook::<HttpResponseStatusCode>(|HttpResponseStatusCode(value), context| {
 ///     // Create a new appendix, which is going to be displayed when someone requests the alternate
 ///     // version (`:#?`) of the report.
-///     if ctx.alternate() {
-///         ctx.push_appendix(format!("error {val}: {} error", if *val < 500 {"client"} else {"server"}))
+///     if context.alternate() {
+///         context.push_appendix(format!("error {value}: {} error", if *value < 500 {"client"} else {"server"}))
 ///     }
 ///
 ///     // This will push a new entry onto the body with the specified value
-///     ctx.push_body(format!("error code: {val}"));
+///     context.push_body(format!("error code: {value}"));
 /// });
 ///
-/// Report::install_debug_hook::<Suggestion>(|Suggestion(val), ctx| {
-///     let idx = ctx.increment_counter();
+/// Report::install_debug_hook::<Suggestion>(|Suggestion(value), context| {
+///     let idx = context.increment_counter();
 ///
 ///     // Create a new appendix, which is going to be displayed when someone requests the alternate
 ///     // version (`:#?`) of the report.
-///     if ctx.alternate() {
-///         ctx.push_body(format!("suggestion {idx}:\n  {val}"));
+///     if context.alternate() {
+///         context.push_body(format!("suggestion {idx}:\n  {value}"));
 ///     }
 ///
 ///     // This will push a new entry onto the body with the specified value
-///     ctx.push_body(format!("suggestion ({idx})"));
+///     context.push_body(format!("suggestion ({idx})"));
 /// });
 ///
-/// Report::install_debug_hook::<Warning>(|Warning(val), ctx| {
+/// Report::install_debug_hook::<Warning>(|Warning(value), context| {
 ///     // You can add multiples entries to the body (and appendix) in the same hook.
-///     ctx.push_body("abnormal program execution detected");
-///     ctx.push_body(format!("warning: {val}"));
+///     context.push_body("abnormal program execution detected");
+///     context.push_body(format!("warning: {value}"));
 /// });
 ///
 /// // By not adding anything you are able to hide an attachment
@@ -184,13 +184,13 @@ impl HookContextInner {
 /// The output of `println!("{report:?}")`:
 ///
 /// <pre>
-#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__emit.snap"))]
+#[doc = include_str ! (concat ! (env ! ("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__emit.snap"))]
 /// </pre>
 ///
 /// The output of `println!("{report:#?}")`:
 ///
 /// <pre>
-#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__emit_alt.snap"))]
+#[doc = include_str ! (concat ! (env ! ("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__emit_alt.snap"))]
 /// </pre>
 ///
 /// ## Storage
@@ -216,22 +216,22 @@ impl HookContextInner {
 ///
 /// struct Computation(u64);
 ///
-/// Report::install_debug_hook::<Computation>(|Computation(val), ctx| {
+/// Report::install_debug_hook::<Computation>(|Computation(value), context| {
 ///     // Get a value of type `u64`, if we didn't insert one yet, default to 0
-///     let mut acc = ctx.get::<u64>().copied().unwrap_or(0);
-///     acc += *val;
+///     let mut acc = context.get::<u64>().copied().unwrap_or(0);
+///     acc += *value;
 ///
 ///     // Get a value of type `f64`, if we didn't insert one yet, default to 1.0
-///     let mut div = ctx.get::<f32>().copied().unwrap_or(1.0);
-///     div /= *val as f32;
+///     let mut div = context.get::<f32>().copied().unwrap_or(1.0);
+///     div /= *value as f32;
 ///
 ///     // Insert the calculated `u64` and `f32` back into storage, so that we can use them
 ///     // in the invocations following this one (for the same `Debug` call)
-///     ctx.insert(acc);
-///     ctx.insert(div);
+///     context.insert(acc);
+///     context.insert(div);
 ///
-///     ctx.push_body(format!(
-///         "computation for {val} (acc = {acc}, div = {div})"
+///     context.push_body(format!(
+///         "computation for {value} (acc = {acc}, div = {div})"
 ///     ));
 /// });
 ///
@@ -257,7 +257,7 @@ impl HookContextInner {
 /// ```
 ///
 /// <pre>
-#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_storage.snap"))]
+#[doc = include_str ! (concat ! (env ! ("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_storage.snap"))]
 /// </pre>
 ///
 /// [`Debug`]: core::fmt::Debug
@@ -301,13 +301,13 @@ impl<T> HookContext<T> {
     ///     reason: &'static str,
     /// }
     ///
-    /// Report::install_debug_hook::<Error>(|Error { code, reason }, ctx| {
-    ///     if ctx.alternate() {
+    /// Report::install_debug_hook::<Error>(|Error { code, reason }, context| {
+    ///     if context.alternate() {
     ///         // Add an entry to the appendix
-    ///         ctx.push_appendix(format!("error {code}:\n  {reason}"));
+    ///         context.push_appendix(format!("error {code}:\n  {reason}"));
     ///     }
     ///
-    ///     ctx.push_body(format!("error {code}"));
+    ///     context.push_body(format!("error {code}"));
     /// });
     ///
     /// let report = Report::new(std::io::Error::from(ErrorKind::InvalidInput))
@@ -338,7 +338,7 @@ impl<T> HookContext<T> {
     /// ```
     ///
     /// <pre>
-    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_emit.snap"))]
+    #[doc = include_str ! (concat ! (env ! ("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_emit.snap"))]
     /// </pre>
     pub fn push_appendix(&mut self, content: impl Into<String>) {
         self.inner.appendix.push(content.into());
@@ -357,11 +357,11 @@ impl<T> HookContext<T> {
     ///
     /// struct Suggestion(&'static str);
     ///
-    /// Report::install_debug_hook::<Suggestion>(|Suggestion(val), ctx| {
-    ///     ctx.push_body(format!("suggestion: {val}"));
+    /// Report::install_debug_hook::<Suggestion>(|Suggestion(value), context| {
+    ///     context.push_body(format!("suggestion: {value}"));
     ///     // We can push multiples entries in a single hook, these lines will be added one after
     ///     // another.
-    ///     ctx.push_body("sorry for the inconvenience!");
+    ///     context.push_body("sorry for the inconvenience!");
     /// });
     ///
     /// let report = Report::new(io::Error::from(io::ErrorKind::InvalidInput))
@@ -385,7 +385,7 @@ impl<T> HookContext<T> {
     /// ```
     ///
     /// <pre>
-    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__diagnostics_add.snap"))]
+    #[doc = include_str ! (concat ! (env ! ("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__diagnostics_add.snap"))]
     /// </pre>
     pub fn push_body(&mut self, content: impl Into<String>) {
         self.inner.body.push(content.into());
@@ -413,18 +413,18 @@ impl<T> HookContext<T> {
     /// struct Warning(&'static str);
     /// struct Error(&'static str);
     ///
-    /// Report::install_debug_hook::<Error>(|Error(frame), ctx| {
-    ///     let idx = ctx.increment_counter() + 1;
+    /// Report::install_debug_hook::<Error>(|Error(frame), context| {
+    ///     let idx = context.increment_counter() + 1;
     ///
-    ///     ctx.push_body(format!("[{idx}] [ERROR] {frame}"));
+    ///     context.push_body(format!("[{idx}] [ERROR] {frame}"));
     /// });
-    /// Report::install_debug_hook::<Warning>(|Warning(frame), ctx| {
+    /// Report::install_debug_hook::<Warning>(|Warning(frame), context| {
     ///     // We want to share the same counter with `Error`, so that we're able to have
     ///     // a global counter to keep track of all errors and warnings in order, this means
     ///     // we need to access the storage of `Error` using `cast()`.
-    ///     let ctx = ctx.cast::<Error>();
-    ///     let idx = ctx.increment_counter() + 1;
-    ///     ctx.push_body(format!("[{idx}] [WARN] {frame}"))
+    ///     let context = context.cast::<Error>();
+    ///     let idx = context.increment_counter() + 1;
+    ///     context.push_body(format!("[{idx}] [WARN] {frame}"))
     /// });
     ///
     /// let report = Report::new(std::io::Error::from(ErrorKind::InvalidInput))
@@ -450,7 +450,7 @@ impl<T> HookContext<T> {
     /// ```
     ///
     /// <pre>
-    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_cast.snap"))]
+    #[doc = include_str ! (concat ! (env ! ("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_cast.snap"))]
     /// </pre>
     #[must_use]
     pub fn cast<U>(&mut self) -> &mut HookContext<U> {
@@ -552,9 +552,9 @@ impl<T: 'static> HookContext<T> {
     ///
     /// struct Suggestion(&'static str);
     ///
-    /// Report::install_debug_hook::<Suggestion>(|Suggestion(val), ctx| {
-    ///     let idx = ctx.increment_counter();
-    ///     ctx.push_body(format!("suggestion {idx}: {val}"));
+    /// Report::install_debug_hook::<Suggestion>(|Suggestion(value), context| {
+    ///     let idx = context.increment_counter();
+    ///     context.push_body(format!("suggestion {idx}: {value}"));
     /// });
     ///
     /// let report = Report::new(std::io::Error::from(ErrorKind::InvalidInput))
@@ -579,7 +579,7 @@ impl<T: 'static> HookContext<T> {
     /// ```
     ///
     /// <pre>
-    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_increment.snap"))]
+    #[doc = include_str ! (concat ! (env ! ("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_increment.snap"))]
     /// </pre>
     ///
     /// [`Debug`]: core::fmt::Debug
@@ -619,9 +619,9 @@ impl<T: 'static> HookContext<T> {
     ///
     /// struct Suggestion(&'static str);
     ///
-    /// Report::install_debug_hook::<Suggestion>(|Suggestion(val), ctx| {
-    ///     let idx = ctx.decrement_counter();
-    ///     ctx.push_body(format!("suggestion {idx}: {val}"));
+    /// Report::install_debug_hook::<Suggestion>(|Suggestion(value), context| {
+    ///     let idx = context.decrement_counter();
+    ///     context.push_body(format!("suggestion {idx}: {value}"));
     /// });
     ///
     /// let report = Report::new(std::io::Error::from(ErrorKind::InvalidInput))
@@ -646,7 +646,7 @@ impl<T: 'static> HookContext<T> {
     /// ```
     ///
     /// <pre>
-    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_decrement.snap"))]
+    #[doc = include_str ! (concat ! (env ! ("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_decrement.snap"))]
     /// </pre>
     pub fn decrement_counter(&mut self) -> isize {
         let counter = self.get_mut::<Counter>();
@@ -676,16 +676,16 @@ type BoxedHook = Box<dyn Fn(&Frame, &mut HookContext<Frame>) -> Option<()> + Sen
 fn into_boxed_hook<T: Send + Sync + 'static>(
     hook: impl Fn(&T, &mut HookContext<T>) + Send + Sync + 'static,
 ) -> BoxedHook {
-    Box::new(move |frame: &Frame, ctx: &mut HookContext<Frame>| {
+    Box::new(move |frame: &Frame, context: &mut HookContext<Frame>| {
         #[cfg(nightly)]
         {
             frame
                 .request_ref::<T>()
-                .map(|val| hook(val, ctx.cast()))
+                .map(|value| hook(value, context.cast()))
                 .or_else(|| {
                     frame
                         .request_value::<T>()
-                        .map(|ref val| hook(val, ctx.cast()))
+                        .map(|ref value| hook(value, context.cast()))
                 })
         }
 
@@ -696,7 +696,7 @@ fn into_boxed_hook<T: Send + Sync + 'static>(
         matches!(frame.kind(), crate::FrameKind::Attachment(_))
             .then_some(frame)
             .and_then(Frame::downcast_ref::<T>)
-            .map(|val| hook(val, ctx.cast()))
+            .map(|value| hook(value, context.cast()))
     })
 }
 
@@ -741,9 +741,9 @@ impl Hooks {
         self.inner.push((type_id, into_boxed_hook(hook)));
     }
 
-    pub(crate) fn call(&self, frame: &Frame, ctx: &mut HookContext<Frame>) {
+    pub(crate) fn call(&self, frame: &Frame, context: &mut HookContext<Frame>) {
         for (_, hook) in &self.inner {
-            hook(frame, ctx);
+            hook(frame, context);
         }
     }
 }
@@ -800,31 +800,31 @@ mod default {
     }
 
     #[cfg(rust_1_65)]
-    fn backtrace(backtrace: &Backtrace, ctx: &mut HookContext<Backtrace>) {
-        let idx = ctx.increment_counter();
+    fn backtrace(backtrace: &Backtrace, context: &mut HookContext<Backtrace>) {
+        let idx = context.increment_counter();
 
-        ctx.push_appendix(format!("backtrace no. {}\n{}", idx + 1, backtrace));
+        context.push_appendix(format!("backtrace no. {}\n{}", idx + 1, backtrace));
         #[cfg(nightly)]
-        ctx.push_body(format!(
+        context.push_body(format!(
             "backtrace with {} frames ({})",
             backtrace.frames().len(),
             idx + 1
         ));
         #[cfg(not(nightly))]
-        ctx.push_body(format!("backtrace ({})", idx + 1));
+        context.push_body(format!("backtrace ({})", idx + 1));
     }
 
     #[cfg(feature = "spantrace")]
-    fn span_trace(spantrace: &SpanTrace, ctx: &mut HookContext<SpanTrace>) {
-        let idx = ctx.increment_counter();
+    fn span_trace(span_trace: &SpanTrace, context: &mut HookContext<SpanTrace>) {
+        let idx = context.increment_counter();
 
         let mut span = 0;
-        spantrace.with_spans(|_, _| {
+        span_trace.with_spans(|_, _| {
             span += 1;
             true
         });
 
-        ctx.push_appendix(format!("span trace No. {}\n{}", idx + 1, spantrace));
-        ctx.push_body(format!("span trace with {span} frames ({})", idx + 1));
+        context.push_appendix(format!("span trace No. {}\n{}", idx + 1, span_trace));
+        context.push_body(format!("span trace with {span} frames ({})", idx + 1));
     }
 }

--- a/packages/libs/error-stack/src/fmt/hook.rs
+++ b/packages/libs/error-stack/src/fmt/hook.rs
@@ -184,13 +184,13 @@ impl HookContextInner {
 /// The output of `println!("{report:?}")`:
 ///
 /// <pre>
-#[doc = include_str ! (concat ! (env ! ("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__emit.snap"))]
+#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__emit.snap"))]
 /// </pre>
 ///
 /// The output of `println!("{report:#?}")`:
 ///
 /// <pre>
-#[doc = include_str ! (concat ! (env ! ("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__emit_alt.snap"))]
+#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__emit_alt.snap"))]
 /// </pre>
 ///
 /// ## Storage
@@ -257,7 +257,7 @@ impl HookContextInner {
 /// ```
 ///
 /// <pre>
-#[doc = include_str ! (concat ! (env ! ("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_storage.snap"))]
+#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_storage.snap"))]
 /// </pre>
 ///
 /// [`Debug`]: core::fmt::Debug
@@ -338,7 +338,7 @@ impl<T> HookContext<T> {
     /// ```
     ///
     /// <pre>
-    #[doc = include_str ! (concat ! (env ! ("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_emit.snap"))]
+    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_emit.snap"))]
     /// </pre>
     pub fn push_appendix(&mut self, content: impl Into<String>) {
         self.inner.appendix.push(content.into());
@@ -385,7 +385,7 @@ impl<T> HookContext<T> {
     /// ```
     ///
     /// <pre>
-    #[doc = include_str ! (concat ! (env ! ("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__diagnostics_add.snap"))]
+    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__diagnostics_add.snap"))]
     /// </pre>
     pub fn push_body(&mut self, content: impl Into<String>) {
         self.inner.body.push(content.into());
@@ -450,7 +450,7 @@ impl<T> HookContext<T> {
     /// ```
     ///
     /// <pre>
-    #[doc = include_str ! (concat ! (env ! ("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_cast.snap"))]
+    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_cast.snap"))]
     /// </pre>
     #[must_use]
     pub fn cast<U>(&mut self) -> &mut HookContext<U> {
@@ -579,7 +579,7 @@ impl<T: 'static> HookContext<T> {
     /// ```
     ///
     /// <pre>
-    #[doc = include_str ! (concat ! (env ! ("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_increment.snap"))]
+    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_increment.snap"))]
     /// </pre>
     ///
     /// [`Debug`]: core::fmt::Debug
@@ -646,7 +646,7 @@ impl<T: 'static> HookContext<T> {
     /// ```
     ///
     /// <pre>
-    #[doc = include_str ! (concat ! (env ! ("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_decrement.snap"))]
+    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_decrement.snap"))]
     /// </pre>
     pub fn decrement_counter(&mut self) -> isize {
         let counter = self.get_mut::<Counter>();

--- a/packages/libs/error-stack/src/fmt/mod.rs
+++ b/packages/libs/error-stack/src/fmt/mod.rs
@@ -48,9 +48,8 @@
 //! struct ErrorCode(u64);
 //!
 //! impl Display for ErrorCode {
-//!   fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-//!     f.write_str("Error: ")?;
-//!     Display::fmt(&self.0, f)
+//!   fn fmt(&self, fmt: &mut Formatter<'_>) -> std::fmt::Result {
+//!     write!(fmt, "error: {}", self.0)
 //!   }
 //! }
 //!
@@ -59,8 +58,8 @@
 //!
 //! // This hook will never be called, because a later invocation of `install_debug_hook` overwrites
 //! // the hook for the type `ErrorCode`.
-//! Report::install_debug_hook::<ErrorCode>(|_, ctx| {
-//!     ctx.push_body("will never be called");
+//! Report::install_debug_hook::<ErrorCode>(|_, _| {
+//!     unreachable!("will never be called");
 //! });
 //!
 //! // `HookContext` always has a type parameter, which needs to be the same as the type of the
@@ -70,13 +69,13 @@
 //! // will not influence the counter of the `ErrorCode` or `Warning` hook.
 //! Report::install_debug_hook::<Suggestion>(|Suggestion(val), ctx| {
 //!     let idx = ctx.increment_counter() + 1;
-//!     ctx.push_body(format!("Suggestion {idx}: {val}"));
+//!     ctx.push_body(format!("suggestion {idx}: {val}"));
 //! });
 //!
 //! // Even though we used `attach_printable`, we can still use hooks, `Display` of a type attached
 //! // via `attach_printable` is only ever used when no hook was found.
 //! Report::install_debug_hook::<ErrorCode>(|ErrorCode(val), ctx| {
-//!     ctx.push_body(format!("Error ({val})"));
+//!     ctx.push_body(format!("error ({val})"));
 //! });
 //!
 //! Report::install_debug_hook::<Warning>(|Warning(val), ctx| {
@@ -85,25 +84,25 @@
 //!     // we set a value, which will be removed on non-alternate views
 //!     // and is going to be appended to the actual return value.
 //!     if ctx.alternate() {
-//!         ctx.push_appendix(format!("Warning {idx}:\n  {val}"));
+//!         ctx.push_appendix(format!("warning {idx}:\n  {val}"));
 //!     }
 //!
-//!     ctx.push_body(format!("Warning ({idx}) occurred"));
+//!     ctx.push_body(format!("warning ({idx}) occurred"));
 //!  });
 //!
 //!
 //! let report = Report::new(Error::from(ErrorKind::InvalidInput))
 //!     .attach_printable(ErrorCode(404))
-//!     .attach(Suggestion("Try to be connected to the internet."))
-//!     .attach(Suggestion("Try better next time!"))
-//!     .attach(Warning("Unable to fetch resource"));
+//!     .attach(Suggestion("try to be connected to the internet."))
+//!     .attach(Suggestion("try better next time!"))
+//!     .attach(Warning("unable to fetch resource"));
 //!
 //! # owo_colors::set_override(true);
 //! # fn render(value: String) -> String {
-//! #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
+//! #     let backtrace = regex::Regex::new(r"backtrace no\. (\d+)\n(?:  .*\n)*  .*").unwrap();
 //! #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
 //! #
-//! #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
+//! #     let value = backtrace.replace_all(&value, "backtrace no. $1\n  [redacted]");
 //! #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
 //! #
 //! #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()

--- a/packages/libs/error-stack/src/fmt/mod.rs
+++ b/packages/libs/error-stack/src/fmt/mod.rs
@@ -122,13 +122,13 @@
 //! The output of `println!("{report:?}")`:
 //!
 //! <pre>
-#![doc = include_str ! (concat ! (env ! ("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__doc.snap"))]
+#![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__doc.snap"))]
 //! </pre>
 //!
 //! The output of `println!("{report:#?}")`:
 //!
 //! <pre>
-#![doc = include_str ! (concat ! (env ! ("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt_doc_alt.snap"))]
+#![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt_doc_alt.snap"))]
 //! </pre>
 //!
 //! [`Display`]: core::fmt::Display

--- a/packages/libs/error-stack/src/frame/mod.rs
+++ b/packages/libs/error-stack/src/frame/mod.rs
@@ -146,7 +146,7 @@ impl fmt::Debug for Frame {
                 debug.field("attachment", &attachment);
             }
             FrameKind::Attachment(AttachmentKind::Opaque(_)) => {
-                debug.field("attachment", &"Opaque");
+                debug.field("attachment", &"opaque");
             }
         }
         debug.finish()

--- a/packages/libs/error-stack/src/hook.rs
+++ b/packages/libs/error-stack/src/hook.rs
@@ -55,18 +55,18 @@ impl Report<()> {
     /// struct Suggestion(&'static str);
     ///
     /// Report::install_debug_hook::<Suggestion>(|val, ctx| {
-    ///     ctx.push_body(format!("Suggestion: {}", val.0));
+    ///     ctx.push_body(format!("suggestion: {}", val.0));
     /// });
     ///
     /// let report =
-    ///     report!(Error::from(ErrorKind::InvalidInput)).attach(Suggestion("O no, try again"));
+    ///     report!(Error::from(ErrorKind::InvalidInput)).attach(Suggestion("oh no, try again"));
     ///
     /// # owo_colors::set_override(true);
     /// # fn render(value: String) -> String {
-    /// #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
+    /// #     let backtrace = regex::Regex::new(r"backtrace no\. (\d+)\n(?:  .*\n)*  .*").unwrap();
     /// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
     /// #
-    /// #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
+    /// #     let value = backtrace.replace_all(&value, "backtrace no. $1\n  [redacted]");
     /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
     /// #
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
@@ -115,33 +115,33 @@ impl Report<()> {
     ///
     /// impl Display for UserError {
     ///     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-    ///         f.write_str("Invalid user input")
+    ///         f.write_str("invalid user input")
     ///     }
     /// }
     ///
     /// impl Error for UserError {
     ///  fn provide<'a>(&'a self, req: &mut Demand<'a>) {
-    ///    req.provide_value(Suggestion("Try better next time!"));
+    ///    req.provide_value(Suggestion("try better next time!"));
     ///    req.provide_ref(&self.code);
     ///  }
     /// }
     ///
     /// # pub fn main() {
     /// Report::install_debug_hook::<Suggestion>(|Suggestion(val), ctx| {
-    ///     ctx.push_body(format!("Suggestion: {val}"));
+    ///     ctx.push_body(format!("suggestion: {val}"));
     /// });
     /// Report::install_debug_hook::<ErrorCode>(|ErrorCode(val), ctx| {
-    ///     ctx.push_body(format!("Error Code: {val}"));
+    ///     ctx.push_body(format!("error code: {val}"));
     /// });
     ///
     /// let report = report!(UserError {code: ErrorCode(420)});
     ///
     /// # owo_colors::set_override(true);
     /// # fn render(value: String) -> String {
-    /// #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
+    /// #     let backtrace = regex::Regex::new(r"backtrace no\. (\d+)\n(?:  .*\n)*  .*").unwrap();
     /// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
     /// #
-    /// #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
+    /// #     let value = backtrace.replace_all(&value, "backtrace no. $1\n  [redacted]");
     /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
     /// #
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()

--- a/packages/libs/error-stack/src/hook.rs
+++ b/packages/libs/error-stack/src/hook.rs
@@ -54,8 +54,8 @@ impl Report<()> {
     ///
     /// struct Suggestion(&'static str);
     ///
-    /// Report::install_debug_hook::<Suggestion>(|val, ctx| {
-    ///     ctx.push_body(format!("suggestion: {}", val.0));
+    /// Report::install_debug_hook::<Suggestion>(|value, context| {
+    ///     context.push_body(format!("suggestion: {}", value.0));
     /// });
     ///
     /// let report =
@@ -81,7 +81,7 @@ impl Report<()> {
     /// Which will result in something like:
     ///
     /// <pre>
-    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/hook__debug_hook.snap"))]
+    #[doc = include_str ! (concat ! (env ! ("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/hook__debug_hook.snap"))]
     /// </pre>
     ///
     /// This example showcases the ability of hooks to be invoked for values provided via the
@@ -127,11 +127,11 @@ impl Report<()> {
     /// }
     ///
     /// # pub fn main() {
-    /// Report::install_debug_hook::<Suggestion>(|Suggestion(val), ctx| {
-    ///     ctx.push_body(format!("suggestion: {val}"));
+    /// Report::install_debug_hook::<Suggestion>(|Suggestion(value), context| {
+    ///     context.push_body(format!("suggestion: {value}"));
     /// });
-    /// Report::install_debug_hook::<ErrorCode>(|ErrorCode(val), ctx| {
-    ///     ctx.push_body(format!("error code: {val}"));
+    /// Report::install_debug_hook::<ErrorCode>(|ErrorCode(value), context| {
+    ///     context.push_body(format!("error code: {value}"));
     /// });
     ///
     /// let report = report!(UserError {code: ErrorCode(420)});
@@ -161,7 +161,7 @@ impl Report<()> {
     /// Which will result in something like:
     ///
     /// <pre>
-    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/hook__debug_hook_provide.snap"))]
+    #[doc = include_str ! (concat ! (env ! ("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/hook__debug_hook_provide.snap"))]
     /// </pre>
     #[cfg(feature = "std")]
     pub fn install_debug_hook<T: Send + Sync + 'static>(

--- a/packages/libs/error-stack/src/hook.rs
+++ b/packages/libs/error-stack/src/hook.rs
@@ -81,7 +81,7 @@ impl Report<()> {
     /// Which will result in something like:
     ///
     /// <pre>
-    #[doc = include_str ! (concat ! (env ! ("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/hook__debug_hook.snap"))]
+    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/hook__debug_hook.snap"))]
     /// </pre>
     ///
     /// This example showcases the ability of hooks to be invoked for values provided via the
@@ -161,7 +161,7 @@ impl Report<()> {
     /// Which will result in something like:
     ///
     /// <pre>
-    #[doc = include_str ! (concat ! (env ! ("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/hook__debug_hook_provide.snap"))]
+    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/hook__debug_hook_provide.snap"))]
     /// </pre>
     #[cfg(feature = "std")]
     pub fn install_debug_hook<T: Send + Sync + 'static>(

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -119,7 +119,7 @@
 //!
 //! impl fmt::Display for ParseConfigError {
 //!     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-//!         fmt.write_str("Could not parse configuration file")
+//!         fmt.write_str("could not parse configuration file")
 //!     }
 //! }
 //!
@@ -160,7 +160,7 @@
 //! # impl ParseConfigError { pub fn new() -> Self { Self } }
 //! # impl std::fmt::Display for ParseConfigError {
 //! #     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-//! #         fmt.write_str("Could not parse configuration file")
+//! #         fmt.write_str("could not parse configuration file")
 //! #     }
 //! # }
 //! # impl Context for ParseConfigError {}
@@ -173,26 +173,26 @@
 //!     let content = fs::read_to_string(path)
 //!         .into_report()
 //!         .change_context(ParseConfigError::new())
-//!         .attach(Suggestion("Use a file you can read next time!"))
-//!         .attach_printable_lazy(|| format!("Could not read file {path:?}"))?;
+//!         .attach(Suggestion("use a file you can read next time!"))
+//!         .attach_printable_lazy(|| format!("could not read file {path:?}"))?;
 //!
 //!     Ok(content)
 //! }
 //! # let report = parse_config("test.txt").unwrap_err();
 //! # assert!(report.contains::<std::io::Error>());
-//! # assert_eq!(report.downcast_ref::<Suggestion>().unwrap(), &Suggestion("Use a file you can read next time!"));
+//! # assert_eq!(report.downcast_ref::<Suggestion>().unwrap(), &Suggestion("use a file you can read next time!"));
 //! # #[cfg(nightly)]
-//! # assert_eq!(report.request_ref::<Suggestion>().next().unwrap(), &Suggestion("Use a file you can read next time!"));
+//! # assert_eq!(report.request_ref::<Suggestion>().next().unwrap(), &Suggestion("use a file you can read next time!"));
 //! # #[cfg(nightly)]
-//! # assert_eq!(report.request_ref::<String>().next().unwrap(), "Could not read file \"test.txt\"");
+//! # assert_eq!(report.request_ref::<String>().next().unwrap(), "could not read file \"test.txt\"");
 //! # assert!(report.contains::<ParseConfigError>());
 //! #
 //! # owo_colors::set_override(true);
 //! # fn render(value: String) -> String {
-//! #     let backtrace = regex::Regex::new(r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*").unwrap();
+//! #     let backtrace = regex::Regex::new(r"backtrace no\. (\d+)\n(?:  .*\n)*  .*").unwrap();
 //! #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
 //! #
-//! #     let value = backtrace.replace_all(&value, "Backtrace No. $1\n  [redacted]");
+//! #     let value = backtrace.replace_all(&value, "backtrace no. $1\n  [redacted]");
 //! #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
 //! #
 //! #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
@@ -325,7 +325,7 @@
 //!     if let Err(report) = parse_config("config.json") {
 //!         # #[cfg(nightly)]
 //!         for suggestion in report.request_ref::<Suggestion>() {
-//!             eprintln!("Suggestion: {}", suggestion.0);
+//!             eprintln!("suggestion: {}", suggestion.0);
 //!         }
 //!     }
 //! }

--- a/packages/libs/error-stack/src/macros.rs
+++ b/packages/libs/error-stack/src/macros.rs
@@ -87,7 +87,7 @@ pub mod __private {
 ///
 /// # fn wrapper() -> error_stack::Result<(), impl core::fmt::Debug> {
 /// match fs::read_to_string("/path/to/file") {
-///     Ok(content) => println!("File contents: {content}"),
+///     Ok(content) => println!("file contents: {content}"),
 ///     Err(err) => return Err(report!(err)),
 /// }
 /// # Ok(()) }
@@ -153,7 +153,7 @@ macro_rules! report {
 /// use error_stack::bail;
 /// # fn wrapper() -> error_stack::Result<(), impl core::fmt::Debug> {
 /// match fs::read_to_string("/path/to/file") {
-///     Ok(content) => println!("File contents: {content}"),
+///     Ok(content) => println!("file contents: {content}"),
 ///     Err(err) => bail!(err),
 /// }
 /// # Ok(()) }

--- a/packages/libs/error-stack/src/report.rs
+++ b/packages/libs/error-stack/src/report.rs
@@ -74,7 +74,7 @@ use crate::{
 /// let config_path = "./path/to/config.file";
 /// let content = std::fs::read_to_string(config_path)
 ///     .into_report()
-///     .attach_printable_lazy(|| format!("Failed to read config file {config_path:?}"))?;
+///     .attach_printable_lazy(|| format!("failed to read config file {config_path:?}"))?;
 ///
 /// # const _: &str = stringify! {
 /// ...
@@ -165,18 +165,18 @@ use crate::{
 /// let config_path = "./path/to/config.file";
 /// let content = std::fs::read_to_string(config_path)
 ///     .into_report()
-///     .attach_printable_lazy(|| format!("Failed to read config file {config_path:?}"));
+///     .attach_printable_lazy(|| format!("failed to read config file {config_path:?}"));
 ///
 /// let content = match content {
 ///     Err(err) => {
 ///         # #[cfg(all(nightly, feature = "std"))]
 ///         for backtrace in err.request_ref::<std::backtrace::Backtrace>() {
-///             println!("Backtrace: {backtrace}");
+///             println!("backtrace: {backtrace}");
 ///         }
 ///
 ///         # #[cfg(all(nightly, feature = "spantrace"))]
-///         for spantrace in err.request_ref::<tracing_error::SpanTrace>() {
-///             println!("Spantrace: {spantrace}")
+///         for span_trace in err.request_ref::<tracing_error::SpanTrace>() {
+///             println!("span trace: {span_trace}")
 ///         }
 ///
 ///         return Err(err)
@@ -420,14 +420,14 @@ impl<C> Report<C> {
     ///
     /// let error = fs::read_to_string("config.txt")
     ///     .into_report()
-    ///     .attach(Suggestion("Better use a file which exists next time!"));
+    ///     .attach(Suggestion("better use a file which exists next time!"));
     /// # #[cfg_attr(not(nightly), allow(unused_variables))]
     /// let report = error.unwrap_err();
     /// # #[cfg(nightly)]
     /// let suggestion = report.request_ref::<Suggestion>().next().unwrap();
     ///
     /// # #[cfg(nightly)]
-    /// assert_eq!(suggestion.0, "Better use a file which exists next time!");
+    /// assert_eq!(suggestion.0, "better use a file which exists next time!");
     /// # }
     #[track_caller]
     pub fn attach_printable<A>(mut self, attachment: A) -> Self

--- a/packages/libs/error-stack/tests/common.rs
+++ b/packages/libs/error-stack/tests/common.rs
@@ -23,7 +23,7 @@ pub struct RootError;
 
 impl fmt::Display for RootError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.write_str("Root error")
+        fmt.write_str("root error")
     }
 }
 
@@ -34,7 +34,7 @@ pub struct ContextA(pub u32);
 
 impl fmt::Display for ContextA {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.write_str("Context A")
+        fmt.write_str("context A")
     }
 }
 
@@ -51,7 +51,7 @@ pub struct ContextB(pub i32);
 
 impl fmt::Display for ContextB {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.write_str("Context B")
+        fmt.write_str("context B")
     }
 }
 
@@ -77,7 +77,7 @@ impl ErrorA {
 #[cfg(feature = "spantrace")]
 impl fmt::Display for ErrorA {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.write_str("Error A")
+        fmt.write_str("error A")
     }
 }
 
@@ -103,7 +103,7 @@ impl ErrorB {
 #[cfg(all(rust_1_65, feature = "std"))]
 impl fmt::Display for ErrorB {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.write_str("Error B")
+        fmt.write_str("error B")
     }
 }
 
@@ -130,7 +130,7 @@ pub struct PrintableA(pub u32);
 
 impl fmt::Display for PrintableA {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.write_str("Printable A")
+        fmt.write_str("printable A")
     }
 }
 
@@ -139,7 +139,7 @@ pub struct PrintableB(pub u32);
 
 impl fmt::Display for PrintableB {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.write_str("Printable B")
+        fmt.write_str("printable B")
     }
 }
 
@@ -156,11 +156,11 @@ pub fn create_future() -> impl Future<Output = Result<(), RootError>> {
 }
 
 pub fn capture_ok<E>(closure: impl FnOnce() -> Result<(), E>) {
-    closure().expect("Expected an OK value, found an error")
+    closure().expect("expected an OK value, found an error")
 }
 
 pub fn capture_error<E>(closure: impl FnOnce() -> Result<(), E>) -> Report<E> {
-    closure().expect_err("Expected an error")
+    closure().expect_err("expected an error")
 }
 
 pub fn messages<E>(report: &Report<E>) -> Vec<String> {
@@ -169,8 +169,8 @@ pub fn messages<E>(report: &Report<E>) -> Vec<String> {
         .map(|frame| match frame.kind() {
             FrameKind::Context(context) => context.to_string(),
             FrameKind::Attachment(AttachmentKind::Printable(attachment)) => attachment.to_string(),
-            FrameKind::Attachment(AttachmentKind::Opaque(_)) => String::from("Opaque"),
-            FrameKind::Attachment(_) => panic!("Attachment was not covered"),
+            FrameKind::Attachment(AttachmentKind::Opaque(_)) => String::from("opaque"),
+            FrameKind::Attachment(_) => panic!("attachment was not covered"),
         })
         .collect()
 }
@@ -210,12 +210,12 @@ pub fn expect_messages<'a>(messages: &[&'a str]) -> Vec<&'a str> {
 
     #[cfg(all(rust_1_65, feature = "std"))]
     if supports_backtrace() {
-        messages.push("Opaque");
+        messages.push("opaque");
     }
 
     #[cfg(feature = "spantrace")]
     if supports_spantrace() {
-        messages.push("Opaque");
+        messages.push("opaque");
     }
 
     messages.push(last);

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__diagnostics_add.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__diagnostics_add.snap
@@ -1,10 +1,10 @@
 <b>invalid input parameter</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/hook.rs:19:14</span>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion: Try better next time
-<span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>Sorry for the inconvenience!
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>suggestion: try better next time
+<span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>sorry for the inconvenience!
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__doc.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__doc.snap
@@ -1,12 +1,12 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/mod.rs:58:14</span>
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/mod.rs:57:14</span>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Error (404)
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion 1: Try to be connected to the internet.
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion 2: Try better next time!
-<span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>Warning (1) occurred
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>error (404)
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>suggestion 1: try to be connected to the internet.
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>suggestion 2: try better next time!
+<span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>warning (1) occurred
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__emit.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__emit.snap
@@ -1,17 +1,17 @@
 <b>invalid input parameter</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/hook.rs:49:14</span>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Error code: 404
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion (0)
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Error code: 405
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Abnormal program execution detected
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Warning: Unable to determine environment
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion (1)
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Error code: 501
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion (2)
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>error code: 404
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>suggestion (0)
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>error code: 405
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>abnormal program execution detected
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>warning: unable to determine environment
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>suggestion (1)
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>error code: 501
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>suggestion (2)
 <span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>1 additional opaque attachment
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__emit_alt.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__emit_alt.snap
@@ -1,29 +1,29 @@
 <b>invalid input parameter</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/hook.rs:49:14</span>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Error code: 404
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion 0:
-<span style='color:#a00'>│</span><span style='color:#a00'> </span>  Do you have a connection to the internet?
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion (0)
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Error code: 405
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Abnormal program execution detected
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Warning: Unable to determine environment
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion 1:
-<span style='color:#a00'>│</span><span style='color:#a00'> </span>  Execute the program from the fish shell
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion (1)
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Error code: 501
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion 2:
-<span style='color:#a00'>│</span><span style='color:#a00'> </span>  Try better next time!
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion (2)
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>error code: 404
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>suggestion 0:
+<span style='color:#a00'>│</span><span style='color:#a00'> </span>  do you have a connection to the internet?
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>suggestion (0)
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>error code: 405
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>abnormal program execution detected
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>warning: unable to determine environment
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>suggestion 1:
+<span style='color:#a00'>│</span><span style='color:#a00'> </span>  execute the program from the fish shell
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>suggestion (1)
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>error code: 501
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>suggestion 2:
+<span style='color:#a00'>│</span><span style='color:#a00'> </span>  try better next time!
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>suggestion (2)
 <span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>1 additional opaque attachment
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Error 404: Client Error
+error 404: client error
 
-Error 405: Client Error
+error 405: client error
 
-Error 501: Server Error
+error 501: server error

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_cast.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_cast.snap
@@ -1,11 +1,11 @@
 <b>invalid input parameter</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/hook.rs:27:14</span>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>[1] [ERROR] Unable to reach remote host
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>[2] [WARN] Disk nearly full
-<span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>[3] [ERROR] Cannot resolve example.com: Unknown host
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>[1] [ERROR] unable to reach remote host
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>[2] [WARN] disk nearly full
+<span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>[3] [ERROR] cannot resolve example.com: unknown host
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_decrement.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_decrement.snap
@@ -1,10 +1,10 @@
 <b>invalid input parameter</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/hook.rs:17:14</span>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion -1: Use a file you can read next time!
-<span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>Suggestion -2: Don&#39;t press any random keys!
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>suggestion -1: use a file you can read next time!
+<span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>suggestion -2: don&#39;t press any random keys!
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_emit.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_emit.snap
@@ -1,16 +1,16 @@
 <b>invalid input parameter</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/hook.rs:24:14</span>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Error 404
-<span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>Error 405
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>error 404
+<span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>error 405
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Error 404:
-  Not Found - Server cannot find requested resource
+error 404:
+  not found - server cannot find requested resource
 
-Error 405:
-  Bad Request - Server cannot or will not process request
+error 405:
+  bad request - server cannot or will not process request

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_increment.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_increment.snap
@@ -1,10 +1,10 @@
 <b>invalid input parameter</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/hook.rs:17:14</span>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion 0: Use a file you can read next time!
-<span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>Suggestion 1: Don&#39;t press any random keys!
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>suggestion 0: use a file you can read next time!
+<span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>suggestion 1: don&#39;t press any random keys!
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_storage.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_storage.snap
@@ -1,10 +1,10 @@
 <b>invalid input parameter</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/hook.rs:31:14</span>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Computation for 2 (acc = 2, div = 0.5)
-<span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>Computation for 3 (acc = 5, div = 0.16666667)
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>computation for 2 (acc = 2, div = 0.5)
+<span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>computation for 3 (acc = 5, div = 0.16666667)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt_doc_alt.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt_doc_alt.snap
@@ -1,15 +1,15 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/mod.rs:58:14</span>
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/fmt/mod.rs:57:14</span>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Error (404)
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion 1: Try to be connected to the internet.
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion 2: Try better next time!
-<span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>Warning (1) occurred
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>error (404)
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>suggestion 1: try to be connected to the internet.
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>suggestion 2: try better next time!
+<span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>warning (1) occurred
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Warning 1:
-  Unable to fetch resource
+warning 1:
+  unable to fetch resource

--- a/packages/libs/error-stack/tests/snapshots/doc/hook__debug_hook.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/hook__debug_hook.snap
@@ -1,9 +1,9 @@
 <b>invalid input parameter</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/hook.rs:19:5</span>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>backtrace (1)
-<span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>Suggestion: O no, try again
+<span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>suggestion: oh no, try again
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/doc/hook__debug_hook_provide.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/hook__debug_hook_provide.snap
@@ -1,10 +1,10 @@
-<b>Invalid user input</b>
+<b>invalid user input</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/hook.rs:49:14</span>
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Suggestion: Try better next time!
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Error Code: 420
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>suggestion: try better next time!
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>error code: 420
 <span style='color:#a00'>╰</span><span style='color:#a00'>╴</span>backtrace (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/doc/lib__suggestion.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/lib__suggestion.snap
@@ -1,6 +1,6 @@
-<b>Could not parse configuration file</b>
+<b>could not parse configuration file</b>
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span><span style='color:#555'>src/lib.rs:25:10</span>
-<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>Could not read file &quot;test.txt&quot;
+<span style='color:#a00'>├</span><span style='color:#a00'>╴</span>could not read file &quot;test.txt&quot;
 <span style='color:#a00'>├</span><span style='color:#a00'>╴</span>1 additional opaque attachment
 <span style='color:#a00'>│</span>
 <span style='color:#a00'>╰</span><span style='color:#a00'>─</span><span style='color:#a00'>▶</span><span style='color:#a00'> </span><b>No such file or directory (os error 2)</b>
@@ -9,5 +9,5 @@
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__alt.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__alt.snap
@@ -2,18 +2,18 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
-Root error
+root error
 ├╴tests/common.rs:147:5
 ├╴backtrace (1)
-├╴spantrace with 2 frames (1)
+├╴span trace with 2 frames (1)
 ╰╴Empty
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Span Trace No. 1
+span trace No. 1
   [redacted]
 
 Snippet

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__complex.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__complex.snap
@@ -2,48 +2,48 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-Context A
+context A
 ├╴tests/test_debug.rs:440:14
-├╴Printable A
+├╴printable A
 │
-╰┬▶ Root error
+╰┬▶ root error
  │  ├╴tests/common.rs:147:5
  │  ├╴backtrace (1)
- │  ├╴spantrace with 2 frames (1)
- │  ╰╴Printable A
+ │  ├╴span trace with 2 frames (1)
+ │  ╰╴printable A
  │
- ├▶ Root error
+ ├▶ root error
  │  ├╴tests/common.rs:147:5
  │  ├╴backtrace (2)
- │  ├╴spantrace with 2 frames (2)
- │  ├╴Printable B
+ │  ├╴span trace with 2 frames (2)
+ │  ├╴printable B
  │  ├╴Test
  │  ╰╴1 additional opaque attachment
  │
- ╰▶ Root error
+ ╰▶ root error
     ├╴tests/common.rs:147:5
     ├╴backtrace (3)
-    ├╴spantrace with 2 frames (3)
-    ├╴Printable B
+    ├╴span trace with 2 frames (3)
+    ├╴printable B
     ├╴Test
     ╰╴3 additional opaque attachments
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Span Trace No. 1
+span trace No. 1
   [redacted]
 
-Backtrace No. 2
+backtrace no. 2
   [redacted]
 
-Span Trace No. 2
+span trace No. 2
   [redacted]
 
-Backtrace No. 3
+backtrace no. 3
   [redacted]
 
-Span Trace No. 3
+span trace No. 3
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook.snap
@@ -2,16 +2,16 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-Root error
+root error
 ├╴tests/common.rs:147:5
 ├╴backtrace (1)
-├╴spantrace with 2 frames (1)
+├╴span trace with 2 frames (1)
 ╰╴unsigned 32bit integer
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Span Trace No. 1
+span trace No. 1
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_context.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_context.snap
@@ -2,16 +2,16 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-Root error
+root error
 ├╴tests/common.rs:147:5
 ├╴backtrace (1)
-├╴spantrace with 2 frames (1)
+├╴span trace with 2 frames (1)
 ╰╴unsigned 32bit integer (No. 0)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Span Trace No. 1
+span trace No. 1
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_decr.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_decr.snap
@@ -2,18 +2,18 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-Root error
+root error
 ├╴tests/common.rs:147:5
 ├╴backtrace (1)
-├╴spantrace with 2 frames (1)
+├╴span trace with 2 frames (1)
 ├╴-1
 ├╴-2
 ╰╴-3
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Span Trace No. 1
+span trace No. 1
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_for_context.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_for_context.snap
@@ -2,16 +2,16 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-Root error
+root error
 ├╴tests/common.rs:147:5
 ├╴backtrace (1)
-├╴spantrace with 2 frames (1)
+├╴span trace with 2 frames (1)
 ╰╴1 additional opaque attachment
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Span Trace No. 1
+span trace No. 1
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_incr.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_incr.snap
@@ -2,18 +2,18 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-Root error
+root error
 ├╴tests/common.rs:147:5
 ├╴backtrace (1)
-├╴spantrace with 2 frames (1)
+├╴span trace with 2 frames (1)
 ├╴0
 ├╴1
 ╰╴2
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Span Trace No. 1
+span trace No. 1
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_multiple.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_multiple.snap
@@ -2,17 +2,17 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-Root error
+root error
 ├╴tests/common.rs:147:5
 ├╴backtrace (1)
-├╴spantrace with 2 frames (1)
+├╴span trace with 2 frames (1)
 ├╴unsigned 32bit integer
 ╰╴unsigned 64bit integer
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Span Trace No. 1
+span trace No. 1
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_provider.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_provider.snap
@@ -2,20 +2,20 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-Context D
+context D
 ├╴tests/test_debug.rs:584:38
 ├╴usize: 420
 ├╴&'static str: Invalid User Input
 │
-╰─▶ Root error
+╰─▶ root error
     ├╴tests/common.rs:147:5
     ├╴backtrace (1)
-    ╰╴spantrace with 2 frames (1)
+    ╰╴span trace with 2 frames (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Span Trace No. 1
+span trace No. 1
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__linear.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__linear.snap
@@ -2,26 +2,26 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-Context B
+context B
 ├╴tests/test_debug.rs:286:14
-├╴Printable C
+├╴printable C
 │
-├─▶ Context A
+├─▶ context A
 │   ├╴tests/test_debug.rs:283:14
-│   ├╴Printable B
+│   ├╴printable B
 │   ╰╴1 additional opaque attachment
 │
-╰─▶ Root error
+╰─▶ root error
     ├╴tests/common.rs:147:5
     ├╴backtrace (1)
-    ├╴spantrace with 2 frames (1)
-    ├╴Printable A
+    ├╴span trace with 2 frames (1)
+    ├╴printable A
     ╰╴2 additional opaque attachments
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Span Trace No. 1
+span trace No. 1
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__linear_ext.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__linear_ext.snap
@@ -2,26 +2,26 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
-Context B
+context B
 ├╴tests/test_debug.rs:303:14
-├╴Printable C
+├╴printable C
 │
-├─▶ Context A
+├─▶ context A
 │   ├╴tests/test_debug.rs:300:14
-│   ├╴Printable B
+│   ├╴printable B
 │   ╰╴1 additional opaque attachment
 │
-╰─▶ Root error
+╰─▶ root error
     ├╴tests/common.rs:147:5
     ├╴backtrace (1)
-    ├╴spantrace with 2 frames (1)
-    ├╴Printable A
+    ├╴span trace with 2 frames (1)
+    ├╴printable A
     ╰╴2 additional opaque attachments
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Span Trace No. 1
+span trace No. 1
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__multiline.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__multiline.snap
@@ -2,10 +2,10 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
-Root error
+root error
 ├╴tests/common.rs:147:5
 ├╴backtrace (1)
-├╴spantrace with 2 frames (1)
+├╴span trace with 2 frames (1)
 ╰╴A multiline
   attachment
   that might have some
@@ -13,8 +13,8 @@ Root error
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Span Trace No. 1
+span trace No. 1
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__multiline_context.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__multiline_context.snap
@@ -1,0 +1,27 @@
+---
+source: tests/test_debug.rs
+expression: "format!(\"{report:#?}\")"
+---
+context B
+├╴tests/test_debug.rs:328:14
+├╴printable C
+│
+├─▶ A multiline
+│   context that might have
+│   a bit more info
+│   ├╴tests/test_debug.rs:325:14
+│   ├╴printable B
+│   ╰╴1 additional opaque attachment
+│
+╰─▶ root error
+    ├╴tests/common.rs:147:5
+    ├╴backtrace (1)
+    ╰╴span trace with 2 frames (1)
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+backtrace no. 1
+  [redacted]
+
+span trace No. 1
+  [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__multiline_ctx.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__multiline_ctx.snap
@@ -2,26 +2,26 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
-Context B
+context B
 ├╴tests/test_debug.rs:328:14
-├╴Printable C
+├╴printable C
 │
 ├─▶ A multiline
 │   context that might have
 │   a bit more info
 │   ├╴tests/test_debug.rs:325:14
-│   ├╴Printable B
+│   ├╴printable B
 │   ╰╴1 additional opaque attachment
 │
-╰─▶ Root error
+╰─▶ root error
     ├╴tests/common.rs:147:5
     ├╴backtrace (1)
-    ╰╴spantrace with 2 frames (1)
+    ╰╴span trace with 2 frames (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Span Trace No. 1
+span trace No. 1
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__norm.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__norm.snap
@@ -2,16 +2,16 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-Root error
+root error
 ├╴tests/common.rs:147:5
 ├╴backtrace (1)
-├╴spantrace with 2 frames (1)
+├╴span trace with 2 frames (1)
 ╰╴Empty
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Span Trace No. 1
+span trace No. 1
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__sources.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__sources.snap
@@ -2,47 +2,47 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-Context A
+context A
 ├╴tests/test_debug.rs:372:14
 ├╴1 additional opaque attachment
 │
-╰┬▶ Root error
+╰┬▶ root error
  │  ├╴tests/common.rs:147:5
  │  ├╴backtrace (1)
- │  ├╴spantrace with 2 frames (1)
- │  ├╴Printable A
+ │  ├╴span trace with 2 frames (1)
+ │  ├╴printable A
  │  ╰╴1 additional opaque attachment
  │
- ├▶ Root error
+ ├▶ root error
  │  ├╴tests/common.rs:147:5
  │  ├╴backtrace (2)
- │  ├╴spantrace with 2 frames (2)
- │  ├╴Printable B
+ │  ├╴span trace with 2 frames (2)
+ │  ├╴printable B
  │  ╰╴1 additional opaque attachment
  │
- ╰▶ Root error
+ ╰▶ root error
     ├╴tests/common.rs:147:5
     ├╴backtrace (3)
-    ├╴spantrace with 2 frames (3)
-    ├╴Printable B
+    ├╴span trace with 2 frames (3)
+    ├╴printable B
     ╰╴1 additional opaque attachment
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Span Trace No. 1
+span trace No. 1
   [redacted]
 
-Backtrace No. 2
+backtrace no. 2
   [redacted]
 
-Span Trace No. 2
+span trace No. 2
   [redacted]
 
-Backtrace No. 3
+backtrace no. 3
   [redacted]
 
-Span Trace No. 3
+span trace No. 3
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__sources_transparent.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__sources_transparent.snap
@@ -2,49 +2,49 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-Context A
+context A
 ├╴tests/test_debug.rs:413:18
 ├╴1 additional opaque attachment
 │
-╰┬▶ Root error
+╰┬▶ root error
  │  ├╴tests/common.rs:147:5
  │  ├╴backtrace (1)
- │  ├╴spantrace with 2 frames (1)
- │  ├╴Printable A
+ │  ├╴span trace with 2 frames (1)
+ │  ├╴printable A
  │  ╰╴1 additional opaque attachment
  │
- ├▶ Root error
+ ├▶ root error
  │  ├╴tests/common.rs:147:5
  │  ├╴backtrace (2)
- │  ├╴spantrace with 2 frames (2)
- │  ├╴Printable B
- │  ├╴Printable A
+ │  ├╴span trace with 2 frames (2)
+ │  ├╴printable B
+ │  ├╴printable A
  │  ╰╴1 additional opaque attachment
  │
- ╰▶ Root error
+ ╰▶ root error
     ├╴tests/common.rs:147:5
     ├╴backtrace (3)
-    ├╴spantrace with 2 frames (3)
-    ├╴Printable B
-    ├╴Printable A
+    ├╴span trace with 2 frames (3)
+    ├╴printable B
+    ├╴printable A
     ╰╴1 additional opaque attachment
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Span Trace No. 1
+span trace No. 1
   [redacted]
 
-Backtrace No. 2
+backtrace no. 2
   [redacted]
 
-Span Trace No. 2
+span trace No. 2
   [redacted]
 
-Backtrace No. 3
+backtrace no. 3
   [redacted]
 
-Span Trace No. 3
+span trace No. 3
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested.snap
@@ -2,38 +2,38 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-Context A
+context A
 |-at tests/test_debug.rs:214:10
 |-2
 |-1
 |
-|-> Context A
+|-> context A
  |  |-at tests/test_debug.rs:208:10
  |  |-4
  |  |-3
  |  |
- |  |-> Root error
+ |  |-> root error
  |      |-at tests/common.rs:147:5
  |      |-6
  |
- |> Context A
+ |> context A
     |-at tests/test_debug.rs:203:10
     |-5
     |-3
     |
-    |-> Context A
+    |-> context A
     |   |-at tests/test_debug.rs:201:10
     |   |-7
     |
-    |-> Context A
+    |-> context A
      |  |-at tests/test_debug.rs:192:34
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:186:10
      |  |-13
      |  |-10
@@ -41,10 +41,10 @@ Context A
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:172:10
      |  |-15
      |  |-14
@@ -53,26 +53,26 @@ Context A
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:182:10
      |  |-11
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |
-     |> Context A
+     |> context A
         |-at tests/test_debug.rs:178:10
         |-12
         |-9
         |-8
         |
-        |-> Context A
+        |-> context A
         |   |-at tests/test_debug.rs:177:10
         |
-        |-> Root error
+        |-> root error
             |-at tests/common.rs:147:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@backtrace-pretty-print.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@backtrace-pretty-print.snap
@@ -2,40 +2,40 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-Context A
+context A
 ├╴tests/test_debug.rs:214:10
 ├╴2
 ├╴1
 │
-╰┬▶ Context A
+╰┬▶ context A
  │  ├╴tests/test_debug.rs:208:10
  │  ├╴4
  │  ├╴3
  │  │
- │  ╰─▶ Root error
+ │  ╰─▶ root error
  │      ├╴tests/common.rs:147:5
  │      ├╴backtrace (1)
  │      ╰╴6
  │
- ╰▶ Context A
+ ╰▶ context A
     ├╴tests/test_debug.rs:203:10
     ├╴5
     ├╴3
     │
-    ├─▶ Context A
+    ├─▶ context A
     │   ├╴tests/test_debug.rs:201:10
     │   ╰╴7
     │
-    ╰┬▶ Context A
+    ╰┬▶ context A
      │  ├╴tests/test_debug.rs:192:34
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
      │      ╰╴backtrace (2)
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:186:10
      │  ├╴13
      │  ├╴10
@@ -43,11 +43,11 @@ Context A
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
      │      ╰╴backtrace (3)
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:172:10
      │  ├╴15
      │  ├╴14
@@ -56,49 +56,49 @@ Context A
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
      │      ╰╴backtrace (4)
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:182:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
      │      ╰╴backtrace (5)
      │
-     ╰▶ Context A
+     ╰▶ context A
         ├╴tests/test_debug.rs:178:10
         ├╴12
         ├╴9
         ├╴8
         │
-        ├─▶ Context A
+        ├─▶ context A
         │   ╰╴tests/test_debug.rs:177:10
         │
-        ╰─▶ Root error
+        ╰─▶ root error
             ├╴tests/common.rs:147:5
             ╰╴backtrace (6)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Backtrace No. 2
+backtrace no. 2
   [redacted]
 
-Backtrace No. 3
+backtrace no. 3
   [redacted]
 
-Backtrace No. 4
+backtrace no. 4
   [redacted]
 
-Backtrace No. 5
+backtrace no. 5
   [redacted]
 
-Backtrace No. 6
+backtrace no. 6
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@backtrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@backtrace.snap
@@ -2,40 +2,40 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-Context A
+context A
 |-at tests/test_debug.rs:214:10
 |-2
 |-1
 |
-|-> Context A
+|-> context A
  |  |-at tests/test_debug.rs:208:10
  |  |-4
  |  |-3
  |  |
- |  |-> Root error
+ |  |-> root error
  |      |-at tests/common.rs:147:5
  |      |-backtrace (1)
  |      |-6
  |
- |> Context A
+ |> context A
     |-at tests/test_debug.rs:203:10
     |-5
     |-3
     |
-    |-> Context A
+    |-> context A
     |   |-at tests/test_debug.rs:201:10
     |   |-7
     |
-    |-> Context A
+    |-> context A
      |  |-at tests/test_debug.rs:192:34
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |      |-backtrace (2)
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:186:10
      |  |-13
      |  |-10
@@ -43,11 +43,11 @@ Context A
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |      |-backtrace (3)
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:172:10
      |  |-15
      |  |-14
@@ -56,49 +56,49 @@ Context A
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |      |-backtrace (4)
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:182:10
      |  |-11
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |      |-backtrace (5)
      |
-     |> Context A
+     |> context A
         |-at tests/test_debug.rs:178:10
         |-12
         |-9
         |-8
         |
-        |-> Context A
+        |-> context A
         |   |-at tests/test_debug.rs:177:10
         |
-        |-> Root error
+        |-> root error
             |-at tests/common.rs:147:5
             |-backtrace (6)
 
 ========================================
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Backtrace No. 2
+backtrace no. 2
   [redacted]
 
-Backtrace No. 3
+backtrace no. 3
   [redacted]
 
-Backtrace No. 4
+backtrace no. 4
   [redacted]
 
-Backtrace No. 5
+backtrace no. 5
   [redacted]
 
-Backtrace No. 6
+backtrace no. 6
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@pretty-print.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@pretty-print.snap
@@ -2,38 +2,38 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-Context A
+context A
 ├╴tests/test_debug.rs:214:10
 ├╴2
 ├╴1
 │
-╰┬▶ Context A
+╰┬▶ context A
  │  ├╴tests/test_debug.rs:208:10
  │  ├╴4
  │  ├╴3
  │  │
- │  ╰─▶ Root error
+ │  ╰─▶ root error
  │      ├╴tests/common.rs:147:5
  │      ╰╴6
  │
- ╰▶ Context A
+ ╰▶ context A
     ├╴tests/test_debug.rs:203:10
     ├╴5
     ├╴3
     │
-    ├─▶ Context A
+    ├─▶ context A
     │   ├╴tests/test_debug.rs:201:10
     │   ╰╴7
     │
-    ╰┬▶ Context A
+    ╰┬▶ context A
      │  ├╴tests/test_debug.rs:192:34
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ╰╴tests/common.rs:147:5
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:186:10
      │  ├╴13
      │  ├╴10
@@ -41,10 +41,10 @@ Context A
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ╰╴tests/common.rs:147:5
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:172:10
      │  ├╴15
      │  ├╴14
@@ -53,26 +53,26 @@ Context A
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ╰╴tests/common.rs:147:5
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:182:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ╰╴tests/common.rs:147:5
      │
-     ╰▶ Context A
+     ╰▶ context A
         ├╴tests/test_debug.rs:178:10
         ├╴12
         ├╴9
         ├╴8
         │
-        ├─▶ Context A
+        ├─▶ context A
         │   ╰╴tests/test_debug.rs:177:10
         │
-        ╰─▶ Root error
+        ╰─▶ root error
             ╰╴tests/common.rs:147:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace-backtrace-pretty-print.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace-backtrace-pretty-print.snap
@@ -2,42 +2,42 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-Context A
+context A
 ├╴tests/test_debug.rs:214:10
 ├╴2
 ├╴1
 │
-╰┬▶ Context A
+╰┬▶ context A
  │  ├╴tests/test_debug.rs:208:10
  │  ├╴4
  │  ├╴3
  │  │
- │  ╰─▶ Root error
+ │  ╰─▶ root error
  │      ├╴tests/common.rs:147:5
  │      ├╴backtrace (1)
- │      ├╴spantrace with 2 frames (1)
+ │      ├╴span trace with 2 frames (1)
  │      ╰╴6
  │
- ╰▶ Context A
+ ╰▶ context A
     ├╴tests/test_debug.rs:203:10
     ├╴5
     ├╴3
     │
-    ├─▶ Context A
+    ├─▶ context A
     │   ├╴tests/test_debug.rs:201:10
     │   ╰╴7
     │
-    ╰┬▶ Context A
+    ╰┬▶ context A
      │  ├╴tests/test_debug.rs:192:34
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
      │      ├╴backtrace (2)
-     │      ╰╴spantrace with 2 frames (2)
+     │      ╰╴span trace with 2 frames (2)
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:186:10
      │  ├╴13
      │  ├╴10
@@ -45,12 +45,12 @@ Context A
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
      │      ├╴backtrace (3)
-     │      ╰╴spantrace with 2 frames (3)
+     │      ╰╴span trace with 2 frames (3)
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:172:10
      │  ├╴15
      │  ├╴14
@@ -59,70 +59,70 @@ Context A
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
      │      ├╴backtrace (4)
-     │      ╰╴spantrace with 2 frames (4)
+     │      ╰╴span trace with 2 frames (4)
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:182:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
      │      ├╴backtrace (5)
-     │      ╰╴spantrace with 2 frames (5)
+     │      ╰╴span trace with 2 frames (5)
      │
-     ╰▶ Context A
+     ╰▶ context A
         ├╴tests/test_debug.rs:178:10
         ├╴12
         ├╴9
         ├╴8
         │
-        ├─▶ Context A
+        ├─▶ context A
         │   ╰╴tests/test_debug.rs:177:10
         │
-        ╰─▶ Root error
+        ╰─▶ root error
             ├╴tests/common.rs:147:5
             ├╴backtrace (6)
-            ╰╴spantrace with 2 frames (6)
+            ╰╴span trace with 2 frames (6)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Span Trace No. 1
+span trace No. 1
   [redacted]
 
-Backtrace No. 2
+backtrace no. 2
   [redacted]
 
-Span Trace No. 2
+span trace No. 2
   [redacted]
 
-Backtrace No. 3
+backtrace no. 3
   [redacted]
 
-Span Trace No. 3
+span trace No. 3
   [redacted]
 
-Backtrace No. 4
+backtrace no. 4
   [redacted]
 
-Span Trace No. 4
+span trace No. 4
   [redacted]
 
-Backtrace No. 5
+backtrace no. 5
   [redacted]
 
-Span Trace No. 5
+span trace No. 5
   [redacted]
 
-Backtrace No. 6
+backtrace no. 6
   [redacted]
 
-Span Trace No. 6
+span trace No. 6
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace-backtrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace-backtrace.snap
@@ -2,42 +2,42 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-Context A
+context A
 |-at tests/test_debug.rs:214:10
 |-2
 |-1
 |
-|-> Context A
+|-> context A
  |  |-at tests/test_debug.rs:208:10
  |  |-4
  |  |-3
  |  |
- |  |-> Root error
+ |  |-> root error
  |      |-at tests/common.rs:147:5
  |      |-backtrace (1)
- |      |-spantrace with 2 frames (1)
+ |      |-span trace with 2 frames (1)
  |      |-6
  |
- |> Context A
+ |> context A
     |-at tests/test_debug.rs:203:10
     |-5
     |-3
     |
-    |-> Context A
+    |-> context A
     |   |-at tests/test_debug.rs:201:10
     |   |-7
     |
-    |-> Context A
+    |-> context A
      |  |-at tests/test_debug.rs:192:34
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |      |-backtrace (2)
-     |      |-spantrace with 2 frames (2)
+     |      |-span trace with 2 frames (2)
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:186:10
      |  |-13
      |  |-10
@@ -45,12 +45,12 @@ Context A
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |      |-backtrace (3)
-     |      |-spantrace with 2 frames (3)
+     |      |-span trace with 2 frames (3)
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:172:10
      |  |-15
      |  |-14
@@ -59,70 +59,70 @@ Context A
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |      |-backtrace (4)
-     |      |-spantrace with 2 frames (4)
+     |      |-span trace with 2 frames (4)
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:182:10
      |  |-11
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |      |-backtrace (5)
-     |      |-spantrace with 2 frames (5)
+     |      |-span trace with 2 frames (5)
      |
-     |> Context A
+     |> context A
         |-at tests/test_debug.rs:178:10
         |-12
         |-9
         |-8
         |
-        |-> Context A
+        |-> context A
         |   |-at tests/test_debug.rs:177:10
         |
-        |-> Root error
+        |-> root error
             |-at tests/common.rs:147:5
             |-backtrace (6)
-            |-spantrace with 2 frames (6)
+            |-span trace with 2 frames (6)
 
 ========================================
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Span Trace No. 1
+span trace No. 1
   [redacted]
 
-Backtrace No. 2
+backtrace no. 2
   [redacted]
 
-Span Trace No. 2
+span trace No. 2
   [redacted]
 
-Backtrace No. 3
+backtrace no. 3
   [redacted]
 
-Span Trace No. 3
+span trace No. 3
   [redacted]
 
-Backtrace No. 4
+backtrace no. 4
   [redacted]
 
-Span Trace No. 4
+span trace No. 4
   [redacted]
 
-Backtrace No. 5
+backtrace no. 5
   [redacted]
 
-Span Trace No. 5
+span trace No. 5
   [redacted]
 
-Backtrace No. 6
+backtrace no. 6
   [redacted]
 
-Span Trace No. 6
+span trace No. 6
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace-pretty-print.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace-pretty-print.snap
@@ -2,40 +2,40 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-Context A
+context A
 ├╴tests/test_debug.rs:214:10
 ├╴2
 ├╴1
 │
-╰┬▶ Context A
+╰┬▶ context A
  │  ├╴tests/test_debug.rs:208:10
  │  ├╴4
  │  ├╴3
  │  │
- │  ╰─▶ Root error
+ │  ╰─▶ root error
  │      ├╴tests/common.rs:147:5
- │      ├╴spantrace with 2 frames (1)
+ │      ├╴span trace with 2 frames (1)
  │      ╰╴6
  │
- ╰▶ Context A
+ ╰▶ context A
     ├╴tests/test_debug.rs:203:10
     ├╴5
     ├╴3
     │
-    ├─▶ Context A
+    ├─▶ context A
     │   ├╴tests/test_debug.rs:201:10
     │   ╰╴7
     │
-    ╰┬▶ Context A
+    ╰┬▶ context A
      │  ├╴tests/test_debug.rs:192:34
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
-     │      ╰╴spantrace with 2 frames (2)
+     │      ╰╴span trace with 2 frames (2)
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:186:10
      │  ├╴13
      │  ├╴10
@@ -43,11 +43,11 @@ Context A
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
-     │      ╰╴spantrace with 2 frames (3)
+     │      ╰╴span trace with 2 frames (3)
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:172:10
      │  ├╴15
      │  ├╴14
@@ -56,49 +56,49 @@ Context A
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
-     │      ╰╴spantrace with 2 frames (4)
+     │      ╰╴span trace with 2 frames (4)
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:182:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
-     │      ╰╴spantrace with 2 frames (5)
+     │      ╰╴span trace with 2 frames (5)
      │
-     ╰▶ Context A
+     ╰▶ context A
         ├╴tests/test_debug.rs:178:10
         ├╴12
         ├╴9
         ├╴8
         │
-        ├─▶ Context A
+        ├─▶ context A
         │   ╰╴tests/test_debug.rs:177:10
         │
-        ╰─▶ Root error
+        ╰─▶ root error
             ├╴tests/common.rs:147:5
-            ╰╴spantrace with 2 frames (6)
+            ╰╴span trace with 2 frames (6)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Span Trace No. 1
+span trace No. 1
   [redacted]
 
-Span Trace No. 2
+span trace No. 2
   [redacted]
 
-Span Trace No. 3
+span trace No. 3
   [redacted]
 
-Span Trace No. 4
+span trace No. 4
   [redacted]
 
-Span Trace No. 5
+span trace No. 5
   [redacted]
 
-Span Trace No. 6
+span trace No. 6
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace.snap
@@ -2,40 +2,40 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-Context A
+context A
 |-at tests/test_debug.rs:214:10
 |-2
 |-1
 |
-|-> Context A
+|-> context A
  |  |-at tests/test_debug.rs:208:10
  |  |-4
  |  |-3
  |  |
- |  |-> Root error
+ |  |-> root error
  |      |-at tests/common.rs:147:5
- |      |-spantrace with 2 frames (1)
+ |      |-span trace with 2 frames (1)
  |      |-6
  |
- |> Context A
+ |> context A
     |-at tests/test_debug.rs:203:10
     |-5
     |-3
     |
-    |-> Context A
+    |-> context A
     |   |-at tests/test_debug.rs:201:10
     |   |-7
     |
-    |-> Context A
+    |-> context A
      |  |-at tests/test_debug.rs:192:34
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
-     |      |-spantrace with 2 frames (2)
+     |      |-span trace with 2 frames (2)
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:186:10
      |  |-13
      |  |-10
@@ -43,11 +43,11 @@ Context A
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
-     |      |-spantrace with 2 frames (3)
+     |      |-span trace with 2 frames (3)
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:172:10
      |  |-15
      |  |-14
@@ -56,49 +56,49 @@ Context A
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
-     |      |-spantrace with 2 frames (4)
+     |      |-span trace with 2 frames (4)
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:182:10
      |  |-11
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
-     |      |-spantrace with 2 frames (5)
+     |      |-span trace with 2 frames (5)
      |
-     |> Context A
+     |> context A
         |-at tests/test_debug.rs:178:10
         |-12
         |-9
         |-8
         |
-        |-> Context A
+        |-> context A
         |   |-at tests/test_debug.rs:177:10
         |
-        |-> Root error
+        |-> root error
             |-at tests/common.rs:147:5
-            |-spantrace with 2 frames (6)
+            |-span trace with 2 frames (6)
 
 ========================================
 
-Span Trace No. 1
+span trace No. 1
   [redacted]
 
-Span Trace No. 2
+span trace No. 2
   [redacted]
 
-Span Trace No. 3
+span trace No. 3
   [redacted]
 
-Span Trace No. 4
+span trace No. 4
   [redacted]
 
-Span Trace No. 5
+span trace No. 5
   [redacted]
 
-Span Trace No. 6
+span trace No. 6
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate.snap
@@ -2,38 +2,38 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
-Context A
+context A
 |-at tests/test_debug.rs:214:10
 |-2
 |-1
 |
-|-> Context A
+|-> context A
  |  |-at tests/test_debug.rs:208:10
  |  |-4
  |  |-3
  |  |
- |  |-> Root error
+ |  |-> root error
  |      |-at tests/common.rs:147:5
  |      |-6
  |
- |> Context A
+ |> context A
     |-at tests/test_debug.rs:203:10
     |-5
     |-3
     |
-    |-> Context A
+    |-> context A
     |   |-at tests/test_debug.rs:201:10
     |   |-7
     |
-    |-> Context A
+    |-> context A
      |  |-at tests/test_debug.rs:192:34
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:186:10
      |  |-13
      |  |-10
@@ -41,10 +41,10 @@ Context A
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:172:10
      |  |-15
      |  |-14
@@ -53,26 +53,26 @@ Context A
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:182:10
      |  |-11
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |
-     |> Context A
+     |> context A
         |-at tests/test_debug.rs:178:10
         |-12
         |-9
         |-8
         |
-        |-> Context A
+        |-> context A
         |   |-at tests/test_debug.rs:177:10
         |
-        |-> Root error
+        |-> root error
             |-at tests/common.rs:147:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@backtrace-pretty-print.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@backtrace-pretty-print.snap
@@ -2,40 +2,40 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
-Context A
+context A
 ├╴tests/test_debug.rs:214:10
 ├╴2
 ├╴1
 │
-╰┬▶ Context A
+╰┬▶ context A
  │  ├╴tests/test_debug.rs:208:10
  │  ├╴4
  │  ├╴3
  │  │
- │  ╰─▶ Root error
+ │  ╰─▶ root error
  │      ├╴tests/common.rs:147:5
  │      ├╴backtrace (1)
  │      ╰╴6
  │
- ╰▶ Context A
+ ╰▶ context A
     ├╴tests/test_debug.rs:203:10
     ├╴5
     ├╴3
     │
-    ├─▶ Context A
+    ├─▶ context A
     │   ├╴tests/test_debug.rs:201:10
     │   ╰╴7
     │
-    ╰┬▶ Context A
+    ╰┬▶ context A
      │  ├╴tests/test_debug.rs:192:34
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
      │      ╰╴backtrace (2)
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:186:10
      │  ├╴13
      │  ├╴10
@@ -43,11 +43,11 @@ Context A
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
      │      ╰╴backtrace (3)
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:172:10
      │  ├╴15
      │  ├╴14
@@ -56,49 +56,49 @@ Context A
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
      │      ╰╴backtrace (4)
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:182:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
      │      ╰╴backtrace (5)
      │
-     ╰▶ Context A
+     ╰▶ context A
         ├╴tests/test_debug.rs:178:10
         ├╴12
         ├╴9
         ├╴8
         │
-        ├─▶ Context A
+        ├─▶ context A
         │   ╰╴tests/test_debug.rs:177:10
         │
-        ╰─▶ Root error
+        ╰─▶ root error
             ├╴tests/common.rs:147:5
             ╰╴backtrace (6)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Backtrace No. 2
+backtrace no. 2
   [redacted]
 
-Backtrace No. 3
+backtrace no. 3
   [redacted]
 
-Backtrace No. 4
+backtrace no. 4
   [redacted]
 
-Backtrace No. 5
+backtrace no. 5
   [redacted]
 
-Backtrace No. 6
+backtrace no. 6
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@backtrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@backtrace.snap
@@ -2,40 +2,40 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
-Context A
+context A
 |-at tests/test_debug.rs:214:10
 |-2
 |-1
 |
-|-> Context A
+|-> context A
  |  |-at tests/test_debug.rs:208:10
  |  |-4
  |  |-3
  |  |
- |  |-> Root error
+ |  |-> root error
  |      |-at tests/common.rs:147:5
  |      |-backtrace (1)
  |      |-6
  |
- |> Context A
+ |> context A
     |-at tests/test_debug.rs:203:10
     |-5
     |-3
     |
-    |-> Context A
+    |-> context A
     |   |-at tests/test_debug.rs:201:10
     |   |-7
     |
-    |-> Context A
+    |-> context A
      |  |-at tests/test_debug.rs:192:34
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |      |-backtrace (2)
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:186:10
      |  |-13
      |  |-10
@@ -43,11 +43,11 @@ Context A
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |      |-backtrace (3)
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:172:10
      |  |-15
      |  |-14
@@ -56,49 +56,49 @@ Context A
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |      |-backtrace (4)
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:182:10
      |  |-11
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |      |-backtrace (5)
      |
-     |> Context A
+     |> context A
         |-at tests/test_debug.rs:178:10
         |-12
         |-9
         |-8
         |
-        |-> Context A
+        |-> context A
         |   |-at tests/test_debug.rs:177:10
         |
-        |-> Root error
+        |-> root error
             |-at tests/common.rs:147:5
             |-backtrace (6)
 
 ========================================
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Backtrace No. 2
+backtrace no. 2
   [redacted]
 
-Backtrace No. 3
+backtrace no. 3
   [redacted]
 
-Backtrace No. 4
+backtrace no. 4
   [redacted]
 
-Backtrace No. 5
+backtrace no. 5
   [redacted]
 
-Backtrace No. 6
+backtrace no. 6
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@pretty-print.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@pretty-print.snap
@@ -2,38 +2,38 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
-Context A
+context A
 ├╴tests/test_debug.rs:214:10
 ├╴2
 ├╴1
 │
-╰┬▶ Context A
+╰┬▶ context A
  │  ├╴tests/test_debug.rs:208:10
  │  ├╴4
  │  ├╴3
  │  │
- │  ╰─▶ Root error
+ │  ╰─▶ root error
  │      ├╴tests/common.rs:147:5
  │      ╰╴6
  │
- ╰▶ Context A
+ ╰▶ context A
     ├╴tests/test_debug.rs:203:10
     ├╴5
     ├╴3
     │
-    ├─▶ Context A
+    ├─▶ context A
     │   ├╴tests/test_debug.rs:201:10
     │   ╰╴7
     │
-    ╰┬▶ Context A
+    ╰┬▶ context A
      │  ├╴tests/test_debug.rs:192:34
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ╰╴tests/common.rs:147:5
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:186:10
      │  ├╴13
      │  ├╴10
@@ -41,10 +41,10 @@ Context A
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ╰╴tests/common.rs:147:5
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:172:10
      │  ├╴15
      │  ├╴14
@@ -53,26 +53,26 @@ Context A
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ╰╴tests/common.rs:147:5
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:182:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ╰╴tests/common.rs:147:5
      │
-     ╰▶ Context A
+     ╰▶ context A
         ├╴tests/test_debug.rs:178:10
         ├╴12
         ├╴9
         ├╴8
         │
-        ├─▶ Context A
+        ├─▶ context A
         │   ╰╴tests/test_debug.rs:177:10
         │
-        ╰─▶ Root error
+        ╰─▶ root error
             ╰╴tests/common.rs:147:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace-backtrace-pretty-print.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace-backtrace-pretty-print.snap
@@ -2,42 +2,42 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
-Context A
+context A
 ├╴tests/test_debug.rs:214:10
 ├╴2
 ├╴1
 │
-╰┬▶ Context A
+╰┬▶ context A
  │  ├╴tests/test_debug.rs:208:10
  │  ├╴4
  │  ├╴3
  │  │
- │  ╰─▶ Root error
+ │  ╰─▶ root error
  │      ├╴tests/common.rs:147:5
  │      ├╴backtrace (1)
- │      ├╴spantrace with 2 frames (1)
+ │      ├╴span trace with 2 frames (1)
  │      ╰╴6
  │
- ╰▶ Context A
+ ╰▶ context A
     ├╴tests/test_debug.rs:203:10
     ├╴5
     ├╴3
     │
-    ├─▶ Context A
+    ├─▶ context A
     │   ├╴tests/test_debug.rs:201:10
     │   ╰╴7
     │
-    ╰┬▶ Context A
+    ╰┬▶ context A
      │  ├╴tests/test_debug.rs:192:34
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
      │      ├╴backtrace (2)
-     │      ╰╴spantrace with 2 frames (2)
+     │      ╰╴span trace with 2 frames (2)
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:186:10
      │  ├╴13
      │  ├╴10
@@ -45,12 +45,12 @@ Context A
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
      │      ├╴backtrace (3)
-     │      ╰╴spantrace with 2 frames (3)
+     │      ╰╴span trace with 2 frames (3)
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:172:10
      │  ├╴15
      │  ├╴14
@@ -59,70 +59,70 @@ Context A
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
      │      ├╴backtrace (4)
-     │      ╰╴spantrace with 2 frames (4)
+     │      ╰╴span trace with 2 frames (4)
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:182:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
      │      ├╴backtrace (5)
-     │      ╰╴spantrace with 2 frames (5)
+     │      ╰╴span trace with 2 frames (5)
      │
-     ╰▶ Context A
+     ╰▶ context A
         ├╴tests/test_debug.rs:178:10
         ├╴12
         ├╴9
         ├╴8
         │
-        ├─▶ Context A
+        ├─▶ context A
         │   ╰╴tests/test_debug.rs:177:10
         │
-        ╰─▶ Root error
+        ╰─▶ root error
             ├╴tests/common.rs:147:5
             ├╴backtrace (6)
-            ╰╴spantrace with 2 frames (6)
+            ╰╴span trace with 2 frames (6)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Span Trace No. 1
+span trace No. 1
   [redacted]
 
-Backtrace No. 2
+backtrace no. 2
   [redacted]
 
-Span Trace No. 2
+span trace No. 2
   [redacted]
 
-Backtrace No. 3
+backtrace no. 3
   [redacted]
 
-Span Trace No. 3
+span trace No. 3
   [redacted]
 
-Backtrace No. 4
+backtrace no. 4
   [redacted]
 
-Span Trace No. 4
+span trace No. 4
   [redacted]
 
-Backtrace No. 5
+backtrace no. 5
   [redacted]
 
-Span Trace No. 5
+span trace No. 5
   [redacted]
 
-Backtrace No. 6
+backtrace no. 6
   [redacted]
 
-Span Trace No. 6
+span trace No. 6
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace-backtrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace-backtrace.snap
@@ -2,42 +2,42 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
-Context A
+context A
 |-at tests/test_debug.rs:214:10
 |-2
 |-1
 |
-|-> Context A
+|-> context A
  |  |-at tests/test_debug.rs:208:10
  |  |-4
  |  |-3
  |  |
- |  |-> Root error
+ |  |-> root error
  |      |-at tests/common.rs:147:5
  |      |-backtrace (1)
- |      |-spantrace with 2 frames (1)
+ |      |-span trace with 2 frames (1)
  |      |-6
  |
- |> Context A
+ |> context A
     |-at tests/test_debug.rs:203:10
     |-5
     |-3
     |
-    |-> Context A
+    |-> context A
     |   |-at tests/test_debug.rs:201:10
     |   |-7
     |
-    |-> Context A
+    |-> context A
      |  |-at tests/test_debug.rs:192:34
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |      |-backtrace (2)
-     |      |-spantrace with 2 frames (2)
+     |      |-span trace with 2 frames (2)
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:186:10
      |  |-13
      |  |-10
@@ -45,12 +45,12 @@ Context A
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |      |-backtrace (3)
-     |      |-spantrace with 2 frames (3)
+     |      |-span trace with 2 frames (3)
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:172:10
      |  |-15
      |  |-14
@@ -59,70 +59,70 @@ Context A
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |      |-backtrace (4)
-     |      |-spantrace with 2 frames (4)
+     |      |-span trace with 2 frames (4)
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:182:10
      |  |-11
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
      |      |-backtrace (5)
-     |      |-spantrace with 2 frames (5)
+     |      |-span trace with 2 frames (5)
      |
-     |> Context A
+     |> context A
         |-at tests/test_debug.rs:178:10
         |-12
         |-9
         |-8
         |
-        |-> Context A
+        |-> context A
         |   |-at tests/test_debug.rs:177:10
         |
-        |-> Root error
+        |-> root error
             |-at tests/common.rs:147:5
             |-backtrace (6)
-            |-spantrace with 2 frames (6)
+            |-span trace with 2 frames (6)
 
 ========================================
 
-Backtrace No. 1
+backtrace no. 1
   [redacted]
 
-Span Trace No. 1
+span trace No. 1
   [redacted]
 
-Backtrace No. 2
+backtrace no. 2
   [redacted]
 
-Span Trace No. 2
+span trace No. 2
   [redacted]
 
-Backtrace No. 3
+backtrace no. 3
   [redacted]
 
-Span Trace No. 3
+span trace No. 3
   [redacted]
 
-Backtrace No. 4
+backtrace no. 4
   [redacted]
 
-Span Trace No. 4
+span trace No. 4
   [redacted]
 
-Backtrace No. 5
+backtrace no. 5
   [redacted]
 
-Span Trace No. 5
+span trace No. 5
   [redacted]
 
-Backtrace No. 6
+backtrace no. 6
   [redacted]
 
-Span Trace No. 6
+span trace No. 6
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace-pretty-print.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace-pretty-print.snap
@@ -2,40 +2,40 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
-Context A
+context A
 ├╴tests/test_debug.rs:214:10
 ├╴2
 ├╴1
 │
-╰┬▶ Context A
+╰┬▶ context A
  │  ├╴tests/test_debug.rs:208:10
  │  ├╴4
  │  ├╴3
  │  │
- │  ╰─▶ Root error
+ │  ╰─▶ root error
  │      ├╴tests/common.rs:147:5
- │      ├╴spantrace with 2 frames (1)
+ │      ├╴span trace with 2 frames (1)
  │      ╰╴6
  │
- ╰▶ Context A
+ ╰▶ context A
     ├╴tests/test_debug.rs:203:10
     ├╴5
     ├╴3
     │
-    ├─▶ Context A
+    ├─▶ context A
     │   ├╴tests/test_debug.rs:201:10
     │   ╰╴7
     │
-    ╰┬▶ Context A
+    ╰┬▶ context A
      │  ├╴tests/test_debug.rs:192:34
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
-     │      ╰╴spantrace with 2 frames (2)
+     │      ╰╴span trace with 2 frames (2)
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:186:10
      │  ├╴13
      │  ├╴10
@@ -43,11 +43,11 @@ Context A
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
-     │      ╰╴spantrace with 2 frames (3)
+     │      ╰╴span trace with 2 frames (3)
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:172:10
      │  ├╴15
      │  ├╴14
@@ -56,49 +56,49 @@ Context A
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
-     │      ╰╴spantrace with 2 frames (4)
+     │      ╰╴span trace with 2 frames (4)
      │
-     ├▶ Context A
+     ├▶ context A
      │  ├╴tests/test_debug.rs:182:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
      │  │
-     │  ╰─▶ Root error
+     │  ╰─▶ root error
      │      ├╴tests/common.rs:147:5
-     │      ╰╴spantrace with 2 frames (5)
+     │      ╰╴span trace with 2 frames (5)
      │
-     ╰▶ Context A
+     ╰▶ context A
         ├╴tests/test_debug.rs:178:10
         ├╴12
         ├╴9
         ├╴8
         │
-        ├─▶ Context A
+        ├─▶ context A
         │   ╰╴tests/test_debug.rs:177:10
         │
-        ╰─▶ Root error
+        ╰─▶ root error
             ├╴tests/common.rs:147:5
-            ╰╴spantrace with 2 frames (6)
+            ╰╴span trace with 2 frames (6)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Span Trace No. 1
+span trace No. 1
   [redacted]
 
-Span Trace No. 2
+span trace No. 2
   [redacted]
 
-Span Trace No. 3
+span trace No. 3
   [redacted]
 
-Span Trace No. 4
+span trace No. 4
   [redacted]
 
-Span Trace No. 5
+span trace No. 5
   [redacted]
 
-Span Trace No. 6
+span trace No. 6
   [redacted]

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace.snap
@@ -2,40 +2,40 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
-Context A
+context A
 |-at tests/test_debug.rs:214:10
 |-2
 |-1
 |
-|-> Context A
+|-> context A
  |  |-at tests/test_debug.rs:208:10
  |  |-4
  |  |-3
  |  |
- |  |-> Root error
+ |  |-> root error
  |      |-at tests/common.rs:147:5
- |      |-spantrace with 2 frames (1)
+ |      |-span trace with 2 frames (1)
  |      |-6
  |
- |> Context A
+ |> context A
     |-at tests/test_debug.rs:203:10
     |-5
     |-3
     |
-    |-> Context A
+    |-> context A
     |   |-at tests/test_debug.rs:201:10
     |   |-7
     |
-    |-> Context A
+    |-> context A
      |  |-at tests/test_debug.rs:192:34
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
-     |      |-spantrace with 2 frames (2)
+     |      |-span trace with 2 frames (2)
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:186:10
      |  |-13
      |  |-10
@@ -43,11 +43,11 @@ Context A
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
-     |      |-spantrace with 2 frames (3)
+     |      |-span trace with 2 frames (3)
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:172:10
      |  |-15
      |  |-14
@@ -56,49 +56,49 @@ Context A
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
-     |      |-spantrace with 2 frames (4)
+     |      |-span trace with 2 frames (4)
      |
-     |> Context A
+     |> context A
      |  |-at tests/test_debug.rs:182:10
      |  |-11
      |  |-9
      |  |-8
      |  |
-     |  |-> Root error
+     |  |-> root error
      |      |-at tests/common.rs:147:5
-     |      |-spantrace with 2 frames (5)
+     |      |-span trace with 2 frames (5)
      |
-     |> Context A
+     |> context A
         |-at tests/test_debug.rs:178:10
         |-12
         |-9
         |-8
         |
-        |-> Context A
+        |-> context A
         |   |-at tests/test_debug.rs:177:10
         |
-        |-> Root error
+        |-> root error
             |-at tests/common.rs:147:5
-            |-spantrace with 2 frames (6)
+            |-span trace with 2 frames (6)
 
 ========================================
 
-Span Trace No. 1
+span trace No. 1
   [redacted]
 
-Span Trace No. 2
+span trace No. 2
   [redacted]
 
-Span Trace No. 3
+span trace No. 3
   [redacted]
 
-Span Trace No. 4
+span trace No. 4
   [redacted]
 
-Span Trace No. 5
+span trace No. 5
   [redacted]
 
-Span Trace No. 6
+span trace No. 6
   [redacted]

--- a/packages/libs/error-stack/tests/test_attach.rs
+++ b/packages/libs/error-stack/tests/test_attach.rs
@@ -10,7 +10,7 @@ use error_stack::{AttachmentKind, FrameKind, FutureExt, Report, ResultExt};
 fn test_messages<E>(report: &Report<E>) {
     assert_eq!(
         messages(report),
-        expect_messages(&["Opaque", "Opaque", "Opaque", "Opaque", "Root error"])
+        expect_messages(&["opaque", "opaque", "opaque", "opaque", "root error"])
     );
 }
 

--- a/packages/libs/error-stack/tests/test_attach_printable.rs
+++ b/packages/libs/error-stack/tests/test_attach_printable.rs
@@ -11,11 +11,11 @@ fn test_messages<E>(report: &Report<E>) {
     assert_eq!(
         messages(report),
         expect_messages(&[
-            "Context B",
-            "Context A",
-            "Printable B",
-            "Printable A",
-            "Root error"
+            "context B",
+            "context A",
+            "printable B",
+            "printable A",
+            "root error"
         ])
     );
 }

--- a/packages/libs/error-stack/tests/test_change_context.rs
+++ b/packages/libs/error-stack/tests/test_change_context.rs
@@ -10,7 +10,7 @@ use error_stack::{AttachmentKind, FrameKind, FutureExt, Report, ResultExt};
 fn test_messages<E>(report: &Report<E>) {
     assert_eq!(
         messages(report),
-        expect_messages(&["Opaque", "Context B", "Opaque", "Context A", "Root error"])
+        expect_messages(&["opaque", "context B", "opaque", "context A", "root error"])
     );
 }
 

--- a/packages/libs/error-stack/tests/test_compatibility.rs
+++ b/packages/libs/error-stack/tests/test_compatibility.rs
@@ -13,14 +13,14 @@ use error_stack::IntoReportCompat;
 use error_stack::Report;
 
 // All frames except backtraces in this file are printable (either a printable attachment or a
-// context), so only backtraces are "Opaque". Depending on how the backtrace is generated, it will
+// context), so only backtraces are "opaque". Depending on how the backtrace is generated, it will
 // appear at different locations. To simplify the general tests, we remove backtraces, they are
 // tested explicitly in other tests. On nightly, anyhow/eyre will capture the backtrace and provide
 // it by `Error::provide`. On non-nightly toolchains since 1.65 the backtrace will be captured by
 // `Report.
 #[cfg(all(rust_1_65, feature = "std"))]
 fn remove_opaque_frames(messages: &mut Vec<String>) {
-    messages.retain(|message| message != "Opaque")
+    messages.retain(|message| message != "opaque")
 }
 
 #[test]
@@ -60,7 +60,7 @@ fn anyhow_nostd() {
         .context(PrintableB(0)));
 
     let report = anyhow.into_report().unwrap_err();
-    let expected_output = ["Printable B"];
+    let expected_output = ["printable B"];
     for (anyhow, expected) in messages(&report).into_iter().zip(expected_output) {
         assert_eq!(anyhow, expected);
     }

--- a/packages/libs/error-stack/tests/test_debug.rs
+++ b/packages/libs/error-stack/tests/test_debug.rs
@@ -99,12 +99,12 @@ fn prepare(suffix: bool) -> impl Drop {
     }
 
     settings.add_filter(
-        r"Backtrace No\. (\d+)\n(?:  .*\n)*  .*",
-        "Backtrace No. $1\n  [redacted]",
+        r"backtrace no\. (\d+)\n(?:  .*\n)*  .*",
+        "backtrace no. $1\n  [redacted]",
     );
     settings.add_filter(
-        r"Span Trace No\. (\d+)\n(?:  .*\n)*  .*",
-        "Span Trace No. $1\n  [redacted]",
+        r"span trace No\. (\d+)\n(?:  .*\n)*  .*",
+        "span trace No. $1\n  [redacted]",
     );
     settings.add_filter(
         r"backtrace with( (\d+) frames)? \((\d+)\)",
@@ -138,7 +138,7 @@ fn prepare(suffix: bool) -> impl Drop {
 ///               P 6       P 7
 ///                │         │
 ///                ▼         ▼
-///          Root Error 1   C 3
+///          root error 1   C 3
 ///                          │
 ///                          ▼
 ///                         P 8
@@ -151,19 +151,19 @@ fn prepare(suffix: bool) -> impl Drop {
 ///      C 4               P 16               P 11          P 12
 ///       │                  │                  │             │
 ///       ▼                  ▼                  ▼             ▼
-/// Root Error 2       ┌───P 10───┐            C 9           C 6
+/// root error 2       ┌───P 10───┐            C 9           C 6
 ///                    │          │             │             │
 ///                    ▼          ▼             ▼             ▼
-///                  P 13       P 14      Root Error 5       C 7
+///                  P 13       P 14      root error 5       C 7
 ///                    │          │                           │
 ///                    ▼          ▼                           ▼
-///                   C 8       P 15                    Root Error 6
+///                   C 8       P 15                    root error 6
 ///                    │          │
 ///                    ▼          ▼
-///              Root Error 3    C 5
+///              root error 3    C 5
 ///                               │
 ///                               ▼
-///                         Root Error 4
+///                         root error 4
 /// ```
 ///
 /// `P = Printable`, `C = Context`
@@ -284,7 +284,7 @@ mod full {
             .attach_printable(PrintableB(0))
             .attach(AttachmentB)
             .change_context(ContextB(0))
-            .attach_printable("Printable C");
+            .attach_printable("printable C");
 
         assert_snapshot!(format!("{report:?}"));
     }
@@ -301,7 +301,7 @@ mod full {
             .attach_printable(PrintableB(0))
             .attach(AttachmentB)
             .change_context(ContextB(0))
-            .attach_printable("Printable C");
+            .attach_printable("printable C");
 
         assert_snapshot!(format!("{report:#?}"));
     }
@@ -326,7 +326,7 @@ mod full {
             .attach_printable(PrintableB(0))
             .attach(AttachmentB)
             .change_context(ContextB(0))
-            .attach_printable("Printable C");
+            .attach_printable("printable C");
 
         assert_snapshot!(format!("{report:#?}"));
     }
@@ -564,7 +564,7 @@ mod full {
     #[cfg(nightly)]
     impl Display for ContextD {
         fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-            f.write_str("Context D")
+            f.write_str("context D")
         }
     }
 

--- a/packages/libs/error-stack/tests/test_debug.rs
+++ b/packages/libs/error-stack/tests/test_debug.rs
@@ -318,7 +318,7 @@ mod full {
     impl Error for ContextC {}
 
     #[test]
-    fn multiline_ctx() {
+    fn multiline_context() {
         let _guard = prepare(false);
 
         let report = create_report()
@@ -449,8 +449,8 @@ mod full {
 
         let report = create_report().attach(2u32);
 
-        Report::install_debug_hook::<u32>(|_, ctx| {
-            ctx.push_body("unsigned 32bit integer");
+        Report::install_debug_hook::<u32>(|_, context| {
+            context.push_body("unsigned 32bit integer");
         });
 
         assert_snapshot!(format!("{report:?}"));
@@ -462,9 +462,9 @@ mod full {
 
         let report = create_report().attach(2u32);
 
-        Report::install_debug_hook::<u32>(|_, ctx| {
-            let idx = ctx.increment_counter();
-            ctx.push_body(format!("unsigned 32bit integer (No. {idx})"));
+        Report::install_debug_hook::<u32>(|_, context| {
+            let idx = context.increment_counter();
+            context.push_body(format!("unsigned 32bit integer (No. {idx})"));
         });
 
         assert_snapshot!(format!("{report:?}"));
@@ -491,11 +491,11 @@ mod full {
 
         let report = create_report().attach(1u32).attach(2u64);
 
-        Report::install_debug_hook::<u32>(|_, ctx| {
-            ctx.push_body("unsigned 32bit integer");
+        Report::install_debug_hook::<u32>(|_, context| {
+            context.push_body("unsigned 32bit integer");
         });
-        Report::install_debug_hook::<u64>(|_, ctx| {
-            ctx.push_body("unsigned 64bit integer");
+        Report::install_debug_hook::<u64>(|_, context| {
+            context.push_body("unsigned 64bit integer");
         });
 
         assert_snapshot!(format!("{report:?}"));
@@ -510,9 +510,9 @@ mod full {
             .attach(2u32)
             .attach(3u32);
 
-        Report::install_debug_hook::<u32>(|_, ctx| {
-            let idx = ctx.decrement_counter();
-            ctx.push_body(idx.to_string());
+        Report::install_debug_hook::<u32>(|_, context| {
+            let idx = context.decrement_counter();
+            context.push_body(idx.to_string());
         });
 
         assert_snapshot!(format!("{report:?}"));
@@ -527,9 +527,9 @@ mod full {
             .attach(2u32)
             .attach(3u32);
 
-        Report::install_debug_hook::<u32>(|_, ctx| {
-            let idx = ctx.increment_counter();
-            ctx.push_body(idx.to_string());
+        Report::install_debug_hook::<u32>(|_, context| {
+            let idx = context.increment_counter();
+            context.push_body(idx.to_string());
         });
 
         assert_snapshot!(format!("{report:?}"));
@@ -541,12 +541,12 @@ mod full {
 
         let report = create_report().attach(2u64);
 
-        Report::install_debug_hook::<u64>(|_, ctx| {
-            if ctx.alternate() {
-                ctx.push_appendix("Snippet");
+        Report::install_debug_hook::<u64>(|_, context| {
+            if context.alternate() {
+                context.push_appendix("Snippet");
             }
 
-            ctx.push_body("Empty");
+            context.push_body("Empty");
         });
 
         assert_snapshot!("norm", format!("{report:?}"));
@@ -586,11 +586,11 @@ mod full {
             reason: "Invalid User Input",
         });
 
-        Report::install_debug_hook::<usize>(|val, ctx| {
-            ctx.push_body(format!("usize: {val}"));
+        Report::install_debug_hook::<usize>(|value, context| {
+            context.push_body(format!("usize: {value}"));
         });
-        Report::install_debug_hook::<&'static str>(|val, ctx| {
-            ctx.push_body(format!("&'static str: {val}"));
+        Report::install_debug_hook::<&'static str>(|value, context| {
+            context.push_body(format!("&'static str: {value}"));
         });
 
         assert_snapshot!(format!("{report:?}"));

--- a/packages/libs/error-stack/tests/test_display.rs
+++ b/packages/libs/error-stack/tests/test_display.rs
@@ -15,7 +15,7 @@ fn normal() {
         .attach(AttachmentB)
         .change_context(ContextB(0));
 
-    assert_eq!(report.to_string(), "Context B");
+    assert_eq!(report.to_string(), "context B");
 }
 
 #[test]
@@ -28,5 +28,5 @@ fn extended() {
         .attach(AttachmentB)
         .change_context(ContextB(0));
 
-    assert_eq!(format!("{report:#}"), "Context B: Context A: Root error");
+    assert_eq!(format!("{report:#}"), "context B: context A: root error");
 }

--- a/packages/libs/error-stack/tests/test_macros.rs
+++ b/packages/libs/error-stack/tests/test_macros.rs
@@ -16,7 +16,7 @@ fn report() {
     assert_eq!(report.frames().count(), expect_count(2));
     assert_eq!(
         messages(&report),
-        expect_messages(&["Printable A", "Root error"])
+        expect_messages(&["printable A", "root error"])
     );
 
     let report = capture_error(|| Err(report!(report))).attach_printable(PrintableB(0));
@@ -27,7 +27,7 @@ fn report() {
     assert_eq!(report.frames().count(), expect_count(3));
     assert_eq!(
         messages(&report),
-        expect_messages(&["Printable B", "Printable A", "Root error"])
+        expect_messages(&["printable B", "printable A", "root error"])
     );
 }
 
@@ -41,7 +41,7 @@ fn bail() {
     assert_eq!(report.frames().count(), expect_count(2));
     assert_eq!(
         messages(&report),
-        expect_messages(&["Printable A", "Root error"])
+        expect_messages(&["printable A", "root error"])
     );
 
     let report = capture_error(|| bail!(report)).attach_printable(PrintableB(0));
@@ -52,7 +52,7 @@ fn bail() {
     assert_eq!(report.frames().count(), expect_count(3));
     assert_eq!(
         messages(&report),
-        expect_messages(&["Printable B", "Printable A", "Root error"])
+        expect_messages(&["printable B", "printable A", "root error"])
     );
 }
 
@@ -74,7 +74,7 @@ fn ensure() {
     assert_eq!(report.frames().count(), expect_count(2));
     assert_eq!(
         messages(&report),
-        expect_messages(&["Printable A", "Root error"])
+        expect_messages(&["printable A", "root error"])
     );
 
     let report = capture_error(|| {
@@ -89,6 +89,6 @@ fn ensure() {
     assert_eq!(report.frames().count(), expect_count(3));
     assert_eq!(
         messages(&report),
-        expect_messages(&["Printable B", "Printable A", "Root error"])
+        expect_messages(&["printable B", "printable A", "root error"])
     );
 }

--- a/packages/libs/error-stack/tests/ui/macro_invalid_args.rs
+++ b/packages/libs/error-stack/tests/ui/macro_invalid_args.rs
@@ -7,7 +7,7 @@ pub struct RootError;
 
 impl fmt::Display for RootError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.write_str("Root error")
+        fmt.write_str("root error")
     }
 }
 

--- a/packages/libs/error-stack/tests/ui/must_use.rs
+++ b/packages/libs/error-stack/tests/ui/must_use.rs
@@ -9,7 +9,7 @@ pub struct RootError;
 
 impl fmt::Display for RootError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.write_str("Root error")
+        fmt.write_str("root error")
     }
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Error messages in Rust should be lower-case. As errors are also used as contexts, these should also be lower-cased.
Generally, we try to avoid abbreviations in variable names, so this also makes variable names more consistent.

## 🔗 Related links

- Fixes #1017
- #1113 