### PR TITLE
Benchmark query entity type

### DIFF
--- a/packages/graph/hash_graph/bench/benches/representative_read/knowledge/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/knowledge/entity.rs
@@ -8,20 +8,6 @@ use tokio::runtime::Runtime;
 
 use crate::util::Store;
 
-/// Benchmark to measure the time taken to query the latest version of an entity by its ID.
-///
-/// Across runs, Criterion compares benchmarks that share the same ID. We'd like to be able to
-/// track performance overtime, so we need to have consistent IDs. This means that if we're
-/// auto-generating entity ID's, we can't use them as inputs to `bench_with_input`, as the
-/// [`BenchmarkId`] will vary between runs and we won't get comparative analysis.
-///
-/// We also don't really want to measure how long it takes to query a sample of IDs (e.g. to make
-/// 100 entity queries). As such, this function takes a list of [`EntityId`]s to sample from, and
-/// uses `iter_batched` to do a per-iteration setup whereby each benchmark iteration picks a
-/// random entity to sample. This should provide us with an idea of average performance for
-/// _querying a single entity_ across the given sample.
-///
-/// [`BenchmarkId`]: criterion::BenchmarkId
 pub fn bench_get_entity_by_id(
     b: &mut Bencher,
     runtime: &Runtime,

--- a/packages/graph/hash_graph/bench/benches/representative_read/mod.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/mod.rs
@@ -1,3 +1,18 @@
+//! Benchmarks to
+//!
+//! Across runs, Criterion compares benchmarks that share the same ID. We'd like to be able to
+//! track performance overtime, so we need to have consistent IDs. This means that if we're
+//! auto-generating entity type ID's, we can't use them as inputs to `bench_with_input`, as the
+//! [`BenchmarkId`] will vary between runs and we won't get comparative analysis.
+//!
+//! We also don't really want to measure how long it takes to query a sample of IDs (e.g. to make
+//! 100 entity type queries). As such, this function takes a list of [`EntityId`]s to sample from,
+//! and uses `iter_batched` to do a per-iteration setup whereby each benchmark iteration picks a
+//! random entity to sample. This should provide us with an idea of average performance for
+//! _querying a single entity type_ across the given sample.
+//!
+//! [`BenchmarkId`]: criterion::BenchmarkId
+
 use criterion::{BenchmarkId, Criterion};
 use criterion_macro::criterion;
 
@@ -11,8 +26,8 @@ mod seed;
 const DB_NAME: &str = "representative_read";
 
 #[criterion]
-fn bench_representative_read(c: &mut Criterion) {
-    let mut group = c.benchmark_group("representative_read");
+fn bench_representative_read_entity(c: &mut Criterion) {
+    let mut group = c.benchmark_group("representative_read_entity");
     let (runtime, mut store_wrapper) = setup(DB_NAME, false);
 
     let samples = runtime.block_on(setup_and_extract_samples(&mut store_wrapper));
@@ -21,15 +36,45 @@ fn bench_representative_read(c: &mut Criterion) {
     for (account_id, type_ids_and_entity_ids) in samples.entities {
         for (entity_type_id, entity_ids) in type_ids_and_entity_ids {
             group.bench_with_input(
-                BenchmarkId::from_parameter(format!(
-                    "Account ID: `{}`, Entity Type ID: `{}`",
-                    account_id, entity_type_id
-                )),
+                BenchmarkId::new(
+                    "get_entity_by_id",
+                    format!(
+                        "Account ID: `{}`, Entity Type ID: `{}`",
+                        account_id, entity_type_id
+                    ),
+                ),
                 &(account_id, entity_type_id, entity_ids),
                 |b, (_account_id, _entity_type_id, entity_ids)| {
                     knowledge::entity::bench_get_entity_by_id(b, &runtime, store, entity_ids);
                 },
             );
         }
+    }
+}
+
+#[criterion]
+fn bench_representative_read_entity_type(c: &mut Criterion) {
+    let mut group = c.benchmark_group("representative_read_entity_type");
+    let (runtime, mut store_wrapper) = setup(DB_NAME, false);
+
+    let samples = runtime.block_on(setup_and_extract_samples(&mut store_wrapper));
+    let store = &store_wrapper.store;
+
+    for (account_id, entity_type_ids) in samples.entity_types {
+        group.bench_with_input(
+            BenchmarkId::new(
+                "get_entity_type_by_id",
+                format!("Account ID: `{}`", account_id),
+            ),
+            &(account_id, entity_type_ids),
+            |b, (_account_id, entity_type_ids)| {
+                ontology::entity_type::bench_get_entity_type_by_id(
+                    b,
+                    &runtime,
+                    store,
+                    entity_type_ids,
+                );
+            },
+        );
     }
 }

--- a/packages/graph/hash_graph/bench/benches/representative_read/mod.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/mod.rs
@@ -1,15 +1,19 @@
-//! Benchmarks to
+//! Benchmarks to check the performance of operations across a "representative" graph.
 //!
-//! Across runs, Criterion compares benchmarks that share the same ID. We'd like to be able to
-//! track performance overtime, so we need to have consistent IDs. This means that if we're
-//! auto-generating entity type ID's, we can't use them as inputs to `bench_with_input`, as the
-//! [`BenchmarkId`] will vary between runs and we won't get comparative analysis.
+//! There are some designs in this module which aren't immediately obvious. Across runs, Criterion
+//! compares benchmarks that share the same ID. We'd like to be able to track performance as
+//! development continues, so we need to have consistent IDs to benefit from the comparative
+//! analysis. This means that if we're auto-generating entity type ID's, we can't use them as inputs
+//! for `bench_with_input` as the [`BenchmarkId`] will vary between runs and we won't get
+//! comparative analysis.
 //!
-//! We also don't really want to measure how long it takes to query a sample of IDs (e.g. to make
-//! 100 entity type queries). As such, this function takes a list of [`EntityId`]s to sample from,
-//! and uses `iter_batched` to do a per-iteration setup whereby each benchmark iteration picks a
+//! For a lot of these queries we want to know the general performance across the graph. This means
+//! that we'd like to query across a sample of elements, but we don't want to benchmark the time it
+//! takes to query 100 (for example) entities, but instead are interested in the average performance
+//! to query _one_ entity. As such a lot of functions take a list of elements to sample from, and
+//! use `iter_batched` to do a per-iteration setup whereby each benchmark iteration picks a
 //! random entity to sample. This should provide us with an idea of average performance for
-//! _querying a single entity type_ across the given sample.
+//! _querying a single element_ across the given sample.
 //!
 //! [`BenchmarkId`]: criterion::BenchmarkId
 

--- a/packages/graph/hash_graph/bench/benches/representative_read/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/ontology/entity_type.rs
@@ -17,7 +17,7 @@ pub fn bench_get_entity_type_by_id(
 ) {
     b.to_async(runtime).iter_batched(
         || {
-            // Each iteration, *before timing*, pick a random entity from the sample to query
+            // Each iteration, *before timing*, pick a random entity type from the sample to query
             entity_type_ids
                 .iter()
                 .choose(&mut thread_rng())

--- a/packages/graph/hash_graph/bench/benches/representative_read/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/ontology/entity_type.rs
@@ -1,0 +1,41 @@
+use criterion::{BatchSize::SmallInput, Bencher};
+use graph::{
+    ontology::EntityTypeQuery,
+    store::{query::Expression, EntityTypeStore},
+};
+use rand::{prelude::IteratorRandom, thread_rng};
+use tokio::runtime::Runtime;
+use type_system::uri::VersionedUri;
+
+use crate::util::Store;
+
+pub fn bench_get_entity_type_by_id(
+    b: &mut Bencher,
+    runtime: &Runtime,
+    store: &Store,
+    entity_type_ids: &[VersionedUri],
+) {
+    b.to_async(runtime).iter_batched(
+        || {
+            // Each iteration, *before timing*, pick a random entity from the sample to query
+            entity_type_ids
+                .iter()
+                .choose(&mut thread_rng())
+                .unwrap()
+                .clone()
+        },
+        |entity_type_id| async move {
+            store
+                .get_entity_type(&EntityTypeQuery {
+                    expression: Expression::for_versioned_uri(&entity_type_id),
+                    data_type_query_depth: 0,
+                    property_type_query_depth: 0,
+                    link_type_query_depth: 0,
+                    entity_type_query_depth: 0,
+                })
+                .await
+                .expect("failed to read entity type from store");
+        },
+        SmallInput,
+    );
+}

--- a/packages/graph/hash_graph/bench/benches/representative_read/ontology/mod.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/ontology/mod.rs
@@ -1,1 +1,1 @@
-
+pub mod entity_type;

--- a/packages/graph/hash_graph/bench/benches/representative_read/seed.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/seed.rs
@@ -166,11 +166,27 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
 /// DOC - TODO
 pub struct Samples {
     pub entities: HashMap<AccountId, HashMap<VersionedUri, Vec<EntityId>>>,
+    pub entity_types: HashMap<AccountId, Vec<VersionedUri>>,
 }
 
 async fn get_samples(account_id: AccountId, store_wrapper: &mut StoreWrapper) -> Samples {
+    let mut entity_types = HashMap::new();
+    entity_types.insert(
+        account_id,
+        SEED_ENTITY_TYPES
+            .into_iter()
+            .map(|entity_type_str| {
+                EntityType::from_str(entity_type_str)
+                    .expect("could not parse entity type")
+                    .id()
+                    .clone()
+            })
+            .collect(),
+    );
+
     let mut samples = Samples {
         entities: HashMap::from([(account_id, HashMap::new())]),
+        entity_types,
     };
 
     let sample_map = samples.entities.get_mut(&account_id).unwrap();


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This follows from #1132. It simply adds a query across the "representative" graph to get an entity type by its ID.

## 🔍 What does this change?

- Introduces a benchmark for getting an entity type by its ID.

## 📜 Does this require a change to the docs?

- No

## 🐾 Next steps

- Query rooted subgraphs
- Check performance of querying across various scales of the graph

## 🛡 What tests cover this?

- The current (single) benchmark group

## ❓ How to test this?

1. Checkout the branch
2. Run `cargo make deployment-up`
3. Run `make recreate-db`
4. Run `make migrate-up`
5. Run `cargo bench`
