### PR TITLE
Entity type editor – persist changes, and related updates

### DIFF
--- a/packages/hash/frontend/src/lib/use-init-type-system.ts
+++ b/packages/hash/frontend/src/lib/use-init-type-system.ts
@@ -1,18 +1,31 @@
 import init from "@blockprotocol/type-system-web";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
-export const useInitTypeSystem = () => {
+export const useAdvancedInitTypeSystem = () => {
   const [loadingTypeSystem, setLoadingTypeSystem] = useState(true);
+  const loadingPromise = useRef<Promise<void> | null>(null);
+
+  const loadTypeSystem = useCallback(() => {
+    if (loadingPromise.current) {
+      return loadingPromise.current;
+    }
+
+    loadingPromise.current = (async () => {
+      await init().then(() => {
+        setLoadingTypeSystem(false);
+      });
+    })();
+
+    return loadingPromise.current;
+  }, []);
 
   useEffect(() => {
     if (loadingTypeSystem) {
-      void (async () => {
-        await init().then(() => {
-          setLoadingTypeSystem(false);
-        });
-      })();
+      void loadTypeSystem();
     }
-  }, [loadingTypeSystem, setLoadingTypeSystem]);
+  }, [loadTypeSystem, loadingTypeSystem]);
 
-  return loadingTypeSystem;
+  return [loadingTypeSystem, loadTypeSystem] as const;
 };
+
+export const useInitTypeSystem = () => useAdvancedInitTypeSystem()[0];

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/[entity-type-id].page.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/[entity-type-id].page.tsx
@@ -1,8 +1,4 @@
-import {
-  extractBaseUri,
-  extractVersion,
-  validateVersionedUri,
-} from "@blockprotocol/type-system-web";
+import { extractBaseUri, extractVersion } from "@blockprotocol/type-system-web";
 import { faAsterisk } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@hashintel/hash-design-system/fontawesome-icon";
 import { Box, Container, Typography } from "@mui/material";
@@ -21,11 +17,13 @@ import {
   PropertyTypesContext,
   useRemotePropertyTypes,
 } from "./use-property-types";
