### PR TITLE
Upgrade HASH Graph dependencies

### DIFF
--- a/packages/graph/hash_graph/Cargo.lock
+++ b/packages/graph/hash_graph/Cargo.lock
@@ -27,15 +27,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,9 +62,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de18bc5f2e9df8f52da03856bf40e29b747de5a84e43aefff90e3dc4a21529b"
+checksum = "c9e3356844c4d6a6d6467b8da2cffb4a2820be256f50a3a386c9d152bab31043"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -187,6 +178,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,32 +238,42 @@ version = "3.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68d43934757334b5c0519ff882e1ab9647ac0258b47c24c4f490d78e42697fd5"
 dependencies = [
- "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap",
- "once_cell",
- "strsim",
- "termcolor",
- "terminal_size",
  "textwrap",
 ]
 
 [[package]]
-name = "clap_complete"
-version = "3.2.4"
+name = "clap"
+version = "4.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4179da71abd56c26b54dd0c248cc081c1f43b0a1a7e8448e28e57a29baa993d"
+checksum = "6ea54a38e4bce14ff6931c72e5b3c43da7051df056913d4e7e1fcdb1c03df69d"
 dependencies = [
- "clap",
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex 0.3.0",
+ "once_cell",
+ "strsim",
+ "termcolor",
+ "terminal_size",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11cba7abac9b56dfe2f035098cdb3a43946f276e6db83b72c4e692343f9aab9a"
+dependencies = [
+ "clap 4.0.14",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -280,6 +287,15 @@ name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -319,7 +335,7 @@ dependencies = [
  "atty",
  "cast",
  "ciborium",
- "clap",
+ "clap 3.2.19",
  "criterion-plot",
  "futures",
  "itertools",
@@ -463,6 +479,27 @@ name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "error-stack"
@@ -618,7 +655,7 @@ dependencies = [
  "axum",
  "bb8-postgres",
  "chrono",
- "clap",
+ "clap 4.0.14",
  "criterion",
  "error-stack",
  "futures",
@@ -654,7 +691,7 @@ name = "hash-graph"
 version = "0.0.0"
 dependencies = [
  "axum",
- "clap",
+ "clap 4.0.14",
  "clap_complete",
  "error-stack",
  "graph",
@@ -836,7 +873,14 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde",
 ]
+
+[[package]]
+name = "io-lifetimes"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
 
 [[package]]
 name = "itertools"
@@ -870,9 +914,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "lock_api"
@@ -957,6 +1007,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1071,12 @@ name = "os_str_bytes"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1311,6 +1377,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.35.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb2fda4666def1433b1b05431ab402e42a1084285477222b72d6c564c417cef"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1348,18 +1428,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1379,9 +1459,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
 dependencies = [
  "itoa",
  "ryu",
@@ -1501,12 +1581,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.17"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+checksum = "8440c860cf79def6164e4a0a983bcc2305d82419177a0e0c71930d049e3ac5a1"
 dependencies = [
- "libc",
- "winapi",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1514,9 +1594,6 @@ name = "textwrap"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
-dependencies = [
- "terminal_size",
-]
 
 [[package]]
 name = "thiserror"
@@ -1596,9 +1673,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.20.1"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1606,7 +1683,6 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "parking_lot",
  "pin-project-lite",
  "socket2",
@@ -1712,9 +1788,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "log",
@@ -1736,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1747,9 +1823,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1788,12 +1864,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
- "ansi_term",
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex",
  "serde",
@@ -1890,9 +1966,11 @@ dependencies = [
 
 [[package]]
 name = "utoipa"
-version = "1.1.0"
-source = "git+https://github.com/juhaku/utoipa?rev=031073f#031073fb9024d6981c9a3d8bb69ae08f2e5a4bbf"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6289c644ea23411b0f81773544ee2a59e7497b8867f268fb30b330dea87cb360"
 dependencies = [
+ "indexmap",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -1900,8 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "1.1.0"
-source = "git+https://github.com/juhaku/utoipa?rev=031073f#031073fb9024d6981c9a3d8bb69ae08f2e5a4bbf"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecf8547910b3e16a2e3506c2edf30c569462b7a975a4435dc5001a92314b43f1"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1912,9 +1991,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.1.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
 dependencies = [
  "getrandom",
  "serde",

--- a/packages/graph/hash_graph/Cargo.lock
+++ b/packages/graph/hash_graph/Cargo.lock
@@ -503,15 +503,13 @@ dependencies = [
 
 [[package]]
 name = "error-stack"
-version = "0.1.1"
-source = "git+https://github.com/hashintel/hash?rev=5edddb5#5edddb5566f9bd82dcdf9ba3b430759bc6b15dc5"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c65ca99f05c8107089b0279932138ff797f2c894dba1efcf8227d32134f7506"
 dependencies = [
  "anyhow",
- "futures-core",
- "once_cell",
- "pin-project",
+ "owo-colors",
  "rustc_version",
- "smallvec",
  "tracing-error",
 ]
 
@@ -884,6 +882,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
 
 [[package]]
+name = "is_ci"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,6 +1082,15 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+dependencies = [
+ "supports-color",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1370,9 +1383,9 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
 ]
@@ -1414,18 +1427,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "0.9.0"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
@@ -1553,6 +1557,16 @@ name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
+name = "supports-color"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872ced36b91d47bae8a214a683fe54e7078875b399dfa251df346c9b547d1f9"
+dependencies = [
+ "atty",
+ "is_ci",
+]
 
 [[package]]
 name = "syn"

--- a/packages/graph/hash_graph/Cargo.lock
+++ b/packages/graph/hash_graph/Cargo.lock
@@ -661,6 +661,7 @@ dependencies = [
  "futures",
  "graph-test-data",
  "include_dir",
+ "indexmap",
  "postgres-types",
  "regex",
  "serde",

--- a/packages/graph/hash_graph/Cargo.lock
+++ b/packages/graph/hash_graph/Cargo.lock
@@ -659,7 +659,6 @@ dependencies = [
  "futures",
  "graph-test-data",
  "include_dir",
- "indexmap",
  "postgres-types",
  "regex",
  "serde",

--- a/packages/graph/hash_graph/bench/Cargo.toml
+++ b/packages/graph/hash_graph/bench/Cargo.toml
@@ -13,16 +13,16 @@ autobenches = false
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
 criterion-macro = "0.4.0"
-futures = "0.3.21"
+futures = "0.3.24"
 graph = { path = "../lib/graph", features = ["__internal_bench"] }
 graph-test-data = { path = "../tests/test_data" }
 rand = "0.8.5"
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.83"
-tokio = { version = "1.18.2", features = ["rt-multi-thread", "macros"] }
-tokio-postgres = { version = "0.7.6", default-features = false }
+serde = { version = "1.0.145", features = ["derive"] }
+serde_json = "1.0.86"
+tokio = { version = "1.21.2", features = ["rt-multi-thread", "macros"] }
+tokio-postgres = { version = "0.7.7", default-features = false }
 type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "6526c0e" }
-uuid = { version = "1.1.2", features = ["v4", "serde"] }
+uuid = { version = "1.2.1", features = ["v4", "serde"] }
 
 [[bench]]
 # TODO - Rename, lib.rs, main.rs, hash_graph_benchmark.rs?

--- a/packages/graph/hash_graph/bin/hash_graph/Cargo.toml
+++ b/packages/graph/hash_graph/bin/hash_graph/Cargo.toml
@@ -8,16 +8,16 @@ description = "The entity-graph query-layer for the HASH datastore"
 
 
 [dependencies]
-axum = "0.5.11"
-clap = { version = "3.2.10", features = ["cargo", "derive", "env", "wrap_help"] }
-clap_complete = "3.2.3"
+axum = "0.5.16"
+clap = { version = "4.0.13", features = ["cargo", "derive", "env", "wrap_help"] }
+clap_complete = "4.0.2"
 # TODO: Change to `version = "0.2"` as soon as it's released
 error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace"] }
 graph = { path = "../../lib/graph", features = ["clap"] }
 regex = "1.6.0"
-serde_json = "1.0.83"
-tokio = { version = "1.18.2", features = ["rt-multi-thread", "macros"] }
-tokio-postgres = { version = "0.7.6", default-features = false }
-tracing = "0.1.35"
+serde_json = "1.0.86"
+tokio = { version = "1.21.2", features = ["rt-multi-thread", "macros"] }
+tokio-postgres = { version = "0.7.7", default-features = false }
+tracing = "0.1.37"
 type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "6526c0e" }
-uuid = "1.1.2"
+uuid = "1.2.1"

--- a/packages/graph/hash_graph/bin/hash_graph/Cargo.toml
+++ b/packages/graph/hash_graph/bin/hash_graph/Cargo.toml
@@ -11,8 +11,7 @@ description = "The entity-graph query-layer for the HASH datastore"
 axum = "0.5.16"
 clap = { version = "4.0.13", features = ["cargo", "derive", "env", "wrap_help"] }
 clap_complete = "4.0.2"
-# TODO: Change to `version = "0.2"` as soon as it's released
-error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace"] }
+error-stack = { version = "0.2.3", features = ["spantrace"] }
 graph = { path = "../../lib/graph", features = ["clap"] }
 regex = "1.6.0"
 serde_json = "1.0.86"

--- a/packages/graph/hash_graph/bin/hash_graph/src/args.rs
+++ b/packages/graph/hash_graph/bin/hash_graph/src/args.rs
@@ -1,11 +1,11 @@
-use clap::{AppSettings::DeriveDisplayOrder, Args as _, Command, Parser};
+use clap::{Args as _, Command, Parser};
 use clap_complete::Shell;
 use graph::{logging::LoggingArgs, store::DatabaseConnectionInfo};
 use regex::Regex;
 
 /// Arguments passed to the program.
 #[derive(Debug, Parser)]
-#[clap(version, author, about, long_about = None, setting = DeriveDisplayOrder)]
+#[clap(version, author, about, long_about = None)]
 pub struct Args {
     #[clap(flatten)]
     pub db_info: DatabaseConnectionInfo,

--- a/packages/graph/hash_graph/bin/hash_graph/src/args.rs
+++ b/packages/graph/hash_graph/bin/hash_graph/src/args.rs
@@ -42,7 +42,7 @@ pub struct Args {
     pub allowed_url_domain: Regex,
 
     /// Generate a completion script for the given shell and outputs it to stdout.
-    #[clap(long, arg_enum, exclusive = true)]
+    #[clap(long, value_enum, exclusive = true)]
     generate_completion: Option<Shell>,
 }
 

--- a/packages/graph/hash_graph/lib/graph/Cargo.toml
+++ b/packages/graph/hash_graph/lib/graph/Cargo.toml
@@ -7,30 +7,30 @@ description = "HASH Graph API"
 
 
 [dependencies]
-async-trait = "0.1.56"
-axum = "0.5.11"
+async-trait = "0.1.57"
+axum = "0.5.16"
 bb8-postgres = "0.8.1"
-clap = { version = "3.2.10", features = ["derive", "env"], optional = true }
-chrono = { version = "0.4.19", features = ["serde"] }
+clap = { version = "4.0.13", features = ["derive", "env"], optional = true }
+chrono = { version = "0.4.22", features = ["serde"] }
 # TODO: Change to `version = "0.2"` as soon as it's released
 error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace", "futures"] }
-futures = "0.3.21"
-postgres-types = { version = "0.2.3", default-features = false, features = ["derive", "with-uuid-1", "with-serde_json-1", "with-chrono-0_4"] }
+futures = "0.3.24"
+postgres-types = { version = "0.2.4", default-features = false, features = ["derive", "with-uuid-1", "with-serde_json-1", "with-chrono-0_4"] }
 regex = "1.6.0"
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.83"
-tokio-postgres = { version = "0.7.6", default-features = false }
-tracing = "0.1.35"
+serde = { version = "1.0.145", features = ["derive"] }
+serde_json = "1.0.86"
+tokio-postgres = { version = "0.7.7", default-features = false }
+tracing = "0.1.37"
 tracing-appender = "0.2.2"
 tracing-error = "0.2.0"
-tracing-subscriber = { version = "0.3.14", features = ["env-filter", "json"] }
+tracing-subscriber = { version = "0.3.16", features = ["env-filter", "json"] }
 type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "6526c0e" }
-uuid = { version = "1.1.2", features = ["v4", "serde"] }
-utoipa = { git = "https://github.com/juhaku/utoipa", rev = "031073f", features = ["uuid"] }
+uuid = { version = "1.2.1", features = ["v4", "serde"] }
+utoipa = { version = " 2.2.0", features = ["uuid"] }
 include_dir = "0.7.2"
 
 [dev-dependencies]
-tokio = { version = "1.18.2", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.21.2", features = ["rt-multi-thread", "macros"] }
 graph-test-data = { path = "../../tests/test_data" }
 criterion = "0.4.0"
 

--- a/packages/graph/hash_graph/lib/graph/Cargo.toml
+++ b/packages/graph/hash_graph/lib/graph/Cargo.toml
@@ -13,8 +13,10 @@ bb8-postgres = "0.8.1"
 clap = { version = "4.0.13", features = ["derive", "env"], optional = true }
 chrono = { version = "0.4.22", features = ["serde"] }
 # TODO: Change to `version = "0.2"` as soon as it's released
+# TODO: Do this as part of this PR
 error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace", "futures"] }
 futures = "0.3.24"
+indexmap = "1.9.1"
 postgres-types = { version = "0.2.4", default-features = false, features = ["derive", "with-uuid-1", "with-serde_json-1", "with-chrono-0_4"] }
 regex = "1.6.0"
 serde = { version = "1.0.145", features = ["derive"] }

--- a/packages/graph/hash_graph/lib/graph/Cargo.toml
+++ b/packages/graph/hash_graph/lib/graph/Cargo.toml
@@ -14,7 +14,6 @@ clap = { version = "4.0.13", features = ["derive", "env"], optional = true }
 chrono = { version = "0.4.22", features = ["serde"] }
 error-stack = { version = "0.2.3", features = ["spantrace"] }
 futures = "0.3.24"
-indexmap = "1.9.1"
 postgres-types = { version = "0.2.4", default-features = false, features = ["derive", "with-uuid-1", "with-serde_json-1", "with-chrono-0_4"] }
 regex = "1.6.0"
 serde = { version = "1.0.145", features = ["derive"] }

--- a/packages/graph/hash_graph/lib/graph/Cargo.toml
+++ b/packages/graph/hash_graph/lib/graph/Cargo.toml
@@ -12,9 +12,7 @@ axum = "0.5.16"
 bb8-postgres = "0.8.1"
 clap = { version = "4.0.13", features = ["derive", "env"], optional = true }
 chrono = { version = "0.4.22", features = ["serde"] }
-# TODO: Change to `version = "0.2"` as soon as it's released
-# TODO: Do this as part of this PR
-error-stack = { git = "https://github.com/hashintel/hash", rev = "5edddb5", features = ["spantrace", "futures"] }
+error-stack = { version = "0.2.3", features = ["spantrace"] }
 futures = "0.3.24"
 indexmap = "1.9.1"
 postgres-types = { version = "0.2.4", default-features = false, features = ["derive", "with-uuid-1", "with-serde_json-1", "with-chrono-0_4"] }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/account.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/account.rs
@@ -14,11 +14,11 @@ use crate::{
 
 #[derive(OpenApi)]
 #[openapi(
-    handlers(
+    paths(
         create_account_id,
     ),
     components(
-        AccountId,
+        schemas(AccountId),
     ),
     tags(
         (name = "Account", description = "Account management API")

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -29,7 +29,7 @@ use crate::{
 
 #[derive(OpenApi)]
 #[openapi(
-    handlers(
+    paths(
         create_data_type,
         get_data_types_by_query,
         get_data_type,
@@ -37,13 +37,15 @@ use crate::{
         update_data_type
     ),
     components(
-        CreateDataTypeRequest,
-        UpdateDataTypeRequest,
-        AccountId,
-        PersistedOntologyIdentifier,
-        PersistedDataType,
-        DataTypeQuery,
-        DataTypeRootedSubgraph,
+        schemas(
+            CreateDataTypeRequest,
+            UpdateDataTypeRequest,
+            AccountId,
+            PersistedOntologyIdentifier,
+            PersistedDataType,
+            DataTypeQuery,
+            DataTypeRootedSubgraph,
+        )
     ),
     tags(
         (name = "DataType", description = "Data Type management API")

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -12,7 +12,7 @@ use error_stack::IntoReport;
 use futures::TryFutureExt;
 use serde::{Deserialize, Serialize};
 use type_system::{uri::VersionedUri, DataType};
-use utoipa::{Component, OpenApi};
+use utoipa::{OpenApi, ToSchema};
 
 use super::api_resource::RoutedResource;
 use crate::{
@@ -70,10 +70,10 @@ impl RoutedResource for DataTypeResource {
     }
 }
 
-#[derive(Serialize, Deserialize, Component)]
+#[derive(Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 struct CreateDataTypeRequest {
-    #[component(value_type = VAR_DATA_TYPE)]
+    #[schema(value_type = VAR_DATA_TYPE)]
     schema: serde_json::Value,
     account_id: AccountId,
 }
@@ -207,12 +207,12 @@ async fn get_data_type<P: StorePool + Send>(
         .map(Json)
 }
 
-#[derive(Component, Serialize, Deserialize)]
+#[derive(ToSchema, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct UpdateDataTypeRequest {
-    #[component(value_type = VAR_UPDATE_DATA_TYPE)]
+    #[schema(value_type = VAR_UPDATE_DATA_TYPE)]
     schema: serde_json::Value,
-    #[component(value_type = String)]
+    #[schema(value_type = String)]
     type_to_update: VersionedUri,
     account_id: AccountId,
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -11,7 +11,7 @@ use axum::{
 use futures::TryFutureExt;
 use serde::{Deserialize, Serialize};
 use type_system::uri::VersionedUri;
-use utoipa::{Component, OpenApi};
+use utoipa::{OpenApi, ToSchema};
 
 use crate::{
     api::rest::{api_resource::RoutedResource, read_from_store, report_to_status_code},
@@ -71,11 +71,11 @@ impl RoutedResource for EntityResource {
     }
 }
 
-#[derive(Serialize, Deserialize, Component)]
+#[derive(Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 struct CreateEntityRequest {
     entity: Entity,
-    #[component(value_type = String)]
+    #[schema(value_type = String)]
     entity_type_id: VersionedUri,
     account_id: AccountId,
     entity_id: Option<EntityId>,
@@ -197,12 +197,12 @@ async fn get_entity<P: StorePool + Send>(
         .map(Json)
 }
 
-#[derive(Component, Serialize, Deserialize)]
+#[derive(ToSchema, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct UpdateEntityRequest {
     entity: Entity,
     entity_id: EntityId,
-    #[component(value_type = String)]
+    #[schema(value_type = String)]
     entity_type_id: VersionedUri,
     account_id: AccountId,
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -29,7 +29,7 @@ use crate::{
 
 #[derive(OpenApi)]
 #[openapi(
-    handlers(
+    paths(
         create_entity,
         get_entities_by_query,
         get_entity,
@@ -37,14 +37,16 @@ use crate::{
         update_entity
     ),
     components(
-        CreateEntityRequest,
-        UpdateEntityRequest,
-        EntityId,
-        PersistedEntityIdentifier,
-        PersistedEntity,
-        Entity,
-        KnowledgeGraphQuery,
-        EntityRootedSubgraph,
+        schemas(
+            CreateEntityRequest,
+            UpdateEntityRequest,
+            EntityId,
+            PersistedEntityIdentifier,
+            PersistedEntity,
+            Entity,
+            KnowledgeGraphQuery,
+            EntityRootedSubgraph,
+        )
     ),
     tags(
         (name = "Entity", description = "entity management API")

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -30,7 +30,7 @@ use crate::{
 
 #[derive(OpenApi)]
 #[openapi(
-    handlers(
+    paths(
         create_entity_type,
         get_entity_types_by_query,
         get_entity_type,
@@ -38,13 +38,15 @@ use crate::{
         update_entity_type
     ),
     components(
-        CreateEntityTypeRequest,
-        UpdateEntityTypeRequest,
-        AccountId,
-        PersistedOntologyIdentifier,
-        PersistedEntityType,
-        EntityTypeQuery,
-        EntityTypeRootedSubgraph,
+        schemas(
+            CreateEntityTypeRequest,
+            UpdateEntityTypeRequest,
+            AccountId,
+            PersistedOntologyIdentifier,
+            PersistedEntityType,
+            EntityTypeQuery,
+            EntityTypeRootedSubgraph,
+        )
     ),
     tags(
         (name = "EntityType", description = "Entity type management API")

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -12,7 +12,7 @@ use error_stack::IntoReport;
 use futures::TryFutureExt;
 use serde::{Deserialize, Serialize};
 use type_system::{uri::VersionedUri, EntityType};
-use utoipa::{Component, OpenApi};
+use utoipa::{OpenApi, ToSchema};
 
 use crate::{
     api::rest::{api_resource::RoutedResource, read_from_store, report_to_status_code},
@@ -71,10 +71,10 @@ impl RoutedResource for EntityTypeResource {
     }
 }
 
-#[derive(Serialize, Deserialize, Component)]
+#[derive(Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 struct CreateEntityTypeRequest {
-    #[component(value_type = VAR_ENTITY_TYPE)]
+    #[schema(value_type = VAR_ENTITY_TYPE)]
     schema: serde_json::Value,
     account_id: AccountId,
 }
@@ -211,12 +211,12 @@ async fn get_entity_type<P: StorePool + Send>(
         .map(Json)
 }
 
-#[derive(Component, Serialize, Deserialize)]
+#[derive(ToSchema, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct UpdateEntityTypeRequest {
-    #[component(value_type = VAR_UPDATE_ENTITY_TYPE)]
+    #[schema(value_type = VAR_UPDATE_ENTITY_TYPE)]
     schema: serde_json::Value,
-    #[component(value_type = String)]
+    #[schema(value_type = String)]
     type_to_update: VersionedUri,
     account_id: AccountId,
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
@@ -17,20 +17,22 @@ use crate::{
 
 #[derive(OpenApi)]
 #[openapi(
-    handlers(
+    paths(
         create_link,
         get_links_by_query,
         get_entity_links,
         remove_link
     ),
     components(
-        AccountId,
-        PersistedLink,
-        Link,
-        CreateLinkRequest,
-        RemoveLinkRequest,
-        KnowledgeGraphQuery,
-        LinkRootedSubgraph
+        schemas(
+            AccountId,
+            PersistedLink,
+            Link,
+            CreateLinkRequest,
+            RemoveLinkRequest,
+            KnowledgeGraphQuery,
+            LinkRootedSubgraph
+        )
     ),
     tags(
         (name = "Link", description = "link management API")

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
@@ -6,7 +6,7 @@ use axum::{extract::Path, http::StatusCode, routing::post, Extension, Json, Rout
 use futures::TryFutureExt;
 use serde::{Deserialize, Serialize};
 use type_system::uri::VersionedUri;
-use utoipa::{Component, OpenApi};
+use utoipa::{OpenApi, ToSchema};
 
 use crate::{
     api::rest::{api_resource::RoutedResource, read_from_store, report_to_status_code},
@@ -57,11 +57,11 @@ impl RoutedResource for LinkResource {
     }
 }
 
-#[derive(Serialize, Deserialize, Component)]
+#[derive(Serialize, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 struct CreateLinkRequest {
     target_entity_id: EntityId,
-    #[component(value_type = String)]
+    #[schema(value_type = String)]
     link_type_id: VersionedUri,
     owned_by_id: AccountId,
     // TODO: Consider if ordering should be exposed on links as they are here. The API consumer
@@ -182,11 +182,11 @@ async fn get_entity_links<P: StorePool + Send>(
     .map(Json)
 }
 
-#[derive(Serialize, Deserialize, Component)]
+#[derive(Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 struct RemoveLinkRequest {
     target_entity_id: EntityId,
-    #[component(value_type = String)]
+    #[schema(value_type = String)]
     link_type_id: VersionedUri,
     removed_by_id: AccountId,
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -29,7 +29,7 @@ use crate::{
 
 #[derive(OpenApi)]
 #[openapi(
-    handlers(
+    paths(
         create_link_type,
         get_link_types_by_query,
         get_link_type,
@@ -37,13 +37,15 @@ use crate::{
         update_link_type
     ),
     components(
-        CreateLinkTypeRequest,
-        UpdateLinkTypeRequest,
-        AccountId,
-        PersistedOntologyIdentifier,
-        PersistedLinkType,
-        LinkTypeQuery,
-        LinkTypeRootedSubgraph,
+        schemas(
+            CreateLinkTypeRequest,
+            UpdateLinkTypeRequest,
+            AccountId,
+            PersistedOntologyIdentifier,
+            PersistedLinkType,
+            LinkTypeQuery,
+            LinkTypeRootedSubgraph,
+        )
     ),
     tags(
         (name = "LinkType", description = "Link type management API")

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -12,7 +12,7 @@ use error_stack::IntoReport;
 use futures::TryFutureExt;
 use serde::{Deserialize, Serialize};
 use type_system::{uri::VersionedUri, LinkType};
-use utoipa::{Component, OpenApi};
+use utoipa::{OpenApi, ToSchema};
 
 use super::api_resource::RoutedResource;
 use crate::{
@@ -70,10 +70,10 @@ impl RoutedResource for LinkTypeResource {
     }
 }
 
-#[derive(Serialize, Deserialize, Component)]
+#[derive(Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 struct CreateLinkTypeRequest {
-    #[component(value_type = VAR_LINK_TYPE)]
+    #[schema(value_type = VAR_LINK_TYPE)]
     schema: serde_json::Value,
     account_id: AccountId,
 }
@@ -206,12 +206,12 @@ async fn get_link_type<P: StorePool + Send>(
         .map(Json)
 }
 
-#[derive(Component, Serialize, Deserialize)]
+#[derive(ToSchema, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct UpdateLinkTypeRequest {
-    #[component(value_type = VAR_UPDATE_LINK_TYPE)]
+    #[schema(value_type = VAR_UPDATE_LINK_TYPE)]
     schema: serde_json::Value,
-    #[component(value_type = String)]
+    #[schema(value_type = String)]
     type_to_update: VersionedUri,
     account_id: AccountId,
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
@@ -241,10 +241,7 @@ impl Modify for ExternalRefAddon {
     }
 }
 
-fn modify_component<'a, I>(content_iter: I)
-where
-    I: IntoIterator<Item = &'a mut openapi::Content>,
-{
+fn modify_component<'a>(content_iter: impl IntoIterator<Item = &'a mut openapi::Content>) {
     for content in content_iter {
         modify_schema_references(&mut content.schema);
     }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
@@ -11,7 +11,7 @@ mod link;
 mod link_type;
 mod property_type;
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 
 use axum::{
     extract::Path,
@@ -23,8 +23,9 @@ use axum::{
 use error_stack::Report;
 use futures::TryFutureExt;
 use include_dir::{include_dir, Dir};
+use indexmap::IndexMap;
 use utoipa::{
-    openapi::{self, schema, ObjectBuilder},
+    openapi::{self, schema, schema::RefOr, ObjectBuilder},
     Modify, OpenApi,
 };
 
@@ -224,11 +225,11 @@ impl Modify for ExternalRefAddon {
         for path_item in openapi.paths.paths.values_mut() {
             for operation in path_item.operations.values_mut() {
                 if let Some(request_body) = &mut operation.request_body {
-                    modify_component_references(&mut request_body.content);
+                    modify_component_body(&mut request_body.content);
                 }
 
                 for response in &mut operation.responses.responses.values_mut() {
-                    modify_component_references(&mut response.content);
+                    modify_component_responses(&mut response.content);
                 }
             }
         }
@@ -241,24 +242,33 @@ impl Modify for ExternalRefAddon {
     }
 }
 
-fn modify_component_references(content: &mut HashMap<String, openapi::Content>) {
+fn modify_component_body(content: &mut BTreeMap<String, openapi::Content>) {
     for content in content.values_mut() {
         modify_schema_references(&mut content.schema);
     }
 }
 
-fn modify_schema_references(schema_component: &mut openapi::Component) {
+// TODO: can we avoid importing IndexMap here?
+fn modify_component_responses(content: &mut IndexMap<String, openapi::Content>) {
+    for content in content.values_mut() {
+        modify_schema_references(&mut content.schema);
+    }
+}
+
+fn modify_schema_references(schema_component: &mut RefOr<openapi::Schema>) {
     match schema_component {
-        openapi::Component::Ref(reference) => modify_reference(reference),
-        openapi::Component::Object(object) => object
-            .properties
-            .values_mut()
-            .for_each(modify_schema_references),
-        openapi::Component::Array(array) => modify_schema_references(array.items.as_mut()),
-        openapi::Component::OneOf(one_of) => {
-            one_of.items.iter_mut().for_each(modify_schema_references);
-        }
-        _ => (),
+        RefOr::Ref(reference) => modify_reference(reference),
+        RefOr::T(schema) => match schema {
+            openapi::Schema::Object(object) => object
+                .properties
+                .values_mut()
+                .for_each(modify_schema_references),
+            openapi::Schema::Array(array) => modify_schema_references(array.items.as_mut()),
+            openapi::Schema::OneOf(one_of) => {
+                one_of.items.iter_mut().for_each(modify_schema_references);
+            }
+            _ => (),
+        },
     }
 }
 
@@ -305,14 +315,15 @@ impl Modify for AnyObjectAddon {
         openapi.components.as_mut().map(|components| {
             components.schemas.insert(
                 "Expression".to_owned(),
-                schema::Component::Object(
-                    ObjectBuilder::default()
+                schema::Schema::Object(
+                    ObjectBuilder::new()
                         .example(Some(
                             serde_json::to_value(Expression::for_latest_version())
                                 .expect("Could not serialize expression"),
                         ))
                         .build(),
-                ),
+                )
+                .into(),
             )
         });
     }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -29,7 +29,7 @@ use crate::{
 
 #[derive(OpenApi)]
 #[openapi(
-    handlers(
+    paths(
         create_property_type,
         get_property_types_by_query,
         get_property_type,
@@ -37,13 +37,15 @@ use crate::{
         update_property_type
     ),
     components(
-        CreatePropertyTypeRequest,
-        UpdatePropertyTypeRequest,
-        AccountId,
-        PersistedOntologyIdentifier,
-        PersistedPropertyType,
-        PropertyTypeQuery,
-        PropertyTypeRootedSubgraph,
+        schemas(
+            CreatePropertyTypeRequest,
+            UpdatePropertyTypeRequest,
+            AccountId,
+            PersistedOntologyIdentifier,
+            PersistedPropertyType,
+            PropertyTypeQuery,
+            PropertyTypeRootedSubgraph,
+        )
     ),
     tags(
         (name = "PropertyType", description = "Property type management API")

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -12,7 +12,7 @@ use error_stack::IntoReport;
 use futures::TryFutureExt;
 use serde::{Deserialize, Serialize};
 use type_system::{uri::VersionedUri, PropertyType};
-use utoipa::{Component, OpenApi};
+use utoipa::{OpenApi, ToSchema};
 
 use super::api_resource::RoutedResource;
 use crate::{
@@ -70,10 +70,10 @@ impl RoutedResource for PropertyTypeResource {
     }
 }
 
-#[derive(Serialize, Deserialize, Component)]
+#[derive(Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 struct CreatePropertyTypeRequest {
-    #[component(value_type = VAR_PROPERTY_TYPE)]
+    #[schema(value_type = VAR_PROPERTY_TYPE)]
     schema: serde_json::Value,
     account_id: AccountId,
 }
@@ -214,12 +214,12 @@ async fn get_property_type<P: StorePool + Send>(
         .map(Json)
 }
 
-#[derive(Component, Serialize, Deserialize)]
+#[derive(ToSchema, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct UpdatePropertyTypeRequest {
-    #[component(value_type = VAR_UPDATE_PROPERTY_TYPE)]
+    #[schema(value_type = VAR_UPDATE_PROPERTY_TYPE)]
     schema: serde_json::Value,
-    #[component(value_type = String)]
+    #[schema(value_type = String)]
     type_to_update: VersionedUri,
     account_id: AccountId,
 }

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -33,6 +33,7 @@ impl fmt::Display for EntityId {
 ///
 /// When expressed as JSON, this should validate against its respective entity type(s).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[schema(value_type = Object)]
 pub struct Entity(HashMap<BaseUri, serde_json::Value>);
 
 impl Entity {

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -4,13 +4,13 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tokio_postgres::types::{FromSql, ToSql};
 use type_system::uri::{BaseUri, VersionedUri};
-use utoipa::Component;
+use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::ontology::AccountId;
 
 #[derive(
-    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Component, FromSql, ToSql,
+    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema, FromSql, ToSql,
 )]
 #[repr(transparent)]
 #[postgres(transparent)]
@@ -32,7 +32,7 @@ impl fmt::Display for EntityId {
 /// An entity.
 ///
 /// When expressed as JSON, this should validate against its respective entity type(s).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct Entity(HashMap<BaseUri, serde_json::Value>);
 
 impl Entity {
@@ -44,11 +44,11 @@ impl Entity {
 
 /// The metadata required to uniquely identify an instance of an [`Entity`] that has been persisted
 /// in the datastore.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PersistedEntityIdentifier {
     entity_id: EntityId,
-    #[component(value_type = String)]
+    #[schema(value_type = String)]
     version: DateTime<Utc>,
     owned_by_id: AccountId,
 }
@@ -81,12 +81,12 @@ impl PersistedEntityIdentifier {
 
 /// A record of an [`Entity`] that has been persisted in the datastore, with its associated
 /// metadata.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PersistedEntity {
     inner: Entity,
     identifier: PersistedEntityIdentifier,
-    #[component(value_type = String)]
+    #[schema(value_type = String)]
     entity_type_id: VersionedUri,
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/link/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/link/mod.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 use type_system::uri::VersionedUri;
-use utoipa::Component;
+use utoipa::ToSchema;
 
 use super::EntityId;
 use crate::ontology::AccountId;
@@ -10,12 +10,12 @@ use crate::ontology::AccountId;
 /// A Link between a source and a target entity identified by [`EntityId`]s.
 ///
 /// The link is described by a link type [`VersionedUri`].
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Component)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Link {
     source_entity_id: EntityId,
     target_entity_id: EntityId,
-    #[component(value_type = String)]
+    #[schema(value_type = String)]
     link_type_id: VersionedUri,
     // TODO: Consider if ordering should be exposed on links as they are here. The API consumer
     //   manages indexes currently.
@@ -62,7 +62,7 @@ impl Link {
 
 /// A record of a [`Link`] that has been persisted in the datastore, with its associated
 /// metadata.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Component)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PersistedLink {
     inner: Link,

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/mod.rs
@@ -5,7 +5,7 @@ mod entity;
 mod link;
 
 use serde::{Deserialize, Serialize};
-use utoipa::Component;
+use utoipa::ToSchema;
 
 pub use self::{
     entity::{Entity, EntityId, PersistedEntity, PersistedEntityIdentifier},
@@ -50,26 +50,26 @@ pub type KnowledgeGraphQueryDepth = u8;
 /// Query to read [`Entities`] or [`Link`]s, which satisfy the [`Expression`].
 ///
 /// [`Entities`]: Entity
-#[derive(Debug, Deserialize, Component)]
+#[derive(Debug, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct KnowledgeGraphQuery {
     #[serde(rename = "query")]
     pub expression: Expression,
-    #[component(value_type = number)]
+    #[schema(value_type = number)]
     pub data_type_query_depth: OntologyQueryDepth,
-    #[component(value_type = number)]
+    #[schema(value_type = number)]
     pub property_type_query_depth: OntologyQueryDepth,
-    #[component(value_type = number)]
+    #[schema(value_type = number)]
     pub link_type_query_depth: OntologyQueryDepth,
-    #[component(value_type = number)]
+    #[schema(value_type = number)]
     pub entity_type_query_depth: OntologyQueryDepth,
-    #[component(value_type = number)]
+    #[schema(value_type = number)]
     pub link_target_entity_query_depth: KnowledgeGraphQueryDepth,
-    #[component(value_type = number)]
+    #[schema(value_type = number)]
     pub link_query_depth: KnowledgeGraphQueryDepth,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct EntityRootedSubgraph {
     pub entity: PersistedEntity,
@@ -81,7 +81,7 @@ pub struct EntityRootedSubgraph {
     pub links: Vec<PersistedLink>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct LinkRootedSubgraph {
     pub link: PersistedLink,

--- a/packages/graph/hash_graph/lib/graph/src/logging/args.rs
+++ b/packages/graph/hash_graph/lib/graph/src/logging/args.rs
@@ -10,7 +10,7 @@ use tracing_subscriber::filter::Directive;
 
 /// Output format emitted to the terminal
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "clap", derive(clap::ArgEnum))]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 pub enum LogFormat {
     /// Human-readable, single-line logs for each event that occurs, with the current span context
     /// displayed before the formatted representation of the event.
@@ -41,7 +41,7 @@ impl Default for LogFormat {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "clap", derive(clap::ArgEnum))]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 pub enum LogLevel {
     Trace,
     Debug,
@@ -84,14 +84,14 @@ pub struct LoggingArgs {
         clap(
             long,
             default_value = "pretty",
-            arg_enum,
+            value_enum,
             env = "HASH_GRAPH_LOG_FORMAT"
         )
     )]
     pub log_format: LogFormat,
 
     /// Logging verbosity to use. If not set `RUST_LOG` will be used
-    #[cfg_attr(feature = "clap", clap(long, arg_enum))]
+    #[cfg_attr(feature = "clap", clap(long, value_enum))]
     pub log_level: Option<LogLevel>,
 
     /// Logging output folder. The folder is created if it doesn't exist.

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize, Serializer};
 use serde_json;
 use tokio_postgres::types::{FromSql, ToSql};
 use type_system::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType};
-use utoipa::Component;
+use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::store::query::Expression;
@@ -17,7 +17,7 @@ use crate::store::query::Expression;
 // TODO - find a good place for AccountId, perhaps it will become redundant in a future design
 
 #[derive(
-    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Component, FromSql, ToSql,
+    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema, FromSql, ToSql,
 )]
 #[repr(transparent)]
 #[postgres(transparent)]
@@ -38,10 +38,10 @@ impl fmt::Display for AccountId {
 
 /// The metadata required to uniquely identify an ontology element that has been persisted in the
 /// datastore.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Component)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PersistedOntologyIdentifier {
-    #[component(value_type = String)]
+    #[schema(value_type = String)]
     uri: VersionedUri,
     owned_by_id: AccountId,
 }
@@ -169,16 +169,16 @@ where
 /// _property type_ references is then resolved to a depth of `property_type_query_depth`.
 pub type OntologyQueryDepth = u8;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 pub struct PersistedDataType {
-    #[component(value_type = VAR_DATA_TYPE)]
+    #[schema(value_type = VAR_DATA_TYPE)]
     #[serde(serialize_with = "serialize_ontology_type")]
     pub inner: DataType,
     pub identifier: PersistedOntologyIdentifier,
 }
 
 /// Query to read [`DataType`]s, which are matching the [`Expression`].
-#[derive(Debug, Deserialize, Component)]
+#[derive(Debug, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct DataTypeQuery {
     #[serde(rename = "query")]
@@ -186,39 +186,39 @@ pub struct DataTypeQuery {
     // TODO: `data_type_query_depth` currently does nothing, in the future it will most probably be
     //       used to resolve user defined data types.
     //   see https://app.asana.com/0/1200211978612931/1202464168422955/f
-    #[component(value_type = number)]
+    #[schema(value_type = number)]
     pub data_type_query_depth: OntologyQueryDepth,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DataTypeRootedSubgraph {
     pub data_type: PersistedDataType,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 pub struct PersistedPropertyType {
-    #[component(value_type = VAR_PROPERTY_TYPE)]
+    #[schema(value_type = VAR_PROPERTY_TYPE)]
     #[serde(serialize_with = "serialize_ontology_type")]
     pub inner: PropertyType,
     pub identifier: PersistedOntologyIdentifier,
 }
 
 /// Query to read [`PropertyType`]s, which are matching the [`Expression`].
-#[derive(Debug, Deserialize, Component)]
+#[derive(Debug, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct PropertyTypeQuery {
     #[serde(rename = "query")]
     pub expression: Expression,
     // TODO: A value greater than `1` currently does not have any effect.
     //   see https://app.asana.com/0/1200211978612931/1202464168422955/f
-    #[component(value_type = number)]
+    #[schema(value_type = number)]
     pub data_type_query_depth: OntologyQueryDepth,
-    #[component(value_type = number)]
+    #[schema(value_type = number)]
     pub property_type_query_depth: OntologyQueryDepth,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PropertyTypeRootedSubgraph {
     pub property_type: PersistedPropertyType,
@@ -226,55 +226,55 @@ pub struct PropertyTypeRootedSubgraph {
     pub referenced_property_types: Vec<PersistedPropertyType>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 pub struct PersistedLinkType {
-    #[component(value_type = VAR_LINK_TYPE)]
+    #[schema(value_type = VAR_LINK_TYPE)]
     #[serde(serialize_with = "serialize_ontology_type")]
     pub inner: LinkType,
     pub identifier: PersistedOntologyIdentifier,
 }
 
 /// Query to read [`LinkType`]s, which are matching the [`Expression`].
-#[derive(Debug, Deserialize, Component)]
+#[derive(Debug, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct LinkTypeQuery {
     #[serde(rename = "query")]
     pub expression: Expression,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct LinkTypeRootedSubgraph {
     pub link_type: PersistedLinkType,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 pub struct PersistedEntityType {
-    #[component(value_type = VAR_ENTITY_TYPE)]
+    #[schema(value_type = VAR_ENTITY_TYPE)]
     #[serde(serialize_with = "serialize_ontology_type")]
     pub inner: EntityType,
     pub identifier: PersistedOntologyIdentifier,
 }
 
 /// Query to read [`EntityType`]s, which are matching the [`Expression`].
-#[derive(Debug, Deserialize, Component)]
+#[derive(Debug, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct EntityTypeQuery {
     #[serde(rename = "query")]
     pub expression: Expression,
     // TODO: A value greater than `1` currently does not have any effect.
     //   see https://app.asana.com/0/1200211978612931/1202464168422955/f
-    #[component(value_type = number)]
+    #[schema(value_type = number)]
     pub data_type_query_depth: OntologyQueryDepth,
-    #[component(value_type = number)]
+    #[schema(value_type = number)]
     pub property_type_query_depth: OntologyQueryDepth,
-    #[component(value_type = number)]
+    #[schema(value_type = number)]
     pub link_type_query_depth: OntologyQueryDepth,
-    #[component(value_type = number)]
+    #[schema(value_type = number)]
     pub entity_type_query_depth: OntologyQueryDepth,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Component)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct EntityTypeRootedSubgraph {
     pub entity_type: PersistedEntityType,

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -42,7 +42,7 @@ impl fmt::Display for StoreError {
 }
 
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "clap", derive(clap::ArgEnum))]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 pub enum DatabaseType {
     #[default]
     Postgres,
@@ -52,7 +52,7 @@ pub enum DatabaseType {
 #[cfg_attr(feature = "clap", derive(clap::Args))]
 pub struct DatabaseConnectionInfo {
     /// The database type to connect to
-    #[cfg_attr(feature = "clap", clap(long, default_value = "postgres", arg_enum))]
+    #[cfg_attr(feature = "clap", clap(long, default_value = "postgres", value_enum))]
     database_type: DatabaseType,
 
     /// Database username

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/version_id.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/version_id.rs
@@ -2,10 +2,10 @@ use std::fmt;
 
 use postgres_types::{FromSql, ToSql};
 use serde::{Deserialize, Serialize};
-use utoipa::Component;
+use utoipa::ToSchema;
 use uuid::Uuid;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Component, FromSql, ToSql)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema, FromSql, ToSql)]
 #[repr(transparent)]
 #[postgres(transparent)]
 pub struct VersionId(Uuid);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We were starting to fall behind on dependency versions, there were a few major (or at least breaking) updates made to our dependencies. This PR upgrades all dependencies (or at least all the ones that were automatically selected by `cargo upgrade --workspace`).

This also means we are using a proper release of `error-stack` again rather than a direct git hash.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1200211978612931/1203157172269841/f) _(internal)_

## 🔍 What does this change?

- Runs `cargo upgrade` and updates the versions for packages (look to diff for comprehensive list)
- Stop depending on a git hash for utoipa and use their newest release
  - Changes our uses of `Component` to `ToSchema`
  - Changes our usages of `handlers` to `paths` in utoipa (they changed the attribute)
  - Changes some of our own modifying code to accept the new API
- Upgrades `clap` to version 4
  - Removes `DeriveDisplayOrder` as apparently this is default now (https://github.com/clap-rs/clap/issues/2808)
  - Removes `AppSettings` because it does not exist anymore (and is unneeded because of above)
  - Replaces `arg_enum` with `value_enum` (https://github.com/clap-rs/clap/pull/4127)

## 📜 Does this require a change to the docs?

- The OpenAPI spec has been regenerated, I don't believe anything else needs changing

## ⚠️ Known issues

~~I've added a new dependency on `indexmap` but we can probably remove it. I've opened a comment to highlight it.~~

## 🐾 Next steps

- Upgrade the engine and other Rust projects to use the new `error-stack`

## 🛡 What tests cover this?

All tests that interact with the graph, follow the READMEs, but CI _should_ be good enough.
