### PR TITLE
Make image link in README.md absolute

### DIFF
--- a/packages/libs/error-stack/README.md
+++ b/packages/libs/error-stack/README.md
@@ -95,7 +95,7 @@ fn main() -> Result<(), ExperimentError> {
 
 This will most likely result in an error and print
 
-![](assets/full.png)
+![](https://github.com/hashintel/hash/blob/8ed55bd73045fba83a7ea2e199b31d5b829537b9/packages/libs/error-stack/assets/full.png?raw=true)
 
 Please see the [documentation] for a full description.
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The link for the output image is broken on external pages, this makes the link absolute

## 🔗 Related links

- Fixes #1151 