### PR TITLE
Introduce ontology/knowledge `metadata` structs

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -717,16 +717,16 @@ export interface LinkTypeRootedSubgraph {
 export interface PersistedDataType {
   /**
    *
-   * @type {PersistedOntologyIdentifier}
-   * @memberof PersistedDataType
-   */
-  identifier: PersistedOntologyIdentifier;
-  /**
-   *
    * @type {DataType}
    * @memberof PersistedDataType
    */
   inner: DataType;
+  /**
+   *
+   * @type {PersistedOntologyMetadata}
+   * @memberof PersistedDataType
+   */
+  metadata: PersistedOntologyMetadata;
 }
 /**
  * A record of an [`Entity`] that has been persisted in the datastore, with its associated
@@ -736,22 +736,16 @@ export interface PersistedDataType {
 export interface PersistedEntity {
   /**
    *
-   * @type {string}
-   * @memberof PersistedEntity
-   */
-  entityTypeId: string;
-  /**
-   *
-   * @type {PersistedEntityIdentifier}
-   * @memberof PersistedEntity
-   */
-  identifier: PersistedEntityIdentifier;
-  /**
-   *
    * @type {object}
    * @memberof PersistedEntity
    */
   inner: object;
+  /**
+   *
+   * @type {PersistedEntityMetadata}
+   * @memberof PersistedEntity
+   */
+  metadata: PersistedEntityMetadata;
 }
 /**
  * The metadata required to uniquely identify an instance of an [`Entity`] that has been persisted
@@ -779,6 +773,25 @@ export interface PersistedEntityIdentifier {
   version: string;
 }
 /**
+ * The metadata of an [`Entity`] record.
+ * @export
+ * @interface PersistedEntityMetadata
+ */
+export interface PersistedEntityMetadata {
+  /**
+   *
+   * @type {string}
+   * @memberof PersistedEntityMetadata
+   */
+  entityTypeId: string;
+  /**
+   *
+   * @type {PersistedEntityIdentifier}
+   * @memberof PersistedEntityMetadata
+   */
+  identifier: PersistedEntityIdentifier;
+}
+/**
  *
  * @export
  * @interface PersistedEntityType
@@ -786,16 +799,16 @@ export interface PersistedEntityIdentifier {
 export interface PersistedEntityType {
   /**
    *
-   * @type {PersistedOntologyIdentifier}
-   * @memberof PersistedEntityType
-   */
-  identifier: PersistedOntologyIdentifier;
-  /**
-   *
    * @type {EntityType}
    * @memberof PersistedEntityType
    */
   inner: EntityType;
+  /**
+   *
+   * @type {PersistedOntologyMetadata}
+   * @memberof PersistedEntityType
+   */
+  metadata: PersistedOntologyMetadata;
 }
 /**
  * A record of a [`Link`] that has been persisted in the datastore, with its associated
@@ -811,8 +824,21 @@ export interface PersistedLink {
   inner: Link;
   /**
    *
-   * @type {string}
+   * @type {PersistedLinkMetadata}
    * @memberof PersistedLink
+   */
+  metadata: PersistedLinkMetadata;
+}
+/**
+ * A record of a [`Link`] that has been persisted in the datastore, with its associated
+ * @export
+ * @interface PersistedLinkMetadata
+ */
+export interface PersistedLinkMetadata {
+  /**
+   *
+   * @type {string}
+   * @memberof PersistedLinkMetadata
    */
   ownedById: string;
 }
