### PR TITLE
Add `useBlockProtocolGetEntity` hook + example entity-editor page

### DIFF
--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/knowledge-shim.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/knowledge-shim.ts
@@ -1,0 +1,43 @@
+/**
+ * This file contains "knowledge" function signatures of the new type system used to augment the
+ * existing set of Block Protocol.
+ *
+ * These signatures will eventually make their way into the @blockprotocol/graph
+ * package and be removed from here.
+ */
+
+import { MessageCallback } from "@blockprotocol/core";
+import { ReadOrModifyResourceError } from "@blockprotocol/graph";
+import {
+  UnknownKnowledgeEntity,
+  EntityTypeRootedSubgraph,
+} from "../../../../graphql/apiTypes.gen";
+
+export type KnolwedgeCallbacks = {
+  getEntity: GetEntityMessageCallback;
+};
+
+/* Entity CRU */
+
+/**
+ * @todo: remove this when we support the corresponding fields in the GQL API, or have implemented alternative fields.
+ * @see ...
+ */
+type UnsupportedKnowledgeEntityFields = "linkedEntities";
+
+type Entity = Omit<
+  UnknownKnowledgeEntity,
+  UnsupportedKnowledgeEntityFields | "entityType"
+> & {
+  entityTypeRootedSubgraph: EntityTypeRootedSubgraph;
+};
+
+export type EntityResponse = Entity;
+
+export type GetEntityRequest = Pick<EntityResponse, "entityId">;
+export type GetEntityMessageCallback = MessageCallback<
+  GetEntityRequest,
+  null,
+  EntityResponse,
+  ReadOrModifyResourceError
+>;

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/knowledge-shim.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/knowledge-shim.ts
@@ -21,7 +21,7 @@ export type KnolwedgeCallbacks = {
 
 /**
  * @todo: remove this when we support the corresponding fields in the GQL API, or have implemented alternative fields.
- * @see ...
+ * @see https://app.asana.com/0/0/1203106234191589/f
  */
 type UnsupportedKnowledgeEntityFields = "linkedEntities";
 

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/knowledge-shim.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/knowledge-shim.ts
@@ -13,7 +13,7 @@ import {
   EntityTypeRootedSubgraph,
 } from "../../../../graphql/apiTypes.gen";
 
-export type KnolwedgeCallbacks = {
+export type KnowledgeCallbacks = {
   getEntity: GetEntityMessageCallback;
 };
 

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/useBlockProtocolGetEntity.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/useBlockProtocolGetEntity.ts
@@ -1,0 +1,97 @@
+import { useLazyQuery } from "@apollo/client";
+import { useCallback } from "react";
+import { getEntityTypeRootedSubgraphQuery } from "../../../../graphql/queries/ontology/entity-type.queries";
+
+import {
+  GetEntityTypeRootedSubgraphQuery,
+  GetEntityTypeRootedSubgraphQueryVariables,
+  Query,
+  QueryKnowledgeEntityArgs,
+} from "../../../../graphql/apiTypes.gen";
+import { getKnowledgeEntity } from "../../../../graphql/queries/knowledge/entity.queries";
+import { GetEntityMessageCallback } from "./knowledge-shim";
+
+export const useBlockProtocolGetEntity = (): {
+  getEntity: GetEntityMessageCallback;
+} => {
+  const [getEntityTypeRootedSubgraphFn] = useLazyQuery<
+    GetEntityTypeRootedSubgraphQuery,
+    GetEntityTypeRootedSubgraphQueryVariables
+  >(getEntityTypeRootedSubgraphQuery, {
+    /** @todo reconsider caching. This is done for testing/demo purposes. */
+    fetchPolicy: "no-cache",
+  });
+
+  const [getEntityFn] = useLazyQuery<Query, QueryKnowledgeEntityArgs>(
+    getKnowledgeEntity,
+    {
+      /** @todo reconsider caching. This is done for testing/demo purposes. */
+      fetchPolicy: "no-cache",
+    },
+  );
+
+  const getEntity = useCallback<GetEntityMessageCallback>(
+    async ({ data }) => {
+      if (!data) {
+        return {
+          errors: [
+            {
+              code: "INVALID_INPUT",
+              message: "'data' must be provided for getEntity",
+            },
+          ],
+        };
+      }
+
+      const { entityId } = data;
+
+      const { data: entityResponseData } = await getEntityFn({
+        query: getKnowledgeEntity,
+        variables: { entityId },
+      });
+
+      if (!entityResponseData) {
+        return {
+          errors: [
+            {
+              code: "INVALID_INPUT",
+              message: "Error calling getEntity",
+            },
+          ],
+        };
+      }
+
+      const { knowledgeEntity } = entityResponseData;
+
+      const { data: entityTypeResponseData } =
+        await getEntityTypeRootedSubgraphFn({
+          query: getEntityTypeRootedSubgraphQuery,
+          variables: {
+            entityTypeId: knowledgeEntity.entityTypeId,
+          },
+        });
+
+      if (!entityTypeResponseData) {
+        return {
+          errors: [
+            {
+              code: "INVALID_INPUT",
+              message:
+                "Error getting the entity type rooted sub graph of the entity",
+            },
+          ],
+        };
+      }
+
+      return {
+        data: {
+          ...knowledgeEntity,
+          entityTypeRootedSubgraph: entityTypeResponseData.getEntityType,
+        },
+      };
+    },
+    [getEntityFn, getEntityTypeRootedSubgraphFn],
+  );
+
+  return { getEntity };
+};

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/useBlockProtocolGetEntity.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/useBlockProtocolGetEntity.ts
@@ -63,6 +63,11 @@ export const useBlockProtocolGetEntity = (): {
 
       const { knowledgeEntity } = entityResponseData;
 
+      /**
+       * @todo: obtain this sub-graph as part of the prior `getEntity` query.
+       * May be addressed as part of https://app.asana.com/0/1200211978612931/1203089535761796/f or related work.
+       */
+
       const { data: entityTypeResponseData } =
         await getEntityTypeRootedSubgraphFn({
           query: getEntityTypeRootedSubgraphQuery,

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/useBlockProtocolGetEntity.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/useBlockProtocolGetEntity.ts
@@ -77,7 +77,7 @@ export const useBlockProtocolGetEntity = (): {
             {
               code: "INVALID_INPUT",
               message:
-                "Error getting the entity type rooted sub graph of the entity",
+                "Error getting the subgraph rooted at entity's entity type",
             },
           ],
         };

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/ontology-types-shim.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/ontology-types-shim.ts
@@ -97,7 +97,10 @@ export type AggregatePropertyTypesMessageCallback = MessageCallback<
   ReadOrModifyResourceError
 >;
 
-export type GetPropertyTypeRequest = Pick<PropertyTypeResponse, "propertyType">;
+export type GetPropertyTypeRequest = Pick<
+  PropertyTypeResponse,
+  "propertyTypeId"
+>;
 export type GetPropertyTypeMessageCallback = MessageCallback<
   GetPropertyTypeRequest,
   null,
@@ -138,7 +141,7 @@ export type AggregateEntityTypesMessageCallback = MessageCallback<
   ReadOrModifyResourceError
 >;
 
-export type GetEntityTypeRequest = Pick<EntityTypeResponse, "entityType">;
+export type GetEntityTypeRequest = Pick<EntityTypeResponse, "entityTypeId">;
 export type GetEntityTypeMessageCallback = MessageCallback<
   GetEntityTypeRequest,
   null,
@@ -179,7 +182,7 @@ export type AggregateLinkTypesMessageCallback = MessageCallback<
   ReadOrModifyResourceError
 >;
 
-export type GetLinkTypeRequest = Pick<LinkTypeResponse, "linkType">;
+export type GetLinkTypeRequest = Pick<LinkTypeResponse, "linkTypeId">;
 export type GetLinkTypeMessageCallback = MessageCallback<
   GetLinkTypeRequest,
   null,

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolGetDataType.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolGetDataType.ts
@@ -32,8 +32,11 @@ export const useBlockProtocolGetDataType = (): {
         };
       }
 
+      const { dataTypeId } = data;
+
       const response = await getFn({
         query: getDataTypeQuery,
+        variables: { dataTypeId },
       });
 
       if (!response.data) {

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolGetEntityType.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolGetEntityType.ts
@@ -32,8 +32,11 @@ export const useBlockProtocolGetEntityType = (): {
         };
       }
 
+      const { entityTypeId } = data;
+
       const response = await getFn({
         query: getEntityTypeQuery,
+        variables: { entityTypeId },
       });
 
       if (!response.data) {

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolGetLinkType.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolGetLinkType.ts
@@ -32,8 +32,11 @@ export const useBlockProtocolGetLinkType = (): {
         };
       }
 
+      const { linkTypeId } = data;
+
       const response = await getFn({
         query: getLinkTypeQuery,
+        variables: { linkTypeId },
       });
 
       if (!response.data) {

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolGetPropertyType.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolGetPropertyType.ts
@@ -32,8 +32,11 @@ export const useBlockProtocolGetPropertyType = (): {
         };
       }
 
+      const { propertyTypeId } = data;
+
       const response = await getFn({
         query: getPropertyTypeQuery,
+        variables: { propertyTypeId },
       });
 
       if (!response.data) {

--- a/packages/hash/frontend/src/graphql/queries/knowledge/entity.queries.ts
+++ b/packages/hash/frontend/src/graphql/queries/knowledge/entity.queries.ts
@@ -1,0 +1,21 @@
+import { gql } from "@apollo/client";
+
+export const knowledgeEntityFieldsFragment = gql`
+  fragment KnowledgeEntityFields on UnknownKnowledgeEntity {
+    accountId
+    entityId
+    entityTypeId
+    entityVersion
+    ownedById
+    properties
+  }
+`;
+
+export const getKnowledgeEntity = gql`
+  query getKnowledgeEntity($entityId: ID!, $entityVersion: String) {
+    knowledgeEntity(entityId: $entityId, entityVersion: $entityVersion) {
+      ...KnowledgeEntityFields
+    }
+  }
+  ${knowledgeEntityFieldsFragment}
+`;

--- a/packages/hash/frontend/src/graphql/queries/ontology/entity-type.queries.ts
+++ b/packages/hash/frontend/src/graphql/queries/ontology/entity-type.queries.ts
@@ -20,6 +20,47 @@ export const getAllLatestEntityTypesQuery = gql`
   }
 `;
 
+export const getEntityTypeRootedSubgraphQuery = gql`
+  query getEntityTypeRootedSubgraph(
+    $entityTypeId: String!
+    $referencedDataTypesDepth: Int
+    $referencedPropertyTypesDepth: Int
+    $referencedLinkTypesDepth: Int
+    $referencedEntityTypesDepth: Int
+  ) {
+    getEntityType(entityTypeId: $entityTypeId) {
+      entityTypeId
+      ownedById
+      accountId
+      entityType
+      referencedDataTypes(depth: $referencedDataTypesDepth) {
+        dataTypeId
+        ownedById
+        accountId
+        dataType
+      }
+      referencedPropertyTypes(depth: $referencedPropertyTypesDepth) {
+        propertyTypeId
+        ownedById
+        accountId
+        propertyType
+      }
+      referencedLinkTypes(depth: $referencedLinkTypesDepth) {
+        linkTypeId
+        ownedById
+        accountId
+        linkType
+      }
+      referencedEntityTypes(depth: $referencedEntityTypesDepth) {
+        entityTypeId
+        ownedById
+        accountId
+        entityType
+      }
+    }
+  }
+`;
+
 export const createEntityTypeMutation = gql`
   mutation createEntityType(
     $ownedById: ID!

--- a/packages/hash/frontend/src/pages/entity-editor.page.tsx
+++ b/packages/hash/frontend/src/pages/entity-editor.page.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { Container } from "@mui/material";
+import init from "@blockprotocol/type-system-web";
+
+import { useUser } from "../components/hooks/useUser";
+import { NextPageWithLayout } from "../shared/layout";
+import { useBlockProtocolFunctionsWithOntology } from "./type-editor/blockprotocol-ontology-functions-hook";
+
+/**
+ * This component is an example usage of the `getEntity` BP function.
+ * This is meant to be removed as soon as it's unneeded.
+ */
+const ExampleUsage = ({ ownedById }: { ownedById: string }) => {
+  const { user } = useUser();
+  const [content, setContent] = useState<string>();
+
+  const { getEntity } = useBlockProtocolFunctionsWithOntology(ownedById);
+
+  useEffect(() => {
+    if (user) {
+      // As an example entity, we are going to use the currenlty logged in user's entity id
+      const entityId = user.entityId;
+
+      void getEntity({ data: { entityId } }).then(({ data: entity }) => {
+        setContent(JSON.stringify(entity ?? {}, null, 2));
+      });
+    }
+  }, [user, getEntity]);
+
+  return (
+    <Container>
+      <pre style={{ overflowX: "scroll" }}>{content}</pre>
+    </Container>
+  );
+};
+
+const ExampleEntityEditorPage: NextPageWithLayout = () => {
+  const router = useRouter();
+  // The user is important to allow using Block Protocol functions
+  // such as: `const functions = useBlockProtocolFunctionsWithOntology(user.accountId);`
+  const { user, loading: loadingUser, kratosSession } = useUser();
+  const [loadingTypeSystem, setLoadingTypeSystem] = useState(true);
+
+  useEffect(() => {
+    if (loadingTypeSystem) {
+      void (async () => {
+        await init().then(() => {
+          setLoadingTypeSystem(false);
+        });
+      })();
+    }
+  }, [loadingTypeSystem, setLoadingTypeSystem]);
+
+  useEffect(() => {
+    if (!loadingUser && !kratosSession) {
+      void router.push("/login");
+    }
+  }, [loadingUser, router, kratosSession]);
+
+  return loadingUser || !user || loadingTypeSystem ? (
+    <Container sx={{ pt: 10 }}>Loading...</Container>
+  ) : (
+    <Container sx={{ pt: 10 }}>
+      Hello!
+      <ExampleUsage ownedById={user.accountId} />
+    </Container>
+  );
+};
+
+export default ExampleEntityEditorPage;

--- a/packages/hash/frontend/src/pages/entity-editor.page.tsx
+++ b/packages/hash/frontend/src/pages/entity-editor.page.tsx
@@ -27,7 +27,7 @@ const ExampleUsage = ({ ownedById }: { ownedById: string }) => {
 
   useEffect(() => {
     if (user) {
-      // As an example entity, we are going to use the currenlty logged in user's entity id
+      // As an example entity, we are going to use the currently logged in user's entity ID
       const entityId = user.entityId;
 
       void getEntity({ data: { entityId } }).then(({ data }) => {

--- a/packages/hash/frontend/src/pages/entity-editor.page.tsx
+++ b/packages/hash/frontend/src/pages/entity-editor.page.tsx
@@ -40,7 +40,7 @@ const ExampleUsage = ({ ownedById }: { ownedById: string }) => {
 
   const { entityType } = entityTypeRootedSubgraph ?? {};
 
-  // The (top-level) property type ids defined in the entity type
+  // The (top-level) property type IDs defined in the entity type
   const propertyTypeIds = useMemo(
     () =>
       entityType

--- a/packages/hash/frontend/src/pages/type-editor/blockprotocol-ontology-functions-hook.ts
+++ b/packages/hash/frontend/src/pages/type-editor/blockprotocol-ontology-functions-hook.ts
@@ -40,6 +40,8 @@ import { useBlockProtocolGetLinkType } from "../../components/hooks/blockProtoco
 import { useBlockProtocolUpdateLinkType } from "../../components/hooks/blockProtocolFunctions/ontology/useBlockProtocolUpdateLinkType";
 
 import { useReadonlyMode } from "../../shared/readonly-mode";
+import { useBlockProtocolGetEntity } from "../../components/hooks/blockProtocolFunctions/knowledge/useBlockProtocolGetEntity";
+import { KnolwedgeCallbacks } from "../../components/hooks/blockProtocolFunctions/knowledge/knowledge-shim";
 
 export type GraphMessageCallbacks = Omit<
   EmbedderGraphMessageCallbacks,
@@ -54,7 +56,8 @@ export type GraphMessageCallbacks = Omit<
   | "updateEntityType"
   | "aggregateEntityTypes"
 > &
-  OntologyCallbacks;
+  OntologyCallbacks &
+  KnolwedgeCallbacks;
 
 /** @todo Consider if we should move this out of the page and into the hooks directory. */
 export const useBlockProtocolFunctionsWithOntology = (
@@ -70,6 +73,7 @@ export const useBlockProtocolFunctionsWithOntology = (
     ownedById,
     readonlyMode,
   );
+  const { getEntity } = useBlockProtocolGetEntity();
   const { deleteLinkedAggregation } =
     useBlockProtocolDeleteLinkedAggregation(readonlyMode);
   const { deleteLink } = useBlockProtocolDeleteLink(readonlyMode);
@@ -118,6 +122,8 @@ export const useBlockProtocolFunctionsWithOntology = (
     uploadFile,
     updateLink,
     updateLinkedAggregation,
+    // Knowledge operations
+    getEntity,
     // Ontology operations
     aggregateDataTypes,
     getDataType,

--- a/packages/hash/frontend/src/pages/type-editor/blockprotocol-ontology-functions-hook.ts
+++ b/packages/hash/frontend/src/pages/type-editor/blockprotocol-ontology-functions-hook.ts
@@ -57,7 +57,7 @@ export type GraphMessageCallbacks = Omit<
   | "aggregateEntityTypes"
 > &
   OntologyCallbacks &
-  KnolwedgeCallbacks;
+  KnowledgeCallbacks;
 
 /** @todo Consider if we should move this out of the page and into the hooks directory. */
 export const useBlockProtocolFunctionsWithOntology = (

--- a/packages/hash/frontend/src/pages/type-editor/blockprotocol-ontology-functions-hook.ts
+++ b/packages/hash/frontend/src/pages/type-editor/blockprotocol-ontology-functions-hook.ts
@@ -41,7 +41,7 @@ import { useBlockProtocolUpdateLinkType } from "../../components/hooks/blockProt
 
 import { useReadonlyMode } from "../../shared/readonly-mode";
 import { useBlockProtocolGetEntity } from "../../components/hooks/blockProtocolFunctions/knowledge/useBlockProtocolGetEntity";
-import { KnolwedgeCallbacks } from "../../components/hooks/blockProtocolFunctions/knowledge/knowledge-shim";
+import { KnowledgeCallbacks } from "../../components/hooks/blockProtocolFunctions/knowledge/knowledge-shim";
 
 export type GraphMessageCallbacks = Omit<
   EmbedderGraphMessageCallbacks,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR adds the `useBlockProtocolGetEntity` hook to be used for the upcoming entity editor.

It also provides an example entity editor page to the frontend, demonstrating its usage.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202805690238892/1203084714149805/f) _(internal)_

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

See commits.

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

No.

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Checkout this branch
2. Run `yarn external-services up` locally
3. Run `yarn dev`
4. Open `localhost:3000` and login
5. Go to `localhost:3000/entity-editor` to view the example entity editor making use of the `useBlockProtocolGetEntity` method

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

https://user-images.githubusercontent.com/42802102/194020333-bd8f0368-aa57-43f9-953b-6e9494978e30.mov

