### PR TITLE
Replace `*VersionedUri` with `*Id` for ontology types

### DIFF
--- a/packages/hash/api/src/graphql/resolvers/ontology/data-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/data-type.ts
@@ -35,11 +35,11 @@ export const getDataType: ResolverFn<
   {},
   GraphQLContext,
   QueryGetDataTypeArgs
-> = async (_, { dataTypeVersionedUri }, { dataSources }) => {
+> = async (_, { dataTypeId }, { dataSources }) => {
   const { graphApi } = dataSources;
 
   const dataTypeModel = await DataTypeModel.get(graphApi, {
-    dataTypeId: dataTypeVersionedUri,
+    dataTypeId,
   }).catch((err: AxiosError) => {
     throw new ApolloError(
       `Unable to retrieve data type. ${err.response?.data}`,

--- a/packages/hash/api/src/graphql/resolvers/ontology/entity-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/entity-type.ts
@@ -72,11 +72,11 @@ export const getEntityType: ResolverFn<
   {},
   LoggedInGraphQLContext,
   QueryGetEntityTypeArgs
-> = async (_, { entityTypeVersionedUri }, { dataSources }, info) => {
+> = async (_, { entityTypeId }, { dataSources }, info) => {
   const { graphApi } = dataSources;
 
   const entityTypeRootedSubgraph = await EntityTypeModel.getResolved(graphApi, {
-    entityTypeId: entityTypeVersionedUri,
+    entityTypeId,
     dataTypeQueryDepth: dataTypeQueryDepth(info),
     propertyTypeQueryDepth: propertyTypeQueryDepth(info),
     linkTypeQueryDepth: linkTypeQueryDepth(info),
@@ -98,13 +98,13 @@ export const updateEntityType: ResolverFn<
   MutationUpdateEntityTypeArgs
 > = async (_, params, { dataSources }) => {
   const { graphApi } = dataSources;
-  const { entityTypeVersionedUri, updatedEntityType } = params;
+  const { entityTypeId, updatedEntityType } = params;
 
   const entityTypeModel = await EntityTypeModel.get(graphApi, {
-    entityTypeId: entityTypeVersionedUri,
+    entityTypeId,
   }).catch((err: AxiosError) => {
     throw new ApolloError(
-      `Unable to retrieve entity type. ${err.response?.data} [URI=${entityTypeVersionedUri}]`,
+      `Unable to retrieve entity type. ${err.response?.data} [URI=${entityTypeId}]`,
       "GET_ERROR",
     );
   });
@@ -116,7 +116,7 @@ export const updateEntityType: ResolverFn<
     .catch((err: AxiosError) => {
       const msg =
         err.response?.status === 409
-          ? `Entity type URI doesn't exist, unable to update. [URI=${entityTypeVersionedUri}]`
+          ? `Entity type URI doesn't exist, unable to update. [URI=${entityTypeId}]`
           : `Couldn't update entity type.`;
 
       throw new ApolloError(msg, "CREATION_ERROR");

--- a/packages/hash/api/src/graphql/resolvers/ontology/link-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/link-type.ts
@@ -58,14 +58,14 @@ export const getLinkType: ResolverFn<
   {},
   LoggedInGraphQLContext,
   QueryGetLinkTypeArgs
-> = async (_, { linkTypeVersionedUri }, { dataSources }) => {
+> = async (_, { linkTypeId }, { dataSources }) => {
   const { graphApi } = dataSources;
 
   const linkTypeModel = await LinkTypeModel.get(graphApi, {
-    linkTypeId: linkTypeVersionedUri,
+    linkTypeId,
   }).catch((err: AxiosError) => {
     throw new ApolloError(
-      `Unable to retrieve link type. ${err.response?.data} [URI=${linkTypeVersionedUri}]`,
+      `Unable to retrieve link type. ${err.response?.data} [URI=${linkTypeId}]`,
       "GET_ERROR",
     );
   });
@@ -80,13 +80,13 @@ export const updateLinkType: ResolverFn<
   MutationUpdateLinkTypeArgs
 > = async (_, params, { dataSources }) => {
   const { graphApi } = dataSources;
-  const { linkTypeVersionedUri, updatedLinkType } = params;
+  const { linkTypeId, updatedLinkType } = params;
 
   const linkTypeModel = await LinkTypeModel.get(graphApi, {
-    linkTypeId: linkTypeVersionedUri,
+    linkTypeId,
   }).catch((err: AxiosError) => {
     throw new ApolloError(
-      `Unable to retrieve link type. ${err.response?.data} [URI=${linkTypeVersionedUri}]`,
+      `Unable to retrieve link type. ${err.response?.data} [URI=${linkTypeId}]`,
       "GET_ERROR",
     );
   });
@@ -98,7 +98,7 @@ export const updateLinkType: ResolverFn<
     .catch((err: AxiosError) => {
       const msg =
         err.response?.status === 409
-          ? `Link type URI doesn't exist, unable to update. [URI=${linkTypeVersionedUri}]`
+          ? `Link type URI doesn't exist, unable to update. [URI=${linkTypeId}]`
           : `Couldn't update link type.`;
 
       throw new ApolloError(msg, "CREATION_ERROR");

--- a/packages/hash/api/src/graphql/resolvers/ontology/model-mapping.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/model-mapping.ts
@@ -18,7 +18,7 @@ export const mapDataTypeModelToGQL = (
 ): PersistedDataType => ({
   ownedById: dataType.ownedById,
   accountId: dataType.ownedById,
-  dataTypeVersionedUri: dataType.schema.$id,
+  dataTypeId: dataType.schema.$id,
   dataType: dataType.schema,
 });
 
@@ -27,7 +27,7 @@ export const mapPropertyTypeModelToGQL = (
 ): PersistedPropertyType => ({
   ownedById: propertyType.ownedById,
   accountId: propertyType.ownedById,
-  propertyTypeVersionedUri: propertyType.schema.$id,
+  propertyTypeId: propertyType.schema.$id,
   propertyType: propertyType.schema,
 });
 
@@ -42,7 +42,7 @@ export const mapPropertyTypeRootedSubgraphToGQL = ({
 }): PropertyTypeRootedSubgraph => ({
   ownedById: propertyType.ownedById,
   accountId: propertyType.ownedById,
-  propertyTypeVersionedUri: propertyType.schema.$id,
+  propertyTypeId: propertyType.schema.$id,
   propertyType: propertyType.schema,
   referencedDataTypes: referencedDataTypes.map(mapDataTypeModelToGQL),
   referencedPropertyTypes: referencedPropertyTypes.map(
@@ -55,7 +55,7 @@ export const mapLinkTypeModelToGQL = (
 ): PersistedLinkType => ({
   ownedById: linkType.ownedById,
   accountId: linkType.ownedById,
-  linkTypeVersionedUri: linkType.schema.$id,
+  linkTypeId: linkType.schema.$id,
   linkType: linkType.schema,
 });
 
@@ -64,7 +64,7 @@ export const mapEntityTypeModelToGQL = (
 ): PersistedEntityType => ({
   ownedById: entityType.ownedById,
   accountId: entityType.ownedById,
-  entityTypeVersionedUri: entityType.schema.$id,
+  entityTypeId: entityType.schema.$id,
   entityType: entityType.schema,
 });
 
@@ -77,7 +77,7 @@ export const mapEntityTypeRootedSubgraphToGQL = (params: {
 }): EntityTypeRootedSubgraph => ({
   ownedById: params.entityType.ownedById,
   accountId: params.entityType.ownedById,
-  entityTypeVersionedUri: params.entityType.schema.$id,
+  entityTypeId: params.entityType.schema.$id,
   entityType: params.entityType.schema,
   referencedDataTypes: params.referencedDataTypes.map(mapDataTypeModelToGQL),
   referencedPropertyTypes: params.referencedPropertyTypes.map(

--- a/packages/hash/api/src/graphql/resolvers/ontology/property-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/property-type.ts
@@ -63,13 +63,13 @@ export const getPropertyType: ResolverFn<
   {},
   LoggedInGraphQLContext,
   QueryGetPropertyTypeArgs
-> = async (_, { propertyTypeVersionedUri }, { dataSources }, info) => {
+> = async (_, { propertyTypeId }, { dataSources }, info) => {
   const { graphApi } = dataSources;
 
   const propertyTypeRootedSubgraph = await PropertyTypeModel.getResolved(
     graphApi,
     {
-      propertyTypeId: propertyTypeVersionedUri,
+      propertyTypeId,
       dataTypeQueryDepth: dataTypeQueryDepth(info),
       propertyTypeQueryDepth: propertyTypeQueryDepth(info),
     },
@@ -90,13 +90,13 @@ export const updatePropertyType: ResolverFn<
   MutationUpdatePropertyTypeArgs
 > = async (_, params, { dataSources }) => {
   const { graphApi } = dataSources;
-  const { propertyTypeVersionedUri, updatedPropertyType } = params;
+  const { propertyTypeId, updatedPropertyType } = params;
 
   const propertyTypeModel = await PropertyTypeModel.get(graphApi, {
-    propertyTypeId: propertyTypeVersionedUri,
+    propertyTypeId,
   }).catch((err: AxiosError) => {
     throw new ApolloError(
-      `Unable to retrieve property type. ${err.response?.data} [URI=${propertyTypeVersionedUri}]`,
+      `Unable to retrieve property type. ${err.response?.data} [URI=${propertyTypeId}]`,
       "GET_ERROR",
     );
   });
@@ -108,7 +108,7 @@ export const updatePropertyType: ResolverFn<
     .catch((err: AxiosError) => {
       const msg =
         err.response?.status === 409
-          ? `Property type URI doesn't exist, unable to update. [URI=${propertyTypeVersionedUri}]`
+          ? `Property type URI doesn't exist, unable to update. [URI=${propertyTypeId}]`
           : `Couldn't update property type.`;
 
       throw new ApolloError(msg, "CREATION_ERROR");

--- a/packages/hash/api/src/graphql/typeDefs/ontology/data-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/data-type.typedef.ts
@@ -8,7 +8,7 @@ export const dataTypeTypedef = gql`
     """
     The specific versioned URI of the data type
     """
-    dataTypeVersionedUri: String!
+    dataTypeId: String!
     """
     The id of the account that owns this data type.
     """
@@ -33,7 +33,7 @@ export const dataTypeTypedef = gql`
     """
     Get a data type by its versioned URI.
     """
-    getDataType(dataTypeVersionedUri: String!): PersistedDataType!
+    getDataType(dataTypeId: String!): PersistedDataType!
   }
 
   # The following mutations should not be exposed until user defined data types

--- a/packages/hash/api/src/graphql/typeDefs/ontology/entity-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/entity-type.typedef.ts
@@ -17,7 +17,7 @@ export const entityTypeTypedef = gql`
     """
     The specific versioned URI of the entity type
     """
-    entityTypeVersionedUri: String!
+    entityTypeId: String!
     """
     The id of the account that owns this entity type.
     """
@@ -38,7 +38,7 @@ export const entityTypeTypedef = gql`
     """
     The specific versioned URI of the entity type
     """
-    entityTypeVersionedUri: String!
+    entityTypeId: String!
     """
     The id of the account that owns this entity type.
     """
@@ -77,7 +77,7 @@ export const entityTypeTypedef = gql`
     """
     The specific versioned URI of the entity type
     """
-    entityTypeVersionedUri: String!
+    entityTypeId: String!
     """
     The id of the account that owns this entity type.
     """
@@ -103,7 +103,7 @@ export const entityTypeTypedef = gql`
     """
     Get a entity type by its versioned URI.
     """
-    getEntityType(entityTypeVersionedUri: String!): EntityTypeRootedSubgraph!
+    getEntityType(entityTypeId: String!): EntityTypeRootedSubgraph!
   }
 
   extend type Mutation {
@@ -125,7 +125,7 @@ export const entityTypeTypedef = gql`
       """
       The entity type versioned $id to update.
       """
-      entityTypeVersionedUri: String!
+      entityTypeId: String!
       """
       New entity type schema contents to be used.
       """

--- a/packages/hash/api/src/graphql/typeDefs/ontology/link-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/link-type.typedef.ts
@@ -8,7 +8,7 @@ export const linkTypeTypedef = gql`
     """
     The specific versioned URI of the link type
     """
-    linkTypeVersionedUri: String!
+    linkTypeId: String!
     """
     The id of the account that owns this link type.
     """
@@ -33,7 +33,7 @@ export const linkTypeTypedef = gql`
     """
     Get an link type by its versioned URI.
     """
-    getLinkType(linkTypeVersionedUri: String!): PersistedLinkType!
+    getLinkType(linkTypeId: String!): PersistedLinkType!
   }
 
   extend type Mutation {
@@ -55,7 +55,7 @@ export const linkTypeTypedef = gql`
       """
       The link type versioned $id to update.
       """
-      linkTypeVersionedUri: String!
+      linkTypeId: String!
       """
       New link type schema contents to be used.
       """

--- a/packages/hash/api/src/graphql/typeDefs/ontology/property-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/property-type.typedef.ts
@@ -17,7 +17,7 @@ export const propertyTypeTypedef = gql`
     """
     The specific versioned URI of the property type
     """
-    propertyTypeVersionedUri: String!
+    propertyTypeId: String!
     """
     The id of the account that owns this property type.
     """
@@ -38,7 +38,7 @@ export const propertyTypeTypedef = gql`
     """
     The specific versioned URI of the property type
     """
-    propertyTypeVersionedUri: String!
+    propertyTypeId: String!
     """
     The id of the account that owns this property type.
     """
@@ -69,7 +69,7 @@ export const propertyTypeTypedef = gql`
     """
     The specific versioned URI of the property type
     """
-    propertyTypeVersionedUri: String!
+    propertyTypeId: String!
     """
     The id of the account that owns this property type.
     """
@@ -95,9 +95,7 @@ export const propertyTypeTypedef = gql`
     """
     Get a property type by its versioned URI.
     """
-    getPropertyType(
-      propertyTypeVersionedUri: String!
-    ): PropertyTypeRootedSubgraph!
+    getPropertyType(propertyTypeId: String!): PropertyTypeRootedSubgraph!
   }
 
   extend type Mutation {
@@ -119,7 +117,7 @@ export const propertyTypeTypedef = gql`
       """
       The property type versioned $id to update.
       """
-      propertyTypeVersionedUri: String!
+      propertyTypeId: String!
       """
       New property type schema contents to be used.
       """

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -283,7 +283,7 @@ export default class {
   /**
    * Get the latest version of an entity by its entity ID.
    *
-   * @param params.versionedUri the unique versioned URI for an entity.
+   * @param params.entityId the ID of an entity.
    */
   static async getLatest(
     graphApi: GraphApi,

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/ontology-types-shim.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/ontology-types-shim.ts
@@ -45,10 +45,10 @@ export type OntologyCallbacks = {
  * For example turning
  *   Response<"dataType", DataType>
  * into
- *   { dataTypeVersionedUri: string; dataType: DataType }
+ *   { dataTypeId: string; dataType: DataType }
  */
 type Response<N extends string, T> = {
-  [_ in `${N}VersionedUri`]: string;
+  [_ in `${N}Id`]: string;
 } & { [_ in N]: T };
 
 export type AggregateResult<T> = {
@@ -67,7 +67,7 @@ export type AggregateDataTypesMessageCallback = MessageCallback<
   ReadOrModifyResourceError
 >;
 
-export type GetDataTypeRequest = Pick<DataTypeResponse, "dataTypeVersionedUri">;
+export type GetDataTypeRequest = Pick<DataTypeResponse, "dataTypeId">;
 export type GetDataTypeMessageCallback = MessageCallback<
   GetDataTypeRequest,
   null,
@@ -106,7 +106,7 @@ export type GetPropertyTypeMessageCallback = MessageCallback<
 >;
 
 export type UpdatePropertyTypeRequest = {
-  propertyTypeVersionedUri: string;
+  propertyTypeId: string;
   propertyType: Omit<PropertyType, "$id">;
 };
 export type UpdatePropertyTypeMessageCallback = MessageCallback<
@@ -147,7 +147,7 @@ export type GetEntityTypeMessageCallback = MessageCallback<
 >;
 
 export type UpdateEntityTypeRequest = {
-  entityTypeVersionedUri: string;
+  entityTypeId: string;
   entityType: Omit<EntityType, "$id">;
 };
 export type UpdateEntityTypeMessageCallback = MessageCallback<
@@ -188,7 +188,7 @@ export type GetLinkTypeMessageCallback = MessageCallback<
 >;
 
 export type UpdateLinkTypeRequest = {
-  linkTypeVersionedUri: string;
+  linkTypeId: string;
   linkType: Omit<LinkType, "$id">;
 };
 export type UpdateLinkTypeMessageCallback = MessageCallback<

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolCreateEntityType.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolCreateEntityType.ts
@@ -64,8 +64,7 @@ export const useBlockProtocolCreateEntityType = (
 
       return {
         data: {
-          entityTypeVersionedUri:
-            responseData.createEntityType.entityTypeVersionedUri,
+          entityTypeId: responseData.createEntityType.entityTypeId,
           entityType: responseData.createEntityType.entityType,
         },
       };

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolCreateLinkType.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolCreateLinkType.ts
@@ -64,8 +64,7 @@ export const useBlockProtocolCreateLinkType = (
 
       return {
         data: {
-          linkTypeVersionedUri:
-            responseData.createLinkType.linkTypeVersionedUri,
+          linkTypeId: responseData.createLinkType.linkTypeId,
           linkType: responseData.createLinkType.linkType,
         },
       };

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolCreatePropertyType.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolCreatePropertyType.ts
@@ -64,8 +64,7 @@ export const useBlockProtocolCreatePropertyType = (
 
       return {
         data: {
-          propertyTypeVersionedUri:
-            responseData.createPropertyType.propertyTypeVersionedUri,
+          propertyTypeId: responseData.createPropertyType.propertyTypeId,
           propertyType: responseData.createPropertyType.propertyType,
         },
       };

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolUpdateEntityType.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolUpdateEntityType.ts
@@ -42,10 +42,10 @@ export const useBlockProtocolUpdateEntityType = (
         };
       }
 
-      const { entityTypeVersionedUri, entityType } = data;
+      const { entityTypeId, entityType } = data;
       const { data: responseData } = await updateFn({
         variables: {
-          entityTypeVersionedUri,
+          entityTypeId,
           updatedEntityType: entityType,
         },
       });
@@ -63,8 +63,7 @@ export const useBlockProtocolUpdateEntityType = (
 
       return {
         data: {
-          entityTypeVersionedUri:
-            responseData.updateEntityType.entityTypeVersionedUri,
+          entityTypeId: responseData.updateEntityType.entityTypeId,
           entityType: responseData.updateEntityType.entityType,
         },
       };

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolUpdateLinkType.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolUpdateLinkType.ts
@@ -42,10 +42,10 @@ export const useBlockProtocolUpdateLinkType = (
         };
       }
 
-      const { linkTypeVersionedUri, linkType } = data;
+      const { linkTypeId, linkType } = data;
       const { data: responseData } = await updateFn({
         variables: {
-          linkTypeVersionedUri,
+          linkTypeId,
           updatedLinkType: linkType,
         },
       });
@@ -63,8 +63,7 @@ export const useBlockProtocolUpdateLinkType = (
 
       return {
         data: {
-          linkTypeVersionedUri:
-            responseData.updateLinkType.linkTypeVersionedUri,
+          linkTypeId: responseData.updateLinkType.linkTypeId,
           linkType: responseData.updateLinkType.linkType,
         },
       };

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolUpdatePropertyType.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolUpdatePropertyType.ts
@@ -42,10 +42,10 @@ export const useBlockProtocolUpdatePropertyType = (
         };
       }
 
-      const { propertyTypeVersionedUri, propertyType } = data;
+      const { propertyTypeId, propertyType } = data;
       const { data: responseData } = await updateFn({
         variables: {
-          propertyTypeVersionedUri,
+          propertyTypeId,
           updatedPropertyType: propertyType,
         },
       });
@@ -63,8 +63,7 @@ export const useBlockProtocolUpdatePropertyType = (
 
       return {
         data: {
-          propertyTypeVersionedUri:
-            responseData.updatePropertyType.propertyTypeVersionedUri,
+          propertyTypeId: responseData.updatePropertyType.propertyTypeId,
           propertyType: responseData.updatePropertyType.propertyType,
         },
       };

--- a/packages/hash/frontend/src/graphql/queries/ontology/data-type.queries.ts
+++ b/packages/hash/frontend/src/graphql/queries/ontology/data-type.queries.ts
@@ -1,9 +1,9 @@
 import { gql } from "@apollo/client";
 
 export const getDataTypeQuery = gql`
-  query getDataType($dataTypeVersionedUri: String!) {
-    getDataType(dataTypeVersionedUri: $dataTypeVersionedUri) {
-      dataTypeVersionedUri
+  query getDataType($dataTypeId: String!) {
+    getDataType(dataTypeId: $dataTypeId) {
+      dataTypeId
       ownedById
       dataType
     }
@@ -13,7 +13,7 @@ export const getDataTypeQuery = gql`
 export const getAllLatestDataTypesQuery = gql`
   query getAllLatestDataTypes {
     getAllLatestDataTypes {
-      dataTypeVersionedUri
+      dataTypeId
       ownedById
       dataType
     }

--- a/packages/hash/frontend/src/graphql/queries/ontology/entity-type.queries.ts
+++ b/packages/hash/frontend/src/graphql/queries/ontology/entity-type.queries.ts
@@ -1,9 +1,9 @@
 import { gql } from "@apollo/client";
 
 export const getEntityTypeQuery = gql`
-  query getEntityType($entityTypeVersionedUri: String!) {
-    getEntityType(entityTypeVersionedUri: $entityTypeVersionedUri) {
-      entityTypeVersionedUri
+  query getEntityType($entityTypeId: String!) {
+    getEntityType(entityTypeId: $entityTypeId) {
+      entityTypeId
       ownedById
       entityType
     }
@@ -13,7 +13,7 @@ export const getEntityTypeQuery = gql`
 export const getAllLatestEntityTypesQuery = gql`
   query getAllLatestEntityTypes {
     getAllLatestEntityTypes {
-      entityTypeVersionedUri
+      entityTypeId
       ownedById
       entityType
     }
@@ -26,7 +26,7 @@ export const createEntityTypeMutation = gql`
     $entityType: EntityTypeWithoutId!
   ) {
     createEntityType(ownedById: $ownedById, entityType: $entityType) {
-      entityTypeVersionedUri
+      entityTypeId
       ownedById
       entityType
     }
@@ -35,14 +35,14 @@ export const createEntityTypeMutation = gql`
 
 export const updateEntityTypeMutation = gql`
   mutation updateEntityType(
-    $entityTypeVersionedUri: String!
+    $entityTypeId: String!
     $updatedEntityType: EntityTypeWithoutId!
   ) {
     updateEntityType(
-      entityTypeVersionedUri: $entityTypeVersionedUri
+      entityTypeId: $entityTypeId
       updatedEntityType: $updatedEntityType
     ) {
-      entityTypeVersionedUri
+      entityTypeId
       ownedById
       entityType
     }

--- a/packages/hash/frontend/src/graphql/queries/ontology/link-type.queries.ts
+++ b/packages/hash/frontend/src/graphql/queries/ontology/link-type.queries.ts
@@ -1,9 +1,9 @@
 import { gql } from "@apollo/client";
 
 export const getLinkTypeQuery = gql`
-  query getLinkType($linkTypeVersionedUri: String!) {
-    getLinkType(linkTypeVersionedUri: $linkTypeVersionedUri) {
-      linkTypeVersionedUri
+  query getLinkType($linkTypeId: String!) {
+    getLinkType(linkTypeId: $linkTypeId) {
+      linkTypeId
       ownedById
       linkType
     }
@@ -13,7 +13,7 @@ export const getLinkTypeQuery = gql`
 export const getAllLatestLinkTypesQuery = gql`
   query getAllLatestLinkTypes {
     getAllLatestLinkTypes {
-      linkTypeVersionedUri
+      linkTypeId
       ownedById
       linkType
     }
@@ -23,7 +23,7 @@ export const getAllLatestLinkTypesQuery = gql`
 export const createLinkTypeMutation = gql`
   mutation createLinkType($ownedById: ID!, $linkType: LinkTypeWithoutId!) {
     createLinkType(ownedById: $ownedById, linkType: $linkType) {
-      linkTypeVersionedUri
+      linkTypeId
       ownedById
       linkType
     }
@@ -32,14 +32,11 @@ export const createLinkTypeMutation = gql`
 
 export const updateLinkTypeMutation = gql`
   mutation updateLinkType(
-    $linkTypeVersionedUri: String!
+    $linkTypeId: String!
     $updatedLinkType: LinkTypeWithoutId!
   ) {
-    updateLinkType(
-      linkTypeVersionedUri: $linkTypeVersionedUri
-      updatedLinkType: $updatedLinkType
-    ) {
-      linkTypeVersionedUri
+    updateLinkType(linkTypeId: $linkTypeId, updatedLinkType: $updatedLinkType) {
+      linkTypeId
       ownedById
       linkType
     }

--- a/packages/hash/frontend/src/graphql/queries/ontology/property-type.queries.ts
+++ b/packages/hash/frontend/src/graphql/queries/ontology/property-type.queries.ts
@@ -1,9 +1,9 @@
 import { gql } from "@apollo/client";
 
 export const getPropertyTypeQuery = gql`
-  query getPropertyType($propertyTypeVersionedUri: String!) {
-    getPropertyType(propertyTypeVersionedUri: $propertyTypeVersionedUri) {
-      propertyTypeVersionedUri
+  query getPropertyType($propertyTypeId: String!) {
+    getPropertyType(propertyTypeId: $propertyTypeId) {
+      propertyTypeId
       ownedById
       propertyType
     }
@@ -13,7 +13,7 @@ export const getPropertyTypeQuery = gql`
 export const getAllLatestPropertyTypesQuery = gql`
   query getAllLatestPropertyTypes {
     getAllLatestPropertyTypes {
-      propertyTypeVersionedUri
+      propertyTypeId
       ownedById
       propertyType
     }
@@ -26,7 +26,7 @@ export const createPropertyTypeMutation = gql`
     $propertyType: PropertyTypeWithoutId!
   ) {
     createPropertyType(ownedById: $ownedById, propertyType: $propertyType) {
-      propertyTypeVersionedUri
+      propertyTypeId
       ownedById
       propertyType
     }
@@ -35,14 +35,14 @@ export const createPropertyTypeMutation = gql`
 
 export const updatePropertyTypeMutation = gql`
   mutation updatePropertyType(
-    $propertyTypeVersionedUri: String!
+    $propertyTypeId: String!
     $updatedPropertyType: PropertyTypeWithoutId!
   ) {
     updatePropertyType(
-      propertyTypeVersionedUri: $propertyTypeVersionedUri
+      propertyTypeId: $propertyTypeId
       updatedPropertyType: $updatedPropertyType
     ) {
-      propertyTypeVersionedUri
+      propertyTypeId
       ownedById
       propertyType
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
Replaces instances of `VersionedUri` with `Id` for any ontology type in the HASH API and frontend. 