### PR TITLE
Deprecate usage of `accountId` in new model classes

### DIFF
--- a/packages/hash/api/src/auth/seed-dev-users.ts
+++ b/packages/hash/api/src/auth/seed-dev-users.ts
@@ -3,7 +3,6 @@ import { AxiosError } from "axios";
 
 import { GraphApi } from "../graph";
 import { UserModel } from "../model";
-import { workspaceAccountId } from "../model/util";
 import { createKratosIdentity } from "./ory-kratos";
 
 type DevelopmentUser = {
@@ -66,12 +65,10 @@ export const ensureDevUsersAreSeeded = async ({
       });
 
       user = await user.updateShortname(graphApi, {
-        updatedByAccountId: workspaceAccountId,
         updatedShortname: shortname,
       });
 
       user = await user.updatePreferredName(graphApi, {
-        updatedByAccountId: workspaceAccountId,
         updatedPreferredName: preferredName,
       });
     }

--- a/packages/hash/api/src/graphql/resolvers/entity/updateEntity.ts
+++ b/packages/hash/api/src/graphql/resolvers/entity/updateEntity.ts
@@ -31,7 +31,7 @@ export const updateEntity: ResolverFn<
     const propertiesToUpdate = properties.properties ?? properties;
     entity.properties = propertiesToUpdate;
     const updatePayload: UpdatePropertiesPayload = {
-      updatedByAccountId: user.accountId,
+      updatedByAccountId: user.entityId,
       properties: entity.properties,
     };
 

--- a/packages/hash/api/src/graphql/resolvers/entityType/createEntityType.ts
+++ b/packages/hash/api/src/graphql/resolvers/entityType/createEntityType.ts
@@ -18,7 +18,7 @@ export const deprecatedCreateEntityType: ResolverFn<
   dataSources.db.transaction(async (client) => {
     const entityType = await EntityType.create(client, {
       accountId,
-      createdByAccountId: user.accountId,
+      createdByAccountId: user.entityId,
       description: description ?? undefined,
       name,
       schema,

--- a/packages/hash/api/src/graphql/resolvers/entityType/updateEntityType.ts
+++ b/packages/hash/api/src/graphql/resolvers/entityType/updateEntityType.ts
@@ -26,7 +26,7 @@ export const deprecatedUpdateEntityType: ResolverFn<
     }
 
     await entityType.update(conn, {
-      updatedByAccountId: user.accountId,
+      updatedByAccountId: user.entityId,
       createdByAccountId: user.entityId,
       schema,
     });

--- a/packages/hash/api/src/graphql/resolvers/knowledge/model-mapping.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/model-mapping.ts
@@ -19,8 +19,8 @@ export const mapEntityModelToGQL = (
   entityType: mapEntityTypeModelToGQL(entityModel.entityTypeModel),
   entityTypeId: entityModel.entityTypeModel.schema.$id,
   entityVersionId: entityModel.version,
-  ownedById: entityModel.accountId,
-  accountId: entityModel.accountId,
+  ownedById: entityModel.ownedById,
+  accountId: entityModel.ownedById,
   properties: entityModel.properties,
 });
 

--- a/packages/hash/api/src/graphql/resolvers/knowledge/page/update-page-actions.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/page/update-page-actions.ts
@@ -16,7 +16,7 @@ export const createEntityWithPlaceholdersFn =
   (graphApi: GraphApi, placeholderResults: PlaceholderResultsMap) =>
   async (
     originalDefinition: KnowledgeEntityDefinition,
-    entityCreatedById: string,
+    entityOwnedById: string,
   ) => {
     const entityDefinition = produce(originalDefinition, (draft) => {
       if (draft.existingEntity) {
@@ -44,7 +44,7 @@ export const createEntityWithPlaceholdersFn =
     });
 
     return await EntityModel.createEntityWithLinks(graphApi, {
-      createdById: entityCreatedById,
+      ownedById: entityOwnedById,
       entityDefinition,
     });
   };
@@ -204,7 +204,7 @@ export const handleInsertNewBlock = async (
     } else if (blockComponentId) {
       block = await BlockModel.createBlock(graphApi, {
         blockData,
-        accountId: userModel.accountId,
+        ownedById: userModel.ownedById,
         componentId: blockComponentId,
       });
     } else {
@@ -240,7 +240,6 @@ export const handleSwapBlockData = async (
   },
 ): Promise<void> => {
   const {
-    userModel,
     swapBlockDataAction: { entityId },
   } = params;
 
@@ -252,15 +251,13 @@ export const handleSwapBlockData = async (
     throw new Error(`Block with entityId ${entityId} not found`);
   }
 
-  const { newEntityOwnedById, newEntityEntityId } = params.swapBlockDataAction;
+  const { newEntityEntityId } = params.swapBlockDataAction;
 
   const newBlockDataEntity = await EntityModel.getLatest(graphApi, {
     entityId: newEntityEntityId,
-    accountId: newEntityOwnedById,
   });
 
   await block.updateBlockDataEntity(graphApi, {
-    updatedById: userModel.accountId,
     newBlockDataEntity,
   });
 };
@@ -277,7 +274,7 @@ export const handleUpdateEntity = async (
     placeholderResults: PlaceholderResultsMap;
   },
 ): Promise<void> => {
-  const { userModel, action, placeholderResults } = params;
+  const { action, placeholderResults } = params;
 
   // If this entity ID is a placeholder, use that instead.
   let entityId = action.entityId;
@@ -286,7 +283,6 @@ export const handleUpdateEntity = async (
   }
 
   const entityModel = await EntityModel.getLatest(graphApi, {
-    accountId: action.ownedById,
     entityId,
   });
 
@@ -294,6 +290,5 @@ export const handleUpdateEntity = async (
     updatedProperties: Object.entries(action.properties).map(
       ([key, value]) => ({ propertyTypeBaseUri: key, value }),
     ),
-    updatedByAccountId: userModel.accountId,
   });
 };

--- a/packages/hash/api/src/graphql/resolvers/knowledge/page/update-page-contents.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/page/update-page-contents.ts
@@ -140,18 +140,17 @@ export const updateKnowledgePageContents: ResolverFn<
         await pageModel.insertBlock(graphApi, {
           block: insertedBlocks[insertCount]!,
           position: action.insertBlock.position,
-          insertedById: userModel.accountId,
         });
         insertCount += 1;
       } else if (action.moveBlock) {
         await pageModel.moveBlock(graphApi, {
           ...action.moveBlock,
-          movedById: userModel.accountId,
+          movedById: userModel.entityId,
         });
       } else if (action.removeBlock) {
         await pageModel.removeBlock(graphApi, {
           ...action.removeBlock,
-          removedById: userModel.accountId,
+          removedById: userModel.entityId,
           allowRemovingFinal: actions
             .slice(i + 1)
             .some((actionToFollow) => actionToFollow.insertBlock),

--- a/packages/hash/api/src/graphql/resolvers/link/createLink.ts
+++ b/packages/hash/api/src/graphql/resolvers/link/createLink.ts
@@ -36,7 +36,7 @@ export const createLink: ResolverFn<
     }
 
     const link = await source.createOutgoingLink(client, {
-      createdByAccountId: user.accountId,
+      createdByAccountId: user.entityId,
       stringifiedPath: linkInput.path,
       index: typeof linkInput.index === "number" ? linkInput.index : undefined,
       destination,

--- a/packages/hash/api/src/graphql/resolvers/link/deleteLink.ts
+++ b/packages/hash/api/src/graphql/resolvers/link/deleteLink.ts
@@ -20,7 +20,7 @@ export const deleteLink: ResolverFn<
     }
 
     await link.delete(client, {
-      deletedByAccountId: user.accountId,
+      deletedByAccountId: user.entityId,
     });
 
     return true;

--- a/packages/hash/api/src/graphql/resolvers/linkedAggregation/deleteLinkedAggregation.ts
+++ b/packages/hash/api/src/graphql/resolvers/linkedAggregation/deleteLinkedAggregation.ts
@@ -23,7 +23,7 @@ export const deleteLinkedAggregation: ResolverFn<
       throw new ApolloError(msg, "NOT_FOUND");
     }
 
-    await aggregation.delete(client, { deletedByAccountId: user.accountId });
+    await aggregation.delete(client, { deletedByAccountId: user.entityId });
 
     return true;
   });

--- a/packages/hash/api/src/graphql/resolvers/linkedAggregation/updateLinkedAggregationOperation.ts
+++ b/packages/hash/api/src/graphql/resolvers/linkedAggregation/updateLinkedAggregationOperation.ts
@@ -35,7 +35,7 @@ export const updateLinkedAggregationOperation: ResolverFn<
         itemsPerPage: updatedOperation.itemsPerPage ?? 10,
         pageNumber: updatedOperation.pageNumber ?? 1,
       },
-      updatedByAccountId: user.accountId,
+      updatedByAccountId: user.entityId,
     });
 
     return aggregation.toGQLLinkedAggregation(dataSources.db);

--- a/packages/hash/api/src/graphql/resolvers/middlewares/canAccessAccount.ts
+++ b/packages/hash/api/src/graphql/resolvers/middlewares/canAccessAccount.ts
@@ -11,7 +11,7 @@ import { ResolverMiddleware } from "./middlewareTypes";
 export const canAccessAccount: ResolverMiddleware<
   GraphQLContext,
   {
-    accountId: Scalars["ID"];
+    ownedById: Scalars["ID"];
   },
   LoggedInGraphQLContext
 > = (next) =>
@@ -21,11 +21,11 @@ export const canAccessAccount: ResolverMiddleware<
       dataSources: { graphApi },
     } = ctx;
     let isAllowed = false;
