### PR TITLE
Basic ontology/knowledge provenance fields in the Graph API and workspace backend

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -55,7 +55,7 @@ export interface CreateDataTypeRequest {
    * @type {string}
    * @memberof CreateDataTypeRequest
    */
-  createdById: string;
+  actorId: string;
   /**
    *
    * @type {string}
@@ -80,7 +80,7 @@ export interface CreateEntityRequest {
    * @type {string}
    * @memberof CreateEntityRequest
    */
-  createdById: string;
+  actorId: string;
   /**
    *
    * @type {object}
@@ -117,7 +117,7 @@ export interface CreateEntityTypeRequest {
    * @type {string}
    * @memberof CreateEntityTypeRequest
    */
-  createdById: string;
+  actorId: string;
   /**
    *
    * @type {string}
@@ -142,7 +142,7 @@ export interface CreateLinkRequest {
    * @type {string}
    * @memberof CreateLinkRequest
    */
-  createdById: string;
+  actorId: string;
   /**
    *
    * @type {number}
@@ -179,7 +179,7 @@ export interface CreateLinkTypeRequest {
    * @type {string}
    * @memberof CreateLinkTypeRequest
    */
-  createdById: string;
+  actorId: string;
   /**
    *
    * @type {string}
@@ -204,7 +204,7 @@ export interface CreatePropertyTypeRequest {
    * @type {string}
    * @memberof CreatePropertyTypeRequest
    */
-  createdById: string;
+  actorId: string;
   /**
    *
    * @type {string}
@@ -1166,13 +1166,13 @@ export interface RemoveLinkRequest {
    * @type {string}
    * @memberof RemoveLinkRequest
    */
-  linkTypeId: string;
+  actorId: string;
   /**
    *
    * @type {string}
    * @memberof RemoveLinkRequest
    */
-  removedById: string;
+  linkTypeId: string;
   /**
    *
    * @type {string}
@@ -1279,6 +1279,12 @@ export type UpdateDataTypeKindEnum =
 export interface UpdateDataTypeRequest {
   /**
    *
+   * @type {string}
+   * @memberof UpdateDataTypeRequest
+   */
+  actorId: string;
+  /**
+   *
    * @type {UpdateDataType}
    * @memberof UpdateDataTypeRequest
    */
@@ -1289,12 +1295,6 @@ export interface UpdateDataTypeRequest {
    * @memberof UpdateDataTypeRequest
    */
   typeToUpdate: string;
-  /**
-   *
-   * @type {string}
-   * @memberof UpdateDataTypeRequest
-   */
-  updatedById: string;
 }
 /**
  *
@@ -1302,6 +1302,12 @@ export interface UpdateDataTypeRequest {
  * @interface UpdateEntityRequest
  */
 export interface UpdateEntityRequest {
+  /**
+   *
+   * @type {string}
+   * @memberof UpdateEntityRequest
+   */
+  actorId: string;
   /**
    *
    * @type {object}
@@ -1320,12 +1326,6 @@ export interface UpdateEntityRequest {
    * @memberof UpdateEntityRequest
    */
   entityTypeId: string;
-  /**
-   *
-   * @type {string}
-   * @memberof UpdateEntityRequest
-   */
-  updatedById: string;
 }
 /**
  * The contents of an Entity Type update request
@@ -1422,6 +1422,12 @@ export type UpdateEntityTypeTypeEnum =
 export interface UpdateEntityTypeRequest {
   /**
    *
+   * @type {string}
+   * @memberof UpdateEntityTypeRequest
+   */
+  actorId: string;
+  /**
+   *
    * @type {UpdateEntityType}
    * @memberof UpdateEntityTypeRequest
    */
@@ -1432,12 +1438,6 @@ export interface UpdateEntityTypeRequest {
    * @memberof UpdateEntityTypeRequest
    */
   typeToUpdate: string;
-  /**
-   *
-   * @type {string}
-   * @memberof UpdateEntityTypeRequest
-   */
-  updatedById: string;
 }
 /**
  * The contents of a Link Type update request
@@ -1492,6 +1492,12 @@ export type UpdateLinkTypeKindEnum =
 export interface UpdateLinkTypeRequest {
   /**
    *
+   * @type {string}
+   * @memberof UpdateLinkTypeRequest
+   */
+  actorId: string;
+  /**
+   *
    * @type {UpdateLinkType}
    * @memberof UpdateLinkTypeRequest
    */
@@ -1502,12 +1508,6 @@ export interface UpdateLinkTypeRequest {
    * @memberof UpdateLinkTypeRequest
    */
   typeToUpdate: string;
-  /**
-   *
-   * @type {string}
-   * @memberof UpdateLinkTypeRequest
-   */
-  updatedById: string;
 }
 /**
  * The contents of a Property Type update request
@@ -1562,6 +1562,12 @@ export type UpdatePropertyTypeKindEnum =
 export interface UpdatePropertyTypeRequest {
   /**
    *
+   * @type {string}
+   * @memberof UpdatePropertyTypeRequest
+   */
+  actorId: string;
+  /**
+   *
    * @type {UpdatePropertyType}
    * @memberof UpdatePropertyTypeRequest
    */
@@ -1572,12 +1578,6 @@ export interface UpdatePropertyTypeRequest {
    * @memberof UpdatePropertyTypeRequest
    */
   typeToUpdate: string;
-  /**
-   *
-   * @type {string}
-   * @memberof UpdatePropertyTypeRequest
-   */
-  updatedById: string;
 }
 /**
  * @type Vertex

--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -55,7 +55,13 @@ export interface CreateDataTypeRequest {
    * @type {string}
    * @memberof CreateDataTypeRequest
    */
-  accountId: string;
+  createdById: string;
+  /**
+   *
+   * @type {string}
+   * @memberof CreateDataTypeRequest
+   */
+  ownedById: string;
   /**
    *
    * @type {DataType}
@@ -74,7 +80,7 @@ export interface CreateEntityRequest {
    * @type {string}
    * @memberof CreateEntityRequest
    */
-  accountId: string;
+  createdById: string;
   /**
    *
    * @type {object}
@@ -93,6 +99,12 @@ export interface CreateEntityRequest {
    * @memberof CreateEntityRequest
    */
   entityTypeId: string;
+  /**
+   *
+   * @type {string}
+   * @memberof CreateEntityRequest
+   */
+  ownedById: string;
 }
 /**
  *
@@ -105,7 +117,13 @@ export interface CreateEntityTypeRequest {
    * @type {string}
    * @memberof CreateEntityTypeRequest
    */
-  accountId: string;
+  createdById: string;
+  /**
+   *
+   * @type {string}
+   * @memberof CreateEntityTypeRequest
+   */
+  ownedById: string;
   /**
    *
    * @type {EntityType}
@@ -119,6 +137,12 @@ export interface CreateEntityTypeRequest {
  * @interface CreateLinkRequest
  */
 export interface CreateLinkRequest {
+  /**
+   *
+   * @type {string}
+   * @memberof CreateLinkRequest
+   */
+  createdById: string;
   /**
    *
    * @type {number}
@@ -155,7 +179,13 @@ export interface CreateLinkTypeRequest {
    * @type {string}
    * @memberof CreateLinkTypeRequest
    */
-  accountId: string;
+  createdById: string;
+  /**
+   *
+   * @type {string}
+   * @memberof CreateLinkTypeRequest
+   */
+  ownedById: string;
   /**
    *
    * @type {LinkType}
@@ -174,7 +204,13 @@ export interface CreatePropertyTypeRequest {
    * @type {string}
    * @memberof CreatePropertyTypeRequest
    */
-  accountId: string;
+  createdById: string;
+  /**
+   *
+   * @type {string}
+   * @memberof CreatePropertyTypeRequest
+   */
+  ownedById: string;
   /**
    *
    * @type {PropertyType}
@@ -748,6 +784,12 @@ export interface PersistedEntityMetadata {
    * @type {string}
    * @memberof PersistedEntityMetadata
    */
+  createdById: string;
+  /**
+   *
+   * @type {string}
+   * @memberof PersistedEntityMetadata
+   */
   entityTypeId: string;
   /**
    *
@@ -755,6 +797,18 @@ export interface PersistedEntityMetadata {
    * @memberof PersistedEntityMetadata
    */
   identifier: PersistedEntityIdentifier;
+  /**
+   *
+   * @type {string}
+   * @memberof PersistedEntityMetadata
+   */
+  removedById?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof PersistedEntityMetadata
+   */
+  updatedById: string;
 }
 /**
  *
@@ -800,6 +854,12 @@ export interface PersistedLink {
  * @interface PersistedLinkMetadata
  */
 export interface PersistedLinkMetadata {
+  /**
+   *
+   * @type {string}
+   * @memberof PersistedLinkMetadata
+   */
+  createdById: string;
   /**
    *
    * @type {string}
@@ -853,10 +913,28 @@ export interface PersistedOntologyIdentifier {
 export interface PersistedOntologyMetadata {
   /**
    *
+   * @type {string}
+   * @memberof PersistedOntologyMetadata
+   */
+  createdById: string;
+  /**
+   *
    * @type {PersistedOntologyIdentifier}
    * @memberof PersistedOntologyMetadata
    */
   identifier: PersistedOntologyIdentifier;
+  /**
+   *
+   * @type {string}
+   * @memberof PersistedOntologyMetadata
+   */
+  removedById?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof PersistedOntologyMetadata
+   */
+  updatedById: string;
 }
 /**
  *
@@ -1201,12 +1279,6 @@ export type UpdateDataTypeKindEnum =
 export interface UpdateDataTypeRequest {
   /**
    *
-   * @type {string}
-   * @memberof UpdateDataTypeRequest
-   */
-  accountId: string;
-  /**
-   *
    * @type {UpdateDataType}
    * @memberof UpdateDataTypeRequest
    */
@@ -1217,6 +1289,12 @@ export interface UpdateDataTypeRequest {
    * @memberof UpdateDataTypeRequest
    */
   typeToUpdate: string;
+  /**
+   *
+   * @type {string}
+   * @memberof UpdateDataTypeRequest
+   */
+  updatedById: string;
 }
 /**
  *
@@ -1224,12 +1302,6 @@ export interface UpdateDataTypeRequest {
  * @interface UpdateEntityRequest
  */
 export interface UpdateEntityRequest {
-  /**
-   *
-   * @type {string}
-   * @memberof UpdateEntityRequest
-   */
-  accountId: string;
   /**
    *
    * @type {object}
@@ -1248,6 +1320,12 @@ export interface UpdateEntityRequest {
    * @memberof UpdateEntityRequest
    */
   entityTypeId: string;
+  /**
+   *
+   * @type {string}
+   * @memberof UpdateEntityRequest
+   */
+  updatedById: string;
 }
 /**
  * The contents of an Entity Type update request
@@ -1344,12 +1422,6 @@ export type UpdateEntityTypeTypeEnum =
 export interface UpdateEntityTypeRequest {
   /**
    *
-   * @type {string}
-   * @memberof UpdateEntityTypeRequest
-   */
-  accountId: string;
-  /**
-   *
    * @type {UpdateEntityType}
    * @memberof UpdateEntityTypeRequest
    */
@@ -1360,6 +1432,12 @@ export interface UpdateEntityTypeRequest {
    * @memberof UpdateEntityTypeRequest
    */
   typeToUpdate: string;
+  /**
+   *
+   * @type {string}
+   * @memberof UpdateEntityTypeRequest
+   */
+  updatedById: string;
 }
 /**
  * The contents of a Link Type update request
@@ -1414,12 +1492,6 @@ export type UpdateLinkTypeKindEnum =
 export interface UpdateLinkTypeRequest {
   /**
    *
-   * @type {string}
-   * @memberof UpdateLinkTypeRequest
-   */
-  accountId: string;
-  /**
-   *
    * @type {UpdateLinkType}
    * @memberof UpdateLinkTypeRequest
    */
@@ -1430,6 +1502,12 @@ export interface UpdateLinkTypeRequest {
    * @memberof UpdateLinkTypeRequest
    */
   typeToUpdate: string;
+  /**
+   *
+   * @type {string}
+   * @memberof UpdateLinkTypeRequest
+   */
+  updatedById: string;
 }
 /**
  * The contents of a Property Type update request
@@ -1484,12 +1562,6 @@ export type UpdatePropertyTypeKindEnum =
 export interface UpdatePropertyTypeRequest {
   /**
    *
-   * @type {string}
-   * @memberof UpdatePropertyTypeRequest
-   */
-  accountId: string;
-  /**
-   *
    * @type {UpdatePropertyType}
    * @memberof UpdatePropertyTypeRequest
    */
