### PR TITLE
Add hint that `hstd` is unavailable in Python

### DIFF
--- a/sites/hashai/resources/docs/simulation/creating-simulations/libraries/hash/README.md
+++ b/sites/hashai/resources/docs/simulation/creating-simulations/libraries/hash/README.md
@@ -8,6 +8,10 @@ objectId: fa7eb71c-7119-4abb-8d6d-226590d6dec1
 
 There are a number of functions that are accessible through the built-in `hstd` . These are specifically designed to make frequent operations in HASH more streamlined. These libraries will be growing as we explore new ways to make it easier for you to build models in HASH.
 
+<Hint style="warning">
+`hstd` is temporarily unavailable for use within Python and the below docs may be out of date.
+</Hint>
+
 Currently, we have functions implemented in the following categories:
 
 **[Init](/docs/simulation/creating-simulations/libraries/hash/init)**


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`hstd` is currently not available in Python but some docs use `import hstd`

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Slack thread](https://hashintel.slack.com/archives/C02HR1B2NP7/p1665615743646959) _(internal)_

## 🎥  Demo

<img width="2083" alt="image" src="https://user-images.githubusercontent.com/21277928/195866389-9bf813f2-a903-48dd-bd7a-4c7808e157ed.png">
