### PR TITLE
Use `ownedById` in GQL ontology mutations

### DIFF
--- a/packages/hash/api/src/graphql/resolvers/ontology/entity-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/entity-type.ts
@@ -29,10 +29,10 @@ export const createEntityType: ResolverFn<
   MutationCreateEntityTypeArgs
 > = async (_, params, { dataSources, user }) => {
   const { graphApi } = dataSources;
-  const { accountId, entityType } = params;
+  const { ownedById, entityType } = params;
 
   const createdEntityTypeModel = await EntityTypeModel.create(graphApi, {
-    ownedById: accountId ?? user.entityId,
+    ownedById: ownedById ?? user.entityId,
     schema: entityType,
   }).catch((err) => {
     throw new ApolloError(err, "CREATION_ERROR");

--- a/packages/hash/api/src/graphql/resolvers/ontology/link-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/link-type.ts
@@ -19,10 +19,10 @@ export const createLinkType: ResolverFn<
   MutationCreateLinkTypeArgs
 > = async (_, params, { dataSources, user }) => {
   const { graphApi } = dataSources;
-  const { accountId, linkType } = params;
+  const { ownedById, linkType } = params;
 
   const createdLinkTypeModel = await LinkTypeModel.create(graphApi, {
-    ownedById: accountId ?? user.entityId,
+    ownedById: ownedById ?? user.entityId,
     schema: linkType,
   }).catch((err) => {
     throw new ApolloError(err, "CREATION_ERROR");

--- a/packages/hash/api/src/graphql/resolvers/ontology/property-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/property-type.ts
@@ -24,10 +24,10 @@ export const createPropertyType: ResolverFn<
   MutationCreatePropertyTypeArgs
 > = async (_, params, { dataSources, user }) => {
   const { graphApi } = dataSources;
-  const { accountId, propertyType } = params;
+  const { ownedById, propertyType } = params;
 
   const createdPropertyTypeModel = await PropertyTypeModel.create(graphApi, {
-    ownedById: accountId ?? user.entityId,
+    ownedById: ownedById ?? user.entityId,
     schema: propertyType,
   }).catch((err) => {
     throw new ApolloError(err, "CREATION_ERROR");

--- a/packages/hash/api/src/graphql/typeDefs/ontology/entity-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/entity-type.typedef.ts
@@ -112,9 +112,9 @@ export const entityTypeTypedef = gql`
     """
     createEntityType(
       """
-      accountId refers to the account to create the entity type in.
+      The id of the owner of the entity type. Defaults to the user calling the mutation.
       """
-      accountId: ID
+      ownedById: ID
       entityType: EntityTypeWithoutId!
     ): PersistedEntityType!
 
@@ -122,10 +122,6 @@ export const entityTypeTypedef = gql`
     Update a entity type.
     """
     updateEntityType(
-      """
-      accountId refers to the account to update the entity type in.
-      """
-      accountId: ID
       """
       The entity type versioned $id to update.
       """

--- a/packages/hash/api/src/graphql/typeDefs/ontology/link-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/link-type.typedef.ts
@@ -42,9 +42,9 @@ export const linkTypeTypedef = gql`
     """
     createLinkType(
       """
-      The id of the account where to create the link type in. Defaults to the account id of the current user.
+      The id of the owner of the link type. Defaults to the user calling the mutation.
       """
-      accountId: ID
+      ownedById: ID
       linkType: LinkTypeWithoutId!
     ): PersistedLinkType!
 
@@ -52,10 +52,6 @@ export const linkTypeTypedef = gql`
     Update an link type.
     """
     updateLinkType(
-      """
-      The id of the account where to create the updated link type in. Defaults to the account id of the current user.
-      """
-      accountId: ID
       """
       The link type versioned $id to update.
       """

--- a/packages/hash/api/src/graphql/typeDefs/ontology/property-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/property-type.typedef.ts
@@ -106,9 +106,9 @@ export const propertyTypeTypedef = gql`
     """
     createPropertyType(
       """
-      The id of the account where to create the property type in. Defaults to the account id of the current user.
+      The id of the owner of the property type. Defaults to the user calling the mutation.
       """
-      accountId: ID
+      ownedById: ID
       propertyType: PropertyTypeWithoutId!
     ): PersistedPropertyType!
 
@@ -116,10 +116,6 @@ export const propertyTypeTypedef = gql`
     Update a property type.
     """
     updatePropertyType(
-      """
-      The id of the account where to create the updated property type in. Defaults to the account id of the current user.
-      """
-      accountId: ID
       """
       The property type versioned $id to update.
       """

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolCreateEntityType.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolCreateEntityType.ts
@@ -9,7 +9,7 @@ import { createEntityTypeMutation } from "../../../../graphql/queries/ontology/e
 import { CreateEntityTypeMessageCallback } from "./ontology-types-shim";
 
 export const useBlockProtocolCreateEntityType = (
-  accountId: string,
+  ownedById: string,
   readonly?: boolean,
 ): {
   createEntityType: CreateEntityTypeMessageCallback;
@@ -46,7 +46,7 @@ export const useBlockProtocolCreateEntityType = (
       const { entityType } = data;
       const { data: responseData } = await createFn({
         variables: {
-          accountId,
+          ownedById,
           entityType,
         },
       });
@@ -70,7 +70,7 @@ export const useBlockProtocolCreateEntityType = (
         },
       };
     },
-    [accountId, createFn, readonly],
+    [ownedById, createFn, readonly],
   );
 
   return {

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolCreateLinkType.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolCreateLinkType.ts
@@ -9,7 +9,7 @@ import { createLinkTypeMutation } from "../../../../graphql/queries/ontology/lin
 import { CreateLinkTypeMessageCallback } from "./ontology-types-shim";
 
 export const useBlockProtocolCreateLinkType = (
-  accountId: string,
+  ownedById: string,
   readonly?: boolean,
 ): {
   createLinkType: CreateLinkTypeMessageCallback;
@@ -46,7 +46,7 @@ export const useBlockProtocolCreateLinkType = (
       const { linkType } = data;
       const { data: responseData } = await createFn({
         variables: {
-          accountId,
+          ownedById,
           linkType,
         },
       });
@@ -70,7 +70,7 @@ export const useBlockProtocolCreateLinkType = (
         },
       };
     },
-    [accountId, createFn, readonly],
+    [ownedById, createFn, readonly],
   );
 
   return {

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolCreatePropertyType.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolCreatePropertyType.ts
@@ -9,7 +9,7 @@ import { createPropertyTypeMutation } from "../../../../graphql/queries/ontology
 import { CreatePropertyTypeMessageCallback } from "./ontology-types-shim";
 
 export const useBlockProtocolCreatePropertyType = (
-  accountId: string,
+  ownedById: string,
   readonly?: boolean,
 ): {
   createPropertyType: CreatePropertyTypeMessageCallback;
@@ -46,7 +46,7 @@ export const useBlockProtocolCreatePropertyType = (
       const { propertyType } = data;
       const { data: responseData } = await createFn({
         variables: {
-          accountId,
+          ownedById,
           propertyType,
         },
       });
@@ -70,7 +70,7 @@ export const useBlockProtocolCreatePropertyType = (
         },
       };
     },
-    [accountId, createFn, readonly],
+    [ownedById, createFn, readonly],
   );
 
   return {

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolUpdateEntityType.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolUpdateEntityType.ts
@@ -9,7 +9,6 @@ import { updateEntityTypeMutation } from "../../../../graphql/queries/ontology/e
 import { UpdateEntityTypeMessageCallback } from "./ontology-types-shim";
 
 export const useBlockProtocolUpdateEntityType = (
-  accountId: string,
   readonly?: boolean,
 ): {
   updateEntityType: UpdateEntityTypeMessageCallback;
@@ -46,7 +45,6 @@ export const useBlockProtocolUpdateEntityType = (
       const { entityTypeVersionedUri, entityType } = data;
       const { data: responseData } = await updateFn({
         variables: {
-          accountId,
           entityTypeVersionedUri,
           updatedEntityType: entityType,
         },
@@ -71,7 +69,7 @@ export const useBlockProtocolUpdateEntityType = (
         },
       };
     },
-    [accountId, updateFn, readonly],
+    [updateFn, readonly],
   );
 
   return {

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolUpdateLinkType.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolUpdateLinkType.ts
@@ -9,7 +9,6 @@ import { updateLinkTypeMutation } from "../../../../graphql/queries/ontology/lin
 import { UpdateLinkTypeMessageCallback } from "./ontology-types-shim";
 
 export const useBlockProtocolUpdateLinkType = (
-  accountId: string,
   readonly?: boolean,
 ): {
   updateLinkType: UpdateLinkTypeMessageCallback;
@@ -46,7 +45,6 @@ export const useBlockProtocolUpdateLinkType = (
       const { linkTypeVersionedUri, linkType } = data;
       const { data: responseData } = await updateFn({
         variables: {
-          accountId,
           linkTypeVersionedUri,
           updatedLinkType: linkType,
         },
@@ -71,7 +69,7 @@ export const useBlockProtocolUpdateLinkType = (
         },
       };
     },
-    [accountId, updateFn, readonly],
+    [updateFn, readonly],
   );
 
   return {

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolUpdatePropertyType.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolUpdatePropertyType.ts
@@ -9,7 +9,6 @@ import { updatePropertyTypeMutation } from "../../../../graphql/queries/ontology
 import { UpdatePropertyTypeMessageCallback } from "./ontology-types-shim";
 
 export const useBlockProtocolUpdatePropertyType = (
-  accountId: string,
   readonly?: boolean,
 ): {
   updatePropertyType: UpdatePropertyTypeMessageCallback;
@@ -46,7 +45,6 @@ export const useBlockProtocolUpdatePropertyType = (
       const { propertyTypeVersionedUri, propertyType } = data;
       const { data: responseData } = await updateFn({
         variables: {
-          accountId,
           propertyTypeVersionedUri,
           updatedPropertyType: propertyType,
         },
@@ -71,7 +69,7 @@ export const useBlockProtocolUpdatePropertyType = (
         },
       };
     },
-    [accountId, updateFn, readonly],
+    [updateFn, readonly],
   );
 
   return {

--- a/packages/hash/frontend/src/graphql/queries/ontology/data-type.queries.ts
+++ b/packages/hash/frontend/src/graphql/queries/ontology/data-type.queries.ts
@@ -4,7 +4,7 @@ export const getDataTypeQuery = gql`
   query getDataType($dataTypeVersionedUri: String!) {
     getDataType(dataTypeVersionedUri: $dataTypeVersionedUri) {
       dataTypeVersionedUri
-      accountId
+      ownedById
       dataType
     }
   }
@@ -14,7 +14,7 @@ export const getAllLatestDataTypesQuery = gql`
   query getAllLatestDataTypes {
     getAllLatestDataTypes {
       dataTypeVersionedUri
-      accountId
+      ownedById
       dataType
     }
   }

--- a/packages/hash/frontend/src/graphql/queries/ontology/entity-type.queries.ts
+++ b/packages/hash/frontend/src/graphql/queries/ontology/entity-type.queries.ts
@@ -4,7 +4,7 @@ export const getEntityTypeQuery = gql`
   query getEntityType($entityTypeVersionedUri: String!) {
     getEntityType(entityTypeVersionedUri: $entityTypeVersionedUri) {
       entityTypeVersionedUri
-      accountId
+      ownedById
       entityType
     }
   }
@@ -14,7 +14,7 @@ export const getAllLatestEntityTypesQuery = gql`
   query getAllLatestEntityTypes {
     getAllLatestEntityTypes {
       entityTypeVersionedUri
-      accountId
+      ownedById
       entityType
     }
   }
@@ -22,12 +22,12 @@ export const getAllLatestEntityTypesQuery = gql`
 
 export const createEntityTypeMutation = gql`
   mutation createEntityType(
-    $accountId: ID!
+    $ownedById: ID!
     $entityType: EntityTypeWithoutId!
   ) {
-    createEntityType(accountId: $accountId, entityType: $entityType) {
+    createEntityType(ownedById: $ownedById, entityType: $entityType) {
       entityTypeVersionedUri
-      accountId
+      ownedById
       entityType
     }
   }
@@ -35,17 +35,15 @@ export const createEntityTypeMutation = gql`
 
 export const updateEntityTypeMutation = gql`
   mutation updateEntityType(
-    $accountId: ID!
     $entityTypeVersionedUri: String!
     $updatedEntityType: EntityTypeWithoutId!
   ) {
     updateEntityType(
-      accountId: $accountId
       entityTypeVersionedUri: $entityTypeVersionedUri
       updatedEntityType: $updatedEntityType
     ) {
       entityTypeVersionedUri
-      accountId
+      ownedById
       entityType
     }
   }

--- a/packages/hash/frontend/src/graphql/queries/ontology/link-type.queries.ts
+++ b/packages/hash/frontend/src/graphql/queries/ontology/link-type.queries.ts
@@ -4,7 +4,7 @@ export const getLinkTypeQuery = gql`
   query getLinkType($linkTypeVersionedUri: String!) {
     getLinkType(linkTypeVersionedUri: $linkTypeVersionedUri) {
       linkTypeVersionedUri
-      accountId
+      ownedById
       linkType
     }
   }
@@ -14,17 +14,17 @@ export const getAllLatestLinkTypesQuery = gql`
   query getAllLatestLinkTypes {
     getAllLatestLinkTypes {
       linkTypeVersionedUri
-      accountId
+      ownedById
       linkType
     }
   }
 `;
 
 export const createLinkTypeMutation = gql`
-  mutation createLinkType($accountId: ID!, $linkType: LinkTypeWithoutId!) {
-    createLinkType(accountId: $accountId, linkType: $linkType) {
+  mutation createLinkType($ownedById: ID!, $linkType: LinkTypeWithoutId!) {
+    createLinkType(ownedById: $ownedById, linkType: $linkType) {
       linkTypeVersionedUri
-      accountId
+      ownedById
       linkType
     }
   }
@@ -32,17 +32,15 @@ export const createLinkTypeMutation = gql`
 
 export const updateLinkTypeMutation = gql`
   mutation updateLinkType(
-    $accountId: ID!
     $linkTypeVersionedUri: String!
     $updatedLinkType: LinkTypeWithoutId!
   ) {
     updateLinkType(
-      accountId: $accountId
       linkTypeVersionedUri: $linkTypeVersionedUri
       updatedLinkType: $updatedLinkType
     ) {
       linkTypeVersionedUri
-      accountId
+      ownedById
       linkType
     }
   }

--- a/packages/hash/frontend/src/graphql/queries/ontology/property-type.queries.ts
+++ b/packages/hash/frontend/src/graphql/queries/ontology/property-type.queries.ts
@@ -4,7 +4,7 @@ export const getPropertyTypeQuery = gql`
   query getPropertyType($propertyTypeVersionedUri: String!) {
     getPropertyType(propertyTypeVersionedUri: $propertyTypeVersionedUri) {
       propertyTypeVersionedUri
-      accountId
+      ownedById
       propertyType
     }
   }
@@ -14,7 +14,7 @@ export const getAllLatestPropertyTypesQuery = gql`
   query getAllLatestPropertyTypes {
     getAllLatestPropertyTypes {
       propertyTypeVersionedUri
-      accountId
+      ownedById
       propertyType
     }
   }
@@ -22,12 +22,12 @@ export const getAllLatestPropertyTypesQuery = gql`
 
 export const createPropertyTypeMutation = gql`
   mutation createPropertyType(
-    $accountId: ID!
+    $ownedById: ID!
     $propertyType: PropertyTypeWithoutId!
   ) {
-    createPropertyType(accountId: $accountId, propertyType: $propertyType) {
+    createPropertyType(ownedById: $ownedById, propertyType: $propertyType) {
       propertyTypeVersionedUri
-      accountId
+      ownedById
       propertyType
     }
   }
@@ -35,17 +35,15 @@ export const createPropertyTypeMutation = gql`
 
 export const updatePropertyTypeMutation = gql`
   mutation updatePropertyType(
-    $accountId: ID!
     $propertyTypeVersionedUri: String!
     $updatedPropertyType: PropertyTypeWithoutId!
   ) {
     updatePropertyType(
-      accountId: $accountId
       propertyTypeVersionedUri: $propertyTypeVersionedUri
       updatedPropertyType: $updatedPropertyType
     ) {
       propertyTypeVersionedUri
-      accountId
+      ownedById
       propertyType
     }
   }

--- a/packages/hash/frontend/src/pages/type-editor/blockprotocol-ontology-functions-hook.ts
+++ b/packages/hash/frontend/src/pages/type-editor/blockprotocol-ontology-functions-hook.ts
@@ -58,23 +58,23 @@ export type GraphMessageCallbacks = Omit<
 
 /** @todo Consider if we should move this out of the page and into the hooks directory. */
 export const useBlockProtocolFunctionsWithOntology = (
-  accountId: string,
+  ownedById: string,
 ): GraphMessageCallbacks => {
   const { readonlyMode } = useReadonlyMode();
 
-  const { aggregateEntities } = useBlockProtocolAggregateEntities(accountId);
+  const { aggregateEntities } = useBlockProtocolAggregateEntities(ownedById);
   const { createLinkedAggregation } =
     useBlockProtocolCreateLinkedAggregation(readonlyMode);
   const { createLink } = useBlockProtocolCreateLink(readonlyMode);
   const { createEntity } = useBlockProtocolCreateEntity(
-    accountId,
+    ownedById,
     readonlyMode,
   );
   const { deleteLinkedAggregation } =
     useBlockProtocolDeleteLinkedAggregation(readonlyMode);
   const { deleteLink } = useBlockProtocolDeleteLink(readonlyMode);
   const { updateEntity } = useBlockProtocolUpdateEntity(false, readonlyMode);
-  const { uploadFile } = useBlockProtocolFileUpload(accountId, readonlyMode);
+  const { uploadFile } = useBlockProtocolFileUpload(ownedById, readonlyMode);
   const { updateLinkedAggregation } =
     useBlockProtocolUpdateLinkedAggregation(readonlyMode);
 
@@ -83,35 +83,27 @@ export const useBlockProtocolFunctionsWithOntology = (
   const { aggregateDataTypes } = useBlockProtocolAggregateDataTypes();
   const { getDataType } = useBlockProtocolGetDataType();
   const { createPropertyType } = useBlockProtocolCreatePropertyType(
-    accountId,
+    ownedById,
     readonlyMode,
   );
   const { aggregatePropertyTypes } = useBlockProtocolAggregatePropertyTypes();
   const { getPropertyType } = useBlockProtocolGetPropertyType();
-  const { updatePropertyType } = useBlockProtocolUpdatePropertyType(
-    accountId,
-    readonlyMode,
-  );
+  const { updatePropertyType } =
+    useBlockProtocolUpdatePropertyType(readonlyMode);
   const { createEntityType } = useBlockProtocolCreateEntityType(
-    accountId,
+    ownedById,
     readonlyMode,
   );
   const { aggregateEntityTypes } = useBlockProtocolAggregateEntityTypes();
   const { getEntityType } = useBlockProtocolGetEntityType();
-  const { updateEntityType } = useBlockProtocolUpdateEntityType(
-    accountId,
-    readonlyMode,
-  );
+  const { updateEntityType } = useBlockProtocolUpdateEntityType(readonlyMode);
   const { createLinkType } = useBlockProtocolCreateLinkType(
-    accountId,
+    ownedById,
     readonlyMode,
   );
   const { aggregateLinkTypes } = useBlockProtocolAggregateLinkTypes();
   const { getLinkType } = useBlockProtocolGetLinkType();
-  const { updateLinkType } = useBlockProtocolUpdateLinkType(
-    accountId,
-    readonlyMode,
-  );
+  const { updateLinkType } = useBlockProtocolUpdateLinkType(readonlyMode);
 
   const { updateLink } = useBlockProtocolUpdateLink();
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR modifies the GQL ontology mutations to use `ownedById` instead of the `accountId` alias. This propagated changes in the frontend, where these mutations are currently being used in the BP hooks.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202805690238892/1203072290779156/f) _(internal)_


## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

No.