@@ -1500,6 +1572,12 @@ export interface UpdatePropertyTypeRequest {
    * @memberof UpdatePropertyTypeRequest
    */
   typeToUpdate: string;
+  /**
+   *
+   * @type {string}
+   * @memberof UpdatePropertyTypeRequest
+   */
+  updatedById: string;
 }
 /**
  * @type Vertex

--- a/packages/graph/hash_graph/bench/benches/util.rs
+++ b/packages/graph/hash_graph/bench/benches/util.rs
@@ -166,7 +166,7 @@ impl Drop for StoreWrapper {
 
 pub async fn seed<D, P, L, E, C>(
     store: &mut PostgresStore<C>,
-    account_id: AccountId,
+    owned_by_id: AccountId,
     data_types: D,
     property_types: P,
     link_types: L,
@@ -181,12 +181,15 @@ pub async fn seed<D, P, L, E, C>(
     for data_type_str in data_types {
         let data_type = DataType::from_str(data_type_str).expect("could not parse data type");
 
-        match store.create_data_type(data_type.clone(), account_id).await {
+        match store
+            .create_data_type(data_type.clone(), owned_by_id, owned_by_id)
+            .await
+        {
             Ok(_) => {}
             Err(report) => {
                 if report.contains::<BaseUriAlreadyExists>() {
                     store
-                        .update_data_type(data_type, account_id)
+                        .update_data_type(data_type, owned_by_id)
                         .await
                         .expect("failed to update data type");
                 } else {
@@ -201,14 +204,14 @@ pub async fn seed<D, P, L, E, C>(
             PropertyType::from_str(property_type_str).expect("could not parse property type");
 
         match store
-            .create_property_type(property_type.clone(), account_id)
+            .create_property_type(property_type.clone(), owned_by_id, owned_by_id)
             .await
         {
             Ok(_) => {}
             Err(report) => {
                 if report.contains::<BaseUriAlreadyExists>() {
                     store
-                        .update_property_type(property_type, account_id)
+                        .update_property_type(property_type, owned_by_id)
                         .await
                         .expect("failed to update property type");
                 } else {
@@ -222,12 +225,15 @@ pub async fn seed<D, P, L, E, C>(
     for link_type_str in link_types {
         let link_type = LinkType::from_str(link_type_str).expect("could not parse link type");
 
-        match store.create_link_type(link_type.clone(), account_id).await {
+        match store
+            .create_link_type(link_type.clone(), owned_by_id, owned_by_id)
+            .await
+        {
             Ok(_) => {}
             Err(report) => {
                 if report.contains::<BaseUriAlreadyExists>() {
                     store
-                        .update_link_type(link_type, account_id)
+                        .update_link_type(link_type, owned_by_id)
                         .await
                         .expect("failed to update link type");
                 } else {
@@ -242,14 +248,14 @@ pub async fn seed<D, P, L, E, C>(
             EntityType::from_str(entity_type_str).expect("could not parse entity type");
 
         match store
-            .create_entity_type(entity_type.clone(), account_id)
+            .create_entity_type(entity_type.clone(), owned_by_id, owned_by_id)
             .await
         {
             Ok(_) => {}
             Err(report) => {
                 if report.contains::<BaseUriAlreadyExists>() {
                     store
-                        .update_entity_type(entity_type, account_id)
+                        .update_entity_type(entity_type, owned_by_id)
                         .await
                         .expect("failed to update entity type");
                 } else {

--- a/packages/graph/hash_graph/bin/hash_graph/src/main.rs
+++ b/packages/graph/hash_graph/bin/hash_graph/src/main.rs
@@ -151,7 +151,7 @@ async fn stop_gap_setup(pool: &PostgresStorePool<NoTls>) -> Result<(), GraphErro
     for data_type in data_types {
         let title = data_type.title().to_owned();
         if connection
-            .create_data_type(data_type, root_account_id)
+            .create_data_type(data_type, root_account_id, root_account_id)
             .await
             .change_context(GraphError)
             .is_err()

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -89,7 +89,7 @@ struct CreateDataTypeRequest {
     #[schema(value_type = VAR_DATA_TYPE)]
     schema: serde_json::Value,
     owned_by_id: AccountId,
-    created_by_id: AccountId,
+    actor_id: AccountId,
 }
 
 #[utoipa::path(
@@ -114,7 +114,7 @@ async fn create_data_type<P: StorePool + Send>(
     let Json(CreateDataTypeRequest {
         schema,
         owned_by_id,
-        created_by_id,
+        actor_id,
     }) = body;
 
     let data_type: DataType = schema.try_into().into_report().map_err(|report| {
@@ -135,7 +135,7 @@ async fn create_data_type<P: StorePool + Send>(
     })?;
 
     store
-        .create_data_type(data_type, owned_by_id, created_by_id)
+        .create_data_type(data_type, owned_by_id, actor_id)
         .await
         .map_err(|report| {
             // TODO: consider adding the data type, or at least its URI in the trace
@@ -232,7 +232,7 @@ struct UpdateDataTypeRequest {
     schema: serde_json::Value,
     #[schema(value_type = String)]
     type_to_update: VersionedUri,
-    updated_by_id: AccountId,
+    actor_id: AccountId,
 }
 
 #[utoipa::path(
@@ -255,7 +255,7 @@ async fn update_data_type<P: StorePool + Send>(
     let Json(UpdateDataTypeRequest {
         schema,
         type_to_update,
-        updated_by_id,
+        actor_id,
     }) = body;
 
     let new_type_id = VersionedUri::new(
@@ -276,7 +276,7 @@ async fn update_data_type<P: StorePool + Send>(
     })?;
 
     store
-        .update_data_type(data_type, updated_by_id)
+        .update_data_type(data_type, actor_id)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not update data type");

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -88,7 +88,8 @@ impl RoutedResource for DataTypeResource {
 struct CreateDataTypeRequest {
     #[schema(value_type = VAR_DATA_TYPE)]
     schema: serde_json::Value,
-    account_id: AccountId,
+    owned_by_id: AccountId,
+    created_by_id: AccountId,
 }
 
 #[utoipa::path(
@@ -110,7 +111,11 @@ async fn create_data_type<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
     domain_validator: Extension<DomainValidator>,
 ) -> Result<Json<PersistedOntologyMetadata>, StatusCode> {
-    let Json(CreateDataTypeRequest { schema, account_id }) = body;
+    let Json(CreateDataTypeRequest {
+        schema,
+        owned_by_id,
+        created_by_id,
+    }) = body;
 
     let data_type: DataType = schema.try_into().into_report().map_err(|report| {
         tracing::error!(error=?report, "Couldn't convert schema to Data Type");
@@ -130,7 +135,7 @@ async fn create_data_type<P: StorePool + Send>(
     })?;
 
     store
-        .create_data_type(data_type, account_id)
+        .create_data_type(data_type, owned_by_id, created_by_id)
         .await
         .map_err(|report| {
             // TODO: consider adding the data type, or at least its URI in the trace
@@ -227,7 +232,7 @@ struct UpdateDataTypeRequest {
     schema: serde_json::Value,
     #[schema(value_type = String)]
     type_to_update: VersionedUri,
-    account_id: AccountId,
+    updated_by_id: AccountId,
 }
 
 #[utoipa::path(
@@ -250,7 +255,7 @@ async fn update_data_type<P: StorePool + Send>(
     let Json(UpdateDataTypeRequest {
         schema,
         type_to_update,
-        account_id,
+        updated_by_id,
     }) = body;
 
     let new_type_id = VersionedUri::new(
@@ -271,7 +276,7 @@ async fn update_data_type<P: StorePool + Send>(
     })?;
 
     store
-        .update_data_type(data_type, account_id)
+        .update_data_type(data_type, updated_by_id)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not update data type");

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -83,7 +83,7 @@ struct CreateEntityRequest {
     entity_type_id: VersionedUri,
     owned_by_id: AccountId,
     entity_id: Option<EntityId>,
-    created_by_id: AccountId,
+    actor_id: AccountId,
 }
 
 #[utoipa::path(
@@ -109,7 +109,7 @@ async fn create_entity<P: StorePool + Send>(
         entity_type_id,
         owned_by_id,
         entity_id,
-        created_by_id,
+        actor_id,
     }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
@@ -118,13 +118,7 @@ async fn create_entity<P: StorePool + Send>(
     })?;
 
     store
-        .create_entity(
-            entity,
-            entity_type_id,
-            owned_by_id,
-            entity_id,
-            created_by_id,
-        )
+        .create_entity(entity, entity_type_id, owned_by_id, entity_id, actor_id)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not create entity");
@@ -216,7 +210,7 @@ struct UpdateEntityRequest {
     entity_id: EntityId,
     #[schema(value_type = String)]
     entity_type_id: VersionedUri,
-    updated_by_id: AccountId,
+    actor_id: AccountId,
 }
 
 #[utoipa::path(
@@ -240,7 +234,7 @@ async fn update_entity<P: StorePool + Send>(
         entity,
         entity_id,
         entity_type_id,
-        updated_by_id,
+        actor_id,
     }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
@@ -249,7 +243,7 @@ async fn update_entity<P: StorePool + Send>(
     })?;
 
     store
-        .update_entity(entity_id, entity, entity_type_id, updated_by_id)
+        .update_entity(entity_id, entity, entity_type_id, actor_id)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not update entity");

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -81,8 +81,9 @@ struct CreateEntityRequest {
     entity: Entity,
     #[schema(value_type = String)]
     entity_type_id: VersionedUri,
-    account_id: AccountId,
+    owned_by_id: AccountId,
     entity_id: Option<EntityId>,
+    created_by_id: AccountId,
 }
 
 #[utoipa::path(
@@ -106,8 +107,9 @@ async fn create_entity<P: StorePool + Send>(
     let Json(CreateEntityRequest {
         entity,
         entity_type_id,
-        account_id,
+        owned_by_id,
         entity_id,
+        created_by_id,
     }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
@@ -116,7 +118,13 @@ async fn create_entity<P: StorePool + Send>(
     })?;
 
     store
-        .create_entity(entity, entity_type_id, account_id, entity_id)
+        .create_entity(
+            entity,
+            entity_type_id,
+            owned_by_id,
+            entity_id,
+            created_by_id,
+        )
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not create entity");
@@ -208,7 +216,7 @@ struct UpdateEntityRequest {
     entity_id: EntityId,
     #[schema(value_type = String)]
     entity_type_id: VersionedUri,
-    account_id: AccountId,
+    updated_by_id: AccountId,
 }
 
 #[utoipa::path(
@@ -232,7 +240,7 @@ async fn update_entity<P: StorePool + Send>(
         entity,
         entity_id,
         entity_type_id,
-        account_id,
+        updated_by_id,
     }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
@@ -241,7 +249,7 @@ async fn update_entity<P: StorePool + Send>(
     })?;
 
     store
-        .update_entity(entity_id, entity, entity_type_id, account_id)
+        .update_entity(entity_id, entity, entity_type_id, updated_by_id)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not update entity");

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -81,7 +81,7 @@ struct CreateEntityTypeRequest {
     #[schema(value_type = VAR_ENTITY_TYPE)]
     schema: serde_json::Value,
     owned_by_id: AccountId,
-    created_by_id: AccountId,
+    actor_id: AccountId,
 }
 
 #[utoipa::path(
@@ -106,7 +106,7 @@ async fn create_entity_type<P: StorePool + Send>(
     let Json(CreateEntityTypeRequest {
         schema,
         owned_by_id,
-        created_by_id,
+        actor_id,
     }) = body;
 
     let entity_type: EntityType = schema.try_into().into_report().map_err(|report| {
@@ -128,7 +128,7 @@ async fn create_entity_type<P: StorePool + Send>(
     })?;
 
     store
-        .create_entity_type(entity_type, owned_by_id, created_by_id)
+        .create_entity_type(entity_type, owned_by_id, actor_id)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not create entity type");
@@ -227,7 +227,7 @@ struct UpdateEntityTypeRequest {
     schema: serde_json::Value,
     #[schema(value_type = String)]
     type_to_update: VersionedUri,
-    updated_by_id: AccountId,
+    actor_id: AccountId,
 }
 
 #[utoipa::path(
@@ -250,7 +250,7 @@ async fn update_entity_type<P: StorePool + Send>(
     let Json(UpdateEntityTypeRequest {
         schema,
         type_to_update,
-        updated_by_id,
+        actor_id,
     }) = body;
 
     let new_type_id = VersionedUri::new(
@@ -272,7 +272,7 @@ async fn update_entity_type<P: StorePool + Send>(
     })?;
 
     store
-        .update_entity_type(entity_type, updated_by_id)
+        .update_entity_type(entity_type, actor_id)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not update entity type");

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
@@ -68,7 +68,7 @@ struct CreateLinkRequest {
     #[schema(value_type = String)]
     link_type_id: VersionedUri,
     owned_by_id: AccountId,
-    created_by_id: AccountId,
+    actor_id: AccountId,
     // TODO: Consider if ordering should be exposed on links as they are here. The API consumer
     //   manages indexes currently.
     //   https://app.asana.com/0/1202805690238892/1202937382769278/f
@@ -101,7 +101,7 @@ async fn create_link<P: StorePool + Send>(
         target_entity_id,
         link_type_id,
         owned_by_id,
-        created_by_id,
+        actor_id,
         index,
     }) = body;
 
@@ -113,7 +113,7 @@ async fn create_link<P: StorePool + Send>(
     let link = Link::new(source_entity_id, target_entity_id, link_type_id, index);
 
     store
-        .create_link(&link, owned_by_id, created_by_id)
+        .create_link(&link, owned_by_id, actor_id)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not create link");
@@ -194,7 +194,7 @@ struct RemoveLinkRequest {
     target_entity_id: EntityId,
     #[schema(value_type = String)]
     link_type_id: VersionedUri,
-    removed_by_id: AccountId,
+    actor_id: AccountId,
 }
 
 #[utoipa::path(
@@ -222,7 +222,7 @@ async fn remove_link<P: StorePool + Send>(
     let Json(RemoveLinkRequest {
         target_entity_id,
         link_type_id,
-        removed_by_id,
+        actor_id,
     }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
@@ -233,7 +233,7 @@ async fn remove_link<P: StorePool + Send>(
     store
         .remove_link(
             &Link::new(source_entity_id, target_entity_id, link_type_id, None),
-            removed_by_id,
+            actor_id,
         )
         .await
         .map_err(|report| {

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
@@ -68,6 +68,7 @@ struct CreateLinkRequest {
     #[schema(value_type = String)]
     link_type_id: VersionedUri,
     owned_by_id: AccountId,
+    created_by_id: AccountId,
     // TODO: Consider if ordering should be exposed on links as they are here. The API consumer
     //   manages indexes currently.
     //   https://app.asana.com/0/1202805690238892/1202937382769278/f
@@ -100,6 +101,7 @@ async fn create_link<P: StorePool + Send>(
         target_entity_id,
         link_type_id,
         owned_by_id,
+        created_by_id,
         index,
     }) = body;
 
@@ -111,7 +113,7 @@ async fn create_link<P: StorePool + Send>(
     let link = Link::new(source_entity_id, target_entity_id, link_type_id, index);
 
     store
-        .create_link(&link, owned_by_id)
+        .create_link(&link, owned_by_id, created_by_id)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not create link");

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -80,7 +80,7 @@ struct CreateLinkTypeRequest {
     #[schema(value_type = VAR_LINK_TYPE)]
     schema: serde_json::Value,
     owned_by_id: AccountId,
-    created_by_id: AccountId,
+    actor_id: AccountId,
 }
 
 #[utoipa::path(
@@ -105,7 +105,7 @@ async fn create_link_type<P: StorePool + Send>(
     let Json(CreateLinkTypeRequest {
         schema,
         owned_by_id,
-        created_by_id,
+        actor_id,
     }) = body;
 
     let link_type: LinkType = schema.try_into().into_report().map_err(|report| {
@@ -126,7 +126,7 @@ async fn create_link_type<P: StorePool + Send>(
     })?;
 
     store
-        .create_link_type(link_type, owned_by_id, created_by_id)
+        .create_link_type(link_type, owned_by_id, actor_id)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not create link type");
@@ -222,7 +222,7 @@ struct UpdateLinkTypeRequest {
     schema: serde_json::Value,
     #[schema(value_type = String)]
     type_to_update: VersionedUri,
-    updated_by_id: AccountId,
+    actor_id: AccountId,
 }
 
 #[utoipa::path(
@@ -245,7 +245,7 @@ async fn update_link_type<P: StorePool + Send>(
     let Json(UpdateLinkTypeRequest {
         schema,
         type_to_update,
-        updated_by_id,
+        actor_id,
     }) = body;
 
     let new_type_id = VersionedUri::new(
@@ -266,7 +266,7 @@ async fn update_link_type<P: StorePool + Send>(
     })?;
 
     store
-        .update_link_type(link_type, updated_by_id)
+        .update_link_type(link_type, actor_id)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not update link type");

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -79,7 +79,8 @@ impl RoutedResource for LinkTypeResource {
 struct CreateLinkTypeRequest {
     #[schema(value_type = VAR_LINK_TYPE)]
     schema: serde_json::Value,
-    account_id: AccountId,
+    owned_by_id: AccountId,
+    created_by_id: AccountId,
 }
 
 #[utoipa::path(
@@ -101,7 +102,11 @@ async fn create_link_type<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
     domain_validator: Extension<DomainValidator>,
 ) -> Result<Json<PersistedOntologyMetadata>, StatusCode> {
-    let Json(CreateLinkTypeRequest { schema, account_id }) = body;
+    let Json(CreateLinkTypeRequest {
+        schema,
+        owned_by_id,
+        created_by_id,
+    }) = body;
 
     let link_type: LinkType = schema.try_into().into_report().map_err(|report| {
         tracing::error!(error=?report, "Couldn't convert schema to Link Type");
@@ -121,7 +126,7 @@ async fn create_link_type<P: StorePool + Send>(
     })?;
 
     store
-        .create_link_type(link_type, account_id)
+        .create_link_type(link_type, owned_by_id, created_by_id)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not create link type");
@@ -217,7 +222,7 @@ struct UpdateLinkTypeRequest {
     schema: serde_json::Value,
     #[schema(value_type = String)]
     type_to_update: VersionedUri,
-    account_id: AccountId,
+    updated_by_id: AccountId,
 }
 
 #[utoipa::path(
@@ -240,7 +245,7 @@ async fn update_link_type<P: StorePool + Send>(
     let Json(UpdateLinkTypeRequest {
         schema,
         type_to_update,
-        account_id,
+        updated_by_id,
     }) = body;
 
     let new_type_id = VersionedUri::new(
@@ -261,7 +266,7 @@ async fn update_link_type<P: StorePool + Send>(
     })?;
 
     store
-        .update_link_type(link_type, account_id)
+        .update_link_type(link_type, updated_by_id)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not update link type");

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -79,7 +79,7 @@ struct CreatePropertyTypeRequest {
     #[schema(value_type = VAR_PROPERTY_TYPE)]
     schema: serde_json::Value,
     owned_by_id: AccountId,
-    created_by_id: AccountId,
+    actor_id: AccountId,
 }
 
 #[utoipa::path(
@@ -104,7 +104,7 @@ async fn create_property_type<P: StorePool + Send>(
     let Json(CreatePropertyTypeRequest {
         schema,
         owned_by_id,
-        created_by_id,
+        actor_id,
     }) = body;
 
     let property_type: PropertyType = schema.try_into().into_report().map_err(|report| {
@@ -127,7 +127,7 @@ async fn create_property_type<P: StorePool + Send>(
     })?;
 
     store
-        .create_property_type(property_type, owned_by_id, created_by_id)
+        .create_property_type(property_type, owned_by_id, actor_id)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not create property type");
@@ -229,7 +229,7 @@ struct UpdatePropertyTypeRequest {
     schema: serde_json::Value,
     #[schema(value_type = String)]
     type_to_update: VersionedUri,
-    updated_by_id: AccountId,
+    actor_id: AccountId,
 }
 
 #[utoipa::path(
@@ -252,7 +252,7 @@ async fn update_property_type<P: StorePool + Send>(
     let Json(UpdatePropertyTypeRequest {
         schema,
         type_to_update,
-        updated_by_id,
+        actor_id,
     }) = body;
 
     let new_type_id = VersionedUri::new(
@@ -273,7 +273,7 @@ async fn update_property_type<P: StorePool + Send>(
     })?;
 
     store
-        .update_property_type(property_type, updated_by_id)
+        .update_property_type(property_type, actor_id)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not update property type");

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -87,14 +87,26 @@ pub struct PersistedEntityMetadata {
     identifier: PersistedEntityIdentifier,
     #[schema(value_type = String)]
     entity_type_id: VersionedUri,
+    created_by_id: AccountId,
+    updated_by_id: AccountId,
+    removed_by_id: Option<AccountId>,
 }
 
 impl PersistedEntityMetadata {
     #[must_use]
-    pub const fn new(identifier: PersistedEntityIdentifier, entity_type_id: VersionedUri) -> Self {
+    pub const fn new(
+        identifier: PersistedEntityIdentifier,
+        entity_type_id: VersionedUri,
+        created_by_id: AccountId,
+        updated_by_id: AccountId,
+        removed_by_id: Option<AccountId>,
+    ) -> Self {
         Self {
             identifier,
             entity_type_id,
+            created_by_id,
+            updated_by_id,
+            removed_by_id,
         }
     }
 
@@ -122,16 +134,20 @@ impl PersistedEntity {
     #[must_use]
     pub const fn new(
         inner: Entity,
-        entity_id: EntityId,
-        version: DateTime<Utc>,
+        identifier: PersistedEntityIdentifier,
         entity_type_id: VersionedUri,
-        owned_by_id: AccountId,
+        created_by_id: AccountId,
+        updated_by_id: AccountId,
+        removed_by_id: Option<AccountId>,
     ) -> Self {
         Self {
             inner,
             metadata: PersistedEntityMetadata::new(
-                PersistedEntityIdentifier::new(entity_id, version, owned_by_id),
+                identifier,
                 entity_type_id,
+                created_by_id,
+                updated_by_id,
+                removed_by_id,
             ),
         }
     }

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/link/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/link/mod.rs
@@ -69,17 +69,26 @@ pub struct PersistedLinkMetadata {
     owned_by_id: AccountId,
     // TODO: add versioning information -
     //   https://app.asana.com/0/1200211978612931/1203006164248577/f
+    created_by_id: AccountId,
 }
 
 impl PersistedLinkMetadata {
     #[must_use]
-    pub const fn new(owned_by_id: AccountId) -> Self {
-        Self { owned_by_id }
+    pub const fn new(owned_by_id: AccountId, created_by_id: AccountId) -> Self {
+        Self {
+            owned_by_id,
+            created_by_id,
+        }
     }
 
     #[must_use]
     pub const fn owned_by_id(&self) -> &AccountId {
         &self.owned_by_id
+    }
+
+    #[must_use]
+    pub const fn created_by_id(&self) -> &AccountId {
+        &self.created_by_id
     }
 }
 
@@ -94,10 +103,10 @@ pub struct PersistedLink {
 
 impl PersistedLink {
     #[must_use]
-    pub const fn new(inner: Link, owned_by_id: AccountId) -> Self {
+    pub const fn new(inner: Link, owned_by_id: AccountId, created_by_id: AccountId) -> Self {
         Self {
             inner,
-            metadata: PersistedLinkMetadata::new(owned_by_id),
+            metadata: PersistedLinkMetadata::new(owned_by_id, created_by_id),
         }
     }
 

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/link/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/link/mod.rs
@@ -82,13 +82,13 @@ impl PersistedLinkMetadata {
     }
 
     #[must_use]
-    pub const fn owned_by_id(&self) -> &AccountId {
-        &self.owned_by_id
+    pub const fn owned_by_id(&self) -> AccountId {
+        self.owned_by_id
     }
 
     #[must_use]
-    pub const fn created_by_id(&self) -> &AccountId {
-        &self.created_by_id
+    pub const fn created_by_id(&self) -> AccountId {
+        self.created_by_id
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/data_type.rs
@@ -1,0 +1,29 @@
+use std::borrow::Cow;
+
+use type_system::DataType;
+
+use crate::store::query::QueryRecord;
+
+/// A path to a [`DataType`] field.
+///
+/// Note: [`DataType`]s currently don't reference other [`DataType`]s, so the path can only be a
+/// single field.
+///
+/// [`DataType`]: type_system::DataType
+// TODO: Adjust enum and docs when adding non-primitive data types
+//   see https://app.asana.com/0/1200211978612931/1202464168422955/f
+#[derive(Debug, PartialEq, Eq)]
+pub enum DataTypeQueryPath<'q> {
+    OwnedById,
+    BaseUri,
+    VersionedUri,
+    Version,
+    Title,
+    Description,
+    Type,
+    Custom(Cow<'q, str>),
+}
+
+impl QueryRecord for DataType {
+    type Path<'q> = DataTypeQueryPath<'q>;
+}

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -1,5 +1,6 @@
 //! TODO: DOC
 
+mod data_type;
 pub mod domain_validator;
 
 use core::fmt;
@@ -11,6 +12,8 @@ use tokio_postgres::types::{FromSql, ToSql};
 use type_system::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType};
 use utoipa::ToSchema;
 use uuid::Uuid;
+
+pub use self::data_type::DataTypeQueryPath;
 
 // TODO - find a good place for AccountId, perhaps it will become redundant in a future design
 

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -59,8 +59,8 @@ impl PersistedOntologyIdentifier {
     }
 
     #[must_use]
-    pub const fn owned_by_id(&self) -> &AccountId {
-        &self.owned_by_id
+    pub const fn owned_by_id(&self) -> AccountId {
+        self.owned_by_id
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -59,8 +59,8 @@ impl PersistedOntologyIdentifier {
     }
 
     #[must_use]
-    pub const fn owned_by_id(&self) -> AccountId {
-        self.owned_by_id
+    pub const fn owned_by_id(&self) -> &AccountId {
+        &self.owned_by_id
     }
 }
 
@@ -258,14 +258,28 @@ pub struct LinkTypeRootedSubgraph {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct PersistedOntologyMetadata {
     identifier: PersistedOntologyIdentifier,
+    created_by_id: AccountId,
+    updated_by_id: AccountId,
+    removed_by_id: Option<AccountId>,
 }
 
 impl PersistedOntologyMetadata {
     #[must_use]
-    pub const fn new(identifier: PersistedOntologyIdentifier) -> Self {
-        Self { identifier }
+    pub const fn new(
+        identifier: PersistedOntologyIdentifier,
+        created_by_id: AccountId,
+        updated_by_id: AccountId,
+        removed_by_id: Option<AccountId>,
+    ) -> Self {
+        Self {
+            identifier,
+            created_by_id,
+            updated_by_id,
+            removed_by_id,
+        }
     }
 
     #[must_use]

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -214,7 +214,7 @@ pub trait DataTypeStore: for<'q> crud::Read<PersistedDataType, Query<'q> = Expre
         &mut self,
         data_type: DataType,
         owned_by_id: AccountId,
-        created_by_id: AccountId,
+        actor_id: AccountId,
     ) -> Result<PersistedOntologyMetadata, InsertionError>;
 
     /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
@@ -232,7 +232,7 @@ pub trait DataTypeStore: for<'q> crud::Read<PersistedDataType, Query<'q> = Expre
     async fn update_data_type(
         &mut self,
         data_type: DataType,
-        updated_by_id: AccountId,
+        actor_id: AccountId,
     ) -> Result<PersistedOntologyMetadata, UpdateError>;
 }
 
@@ -253,7 +253,7 @@ pub trait PropertyTypeStore:
         &mut self,
         property_type: PropertyType,
         owned_by_id: AccountId,
-        created_by_id: AccountId,
+        actor_id: AccountId,
     ) -> Result<PersistedOntologyMetadata, InsertionError>;
 
     /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
@@ -271,7 +271,7 @@ pub trait PropertyTypeStore:
     async fn update_property_type(
         &mut self,
         property_type: PropertyType,
-        updated_by: AccountId,
+        actor_id: AccountId,
     ) -> Result<PersistedOntologyMetadata, UpdateError>;
 }
 
@@ -290,7 +290,7 @@ pub trait EntityTypeStore: for<'q> crud::Read<PersistedEntityType, Query<'q> = E
         &mut self,
         entity_type: EntityType,
         owned_by_id: AccountId,
-        created_by_id: AccountId,
+        actor_id: AccountId,
     ) -> Result<PersistedOntologyMetadata, InsertionError>;
 
     /// Get the [`EntityTypeRootedSubgraph`]s specified by the [`StructuralQuery`].
@@ -311,7 +311,7 @@ pub trait EntityTypeStore: for<'q> crud::Read<PersistedEntityType, Query<'q> = E
     async fn update_entity_type(
         &mut self,
         entity_type: EntityType,
-        updated_by: AccountId,
+        actor_id: AccountId,
     ) -> Result<PersistedOntologyMetadata, UpdateError>;
 }
 
@@ -330,7 +330,7 @@ pub trait LinkTypeStore: for<'q> crud::Read<PersistedLinkType, Query<'q> = Expre
         &mut self,
         link_type: LinkType,
         owned_by_id: AccountId,
-        created_by_id: AccountId,
+        actor_id: AccountId,
     ) -> Result<PersistedOntologyMetadata, InsertionError>;
 
     /// Get the [`LinkTypeRootedSubgraph`]s specified by the [`StructuralQuery`].
@@ -351,7 +351,7 @@ pub trait LinkTypeStore: for<'q> crud::Read<PersistedLinkType, Query<'q> = Expre
     async fn update_link_type(
         &mut self,
         property_type: LinkType,
-        updated_by_id: AccountId,
+        actor_id: AccountId,
     ) -> Result<PersistedOntologyMetadata, UpdateError>;
 }
 
@@ -374,7 +374,7 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Expressio
         entity_type_id: VersionedUri,
         owned_by_id: AccountId,
         entity_id: Option<EntityId>,
-        created_by_id: AccountId,
+        actor_id: AccountId,
     ) -> Result<PersistedEntityMetadata, InsertionError>;
 
     /// Inserts the entities with the specified [`EntityType`] into the `Store`.
@@ -426,7 +426,7 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Expressio
         entity_id: EntityId,
         entity: Entity,
         entity_type_id: VersionedUri,
-        updated_by_id: AccountId,
+        actor_id: AccountId,
     ) -> Result<PersistedEntityMetadata, UpdateError>;
 }
 
@@ -444,7 +444,7 @@ pub trait LinkStore: for<'q> crud::Read<PersistedLink, Query<'q> = Expression> {
         &mut self,
         link: &Link,
         owned_by_id: AccountId,
-        created_by_id: AccountId,
+        actor_id: AccountId,
     ) -> Result<(), InsertionError>;
 
     /// Get the [`LinkRootedSubgraph`]s specified by the [`StructuralQuery`].
@@ -467,6 +467,6 @@ pub trait LinkStore: for<'q> crud::Read<PersistedLink, Query<'q> = Expression> {
     async fn remove_link(
         &mut self,
         link: &Link,
-        removed_by_id: AccountId,
+        actor_id: AccountId,
     ) -> Result<(), LinkRemovalError>;
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -374,6 +374,7 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Expressio
         entity_type_id: VersionedUri,
         owned_by_id: AccountId,
         entity_id: Option<EntityId>,
+        created_by_id: AccountId,
     ) -> Result<PersistedEntityMetadata, InsertionError>;
 
     /// Inserts the entities with the specified [`EntityType`] into the `Store`.
@@ -425,7 +426,7 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Expressio
         entity_id: EntityId,
         entity: Entity,
         entity_type_id: VersionedUri,
-        updated_by: AccountId,
+        updated_by_id: AccountId,
     ) -> Result<PersistedEntityMetadata, UpdateError>;
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -444,6 +444,7 @@ pub trait LinkStore: for<'q> crud::Read<PersistedLink, Query<'q> = Expression> {
         &mut self,
         link: &Link,
         owned_by_id: AccountId,
+        created_by_id: AccountId,
     ) -> Result<(), InsertionError>;
 
     /// Get the [`LinkRootedSubgraph`]s specified by the [`StructuralQuery`].

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -214,6 +214,7 @@ pub trait DataTypeStore: for<'q> crud::Read<PersistedDataType, Query<'q> = Expre
         &mut self,
         data_type: DataType,
         owned_by_id: AccountId,
+        created_by_id: AccountId,
     ) -> Result<PersistedOntologyMetadata, InsertionError>;
 
     /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
@@ -231,7 +232,7 @@ pub trait DataTypeStore: for<'q> crud::Read<PersistedDataType, Query<'q> = Expre
     async fn update_data_type(
         &mut self,
         data_type: DataType,
-        updated_by: AccountId,
+        updated_by_id: AccountId,
     ) -> Result<PersistedOntologyMetadata, UpdateError>;
 }
 
@@ -252,6 +253,7 @@ pub trait PropertyTypeStore:
         &mut self,
         property_type: PropertyType,
         owned_by_id: AccountId,
+        created_by_id: AccountId,
     ) -> Result<PersistedOntologyMetadata, InsertionError>;
 
     /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
@@ -288,6 +290,7 @@ pub trait EntityTypeStore: for<'q> crud::Read<PersistedEntityType, Query<'q> = E
         &mut self,
         entity_type: EntityType,
         owned_by_id: AccountId,
+        created_by_id: AccountId,
     ) -> Result<PersistedOntologyMetadata, InsertionError>;
 
     /// Get the [`EntityTypeRootedSubgraph`]s specified by the [`StructuralQuery`].
@@ -327,6 +330,7 @@ pub trait LinkTypeStore: for<'q> crud::Read<PersistedLinkType, Query<'q> = Expre
         &mut self,
         link_type: LinkType,
         owned_by_id: AccountId,
+        created_by_id: AccountId,
     ) -> Result<PersistedOntologyMetadata, InsertionError>;
 
     /// Get the [`LinkTypeRootedSubgraph`]s specified by the [`StructuralQuery`].
@@ -347,7 +351,7 @@ pub trait LinkTypeStore: for<'q> crud::Read<PersistedLinkType, Query<'q> = Expre
     async fn update_link_type(
         &mut self,
         property_type: LinkType,
-        updated_by: AccountId,
+        updated_by_id: AccountId,
     ) -> Result<PersistedOntologyMetadata, UpdateError>;
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -279,6 +279,9 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 .change_context(UpdateError)?,
         );
 
+        // TODO - address potential race condition
+        //  https://app.asana.com/0/1202805690238892/1203201674100967/f
+
         let previous_entity = transaction
             .read_latest_entity_by_id(entity_id)
             .await

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -3,7 +3,7 @@ use error_stack::{bail, Report, Result, ResultExt};
 use futures::{stream, StreamExt, TryStreamExt};
 
 use crate::{
-    knowledge::PersistedEntity,
+    knowledge::{PersistedEntity, PersistedEntityIdentifier},
     store::{
         crud,
         postgres::context::PostgresContext,
@@ -32,10 +32,15 @@ impl<C: AsClient> crud::Read<PersistedEntity> for PostgresStore<C> {
                     Ok(result.then(|| {
                         PersistedEntity::new(
                             record.entity,
-                            record.id,
-                            record.version,
+                            PersistedEntityIdentifier::new(
+                                record.id,
+                                record.version,
+                                record.owned_by_id,
+                            ),
                             record.entity_type_id,
-                            record.account_id,
+                            record.created_by_id,
+                            record.updated_by_id,
+                            record.removed_by_id,
                         )
                     }))
                 } else {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/resolve.rs
@@ -25,7 +25,7 @@ where
                 // TODO: Avoid cloning on literals
                 //   see https://app.asana.com/0/0/1202884883200947/f
                 let literal = match head_path_segment.identifier.as_str() {
-                    "ownedById" => Literal::String(self.account_id.to_string()),
+                    "ownedById" => Literal::String(self.owned_by_id.to_string()),
                     "id" => Literal::String(self.id.to_string()),
                     "version" => Literal::Version(Version::Entity(self.version), self.is_latest),
                     "type" => {
@@ -71,6 +71,11 @@ where
                                 .await?,
                         ));
                     }
+                    "createdById" => Literal::String(self.created_by_id.to_string()),
+                    "updatedById" => Literal::String(self.updated_by_id.to_string()),
+                    "removedById" => self.removed_by_id.map_or(Literal::Null, |removed_by_id| {
+                        Literal::String(removed_by_id.to_string())
+                    }),
                     _ => Literal::Null,
                 };
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/resolve.rs
@@ -71,11 +71,6 @@ where
                                 .await?,
                         ));
                     }
-                    "createdById" => Literal::String(self.created_by_id.to_string()),
-                    "updatedById" => Literal::String(self.updated_by_id.to_string()),
-                    "removedById" => self.removed_by_id.map_or(Literal::Null, |removed_by_id| {
-                        Literal::String(removed_by_id.to_string())
-                    }),
                     _ => Literal::Null,
                 };
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/mod.rs
@@ -95,6 +95,7 @@ impl<C: AsClient> LinkStore for PostgresStore<C> {
         &mut self,
         link: &Link,
         owned_by_id: AccountId,
+        created_by_id: AccountId,
     ) -> Result<(), InsertionError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
@@ -104,7 +105,9 @@ impl<C: AsClient> LinkStore for PostgresStore<C> {
                 .change_context(InsertionError)?,
         );
 
-        transaction.insert_link(link, owned_by_id).await?;
+        transaction
+            .insert_link(link, owned_by_id, created_by_id)
+            .await?;
 
         transaction
             .client

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/resolve.rs
@@ -17,7 +17,7 @@ where
             [] => todo!("{}", UNIMPLEMENTED_LITERAL_OBJECT),
             [head_path_segment, tail_path_segments @ ..] => {
                 let literal = match head_path_segment.identifier.as_str() {
-                    "ownedById" => Literal::String(self.account_id.to_string()),
+                    "ownedById" => Literal::String(self.owned_by_id.to_string()),
                     "type" => {
                         return context
                             .read_versioned_ontology_type::<LinkType>(&self.link_type_id)

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -24,7 +24,7 @@ use type_system::{
 };
 use uuid::Uuid;
 
-use self::context::PostgresContext;
+use self::context::{OntologyRecord, PostgresContext};
 pub use self::{
     ontology::PersistedOntologyType,
     pool::{AsClient, PostgresStorePool},
@@ -504,7 +504,11 @@ where
             .await
             .change_context(UpdateError)?;
 
-        let owned_by_id = previous_ontology_type.owned_by_id;
+        let OntologyRecord {
+            owned_by_id,
+            created_by_id,
+            ..
+        } = previous_ontology_type;
 
         let version_id = VersionId::new(Uuid::new_v4());
         self.insert_version_id(version_id)
@@ -517,7 +521,7 @@ where
             version_id,
             database_type,
             owned_by_id,
-            previous_ontology_type.created_by_id,
+            created_by_id,
             updated_by_id,
         )
         .await
@@ -527,7 +531,7 @@ where
             version_id,
             PersistedOntologyMetadata::new(
                 PersistedOntologyIdentifier::new(uri, owned_by_id),
-                previous_ontology_type.created_by_id,
+                created_by_id,
                 updated_by_id,
                 None,
             ),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -58,6 +58,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
         &mut self,
         data_type: DataType,
         owned_by_id: AccountId,
+        created_by_id: AccountId,
     ) -> Result<PersistedOntologyMetadata, InsertionError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
@@ -67,7 +68,9 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
                 .change_context(InsertionError)?,
         );
 
-        let (_, metadata) = transaction.create(data_type, owned_by_id).await?;
+        let (_, metadata) = transaction
+            .create(data_type, owned_by_id, created_by_id)
+            .await?;
 
         transaction
             .client
@@ -142,7 +145,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
     async fn update_data_type(
         &mut self,
         data_type: DataType,
-        updated_by: AccountId,
+        updated_by_id: AccountId,
     ) -> Result<PersistedOntologyMetadata, UpdateError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
@@ -152,7 +155,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
                 .change_context(UpdateError)?,
         );
 
-        let (_, metadata) = transaction.update(data_type, updated_by).await?;
+        let (_, metadata) = transaction.update(data_type, updated_by_id).await?;
 
         transaction
             .client

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/resolve.rs
@@ -61,7 +61,12 @@ where
                 // TODO: Avoid cloning on literals
                 //   see https://app.asana.com/0/0/1202884883200947/f
                 let literal = match segment.identifier.as_str() {
-                    "ownedById" => Literal::String(self.account_id.to_string()),
+                    "ownedById" => Literal::String(self.owned_by_id.to_string()),
+                    "createdById" => Literal::String(self.created_by_id.to_string()),
+                    "updatedById" => Literal::String(self.updated_by_id.to_string()),
+                    "removedById" => self.removed_by_id.map_or(Literal::Null, |removed_by_id| {
+                        Literal::String(removed_by_id.to_string())
+                    }),
                     "baseUri" => Literal::String(self.record.id().base_uri().to_string()),
                     "versionedUri" => Literal::String(self.record.id().to_string()),
                     "version" => Literal::Version(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/resolve.rs
@@ -62,11 +62,6 @@ where
                 //   see https://app.asana.com/0/0/1202884883200947/f
                 let literal = match segment.identifier.as_str() {
                     "ownedById" => Literal::String(self.owned_by_id.to_string()),
-                    "createdById" => Literal::String(self.created_by_id.to_string()),
-                    "updatedById" => Literal::String(self.updated_by_id.to_string()),
-                    "removedById" => self.removed_by_id.map_or(Literal::Null, |removed_by_id| {
-                        Literal::String(removed_by_id.to_string())
-                    }),
                     "baseUri" => Literal::String(self.record.id().base_uri().to_string()),
                     "versionedUri" => Literal::String(self.record.id().to_string()),
                     "version" => Literal::Version(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
@@ -166,6 +166,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         &mut self,
         entity_type: EntityType,
         owned_by_id: AccountId,
+        created_by_id: AccountId,
     ) -> Result<PersistedOntologyMetadata, InsertionError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
@@ -178,7 +179,9 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         // This clone is currently necessary because we extract the references as we insert them.
         // We can only insert them after the type has been created, and so we currently extract them
         // after as well. See `insert_entity_type_references` taking `&entity_type`
-        let (version_id, metadata) = transaction.create(entity_type.clone(), owned_by_id).await?;
+        let (version_id, metadata) = transaction
+            .create(entity_type.clone(), owned_by_id, created_by_id)
+            .await?;
 
         transaction
             .insert_entity_type_references(&entity_type, version_id)

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/resolve.rs
@@ -20,11 +20,6 @@ where
                 //   see https://app.asana.com/0/0/1202884883200947/f
                 let literal = match head_path_segment.identifier.as_str() {
                     "ownedById" => Literal::String(self.owned_by_id.to_string()),
-                    "createdById" => Literal::String(self.created_by_id.to_string()),
-                    "updatedById" => Literal::String(self.updated_by_id.to_string()),
-                    "removedById" => self.removed_by_id.map_or(Literal::Null, |removed_by_id| {
-                        Literal::String(removed_by_id.to_string())
-                    }),
                     "baseUri" => Literal::String(self.record.id().base_uri().to_string()),
                     "versionedUri" => Literal::String(self.record.id().to_string()),
                     "version" => Literal::Version(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/resolve.rs
@@ -19,7 +19,12 @@ where
                 // TODO: Avoid cloning on literals
                 //   see https://app.asana.com/0/0/1202884883200947/f
                 let literal = match head_path_segment.identifier.as_str() {
-                    "ownedById" => Literal::String(self.account_id.to_string()),
+                    "ownedById" => Literal::String(self.owned_by_id.to_string()),
+                    "createdById" => Literal::String(self.created_by_id.to_string()),
+                    "updatedById" => Literal::String(self.updated_by_id.to_string()),
+                    "removedById" => self.removed_by_id.map_or(Literal::Null, |removed_by_id| {
+                        Literal::String(removed_by_id.to_string())
+                    }),
                     "baseUri" => Literal::String(self.record.id().base_uri().to_string()),
                     "versionedUri" => Literal::String(self.record.id().to_string()),
                     "version" => Literal::Version(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
@@ -53,6 +53,7 @@ impl<C: AsClient> LinkTypeStore for PostgresStore<C> {
         &mut self,
         link_type: LinkType,
         owned_by_id: AccountId,
+        created_by_id: AccountId,
     ) -> Result<PersistedOntologyMetadata, InsertionError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
@@ -62,7 +63,9 @@ impl<C: AsClient> LinkTypeStore for PostgresStore<C> {
                 .change_context(InsertionError)?,
         );
 
-        let (_, metadata) = transaction.create(link_type, owned_by_id).await?;
+        let (_, metadata) = transaction
+            .create(link_type, owned_by_id, created_by_id)
+            .await?;
 
         transaction
             .client

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/resolve.rs
@@ -84,7 +84,12 @@ where
                 // TODO: Avoid cloning on literals
                 //   see https://app.asana.com/0/0/1202884883200947/f
                 let literal = match segment.identifier.as_str() {
-                    "ownedById" => Literal::String(self.account_id.to_string()),
+                    "ownedById" => Literal::String(self.owned_by_id.to_string()),
+                    "createdById" => Literal::String(self.created_by_id.to_string()),
+                    "updatedById" => Literal::String(self.updated_by_id.to_string()),
+                    "removedById" => self.removed_by_id.map_or(Literal::Null, |removed_by_id| {
+                        Literal::String(removed_by_id.to_string())
+                    }),
                     "baseUri" => Literal::String(self.record.id().base_uri().to_string()),
                     "versionedUri" => Literal::String(self.record.id().to_string()),
                     "version" => Literal::Version(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/resolve.rs
@@ -85,11 +85,6 @@ where
                 //   see https://app.asana.com/0/0/1202884883200947/f
                 let literal = match segment.identifier.as_str() {
                     "ownedById" => Literal::String(self.owned_by_id.to_string()),
-                    "createdById" => Literal::String(self.created_by_id.to_string()),
-                    "updatedById" => Literal::String(self.updated_by_id.to_string()),
-                    "removedById" => self.removed_by_id.map_or(Literal::Null, |removed_by_id| {
-                        Literal::String(removed_by_id.to_string())
-                    }),
                     "baseUri" => Literal::String(self.record.id().base_uri().to_string()),
                     "versionedUri" => Literal::String(self.record.id().to_string()),
                     "version" => Literal::Version(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -125,6 +125,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         &mut self,
         property_type: PropertyType,
         owned_by_id: AccountId,
+        created_by_id: AccountId,
     ) -> Result<PersistedOntologyMetadata, InsertionError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
@@ -138,7 +139,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         // We can only insert them after the type has been created, and so we currently extract them
         // after as well. See `insert_property_type_references` taking `&property_type`
         let (version_id, metadata) = transaction
-            .create(property_type.clone(), owned_by_id)
+            .create(property_type.clone(), owned_by_id, created_by_id)
             .await?;
 
         transaction

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/resolve.rs
@@ -63,7 +63,12 @@ where
                 // TODO: Avoid cloning on literals
                 //   see https://app.asana.com/0/0/1202884883200947/f
                 let literal = match head_path_segment.identifier.as_str() {
-                    "ownedById" => Literal::String(self.account_id.to_string()),
+                    "ownedById" => Literal::String(self.owned_by_id.to_string()),
+                    "createdById" => Literal::String(self.created_by_id.to_string()),
+                    "updatedById" => Literal::String(self.updated_by_id.to_string()),
+                    "removedById" => self.removed_by_id.map_or(Literal::Null, |removed_by_id| {
+                        Literal::String(removed_by_id.to_string())
+                    }),
                     "baseUri" => Literal::String(self.record.id().base_uri().to_string()),
                     "versionedUri" => Literal::String(self.record.id().to_string()),
                     "version" => Literal::Version(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/resolve.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/resolve.rs
@@ -64,11 +64,6 @@ where
                 //   see https://app.asana.com/0/0/1202884883200947/f
                 let literal = match head_path_segment.identifier.as_str() {
                     "ownedById" => Literal::String(self.owned_by_id.to_string()),
-                    "createdById" => Literal::String(self.created_by_id.to_string()),
-                    "updatedById" => Literal::String(self.updated_by_id.to_string()),
-                    "removedById" => self.removed_by_id.map_or(Literal::Null, |removed_by_id| {
-                        Literal::String(removed_by_id.to_string())
-                    }),
                     "baseUri" => Literal::String(self.record.id().base_uri().to_string()),
                     "versionedUri" => Literal::String(self.record.id().to_string()),
                     "version" => Literal::Version(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -30,8 +30,17 @@ impl PersistedOntologyType for PersistedDataType {
 
     fn from_record(data_type: OntologyRecord<Self::Inner>) -> Self {
         let identifier =
-            PersistedOntologyIdentifier::new(data_type.record.id().clone(), data_type.account_id);
-        Self::new(data_type.record, PersistedOntologyMetadata::new(identifier))
+            PersistedOntologyIdentifier::new(data_type.record.id().clone(), data_type.owned_by_id);
+
+        Self::new(
+            data_type.record,
+            PersistedOntologyMetadata::new(
+                identifier,
+                data_type.created_by_id,
+                data_type.updated_by_id,
+                data_type.removed_by_id,
+            ),
+        )
     }
 }
 
@@ -41,11 +50,17 @@ impl PersistedOntologyType for PersistedPropertyType {
     fn from_record(property_type: OntologyRecord<Self::Inner>) -> Self {
         let identifier = PersistedOntologyIdentifier::new(
             property_type.record.id().clone(),
-            property_type.account_id,
+            property_type.owned_by_id,
         );
+
         Self::new(
             property_type.record,
-            PersistedOntologyMetadata::new(identifier),
+            PersistedOntologyMetadata::new(
+                identifier,
+                property_type.created_by_id,
+                property_type.updated_by_id,
+                property_type.removed_by_id,
+            ),
         )
     }
 }
@@ -55,8 +70,17 @@ impl PersistedOntologyType for PersistedLinkType {
 
     fn from_record(link_type: OntologyRecord<Self::Inner>) -> Self {
         let identifier =
-            PersistedOntologyIdentifier::new(link_type.record.id().clone(), link_type.account_id);
-        Self::new(link_type.record, PersistedOntologyMetadata::new(identifier))
+            PersistedOntologyIdentifier::new(link_type.record.id().clone(), link_type.owned_by_id);
+
+        Self::new(
+            link_type.record,
+            PersistedOntologyMetadata::new(
+                identifier,
+                link_type.created_by_id,
+                link_type.updated_by_id,
+                link_type.removed_by_id,
+            ),
+        )
     }
 }
 
@@ -66,11 +90,16 @@ impl PersistedOntologyType for PersistedEntityType {
     fn from_record(entity_type: OntologyRecord<Self::Inner>) -> Self {
         let identifier = PersistedOntologyIdentifier::new(
             entity_type.record.id().clone(),
-            entity_type.account_id,
+            entity_type.owned_by_id,
         );
         Self::new(
             entity_type.record,
-            PersistedOntologyMetadata::new(identifier),
+            PersistedOntologyMetadata::new(
+                identifier,
+                entity_type.created_by_id,
+                entity_type.updated_by_id,
+                entity_type.removed_by_id,
+            ),
         )
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
@@ -1,0 +1,138 @@
+use std::borrow::Cow;
+
+use type_system::DataType;
+
+use crate::{
+    ontology::DataTypeQueryPath,
+    store::{
+        postgres::query::{
+            database::{ColumnAccess, TableName},
+            Field, Path, Query,
+        },
+        query::ReadQuery,
+    },
+};
+
+impl<'q> Query for ReadQuery<'q, DataType> {
+    type Field = DataTypeQueryField<'q>;
+    type Record = DataType;
+
+    fn base_table() -> TableName {
+        TableName::DataTypes
+    }
+}
+
+/// A [`Field`] available in [`DataType`]s.
+///
+/// [`DataType`]: type_system::DataType
+#[derive(Debug, PartialEq, Eq)]
+pub enum DataTypeQueryField<'q> {
+    BaseUri,
+    Version,
+    VersionId,
+    OwnedById,
+    Schema,
+    VersionedUri,
+    Title,
+    Description,
+    Type,
+    Custom(Cow<'q, str>),
+}
+
+impl Field for DataTypeQueryField<'_> {
+    fn table_name(&self) -> TableName {
+        match self {
+            Self::BaseUri | Self::Version => TableName::TypeIds,
+            Self::VersionId
+            | Self::OwnedById
+            | Self::Schema
+            | Self::VersionedUri
+            | Self::Title
+            | Self::Type
+            | Self::Description
+            | Self::Custom(_) => TableName::DataTypes,
+        }
+    }
+
+    fn column_access(&self) -> ColumnAccess {
+        match self {
+            Self::BaseUri => ColumnAccess::Table { column: "base_uri" },
+            Self::Version => ColumnAccess::Table { column: "version" },
+            Self::VersionId => ColumnAccess::Table {
+                column: "version_id",
+            },
+            Self::OwnedById => ColumnAccess::Table {
+                column: "owned_by_id",
+            },
+            Self::Schema => ColumnAccess::Table { column: "schema" },
+            Self::VersionedUri => ColumnAccess::Json {
+                column: "schema",
+                field: Cow::Borrowed("$id"),
+            },
+            Self::Title => ColumnAccess::Json {
+                column: "schema",
+                field: Cow::Borrowed("title"),
+            },
+            Self::Type => ColumnAccess::Json {
+                column: "schema",
+                field: Cow::Borrowed("type"),
+            },
+            Self::Description => ColumnAccess::Json {
+                column: "schema",
+                field: Cow::Borrowed("description"),
+            },
+            Self::Custom(field) => ColumnAccess::Json {
+                column: "schema",
+                field: field.clone(),
+            },
+        }
+    }
+}
+
+impl Path for DataTypeQueryPath<'_> {
+    fn tables(&self) -> Vec<TableName> {
+        vec![self.terminating_table_name()]
+    }
+
+    fn terminating_table_name(&self) -> TableName {
+        match self {
+            Self::BaseUri | Self::Version => TableName::TypeIds,
+            Self::OwnedById
+            | Self::VersionedUri
+            | Self::Title
+            | Self::Type
+            | Self::Description
+            | Self::Custom(_) => TableName::DataTypes,
+        }
+    }
+
+    fn column_access(&self) -> ColumnAccess {
+        match self {
+            Self::BaseUri => ColumnAccess::Table { column: "base_uri" },
+            Self::Version => ColumnAccess::Table { column: "version" },
+            Self::OwnedById => ColumnAccess::Table {
+                column: "owned_by_id",
+            },
+            Self::VersionedUri => ColumnAccess::Json {
+                column: "schema",
+                field: Cow::Borrowed("$id"),
+            },
+            Self::Title => ColumnAccess::Json {
+                column: "schema",
+                field: Cow::Borrowed("title"),
+            },
+            Self::Type => ColumnAccess::Json {
+                column: "schema",
+                field: Cow::Borrowed("type"),
+            },
+            Self::Description => ColumnAccess::Json {
+                column: "schema",
+                field: Cow::Borrowed("description"),
+            },
+            Self::Custom(field) => ColumnAccess::Json {
+                column: "schema",
+                field: field.clone(),
+            },
+        }
+    }
+}

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -294,10 +294,15 @@ impl DatabaseApi<'_> {
         entity: Entity,
         entity_type_id: VersionedUri,
         entity_id: Option<EntityId>,
-        created_by_id: AccountId,
     ) -> Result<PersistedEntityMetadata, InsertionError> {
         self.store
-            .create_entity(entity, entity_type_id, self.account_id, entity_id)
+            .create_entity(
+                entity,
+                entity_type_id,
+                self.account_id,
+                entity_id,
+                self.account_id,
+            )
             .await
     }
 
@@ -332,7 +337,9 @@ impl DatabaseApi<'_> {
         link_type_id: VersionedUri,
     ) -> Result<(), InsertionError> {
         let link = Link::new(source_entity_id, target_entity_id, link_type_id, None);
-        self.store.create_link(&link, self.account_id).await
+        self.store
+            .create_link(&link, self.account_id, self.account_id)
+            .await
     }
 
     async fn create_ordered_link(
@@ -348,7 +355,9 @@ impl DatabaseApi<'_> {
             link_type_id,
             Some(index),
         );
-        self.store.create_link(&link, self.account_id).await
+        self.store
+            .create_link(&link, self.account_id, self.account_id)
+            .await
     }
 
     pub async fn get_link_target(

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -101,6 +101,7 @@ impl DatabaseTestWrapper {
                 .create_data_type(
                     DataType::from_str(data_type).expect("could not parse data type"),
                     account_id,
+                    account_id,
                 )
                 .await?;
         }
@@ -109,6 +110,7 @@ impl DatabaseTestWrapper {
             store
                 .create_property_type(
                     PropertyType::from_str(property_type).expect("could not parse property type"),
+                    account_id,
                     account_id,
                 )
                 .await?;
@@ -120,6 +122,7 @@ impl DatabaseTestWrapper {
                 .create_link_type(
                     LinkType::from_str(link_type).expect("could not parse link type"),
                     account_id,
+                    account_id,
                 )
                 .await?;
         }
@@ -128,6 +131,7 @@ impl DatabaseTestWrapper {
             store
                 .create_entity_type(
                     EntityType::from_str(entity_type).expect("could not parse entity type"),
+                    account_id,
                     account_id,
                 )
                 .await?;
@@ -144,7 +148,7 @@ impl DatabaseApi<'_> {
         data_type: DataType,
     ) -> Result<PersistedOntologyMetadata, InsertionError> {
         self.store
-            .create_data_type(data_type, self.account_id)
+            .create_data_type(data_type, self.account_id, self.account_id)
             .await
     }
 
@@ -183,7 +187,7 @@ impl DatabaseApi<'_> {
         property_type: PropertyType,
     ) -> Result<PersistedOntologyMetadata, InsertionError> {
         self.store
-            .create_property_type(property_type, self.account_id)
+            .create_property_type(property_type, self.account_id, self.account_id)
             .await
     }
 
@@ -222,7 +226,7 @@ impl DatabaseApi<'_> {
         entity_type: EntityType,
     ) -> Result<PersistedOntologyMetadata, InsertionError> {
         self.store
-            .create_entity_type(entity_type, self.account_id)
+            .create_entity_type(entity_type, self.account_id, self.account_id)
             .await
     }
 
@@ -256,7 +260,7 @@ impl DatabaseApi<'_> {
         link_type: LinkType,
     ) -> Result<PersistedOntologyMetadata, InsertionError> {
         self.store
-            .create_link_type(link_type, self.account_id)
+            .create_link_type(link_type, self.account_id, self.account_id)
             .await
     }
 

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -294,6 +294,7 @@ impl DatabaseApi<'_> {
         entity: Entity,
         entity_type_id: VersionedUri,
         entity_id: Option<EntityId>,
+        created_by_id: AccountId,
     ) -> Result<PersistedEntityMetadata, InsertionError> {
         self.store
             .create_entity(entity, entity_type_id, self.account_id, entity_id)

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -26,7 +26,8 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "accountId": "{{account_id}}",
+  "ownedById": "{{account_id}}",
+  "createdById": "{{account_id}}",
   "schema": {
     "kind": "dataType",
     "$id": "http://localhost:3000/@alice/types/data-type/text/v/1",
@@ -57,7 +58,7 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "accountId": "{{account_id}}",
+  "updatedById": "{{account_id}}",
   "typeToUpdate": "http://localhost:3000/@alice/types/data-type/text/v/1",
   "schema": {
     "kind": "dataType",
@@ -79,7 +80,8 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "accountId": "{{account_id}}",
+  "ownedById": "{{account_id}}",
+  "createdById": "{{account_id}}",
   "schema": {
     "kind": "propertyType",
     "$id": "http://localhost:3000/@alice/types/property-type/name/v/1",
@@ -115,7 +117,7 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "accountId": "{{account_id}}",
+  "updatedById": "{{account_id}}",
   "typeToUpdate": "http://localhost:3000/@alice/types/property-type/name/v/1",
   "schema": {
     "kind": "propertyType",
@@ -151,7 +153,8 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "accountId": "{{account_id}}",
+  "ownedById": "{{account_id}}",
+  "createdById": "{{account_id}}",
   "schema": {
     "kind": "linkType",
     "$id": "http://localhost:3000/@alice/types/link-type/friend-of/v/1",
@@ -185,7 +188,7 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "accountId": "{{account_id}}",
+  "updatedById": "{{account_id}}",
   "typeToUpdate": "http://localhost:3000/@alice/types/link-type/friend-of/v/1",
   "schema": {
     "kind": "linkType",
@@ -220,7 +223,8 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "accountId": "{{account_id}}",
+  "ownedById": "{{account_id}}",
+  "createdById": "{{account_id}}",
   "schema": {
     "kind": "entityType",
     "$id": "http://localhost:3000/@alice/types/entity-type/person/v/1",
@@ -257,7 +261,7 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "accountId": "{{account_id}}",
+  "updatedById": "{{account_id}}",
   "typeToUpdate": "http://localhost:3000/@alice/types/entity-type/person/v/1",
   "schema": {
     "kind": "entityType",

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -27,7 +27,7 @@ Accept: application/json
 
 {
   "ownedById": "{{account_id}}",
-  "createdById": "{{account_id}}",
+  "actorId": "{{account_id}}",
   "schema": {
     "kind": "dataType",
     "$id": "http://localhost:3000/@alice/types/data-type/text/v/1",
@@ -58,7 +58,7 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "updatedById": "{{account_id}}",
+  "actorId": "{{account_id}}",
   "typeToUpdate": "http://localhost:3000/@alice/types/data-type/text/v/1",
   "schema": {
     "kind": "dataType",
@@ -81,7 +81,7 @@ Accept: application/json
 
 {
   "ownedById": "{{account_id}}",
-  "createdById": "{{account_id}}",
+  "actorId": "{{account_id}}",
   "schema": {
     "kind": "propertyType",
     "$id": "http://localhost:3000/@alice/types/property-type/name/v/1",
@@ -117,7 +117,7 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "updatedById": "{{account_id}}",
+  "actorId": "{{account_id}}",
   "typeToUpdate": "http://localhost:3000/@alice/types/property-type/name/v/1",
   "schema": {
     "kind": "propertyType",
@@ -154,7 +154,7 @@ Accept: application/json
 
 {
   "ownedById": "{{account_id}}",
-  "createdById": "{{account_id}}",
+  "actorId": "{{account_id}}",
   "schema": {
     "kind": "linkType",
     "$id": "http://localhost:3000/@alice/types/link-type/friend-of/v/1",
@@ -188,7 +188,7 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "updatedById": "{{account_id}}",
+  "actorId": "{{account_id}}",
   "typeToUpdate": "http://localhost:3000/@alice/types/link-type/friend-of/v/1",
   "schema": {
     "kind": "linkType",
@@ -224,7 +224,7 @@ Accept: application/json
 
 {
   "ownedById": "{{account_id}}",
-  "createdById": "{{account_id}}",
+  "actorId": "{{account_id}}",
   "schema": {
     "kind": "entityType",
     "$id": "http://localhost:3000/@alice/types/entity-type/person/v/1",
@@ -261,7 +261,7 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "updatedById": "{{account_id}}",
+  "actorId": "{{account_id}}",
   "typeToUpdate": "http://localhost:3000/@alice/types/entity-type/person/v/1",
   "schema": {
     "kind": "entityType",
@@ -313,7 +313,7 @@ Accept: application/json
 
 {
   "ownedById": "{{account_id}}",
-  "createdById": "{{account_id}}",
+  "actorId": "{{account_id}}",
   "entity": {
     "http://localhost:3000/@alice/types/property-type/name/": "Alice"
   },
@@ -342,7 +342,7 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "updatedById": "{{account_id}}",
+  "actorId": "{{account_id}}",
   "entityId": "{{person_a_entity_id}}",
   "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/2",
   "entity": {
@@ -363,7 +363,7 @@ Accept: application/json
 
 {
   "ownedById": "{{account_id}}",
-  "createdById": "{{account_id}}",
+  "actorId": "{{account_id}}",
   "entity": {
     "http://localhost:3000/@alice/types/property-type/name/": "Bob"
   },
@@ -427,7 +427,7 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "createdById": "{{account_id}}",
+  "actorId": "{{account_id}}",
   "ownedById": "{{account_id}}",
   "targetEntityId": "{{person_b_entity_id}}",
   "linkTypeId": "{{friend_of_link_type_id_raw}}"
@@ -461,7 +461,7 @@ Accept: application/json
 {
   "targetEntityId": "{{person_b_entity_id}}",
   "linkTypeId": "{{friend_of_link_type_id_raw}}",
-  "removedById": "{{account_id}}"
+  "actorId": "{{account_id}}"
 }
 
 > {%
@@ -477,7 +477,7 @@ Accept: application/json
 
 {
   "ownedById": "{{account_id}}",
-  "createdById": "{{account_id}}",
+  "actorId": "{{account_id}}",
   "entity": {
     "http://localhost:3000/@alice/types/property-type/name/": "Charles"
   },
@@ -509,7 +509,7 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "createdById": "{{account_id}}",
+  "actorId": "{{account_id}}",
   "ownedById": "{{account_id}}",
   "targetEntityId": "{{person_b_entity_id}}",
   "linkTypeId": "{{friend_of_link_type_id_raw}}",
@@ -528,7 +528,7 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "createdById": "{{account_id}}",
+  "actorId": "{{account_id}}",
   "ownedById": "{{account_id}}",
   "targetEntityId": "{{person_c_entity_id}}",
   "linkTypeId": "{{friend_of_link_type_id_raw}}",

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -312,7 +312,8 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "accountId": "{{account_id}}",
+  "ownedById": "{{account_id}}",
+  "createdById": "{{account_id}}",
   "entity": {
     "http://localhost:3000/@alice/types/property-type/name/": "Alice"
   },
@@ -341,7 +342,7 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "accountId": "{{account_id}}",
+  "updatedById": "{{account_id}}",
   "entityId": "{{person_a_entity_id}}",
   "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/2",
   "entity": {
@@ -361,7 +362,8 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "accountId": "{{account_id}}",
+  "ownedById": "{{account_id}}",
+  "createdById": "{{account_id}}",
   "entity": {
     "http://localhost:3000/@alice/types/property-type/name/": "Bob"
   },
@@ -425,6 +427,7 @@ Content-Type: application/json
 Accept: application/json
 
 {
+  "createdById": "{{account_id}}",
   "ownedById": "{{account_id}}",
   "targetEntityId": "{{person_b_entity_id}}",
   "linkTypeId": "{{friend_of_link_type_id_raw}}"
@@ -473,7 +476,8 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "accountId": "{{account_id}}",
+  "ownedById": "{{account_id}}",
+  "createdById": "{{account_id}}",
   "entity": {
     "http://localhost:3000/@alice/types/property-type/name/": "Charles"
   },
@@ -505,6 +509,7 @@ Content-Type: application/json
 Accept: application/json
 
 {
+  "createdById": "{{account_id}}",
   "ownedById": "{{account_id}}",
   "targetEntityId": "{{person_b_entity_id}}",
   "linkTypeId": "{{friend_of_link_type_id_raw}}",
@@ -523,6 +528,7 @@ Content-Type: application/json
 Accept: application/json
 
 {
+  "createdById": "{{account_id}}",
   "ownedById": "{{account_id}}",
   "targetEntityId": "{{person_c_entity_id}}",
   "linkTypeId": "{{friend_of_link_type_id_raw}}",

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -99,6 +99,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         notNull: true,
         references: "accounts",
       },
+      /**
+       * @todo: remove this column if we introduce a delete table similar to links
+       * @see https://app.asana.com/0/1201095311341924/1202697596928142/f
+       */
       removed_by_id: {
         type: "UUID",
         references: "accounts",
@@ -136,7 +140,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         notNull: true,
         references: "accounts",
       },
