### PR TITLE
Add `createKnowledgeEntity` mutation

### DIFF
--- a/packages/hash/api/src/graphql/resolvers/index.ts
+++ b/packages/hash/api/src/graphql/resolvers/index.ts
@@ -108,7 +108,10 @@ import {
 import { knowledgePage } from "./knowledge/page/page";
 import { knowledgeBlocks } from "./knowledge/block/block";
 import { getBlockProtocolBlocks } from "./blockprotocol/getBlock";
-import { knowledgeEntity } from "./knowledge/entity/entity";
+import {
+  createKnowledgeEntity,
+  knowledgeEntity,
+} from "./knowledge/entity/entity";
 import { UnresolvedKnowledgeEntityGQL } from "./knowledge/model-mapping";
 import {
   createKnowledgeLink,
@@ -226,6 +229,7 @@ export const resolvers = {
     createEntityType: loggedInAndSignedUp(createEntityType),
     updateEntityType: loggedInAndSignedUp(updateEntityType),
     // Knowledge
+    createKnowledgeEntity: loggedInAndSignedUp(createKnowledgeEntity),
     createKnowledgeLink: loggedInAndSignedUp(createKnowledgeLink),
     deleteKnowledgeLink: loggedInAndSignedUp(deleteKnowledgeLink),
   },

--- a/packages/hash/api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -1,10 +1,41 @@
 import { EntityModel } from "../../../../model";
-import { QueryKnowledgeEntityArgs, ResolverFn } from "../../../apiTypes.gen";
+import {
+  MutationCreateKnowledgeEntityArgs,
+  QueryKnowledgeEntityArgs,
+  ResolverFn,
+} from "../../../apiTypes.gen";
 import {
   mapEntityModelToGQL,
   UnresolvedKnowledgeEntityGQL,
 } from "../model-mapping";
 import { LoggedInGraphQLContext } from "../../../context";
+
+export const createKnowledgeEntity: ResolverFn<
+  Promise<UnresolvedKnowledgeEntityGQL>,
+  {},
+  LoggedInGraphQLContext,
+  MutationCreateKnowledgeEntityArgs
+> = async (
+  _,
+  { ownedById, properties, entityTypeId, linkedEntities },
+  { dataSources: { graphApi }, user },
+) => {
+  /**
+   * @todo: prevent callers of this mutation from being able to create restricted
+   * workspace types (e.g. a `User` or an `Org`)
+   *
+   * @see https://app.asana.com/0/1202805690238892/1203084714149803/f
+   */
+
+  const entity = await EntityModel.createEntityWithLinks(graphApi, {
+    ownedById: ownedById ?? user.entityId,
+    entityTypeId,
+    properties,
+    linkedEntities: linkedEntities ?? undefined,
+  });
+
+  return mapEntityModelToGQL(entity);
+};
 
 export const knowledgeEntity: ResolverFn<
   Promise<UnresolvedKnowledgeEntityGQL>,

--- a/packages/hash/api/src/graphql/resolvers/knowledge/page/update-page-actions.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/page/update-page-actions.ts
@@ -45,7 +45,9 @@ export const createEntityWithPlaceholdersFn =
 
     return await EntityModel.createEntityWithLinks(graphApi, {
       ownedById: entityOwnedById,
-      entityDefinition,
+      entityTypeId: entityDefinition.entityType?.entityTypeId!,
+      properties: entityDefinition.entityProperties,
+      linkedEntities: entityDefinition.linkedEntities ?? undefined,
     });
   };
 

--- a/packages/hash/api/src/graphql/typeDefs/knowledge/entity.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/knowledge/entity.typedef.ts
@@ -152,4 +152,28 @@ export const knowledgeEntityTypedef = gql`
       entityVersion: String
     ): KnowledgeEntity!
   }
+
+  extend type Mutation {
+    """
+    Create an entity.
+    """
+    createKnowledgeEntity(
+      """
+      The owner of the create entity. Defaults to the user calling the mutation.
+      """
+      ownedById: ID
+      """
+      The type of which to instantiate the new entity.
+      """
+      entityTypeId: ID!
+      """
+      The properties of new entity.
+      """
+      properties: JSONObject!
+      """
+      Associated Entities to either create/get and link to this entity.
+      """
+      linkedEntities: [KnowledgeLinkedEntityDefinition!]
+    ): KnowledgeEntity!
+  }
 `;

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -124,24 +124,36 @@ export default class {
   /**
    * Create an entity along with any new/existing entities specified through links.
    *
-   * @param params.ownedById the id of owner of the entity
-   * @param params.entityDefinition the definition of how to get or create the entity optionally with linked entities
+   * @param params.ownedById - the id of owner of the entity
+   * @param params.entityTypeId - the id of the entity's type
+   * @param params.entityProperties - the properties of the entity
+   * @param params.linkedEntities (optional) - the linked entity definitions of the entity
    */
   static async createEntityWithLinks(
     graphApi: GraphApi,
     params: {
       ownedById: string;
-      entityDefinition: KnowledgeEntityDefinition;
+      entityTypeId: string;
+      properties: any;
+      linkedEntities?: KnowledgeLinkedEntityDefinition[];
     },
   ): Promise<EntityModel> {
-    const { ownedById, entityDefinition } = params;
+    const { ownedById, entityTypeId, properties, linkedEntities } = params;
 
     const entitiesInTree = linkedTreeFlatten<
       KnowledgeEntityDefinition,
       KnowledgeLinkedEntityDefinition,
       "linkedEntities",
       "entity"
-    >(entityDefinition, "linkedEntities", "entity");
+    >(
+      {
+        entityType: { entityTypeId },
+        entityProperties: properties,
+        linkedEntities,
+      },
+      "linkedEntities",
+      "entity",
+    );
 
     /**
      * @todo Once the graph API validates the required links of entities on creation, this may have to be reworked in order

--- a/packages/hash/integration/src/tests/model/knowledge/entity.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/entity.model.test.ts
@@ -188,30 +188,26 @@ describe("Entity CRU", () => {
   it("can create entity with linked entities from an entity definition", async () => {
     const aliceEntityModel = await EntityModel.createEntityWithLinks(graphApi, {
       ownedById,
-      entityDefinition: {
-        // First create a new entity given the following definition
-        entityType: {
-          entityTypeId: entityTypeModel.schema.$id,
-        },
-        entityProperties: {
-          [namePropertyTypeModel.baseUri]: "Alice",
-          [favoriteBookPropertyTypeModel.baseUri]: "some text",
-        },
-        linkedEntities: [
-          {
-            // Then create an entity + link
-            destinationAccountId: ownedById,
-            linkTypeId: linkTypeFriend.schema.$id,
-            entity: {
-              // The "new" entity is in fact just an existing entity, so only a link will be created.
-              existingEntity: {
-                entityId: updatedEntityModel.entityId,
-                ownedById: updatedEntityModel.ownedById,
-              },
+      // First create a new entity given the following definition
+      entityTypeId: entityTypeModel.schema.$id,
+      properties: {
+        [namePropertyTypeModel.baseUri]: "Alice",
+        [favoriteBookPropertyTypeModel.baseUri]: "some text",
+      },
+      linkedEntities: [
+        {
+          // Then create an entity + link
+          destinationAccountId: ownedById,
+          linkTypeId: linkTypeFriend.schema.$id,
+          entity: {
+            // The "new" entity is in fact just an existing entity, so only a link will be created.
+            existingEntity: {
+              entityId: updatedEntityModel.entityId,
+              ownedById: updatedEntityModel.ownedById,
             },
           },
-        ],
-      },
+        },
+      ],
     });
 
     const linkedEntity = (


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR introduces the `createKnowledgeEntity` mutation, and slightly modifies the arguments of a related a model class method

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202953520344818/1203086812814267/f) _(internal)_

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

See commits.

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

No.

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->


We are currently conducting manual tests for GQL queries/mutations

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Checkout this branch
2. Run `yarn external-services up` locally
3. Run `yarn test:backend-integration page.model` in a separate terminal window to seed the database with some pages and blocks
4. Run `yarn dev`
5. Open `localhost:3000` and login
6. Open `localhost:5001/graphql` to access the GQL playground
7. Execute a `createKnowledgeEntity` mutation (like the example below) to test that fetching entities works, and returns the appropriate GQL type.

<details>
<summary>createKnowledgeEntity mutation</summary>

```gql
mutation createKnowledgeEntity {
  createKnowledgeEntity(entityTypeId: "http://localhost:3000/@example/types/entity-type/dummy/v/1", properties: {}){
    entityId
    properties
  }
}
```
</details>

## 📹 Demo

<img width="1950" alt="image" src="https://user-images.githubusercontent.com/42802102/193558855-679e5bac-ea9f-458e-8420-cd58922f69ee.png">
