### PR TITLE
Benchmark asymptotic performance of `get_entity_by_id` 

### DIFF
--- a/packages/graph/hash_graph/bench/Cargo.toml
+++ b/packages/graph/hash_graph/bench/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 autobenches = false
 
 [dev-dependencies]
-criterion = { version = "0.4.0", features = ["async_tokio"] }
+criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
 criterion-macro = "0.4.0"
 futures = "0.3.21"
 graph = { path = "../lib/graph", features = ["clap"] }

--- a/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
@@ -1,0 +1,142 @@
+use std::str::FromStr;
+
+use criterion::{BatchSize::SmallInput, Bencher, BenchmarkId, Criterion};
+use criterion_macro::criterion;
+use graph::{
+    knowledge::{Entity, EntityId, KnowledgeGraphQuery},
+    ontology::AccountId,
+    store::{query::Expression, AccountStore, AsClient, EntityStore, PostgresStore},
+};
+use graph_test_data::{data_type, entity, entity_type, link_type, property_type};
+use rand::{prelude::IteratorRandom, thread_rng};
+use tokio::runtime::Runtime;
+use type_system::EntityType;
+use uuid::Uuid;
+
+use crate::util::{seed, setup, Store, StoreWrapper};
+
+const DB_NAME: &str = "ENTITY_SCALE";
+
+async fn seed_db(
+    account_id: AccountId,
+    store_wrapper: &mut StoreWrapper,
+    total: usize,
+) -> Vec<EntityId> {
+    let transaction = store_wrapper
+        .store
+        .as_mut_client()
+        .transaction()
+        .await
+        .expect("failed to start transaction");
+
+    let mut store = PostgresStore::new(transaction);
+
+    let now = std::time::SystemTime::now();
+    eprintln!("Seeding database: {}", store_wrapper.bench_db_name);
+
+    store
+        .insert_account_id(account_id)
+        .await
+        .expect("could not insert account id");
+
+    seed(
+        &mut store,
+        account_id,
+        [data_type::TEXT_V1],
+        [
+            property_type::NAME_V1,
+            property_type::BLURB_V1,
+            property_type::PUBLISHED_ON_V1,
+        ],
+        [link_type::WRITTEN_BY_V1],
+        [entity_type::BOOK_V1],
+    )
+    .await;
+
+    let entity: Entity = serde_json::from_str(entity::BOOK_V1).expect("could not parse entity");
+    let entity_type_id = EntityType::from_str(entity_type::BOOK_V1)
+        .expect("could not parse entity type")
+        .id()
+        .clone();
+
+    let mut entity_ids = Vec::with_capacity(total);
+    for _ in 0..total {
+        entity_ids.push(
+            store
+                .create_entity(entity.clone(), entity_type_id.clone(), account_id, None)
+                .await
+                .expect("failed to create entity")
+                .entity_id(),
+        );
+    }
+
+    store
+        .into_client()
+        .commit()
+        .await
+        .expect("failed to commit transaction");
+
+    eprintln!(
+        "Finished seeding database {} with {} entities after {:#?}",
+        store_wrapper.bench_db_name,
+        total,
+        now.elapsed().unwrap()
+    );
+
+    entity_ids
+}
+
+pub fn bench_get_entity_by_id(
+    b: &mut Bencher,
+    runtime: &Runtime,
+    store: &Store,
+    entity_ids: &[EntityId],
+) {
+    b.to_async(runtime).iter_batched(
+        || {
+            // Each iteration, *before timing*, pick a random entity from the sample to
+            // query
+            *entity_ids.iter().choose(&mut thread_rng()).unwrap()
+        },
+        |entity_id| async move {
+            store
+                .get_entity(&KnowledgeGraphQuery {
+                    expression: Expression::for_latest_entity_id(entity_id),
+                    data_type_query_depth: 0,
+                    property_type_query_depth: 0,
+                    link_type_query_depth: 0,
+                    entity_type_query_depth: 0,
+                    link_target_entity_query_depth: 0,
+                    link_query_depth: 0,
+                })
+                .await
+                .expect("failed to read entity from store");
+        },
+        SmallInput,
+    );
+}
+
+#[criterion]
+fn bench_scaling_read_entity(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scaling_read_entity");
+    // We use a hard-coded UUID to keep it consistent across tests so that we can use it as a
+    // parameter argument to criterion and get comparison analysis
+    let account_id =
+        AccountId::new(Uuid::from_str("bf5a9ef5-dc3b-43cf-a291-6210c0321eba").unwrap());
+
+    for size in [1, 10, 100, 1_000, 10_000, 100_000, 1_000_000] {
+        let (runtime, mut store_wrapper) = setup(DB_NAME, true);
+
+        let entity_ids = runtime.block_on(seed_db(account_id, &mut store_wrapper, size));
+        let store = store_wrapper.store;
+
+        group.bench_with_input(
+            BenchmarkId::new(
+                "get_entity_type_by_id",
+                format!("Account ID: `{}`", account_id),
+            ),
+            &(account_id, entity_ids),
+            |b, (_account_id, entity_ids)| bench_get_entity_by_id(b, &runtime, &store, entity_ids),
+        );
+    }
+}

