### PR TITLE
Add structures for `DataType` for query compilation

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/data_type.rs
@@ -1,0 +1,27 @@
+use std::borrow::Cow;
+
+use type_system::DataType;
+
+use crate::store::query::QueryRecord;
+
+/// A path to a [`DataType`] field.
+///
+/// Note: [`DataType`]s currently don't reference other [`DataType`]s, so the path can only be a
+/// single field.
+///
+/// [`DataType`]: type_system::DataType
+#[derive(Debug, PartialEq, Eq)]
+pub enum DataTypeQueryPath<'q> {
+    OwnedById,
+    BaseUri,
+    VersionedUri,
+    Version,
+    Title,
+    Description,
+    Type,
+    Custom(Cow<'q, str>),
+}
+
+impl QueryRecord for DataType {
+    type Path<'q> = DataTypeQueryPath<'q>;
+}

--- a/packages/graph/hash_graph/lib/graph/src/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/data_type.rs
@@ -10,6 +10,8 @@ use crate::store::query::QueryRecord;
 /// single field.
 ///
 /// [`DataType`]: type_system::DataType
+// TODO: Adjust enum and docs when adding non-primitive data types
+//   see https://app.asana.com/0/1200211978612931/1202464168422955/f
 #[derive(Debug, PartialEq, Eq)]
 pub enum DataTypeQueryPath<'q> {
     OwnedById,

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -1,5 +1,6 @@
 //! TODO: DOC
 
+mod data_type;
 pub mod domain_validator;
 
 use core::fmt;
@@ -11,6 +12,9 @@ use tokio_postgres::types::{FromSql, ToSql};
 use type_system::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType};
 use utoipa::ToSchema;
 use uuid::Uuid;
+
+pub use self::data_type::DataTypeQueryPath;
+use crate::{store::query::Expression, subgraph::GraphResolveDepths};
 
 // TODO - find a good place for AccountId, perhaps it will become redundant in a future design
 

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -14,7 +14,6 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 pub use self::data_type::DataTypeQueryPath;
-use crate::{store::query::Expression, subgraph::GraphResolveDepths};
 
 // TODO - find a good place for AccountId, perhaps it will become redundant in a future design
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
@@ -22,7 +22,7 @@ impl<'q> Query for ReadQuery<'q, DataType> {
     }
 }
 
-/// A field available in [`DataType`]s.
+/// A [`Field`] available in [`DataType`]s.
 ///
 /// [`DataType`]: type_system::DataType
 #[derive(Debug, PartialEq, Eq)]
@@ -91,10 +91,10 @@ impl Field for DataTypeQueryField<'_> {
 
 impl Path for DataTypeQueryPath<'_> {
     fn tables(&self) -> Vec<TableName> {
-        vec![self.table_name()]
+        vec![self.terminating_table_name()]
     }
 
