### PR TITLE
Re-enable UI tests

### DIFF
--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -13,7 +13,7 @@ description = "A context-aware error-handling library that supports arbitrary at
 documentation = "https://docs.rs/error-stack"
 readme = "README.md"
 repository = "https://github.com/hashintel/hash/tree/main/packages/libs/error-stack"
-keywords = ["error", "library", "report", "no_std", "stack"]
+keywords = ["no_std", "error", "errorstack", "error-handling", "report"]
 categories = ["rust-patterns", "no-std"]
 
 [dependencies]

--- a/packages/libs/error-stack/macros/Cargo.toml
+++ b/packages/libs/error-stack/macros/Cargo.toml
@@ -9,7 +9,7 @@ description = "Macros for the `error-stack` crate"
 documentation = "https://docs.rs/error-stack"
 readme = "../README.md"
 repository = "https://github.com/hashintel/hash/tree/main/packages/libs/error-stack"
-keywords = ["error", "library", "report", "no_std", "stack"]
+keywords = ["errorstack", "derive", "macros", "no_std", "error-handling"]
 categories = ["rust-patterns", "no-std"]
 
 [lib]

--- a/packages/libs/error-stack/tests/compiletest.rs
+++ b/packages/libs/error-stack/tests/compiletest.rs
@@ -1,5 +1,3 @@
-//! Currently disabled because of https://github.com/dtolnay/trybuild/issues/171
-
 #[cfg_attr(not(nightly), ignore = "Outputs are different across toolchains")]
 #[cfg_attr(miri, ignore = "Miri does not support UI tests")]
 #[test]

--- a/packages/libs/error-stack/tests/compiletest.rs
+++ b/packages/libs/error-stack/tests/compiletest.rs
@@ -1,9 +1,9 @@
 //! Currently disabled because of https://github.com/dtolnay/trybuild/issues/171
 
-// #[cfg_attr(not(nightly), ignore = "Outputs are different across toolchains")]
-// #[cfg_attr(miri, ignore = "Miri does not support UI tests")]
-// #[test]
-// fn ui() {
-//     let t = trybuild::TestCases::new();
-//     t.compile_fail("tests/ui/*.rs");
-// }
+#[cfg_attr(not(nightly), ignore = "Outputs are different across toolchains")]
+#[cfg_attr(miri, ignore = "Miri does not support UI tests")]
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

UI tests were disabled previously because of an error in the `trybuild` crate. The issue is fixed and UI tests can be re-enabled.

## 🔗 Related links

- https://github.com/dtolnay/trybuild/issues/171