--- a/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/mod.rs
+++ b/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/mod.rs
@@ -1,0 +1,1 @@
+mod entity;

--- a/packages/graph/hash_graph/bench/benches/read_scaling/mod.rs
+++ b/packages/graph/hash_graph/bench/benches/read_scaling/mod.rs
@@ -1,2 +1,3 @@
 //! TODO: Introduce benchmarks testing the differing performance of operations as the graph's scale
 //!  changes
+mod knowledge;

--- a/packages/graph/hash_graph/bench/benches/representative_read/mod.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/mod.rs
@@ -32,7 +32,7 @@ const DB_NAME: &str = "representative_read";
 #[criterion]
 fn bench_representative_read_entity(c: &mut Criterion) {
     let mut group = c.benchmark_group("representative_read_entity");
-    let (runtime, mut store_wrapper) = setup(DB_NAME, false);
+    let (runtime, mut store_wrapper) = setup(DB_NAME, false, false);
 
     let samples = runtime.block_on(setup_and_extract_samples(&mut store_wrapper));
     let store = &store_wrapper.store;
@@ -59,7 +59,7 @@ fn bench_representative_read_entity(c: &mut Criterion) {
 #[criterion]
 fn bench_representative_read_entity_type(c: &mut Criterion) {
     let mut group = c.benchmark_group("representative_read_entity_type");
-    let (runtime, mut store_wrapper) = setup(DB_NAME, false);
+    let (runtime, mut store_wrapper) = setup(DB_NAME, false, false);
 
     let samples = runtime.block_on(setup_and_extract_samples(&mut store_wrapper));
     let store = &store_wrapper.store;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This follows from #1137. It adds a benchmark to query an entity by its ID, comparing the performance at various sizes of database (numbers of that specific entity type).

## 🔗 Related links

- [Asana task](https://app.asana.com/0/0/1203072189010770/f) _(internal)_

## 🔍 What does this change?

- Introduces a scaling benchmark for get_entity_by_id
- Adds a parameter to the `StoreWrapper` to optionally delete the database on drop
- Adds the `Drop` implementation
- Adds the `html_reports` feature to criterion to generate HTML reports

## 📜 Does this require a change to the docs?

- No, although if we start to use the reports we should update the README to say where to find them (they are currently made inside `./target/criterion/reports`

## 🐾 Next steps

- Write scaling benchmarks for other queries

## 🛡 What tests cover this?

- The current (single) benchmark group

## ❓ How to test this?

1. Checkout the branch
2. Run `cargo make deployment-up`
3. Run `make recreate-db`
4. Run `make migrate-up`
5. Run `cargo bench`
