### PR TITLE
Add `link` resolvers

### DIFF
--- a/packages/hash/api/src/graphql/resolvers/index.ts
+++ b/packages/hash/api/src/graphql/resolvers/index.ts
@@ -110,7 +110,11 @@ import { knowledgeBlocks } from "./knowledge/block/block";
 import { getBlockProtocolBlocks } from "./blockprotocol/getBlock";
 import { knowledgeEntity } from "./knowledge/entity/entity";
 import { UnresolvedKnowledgeEntityGQL } from "./knowledge/model-mapping";
-import { createKnowledgeLink, knowledgeLinks } from "./knowledge/link/link";
+import {
+  createKnowledgeLink,
+  deleteKnowledgeLink,
+  knowledgeLinks,
+} from "./knowledge/link/link";
 
 /**
  * @todo: derive these from the statically declared workspace type names
@@ -223,6 +227,7 @@ export const resolvers = {
     updateEntityType: loggedInAndSignedUp(updateEntityType),
     // Knowledge
     createKnowledgeLink: loggedInAndSignedUp(createKnowledgeLink),
+    deleteKnowledgeLink: loggedInAndSignedUp(deleteKnowledgeLink),
   },
 
   JSONObject: JSONObjectResolver,

--- a/packages/hash/api/src/graphql/resolvers/index.ts
+++ b/packages/hash/api/src/graphql/resolvers/index.ts
@@ -113,7 +113,7 @@ import { UnresolvedKnowledgeEntityGQL } from "./knowledge/model-mapping";
 import {
   createKnowledgeLink,
   deleteKnowledgeLink,
-  knowledgeLinks,
+  outgoingKnowledgeLinks,
 } from "./knowledge/link/link";
 
 /**
@@ -176,7 +176,7 @@ export const resolvers = {
     knowledgePage: loggedInAndSignedUp(knowledgePage),
     knowledgeBlocks: loggedInAndSignedUp(knowledgeBlocks),
     knowledgeEntity: loggedInAndSignedUp(knowledgeEntity),
-    knowledgeLinks: loggedInAndSignedUp(knowledgeLinks),
+    outgoingKnowledgeLinks: loggedInAndSignedUp(outgoingKnowledgeLinks),
   },
 
   Mutation: {

--- a/packages/hash/api/src/graphql/resolvers/index.ts
+++ b/packages/hash/api/src/graphql/resolvers/index.ts
@@ -110,7 +110,7 @@ import { knowledgeBlocks } from "./knowledge/block/block";
 import { getBlockProtocolBlocks } from "./blockprotocol/getBlock";
 import { knowledgeEntity } from "./knowledge/entity/entity";
 import { UnresolvedKnowledgeEntityGQL } from "./knowledge/model-mapping";
-import { knowledgeLinks } from "./knowledge/link/link";
+import { createKnowledgeLink, knowledgeLinks } from "./knowledge/link/link";
 
 /**
  * @todo: derive these from the statically declared workspace type names
@@ -221,6 +221,8 @@ export const resolvers = {
     updateLinkType: loggedInAndSignedUp(updateLinkType),
     createEntityType: loggedInAndSignedUp(createEntityType),
     updateEntityType: loggedInAndSignedUp(updateEntityType),
+    // Knowledge
+    createKnowledgeLink: loggedInAndSignedUp(createKnowledgeLink),
   },
 
   JSONObject: JSONObjectResolver,

--- a/packages/hash/api/src/graphql/resolvers/index.ts
+++ b/packages/hash/api/src/graphql/resolvers/index.ts
@@ -110,6 +110,7 @@ import { knowledgeBlocks } from "./knowledge/block/block";
 import { getBlockProtocolBlocks } from "./blockprotocol/getBlock";
 import { knowledgeEntity } from "./knowledge/entity/entity";
 import { UnresolvedKnowledgeEntityGQL } from "./knowledge/model-mapping";
+import { knowledgeLinks } from "./knowledge/link/link";
 
 /**
  * @todo: derive these from the statically declared workspace type names
@@ -171,6 +172,7 @@ export const resolvers = {
     knowledgePage: loggedInAndSignedUp(knowledgePage),
     knowledgeBlocks: loggedInAndSignedUp(knowledgeBlocks),
     knowledgeEntity: loggedInAndSignedUp(knowledgeEntity),
+    knowledgeLinks: loggedInAndSignedUp(knowledgeLinks),
   },
 
   Mutation: {

--- a/packages/hash/api/src/graphql/resolvers/knowledge/link/link.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/link/link.ts
@@ -1,0 +1,36 @@
+import { LinkModel } from "../../../../model";
+import { QueryKnowledgeLinksArgs, ResolverFn } from "../../../apiTypes.gen";
+import { LoggedInGraphQLContext } from "../../../context";
+import {
+  mapLinkModelToGQL,
+  UnresolvedKnowledgeLinkGQL,
+} from "../model-mapping";
+
+export const knowledgeLinks: ResolverFn<
+  Promise<UnresolvedKnowledgeLinkGQL[]>,
+  {},
+  LoggedInGraphQLContext,
+  QueryKnowledgeLinksArgs
+> = async (
+  _,
+  { sourceEntityId, linkTypeId },
+  { dataSources: { graphApi } },
+) => {
+  const linkModels = await LinkModel.getByQuery(graphApi, {
+    all: [
+      {
+        eq: [{ path: ["source", "id"] }, { literal: sourceEntityId }],
+      },
+      {
+        eq: [
+          { path: ["type", "versionedUri"] },
+          {
+            literal: linkTypeId,
+          },
+        ],
+      },
+    ],
+  });
+
+  return linkModels.map(mapLinkModelToGQL);
+};

--- a/packages/hash/api/src/graphql/resolvers/knowledge/link/link.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/link/link.ts
@@ -1,4 +1,4 @@
-import { ApolloError } from "apollo-server-errors";
+import { ApolloError, UserInputError } from "apollo-server-errors";
 import { EntityModel, LinkModel, LinkTypeModel } from "../../../../model";
 import {
   MutationCreateKnowledgeLinkArgs,
@@ -102,10 +102,7 @@ export const deleteKnowledgeLink: ResolverFn<
       "NOT_FOUND",
     );
   } else if (linkModels.length > 1) {
-    throw new ApolloError(
-      `Could not identify one single link with query.`,
-      "BAD_REQUEST",
-    );
+    throw new UserInputError(`Could not identify one single link with query.`);
   }
 
   await linkModels[0].remove(graphApi, { removedById: user.entityId });

--- a/packages/hash/api/src/graphql/resolvers/knowledge/link/link.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/link/link.ts
@@ -1,10 +1,46 @@
-import { LinkModel } from "../../../../model";
-import { QueryKnowledgeLinksArgs, ResolverFn } from "../../../apiTypes.gen";
+import { EntityModel, LinkModel, LinkTypeModel } from "../../../../model";
+import {
+  MutationCreateKnowledgeLinkArgs,
+  QueryKnowledgeLinksArgs,
+  ResolverFn,
+} from "../../../apiTypes.gen";
 import { LoggedInGraphQLContext } from "../../../context";
 import {
   mapLinkModelToGQL,
   UnresolvedKnowledgeLinkGQL,
 } from "../model-mapping";
+
+export const createKnowledgeLink: ResolverFn<
+  Promise<UnresolvedKnowledgeLinkGQL>,
+  {},
+  LoggedInGraphQLContext,
+  MutationCreateKnowledgeLinkArgs
+> = async (_, { link }, { dataSources: { graphApi } }) => {
+  const { linkTypeId, ownedById, index, sourceEntityId, targetEntityId } = link;
+
+  const [linkTypeModel, sourceEntityModel, targetEntityModel] =
+    await Promise.all([
+      LinkTypeModel.get(graphApi, {
+        linkTypeId,
+      }),
+      EntityModel.getLatest(graphApi, {
+        entityId: sourceEntityId,
+      }),
+      EntityModel.getLatest(graphApi, {
+        entityId: targetEntityId,
+      }),
+    ]);
+
+  const linkModel = await LinkModel.create(graphApi, {
+    linkTypeModel,
+    ownedById,
+    index: index ?? undefined,
+    sourceEntityModel,
+    targetEntityModel,
+  });
+
+  return mapLinkModelToGQL(linkModel);
+};
 
 export const knowledgeLinks: ResolverFn<
   Promise<UnresolvedKnowledgeLinkGQL[]>,

--- a/packages/hash/api/src/graphql/resolvers/knowledge/link/link.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/link/link.ts
@@ -3,7 +3,7 @@ import { EntityModel, LinkModel, LinkTypeModel } from "../../../../model";
 import {
   MutationCreateKnowledgeLinkArgs,
   MutationDeleteKnowledgeLinkArgs,
-  QueryKnowledgeLinksArgs,
+  QueryOutgoingKnowledgeLinksArgs,
   ResolverFn,
 } from "../../../apiTypes.gen";
 import { LoggedInGraphQLContext } from "../../../context";
@@ -44,11 +44,11 @@ export const createKnowledgeLink: ResolverFn<
   return mapLinkModelToGQL(linkModel);
 };
 
-export const knowledgeLinks: ResolverFn<
+export const outgoingKnowledgeLinks: ResolverFn<
   Promise<UnresolvedKnowledgeLinkGQL[]>,
   {},
   LoggedInGraphQLContext,
-  QueryKnowledgeLinksArgs
+  QueryOutgoingKnowledgeLinksArgs
 > = async (
   _,
   { sourceEntityId, linkTypeId },
@@ -56,18 +56,18 @@ export const knowledgeLinks: ResolverFn<
 ) => {
   const linkModels = await LinkModel.getByQuery(graphApi, {
     all: [
-      {
-        eq: [{ path: ["source", "id"] }, { literal: sourceEntityId }],
-      },
-      {
-        eq: [
-          { path: ["type", "versionedUri"] },
-          {
-            literal: linkTypeId,
-          },
-        ],
-      },
-    ],
+      { eq: [{ path: ["source", "id"] }, { literal: sourceEntityId }] },
+      linkTypeId
+        ? {
+            eq: [
+              { path: ["type", "versionedUri"] },
+              {
+                literal: linkTypeId,
+              },
+            ],
+          }
+        : [],
+    ].flat(),
   });
 
   return linkModels.map(mapLinkModelToGQL);

--- a/packages/hash/api/src/graphql/resolvers/knowledge/model-mapping.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/model-mapping.ts
@@ -1,7 +1,8 @@
-import { BlockModel, EntityModel, PageModel } from "../../../model";
+import { BlockModel, EntityModel, LinkModel, PageModel } from "../../../model";
 import {
   KnowledgeBlock,
   KnowledgeEntity,
+  KnowledgeLink,
   KnowledgePage,
 } from "../../apiTypes.gen";
 import { mapEntityTypeModelToGQL } from "../ontology/model-mapping";
@@ -60,4 +61,26 @@ export const mapBlockModelToGQL = (
 ): UnresolvedKnowledgeBlockGQL => ({
   ...mapEntityModelToGQL(blockModel),
   componentId: blockModel.getComponentId(),
+});
+
+export type UnresolvedKnowledgeLinkGQL = Omit<
+  KnowledgeLink,
+  "sourceEntity" | "targetEntity"
+> & {
+  sourceEntity: UnresolvedKnowledgeEntityGQL;
+  targetEntity: UnresolvedKnowledgeEntityGQL;
+};
+
+export const mapLinkModelToGQL = (
+  linkModel: LinkModel,
+): UnresolvedKnowledgeLinkGQL => ({
+  ownedById: linkModel.ownedById,
+  linkTypeId: linkModel.linkTypeModel.schema.$id,
+  index: linkModel.index,
+  sourceEntityId: linkModel.sourceEntityModel.entityId,
+  targetEntityId: linkModel.targetEntityModel.entityId,
+  // These may be field resolvers at some point.
+  // Currently we require source and target on link model instantiation.
+  sourceEntity: mapEntityModelToGQL(linkModel.sourceEntityModel),
+  targetEntity: mapEntityModelToGQL(linkModel.targetEntityModel),
 });

--- a/packages/hash/api/src/graphql/typeDefs/index.ts
+++ b/packages/hash/api/src/graphql/typeDefs/index.ts
@@ -26,6 +26,7 @@ import { entityTypeTypedef } from "./ontology/entity-type.typedef";
 import { knowledgeEntityTypedef } from "./knowledge/entity.typedef";
 import { knowledgePageTypedef } from "./knowledge/page.typedef";
 import { knowledgeBlockTypedef } from "./knowledge/block.typedef";
+import { knowledgeLinkTypedef } from "./knowledge/link.typedef";
 import { blockprotocolTypedef } from "./blockprotocol.typedef";
 
 const baseSchema = gql`
@@ -59,6 +60,7 @@ const knowledge = [
   knowledgeEntityTypedef,
   knowledgeBlockTypedef,
   knowledgePageTypedef,
+  knowledgeLinkTypedef,
 ];
 
 // This needs to be called 'schema' to be picked up by codegen -

--- a/packages/hash/api/src/graphql/typeDefs/knowledge/link.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/knowledge/link.typedef.ts
@@ -72,17 +72,17 @@ export const knowledgeLinkTypedef = gql`
 
   extend type Query {
     """
-    Get a link.
+    Get the outgoing links of an entity.
     """
-    knowledgeLinks(
+    outgoingKnowledgeLinks(
       """
-      The id of the link's source entity.
+      The id of the source entity.
       """
       sourceEntityId: ID!
       """
-      The id of the link type that's being fetched.
+      The id of the link's type.
       """
-      linkTypeId: String!
+      linkTypeId: String
     ): [KnowledgeLink!]!
   }
 

--- a/packages/hash/api/src/graphql/typeDefs/knowledge/link.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/knowledge/link.typedef.ts
@@ -55,7 +55,7 @@ export const knowledgeLinkTypedef = gql`
     targetEntityId: ID!
   }
 
-  input DeleteKnowledgeLinkInput {
+  input LinkIdentifier {
     """
     The versioned URI of this link's type.
     """
@@ -94,6 +94,6 @@ export const knowledgeLinkTypedef = gql`
     """
     Create a link.
     """
-    deleteKnowledgeLink(link: DeleteKnowledgeLinkInput!): Boolean!
+    deleteKnowledgeLink(link: LinkIdentifier!): Boolean!
   }
 `;

--- a/packages/hash/api/src/graphql/typeDefs/knowledge/link.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/knowledge/link.typedef.ts
@@ -15,6 +15,14 @@ export const knowledgeLinkTypedef = gql`
     """
     index: Int
     """
+    The id of the link's source entity.
+    """
+    sourceEntityId: ID!
+    """
+    The id of the link's source entity.
+    """
+    targetEntityId: ID!
+    """
     The link's source entity.
     """
     sourceEntity: KnowledgeEntity!
@@ -22,5 +30,21 @@ export const knowledgeLinkTypedef = gql`
     The link's destination entity.
     """
     targetEntity: KnowledgeEntity!
+  }
+
+  extend type Query {
+    """
+    Get a link
+    """
+    knowledgeLinks(
+      """
+      The id of the link's source entity
+      """
+      sourceEntityId: ID!
+      """
+      The id of the link type that's being fetched.
+      """
+      linkTypeId: String!
+    ): [KnowledgeLink!]!
   }
 `;

--- a/packages/hash/api/src/graphql/typeDefs/knowledge/link.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/knowledge/link.typedef.ts
@@ -1,0 +1,26 @@
+import { gql } from "apollo-server-express";
+
+export const knowledgeLinkTypedef = gql`
+  type KnowledgeLink {
+    """
+    The id of the account that owns this link.
+    """
+    ownedById: ID!
+    """
+    The fixed id of the link type this link is of.
+    """
+    linkTypeId: String!
+    """
+    The index of the link (if any).
+    """
+    index: Int
+    """
+    The link's source entity.
+    """
+    sourceEntity: KnowledgeEntity!
+    """
+    The link's destination entity.
+    """
+    targetEntity: KnowledgeEntity!
+  }
+`;

--- a/packages/hash/api/src/graphql/typeDefs/knowledge/link.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/knowledge/link.typedef.ts
@@ -19,7 +19,7 @@ export const knowledgeLinkTypedef = gql`
     """
     sourceEntityId: ID!
     """
-    The id of the link's source entity.
+    The id of the link's target entity.
     """
     targetEntityId: ID!
     """
@@ -27,18 +27,41 @@ export const knowledgeLinkTypedef = gql`
     """
     sourceEntity: KnowledgeEntity!
     """
-    The link's destination entity.
+    The link's target entity.
     """
     targetEntity: KnowledgeEntity!
   }
 
+  input CreateKnowledgeLinkInput {
+    """
+    The fixed id of the link type.
+    """
+    linkTypeId: String!
+    """
+    The index of the link (if any).
+    """
+    index: Int
+    """
+    The id of the account that should own this link.
+    """
+    ownedById: ID!
+    """
+    The id of the link's source entity.
+    """
+    sourceEntityId: ID!
+    """
+    The id of the link's target entity.
+    """
+    targetEntityId: ID!
+  }
+
   extend type Query {
     """
-    Get a link
+    Get a link.
     """
     knowledgeLinks(
       """
-      The id of the link's source entity
+      The id of the link's source entity.
       """
       sourceEntityId: ID!
       """
@@ -46,5 +69,12 @@ export const knowledgeLinkTypedef = gql`
       """
       linkTypeId: String!
     ): [KnowledgeLink!]!
+  }
+
+  extend type Mutation {
+    """
+    Create a link.
+    """
+    createKnowledgeLink(link: CreateKnowledgeLinkInput!): KnowledgeLink!
   }
 `;

--- a/packages/hash/api/src/graphql/typeDefs/knowledge/link.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/knowledge/link.typedef.ts
@@ -92,7 +92,7 @@ export const knowledgeLinkTypedef = gql`
     """
     createKnowledgeLink(link: CreateKnowledgeLinkInput!): KnowledgeLink!
     """
-    Create a link.
+    Delete a link.
     """
     deleteKnowledgeLink(link: LinkIdentifier!): Boolean!
   }

--- a/packages/hash/api/src/graphql/typeDefs/knowledge/link.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/knowledge/link.typedef.ts
@@ -55,6 +55,21 @@ export const knowledgeLinkTypedef = gql`
     targetEntityId: ID!
   }
 
+  input DeleteKnowledgeLinkInput {
+    """
+    The versioned URI of this link's type.
+    """
+    linkTypeId: String!
+    """
+    The id of the link's source entity.
+    """
+    sourceEntityId: ID!
+    """
+    The id of the link's target entity.
+    """
+    targetEntityId: ID!
+  }
+
   extend type Query {
     """
     Get a link.
@@ -76,5 +91,9 @@ export const knowledgeLinkTypedef = gql`
     Create a link.
     """
     createKnowledgeLink(link: CreateKnowledgeLinkInput!): KnowledgeLink!
+    """
+    Create a link.
+    """
+    deleteKnowledgeLink(link: DeleteKnowledgeLinkInput!): Boolean!
   }
 `;

--- a/packages/hash/api/src/graphql/typeDefs/knowledge/link.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/knowledge/link.typedef.ts
@@ -7,7 +7,7 @@ export const knowledgeLinkTypedef = gql`
     """
     ownedById: ID!
     """
-    The fixed id of the link type this link is of.
+    The versioned URI of this link's type.
     """
     linkTypeId: String!
     """
@@ -34,7 +34,7 @@ export const knowledgeLinkTypedef = gql`
 
   input CreateKnowledgeLinkInput {
     """
-    The fixed id of the link type.
+    The versioned URI of this link's type.
     """
     linkTypeId: String!
     """

--- a/packages/hash/api/src/model/knowledge/link.model.ts
+++ b/packages/hash/api/src/model/knowledge/link.model.ts
@@ -94,6 +94,44 @@ export default class {
     );
   }
 
+  static async get(
+    graphApi: GraphApi,
+    params: {
+      sourceEntityId: string;
+      targetEntityId: string;
+      linkTypeId: string;
+    },
+  ): Promise<LinkModel> {
+    const { sourceEntityId, targetEntityId, linkTypeId } = params;
+
+    const linkModels = await LinkModel.getByQuery(graphApi, {
+      all: [
+        { eq: [{ path: ["source", "id"] }, { literal: sourceEntityId }] },
+        { eq: [{ path: ["target", "id"] }, { literal: targetEntityId }] },
+        {
+          eq: [
+            { path: ["type", "versionedUri"] },
+            {
+              literal: linkTypeId,
+            },
+          ],
+        },
+      ],
+    });
+
+    const [linkModel] = linkModels;
+
+    if (!linkModel) {
+      throw new Error(
+        `Link with source enitty ID = '${sourceEntityId}', target entity ID = '${targetEntityId}' and link type ID = '${linkTypeId}' not found.`,
+      );
+    } else if (linkModels.length > 1) {
+      throw new Error(`Could not identify one single link with query.`);
+    }
+
+    return linkModel;
+  }
+
   /**
    * Create a link between a source and a target entity using a specific link
    * type, without modifying the indexes of its sibling links.

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -332,7 +332,9 @@ export default class {
     )?.[1];
 
     if (!outgoingLinkDefinition) {
-      throw new Error("Link is not an outgoing link on this entity");
+      throw new Error(
+        `Link type with ID = '${outgoingLinkType.schema.$id}' is not an outgoing link on entity type with ID = '${this.schema.$id}'`,
+      );
     }
 
     if (


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
This PR adds resolvers for interacting with Links in the API.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202953520344818/1203055428965602/f) _(internal)_

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->


## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Adds new `typedefs` for `link`s
- Add get, create and delete links

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

- GQL docs have been added

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->
- There is some uncertainty with how we want the GQL types to be exposed, so the structure of this addition is subject to change.

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->
- The Get query here specifically will allow implementing more of collab ([Asana task](https://app.asana.com/0/0/1203055428965600/f)).

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- None yet

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch / view the deployment
1.  Set up external services
1.  Run `yarn dev` and login
1.  run queries on http://localhost:5001/graphql

## 📹 Demo
These demos assume the http tests at `packages/graph/hash_graph/tests/rest-test.http` have been run to seed some data.

<details>
<summary>GQL named queries and data</summary>

```gql
mutation create($sourceEntityId:ID!, $targetEntityId:ID!, $linkTypeId:String!) {
  createKnowledgeLink(
    link: {
      linkTypeId: $linkTypeId
      sourceEntityId: $sourceEntityId
      targetEntityId: $targetEntityId
      ownedById: "00000000-0000-0000-0000-000000000000"
    }
  ) {
    ownedById
    linkTypeId
    sourceEntityId
    targetEntityId
  }
}

query get($sourceEntityId:ID!, $linkTypeId:String!) {
  outgoingKnowledgeLinks(
    sourceEntityId: $sourceEntityId
    linkTypeId: $linkTypeId
  ) {
    ownedById
    linkTypeId
    sourceEntityId
    targetEntityId
  }
}

mutation delete($sourceEntityId:ID!, $targetEntityId:ID!, $linkTypeId:String!)  {
  deleteKnowledgeLink(
    link: {
      linkTypeId: $linkTypeId
      sourceEntityId: $sourceEntityId
      targetEntityId: $targetEntityId
    }
  )
}
```

with data (replace with manual test data from http tests for example):

```json
{
  "linkTypeId": "http://localhost:3000/@alice/types/link-type/friend-of/v/2",
  "sourceEntityId":"dceff223-1155-4ed1-aa87-c2c598ba9727",
  "targetEntityId":"5de7171b-4d44-4226-b96b-bf25c83ac872"
}
```

</details>