-    fn table_name(&self) -> TableName {
+    fn terminating_table_name(&self) -> TableName {
         match self {
             Self::BaseUri | Self::Version => TableName::TypeIds,
             Self::OwnedById

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
@@ -1,0 +1,138 @@
+use std::borrow::Cow;
+
+use type_system::DataType;
+
+use crate::{
+    ontology::DataTypeQueryPath,
+    store::{
+        postgres::query::{
+            database::{ColumnAccess, TableName},
+            Field, Path, Query,
+        },
+        query::ReadQuery,
+    },
+};
+
+impl<'q> Query for ReadQuery<'q, DataType> {
+    type Field = DataTypeQueryField<'q>;
+    type Record = DataType;
+
+    fn base_table() -> TableName {
+        TableName::DataTypes
+    }
+}
+
+/// A field available in [`DataType`]s.
+///
+/// [`DataType`]: type_system::DataType
+#[derive(Debug, PartialEq, Eq)]
+pub enum DataTypeQueryField<'q> {
+    BaseUri,
+    Version,
+    VersionId,
+    OwnedById,
+    Schema,
+    VersionedUri,
+    Title,
+    Description,
+    Type,
+    Custom(Cow<'q, str>),
+}
+
+impl Field for DataTypeQueryField<'_> {
+    fn table_name(&self) -> TableName {
+        match self {
+            Self::BaseUri | Self::Version => TableName::TypeIds,
+            Self::VersionId
+            | Self::OwnedById
+            | Self::Schema
+            | Self::VersionedUri
+            | Self::Title
+            | Self::Type
+            | Self::Description
+            | Self::Custom(_) => TableName::DataTypes,
+        }
+    }
+
+    fn column_access(&self) -> ColumnAccess {
+        match self {
+            Self::BaseUri => ColumnAccess::Table { column: "base_uri" },
+            Self::Version => ColumnAccess::Table { column: "version" },
+            Self::VersionId => ColumnAccess::Table {
+                column: "version_id",
+            },
+            Self::OwnedById => ColumnAccess::Table {
+                column: "owned_by_id",
+            },
+            Self::Schema => ColumnAccess::Table { column: "schema" },
+            Self::VersionedUri => ColumnAccess::Json {
+                column: "schema",
+                field: Cow::Borrowed("$id"),
+            },
+            Self::Title => ColumnAccess::Json {
+                column: "schema",
+                field: Cow::Borrowed("title"),
+            },
+            Self::Type => ColumnAccess::Json {
+                column: "schema",
+                field: Cow::Borrowed("type"),
+            },
+            Self::Description => ColumnAccess::Json {
+                column: "schema",
+                field: Cow::Borrowed("description"),
+            },
+            Self::Custom(field) => ColumnAccess::Json {
+                column: "schema",
+                field: field.clone(),
+            },
+        }
+    }
+}
+
+impl Path for DataTypeQueryPath<'_> {
+    fn tables(&self) -> Vec<TableName> {
+        vec![self.table_name()]
+    }
+
+    fn table_name(&self) -> TableName {
+        match self {
+            Self::BaseUri | Self::Version => TableName::TypeIds,
+            Self::OwnedById
+            | Self::VersionedUri
+            | Self::Title
+            | Self::Type
+            | Self::Description
+            | Self::Custom(_) => TableName::DataTypes,
+        }
+    }
+
+    fn column_access(&self) -> ColumnAccess {
+        match self {
+            Self::BaseUri => ColumnAccess::Table { column: "base_uri" },
+            Self::Version => ColumnAccess::Table { column: "version" },
+            Self::OwnedById => ColumnAccess::Table {
+                column: "owned_by_id",
+            },
+            Self::VersionedUri => ColumnAccess::Json {
+                column: "schema",
+                field: Cow::Borrowed("$id"),
+            },
+            Self::Title => ColumnAccess::Json {
+                column: "schema",
+                field: Cow::Borrowed("title"),
+            },
+            Self::Type => ColumnAccess::Json {
+                column: "schema",
+                field: Cow::Borrowed("type"),
+            },
+            Self::Description => ColumnAccess::Json {
+                column: "schema",
+                field: Cow::Borrowed("description"),
+            },
+            Self::Custom(field) => ColumnAccess::Json {
+                column: "schema",
+                field: field.clone(),
+            },
+        }
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
@@ -24,10 +24,10 @@ pub trait Query {
 
 /// An attribute of an ontology type or a knowledge element.
 pub trait Field {
-    /// The [`TableName`], where this field lives in.
+    /// The [`TableName`] of the [`Table`] where this field is located.
     fn table_name(&self) -> TableName;
 
-    /// The way, how to access the column inside of [`table_name()`] where this field lives in.
+    /// The way to access the column inside of [`table_name()`] where this field is located.
     ///
     /// [`table_name()`]: Self::table_name
     fn column_access(&self) -> ColumnAccess;
@@ -38,10 +38,10 @@ pub trait Path {
     /// Returns a list of [`TableName`]s required to traverse this path.
     fn tables(&self) -> Vec<TableName>;
 
-    /// The [`TableName`], where this path ends at.
-    fn table_name(&self) -> TableName;
+    /// The [`TableName`] that marks the end of the path.
+    fn terminating_table_name(&self) -> TableName;
 
-    /// The way, how to access the column inside of [`table_name()`] where this path ends at.
+    /// How to access the column inside of [`table_name()`] where this path ends.
     ///
     /// [`table_name()`]: Self::table_name
     fn column_access(&self) -> ColumnAccess;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
@@ -25,6 +25,8 @@ pub trait Query {
 /// An attribute of an ontology type or a knowledge element.
 pub trait Field {
     /// The [`TableName`] of the [`Table`] where this field is located.
+    ///
+    /// [`Table`]: database::Table
     fn table_name(&self) -> TableName;
 
     /// The way to access the column inside of [`table_name()`] where this field is located.
@@ -41,9 +43,9 @@ pub trait Path {
     /// The [`TableName`] that marks the end of the path.
     fn terminating_table_name(&self) -> TableName;
 
-    /// How to access the column inside of [`table_name()`] where this path ends.
+    /// How to access the column inside of [`terminating_table_name()`] where this path ends.
     ///
-    /// [`table_name()`]: Self::table_name
+    /// [`terminating_table_name()`]: Self::terminating_table_name
     fn column_access(&self) -> ColumnAccess;
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
@@ -18,7 +18,7 @@ pub trait Query {
     type Field: Field;
     type Record: QueryRecord;
 
-    /// The [`Table`] used for this `Query`.
+    /// The [`TableName`] used for this `Query`.
     fn base_table() -> TableName;
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
@@ -2,41 +2,49 @@
 
 //! Postgres implementation to compile queries.
 
+mod data_type;
 pub mod database;
 
 use std::fmt::{self, Formatter};
 
+pub use self::data_type::DataTypeQueryField;
 use crate::store::{
-    postgres::query::database::{Column, Table},
+    postgres::query::database::{ColumnAccess, TableName},
     query::QueryRecord,
 };
 
 /// A structural query, which can be compiled into a statement in Postgres.
-// TODO: Implement for `ReadQuery<DataType>`, `ReadQuery<PropertyType>`, etc. when associated types
-//       are implemented
 pub trait Query {
     type Field: Field;
     type Record: QueryRecord;
 
     /// The [`Table`] used for this `Query`.
-    fn base_table() -> Table;
+    fn base_table() -> TableName;
 }
 
 /// An attribute of an ontology type or a knowledge element.
-// TODO: Implement for `DataTypeField`, `PropertyTypeQueryField`, etc. (not added yet)
 pub trait Field {
-    /// The [`Column`] which contains this `Field`.
-    fn column(&self) -> Column;
+    /// The [`TableName`], where this field lives in.
+    fn table_name(&self) -> TableName;
+
+    /// The way, how to access the column inside of [`table_name()`] where this field lives in.
+    ///
+    /// [`table_name()`]: Self::table_name
+    fn column_access(&self) -> ColumnAccess;
 }
 
 /// An absolute path to a [`Field`].
-// TODO: Implement for `DataTypeQueryPath`, `PropertyTypeQueryPath`, etc. (not added yet)
 pub trait Path {
-    /// Returns a list of [`Table`]s required to traverse this path.
-    fn tables(&self) -> Vec<Table>;
+    /// Returns a list of [`TableName`]s required to traverse this path.
+    fn tables(&self) -> Vec<TableName>;
 
-    /// Returns the [`Column`] where the path ends at.
-    fn column(&self) -> Column;
+    /// The [`TableName`], where this path ends at.
+    fn table_name(&self) -> TableName;
+
+    /// The way, how to access the column inside of [`table_name()`] where this path ends at.
+    ///
+    /// [`table_name()`]: Self::table_name
+    fn column_access(&self) -> ColumnAccess;
 }
 
 /// Renders the object into a Postgres compatible format.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds structures for `DataType`s required for compiling data type queries.

This commit is not adding compilation code logic, but the required structures to feed the compiler.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/0/1203157447338103/f) _(internal)_

## 🚫 Blocked by

- #1202
- #1208

## 🔍 What does this change?

- Adds `DataTypeQuery`, `DataTypeQueryField`, and `DataTypeQueryPath`
- Implement the query traits on these

## 📜 Does this require a change to the docs?

Documentation was added for the newly added structs

## ⚠️ Known issues

The structs and traits are currently unused. They will be used in a follow-up.

## 🐾 Next steps

Please see the list of subtasks of the [main Asana task](https://app.asana.com/0/1200211978612931/1203073992606533/f) _(internal)_

## 🛡 What tests cover this?

Tests were added for functions and rendering