-      removed_by_id: {
+      /**
+       * @todo: remove this column if we introduce a delete table similar to links
+       * @see https://app.asana.com/0/1201095311341924/1202697596928142/f
+       */ removed_by_id: {
         type: "UUID",
         references: "accounts",
       },
@@ -173,6 +180,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         notNull: true,
         references: "accounts",
       },
+      /**
+       * @todo: remove this column if we introduce a delete table similar to links
+       * @see https://app.asana.com/0/1201095311341924/1202697596928142/f
+       */
       removed_by_id: {
         type: "UUID",
         references: "accounts",
@@ -210,6 +221,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         notNull: true,
         references: "accounts",
       },
+      /**
+       * @todo: remove this column if we introduce a delete table similar to links
+       * @see https://app.asana.com/0/1201095311341924/1202697596928142/f
+       */
       removed_by_id: {
         type: "UUID",
         references: "accounts",
@@ -365,6 +380,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         notNull: true,
         references: "accounts",
       },
+      /**
+       * @todo: remove this column if we introduce a delete table similar to links
+       * @see https://app.asana.com/0/1201095311341924/1202697596928142/f
+       */
       removed_by_id: {
         type: "UUID",
         references: "accounts",

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -89,6 +89,20 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         notNull: true,
         references: "accounts",
       },
+      created_by_id: {
+        type: "UUID",
+        notNull: true,
+        references: "accounts",
+      },
+      updated_by_id: {
+        type: "UUID",
+        notNull: true,
+        references: "accounts",
+      },
+      removed_by_id: {
+        type: "UUID",
+        references: "accounts",
+      },
     },
     {
       ifNotExists: true,
@@ -112,11 +126,26 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         notNull: true,
         references: "accounts",
       },
+      created_by_id: {
+        type: "UUID",
+        notNull: true,
+        references: "accounts",
+      },
+      updated_by_id: {
+        type: "UUID",
+        notNull: true,
+        references: "accounts",
+      },
+      removed_by_id: {
+        type: "UUID",
+        references: "accounts",
+      },
     },
     {
       ifNotExists: true,
     },
   );
+
   pgm.createTable(
     "entity_types",
     {
@@ -132,6 +161,20 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       owned_by_id: {
         type: "UUID",
         notNull: true,
+        references: "accounts",
+      },
+      created_by_id: {
+        type: "UUID",
+        notNull: true,
+        references: "accounts",
+      },
+      updated_by_id: {
+        type: "UUID",
+        notNull: true,
+        references: "accounts",
+      },
+      removed_by_id: {
+        type: "UUID",
         references: "accounts",
       },
     },
@@ -155,6 +198,20 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       owned_by_id: {
         type: "UUID",
         notNull: true,
+        references: "accounts",
+      },
+      created_by_id: {
+        type: "UUID",
+        notNull: true,
+        references: "accounts",
+      },
+      updated_by_id: {
+        type: "UUID",
+        notNull: true,
+        references: "accounts",
+      },
+      removed_by_id: {
+        type: "UUID",
         references: "accounts",
       },
     },

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -355,6 +355,20 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         notNull: true,
         references: "accounts",
       },
+      created_by_id: {
+        type: "UUID",
+        notNull: true,
+        references: "accounts",
+      },
+      updated_by_id: {
+        type: "UUID",
+        notNull: true,
+        references: "accounts",
+      },
+      removed_by_id: {
+        type: "UUID",
+        references: "accounts",
+      },
     },
     {
       ifNotExists: true,

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -407,6 +407,11 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         notNull: true,
         references: "accounts",
       },
+      created_by_id: {
+        type: "UUID",
+        notNull: true,
+        references: "accounts",
+      },
       created_at: {
         type: "TIMESTAMP WITH TIME ZONE",
         notNull: true,
@@ -453,6 +458,11 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         notNull: false,
       },
       owned_by_id: {
+        type: "UUID",
+        notNull: true,
+        references: "accounts",
+      },
+      created_by_id: {
         type: "UUID",
         notNull: true,
         references: "accounts",

--- a/packages/hash/api/src/auth/index.ts
+++ b/packages/hash/api/src/auth/index.ts
@@ -10,12 +10,13 @@ import {
   publicKratosSdk,
 } from "./ory-kratos";
 import { UserModel } from "../model";
+import { workspaceAccountId } from "../model/util";
 
 declare global {
   namespace Express {
     interface Request {
       session: Session | undefined;
-      user: UserModel | undefined;
+      userModel: UserModel | undefined;
     }
   }
 }
@@ -57,6 +58,7 @@ const kratosAfterRegistrationHookHandler =
         await UserModel.createUser(graphApi, {
           emails,
           kratosIdentityId,
+          createdById: workspaceAccountId,
         });
 
         res.status(200).end();
@@ -105,17 +107,17 @@ const setupAuth = (params: {
 
       const { id: kratosIdentityId } = identity;
 
-      const user = await UserModel.getUserByKratosIdentityId(graphApi, {
+      const userModel = await UserModel.getUserByKratosIdentityId(graphApi, {
         kratosIdentityId,
       });
 
-      if (!user) {
+      if (!userModel) {
         throw new Error(
           `Could not find user with kratos identity id "${kratosIdentityId}"`,
         );
       }
 
-      req.user = user;
+      req.userModel = userModel;
     }
 
     next();

--- a/packages/hash/api/src/auth/index.ts
+++ b/packages/hash/api/src/auth/index.ts
@@ -58,7 +58,7 @@ const kratosAfterRegistrationHookHandler =
         await UserModel.createUser(graphApi, {
           emails,
           kratosIdentityId,
-          createdById: workspaceAccountId,
+          actorId: workspaceAccountId,
         });
 
         res.status(200).end();

--- a/packages/hash/api/src/auth/seed-dev-users.ts
+++ b/packages/hash/api/src/auth/seed-dev-users.ts
@@ -3,6 +3,7 @@ import { AxiosError } from "axios";
 
 import { GraphApi } from "../graph";
 import { UserModel } from "../model";
+import { workspaceAccountId } from "../model/util";
 import { createKratosIdentity } from "./ory-kratos";
 
 type DevelopmentUser = {
@@ -62,14 +63,17 @@ export const ensureDevUsersAreSeeded = async ({
       let user = await UserModel.createUser(graphApi, {
         emails,
         kratosIdentityId,
+        createdById: workspaceAccountId,
       });
 
       user = await user.updateShortname(graphApi, {
         updatedShortname: shortname,
+        updatedById: workspaceAccountId,
       });
 
       user = await user.updatePreferredName(graphApi, {
         updatedPreferredName: preferredName,
+        updatedById: workspaceAccountId,
       });
     }
 

--- a/packages/hash/api/src/auth/seed-dev-users.ts
+++ b/packages/hash/api/src/auth/seed-dev-users.ts
@@ -63,17 +63,17 @@ export const ensureDevUsersAreSeeded = async ({
       let user = await UserModel.createUser(graphApi, {
         emails,
         kratosIdentityId,
-        createdById: workspaceAccountId,
+        actorId: workspaceAccountId,
       });
 
       user = await user.updateShortname(graphApi, {
         updatedShortname: shortname,
-        updatedById: workspaceAccountId,
+        actorId: workspaceAccountId,
       });
 
       user = await user.updatePreferredName(graphApi, {
         updatedPreferredName: preferredName,
-        updatedById: workspaceAccountId,
+        actorId: workspaceAccountId,
       });
     }
 

--- a/packages/hash/api/src/graph/workspace-types.ts
+++ b/packages/hash/api/src/graph/workspace-types.ts
@@ -8,6 +8,7 @@ import {
   propertyTypeInitializer,
   entityTypeInitializer,
   linkTypeInitializer,
+  workspaceAccountId,
 } from "../model/util";
 
 // eslint-disable-next-line import/no-mutable-exports
@@ -93,6 +94,7 @@ export const orgProvidedInfoPropertyTypeInitializer = async (
         },
       },
     ],
+    createdById: workspaceAccountId,
   })(graphApi);
 };
 
@@ -126,6 +128,7 @@ export const orgEntityTypeInitializer = async (graphApi: GraphApi) => {
       },
     ],
     outgoingLinks: [],
+    createdById: workspaceAccountId,
   })(graphApi);
 };
 
@@ -158,50 +161,60 @@ const orgMembershipEntityTypeInitializer = async (graphApi: GraphApi) => {
         required: true,
       },
     ],
+    createdById: workspaceAccountId,
   })(graphApi);
 };
 
 const shortnamePropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.shortName,
   possibleValues: [{ primitiveDataType: "text" }],
+  createdById: workspaceAccountId,
 });
 
 const orgNamePropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.orgName,
   possibleValues: [{ primitiveDataType: "text" }],
+  createdById: workspaceAccountId,
 });
 
 const orgSizePropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.orgSize,
   possibleValues: [{ primitiveDataType: "text" }],
+  createdById: workspaceAccountId,
 });
 
 const emailPropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.email,
   possibleValues: [{ primitiveDataType: "text" }],
+  createdById: workspaceAccountId,
 });
 
 const kratosIdentityIdPropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.kratosIdentityId,
   possibleValues: [{ primitiveDataType: "text" }],
+  createdById: workspaceAccountId,
 });
 
 const preferredNamePropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.preferredName,
   possibleValues: [{ primitiveDataType: "text" }],
+  createdById: workspaceAccountId,
 });
 
 const responsibilityPropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.responsibility,
   possibleValues: [{ primitiveDataType: "text" }],
+  createdById: workspaceAccountId,
 });
 
 const ofOrgLinkTypeInitializer = linkTypeInitializer({
   ...types.linkType.ofOrg,
+  createdById: workspaceAccountId,
 });
 
 const hasMembershipLinkTypeInitializer = linkTypeInitializer({
   ...types.linkType.hasMembership,
+  createdById: workspaceAccountId,
 });
 
 const userEntityTypeInitializer = async (graphApi: GraphApi) => {
@@ -252,17 +265,20 @@ const userEntityTypeInitializer = async (graphApi: GraphApi) => {
         destinationEntityTypeModels: [orgMembershipEntityTypeModel],
       },
     ],
+    createdById: workspaceAccountId,
   })(graphApi);
 };
 
 const componentIdPropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.componentId,
   possibleValues: [{ primitiveDataType: "text" }],
+  createdById: workspaceAccountId,
 });
 
-const blockDataLinkTypeInitializer = linkTypeInitializer(
-  types.linkType.blockData,
-);
+const blockDataLinkTypeInitializer = linkTypeInitializer({
+  ...types.linkType.blockData,
+  createdById: workspaceAccountId,
+});
 
 const blockEntityTypeInitializer = async (graphApi: GraphApi) => {
   /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -297,6 +313,7 @@ const blockEntityTypeInitializer = async (graphApi: GraphApi) => {
         required: true,
       },
     ],
+    createdById: workspaceAccountId,
   })(graphApi);
 };
 
@@ -307,6 +324,7 @@ const tokensPropertyTypeInitializer = propertyTypeInitializer({
    * @see https://app.asana.com/0/1202805690238892/1203045933021778/f
    */
   possibleValues: [{ primitiveDataType: "object" }],
+  createdById: workspaceAccountId,
 });
 
 const textEntityTypeInitializer = async (graphApi: GraphApi) => {
@@ -326,6 +344,7 @@ const textEntityTypeInitializer = async (graphApi: GraphApi) => {
       },
     ],
     outgoingLinks: [],
+    createdById: workspaceAccountId,
   })(graphApi);
 };
 
@@ -338,39 +357,49 @@ const dummyEntityTypeInitializer = async (graphApi: GraphApi) => {
     ...types.entityType.dummy,
     properties: [],
     outgoingLinks: [],
+    createdById: workspaceAccountId,
   })(graphApi);
 };
 
 const archivedPropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.archived,
   possibleValues: [{ primitiveDataType: "boolean" }],
+  createdById: workspaceAccountId,
 });
 
 const summaryPropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.summary,
   possibleValues: [{ primitiveDataType: "text" }],
+  createdById: workspaceAccountId,
 });
 
 const titlePropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.title,
   possibleValues: [{ primitiveDataType: "text" }],
+  createdById: workspaceAccountId,
 });
 
 const indexPropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.index,
   possibleValues: [{ primitiveDataType: "text" }],
+  createdById: workspaceAccountId,
 });
 
 const iconPropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.icon,
   possibleValues: [{ primitiveDataType: "text" }],
+  createdById: workspaceAccountId,
 });
 
-const containsLinkTypeInitializer = linkTypeInitializer(
-  types.linkType.contains,
-);
+const containsLinkTypeInitializer = linkTypeInitializer({
+  ...types.linkType.contains,
+  createdById: workspaceAccountId,
+});
 
-const parentLinkTypeInitializer = linkTypeInitializer(types.linkType.parent);
+const parentLinkTypeInitializer = linkTypeInitializer({
+  ...types.linkType.parent,
+  createdById: workspaceAccountId,
+});
 
 const pageEntityTypeInitializer = async (graphApi: GraphApi) => {
   /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -435,6 +464,7 @@ const pageEntityTypeInitializer = async (graphApi: GraphApi) => {
         destinationEntityTypeModels: ["SELF_REFERENCE"],
       },
     ],
+    createdById: workspaceAccountId,
   })(graphApi);
 };
 

--- a/packages/hash/api/src/graph/workspace-types.ts
+++ b/packages/hash/api/src/graph/workspace-types.ts
@@ -94,7 +94,7 @@ export const orgProvidedInfoPropertyTypeInitializer = async (
         },
       },
     ],
-    createdById: workspaceAccountId,
+    actorId: workspaceAccountId,
   })(graphApi);
 };
 
@@ -128,7 +128,7 @@ export const orgEntityTypeInitializer = async (graphApi: GraphApi) => {
       },
     ],
     outgoingLinks: [],
-    createdById: workspaceAccountId,
+    actorId: workspaceAccountId,
   })(graphApi);
 };
 
@@ -161,60 +161,60 @@ const orgMembershipEntityTypeInitializer = async (graphApi: GraphApi) => {
         required: true,
       },
     ],
-    createdById: workspaceAccountId,
+    actorId: workspaceAccountId,
   })(graphApi);
 };
 
 const shortnamePropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.shortName,
   possibleValues: [{ primitiveDataType: "text" }],
-  createdById: workspaceAccountId,
+  actorId: workspaceAccountId,
 });
 
 const orgNamePropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.orgName,
   possibleValues: [{ primitiveDataType: "text" }],
-  createdById: workspaceAccountId,
+  actorId: workspaceAccountId,
 });
 
 const orgSizePropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.orgSize,
   possibleValues: [{ primitiveDataType: "text" }],
-  createdById: workspaceAccountId,
+  actorId: workspaceAccountId,
 });
 
 const emailPropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.email,
   possibleValues: [{ primitiveDataType: "text" }],
-  createdById: workspaceAccountId,
+  actorId: workspaceAccountId,
 });
 
 const kratosIdentityIdPropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.kratosIdentityId,
   possibleValues: [{ primitiveDataType: "text" }],
-  createdById: workspaceAccountId,
+  actorId: workspaceAccountId,
 });
 
 const preferredNamePropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.preferredName,
   possibleValues: [{ primitiveDataType: "text" }],
-  createdById: workspaceAccountId,
+  actorId: workspaceAccountId,
 });
 
 const responsibilityPropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.responsibility,
   possibleValues: [{ primitiveDataType: "text" }],
-  createdById: workspaceAccountId,
+  actorId: workspaceAccountId,
 });
 
 const ofOrgLinkTypeInitializer = linkTypeInitializer({
   ...types.linkType.ofOrg,
-  createdById: workspaceAccountId,
+  actorId: workspaceAccountId,
 });
 
 const hasMembershipLinkTypeInitializer = linkTypeInitializer({
   ...types.linkType.hasMembership,
-  createdById: workspaceAccountId,
+  actorId: workspaceAccountId,
 });
 
 const userEntityTypeInitializer = async (graphApi: GraphApi) => {
@@ -265,19 +265,19 @@ const userEntityTypeInitializer = async (graphApi: GraphApi) => {
         destinationEntityTypeModels: [orgMembershipEntityTypeModel],
       },
     ],
-    createdById: workspaceAccountId,
+    actorId: workspaceAccountId,
   })(graphApi);
 };
 
 const componentIdPropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.componentId,
   possibleValues: [{ primitiveDataType: "text" }],
-  createdById: workspaceAccountId,
+  actorId: workspaceAccountId,
 });
 
 const blockDataLinkTypeInitializer = linkTypeInitializer({
   ...types.linkType.blockData,
-  createdById: workspaceAccountId,
+  actorId: workspaceAccountId,
 });
 
 const blockEntityTypeInitializer = async (graphApi: GraphApi) => {
@@ -313,7 +313,7 @@ const blockEntityTypeInitializer = async (graphApi: GraphApi) => {
         required: true,
       },
     ],
-    createdById: workspaceAccountId,
+    actorId: workspaceAccountId,
   })(graphApi);
 };
 
@@ -324,7 +324,7 @@ const tokensPropertyTypeInitializer = propertyTypeInitializer({
    * @see https://app.asana.com/0/1202805690238892/1203045933021778/f
    */
   possibleValues: [{ primitiveDataType: "object" }],
-  createdById: workspaceAccountId,
+  actorId: workspaceAccountId,
 });
 
 const textEntityTypeInitializer = async (graphApi: GraphApi) => {
@@ -344,7 +344,7 @@ const textEntityTypeInitializer = async (graphApi: GraphApi) => {
       },
     ],
     outgoingLinks: [],
-    createdById: workspaceAccountId,
+    actorId: workspaceAccountId,
   })(graphApi);
 };
 
@@ -357,48 +357,48 @@ const dummyEntityTypeInitializer = async (graphApi: GraphApi) => {
     ...types.entityType.dummy,
     properties: [],
     outgoingLinks: [],
-    createdById: workspaceAccountId,
+    actorId: workspaceAccountId,
   })(graphApi);
 };
 
 const archivedPropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.archived,
   possibleValues: [{ primitiveDataType: "boolean" }],
-  createdById: workspaceAccountId,
+  actorId: workspaceAccountId,
 });
 
 const summaryPropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.summary,
   possibleValues: [{ primitiveDataType: "text" }],
-  createdById: workspaceAccountId,
+  actorId: workspaceAccountId,
 });
 
 const titlePropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.title,
   possibleValues: [{ primitiveDataType: "text" }],
-  createdById: workspaceAccountId,
+  actorId: workspaceAccountId,
 });
 
 const indexPropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.index,
   possibleValues: [{ primitiveDataType: "text" }],
