### PR TITLE
Bump `error-stack` to version `0.2.3`

### DIFF
--- a/packages/libs/error-stack/CHANGELOG.md
+++ b/packages/libs/error-stack/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to `error-stack` will be documented in this file.
 - Support for [`serde`](https://serde.rs) (`Serialize` only)
 - Support for [`defmt`](https://defmt.ferrous-systems.com)
 
-## Unreleased
+## [0.2.3](https://github.com/hashintel/hash/tree/error-stack%400.2.3/packages/libs/error-stack) - 2022-10-12
 
 - Add Apache 2.0 as an additional license option ([#1172](https://github.com/hashintel/hash/pull/1172))
 

--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["."]
 
 [package]
 name = "error-stack"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["HASH"]
 edition = "2021"
 rust-version = "1.63.0"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We added a new license option and tweaked some bits. The license change is the only notable change, but worth doing a release.

## 🚫 Blocked by

- #1187
- #1188
- #1189

## 🔍 What does this change?

- Bump `error-stack` version to `0.2.3`
- Update heading in changelog