### PR TITLE
Update CHANGELOG.md for latest release

### DIFF
--- a/packages/libs/error-stack/CHANGELOG.md
+++ b/packages/libs/error-stack/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to `error-stack` will be documented in this file.
 - Support for [`serde`](https://serde.rs) (`Serialize` only)
 - Support for [`defmt`](https://defmt.ferrous-systems.com)
 
-## 0.2.0 - Unreleased
+## [0.2.0](https://github.com/hashintel/hash/tree/8ed55bd73045fba83a7ea2e199b31d5b829537b9/packages/libs/error-stack) - 2022-10-03
 
 ### Breaking Changes
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`error-stack` was released in #1113, this will adjust the changelog to link to that commit.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1200211978612931/1202958255787895/f) _(internal)_


## 🐾 Next steps

- Tag the release when this PR is merged