+import { mustBeVersionedUri } from "./util";
 
 // @todo loading state
 // @todo handle displaying entity type not yet created
 const Page: NextPageWithLayout = () => {
   const router = useRouter();
+  // @todo how to handle remote types
   const baseEntityTypeUri = `${FRONTEND_URL}/${router.query["account-slug"]}/types/entity-type/${router.query["entity-type-id"]}/`;
 
   const formMethods = useForm<EntityTypeEditorForm>({
@@ -39,13 +37,10 @@ const Page: NextPageWithLayout = () => {
       reset({
         properties: Object.values(fetchedEntityType.properties).map((ref) => {
           if ("type" in ref) {
-            throw new Error("handle arrays");
+            // @todo handle property arrays
+            throw new Error("handle property arrays");
           }
-          const validatedRef = validateVersionedUri(ref.$ref);
-          if (validatedRef.type === "Err") {
-            throw new Error("How would this happen?");
-          }
-          return { $id: validatedRef.inner };
+          return { $id: mustBeVersionedUri(ref.$ref) };
         }),
       });
     },
@@ -81,8 +76,7 @@ const Page: NextPageWithLayout = () => {
     return null;
   }
 
-  // @todo fix $id on EntityType
-  const currentVersion = extractVersion(entityType.$id as any);
+  const currentVersion = extractVersion(mustBeVersionedUri(entityType.$id));
 
   return (
     <PropertyTypesContext.Provider value={propertyTypes}>

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/[entity-type-id].page.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/[entity-type-id].page.tsx
@@ -1,15 +1,17 @@
-import { EntityType, PropertyType } from "@blockprotocol/type-system-web";
+import { EntityType } from "@blockprotocol/type-system-web";
 import { faAsterisk } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@hashintel/hash-design-system/fontawesome-icon";
-import { Box, Collapse, Container, Stack, Typography } from "@mui/material";
+import { Box, Collapse, Container, Typography } from "@mui/material";
 import { useRouter } from "next/router";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { FormProvider, useForm } from "react-hook-form";
 import { useBlockProtocolGetEntityType } from "../../../../components/hooks/blockProtocolFunctions/ontology/useBlockProtocolGetEntityType";
 import { FRONTEND_URL } from "../../../../lib/config";
 import { useInitTypeSystem } from "../../../../lib/use-init-type-system";
 import { getPlainLayout, NextPageWithLayout } from "../../../../shared/layout";
 import { TopContextBar } from "../../../shared/top-context-bar";
 import { EditBar } from "./edit-bar";
+import { EntityEditorForm } from "./form-types";
 import { HashOntologyIcon } from "./hash-ontology-icon";
 import { OntologyChip } from "./ontology-chip";
 import { PropertyListCard } from "./property-list-card";
@@ -46,24 +48,32 @@ const useEntityType = (entityTypeId: string, onCompleted?: () => void) => {
 // @todo handle displaying entity type not yet created
 const Page: NextPageWithLayout = () => {
   const router = useRouter();
-  const [insertedPropertyTypes, setInsertedPropertyTypes] = useState<
-    PropertyType[]
-  >([]);
-  const [removedPropertyTypes, setRemovedPropertyTypes] = useState<
-    PropertyType[]
-  >([]);
-
   // @todo find this out somehow
   const currentVersion = 1;
   const entityTypeId = `${FRONTEND_URL}/${router.query["account-slug"]}/types/entity-type/${router.query["entity-type-id"]}/v/${currentVersion}`;
 
+  const formMethods = useForm<EntityEditorForm>({
+    defaultValues: { properties: [] },
+  });
+  const {
+    handleSubmit: wrapHandleSubmit,
+    reset,
+    formState: { isDirty },
+  } = formMethods;
+
   const entityType = useEntityType(entityTypeId, () => {
-    setInsertedPropertyTypes([]);
-    setRemovedPropertyTypes([]);
+    // @todo set new default properties
+    reset();
   });
 
   const propertyTypes = useRemotePropertyTypes();
   const loadingTypeSystem = useInitTypeSystem();
+
+  // @todo set default property types
+
+  const handleSubmit = wrapHandleSubmit(() => {
+    // @todo use data
+  });
 
   if (!entityType || loadingTypeSystem) {
     return null;
@@ -71,128 +81,106 @@ const Page: NextPageWithLayout = () => {
 
   return (
     <PropertyTypesContext.Provider value={propertyTypes}>
-      <Box
-        component={Stack}
-        sx={(theme) => ({
-          minHeight: "100vh",
-          background: theme.palette.gray[10],
-        })}
-      >
-        <Box bgcolor="white" borderBottom={1} borderColor="gray.20">
-          <TopContextBar
-            defaultCrumbIcon={null}
-            crumbs={[
-              {
-                title: "Types",
-                href: "#",
-                id: "types",
-              },
-              {
-                title: "Entity types",
-                href: "#",
-                id: "entity-types",
-              },
-              {
-                title: entityType.title,
-                href: "#",
-                id: entityType.$id,
-                icon: <FontAwesomeIcon icon={faAsterisk} />,
-              },
-            ]}
-            scrollToTop={() => {}}
-          />
-          <Collapse
-            in={insertedPropertyTypes.length + removedPropertyTypes.length > 0}
-          >
-            <EditBar
-              currentVersion={currentVersion}
-              onDiscardChanges={() => {
-                setInsertedPropertyTypes([]);
-                setRemovedPropertyTypes([]);
-              }}
+      <FormProvider {...formMethods}>
+        <Box
+          sx={(theme) => ({
+            minHeight: "100vh",
+            background: theme.palette.gray[10],
+            display: "flex",
+            flexDirection: "column",
+          })}
+          component="form"
+          onSubmit={handleSubmit}
+        >
+          <Box bgcolor="white" borderBottom={1} borderColor="gray.20">
+            <TopContextBar
+              defaultCrumbIcon={null}
+              crumbs={[
+                {
+                  title: "Types",
+                  href: "#",
+                  id: "types",
+                },
+                {
+                  title: "Entity types",
+                  href: "#",
+                  id: "entity-types",
+                },
+                {
+                  title: entityType.title,
+                  href: "#",
+                  id: entityType.$id,
+                  icon: <FontAwesomeIcon icon={faAsterisk} />,
+                },
+              ]}
+              scrollToTop={() => {}}
             />
-          </Collapse>
-          <Box pt={3.75}>
-            <Container>
-              <OntologyChip
-                icon={<HashOntologyIcon />}
-                domain="hash.ai"
-                path={
-                  <>
-                    <Typography
-                      component="span"
-                      fontWeight="bold"
-                      color={(theme) => theme.palette.blue[70]}
-                    >
-                      {router.query["account-slug"]}
-                    </Typography>
-                    <Typography
-                      component="span"
-                      color={(theme) => theme.palette.blue[70]}
-                    >
-                      /types/entity-types/
-                    </Typography>
-                    <Typography
-                      component="span"
-                      fontWeight="bold"
-                      color={(theme) => theme.palette.blue[70]}
-                    >
-                      {router.query["entity-type-id"]}
-                    </Typography>
-                  </>
-                }
+            <Collapse in={isDirty}>
+              <EditBar
+                currentVersion={currentVersion}
+                onDiscardChanges={() => {
+                  reset();
+                }}
               />
-              <Typography variant="h1" fontWeight="bold" mt={3} mb={4.5}>
-                <FontAwesomeIcon
-                  icon={faAsterisk}
-                  sx={(theme) => ({
-                    fontSize: 40,
-                    mr: 3,
-                    color: theme.palette.gray[70],
-                    verticalAlign: "middle",
-                  })}
+            </Collapse>
+            <Box pt={3.75}>
+              <Container>
+                <OntologyChip
+                  icon={<HashOntologyIcon />}
+                  domain="hash.ai"
+                  path={
+                    <>
+                      <Typography
+                        component="span"
+                        fontWeight="bold"
+                        color={(theme) => theme.palette.blue[70]}
+                      >
+                        {router.query["account-slug"]}
+                      </Typography>
+                      <Typography
+                        component="span"
+                        color={(theme) => theme.palette.blue[70]}
+                      >
+                        /types/entity-types/
+                      </Typography>
+                      <Typography
+                        component="span"
+                        fontWeight="bold"
+                        color={(theme) => theme.palette.blue[70]}
+                      >
+                        {router.query["entity-type-id"]}
+                      </Typography>
+                    </>
+                  }
                 />
-                {entityType.title}
+                <Typography variant="h1" fontWeight="bold" mt={3} mb={4.5}>
+                  <FontAwesomeIcon
+                    icon={faAsterisk}
+                    sx={(theme) => ({
+                      fontSize: 40,
+                      mr: 3,
+                      color: theme.palette.gray[70],
+                      verticalAlign: "middle",
+                    })}
+                  />
+                  {entityType.title}
+                </Typography>
+              </Container>
+            </Box>
+          </Box>
+          <Box py={5}>
+            <Container>
+              <Typography variant="h5" mb={1.25}>
+                Properties of{" "}
+                <Box component="span" sx={{ fontWeight: "bold" }}>
+                  {entityType.title}
+                </Box>
               </Typography>
+              <PropertyListCard />
             </Container>
           </Box>
         </Box>
-        <Box py={5}>
-          <Container>
-            <Typography variant="h5" mb={1.25}>
-              Properties of{" "}
-              <Box component="span" sx={{ fontWeight: "bold" }}>
-                {entityType.title}
-              </Box>
-            </Typography>
-            <PropertyListCard
-              propertyTypes={insertedPropertyTypes}
-              onRemovePropertyType={(propertyType) => {
-                if (insertedPropertyTypes.includes(propertyType)) {
-                  const nextInsertedPropertyTypes =
-                    insertedPropertyTypes.filter(
-                      (type) => type !== propertyType,
-                    );
-                  setInsertedPropertyTypes(nextInsertedPropertyTypes);
-                } else if (!removedPropertyTypes.includes(propertyType)) {
-                  setRemovedPropertyTypes([
-                    ...removedPropertyTypes,
-                    propertyType,
-                  ]);
-                }
-              }}
-              onAddPropertyType={(propertyType) => {
-                if (!insertedPropertyTypes.includes(propertyType)) {
-                  setInsertedPropertyTypes([
-                    ...insertedPropertyTypes,
-                    propertyType,
-                  ]);
-                }
-              }}
-            />
-          </Container>
-        </Box>
-      </Box>
+      </FormProvider>
     </PropertyTypesContext.Provider>
   );
 };

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/edit-bar.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/edit-bar.tsx
@@ -7,7 +7,21 @@ import { PencilSimpleLine } from "../../../../shared/icons/svg";
 import { Button, ButtonProps } from "../../../../shared/ui/button";
 import { EntityTypeEditorForm } from "./form-types";
 
-// @todo disabled button styles – do this
+const useFrozenValue = <T extends any>(value: T): T => {
+  const {
+    formState: { isDirty },
+  } = useFormContext<EntityTypeEditorForm>();
+
+  const [frozen, setFrozen] = useState(value);
+
+  if (isDirty && frozen !== value) {
+    setFrozen(value);
+  }
+
+  return frozen;
+};
+
+// @todo disabled button styles
 const EditBarContents = ({
   icon,
   title,
@@ -22,14 +36,10 @@ const EditBarContents = ({
   confirmButtonProps: ButtonProps;
 }) => {
   const {
-    formState: { isSubmitting, isDirty },
+    formState: { isSubmitting },
   } = useFormContext<EntityTypeEditorForm>();
 
-  const [wasSubmitting, setWasSubmitting] = useState(isSubmitting);
-
-  if (isDirty && wasSubmitting !== isSubmitting) {
-    setWasSubmitting(isSubmitting);
-  }
+  const frozenSubmitting = useFrozenValue(isSubmitting);
 
   return (
     <Container
@@ -58,7 +68,7 @@ const EditBarContents = ({
               color: "white",
             },
           })}
-          disabled={wasSubmitting}
+          disabled={frozenSubmitting}
           {...discardButtonProps}
         >
           {discardButtonProps.children}
@@ -67,9 +77,9 @@ const EditBarContents = ({
           variant="secondary"
           size="xs"
           type="submit"
-          loading={wasSubmitting}
+          loading={frozenSubmitting}
           loadingWithoutText
-          disabled={wasSubmitting}
+          disabled={frozenSubmitting}
           {...confirmButtonProps}
         >
           {confirmButtonProps.children}
@@ -90,12 +100,7 @@ export const EditBar = ({
     formState: { isDirty },
   } = useFormContext<EntityTypeEditorForm>();
 
-  const [versionNumberToDisplay, setVersionNumberToDisplay] =
-    useState(currentVersion);
-
-  if (isDirty && currentVersion !== versionNumberToDisplay) {
-    setVersionNumberToDisplay(currentVersion);
-  }
+  const frozenVersion = useFrozenValue(currentVersion);
 
   return (
     <Collapse in={isDirty}>
@@ -114,7 +119,7 @@ export const EditBar = ({
             title="Currently editing"
             label="- this type has not yet been created"
             discardButtonProps={{
-              // @todo implement this – do this
+              // @todo implement this
               href: "#",
               children: "Discard this type",
             }}
@@ -126,9 +131,7 @@ export const EditBar = ({
           <EditBarContents
             icon={<PencilSimpleLine />}
             title="Currently editing"
-            label={`Version ${versionNumberToDisplay} -> ${
-              versionNumberToDisplay + 1
-            }`}
+            label={`Version ${frozenVersion} -> ${frozenVersion + 1}`}
             discardButtonProps={{
               onClick: onDiscardChanges,
               children: "Discard changes",

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/edit-bar.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/edit-bar.tsx
@@ -1,7 +1,7 @@
 import { faSmile } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon } from "@hashintel/hash-design-system/fontawesome-icon";
-import { Box, Container, Stack, Typography } from "@mui/material";
-import { ReactNode } from "react";
+import { Box, Collapse, Container, Stack, Typography } from "@mui/material";
+import { ReactNode, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import { PencilSimpleLine } from "../../../../shared/icons/svg";
 import { Button, ButtonProps } from "../../../../shared/ui/button";
@@ -80,44 +80,59 @@ export const EditBar = ({
   currentVersion: number;
   onDiscardChanges: () => void;
 }) => {
+  const {
+    formState: { isDirty },
+  } = useFormContext<EntityTypeEditorForm>();
+
+  const [versionNumberToDisplay, setVersionNumberToDisplay] =
+    useState(currentVersion);
+
+  if (isDirty && currentVersion !== versionNumberToDisplay) {
+    setVersionNumberToDisplay(currentVersion);
+  }
+
   return (
-    <Box
-      sx={(theme) => ({
-        height: 66,
-        backgroundColor: theme.palette.blue[70],
-        color: theme.palette.white,
-        display: "flex",
-        alignItems: "center",
-      })}
-    >
-      {currentVersion === 0 ? (
-        <EditBarContents
-          icon={<FontAwesomeIcon icon={faSmile} sx={{ fontSize: 14 }} />}
-          title="Currently editing"
-          label="- this type has not yet been created"
-          discardButtonProps={{
-            // @todo implement this
-            href: "#",
-            children: "Discard this type",
-          }}
-          confirmButtonProps={{
-            children: "Create",
-          }}
-        />
-      ) : (
-        <EditBarContents
-          icon={<PencilSimpleLine />}
-          title="Currently editing"
-          label={`Version ${currentVersion} -> ${currentVersion + 1}`}
-          discardButtonProps={{
-            onClick: onDiscardChanges,
-            children: "Discard changes",
-          }}
-          confirmButtonProps={{
-            children: "Publish update",
-          }}
-        />
-      )}
-    </Box>
+    <Collapse in={isDirty}>
+      <Box
+        sx={(theme) => ({
+          height: 66,
+          backgroundColor: theme.palette.blue[70],
+          color: theme.palette.white,
+          display: "flex",
+          alignItems: "center",
+        })}
+      >
+        {currentVersion === 0 ? (
+          <EditBarContents
+            icon={<FontAwesomeIcon icon={faSmile} sx={{ fontSize: 14 }} />}
+            title="Currently editing"
+            label="- this type has not yet been created"
+            discardButtonProps={{
+              // @todo implement this
+              href: "#",
+              children: "Discard this type",
+            }}
+            confirmButtonProps={{
+              children: "Create",
+            }}
+          />
+        ) : (
+          <EditBarContents
+            icon={<PencilSimpleLine />}
+            title="Currently editing"
+            label={`Version ${versionNumberToDisplay} -> ${
+              versionNumberToDisplay + 1
+            }`}
+            discardButtonProps={{
+              onClick: onDiscardChanges,
+              children: "Discard changes",
+            }}
+            confirmButtonProps={{
+              children: "Publish update",
+            }}
+          />
+        )}
+      </Box>
+    </Collapse>
   );
 };

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/edit-bar.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/edit-bar.tsx
@@ -7,7 +7,7 @@ import { PencilSimpleLine } from "../../../../shared/icons/svg";
 import { Button, ButtonProps } from "../../../../shared/ui/button";
 import { EntityTypeEditorForm } from "./form-types";
 
-// @todo disabled button styles
+// @todo disabled button styles – do this
 const EditBarContents = ({
   icon,
   title,
@@ -108,7 +108,7 @@ export const EditBar = ({
             title="Currently editing"
             label="- this type has not yet been created"
             discardButtonProps={{
-              // @todo implement this
+              // @todo implement this – do this
               href: "#",
               children: "Discard this type",
             }}

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/edit-bar.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/edit-bar.tsx
@@ -22,8 +22,14 @@ const EditBarContents = ({
   confirmButtonProps: ButtonProps;
 }) => {
   const {
-    formState: { isSubmitting },
+    formState: { isSubmitting, isDirty },
   } = useFormContext<EntityTypeEditorForm>();
+
+  const [wasSubmitting, setWasSubmitting] = useState(isSubmitting);
+
+  if (isDirty && wasSubmitting !== isSubmitting) {
+    setWasSubmitting(isSubmitting);
+  }
 
   return (
     <Container
@@ -52,7 +58,7 @@ const EditBarContents = ({
               color: "white",
             },
           })}
-          disabled={isSubmitting}
+          disabled={wasSubmitting}
           {...discardButtonProps}
         >
           {discardButtonProps.children}
@@ -61,9 +67,9 @@ const EditBarContents = ({
           variant="secondary"
           size="xs"
           type="submit"
-          loading={isSubmitting}
+          loading={wasSubmitting}
           loadingWithoutText
-          disabled={isSubmitting}
+          disabled={wasSubmitting}
           {...confirmButtonProps}
         >
           {confirmButtonProps.children}

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/edit-bar.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/edit-bar.tsx
@@ -48,7 +48,12 @@ const EditBarContents = ({
       >
         {discardButtonProps.children}
       </Button>
-      <Button variant="secondary" size="xs" {...confirmButtonProps}>
+      <Button
+        variant="secondary"
+        size="xs"
+        type="submit"
+        {...confirmButtonProps}
+      >
         {confirmButtonProps.children}
       </Button>
     </Stack>
@@ -67,7 +72,6 @@ export const EditBar = ({
       height: 66,
       backgroundColor: theme.palette.blue[70],
       color: theme.palette.white,
-
       display: "flex",
       alignItems: "center",
     })}
@@ -83,9 +87,6 @@ export const EditBar = ({
           children: "Discard this type",
         }}
         confirmButtonProps={{
-          onClick() {
-            // @todo implement
-          },
           children: "Create",
         }}
       />
@@ -99,9 +100,6 @@ export const EditBar = ({
           children: "Discard changes",
         }}
         confirmButtonProps={{
-          onClick() {
-            // @todo implement
-          },
           children: "Publish update",
         }}
       />

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/edit-bar.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/edit-bar.tsx
@@ -2,9 +2,12 @@ import { faSmile } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon } from "@hashintel/hash-design-system/fontawesome-icon";
 import { Box, Container, Stack, Typography } from "@mui/material";
 import { ReactNode } from "react";
+import { useFormContext } from "react-hook-form";
 import { PencilSimpleLine } from "../../../../shared/icons/svg";
 import { Button, ButtonProps } from "../../../../shared/ui/button";
+import { EntityTypeEditorForm } from "./form-types";
 
+// @todo disabled button styles
 const EditBarContents = ({
   icon,
   title,
@@ -17,48 +20,58 @@ const EditBarContents = ({
   label: ReactNode;
   discardButtonProps: ButtonProps;
   confirmButtonProps: ButtonProps;
-}) => (
-  <Container
-    sx={{
-      display: "flex",
-      alignItems: "center",
-    }}
-  >
-    {icon}
-    <Typography variant="smallTextLabels" sx={{ ml: 1 }}>
-      <Box component="span" sx={{ fontWeight: "bold", mr: 1 }}>
-        {title}
-      </Box>{" "}
-      {label}
-    </Typography>
-    <Stack spacing={1.25} sx={{ marginLeft: "auto" }} direction="row">
-      <Button
-        variant="tertiary"
-        size="xs"
-        sx={(theme) => ({
-          borderColor: theme.palette.blue[50],
-          backgroundColor: "transparent",
-          color: "white",
-          "&:hover": {
-            backgroundColor: theme.palette.blue[80],
+}) => {
+  const {
+    formState: { isSubmitting },
+  } = useFormContext<EntityTypeEditorForm>();
+
+  return (
+    <Container
+      sx={{
+        display: "flex",
+        alignItems: "center",
+      }}
+    >
+      {icon}
+      <Typography variant="smallTextLabels" sx={{ ml: 1 }}>
+        <Box component="span" sx={{ fontWeight: "bold", mr: 1 }}>
+          {title}
+        </Box>{" "}
+        {label}
+      </Typography>
+      <Stack spacing={1.25} sx={{ marginLeft: "auto" }} direction="row">
+        <Button
+          variant="tertiary"
+          size="xs"
+          sx={(theme) => ({
+            borderColor: theme.palette.blue[50],
+            backgroundColor: "transparent",
             color: "white",
-          },
-        })}
-        {...discardButtonProps}
-      >
-        {discardButtonProps.children}
-      </Button>
-      <Button
-        variant="secondary"
-        size="xs"
-        type="submit"
-        {...confirmButtonProps}
-      >
-        {confirmButtonProps.children}
-      </Button>
-    </Stack>
-  </Container>
-);
+            "&:hover": {
+              backgroundColor: theme.palette.blue[80],
+              color: "white",
+            },
+          })}
+          disabled={isSubmitting}
+          {...discardButtonProps}
+        >
+          {discardButtonProps.children}
+        </Button>
+        <Button
+          variant="secondary"
+          size="xs"
+          type="submit"
+          loading={isSubmitting}
+          loadingWithoutText
+          disabled={isSubmitting}
+          {...confirmButtonProps}
+        >
+          {confirmButtonProps.children}
+        </Button>
+      </Stack>
+    </Container>
+  );
+};
 
 export const EditBar = ({
   currentVersion,
@@ -66,43 +79,45 @@ export const EditBar = ({
 }: {
   currentVersion: number;
   onDiscardChanges: () => void;
-}) => (
-  <Box
-    sx={(theme) => ({
-      height: 66,
-      backgroundColor: theme.palette.blue[70],
-      color: theme.palette.white,
-      display: "flex",
-      alignItems: "center",
-    })}
-  >
-    {currentVersion === 0 ? (
-      <EditBarContents
-        icon={<FontAwesomeIcon icon={faSmile} sx={{ fontSize: 14 }} />}
-        title="Currently editing"
-        label="- this type has not yet been created"
-        discardButtonProps={{
-          // @todo implement this
-          href: "#",
-          children: "Discard this type",
-        }}
-        confirmButtonProps={{
-          children: "Create",
-        }}
-      />
-    ) : (
-      <EditBarContents
-        icon={<PencilSimpleLine />}
-        title="Currently editing"
-        label={`Version ${currentVersion} -> ${currentVersion + 1}`}
-        discardButtonProps={{
-          onClick: onDiscardChanges,
-          children: "Discard changes",
-        }}
-        confirmButtonProps={{
-          children: "Publish update",
-        }}
-      />
-    )}
-  </Box>
-);
+}) => {
+  return (
+    <Box
+      sx={(theme) => ({
+        height: 66,
+        backgroundColor: theme.palette.blue[70],
+        color: theme.palette.white,
+        display: "flex",
+        alignItems: "center",
+      })}
+    >
+      {currentVersion === 0 ? (
+        <EditBarContents
+          icon={<FontAwesomeIcon icon={faSmile} sx={{ fontSize: 14 }} />}
+          title="Currently editing"
+          label="- this type has not yet been created"
+          discardButtonProps={{
+            // @todo implement this
+            href: "#",
+            children: "Discard this type",
+          }}
+          confirmButtonProps={{
+            children: "Create",
+          }}
+        />
+      ) : (
+        <EditBarContents
+          icon={<PencilSimpleLine />}
+          title="Currently editing"
+          label={`Version ${currentVersion} -> ${currentVersion + 1}`}
+          discardButtonProps={{
+            onClick: onDiscardChanges,
+            children: "Discard changes",
+          }}
+          confirmButtonProps={{
+            children: "Publish update",
+          }}
+        />
+      )}
+    </Box>
+  );
+};

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/form-types.ts
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/form-types.ts
@@ -1,5 +1,7 @@
+import { VersionedUri } from "@blockprotocol/type-system-web";
+
 type PropertyFormData = {
-  $id: string;
+  $id: VersionedUri;
 };
 
 export type EntityEditorForm = {

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/form-types.ts
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/form-types.ts
@@ -1,7 +1,4 @@
 type PropertyFormData = {
-  persisted: boolean;
-  changed: boolean;
-  removed: boolean;
   $id: string;
 };
 

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/form-types.ts
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/form-types.ts
@@ -1,0 +1,10 @@
+type PropertyFormData = {
+  persisted: boolean;
+  changed: boolean;
+  removed: boolean;
+  $id: string;
+};
+
+export type EntityEditorForm = {
+  properties: PropertyFormData[];
+};

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/form-types.ts
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/form-types.ts
@@ -1,9 +1,9 @@
 import { VersionedUri } from "@blockprotocol/type-system-web";
 
-type PropertyFormData = {
+type EntityTypeEditorPropertyData = {
   $id: VersionedUri;
 };
 
-export type EntityEditorForm = {
-  properties: PropertyFormData[];
+export type EntityTypeEditorForm = {
+  properties: EntityTypeEditorPropertyData[];
 };

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-expected-values.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-expected-values.tsx
@@ -1,6 +1,16 @@
 import { PropertyType } from "@blockprotocol/type-system-web";
 import { Chip } from "@hashintel/hash-design-system/chip";
-import { dataTypeNames } from "./use-property-types";
+
+const dataTypeNames = {
+  "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1": "Text",
+  "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1":
+    "Number",
+  "https://blockprotocol.org/@blockprotocol/types/data-type/boolean/v/1":
+    "Boolean",
+  "https://blockprotocol.org/@blockprotocol/types/data-type/null/v/1": "Null",
+  "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1":
+    "JSON Object",
+} as Record<string, string>;
 
 // @todo handle this being too many
 export const PropertyExpectedValues = ({

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-list-card.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-list-card.tsx
@@ -184,9 +184,10 @@ export const PropertyTypeRow = ({
 }) => {
   const { watch } = useFormContext<EntityTypeEditorForm>();
   const propertyTypes = usePropertyTypes();
-  const propertyId = watch(`properties.${propertyIndex}.$id`);
-  // @todo use a map? – do this
-  const property = propertyTypes.find((type) => type.$id === propertyId);
+  const propertyId = mustBeVersionedUri(
+    watch(`properties.${propertyIndex}.$id`),
+  );
+  const property = propertyTypes[propertyId];
 
   if (!property) {
     throw new Error("Missing property type");

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-list-card.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-list-card.tsx
@@ -42,7 +42,7 @@ import { PropertyTypeForm } from "./property-type-form";
 import { QuestionIcon } from "./question-icon";
 import { StyledPlusCircleIcon } from "./styled-plus-circle-icon";
 import { usePropertyTypes } from "./use-property-types";
-import { useStateCallback, withHandler } from "./util";
+import { mustBeVersionedUri, useStateCallback, withHandler } from "./util";
 import { WhiteCard } from "./white-card";
 
 const CenteredTableCell = styled(TableCell)(
@@ -348,7 +348,7 @@ export const PropertyListCard = () => {
                     !getValues("properties").some(({ $id }) => $id === type.$id)
                   ) {
                     append({
-                      $id: type.$id,
+                      $id: mustBeVersionedUri(type.$id),
                     });
                   }
                 }}

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-list-card.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-list-card.tsx
@@ -337,7 +337,6 @@ export const PropertyListCard = () => {
                 propertyIndex={index}
                 onRemove={() => {
                   remove(index);
-                  // onRemovePropertyType(type);
                 }}
               />
             ))}
@@ -356,13 +355,8 @@ export const PropertyListCard = () => {
                   ) {
                     append({
                       $id: type.$id,
-                      changed: true,
-                      persisted: false,
-                      removed: false,
                     });
                   }
-
-                  // onAddPropertyType(type);
                 }}
               />
             ) : (

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-list-card.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-list-card.tsx
@@ -186,12 +186,12 @@ export const PropertyTypeRow = ({
   const propertyTypes = usePropertyTypes();
 
   if (!propertyTypes) {
-    // @todo take into hook
+    // @todo take into hook – do this
     throw new Error("Property types must be loaded");
   }
 
   const propertyId = watch(`properties.${propertyIndex}.$id`);
-  // @todo use a map?
+  // @todo use a map? – do this
   const property = propertyTypes.find((type) => type.$id === propertyId);
 
   if (!property) {

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-list-card.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-list-card.tsx
@@ -184,12 +184,6 @@ export const PropertyTypeRow = ({
 }) => {
   const { watch } = useFormContext<EntityTypeEditorForm>();
   const propertyTypes = usePropertyTypes();
-
-  if (!propertyTypes) {
-    // @todo take into hook – do this
-    throw new Error("Property types must be loaded");
-  }
-
   const propertyId = watch(`properties.${propertyIndex}.$id`);
   // @todo use a map? – do this
   const property = propertyTypes.find((type) => type.$id === propertyId);

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-list-card.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-list-card.tsx
@@ -30,8 +30,10 @@ import {
   usePopupState,
 } from "material-ui-popup-state/hooks";
 import { Ref, useId, useRef, useState } from "react";
+import { useFieldArray, useFormContext } from "react-hook-form";
 import { Modal } from "../../../../components/Modals/Modal";
 import { EmptyPropertyListCard } from "./empty-property-list-card";
+import { EntityEditorForm } from "./form-types";
 import { PropertyExpectedValues } from "./property-expected-values";
 import { PropertyListSelectorDropdownContext } from "./property-list-selector-dropdown";
 import { PropertyMenu } from "./property-menu";
@@ -39,6 +41,7 @@ import { PropertySelector } from "./property-selector";
 import { PropertyTypeForm } from "./property-type-form";
 import { QuestionIcon } from "./question-icon";
 import { StyledPlusCircleIcon } from "./styled-plus-circle-icon";
+import { usePropertyTypes } from "./use-property-types";
 import { useStateCallback, withHandler } from "./util";
 import { WhiteCard } from "./white-card";
 
@@ -53,12 +56,10 @@ const InsertPropertyRow = ({
   inputRef,
   onCancel,
   onAdd,
-  filterProperty,
 }: {
   inputRef: Ref<HTMLInputElement | null>;
   onCancel: () => void;
   onAdd: (option: PropertyType) => void;
-  filterProperty: (property: PropertyType) => boolean;
 }) => {
   const modalTooltipId = useId();
   const modalPopupState = usePopupState({
@@ -70,6 +71,9 @@ const InsertPropertyRow = ({
 
   const ourInputRef = useRef<HTMLInputElement>(null);
   const sharedRef = useForkRef(inputRef, ourInputRef);
+
+  const { watch } = useFormContext<EntityEditorForm>();
+  const properties = watch("properties");
 
   return (
     <TableRow
@@ -104,7 +108,11 @@ const InsertPropertyRow = ({
             modalPopupState={modalPopupState}
             onAdd={onAdd}
             onCancel={onCancel}
-            filterProperty={filterProperty}
+            filterProperty={(property) =>
+              !properties.some(
+                (includedProperty) => includedProperty.$id === property.$id,
+              )
+            }
           />
         </PropertyListSelectorDropdownContext.Provider>
         <Modal
@@ -168,65 +176,81 @@ const InsertPropertyRow = ({
 };
 
 export const PropertyTypeRow = ({
-  property,
+  propertyIndex,
   onRemove,
 }: {
-  property: PropertyType;
+  propertyIndex: number;
   onRemove: () => void;
-}) => (
-  <TableRow>
-    <TableCell>
-      <Typography variant="smallTextLabels" fontWeight={500}>
-        {property.title}
-      </Typography>
-    </TableCell>
-    <TableCell>
-      <PropertyExpectedValues property={property} />
-    </TableCell>
-    <TableCell sx={{ textAlign: "center" }}>
-      <Checkbox />
-    </TableCell>
-    <TableCell sx={{ textAlign: "center" }}>
-      <Checkbox />
-    </TableCell>
-    <TableCell sx={{ px: "0px !important" }}>
-      <TextField
-        placeholder="Add default value"
-        sx={{
-          width: "100%",
-          [`.${tableRowClasses.root}:not(:hover) & .${outlinedInputClasses.root}:not(:focus-within)`]:
-            {
-              boxShadow: "none",
-              [`.${outlinedInputClasses.notchedOutline}`]: {
-                borderColor: "transparent",
-              },
-              [`.${outlinedInputClasses.input}::placeholder`]: {
-                color: "transparent",
-              },
-            },
-        }}
-        inputProps={{ sx: { textOverflow: "ellipsis" } }}
-      />
-    </TableCell>
-    <TableCell>
-      <PropertyMenu onRemove={onRemove} property={property} />
-    </TableCell>
-  </TableRow>
-);
-
-export const PropertyListCard = ({
-  propertyTypes,
-  onAddPropertyType,
-  onRemovePropertyType,
-}: {
-  propertyTypes: PropertyType[];
-  onAddPropertyType: (type: PropertyType) => void;
-  onRemovePropertyType: (type: PropertyType) => void;
 }) => {
+  const { watch } = useFormContext<EntityEditorForm>();
+  const propertyTypes = usePropertyTypes();
+
+  if (!propertyTypes) {
+    // @todo take into hook
+    throw new Error("Property types must be loaded");
+  }
+
+  const propertyId = watch(`properties.${propertyIndex}.$id`);
+  // @todo use a map?
+  const property = propertyTypes.find((type) => type.$id === propertyId);
+
+  if (!property) {
+    throw new Error("Missing property type");
+  }
+
+  return (
+    <TableRow>
+      <TableCell>
+        <Typography variant="smallTextLabels" fontWeight={500}>
+          {property.title}
+        </Typography>
+      </TableCell>
+      <TableCell>
+        <PropertyExpectedValues property={property} />
+      </TableCell>
+      <TableCell sx={{ textAlign: "center" }}>
+        <Checkbox />
+      </TableCell>
+      <TableCell sx={{ textAlign: "center" }}>
+        <Checkbox />
+      </TableCell>
+      <TableCell sx={{ px: "0px !important" }}>
+        <TextField
+          placeholder="Add default value"
+          sx={{
+            width: "100%",
+            [`.${tableRowClasses.root}:not(:hover) & .${outlinedInputClasses.root}:not(:focus-within)`]:
+              {
+                boxShadow: "none",
+                [`.${outlinedInputClasses.notchedOutline}`]: {
+                  borderColor: "transparent",
+                },
+                [`.${outlinedInputClasses.input}::placeholder`]: {
+                  color: "transparent",
+                },
+              },
+          }}
+          inputProps={{ sx: { textOverflow: "ellipsis" } }}
+        />
+      </TableCell>
+      <TableCell>
+        <PropertyMenu onRemove={onRemove} property={property} />
+      </TableCell>
+    </TableRow>
+  );
+};
+
+export const PropertyListCard = () => {
+  const { control, getValues } = useFormContext<EntityEditorForm>();
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "properties",
+  });
+
   const [addingNewProperty, setAddingNewProperty] = useStateCallback(false);
   const addingNewPropertyRef = useRef<HTMLInputElement>(null);
 
-  if (!addingNewProperty && propertyTypes.length === 0) {
+  if (!addingNewProperty && fields.length === 0) {
     return (
       <EmptyPropertyListCard
         onClick={() => {
@@ -307,12 +331,13 @@ export const PropertyListCard = ({
             </Typography>
           </TableHead>
           <TableBody>
-            {propertyTypes.map((type) => (
+            {fields.map((type, index) => (
               <PropertyTypeRow
-                key={type.$id}
-                property={type}
+                key={type.id}
+                propertyIndex={index}
                 onRemove={() => {
-                  onRemovePropertyType(type);
+                  remove(index);
+                  // onRemovePropertyType(type);
                 }}
               />
             ))}
@@ -326,9 +351,19 @@ export const PropertyListCard = ({
                 }}
                 onAdd={(type) => {
                   setAddingNewProperty(false);
-                  onAddPropertyType(type);
+                  if (
+                    !getValues("properties").some(({ $id }) => $id === type.$id)
+                  ) {
+                    append({
+                      $id: type.$id,
+                      changed: true,
+                      persisted: false,
+                      removed: false,
+                    });
+                  }
+
+                  // onAddPropertyType(type);
                 }}
-                filterProperty={(property) => !propertyTypes.includes(property)}
               />
             ) : (
               <TableRow>

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-list-card.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-list-card.tsx
@@ -33,7 +33,7 @@ import { Ref, useId, useRef, useState } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 import { Modal } from "../../../../components/Modals/Modal";
 import { EmptyPropertyListCard } from "./empty-property-list-card";
-import { EntityEditorForm } from "./form-types";
+import { EntityTypeEditorForm } from "./form-types";
 import { PropertyExpectedValues } from "./property-expected-values";
 import { PropertyListSelectorDropdownContext } from "./property-list-selector-dropdown";
 import { PropertyMenu } from "./property-menu";
@@ -72,7 +72,7 @@ const InsertPropertyRow = ({
   const ourInputRef = useRef<HTMLInputElement>(null);
   const sharedRef = useForkRef(inputRef, ourInputRef);
 
-  const { watch } = useFormContext<EntityEditorForm>();
+  const { watch } = useFormContext<EntityTypeEditorForm>();
   const properties = watch("properties");
 
   return (
@@ -182,7 +182,7 @@ export const PropertyTypeRow = ({
   propertyIndex: number;
   onRemove: () => void;
 }) => {
-  const { watch } = useFormContext<EntityEditorForm>();
+  const { watch } = useFormContext<EntityTypeEditorForm>();
   const propertyTypes = usePropertyTypes();
 
   if (!propertyTypes) {
@@ -241,7 +241,7 @@ export const PropertyTypeRow = ({
 };
 
 export const PropertyListCard = () => {
-  const { control, getValues } = useFormContext<EntityEditorForm>();
+  const { control, getValues } = useFormContext<EntityTypeEditorForm>();
   const { fields, append, remove } = useFieldArray({
     control,
     name: "properties",

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-menu.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-menu.tsx
@@ -1,8 +1,4 @@
-import {
-  extractVersion,
-  PropertyType,
-  validateVersionedUri,
-} from "@blockprotocol/type-system-web";
+import { extractVersion, PropertyType } from "@blockprotocol/type-system-web";
 import { faEllipsis } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@hashintel/hash-design-system/fontawesome-icon";
 import { IconButton } from "@hashintel/hash-design-system/icon-button";
@@ -26,12 +22,7 @@ import {
 } from "material-ui-popup-state/hooks";
 import { Fragment, useId } from "react";
 import { OntologyChip, parseUriForOntologyChip } from "./ontology-chip";
-
-const parseVersion = (id: string) => {
-  const uri = validateVersionedUri(id);
-
-  return uri.type === "Ok" ? extractVersion(uri.inner) : null;
-};
+import { mustBeVersionedUri } from "./util";
 
 export const PropertyMenu = ({
   onRemove,
@@ -47,7 +38,7 @@ export const PropertyMenu = ({
     popupId: `property-${id}`,
   });
 
-  const version = parseVersion(property.$id);
+  const version = extractVersion(mustBeVersionedUri(property.$id));
   const ontology = parseUriForOntologyChip(property.$id);
 
   return (

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-selector.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-selector.tsx
@@ -76,7 +76,7 @@ const PropertySelector: ForwardRefRenderFunction<
   const highlightedRef = useRef<null | PropertyType>(null);
 
   if (!propertyTypes) {
-    // @todo loading indicator
+    // @todo loading indicator - do this / won't need this
     return null;
   }
 

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-selector.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-selector.tsx
@@ -72,13 +72,7 @@ const PropertySelector: ForwardRefRenderFunction<
   );
 
   const [open, setOpen] = useState(false);
-
   const highlightedRef = useRef<null | PropertyType>(null);
-
-  if (!propertyTypes) {
-    // @todo loading indicator - do this / won't need this
-    return null;
-  }
 
   return (
     <Autocomplete

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-selector.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-selector.tsx
@@ -46,7 +46,8 @@ const PropertySelector: ForwardRefRenderFunction<
   },
   ref,
 ) => {
-  const propertyTypes = usePropertyTypes();
+  const propertyTypesObj = usePropertyTypes();
+  const propertyTypes = Object.values(propertyTypesObj);
 
   const modifiers = useMemo(
     (): PopperProps["modifiers"] => [
@@ -166,7 +167,10 @@ const PropertySelector: ForwardRefRenderFunction<
           }}
         />
       )}
-      options={propertyTypes.filter((type) => filterProperty(type))}
+      options={
+        // @todo make this more efficient
+        propertyTypes.filter((type) => filterProperty(type))
+      }
       getOptionLabel={(obj) => obj.title}
       renderOption={(props, property: PropertyType) => {
         const ontology = parseUriForOntologyChip(property.$id);

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/use-entity-type.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/use-entity-type.tsx
@@ -1,0 +1,97 @@
+import {
+  EntityType,
+  extractBaseUri,
+  validateVersionedUri,
+} from "@blockprotocol/type-system-web";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { useBlockProtocolAggregateEntityTypes } from "../../../../components/hooks/blockProtocolFunctions/ontology/useBlockProtocolAggregateEntityTypes";
+import { useBlockProtocolUpdateEntityType } from "../../../../components/hooks/blockProtocolFunctions/ontology/useBlockProtocolUpdateEntityType";
+import { useAdvancedInitTypeSystem } from "../../../../lib/use-init-type-system";
+
+export const useEntityType = (
+  entityTypeBaseUri: string,
+  onCompleted?: (entityType: EntityType) => void,
+) => {
+  const [typeSystemLoading, loadTypeSystem] = useAdvancedInitTypeSystem();
+
+  const [entityType, setEntityType] = useState<EntityType | null>(null);
+  const entityTypeRef = useRef(entityType);
+
+  const onCompletedRef = useRef(onCompleted);
+  useLayoutEffect(() => {
+    onCompletedRef.current = onCompleted;
+  });
+
+  const { aggregateEntityTypes } = useBlockProtocolAggregateEntityTypes();
+  const { updateEntityType } = useBlockProtocolUpdateEntityType();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setEntityType(null);
+    entityTypeRef.current = null;
+
+    void aggregateEntityTypes({ data: {} }).then(async (res) => {
+      const relevantEntity =
+        res.data?.results.find((item) => {
+          const validated = validateVersionedUri(item.entityTypeId);
+          if (validated.type === "Err") {
+            throw new Error("?");
+          }
+          const baseUri = extractBaseUri(validated.inner);
+          return baseUri === entityTypeBaseUri;
+        })?.entityType ?? null;
+
+      await loadTypeSystem();
+
+      if (!cancelled) {
+        setEntityType(relevantEntity);
+        entityTypeRef.current = relevantEntity;
+        if (relevantEntity) {
+          onCompletedRef.current?.(relevantEntity);
+        }
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [aggregateEntityTypes, entityTypeBaseUri, loadTypeSystem]);
+
+  const updateCallback = useCallback(
+    async (partialEntityType: Partial<Omit<EntityType, "$id">>) => {
+      if (!entityTypeRef.current) {
+        throw new Error("Cannot update yet");
+      }
+
+      const currentEntity = entityTypeRef.current;
+      const { $id, ...restOfEntityType } = currentEntity;
+
+      const res = await updateEntityType({
+        data: {
+          entityTypeId: $id,
+          entityType: {
+            ...restOfEntityType,
+            ...partialEntityType,
+          },
+        },
+      });
+
+      if (entityTypeRef.current === currentEntity && res.data) {
+        setEntityType(res.data.entityType);
+        entityTypeRef.current = res.data.entityType;
+      }
+
+      return res;
+    },
+    [updateEntityType],
+  );
+
+  return [typeSystemLoading ? null : entityType, updateCallback] as const;
+};

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/use-entity-type.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/use-entity-type.tsx
@@ -1,8 +1,4 @@
-import {
-  EntityType,
-  extractBaseUri,
-  validateVersionedUri,
-} from "@blockprotocol/type-system-web";
+import { EntityType, extractBaseUri } from "@blockprotocol/type-system-web";
 import {
   useCallback,
   useEffect,
@@ -13,6 +9,7 @@ import {
 import { useBlockProtocolAggregateEntityTypes } from "../../../../components/hooks/blockProtocolFunctions/ontology/useBlockProtocolAggregateEntityTypes";
 import { useBlockProtocolUpdateEntityType } from "../../../../components/hooks/blockProtocolFunctions/ontology/useBlockProtocolUpdateEntityType";
 import { useAdvancedInitTypeSystem } from "../../../../lib/use-init-type-system";
+import { mustBeVersionedUri } from "./util";
 
 export const useEntityType = (
   entityTypeBaseUri: string,
@@ -40,11 +37,7 @@ export const useEntityType = (
     void aggregateEntityTypes({ data: {} }).then(async (res) => {
       const relevantEntity =
         res.data?.results.find((item) => {
-          const validated = validateVersionedUri(item.entityTypeId);
-          if (validated.type === "Err") {
-            throw new Error("?");
-          }
-          const baseUri = extractBaseUri(validated.inner);
+          const baseUri = extractBaseUri(mustBeVersionedUri(item.entityTypeId));
           return baseUri === entityTypeBaseUri;
         })?.entityType ?? null;
 

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/use-property-types.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/use-property-types.tsx
@@ -33,5 +33,5 @@ export const useRemotePropertyTypes = () => {
 
 export const PropertyTypesContext = createContext<null | PropertyType[]>(null);
 
-// @todo throw if null
+// @todo throw if null – do this
 export const usePropertyTypes = () => useContext(PropertyTypesContext);

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/use-property-types.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/use-property-types.tsx
@@ -33,4 +33,5 @@ export const useRemotePropertyTypes = () => {
 
 export const PropertyTypesContext = createContext<null | PropertyType[]>(null);
 
+// @todo throw if null
 export const usePropertyTypes = () => useContext(PropertyTypesContext);

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/use-property-types.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/use-property-types.tsx
@@ -33,5 +33,12 @@ export const useRemotePropertyTypes = () => {
 
 export const PropertyTypesContext = createContext<null | PropertyType[]>(null);
 
-// @todo throw if null – do this
-export const usePropertyTypes = () => useContext(PropertyTypesContext);
+export const usePropertyTypes = () => {
+  const types = useContext(PropertyTypesContext);
+
+  if (!types) {
+    throw new Error("Property types not loaded yet");
+  }
+
+  return types;
+};

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/util.ts
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/util.ts
@@ -1,3 +1,4 @@
+import { validateVersionedUri } from "@blockprotocol/type-system-web";
 import { bindToggle, bindTrigger } from "material-ui-popup-state/hooks";
 import { SetStateAction, useLayoutEffect, useRef, useState } from "react";
 
@@ -50,4 +51,14 @@ export const withHandler = <
       return trigger.onTouchStart(...args);
     },
   };
+};
+/**
+ * Necessary as type system isn't fully correctly typed yet
+ */
+export const mustBeVersionedUri = (uri: string) => {
+  const validatedId = validateVersionedUri(uri);
+  if (validatedId.type === "Err") {
+    throw new Error("uri not versioned");
+  }
+  return validatedId.inner;
 };

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/util.ts
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/util.ts
@@ -52,6 +52,7 @@ export const withHandler = <
     },
   };
 };
+
 /**
  * Necessary as type system isn't fully correctly typed yet
  */


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

Persist updates to list of properties in the entity type editor, and related changes. See below

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203007126736604/1203144688196124/f) _(internal)_

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

N/A

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

Functionality changes:

- Always display the latest entity type version, not just version 1
- Make publish changes and discard changes buttons on entity type edit bar work
- New loading state for the edit bar while publishing, which disabled buttons. @nonparibus I'll need to consult on what these buttons should look like while disabled, not sure we have that design anywhere
- Display already persisted property types for an entity type when loading the editor

Code changes:

- Integrate the type system loading process into `useEntityType` so that `onComplete` isn't called until the type system has loaded (as we need the type system to be loaded for that). This is enabled by new hook `useAdvancedInitTypeSystem` so as to not mess with other consumers of `useInitTypeSystem`. This provides a function which you call to get a promise which will resolve (or already be resolved) when the type system has loaded.
- New `mustBeVersionedUri` to make it easier to handle strings we know to be versioned URIs already
- Integrate `react-hook-form` for storing the list of properties for an entity type
- New function to update the entity type, and replace the stored entity type version once that's completed
- Edit bar set up to not update values while animating its exit, using a new `useFrozenValue` hook
- Property types context is now a map, to make finding the right one easier

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

- The docs for x need updating to explain that y

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

-

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Open the entity type editor
2. Trying making a change and clicking publish changes
3. Make sure the contents of the edit bar don't change while it animates away
4. Try making another change
5. Click discard, see reverts back to where you were after save
6. Refresh, see the changes persisted
7. Try making another change
8. Click discard, see reverts back to where you were after save

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
