### PR TITLE
Support batch insertion of entities

### DIFF
--- a/packages/graph/hash_graph/bench/Cargo.toml
+++ b/packages/graph/hash_graph/bench/Cargo.toml
@@ -14,7 +14,7 @@ autobenches = false
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
 criterion-macro = "0.4.0"
 futures = "0.3.21"
-graph = { path = "../lib/graph", features = ["clap"] }
+graph = { path = "../lib/graph", features = ["__internal_bench"] }
 graph-test-data = { path = "../tests/test_data" }
 rand = "0.8.5"
 serde = { version = "1.0.137", features = ["derive"] }

--- a/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
@@ -66,7 +66,7 @@ async fn seed_db(
             account_id,
         )
         .await
-        .expect("failed to create entity");
+        .expect("failed to create entities");
 
     store
         .into_client()

--- a/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{iter::repeat, str::FromStr};
 
 use criterion::{BatchSize::SmallInput, Bencher, BenchmarkId, Criterion};
 use criterion_macro::criterion;
@@ -59,16 +59,14 @@ async fn seed_db(
         .id()
         .clone();
 
-    let mut entity_ids = Vec::with_capacity(total);
-    for _ in 0..total {
-        entity_ids.push(
-            store
-                .create_entity(entity.clone(), entity_type_id.clone(), account_id, None)
-                .await
-                .expect("failed to create entity")
-                .entity_id(),
-        );
-    }
+    let entity_ids = store
+        .create_entities(
+            repeat(None).zip(repeat(&entity).take(total).cloned()),
+            entity_type_id,
+            account_id,
+        )
+        .await
+        .expect("failed to create entity");
 
     store
         .into_client()

--- a/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
@@ -61,7 +61,7 @@ async fn seed_db(
 
     let entity_ids = store
         .create_entities(
-            repeat(None).zip(repeat(&entity).take(total).cloned()),
+            repeat((None, entity)).take(total),
             entity_type_id,
             account_id,
         )

--- a/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
@@ -60,7 +60,7 @@ async fn seed_db(
         .clone();
 
     let entity_ids = store
-        .create_entities(
+        .insert_entities_batched_by_type(
             repeat((None, entity)).take(total),
             entity_type_id,
             account_id,

--- a/packages/graph/hash_graph/bench/benches/representative_read/seed.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/seed.rs
@@ -137,7 +137,7 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
             .clone();
 
         store
-            .create_entities(
+            .insert_entities_batched_by_type(
                 repeat((None, entity)).take(quantity),
                 entity_type_id,
                 account_id,

--- a/packages/graph/hash_graph/bench/benches/representative_read/seed.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/seed.rs
@@ -138,7 +138,7 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
 
         store
             .create_entities(
-                repeat(None).zip(repeat(&entity).take(quantity).cloned()),
+                repeat((None, entity)).take(quantity),
                 entity_type_id,
                 account_id,
             )

--- a/packages/graph/hash_graph/bench/benches/representative_read/seed.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/seed.rs
@@ -143,7 +143,7 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
                 account_id,
             )
             .await
-            .expect("failed to create entity");
+            .expect("failed to create entities");
 
         total_entities += quantity;
     }

--- a/packages/graph/hash_graph/bench/benches/representative_read/seed.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/seed.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{hash_map::Entry, HashMap},
+    iter::repeat,
     str::FromStr,
 };
 
@@ -135,16 +136,14 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
             .id()
             .clone();
 
-        let mut entity_ids = Vec::with_capacity(quantity);
-        for _ in 0..quantity {
-            entity_ids.push(
-                store
-                    .create_entity(entity.clone(), entity_type_id.clone(), account_id, None)
-                    .await
-                    .expect("failed to create entity")
-                    .entity_id(),
-            );
-        }
+        store
+            .create_entities(
+                repeat(None).zip(repeat(&entity).take(quantity).cloned()),
+                entity_type_id,
+                account_id,
+            )
+            .await
+            .expect("failed to create entity");
 
         total_entities += quantity;
     }

--- a/packages/graph/hash_graph/lib/graph/Cargo.toml
+++ b/packages/graph/hash_graph/lib/graph/Cargo.toml
@@ -37,6 +37,9 @@ criterion = "0.4.0"
 [build-dependencies]
 
 [features]
+# WARNING: this is an internal feature which should not be used outside of HASH. It's introduced to conditionally
+#          compile code on externally written benchmarks to avoid exposing internals of the data store
+__internal_bench = []
 clap = ["dep:clap"]
 
 [[test]]

--- a/packages/graph/hash_graph/lib/graph/Cargo.toml
+++ b/packages/graph/hash_graph/lib/graph/Cargo.toml
@@ -38,7 +38,7 @@ criterion = "0.4.0"
 
 [features]
 # WARNING: this is an internal feature which should not be used outside of HASH. It's introduced to conditionally
-#          compile code on externally written benchmarks to avoid exposing internals of the data store
+#          compile code for externally written benchmarks to avoid exposing internals of the data store
 __internal_bench = []
 clap = ["dep:clap"]
 

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -381,20 +381,21 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Expressio
 
     /// Inserts the entities with the specified [`EntityType`] into the `Store`.
     ///
-    /// # Errors:
+    /// This is only supporting a single entity type, not an entity type per entity. Entity type
+    /// is stored in a different table and would need to be queried for each, this would be a lot
+    /// less efficient.
+    ///
+    /// This is not supposed to be used outside of benchmarking as in the long term we need to
+    /// figure out how to deal with batch inserting.
+    ///
+    /// # Errors
     ///
     /// - if the [`EntityType`] doesn't exist
     /// - if on of the [`Entity`] is not valid with respect to the specified [`EntityType`]
     /// - if the account referred to by `owned_by_id` does not exist
     /// - if an [`EntityId`] was supplied and already exists in the store
     ///
-    /// # Note
-    ///
-    /// - This is only supporting a single entity type, not an entity type per entity. Entity type
-    ///   is stored in a different table and would need to be queried for each, this would be a lot
-    ///   less efficient.
-    /// - This is not supposed to be used outside of benchmarking as in the long term we need to
-    ///   figure out how to deal with batch inserting.
+    /// # Notes
     #[doc(hidden)]
     #[cfg(feature = "__internal_bench")]
     async fn insert_entities_batched_by_type(

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -379,14 +379,8 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Expressio
         entity_id: Option<EntityId>,
     ) -> Result<PersistedEntityIdentifier, InsertionError>;
 
-    /// Creates new entities.
-    ///
-    /// # Errors:
-    ///
-    /// - if the [`EntityType`] doesn't exist
-    /// - if the entities are not valid with respect to the specified [`EntityType`]
-    /// - if the account referred to by `owned_by_id` does not exist
-    /// - if an [`EntityId`] was supplied and already exists in the store
+    #[doc(hidden)]
+    #[cfg(feature = "__internal_bench")]
     async fn create_entities(
         &mut self,
         entities: impl IntoIterator<Item = (Option<EntityId>, Entity), IntoIter: Send> + Send,

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -381,7 +381,7 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Expressio
 
     #[doc(hidden)]
     #[cfg(feature = "__internal_bench")]
-    async fn create_entities(
+    async fn insert_entities_batched_by_type(
         &mut self,
         entities: impl IntoIterator<Item = (Option<EntityId>, Entity), IntoIter: Send> + Send,
         entity_type_id: VersionedUri,

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -379,6 +379,21 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Expressio
         entity_id: Option<EntityId>,
     ) -> Result<PersistedEntityIdentifier, InsertionError>;
 
+    /// Creates new entities.
+    ///
+    /// # Errors:
+    ///
+    /// - if the [`EntityType`] doesn't exist
+    /// - if the entities are not valid with respect to the specified [`EntityType`]
+    /// - if the account referred to by `owned_by_id` does not exist
+    /// - if an [`EntityId`] was supplied and already exists in the store
+    async fn create_entities(
+        &mut self,
+        entities: impl IntoIterator<Item = (Option<EntityId>, Entity), IntoIter: Send> + Send,
+        entity_type_id: VersionedUri,
+        owned_by_id: AccountId,
+    ) -> Result<Vec<EntityId>, InsertionError>;
+
     /// Get the [`EntityRootedSubgraph`]s specified by the [`KnowledgeGraphQuery`].
     ///
     /// # Errors

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -381,9 +381,9 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Expressio
 
     /// Inserts the entities with the specified [`EntityType`] into the `Store`.
     ///
-    /// This is only supporting a single entity type, not an entity type per entity. Entity type
-    /// is stored in a different table and would need to be queried for each, this would be a lot
-    /// less efficient.
+    /// This is only supporting a single [`EntityType`], not one [`EntityType`] per entity.
+    /// [`EntityType`]s is stored in a different table and would need to be queried for each,
+    /// this would be a lot less efficient.
     ///
     /// This is not supposed to be used outside of benchmarking as in the long term we need to
     /// figure out how to deal with batch inserting.

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -379,6 +379,22 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Expressio
         entity_id: Option<EntityId>,
     ) -> Result<PersistedEntityIdentifier, InsertionError>;
 
+    /// Inserts the entities with the specified [`EntityType`] into the `Store`.
+    ///
+    /// # Errors:
+    ///
+    /// - if the [`EntityType`] doesn't exist
+    /// - if on of the [`Entity`] is not valid with respect to the specified [`EntityType`]
+    /// - if the account referred to by `owned_by_id` does not exist
+    /// - if an [`EntityId`] was supplied and already exists in the store
+    ///
+    /// # Note
+    ///
+    /// - This is only supporting a single entity type, not an entity type per entity. Entity type
+    ///   is stored in a different table and would need to be queried for each, this would be a lot
+    ///   less efficient.
+    /// - This is not supposed to be used outside of benchmarking as in the long term we need to
+    ///   figure out how to deal with batch inserting.
     #[doc(hidden)]
     #[cfg(feature = "__internal_bench")]
     async fn insert_entities_batched_by_type(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -148,6 +148,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         Ok(identifier)
     }
 
+    #[doc(hidden)]
+    #[cfg(feature = "__internal_bench")]
     async fn create_entities(
         &mut self,
         entities: impl IntoIterator<Item = (Option<EntityId>, Entity), IntoIter: Send> + Send,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -150,7 +150,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
 
     #[doc(hidden)]
     #[cfg(feature = "__internal_bench")]
-    async fn create_entities(
+    async fn insert_entities_batched_by_type(
         &mut self,
         entities: impl IntoIterator<Item = (Option<EntityId>, Entity), IntoIter: Send> + Send,
         entity_type_id: VersionedUri,
@@ -179,7 +179,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             .await
             .change_context(InsertionError)?;
         transaction
-            .insert_entities(
+            .insert_entity_batch_by_type(
                 entity_ids.iter().copied(),
                 entities,
                 entity_type_version_id,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -148,6 +148,53 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         Ok(identifier)
     }
 
+    async fn create_entities(
+        &mut self,
+        entities: impl IntoIterator<Item = (Option<EntityId>, Entity), IntoIter: Send> + Send,
+        entity_type_id: VersionedUri,
+        owned_by_id: AccountId,
+    ) -> Result<Vec<EntityId>, InsertionError> {
+        let transaction = PostgresStore::new(
+            self.as_mut_client()
+                .transaction()
+                .await
+                .into_report()
+                .change_context(InsertionError)?,
+        );
+
+        let (entity_ids, entities): (Vec<_>, Vec<_>) = entities
+            .into_iter()
+            .map(|(id, entity)| (id.unwrap_or_else(|| EntityId::new(Uuid::new_v4())), entity))
+            .unzip();
+
+        // TODO: match on and return the relevant error
+        //   https://app.asana.com/0/1200211978612931/1202574350052904/f
+        transaction
+            .insert_entity_ids(entity_ids.iter().copied())
+            .await?;
+        let entity_type_version_id = transaction
+            .version_id_by_uri(&entity_type_id)
+            .await
+            .change_context(InsertionError)?;
+        transaction
+            .insert_entities(
+                entity_ids.iter().copied(),
+                entities,
+                entity_type_version_id,
+                owned_by_id,
+            )
+            .await?;
+
+        transaction
+            .client
+            .commit()
+            .await
+            .into_report()
+            .change_context(InsertionError)?;
+
+        Ok(entity_ids)
+    }
+
     async fn get_entity(
         &self,
         query: &KnowledgeGraphQuery,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -174,6 +174,10 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         transaction
             .insert_entity_ids(entity_ids.iter().copied())
             .await?;
+
+        // Using one entity type per entity would result in more lookups, which results in a more
+        // complex logic and/or be inefficient.
+        // Please see the documentation for this function on the trait for more information.
         let entity_type_version_id = transaction
             .version_id_by_uri(&entity_type_id)
             .await

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -888,7 +888,7 @@ impl PostgresStore<Transaction<'_>> {
 
     #[doc(hidden)]
     #[cfg(feature = "__internal_bench")]
-    async fn insert_entities(
+    async fn insert_entity_batch_by_type(
         &self,
         entity_ids: impl IntoIterator<Item = EntityId, IntoIter: Send> + Send,
         entities: impl IntoIterator<Item = Entity, IntoIter: Send> + Send,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -524,13 +524,13 @@ where
 
         for target_id in property_type_ids {
             self.as_client().query_one(
-                r#"
+                    r#"
                         INSERT INTO property_type_property_type_references (source_property_type_version_id, target_property_type_version_id)
                         VALUES ($1, $2)
                         RETURNING source_property_type_version_id;
                     "#,
-                &[&version_id, &target_id],
-            )
+                    &[&version_id, &target_id],
+                )
                 .await
                 .into_report()
                 .change_context(InsertionError)?;
@@ -544,13 +544,13 @@ where
 
         for target_id in data_type_ids {
             self.as_client().query_one(
-                r#"
+                    r#"
                         INSERT INTO property_type_data_type_references (source_property_type_version_id, target_data_type_version_id)
                         VALUES ($1, $2)
                         RETURNING source_property_type_version_id;
                     "#,
-                &[&version_id, &target_id],
-            )
+                    &[&version_id, &target_id],
+                )
                 .await
                 .into_report()
                 .change_context(InsertionError)?;
@@ -572,13 +572,13 @@ where
 
         for target_id in property_type_ids {
             self.as_client().query_one(
-                r#"
+                    r#"
                         INSERT INTO entity_type_property_type_references (source_entity_type_version_id, target_property_type_version_id)
                         VALUES ($1, $2)
                         RETURNING source_entity_type_version_id;
                     "#,
-                &[&version_id, &target_id],
-            )
+                    &[&version_id, &target_id],
+                )
                 .await
                 .into_report()
                 .change_context(InsertionError)?;
@@ -597,13 +597,13 @@ where
 
         for target_id in link_type_ids {
             self.as_client().query_one(
-                r#"
+                    r#"
                         INSERT INTO entity_type_link_type_references (source_entity_type_version_id, target_link_type_version_id)
                         VALUES ($1, $2)
                         RETURNING source_entity_type_version_id;
                     "#,
-                &[&version_id, &target_id],
-            )
+                    &[&version_id, &target_id],
+                )
                 .await
                 .into_report()
                 .change_context(InsertionError)?;
@@ -617,13 +617,13 @@ where
 
         for target_id in entity_type_reference_ids {
             self.as_client().query_one(
-                r#"
+                    r#"
                         INSERT INTO entity_type_entity_type_links (source_entity_type_version_id, target_entity_type_version_id)
                         VALUES ($1, $2)
                         RETURNING source_entity_type_version_id;
                     "#,
-                &[&version_id, &target_id],
-            )
+                    &[&version_id, &target_id],
+                )
                 .await
                 .into_report()
                 .change_context(InsertionError)?;
@@ -716,13 +716,13 @@ where
             .into_report()
             .change_context(InsertionError)?;
         let version = self.as_client().query_one(
-            r#"
+                r#"
                     INSERT INTO entities (entity_id, version, entity_type_version_id, properties, owned_by_id)
                     VALUES ($1, clock_timestamp(), $2, $3, $4)
                     RETURNING version;
                 "#,
-            &[&entity_id, &entity_type_id, &value, &account_id],
-        )
+                &[&entity_id, &entity_type_id, &value, &account_id]
+            )
             .await
             .into_report()
             .change_context(InsertionError)?.get(0);
@@ -772,22 +772,22 @@ where
             .attach_printable(link.source_entity())?;
 
         self.as_client()
-            .query_one(
-                // TODO: Revisit insertion strategy, currently the burden of ordering is put on the
-                //   consumer of the API.
-                //   https://app.asana.com/0/1202805690238892/1202937382769278/f
-                r#"
+        .query_one(
+            // TODO: Revisit insertion strategy, currently the burden of ordering is put on the
+            //   consumer of the API.
+            //   https://app.asana.com/0/1202805690238892/1202937382769278/f
+            r#"
             INSERT INTO links (source_entity_id, target_entity_id, link_type_version_id, owned_by_id, link_index, created_at)
             VALUES ($1, $2, $3, $4, $5, clock_timestamp())
             RETURNING source_entity_id, target_entity_id, link_type_version_id;
             "#,
-                &[&link.source_entity(), &link.target_entity(), &link_type_version_id, &owned_by_id, &link.index()],
-            )
-            .await
-            .into_report()
-            .change_context(InsertionError)
-            .attach_printable(owned_by_id)
-            .attach_lazy(|| link.clone())?;
+            &[&link.source_entity(), &link.target_entity(), &link_type_version_id, &owned_by_id, &link.index()],
+        )
+        .await
+        .into_report()
+        .change_context(InsertionError)
+        .attach_printable(owned_by_id)
+        .attach_lazy(|| link.clone())?;
 
         Ok(())
     }

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -282,6 +282,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       version: {
         type: "TIMESTAMP WITH TIME ZONE",
         notNull: true,
+        default: "now()",
       },
       entity_type_version_id: {
         type: "UUID",

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -282,7 +282,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       version: {
         type: "TIMESTAMP WITH TIME ZONE",
         notNull: true,
-        default: "now()",
+        default: pgm.func("clock_timestamp()"),
       },
       entity_type_version_id: {
         type: "UUID",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In benchmarks, seeding the database takes a long time as we insert entities one by one. 


## 🔍 What does this change?

- Add a default to `entities.version` to be the time of creation, this is required in order to use the COPY query
- Add functions to batch-insert entity ids and entities
- Use batch-insertion in benchmarking

## ⚠️  Known issues

For testing this PR locally or after this PR is merged, the database needs to be migrated. This functionality was added to speed up seeding in benchmarks, so it's hidden behind a feature flag.

## 📹 Demo

before:
> Finished seeding database representative_read with 16500 entities after 134.974929s

after:
> Finished seeding database representative_read with 16500 entities after 1.514568s

