### PR TITLE
Re-enable playwright workflow in CI on the `dev/graph` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,13 +184,13 @@ jobs:
       - name: Launch external services
         if: ${{ success() || failure() }}
         run: |
-          docker compose --file packages/hash/external-services/docker-compose.yml --env-file .env build
-          docker-compose --file packages/hash/external-services/docker-compose.yml --env-file .env up --detach
+          yarn external-services up --build --detach
 
-      - name: Seed data
-        if: ${{ success() || failure() }}
-        run: |
-          yarn seed-data
+      # @todo: re-implement seed-data scripts for the new type system
+      # - name: Seed data
+      #   if: ${{ success() || failure() }}
+      #   run: |
+      #     yarn seed-data
 
       - name: Launch backend
         if: ${{ success() || failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,6 @@ jobs:
 
   playwright-tests:
     name: Playwright tests
-    if: ${{ github.base_ref != 'dev/graph' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,8 +184,8 @@ jobs:
       - name: Launch external services
         if: ${{ success() || failure() }}
         run: |
-          docker-compose --file packages/hash/external-services/docker-compose.yml build
-          docker-compose --file packages/hash/external-services/docker-compose.yml up --detach
+          docker compose --file packages/hash/external-services/docker-compose.yml --env-file .env build
+          docker-compose --file packages/hash/external-services/docker-compose.yml --env-file .env up --detach
 
       - name: Seed data
         if: ${{ success() || failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
         run: |
           yarn external-services up --build --detach
 
-      # @todo: re-implement seed-data scripts for the new type system
+      ## @todo: re-implement seed-data scripts for the new type system, so that they can be used here. Can potentially be addressed as part of https://app.asana.com/0/1202805690238892/1203106234191606/f
       # - name: Seed data
       #   if: ${{ success() || failure() }}
       #   run: |

--- a/packages/hash/playwright/tests/entity-creation.spec.ts
+++ b/packages/hash/playwright/tests/entity-creation.spec.ts
@@ -7,7 +7,11 @@ test.beforeEach(async () => {
   await resetDb();
 });
 
-test("user can create and update entity", async ({ page }) => {
+/**
+ * @todo: Re-enable this playwright test when required workspace functionality is fixed
+ * @see https://app.asana.com/0/1202805690238892/1203106234191599/f
+ */
+test.skip("user can create and update entity", async ({ page }) => {
   await loginUsingUi({ page, accountShortName: "bob" });
 
   // Check if we are on the user page

--- a/packages/hash/playwright/tests/guest-user.spec.ts
+++ b/packages/hash/playwright/tests/guest-user.spec.ts
@@ -5,7 +5,13 @@ test.beforeEach(async () => {
   await resetDb();
 });
 
-test("guest user navigation to login and signup pages", async ({ page }) => {
+/**
+ * @todo: Re-enable this playwright test when required workspace functionality is fixed
+ * @see https://app.asana.com/0/1202805690238892/1203106234191599/f
+ */
+test.skip("guest user navigation to login and signup pages", async ({
+  page,
+}) => {
   await page.goto("/");
   await page.waitForURL("**/login");
 
@@ -56,7 +62,11 @@ test("guest user navigation to login and signup pages", async ({ page }) => {
   );
 });
 
-test("guest user navigation to inaccessible pages", async ({ page }) => {
+/**
+ * @todo: Re-enable this playwright test when required workspace functionality is fixed
+ * @see https://app.asana.com/0/1202805690238892/1203106234191599/f
+ */
+test.skip("guest user navigation to inaccessible pages", async ({ page }) => {
   await page.goto("/non/existing/page");
   await expect(page).toHaveTitle("404: This page could not be found");
 

--- a/packages/hash/playwright/tests/page-creation.spec.ts
+++ b/packages/hash/playwright/tests/page-creation.spec.ts
@@ -16,7 +16,11 @@ test.beforeEach(async () => {
   await resetDb();
 });
 
-test("user can create page", async ({ page }) => {
+/**
+ * @todo: Re-enable this playwright test when required workspace functionality is fixed
+ * @see https://app.asana.com/0/1202805690238892/1203106234191599/f
+ */
+test.skip("user can create page", async ({ page }) => {
   await loginUsingUi({
     page,
     accountShortName: "alice",
@@ -164,7 +168,11 @@ test("user can create page", async ({ page }) => {
   ).toHaveCount(5);
 });
 
-test("user can rename page", async ({ page }) => {
+/**
+ * @todo: Re-enable this playwright test when required workspace functionality is fixed
+ * @see https://app.asana.com/0/1202805690238892/1203106234191599/f
+ */
+test.skip("user can rename page", async ({ page }) => {
   const pageName1 = `Page ${pageNameSuffix}`;
   const pageName2 = `Page 2 ${pageNameSuffix}`;
 

--- a/packages/hash/playwright/tests/page-readonly-mode.spec.ts
+++ b/packages/hash/playwright/tests/page-readonly-mode.spec.ts
@@ -7,7 +7,11 @@ test.beforeEach(async () => {
   await resetDb();
 });
 
-test("user can view page in read-only mode but not update", async ({
+/**
+ * @todo: Re-enable this playwright test when required workspace functionality is fixed
+ * @see https://app.asana.com/0/1202805690238892/1203106234191599/f
+ */
+test.skip("user can view page in read-only mode but not update", async ({
   page,
 }) => {
   await loginUsingUi({


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR re-enables the playwright CI workflow, and individually "skips" each of the playwright tests that are broken (currently that's all of them).

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202805690238892/1203106234191591/f) _(internal)_

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

- The seed-data scripts that the playwright tests depend on have not been re-implemented yet. Follow-up task has been linked in a todo.
