### PR TITLE
`knowledgePage` GQL query

### DIFF
--- a/packages/hash/api/src/graphql/resolvers/index.ts
+++ b/packages/hash/api/src/graphql/resolvers/index.ts
@@ -100,6 +100,7 @@ import {
   updateKnowledgePageContents,
   knowledgePageContents,
 } from "./knowledge/page";
+import { knowledgePage } from "./knowledge/page/page";
 
 export const resolvers = {
   Query: {
@@ -140,6 +141,8 @@ export const resolvers = {
     getLinkType: loggedInAndSignedUp(getLinkType),
     getAllLatestEntityTypes: loggedInAndSignedUp(getAllLatestEntityTypes),
     getEntityType: loggedInAndSignedUp(getEntityType),
+    // Knowledge
+    knowledgePage: loggedInAndSignedUp(knowledgePage),
   },
 
   Mutation: {

--- a/packages/hash/api/src/graphql/resolvers/knowledge/page/page.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/page/page.ts
@@ -1,0 +1,22 @@
+import { PageModel } from "../../../../model";
+
+import { QueryKnowledgePageArgs, ResolverFn } from "../../../apiTypes.gen";
+import { GraphQLContext } from "../../../context";
+import {
+  UnresolvedKnowledgePageGQL,
+  mapPageModelToGQL,
+} from "../model-mapping";
+
+export const knowledgePage: ResolverFn<
+  Promise<UnresolvedKnowledgePageGQL>,
+  {},
+  GraphQLContext,
+  QueryKnowledgePageArgs
+> = async (_, { entityId, entityVersion }, { dataSources: { graphApi } }) => {
+  const pageModel = await PageModel.getPageById(graphApi, {
+    entityId,
+    entityVersion: entityVersion ?? undefined,
+  });
+
+  return mapPageModelToGQL(pageModel);
+};

--- a/packages/hash/api/src/graphql/typeDefs/knowledge/page.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/knowledge/page.typedef.ts
@@ -74,6 +74,22 @@ export const knowledgePageTypedef = gql`
     entityVersion: String!
   }
 
+  extend type Query {
+    """
+    Get a page by its entity id.
+    """
+    knowledgePage(
+      """
+      The id of the page entity.
+      """
+      entityId: ID!
+      """
+      The version of the page entity. Defaults to the latest version.
+      """
+      entityVersion: String
+    ): KnowledgePage!
+  }
+
   """
   Insert a block into a page with a corresponding entity.
   """

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -311,7 +311,7 @@ export default class {
     },
   ): Promise<EntityModel> {
     throw new Error(
-      "Graph API does not yet support getting a specific version of an entity",
+      "Getting the specific version of an entity is not yet implemented.",
     );
   }
 

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -283,7 +283,7 @@ export default class {
   /**
    * Get the latest version of an entity by its entity ID.
    *
-   * @param params.versionedUri the unique versioned URI for an entity.
+   * @param params.entityId - the id of the entity
    */
   static async getLatest(
     graphApi: GraphApi,
@@ -295,6 +295,24 @@ export default class {
     const { data: persistedEntity } = await graphApi.getEntity(entityId);
 
     return await EntityModel.fromPersistedEntity(graphApi, persistedEntity);
+  }
+
+  /**
+   * Get a specific version of an entity.
+   *
+   * @param params.entityId - the id of the entity
+   * @param params.version - the version of the entity
+   */
+  static async getVersion(
+    _graphApi: GraphApi,
+    _params: {
+      entityId: string;
+      entityVersion: string;
+    },
+  ): Promise<EntityModel> {
+    throw new Error(
+      "Graph API does not yet support getting a specific version of an entity",
+    );
   }
 
   /**

--- a/packages/hash/api/src/model/knowledge/page.model.ts
+++ b/packages/hash/api/src/model/knowledge/page.model.ts
@@ -46,9 +46,18 @@ export default class extends EntityModel {
    */
   static async getPageById(
     graphApi: GraphApi,
-    params: { entityId: string },
+    params: { entityId: string; entityVersion?: string },
   ): Promise<PageModel> {
-    const entity = await EntityModel.getLatest(graphApi, params);
+    const { entityId, entityVersion } = params;
+
+    const entity = entityVersion
+      ? await EntityModel.getVersion(graphApi, {
+          entityId,
+          entityVersion,
+        })
+      : await EntityModel.getLatest(graphApi, {
+          entityId,
+        });
 
     return PageModel.fromEntityModel(entity);
   }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR introduces a `knowledgePage` GQL query.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202953520344818/1203064073566616/f) _(internal)_

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- introduces the `knowledgePage` GQL query
- adds an unimplemented `EntityModel.getVersion` method

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

No.

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

- the current implementation of the `KnowledgePage` GQL type cannot directly replace the existing `Page` GQL type, as it's properties don't resolve linked entities using legacy fields.

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

We are currently conducting manual tests for GQL queries/mutations

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Checkout this branch
2. Run `yarn external-services up` locally
3. Run `yarn test:backend-integration page.model` in a separate terminal window to seed the database with some pages
4. Run `yarn dev`
5. Open `localhost:3000` and login
6. Open `localhost:5001/graphql` to access the GQL playground
7. Execute the below query to fetch a page by its id

<details>
<summary>knowledgePage query</summary>

```gql
{
  knowledgePage(entityId: "..") {
    entityId
    contents{
      entityId
      properties
    }
  }
}
```
</details>


## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

<img width="2295" alt="image" src="https://user-images.githubusercontent.com/42802102/193071785-38ee4f6a-1471-4e3c-b44f-4bcd55be114f.png">