@@ -824,16 +850,16 @@ export interface PersistedLink {
 export interface PersistedLinkType {
   /**
    *
-   * @type {PersistedOntologyIdentifier}
-   * @memberof PersistedLinkType
-   */
-  identifier: PersistedOntologyIdentifier;
-  /**
-   *
    * @type {LinkType}
    * @memberof PersistedLinkType
    */
   inner: LinkType;
+  /**
+   *
+   * @type {PersistedOntologyMetadata}
+   * @memberof PersistedLinkType
+   */
+  metadata: PersistedOntologyMetadata;
 }
 /**
  * The metadata required to uniquely identify an ontology element that has been persisted in the
@@ -857,21 +883,34 @@ export interface PersistedOntologyIdentifier {
 /**
  *
  * @export
- * @interface PersistedPropertyType
+ * @interface PersistedOntologyMetadata
  */
-export interface PersistedPropertyType {
+export interface PersistedOntologyMetadata {
   /**
    *
    * @type {PersistedOntologyIdentifier}
-   * @memberof PersistedPropertyType
+   * @memberof PersistedOntologyMetadata
    */
   identifier: PersistedOntologyIdentifier;
+}
+/**
+ *
+ * @export
+ * @interface PersistedPropertyType
+ */
+export interface PersistedPropertyType {
   /**
    *
    * @type {PropertyType}
    * @memberof PersistedPropertyType
    */
   inner: PropertyType;
+  /**
+   *
+   * @type {PersistedOntologyMetadata}
+   * @memberof PersistedPropertyType
+   */
+  metadata: PersistedOntologyMetadata;
 }
 /**
  *

--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -830,7 +830,7 @@ export interface PersistedLink {
   metadata: PersistedLinkMetadata;
 }
 /**
- * A record of a [`Link`] that has been persisted in the datastore, with its associated
+ * The metadata of a [`Link`] record.
  * @export
  * @interface PersistedLinkMetadata
  */

--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -1944,7 +1944,7 @@ export const DataTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyIdentifier>
+      ) => AxiosPromise<PersistedOntologyMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.createDataType(
         createDataTypeRequest,
@@ -2042,7 +2042,7 @@ export const DataTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyIdentifier>
+      ) => AxiosPromise<PersistedOntologyMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.updateDataType(
         updateDataTypeRequest,
@@ -2078,7 +2078,7 @@ export const DataTypeApiFactory = function (
     createDataType(
       createDataTypeRequest: CreateDataTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyIdentifier> {
+    ): AxiosPromise<PersistedOntologyMetadata> {
       return localVarFp
         .createDataType(createDataTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -2127,7 +2127,7 @@ export const DataTypeApiFactory = function (
     updateDataType(
       updateDataTypeRequest: UpdateDataTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyIdentifier> {
+    ): AxiosPromise<PersistedOntologyMetadata> {
       return localVarFp
         .updateDataType(updateDataTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -2151,7 +2151,7 @@ export interface DataTypeApiInterface {
   createDataType(
     createDataTypeRequest: CreateDataTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyIdentifier>;
+  ): AxiosPromise<PersistedOntologyMetadata>;
 
   /**
    *
@@ -2197,7 +2197,7 @@ export interface DataTypeApiInterface {
   updateDataType(
     updateDataTypeRequest: UpdateDataTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyIdentifier>;
+  ): AxiosPromise<PersistedOntologyMetadata>;
 }
 
 /**
@@ -2551,7 +2551,7 @@ export const EntityApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedEntityIdentifier>
+      ) => AxiosPromise<PersistedEntityMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.createEntity(
         createEntityRequest,
@@ -2652,7 +2652,7 @@ export const EntityApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedEntityIdentifier>
+      ) => AxiosPromise<PersistedEntityMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.updateEntity(
         updateEntityRequest,
@@ -2688,7 +2688,7 @@ export const EntityApiFactory = function (
     createEntity(
       createEntityRequest: CreateEntityRequest,
       options?: any,
-    ): AxiosPromise<PersistedEntityIdentifier> {
+    ): AxiosPromise<PersistedEntityMetadata> {
       return localVarFp
         .createEntity(createEntityRequest, options)
         .then((request) => request(axios, basePath));
@@ -2737,7 +2737,7 @@ export const EntityApiFactory = function (
     updateEntity(
       updateEntityRequest: UpdateEntityRequest,
       options?: any,
-    ): AxiosPromise<PersistedEntityIdentifier> {
+    ): AxiosPromise<PersistedEntityMetadata> {
       return localVarFp
         .updateEntity(updateEntityRequest, options)
         .then((request) => request(axios, basePath));
@@ -2761,7 +2761,7 @@ export interface EntityApiInterface {
   createEntity(
     createEntityRequest: CreateEntityRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedEntityIdentifier>;
+  ): AxiosPromise<PersistedEntityMetadata>;
 
   /**
    *
@@ -2807,7 +2807,7 @@ export interface EntityApiInterface {
   updateEntity(
     updateEntityRequest: UpdateEntityRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedEntityIdentifier>;
+  ): AxiosPromise<PersistedEntityMetadata>;
 }
 
 /**
@@ -3165,7 +3165,7 @@ export const EntityTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyIdentifier>
+      ) => AxiosPromise<PersistedOntologyMetadata>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.createEntityType(
@@ -3267,7 +3267,7 @@ export const EntityTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyIdentifier>
+      ) => AxiosPromise<PersistedOntologyMetadata>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.updateEntityType(
@@ -3304,7 +3304,7 @@ export const EntityTypeApiFactory = function (
     createEntityType(
       createEntityTypeRequest: CreateEntityTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyIdentifier> {
+    ): AxiosPromise<PersistedOntologyMetadata> {
       return localVarFp
         .createEntityType(createEntityTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -3358,7 +3358,7 @@ export const EntityTypeApiFactory = function (
     updateEntityType(
       updateEntityTypeRequest: UpdateEntityTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyIdentifier> {
+    ): AxiosPromise<PersistedOntologyMetadata> {
       return localVarFp
         .updateEntityType(updateEntityTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -3382,7 +3382,7 @@ export interface EntityTypeApiInterface {
   createEntityType(
     createEntityTypeRequest: CreateEntityTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyIdentifier>;
+  ): AxiosPromise<PersistedOntologyMetadata>;
 
   /**
    *
@@ -3428,7 +3428,7 @@ export interface EntityTypeApiInterface {
   updateEntityType(
     updateEntityTypeRequest: UpdateEntityTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyIdentifier>;
+  ): AxiosPromise<PersistedOntologyMetadata>;
 }
 
 /**
@@ -5013,7 +5013,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyIdentifier>
+      ) => AxiosPromise<PersistedOntologyMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.createDataType(
         createDataTypeRequest,
@@ -5039,7 +5039,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedEntityIdentifier>
+      ) => AxiosPromise<PersistedEntityMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.createEntity(
         createEntityRequest,
@@ -5065,7 +5065,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyIdentifier>
+      ) => AxiosPromise<PersistedOntologyMetadata>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.createEntityType(
@@ -5118,7 +5118,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyIdentifier>
+      ) => AxiosPromise<PersistedOntologyMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.createLinkType(
         createLinkTypeRequest,
@@ -5144,7 +5144,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyIdentifier>
+      ) => AxiosPromise<PersistedOntologyMetadata>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.createPropertyType(
@@ -5621,7 +5621,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyIdentifier>
+      ) => AxiosPromise<PersistedOntologyMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.updateDataType(
         updateDataTypeRequest,
@@ -5647,7 +5647,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedEntityIdentifier>
+      ) => AxiosPromise<PersistedEntityMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.updateEntity(
         updateEntityRequest,
@@ -5673,7 +5673,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyIdentifier>
+      ) => AxiosPromise<PersistedOntologyMetadata>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.updateEntityType(
@@ -5700,7 +5700,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyIdentifier>
+      ) => AxiosPromise<PersistedOntologyMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.updateLinkType(
         updateLinkTypeRequest,
@@ -5726,7 +5726,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyIdentifier>
+      ) => AxiosPromise<PersistedOntologyMetadata>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.updatePropertyType(
@@ -5773,7 +5773,7 @@ export const GraphApiFactory = function (
     createDataType(
       createDataTypeRequest: CreateDataTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyIdentifier> {
+    ): AxiosPromise<PersistedOntologyMetadata> {
       return localVarFp
         .createDataType(createDataTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -5787,7 +5787,7 @@ export const GraphApiFactory = function (
     createEntity(
       createEntityRequest: CreateEntityRequest,
       options?: any,
-    ): AxiosPromise<PersistedEntityIdentifier> {
+    ): AxiosPromise<PersistedEntityMetadata> {
       return localVarFp
         .createEntity(createEntityRequest, options)
         .then((request) => request(axios, basePath));
@@ -5801,7 +5801,7 @@ export const GraphApiFactory = function (
     createEntityType(
       createEntityTypeRequest: CreateEntityTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyIdentifier> {
+    ): AxiosPromise<PersistedOntologyMetadata> {
       return localVarFp
         .createEntityType(createEntityTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -5831,7 +5831,7 @@ export const GraphApiFactory = function (
     createLinkType(
       createLinkTypeRequest: CreateLinkTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyIdentifier> {
+    ): AxiosPromise<PersistedOntologyMetadata> {
       return localVarFp
         .createLinkType(createLinkTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -5845,7 +5845,7 @@ export const GraphApiFactory = function (
     createPropertyType(
       createPropertyTypeRequest: CreatePropertyTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyIdentifier> {
+    ): AxiosPromise<PersistedOntologyMetadata> {
       return localVarFp
         .createPropertyType(createPropertyTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -6088,7 +6088,7 @@ export const GraphApiFactory = function (
     updateDataType(
       updateDataTypeRequest: UpdateDataTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyIdentifier> {
+    ): AxiosPromise<PersistedOntologyMetadata> {
       return localVarFp
         .updateDataType(updateDataTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -6102,7 +6102,7 @@ export const GraphApiFactory = function (
     updateEntity(
       updateEntityRequest: UpdateEntityRequest,
       options?: any,
-    ): AxiosPromise<PersistedEntityIdentifier> {
+    ): AxiosPromise<PersistedEntityMetadata> {
       return localVarFp
         .updateEntity(updateEntityRequest, options)
         .then((request) => request(axios, basePath));
@@ -6116,7 +6116,7 @@ export const GraphApiFactory = function (
     updateEntityType(
       updateEntityTypeRequest: UpdateEntityTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyIdentifier> {
+    ): AxiosPromise<PersistedOntologyMetadata> {
       return localVarFp
         .updateEntityType(updateEntityTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -6130,7 +6130,7 @@ export const GraphApiFactory = function (
     updateLinkType(
       updateLinkTypeRequest: UpdateLinkTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyIdentifier> {
+    ): AxiosPromise<PersistedOntologyMetadata> {
       return localVarFp
         .updateLinkType(updateLinkTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -6144,7 +6144,7 @@ export const GraphApiFactory = function (
     updatePropertyType(
       updatePropertyTypeRequest: UpdatePropertyTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyIdentifier> {
+    ): AxiosPromise<PersistedOntologyMetadata> {
       return localVarFp
         .updatePropertyType(updatePropertyTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -6176,7 +6176,7 @@ export interface GraphApiInterface {
   createDataType(
     createDataTypeRequest: CreateDataTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyIdentifier>;
+  ): AxiosPromise<PersistedOntologyMetadata>;
 
   /**
    *
@@ -6188,7 +6188,7 @@ export interface GraphApiInterface {
   createEntity(
     createEntityRequest: CreateEntityRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedEntityIdentifier>;
+  ): AxiosPromise<PersistedEntityMetadata>;
 
   /**
    *
@@ -6200,7 +6200,7 @@ export interface GraphApiInterface {
   createEntityType(
     createEntityTypeRequest: CreateEntityTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyIdentifier>;
+  ): AxiosPromise<PersistedOntologyMetadata>;
 
   /**
    *
@@ -6226,7 +6226,7 @@ export interface GraphApiInterface {
   createLinkType(
     createLinkTypeRequest: CreateLinkTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyIdentifier>;
+  ): AxiosPromise<PersistedOntologyMetadata>;
 
   /**
    *
@@ -6238,7 +6238,7 @@ export interface GraphApiInterface {
   createPropertyType(
     createPropertyTypeRequest: CreatePropertyTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyIdentifier>;
+  ): AxiosPromise<PersistedOntologyMetadata>;
 
   /**
    *
@@ -6458,7 +6458,7 @@ export interface GraphApiInterface {
   updateDataType(
     updateDataTypeRequest: UpdateDataTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyIdentifier>;
+  ): AxiosPromise<PersistedOntologyMetadata>;
 
   /**
    *
@@ -6470,7 +6470,7 @@ export interface GraphApiInterface {
   updateEntity(
     updateEntityRequest: UpdateEntityRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedEntityIdentifier>;
+  ): AxiosPromise<PersistedEntityMetadata>;
 
   /**
    *
@@ -6482,7 +6482,7 @@ export interface GraphApiInterface {
   updateEntityType(
     updateEntityTypeRequest: UpdateEntityTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyIdentifier>;
+  ): AxiosPromise<PersistedOntologyMetadata>;
 
   /**
    *
@@ -6494,7 +6494,7 @@ export interface GraphApiInterface {
   updateLinkType(
     updateLinkTypeRequest: UpdateLinkTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyIdentifier>;
+  ): AxiosPromise<PersistedOntologyMetadata>;
 
   /**
    *
@@ -6506,7 +6506,7 @@ export interface GraphApiInterface {
   updatePropertyType(
     updatePropertyTypeRequest: UpdatePropertyTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyIdentifier>;
+  ): AxiosPromise<PersistedOntologyMetadata>;
 }
 
 /**
@@ -7766,7 +7766,7 @@ export const LinkTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyIdentifier>
+      ) => AxiosPromise<PersistedOntologyMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.createLinkType(
         createLinkTypeRequest,
@@ -7867,7 +7867,7 @@ export const LinkTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyIdentifier>
+      ) => AxiosPromise<PersistedOntologyMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.updateLinkType(
         updateLinkTypeRequest,
@@ -7903,7 +7903,7 @@ export const LinkTypeApiFactory = function (
     createLinkType(
       createLinkTypeRequest: CreateLinkTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyIdentifier> {
+    ): AxiosPromise<PersistedOntologyMetadata> {
       return localVarFp
         .createLinkType(createLinkTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -7952,7 +7952,7 @@ export const LinkTypeApiFactory = function (
     updateLinkType(
       updateLinkTypeRequest: UpdateLinkTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyIdentifier> {
+    ): AxiosPromise<PersistedOntologyMetadata> {
       return localVarFp
         .updateLinkType(updateLinkTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -7976,7 +7976,7 @@ export interface LinkTypeApiInterface {
   createLinkType(
     createLinkTypeRequest: CreateLinkTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyIdentifier>;
+  ): AxiosPromise<PersistedOntologyMetadata>;
 
   /**
    *
@@ -8022,7 +8022,7 @@ export interface LinkTypeApiInterface {
   updateLinkType(
     updateLinkTypeRequest: UpdateLinkTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyIdentifier>;
+  ): AxiosPromise<PersistedOntologyMetadata>;
 }
 
 /**
@@ -8380,7 +8380,7 @@ export const PropertyTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyIdentifier>
+      ) => AxiosPromise<PersistedOntologyMetadata>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.createPropertyType(
@@ -8482,7 +8482,7 @@ export const PropertyTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyIdentifier>
+      ) => AxiosPromise<PersistedOntologyMetadata>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.updatePropertyType(
@@ -8519,7 +8519,7 @@ export const PropertyTypeApiFactory = function (
     createPropertyType(
       createPropertyTypeRequest: CreatePropertyTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyIdentifier> {
+    ): AxiosPromise<PersistedOntologyMetadata> {
       return localVarFp
         .createPropertyType(createPropertyTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -8573,7 +8573,7 @@ export const PropertyTypeApiFactory = function (
     updatePropertyType(
       updatePropertyTypeRequest: UpdatePropertyTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyIdentifier> {
+    ): AxiosPromise<PersistedOntologyMetadata> {
       return localVarFp
         .updatePropertyType(updatePropertyTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -8597,7 +8597,7 @@ export interface PropertyTypeApiInterface {
   createPropertyType(
     createPropertyTypeRequest: CreatePropertyTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyIdentifier>;
+  ): AxiosPromise<PersistedOntologyMetadata>;
 
   /**
    *
@@ -8643,7 +8643,7 @@ export interface PropertyTypeApiInterface {
   updatePropertyType(
     updatePropertyTypeRequest: UpdatePropertyTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyIdentifier>;
+  ): AxiosPromise<PersistedOntologyMetadata>;
 }
 
 /**

--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -1724,16 +1724,16 @@ export type VertexOneOf1KindEnum =
 export interface VertexOneOf1Inner {
   /**
    *
-   * @type {PersistedOntologyIdentifier}
-   * @memberof VertexOneOf1Inner
-   */
-  identifier: PersistedOntologyIdentifier;
-  /**
-   *
    * @type {PropertyType}
    * @memberof VertexOneOf1Inner
    */
   inner: PropertyType;
+  /**
+   *
+   * @type {PersistedOntologyMetadata}
+   * @memberof VertexOneOf1Inner
+   */
+  metadata: PersistedOntologyMetadata;
 }
 /**
  *
@@ -1770,16 +1770,16 @@ export type VertexOneOf2KindEnum =
 export interface VertexOneOf2Inner {
   /**
    *
-   * @type {PersistedOntologyIdentifier}
-   * @memberof VertexOneOf2Inner
-   */
-  identifier: PersistedOntologyIdentifier;
-  /**
-   *
    * @type {LinkType}
    * @memberof VertexOneOf2Inner
    */
   inner: LinkType;
+  /**
+   *
+   * @type {PersistedOntologyMetadata}
+   * @memberof VertexOneOf2Inner
+   */
+  metadata: PersistedOntologyMetadata;
 }
 /**
  *
@@ -1816,16 +1816,16 @@ export type VertexOneOf3KindEnum =
 export interface VertexOneOf3Inner {
   /**
    *
-   * @type {PersistedOntologyIdentifier}
-   * @memberof VertexOneOf3Inner
-   */
-  identifier: PersistedOntologyIdentifier;
-  /**
-   *
    * @type {EntityType}
    * @memberof VertexOneOf3Inner
    */
   inner: EntityType;
+  /**
+   *
+   * @type {PersistedOntologyMetadata}
+   * @memberof VertexOneOf3Inner
+   */
+  metadata: PersistedOntologyMetadata;
 }
 /**
  *
@@ -1862,22 +1862,16 @@ export type VertexOneOf4KindEnum =
 export interface VertexOneOf4Inner {
   /**
    *
-   * @type {string}
-   * @memberof VertexOneOf4Inner
-   */
-  entityTypeId: string;
-  /**
-   *
-   * @type {PersistedEntityIdentifier}
-   * @memberof VertexOneOf4Inner
-   */
-  identifier: PersistedEntityIdentifier;
-  /**
-   *
    * @type {object}
    * @memberof VertexOneOf4Inner
    */
   inner: object;
+  /**
+   *
+   * @type {PersistedEntityMetadata}
+   * @memberof VertexOneOf4Inner
+   */
+  metadata: PersistedEntityMetadata;
 }
 /**
  *
@@ -1920,10 +1914,10 @@ export interface VertexOneOf5Inner {
   inner: Link;
   /**
    *
-   * @type {string}
+   * @type {PersistedLinkMetadata}
    * @memberof VertexOneOf5Inner
    */
-  ownedById: string;
+  metadata: PersistedLinkMetadata;
 }
 /**
  *
@@ -1933,16 +1927,16 @@ export interface VertexOneOf5Inner {
 export interface VertexOneOfInner {
   /**
    *
-   * @type {PersistedOntologyIdentifier}
-   * @memberof VertexOneOfInner
-   */
-  identifier: PersistedOntologyIdentifier;
-  /**
-   *
    * @type {DataType}
    * @memberof VertexOneOfInner
    */
   inner: DataType;
+  /**
+   *
+   * @type {PersistedOntologyMetadata}
+   * @memberof VertexOneOfInner
+   */
+  metadata: PersistedOntologyMetadata;
 }
 
 /**

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -87,7 +87,7 @@ struct CreateDataTypeRequest {
     request_body = CreateDataTypeRequest,
     tag = "DataType",
     responses(
-        (status = 201, content_type = "application/json", description = "The schema of the created data type", body = PersistedOntologyMetadata),
+        (status = 201, content_type = "application/json", description = "The metadata of the created data type", body = PersistedOntologyMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 409, description = "Unable to create data type in the store as the base data type URI already exists"),
@@ -225,7 +225,7 @@ struct UpdateDataTypeRequest {
     path = "/data-types",
     tag = "DataType",
     responses(
-        (status = 200, content_type = "application/json", description = "The schema of the updated data type", body = PersistedOntologyMetadata),
+        (status = 200, content_type = "application/json", description = "The metadata of the updated data type", body = PersistedOntologyMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Base data type ID was not found"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -20,7 +20,7 @@ use crate::{
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
         patch_id_and_parse, AccountId, DataTypeQuery, DataTypeRootedSubgraph, PersistedDataType,
-        PersistedOntologyIdentifier,
+        PersistedOntologyIdentifier, PersistedOntologyMetadata,
     },
     store::{
         query::Expression, BaseUriAlreadyExists, BaseUriDoesNotExist, DataTypeStore, StorePool,
@@ -98,7 +98,7 @@ async fn create_data_type<P: StorePool + Send>(
     body: Json<CreateDataTypeRequest>,
     pool: Extension<Arc<P>>,
     domain_validator: Extension<DomainValidator>,
-) -> Result<Json<PersistedOntologyIdentifier>, StatusCode> {
+) -> Result<Json<PersistedOntologyMetadata>, StatusCode> {
     let Json(CreateDataTypeRequest { schema, account_id }) = body;
 
     let data_type: DataType = schema.try_into().into_report().map_err(|report| {
@@ -235,7 +235,7 @@ struct UpdateDataTypeRequest {
 async fn update_data_type<P: StorePool + Send>(
     body: Json<UpdateDataTypeRequest>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<PersistedOntologyIdentifier>, StatusCode> {
+) -> Result<Json<PersistedOntologyMetadata>, StatusCode> {
     let Json(UpdateDataTypeRequest {
         schema,
         type_to_update,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -87,7 +87,7 @@ struct CreateDataTypeRequest {
     request_body = CreateDataTypeRequest,
     tag = "DataType",
     responses(
-        (status = 201, content_type = "application/json", description = "The schema of the created data type", body = PersistedOntologyIdentifier),
+        (status = 201, content_type = "application/json", description = "The schema of the created data type", body = PersistedOntologyMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 409, description = "Unable to create data type in the store as the base data type URI already exists"),
@@ -225,7 +225,7 @@ struct UpdateDataTypeRequest {
     path = "/data-types",
     tag = "DataType",
     responses(
-        (status = 200, content_type = "application/json", description = "The schema of the updated data type", body = PersistedOntologyIdentifier),
+        (status = 200, content_type = "application/json", description = "The schema of the updated data type", body = PersistedOntologyMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Base data type ID was not found"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -42,6 +42,7 @@ use crate::{
             UpdateDataTypeRequest,
             AccountId,
             PersistedOntologyIdentifier,
+            PersistedOntologyMetadata,
             PersistedDataType,
             DataTypeQuery,
             DataTypeRootedSubgraph,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -17,7 +17,7 @@ use crate::{
     api::rest::{api_resource::RoutedResource, read_from_store, report_to_status_code},
     knowledge::{
         Entity, EntityId, EntityRootedSubgraph, KnowledgeGraphQuery, PersistedEntity,
-        PersistedEntityIdentifier,
+        PersistedEntityIdentifier, PersistedEntityMetadata,
     },
     ontology::AccountId,
     store::{
@@ -100,7 +100,7 @@ struct CreateEntityRequest {
 async fn create_entity<P: StorePool + Send>(
     body: Json<CreateEntityRequest>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<PersistedEntityIdentifier>, StatusCode> {
+) -> Result<Json<PersistedEntityMetadata>, StatusCode> {
     let Json(CreateEntityRequest {
         entity,
         entity_type_id,
@@ -225,7 +225,7 @@ struct UpdateEntityRequest {
 async fn update_entity<P: StorePool + Send>(
     body: Json<UpdateEntityRequest>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<PersistedEntityIdentifier>, StatusCode> {
+) -> Result<Json<PersistedEntityMetadata>, StatusCode> {
     let Json(UpdateEntityRequest {
         entity,
         entity_id,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -90,7 +90,7 @@ struct CreateEntityRequest {
     request_body = CreateEntityRequest,
     tag = "Entity",
     responses(
-        (status = 201, content_type = "application/json", description = "The created entity", body = PersistedEntityIdentifier),
+        (status = 201, content_type = "application/json", description = "The created entity", body = PersistedEntityMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Entity Type URI was not found"),
@@ -215,7 +215,7 @@ struct UpdateEntityRequest {
     path = "/entities",
     tag = "Entity",
     responses(
-        (status = 200, content_type = "application/json", description = "The updated entity", body = PersistedEntityIdentifier),
+        (status = 200, content_type = "application/json", description = "The updated entity", body = PersistedEntityMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Entity ID or Entity Type URI was not found"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -90,7 +90,7 @@ struct CreateEntityRequest {
     request_body = CreateEntityRequest,
     tag = "Entity",
     responses(
-        (status = 201, content_type = "application/json", description = "The created entity", body = PersistedEntityMetadata),
+        (status = 201, content_type = "application/json", description = "The metadata of the created entity", body = PersistedEntityMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Entity Type URI was not found"),
@@ -215,7 +215,7 @@ struct UpdateEntityRequest {
     path = "/entities",
     tag = "Entity",
     responses(
-        (status = 200, content_type = "application/json", description = "The updated entity", body = PersistedEntityMetadata),
+        (status = 200, content_type = "application/json", description = "The metadata of the updated entity", body = PersistedEntityMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Entity ID or Entity Type URI was not found"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -42,6 +42,7 @@ use crate::{
             UpdateEntityRequest,
             EntityId,
             PersistedEntityIdentifier,
+            PersistedEntityMetadata,
             PersistedEntity,
             Entity,
             KnowledgeGraphQuery,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -88,7 +88,7 @@ struct CreateEntityTypeRequest {
     request_body = CreateEntityTypeRequest,
     tag = "EntityType",
     responses(
-        (status = 201, content_type = "application/json", description = "The schema of the created entity type", body = PersistedOntologyIdentifier),
+        (status = 201, content_type = "application/json", description = "The schema of the created entity type", body = PersistedOntologyMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 409, description = "Unable to create entity type in the datastore as the base entity type ID already exists"),
@@ -229,7 +229,7 @@ struct UpdateEntityTypeRequest {
     path = "/entity-types",
     tag = "EntityType",
     responses(
-        (status = 200, content_type = "application/json", description = "The schema of the updated entity type", body = PersistedOntologyIdentifier),
+        (status = 200, content_type = "application/json", description = "The schema of the updated entity type", body = PersistedOntologyMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Base entity type ID was not found"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -88,7 +88,7 @@ struct CreateEntityTypeRequest {
     request_body = CreateEntityTypeRequest,
     tag = "EntityType",
     responses(
-        (status = 201, content_type = "application/json", description = "The schema of the created entity type", body = PersistedOntologyMetadata),
+        (status = 201, content_type = "application/json", description = "The metadata of the created entity type", body = PersistedOntologyMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 409, description = "Unable to create entity type in the datastore as the base entity type ID already exists"),
@@ -229,7 +229,7 @@ struct UpdateEntityTypeRequest {
     path = "/entity-types",
     tag = "EntityType",
     responses(
-        (status = 200, content_type = "application/json", description = "The schema of the updated entity type", body = PersistedOntologyMetadata),
+        (status = 200, content_type = "application/json", description = "The metadata of the updated entity type", body = PersistedOntologyMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Base entity type ID was not found"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -19,7 +19,7 @@ use crate::{
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
         patch_id_and_parse, AccountId, EntityTypeQuery, EntityTypeRootedSubgraph,
-        PersistedEntityType, PersistedOntologyIdentifier,
+        PersistedEntityType, PersistedOntologyIdentifier, PersistedOntologyMetadata,
     },
     store::{
         error::{BaseUriAlreadyExists, BaseUriDoesNotExist},
@@ -43,6 +43,7 @@ use crate::{
             UpdateEntityTypeRequest,
             AccountId,
             PersistedOntologyIdentifier,
+            PersistedOntologyMetadata,
             PersistedEntityType,
             EntityTypeQuery,
             EntityTypeRootedSubgraph,
@@ -99,7 +100,7 @@ async fn create_entity_type<P: StorePool + Send>(
     body: Json<CreateEntityTypeRequest>,
     pool: Extension<Arc<P>>,
     domain_validator: Extension<DomainValidator>,
-) -> Result<Json<PersistedOntologyIdentifier>, StatusCode> {
+) -> Result<Json<PersistedOntologyMetadata>, StatusCode> {
     let Json(CreateEntityTypeRequest { schema, account_id }) = body;
 
     let entity_type: EntityType = schema.try_into().into_report().map_err(|report| {
@@ -239,7 +240,7 @@ struct UpdateEntityTypeRequest {
 async fn update_entity_type<P: StorePool + Send>(
     body: Json<UpdateEntityTypeRequest>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<PersistedOntologyIdentifier>, StatusCode> {
+) -> Result<Json<PersistedOntologyMetadata>, StatusCode> {
     let Json(UpdateEntityTypeRequest {
         schema,
         type_to_update,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link.rs
@@ -10,7 +10,10 @@ use utoipa::{OpenApi, ToSchema};
 
 use crate::{
     api::rest::{api_resource::RoutedResource, read_from_store, report_to_status_code},
-    knowledge::{EntityId, KnowledgeGraphQuery, Link, LinkRootedSubgraph, PersistedLink},
+    knowledge::{
+        EntityId, KnowledgeGraphQuery, Link, LinkRootedSubgraph, PersistedLink,
+        PersistedLinkMetadata,
+    },
     ontology::AccountId,
     store::{error::QueryError, query::Expression, LinkStore, StorePool},
 };
@@ -31,7 +34,8 @@ use crate::{
             CreateLinkRequest,
             RemoveLinkRequest,
             KnowledgeGraphQuery,
-            LinkRootedSubgraph
+            LinkRootedSubgraph,
+            PersistedLinkMetadata
         )
     ),
     tags(

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -87,7 +87,7 @@ struct CreateLinkTypeRequest {
     request_body = CreateLinkTypeRequest,
     tag = "LinkType",
     responses(
-        (status = 201, content_type = "application/json", description = "The schema of the created link type", body = PersistedOntologyMetadata),
+        (status = 201, content_type = "application/json", description = "The metadata of the created link type", body = PersistedOntologyMetadata),
 
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
         (status = 409, description = "Unable to create link type in the store as the base link type ID already exists"),
@@ -224,7 +224,7 @@ struct UpdateLinkTypeRequest {
     path = "/link-types",
     tag = "LinkType",
     responses(
-        (status = 200, content_type = "application/json", description = "The schema of the updated link type", body = PersistedOntologyMetadata),
+        (status = 200, content_type = "application/json", description = "The metadata of the updated link type", body = PersistedOntologyMetadata),
 
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
         (status = 404, description = "Base link type ID was not found"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -87,7 +87,7 @@ struct CreateLinkTypeRequest {
     request_body = CreateLinkTypeRequest,
     tag = "LinkType",
     responses(
-        (status = 201, content_type = "application/json", description = "The schema of the created link type", body = PersistedOntologyIdentifier),
+        (status = 201, content_type = "application/json", description = "The schema of the created link type", body = PersistedOntologyMetadata),
 
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
         (status = 409, description = "Unable to create link type in the store as the base link type ID already exists"),
@@ -224,7 +224,7 @@ struct UpdateLinkTypeRequest {
     path = "/link-types",
     tag = "LinkType",
     responses(
-        (status = 200, content_type = "application/json", description = "The schema of the updated link type", body = PersistedOntologyIdentifier),
+        (status = 200, content_type = "application/json", description = "The schema of the updated link type", body = PersistedOntologyMetadata),
 
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
         (status = 404, description = "Base link type ID was not found"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -20,7 +20,7 @@ use crate::{
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
         patch_id_and_parse, AccountId, LinkTypeQuery, LinkTypeRootedSubgraph, PersistedLinkType,
-        PersistedOntologyIdentifier,
+        PersistedOntologyIdentifier, PersistedOntologyMetadata,
     },
     store::{
         query::Expression, BaseUriAlreadyExists, BaseUriDoesNotExist, LinkTypeStore, StorePool,
@@ -42,6 +42,7 @@ use crate::{
             UpdateLinkTypeRequest,
             AccountId,
             PersistedOntologyIdentifier,
+            PersistedOntologyMetadata,
             PersistedLinkType,
             LinkTypeQuery,
             LinkTypeRootedSubgraph,
@@ -98,7 +99,7 @@ async fn create_link_type<P: StorePool + Send>(
     body: Json<CreateLinkTypeRequest>,
     pool: Extension<Arc<P>>,
     domain_validator: Extension<DomainValidator>,
-) -> Result<Json<PersistedOntologyIdentifier>, StatusCode> {
+) -> Result<Json<PersistedOntologyMetadata>, StatusCode> {
     let Json(CreateLinkTypeRequest { schema, account_id }) = body;
 
     let link_type: LinkType = schema.try_into().into_report().map_err(|report| {
@@ -234,7 +235,7 @@ struct UpdateLinkTypeRequest {
 async fn update_link_type<P: StorePool + Send>(
     body: Json<UpdateLinkTypeRequest>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<PersistedOntologyIdentifier>, StatusCode> {
+) -> Result<Json<PersistedOntologyMetadata>, StatusCode> {
     let Json(UpdateLinkTypeRequest {
         schema,
         type_to_update,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -19,8 +19,8 @@ use crate::{
     api::rest::{read_from_store, report_to_status_code},
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
-        patch_id_and_parse, AccountId, PersistedOntologyIdentifier, PersistedPropertyType,
-        PropertyTypeQuery, PropertyTypeRootedSubgraph,
+        patch_id_and_parse, AccountId, PersistedOntologyIdentifier, PersistedOntologyMetadata,
+        PersistedPropertyType, PropertyTypeQuery, PropertyTypeRootedSubgraph,
     },
     store::{
         query::Expression, BaseUriAlreadyExists, BaseUriDoesNotExist, PropertyTypeStore, StorePool,
@@ -42,6 +42,7 @@ use crate::{
             UpdatePropertyTypeRequest,
             AccountId,
             PersistedOntologyIdentifier,
+            PersistedOntologyMetadata,
             PersistedPropertyType,
             PropertyTypeQuery,
             PropertyTypeRootedSubgraph,
@@ -98,7 +99,7 @@ async fn create_property_type<P: StorePool + Send>(
     body: Json<CreatePropertyTypeRequest>,
     pool: Extension<Arc<P>>,
     domain_validator: Extension<DomainValidator>,
-) -> Result<Json<PersistedOntologyIdentifier>, StatusCode> {
+) -> Result<Json<PersistedOntologyMetadata>, StatusCode> {
     let Json(CreatePropertyTypeRequest { schema, account_id }) = body;
 
     let property_type: PropertyType = schema.try_into().into_report().map_err(|report| {
@@ -242,7 +243,7 @@ struct UpdatePropertyTypeRequest {
 async fn update_property_type<P: StorePool + Send>(
     body: Json<UpdatePropertyTypeRequest>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<PersistedOntologyIdentifier>, StatusCode> {
+) -> Result<Json<PersistedOntologyMetadata>, StatusCode> {
     let Json(UpdatePropertyTypeRequest {
         schema,
         type_to_update,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -87,7 +87,7 @@ struct CreatePropertyTypeRequest {
     request_body = CreatePropertyTypeRequest,
     tag = "PropertyType",
     responses(
-        (status = 201, content_type = "application/json", description = "The schema of the created property type", body = PersistedOntologyIdentifier),
+        (status = 201, content_type = "application/json", description = "The schema of the created property type", body = PersistedOntologyMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 409, description = "Unable to create property type in the store as the base property type ID already exists"),
@@ -232,7 +232,7 @@ struct UpdatePropertyTypeRequest {
     path = "/property-types",
     tag = "PropertyType",
     responses(
-        (status = 200, content_type = "application/json", description = "The schema of the updated property type", body = PersistedOntologyIdentifier),
+        (status = 200, content_type = "application/json", description = "The schema of the updated property type", body = PersistedOntologyMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Base property type ID was not found"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -87,7 +87,7 @@ struct CreatePropertyTypeRequest {
     request_body = CreatePropertyTypeRequest,
     tag = "PropertyType",
     responses(
-        (status = 201, content_type = "application/json", description = "The schema of the created property type", body = PersistedOntologyMetadata),
+        (status = 201, content_type = "application/json", description = "The metadata of the created property type", body = PersistedOntologyMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 409, description = "Unable to create property type in the store as the base property type ID already exists"),
@@ -232,7 +232,7 @@ struct UpdatePropertyTypeRequest {
     path = "/property-types",
     tag = "PropertyType",
     responses(
-        (status = 200, content_type = "application/json", description = "The schema of the updated property type", body = PersistedOntologyMetadata),
+        (status = 200, content_type = "application/json", description = "The metadata of the updated property type", body = PersistedOntologyMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Base property type ID was not found"),

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -80,15 +80,42 @@ impl PersistedEntityIdentifier {
     }
 }
 
+/// The metadata of an [`Entity`] record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PersistedEntityMetadata {
+    identifier: PersistedEntityIdentifier,
+    #[schema(value_type = String)]
+    entity_type_id: VersionedUri,
+}
+
+impl PersistedEntityMetadata {
+    #[must_use]
+    pub const fn new(identifier: PersistedEntityIdentifier, entity_type_id: VersionedUri) -> Self {
+        Self {
+            identifier,
+            entity_type_id,
+        }
+    }
+
+    #[must_use]
+    pub const fn identifier(&self) -> &PersistedEntityIdentifier {
+        &self.identifier
+    }
+
+    #[must_use]
+    pub const fn entity_type_id(&self) -> &VersionedUri {
+        &self.entity_type_id
+    }
+}
+
 /// A record of an [`Entity`] that has been persisted in the datastore, with its associated
 /// metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PersistedEntity {
     inner: Entity,
-    identifier: PersistedEntityIdentifier,
-    #[schema(value_type = String)]
-    entity_type_id: VersionedUri,
+    metadata: PersistedEntityMetadata,
 }
 
 impl PersistedEntity {
@@ -102,8 +129,10 @@ impl PersistedEntity {
     ) -> Self {
         Self {
             inner,
-            identifier: PersistedEntityIdentifier::new(entity_id, version, owned_by_id),
-            entity_type_id,
+            metadata: PersistedEntityMetadata::new(
+                PersistedEntityIdentifier::new(entity_id, version, owned_by_id),
+                entity_type_id,
+            ),
         }
     }
 
@@ -113,13 +142,8 @@ impl PersistedEntity {
     }
 
     #[must_use]
-    pub const fn identifier(&self) -> &PersistedEntityIdentifier {
-        &self.identifier
-    }
-
-    #[must_use]
-    pub const fn entity_type_id(&self) -> &VersionedUri {
-        &self.entity_type_id
+    pub const fn metadata(&self) -> &PersistedEntityMetadata {
+        &self.metadata
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/link/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/link/mod.rs
@@ -60,8 +60,7 @@ impl Link {
     }
 }
 
-/// A record of a [`Link`] that has been persisted in the datastore, with its associated
-/// metadata.
+/// The metadata of a [`Link`] record.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PersistedLinkMetadata {

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/link/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/link/mod.rs
@@ -64,8 +64,7 @@ impl Link {
 /// metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct PersistedLink {
-    inner: Link,
+pub struct PersistedLinkMetadata {
     // Note: this is inconsistent with `PersistedEntity` as the analog of
     // `PersistedEntityIdentifier` is encapsulated within the `Link` struct..
     owned_by_id: AccountId,
@@ -73,20 +72,44 @@ pub struct PersistedLink {
     //   https://app.asana.com/0/1200211978612931/1203006164248577/f
 }
 
-impl PersistedLink {
+impl PersistedLinkMetadata {
     #[must_use]
-    pub const fn new(inner: Link, owned_by_id: AccountId) -> Self {
-        Self { inner, owned_by_id }
-    }
-
-    #[must_use]
-    pub const fn inner(&self) -> &Link {
-        &self.inner
+    pub const fn new(owned_by_id: AccountId) -> Self {
+        Self { owned_by_id }
     }
 
     #[must_use]
     pub const fn owned_by_id(&self) -> &AccountId {
         &self.owned_by_id
+    }
+}
+
+/// A record of a [`Link`] that has been persisted in the datastore, with its associated
+/// metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PersistedLink {
+    inner: Link,
+    metadata: PersistedLinkMetadata,
+}
+
+impl PersistedLink {
+    #[must_use]
+    pub const fn new(inner: Link, owned_by_id: AccountId) -> Self {
+        Self {
+            inner,
+            metadata: PersistedLinkMetadata::new(owned_by_id),
+        }
+    }
+
+    #[must_use]
+    pub const fn metadata(&self) -> &PersistedLinkMetadata {
+        &self.metadata
+    }
+
+    #[must_use]
+    pub const fn inner(&self) -> &Link {
+        &self.inner
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/mod.rs
@@ -11,7 +11,7 @@ pub use self::{
     entity::{
         Entity, EntityId, PersistedEntity, PersistedEntityIdentifier, PersistedEntityMetadata,
     },
-    link::{Link, PersistedLink},
+    link::{Link, PersistedLink, PersistedLinkMetadata},
 };
 use crate::{
     ontology::{

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/mod.rs
@@ -8,7 +8,9 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 pub use self::{
-    entity::{Entity, EntityId, PersistedEntity, PersistedEntityIdentifier},
+    entity::{
+        Entity, EntityId, PersistedEntity, PersistedEntityIdentifier, PersistedEntityMetadata,
+    },
     link::{Link, PersistedLink},
 };
 use crate::{

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -250,7 +250,7 @@ pub struct LinkTypeRootedSubgraph {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 pub struct PersistedOntologyMetadata {
-    pub identifier: PersistedOntologyIdentifier,
+    identifier: PersistedOntologyIdentifier,
 }
 
 impl PersistedOntologyMetadata {

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -174,7 +174,7 @@ pub struct PersistedDataType {
     #[schema(value_type = VAR_DATA_TYPE)]
     #[serde(serialize_with = "serialize_ontology_type")]
     pub inner: DataType,
-    pub identifier: PersistedOntologyIdentifier,
+    pub metadata: PersistedOntologyMetadata,
 }
 
 /// Query to read [`DataType`]s, which are matching the [`Expression`].
@@ -201,7 +201,7 @@ pub struct PersistedPropertyType {
     #[schema(value_type = VAR_PROPERTY_TYPE)]
     #[serde(serialize_with = "serialize_ontology_type")]
     pub inner: PropertyType,
-    pub identifier: PersistedOntologyIdentifier,
+    pub metadata: PersistedOntologyMetadata,
 }
 
 /// Query to read [`PropertyType`]s, which are matching the [`Expression`].
@@ -231,7 +231,7 @@ pub struct PersistedLinkType {
     #[schema(value_type = VAR_LINK_TYPE)]
     #[serde(serialize_with = "serialize_ontology_type")]
     pub inner: LinkType,
-    pub identifier: PersistedOntologyIdentifier,
+    pub metadata: PersistedOntologyMetadata,
 }
 
 /// Query to read [`LinkType`]s, which are matching the [`Expression`].
@@ -249,11 +249,28 @@ pub struct LinkTypeRootedSubgraph {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
+pub struct PersistedOntologyMetadata {
+    pub identifier: PersistedOntologyIdentifier,
+}
+
+impl PersistedOntologyMetadata {
+    #[must_use]
+    pub const fn new(identifier: PersistedOntologyIdentifier) -> Self {
+        Self { identifier }
+    }
+
+    #[must_use]
+    pub const fn identifier(&self) -> &PersistedOntologyIdentifier {
+        &self.identifier
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 pub struct PersistedEntityType {
     #[schema(value_type = VAR_ENTITY_TYPE)]
     #[serde(serialize_with = "serialize_ontology_type")]
     pub inner: EntityType,
-    pub identifier: PersistedOntologyIdentifier,
+    pub metadata: PersistedOntologyMetadata,
 }
 
 /// Query to read [`EntityType`]s, which are matching the [`Expression`].

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -19,7 +19,7 @@ pub use self::{
 use crate::{
     knowledge::{
         Entity, EntityId, EntityRootedSubgraph, KnowledgeGraphQuery, Link, LinkRootedSubgraph,
-        PersistedEntity, PersistedEntityIdentifier, PersistedLink,
+        PersistedEntity, PersistedEntityMetadata, PersistedLink,
     },
     ontology::{
         AccountId, DataTypeQuery, DataTypeRootedSubgraph, EntityTypeQuery,
@@ -377,7 +377,7 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Expressio
         entity_type_id: VersionedUri,
         owned_by_id: AccountId,
         entity_id: Option<EntityId>,
-    ) -> Result<PersistedEntityIdentifier, InsertionError>;
+    ) -> Result<PersistedEntityMetadata, InsertionError>;
 
     /// Inserts the entities with the specified [`EntityType`] into the `Store`.
     ///
@@ -429,7 +429,7 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Expressio
         entity: Entity,
         entity_type_id: VersionedUri,
         updated_by: AccountId,
-    ) -> Result<PersistedEntityIdentifier, UpdateError>;
+    ) -> Result<PersistedEntityMetadata, UpdateError>;
 }
 
 /// Describes the API of a store implementation for [`Link`]s.

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     ontology::{
         AccountId, DataTypeQuery, DataTypeRootedSubgraph, EntityTypeQuery,
         EntityTypeRootedSubgraph, LinkTypeQuery, LinkTypeRootedSubgraph, PersistedDataType,
-        PersistedEntityType, PersistedLinkType, PersistedOntologyIdentifier, PersistedPropertyType,
+        PersistedEntityType, PersistedLinkType, PersistedOntologyMetadata, PersistedPropertyType,
         PropertyTypeQuery, PropertyTypeRootedSubgraph,
     },
     store::{error::LinkRemovalError, query::Expression},
@@ -215,7 +215,7 @@ pub trait DataTypeStore: for<'q> crud::Read<PersistedDataType, Query<'q> = Expre
         &mut self,
         data_type: DataType,
         owned_by_id: AccountId,
-    ) -> Result<PersistedOntologyIdentifier, InsertionError>;
+    ) -> Result<PersistedOntologyMetadata, InsertionError>;
 
     /// Get the [`DataTypeRootedSubgraph`]s specified by the [`DataTypeQuery`].
     ///
@@ -236,7 +236,7 @@ pub trait DataTypeStore: for<'q> crud::Read<PersistedDataType, Query<'q> = Expre
         &mut self,
         data_type: DataType,
         updated_by: AccountId,
-    ) -> Result<PersistedOntologyIdentifier, UpdateError>;
+    ) -> Result<PersistedOntologyMetadata, UpdateError>;
 }
 
 /// Describes the API of a store implementation for [`PropertyType`]s.
@@ -256,7 +256,7 @@ pub trait PropertyTypeStore:
         &mut self,
         property_type: PropertyType,
         owned_by_id: AccountId,
-    ) -> Result<PersistedOntologyIdentifier, InsertionError>;
+    ) -> Result<PersistedOntologyMetadata, InsertionError>;
 
     /// Get the [`PropertyTypeRootedSubgraph`]s specified by the [`PropertyTypeQuery`].
     ///
@@ -277,7 +277,7 @@ pub trait PropertyTypeStore:
         &mut self,
         property_type: PropertyType,
         updated_by: AccountId,
-    ) -> Result<PersistedOntologyIdentifier, UpdateError>;
+    ) -> Result<PersistedOntologyMetadata, UpdateError>;
 }
 
 /// Describes the API of a store implementation for [`EntityType`]s.
@@ -295,7 +295,7 @@ pub trait EntityTypeStore: for<'q> crud::Read<PersistedEntityType, Query<'q> = E
         &mut self,
         entity_type: EntityType,
         owned_by_id: AccountId,
-    ) -> Result<PersistedOntologyIdentifier, InsertionError>;
+    ) -> Result<PersistedOntologyMetadata, InsertionError>;
 
     /// Get the [`EntityTypeRootedSubgraph`]s specified by the [`EntityTypeQuery`].
     ///
@@ -316,7 +316,7 @@ pub trait EntityTypeStore: for<'q> crud::Read<PersistedEntityType, Query<'q> = E
         &mut self,
         entity_type: EntityType,
         updated_by: AccountId,
-    ) -> Result<PersistedOntologyIdentifier, UpdateError>;
+    ) -> Result<PersistedOntologyMetadata, UpdateError>;
 }
 
 /// Describes the API of a store implementation for [`LinkType`]s.
@@ -334,7 +334,7 @@ pub trait LinkTypeStore: for<'q> crud::Read<PersistedLinkType, Query<'q> = Expre
         &mut self,
         link_type: LinkType,
         owned_by_id: AccountId,
-    ) -> Result<PersistedOntologyIdentifier, InsertionError>;
+    ) -> Result<PersistedOntologyMetadata, InsertionError>;
 
     /// Get the [`LinkTypeRootedSubgraph`]s specified by the [`LinkTypeQuery`].
     ///
@@ -355,7 +355,7 @@ pub trait LinkTypeStore: for<'q> crud::Read<PersistedLinkType, Query<'q> = Expre
         &mut self,
         property_type: LinkType,
         updated_by: AccountId,
-    ) -> Result<PersistedOntologyIdentifier, UpdateError>;
+    ) -> Result<PersistedOntologyMetadata, UpdateError>;
 }
 
 /// Describes the API of a store implementation for [Entities].

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -468,9 +468,10 @@ where
             .await
             .change_context(UpdateError)?;
 
-        Ok((version_id, PersistedOntologyMetadata {
-            identifier: PersistedOntologyIdentifier::new(uri, updated_by),
-        }))
+        Ok((
+            version_id,
+            PersistedOntologyMetadata::new(PersistedOntologyIdentifier::new(uri, updated_by)),
+        ))
     }
 
     /// Inserts an [`OntologyDatabaseType`] identified by [`VersionId`], and associated with an

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -30,7 +30,7 @@ pub use self::{
 use super::error::LinkRemovalError;
 use crate::{
     knowledge::{Entity, EntityId, Link, PersistedEntityIdentifier, PersistedEntityMetadata},
-    ontology::{AccountId, PersistedOntologyIdentifier},
+    ontology::{AccountId, PersistedOntologyIdentifier, PersistedOntologyMetadata},
     store::{
         error::VersionedUriAlreadyExists,
         postgres::{ontology::OntologyDatabaseType, version_id::VersionId},
@@ -386,7 +386,7 @@ where
         &self,
         database_type: T,
         owned_by_id: AccountId,
-    ) -> Result<(VersionId, PersistedOntologyIdentifier), InsertionError>
+    ) -> Result<(VersionId, PersistedOntologyMetadata), InsertionError>
     where
         T: OntologyDatabaseType + Send + Sync + Into<serde_json::Value>,
     {
@@ -423,7 +423,7 @@ where
 
         Ok((
             version_id,
-            PersistedOntologyIdentifier::new(uri, owned_by_id),
+            PersistedOntologyMetadata::new(PersistedOntologyIdentifier::new(uri, owned_by_id)),
         ))
     }
 
@@ -441,7 +441,7 @@ where
         &self,
         database_type: T,
         updated_by: AccountId,
-    ) -> Result<(VersionId, PersistedOntologyIdentifier), UpdateError>
+    ) -> Result<(VersionId, PersistedOntologyMetadata), UpdateError>
     where
         T: OntologyDatabaseType + Send + Sync + Into<serde_json::Value>,
     {
@@ -468,10 +468,9 @@ where
             .await
             .change_context(UpdateError)?;
 
-        Ok((
-            version_id,
-            PersistedOntologyIdentifier::new(uri, updated_by),
-        ))
+        Ok((version_id, PersistedOntologyMetadata {
+            identifier: PersistedOntologyIdentifier::new(uri, updated_by),
+        }))
     }
 
     /// Inserts an [`OntologyDatabaseType`] identified by [`VersionId`], and associated with an

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -93,7 +93,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
                 let mut referenced_data_types = DependencyMap::new();
 
                 self.get_data_type_as_dependency(
-                    data_type.metadata.identifier.uri(),
+                    data_type.metadata.identifier().uri(),
                     DataTypeDependencyContext {
                         referenced_data_types: &mut referenced_data_types,
                         data_type_query_depth,
@@ -102,7 +102,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
                 .await?;
 
                 let root = referenced_data_types
-                    .remove(data_type.metadata.identifier.uri())
+                    .remove(data_type.metadata.identifier().uri())
                     .expect("root was not added to the subgraph");
 
                 Ok(DataTypeRootedSubgraph { data_type: root })

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
@@ -208,7 +208,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
                 let mut referenced_entity_types = DependencyMap::new();
 
                 self.get_entity_type_as_dependency(
-                    entity_type.metadata.identifier.uri(),
+                    entity_type.metadata.identifier().uri(),
                     EntityTypeDependencyContext {
                         referenced_data_types: &mut referenced_data_types,
                         referenced_property_types: &mut referenced_property_types,
@@ -223,7 +223,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
                 .await?;
 
                 let root = referenced_entity_types
-                    .remove(entity_type.metadata.identifier.uri())
+                    .remove(entity_type.metadata.identifier().uri())
                     .expect("root was not added to the subgraph");
 
                 Ok(EntityTypeRootedSubgraph {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
@@ -89,7 +89,7 @@ impl<C: AsClient> LinkTypeStore for PostgresStore<C> {
                 let mut referenced_link_types = DependencyMap::new();
 
                 self.get_link_type_as_dependency(
-                    link_type.metadata.identifier.uri(),
+                    link_type.metadata.identifier().uri(),
                     LinkTypeDependencyContext {
                         referenced_link_types: &mut referenced_link_types,
                         link_type_query_depth: 0,
@@ -98,7 +98,7 @@ impl<C: AsClient> LinkTypeStore for PostgresStore<C> {
                 .await?;
 
                 let root = referenced_link_types
-                    .remove(link_type.metadata.identifier.uri())
+                    .remove(link_type.metadata.identifier().uri())
                     .expect("root was not added to the subgraph");
 
                 Ok(LinkTypeRootedSubgraph { link_type: root })

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -165,7 +165,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                 let mut referenced_property_types = DependencyMap::new();
 
                 self.get_property_type_as_dependency(
-                    property_type.metadata.identifier.uri(),
+                    property_type.metadata.identifier().uri(),
                     PropertyTypeDependencyContext {
                         referenced_data_types: &mut referenced_data_types,
                         referenced_property_types: &mut referenced_property_types,
@@ -176,7 +176,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                 .await?;
 
                 let root = referenced_property_types
-                    .remove(property_type.metadata.identifier.uri())
+                    .remove(property_type.metadata.identifier().uri())
                     .expect("root was not added to the subgraph");
 
                 Ok(PropertyTypeRootedSubgraph {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -33,7 +33,7 @@ impl PersistedOntologyType for PersistedDataType {
             PersistedOntologyIdentifier::new(data_type.record.id().clone(), data_type.account_id);
         Self {
             inner: data_type.record,
-            metadata: PersistedOntologyMetadata { identifier },
+            metadata: PersistedOntologyMetadata::new(identifier),
         }
     }
 }
@@ -48,7 +48,7 @@ impl PersistedOntologyType for PersistedPropertyType {
         );
         Self {
             inner: property_type.record,
-            metadata: PersistedOntologyMetadata { identifier },
+            metadata: PersistedOntologyMetadata::new(identifier),
         }
     }
 }
@@ -61,7 +61,7 @@ impl PersistedOntologyType for PersistedLinkType {
             PersistedOntologyIdentifier::new(link_type.record.id().clone(), link_type.account_id);
         Self {
             inner: link_type.record,
-            metadata: PersistedOntologyMetadata { identifier },
+            metadata: PersistedOntologyMetadata::new(identifier),
         }
     }
 }
@@ -76,7 +76,7 @@ impl PersistedOntologyType for PersistedEntityType {
         );
         Self {
             inner: entity_type.record,
-            metadata: PersistedOntologyMetadata { identifier },
+            metadata: PersistedOntologyMetadata::new(identifier),
         }
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -6,7 +6,7 @@ use type_system::{DataType, EntityType, LinkType, PropertyType};
 use crate::{
     ontology::{
         PersistedDataType, PersistedEntityType, PersistedLinkType, PersistedOntologyIdentifier,
-        PersistedPropertyType,
+        PersistedOntologyMetadata, PersistedPropertyType,
     },
     store::{
         crud::Read,
@@ -33,7 +33,7 @@ impl PersistedOntologyType for PersistedDataType {
             PersistedOntologyIdentifier::new(data_type.record.id().clone(), data_type.account_id);
         Self {
             inner: data_type.record,
-            identifier,
+            metadata: PersistedOntologyMetadata { identifier },
         }
     }
 }
@@ -48,7 +48,7 @@ impl PersistedOntologyType for PersistedPropertyType {
         );
         Self {
             inner: property_type.record,
-            identifier,
+            metadata: PersistedOntologyMetadata { identifier },
         }
     }
 }
@@ -61,7 +61,7 @@ impl PersistedOntologyType for PersistedLinkType {
             PersistedOntologyIdentifier::new(link_type.record.id().clone(), link_type.account_id);
         Self {
             inner: link_type.record,
-            identifier,
+            metadata: PersistedOntologyMetadata { identifier },
         }
     }
 }
@@ -76,7 +76,7 @@ impl PersistedOntologyType for PersistedEntityType {
         );
         Self {
             inner: entity_type.record,
-            identifier,
+            metadata: PersistedOntologyMetadata { identifier },
         }
     }
 }

--- a/packages/graph/hash_graph/tests/integration/postgres/entity.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/entity.rs
@@ -19,7 +19,7 @@ async fn insert() {
         .await
         .expect("could not seed database");
 
-    let identifier = api
+    let metadata = api
         .create_entity(
             person.clone(),
             VersionedUri::new(
@@ -33,6 +33,8 @@ async fn insert() {
         )
         .await
         .expect("could not create entity");
+
+    let identifier = metadata.identifier();
 
     let persisted_entity = api
         .get_entity(identifier.entity_id())
@@ -55,7 +57,7 @@ async fn query() {
         .await
         .expect("could not seed database");
 
-    let identifier = api
+    let metadata = api
         .create_entity(
             organization.clone(),
             VersionedUri::new(
@@ -69,6 +71,8 @@ async fn query() {
         )
         .await
         .expect("could not create entity");
+
+    let identifier = metadata.identifier();
 
     let queried_organization = api
         .get_entity(identifier.entity_id())
@@ -90,7 +94,7 @@ async fn update() {
         .await
         .expect("could not seed database:");
 
-    let identifier = api
+    let metadata = api
         .create_entity(
             page_v1.clone(),
             VersionedUri::new(
@@ -102,6 +106,8 @@ async fn update() {
         )
         .await
         .expect("could not create entity");
+
+    let identifier = metadata.identifier();
 
     api.update_entity(
         identifier.entity_id(),

--- a/packages/graph/hash_graph/tests/integration/postgres/entity.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/entity.rs
@@ -72,12 +72,11 @@ async fn query() {
         .await
         .expect("could not create entity");
 
-    let identifier = metadata.identifier();
-
     let queried_organization = api
-        .get_entity(identifier.entity_id())
+        .get_entity(metadata.identifier().entity_id())
         .await
         .expect("could not get entity");
+
     assert_eq!(&organization, queried_organization.inner());
 }
 

--- a/packages/graph/hash_graph/tests/integration/postgres/entity.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/entity.rs
@@ -34,10 +34,8 @@ async fn insert() {
         .await
         .expect("could not create entity");
 
-    let identifier = metadata.identifier();
-
     let persisted_entity = api
-        .get_entity(identifier.entity_id())
+        .get_entity(metadata.identifier().entity_id())
         .await
         .expect("could not get entity");
 
@@ -106,10 +104,8 @@ async fn update() {
         .await
         .expect("could not create entity");
 
-    let identifier = metadata.identifier();
-
     api.update_entity(
-        identifier.entity_id(),
+        metadata.identifier().entity_id(),
         page_v2.clone(),
         VersionedUri::new(
             BaseUri::new("https://blockprotocol.org/@alice/types/entity-type/page/".to_owned())
@@ -121,7 +117,7 @@ async fn update() {
     .expect("could not update entity");
 
     let persisted_entity = api
-        .get_entity(identifier.entity_id())
+        .get_entity(metadata.identifier().entity_id())
         .await
         .expect("could not get entity");
 

--- a/packages/graph/hash_graph/tests/integration/postgres/links.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/links.rs
@@ -31,15 +31,19 @@ async fn insert() {
         1,
     );
 
-    let person_a_identifier = api
+    let person_a_metadata = api
         .create_entity(person_a, person_type_id.clone(), None)
         .await
         .expect("could not create entity");
 
-    let person_b_identifier = api
+    let person_a_identifier = person_a_metadata.identifier();
+
+    let person_b_metadata = api
         .create_entity(person_b, person_type_id.clone(), None)
         .await
         .expect("could not create entity");
+
+    let person_b_identifier = person_b_metadata.identifier();
 
     api.create_link(
         person_a_identifier.entity_id(),
@@ -97,20 +101,26 @@ async fn get_entity_links() {
         1,
     );
 
-    let person_a_identifier = api
+    let person_a_metadata = api
         .create_entity(person_a, person_type_id.clone(), None)
         .await
         .expect("could not create entity");
 
-    let person_b_identifier = api
+    let person_a_identifier = person_a_metadata.identifier();
+
+    let person_b_metadata = api
         .create_entity(person_b, person_type_id.clone(), None)
         .await
         .expect("could not create entity");
 
-    let person_c_identifier = api
+    let person_b_identifier = person_b_metadata.identifier();
+
+    let person_c_metadata = api
         .create_entity(person_c, person_type_id.clone(), None)
         .await
         .expect("could not create entity");
+
+    let person_c_identifier = person_c_metadata.identifier();
 
     let _a_b_link = api
         .create_link(
@@ -177,15 +187,19 @@ async fn remove_link() {
         1,
     );
 
-    let person_a_identifier = api
+    let person_a_metadata = api
         .create_entity(person_a, person_type_id.clone(), None)
         .await
         .expect("could not create entity");
 
-    let person_b_identifier = api
+    let person_a_identifier = person_a_metadata.identifier();
+
+    let person_b_metadata = api
         .create_entity(person_b, person_type_id.clone(), None)
         .await
         .expect("could not create entity");
+
+    let person_b_identifier = person_b_metadata.identifier();
 
     let _a_b_link = api
         .create_link(
@@ -239,20 +253,26 @@ async fn ordered_links() {
         1,
     );
 
-    let person_a_identifier = api
+    let person_a_metadata = api
         .create_entity(person_a, person_type_id.clone(), None)
         .await
         .expect("could not create entity");
 
-    let person_b_identifier = api
+    let person_a_identifier = person_a_metadata.identifier();
+
+    let person_b_metadata = api
         .create_entity(person_b, person_type_id.clone(), None)
         .await
         .expect("could not create entity");
 
-    let person_c_identifier = api
+    let person_b_identifier = person_b_metadata.identifier();
+
+    let person_c_metadata = api
         .create_entity(person_c, person_type_id.clone(), None)
         .await
         .expect("could not create entity");
+
+    let person_c_identifier = person_c_metadata.identifier();
 
     let _a_b_link = api
         .create_ordered_link(

--- a/packages/graph/hash_graph/tests/integration/postgres/links.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/links.rs
@@ -36,31 +36,30 @@ async fn insert() {
         .await
         .expect("could not create entity");
 
-    let person_a_identifier = person_a_metadata.identifier();
-
     let person_b_metadata = api
         .create_entity(person_b, person_type_id.clone(), None)
         .await
         .expect("could not create entity");
 
-    let person_b_identifier = person_b_metadata.identifier();
-
     api.create_link(
-        person_a_identifier.entity_id(),
-        person_b_identifier.entity_id(),
+        person_a_metadata.identifier().entity_id(),
+        person_b_metadata.identifier().entity_id(),
         link_type_id.clone(),
     )
     .await
     .expect("could not create link");
 
     let link_target = api
-        .get_link_target(person_a_identifier.entity_id(), link_type_id.clone())
+        .get_link_target(
+            person_a_metadata.identifier().entity_id(),
+            link_type_id.clone(),
+        )
         .await
         .expect("could not fetch link");
 
     assert_eq!(
         link_target.inner().target_entity(),
-        person_b_identifier.entity_id()
+        person_b_metadata.identifier().entity_id()
     );
 }
 
@@ -106,26 +105,20 @@ async fn get_entity_links() {
         .await
         .expect("could not create entity");
 
-    let person_a_identifier = person_a_metadata.identifier();
-
     let person_b_metadata = api
         .create_entity(person_b, person_type_id.clone(), None)
         .await
         .expect("could not create entity");
-
-    let person_b_identifier = person_b_metadata.identifier();
 
     let person_c_metadata = api
         .create_entity(person_c, person_type_id.clone(), None)
         .await
         .expect("could not create entity");
 
-    let person_c_identifier = person_c_metadata.identifier();
-
     let _a_b_link = api
         .create_link(
-            person_a_identifier.entity_id(),
-            person_b_identifier.entity_id(),
+            person_a_metadata.identifier().entity_id(),
+            person_b_metadata.identifier().entity_id(),
             friend_link_type_id.clone(),
         )
         .await
@@ -133,15 +126,15 @@ async fn get_entity_links() {
 
     let _a_c_link = api
         .create_link(
-            person_a_identifier.entity_id(),
-            person_c_identifier.entity_id(),
+            person_a_metadata.identifier().entity_id(),
+            person_c_metadata.identifier().entity_id(),
             acquaintance_link_type_id.clone(),
         )
         .await
         .expect("could not create link");
 
     let links_from_source = api
-        .get_entity_links(person_a_identifier.entity_id())
+        .get_entity_links(person_a_metadata.identifier().entity_id())
         .await
         .expect("could not fetch link");
 
@@ -192,34 +185,30 @@ async fn remove_link() {
         .await
         .expect("could not create entity");
 
-    let person_a_identifier = person_a_metadata.identifier();
-
     let person_b_metadata = api
         .create_entity(person_b, person_type_id.clone(), None)
         .await
         .expect("could not create entity");
 
-    let person_b_identifier = person_b_metadata.identifier();
-
     let _a_b_link = api
         .create_link(
-            person_a_identifier.entity_id(),
-            person_b_identifier.entity_id(),
+            person_a_metadata.identifier().entity_id(),
+            person_b_metadata.identifier().entity_id(),
             link_type_id.clone(),
         )
         .await
         .expect("could not create link");
 
     api.remove_link(
-        person_a_identifier.entity_id(),
-        person_b_identifier.entity_id(),
+        person_a_metadata.identifier().entity_id(),
+        person_b_metadata.identifier().entity_id(),
         link_type_id.clone(),
     )
     .await
     .expect("could not remove link");
 
     let _ = api
-        .get_link_target(person_a_identifier.entity_id(), link_type_id)
+        .get_link_target(person_a_metadata.identifier().entity_id(), link_type_id)
         .await
         .expect_err("found link that should have been deleted");
 }
@@ -258,26 +247,20 @@ async fn ordered_links() {
         .await
         .expect("could not create entity");
 
-    let person_a_identifier = person_a_metadata.identifier();
-
     let person_b_metadata = api
         .create_entity(person_b, person_type_id.clone(), None)
         .await
         .expect("could not create entity");
-
-    let person_b_identifier = person_b_metadata.identifier();
 
     let person_c_metadata = api
         .create_entity(person_c, person_type_id.clone(), None)
         .await
         .expect("could not create entity");
 
-    let person_c_identifier = person_c_metadata.identifier();
-
     let _a_b_link = api
         .create_ordered_link(
-            person_a_identifier.entity_id(),
-            person_b_identifier.entity_id(),
+            person_a_metadata.identifier().entity_id(),
+            person_b_metadata.identifier().entity_id(),
             friend_link_type_id.clone(),
             2,
         )
@@ -286,8 +269,8 @@ async fn ordered_links() {
 
     let _a_c_link = api
         .create_ordered_link(
-            person_a_identifier.entity_id(),
-            person_c_identifier.entity_id(),
+            person_a_metadata.identifier().entity_id(),
+            person_c_metadata.identifier().entity_id(),
             friend_link_type_id.clone(),
             1,
         )
@@ -295,14 +278,14 @@ async fn ordered_links() {
         .expect("could not create link");
 
     let links_from_source = api
-        .get_entity_links(person_a_identifier.entity_id())
+        .get_entity_links(person_a_metadata.identifier().entity_id())
         .await
         .expect("could not fetch link");
 
     assert_eq!(
         [
-            person_c_identifier.entity_id(),
-            person_b_identifier.entity_id(),
+            person_c_metadata.identifier().entity_id(),
+            person_b_metadata.identifier().entity_id(),
         ][..],
         links_from_source
             .iter()

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -10,12 +10,12 @@ use std::str::FromStr;
 use error_stack::{Report, Result};
 use graph::{
     knowledge::{
-        Entity, EntityId, KnowledgeGraphQuery, Link, PersistedEntity, PersistedEntityIdentifier,
+        Entity, EntityId, KnowledgeGraphQuery, Link, PersistedEntity, PersistedEntityMetadata,
         PersistedLink,
     },
     ontology::{
         AccountId, DataTypeQuery, EntityTypeQuery, LinkTypeQuery, PersistedDataType,
-        PersistedEntityType, PersistedLinkType, PersistedOntologyIdentifier, PersistedPropertyType,
+        PersistedEntityType, PersistedLinkType, PersistedOntologyMetadata, PersistedPropertyType,
         PropertyTypeQuery,
     },
     store::{
@@ -145,7 +145,7 @@ impl DatabaseApi<'_> {
     pub async fn create_data_type(
         &mut self,
         data_type: DataType,
-    ) -> Result<PersistedOntologyIdentifier, InsertionError> {
+    ) -> Result<PersistedOntologyMetadata, InsertionError> {
         self.store
             .create_data_type(data_type, self.account_id)
             .await
@@ -170,7 +170,7 @@ impl DatabaseApi<'_> {
     pub async fn update_data_type(
         &mut self,
         data_type: DataType,
-    ) -> Result<PersistedOntologyIdentifier, UpdateError> {
+    ) -> Result<PersistedOntologyMetadata, UpdateError> {
         self.store
             .update_data_type(data_type, self.account_id)
             .await
@@ -179,7 +179,7 @@ impl DatabaseApi<'_> {
     pub async fn create_property_type(
         &mut self,
         property_type: PropertyType,
-    ) -> Result<PersistedOntologyIdentifier, InsertionError> {
+    ) -> Result<PersistedOntologyMetadata, InsertionError> {
         self.store
             .create_property_type(property_type, self.account_id)
             .await
@@ -205,7 +205,7 @@ impl DatabaseApi<'_> {
     pub async fn update_property_type(
         &mut self,
         property_type: PropertyType,
-    ) -> Result<PersistedOntologyIdentifier, UpdateError> {
+    ) -> Result<PersistedOntologyMetadata, UpdateError> {
         self.store
             .update_property_type(property_type, self.account_id)
             .await
@@ -214,7 +214,7 @@ impl DatabaseApi<'_> {
     pub async fn create_entity_type(
         &mut self,
         entity_type: EntityType,
-    ) -> Result<PersistedOntologyIdentifier, InsertionError> {
+    ) -> Result<PersistedOntologyMetadata, InsertionError> {
         self.store
             .create_entity_type(entity_type, self.account_id)
             .await
@@ -242,7 +242,7 @@ impl DatabaseApi<'_> {
     pub async fn update_entity_type(
         &mut self,
         entity_type: EntityType,
-    ) -> Result<PersistedOntologyIdentifier, UpdateError> {
+    ) -> Result<PersistedOntologyMetadata, UpdateError> {
         self.store
             .update_entity_type(entity_type, self.account_id)
             .await
@@ -251,7 +251,7 @@ impl DatabaseApi<'_> {
     pub async fn create_link_type(
         &mut self,
         link_type: LinkType,
-    ) -> Result<PersistedOntologyIdentifier, InsertionError> {
+    ) -> Result<PersistedOntologyMetadata, InsertionError> {
         self.store
             .create_link_type(link_type, self.account_id)
             .await
@@ -275,7 +275,7 @@ impl DatabaseApi<'_> {
     pub async fn update_link_type(
         &mut self,
         link_type: LinkType,
-    ) -> Result<PersistedOntologyIdentifier, UpdateError> {
+    ) -> Result<PersistedOntologyMetadata, UpdateError> {
         self.store
             .update_link_type(link_type, self.account_id)
             .await
@@ -286,7 +286,7 @@ impl DatabaseApi<'_> {
         entity: Entity,
         entity_type_id: VersionedUri,
         entity_id: Option<EntityId>,
-    ) -> Result<PersistedEntityIdentifier, InsertionError> {
+    ) -> Result<PersistedEntityMetadata, InsertionError> {
         self.store
             .create_entity(entity, entity_type_id, self.account_id, entity_id)
             .await
@@ -315,7 +315,7 @@ impl DatabaseApi<'_> {
         entity_id: EntityId,
         entity: Entity,
         entity_type_id: VersionedUri,
-    ) -> Result<PersistedEntityIdentifier, UpdateError> {
+    ) -> Result<PersistedEntityMetadata, UpdateError> {
         self.store
             .update_entity(entity_id, entity, entity_type_id, self.account_id)
             .await

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -39,7 +39,7 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("text_data_type_id", encodeURIComponent(response.body.uri));
+    client.global.set("text_data_type_id", encodeURIComponent(response.body.identifier.uri));
 %}
 
 ### Get Text data type
@@ -97,7 +97,7 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("person_property_type_id", encodeURIComponent(response.body.uri));
+    client.global.set("person_property_type_id", encodeURIComponent(response.body.identifier.uri));
 %}
 
 ### Get Name property type
@@ -166,8 +166,8 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("friend_of_link_type_id", encodeURIComponent(response.body.uri));
-    client.global.set("friend_of_link_type_id_raw", response.body.uri);
+    client.global.set("friend_of_link_type_id", encodeURIComponent(response.body.identifier.uri));
+    client.global.set("friend_of_link_type_id_raw", response.body.identifier.uri);
 %}
 
 ### Get FriendOf link type
@@ -239,7 +239,7 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("person_entity_type_id", encodeURIComponent(response.body.uri));
+    client.global.set("person_entity_type_id", encodeURIComponent(response.body.identifier.uri));
 %}
 
 ### Get Person entity type
@@ -319,7 +319,7 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("person_a_entity_id", encodeURIComponent(response.body.entityId));
+    client.global.set("person_a_entity_id", encodeURIComponent(response.body.identifier.entityId));
 %}
 
 ### Get Person entity
@@ -368,7 +368,7 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("person_b_entity_id", encodeURIComponent(response.body.entityId));
+    client.global.set("person_b_entity_id", encodeURIComponent(response.body.identifier.entityId));
 %}
 
 ### Get all latest entities
@@ -478,7 +478,7 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("person_c_entity_id", encodeURIComponent(response.body.entityId));
+    client.global.set("person_c_entity_id", encodeURIComponent(response.body.identifier.entityId));
 %}
 
 ### Check that person "a" to person "b" link is removed

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -104,14 +104,16 @@ export default class {
       entityId: overrideEntityId,
     }: EntityModelCreateParams,
   ): Promise<EntityModel> {
-    const {
-      data: { entityId, version },
-    } = await graphApi.createEntity({
+    const { data: metadata } = await graphApi.createEntity({
       accountId: ownedById,
       entityTypeId: entityTypeModel.schema.$id,
       entity: properties,
       entityId: overrideEntityId,
     });
+
+    const {
+      identifier: { entityId, version },
+    } = metadata;
 
     return new EntityModel({
       ownedById,
@@ -342,9 +344,7 @@ export default class {
     const { properties } = params;
     const { ownedById, entityId, entityTypeModel } = this;
 
-    const {
-      data: { version },
-    } = await graphApi.updateEntity({
+    const { data: metadata } = await graphApi.updateEntity({
       /**
        * @todo: let caller update who owns the entity, or create new method dedicated to changing the owner of the entity
        * @see https://app.asana.com/0/1202805690238892/1203063463721793/f
@@ -358,6 +358,10 @@ export default class {
       entityTypeId: entityTypeModel.schema.$id,
       entity: properties,
     });
+
+    const {
+      identifier: { version },
+    } = metadata;
 
     return new EntityModel({
       ownedById,

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -62,9 +62,10 @@ export default class {
 
   private static async fromPersistedEntity(
     graphApi: GraphApi,
-    { identifier, inner, entityTypeId }: PersistedEntity,
+    { metadata, inner }: PersistedEntity,
     cachedEntityTypeModels?: Map<string, EntityTypeModel>,
   ): Promise<EntityModel> {
+    const { identifier, entityTypeId } = metadata;
     const { ownedById, entityId, version } = identifier;
     const cachedEntityTypeModel = cachedEntityTypeModels?.get(entityTypeId);
 

--- a/packages/hash/api/src/model/knowledge/link.model.ts
+++ b/packages/hash/api/src/model/knowledge/link.model.ts
@@ -52,7 +52,7 @@ export default class {
   static async fromPersistedLink(
     graphApi: GraphApi,
     {
-      ownedById,
+      metadata: { ownedById },
       inner: { sourceEntityId, targetEntityId, linkTypeId, index },
     }: PersistedLink,
   ): Promise<LinkModel> {
@@ -172,7 +172,7 @@ export default class {
      */
     const persistedLink = {
       inner: link,
-      ownedById,
+      metadata: { ownedById },
     };
 
     return LinkModel.fromPersistedLink(graphApi, persistedLink);

--- a/packages/hash/api/src/model/ontology/data-type.model.ts
+++ b/packages/hash/api/src/model/ontology/data-type.model.ts
@@ -84,7 +84,7 @@ export default class {
     });
     const fullDataType = { $id: dataTypeUri, ...params.schema };
 
-    const { data: identifier } = await graphApi
+    const { data: metadata } = await graphApi
       .createDataType({
         /**
          * @todo: replace uses of `accountId` with `ownedById` in the Graph API
@@ -100,6 +100,8 @@ export default class {
             : `[${err.code}] couldn't create data type: ${err.response?.data}.`,
         );
       });
+
+    const { identifier } = metadata;
 
     return new DataTypeModel({
       schema: fullDataType,
@@ -176,7 +178,9 @@ export default class {
       schema,
     };
 
-    const { data: identifier } = await graphApi.updateDataType(updateArguments);
+    const { data: metadata } = await graphApi.updateDataType(updateArguments);
+
+    const { identifier } = metadata;
 
     return new DataTypeModel({
       schema: { ...schema, $id: identifier.uri },

--- a/packages/hash/api/src/model/ontology/data-type.model.ts
+++ b/packages/hash/api/src/model/ontology/data-type.model.ts
@@ -31,7 +31,7 @@ export default class {
 
   static fromPersistedDataType({
     inner,
-    identifier,
+    metadata: { identifier },
   }: PersistedDataType): DataTypeModel {
     /**
      * @todo and a warning, these type casts are here to compensate for

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -47,7 +47,7 @@ export default class {
 
   static fromPersistedEntityType({
     inner,
-    identifier,
+    metadata: { identifier },
   }: PersistedEntityType): EntityTypeModel {
     /**
      * @todo and a warning, these type casts are here to compensate for

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -87,7 +87,7 @@ export default class {
     });
     const fullEntityType = { $id: entityTypeId, ...params.schema };
 
-    const { data: identifier } = await graphApi
+    const { data: metadata } = await graphApi
       .createEntityType({
         /**
          * @todo: replace uses of `accountId` with `ownedById` in the Graph API
@@ -103,6 +103,8 @@ export default class {
             : `[${err.code}] couldn't create entity type: ${err.response?.data}.`,
         );
       });
+
+    const { identifier } = metadata;
 
     return new EntityTypeModel({
       schema: fullEntityType,
@@ -293,9 +295,9 @@ export default class {
       schema,
     };
 
-    const { data: identifier } = await graphApi.updateEntityType(
-      updateArguments,
-    );
+    const { data: metadata } = await graphApi.updateEntityType(updateArguments);
+
+    const { identifier } = metadata;
 
     return new EntityTypeModel({
       schema: { ...schema, $id: identifier.uri },

--- a/packages/hash/api/src/model/ontology/link-type.model.ts
+++ b/packages/hash/api/src/model/ontology/link-type.model.ts
@@ -31,7 +31,7 @@ export default class {
 
   static fromPersistedLinkType({
     inner,
-    identifier,
+    metadata: { identifier },
   }: PersistedLinkType): LinkTypeModel {
     /**
      * @todo and a warning, these type casts are here to compensate for

--- a/packages/hash/api/src/model/ontology/link-type.model.ts
+++ b/packages/hash/api/src/model/ontology/link-type.model.ts
@@ -74,7 +74,7 @@ export default class {
     });
     const fullLinkType = { $id: linkTypeId, ...params.schema };
 
-    const { data: identifier } = await graphApi
+    const { data: metadata } = await graphApi
       .createLinkType({
         /**
          * @todo: replace uses of `accountId` with `ownedById` in the Graph API
@@ -90,6 +90,8 @@ export default class {
             : `[${err.code}] couldn't create link type: ${err.response?.data}.`,
         );
       });
+
+    const { identifier } = metadata;
 
     return new LinkTypeModel({
       schema: fullLinkType,
@@ -154,7 +156,9 @@ export default class {
       schema,
     };
 
-    const { data: identifier } = await graphApi.updateLinkType(updateArguments);
+    const { data: metadata } = await graphApi.updateLinkType(updateArguments);
+
+    const { identifier } = metadata;
 
     return new LinkTypeModel({
       schema: { ...schema, $id: identifier.uri },

--- a/packages/hash/api/src/model/ontology/property-type.model.ts
+++ b/packages/hash/api/src/model/ontology/property-type.model.ts
@@ -31,7 +31,7 @@ export default class {
 
   static fromPersistedPropertyType({
     inner,
-    identifier,
+    metadata: { identifier },
   }: PersistedPropertyType): PropertyTypeModel {
     /**
      * @todo and a warning, these type casts are here to compensate for

--- a/packages/hash/api/src/model/ontology/property-type.model.ts
+++ b/packages/hash/api/src/model/ontology/property-type.model.ts
@@ -74,7 +74,7 @@ export default class {
     });
     const fullPropertyType = { $id: propertyTypeId, ...params.schema };
 
-    const { data: identifier } = await graphApi
+    const { data: metadata } = await graphApi
       .createPropertyType({
         /**
          * @todo: replace uses of `accountId` with `ownedById` in the Graph API
@@ -90,6 +90,8 @@ export default class {
             : `[${err.code}] couldn't create property type: ${err.response?.data}.`,
         );
       });
+
+    const { identifier } = metadata;
 
     return new PropertyTypeModel({
       schema: fullPropertyType,
@@ -248,9 +250,11 @@ export default class {
       schema,
     };
 
-    const { data: identifier } = await graphApi.updatePropertyType(
+    const { data: metadata } = await graphApi.updatePropertyType(
       updateArguments,
     );
+
+    const { identifier } = metadata;
 
     return new PropertyTypeModel({
       schema: { ...schema, $id: identifier.uri },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR introduces the `PersistedOntologyMetadata`, `PersistedEntityMetadata` and `PersistedLinkMetadata` structs.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203007126736604/1203157427866931/f) _(internal)_

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- adds a `metadata` field to the existing persisted ontology/knowledge types
- updates the return types of the Graph API to return the metadata field instead of an identifier

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

The existing rust tests/workspace integration tests

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Check CI to see the rust tests/workspace integration tests are passing, or run them locally

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
