### PR TITLE
Reorder changelog by importance

### DIFF
--- a/packages/libs/error-stack/CHANGELOG.md
+++ b/packages/libs/error-stack/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to `error-stack` will be documented in this file.
 
 ### Features
 
-- Support backtraces on non-nightly channels starting with 1.65.0-beta ([#1098](https://github.com/hashintel/hash/pull/1098))(https://github.com/hashintel/hash/pull/671))
+- Support backtraces on non-nightly channels starting with 1.65.0-beta ([#1098](https://github.com/hashintel/hash/pull/1098))
 - Add support for [`core::error::Error`](https://doc.rust-lang.org/nightly/core/error/trait.Error.html) on nightly ([#1038](https://github.com/hashintel/hash/pull/1038))
 - Add support for [`Error::provide()`](https://doc.rust-lang.org/nightly/core/error/trait.Error.html#method.provide) ([#904](https://github.com/hashintel/hash/pull/904))
 - New output for [Debug](https://doc.rust-lang.org/nightly/core/fmt/trait.Debug.html) ([#794](https://github.com/hashintel/hash/pull/794))

--- a/packages/libs/error-stack/CHANGELOG.md
+++ b/packages/libs/error-stack/CHANGELOG.md
@@ -11,28 +11,26 @@ All notable changes to `error-stack` will be documented in this file.
 
 ### Breaking Changes
 
-- Use `Provider` API from `core::any` ([#697](https://github.com/hashintel/hash/pull/697))
-- Hide `futures-core` feature ([#695](https://github.com/hashintel/hash/pull/695))
 - Set the MSRV to 1.63 ([#944](https://github.com/hashintel/hash/pull/944))
-- Move extension traits into `error_stack::ext` module ([#970](https://github.com/hashintel/hash/pull/970))
+- Use `Provider` API from `core::any` ([#697](https://github.com/hashintel/hash/pull/697))
+- Move helper structs for extension traits into the `error_stack::ext` module ([#970](https://github.com/hashintel/hash/pull/970))
+- Hide `futures-core` feature ([#695](https://github.com/hashintel/hash/pull/695))
 
 ### Features
 
-- Support backtraces on non-nightly channels starting with 1.65.0-beta ([#1098](https://github.com/hashintel/hash/pull/1098))
-- Implement [`Termination`](https://doc.rust-lang.org/stable/std/process/trait.Termination.html) for `Report` ([#671](https://github.com/hashintel/hash/pull/671))
+- Support backtraces on non-nightly channels starting with 1.65.0-beta ([#1098](https://github.com/hashintel/hash/pull/1098))(https://github.com/hashintel/hash/pull/671))
 - Add support for [`core::error::Error`](https://doc.rust-lang.org/nightly/core/error/trait.Error.html) on nightly ([#1038](https://github.com/hashintel/hash/pull/1038))
 - Add support for [`Error::provide()`](https://doc.rust-lang.org/nightly/core/error/trait.Error.html#method.provide) ([#904](https://github.com/hashintel/hash/pull/904))
-- Add compatibility for `anyhow` and `eyre` to convert their types into `Report` ([#763](https://github.com/hashintel/hash/pull/763))
-- Add support for related errors and multiple error sources ([#747](https://github.com/hashintel/hash/pull/747))
 - New output for [Debug](https://doc.rust-lang.org/nightly/core/fmt/trait.Debug.html) ([#794](https://github.com/hashintel/hash/pull/794))
 - New hook interface for [Debug](https://doc.rust-lang.org/nightly/core/fmt/trait.Debug.html) ([#794](https://github.com/hashintel/hash/pull/794))
+- Add support for related errors and multiple error sources ([#747](https://github.com/hashintel/hash/pull/747))
+- Add compatibility for `anyhow` and `eyre` to convert their types into `Report` ([#763](https://github.com/hashintel/hash/pull/763))
+- Implement [`Termination`](https://doc.rust-lang.org/stable/std/process/trait.Termination.html) for `Report` ([#671]
 - `Report::set_debug_hook` and `Report::set_display_hook` no longer return an error ([#794](https://github.com/hashintel/hash/pull/794))
 
 ### Deprecations
 
 - `IntoReport::report`: Use `IntoReport::into_report` instead ([#698](https://github.com/hashintel/hash/pull/698))
-- `Report::source`: Use `Report::sources` instead ([#747](https://github.com/hashintel/hash/pull/747))
-- `Report::source_mut`: Use `Report::sources_mut` instead ([#747](https://github.com/hashintel/hash/pull/747))
 - `Report::backtrace`: Use `Report::downcast_ref::<Backtrace>` (non-nightly), `Report::requested_ref::<Backtrace>` (nightly) instead ([#747](https://github.com/hashintel/hash/pull/747))
 - `Report::span_trace`: Use `Report::downcast_ref::<SpanTrace>` (non-nightly), `Report::requested_ref::<SpanTrace>` (nightly) instead ([#747](https://github.com/hashintel/hash/pull/747))
 - `Frame::source`: Use `Frame::sources` instead ([#747](https://github.com/hashintel/hash/pull/747))
@@ -42,7 +40,7 @@ All notable changes to `error-stack` will be documented in this file.
 
 ### Internal improvements
 
-- Greatly reduce the usage of `unsafe` code ([#774](https://github.com/hashintel/hash/pull/774))
+- Greatly reduce the amount of `unsafe` code ([#774](https://github.com/hashintel/hash/pull/774))
 
 ## [0.1.0](https://github.com/hashintel/hash/tree/d14efbc38559fc38d36e03ebdd499b44cb80c668/packages/libs/error-stack) - 2022-06-10
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`Report::source(_mut)` wasn't a public method, so it does not need to be shown in the changelog. Additionally, it's easier to read changelogs if they are ordered by the importance of the different items. I attempted to re-order the changelog to improve this

## 🎥  Demo

[Rendered](https://github.com/hashintel/hash/blob/td/error-stack/changelog-reorder/packages/libs/error-stack/CHANGELOG.md)