-  createdById: workspaceAccountId,
+  actorId: workspaceAccountId,
 });
 
 const iconPropertyTypeInitializer = propertyTypeInitializer({
   ...types.propertyType.icon,
   possibleValues: [{ primitiveDataType: "text" }],
-  createdById: workspaceAccountId,
+  actorId: workspaceAccountId,
 });
 
 const containsLinkTypeInitializer = linkTypeInitializer({
   ...types.linkType.contains,
-  createdById: workspaceAccountId,
+  actorId: workspaceAccountId,
 });
 
 const parentLinkTypeInitializer = linkTypeInitializer({
   ...types.linkType.parent,
-  createdById: workspaceAccountId,
+  actorId: workspaceAccountId,
 });
 
 const pageEntityTypeInitializer = async (graphApi: GraphApi) => {
@@ -464,7 +464,7 @@ const pageEntityTypeInitializer = async (graphApi: GraphApi) => {
         destinationEntityTypeModels: ["SELF_REFERENCE"],
       },
     ],
-    createdById: workspaceAccountId,
+    actorId: workspaceAccountId,
   })(graphApi);
 };
 

--- a/packages/hash/api/src/graphql/context.ts
+++ b/packages/hash/api/src/graphql/context.ts
@@ -24,9 +24,9 @@ export interface GraphQLContext {
   emailTransporter: EmailTransporter;
   uploadProvider: StorageType;
   logger: Logger;
-  user?: UserModel;
+  userModel?: UserModel;
 }
 
 export interface LoggedInGraphQLContext extends GraphQLContext {
-  user: UserModel;
+  userModel: UserModel;
 }

