### PR TITLE
Cleanup Makefile

### DIFF
--- a/.github/scripts/rust/Makefile.toml
+++ b/.github/scripts/rust/Makefile.toml
@@ -32,6 +32,8 @@ CARGO_DOC_TEST_FLAGS = "--workspace --all-features"
 CARGO_MIRI_FLAGS = ""
 CARGO_MIRI_HACK_FLAGS = "--workspace"
 
+REPO_ROOT = { script = ["git rev-parse --show-toplevel"] }
+
 [env.production]
 CARGO_MAKE_CARGO_PROFILE = "release"
 

--- a/.github/scripts/rust/Makefile.toml
+++ b/.github/scripts/rust/Makefile.toml
@@ -106,8 +106,8 @@ args = ["hack", "@@split(CARGO_FORMAT_HACK_FLAGS, )", "fmt", "@@split(CARGO_FORM
 dependencies = ["install-rustfmt"]
 
 [tasks.clippy]
-description = "Runs clippy with all feature flag permutations"
 category = "Lint"
+description = "Runs clippy with all feature flag permutations"
 run_task = { name = ["clippy-task"] }
 
 [tasks.clippy-task]

--- a/.github/scripts/rust/Makefile.toml
+++ b/.github/scripts/rust/Makefile.toml
@@ -55,7 +55,6 @@ command = "cargo"
 dependencies = ["install-cargo-hack"]
 
 [tasks.yarn]
-private = true
 command = "yarn"
 
 [tasks.docker]

--- a/.github/scripts/rust/Makefile.toml
+++ b/.github/scripts/rust/Makefile.toml
@@ -51,6 +51,7 @@ dependencies = ["install-cargo-hack"]
 ################################################################################
 ## Build                                                                      ##
 ################################################################################
+
 [tasks.build]
 category = "Build"
 description = "Builds the crate"
@@ -60,10 +61,10 @@ run_task = { name = "build-task" }
 extend = "cargo"
 args = ["build", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_BUILD_FLAGS, )", "${@}"]
 
-
 ################################################################################
 ## Run                                                                        ##
 ################################################################################
+
 [tasks.run]
 category = "Run"
 description = "Builds the binary and runs it"
@@ -73,15 +74,14 @@ run_task = { name = "run-task" }
 extend = "cargo"
 args = ["run", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_RUN_FLAGS, )", "${@}"]
 
-
 ################################################################################
 ## Lints                                                                      ##
 ################################################################################
+
 [tasks.lint]
 category = "Lint"
 description = "Runs all lints"
 run_task = { name = ["format", "clippy", "doc"] }
-
 
 [tasks.format]
 category = "Lint"
@@ -93,7 +93,6 @@ extend = "cargo"
 args = ["hack", "@@split(CARGO_FORMAT_HACK_FLAGS, )", "fmt", "@@split(CARGO_FORMAT_FLAGS, )", "${@}"]
 dependencies = ["install-rustfmt"]
 
-
 [tasks.clippy]
 description = "Runs clippy with all feature flag permutations"
 category = "Lint"
@@ -104,10 +103,10 @@ extend = "cargo"
 args = ["hack", "@@split(CARGO_CLIPPY_HACK_FLAGS, )", "clippy", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_CLIPPY_FLAGS, )", "${@}"]
 dependencies = ["install-clippy"]
 
-
 ################################################################################
 ## Docs                                                                       ##
 ################################################################################
+
 [tasks.doc]
 category = "Docs"
 description = "Builds the documentation for the crate"
@@ -116,7 +115,6 @@ run_task = { name = ["doc-task"] }
 [tasks.doc-task]
 extend = "cargo"
 args = ["hack", "@@split(CARGO_DOC_HACK_FLAGS, )", "doc", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_DOC_FLAGS, )", "${@}"]
-
 
 [tasks.rustdoc]
 category = "Docs"
@@ -127,10 +125,10 @@ run_task = { name = ["rustdoc-task"] }
 extend = "cargo"
 args = ["hack", "@@split(CARGO_RUSTDOC_HACK_FLAGS, )", "rustdoc", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_RUSTDOC_FLAGS, )", "${@}"]
 
-
 ################################################################################
 ## Tests                                                                      ##
 ################################################################################
+
 [tasks.test]
 category = "Test"
 description = "Runs the test suite"
@@ -170,10 +168,10 @@ extend = "cargo"
 args = ["hack", "@@split(CARGO_MIRI_HACK_FLAGS, )", "miri", "test", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_MIRI_FLAGS, )", "--all-features", "${@}"]
 dependencies = ["install-miri"]
 
-
 ################################################################################
 ## Tools                                                                      ##
 ################################################################################
+
 [tasks.install-clippy]
 private = true
 install_crate = { rustup_component_name = "clippy" }

--- a/.github/scripts/rust/Makefile.toml
+++ b/.github/scripts/rust/Makefile.toml
@@ -7,25 +7,33 @@ namespace = "default"
 
 [env]
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+
 CARGO_BUILD_FLAGS = "--workspace"
+
 CARGO_RUN_FLAGS = ""
+
 CARGO_FORMAT_FLAGS = ""
 CARGO_FORMAT_HACK_FLAGS = "--workspace"
+
 CARGO_CLIPPY_FLAGS = "--no-deps --tests"
 CARGO_CLIPPY_HACK_FLAGS = "--workspace --feature-powerset"
+
 CARGO_DOC_FLAGS = "--no-deps --all-features -Zunstable-options -Zrustdoc-scrape-examples=examples"
 CARGO_DOC_HACK_FLAGS = "--workspace"
+
 CARGO_RUSTDOC_FLAGS = "--all-features -Zunstable-options -Zrustdoc-scrape-examples=examples -- -Zunstable-options"
 CARGO_RUSTDOC_HACK_FLAGS = "--workspace"
+
 CARGO_TEST_FLAGS = ""
 CARGO_TEST_HACK_FLAGS = "--workspace --feature-powerset"
+
 CARGO_DOC_TEST_FLAGS = "--workspace --all-features"
+
 CARGO_MIRI_FLAGS = ""
 CARGO_MIRI_HACK_FLAGS = "--workspace"
 
 [env.production]
 CARGO_MAKE_CARGO_PROFILE = "release"
-
 
 [tasks.default]
 extend = "build"
@@ -35,8 +43,7 @@ category = ""
 description = "Builds the project, checks lints, and runs the tests."
 run_task = { name = ["build", "lint", "test"] }
 
-
-[tasks.task]
+[tasks.cargo]
 private = true
 command = "cargo"
 dependencies = ["install-cargo-hack"]
@@ -50,7 +57,7 @@ description = "Builds the crate"
 run_task = { name = "build-task" }
 
 [tasks.build-task]
-extend = "task"
+extend = "cargo"
 args = ["build", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_BUILD_FLAGS, )", "${@}"]
 
 
@@ -63,7 +70,7 @@ description = "Builds the binary and runs it"
 run_task = { name = "run-task" }
 
 [tasks.run-task]
-extend = "task"
+extend = "cargo"
 args = ["run", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_RUN_FLAGS, )", "${@}"]
 
 
@@ -82,7 +89,7 @@ description = "Runs the rustfmt formatter"
 run_task = { name = ["format-task"] }
 
 [tasks.format-task]
-extend = "task"
+extend = "cargo"
 args = ["hack", "@@split(CARGO_FORMAT_HACK_FLAGS, )", "fmt", "@@split(CARGO_FORMAT_FLAGS, )", "${@}"]
 dependencies = ["install-rustfmt"]
 
@@ -93,7 +100,7 @@ category = "Lint"
 run_task = { name = ["clippy-task"] }
 
 [tasks.clippy-task]
-extend = "task"
+extend = "cargo"
 args = ["hack", "@@split(CARGO_CLIPPY_HACK_FLAGS, )", "clippy", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_CLIPPY_FLAGS, )", "${@}"]
 dependencies = ["install-clippy"]
 
@@ -107,7 +114,7 @@ description = "Builds the documentation for the crate"
 run_task = { name = ["doc-task"] }
 
 [tasks.doc-task]
-extend = "task"
+extend = "cargo"
 args = ["hack", "@@split(CARGO_DOC_HACK_FLAGS, )", "doc", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_DOC_FLAGS, )", "${@}"]
 
 
@@ -117,7 +124,7 @@ description = "Builds the documentation for the crate"
 run_task = { name = ["rustdoc-task"] }
 
 [tasks.rustdoc-task]
-extend = "task"
+extend = "cargo"
 args = ["hack", "@@split(CARGO_RUSTDOC_HACK_FLAGS, )", "rustdoc", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_RUSTDOC_FLAGS, )", "${@}"]
 
 
@@ -134,12 +141,12 @@ private = true
 run_task = { name = ["test-task-lib", "test-task-doc"]}
 
 [tasks.test-task-lib]
-extend = "task"
+extend = "cargo"
 args = ["hack", "@@split(CARGO_TEST_HACK_FLAGS, )", "nextest", "run", "--cargo-profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_TEST_FLAGS, )", "${@}"]
 dependencies = ["install-cargo-nextest"]
 
 [tasks.test-task-doc]
-extend = "task"
+extend = "cargo"
 args = ["test", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_DOC_TEST_FLAGS, )", "--doc", "${@}"]
 
 
@@ -149,17 +156,17 @@ description = "Runs miri tests suite"
 run_task = { name = ["miri-task-no-features", "miri-task", "miri-task-all-features"] }
 
 [tasks.miri-task-no-features]
-extend = "task"
+extend = "cargo"
 args = ["hack", "@@split(CARGO_MIRI_HACK_FLAGS, )", "miri", "test", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_MIRI_FLAGS, )", "--no-default-features", "${@}"]
 dependencies = ["install-miri"]
 
 [tasks.miri-task]
-extend = "task"
+extend = "cargo"
 args = ["hack", "@@split(CARGO_MIRI_HACK_FLAGS, )", "miri", "test", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_MIRI_FLAGS, )", "${@}"]
 dependencies = ["install-miri"]
 
 [tasks.miri-task-all-features]
-extend = "task"
+extend = "cargo"
 args = ["hack", "@@split(CARGO_MIRI_HACK_FLAGS, )", "miri", "test", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_MIRI_FLAGS, )", "--all-features", "${@}"]
 dependencies = ["install-miri"]
 

--- a/.github/scripts/rust/Makefile.toml
+++ b/.github/scripts/rust/Makefile.toml
@@ -35,6 +35,10 @@ CARGO_MIRI_HACK_FLAGS = "--workspace"
 [env.production]
 CARGO_MAKE_CARGO_PROFILE = "release"
 
+################################################################################
+## General                                                                    ##
+################################################################################
+
 [tasks.default]
 extend = "build"
 category = ""
@@ -47,6 +51,14 @@ run_task = { name = ["build", "lint", "test"] }
 private = true
 command = "cargo"
 dependencies = ["install-cargo-hack"]
+
+[tasks.yarn]
+private = true
+command = "yarn"
+
+[tasks.docker]
+private = true
+command = "docker"
 
 ################################################################################
 ## Build                                                                      ##
@@ -147,7 +159,6 @@ dependencies = ["install-cargo-nextest"]
 extend = "cargo"
 args = ["test", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_DOC_TEST_FLAGS, )", "--doc", "${@}"]
 
-
 [tasks.miri]
 category = "Test"
 description = "Runs miri tests suite"
@@ -169,7 +180,7 @@ args = ["hack", "@@split(CARGO_MIRI_HACK_FLAGS, )", "miri", "test", "--profile",
 dependencies = ["install-miri"]
 
 ################################################################################
-## Tools                                                                      ##
+## Tool Installs                                                              ##
 ################################################################################
 
 [tasks.install-clippy]

--- a/packages/graph/Makefile.toml
+++ b/packages/graph/Makefile.toml
@@ -3,12 +3,12 @@ extend = { path = "../../.github/scripts/rust/Makefile.toml" }
 [tasks.touch-environment]
 private = true
 command = "touch"
-args = ["${CARGO_MAKE_WORKING_DIRECTORY}/../../.env.local"]
+args = ["${REPO_ROOT}/.env.local"]
 
 [tasks.yarn-install-migrations]
 description = "Installs the required yarn dependencies for the migrations"
 extend = "yarn"
-cwd = "${CARGO_MAKE_WORKING_DIRECTORY}/migrations"
+cwd = "${REPO_ROOT}/packages/graph/migrations"
 
 [tasks.recreate-db]
 run_task = { name = ["recreate-db-task", "migrate-up"] }
@@ -18,14 +18,14 @@ private = true
 description = "Recreates the database"
 extend = "yarn"
 args = ["graph:recreate-db"]
-cwd = "${CARGO_MAKE_WORKING_DIRECTORY}/migrations"
+cwd = "${REPO_ROOT}/packages/graph/migrations"
 
 [tasks.migrate-up]
 category = "Deploy"
 description = "Runs all migrations"
 extend = "yarn"
 args = ["graph:migrate", "up"]
-cwd = "${CARGO_MAKE_WORKING_DIRECTORY}/migrations"
+cwd = "${REPO_ROOT}/packages/graph/migrations"
 env_files = ["../.env"]
 
 [tasks.deployment-up]
@@ -33,21 +33,21 @@ category = "Deploy"
 description = "Spins up the deployment environment"
 extend = "docker"
 args = ["compose", "--env-file", "../.env", "up", "--wait"]
-cwd = "${CARGO_MAKE_WORKING_DIRECTORY}/deployment"
+cwd = "${REPO_ROOT}/packages/graph/deployment"
 
 [tasks.deployment-down]
 category = "Deploy"
 description = "Tears down the deployment environment"
 extend = "docker"
 args = ["compose", "--env-file", "../.env", "down"]
-cwd = "${CARGO_MAKE_WORKING_DIRECTORY}/deployment"
+cwd = "${REPO_ROOT}/packages/graph/deployment"
 
 [tasks.build-docker]
 category = "Deploy"
 description = "Spins up the Graph API as external service"
 extend = "yarn"
 args = ["external-services", "build", "graph", "${@}"]
-cwd = "${CARGO_MAKE_WORKING_DIRECTORY}/../../"
+cwd = "${REPO_ROOT}"
 env = { DOCKER_BUILDKIT = 1 }
 dependencies = ["touch-environment"]
 
@@ -56,7 +56,7 @@ category = "Deploy"
 description = "Spins up the Graph API as external service"
 extend = "yarn"
 args = ["external-services", "up", "--wait", "graph", "${@}"]
-cwd = "${CARGO_MAKE_WORKING_DIRECTORY}/../../"
+cwd = "${REPO_ROOT}"
 dependencies = ["touch-environment"]
 
 [tasks.graph-down]
@@ -64,7 +64,7 @@ category = "Deploy"
 description = "Tears down up the Graph API"
 extend = "yarn"
 args = ["external-services", "down", "${@}"]
-cwd = "${CARGO_MAKE_WORKING_DIRECTORY}/../../"
+cwd = "${REPO_ROOT}"
 
 [tasks.test-docker]
 run_task = { name = ["yarn-install-migrations", "graph-up", "test-rest-api", "graph-down"] }
@@ -72,4 +72,4 @@ run_task = { name = ["yarn-install-migrations", "graph-up", "test-rest-api", "gr
 [tasks.test-rest-api]
 # This is a temporary solution until we have e2e tests in place
 extend = "yarn"
-args = ["httpyac", "send", "--all", "${CARGO_MAKE_WORKING_DIRECTORY}/hash_graph/tests/rest-test.http", "${@}"]
+args = ["httpyac", "send", "--all", "${REPO_ROOT}/packages/graph/hash_graph/tests/rest-test.http", "${@}"]

--- a/packages/graph/Makefile.toml
+++ b/packages/graph/Makefile.toml
@@ -5,10 +5,9 @@ private = true
 command = "touch"
 args = ["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../../.env.local"]
 
-[tasks.yarn]
-category = "Deploy"
-description = "Installs the required dependencies"
-command = "yarn"
+[tasks.yarn-install-migrations]
+description = "Installs the required yarn dependencies for the migrations"
+extend = "yarn"
 cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/migrations"
 
 [tasks.recreate-db]
@@ -16,62 +15,61 @@ run_task = { name = ["recreate-db-task", "migrate-up"] }
 
 [tasks.recreate-db-task]
 private = true
-category = "Deploy"
 description = "Recreates the database"
+extend = "yarn"
 cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/migrations"
-command = "yarn"
 args = ["graph:recreate-db"]
 
 [tasks.migrate-up]
 category = "Deploy"
 description = "Runs all migrations"
+extend = "yarn"
 cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/migrations"
 env_files = ["../.env"]
-command = "yarn"
 args = ["graph:migrate", "up"]
 
 [tasks.deployment-up]
 category = "Deploy"
 description = "Spins up the deployment environment"
+extend = "docker"
 cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/deployment"
-command = "docker"
 args = ["compose", "--env-file", "../.env", "up", "--wait"]
 
 [tasks.deployment-down]
 category = "Deploy"
 description = "Tears down the deployment environment"
+extend = "docker"
 cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/deployment"
-command = "docker"
 args = ["compose", "--env-file", "../.env", "down"]
 
 [tasks.build-docker]
 category = "Deploy"
 description = "Spins up the Graph API as external service"
+extend = "yarn"
 cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../../"
 env = { DOCKER_BUILDKIT = 1 }
-command = "yarn"
 args = ["external-services", "build", "graph", "${@}"]
 dependencies = ["touch-environment"]
 
 [tasks.graph-up]
 category = "Deploy"
 description = "Spins up the Graph API as external service"
+extend = "yarn"
 cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../../"
-command = "yarn"
 args = ["external-services", "up", "--wait", "graph", "${@}"]
 dependencies = ["touch-environment"]
 
 [tasks.graph-down]
 category = "Deploy"
 description = "Tears down up the Graph API"
+extend = "yarn"
 cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../../"
-command = "yarn"
 args = ["external-services", "down", "${@}"]
 
 [tasks.test-docker]
-run_task = { name = ["yarn", "graph-up", "test-rest-api", "graph-down"] }
+run_task = { name = ["yarn-install-migrations", "graph-up", "test-rest-api", "graph-down"] }
 
 [tasks.test-rest-api]
 # This is a temporary solution until we have e2e tests in place
-command = "yarn"
+extend = "yarn"
 args = ["httpyac", "send", "--all", "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/hash_graph/tests/rest-test.http", "${@}"]

--- a/packages/graph/Makefile.toml
+++ b/packages/graph/Makefile.toml
@@ -29,6 +29,7 @@ cwd = "${REPO_ROOT}/packages/graph/migrations"
 env_files = ["../.env"]
 
 [tasks.deployment-up]
+private = false
 category = "Deploy"
 description = "Spins up the deployment environment"
 extend = "docker"
@@ -36,6 +37,7 @@ args = ["compose", "--env-file", "../.env", "up", "--wait"]
 cwd = "${REPO_ROOT}/packages/graph/deployment"
 
 [tasks.deployment-down]
+private = false
 category = "Deploy"
 description = "Tears down the deployment environment"
 extend = "docker"

--- a/packages/graph/Makefile.toml
+++ b/packages/graph/Makefile.toml
@@ -3,12 +3,12 @@ extend = { path = "../../.github/scripts/rust/Makefile.toml" }
 [tasks.touch-environment]
 private = true
 command = "touch"
-args = ["${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../../.env.local"]
+args = ["${CARGO_MAKE_WORKING_DIRECTORY}/../../.env.local"]
 
 [tasks.yarn-install-migrations]
 description = "Installs the required yarn dependencies for the migrations"
 extend = "yarn"
-cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/migrations"
+cwd = "${CARGO_MAKE_WORKING_DIRECTORY}/migrations"
 
 [tasks.recreate-db]
 run_task = { name = ["recreate-db-task", "migrate-up"] }
@@ -18,14 +18,14 @@ private = true
 description = "Recreates the database"
 extend = "yarn"
 args = ["graph:recreate-db"]
-cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/migrations"
+cwd = "${CARGO_MAKE_WORKING_DIRECTORY}/migrations"
 
 [tasks.migrate-up]
 category = "Deploy"
 description = "Runs all migrations"
 extend = "yarn"
 args = ["graph:migrate", "up"]
-cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/migrations"
+cwd = "${CARGO_MAKE_WORKING_DIRECTORY}/migrations"
 env_files = ["../.env"]
 
 [tasks.deployment-up]
@@ -33,21 +33,21 @@ category = "Deploy"
 description = "Spins up the deployment environment"
 extend = "docker"
 args = ["compose", "--env-file", "../.env", "up", "--wait"]
-cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/deployment"
+cwd = "${CARGO_MAKE_WORKING_DIRECTORY}/deployment"
 
 [tasks.deployment-down]
 category = "Deploy"
 description = "Tears down the deployment environment"
 extend = "docker"
 args = ["compose", "--env-file", "../.env", "down"]
-cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/deployment"
+cwd = "${CARGO_MAKE_WORKING_DIRECTORY}/deployment"
 
 [tasks.build-docker]
 category = "Deploy"
 description = "Spins up the Graph API as external service"
 extend = "yarn"
 args = ["external-services", "build", "graph", "${@}"]
-cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../../"
+cwd = "${CARGO_MAKE_WORKING_DIRECTORY}/../../"
 env = { DOCKER_BUILDKIT = 1 }
 dependencies = ["touch-environment"]
 
@@ -56,7 +56,7 @@ category = "Deploy"
 description = "Spins up the Graph API as external service"
 extend = "yarn"
 args = ["external-services", "up", "--wait", "graph", "${@}"]
-cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../../"
+cwd = "${CARGO_MAKE_WORKING_DIRECTORY}/../../"
 dependencies = ["touch-environment"]
 
 [tasks.graph-down]
@@ -64,7 +64,7 @@ category = "Deploy"
 description = "Tears down up the Graph API"
 extend = "yarn"
 args = ["external-services", "down", "${@}"]
-cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../../"
+cwd = "${CARGO_MAKE_WORKING_DIRECTORY}/../../"
 
 [tasks.test-docker]
 run_task = { name = ["yarn-install-migrations", "graph-up", "test-rest-api", "graph-down"] }
@@ -72,4 +72,4 @@ run_task = { name = ["yarn-install-migrations", "graph-up", "test-rest-api", "gr
 [tasks.test-rest-api]
 # This is a temporary solution until we have e2e tests in place
 extend = "yarn"
-args = ["httpyac", "send", "--all", "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/hash_graph/tests/rest-test.http", "${@}"]
+args = ["httpyac", "send", "--all", "${CARGO_MAKE_WORKING_DIRECTORY}/hash_graph/tests/rest-test.http", "${@}"]

--- a/packages/graph/Makefile.toml
+++ b/packages/graph/Makefile.toml
@@ -17,54 +17,54 @@ run_task = { name = ["recreate-db-task", "migrate-up"] }
 private = true
 description = "Recreates the database"
 extend = "yarn"
-cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/migrations"
 args = ["graph:recreate-db"]
+cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/migrations"
 
 [tasks.migrate-up]
 category = "Deploy"
 description = "Runs all migrations"
 extend = "yarn"
+args = ["graph:migrate", "up"]
 cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/migrations"
 env_files = ["../.env"]
-args = ["graph:migrate", "up"]
 
 [tasks.deployment-up]
 category = "Deploy"
 description = "Spins up the deployment environment"
 extend = "docker"
-cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/deployment"
 args = ["compose", "--env-file", "../.env", "up", "--wait"]
+cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/deployment"
 
 [tasks.deployment-down]
 category = "Deploy"
 description = "Tears down the deployment environment"
 extend = "docker"
-cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/deployment"
 args = ["compose", "--env-file", "../.env", "down"]
+cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/deployment"
 
 [tasks.build-docker]
 category = "Deploy"
 description = "Spins up the Graph API as external service"
 extend = "yarn"
+args = ["external-services", "build", "graph", "${@}"]
 cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../../"
 env = { DOCKER_BUILDKIT = 1 }
-args = ["external-services", "build", "graph", "${@}"]
 dependencies = ["touch-environment"]
 
 [tasks.graph-up]
 category = "Deploy"
 description = "Spins up the Graph API as external service"
 extend = "yarn"
-cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../../"
 args = ["external-services", "up", "--wait", "graph", "${@}"]
+cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../../"
 dependencies = ["touch-environment"]
 
 [tasks.graph-down]
 category = "Deploy"
 description = "Tears down up the Graph API"
 extend = "yarn"
-cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../../"
 args = ["external-services", "down", "${@}"]
+cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/../../"
 
 [tasks.test-docker]
 run_task = { name = ["yarn-install-migrations", "graph-up", "test-rest-api", "graph-down"] }

--- a/packages/graph/hash_graph/Makefile.toml
+++ b/packages/graph/hash_graph/Makefile.toml
@@ -12,7 +12,7 @@ CARGO_MAKE_CARGO_PROFILE = "production"
 
 [tasks.test]
 run_task = [
-    { name = ["test-task", "yarn", "deployment-up", "test-integration", "generate-openapi-client", "deployment-down"], condition = { env_true = ["CARGO_MAKE_CI"] } },
+    { name = ["test-task", "yarn-install-migrations", "deployment-up", "test-integration", "generate-openapi-client", "deployment-down"], condition = { env_true = ["CARGO_MAKE_CI"] } },
     { name = ["test-task"] }
 ]
 

--- a/packages/graph/hash_graph/Makefile.toml
+++ b/packages/graph/hash_graph/Makefile.toml
@@ -2,12 +2,13 @@ extend = { path = "../Makefile.toml" }
 
 [env]
 CARGO_CLIPPY_HACK_FLAGS = "--workspace --feature-powerset --optional-deps clap"
+
 CARGO_TEST_HACK_FLAGS = "--workspace --feature-powerset --optional-deps clap"
+
 RUST_LOG = "debug,hyper=warn"
 
 [env.production]
 CARGO_MAKE_CARGO_PROFILE = "production"
-
 
 [tasks.test]
 run_task = [
@@ -22,7 +23,7 @@ args = ["Miri is disabled as unsafe code is forbidden"]
 
 [tasks.test-integration]
 private = false
-extend = "task"
+extend = "cargo"
 args = ["nextest", "run", "--cargo-profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_TEST_FLAGS, )", "--workspace", "--test", "integration", "--profile", "integration", "${@}"]
 dependencies = ["install-cargo-nextest"]
 

--- a/packages/libs/error-stack/Makefile.toml
+++ b/packages/libs/error-stack/Makefile.toml
@@ -107,13 +107,13 @@ private = true
 run_task = { name = ['update-snapshots-task-lib', 'update-snapshots-task-doc'] }
 
 [tasks.update-snapshots-task-lib]
-extend = "task"
+extend = "cargo"
 args = ["hack", "@@split(CARGO_INSTA_TEST_HACK_FLAGS, )", "nextest", "run", "--cargo-profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_TEST_FLAGS, )", "@@split(CARGO_INSTA_TEST_FLAGS, )", "${@}"]
 env = { "INSTA_FORCE_PASS" = "1", "RUST_BACKTRACE" = "1", "INSTA_UPDATE" = "new" }
 
 [tasks.update-snapshots-task-doc]
 # only run on nightly, as backtraces are otherwise not included
 condition = { channels = ["nightly"] }
-extend = "task"
+extend = "cargo"
 args = ["test", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_DOC_TEST_FLAGS, )", "--doc", "${@}"]
 env = { "UPDATE_EXPECT" = "1", "RUST_BACKTRACE" = "1" }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Simply cleans up the make files a bit.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1200211978612931/1202840100810875/f) _(internal)_

## 🔍 What does this change?

- Renames `task` to `cargo`
- Introduces more of the tooling at the top level such as `docker` and `yarn`
- Refactors tasks to extend from the respective tooling
- Reworks the top level makefile formatting a little
- Re-orders attributes to be somewhat consistent, putting the command close to the args, the description at the top, etc.

## 📜 Does this require a change to the docs?

No, it should be functionally the same

## 🛡 What tests cover this?

- CI should be fairly comprehensive

## ❓ How to test this?

1.  Checkout the branch / view the deployment
1.  Run whatever `cargo make` commands you feel like
