### PR TITLE
Aliased accountId

### DIFF
--- a/packages/hash/api/src/graphql/resolvers/knowledge/model-mapping.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/model-mapping.ts
@@ -20,6 +20,7 @@ export const mapEntityModelToGQL = (
   entityTypeId: entityModel.entityTypeModel.schema.$id,
   entityVersionId: entityModel.version,
   ownedById: entityModel.accountId,
+  accountId: entityModel.accountId,
   properties: entityModel.properties,
 });
 

--- a/packages/hash/api/src/graphql/typeDefs/knowledge/block.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/knowledge/block.typedef.ts
@@ -25,6 +25,10 @@ export const knowledgeBlockTypedef = gql`
     """
     ownedById: ID!
     """
+    Alias of ownedById - the id of the account that owns this entity.
+    """
+    accountId: ID!
+    """
     The fixed id of the type this entity is of.
     """
     entityTypeId: ID!

--- a/packages/hash/api/src/graphql/typeDefs/knowledge/block.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/knowledge/block.typedef.ts
@@ -28,6 +28,7 @@ export const knowledgeBlockTypedef = gql`
     Alias of ownedById - the id of the account that owns this entity.
     """
     accountId: ID!
+      @deprecated(reason: "accountId is deprecated. Use ownedById instead.")
     """
     The fixed id of the type this entity is of.
     """

--- a/packages/hash/api/src/graphql/typeDefs/knowledge/entity.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/knowledge/entity.typedef.ts
@@ -23,6 +23,10 @@ export const knowledgeEntityTypedef = gql`
     """
     ownedById: ID!
     """
+    Alias of ownedById - the id of the account that owns this entity.
+    """
+    accountId: ID!
+    """
     The fixed id of the type this entity is of.
     """
     entityTypeId: ID!

--- a/packages/hash/api/src/graphql/typeDefs/knowledge/entity.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/knowledge/entity.typedef.ts
@@ -26,6 +26,7 @@ export const knowledgeEntityTypedef = gql`
     Alias of ownedById - the id of the account that owns this entity.
     """
     accountId: ID!
+      @deprecated(reason: "accountId is deprecated. Use ownedById instead.")
     """
     The fixed id of the type this entity is of.
     """

--- a/packages/hash/api/src/graphql/typeDefs/knowledge/page.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/knowledge/page.typedef.ts
@@ -37,6 +37,10 @@ export const knowledgePageTypedef = gql`
     """
     ownedById: ID!
     """
+    Alias of ownedById - the id of the account that owns this entity.
+    """
+    accountId: ID!
+    """
     The fixed id of the type this entity is of.
     """
     entityTypeId: ID!
@@ -56,7 +60,14 @@ export const knowledgePageTypedef = gql`
   }
 
   type KnowledgeEntityRef {
+    """
+    The id of the account that owns this entity.
+    """
     ownedById: ID!
+    """
+    Alias of ownedById - the id of the account that owns this entity.
+    """
+    accountId: ID!
     entityId: ID!
     entityVersion: String!
   }

--- a/packages/hash/api/src/graphql/typeDefs/knowledge/page.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/knowledge/page.typedef.ts
@@ -40,6 +40,7 @@ export const knowledgePageTypedef = gql`
     Alias of ownedById - the id of the account that owns this entity.
     """
     accountId: ID!
+      @deprecated(reason: "accountId is deprecated. Use ownedById instead.")
     """
     The fixed id of the type this entity is of.
     """
@@ -68,6 +69,7 @@ export const knowledgePageTypedef = gql`
     Alias of ownedById - the id of the account that owns this entity.
     """
     accountId: ID!
+      @deprecated(reason: "accountId is deprecated. Use ownedById instead.")
     entityId: ID!
     entityVersion: String!
   }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
A follow-up PR to address an alias we wanted in https://github.com/hashintel/hash/pull/1090
This PR simply adds `accountId` to the knowledge GQL types that should alias the `ownedById` 