--- a/packages/hash/api/src/graphql/createApolloServer.ts
+++ b/packages/hash/api/src/graphql/createApolloServer.ts
@@ -69,7 +69,7 @@ export const createApolloServer = ({
     dataSources: getDataSources,
     context: (ctx): Omit<GraphQLContext, "dataSources"> => ({
       ...ctx,
-      user: ctx.req.user,
+      userModel: ctx.req.userModel,
       emailTransporter,
       uploadProvider,
       logger: logger.child({

--- a/packages/hash/api/src/graphql/resolvers/comments/createComment.ts
+++ b/packages/hash/api/src/graphql/resolvers/comments/createComment.ts
@@ -11,7 +11,7 @@ export const createComment: ResolverFn<
 > = async (
   _,
   { accountId, parentId, tokens },
-  { dataSources: { db }, user },
+  { dataSources: { db }, userModel },
 ) => {
   return await db.transaction(async (client) => {
     const parent = await Block.getBlockById(client, {
@@ -29,7 +29,8 @@ export const createComment: ResolverFn<
     const comment = await Comment.createComment(db, {
       accountId,
       parent,
-      createdBy: user as any /** @todo: replace with updated model class */,
+      createdBy:
+        userModel as any /** @todo: replace with updated model class */,
       tokens,
     });
 

--- a/packages/hash/api/src/graphql/resolvers/entity/createEntity.ts
+++ b/packages/hash/api/src/graphql/resolvers/entity/createEntity.ts
@@ -10,11 +10,11 @@ export const createEntity: ResolverFn<
 > = async (
   _,
   { accountId, entity: entityDefinition },
-  { dataSources, user },
+  { dataSources, userModel },
 ) => {
   /** @todo restrict creation of protected types, e.g. User, Org */
   const entity = await Entity.createEntityWithLinks(dataSources.db, {
-    user: user as any /** @todo: replace with updated model class */,
+    user: userModel as any /** @todo: replace with updated model class */,
     accountId,
     entityDefinition,
   });

--- a/packages/hash/api/src/graphql/resolvers/entity/updateEntity.ts
+++ b/packages/hash/api/src/graphql/resolvers/entity/updateEntity.ts
@@ -13,7 +13,11 @@ export const updateEntity: ResolverFn<
   {},
   LoggedInGraphQLContext,
   MutationUpdateEntityArgs
-> = async (_, { accountId, entityId, properties }, { dataSources, user }) => {
+> = async (
+  _,
+  { accountId, entityId, properties },
+  { dataSources, userModel },
+) => {
   return await dataSources.db.transaction(async (client) => {
     // @todo: always get the latest version for now. This is a temporary measure.
     // return here when strict vs. optimistic entity mutation question is resolved.
@@ -31,7 +35,7 @@ export const updateEntity: ResolverFn<
     const propertiesToUpdate = properties.properties ?? properties;
     entity.properties = propertiesToUpdate;
     const updatePayload: UpdatePropertiesPayload = {
-      updatedByAccountId: user.entityId,
+      updatedByAccountId: userModel.entityId,
       properties: entity.properties,
     };
 

--- a/packages/hash/api/src/graphql/resolvers/entityType/createEntityType.ts
+++ b/packages/hash/api/src/graphql/resolvers/entityType/createEntityType.ts
@@ -13,12 +13,12 @@ export const deprecatedCreateEntityType: ResolverFn<
 > = async (
   _,
   { accountId, description, name, schema },
-  { dataSources, user },
+  { dataSources, userModel },
 ) =>
   dataSources.db.transaction(async (client) => {
     const entityType = await EntityType.create(client, {
       accountId,
-      createdByAccountId: user.entityId,
+      createdByAccountId: userModel.entityId,
       description: description ?? undefined,
       name,
       schema,

--- a/packages/hash/api/src/graphql/resolvers/entityType/updateEntityType.ts
+++ b/packages/hash/api/src/graphql/resolvers/entityType/updateEntityType.ts
@@ -12,7 +12,7 @@ export const deprecatedUpdateEntityType: ResolverFn<
   {},
   LoggedInGraphQLContext,
   MutationDeprecatedUpdateEntityTypeArgs
-> = async (_, { entityId, schema }, { dataSources: { db }, user }) => {
+> = async (_, { entityId, schema }, { dataSources: { db }, userModel }) => {
   return await db.transaction(async (conn) => {
     const entityType = await EntityType.getEntityType(conn, {
       entityTypeId: entityId,
@@ -26,8 +26,8 @@ export const deprecatedUpdateEntityType: ResolverFn<
     }
 
     await entityType.update(conn, {
-      updatedByAccountId: user.entityId,
-      createdByAccountId: user.entityId,
+      updatedByAccountId: userModel.entityId,
+      createdByAccountId: userModel.entityId,
       schema,
     });
 

--- a/packages/hash/api/src/graphql/resolvers/file/createFileFromLink.ts
+++ b/packages/hash/api/src/graphql/resolvers/file/createFileFromLink.ts
@@ -18,8 +18,8 @@ export const createFileFromLink: ResolverFn<
   {},
   LoggedInGraphQLContext,
   MutationCreateFileFromLinkArgs
-> = async (_, { name, url, accountId }, { user, dataSources }) => {
-  const createdByAccountId = user.entityId;
+> = async (_, { name, url, accountId }, { userModel, dataSources }) => {
+  const createdByAccountId = userModel.entityId;
   const fileName = name || guessFileNameFromURL(url);
   const file = await File.createFileEntityFromLink(dataSources.db, {
     accountId,

--- a/packages/hash/api/src/graphql/resolvers/file/requestFileUpload.ts
+++ b/packages/hash/api/src/graphql/resolvers/file/requestFileUpload.ts
@@ -12,8 +12,8 @@ export const requestFileUpload: ResolverFn<
   {},
   LoggedInGraphQLContext,
   MutationRequestFileUploadArgs
-> = async (_, { name, contentMd5, size }, { user, dataSources }) => {
-  const accountId = user.entityId;
+> = async (_, { name, contentMd5, size }, { userModel, dataSources }) => {
+  const accountId = userModel.entityId;
   const { presignedPost, file } = await File.createFileEntityFromUploadRequest(
     dataSources.db,
     {

--- a/packages/hash/api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -33,7 +33,7 @@ export const createPersistedEntity: ResolverFn<
     entityTypeId,
     properties,
     linkedEntities: linkedEntities ?? undefined,
-    createdById: userModel.entityId,
+    actorId: userModel.entityId,
   });
 
   return mapEntityModelToGQL(entity);
@@ -55,7 +55,7 @@ export const updatePersistedEntity: ResolverFn<
 
   const updatedEntityModel = await entityModel.update(graphApi, {
     properties: updatedProperties,
-    updatedById: userModel.entityId,
+    actorId: userModel.entityId,
   });
 
   return mapEntityModelToGQL(updatedEntityModel);

--- a/packages/hash/api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -19,7 +19,7 @@ export const createPersistedEntity: ResolverFn<
 > = async (
   _,
   { ownedById, properties, entityTypeId, linkedEntities },
-  { dataSources: { graphApi }, user },
+  { dataSources: { graphApi }, userModel },
 ) => {
   /**
    * @todo: prevent callers of this mutation from being able to create restricted
@@ -29,10 +29,11 @@ export const createPersistedEntity: ResolverFn<
    */
 
   const entity = await EntityModel.createEntityWithLinks(graphApi, {
-    ownedById: ownedById ?? user.entityId,
+    ownedById: ownedById ?? userModel.entityId,
     entityTypeId,
     properties,
     linkedEntities: linkedEntities ?? undefined,
+    createdById: userModel.entityId,
   });
 
   return mapEntityModelToGQL(entity);
@@ -46,7 +47,7 @@ export const updatePersistedEntity: ResolverFn<
 > = async (
   _,
   { entityId, updatedProperties },
-  { dataSources: { graphApi } },
+  { dataSources: { graphApi }, userModel },
 ) => {
   const entityModel = await EntityModel.getLatest(graphApi, {
     entityId,
@@ -54,6 +55,7 @@ export const updatePersistedEntity: ResolverFn<
 
   const updatedEntityModel = await entityModel.update(graphApi, {
     properties: updatedProperties,
+    updatedById: userModel.entityId,
   });
 
   return mapEntityModelToGQL(updatedEntityModel);

--- a/packages/hash/api/src/graphql/resolvers/knowledge/link/link.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/link/link.ts
@@ -16,7 +16,7 @@ export const createPersistedLink: ResolverFn<
   {},
   LoggedInGraphQLContext,
   MutationCreatePersistedLinkArgs
-> = async (_, { link }, { dataSources: { graphApi } }) => {
+> = async (_, { link }, { dataSources: { graphApi }, userModel }) => {
   const { linkTypeId, ownedById, index, sourceEntityId, targetEntityId } = link;
 
   const [linkTypeModel, sourceEntityModel, targetEntityModel] =
@@ -38,6 +38,7 @@ export const createPersistedLink: ResolverFn<
     index: index ?? undefined,
     sourceEntityModel,
     targetEntityModel,
+    createdById: userModel.entityId,
   });
 
   return mapLinkModelToGQL(linkModel);
@@ -77,10 +78,10 @@ export const deletePersistedLink: ResolverFn<
   {},
   LoggedInGraphQLContext,
   MutationDeletePersistedLinkArgs
-> = async (_, { link }, { dataSources: { graphApi }, user }) => {
+> = async (_, { link }, { dataSources: { graphApi }, userModel }) => {
   const linkModel = await LinkModel.get(graphApi, link);
 
-  await linkModel.remove(graphApi, { removedById: user.entityId });
+  await linkModel.remove(graphApi, { removedById: userModel.entityId });
 
   return true;
 };

--- a/packages/hash/api/src/graphql/resolvers/knowledge/link/link.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/link/link.ts
@@ -38,7 +38,7 @@ export const createPersistedLink: ResolverFn<
     index: index ?? undefined,
     sourceEntityModel,
     targetEntityModel,
-    createdById: userModel.entityId,
+    actorId: userModel.entityId,
   });
 
   return mapLinkModelToGQL(linkModel);
@@ -81,7 +81,7 @@ export const deletePersistedLink: ResolverFn<
 > = async (_, { link }, { dataSources: { graphApi }, userModel }) => {
   const linkModel = await LinkModel.get(graphApi, link);
 
-  await linkModel.remove(graphApi, { removedById: userModel.entityId });
+  await linkModel.remove(graphApi, { actorId: userModel.entityId });
 
   return true;
 };

--- a/packages/hash/api/src/graphql/resolvers/knowledge/page/page.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/page/page.ts
@@ -40,7 +40,7 @@ export const createPersistedPage: ResolverFn<
     ownedById,
     title,
     prevIndex: prevIndex ?? undefined,
-    createdById: userModel.entityId,
+    actorId: userModel.entityId,
   });
 
   return mapPageModelToGQL(pageModel);

--- a/packages/hash/api/src/graphql/resolvers/knowledge/page/page.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/page/page.ts
@@ -34,12 +34,13 @@ export const createPersistedPage: ResolverFn<
 > = async (
   _,
   { ownedById, properties: { title, prevIndex } },
-  { dataSources: { graphApi } },
+  { dataSources: { graphApi }, userModel },
 ) => {
   const pageModel = await PageModel.createPage(graphApi, {
     ownedById,
     title,
     prevIndex: prevIndex ?? undefined,
+    createdById: userModel.entityId,
   });
 
   return mapPageModelToGQL(pageModel);
@@ -64,10 +65,10 @@ export const persistedPages: ResolverFn<
   {},
   LoggedInGraphQLContext,
   QueryPersistedPagesArgs
-> = async (_, { ownedById }, { dataSources: { graphApi }, user }) => {
+> = async (_, { ownedById }, { dataSources: { graphApi }, userModel }) => {
   const accountModel = ownedById
     ? await UserModel.getUserById(graphApi, { entityId: ownedById })
-    : user;
+    : userModel;
 
   const pageModels = await PageModel.getAllPagesInAccount(graphApi, {
     accountModel,

--- a/packages/hash/api/src/graphql/resolvers/knowledge/page/set-parent-page.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/page/set-parent-page.ts
@@ -19,7 +19,7 @@ export const setParentPersistedPage: ResolverFn<
 > = async (
   _,
   { pageEntityId, parentPageEntityId, prevIndex = null, nextIndex = null },
-  { dataSources: { graphApi }, user },
+  { dataSources: { graphApi }, userModel },
 ) => {
   if (pageEntityId === parentPageEntityId) {
     throw new ApolloError("A page cannot be the parent of itself");
@@ -37,7 +37,7 @@ export const setParentPersistedPage: ResolverFn<
 
   const updatedPageModel = await pageModel.setParentPage(graphApi, {
     parentPageModel: newParentPageModel,
-    setById: user.entityId,
+    setById: userModel.entityId,
     prevIndex,
     nextIndex,
   });

--- a/packages/hash/api/src/graphql/resolvers/knowledge/page/set-parent-page.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/page/set-parent-page.ts
@@ -37,7 +37,7 @@ export const setParentPersistedPage: ResolverFn<
 
   const updatedPageModel = await pageModel.setParentPage(graphApi, {
     parentPageModel: newParentPageModel,
-    setById: userModel.entityId,
+    actorId: userModel.entityId,
     prevIndex,
     nextIndex,
   });

--- a/packages/hash/api/src/graphql/resolvers/knowledge/page/update-page-actions.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/page/update-page-actions.ts
@@ -16,7 +16,7 @@ export const createEntityWithPlaceholdersFn =
   (graphApi: GraphApi, placeholderResults: PlaceholderResultsMap) =>
   async (
     originalDefinition: PersistedEntityDefinition,
-    entityCreatedById: string,
+    entityActorId: string,
   ) => {
     const entityDefinition = produce(originalDefinition, (draft) => {
       if (draft.existingEntity) {
@@ -33,17 +33,17 @@ export const createEntityWithPlaceholdersFn =
 
     if (entityDefinition.existingEntity) {
       return await EntityModel.getOrCreate(graphApi, {
-        ownedById: entityCreatedById,
+        ownedById: entityActorId,
         entityDefinition,
-        createdById: entityCreatedById,
+        actorId: entityActorId,
       });
     } else {
       return await EntityModel.createEntityWithLinks(graphApi, {
-        ownedById: entityCreatedById,
+        ownedById: entityActorId,
         entityTypeId: entityDefinition.entityType?.entityTypeId!,
         properties: entityDefinition.entityProperties,
         linkedEntities: entityDefinition.linkedEntities ?? undefined,
-        createdById: entityCreatedById,
+        actorId: entityActorId,
       });
     }
   };
@@ -115,7 +115,7 @@ export const handleCreateNewEntity = async (params: {
   placeholderResults: PlaceholderResultsMap;
   createEntityWithPlaceholders: (
     originalDefinition: PersistedEntityDefinition,
-    entityCreatedById: string,
+    entityActorId: string,
   ) => Promise<EntityModel>;
 }): Promise<void> => {
   try {
@@ -154,7 +154,7 @@ export const handleInsertNewBlock = async (
     index: number;
     createEntityWithPlaceholders: (
       originalDefinition: PersistedEntityDefinition,
-      entityCreatedById: string,
+      entityActorId: string,
     ) => Promise<EntityModel>;
     placeholderResults: PlaceholderResultsMap;
   },
@@ -205,7 +205,7 @@ export const handleInsertNewBlock = async (
         blockData,
         ownedById: userModel.entityId,
         componentId: blockComponentId,
-        createdById: userModel.entityId,
+        actorId: userModel.entityId,
       });
     } else {
       throw new Error(
@@ -260,7 +260,7 @@ export const handleSwapBlockData = async (
 
   await block.updateBlockDataEntity(graphApi, {
     newBlockDataEntity,
-    updatedById: userModel.entityId,
+    actorId: userModel.entityId,
   });
 };
 
@@ -292,6 +292,6 @@ export const handleUpdateEntity = async (
     updatedProperties: Object.entries(action.properties).map(
       ([key, value]) => ({ propertyTypeBaseUri: key, value }),
     ),
-    updatedById: userModel.entityId,
+    actorId: userModel.entityId,
   });
 };

--- a/packages/hash/api/src/graphql/resolvers/knowledge/page/update-page-actions.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/page/update-page-actions.ts
@@ -16,7 +16,7 @@ export const createEntityWithPlaceholdersFn =
   (graphApi: GraphApi, placeholderResults: PlaceholderResultsMap) =>
   async (
     originalDefinition: PersistedEntityDefinition,
-    entityOwnedById: string,
+    entityCreatedById: string,
   ) => {
     const entityDefinition = produce(originalDefinition, (draft) => {
       if (draft.existingEntity) {
@@ -44,10 +44,11 @@ export const createEntityWithPlaceholdersFn =
     });
 
     return await EntityModel.createEntityWithLinks(graphApi, {
-      ownedById: entityOwnedById,
+      ownedById: entityCreatedById,
       entityTypeId: entityDefinition.entityType?.entityTypeId!,
       properties: entityDefinition.entityProperties,
       linkedEntities: entityDefinition.linkedEntities ?? undefined,
+      createdById: entityCreatedById,
     });
   };
 
@@ -208,6 +209,7 @@ export const handleInsertNewBlock = async (
         blockData,
         ownedById: userModel.entityId,
         componentId: blockComponentId,
+        createdById: userModel.entityId,
       });
     } else {
       throw new Error(
@@ -243,6 +245,7 @@ export const handleSwapBlockData = async (
 ): Promise<void> => {
   const {
     swapBlockDataAction: { entityId },
+    userModel,
   } = params;
 
   const block = await BlockModel.getBlockById(graphApi, {
@@ -261,6 +264,7 @@ export const handleSwapBlockData = async (
 
   await block.updateBlockDataEntity(graphApi, {
     newBlockDataEntity,
+    updatedById: userModel.entityId,
   });
 };
 
@@ -276,7 +280,7 @@ export const handleUpdateEntity = async (
     placeholderResults: PlaceholderResultsMap;
   },
 ): Promise<void> => {
-  const { action, placeholderResults } = params;
+  const { action, placeholderResults, userModel } = params;
 
   // If this entity ID is a placeholder, use that instead.
   let entityId = action.entityId;
@@ -292,5 +296,6 @@ export const handleUpdateEntity = async (
     updatedProperties: Object.entries(action.properties).map(
       ([key, value]) => ({ propertyTypeBaseUri: key, value }),
     ),
+    updatedById: userModel.entityId,
   });
 };

--- a/packages/hash/api/src/graphql/resolvers/knowledge/page/update-page-contents.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/page/update-page-contents.ts
@@ -141,18 +141,18 @@ export const updatePersistedPageContents: ResolverFn<
           block: insertedBlocks[insertCount]!,
           position: action.insertBlock.position,
           updateSiblings: false,
-          insertedById: userModel.entityId,
+          actorId: userModel.entityId,
         });
         insertCount += 1;
       } else if (action.moveBlock) {
         await pageModel.moveBlock(graphApi, {
           ...action.moveBlock,
-          movedById: userModel.entityId,
+          actorId: userModel.entityId,
         });
       } else if (action.removeBlock) {
         await pageModel.removeBlock(graphApi, {
           position: action.removeBlock.position,
-          removedById: userModel.entityId,
+          actorId: userModel.entityId,
           allowRemovingFinal: actions
             .slice(i + 1)
             .some((actionToFollow) => actionToFollow.insertBlock),

--- a/packages/hash/api/src/graphql/resolvers/knowledge/page/update-page-contents.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/page/update-page-contents.ts
@@ -41,7 +41,7 @@ export const updatePersistedPageContents: ResolverFn<
 > = async (
   _,
   { ownedById, entityId: pageEntityId, actions },
-  { dataSources, user: userModel },
+  { dataSources, userModel },
 ) => {
   for (const [i, action] of actions.entries()) {
     if (
@@ -140,6 +140,7 @@ export const updatePersistedPageContents: ResolverFn<
         await pageModel.insertBlock(graphApi, {
           block: insertedBlocks[insertCount]!,
           position: action.insertBlock.position,
+          insertedById: userModel.entityId,
         });
         insertCount += 1;
       } else if (action.moveBlock) {

--- a/packages/hash/api/src/graphql/resolvers/knowledge/page/update-page.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/page/update-page.ts
@@ -18,7 +18,7 @@ export const updatePersistedPage: ResolverFn<
 > = async (
   _,
   { entityId, updatedProperties },
-  { dataSources: { graphApi } },
+  { dataSources: { graphApi }, userModel },
 ) => {
   const pageModel = await PageModel.getPageById(graphApi, { entityId });
 
@@ -32,6 +32,7 @@ export const updatePersistedPage: ResolverFn<
         value,
       }),
     ),
+    updatedById: userModel.entityId,
   });
 
   const updatedPageModel = PageModel.fromEntityModel(updatedPageEntityModel);

--- a/packages/hash/api/src/graphql/resolvers/knowledge/page/update-page.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/page/update-page.ts
@@ -32,7 +32,7 @@ export const updatePersistedPage: ResolverFn<
         value,
       }),
     ),
-    updatedById: userModel.entityId,
+    actorId: userModel.entityId,
   });
 
   const updatedPageModel = PageModel.fromEntityModel(updatedPageEntityModel);

--- a/packages/hash/api/src/graphql/resolvers/link/createLink.ts
+++ b/packages/hash/api/src/graphql/resolvers/link/createLink.ts
@@ -8,7 +8,7 @@ export const createLink: ResolverFn<
   {},
   LoggedInGraphQLContext,
   MutationCreateLinkArgs
-> = async (_, { link: linkInput }, { dataSources, user }) =>
+> = async (_, { link: linkInput }, { dataSources, userModel }) =>
   dataSources.db.transaction(async (client) => {
     const { sourceAccountId, sourceEntityId } = linkInput;
     const source = await Entity.getEntityLatestVersion(client, {
@@ -36,7 +36,7 @@ export const createLink: ResolverFn<
     }
 
     const link = await source.createOutgoingLink(client, {
-      createdByAccountId: user.entityId,
+      createdByAccountId: userModel.entityId,
       stringifiedPath: linkInput.path,
       index: typeof linkInput.index === "number" ? linkInput.index : undefined,
       destination,

--- a/packages/hash/api/src/graphql/resolvers/link/deleteLink.ts
+++ b/packages/hash/api/src/graphql/resolvers/link/deleteLink.ts
@@ -8,7 +8,7 @@ export const deleteLink: ResolverFn<
   {},
   LoggedInGraphQLContext,
   MutationDeleteLinkArgs
-> = (_, { sourceAccountId, linkId }, { dataSources, user }) =>
+> = (_, { sourceAccountId, linkId }, { dataSources, userModel }) =>
   dataSources.db.transaction(async (client) => {
     const link = await Link.get(client, { sourceAccountId, linkId });
 
@@ -20,7 +20,7 @@ export const deleteLink: ResolverFn<
     }
 
     await link.delete(client, {
-      deletedByAccountId: user.entityId,
+      deletedByAccountId: userModel.entityId,
     });
 
     return true;

--- a/packages/hash/api/src/graphql/resolvers/linkedAggregation/createLinkedAggregation.ts
+++ b/packages/hash/api/src/graphql/resolvers/linkedAggregation/createLinkedAggregation.ts
@@ -14,7 +14,7 @@ export const createLinkedAggregation: ResolverFn<
 > = async (
   _,
   { sourceAccountId, sourceEntityId, path, operation },
-  { dataSources, user },
+  { dataSources, userModel },
 ) =>
   dataSources.db.transaction(async (client) => {
     const source = await Entity.getEntityLatestVersion(client, {
@@ -36,7 +36,8 @@ export const createLinkedAggregation: ResolverFn<
         itemsPerPage: operation.itemsPerPage ?? 10,
         pageNumber: operation.pageNumber ?? 1,
       },
-      createdBy: user as any /** @todo: replace with updated model class */,
+      createdBy:
+        userModel as any /** @todo: replace with updated model class */,
     });
 
     return aggregation.toGQLLinkedAggregation(dataSources.db);

--- a/packages/hash/api/src/graphql/resolvers/linkedAggregation/deleteLinkedAggregation.ts
+++ b/packages/hash/api/src/graphql/resolvers/linkedAggregation/deleteLinkedAggregation.ts
@@ -11,7 +11,7 @@ export const deleteLinkedAggregation: ResolverFn<
   {},
   LoggedInGraphQLContext,
   MutationDeleteLinkedAggregationArgs
-> = async (_, { sourceAccountId, aggregationId }, { dataSources, user }) =>
+> = async (_, { sourceAccountId, aggregationId }, { dataSources, userModel }) =>
   dataSources.db.transaction(async (client) => {
     const aggregation = await Aggregation.getAggregationById(client, {
       sourceAccountId,
@@ -23,7 +23,9 @@ export const deleteLinkedAggregation: ResolverFn<
       throw new ApolloError(msg, "NOT_FOUND");
     }
 
-    await aggregation.delete(client, { deletedByAccountId: user.entityId });
+    await aggregation.delete(client, {
+      deletedByAccountId: userModel.entityId,
+    });
 
     return true;
   });

--- a/packages/hash/api/src/graphql/resolvers/linkedAggregation/updateLinkedAggregationOperation.ts
+++ b/packages/hash/api/src/graphql/resolvers/linkedAggregation/updateLinkedAggregationOperation.ts
@@ -14,7 +14,7 @@ export const updateLinkedAggregationOperation: ResolverFn<
 > = async (
   _,
   { sourceAccountId, aggregationId, updatedOperation },
-  { dataSources, user },
+  { dataSources, userModel },
 ) =>
   dataSources.db.transaction(async (client) => {
     const aggregation = await Aggregation.getAggregationById(client, {
@@ -35,7 +35,7 @@ export const updateLinkedAggregationOperation: ResolverFn<
         itemsPerPage: updatedOperation.itemsPerPage ?? 10,
         pageNumber: updatedOperation.pageNumber ?? 1,
       },
-      updatedByAccountId: user.entityId,
+      updatedByAccountId: userModel.entityId,
     });
 
     return aggregation.toGQLLinkedAggregation(dataSources.db);

--- a/packages/hash/api/src/graphql/resolvers/middlewares/canAccessAccount.ts
+++ b/packages/hash/api/src/graphql/resolvers/middlewares/canAccessAccount.ts
@@ -17,14 +17,14 @@ export const canAccessAccount: ResolverMiddleware<
 > = (next) =>
   loggedInAndSignedUp(async (_, args, ctx, info) => {
     const {
-      user,
+      userModel,
       dataSources: { graphApi },
     } = ctx;
     let isAllowed = false;
-    if (user.entityId === args.ownedById) {
+    if (userModel.entityId === args.ownedById) {
       isAllowed = true;
     } else {
-      isAllowed = await user.isMemberOfOrg(graphApi, {
+      isAllowed = await userModel.isMemberOfOrg(graphApi, {
         orgEntityId: args.ownedById,
       });
     }

--- a/packages/hash/api/src/graphql/resolvers/middlewares/loggedIn.ts
+++ b/packages/hash/api/src/graphql/resolvers/middlewares/loggedIn.ts
@@ -7,7 +7,7 @@ export const loggedIn: ResolverMiddleware<
   any,
   LoggedInGraphQLContext
 > = (next) => (obj: any, args: any, ctx: GraphQLContext, info: any) => {
-  if (!ctx.user) {
+  if (!ctx.userModel) {
     throw new ForbiddenError("You must be logged in to perform this action.");
   }
   return next(obj, args, ctx as LoggedInGraphQLContext, info);

--- a/packages/hash/api/src/graphql/resolvers/middlewares/signedUp.ts
+++ b/packages/hash/api/src/graphql/resolvers/middlewares/signedUp.ts
@@ -4,7 +4,7 @@ import { ResolverMiddleware } from "./middlewareTypes";
 
 export const signedUp: ResolverMiddleware<LoggedInGraphQLContext, any> =
   (next) => (obj: any, args: any, ctx: LoggedInGraphQLContext, info: any) => {
-    if (!ctx.user.isAccountSignupComplete()) {
+    if (!ctx.userModel.isAccountSignupComplete()) {
       throw new ForbiddenError(
         "You must complete the sign-up process to perform this action.",
       );

--- a/packages/hash/api/src/graphql/resolvers/ontology/entity-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/entity-type.ts
@@ -34,7 +34,7 @@ export const createEntityType: ResolverFn<
   const createdEntityTypeModel = await EntityTypeModel.create(graphApi, {
     ownedById: ownedById ?? userModel.entityId,
     schema: entityType,
-    createdById: userModel.entityId,
+    actorId: userModel.entityId,
   }).catch((err) => {
     throw new ApolloError(err, "CREATION_ERROR");
   });
@@ -113,7 +113,7 @@ export const updateEntityType: ResolverFn<
   const updatedEntityTypeModel = await entityTypeModel
     .update(graphApi, {
       schema: updatedEntityType,
-      updatedById: userModel.entityId,
+      actorId: userModel.entityId,
     })
     .catch((err: AxiosError) => {
       const msg =

--- a/packages/hash/api/src/graphql/resolvers/ontology/entity-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/entity-type.ts
@@ -27,13 +27,14 @@ export const createEntityType: ResolverFn<
   {},
   LoggedInGraphQLContext,
   MutationCreateEntityTypeArgs
-> = async (_, params, { dataSources, user }) => {
+> = async (_, params, { dataSources, userModel }) => {
   const { graphApi } = dataSources;
   const { ownedById, entityType } = params;
 
   const createdEntityTypeModel = await EntityTypeModel.create(graphApi, {
-    ownedById: ownedById ?? user.entityId,
+    ownedById: ownedById ?? userModel.entityId,
     schema: entityType,
+    createdById: userModel.entityId,
   }).catch((err) => {
     throw new ApolloError(err, "CREATION_ERROR");
   });
@@ -96,7 +97,7 @@ export const updateEntityType: ResolverFn<
   {},
   LoggedInGraphQLContext,
   MutationUpdateEntityTypeArgs
-> = async (_, params, { dataSources }) => {
+> = async (_, params, { dataSources, userModel }) => {
   const { graphApi } = dataSources;
   const { entityTypeId, updatedEntityType } = params;
 
@@ -112,6 +113,7 @@ export const updateEntityType: ResolverFn<
   const updatedEntityTypeModel = await entityTypeModel
     .update(graphApi, {
       schema: updatedEntityType,
+      updatedById: userModel.entityId,
     })
     .catch((err: AxiosError) => {
       const msg =

--- a/packages/hash/api/src/graphql/resolvers/ontology/link-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/link-type.ts
@@ -17,13 +17,14 @@ export const createLinkType: ResolverFn<
   {},
   LoggedInGraphQLContext,
   MutationCreateLinkTypeArgs
-> = async (_, params, { dataSources, user }) => {
+> = async (_, params, { dataSources, userModel }) => {
   const { graphApi } = dataSources;
   const { ownedById, linkType } = params;
 
   const createdLinkTypeModel = await LinkTypeModel.create(graphApi, {
-    ownedById: ownedById ?? user.entityId,
+    ownedById: ownedById ?? userModel.entityId,
     schema: linkType,
+    createdById: userModel.entityId,
   }).catch((err) => {
     throw new ApolloError(err, "CREATION_ERROR");
   });
@@ -78,7 +79,7 @@ export const updateLinkType: ResolverFn<
   {},
   LoggedInGraphQLContext,
   MutationUpdateLinkTypeArgs
-> = async (_, params, { dataSources }) => {
+> = async (_, params, { dataSources, userModel }) => {
   const { graphApi } = dataSources;
   const { linkTypeId, updatedLinkType } = params;
 
@@ -94,6 +95,7 @@ export const updateLinkType: ResolverFn<
   const updatedLinkTypeModel = await linkTypeModel
     .update(graphApi, {
       schema: updatedLinkType,
+      updatedById: userModel.entityId,
     })
     .catch((err: AxiosError) => {
       const msg =

--- a/packages/hash/api/src/graphql/resolvers/ontology/link-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/link-type.ts
@@ -24,7 +24,7 @@ export const createLinkType: ResolverFn<
   const createdLinkTypeModel = await LinkTypeModel.create(graphApi, {
     ownedById: ownedById ?? userModel.entityId,
     schema: linkType,
-    createdById: userModel.entityId,
+    actorId: userModel.entityId,
   }).catch((err) => {
     throw new ApolloError(err, "CREATION_ERROR");
   });
@@ -95,7 +95,7 @@ export const updateLinkType: ResolverFn<
   const updatedLinkTypeModel = await linkTypeModel
     .update(graphApi, {
       schema: updatedLinkType,
-      updatedById: userModel.entityId,
+      actorId: userModel.entityId,
     })
     .catch((err: AxiosError) => {
       const msg =

--- a/packages/hash/api/src/graphql/resolvers/ontology/property-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/property-type.ts
@@ -26,7 +26,7 @@ export const createPropertyType: ResolverFn<
   const createdPropertyTypeModel = await PropertyTypeModel.create(graphApi, {
     ownedById: ownedById ?? userModel.entityId,
     schema: propertyType,
-    createdById: userModel.entityId,
+    actorId: userModel.entityId,
   }).catch((err) => {
     throw new ApolloError(err, "CREATION_ERROR");
   });
@@ -123,7 +123,7 @@ export const updatePropertyType: ResolverFn<
   const updatedPropertyTypeModel = await propertyTypeModel
     .update(graphApi, {
       schema: updatedPropertyType,
-      updatedById: userModel.entityId,
+      actorId: userModel.entityId,
     })
     .catch((err: AxiosError) => {
       const msg =

--- a/packages/hash/api/src/graphql/resolvers/ontology/property-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/property-type.ts
@@ -19,13 +19,14 @@ export const createPropertyType: ResolverFn<
   {},
   LoggedInGraphQLContext,
   MutationCreatePropertyTypeArgs
-> = async (_, params, { dataSources, user }) => {
+> = async (_, params, { dataSources, userModel }) => {
   const { graphApi } = dataSources;
   const { ownedById, propertyType } = params;
 
   const createdPropertyTypeModel = await PropertyTypeModel.create(graphApi, {
-    ownedById: ownedById ?? user.entityId,
+    ownedById: ownedById ?? userModel.entityId,
     schema: propertyType,
+    createdById: userModel.entityId,
   }).catch((err) => {
     throw new ApolloError(err, "CREATION_ERROR");
   });
@@ -106,7 +107,7 @@ export const updatePropertyType: ResolverFn<
   {},
   LoggedInGraphQLContext,
   MutationUpdatePropertyTypeArgs
-> = async (_, params, { dataSources }) => {
+> = async (_, params, { dataSources, userModel }) => {
   const { graphApi } = dataSources;
   const { propertyTypeId, updatedPropertyType } = params;
 
@@ -122,6 +123,7 @@ export const updatePropertyType: ResolverFn<
   const updatedPropertyTypeModel = await propertyTypeModel
     .update(graphApi, {
       schema: updatedPropertyType,
+      updatedById: userModel.entityId,
     })
     .catch((err: AxiosError) => {
       const msg =

--- a/packages/hash/api/src/graphql/resolvers/org/createOrgEmailInvitation.ts
+++ b/packages/hash/api/src/graphql/resolvers/org/createOrgEmailInvitation.ts
@@ -14,7 +14,7 @@ export const createOrgEmailInvitation: ResolverFn<
 > = async (
   _,
   { orgEntityId, inviteeEmailAddress },
-  { emailTransporter, dataSources, user },
+  { emailTransporter, dataSources, userModel },
 ) =>
   dataSources.db.transaction(async (client) => {
     const { graphApi } = dataSources;
@@ -25,9 +25,11 @@ export const createOrgEmailInvitation: ResolverFn<
       throw new ApolloError(msg, "NOT_FOUND");
     }
 
-    if (!(await user.isMemberOfOrg(graphApi, { orgEntityId: org.entityId }))) {
+    if (
+      !(await userModel.isMemberOfOrg(graphApi, { orgEntityId: org.entityId }))
+    ) {
       throw new ForbiddenError(
-        `User with entityId ${user.entityId} is not a member of the org with entityId ${org.entityId}`,
+        `User with entityId ${userModel.entityId} is not a member of the org with entityId ${org.entityId}`,
       );
     }
 
@@ -52,7 +54,8 @@ export const createOrgEmailInvitation: ResolverFn<
       emailTransporter,
       {
         org,
-        inviter: user as any /** @todo: replace with updated model class */,
+        inviter:
+          userModel as any /** @todo: replace with updated model class */,
         inviteeEmailAddress,
       },
     );

--- a/packages/hash/api/src/graphql/resolvers/pages/updatePage.ts
+++ b/packages/hash/api/src/graphql/resolvers/pages/updatePage.ts
@@ -9,7 +9,11 @@ export const updatePage: ResolverFn<
   {},
   LoggedInGraphQLContext,
   MutationUpdatePageArgs
-> = async (_, { accountId, entityId, properties }, { dataSources, user }) => {
+> = async (
+  _,
+  { accountId, entityId, properties },
+  { dataSources, userModel },
+) => {
   return await dataSources.db.transaction(async (client) => {
     // @todo: always get the latest version for now. This is a temporary measure.
     // return here when strict vs. optimistic entity mutation question is resolved.
@@ -29,7 +33,7 @@ export const updatePage: ResolverFn<
         ...(entity.properties ?? {}),
         ...properties,
       },
-      updatedByAccountId: user.entityId,
+      updatedByAccountId: userModel.entityId,
     });
 
     // @todo: for now, all entities are non-versioned, so the array only has a single

--- a/packages/hash/api/src/graphql/resolvers/pages/updatePageContents.ts
+++ b/packages/hash/api/src/graphql/resolvers/pages/updatePageContents.ts
@@ -85,7 +85,7 @@ export const updatePageContents: ResolverFn<
 > = async (
   _,
   { accountId, entityId: pageEntityId, actions },
-  { dataSources, user },
+  { dataSources, userModel },
 ) => {
   validateActionsInput(actions);
 
@@ -121,7 +121,7 @@ export const updatePageContents: ResolverFn<
 
       return await Entity.createEntityWithLinks(client, {
         accountId: entityAccountId,
-        user: user as any /** @todo: replace with updated model class */,
+        user: userModel as any /** @todo: replace with updated model class */,
         entityDefinition,
       });
     };
@@ -145,7 +145,7 @@ export const updatePageContents: ResolverFn<
               placeholderId,
               await EntityType.create(client, {
                 accountId: entityTypeAccountId,
-                createdByAccountId: user.entityId,
+                createdByAccountId: userModel.entityId,
                 description: description ?? undefined,
                 name,
                 schema,
@@ -235,8 +235,8 @@ export const updatePageContents: ResolverFn<
               block = await Block.createBlock(client, {
                 blockData,
                 createdBy:
-                  user as any /** @todo: replace with updated model class */,
-                accountId: user.entityId,
+                  userModel as any /** @todo: replace with updated model class */,
+                accountId: userModel.entityId,
                 properties: {
                   componentId: blockComponentId,
                 },
@@ -281,7 +281,7 @@ export const updatePageContents: ResolverFn<
           return await block.swapBlockData(client, {
             targetDataAccountId: swapBlockData.newEntityAccountId,
             targetDataEntityId: swapBlockData.newEntityEntityId,
-            updatedByAccountId: user.entityId,
+            updatedByAccountId: userModel.entityId,
           });
         }),
     );
@@ -306,7 +306,7 @@ export const updatePageContents: ResolverFn<
                 }
               },
             ),
-            updatedByAccountId: user.entityId,
+            updatedByAccountId: userModel.entityId,
           });
         }),
     );
@@ -330,18 +330,18 @@ export const updatePageContents: ResolverFn<
           await page.insertBlock(client, {
             block: insertedBlocks[insertCount]!,
             position: action.insertBlock.position,
-            insertedByAccountId: user.entityId,
+            insertedByAccountId: userModel.entityId,
           });
           insertCount += 1;
         } else if (action.moveBlock) {
           await page.moveBlock(client, {
             ...action.moveBlock,
-            movedByAccountId: user.entityId,
+            movedByAccountId: userModel.entityId,
           });
         } else if (action.removeBlock) {
           await page.removeBlock(client, {
             ...action.removeBlock,
-            removedByAccountId: user.entityId,
+            removedByAccountId: userModel.entityId,
             allowRemovingFinal: actions
               .slice(i + 1)
               .some((actionToFollow) => actionToFollow.insertBlock),

--- a/packages/hash/api/src/graphql/resolvers/taskExecutor/index.ts
+++ b/packages/hash/api/src/graphql/resolvers/taskExecutor/index.ts
@@ -113,7 +113,7 @@ export const executeGithubDiscoverTask: ResolverFn<
 > = async (
   _,
   { config },
-  { dataSources: { db, taskExecutor }, user, logger },
+  { dataSources: { db, taskExecutor }, userModel, logger },
 ) => {
   if (!taskExecutor) {
     throw new ApolloError(
@@ -126,7 +126,7 @@ export const executeGithubDiscoverTask: ResolverFn<
         config,
       );
 
-      const existingEntityChecker = await CachedEntityTypes(db, user);
+      const existingEntityChecker = await CachedEntityTypes(db, userModel);
 
       for (const message of catalog) {
         if (!message.name || !message.json_schema) {
@@ -159,7 +159,7 @@ export const executeGithubReadTask: ResolverFn<
 > = async (
   _,
   { config },
-  { dataSources: { db, taskExecutor }, user, logger },
+  { dataSources: { db, taskExecutor }, userModel, logger },
 ) => {
   if (!taskExecutor) {
     throw new ApolloError(
@@ -174,7 +174,7 @@ export const executeGithubReadTask: ResolverFn<
       );
       logger.debug(`Received ${airbyteRecords.length} records from Github`);
 
-      const existingEntityChecker = await CachedEntityTypes(db, user);
+      const existingEntityChecker = await CachedEntityTypes(db, userModel);
       for (const record of airbyteRecords) {
         const entityTypeName = streamNameToEntityTypeName(record.stream);
         /** @todo - Check if entity already exists */
@@ -188,8 +188,8 @@ export const executeGithubReadTask: ResolverFn<
         /** @todo - check primary key to see if entity already exists */
         // Insert the entity
         const entity = await Entity.create(db, {
-          accountId: user.entityId,
-          createdByAccountId: user.entityId,
+          accountId: userModel.entityId,
+          createdByAccountId: userModel.entityId,
           versioned: true,
           entityTypeId,
           properties: record.data,

--- a/packages/hash/api/src/graphql/resolvers/user/me.ts
+++ b/packages/hash/api/src/graphql/resolvers/user/me.ts
@@ -7,4 +7,4 @@ export const me: ResolverFn<
   {},
   LoggedInGraphQLContext,
   {}
-> = async (_, __, { user }) => mapUserModelToGQL(user);
+> = async (_, __, { userModel }) => mapUserModelToGQL(userModel);

--- a/packages/hash/api/src/graphql/resolvers/user/updateUser.ts
+++ b/packages/hash/api/src/graphql/resolvers/user/updateUser.ts
@@ -68,7 +68,7 @@ export const updateUser: ResolverFn<
 
     updatedUser = await updatedUser.updateShortname(graphApi, {
       updatedShortname: shortname,
-      updatedById: userModel.entityId,
+      actorId: userModel.entityId,
     });
   }
 
@@ -86,7 +86,7 @@ export const updateUser: ResolverFn<
 
     updatedUser = await updatedUser.updatePreferredName(graphApi, {
       updatedPreferredName: preferredName,
-      updatedById: userModel.entityId,
+      actorId: userModel.entityId,
     });
   }
 

--- a/packages/hash/api/src/graphql/resolvers/user/updateUser.ts
+++ b/packages/hash/api/src/graphql/resolvers/user/updateUser.ts
@@ -46,35 +46,36 @@ export const updateUser: ResolverFn<
 > = async (
   _,
   { userEntityId, properties },
-  { dataSources: { graphApi }, user },
+  { dataSources: { graphApi }, userModel },
 ) => {
   /** @todo: run this mutation in a transaction */
 
   /** @todo: allow HASH admins to bypass this */
-  if (userEntityId !== user.entityId) {
+  if (userEntityId !== userModel.entityId) {
     throw new ForbiddenError("You can only update your own user properties");
   }
 
-  let updatedUser = user;
+  let updatedUser = userModel;
 
   const { shortname, preferredName } = properties;
 
   if (
     shortname !== undefined &&
     shortname !== null &&
-    user.getShortname() !== shortname
+    userModel.getShortname() !== shortname
   ) {
     await validateShortname(graphApi, shortname);
 
     updatedUser = await updatedUser.updateShortname(graphApi, {
       updatedShortname: shortname,
+      updatedById: userModel.entityId,
     });
   }
 
   if (
     preferredName !== undefined &&
     preferredName !== null &&
-    user.getPreferredName() !== preferredName
+    userModel.getPreferredName() !== preferredName
   ) {
     if (UserModel.preferredNameIsInvalid(preferredName)) {
       throw new ApolloError(
@@ -85,6 +86,7 @@ export const updateUser: ResolverFn<
 
     updatedUser = await updatedUser.updatePreferredName(graphApi, {
       updatedPreferredName: preferredName,
+      updatedById: userModel.entityId,
     });
   }
 

--- a/packages/hash/api/src/graphql/typeDefs/ontology/entity-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/entity-type.typedef.ts
@@ -112,7 +112,7 @@ export const entityTypeTypedef = gql`
     """
     createEntityType(
       """
-      The id of the owner of the entity type. Defaults to the user calling the mutation.
+      The id of the account who owns the entity type. Defaults to the user calling the mutation.
       """
       ownedById: ID
       entityType: EntityTypeWithoutId!

--- a/packages/hash/api/src/graphql/typeDefs/ontology/link-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/link-type.typedef.ts
@@ -42,7 +42,7 @@ export const linkTypeTypedef = gql`
     """
     createLinkType(
       """
-      The id of the owner of the link type. Defaults to the user calling the mutation.
+      The id of the account who owns the link type. Defaults to the user calling the mutation.
       """
       ownedById: ID
       linkType: LinkTypeWithoutId!

--- a/packages/hash/api/src/graphql/typeDefs/ontology/property-type.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/ontology/property-type.typedef.ts
@@ -42,7 +42,7 @@ export const propertyTypeTypedef = gql`
     """
     createPropertyType(
       """
-      The id of the owner of the property type. Defaults to the user calling the mutation.
+      The id of the account who owns the property type. Defaults to the user calling the mutation.
       """
       ownedById: ID
       propertyType: PropertyTypeWithoutId!

--- a/packages/hash/api/src/model/knowledge/block.model.ts
+++ b/packages/hash/api/src/model/knowledge/block.model.ts
@@ -52,7 +52,7 @@ export default class extends EntityModel {
     graphApi: GraphApi,
     params: BlockModelCreateParams,
   ): Promise<BlockModel> {
-    const { componentId, blockData, ownedById } = params;
+    const { componentId, blockData, ownedById, createdById } = params;
 
     const properties: object = {
       [WORKSPACE_TYPES.propertyType.componentId.baseUri]: componentId,
@@ -64,12 +64,14 @@ export default class extends EntityModel {
       ownedById,
       properties,
       entityTypeModel,
+      createdById,
     });
 
     await entity.createOutgoingLink(graphApi, {
       linkTypeModel: WORKSPACE_TYPES.linkType.blockData,
       targetEntityModel: blockData,
       ownedById,
+      createdById,
     });
 
     return BlockModel.fromEntityModel(entity);
@@ -107,14 +109,16 @@ export default class extends EntityModel {
    * Update the linked block data entity of a block.
    *
    * @param params.newBlockDataEntity - the new block data entity
+   * @param params.updatedById - the id of the account that is updating the block data entity
    */
   async updateBlockDataEntity(
     graphApi: GraphApi,
     params: {
       newBlockDataEntity: EntityModel;
+      updatedById: string;
     },
   ): Promise<void> {
-    const { newBlockDataEntity } = params;
+    const { newBlockDataEntity, updatedById } = params;
     const outgoingBlockDataLinks = await this.getOutgoingLinks(graphApi, {
       linkTypeModel: WORKSPACE_TYPES.linkType.blockData,
     });
@@ -137,17 +141,14 @@ export default class extends EntityModel {
     }
 
     await outgoingBlockDataLink.remove(graphApi, {
-      /**
-       * @todo: don't assume the owner of the link is the user that's responsible for removing it.
-       * Related to https://app.asana.com/0/1200211978612931/1202848989198291/f
-       */
-      removedById: this.ownedById,
+      removedById: updatedById,
     });
 
     await this.createOutgoingLink(graphApi, {
       linkTypeModel: WORKSPACE_TYPES.linkType.blockData,
       targetEntityModel: newBlockDataEntity,
       ownedById: this.ownedById,
+      createdById: updatedById,
     });
   }
 }

--- a/packages/hash/api/src/model/knowledge/block.model.ts
+++ b/packages/hash/api/src/model/knowledge/block.model.ts
@@ -52,7 +52,7 @@ export default class extends EntityModel {
     graphApi: GraphApi,
     params: BlockModelCreateParams,
   ): Promise<BlockModel> {
-    const { componentId, blockData, ownedById, createdById } = params;
+    const { componentId, blockData, ownedById, actorId } = params;
 
     const properties: object = {
       [WORKSPACE_TYPES.propertyType.componentId.baseUri]: componentId,
@@ -64,14 +64,14 @@ export default class extends EntityModel {
       ownedById,
       properties,
       entityTypeModel,
-      createdById,
+      actorId,
     });
 
     await entity.createOutgoingLink(graphApi, {
       linkTypeModel: WORKSPACE_TYPES.linkType.blockData,
       targetEntityModel: blockData,
       ownedById,
-      createdById,
+      actorId,
     });
 
     return BlockModel.fromEntityModel(entity);
@@ -109,16 +109,16 @@ export default class extends EntityModel {
    * Update the linked block data entity of a block.
    *
    * @param params.newBlockDataEntity - the new block data entity
-   * @param params.updatedById - the id of the account that is updating the block data entity
+   * @param params.actorId - the id of the account that is updating the block data entity
    */
   async updateBlockDataEntity(
     graphApi: GraphApi,
     params: {
       newBlockDataEntity: EntityModel;
-      updatedById: string;
+      actorId: string;
     },
   ): Promise<void> {
-    const { newBlockDataEntity, updatedById } = params;
+    const { newBlockDataEntity, actorId } = params;
     const outgoingBlockDataLinks = await this.getOutgoingLinks(graphApi, {
       linkTypeModel: WORKSPACE_TYPES.linkType.blockData,
     });
@@ -140,15 +140,13 @@ export default class extends EntityModel {
       );
     }
 
-    await outgoingBlockDataLink.remove(graphApi, {
-      removedById: updatedById,
-    });
+    await outgoingBlockDataLink.remove(graphApi, { actorId });
 
     await this.createOutgoingLink(graphApi, {
       linkTypeModel: WORKSPACE_TYPES.linkType.blockData,
       targetEntityModel: newBlockDataEntity,
       ownedById: this.ownedById,
-      createdById: updatedById,
+      actorId,
     });
   }
 }

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -35,7 +35,7 @@ export type EntityModelCreateParams = {
   properties: object;
   entityTypeModel: EntityTypeModel;
   entityId?: string;
-  createdById: string;
+  actorId: string;
 };
 
 /**
@@ -114,7 +114,7 @@ export default class {
    * @param params.ownedById - the id of the account who owns the entity
    * @param params.entityTypeModel - the type of the entity
    * @param params.properties - the properties object of the entity
-   * @param params.createdById - the id of the account that is creating the entity
+   * @param params.actorId - the id of the account that is creating the entity
    * @param params.entityId (optional) - the id of the entity, is generated if left undefined
    */
   static async create(
@@ -125,7 +125,7 @@ export default class {
       ownedById,
       entityTypeModel,
       properties,
-      createdById,
+      actorId,
       entityId: overrideEntityId,
     } = params;
 
@@ -134,7 +134,7 @@ export default class {
       entityTypeId: entityTypeModel.schema.$id,
       entity: properties,
       entityId: overrideEntityId,
-      createdById,
+      createdById: actorId,
     });
 
     const persistedEntity: PersistedEntity = {
@@ -152,7 +152,7 @@ export default class {
    * @param params.entityTypeId - the id of the entity's type
    * @param params.entityProperties - the properties of the entity
    * @param params.linkedEntities (optional) - the linked entity definitions of the entity
-   * @param params.createdById - the id of the account that is creating the entity
+   * @param params.actorId - the id of the account that is creating the entity
    */
   static async createEntityWithLinks(
     graphApi: GraphApi,
@@ -161,10 +161,10 @@ export default class {
       entityTypeId: string;
       properties: any;
       linkedEntities?: PersistedLinkedEntityDefinition[];
-      createdById: string;
+      actorId: string;
     },
   ): Promise<EntityModel> {
-    const { ownedById, entityTypeId, properties, linkedEntities, createdById } =
+    const { ownedById, entityTypeId, properties, linkedEntities, actorId } =
       params;
 
     const entitiesInTree = linkedTreeFlatten<
@@ -199,7 +199,7 @@ export default class {
         entity: await EntityModel.getOrCreate(graphApi, {
           ownedById,
           entityDefinition: definition,
-          createdById,
+          actorId,
         }),
       })),
     );
@@ -232,7 +232,7 @@ export default class {
             targetEntityModel: entity,
             index: link.meta.index ?? undefined,
             ownedById,
-            createdById,
+            actorId,
           });
         }
       }),
@@ -254,10 +254,10 @@ export default class {
     params: {
       ownedById: string;
       entityDefinition: Omit<PersistedEntityDefinition, "linkedEntities">;
-      createdById: string;
+      actorId: string;
     },
   ): Promise<EntityModel> {
-    const { entityDefinition, ownedById, createdById } = params;
+    const { entityDefinition, ownedById, actorId } = params;
     const { entityProperties, existingEntity } = entityDefinition;
 
     let entity;
@@ -291,7 +291,7 @@ export default class {
         ownedById,
         entityTypeModel,
         properties: entityProperties,
-        createdById,
+        actorId,
       });
     } else {
       throw new Error(
@@ -370,20 +370,20 @@ export default class {
    * Update an entity.
    *
    * @param params.properties - the properties object of the entity
-   * @param params.updatedById - the id of the account that is updating the entity
+   * @param params.actorId - the id of the account that is updating the entity
    */
   async update(
     graphApi: GraphApi,
     params: {
       properties: object;
-      updatedById: string;
+      actorId: string;
     },
   ): Promise<EntityModel> {
-    const { properties, updatedById } = params;
+    const { properties, actorId } = params;
     const { entityId, entityTypeModel } = this;
 
     const { data: metadata } = await graphApi.updateEntity({
-      updatedById,
+      updatedById: actorId,
       entityId,
       /** @todo: make this argument optional */
       entityTypeId: entityTypeModel.schema.$id,
@@ -400,16 +400,16 @@ export default class {
    * Update multiple top-level properties on an entity.
    *
    * @param params.updatedProperties - an array of the properties being updated
-   * @param params.updatedById - the id of the account that is updating the entity
+   * @param params.actorId - the id of the account that is updating the entity
    */
   async updateProperties(
     graphApi: GraphApi,
     params: {
       updatedProperties: { propertyTypeBaseUri: string; value: any }[];
-      updatedById: string;
+      actorId: string;
     },
   ): Promise<EntityModel> {
-    const { updatedProperties, updatedById } = params;
+    const { updatedProperties, actorId } = params;
 
     return await this.update(graphApi, {
       properties: updatedProperties.reduce(
@@ -419,7 +419,7 @@ export default class {
         }),
         this.properties,
       ),
-      updatedById,
+      actorId,
     });
   }
 
@@ -428,21 +428,21 @@ export default class {
    *
    * @param params.propertyTypeBaseUri - the property type base URI of the property being updated
    * @param params.value - the updated value of the property
-   * @param params.updatedById - the id of the account that is updating the entity
+   * @param params.actorId - the id of the account that is updating the entity
    */
   async updateProperty(
     graphApi: GraphApi,
     params: {
       propertyTypeBaseUri: string;
       value: any;
-      updatedById: string;
+      actorId: string;
     },
   ): Promise<EntityModel> {
-    const { propertyTypeBaseUri, value, updatedById } = params;
+    const { propertyTypeBaseUri, value, actorId } = params;
 
     return await this.updateProperties(graphApi, {
       updatedProperties: [{ propertyTypeBaseUri, value }],
-      updatedById,
+      actorId,
     });
   }
 

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -134,7 +134,7 @@ export default class {
       entityTypeId: entityTypeModel.schema.$id,
       entity: properties,
       entityId: overrideEntityId,
-      createdById: actorId,
+      actorId,
     });
 
     const persistedEntity: PersistedEntity = {
@@ -383,7 +383,7 @@ export default class {
     const { entityId, entityTypeModel } = this;
 
     const { data: metadata } = await graphApi.updateEntity({
-      updatedById: actorId,
+      actorId,
       entityId,
       /** @todo: make this argument optional */
       entityTypeId: entityTypeModel.schema.$id,

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -111,7 +111,7 @@ export default class {
   /**
    * Create an entity.
    *
-   * @param params.ownedById - the id of the owner of the entity
+   * @param params.ownedById - the id of the account who owns the entity
    * @param params.entityTypeModel - the type of the entity
    * @param params.properties - the properties object of the entity
    * @param params.createdById - the id of the account that is creating the entity

--- a/packages/hash/api/src/model/knowledge/link.model.ts
+++ b/packages/hash/api/src/model/knowledge/link.model.ts
@@ -154,9 +154,9 @@ export default class {
    * @todo: deprecate this method when the Graph API handles updating the sibling indexes
    * @see https://app.asana.com/0/1200211978612931/1203031430417465/f
    *
-   * @param params.ownedById - the id of the owner of the new link
+   * @param params.ownedById - the id of the account who owns the new link
    * @param params.sourceEntityModel - the source entity of the link
-   * @param params.linkTypeModel - the Link Type of the link
+   * @param params.linkTypeModel - the link type of the link
    * @param params.targetEntityModel - the target entity of the link
    * @param params.createdById - the id of the account that is creating the link
    */
@@ -200,9 +200,9 @@ export default class {
    * Create a link between a source and a target entity using a specific link
    * type.
    *
-   * @param params.ownedById - the id of the owner of the new link
+   * @param params.ownedById - the id of the account who owns the new link
    * @param params.sourceEntityModel - the source entity of the link
-   * @param params.linkTypeModel - the Link Type of the link
+   * @param params.linkTypeModel - the link type of the link
    * @param params.targetEntityModel - the target entity of the link
    * @param params.createdById - the id of the account that is creating the link
    */
@@ -270,7 +270,7 @@ export default class {
    * @see https://app.asana.com/0/1200211978612931/1203031430417465/f
    *
    * @param params.updatedIndex - the updated index of the link
-   * @param params.updatedById - the id of the user that is updating the link
+   * @param params.updatedById - the id of the account that is updating the link
    */
   private async updateWithoutUpdatingSiblings(
     graphApi: GraphApi,
@@ -394,7 +394,7 @@ export default class {
    * @todo: deprecate this method when the Graph API handles updating the sibling indexes
    * @see https://app.asana.com/0/1200211978612931/1203031430417465/f
    *
-   * @param removedById - the id of the user removing the link
+   * @param removedById - the id of the account that is removing the link
    */
   async removeWithoutUpdatingSiblings(
     graphApi: GraphApi,
@@ -410,7 +410,7 @@ export default class {
   /**
    * Remove the link.
    *
-   * @param params.removedById - the id of the user removing the link
+   * @param params.removedById - the id of the account that is removing the link
    */
   async remove(
     graphApi: GraphApi,

--- a/packages/hash/api/src/model/knowledge/link.model.ts
+++ b/packages/hash/api/src/model/knowledge/link.model.ts
@@ -180,7 +180,7 @@ export default class {
         index,
         linkTypeId: linkTypeModel.schema.$id,
         targetEntityId: targetEntityModel.entityId,
-        createdById: actorId,
+        actorId,
       },
     );
 
@@ -401,7 +401,7 @@ export default class {
     await graphApi.removeLink(this.sourceEntityModel.entityId, {
       linkTypeId: this.linkTypeModel.schema.$id,
       targetEntityId: this.targetEntityModel.entityId,
-      removedById: actorId,
+      actorId,
     });
   }
 
@@ -415,7 +415,7 @@ export default class {
     await graphApi.removeLink(this.sourceEntityModel.entityId, {
       linkTypeId: this.linkTypeModel.schema.$id,
       targetEntityId: this.targetEntityModel.entityId,
-      removedById: actorId,
+      actorId,
     });
 
     /**

--- a/packages/hash/api/src/model/knowledge/link.model.ts
+++ b/packages/hash/api/src/model/knowledge/link.model.ts
@@ -20,6 +20,7 @@ export type LinkModelCreateParams = {
   sourceEntityModel: EntityModel;
   linkTypeModel: LinkTypeModel;
   targetEntityModel: EntityModel;
+  createdById: string;
 };
 
 /**
@@ -130,7 +131,7 @@ export default class {
 
     if (!linkModel) {
       throw new Error(
-        `Link with source enitty ID = '${sourceEntityId}', target entity ID = '${targetEntityId}' and link type ID = '${linkTypeId}' not found.`,
+        `Link with source entity ID = '${sourceEntityId}', target entity ID = '${targetEntityId}' and link type ID = '${linkTypeId}' not found.`,
       );
     } else if (linkModels.length > 1) {
       throw new Error(`Could not identify one single link with query.`);
@@ -146,10 +147,11 @@ export default class {
    * @todo: deprecate this method when the Graph API handles updating the sibling indexes
    * @see https://app.asana.com/0/1200211978612931/1203031430417465/f
    *
-   * @param params.ownedById the id of the owner of the new link
-   * @param params.sourceEntityModel the source entity of the link
-   * @param params.linkTypeModel the Link Type of the link
-   * @param params.targetEntityModel the target entity of the link
+   * @param params.ownedById - the id of the owner of the new link
+   * @param params.sourceEntityModel - the source entity of the link
+   * @param params.linkTypeModel - the Link Type of the link
+   * @param params.targetEntityModel - the target entity of the link
+   * @param params.createdById - the id of the account that is creating the link
    */
   private static async createLinkWithoutUpdatingSiblings(
     graphApi: GraphApi,
@@ -161,6 +163,7 @@ export default class {
       linkTypeModel,
       targetEntityModel,
       index,
+      createdById,
     } = params;
 
     const { data: link } = await graphApi.createLink(
@@ -170,6 +173,7 @@ export default class {
         index,
         linkTypeId: linkTypeModel.schema.$id,
         targetEntityId: targetEntityModel.entityId,
+        createdById,
       },
     );
 
@@ -177,9 +181,9 @@ export default class {
      * @todo: this should be returned directly from the `createLink` method
      * @see https://app.asana.com/0/1202805690238892/1203045933021776/f
      */
-    const persistedLink = {
+    const persistedLink: PersistedLink = {
       inner: link,
-      metadata: { ownedById },
+      metadata: { ownedById, createdById },
     };
 
     return LinkModel.fromPersistedLink(graphApi, persistedLink);
@@ -189,16 +193,17 @@ export default class {
    * Create a link between a source and a target entity using a specific link
    * type.
    *
-   * @param params.ownedById the id of the owner of the link
-   * @param params.sourceEntityModel the source entity of the link
-   * @param params.linkTypeModel the Link Type of the link
-   * @param params.targetEntityModel the target entity of the link
+   * @param params.ownedById - the id of the owner of the new link
+   * @param params.sourceEntityModel - the source entity of the link
+   * @param params.linkTypeModel - the Link Type of the link
+   * @param params.targetEntityModel - the target entity of the link
+   * @param params.createdById - the id of the account that is creating the link
    */
   static async create(
     graphApi: GraphApi,
     params: LinkModelCreateParams,
   ): Promise<LinkModel> {
-    const { sourceEntityModel, linkTypeModel, ownedById } = params;
+    const { sourceEntityModel, linkTypeModel, createdById } = params;
     const siblingLinks = await sourceEntityModel.getOutgoingLinks(graphApi, {
       linkTypeModel,
     });
@@ -239,11 +244,7 @@ export default class {
           .map((sibling) =>
             sibling.updateWithoutUpdatingSiblings(graphApi, {
               updatedIndex: sibling.index! + 1,
-              /**
-               * @todo: don't assume the owner of the new link is the user that's responsible for creating it.
-               * Related to https://app.asana.com/0/1200211978612931/1202848989198291/f
-               */
-              updatedById: ownedById,
+              updatedById: createdById,
             }),
           ),
       );
@@ -262,7 +263,7 @@ export default class {
    * @see https://app.asana.com/0/1200211978612931/1203031430417465/f
    *
    * @param params.updatedIndex - the updated index of the link
-   * @param params.updatedbyId - the id of the user that is updating the link
+   * @param params.updatedById - the id of the user that is updating the link
    */
   private async updateWithoutUpdatingSiblings(
     graphApi: GraphApi,
@@ -299,6 +300,7 @@ export default class {
         linkTypeModel,
         targetEntityModel,
         index: updatedIndex,
+        createdById: updatedById,
       },
     );
 
@@ -309,7 +311,7 @@ export default class {
    * Update the link
    *
    * @param params.updatedIndex - the updated index of the link
-   * @param params.updatedbyId - the account updating the link
+   * @param params.updatedById - the id of the account updating the link
    */
   async update(
     graphApi: GraphApi,
@@ -401,12 +403,13 @@ export default class {
   /**
    * Remove the link.
    *
-   * @param removedbyId - the id of the user removing the link
+   * @param params.removedById - the id of the user removing the link
    */
   async remove(
     graphApi: GraphApi,
-    { removedById }: { removedById: string },
+    params: { removedById: string },
   ): Promise<void> {
+    const { removedById } = params;
     await graphApi.removeLink(this.sourceEntityModel.entityId, {
       linkTypeId: this.linkTypeModel.schema.$id,
       targetEntityId: this.targetEntityModel.entityId,

--- a/packages/hash/api/src/model/knowledge/link.model.ts
+++ b/packages/hash/api/src/model/knowledge/link.model.ts
@@ -12,6 +12,7 @@ export type LinkModelConstructorParams = {
   sourceEntityModel: EntityModel;
   linkTypeModel: LinkTypeModel;
   targetEntityModel: EntityModel;
+  createdById: string;
 };
 
 export type LinkModelCreateParams = {
@@ -35,12 +36,15 @@ export default class {
   linkTypeModel: LinkTypeModel;
   targetEntityModel: EntityModel;
 
+  createdById: string;
+
   constructor({
     ownedById,
     index,
     sourceEntityModel,
     linkTypeModel,
     targetEntityModel,
+    createdById,
   }: LinkModelConstructorParams) {
     this.ownedById = ownedById;
     this.index = index;
@@ -48,12 +52,14 @@ export default class {
     this.sourceEntityModel = sourceEntityModel;
     this.linkTypeModel = linkTypeModel;
     this.targetEntityModel = targetEntityModel;
+
+    this.createdById = createdById;
   }
 
   static async fromPersistedLink(
     graphApi: GraphApi,
     {
-      metadata: { ownedById },
+      metadata: { ownedById, createdById },
       inner: { sourceEntityId, targetEntityId, linkTypeId, index },
     }: PersistedLink,
   ): Promise<LinkModel> {
@@ -70,6 +76,7 @@ export default class {
       sourceEntityModel,
       linkTypeModel,
       targetEntityModel,
+      createdById,
     });
   }
 

--- a/packages/hash/api/src/model/knowledge/org.model.ts
+++ b/packages/hash/api/src/model/knowledge/org.model.ts
@@ -47,7 +47,7 @@ export default class extends EntityModel {
    * @see {@link EntityModel.create} for the remaining params
    */
   static async createOrg(graphApi: GraphApi, params: OrgModelCreateParams) {
-    const { shortname, name, providedInfo } = params;
+    const { shortname, name, providedInfo, createdById } = params;
 
     const { data: orgAccountId } = await graphApi.createAccountId();
 
@@ -69,6 +69,7 @@ export default class extends EntityModel {
       properties,
       entityTypeModel,
       entityId: orgAccountId,
+      createdById,
     });
 
     return OrgModel.fromEntityModel(entity);
@@ -142,12 +143,13 @@ export default class extends EntityModel {
    * Update the shortname of an Organization
    *
    * @param params.updatedShortname - the new shortname to assign to the Organization
+   * @param params.updatedById - the id of the account updating the shortname
    */
   async updateShortname(
     graphApi: GraphApi,
-    params: { updatedShortname: string },
+    params: { updatedShortname: string; updatedById: string },
   ): Promise<OrgModel> {
-    const { updatedShortname } = params;
+    const { updatedShortname, updatedById } = params;
 
     if (AccountFields.shortnameIsInvalid(updatedShortname)) {
       throw new Error(`The shortname "${updatedShortname}" is invalid`);
@@ -167,6 +169,7 @@ export default class extends EntityModel {
     return await this.updateProperty(graphApi, {
       propertyTypeBaseUri: WORKSPACE_TYPES.propertyType.shortName.baseUri,
       value: updatedShortname,
+      updatedById,
     }).then((updatedEntity) => new OrgModel(updatedEntity));
   }
 
@@ -184,9 +187,13 @@ export default class extends EntityModel {
    * Update the name of an Organization
    *
    * @param params.updatedOrgName - the new name to assign to the Organization
+   * @param params.updatedById - the id of the account updating the name
    */
-  async updateOrgName(graphApi: GraphApi, params: { updatedOrgName: string }) {
-    const { updatedOrgName } = params;
+  async updateOrgName(
+    graphApi: GraphApi,
+    params: { updatedOrgName: string; updatedById: string },
+  ) {
+    const { updatedOrgName, updatedById } = params;
 
     if (OrgModel.orgNameIsInvalid(updatedOrgName)) {
       throw new Error(`Organization name "${updatedOrgName}" is invalid.`);
@@ -195,6 +202,7 @@ export default class extends EntityModel {
     const updatedEntity = await this.updateProperty(graphApi, {
       propertyTypeBaseUri: WORKSPACE_TYPES.propertyType.orgName.baseUri,
       value: updatedOrgName,
+      updatedById,
     });
 
     return OrgModel.fromEntityModel(updatedEntity);

--- a/packages/hash/api/src/model/knowledge/org.model.ts
+++ b/packages/hash/api/src/model/knowledge/org.model.ts
@@ -47,7 +47,7 @@ export default class extends EntityModel {
    * @see {@link EntityModel.create} for the remaining params
    */
   static async createOrg(graphApi: GraphApi, params: OrgModelCreateParams) {
-    const { shortname, name, providedInfo, createdById } = params;
+    const { shortname, name, providedInfo, actorId } = params;
 
     const { data: orgAccountId } = await graphApi.createAccountId();
 
@@ -69,7 +69,7 @@ export default class extends EntityModel {
       properties,
       entityTypeModel,
       entityId: orgAccountId,
-      createdById,
+      actorId,
     });
 
     return OrgModel.fromEntityModel(entity);
@@ -143,13 +143,13 @@ export default class extends EntityModel {
    * Update the shortname of an Organization
    *
    * @param params.updatedShortname - the new shortname to assign to the Organization
-   * @param params.updatedById - the id of the account updating the shortname
+   * @param params.actorId - the id of the account updating the shortname
    */
   async updateShortname(
     graphApi: GraphApi,
-    params: { updatedShortname: string; updatedById: string },
+    params: { updatedShortname: string; actorId: string },
   ): Promise<OrgModel> {
-    const { updatedShortname, updatedById } = params;
+    const { updatedShortname, actorId } = params;
 
     if (AccountFields.shortnameIsInvalid(updatedShortname)) {
       throw new Error(`The shortname "${updatedShortname}" is invalid`);
@@ -169,7 +169,7 @@ export default class extends EntityModel {
     return await this.updateProperty(graphApi, {
       propertyTypeBaseUri: WORKSPACE_TYPES.propertyType.shortName.baseUri,
       value: updatedShortname,
-      updatedById,
+      actorId,
     }).then((updatedEntity) => new OrgModel(updatedEntity));
   }
 
@@ -187,13 +187,13 @@ export default class extends EntityModel {
    * Update the name of an Organization
    *
    * @param params.updatedOrgName - the new name to assign to the Organization
-   * @param params.updatedById - the id of the account updating the name
+   * @param params.actorId - the id of the account updating the name
    */
   async updateOrgName(
     graphApi: GraphApi,
-    params: { updatedOrgName: string; updatedById: string },
+    params: { updatedOrgName: string; actorId: string },
   ) {
-    const { updatedOrgName, updatedById } = params;
+    const { updatedOrgName, actorId } = params;
 
     if (OrgModel.orgNameIsInvalid(updatedOrgName)) {
       throw new Error(`Organization name "${updatedOrgName}" is invalid.`);
@@ -202,7 +202,7 @@ export default class extends EntityModel {
     const updatedEntity = await this.updateProperty(graphApi, {
       propertyTypeBaseUri: WORKSPACE_TYPES.propertyType.orgName.baseUri,
       value: updatedOrgName,
-      updatedById,
+      actorId,
     });
 
     return OrgModel.fromEntityModel(updatedEntity);

--- a/packages/hash/api/src/model/knowledge/orgMembership.model.ts
+++ b/packages/hash/api/src/model/knowledge/orgMembership.model.ts
@@ -45,7 +45,7 @@ export default class extends EntityModel {
     graphApi: GraphApi,
     params: OrgMembershipModelCreateParams,
   ) {
-    const { responsibility, org, createdById } = params;
+    const { responsibility, org, actorId } = params;
 
     const properties: object = {
       [WORKSPACE_TYPES.propertyType.responsibility.baseUri]: responsibility,
@@ -57,14 +57,14 @@ export default class extends EntityModel {
       ownedById: workspaceAccountId,
       properties,
       entityTypeModel,
-      createdById,
+      actorId,
     });
 
     await entity.createOutgoingLink(graphApi, {
       linkTypeModel: WORKSPACE_TYPES.linkType.ofOrg,
       targetEntityModel: org,
       ownedById: workspaceAccountId,
-      createdById,
+      actorId,
     });
 
     return OrgMembershipModel.fromEntityModel(entity);

--- a/packages/hash/api/src/model/knowledge/orgMembership.model.ts
+++ b/packages/hash/api/src/model/knowledge/orgMembership.model.ts
@@ -45,7 +45,7 @@ export default class extends EntityModel {
     graphApi: GraphApi,
     params: OrgMembershipModelCreateParams,
   ) {
-    const { responsibility, org } = params;
+    const { responsibility, org, createdById } = params;
 
     const properties: object = {
       [WORKSPACE_TYPES.propertyType.responsibility.baseUri]: responsibility,
@@ -57,12 +57,14 @@ export default class extends EntityModel {
       ownedById: workspaceAccountId,
       properties,
       entityTypeModel,
+      createdById,
     });
 
     await entity.createOutgoingLink(graphApi, {
       linkTypeModel: WORKSPACE_TYPES.linkType.ofOrg,
       targetEntityModel: org,
       ownedById: workspaceAccountId,
+      createdById,
     });
 
     return OrgMembershipModel.fromEntityModel(entity);

--- a/packages/hash/api/src/model/knowledge/page.model.ts
+++ b/packages/hash/api/src/model/knowledge/page.model.ts
@@ -431,7 +431,7 @@ export default class extends EntityModel {
    *
    * @param params.currentPosition - the current position of the block being moved
    * @param params.newPosition - the new position of the block being moved
-   * @param params.movedById - the id of the user that is moving the block
+   * @param params.movedById - the id of the account that is moving the block
    */
   async moveBlock(
     graphApi: GraphApi,
@@ -476,7 +476,7 @@ export default class extends EntityModel {
    * Remove a block from the page.
    *
    * @param params.position - the position of the block being removed
-   * @param params.removedById - the id of the user that is removing the block
+   * @param params.removedById - the id of the account that is removing the block
    * @param params.allowRemovingFinal (optional) - whether or not removing the final block in the page should be permitted (defaults to `true`)
    */
   async removeBlock(

--- a/packages/hash/api/src/model/knowledge/user.model.ts
+++ b/packages/hash/api/src/model/knowledge/user.model.ts
@@ -134,7 +134,7 @@ export default class extends EntityModel {
     graphApi: GraphApi,
     params: UserModelCreateParams,
   ): Promise<UserModel> {
-    const { emails, kratosIdentityId, createdById } = params;
+    const { emails, kratosIdentityId, actorId } = params;
 
     const existingUserWithKratosIdentityId =
       await UserModel.getUserByKratosIdentityId(graphApi, {
@@ -163,7 +163,7 @@ export default class extends EntityModel {
       properties,
       entityTypeModel,
       entityId: userAccountId,
-      createdById,
+      actorId,
     });
 
     return UserModel.fromEntityModel(entity);
@@ -256,13 +256,13 @@ export default class extends EntityModel {
    * Update the shortname of a User.
    *
    * @param params.updatedShortname - the new shortname to assign to the User
-   * @param params.updatedById - the id of the account that is updating the shortname
+   * @param params.actorId - the id of the account that is updating the shortname
    */
   async updateShortname(
     graphApi: GraphApi,
-    params: { updatedShortname: string; updatedById: string },
+    params: { updatedShortname: string; actorId: string },
   ): Promise<UserModel> {
-    const { updatedShortname, updatedById } = params;
+    const { updatedShortname, actorId } = params;
 
     if (AccountFields.shortnameIsInvalid(updatedShortname)) {
       throw new Error(`The shortname "${updatedShortname}" is invalid`);
@@ -284,7 +284,7 @@ export default class extends EntityModel {
     const updatedUser = await this.updateProperty(graphApi, {
       propertyTypeBaseUri: WORKSPACE_TYPES.propertyType.shortName.baseUri,
       value: updatedShortname,
-      updatedById,
+      actorId,
     }).then((updatedEntity) => new UserModel(updatedEntity));
 
     await this.updateKratosIdentityTraits({
@@ -294,7 +294,7 @@ export default class extends EntityModel {
       await this.updateProperty(graphApi, {
         propertyTypeBaseUri: WORKSPACE_TYPES.propertyType.shortName.baseUri,
         value: previousShortname,
-        updatedById,
+        actorId,
       });
 
       return Promise.reject(error);
@@ -317,13 +317,13 @@ export default class extends EntityModel {
    * Update the preferred name of a User.
    *
    * @param params.updatedPreferredName - the new preferred name to assign to the User
-   * @param params.updatedById - the id of the account that is updating the preferred name
+   * @param params.actorId - the id of the account that is updating the preferred name
    */
   async updatePreferredName(
     graphApi: GraphApi,
-    params: { updatedPreferredName: string; updatedById: string },
+    params: { updatedPreferredName: string; actorId: string },
   ) {
-    const { updatedPreferredName, updatedById } = params;
+    const { updatedPreferredName, actorId } = params;
 
     if (UserModel.preferredNameIsInvalid(updatedPreferredName)) {
       throw new Error(`Preferred name "${updatedPreferredName}" is invalid.`);
@@ -332,7 +332,7 @@ export default class extends EntityModel {
     const updatedEntity = await this.updateProperty(graphApi, {
       propertyTypeBaseUri: WORKSPACE_TYPES.propertyType.preferredName.baseUri,
       value: updatedPreferredName,
-      updatedById,
+      actorId,
     });
 
     return new UserModel(updatedEntity);
@@ -363,28 +363,28 @@ export default class extends EntityModel {
    *
    * @param params.org - the organization the user is joining
    * @param params.responsibility - the responsibility of the user at the organization
-   * @param params.joinedById - the id of the account that is making the user a member of the organization
+   * @param params.actorId - the id of the account that is making the user a member of the organization
    */
   async joinOrg(
     graphApi: GraphApi,
     params: {
       org: OrgModel;
       responsibility: string;
-      joinedById: string;
+      actorId: string;
     },
   ) {
-    const { org, responsibility, joinedById } = params;
+    const { org, responsibility, actorId } = params;
 
     const orgMembership = await OrgMembershipModel.createOrgMembership(
       graphApi,
-      { responsibility, org, createdById: joinedById },
+      { responsibility, org, actorId },
     );
 
     await this.createOutgoingLink(graphApi, {
       linkTypeModel: WORKSPACE_TYPES.linkType.hasMembership,
       targetEntityModel: orgMembership,
       ownedById: workspaceAccountId,
-      createdById: joinedById,
+      actorId,
     });
   }
 

--- a/packages/hash/api/src/model/knowledge/user.model.ts
+++ b/packages/hash/api/src/model/knowledge/user.model.ts
@@ -362,7 +362,7 @@ export default class extends EntityModel {
    * Make the user a member of an organization.
    *
    * @param params.org - the organization the user is joining
-   * @param params.responsibility - the responsibility fo the user at the organization
+   * @param params.responsibility - the responsibility of the user at the organization
    * @param params.joinedById - the id of the account that is making the user a member of the organization
    */
   async joinOrg(

--- a/packages/hash/api/src/model/ontology/data-type.model.ts
+++ b/packages/hash/api/src/model/ontology/data-type.model.ts
@@ -13,6 +13,9 @@ import { getNamespaceOfAccountOwner } from "./util";
 type DataTypeModelConstructorArgs = {
   ownedById: string;
   schema: DataType;
+  createdById: string;
+  updatedById: string;
+  removedById?: string;
 };
 
 /**
@@ -23,14 +26,28 @@ export default class {
 
   schema: DataType;
 
-  constructor({ schema, ownedById }: DataTypeModelConstructorArgs) {
+  createdById: string;
+  updatedById: string;
+  removedById?: string;
+
+  constructor({
+    schema,
+    ownedById,
+    createdById,
+    updatedById,
+    removedById,
+  }: DataTypeModelConstructorArgs) {
     this.ownedById = ownedById;
     this.schema = schema;
+
+    this.createdById = createdById;
+    this.updatedById = updatedById;
+    this.removedById = removedById;
   }
 
   static fromPersistedDataType({
     inner,
-    metadata: { identifier },
+    metadata: { identifier, createdById, updatedById, removedById },
   }: PersistedDataType): DataTypeModel {
     /**
      * @todo and a warning, these type casts are here to compensate for
@@ -46,6 +63,9 @@ export default class {
     return new DataTypeModel({
       schema: inner as DataType,
       ownedById: identifier.ownedById,
+      createdById,
+      updatedById,
+      removedById,
     });
   }
 
@@ -100,11 +120,9 @@ export default class {
         );
       });
 
-    const { identifier } = metadata;
-
-    return new DataTypeModel({
-      schema: fullDataType,
-      ownedById: identifier.ownedById,
+    return DataTypeModel.fromPersistedDataType({
+      inner: fullDataType,
+      metadata,
     });
   }
 
@@ -160,9 +178,9 @@ export default class {
 
     const { identifier } = metadata;
 
-    return new DataTypeModel({
-      schema: { ...schema, $id: identifier.uri },
-      ownedById: identifier.ownedById,
+    return DataTypeModel.fromPersistedDataType({
+      inner: { ...schema, $id: identifier.uri },
+      metadata,
     });
   }
 }

--- a/packages/hash/api/src/model/ontology/data-type.model.ts
+++ b/packages/hash/api/src/model/ontology/data-type.model.ts
@@ -78,7 +78,7 @@ export default class {
    *   Depends on the RFC captured by:
    *   https://app.asana.com/0/1200211978612931/1202464168422955/f
    *
-   * @param params.ownedById - the id of the owner of the data type
+   * @param params.ownedById - the id of the account who owns the data type
    * @param params.schema - the `DataType`
    * @param params.createdById - the id of the account that is creating the data type
    */

--- a/packages/hash/api/src/model/ontology/data-type.model.ts
+++ b/packages/hash/api/src/model/ontology/data-type.model.ts
@@ -80,7 +80,7 @@ export default class {
    *
    * @param params.ownedById - the id of the account who owns the data type
    * @param params.schema - the `DataType`
-   * @param params.createdById - the id of the account that is creating the data type
+   * @param params.actorId - the id of the account that is creating the data type
    */
   static async create(
     graphApi: GraphApi,
@@ -91,10 +91,10 @@ export default class {
       //  this is needed for as long as DataType extends Record
       schema: Pick<DataType, "kind" | "title" | "description" | "type"> &
         Record<string, any>;
-      createdById: string;
+      actorId: string;
     },
   ): Promise<DataTypeModel> {
-    const { ownedById, createdById } = params;
+    const { ownedById, actorId } = params;
     const namespace = await getNamespaceOfAccountOwner(graphApi, {
       ownerId: params.ownedById,
     });
@@ -110,7 +110,7 @@ export default class {
       .createDataType({
         schema: fullDataType,
         ownedById,
-        createdById,
+        createdById: actorId,
       })
       .catch((err: AxiosError) => {
         throw new Error(
@@ -153,7 +153,7 @@ export default class {
    *   https://app.asana.com/0/1200211978612931/1202464168422955/f
    *
    * @param params.schema - the updated `DataType`
-   * @param params.updatedById - the id of the account that is updating the data type
+   * @param params.actorId - the id of the account that is updating the data type
    */
   async update(
     graphApi: GraphApi,
@@ -163,13 +163,13 @@ export default class {
       //  this is needed for as long as DataType extends Record
       schema: Pick<DataType, "kind" | "title" | "description" | "type"> &
         Record<string, any>;
-      updatedById: string;
+      actorId: string;
     },
   ): Promise<DataTypeModel> {
-    const { schema, updatedById } = params;
+    const { schema, actorId } = params;
 
     const updateArguments: UpdateDataTypeRequest = {
-      updatedById,
+      updatedById: actorId,
       typeToUpdate: this.schema.$id,
       schema,
     };

--- a/packages/hash/api/src/model/ontology/data-type.model.ts
+++ b/packages/hash/api/src/model/ontology/data-type.model.ts
@@ -110,7 +110,7 @@ export default class {
       .createDataType({
         schema: fullDataType,
         ownedById,
-        createdById: actorId,
+        actorId,
       })
       .catch((err: AxiosError) => {
         throw new Error(
@@ -169,7 +169,7 @@ export default class {
     const { schema, actorId } = params;
 
     const updateArguments: UpdateDataTypeRequest = {
-      updatedById: actorId,
+      actorId,
       typeToUpdate: this.schema.$id,
       schema,
     };

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -86,7 +86,7 @@ export default class {
   /**
    * Create an entity type.
    *
-   * @param params.ownedById - the id of the owner of the entity type
+   * @param params.ownedById - the id of the account who owns the entity type
    * @param params.schema - the `EntityType`
    * @param params.createdById - the id of the account that is creating the entity type
    */

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -21,6 +21,9 @@ import { WORKSPACE_TYPES } from "../../graph/workspace-types";
 export type EntityTypeModelConstructorParams = {
   ownedById: string;
   schema: EntityType;
+  createdById: string;
+  updatedById: string;
+  removedById?: string;
 };
 
 export type EntityTypeModelCreateParams = {
@@ -37,14 +40,28 @@ export default class {
 
   schema: EntityType;
 
-  constructor({ schema, ownedById }: EntityTypeModelConstructorParams) {
+  createdById: string;
+  updatedById: string;
+  removedById?: string;
+
+  constructor({
+    schema,
+    ownedById,
+    createdById,
+    updatedById,
+    removedById,
+  }: EntityTypeModelConstructorParams) {
     this.ownedById = ownedById;
     this.schema = schema;
+
+    this.createdById = createdById;
+    this.updatedById = updatedById;
+    this.removedById = removedById;
   }
 
   static fromPersistedEntityType({
     inner,
-    metadata: { identifier },
+    metadata: { identifier, createdById, updatedById, removedById },
   }: PersistedEntityType): EntityTypeModel {
     /**
      * @todo and a warning, these type casts are here to compensate for
@@ -60,6 +77,9 @@ export default class {
     return new EntityTypeModel({
       schema: inner as EntityType,
       ownedById: identifier.ownedById,
+      createdById,
+      updatedById,
+      removedById,
     });
   }
 
@@ -100,11 +120,9 @@ export default class {
         );
       });
 
-    const { identifier } = metadata;
-
-    return new EntityTypeModel({
-      schema: fullEntityType,
-      ownedById: identifier.ownedById,
+    return EntityTypeModel.fromPersistedEntityType({
+      inner: fullEntityType,
+      metadata,
     });
   }
 
@@ -298,9 +316,9 @@ export default class {
 
     const { identifier } = metadata;
 
-    return new EntityTypeModel({
-      schema: { ...schema, $id: identifier.uri },
-      ownedById: identifier.ownedById,
+    return EntityTypeModel.fromPersistedEntityType({
+      inner: { ...schema, $id: identifier.uri },
+      metadata,
     });
   }
 

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -108,7 +108,7 @@ export default class {
 
     const { data: metadata } = await graphApi
       .createEntityType({
-        createdById: actorId,
+        actorId,
         ownedById,
         schema: fullEntityType,
       })
@@ -307,7 +307,7 @@ export default class {
   ): Promise<EntityTypeModel> {
     const { schema, actorId } = params;
     const updateArguments: UpdateEntityTypeRequest = {
-      updatedById: actorId,
+      actorId,
       typeToUpdate: this.schema.$id,
       schema,
     };

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -26,6 +26,7 @@ export type EntityTypeModelConstructorParams = {
 export type EntityTypeModelCreateParams = {
   ownedById: string;
   schema: Omit<EntityType, "$id">;
+  createdById: string;
 };
 
 /**
@@ -67,11 +68,13 @@ export default class {
    *
    * @param params.ownedById - the id of the owner of the entity type
    * @param params.schema - the `EntityType`
+   * @param params.createdById - the id of the account that is creating the entity type
    */
   static async create(
     graphApi: GraphApi,
     params: EntityTypeModelCreateParams,
   ): Promise<EntityTypeModel> {
+    const { ownedById, createdById } = params;
     const namespace = await getNamespaceOfAccountOwner(graphApi, {
       ownerId: params.ownedById,
     });
@@ -85,11 +88,8 @@ export default class {
 
     const { data: metadata } = await graphApi
       .createEntityType({
-        /**
-         * @todo: replace uses of `accountId` with `ownedById` in the Graph API
-         * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
-         */
-        accountId: params.ownedById,
+        createdById,
+        ownedById,
         schema: fullEntityType,
       })
       .catch((err: AxiosError) => {
@@ -277,24 +277,19 @@ export default class {
   /**
    * Update an entity type.
    *
-   * @param params.schema an `EntityType`
+   * @param params.schema - the updated `EntityType`
+   * @param params.updatedById - the id of the account that is updating the entity type
    */
   async update(
     graphApi: GraphApi,
     params: {
       schema: Omit<EntityType, "$id">;
+      updatedById: string;
     },
   ): Promise<EntityTypeModel> {
-    const { schema } = params;
+    const { schema, updatedById } = params;
     const updateArguments: UpdateEntityTypeRequest = {
-      /**
-       * @todo: let caller update who owns the type, or create new method dedicated to changing the owner of the type
-       * @see https://app.asana.com/0/1202805690238892/1203063463721793/f
-       *
-       * @todo: replace uses of `accountId` with `ownedById` in the Graph API
-       * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
-       */
-      accountId: this.ownedById,
+      updatedById,
       typeToUpdate: this.schema.$id,
       schema,
     };

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -29,7 +29,7 @@ export type EntityTypeModelConstructorParams = {
 export type EntityTypeModelCreateParams = {
   ownedById: string;
   schema: Omit<EntityType, "$id">;
-  createdById: string;
+  actorId: string;
 };
 
 /**
@@ -88,13 +88,13 @@ export default class {
    *
    * @param params.ownedById - the id of the account who owns the entity type
    * @param params.schema - the `EntityType`
-   * @param params.createdById - the id of the account that is creating the entity type
+   * @param params.actorId - the id of the account that is creating the entity type
    */
   static async create(
     graphApi: GraphApi,
     params: EntityTypeModelCreateParams,
   ): Promise<EntityTypeModel> {
-    const { ownedById, createdById } = params;
+    const { ownedById, actorId } = params;
     const namespace = await getNamespaceOfAccountOwner(graphApi, {
       ownerId: params.ownedById,
     });
@@ -108,7 +108,7 @@ export default class {
 
     const { data: metadata } = await graphApi
       .createEntityType({
-        createdById,
+        createdById: actorId,
         ownedById,
         schema: fullEntityType,
       })
@@ -296,18 +296,18 @@ export default class {
    * Update an entity type.
    *
    * @param params.schema - the updated `EntityType`
-   * @param params.updatedById - the id of the account that is updating the entity type
+   * @param params.actorId - the id of the account that is updating the entity type
    */
   async update(
     graphApi: GraphApi,
     params: {
       schema: Omit<EntityType, "$id">;
-      updatedById: string;
+      actorId: string;
     },
   ): Promise<EntityTypeModel> {
-    const { schema, updatedById } = params;
+    const { schema, actorId } = params;
     const updateArguments: UpdateEntityTypeRequest = {
-      updatedById,
+      updatedById: actorId,
       typeToUpdate: this.schema.$id,
       schema,
     };

--- a/packages/hash/api/src/model/ontology/link-type.model.ts
+++ b/packages/hash/api/src/model/ontology/link-type.model.ts
@@ -99,7 +99,7 @@ export default class {
       .createLinkType({
         schema: fullLinkType,
         ownedById,
-        createdById: actorId,
+        actorId,
       })
       .catch((err: AxiosError) => {
         throw new Error(
@@ -164,7 +164,7 @@ export default class {
     const updateArguments: UpdateLinkTypeRequest = {
       typeToUpdate: this.schema.$id,
       schema,
-      updatedById: actorId,
+      actorId,
     };
 
     const { data: metadata } = await graphApi.updateLinkType(updateArguments);

--- a/packages/hash/api/src/model/ontology/link-type.model.ts
+++ b/packages/hash/api/src/model/ontology/link-type.model.ts
@@ -71,18 +71,19 @@ export default class {
   /**
    * Create a link type.
    *
-   * @param params.ownedById the id of the owner creating the link type
-   * @param params.schema a `LinkType`
+   * @param params.ownedById - the id of the account who owns the link type
+   * @param params.schema - the `LinkType`
+   * @param params.actorId - the id of the account that is creating the link type
    */
   static async create(
     graphApi: GraphApi,
     params: {
       ownedById: string;
       schema: Omit<LinkType, "$id">;
-      createdById: string;
+      actorId: string;
     },
   ): Promise<LinkTypeModel> {
-    const { ownedById, createdById } = params;
+    const { ownedById, actorId } = params;
     const namespace = await getNamespaceOfAccountOwner(graphApi, {
       ownerId: ownedById,
     });
@@ -98,7 +99,7 @@ export default class {
       .createLinkType({
         schema: fullLinkType,
         ownedById,
-        createdById,
+        createdById: actorId,
       })
       .catch((err: AxiosError) => {
         throw new Error(
@@ -150,20 +151,20 @@ export default class {
    * Update a link type.
    *
    * @param params.schema - the updated `LinkType`
-   * @param params.updatedById - the id of the account that is updating the link type
+   * @param params.actorId - the id of the account that is updating the link type
    */
   async update(
     graphApi: GraphApi,
     params: {
       schema: Omit<LinkType, "$id">;
-      updatedById: string;
+      actorId: string;
     },
   ): Promise<LinkTypeModel> {
-    const { schema, updatedById } = params;
+    const { schema, actorId } = params;
     const updateArguments: UpdateLinkTypeRequest = {
       typeToUpdate: this.schema.$id,
       schema,
-      updatedById,
+      updatedById: actorId,
     };
 
     const { data: metadata } = await graphApi.updateLinkType(updateArguments);

--- a/packages/hash/api/src/model/ontology/link-type.model.ts
+++ b/packages/hash/api/src/model/ontology/link-type.model.ts
@@ -13,6 +13,9 @@ import { getNamespaceOfAccountOwner } from "./util";
 type LinkTypeModelConstructorParams = {
   ownedById: string;
   schema: LinkType;
+  createdById: string;
+  updatedById: string;
+  removedById?: string;
 };
 
 /**
@@ -23,14 +26,27 @@ export default class {
 
   schema: LinkType;
 
-  constructor({ schema, ownedById }: LinkTypeModelConstructorParams) {
+  createdById: string;
+  updatedById: string;
+  removedById?: string;
+
+  constructor({
+    schema,
+    ownedById,
+    createdById,
+    updatedById,
+    removedById,
+  }: LinkTypeModelConstructorParams) {
     this.ownedById = ownedById;
     this.schema = schema;
+    this.createdById = createdById;
+    this.updatedById = updatedById;
+    this.removedById = removedById;
   }
 
   static fromPersistedLinkType({
     inner,
-    metadata: { identifier },
+    metadata: { identifier, createdById, updatedById, removedById },
   }: PersistedLinkType): LinkTypeModel {
     /**
      * @todo and a warning, these type casts are here to compensate for
@@ -46,6 +62,9 @@ export default class {
     return new LinkTypeModel({
       schema: inner as LinkType,
       ownedById: identifier.ownedById,
+      createdById,
+      updatedById,
+      removedById,
     });
   }
 
@@ -89,11 +108,9 @@ export default class {
         );
       });
 
-    const { identifier } = metadata;
-
-    return new LinkTypeModel({
-      schema: fullLinkType,
-      ownedById: identifier.ownedById,
+    return LinkTypeModel.fromPersistedLinkType({
+      inner: fullLinkType,
+      metadata,
     });
   }
 
@@ -151,11 +168,9 @@ export default class {
 
     const { data: metadata } = await graphApi.updateLinkType(updateArguments);
 
-    const { identifier } = metadata;
-
-    return new LinkTypeModel({
-      schema: { ...schema, $id: identifier.uri },
-      ownedById: identifier.ownedById,
+    return LinkTypeModel.fromPersistedLinkType({
+      inner: { ...schema, $id: metadata.identifier.uri },
+      metadata,
     });
   }
 }

--- a/packages/hash/api/src/model/ontology/link-type.model.ts
+++ b/packages/hash/api/src/model/ontology/link-type.model.ts
@@ -60,10 +60,12 @@ export default class {
     params: {
       ownedById: string;
       schema: Omit<LinkType, "$id">;
+      createdById: string;
     },
   ): Promise<LinkTypeModel> {
+    const { ownedById, createdById } = params;
     const namespace = await getNamespaceOfAccountOwner(graphApi, {
-      ownerId: params.ownedById,
+      ownerId: ownedById,
     });
 
     const linkTypeId = generateTypeId({
@@ -75,12 +77,9 @@ export default class {
 
     const { data: metadata } = await graphApi
       .createLinkType({
-        /**
-         * @todo: replace uses of `accountId` with `ownedById` in the Graph API
-         * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
-         */
-        accountId: params.ownedById,
         schema: fullLinkType,
+        ownedById,
+        createdById,
       })
       .catch((err: AxiosError) => {
         throw new Error(
@@ -133,26 +132,21 @@ export default class {
   /**
    * Update a link type.
    *
-   * @param params.schema a `LinkType`
+   * @param params.schema - the updated `LinkType`
+   * @param params.updatedById - the id of the account that is updating the link type
    */
   async update(
     graphApi: GraphApi,
     params: {
       schema: Omit<LinkType, "$id">;
+      updatedById: string;
     },
   ): Promise<LinkTypeModel> {
-    const { schema } = params;
+    const { schema, updatedById } = params;
     const updateArguments: UpdateLinkTypeRequest = {
-      /**
-       * @todo: let caller update who owns the type, or create new method dedicated to changing the owner of the type
-       * @see https://app.asana.com/0/1202805690238892/1203063463721793/f
-       *
-       * @todo: replace uses of `accountId` with `ownedById` in the Graph API
-       * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
-       */
-      accountId: this.ownedById,
       typeToUpdate: this.schema.$id,
       schema,
+      updatedById,
     };
 
     const { data: metadata } = await graphApi.updateLinkType(updateArguments);

--- a/packages/hash/api/src/model/ontology/property-type.model.ts
+++ b/packages/hash/api/src/model/ontology/property-type.model.ts
@@ -53,18 +53,22 @@ export default class {
   /**
    * Create a property type.
    *
-   * @param params.ownedById the id of the owner of the property type
-   * @param params.schema a `PropertyType`
+   * @param params.ownedById - the id of the owner of the property type
+   * @param params.schema - the `PropertyType`
+   * @param params.createdById - the id of the account that is creating the property type
    */
   static async create(
     graphApi: GraphApi,
     params: {
       ownedById: string;
       schema: Omit<PropertyType, "$id">;
+      createdById: string;
     },
   ): Promise<PropertyTypeModel> {
+    const { ownedById, createdById } = params;
+
     const namespace = await getNamespaceOfAccountOwner(graphApi, {
-      ownerId: params.ownedById,
+      ownerId: ownedById,
     });
 
     const propertyTypeId = generateTypeId({
@@ -77,12 +81,9 @@ export default class {
 
     const { data: metadata } = await graphApi
       .createPropertyType({
-        /**
-         * @todo: replace uses of `accountId` with `ownedById` in the Graph API
-         * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
-         */
-        accountId: params.ownedById,
+        ownedById,
         schema: fullPropertyType,
+        createdById,
       })
       .catch((err: AxiosError) => {
         throw new Error(
@@ -122,26 +123,21 @@ export default class {
   /**
    * Update a property type.
    *
-   * @param params.schema a `PropertyType`
+   * @param params.schema - the updated `PropertyType`
+   * @param params.updatedById - the id of the account that is updating the type
    */
   async update(
     graphApi: GraphApi,
     params: {
       schema: Omit<PropertyType, "$id">;
+      updatedById: string;
     },
   ): Promise<PropertyTypeModel> {
-    const { schema } = params;
+    const { schema, updatedById } = params;
     const updateArguments: UpdatePropertyTypeRequest = {
-      /**
-       * @todo: let caller update who owns the type, or create new method dedicated to changing the owner of the type
-       * @see https://app.asana.com/0/1202805690238892/1203063463721793/f
-       *
-       * @todo: replace uses of `accountId` with `ownedById` in the Graph API
-       * @see https://app.asana.com/0/1202805690238892/1203063463721791/f
-       */
-      accountId: this.ownedById,
       typeToUpdate: this.schema.$id,
       schema,
+      updatedById,
     };
 
     const { data: metadata } = await graphApi.updatePropertyType(

--- a/packages/hash/api/src/model/ontology/property-type.model.ts
+++ b/packages/hash/api/src/model/ontology/property-type.model.ts
@@ -72,7 +72,7 @@ export default class {
   /**
    * Create a property type.
    *
-   * @param params.ownedById - the id of the owner of the property type
+   * @param params.ownedById - the id of the account who owns the property type
    * @param params.schema - the `PropertyType`
    * @param params.createdById - the id of the account that is creating the property type
    */

--- a/packages/hash/api/src/model/ontology/property-type.model.ts
+++ b/packages/hash/api/src/model/ontology/property-type.model.ts
@@ -102,7 +102,7 @@ export default class {
       .createPropertyType({
         ownedById,
         schema: fullPropertyType,
-        createdById: actorId,
+        actorId,
       })
       .catch((err: AxiosError) => {
         throw new Error(
@@ -154,7 +154,7 @@ export default class {
     const updateArguments: UpdatePropertyTypeRequest = {
       typeToUpdate: this.schema.$id,
       schema,
-      updatedById: actorId,
+      actorId,
     };
 
     const { data: metadata } = await graphApi.updatePropertyType(

--- a/packages/hash/api/src/model/ontology/property-type.model.ts
+++ b/packages/hash/api/src/model/ontology/property-type.model.ts
@@ -14,6 +14,9 @@ import { getNamespaceOfAccountOwner } from "./util";
 type PropertyTypeModelConstructorParams = {
   ownedById: string;
   schema: PropertyType;
+  createdById: string;
+  updatedById: string;
+  removedById?: string;
 };
 
 /**
@@ -24,14 +27,27 @@ export default class {
 
   schema: PropertyType;
 
-  constructor({ schema, ownedById }: PropertyTypeModelConstructorParams) {
+  createdById: string;
+  updatedById: string;
+  removedById: string | undefined;
+
+  constructor({
+    schema,
+    ownedById,
+    createdById,
+    updatedById,
+    removedById,
+  }: PropertyTypeModelConstructorParams) {
     this.ownedById = ownedById;
     this.schema = schema;
+    this.createdById = createdById;
+    this.updatedById = updatedById;
+    this.removedById = removedById;
   }
 
   static fromPersistedPropertyType({
     inner,
-    metadata: { identifier },
+    metadata: { identifier, createdById, updatedById, removedById },
   }: PersistedPropertyType): PropertyTypeModel {
     /**
      * @todo and a warning, these type casts are here to compensate for
@@ -47,6 +63,9 @@ export default class {
     return new PropertyTypeModel({
       schema: inner as PropertyType,
       ownedById: identifier.ownedById,
+      createdById,
+      updatedById,
+      removedById,
     });
   }
 
@@ -93,11 +112,9 @@ export default class {
         );
       });
 
-    const { identifier } = metadata;
-
-    return new PropertyTypeModel({
-      schema: fullPropertyType,
-      ownedById: identifier.ownedById,
+    return PropertyTypeModel.fromPersistedPropertyType({
+      inner: fullPropertyType,
+      metadata,
     });
   }
 
@@ -144,11 +161,9 @@ export default class {
       updateArguments,
     );
 
-    const { identifier } = metadata;
-
-    return new PropertyTypeModel({
-      schema: { ...schema, $id: identifier.uri },
-      ownedById: identifier.ownedById,
+    return PropertyTypeModel.fromPersistedPropertyType({
+      inner: { ...schema, $id: metadata.identifier.uri },
+      metadata,
     });
   }
 

--- a/packages/hash/api/src/model/ontology/property-type.model.ts
+++ b/packages/hash/api/src/model/ontology/property-type.model.ts
@@ -74,17 +74,17 @@ export default class {
    *
    * @param params.ownedById - the id of the account who owns the property type
    * @param params.schema - the `PropertyType`
-   * @param params.createdById - the id of the account that is creating the property type
+   * @param params.actorId - the id of the account that is creating the property type
    */
   static async create(
     graphApi: GraphApi,
     params: {
       ownedById: string;
       schema: Omit<PropertyType, "$id">;
-      createdById: string;
+      actorId: string;
     },
   ): Promise<PropertyTypeModel> {
-    const { ownedById, createdById } = params;
+    const { ownedById, actorId } = params;
 
     const namespace = await getNamespaceOfAccountOwner(graphApi, {
       ownerId: ownedById,
@@ -102,7 +102,7 @@ export default class {
       .createPropertyType({
         ownedById,
         schema: fullPropertyType,
-        createdById,
+        createdById: actorId,
       })
       .catch((err: AxiosError) => {
         throw new Error(
@@ -141,20 +141,20 @@ export default class {
    * Update a property type.
    *
    * @param params.schema - the updated `PropertyType`
-   * @param params.updatedById - the id of the account that is updating the type
+   * @param params.actorId - the id of the account that is updating the type
    */
   async update(
     graphApi: GraphApi,
     params: {
       schema: Omit<PropertyType, "$id">;
-      updatedById: string;
+      actorId: string;
     },
   ): Promise<PropertyTypeModel> {
-    const { schema, updatedById } = params;
+    const { schema, actorId } = params;
     const updateArguments: UpdatePropertyTypeRequest = {
       typeToUpdate: this.schema.$id,
       schema,
-      updatedById,
+      updatedById: actorId,
     };
 
     const { data: metadata } = await graphApi.updatePropertyType(

--- a/packages/hash/api/src/model/util.ts
+++ b/packages/hash/api/src/model/util.ts
@@ -114,7 +114,7 @@ export type PropertyTypeCreatorParams = {
     propertyTypeObjectProperties?: { [_ in string]: { $ref: string } };
     array?: boolean;
   }[];
-  createdById: string;
+  actorId: string;
 };
 
 /**
@@ -201,7 +201,7 @@ export const propertyTypeInitializer = (
           return await PropertyTypeModel.create(graphApi, {
             ownedById: workspaceAccountId,
             schema: propertyType,
-            createdById: params.createdById,
+            actorId: params.actorId,
           }).catch((createError: AxiosError) => {
             logger.warn(`Failed to create property type: ${params.title}`);
             throw createError;
@@ -238,7 +238,7 @@ export type EntityTypeCreatorParams = {
     array?: { minItems?: number; maxItems?: number } | boolean;
     ordered?: boolean;
   }[];
-  createdById: string;
+  actorId: string;
 };
 
 /**
@@ -357,7 +357,7 @@ export const entityTypeInitializer = (
           return await EntityTypeModel.create(graphApi, {
             ownedById: workspaceAccountId,
             schema: entityType,
-            createdById: params.createdById,
+            actorId: params.actorId,
           }).catch((createError: AxiosError) => {
             logger.warn(`Failed to create entity type: ${params.title}`);
             throw createError;
@@ -380,7 +380,7 @@ export type LinkTypeCreatorParams = {
   title: string;
   description: string;
   relatedKeywords?: string[];
-  createdById: string;
+  actorId: string;
 };
 
 /**
@@ -434,7 +434,7 @@ export const linkTypeInitializer = (
           return await LinkTypeModel.create(graphApi, {
             ownedById: workspaceAccountId,
             schema: linkType,
-            createdById: params.createdById,
+            actorId: params.actorId,
           }).catch((createError: AxiosError) => {
             logger.warn(`Failed to create link type: ${params.title}`);
             throw createError;

--- a/packages/hash/api/src/model/util.ts
+++ b/packages/hash/api/src/model/util.ts
@@ -114,6 +114,7 @@ export type PropertyTypeCreatorParams = {
     propertyTypeObjectProperties?: { [_ in string]: { $ref: string } };
     array?: boolean;
   }[];
+  createdById: string;
 };
 
 /**
@@ -200,6 +201,7 @@ export const propertyTypeInitializer = (
           return await PropertyTypeModel.create(graphApi, {
             ownedById: workspaceAccountId,
             schema: propertyType,
+            createdById: params.createdById,
           }).catch((createError: AxiosError) => {
             logger.warn(`Failed to create property type: ${params.title}`);
             throw createError;
@@ -236,6 +238,7 @@ export type EntityTypeCreatorParams = {
     array?: { minItems?: number; maxItems?: number } | boolean;
     ordered?: boolean;
   }[];
+  createdById: string;
 };
 
 /**
@@ -354,6 +357,7 @@ export const entityTypeInitializer = (
           return await EntityTypeModel.create(graphApi, {
             ownedById: workspaceAccountId,
             schema: entityType,
+            createdById: params.createdById,
           }).catch((createError: AxiosError) => {
             logger.warn(`Failed to create entity type: ${params.title}`);
             throw createError;
@@ -376,6 +380,7 @@ export type LinkTypeCreatorParams = {
   title: string;
   description: string;
   relatedKeywords?: string[];
+  createdById: string;
 };
 
 /**
@@ -429,6 +434,7 @@ export const linkTypeInitializer = (
           return await LinkTypeModel.create(graphApi, {
             ownedById: workspaceAccountId,
             schema: linkType,
+            createdById: params.createdById,
           }).catch((createError: AxiosError) => {
             logger.warn(`Failed to create link type: ${params.title}`);
             throw createError;

--- a/packages/hash/integration/src/tests/model/knowledge/block.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/block.model.test.ts
@@ -59,13 +59,16 @@ describe("Block model class", () => {
         title: "Dummy",
         properties: [],
         outgoingLinks: [],
+        createdById: testUser.entityId,
       }),
+      createdById: testUser.entityId,
     });
 
     testBlockDataEntity = await EntityModel.create(graphApi, {
       ownedById: testUser.entityId,
       properties: {},
       entityTypeModel: dummyEntityType,
+      createdById: testUser.entityId,
     });
   });
 
@@ -74,6 +77,7 @@ describe("Block model class", () => {
       ownedById: testUser.entityId,
       componentId: testBlockComponentId,
       blockData: testBlockDataEntity,
+      createdById: testUser.entityId,
     });
   });
 
@@ -98,6 +102,7 @@ describe("Block model class", () => {
       ownedById: testUser.entityId,
       properties: {},
       entityTypeModel: dummyEntityType,
+      createdById: testUser.entityId,
     });
 
     expect(testBlockDataEntity).not.toEqual(newBlockDataEntity);
@@ -105,6 +110,7 @@ describe("Block model class", () => {
 
     await testBlock.updateBlockDataEntity(graphApi, {
       newBlockDataEntity,
+      updatedById: testUser.entityId,
     });
 
     expect(await testBlock.getBlockData(graphApi)).toEqual(newBlockDataEntity);
@@ -116,6 +122,7 @@ describe("Block model class", () => {
     await expect(
       testBlock.updateBlockDataEntity(graphApi, {
         newBlockDataEntity: currentDataEntity,
+        updatedById: testUser.entityId,
       }),
     ).rejects.toThrow(/already has a linked block data entity with entity id/);
   });

--- a/packages/hash/integration/src/tests/model/knowledge/block.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/block.model.test.ts
@@ -59,16 +59,16 @@ describe("Block model class", () => {
         title: "Dummy",
         properties: [],
         outgoingLinks: [],
-        createdById: testUser.entityId,
+        actorId: testUser.entityId,
       }),
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
 
     testBlockDataEntity = await EntityModel.create(graphApi, {
       ownedById: testUser.entityId,
       properties: {},
       entityTypeModel: dummyEntityType,
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
   });
 
@@ -77,7 +77,7 @@ describe("Block model class", () => {
       ownedById: testUser.entityId,
       componentId: testBlockComponentId,
       blockData: testBlockDataEntity,
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
   });
 
@@ -102,7 +102,7 @@ describe("Block model class", () => {
       ownedById: testUser.entityId,
       properties: {},
       entityTypeModel: dummyEntityType,
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
 
     expect(testBlockDataEntity).not.toEqual(newBlockDataEntity);
@@ -110,7 +110,7 @@ describe("Block model class", () => {
 
     await testBlock.updateBlockDataEntity(graphApi, {
       newBlockDataEntity,
-      updatedById: testUser.entityId,
+      actorId: testUser.entityId,
     });
 
     expect(await testBlock.getBlockData(graphApi)).toEqual(newBlockDataEntity);
@@ -122,7 +122,7 @@ describe("Block model class", () => {
     await expect(
       testBlock.updateBlockDataEntity(graphApi, {
         newBlockDataEntity: currentDataEntity,
-        updatedById: testUser.entityId,
+        actorId: testUser.entityId,
       }),
     ).rejects.toThrow(/already has a linked block data entity with entity id/);
   });

--- a/packages/hash/integration/src/tests/model/knowledge/entity.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/entity.model.test.ts
@@ -50,7 +50,7 @@ describe("Entity CRU", () => {
         title: "Text",
         type: "string",
       },
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     }).catch((err) => {
       logger.error(`Something went wrong making Text: ${err}`);
       throw err;
@@ -65,7 +65,7 @@ describe("Entity CRU", () => {
           pluralTitle: "Friends",
           description: "Friend of",
         },
-        createdById: testUser.entityId,
+        actorId: testUser.entityId,
       })
         .then((val) => {
           linkTypeFriend = val;
@@ -83,7 +83,7 @@ describe("Entity CRU", () => {
           pluralTitle: "Favorite Books",
           oneOf: [{ $ref: textDataTypeModel.schema.$id }],
         },
-        createdById: testUser.entityId,
+        actorId: testUser.entityId,
       })
         .then((val) => {
           favoriteBookPropertyTypeModel = val;
@@ -100,7 +100,7 @@ describe("Entity CRU", () => {
           pluralTitle: "Names",
           oneOf: [{ $ref: textDataTypeModel.schema.$id }],
         },
-        createdById: testUser.entityId,
+        actorId: testUser.entityId,
       })
         .then((val) => {
           namePropertyTypeModel = val;
@@ -131,9 +131,9 @@ describe("Entity CRU", () => {
             array: true,
           },
         ],
-        createdById: testUser.entityId,
+        actorId: testUser.entityId,
       }),
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
   });
 
@@ -146,7 +146,7 @@ describe("Entity CRU", () => {
         [favoriteBookPropertyTypeModel.baseUri]: "some text",
       },
       entityTypeModel,
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
   });
 
@@ -170,7 +170,7 @@ describe("Entity CRU", () => {
           [namePropertyTypeModel.baseUri]: "Updated Bob",
           [favoriteBookPropertyTypeModel.baseUri]: "Even more text than before",
         },
-        updatedById: testUser2.entityId,
+        actorId: testUser2.entityId,
       })
       .catch((err) => Promise.reject(err.data));
 
@@ -227,7 +227,7 @@ describe("Entity CRU", () => {
           },
         },
       ],
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
 
     const linkedEntity = (

--- a/packages/hash/integration/src/tests/model/knowledge/entity.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/entity.model.test.ts
@@ -32,6 +32,7 @@ const graphApi = createGraphClient(logger, {
 
 describe("Entity CRU", () => {
   let testUser: UserModel;
+  let testUser2: UserModel;
   let entityTypeModel: EntityTypeModel;
   let textDataTypeModel: DataTypeModel;
   let namePropertyTypeModel: PropertyTypeModel;
@@ -40,6 +41,7 @@ describe("Entity CRU", () => {
 
   beforeAll(async () => {
     testUser = await createTestUser(graphApi, "entitytest", logger);
+    testUser2 = await createTestUser(graphApi, "entitytest", logger);
 
     textDataTypeModel = await DataTypeModel.create(graphApi, {
       ownedById: testUser.entityId,
@@ -159,15 +161,21 @@ describe("Entity CRU", () => {
 
   let updatedEntityModel: EntityModel;
   it("can update an entity", async () => {
+    expect(createdEntityModel.createdById).toBe(testUser.entityId);
+    expect(createdEntityModel.updatedById).toBe(testUser.entityId);
+
     updatedEntityModel = await createdEntityModel
       .update(graphApi, {
         properties: {
           [namePropertyTypeModel.baseUri]: "Updated Bob",
           [favoriteBookPropertyTypeModel.baseUri]: "Even more text than before",
         },
-        updatedById: testUser.entityId,
+        updatedById: testUser2.entityId,
       })
       .catch((err) => Promise.reject(err.data));
+
+    expect(updatedEntityModel.createdById).toBe(testUser.entityId);
+    expect(updatedEntityModel.updatedById).toBe(testUser2.entityId);
   });
 
   it("can read all latest entities", async () => {

--- a/packages/hash/integration/src/tests/model/knowledge/link.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/link.model.test.ts
@@ -44,7 +44,7 @@ describe("Link model class", () => {
   let targetEntityAcquaintance: EntityModel;
 
   const createEntityType = (
-    params: Omit<EntityTypeCreatorParams, "entityTypeId" | "createdById">,
+    params: Omit<EntityTypeCreatorParams, "entityTypeId" | "actorId">,
   ) => {
     const entityTypeId = generateTypeId({
       namespace,
@@ -55,10 +55,10 @@ describe("Link model class", () => {
       ownedById: testUser.entityId,
       schema: generateWorkspaceEntityTypeSchema({
         entityTypeId,
-        createdById: testUser.entityId,
+        actorId: testUser.entityId,
         ...params,
       }),
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
   };
 
@@ -66,7 +66,7 @@ describe("Link model class", () => {
     EntityModel.create(graphApi, {
       ownedById: testUser.entityId,
       properties: {},
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
       ...params,
     });
 
@@ -84,7 +84,7 @@ describe("Link model class", () => {
           pluralTitle: "Friends",
           description: "Friend of",
         },
-        createdById: testUser.entityId,
+        actorId: testUser.entityId,
       }).then((linkType) => {
         linkTypeFriend = linkType;
       }),
@@ -96,7 +96,7 @@ describe("Link model class", () => {
           pluralTitle: "Acquaintances",
           description: "Acquainted with",
         },
-        createdById: testUser.entityId,
+        actorId: testUser.entityId,
       }).then((linkType) => {
         linkTypeAcquaintance = linkType;
       }),
@@ -126,7 +126,7 @@ describe("Link model class", () => {
         ownedById: testUser.entityId,
         entityTypeModel: testEntityType,
         properties: {},
-        createdById: testUser.entityId,
+        actorId: testUser.entityId,
       }).then((entity) => {
         sourceEntityModel = entity;
       }),
@@ -134,7 +134,7 @@ describe("Link model class", () => {
         ownedById: testUser.entityId,
         entityTypeModel: testEntityType,
         properties: {},
-        createdById: testUser.entityId,
+        actorId: testUser.entityId,
       }).then((entity) => {
         targetEntityFriend = entity;
       }),
@@ -142,7 +142,7 @@ describe("Link model class", () => {
         ownedById: testUser.entityId,
         entityTypeModel: testEntityType,
         properties: {},
-        createdById: testUser.entityId,
+        actorId: testUser.entityId,
       }).then((entity) => {
         targetEntityAcquaintance = entity;
       }),
@@ -158,7 +158,7 @@ describe("Link model class", () => {
       sourceEntityModel,
       linkTypeModel: linkTypeFriend,
       targetEntityModel: targetEntityFriend,
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
 
     acquaintanceLink = await LinkModel.create(graphApi, {
@@ -166,7 +166,7 @@ describe("Link model class", () => {
       sourceEntityModel,
       linkTypeModel: linkTypeAcquaintance,
       targetEntityModel: targetEntityAcquaintance,
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
   });
 
@@ -191,7 +191,7 @@ describe("Link model class", () => {
   });
 
   it("can remove a link", async () => {
-    await acquaintanceLink.remove(graphApi, { removedById: testUser.entityId });
+    await acquaintanceLink.remove(graphApi, { actorId: testUser.entityId });
 
     const links = await sourceEntityModel.getOutgoingLinks(graphApi, {
       linkTypeModel: linkTypeAcquaintance,
@@ -235,7 +235,7 @@ describe("Link model class", () => {
         pluralTitle: "Has songs",
         description: "Has song",
       },
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
 
     playlistEntityType = await createEntityType({
@@ -268,7 +268,7 @@ describe("Link model class", () => {
       linkTypeModel: hasSongLinkType,
       sourceEntityModel: playlistEntity,
       targetEntityModel: songEntity2,
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
 
     expect(hasSongLink2.index).toBe(0);
@@ -279,7 +279,7 @@ describe("Link model class", () => {
       linkTypeModel: hasSongLinkType,
       sourceEntityModel: playlistEntity,
       targetEntityModel: songEntity3,
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
 
     expect(hasSongLink3.index).toBe(1);
@@ -291,7 +291,7 @@ describe("Link model class", () => {
       linkTypeModel: hasSongLinkType,
       sourceEntityModel: playlistEntity,
       targetEntityModel: songEntity1,
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
 
     expect(hasSongLink1.index).toBe(0);
@@ -330,7 +330,7 @@ describe("Link model class", () => {
 
     await hasSongLink1.update(graphApi, {
       updatedIndex: 1,
-      updatedById: testUser.entityId,
+      actorId: testUser.entityId,
     });
 
     const playlistHasSongLinks = (await playlistEntity.getOutgoingLinks(
@@ -360,7 +360,7 @@ describe("Link model class", () => {
 
     await hasSongLink1.update(graphApi, {
       updatedIndex: 0,
-      updatedById: testUser.entityId,
+      actorId: testUser.entityId,
     });
 
     const playlistHasSongLinks = (await playlistEntity.getOutgoingLinks(
@@ -380,7 +380,7 @@ describe("Link model class", () => {
   });
 
   it("can remove an ordered link", async () => {
-    await hasSongLink2.remove(graphApi, { removedById: testUser.entityId });
+    await hasSongLink2.remove(graphApi, { actorId: testUser.entityId });
 
     const playlistHasSongLinks = (await playlistEntity.getOutgoingLinks(
       graphApi,

--- a/packages/hash/integration/src/tests/model/knowledge/org.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/org.model.test.ts
@@ -3,6 +3,7 @@ import { createGraphClient } from "@hashintel/hash-api/src/graph";
 import { ensureWorkspaceTypesExist } from "@hashintel/hash-api/src/graph/workspace-types";
 import { OrgModel, OrgSize } from "@hashintel/hash-api/src/model";
 import { Logger } from "@hashintel/hash-backend-utils/logger";
+import { workspaceAccountId } from "@hashintel/hash-api/src/model/util";
 import { generateRandomShortname } from "../../util";
 
 jest.setTimeout(60000);
@@ -35,6 +36,7 @@ describe("Org model class", () => {
       providedInfo: {
         orgSize: OrgSize.ElevenToFifty,
       },
+      createdById: workspaceAccountId,
     });
   });
 
@@ -46,12 +48,14 @@ describe("Org model class", () => {
     shortname = generateRandomShortname("orgTest");
     createdOrg = await createdOrg.updateShortname(graphApi, {
       updatedShortname: shortname,
+      updatedById: workspaceAccountId,
     });
   });
 
   it("can update the preferred name of an org", async () => {
     createdOrg = await createdOrg.updateOrgName(graphApi, {
       updatedOrgName: "The testing org",
+      updatedById: workspaceAccountId,
     });
   });
 

--- a/packages/hash/integration/src/tests/model/knowledge/org.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/org.model.test.ts
@@ -36,7 +36,7 @@ describe("Org model class", () => {
       providedInfo: {
         orgSize: OrgSize.ElevenToFifty,
       },
-      createdById: workspaceAccountId,
+      actorId: workspaceAccountId,
     });
   });
 
@@ -48,14 +48,14 @@ describe("Org model class", () => {
     shortname = generateRandomShortname("orgTest");
     createdOrg = await createdOrg.updateShortname(graphApi, {
       updatedShortname: shortname,
-      updatedById: workspaceAccountId,
+      actorId: workspaceAccountId,
     });
   });
 
   it("can update the preferred name of an org", async () => {
     createdOrg = await createdOrg.updateOrgName(graphApi, {
       updatedOrgName: "The testing org",
-      updatedById: workspaceAccountId,
+      actorId: workspaceAccountId,
     });
   });
 

--- a/packages/hash/integration/src/tests/model/knowledge/orgMembership.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/orgMembership.model.test.ts
@@ -45,6 +45,7 @@ describe("OrgMembership model class", () => {
       providedInfo: {
         orgSize: OrgSize.ElevenToFifty,
       },
+      createdById: testUser.entityId,
     });
   });
 
@@ -54,12 +55,14 @@ describe("OrgMembership model class", () => {
     testOrgMembership = await OrgMembershipModel.createOrgMembership(graphApi, {
       responsibility: "test",
       org: testOrg,
+      createdById: testUser.entityId,
     });
 
     await testUser.createOutgoingLink(graphApi, {
       linkTypeModel: WORKSPACE_TYPES.linkType.hasMembership,
       targetEntityModel: testOrgMembership,
       ownedById: workspaceAccountId,
+      createdById: testUser.entityId,
     });
   });
 

--- a/packages/hash/integration/src/tests/model/knowledge/orgMembership.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/orgMembership.model.test.ts
@@ -45,7 +45,7 @@ describe("OrgMembership model class", () => {
       providedInfo: {
         orgSize: OrgSize.ElevenToFifty,
       },
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
   });
 
@@ -55,14 +55,14 @@ describe("OrgMembership model class", () => {
     testOrgMembership = await OrgMembershipModel.createOrgMembership(graphApi, {
       responsibility: "test",
       org: testOrg,
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
 
     await testUser.createOutgoingLink(graphApi, {
       linkTypeModel: WORKSPACE_TYPES.linkType.hasMembership,
       targetEntityModel: testOrgMembership,
       ownedById: workspaceAccountId,
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
   });
 

--- a/packages/hash/integration/src/tests/model/knowledge/page.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/page.model.test.ts
@@ -45,7 +45,9 @@ describe("Page model class", () => {
         ownedById: testUser.entityId,
         entityTypeModel: WORKSPACE_TYPES.entityType.dummy,
         properties: {},
+        createdById: testUser.entityId,
       }),
+      createdById: testUser.entityId,
     });
 
   let testPage: PageModel;
@@ -54,6 +56,7 @@ describe("Page model class", () => {
     testPage = await PageModel.createPage(graphApi, {
       ownedById: testUser.entityId,
       title: "Test Page",
+      createdById: testUser.entityId,
     });
 
     const initialBlocks = await testPage.getBlocks(graphApi);
@@ -74,6 +77,7 @@ describe("Page model class", () => {
       title: "Test Page 2",
       summary: "Test page 2 summary",
       initialBlocks: [initialBlock1, initialBlock2],
+      createdById: testUser.entityId,
     });
 
     const initialBlocks = await testPage2.getBlocks(graphApi);
@@ -110,6 +114,7 @@ describe("Page model class", () => {
       ownedById: testUser.entityId,
       title: "Test Parent Page",
       summary: "Test page summary",
+      createdById: testUser.entityId,
     });
 
     expect(await testPage.getParentPage(graphApi)).toBeNull();
@@ -145,12 +150,14 @@ describe("Page model class", () => {
     // insert block at un-specified position
     await testPage.insertBlock(graphApi, {
       block: testBlock3,
+      insertedById: testUser.entityId,
     });
 
     // insert block at specified position
     await testPage.insertBlock(graphApi, {
       block: testBlock2,
       position: 1,
+      insertedById: testUser.entityId,
     });
 
     expect(await testPage.getBlocks(graphApi)).toEqual([

--- a/packages/hash/integration/src/tests/model/knowledge/page.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/page.model.test.ts
@@ -45,9 +45,9 @@ describe("Page model class", () => {
         ownedById: testUser.entityId,
         entityTypeModel: WORKSPACE_TYPES.entityType.dummy,
         properties: {},
-        createdById: testUser.entityId,
+        actorId: testUser.entityId,
       }),
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
 
   let testPage: PageModel;
@@ -56,7 +56,7 @@ describe("Page model class", () => {
     testPage = await PageModel.createPage(graphApi, {
       ownedById: testUser.entityId,
       title: "Test Page",
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
 
     const initialBlocks = await testPage.getBlocks(graphApi);
@@ -77,7 +77,7 @@ describe("Page model class", () => {
       title: "Test Page 2",
       summary: "Test page 2 summary",
       initialBlocks: [initialBlock1, initialBlock2],
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
 
     const initialBlocks = await testPage2.getBlocks(graphApi);
@@ -114,14 +114,14 @@ describe("Page model class", () => {
       ownedById: testUser.entityId,
       title: "Test Parent Page",
       summary: "Test page summary",
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
 
     expect(await testPage.getParentPage(graphApi)).toBeNull();
 
     await testPage.setParentPage(graphApi, {
       parentPageModel,
-      setById: testUser.entityId,
+      actorId: testUser.entityId,
       prevIndex: null,
       nextIndex: null,
     });
@@ -150,7 +150,7 @@ describe("Page model class", () => {
     // insert block at un-specified position
     await testPage.insertBlock(graphApi, {
       block: testBlock3,
-      insertedById: testUser.entityId,
+      actorId: testUser.entityId,
       updateSiblings: true,
     });
 
@@ -159,7 +159,7 @@ describe("Page model class", () => {
       block: testBlock2,
       updateSiblings: true,
       position: 1,
-      insertedById: testUser.entityId,
+      actorId: testUser.entityId,
     });
 
     expect(await testPage.getBlocks(graphApi)).toEqual([
@@ -173,7 +173,7 @@ describe("Page model class", () => {
     await testPage.moveBlock(graphApi, {
       currentPosition: 0,
       newPosition: 2,
-      movedById: testUser.entityId,
+      actorId: testUser.entityId,
     });
 
     expect(await testPage.getBlocks(graphApi)).toEqual([
@@ -185,7 +185,7 @@ describe("Page model class", () => {
     await testPage.moveBlock(graphApi, {
       currentPosition: 2,
       newPosition: 0,
-      movedById: testUser.entityId,
+      actorId: testUser.entityId,
     });
 
     expect(await testPage.getBlocks(graphApi)).toEqual([
@@ -198,7 +198,7 @@ describe("Page model class", () => {
   it("can remove blocks", async () => {
     await testPage.removeBlock(graphApi, {
       position: 0,
-      removedById: testUser.entityId,
+      actorId: testUser.entityId,
       updateSiblings: true,
     });
 

--- a/packages/hash/integration/src/tests/model/knowledge/user.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/user.model.test.ts
@@ -50,7 +50,7 @@ describe("User model class", () => {
     createdUser = await UserModel.createUser(graphApi, {
       emails: ["alice@example.com"],
       kratosIdentityId,
-      createdById: workspaceAccountId,
+      actorId: workspaceAccountId,
     });
   });
 
@@ -59,7 +59,7 @@ describe("User model class", () => {
       UserModel.createUser(graphApi, {
         emails: ["bob@example.com"],
         kratosIdentityId,
-        createdById: workspaceAccountId,
+        actorId: workspaceAccountId,
       }),
     ).rejects.toThrowError(`"${kratosIdentityId}" already exists.`);
   });
@@ -71,14 +71,14 @@ describe("User model class", () => {
   it("can update the shortname of a user", async () => {
     createdUser = await createdUser.updateShortname(graphApi, {
       updatedShortname: shortname,
-      updatedById: createdUser.entityId,
+      actorId: createdUser.entityId,
     });
   });
 
   it("can update the preferred name of a user", async () => {
     createdUser = await createdUser.updatePreferredName(graphApi, {
       updatedPreferredName: "Alice",
-      updatedById: createdUser.entityId,
+      actorId: createdUser.entityId,
     });
   });
 
@@ -109,7 +109,7 @@ describe("User model class", () => {
       providedInfo: {
         orgSize: OrgSize.ElevenToFifty,
       },
-      createdById: workspaceAccountId,
+      actorId: workspaceAccountId,
     });
 
     const { entityId: orgEntityId } = testOrg;
@@ -121,7 +121,7 @@ describe("User model class", () => {
     await createdUser.joinOrg(graphApi, {
       org: testOrg,
       responsibility: "developer",
-      joinedById: workspaceAccountId,
+      actorId: workspaceAccountId,
     });
 
     expect(await createdUser.isMemberOfOrg(graphApi, { orgEntityId })).toBe(

--- a/packages/hash/integration/src/tests/model/knowledge/user.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/user.model.test.ts
@@ -8,6 +8,7 @@ import {
   adminKratosSdk,
   createKratosIdentity,
 } from "@hashintel/hash-api/src/auth/ory-kratos";
+import { workspaceAccountId } from "@hashintel/hash-api/src/model/util";
 import { generateRandomShortname } from "../../util";
 
 jest.setTimeout(60000);
@@ -49,6 +50,7 @@ describe("User model class", () => {
     createdUser = await UserModel.createUser(graphApi, {
       emails: ["alice@example.com"],
       kratosIdentityId,
+      createdById: workspaceAccountId,
     });
   });
 
@@ -57,6 +59,7 @@ describe("User model class", () => {
       UserModel.createUser(graphApi, {
         emails: ["bob@example.com"],
         kratosIdentityId,
+        createdById: workspaceAccountId,
       }),
     ).rejects.toThrowError(`"${kratosIdentityId}" already exists.`);
   });
@@ -68,12 +71,14 @@ describe("User model class", () => {
   it("can update the shortname of a user", async () => {
     createdUser = await createdUser.updateShortname(graphApi, {
       updatedShortname: shortname,
+      updatedById: createdUser.entityId,
     });
   });
 
   it("can update the preferred name of a user", async () => {
     createdUser = await createdUser.updatePreferredName(graphApi, {
       updatedPreferredName: "Alice",
+      updatedById: createdUser.entityId,
     });
   });
 
@@ -104,6 +109,7 @@ describe("User model class", () => {
       providedInfo: {
         orgSize: OrgSize.ElevenToFifty,
       },
+      createdById: workspaceAccountId,
     });
 
     const { entityId: orgEntityId } = testOrg;
@@ -115,6 +121,7 @@ describe("User model class", () => {
     await createdUser.joinOrg(graphApi, {
       org: testOrg,
       responsibility: "developer",
+      joinedById: workspaceAccountId,
     });
 
     expect(await createdUser.isMemberOfOrg(graphApi, { orgEntityId })).toBe(

--- a/packages/hash/integration/src/tests/model/ontology/data-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/data-type.model.test.ts
@@ -3,7 +3,7 @@ import { createGraphClient } from "@hashintel/hash-api/src/graph";
 import { Logger } from "@hashintel/hash-backend-utils/logger";
 
 import { DataType } from "@blockprotocol/type-system-web";
-import { DataTypeModel } from "@hashintel/hash-api/src/model";
+import { DataTypeModel, UserModel } from "@hashintel/hash-api/src/model";
 import { createTestUser } from "../../util";
 
 jest.setTimeout(60000);
@@ -22,7 +22,7 @@ const graphApi = createGraphClient(logger, {
   port: graphApiPort,
 });
 
-let ownedById: string;
+let testUser: UserModel;
 
 // we have to manually specify this type because of 'intended' limitations of `Omit` with extended Record types:
 //  https://github.com/microsoft/TypeScript/issues/50638
@@ -38,9 +38,7 @@ const dataTypeSchema: Pick<
 };
 
 beforeAll(async () => {
-  const testUser = await createTestUser(graphApi, "data-type-test", logger);
-
-  ownedById = testUser.entityId;
+  testUser = await createTestUser(graphApi, "data-type-test", logger);
 });
 
 describe("Data type CRU", () => {
@@ -48,8 +46,9 @@ describe("Data type CRU", () => {
 
   it("can create a data type", async () => {
     createdDataTypeModel = await DataTypeModel.create(graphApi, {
-      ownedById,
+      ownedById: testUser.entityId,
       schema: dataTypeSchema,
+      createdById: testUser.entityId,
     });
   });
 
@@ -66,6 +65,7 @@ describe("Data type CRU", () => {
     await createdDataTypeModel
       .update(graphApi, {
         schema: { ...dataTypeSchema, title: updatedTitle },
+        updatedById: testUser.entityId,
       })
       .catch((err) => Promise.reject(err.data));
   });

--- a/packages/hash/integration/src/tests/model/ontology/data-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/data-type.model.test.ts
@@ -23,6 +23,7 @@ const graphApi = createGraphClient(logger, {
 });
 
 let testUser: UserModel;
+let testUser2: UserModel;
 
 // we have to manually specify this type because of 'intended' limitations of `Omit` with extended Record types:
 //  https://github.com/microsoft/TypeScript/issues/50638
@@ -39,6 +40,7 @@ const dataTypeSchema: Pick<
 
 beforeAll(async () => {
   testUser = await createTestUser(graphApi, "data-type-test", logger);
+  testUser2 = await createTestUser(graphApi, "data-type-test", logger);
 });
 
 describe("Data type CRU", () => {
@@ -62,11 +64,17 @@ describe("Data type CRU", () => {
 
   const updatedTitle = "New text!";
   it("can update a data type", async () => {
-    await createdDataTypeModel
+    expect(createdDataTypeModel.createdById).toBe(testUser.entityId);
+    expect(createdDataTypeModel.updatedById).toBe(testUser.entityId);
+
+    createdDataTypeModel = await createdDataTypeModel
       .update(graphApi, {
         schema: { ...dataTypeSchema, title: updatedTitle },
-        updatedById: testUser.entityId,
+        updatedById: testUser2.entityId,
       })
       .catch((err) => Promise.reject(err.data));
+
+    expect(createdDataTypeModel.createdById).toBe(testUser.entityId);
+    expect(createdDataTypeModel.updatedById).toBe(testUser2.entityId);
   });
 });

--- a/packages/hash/integration/src/tests/model/ontology/data-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/data-type.model.test.ts
@@ -39,8 +39,8 @@ const dataTypeSchema: Pick<
 };
 
 beforeAll(async () => {
-  testUser = await createTestUser(graphApi, "data-type-test", logger);
-  testUser2 = await createTestUser(graphApi, "data-type-test", logger);
+  testUser = await createTestUser(graphApi, "data-type-test-1", logger);
+  testUser2 = await createTestUser(graphApi, "data-type-test-2", logger);
 });
 
 describe("Data type CRU", () => {

--- a/packages/hash/integration/src/tests/model/ontology/data-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/data-type.model.test.ts
@@ -50,7 +50,7 @@ describe("Data type CRU", () => {
     createdDataTypeModel = await DataTypeModel.create(graphApi, {
       ownedById: testUser.entityId,
       schema: dataTypeSchema,
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
   });
 
@@ -70,7 +70,7 @@ describe("Data type CRU", () => {
     createdDataTypeModel = await createdDataTypeModel
       .update(graphApi, {
         schema: { ...dataTypeSchema, title: updatedTitle },
-        updatedById: testUser2.entityId,
+        actorId: testUser2.entityId,
       })
       .catch((err) => Promise.reject(err.data));
 

--- a/packages/hash/integration/src/tests/model/ontology/entity-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/entity-type.model.test.ts
@@ -40,8 +40,8 @@ let previousAddressLinkTypeModel: LinkTypeModel;
 let addressEntityTypeModel: EntityTypeModel;
 
 beforeAll(async () => {
-  testUser = await createTestUser(graphApi, "entity-type-test", logger);
-  testUser2 = await createTestUser(graphApi, "entity-type-test", logger);
+  testUser = await createTestUser(graphApi, "entity-type-test-1", logger);
+  testUser2 = await createTestUser(graphApi, "entity-type-test-2", logger);
 
   textDataTypeModel = await DataTypeModel.create(graphApi, {
     ownedById: testUser.entityId,

--- a/packages/hash/integration/src/tests/model/ontology/entity-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/entity-type.model.test.ts
@@ -29,6 +29,7 @@ const graphApi = createGraphClient(logger, {
 });
 
 let testUser: UserModel;
+let testUser2: UserModel;
 let entityTypeSchema: Omit<EntityType, "$id">;
 let workerEntityTypeModel: EntityTypeModel;
 let textDataTypeModel: DataTypeModel;
@@ -40,6 +41,7 @@ let addressEntityTypeModel: EntityTypeModel;
 
 beforeAll(async () => {
   testUser = await createTestUser(graphApi, "entity-type-test", logger);
+  testUser2 = await createTestUser(graphApi, "entity-type-test", logger);
 
   textDataTypeModel = await DataTypeModel.create(graphApi, {
     ownedById: testUser.entityId,
@@ -182,12 +184,18 @@ describe("Entity type CRU", () => {
   const updatedTitle = "New text!";
   let updatedId: string | undefined;
   it("can update an entity type", async () => {
+    expect(createdEntityType.createdById).toBe(testUser.entityId);
+    expect(createdEntityType.updatedById).toBe(testUser.entityId);
+
     const updatedEntityTypeModel = await createdEntityType
       .update(graphApi, {
         schema: { ...entityTypeSchema, title: updatedTitle },
-        updatedById: testUser.entityId,
+        updatedById: testUser2.entityId,
       })
       .catch((err) => Promise.reject(err.data));
+
+    expect(updatedEntityTypeModel.createdById).toBe(testUser.entityId);
+    expect(updatedEntityTypeModel.updatedById).toBe(testUser2.entityId);
 
     updatedId = updatedEntityTypeModel.schema.$id;
   });

--- a/packages/hash/integration/src/tests/model/ontology/entity-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/entity-type.model.test.ts
@@ -7,6 +7,7 @@ import {
   DataTypeModel,
   PropertyTypeModel,
   LinkTypeModel,
+  UserModel,
 } from "@hashintel/hash-api/src/model";
 import { EntityType } from "@blockprotocol/type-system-web";
 import { createTestUser } from "../../util";
@@ -27,7 +28,7 @@ const graphApi = createGraphClient(logger, {
   port: graphApiPort,
 });
 
-let ownedById: string;
+let testUser: UserModel;
 let entityTypeSchema: Omit<EntityType, "$id">;
 let workerEntityTypeModel: EntityTypeModel;
 let textDataTypeModel: DataTypeModel;
@@ -38,22 +39,21 @@ let previousAddressLinkTypeModel: LinkTypeModel;
 let addressEntityTypeModel: EntityTypeModel;
 
 beforeAll(async () => {
-  const testUser = await createTestUser(graphApi, "entity-type-test", logger);
-
-  ownedById = testUser.entityId;
+  testUser = await createTestUser(graphApi, "entity-type-test", logger);
 
   textDataTypeModel = await DataTypeModel.create(graphApi, {
-    ownedById,
+    ownedById: testUser.entityId,
     schema: {
       kind: "dataType",
       title: "Text",
       type: "string",
     },
+    createdById: testUser.entityId,
   });
 
   await Promise.all([
     EntityTypeModel.create(graphApi, {
-      ownedById,
+      ownedById: testUser.entityId,
       schema: {
         kind: "entityType",
         title: "Worker",
@@ -61,11 +61,12 @@ beforeAll(async () => {
         type: "object",
         properties: {},
       },
+      createdById: testUser.entityId,
     }).then((val) => {
       workerEntityTypeModel = val;
     }),
     EntityTypeModel.create(graphApi, {
-      ownedById,
+      ownedById: testUser.entityId,
       schema: {
         kind: "entityType",
         title: "Address",
@@ -73,50 +74,55 @@ beforeAll(async () => {
         type: "object",
         properties: {},
       },
+      createdById: testUser.entityId,
     }).then((val) => {
       addressEntityTypeModel = val;
     }),
     PropertyTypeModel.create(graphApi, {
-      ownedById,
+      ownedById: testUser.entityId,
       schema: {
         kind: "propertyType",
         title: "Favorite Book",
         pluralTitle: "Favorite Books",
         oneOf: [{ $ref: textDataTypeModel.schema.$id }],
       },
+      createdById: testUser.entityId,
     }).then((val) => {
       favoriteBookPropertyTypeModel = val;
     }),
     PropertyTypeModel.create(graphApi, {
-      ownedById,
+      ownedById: testUser.entityId,
       schema: {
         kind: "propertyType",
         title: "Name",
         pluralTitle: "Names",
         oneOf: [{ $ref: textDataTypeModel.schema.$id }],
       },
+      createdById: testUser.entityId,
     }).then((val) => {
       namePropertyTypeModel = val;
     }),
     LinkTypeModel.create(graphApi, {
-      ownedById,
+      ownedById: testUser.entityId,
       schema: {
         kind: "linkType",
         title: "Knows",
         pluralTitle: "Knows",
         description: "Knows of someone",
       },
+      createdById: testUser.entityId,
     }).then((val) => {
       knowsLinkTypeModel = val;
     }),
     LinkTypeModel.create(graphApi, {
-      ownedById,
+      ownedById: testUser.entityId,
       schema: {
         kind: "linkType",
         title: "Previous Address",
         pluralTitle: "Previous Addresses",
         description: "A previous address of something.",
       },
+      createdById: testUser.entityId,
     }).then((val) => {
       previousAddressLinkTypeModel = val;
     }),
@@ -159,8 +165,9 @@ describe("Entity type CRU", () => {
 
   it("can create an entity type", async () => {
     createdEntityType = await EntityTypeModel.create(graphApi, {
-      ownedById,
+      ownedById: testUser.entityId,
       schema: entityTypeSchema,
+      createdById: testUser.entityId,
     });
   });
 
@@ -178,6 +185,7 @@ describe("Entity type CRU", () => {
     const updatedEntityTypeModel = await createdEntityType
       .update(graphApi, {
         schema: { ...entityTypeSchema, title: updatedTitle },
+        updatedById: testUser.entityId,
       })
       .catch((err) => Promise.reject(err.data));
 

--- a/packages/hash/integration/src/tests/model/ontology/entity-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/entity-type.model.test.ts
@@ -50,7 +50,7 @@ beforeAll(async () => {
       title: "Text",
       type: "string",
     },
-    createdById: testUser.entityId,
+    actorId: testUser.entityId,
   });
 
   await Promise.all([
@@ -63,7 +63,7 @@ beforeAll(async () => {
         type: "object",
         properties: {},
       },
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     }).then((val) => {
       workerEntityTypeModel = val;
     }),
@@ -76,7 +76,7 @@ beforeAll(async () => {
         type: "object",
         properties: {},
       },
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     }).then((val) => {
       addressEntityTypeModel = val;
     }),
@@ -88,7 +88,7 @@ beforeAll(async () => {
         pluralTitle: "Favorite Books",
         oneOf: [{ $ref: textDataTypeModel.schema.$id }],
       },
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     }).then((val) => {
       favoriteBookPropertyTypeModel = val;
     }),
@@ -100,7 +100,7 @@ beforeAll(async () => {
         pluralTitle: "Names",
         oneOf: [{ $ref: textDataTypeModel.schema.$id }],
       },
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     }).then((val) => {
       namePropertyTypeModel = val;
     }),
@@ -112,7 +112,7 @@ beforeAll(async () => {
         pluralTitle: "Knows",
         description: "Knows of someone",
       },
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     }).then((val) => {
       knowsLinkTypeModel = val;
     }),
@@ -124,7 +124,7 @@ beforeAll(async () => {
         pluralTitle: "Previous Addresses",
         description: "A previous address of something.",
       },
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     }).then((val) => {
       previousAddressLinkTypeModel = val;
     }),
@@ -169,7 +169,7 @@ describe("Entity type CRU", () => {
     createdEntityType = await EntityTypeModel.create(graphApi, {
       ownedById: testUser.entityId,
       schema: entityTypeSchema,
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
   });
 
@@ -190,7 +190,7 @@ describe("Entity type CRU", () => {
     const updatedEntityTypeModel = await createdEntityType
       .update(graphApi, {
         schema: { ...entityTypeSchema, title: updatedTitle },
-        updatedById: testUser2.entityId,
+        actorId: testUser2.entityId,
       })
       .catch((err) => Promise.reject(err.data));
 

--- a/packages/hash/integration/src/tests/model/ontology/link-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/link-type.model.test.ts
@@ -3,7 +3,7 @@ import { createGraphClient } from "@hashintel/hash-api/src/graph";
 import { Logger } from "@hashintel/hash-backend-utils/logger";
 
 import { LinkType } from "@hashintel/hash-graph-client/";
-import { LinkTypeModel } from "@hashintel/hash-api/src/model";
+import { LinkTypeModel, UserModel } from "@hashintel/hash-api/src/model";
 import { createTestUser } from "../../util";
 
 jest.setTimeout(60000);
@@ -22,7 +22,8 @@ const graphApi = createGraphClient(logger, {
   port: graphApiPort,
 });
 
-let ownedById: string;
+let testUser: UserModel;
+
 const linkTypeSchema: Omit<LinkType, "$id"> = {
   kind: "linkType",
   title: "A link",
@@ -31,9 +32,7 @@ const linkTypeSchema: Omit<LinkType, "$id"> = {
 };
 
 beforeAll(async () => {
-  const testUser = await createTestUser(graphApi, "link-type-test", logger);
-
-  ownedById = testUser.entityId;
+  testUser = await createTestUser(graphApi, "link-type-test", logger);
 });
 
 describe("Link type CRU", () => {
@@ -42,8 +41,9 @@ describe("Link type CRU", () => {
 
   it("can create a link type", async () => {
     createdLinkTypeModel = await LinkTypeModel.create(graphApi, {
-      ownedById,
+      ownedById: testUser.entityId,
       schema: linkTypeSchema,
+      createdById: testUser.entityId,
     });
   });
 
@@ -64,6 +64,7 @@ describe("Link type CRU", () => {
           ...linkTypeSchema,
           title: updatedTitle,
         },
+        updatedById: testUser.entityId,
       })
       .catch((err) => Promise.reject(err.data));
   });

--- a/packages/hash/integration/src/tests/model/ontology/link-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/link-type.model.test.ts
@@ -45,7 +45,7 @@ describe("Link type CRU", () => {
     createdLinkTypeModel = await LinkTypeModel.create(graphApi, {
       ownedById: testUser.entityId,
       schema: linkTypeSchema,
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
   });
 
@@ -69,7 +69,7 @@ describe("Link type CRU", () => {
           ...linkTypeSchema,
           title: updatedTitle,
         },
-        updatedById: testUser2.entityId,
+        actorId: testUser2.entityId,
       })
       .catch((err) => Promise.reject(err.data));
 

--- a/packages/hash/integration/src/tests/model/ontology/link-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/link-type.model.test.ts
@@ -69,7 +69,7 @@ describe("Link type CRU", () => {
           ...linkTypeSchema,
           title: updatedTitle,
         },
-        updatedById: testUser.entityId,
+        updatedById: testUser2.entityId,
       })
       .catch((err) => Promise.reject(err.data));
 

--- a/packages/hash/integration/src/tests/model/ontology/link-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/link-type.model.test.ts
@@ -33,8 +33,8 @@ const linkTypeSchema: Omit<LinkType, "$id"> = {
 };
 
 beforeAll(async () => {
-  testUser = await createTestUser(graphApi, "link-type-test", logger);
-  testUser2 = await createTestUser(graphApi, "link-type-test", logger);
+  testUser = await createTestUser(graphApi, "link-type-test-1", logger);
+  testUser2 = await createTestUser(graphApi, "link-type-test-2", logger);
 });
 
 describe("Link type CRU", () => {

--- a/packages/hash/integration/src/tests/model/ontology/link-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/link-type.model.test.ts
@@ -23,6 +23,7 @@ const graphApi = createGraphClient(logger, {
 });
 
 let testUser: UserModel;
+let testUser2: UserModel;
 
 const linkTypeSchema: Omit<LinkType, "$id"> = {
   kind: "linkType",
@@ -33,6 +34,7 @@ const linkTypeSchema: Omit<LinkType, "$id"> = {
 
 beforeAll(async () => {
   testUser = await createTestUser(graphApi, "link-type-test", logger);
+  testUser2 = await createTestUser(graphApi, "link-type-test", logger);
 });
 
 describe("Link type CRU", () => {
@@ -58,6 +60,9 @@ describe("Link type CRU", () => {
   const updatedTitle = "A new link!";
 
   it("can update a link type", async () => {
+    expect(createdLinkTypeModel.createdById).toBe(testUser.entityId);
+    expect(createdLinkTypeModel.updatedById).toBe(testUser.entityId);
+
     updatedLinkTypeModel = await createdLinkTypeModel
       .update(graphApi, {
         schema: {
@@ -67,6 +72,9 @@ describe("Link type CRU", () => {
         updatedById: testUser.entityId,
       })
       .catch((err) => Promise.reject(err.data));
+
+    expect(updatedLinkTypeModel.createdById).toBe(testUser.entityId);
+    expect(updatedLinkTypeModel.updatedById).toBe(testUser2.entityId);
   });
 
   it("can read all latest link types", async () => {

--- a/packages/hash/integration/src/tests/model/ontology/property-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/property-type.model.test.ts
@@ -32,8 +32,8 @@ let textDataTypeModel: DataTypeModel;
 let propertyTypeSchema: Omit<PropertyType, "$id">;
 
 beforeAll(async () => {
-  testUser = await createTestUser(graphApi, "property-type-test", logger);
-  testUser2 = await createTestUser(graphApi, "property-type-test", logger);
+  testUser = await createTestUser(graphApi, "property-type-test-1", logger);
+  testUser2 = await createTestUser(graphApi, "property-type-test-2", logger);
 
   textDataTypeModel = await DataTypeModel.create(graphApi, {
     ownedById: testUser.entityId,

--- a/packages/hash/integration/src/tests/model/ontology/property-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/property-type.model.test.ts
@@ -42,7 +42,7 @@ beforeAll(async () => {
       title: "Text",
       type: "string",
     },
-    createdById: testUser.entityId,
+    actorId: testUser.entityId,
   });
 
   propertyTypeSchema = {
@@ -64,7 +64,7 @@ describe("Property type CRU", () => {
     createdPropertyTypeModel = await PropertyTypeModel.create(graphApi, {
       ownedById: testUser.entityId,
       schema: propertyTypeSchema,
-      createdById: testUser.entityId,
+      actorId: testUser.entityId,
     });
   });
 
@@ -88,7 +88,7 @@ describe("Property type CRU", () => {
           ...propertyTypeSchema,
           title: updatedTitle,
         },
-        updatedById: testUser2.entityId,
+        actorId: testUser2.entityId,
       })
       .catch((err) => Promise.reject(err.data));
 

--- a/packages/hash/integration/src/tests/model/ontology/property-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/property-type.model.test.ts
@@ -6,6 +6,7 @@ import { PropertyType } from "@blockprotocol/type-system-web";
 import {
   DataTypeModel,
   PropertyTypeModel,
+  UserModel,
 } from "@hashintel/hash-api/src/model";
 import { createTestUser } from "../../util";
 
@@ -25,22 +26,21 @@ const graphApi = createGraphClient(logger, {
   port: graphApiPort,
 });
 
-let ownedById: string;
+let testUser: UserModel;
 let textDataTypeModel: DataTypeModel;
 let propertyTypeSchema: Omit<PropertyType, "$id">;
 
 beforeAll(async () => {
-  const testUser = await createTestUser(graphApi, "property-type-test", logger);
-
-  ownedById = testUser.entityId;
+  testUser = await createTestUser(graphApi, "property-type-test", logger);
 
   textDataTypeModel = await DataTypeModel.create(graphApi, {
-    ownedById,
+    ownedById: testUser.entityId,
     schema: {
       kind: "dataType",
       title: "Text",
       type: "string",
     },
+    createdById: testUser.entityId,
   });
 
   propertyTypeSchema = {
@@ -60,8 +60,9 @@ describe("Property type CRU", () => {
 
   it("can create a property type", async () => {
     createdPropertyTypeModel = await PropertyTypeModel.create(graphApi, {
-      ownedById,
+      ownedById: testUser.entityId,
       schema: propertyTypeSchema,
+      createdById: testUser.entityId,
     });
   });
 
@@ -82,6 +83,7 @@ describe("Property type CRU", () => {
           ...propertyTypeSchema,
           title: updatedTitle,
         },
+        updatedById: testUser.entityId,
       })
       .catch((err) => Promise.reject(err.data));
   });

--- a/packages/hash/integration/src/tests/model/ontology/property-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/property-type.model.test.ts
@@ -27,11 +27,13 @@ const graphApi = createGraphClient(logger, {
 });
 
 let testUser: UserModel;
+let testUser2: UserModel;
 let textDataTypeModel: DataTypeModel;
 let propertyTypeSchema: Omit<PropertyType, "$id">;
 
 beforeAll(async () => {
   testUser = await createTestUser(graphApi, "property-type-test", logger);
+  testUser2 = await createTestUser(graphApi, "property-type-test", logger);
 
   textDataTypeModel = await DataTypeModel.create(graphApi, {
     ownedById: testUser.entityId,
@@ -77,14 +79,20 @@ describe("Property type CRU", () => {
   const updatedTitle = "New test!";
 
   it("can update a property type", async () => {
-    await createdPropertyTypeModel
+    expect(createdPropertyTypeModel.createdById).toBe(testUser.entityId);
+    expect(createdPropertyTypeModel.updatedById).toBe(testUser.entityId);
+
+    createdPropertyTypeModel = await createdPropertyTypeModel
       .update(graphApi, {
         schema: {
           ...propertyTypeSchema,
           title: updatedTitle,
         },
-        updatedById: testUser.entityId,
+        updatedById: testUser2.entityId,
       })
       .catch((err) => Promise.reject(err.data));
+
+    expect(createdPropertyTypeModel.createdById).toBe(testUser.entityId);
+    expect(createdPropertyTypeModel.updatedById).toBe(testUser2.entityId);
   });
 });

--- a/packages/hash/integration/src/tests/model/ontology/property-type.model.test.ts
+++ b/packages/hash/integration/src/tests/model/ontology/property-type.model.test.ts
@@ -32,8 +32,8 @@ let textDataTypeModel: DataTypeModel;
 let propertyTypeSchema: Omit<PropertyType, "$id">;
 
 beforeAll(async () => {
-  testUser = await createTestUser(graphApi, "property-type-test-1", logger);
-  testUser2 = await createTestUser(graphApi, "property-type-test-2", logger);
+  testUser = await createTestUser(graphApi, "pt-test-1", logger);
+  testUser2 = await createTestUser(graphApi, "pt-test-2", logger);
 
   textDataTypeModel = await DataTypeModel.create(graphApi, {
     ownedById: testUser.entityId,

--- a/packages/hash/integration/src/tests/util.ts
+++ b/packages/hash/integration/src/tests/util.ts
@@ -130,7 +130,7 @@ export const createTestUser = async (
   const createdUser = await UserModel.createUser(graphApi, {
     emails: [`${shortname}@example.com`],
     kratosIdentityId,
-    createdById: workspaceAccountId,
+    actorId: workspaceAccountId,
   }).catch((err) => {
     logger.error(`Error making UserModel for ${shortname}`);
     throw err;
@@ -139,7 +139,7 @@ export const createTestUser = async (
   const updatedUser = await createdUser
     .updateShortname(graphApi, {
       updatedShortname: shortname,
-      updatedById: createdUser.entityId,
+      actorId: createdUser.entityId,
     })
     .catch((err) => {
       logger.error(`Error updating shortname for UserModel to ${shortname}`);

--- a/packages/hash/integration/src/tests/util.ts
+++ b/packages/hash/integration/src/tests/util.ts
@@ -5,7 +5,7 @@ import { GraphApi } from "@hashintel/hash-api/src/graph";
 import { UserModel } from "@hashintel/hash-api/src/model";
 import { ensureWorkspaceTypesExist } from "@hashintel/hash-api/src/graph/workspace-types";
 import { Logger } from "@hashintel/hash-backend-utils/logger";
-
+import { workspaceAccountId } from "@hashintel/hash-api/src/model/util";
 import {
   createLinkedAggregation,
   deleteLinkedAggregation,
@@ -130,6 +130,7 @@ export const createTestUser = async (
   const createdUser = await UserModel.createUser(graphApi, {
     emails: [`${shortname}@example.com`],
     kratosIdentityId,
+    createdById: workspaceAccountId,
   }).catch((err) => {
     logger.error(`Error making UserModel for ${shortname}`);
     throw err;
@@ -138,6 +139,7 @@ export const createTestUser = async (
   const updatedUser = await createdUser
     .updateShortname(graphApi, {
       updatedShortname: shortname,
+      updatedById: createdUser.entityId,
     })
     .catch((err) => {
       logger.error(`Error updating shortname for UserModel to ${shortname}`);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR introduces some basic provenance fields for ontology types, entities and links.

Specifically for ontology types and entities `created_by`, `updated_by` and `removed_by` fields were introduced.

For links a `created_by` field was introduced (as links already have a `removed_by` field, and don't currently have a need for an `updated_by_id` field as links cannot currently be updated).

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1200211978612931/1202848989198291/f) _(internal)_

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- replaces various instances of `accountId` with `ownedById`
- adds provenance fields to the database schema, metadata rust structs, and workspace model classes

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

No.

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

- links currently cannot be updated, which is why they don't have an `updatedById` field

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

- [Add basic provenance fields to GraphQL types](https://app.asana.com/0/1203007126736607/1203170881776185/f)
- [Create a provenance module in rust, and create new types for the provenance identifier fields](https://app.asana.com/0/1202805690238892/1203193667254522/f)

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- rust and workspace integration tests ensure no errors have been introduced
- some workspace integration tests have been modified to verify the `createdById`/`updatedById` provenance fields behave as expected

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Checkout the branch and run the tests locally, or check CI