-    if (user.accountId === args.accountId) {
+    if (user.entityId === args.ownedById) {
       isAllowed = true;
     } else {
       isAllowed = await user.isMemberOfOrg(graphApi, {
-        orgEntityId: args.accountId,
+        orgEntityId: args.ownedById,
       });
     }
     if (!isAllowed) {

--- a/packages/hash/api/src/graphql/resolvers/ontology/data-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/data-type.ts
@@ -15,12 +15,12 @@ export const getAllLatestDataTypes: ResolverFn<
   {},
   LoggedInGraphQLContext,
   {}
-> = async (_, __, { dataSources, user }) => {
+> = async (_, __, { dataSources }) => {
   const { graphApi } = dataSources;
 
-  const allLatestDataTypeModels = await DataTypeModel.getAllLatest(graphApi, {
-    accountId: user.entityId,
-  }).catch((err: AxiosError) => {
+  const allLatestDataTypeModels = await DataTypeModel.getAllLatest(
+    graphApi,
+  ).catch((err: AxiosError) => {
     throw new ApolloError(
       `Unable to retrieve all latest data types. ${err.response?.data}`,
       "GET_ALL_ERROR",

--- a/packages/hash/api/src/graphql/resolvers/ontology/entity-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/entity-type.ts
@@ -32,7 +32,7 @@ export const createEntityType: ResolverFn<
   const { accountId, entityType } = params;
 
   const createdEntityTypeModel = await EntityTypeModel.create(graphApi, {
-    accountId: accountId ?? user.entityId,
+    ownedById: accountId ?? user.entityId,
     schema: entityType,
   }).catch((err) => {
     throw new ApolloError(err, "CREATION_ERROR");
@@ -46,13 +46,12 @@ export const getAllLatestEntityTypes: ResolverFn<
   {},
   LoggedInGraphQLContext,
   {}
-> = async (_, __, { dataSources, user }, info) => {
+> = async (_, __, { dataSources }, info) => {
   const { graphApi } = dataSources;
 
   const entityTypeRootedSubgraphs = await EntityTypeModel.getAllLatestResolved(
     graphApi,
     {
-      accountId: user.entityId,
       dataTypeQueryDepth: dataTypeQueryDepth(info),
       propertyTypeQueryDepth: propertyTypeQueryDepth(info),
       linkTypeQueryDepth: linkTypeQueryDepth(info),
@@ -97,9 +96,9 @@ export const updateEntityType: ResolverFn<
   {},
   LoggedInGraphQLContext,
   MutationUpdateEntityTypeArgs
-> = async (_, params, { dataSources, user }) => {
+> = async (_, params, { dataSources }) => {
   const { graphApi } = dataSources;
-  const { accountId, entityTypeVersionedUri, updatedEntityType } = params;
+  const { entityTypeVersionedUri, updatedEntityType } = params;
 
   const entityTypeModel = await EntityTypeModel.get(graphApi, {
     entityTypeId: entityTypeVersionedUri,
@@ -112,7 +111,6 @@ export const updateEntityType: ResolverFn<
 
   const updatedEntityTypeModel = await entityTypeModel
     .update(graphApi, {
-      accountId: accountId ?? user.entityId,
       schema: updatedEntityType,
     })
     .catch((err: AxiosError) => {

--- a/packages/hash/api/src/graphql/resolvers/ontology/link-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/link-type.ts
@@ -22,7 +22,7 @@ export const createLinkType: ResolverFn<
   const { accountId, linkType } = params;
 
   const createdLinkTypeModel = await LinkTypeModel.create(graphApi, {
-    accountId: accountId ?? user.entityId,
+    ownedById: accountId ?? user.entityId,
     schema: linkType,
   }).catch((err) => {
     throw new ApolloError(err, "CREATION_ERROR");
@@ -36,12 +36,12 @@ export const getAllLatestLinkTypes: ResolverFn<
   {},
   LoggedInGraphQLContext,
   {}
-> = async (_, __, { dataSources, user }) => {
+> = async (_, __, { dataSources }) => {
   const { graphApi } = dataSources;
 
-  const allLatestLinkTypeModels = await LinkTypeModel.getAllLatest(graphApi, {
-    accountId: user.entityId,
-  }).catch((err: AxiosError) => {
+  const allLatestLinkTypeModels = await LinkTypeModel.getAllLatest(
+    graphApi,
+  ).catch((err: AxiosError) => {
     throw new ApolloError(
       `Unable to retrieve all latest link types. ${err.response?.data}`,
       "GET_ALL_ERROR",
@@ -78,9 +78,9 @@ export const updateLinkType: ResolverFn<
   {},
   LoggedInGraphQLContext,
   MutationUpdateLinkTypeArgs
-> = async (_, params, { dataSources, user }) => {
+> = async (_, params, { dataSources }) => {
   const { graphApi } = dataSources;
-  const { accountId, linkTypeVersionedUri, updatedLinkType } = params;
+  const { linkTypeVersionedUri, updatedLinkType } = params;
 
   const linkTypeModel = await LinkTypeModel.get(graphApi, {
     linkTypeId: linkTypeVersionedUri,
@@ -93,7 +93,6 @@ export const updateLinkType: ResolverFn<
 
   const updatedLinkTypeModel = await linkTypeModel
     .update(graphApi, {
-      accountId: accountId ?? user.entityId,
       schema: updatedLinkType,
     })
     .catch((err: AxiosError) => {

--- a/packages/hash/api/src/graphql/resolvers/ontology/model-mapping.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/model-mapping.ts
@@ -16,7 +16,7 @@ import {
 export const mapDataTypeModelToGQL = (
   dataType: DataTypeModel,
 ): PersistedDataType => ({
-  accountId: dataType.accountId,
+  accountId: dataType.ownedById,
   dataTypeVersionedUri: dataType.schema.$id,
   dataType: dataType.schema,
 });
@@ -24,7 +24,7 @@ export const mapDataTypeModelToGQL = (
 export const mapPropertyTypeModelToGQL = (
   propertyType: PropertyTypeModel,
 ): PersistedPropertyType => ({
-  accountId: propertyType.accountId,
+  accountId: propertyType.ownedById,
   propertyTypeVersionedUri: propertyType.schema.$id,
   propertyType: propertyType.schema,
 });
@@ -38,7 +38,7 @@ export const mapPropertyTypeRootedSubgraphToGQL = ({
   referencedDataTypes: DataTypeModel[];
   referencedPropertyTypes: PropertyTypeModel[];
 }): PropertyTypeRootedSubgraph => ({
-  accountId: propertyType.accountId,
+  accountId: propertyType.ownedById,
   propertyTypeVersionedUri: propertyType.schema.$id,
   propertyType: propertyType.schema,
   referencedDataTypes: referencedDataTypes.map(mapDataTypeModelToGQL),
@@ -50,7 +50,7 @@ export const mapPropertyTypeRootedSubgraphToGQL = ({
 export const mapLinkTypeModelToGQL = (
   linkType: LinkTypeModel,
 ): PersistedLinkType => ({
-  accountId: linkType.accountId,
+  accountId: linkType.ownedById,
   linkTypeVersionedUri: linkType.schema.$id,
   linkType: linkType.schema,
 });
@@ -58,7 +58,7 @@ export const mapLinkTypeModelToGQL = (
 export const mapEntityTypeModelToGQL = (
   entityType: EntityTypeModel,
 ): PersistedEntityType => ({
-  accountId: entityType.accountId,
+  accountId: entityType.ownedById,
   entityTypeVersionedUri: entityType.schema.$id,
   entityType: entityType.schema,
 });
@@ -70,7 +70,7 @@ export const mapEntityTypeRootedSubgraphToGQL = (params: {
   referencedLinkTypes: LinkTypeModel[];
   referencedEntityTypes: EntityTypeModel[];
 }): EntityTypeRootedSubgraph => ({
-  accountId: params.entityType.accountId,
+  accountId: params.entityType.ownedById,
   entityTypeVersionedUri: params.entityType.schema.$id,
   entityType: params.entityType.schema,
   referencedDataTypes: params.referencedDataTypes.map(mapDataTypeModelToGQL),

--- a/packages/hash/api/src/graphql/resolvers/ontology/model-mapping.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/model-mapping.ts
@@ -16,6 +16,7 @@ import {
 export const mapDataTypeModelToGQL = (
   dataType: DataTypeModel,
 ): PersistedDataType => ({
+  ownedById: dataType.ownedById,
   accountId: dataType.ownedById,
   dataTypeVersionedUri: dataType.schema.$id,
   dataType: dataType.schema,
@@ -24,6 +25,7 @@ export const mapDataTypeModelToGQL = (
 export const mapPropertyTypeModelToGQL = (
   propertyType: PropertyTypeModel,
 ): PersistedPropertyType => ({
+  ownedById: propertyType.ownedById,
   accountId: propertyType.ownedById,
   propertyTypeVersionedUri: propertyType.schema.$id,
   propertyType: propertyType.schema,
@@ -38,6 +40,7 @@ export const mapPropertyTypeRootedSubgraphToGQL = ({
   referencedDataTypes: DataTypeModel[];
   referencedPropertyTypes: PropertyTypeModel[];
 }): PropertyTypeRootedSubgraph => ({
+  ownedById: propertyType.ownedById,
   accountId: propertyType.ownedById,
   propertyTypeVersionedUri: propertyType.schema.$id,
   propertyType: propertyType.schema,
@@ -50,6 +53,7 @@ export const mapPropertyTypeRootedSubgraphToGQL = ({
 export const mapLinkTypeModelToGQL = (
   linkType: LinkTypeModel,
 ): PersistedLinkType => ({
+  ownedById: linkType.ownedById,
   accountId: linkType.ownedById,
   linkTypeVersionedUri: linkType.schema.$id,
   linkType: linkType.schema,
@@ -58,6 +62,7 @@ export const mapLinkTypeModelToGQL = (
 export const mapEntityTypeModelToGQL = (
   entityType: EntityTypeModel,
 ): PersistedEntityType => ({
+  ownedById: entityType.ownedById,
   accountId: entityType.ownedById,
   entityTypeVersionedUri: entityType.schema.$id,
   entityType: entityType.schema,
@@ -70,6 +75,7 @@ export const mapEntityTypeRootedSubgraphToGQL = (params: {
   referencedLinkTypes: LinkTypeModel[];
   referencedEntityTypes: EntityTypeModel[];
 }): EntityTypeRootedSubgraph => ({
+  ownedById: params.entityType.ownedById,
   accountId: params.entityType.ownedById,
   entityTypeVersionedUri: params.entityType.schema.$id,
   entityType: params.entityType.schema,

--- a/packages/hash/api/src/graphql/resolvers/ontology/property-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/property-type.ts
@@ -27,7 +27,7 @@ export const createPropertyType: ResolverFn<
   const { accountId, propertyType } = params;
 
   const createdPropertyTypeModel = await PropertyTypeModel.create(graphApi, {
-    accountId: accountId ?? user.entityId,
+    ownedById: accountId ?? user.entityId,
     schema: propertyType,
   }).catch((err) => {
     throw new ApolloError(err, "CREATION_ERROR");
@@ -41,12 +41,11 @@ export const getAllLatestPropertyTypes: ResolverFn<
   {},
   LoggedInGraphQLContext,
   {}
-> = async (_, __, { dataSources, user }, info) => {
+> = async (_, __, { dataSources }, info) => {
   const { graphApi } = dataSources;
 
   const propertyTypeRootedSubgraphs =
     await PropertyTypeModel.getAllLatestResolved(graphApi, {
-      accountId: user.entityId,
       dataTypeQueryDepth: dataTypeQueryDepth(info),
       propertyTypeQueryDepth: propertyTypeQueryDepth(info),
     }).catch((err: AxiosError) => {
@@ -89,9 +88,9 @@ export const updatePropertyType: ResolverFn<
   {},
   LoggedInGraphQLContext,
   MutationUpdatePropertyTypeArgs
-> = async (_, params, { dataSources, user }) => {
+> = async (_, params, { dataSources }) => {
   const { graphApi } = dataSources;
-  const { accountId, propertyTypeVersionedUri, updatedPropertyType } = params;
+  const { propertyTypeVersionedUri, updatedPropertyType } = params;
 
   const propertyTypeModel = await PropertyTypeModel.get(graphApi, {
     propertyTypeId: propertyTypeVersionedUri,
@@ -104,7 +103,6 @@ export const updatePropertyType: ResolverFn<
 
   const updatedPropertyTypeModel = await propertyTypeModel
     .update(graphApi, {
-      accountId: accountId ?? user.entityId,
       schema: updatedPropertyType,
     })
     .catch((err: AxiosError) => {

--- a/packages/hash/api/src/graphql/resolvers/pages/setParentPage.ts
+++ b/packages/hash/api/src/graphql/resolvers/pages/setParentPage.ts
@@ -54,7 +54,7 @@ export const setParentPage: ResolverFn<
 
     await pageEntity.setParentPage(client, {
       parentPage,
-      setByAccountId: user.accountId,
+      setByAccountId: user.entityId,
       prevIndex,
       nextIndex,
     });

--- a/packages/hash/api/src/graphql/resolvers/pages/updatePage.ts
+++ b/packages/hash/api/src/graphql/resolvers/pages/updatePage.ts
@@ -29,7 +29,7 @@ export const updatePage: ResolverFn<
         ...(entity.properties ?? {}),
         ...properties,
       },
-      updatedByAccountId: user.accountId,
+      updatedByAccountId: user.entityId,
     });
 
     // @todo: for now, all entities are non-versioned, so the array only has a single

--- a/packages/hash/api/src/graphql/resolvers/pages/updatePageContents.ts
+++ b/packages/hash/api/src/graphql/resolvers/pages/updatePageContents.ts
@@ -145,7 +145,7 @@ export const updatePageContents: ResolverFn<
               placeholderId,
               await EntityType.create(client, {
                 accountId: entityTypeAccountId,
-                createdByAccountId: user.accountId,
+                createdByAccountId: user.entityId,
                 description: description ?? undefined,
                 name,
                 schema,
@@ -236,7 +236,7 @@ export const updatePageContents: ResolverFn<
                 blockData,
                 createdBy:
                   user as any /** @todo: replace with updated model class */,
-                accountId: user.accountId,
+                accountId: user.entityId,
                 properties: {
                   componentId: blockComponentId,
                 },
@@ -281,7 +281,7 @@ export const updatePageContents: ResolverFn<
           return await block.swapBlockData(client, {
             targetDataAccountId: swapBlockData.newEntityAccountId,
             targetDataEntityId: swapBlockData.newEntityEntityId,
-            updatedByAccountId: user.accountId,
+            updatedByAccountId: user.entityId,
           });
         }),
     );
@@ -306,7 +306,7 @@ export const updatePageContents: ResolverFn<
                 }
               },
             ),
-            updatedByAccountId: user.accountId,
+            updatedByAccountId: user.entityId,
           });
         }),
     );
@@ -330,18 +330,18 @@ export const updatePageContents: ResolverFn<
           await page.insertBlock(client, {
             block: insertedBlocks[insertCount]!,
             position: action.insertBlock.position,
-            insertedByAccountId: user.accountId,
+            insertedByAccountId: user.entityId,
           });
           insertCount += 1;
         } else if (action.moveBlock) {
           await page.moveBlock(client, {
             ...action.moveBlock,
-            movedByAccountId: user.accountId,
+            movedByAccountId: user.entityId,
           });
         } else if (action.removeBlock) {
           await page.removeBlock(client, {
             ...action.removeBlock,
-            removedByAccountId: user.accountId,
+            removedByAccountId: user.entityId,
             allowRemovingFinal: actions
               .slice(i + 1)
               .some((actionToFollow) => actionToFollow.insertBlock),

--- a/packages/hash/api/src/graphql/resolvers/taskExecutor/index.ts
+++ b/packages/hash/api/src/graphql/resolvers/taskExecutor/index.ts
@@ -188,8 +188,8 @@ export const executeGithubReadTask: ResolverFn<
         /** @todo - check primary key to see if entity already exists */
         // Insert the entity
         const entity = await Entity.create(db, {
-          accountId: user.accountId,
-          createdByAccountId: user.accountId,
+          accountId: user.entityId,
+          createdByAccountId: user.entityId,
           versioned: true,
           entityTypeId,
           properties: record.data,

--- a/packages/hash/api/src/graphql/resolvers/user/accountSignupComplete.ts
+++ b/packages/hash/api/src/graphql/resolvers/user/accountSignupComplete.ts
@@ -9,7 +9,7 @@ export const accountSignupComplete: ResolverFn<
   GraphQLContext,
   {}
 > = async ({ entityId }, _, { dataSources: { graphApi } }) => {
-  const userModel = await UserModel.getUserByEntityId(graphApi, { entityId });
+  const userModel = await UserModel.getUserById(graphApi, { entityId });
 
   if (!userModel) {
     const msg = `User with entityId ${entityId} not found in graph`;

--- a/packages/hash/api/src/graphql/resolvers/user/linkedEntities.ts
+++ b/packages/hash/api/src/graphql/resolvers/user/linkedEntities.ts
@@ -10,7 +10,7 @@ export const memberOf: ResolverFn<
   GraphQLContext,
   {}
 > = async ({ entityId }, _, { dataSources: { graphApi } }) => {
-  const user = await UserModel.getUserByEntityId(graphApi, { entityId });
+  const user = await UserModel.getUserById(graphApi, { entityId });
 
   if (!user) {
     const msg = `User with entityId ${entityId} not found in graph`;

--- a/packages/hash/api/src/graphql/resolvers/user/updateUser.ts
+++ b/packages/hash/api/src/graphql/resolvers/user/updateUser.ts
@@ -67,7 +67,6 @@ export const updateUser: ResolverFn<
     await validateShortname(graphApi, shortname);
 
     updatedUser = await updatedUser.updateShortname(graphApi, {
-      updatedByAccountId: user.accountId,
       updatedShortname: shortname,
     });
   }
@@ -85,7 +84,6 @@ export const updateUser: ResolverFn<
     }
 
     updatedUser = await updatedUser.updatePreferredName(graphApi, {
-      updatedByAccountId: user.accountId,
       updatedPreferredName: preferredName,
     });
   }

--- a/packages/hash/api/src/graphql/typeDefs/ontology/data-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/data-type.typedef.ts
@@ -10,9 +10,14 @@ export const dataTypeTypedef = gql`
     """
     dataTypeVersionedUri: String!
     """
-    The user who created the data type
+    The id of the account that owns this data type.
+    """
+    ownedById: ID!
+    """
+    Alias of ownedById - the id of the account that owns this data type.
     """
     accountId: ID!
+      @deprecated(reason: "accountId is deprecated. Use ownedById instead.")
     """
     The data type
     """

--- a/packages/hash/api/src/graphql/typeDefs/ontology/entity-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/entity-type.typedef.ts
@@ -19,9 +19,14 @@ export const entityTypeTypedef = gql`
     """
     entityTypeVersionedUri: String!
     """
-    The user who created the entity type
+    The id of the account that owns this entity type.
+    """
+    ownedById: ID!
+    """
+    Alias of ownedById - the id of the account that owns this entity type.
     """
     accountId: ID!
+      @deprecated(reason: "accountId is deprecated. Use ownedById instead.")
     """
     The entity type
     """
@@ -35,9 +40,14 @@ export const entityTypeTypedef = gql`
     """
     entityTypeVersionedUri: String!
     """
-    The user who created the entity type
+    The id of the account that owns this entity type.
+    """
+    ownedById: ID!
+    """
+    Alias of ownedById - the id of the account that owns this entity type.
     """
     accountId: ID!
+      @deprecated(reason: "accountId is deprecated. Use ownedById instead.")
     """
     The entity type
     """
@@ -69,9 +79,14 @@ export const entityTypeTypedef = gql`
     """
     entityTypeVersionedUri: String!
     """
-    The user who created the entity type
+    The id of the account that owns this entity type.
+    """
+    ownedById: ID!
+    """
+    Alias of ownedById - the id of the account that owns this entity type.
     """
     accountId: ID!
+      @deprecated(reason: "accountId is deprecated. Use ownedById instead.")
     """
     The entity type
     """

--- a/packages/hash/api/src/graphql/typeDefs/ontology/link-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/link-type.typedef.ts
@@ -10,9 +10,14 @@ export const linkTypeTypedef = gql`
     """
     linkTypeVersionedUri: String!
     """
-    The user who created the link type
+    The id of the account that owns this link type.
+    """
+    ownedById: ID!
+    """
+    Alias of ownedById - the id of the account that owns this link type.
     """
     accountId: ID!
+      @deprecated(reason: "accountId is deprecated. Use ownedById instead.")
     """
     The link type
     """

--- a/packages/hash/api/src/graphql/typeDefs/ontology/property-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/property-type.typedef.ts
@@ -19,9 +19,14 @@ export const propertyTypeTypedef = gql`
     """
     propertyTypeVersionedUri: String!
     """
-    The user who created the property type
+    The id of the account that owns this property type.
+    """
+    ownedById: ID!
+    """
+    Alias of ownedById - the id of the account that owns this property type.
     """
     accountId: ID!
+      @deprecated(reason: "accountId is deprecated. Use ownedById instead.")
     """
     The property type
     """
@@ -35,9 +40,14 @@ export const propertyTypeTypedef = gql`
     """
     propertyTypeVersionedUri: String!
     """
-    The user who created the property type
+    The id of the account that owns this property type.
+    """
+    ownedById: ID!
+    """
+    Alias of ownedById - the id of the account that owns this property type.
     """
     accountId: ID!
+      @deprecated(reason: "accountId is deprecated. Use ownedById instead.")
     """
     The property type
     """
@@ -61,9 +71,14 @@ export const propertyTypeTypedef = gql`
     """
     propertyTypeVersionedUri: String!
     """
-    The user who created the property type
+    The id of the account that owns this property type.
+    """
+    ownedById: ID!
+    """
+    Alias of ownedById - the id of the account that owns this property type.
     """
     accountId: ID!
+      @deprecated(reason: "accountId is deprecated. Use ownedById instead.")
     """
     The property type
     """

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -316,7 +316,7 @@ export default class {
     } = await graphApi.updateEntity({
       /**
        * @todo: let caller update who owns the entity, or create new method dedicated to changing the owner of the entity
-       * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
+       * @see https://app.asana.com/0/1202805690238892/1203063463721793/f
        *
        * @todo: replace uses of `accountId` with `ownedById` in the Graph API
        * @see https://app.asana.com/0/1202805690238892/1203063463721791/f

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -20,7 +20,7 @@ import {
 import { exactlyOne, linkedTreeFlatten } from "../../util";
 
 export type EntityModelConstructorParams = {
-  accountId: string;
+  ownedById: string;
   entityId: string;
   version: string;
   entityTypeModel: EntityTypeModel;
@@ -28,7 +28,7 @@ export type EntityModelConstructorParams = {
 };
 
 export type EntityModelCreateParams = {
-  accountId: string;
+  ownedById: string;
   properties: object;
   entityTypeModel: EntityTypeModel;
   entityId?: string;
@@ -38,7 +38,7 @@ export type EntityModelCreateParams = {
  * @class {@link EntityModel}
  */
 export default class {
-  accountId: string;
+  ownedById: string;
 
   entityId: string;
   version: string;
@@ -46,13 +46,13 @@ export default class {
   properties: object;
 
   constructor({
-    accountId,
+    ownedById,
     entityId,
     version,
     entityTypeModel,
     properties,
   }: EntityModelConstructorParams) {
-    this.accountId = accountId;
+    this.ownedById = ownedById;
 
     this.entityId = entityId;
     this.version = version;
@@ -65,7 +65,7 @@ export default class {
     { identifier, inner, entityTypeId }: PersistedEntity,
     cachedEntityTypeModels?: Map<string, EntityTypeModel>,
   ): Promise<EntityModel> {
-    const { ownedById: accountId, version } = identifier;
+    const { ownedById, entityId, version } = identifier;
     const cachedEntityTypeModel = cachedEntityTypeModels?.get(entityTypeId);
 
     let entityTypeModel: EntityTypeModel;
@@ -80,8 +80,8 @@ export default class {
     }
 
     return new EntityModel({
-      accountId,
-      entityId: identifier.entityId,
+      ownedById,
+      entityId,
       version,
       entityTypeModel,
       properties: inner,
@@ -91,13 +91,13 @@ export default class {
   /**
    * Create an entity.
    *
-   * @param params.accountId the accountId of the account creating the entity
+   * @param params.ownedById the id of the owner of the entiy
    * @param params.schema an `Entity`
    */
   static async create(
     graphApi: GraphApi,
     {
-      accountId,
+      ownedById,
       entityTypeModel,
       properties,
       entityId: overrideEntityId,
@@ -106,14 +106,14 @@ export default class {
     const {
       data: { entityId, version },
     } = await graphApi.createEntity({
-      accountId,
+      accountId: ownedById,
       entityTypeId: entityTypeModel.schema.$id,
       entity: properties,
       entityId: overrideEntityId,
     });
 
     return new EntityModel({
-      accountId,
+      ownedById,
       entityId,
       version,
       entityTypeModel,
@@ -124,17 +124,17 @@ export default class {
   /**
    * Create an entity along with any new/existing entities specified through links.
    *
-   * @param params.createdById the account id that is creating the entity
+   * @param params.ownedById the id of owner of the entity
    * @param params.entityDefinition the definition of how to get or create the entity optionally with linked entities
    */
   static async createEntityWithLinks(
     graphApi: GraphApi,
     params: {
-      createdById: string;
+      ownedById: string;
       entityDefinition: KnowledgeEntityDefinition;
     },
   ): Promise<EntityModel> {
-    const { createdById, entityDefinition } = params;
+    const { ownedById, entityDefinition } = params;
 
     const entitiesInTree = linkedTreeFlatten<
       KnowledgeEntityDefinition,
@@ -158,7 +158,7 @@ export default class {
             }
           : undefined,
         entity: await EntityModel.getOrCreate(graphApi, {
-          createdById,
+          ownedById,
           entityDefinition: definition,
         }),
       })),
@@ -191,7 +191,7 @@ export default class {
             linkTypeModel,
             targetEntityModel: entity,
             index: link.meta.index ?? undefined,
-            createdById,
+            ownedById,
           });
         }
       }),
@@ -204,17 +204,17 @@ export default class {
    * Get or create an entity given either by new entity properties or a reference
    * to an existing entity.
    *
-   * @param params.createdById the account id that is creating the entity
+   * @param params.ownedById the id of owner of the entity
    * @param params.entityDefinition the definition of how to get or create the entity (excluding any linked entities)
    */
   static async getOrCreate(
     graphApi: GraphApi,
     params: {
-      createdById: string;
+      ownedById: string;
       entityDefinition: Omit<KnowledgeEntityDefinition, "linkedEntities">;
     },
   ): Promise<EntityModel> {
-    const { entityDefinition } = params;
+    const { entityDefinition, ownedById } = params;
     const { entityProperties, existingEntity } = entityDefinition;
 
     let entity;
@@ -222,7 +222,6 @@ export default class {
     if (existingEntity) {
       entity = await EntityModel.getLatest(graphApi, {
         entityId: existingEntity.entityId,
-        accountId: existingEntity.ownedById,
       });
       if (!entity) {
         throw new ApolloError(
@@ -246,7 +245,7 @@ export default class {
       });
 
       entity = await EntityModel.create(graphApi, {
-        accountId: params.createdById,
+        ownedById,
         entityTypeModel,
         properties: entityProperties,
       });
@@ -284,13 +283,11 @@ export default class {
   /**
    * Get the latest version of an entity by its entity ID.
    *
-   * @param params.accountId the accountId of the account requesting the entity
    * @param params.versionedUri the unique versioned URI for an entity.
    */
   static async getLatest(
     graphApi: GraphApi,
     params: {
-      accountId?: string;
       entityId: string;
     },
   ): Promise<EntityModel> {
@@ -303,23 +300,22 @@ export default class {
   /**
    * Update an entity.
    *
-   * @param params.accountId the accountId of the account making the update
    * @param params.schema an `Entity`
    */
   async update(
     graphApi: GraphApi,
     params: {
-      accountId: string;
       properties: object;
     },
   ): Promise<EntityModel> {
-    const { accountId, properties } = params;
-    const { entityId, entityTypeModel } = this;
+    const { properties } = params;
+    const { ownedById, entityId, entityTypeModel } = this;
 
     const {
       data: { version },
     } = await graphApi.updateEntity({
-      accountId,
+      /** @todo: let caller update who owns the entity, or create new method dedicated to changing the owner of the entity */
+      accountId: ownedById,
       entityId,
       /** @todo: make this argument optional */
       entityTypeId: entityTypeModel.schema.$id,
@@ -327,7 +323,7 @@ export default class {
     });
 
     return new EntityModel({
-      accountId,
+      ownedById,
       entityId,
       version,
       entityTypeModel,
@@ -339,20 +335,17 @@ export default class {
    * Update multiple top-level properties on an entity.
    *
    * @param params.updatedProperties - an array of the properties being updated
-   * @param params.updatedByAccountId - the account id of the account updating the property value
    * @returns
    */
   async updateProperties(
     graphApi: GraphApi,
     params: {
-      updatedByAccountId: string;
       updatedProperties: { propertyTypeBaseUri: string; value: any }[];
     },
   ): Promise<EntityModel> {
-    const { updatedProperties, updatedByAccountId } = params;
+    const { updatedProperties } = params;
 
     return await this.update(graphApi, {
-      accountId: updatedByAccountId,
       properties: updatedProperties.reduce(
         (prev, { propertyTypeBaseUri, value }) => ({
           ...prev,
@@ -368,29 +361,28 @@ export default class {
    *
    * @param params.propertyTypeBaseUri - the property type base URI of the property being updated
    * @param params.value - the updated value of the property
-   * @param params.updatedByAccountId - the account id of the account updating the property value
-   * @returns
    */
   async updateProperty(
     graphApi: GraphApi,
     params: {
       propertyTypeBaseUri: string;
       value: any;
-      updatedByAccountId: string;
     },
   ): Promise<EntityModel> {
-    const { updatedByAccountId, propertyTypeBaseUri, value } = params;
+    const { propertyTypeBaseUri, value } = params;
 
     return await this.updateProperties(graphApi, {
-      updatedByAccountId,
       updatedProperties: [{ propertyTypeBaseUri, value }],
     });
   }
 
+  /**
+   * Get the latest version of this entity.
+   */
   async getLatestVersion(graphApi: GraphApi) {
-    const { accountId, entityId } = this;
+    const { entityId } = this;
 
-    return await EntityModel.getLatest(graphApi, { accountId, entityId });
+    return await EntityModel.getLatest(graphApi, { entityId });
   }
 
   /** @see {@link LinkModel.create} */

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -91,7 +91,7 @@ export default class {
   /**
    * Create an entity.
    *
-   * @param params.ownedById the id of the owner of the entiy
+   * @param params.ownedById the id of the owner of the entity
    * @param params.schema an `Entity`
    */
   static async create(
@@ -314,7 +314,13 @@ export default class {
     const {
       data: { version },
     } = await graphApi.updateEntity({
-      /** @todo: let caller update who owns the entity, or create new method dedicated to changing the owner of the entity */
+      /**
+       * @todo: let caller update who owns the entity, or create new method dedicated to changing the owner of the entity
+       * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
+       *
+       * @todo: replace uses of `accountId` with `ownedById` in the Graph API
+       * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
+       */
       accountId: ownedById,
       entityId,
       /** @todo: make this argument optional */

--- a/packages/hash/api/src/model/knowledge/page.model.ts
+++ b/packages/hash/api/src/model/knowledge/page.model.ts
@@ -57,12 +57,14 @@ export default class extends EntityModel {
    * Create a workspace page entity.
    *
    * @param params.title - the title of the page
+   *
+   * @see {@link EntityModel.create} for the remaining params
    */
   static async createPage(
     graphApi: GraphApi,
     params: PageModelCreateParams,
   ): Promise<PageModel> {
-    const { title, summary, prevIndex, accountId } = params;
+    const { title, summary, prevIndex, ownedById } = params;
 
     const index = generateKeyBetween(prevIndex ?? null, null);
 
@@ -75,7 +77,7 @@ export default class extends EntityModel {
     const entityTypeModel = WORKSPACE_TYPES.entityType.page;
 
     const entity = await EntityModel.create(graphApi, {
-      accountId,
+      ownedById,
       properties,
       entityTypeModel,
     });
@@ -87,10 +89,10 @@ export default class extends EntityModel {
         ? params.initialBlocks
         : [
             await BlockModel.createBlock(graphApi, {
-              accountId,
+              ownedById,
               componentId: "https://blockprotocol.org/blocks/@hash/paragraph",
               blockData: await EntityModel.create(graphApi, {
-                accountId,
+                ownedById,
                 properties: {
                   [WORKSPACE_TYPES.propertyType.tokens.baseUri]: [],
                 },
@@ -100,10 +102,7 @@ export default class extends EntityModel {
           ];
 
     for (const block of initialBlocks) {
-      await page.insertBlock(graphApi, {
-        block,
-        insertedById: accountId,
-      });
+      await page.insertBlock(graphApi, { block });
     }
 
     return page;
@@ -137,7 +136,7 @@ export default class extends EntityModel {
        * @todo: filter the pages by their ownedById in the query instead once it's supported
        * @see https://app.asana.com/0/1202805690238892/1203015527055374/f
        */
-      .filter(({ accountId }) => accountId === params.accountModel.entityId)
+      .filter(({ ownedById }) => ownedById === params.accountModel.entityId)
       .map(PageModel.fromEntityModel);
 
     return await Promise.all(
@@ -207,7 +206,7 @@ export default class extends EntityModel {
 
     if (unexpectedParentPageLinks.length > 0) {
       throw new Error(
-        `Critical: Page with entityId ${this.entityId} in account ${this.accountId} has more than one parent page`,
+        `Critical: Page with entityId ${this.entityId} in account ${this.ownedById} has more than one parent page`,
       );
     }
 
@@ -267,13 +266,13 @@ export default class extends EntityModel {
 
     if (unexpectedParentPageLinks.length > 0) {
       throw new Error(
-        `Critical: Page with entityId ${this.entityId} in account ${this.accountId} has more than one parent page`,
+        `Critical: Page with entityId ${this.entityId} in account ${this.ownedById} has more than one parent page`,
       );
     }
 
     if (!parentPageLink) {
       throw new Error(
-        `Page with entityId ${this.entityId} in account ${this.accountId} does not have a parent page`,
+        `Page with entityId ${this.entityId} in account ${this.ownedById} does not have a parent page`,
       );
     }
 
@@ -323,7 +322,7 @@ export default class extends EntityModel {
       await this.createOutgoingLink(graphApi, {
         linkTypeModel: WORKSPACE_TYPES.linkType.parent,
         targetEntityModel: parentPage,
-        createdById: setById,
+        ownedById: setById,
       });
     }
 
@@ -331,7 +330,6 @@ export default class extends EntityModel {
       await this.updateProperty(graphApi, {
         propertyTypeBaseUri: WORKSPACE_TYPES.propertyType.index.baseUri,
         value: newIndex,
-        updatedByAccountId: this.accountId,
       });
     }
   }
@@ -365,20 +363,18 @@ export default class extends EntityModel {
    * Insert a block into this page
    *
    * @param params.block - the block to insert in the page
-   * @param params.insertedById - the account that is inserting the block
    * @param params.position (optional) - the position of the block in the page
    */
   async insertBlock(
     graphApi: GraphApi,
     params: {
       block: BlockModel;
-      insertedById: string;
       position?: number;
     },
   ) {
     const { position: specifiedPosition } = params;
 
-    const { block, insertedById } = params;
+    const { block } = params;
 
     await this.createOutgoingLink(graphApi, {
       targetEntityModel: block,
@@ -387,7 +383,8 @@ export default class extends EntityModel {
         specifiedPosition ??
         // if position is not specified and there are no blocks currently in the page, specify the index of the link is `0`
         ((await this.getBlocks(graphApi)).length === 0 ? 0 : undefined),
-      createdById: insertedById,
+      // assume that link to block is owned by the same account as the page
+      ownedById: this.ownedById,
     });
   }
 
@@ -396,7 +393,7 @@ export default class extends EntityModel {
    *
    * @param params.currentPosition - the current position of the block being moved
    * @param params.newPosition - the new position of the block being moved
-   * @param params.movedById (optional) - the account that is moving the block
+   * @param params.movedById - the id of the user that is moving the block
    */
   async moveBlock(
     graphApi: GraphApi,
@@ -425,7 +422,7 @@ export default class extends EntityModel {
 
     if (!link) {
       throw new Error(
-        `Critical: could not find contents link with index ${currentPosition} for page with entityId ${this.entityId} in account ${this.accountId}`,
+        `Critical: could not find contents link with index ${currentPosition} for page with entityId ${this.entityId} in account ${this.ownedById}`,
       );
     }
 
@@ -441,7 +438,7 @@ export default class extends EntityModel {
    * Remove a block from the page.
    *
    * @param params.position - the position of the block being removed
-   * @param params.removedById - the account that is removing the block
+   * @param params.removedById - the id of the user that is removing the block
    * @param params.allowRemovingFinal (optional) - whether or not removing the final block in the page should be permitted (defaults to `true`)
    */
   async removeBlock(
@@ -466,7 +463,7 @@ export default class extends EntityModel {
 
     if (!link) {
       throw new Error(
-        `Critical: could not find contents link with index ${position} for page with entityId ${this.entityId} in account ${this.accountId}`,
+        `Critical: could not find contents link with index ${position} for page with entityId ${this.entityId} in account ${this.ownedById}`,
       );
     }
 

--- a/packages/hash/api/src/model/ontology/data-type.model.ts
+++ b/packages/hash/api/src/model/ontology/data-type.model.ts
@@ -166,7 +166,7 @@ export default class {
     const updateArguments: UpdateDataTypeRequest = {
       /**
        * @todo: let caller update who owns the type, or create new method dedicated to changing the owner of the type
-       * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
+       * @see https://app.asana.com/0/1202805690238892/1203063463721793/f
        *
        * @todo: replace uses of `accountId` with `ownedById` in the Graph API
        * @see https://app.asana.com/0/1202805690238892/1203063463721791/f

--- a/packages/hash/api/src/model/ontology/data-type.model.ts
+++ b/packages/hash/api/src/model/ontology/data-type.model.ts
@@ -78,8 +78,8 @@ export default class {
       params.accountId === workspaceAccountId
         ? WORKSPACE_ACCOUNT_SHORTNAME
         : (
-            await UserModel.getUserByAccountId(graphApi, {
-              accountId: params.accountId,
+            await UserModel.getUserById(graphApi, {
+              entityId: params.accountId,
             })
           )?.getShortname();
 

--- a/packages/hash/api/src/model/ontology/data-type.model.ts
+++ b/packages/hash/api/src/model/ontology/data-type.model.ts
@@ -6,10 +6,10 @@ import {
   UpdateDataTypeRequest,
 } from "@hashintel/hash-graph-client";
 import { DataType } from "@blockprotocol/type-system-web";
-import { WORKSPACE_ACCOUNT_SHORTNAME } from "@hashintel/hash-backend-utils/system";
 
-import { DataTypeModel, UserModel } from "../index";
-import { generateTypeId, workspaceAccountId } from "../util";
+import { DataTypeModel } from "../index";
+import { generateTypeId } from "../util";
+import { getNamespaceOfAccountOwner } from "./util";
 
 type DataTypeModelConstructorArgs = {
   ownedById: string;
@@ -73,20 +73,9 @@ export default class {
         Record<string, any>;
     },
   ): Promise<DataTypeModel> {
-    /** @todo - get rid of this hack for the root account */
-    const namespace =
-      params.ownedById === workspaceAccountId
-        ? WORKSPACE_ACCOUNT_SHORTNAME
-        : /** @todo: account for types with an org as its owner */
-          (
-            await UserModel.getUserById(graphApi, {
-              entityId: params.ownedById,
-            })
-          )?.getShortname();
-
-    if (namespace == null) {
-      throw new Error(`failed to get namespace for owner: ${params.ownedById}`);
-    }
+    const namespace = await getNamespaceOfAccountOwner(graphApi, {
+      ownerId: params.ownedById,
+    });
 
     const dataTypeUri = generateTypeId({
       namespace,

--- a/packages/hash/api/src/model/ontology/data-type.model.ts
+++ b/packages/hash/api/src/model/ontology/data-type.model.ts
@@ -88,7 +88,7 @@ export default class {
       .createDataType({
         /**
          * @todo: replace uses of `accountId` with `ownedById` in the Graph API
-         * @see [ADD ASANA LINK]
+         * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
          */
         accountId: params.ownedById,
         schema: fullDataType,
@@ -166,9 +166,10 @@ export default class {
     const updateArguments: UpdateDataTypeRequest = {
       /**
        * @todo: let caller update who owns the type, or create new method dedicated to changing the owner of the type
+       * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
        *
        * @todo: replace uses of `accountId` with `ownedById` in the Graph API
-       * @see [ADD ASANA LINK]
+       * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
        */
       accountId: this.ownedById,
       typeToUpdate: this.schema.$id,

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -279,7 +279,7 @@ export default class {
     const updateArguments: UpdateEntityTypeRequest = {
       /**
        * @todo: let caller update who owns the type, or create new method dedicated to changing the owner of the type
-       * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
+       * @see https://app.asana.com/0/1202805690238892/1203063463721793/f
        *
        * @todo: replace uses of `accountId` with `ownedById` in the Graph API
        * @see https://app.asana.com/0/1202805690238892/1203063463721791/f

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -87,7 +87,7 @@ export default class {
       .createEntityType({
         /**
          * @todo: replace uses of `accountId` with `ownedById` in the Graph API
-         * @see [ADD ASANA LINK]
+         * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
          */
         accountId: params.ownedById,
         schema: fullEntityType,
@@ -279,9 +279,10 @@ export default class {
     const updateArguments: UpdateEntityTypeRequest = {
       /**
        * @todo: let caller update who owns the type, or create new method dedicated to changing the owner of the type
+       * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
        *
        * @todo: replace uses of `accountId` with `ownedById` in the Graph API
-       * @see [ADD ASANA LINK]
+       * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
        */
       accountId: this.ownedById,
       typeToUpdate: this.schema.$id,

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -6,18 +6,17 @@ import {
   PersistedEntityType,
   UpdateEntityTypeRequest,
 } from "@hashintel/hash-graph-client";
-import { WORKSPACE_ACCOUNT_SHORTNAME } from "@hashintel/hash-backend-utils/system";
 
 import {
   EntityTypeModel,
   PropertyTypeModel,
   LinkTypeModel,
-  UserModel,
   DataTypeModel,
 } from "../index";
-import { generateTypeId, workspaceAccountId } from "../util";
+import { generateTypeId } from "../util";
 import dataTypeModel from "./data-type.model";
 import linkTypeModel from "./link-type.model";
+import { getNamespaceOfAccountOwner } from "./util";
 
 export type EntityTypeModelConstructorParams = {
   ownedById: string;
@@ -73,21 +72,9 @@ export default class {
     graphApi: GraphApi,
     params: EntityTypeModelCreateParams,
   ): Promise<EntityTypeModel> {
-    /** @todo - get rid of this hack for the root account */
-    const namespace =
-      params.ownedById === workspaceAccountId
-        ? WORKSPACE_ACCOUNT_SHORTNAME
-        : (
-            await UserModel.getUserById(graphApi, {
-              entityId: params.ownedById,
-            })
-          )?.getShortname();
-
-    if (namespace == null) {
-      throw new Error(
-        `failed to get namespace for account: ${params.ownedById}`,
-      );
-    }
+    const namespace = await getNamespaceOfAccountOwner(graphApi, {
+      ownerId: params.ownedById,
+    });
 
     const entityTypeId = generateTypeId({
       namespace,

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -78,8 +78,8 @@ export default class {
       params.accountId === workspaceAccountId
         ? WORKSPACE_ACCOUNT_SHORTNAME
         : (
-            await UserModel.getUserByAccountId(graphApi, {
-              accountId: params.accountId,
+            await UserModel.getUserById(graphApi, {
+              entityId: params.accountId,
             })
           )?.getShortname();
 

--- a/packages/hash/api/src/model/ontology/link-type.model.ts
+++ b/packages/hash/api/src/model/ontology/link-type.model.ts
@@ -78,7 +78,7 @@ export default class {
       .createLinkType({
         /**
          * @todo: replace uses of `accountId` with `ownedById` in the Graph API
-         * @see [ADD ASANA LINK]
+         * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
          */
         accountId: params.ownedById,
         schema: fullLinkType,
@@ -144,9 +144,10 @@ export default class {
     const updateArguments: UpdateLinkTypeRequest = {
       /**
        * @todo: let caller update who owns the type, or create new method dedicated to changing the owner of the type
+       * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
        *
        * @todo: replace uses of `accountId` with `ownedById` in the Graph API
-       * @see [ADD ASANA LINK]
+       * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
        */
       accountId: this.ownedById,
       typeToUpdate: this.schema.$id,

--- a/packages/hash/api/src/model/ontology/link-type.model.ts
+++ b/packages/hash/api/src/model/ontology/link-type.model.ts
@@ -6,10 +6,10 @@ import {
   PersistedLinkType,
   UpdateLinkTypeRequest,
 } from "@hashintel/hash-graph-client";
-import { WORKSPACE_ACCOUNT_SHORTNAME } from "@hashintel/hash-backend-utils/system";
 
-import { LinkTypeModel, UserModel } from "../index";
-import { generateTypeId, workspaceAccountId } from "../util";
+import { LinkTypeModel } from "../index";
+import { generateTypeId } from "../util";
+import { getNamespaceOfAccountOwner } from "./util";
 
 type LinkTypeModelConstructorParams = {
   ownedById: string;
@@ -63,21 +63,9 @@ export default class {
       schema: Omit<LinkType, "$id">;
     },
   ): Promise<LinkTypeModel> {
-    /** @todo - get rid of this hack for the root account */
-    const namespace =
-      params.ownedById === workspaceAccountId
-        ? WORKSPACE_ACCOUNT_SHORTNAME
-        : (
-            await UserModel.getUserById(graphApi, {
-              entityId: params.ownedById,
-            })
-          )?.getShortname();
-
-    if (namespace == null) {
-      throw new Error(
-        `failed to get namespace for account: ${params.ownedById}`,
-      );
-    }
+    const namespace = await getNamespaceOfAccountOwner(graphApi, {
+      ownerId: params.ownedById,
+    });
 
     const linkTypeId = generateTypeId({
       namespace,

--- a/packages/hash/api/src/model/ontology/link-type.model.ts
+++ b/packages/hash/api/src/model/ontology/link-type.model.ts
@@ -144,7 +144,7 @@ export default class {
     const updateArguments: UpdateLinkTypeRequest = {
       /**
        * @todo: let caller update who owns the type, or create new method dedicated to changing the owner of the type
-       * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
+       * @see https://app.asana.com/0/1202805690238892/1203063463721793/f
        *
        * @todo: replace uses of `accountId` with `ownedById` in the Graph API
        * @see https://app.asana.com/0/1202805690238892/1203063463721791/f

--- a/packages/hash/api/src/model/ontology/link-type.model.ts
+++ b/packages/hash/api/src/model/ontology/link-type.model.ts
@@ -68,8 +68,8 @@ export default class {
       params.accountId === workspaceAccountId
         ? WORKSPACE_ACCOUNT_SHORTNAME
         : (
-            await UserModel.getUserByAccountId(graphApi, {
-              accountId: params.accountId,
+            await UserModel.getUserById(graphApi, {
+              entityId: params.accountId,
             })
           )?.getShortname();
 

--- a/packages/hash/api/src/model/ontology/property-type.model.ts
+++ b/packages/hash/api/src/model/ontology/property-type.model.ts
@@ -238,7 +238,7 @@ export default class {
     const updateArguments: UpdatePropertyTypeRequest = {
       /**
        * @todo: let caller update who owns the type, or create new method dedicated to changing the owner of the type
-       * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
+       * @see https://app.asana.com/0/1202805690238892/1203063463721793/f
        *
        * @todo: replace uses of `accountId` with `ownedById` in the Graph API
        * @see https://app.asana.com/0/1202805690238892/1203063463721791/f

--- a/packages/hash/api/src/model/ontology/property-type.model.ts
+++ b/packages/hash/api/src/model/ontology/property-type.model.ts
@@ -6,10 +6,10 @@ import {
   PersistedPropertyType,
   UpdatePropertyTypeRequest,
 } from "@hashintel/hash-graph-client";
-import { WORKSPACE_ACCOUNT_SHORTNAME } from "@hashintel/hash-backend-utils/system";
 
-import { DataTypeModel, PropertyTypeModel, UserModel } from "../index";
-import { extractBaseUri, generateTypeId, workspaceAccountId } from "../util";
+import { DataTypeModel, PropertyTypeModel } from "../index";
+import { extractBaseUri, generateTypeId } from "../util";
+import { getNamespaceOfAccountOwner } from "./util";
 
 type PropertyTypeModelConstructorParams = {
   ownedById: string;
@@ -63,21 +63,9 @@ export default class {
       schema: Omit<PropertyType, "$id">;
     },
   ): Promise<PropertyTypeModel> {
-    /** @todo - get rid of this hack for the root account */
-    const namespace =
-      params.ownedById === workspaceAccountId
-        ? WORKSPACE_ACCOUNT_SHORTNAME
-        : (
-            await UserModel.getUserById(graphApi, {
-              entityId: params.ownedById,
-            })
-          )?.getShortname();
-
-    if (namespace == null) {
-      throw new Error(
-        `failed to get namespace for account: ${params.ownedById}`,
-      );
-    }
+    const namespace = await getNamespaceOfAccountOwner(graphApi, {
+      ownerId: params.ownedById,
+    });
 
     const propertyTypeId = generateTypeId({
       namespace,

--- a/packages/hash/api/src/model/ontology/property-type.model.ts
+++ b/packages/hash/api/src/model/ontology/property-type.model.ts
@@ -78,7 +78,7 @@ export default class {
       .createPropertyType({
         /**
          * @todo: replace uses of `accountId` with `ownedById` in the Graph API
-         * @see [ADD ASANA LINK]
+         * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
          */
         accountId: params.ownedById,
         schema: fullPropertyType,
@@ -238,9 +238,10 @@ export default class {
     const updateArguments: UpdatePropertyTypeRequest = {
       /**
        * @todo: let caller update who owns the type, or create new method dedicated to changing the owner of the type
+       * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
        *
        * @todo: replace uses of `accountId` with `ownedById` in the Graph API
-       * @see [ADD ASANA LINK]
+       * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
        */
       accountId: this.ownedById,
       typeToUpdate: this.schema.$id,

--- a/packages/hash/api/src/model/ontology/property-type.model.ts
+++ b/packages/hash/api/src/model/ontology/property-type.model.ts
@@ -68,8 +68,8 @@ export default class {
       params.accountId === workspaceAccountId
         ? WORKSPACE_ACCOUNT_SHORTNAME
         : (
-            await UserModel.getUserByAccountId(graphApi, {
-              accountId: params.accountId,
+            await UserModel.getUserById(graphApi, {
+              entityId: params.accountId,
             })
           )?.getShortname();
 

--- a/packages/hash/api/src/model/ontology/util.ts
+++ b/packages/hash/api/src/model/ontology/util.ts
@@ -1,0 +1,33 @@
+import { WORKSPACE_ACCOUNT_SHORTNAME } from "@hashintel/hash-backend-utils/system";
+import { OrgModel, UserModel } from "..";
+import { GraphApi } from "../../graph";
+import { workspaceAccountId } from "../util";
+
+/**
+ * Get the namespace of an account owner by its id
+ *
+ * @param params.ownerId - the id of the owner
+ */
+export const getNamespaceOfAccountOwner = async (
+  graphApi: GraphApi,
+  params: { ownerId: string },
+) => {
+  /** @todo - get rid of this hack for the root account */
+  const namespace =
+    params.ownerId === workspaceAccountId
+      ? WORKSPACE_ACCOUNT_SHORTNAME
+      : (
+          (await UserModel.getUserById(graphApi, {
+            entityId: params.ownerId,
+          }).catch(() => undefined)) ??
+          (await OrgModel.getOrgById(graphApi, {
+            entityId: params.ownerId,
+          }).catch(() => undefined))
+        )?.getShortname();
+
+  if (!namespace) {
+    throw new Error(`failed to get namespace for owner: ${params.ownerId}`);
+  }
+
+  return namespace;
+};

--- a/packages/hash/api/src/model/util.ts
+++ b/packages/hash/api/src/model/util.ts
@@ -250,7 +250,7 @@ export const propertyTypeInitializer = (
         if (error.response?.status === 404) {
           // The type was missing, try and create it
           return await PropertyTypeModel.create(graphApi, {
-            accountId: workspaceAccountId,
+            ownedById: workspaceAccountId,
             schema: propertyType,
           }).catch((createError: AxiosError) => {
             logger.warn(`Failed to create property type: ${params.title}`);
@@ -411,7 +411,7 @@ export const entityTypeInitializer = (
         if (error.response?.status === 404) {
           // The type was missing, try and create it
           return await EntityTypeModel.create(graphApi, {
-            accountId: workspaceAccountId,
+            ownedById: workspaceAccountId,
             schema: entityType,
           }).catch((createError: AxiosError) => {
             logger.warn(`Failed to create entity type: ${params.title}`);
@@ -492,7 +492,7 @@ export const linkTypeInitializer = (
         if (error.response?.status === 404) {
           // The type was missing, try and create it
           return await LinkTypeModel.create(graphApi, {
-            accountId: workspaceAccountId,
+            ownedById: workspaceAccountId,
             schema: linkType,
           }).catch((createError: AxiosError) => {
             logger.warn(`Failed to create link type: ${params.title}`);

--- a/packages/hash/api/src/task-execution/index.ts
+++ b/packages/hash/api/src/task-execution/index.ts
@@ -65,7 +65,7 @@ export const connectToTaskExecutor = (config: Config) => {
 export const CachedEntityTypes = async (db: DbAdapter, user: UserModel) => {
   const streamsWithEntityTypes: Map<string, string> = new Map();
   const dbTypes = await db.getAccountEntityTypes({
-    accountId: user.accountId,
+    accountId: user.entityId,
   });
 
   return {
@@ -85,8 +85,8 @@ export const CachedEntityTypes = async (db: DbAdapter, user: UserModel) => {
     createNew: async (entityTypeName: string, jsonSchema?: JsonObject) => {
       const { entityId } = await EntityType.create(db, {
         /** @todo should this be a param on the graphql endpoint */
-        accountId: user.accountId,
-        createdByAccountId: user.accountId,
+        accountId: user.entityId,
+        createdByAccountId: user.entityId,
         description: undefined,
         name: entityTypeName,
         schema: jsonSchema,

--- a/packages/hash/integration/src/tests/model/knowledge/block.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/block.model.test.ts
@@ -58,7 +58,7 @@ describe("Block model class", () => {
     });
 
     testBlockDataEntity = await EntityModel.create(graphApi, {
-      accountId: testUser.entityId,
+      ownedById: testUser.entityId,
       properties: {},
       entityTypeModel: dummyEntityType,
     });
@@ -66,7 +66,7 @@ describe("Block model class", () => {
 
   it("can create a Block", async () => {
     testBlock = await BlockModel.createBlock(graphApi, {
-      accountId: testUser.entityId,
+      ownedById: testUser.entityId,
       componentId: testBlockComponentId,
       blockData: testBlockDataEntity,
     });
@@ -90,7 +90,7 @@ describe("Block model class", () => {
 
   it("can update the block data entity", async () => {
     const newBlockDataEntity = await EntityModel.create(graphApi, {
-      accountId: testUser.entityId,
+      ownedById: testUser.entityId,
       properties: {},
       entityTypeModel: dummyEntityType,
     });
@@ -99,7 +99,6 @@ describe("Block model class", () => {
     expect(await testBlock.getBlockData(graphApi)).toEqual(testBlockDataEntity);
 
     await testBlock.updateBlockDataEntity(graphApi, {
-      updatedById: testUser.entityId,
       newBlockDataEntity,
     });
 
@@ -111,7 +110,6 @@ describe("Block model class", () => {
 
     await expect(
       testBlock.updateBlockDataEntity(graphApi, {
-        updatedById: testUser.entityId,
         newBlockDataEntity: currentDataEntity,
       }),
     ).rejects.toThrow(/already has a linked block data entity with entity id/);

--- a/packages/hash/integration/src/tests/model/knowledge/block.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/block.model.test.ts
@@ -48,7 +48,7 @@ describe("Block model class", () => {
      * once the exact role of the block data entity's entity type is known.
      */
     dummyEntityType = await EntityTypeModel.create(graphApi, {
-      accountId: testUser.entityId,
+      ownedById: testUser.entityId,
       schema: generateWorkspaceEntityTypeSchema({
         namespace: testUser.getShortname()!,
         title: "Dummy",

--- a/packages/hash/integration/src/tests/model/knowledge/entity.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/entity.model.test.ts
@@ -29,7 +29,7 @@ const graphApi = createGraphClient(logger, {
 });
 
 describe("Entity CRU", () => {
-  let accountId: string;
+  let ownedById: string;
   let entityTypeModel: EntityTypeModel;
   let textDataTypeModel: DataTypeModel;
   let namePropertyTypeModel: PropertyTypeModel;
@@ -39,10 +39,10 @@ describe("Entity CRU", () => {
   beforeAll(async () => {
     const testUser = await createTestUser(graphApi, "entitytest", logger);
 
-    accountId = testUser.entityId;
+    ownedById = testUser.entityId;
 
     textDataTypeModel = await DataTypeModel.create(graphApi, {
-      accountId,
+      accountId: ownedById,
       schema: {
         kind: "dataType",
         title: "Text",
@@ -55,7 +55,7 @@ describe("Entity CRU", () => {
 
     await Promise.all([
       LinkTypeModel.create(graphApi, {
-        accountId,
+        accountId: ownedById,
         schema: {
           kind: "linkType",
           title: "Friends",
@@ -72,7 +72,7 @@ describe("Entity CRU", () => {
         }),
 
       PropertyTypeModel.create(graphApi, {
-        accountId,
+        accountId: ownedById,
         schema: {
           kind: "propertyType",
           title: "Favorite Book",
@@ -88,7 +88,7 @@ describe("Entity CRU", () => {
           throw err;
         }),
       PropertyTypeModel.create(graphApi, {
-        accountId,
+        accountId: ownedById,
         schema: {
           kind: "propertyType",
           title: "Name",
@@ -106,7 +106,7 @@ describe("Entity CRU", () => {
     ]);
 
     entityTypeModel = await EntityTypeModel.create(graphApi, {
-      accountId,
+      accountId: ownedById,
       schema: generateWorkspaceEntityTypeSchema({
         namespace: testUser.getShortname()!,
         title: "Person",
@@ -129,7 +129,7 @@ describe("Entity CRU", () => {
   let createdEntityModel: EntityModel;
   it("can create an entity", async () => {
     createdEntityModel = await EntityModel.create(graphApi, {
-      accountId,
+      ownedById,
       properties: {
         [namePropertyTypeModel.baseUri]: "Bob",
         [favoriteBookPropertyTypeModel.baseUri]: "some text",
@@ -140,7 +140,6 @@ describe("Entity CRU", () => {
 
   it("can read an entity", async () => {
     const fetchedEntityModel = await EntityModel.getLatest(graphApi, {
-      accountId,
       entityId: createdEntityModel.entityId,
     });
 
@@ -152,7 +151,6 @@ describe("Entity CRU", () => {
   it("can update an entity", async () => {
     updatedEntityModel = await createdEntityModel
       .update(graphApi, {
-        accountId,
         properties: {
           [namePropertyTypeModel.baseUri]: "Updated Bob",
           [favoriteBookPropertyTypeModel.baseUri]: "Even more text than before",
@@ -166,7 +164,7 @@ describe("Entity CRU", () => {
       await EntityModel.getByQuery(graphApi, {
         all: [{ eq: [{ path: ["version"] }, { literal: "latest" }] }],
       })
-    ).filter((entity) => entity.accountId === accountId);
+    ).filter((entity) => entity.ownedById === ownedById);
 
     const newlyUpdatedModel = allEntityModels.find(
       (ent) => ent.entityId === updatedEntityModel.entityId,
@@ -189,7 +187,7 @@ describe("Entity CRU", () => {
 
   it("can create entity with linked entities from an entity definition", async () => {
     const aliceEntityModel = await EntityModel.createEntityWithLinks(graphApi, {
-      createdById: accountId,
+      ownedById,
       entityDefinition: {
         // First create a new entity given the following definition
         entityType: {
@@ -202,13 +200,13 @@ describe("Entity CRU", () => {
         linkedEntities: [
           {
             // Then create an entity + link
-            destinationAccountId: accountId,
+            destinationAccountId: ownedById,
             linkTypeId: linkTypeFriend.schema.$id,
             entity: {
               // The "new" entity is in fact just an existing entity, so only a link will be created.
               existingEntity: {
                 entityId: updatedEntityModel.entityId,
-                ownedById: updatedEntityModel.accountId,
+                ownedById: updatedEntityModel.ownedById,
               },
             },
           },

--- a/packages/hash/integration/src/tests/model/knowledge/entity.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/entity.model.test.ts
@@ -42,7 +42,7 @@ describe("Entity CRU", () => {
     ownedById = testUser.entityId;
 
     textDataTypeModel = await DataTypeModel.create(graphApi, {
-      accountId: ownedById,
+      ownedById,
       schema: {
         kind: "dataType",
         title: "Text",
@@ -55,7 +55,7 @@ describe("Entity CRU", () => {
 
     await Promise.all([
       LinkTypeModel.create(graphApi, {
-        accountId: ownedById,
+        ownedById,
         schema: {
           kind: "linkType",
           title: "Friends",
@@ -72,7 +72,7 @@ describe("Entity CRU", () => {
         }),
 
       PropertyTypeModel.create(graphApi, {
-        accountId: ownedById,
+        ownedById,
         schema: {
           kind: "propertyType",
           title: "Favorite Book",
@@ -88,7 +88,7 @@ describe("Entity CRU", () => {
           throw err;
         }),
       PropertyTypeModel.create(graphApi, {
-        accountId: ownedById,
+        ownedById,
         schema: {
           kind: "propertyType",
           title: "Name",
@@ -106,7 +106,7 @@ describe("Entity CRU", () => {
     ]);
 
     entityTypeModel = await EntityTypeModel.create(graphApi, {
-      accountId: ownedById,
+      ownedById,
       schema: generateWorkspaceEntityTypeSchema({
         namespace: testUser.getShortname()!,
         title: "Person",

--- a/packages/hash/integration/src/tests/model/knowledge/link.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/link.model.test.ts
@@ -33,7 +33,7 @@ const graphApi = createGraphClient(logger, {
 describe("Link model class", () => {
   let namespace: string;
 
-  let accountId: string;
+  let ownedById: string;
   let testEntityType: EntityTypeModel;
   let linkTypeFriend: LinkTypeModel;
   let linkTypeAcquaintance: LinkTypeModel;
@@ -45,13 +45,13 @@ describe("Link model class", () => {
     params: Omit<EntityTypeCreatorParams, "namespace">,
   ) =>
     EntityTypeModel.create(graphApi, {
-      accountId,
+      accountId: ownedById,
       schema: generateWorkspaceEntityTypeSchema({ namespace, ...params }),
     });
 
   const createEntity = (params: { entityTypeModel: EntityTypeModel }) =>
     EntityModel.create(graphApi, {
-      accountId,
+      ownedById,
       properties: {},
       ...params,
     });
@@ -61,11 +61,11 @@ describe("Link model class", () => {
 
     namespace = testUser.getShortname()!;
 
-    accountId = testUser.entityId;
+    ownedById = testUser.entityId;
 
     await Promise.all([
       LinkTypeModel.create(graphApi, {
-        accountId,
+        accountId: ownedById,
         schema: {
           kind: "linkType",
           title: "Friends",
@@ -76,7 +76,7 @@ describe("Link model class", () => {
         linkTypeFriend = linkType;
       }),
       LinkTypeModel.create(graphApi, {
-        accountId,
+        accountId: ownedById,
         schema: {
           kind: "linkType",
           title: "Acquaintance",
@@ -109,21 +109,21 @@ describe("Link model class", () => {
 
     await Promise.all([
       EntityModel.create(graphApi, {
-        accountId,
+        ownedById,
         entityTypeModel: testEntityType,
         properties: {},
       }).then((entity) => {
         sourceEntityModel = entity;
       }),
       EntityModel.create(graphApi, {
-        accountId,
+        ownedById,
         entityTypeModel: testEntityType,
         properties: {},
       }).then((entity) => {
         targetEntityFriend = entity;
       }),
       EntityModel.create(graphApi, {
-        accountId,
+        ownedById,
         entityTypeModel: testEntityType,
         properties: {},
       }).then((entity) => {
@@ -137,14 +137,14 @@ describe("Link model class", () => {
 
   it("can link entities", async () => {
     friendLink = await LinkModel.create(graphApi, {
-      createdById: accountId,
+      ownedById,
       sourceEntityModel,
       linkTypeModel: linkTypeFriend,
       targetEntityModel: targetEntityFriend,
     });
 
     acquaintanceLink = await LinkModel.create(graphApi, {
-      createdById: accountId,
+      ownedById,
       sourceEntityModel,
       linkTypeModel: linkTypeAcquaintance,
       targetEntityModel: targetEntityAcquaintance,
@@ -172,7 +172,7 @@ describe("Link model class", () => {
   });
 
   it("can remove a link", async () => {
-    await acquaintanceLink.remove(graphApi, { removedById: accountId });
+    await acquaintanceLink.remove(graphApi, { removedById: ownedById });
 
     const links = await sourceEntityModel.getOutgoingLinks(graphApi, {
       linkTypeModel: linkTypeAcquaintance,
@@ -209,7 +209,7 @@ describe("Link model class", () => {
     });
 
     hasSongLinkType = await LinkTypeModel.create(graphApi, {
-      accountId,
+      accountId: ownedById,
       schema: {
         kind: "linkType",
         title: "Has song",
@@ -243,7 +243,7 @@ describe("Link model class", () => {
 
     // create link at specified index which is currently unoccupied
     hasSongLink2 = await LinkModel.create(graphApi, {
-      createdById: accountId,
+      ownedById,
       index: 0,
       linkTypeModel: hasSongLinkType,
       sourceEntityModel: playlistEntity,
@@ -254,7 +254,7 @@ describe("Link model class", () => {
 
     // create link at un-specified index
     hasSongLink3 = await LinkModel.create(graphApi, {
-      createdById: accountId,
+      ownedById,
       linkTypeModel: hasSongLinkType,
       sourceEntityModel: playlistEntity,
       targetEntityModel: songEntity3,
@@ -264,7 +264,7 @@ describe("Link model class", () => {
 
     // create link at specified index which is currently occupied
     hasSongLink1 = await LinkModel.create(graphApi, {
-      createdById: accountId,
+      ownedById,
       index: 0,
       linkTypeModel: hasSongLinkType,
       sourceEntityModel: playlistEntity,
@@ -307,7 +307,7 @@ describe("Link model class", () => {
 
     await hasSongLink1.update(graphApi, {
       updatedIndex: 1,
-      updatedById: accountId,
+      updatedById: ownedById,
     });
 
     const playlistHasSongLinks = (await playlistEntity.getOutgoingLinks(
@@ -337,7 +337,7 @@ describe("Link model class", () => {
 
     await hasSongLink1.update(graphApi, {
       updatedIndex: 0,
-      updatedById: accountId,
+      updatedById: ownedById,
     });
 
     const playlistHasSongLinks = (await playlistEntity.getOutgoingLinks(
@@ -357,7 +357,7 @@ describe("Link model class", () => {
   });
 
   it("can remove an ordered link", async () => {
-    await hasSongLink2.remove(graphApi, { removedById: accountId });
+    await hasSongLink2.remove(graphApi, { removedById: ownedById });
 
     const playlistHasSongLinks = (await playlistEntity.getOutgoingLinks(
       graphApi,

--- a/packages/hash/integration/src/tests/model/knowledge/link.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/link.model.test.ts
@@ -45,7 +45,7 @@ describe("Link model class", () => {
     params: Omit<EntityTypeCreatorParams, "namespace">,
   ) =>
     EntityTypeModel.create(graphApi, {
-      accountId: ownedById,
+      ownedById,
       schema: generateWorkspaceEntityTypeSchema({ namespace, ...params }),
     });
 
@@ -65,7 +65,7 @@ describe("Link model class", () => {
 
     await Promise.all([
       LinkTypeModel.create(graphApi, {
-        accountId: ownedById,
+        ownedById,
         schema: {
           kind: "linkType",
           title: "Friends",
@@ -76,7 +76,7 @@ describe("Link model class", () => {
         linkTypeFriend = linkType;
       }),
       LinkTypeModel.create(graphApi, {
-        accountId: ownedById,
+        ownedById,
         schema: {
           kind: "linkType",
           title: "Acquaintance",
@@ -209,7 +209,7 @@ describe("Link model class", () => {
     });
 
     hasSongLinkType = await LinkTypeModel.create(graphApi, {
-      accountId: ownedById,
+      ownedById,
       schema: {
         kind: "linkType",
         title: "Has song",

--- a/packages/hash/integration/src/tests/model/knowledge/org.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/org.model.test.ts
@@ -45,14 +45,12 @@ describe("Org model class", () => {
   it("can update the shortname of an org", async () => {
     shortname = generateRandomShortname("orgTest");
     createdOrg = await createdOrg.updateShortname(graphApi, {
-      updatedByAccountId: createdOrg.entityId,
       updatedShortname: shortname,
     });
   });
 
   it("can update the preferred name of an org", async () => {
     createdOrg = await createdOrg.updateOrgName(graphApi, {
-      updatedByAccountId: createdOrg.entityId,
       updatedOrgName: "The testing org",
     });
   });

--- a/packages/hash/integration/src/tests/model/knowledge/orgMembership.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/orgMembership.model.test.ts
@@ -59,7 +59,7 @@ describe("OrgMembership model class", () => {
     await testUser.createOutgoingLink(graphApi, {
       linkTypeModel: WORKSPACE_TYPES.linkType.hasMembership,
       targetEntityModel: testOrgMembership,
-      createdById: workspaceAccountId,
+      ownedById: workspaceAccountId,
     });
   });
 

--- a/packages/hash/integration/src/tests/model/knowledge/page.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/page.model.test.ts
@@ -39,10 +39,10 @@ describe("Page model class", () => {
 
   const createBlock = async () =>
     await BlockModel.createBlock(graphApi, {
-      accountId: testUser.accountId,
+      ownedById: testUser.ownedById,
       componentId: "dummy-component-id",
       blockData: await EntityModel.create(graphApi, {
-        accountId: testUser.accountId,
+        ownedById: testUser.entityId,
         entityTypeModel: WORKSPACE_TYPES.entityType.dummy,
         properties: {},
       }),
@@ -52,7 +52,7 @@ describe("Page model class", () => {
 
   it("can create a page", async () => {
     testPage = await PageModel.createPage(graphApi, {
-      accountId: testUser.entityId,
+      ownedById: testUser.entityId,
       title: "Test Page",
     });
 
@@ -70,7 +70,7 @@ describe("Page model class", () => {
     ]);
 
     testPage2 = await PageModel.createPage(graphApi, {
-      accountId: testUser.entityId,
+      ownedById: testUser.entityId,
       title: "Test Page 2",
       summary: "Test page 2 summary",
       initialBlocks: [initialBlock1, initialBlock2],
@@ -107,7 +107,7 @@ describe("Page model class", () => {
 
   it("can get/set a parent page", async () => {
     parentPage = await PageModel.createPage(graphApi, {
-      accountId: testUser.entityId,
+      ownedById: testUser.entityId,
       title: "Test Parent Page",
       summary: "Test page summary",
     });
@@ -116,7 +116,7 @@ describe("Page model class", () => {
 
     await testPage.setParentPage(graphApi, {
       parentPage,
-      setById: testUser.accountId,
+      setById: testUser.entityId,
       prevIndex: null,
       nextIndex: null,
     });
@@ -145,13 +145,11 @@ describe("Page model class", () => {
     // insert block at un-specified position
     await testPage.insertBlock(graphApi, {
       block: testBlock3,
-      insertedById: testUser.accountId,
     });
 
     // insert block at specified position
     await testPage.insertBlock(graphApi, {
       block: testBlock2,
-      insertedById: testUser.accountId,
       position: 1,
     });
 
@@ -166,7 +164,7 @@ describe("Page model class", () => {
     await testPage.moveBlock(graphApi, {
       currentPosition: 0,
       newPosition: 2,
-      movedById: testUser.accountId,
+      movedById: testUser.entityId,
     });
 
     expect(await testPage.getBlocks(graphApi)).toEqual([
@@ -178,7 +176,7 @@ describe("Page model class", () => {
     await testPage.moveBlock(graphApi, {
       currentPosition: 2,
       newPosition: 0,
-      movedById: testUser.accountId,
+      movedById: testUser.entityId,
     });
 
     expect(await testPage.getBlocks(graphApi)).toEqual([
@@ -191,7 +189,7 @@ describe("Page model class", () => {
   it("can remove blocks", async () => {
     await testPage.removeBlock(graphApi, {
       position: 0,
-      removedById: testUser.accountId,
+      removedById: testUser.entityId,
     });
 
     expect(await testPage.getBlocks(graphApi)).toEqual([

--- a/packages/hash/integration/src/tests/model/knowledge/user.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/user.model.test.ts
@@ -67,14 +67,12 @@ describe("User model class", () => {
 
   it("can update the shortname of a user", async () => {
     createdUser = await createdUser.updateShortname(graphApi, {
-      updatedByAccountId: createdUser.entityId,
       updatedShortname: shortname,
     });
   });
 
   it("can update the preferred name of a user", async () => {
     createdUser = await createdUser.updatePreferredName(graphApi, {
-      updatedByAccountId: createdUser.entityId,
       updatedPreferredName: "Alice",
     });
   });

--- a/packages/hash/integration/src/tests/model/ontology/data-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/data-type.model.test.ts
@@ -22,7 +22,7 @@ const graphApi = createGraphClient(logger, {
   port: graphApiPort,
 });
 
-let accountId: string;
+let ownedById: string;
 
 // we have to manually specify this type because of 'intended' limitations of `Omit` with extended Record types:
 //  https://github.com/microsoft/TypeScript/issues/50638
@@ -40,7 +40,7 @@ const dataTypeSchema: Pick<
 beforeAll(async () => {
   const testUser = await createTestUser(graphApi, "data-type-test", logger);
 
-  accountId = testUser.entityId;
+  ownedById = testUser.entityId;
 });
 
 describe("Data type CRU", () => {
@@ -49,7 +49,7 @@ describe("Data type CRU", () => {
 
   it("can create a data type", async () => {
     createdDataTypeModel = await DataTypeModel.create(graphApi, {
-      accountId,
+      ownedById,
       schema: dataTypeSchema,
     });
   });
@@ -66,16 +66,13 @@ describe("Data type CRU", () => {
   it("can update a data type", async () => {
     updatedDataTypeModel = await createdDataTypeModel
       .update(graphApi, {
-        accountId,
         schema: { ...dataTypeSchema, title: updatedTitle },
       })
       .catch((err) => Promise.reject(err.data));
   });
 
   it("can read all latest data types", async () => {
-    const allDataTypes = await DataTypeModel.getAllLatest(graphApi, {
-      accountId,
-    });
+    const allDataTypes = await DataTypeModel.getAllLatest(graphApi);
 
     const newlyUpdated = allDataTypes.find(
       (dt) => dt.schema.$id === updatedDataTypeModel.schema.$id,

--- a/packages/hash/integration/src/tests/model/ontology/entity-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/entity-type.model.test.ts
@@ -27,7 +27,7 @@ const graphApi = createGraphClient(logger, {
   port: graphApiPort,
 });
 
-let accountId: string;
+let ownedById: string;
 let entityTypeSchema: Omit<EntityType, "$id">;
 let workerEntityTypeModel: EntityTypeModel;
 let textDataTypeModel: DataTypeModel;
@@ -40,10 +40,10 @@ let addressEntityTypeModel: EntityTypeModel;
 beforeAll(async () => {
   const testUser = await createTestUser(graphApi, "entity-type-test", logger);
 
-  accountId = testUser.entityId;
+  ownedById = testUser.entityId;
 
   textDataTypeModel = await DataTypeModel.create(graphApi, {
-    accountId,
+    ownedById,
     schema: {
       kind: "dataType",
       title: "Text",
@@ -53,7 +53,7 @@ beforeAll(async () => {
 
   await Promise.all([
     EntityTypeModel.create(graphApi, {
-      accountId,
+      ownedById,
       schema: {
         kind: "entityType",
         title: "Worker",
@@ -65,7 +65,7 @@ beforeAll(async () => {
       workerEntityTypeModel = val;
     }),
     EntityTypeModel.create(graphApi, {
-      accountId,
+      ownedById,
       schema: {
         kind: "entityType",
         title: "Address",
@@ -77,7 +77,7 @@ beforeAll(async () => {
       addressEntityTypeModel = val;
     }),
     PropertyTypeModel.create(graphApi, {
-      accountId,
+      ownedById,
       schema: {
         kind: "propertyType",
         title: "Favorite Book",
@@ -88,7 +88,7 @@ beforeAll(async () => {
       favoriteBookPropertyTypeModel = val;
     }),
     PropertyTypeModel.create(graphApi, {
-      accountId,
+      ownedById,
       schema: {
         kind: "propertyType",
         title: "Name",
@@ -99,7 +99,7 @@ beforeAll(async () => {
       namePropertyTypeModel = val;
     }),
     LinkTypeModel.create(graphApi, {
-      accountId,
+      ownedById,
       schema: {
         kind: "linkType",
         title: "Knows",
@@ -110,7 +110,7 @@ beforeAll(async () => {
       knowsLinkTypeModel = val;
     }),
     LinkTypeModel.create(graphApi, {
-      accountId,
+      ownedById,
       schema: {
         kind: "linkType",
         title: "Previous Address",
@@ -159,7 +159,7 @@ describe("Entity type CRU", () => {
 
   it("can create an entity type", async () => {
     createdEntityType = await EntityTypeModel.create(graphApi, {
-      accountId,
+      ownedById,
       schema: entityTypeSchema,
     });
   });
@@ -177,7 +177,6 @@ describe("Entity type CRU", () => {
   it("can update an entity type", async () => {
     const updatedEntityTypeModel = await createdEntityType
       .update(graphApi, {
-        accountId,
         schema: { ...entityTypeSchema, title: updatedTitle },
       })
       .catch((err) => Promise.reject(err.data));
@@ -186,9 +185,7 @@ describe("Entity type CRU", () => {
   });
 
   it("can read all latest entity types", async () => {
-    const allEntityTypes = await EntityTypeModel.getAllLatest(graphApi, {
-      accountId,
-    });
+    const allEntityTypes = await EntityTypeModel.getAllLatest(graphApi);
 
     const newlyUpdated = allEntityTypes.find(
       (dt) => dt.schema.$id === updatedId,

--- a/packages/hash/integration/src/tests/model/ontology/link-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/link-type.model.test.ts
@@ -22,7 +22,7 @@ const graphApi = createGraphClient(logger, {
   port: graphApiPort,
 });
 
-let accountId: string;
+let ownedById: string;
 const linkTypeSchema: Omit<LinkType, "$id"> = {
   kind: "linkType",
   title: "A link",
@@ -33,7 +33,7 @@ const linkTypeSchema: Omit<LinkType, "$id"> = {
 beforeAll(async () => {
   const testUser = await createTestUser(graphApi, "link-type-test", logger);
 
-  accountId = testUser.entityId;
+  ownedById = testUser.entityId;
 });
 
 describe("Link type CRU", () => {
@@ -42,7 +42,7 @@ describe("Link type CRU", () => {
 
   it("can create a link type", async () => {
     createdLinkTypeModel = await LinkTypeModel.create(graphApi, {
-      accountId,
+      ownedById,
       schema: linkTypeSchema,
     });
   });
@@ -60,7 +60,6 @@ describe("Link type CRU", () => {
   it("can update a link type", async () => {
     updatedLinkTypeModel = await createdLinkTypeModel
       .update(graphApi, {
-        accountId,
         schema: {
           ...linkTypeSchema,
           title: updatedTitle,
@@ -70,9 +69,7 @@ describe("Link type CRU", () => {
   });
 
   it("can read all latest link types", async () => {
-    const allLinkTypes = await LinkTypeModel.getAllLatest(graphApi, {
-      accountId,
-    });
+    const allLinkTypes = await LinkTypeModel.getAllLatest(graphApi);
 
     const newlyUpdated = allLinkTypes.find(
       (lt) => lt.schema.$id === updatedLinkTypeModel.schema.$id,

--- a/packages/hash/integration/src/tests/model/ontology/property-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/property-type.model.test.ts
@@ -25,17 +25,17 @@ const graphApi = createGraphClient(logger, {
   port: graphApiPort,
 });
 
-let accountId: string;
+let ownedById: string;
 let textDataTypeModel: DataTypeModel;
 let propertyTypeSchema: Omit<PropertyType, "$id">;
 
 beforeAll(async () => {
   const testUser = await createTestUser(graphApi, "property-type-test", logger);
 
-  accountId = testUser.entityId;
+  ownedById = testUser.entityId;
 
   textDataTypeModel = await DataTypeModel.create(graphApi, {
-    accountId,
+    ownedById,
     schema: {
       kind: "dataType",
       title: "Text",
@@ -61,7 +61,7 @@ describe("Property type CRU", () => {
 
   it("can create a property type", async () => {
     createdPropertyTypeModel = await PropertyTypeModel.create(graphApi, {
-      accountId,
+      ownedById,
       schema: propertyTypeSchema,
     });
   });
@@ -79,7 +79,6 @@ describe("Property type CRU", () => {
   it("can update a property type", async () => {
     updatedPropertyTypeModel = await createdPropertyTypeModel
       .update(graphApi, {
-        accountId,
         schema: {
           ...propertyTypeSchema,
           title: updatedTitle,
@@ -89,9 +88,7 @@ describe("Property type CRU", () => {
   });
 
   it("can read all latest property types", async () => {
-    const allPropertyTypes = await PropertyTypeModel.getAllLatest(graphApi, {
-      accountId,
-    });
+    const allPropertyTypes = await PropertyTypeModel.getAllLatest(graphApi);
 
     const newlyUpdated = allPropertyTypes.find(
       (pt) => pt.schema.$id === updatedPropertyTypeModel.schema.$id,

--- a/packages/hash/integration/src/tests/util.ts
+++ b/packages/hash/integration/src/tests/util.ts
@@ -3,7 +3,6 @@ import { GraphQLClient, ClientError } from "graphql-request";
 import { createKratosIdentity } from "@hashintel/hash-api/src/auth/ory-kratos";
 import { GraphApi } from "@hashintel/hash-api/src/graph";
 import { UserModel } from "@hashintel/hash-api/src/model";
-import { workspaceAccountId } from "@hashintel/hash-api/src/model/util";
 import { ensureWorkspaceTypesExist } from "@hashintel/hash-api/src/graph/workspace-types";
 import { Logger } from "@hashintel/hash-backend-utils/logger";
 
@@ -138,7 +137,6 @@ export const createTestUser = async (
 
   const updatedUser = await createdUser
     .updateShortname(graphApi, {
-      updatedByAccountId: workspaceAccountId,
       updatedShortname: shortname,
     })
     .catch((err) => {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR replaces the usage of `accountId` with `ownedById` in the new model classes.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202805690238892/1203063464592800/f) _(internal)_

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

See the commits and PR comments.

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

No.

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- the existing integration tests

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Verify the integration tests succeed in CI, or by running them locally.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
