### PR TITLE
Add Termination support for the E side of Result<_, E>

### DIFF
--- a/packages/libs/error-stack/src/exit.rs
+++ b/packages/libs/error-stack/src/exit.rs
@@ -1,0 +1,48 @@
+use std::{
+    io,
+    io::Write,
+    process::{ExitCode, Termination},
+};
+
+use crate::result::Result;
+
+/// TODO
+/// ```should_panic
+/// # use std::io::{Error, ErrorKind};
+/// # use std::process::ExitCode;
+/// # use error_stack::{Exit, IntoExit, IntoReport, ResultExt};
+/// #
+/// fn main() -> Exit<(), Error> {
+///     Err(Error::from(ErrorKind::NotFound))
+///         .into_report()
+///         .attach(ExitCode::from(42))
+///         .into_exit()
+/// }
+/// ```
+pub struct Exit<T, C>(Result<T, C>);
+
+impl<T, C> Exit<T, C> {
+    pub fn into_result(self) -> Result<T, C> {
+        self.0
+    }
+}
+
+impl<T, C> From<Result<T, C>> for Exit<T, C> {
+    fn from(result: Result<T, C>) -> Self {
+        Self(result)
+    }
+}
+
+impl<T, C> Termination for Exit<T, C> {
+    fn report(self) -> ExitCode {
+        match self.0 {
+            Ok(_) => ExitCode::SUCCESS,
+            Err(err) => {
+                // Ignore error if the write fails, for example because stderr is
+                // already closed. There is not much point panicking at this point.
+                drop(writeln!(io::stderr(), "Error: {err:?}"));
+                err.report()
+            }
+        }
+    }
+}

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -464,6 +464,7 @@ pub mod future;
 pub mod iter;
 
 mod compat;
+mod exit;
 mod frame;
 mod macros;
 mod report;
@@ -483,10 +484,11 @@ pub use self::hook::HookAlreadySet;
 pub use self::{
     compat::IntoReportCompat,
     context::Context,
+    exit::Exit,
     frame::{AttachmentKind, Frame, FrameKind},
     macros::*,
     report::Report,
-    result::Result,
+    result::{IntoExit, Result},
 };
 #[doc(inline)]
 pub use self::{

--- a/packages/libs/error-stack/src/result.rs
+++ b/packages/libs/error-stack/src/result.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use crate::{Context, Report};
+use crate::{exit::Exit, Context, Report};
 
 /// [`Result`](std::result::Result)`<T, `[`Report<C>`](Report)`>`
 ///
@@ -209,5 +209,15 @@ where
             Ok(value) => Ok(value),
             Err(error) => Err(Report::from(error)),
         }
+    }
+}
+
+pub trait IntoExit<T, C> {
+    fn into_exit(self) -> Exit<T, C>;
+}
+
+impl<T, C> IntoExit<T, C> for Result<T, C> {
+    fn into_exit(self) -> Exit<T, C> {
+        Exit::from(self)
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The fact that Report implements Termination and is in the Err variant of Result is very confusing because the stdlib completely ignores the Err variant's termination, leading to the exit code being dropped. This PR adds a new type `Exit` that will return the ExitCode provided from the Report Termination. Without this PR, one must write:

```rust
        match result {
            Ok(()) => ExitCode::SUCCESS,
            Err(err) => {
                // Ignore error if the write fails, for example because stderr is
                // already closed. There is not much point panicking at this point.
                drop(writeln!(io::stderr(), "Error: {err:?}"));
                err.report()
            }
        }
```

## 🔗 Related links

https://github.com/rust-lang/rust/issues/48711#issuecomment-1266428245

## TODO

I need to write docs if this moves forward.