### PR TITLE
`knowledgeBlocks` GQL query

### DIFF
--- a/packages/hash/api/src/graphql/resolvers/index.ts
+++ b/packages/hash/api/src/graphql/resolvers/index.ts
@@ -101,6 +101,7 @@ import {
   knowledgePageContents,
 } from "./knowledge/page";
 import { knowledgePage } from "./knowledge/page/page";
+import { knowledgeBlocks } from "./knowledge/block/block";
 
 export const resolvers = {
   Query: {
@@ -143,6 +144,7 @@ export const resolvers = {
     getEntityType: loggedInAndSignedUp(getEntityType),
     // Knowledge
     knowledgePage: loggedInAndSignedUp(knowledgePage),
+    knowledgeBlocks: loggedInAndSignedUp(knowledgeBlocks),
   },
 
   Mutation: {

--- a/packages/hash/api/src/graphql/resolvers/knowledge/block/block.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/block/block.ts
@@ -1,0 +1,23 @@
+import { BlockModel } from "../../../../model";
+
+import { QueryKnowledgeBlocksArgs, ResolverFn } from "../../../apiTypes.gen";
+import { GraphQLContext } from "../../../context";
+import {
+  UnresolvedKnowledgeBlockGQL,
+  mapBlockModelToGQL,
+} from "../model-mapping";
+
+export const knowledgeBlocks: ResolverFn<
+  Promise<UnresolvedKnowledgeBlockGQL[]>,
+  {},
+  GraphQLContext,
+  QueryKnowledgeBlocksArgs
+> = async (_, params, { dataSources: { graphApi } }) => {
+  const blocks = await Promise.all(
+    params.blocks.map(({ entityId }) =>
+      BlockModel.getBlockById(graphApi, { entityId }),
+    ),
+  );
+
+  return blocks.map(mapBlockModelToGQL);
+};

--- a/packages/hash/api/src/graphql/typeDefs/knowledge/block.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/knowledge/block.typedef.ts
@@ -47,4 +47,15 @@ export const knowledgeBlockTypedef = gql`
     properties: JSONObject!
     # ENTITY INTERFACE FIELDS END #
   }
+
+  input LatestKnowledgeEntityRef {
+    entityId: ID!
+  }
+
+  extend type Query {
+    """
+    Get a specified list of blocks by their entity id
+    """
+    knowledgeBlocks(blocks: [LatestKnowledgeEntityRef!]!): [KnowledgeBlock!]!
+  }
 `;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR introduces a `knowledgeBlocks` GQL query.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202953520344818/1203064073566618/f) _(internal)_

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- introduces the `knowledgeBlocks` GQL query

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

No.

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

- the current implementation of the `KnowledgeBlock` GQL type cannot directly replace the existing `Block` GQL type, as it's properties don't resolve linked entities using legacy fields.

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

We are currently conducting manual tests for GQL queries/mutations

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Checkout this branch
2. Run `yarn external-services up` locally
3. Run `yarn test:backend-integration page.model` in a separate terminal window to seed the database with some pages and blocks
4. Run `yarn dev`
5. Open `localhost:3000` and login
6. Open `localhost:5001/graphql` to access the GQL playground
7. Execute the below query to fetch a page by its id

<details>
<summary>knowledgeBlocks query</summary>

```gql
{
  knowledgeBlocks(blocks: [{entityId:"..."}, {entityId:"..."}]) {
    entityId
    componentId
  }
}
```
</details>


## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

<img width="2301" alt="image" src="https://user-images.githubusercontent.com/42802102/193078826-046f80fb-f45f-4806-a78a-69f5e149ff67.png">

