### PR TITLE
Fix visibility on `Persisted*` structs

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -278,8 +278,25 @@ impl PersistedOntologyMetadata {
 pub struct PersistedEntityType {
     #[schema(value_type = VAR_ENTITY_TYPE)]
     #[serde(serialize_with = "serialize_ontology_type")]
-    pub inner: EntityType,
-    pub metadata: PersistedOntologyMetadata,
+    inner: EntityType,
+    metadata: PersistedOntologyMetadata,
+}
+
+impl PersistedEntityType {
+    #[must_use]
+    pub const fn new(inner: EntityType, metadata: PersistedOntologyMetadata) -> Self {
+        Self { inner, metadata }
+    }
+
+    #[must_use]
+    pub const fn inner(&self) -> &EntityType {
+        &self.inner
+    }
+
+    #[must_use]
+    pub const fn metadata(&self) -> &PersistedOntologyMetadata {
+        &self.metadata
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -167,7 +167,6 @@ where
 /// _property type_ references is then resolved to a depth of `property_type_query_depth`.
 pub type OntologyQueryDepth = u8;
 
-// TODO: should the fields be public
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 pub struct PersistedDataType {
     #[schema(value_type = VAR_DATA_TYPE)]
@@ -224,7 +223,6 @@ impl PersistedPropertyType {
     }
 }
 
-// TODO: should the fields be public
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 pub struct PersistedLinkType {
     #[schema(value_type = VAR_LINK_TYPE)]
@@ -273,7 +271,6 @@ impl PersistedOntologyMetadata {
     }
 }
 
-// TODO: should the fields be public
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 pub struct PersistedEntityType {
     #[schema(value_type = VAR_ENTITY_TYPE)]

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -172,8 +172,25 @@ pub type OntologyQueryDepth = u8;
 pub struct PersistedDataType {
     #[schema(value_type = VAR_DATA_TYPE)]
     #[serde(serialize_with = "serialize_ontology_type")]
-    pub inner: DataType,
-    pub metadata: PersistedOntologyMetadata,
+    inner: DataType,
+    metadata: PersistedOntologyMetadata,
+}
+
+impl PersistedDataType {
+    #[must_use]
+    pub const fn new(inner: DataType, metadata: PersistedOntologyMetadata) -> Self {
+        Self { inner, metadata }
+    }
+
+    #[must_use]
+    pub const fn inner(&self) -> &DataType {
+        &self.inner
+    }
+
+    #[must_use]
+    pub const fn metadata(&self) -> &PersistedOntologyMetadata {
+        &self.metadata
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -182,13 +182,29 @@ pub struct DataTypeRootedSubgraph {
     pub data_type: PersistedDataType,
 }
 
-// TODO: should the fields be public
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 pub struct PersistedPropertyType {
     #[schema(value_type = VAR_PROPERTY_TYPE)]
     #[serde(serialize_with = "serialize_ontology_type")]
-    pub inner: PropertyType,
-    pub metadata: PersistedOntologyMetadata,
+    inner: PropertyType,
+    metadata: PersistedOntologyMetadata,
+}
+
+impl PersistedPropertyType {
+    #[must_use]
+    pub const fn new(inner: PropertyType, metadata: PersistedOntologyMetadata) -> Self {
+        Self { inner, metadata }
+    }
+
+    #[must_use]
+    pub const fn inner(&self) -> &PropertyType {
+        &self.inner
+    }
+
+    #[must_use]
+    pub const fn metadata(&self) -> &PersistedOntologyMetadata {
+        &self.metadata
+    }
 }
 
 // TODO: should the fields be public

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -229,8 +229,25 @@ impl PersistedPropertyType {
 pub struct PersistedLinkType {
     #[schema(value_type = VAR_LINK_TYPE)]
     #[serde(serialize_with = "serialize_ontology_type")]
-    pub inner: LinkType,
-    pub metadata: PersistedOntologyMetadata,
+    inner: LinkType,
+    metadata: PersistedOntologyMetadata,
+}
+
+impl PersistedLinkType {
+    #[must_use]
+    pub const fn new(inner: LinkType, metadata: PersistedOntologyMetadata) -> Self {
+        Self { inner, metadata }
+    }
+
+    #[must_use]
+    pub const fn inner(&self) -> &LinkType {
+        &self.inner
+    }
+
+    #[must_use]
+    pub const fn metadata(&self) -> &PersistedOntologyMetadata {
+        &self.metadata
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -97,7 +97,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
                     let mut links = DependencySet::new();
 
                     self.get_data_type_as_dependency(
-                        data_type.metadata.identifier().uri(),
+                        data_type.metadata().identifier().uri(),
                         DependencyContext {
                             edges: &mut edges,
                             referenced_data_types: &mut referenced_data_types,
@@ -112,11 +112,11 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
                     .await?;
 
                     let data_type = referenced_data_types
-                        .remove(data_type.metadata.identifier().uri())
+                        .remove(data_type.metadata().identifier().uri())
                         .expect("root was not added to the subgraph");
 
                     let identifier = GraphElementIdentifier::OntologyElementId(
-                        data_type.metadata.identifier().uri().clone(),
+                        data_type.metadata().identifier().uri().clone(),
                     );
 
                     Ok::<_, Report<QueryError>>((

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
@@ -65,7 +65,7 @@ impl<C: AsClient> PostgresStore<C> {
                 if graph_resolve_depths.property_type_resolve_depth > 0 {
                     // TODO: Use relation tables
                     //   see https://app.asana.com/0/0/1202884883200942/f
-                    for property_type_ref in entity_type.inner.property_type_references() {
+                    for property_type_ref in entity_type.inner().property_type_references() {
                         self.get_property_type_as_dependency(
                             property_type_ref.uri(),
                             DependencyContext {
@@ -92,7 +92,7 @@ impl<C: AsClient> PostgresStore<C> {
                     || context.graph_resolve_depths.entity_type_resolve_depth > 0
                 {
                     let linked_uris = entity_type
-                        .inner
+                        .inner()
                         .link_type_references()
                         .into_iter()
                         .map(|(link_type_id, entity_type_ids)| {
@@ -222,7 +222,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
                 let mut links = DependencySet::new();
 
                 self.get_entity_type_as_dependency(
-                    entity_type.metadata.identifier().uri(),
+                    entity_type.metadata().identifier().uri(),
                     DependencyContext {
                         edges: &mut edges,
                         referenced_data_types: &mut referenced_data_types,
@@ -237,7 +237,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
                 .await?;
 
                 let root = referenced_entity_types
-                    .remove(entity_type.metadata.identifier().uri())
+                    .remove(entity_type.metadata().identifier().uri())
                     .expect("root was not added to the subgraph");
 
                 Ok(EntityTypeRootedSubgraph {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
@@ -94,7 +94,7 @@ impl<C: AsClient> LinkTypeStore for PostgresStore<C> {
                 let mut links = DependencySet::new();
 
                 self.get_link_type_as_dependency(
-                    link_type.metadata.identifier().uri(),
+                    link_type.metadata().identifier().uri(),
                     DependencyContext {
                         edges: &mut edges,
                         referenced_data_types: &mut referenced_data_types,
@@ -109,7 +109,7 @@ impl<C: AsClient> LinkTypeStore for PostgresStore<C> {
                 .await?;
 
                 let root = referenced_link_types
-                    .remove(link_type.metadata.identifier().uri())
+                    .remove(link_type.metadata().identifier().uri())
                     .expect("root was not added to the subgraph");
 
                 Ok(LinkTypeRootedSubgraph { link_type: root })

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -58,7 +58,7 @@ impl<C: AsClient> PostgresStore<C> {
                 if graph_resolve_depths.data_type_resolve_depth > 0 {
                     // TODO: Use relation tables
                     //   see https://app.asana.com/0/0/1202884883200942/f
-                    for data_type_ref in property_type.inner.data_type_references() {
+                    for data_type_ref in property_type.inner().data_type_references() {
                         self.get_data_type_as_dependency(data_type_ref.uri(), DependencyContext {
                             graph_resolve_depths: GraphResolveDepths {
                                 data_type_resolve_depth: graph_resolve_depths
@@ -82,7 +82,7 @@ impl<C: AsClient> PostgresStore<C> {
                     // TODO: Use relation tables
                     //   see https://app.asana.com/0/0/1202884883200942/f
                     let property_type_ids = property_type
-                        .inner
+                        .inner()
                         .property_type_references()
                         .into_iter()
                         .map(PropertyTypeReference::uri)
@@ -181,7 +181,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                     let mut links = DependencySet::new();
 
                     self.get_property_type_as_dependency(
-                        property_type.metadata.identifier().uri(),
+                        property_type.metadata().identifier().uri(),
                         DependencyContext {
                             edges: &mut edges,
                             referenced_data_types: &mut referenced_data_types,
@@ -196,11 +196,11 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                     .await?;
 
                     let property_type = referenced_property_types
-                        .remove(property_type.metadata.identifier().uri())
+                        .remove(property_type.metadata().identifier().uri())
                         .expect("root was not added to the subgraph");
 
                     let identifier = GraphElementIdentifier::OntologyElementId(
-                        property_type.metadata.identifier().uri().clone(),
+                        property_type.metadata().identifier().uri().clone(),
                     );
 
                     Ok::<_, Report<QueryError>>((

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -56,10 +56,7 @@ impl PersistedOntologyType for PersistedLinkType {
     fn from_record(link_type: OntologyRecord<Self::Inner>) -> Self {
         let identifier =
             PersistedOntologyIdentifier::new(link_type.record.id().clone(), link_type.account_id);
-        Self {
-            inner: link_type.record,
-            metadata: PersistedOntologyMetadata::new(identifier),
-        }
+        Self::new(link_type.record, PersistedOntologyMetadata::new(identifier))
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -31,10 +31,7 @@ impl PersistedOntologyType for PersistedDataType {
     fn from_record(data_type: OntologyRecord<Self::Inner>) -> Self {
         let identifier =
             PersistedOntologyIdentifier::new(data_type.record.id().clone(), data_type.account_id);
-        Self {
-            inner: data_type.record,
-            metadata: PersistedOntologyMetadata::new(identifier),
-        }
+        Self::new(data_type.record, PersistedOntologyMetadata::new(identifier))
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -68,10 +68,10 @@ impl PersistedOntologyType for PersistedEntityType {
             entity_type.record.id().clone(),
             entity_type.account_id,
         );
-        Self {
-            inner: entity_type.record,
-            metadata: PersistedOntologyMetadata::new(identifier),
-        }
+        Self::new(
+            entity_type.record,
+            PersistedOntologyMetadata::new(identifier),
+        )
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -46,10 +46,10 @@ impl PersistedOntologyType for PersistedPropertyType {
             property_type.record.id().clone(),
             property_type.account_id,
         );
-        Self {
-            inner: property_type.record,
-            metadata: PersistedOntologyMetadata::new(identifier),
-        }
+        Self::new(
+            property_type.record,
+            PersistedOntologyMetadata::new(identifier),
+        )
     }
 }
 

--- a/packages/graph/hash_graph/tests/integration/postgres/data_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/data_type.rs
@@ -40,7 +40,7 @@ async fn query() {
         .await
         .expect("could not get data type");
 
-    assert_eq!(data_type.inner, empty_list_dt);
+    assert_eq!(data_type.inner(), &empty_list_dt);
 }
 
 #[tokio::test]
@@ -77,6 +77,6 @@ async fn update() {
         .await
         .expect("could not get property type");
 
-    assert_eq!(object_dt_v1, returned_object_dt_v1.inner);
-    assert_eq!(object_dt_v2, returned_object_dt_v2.inner);
+    assert_eq!(&object_dt_v1, returned_object_dt_v1.inner());
+    assert_eq!(&object_dt_v2, returned_object_dt_v2.inner());
 }

--- a/packages/graph/hash_graph/tests/integration/postgres/entity_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/entity_type.rs
@@ -82,7 +82,7 @@ async fn update() {
     let returned_page_et_v1 = api
         .get_entity_type(page_et_v1.id())
         .await
-        .expect("could not get property type");
+        .expect("could not get entity type");
 
     // TODO: we probably want to be testing more interesting queries, checking an update should
     //  probably use getLatestVersion
@@ -90,7 +90,7 @@ async fn update() {
     let returned_page_et_v2 = api
         .get_entity_type(page_et_v2.id())
         .await
-        .expect("could not get property type");
+        .expect("could not get entity type");
 
     assert_eq!(&page_et_v1, returned_page_et_v1.inner());
     assert_eq!(&page_et_v2, returned_page_et_v2.inner());

--- a/packages/graph/hash_graph/tests/integration/postgres/entity_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/entity_type.rs
@@ -46,7 +46,7 @@ async fn query() {
         .await
         .expect("could not get entity type");
 
-    assert_eq!(entity_type.inner, organization_et);
+    assert_eq!(entity_type.inner(), &organization_et);
 }
 
 #[tokio::test]
@@ -92,6 +92,6 @@ async fn update() {
         .await
         .expect("could not get property type");
 
-    assert_eq!(page_et_v1, returned_page_et_v1.inner);
-    assert_eq!(page_et_v2, returned_page_et_v2.inner);
+    assert_eq!(&page_et_v1, returned_page_et_v1.inner());
+    assert_eq!(&page_et_v2, returned_page_et_v2.inner());
 }

--- a/packages/graph/hash_graph/tests/integration/postgres/link_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/link_type.rs
@@ -40,7 +40,7 @@ async fn query() {
         .await
         .expect("could not get link type");
 
-    assert_eq!(link_type.inner, submitted_by_lt);
+    assert_eq!(link_type.inner(), &submitted_by_lt);
 }
 
 #[tokio::test]
@@ -77,6 +77,6 @@ async fn update() {
     // TODO: we probably want to be testing more interesting queries, checking an update should
     //  probably use getLatestVersion
     //  https://app.asana.com/0/0/1202884883200974/f
-    assert_eq!(owns_lt_v1, returned_owns_lt_v1.inner);
-    assert_eq!(owns_lt_v2, returned_owns_lt_v2.inner);
+    assert_eq!(&owns_lt_v1, returned_owns_lt_v1.inner());
+    assert_eq!(&owns_lt_v2, returned_owns_lt_v2.inner());
 }

--- a/packages/graph/hash_graph/tests/integration/postgres/property_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/property_type.rs
@@ -41,7 +41,7 @@ async fn query() {
         .await
         .expect("could not get property type");
 
-    assert_eq!(property_type.inner, favorite_quote_pt);
+    assert_eq!(property_type.inner(), &favorite_quote_pt);
 }
 
 #[tokio::test]
@@ -79,6 +79,6 @@ async fn update() {
     // TODO: we probably want to be testing more interesting queries, checking an update should
     //  probably use getLatestVersion
     //  https://app.asana.com/0/0/1202884883200974/f
-    assert_eq!(user_id_pt_v1, returned_user_id_pt_v1.inner);
-    assert_eq!(user_id_pt_v2, returned_user_id_pt_v2.inner);
+    assert_eq!(&user_id_pt_v1, returned_user_id_pt_v1.inner());
+    assert_eq!(&user_id_pt_v2, returned_user_id_pt_v2.inner());
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We had inconsistent visibilities on our `Persisted*` structs. Ideally we don't want these to be constructed unless the record actually exists, and at that point we don't want them to be mutable.

This makes the fields within them private, and updates accessors.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1200211978612931/1203179088220798/f) _(internal)_

## 🛡 What tests cover this?

- Rust tests (and compilation)

## ❓ How to test this?

1.  Follow instructions for setting up the Graph dev env
2. Run `cargo make test`
