### PR TITLE
Bump error-stack to version 0.2.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-error-stack.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-error-stack.yml
@@ -75,7 +75,7 @@ body:
     attributes:
       label: Version
       description: What error-stack version do you use? If you use the git version please also post the revision.
-      placeholder: e.g. v0.2.0
+      placeholder: e.g. v0.2.1
     validations:
       required: false
 

--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["."]
 
 [package]
 name = "error-stack"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["HASH"]
 edition = "2021"
 rust-version = "1.63.0"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

error-stack v0.2.0 had a relative link in the readme, so it was not rendered correctly on crates.io

## 🔗 Related links

- https://github.com/hashintel/hash/issues/1151