### PR TITLE
include `indietyp` in error-stack issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-error-stack.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-error-stack.yml
@@ -6,6 +6,7 @@ labels:
 assignees:
   - Alfred-Mountfield
   - TimDiekmann
+  - indietyp
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Include myself (@indietyp) in the assignees of error-stack issues. 

This was previously not possible (due to me not being a collaborator).

This would make noticing and reacting to issues a lot easier!