### PR TITLE
Add `Condition` and conversion from `Filter`

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
@@ -1,0 +1,331 @@
+use std::{fmt, fmt::Write};
+
+use postgres_types::ToSql;
+
+use crate::store::{
+    postgres::query::{
+        database::{Column, Table, TableAlias},
+        Path, Transpile,
+    },
+    query::{Filter, FilterValue, Parameter, QueryRecord},
+};
+
+/// A [`Filter`] compiled to postgres.
+pub enum Condition<'q> {
+    All(Vec<Self>),
+    Any(Vec<Self>),
+    Not(Box<Self>),
+    Equal(Option<ConditionValue<'q>>, Option<ConditionValue<'q>>),
+    NotEqual(Option<ConditionValue<'q>>, Option<ConditionValue<'q>>),
+}
+
+impl<'q> Condition<'q> {
+    /// Compiles a [`Filter`] to a `Condition`.
+    ///
+    /// In addition to the provided [`Filter`], a list of parameters needs to be passed, which will
+    /// be populated from [`FilterValue::Parameter`]. Also, [`TableAlias`] is used to populate
+    /// [`Table::alias`] inside of [`ConditionValue::Column`].
+    pub fn from_filter<'f: 'q, T: QueryRecord<Path<'q>: Path>>(
+        filter: &'f Filter<'q, T>,
+        parameters: &mut Vec<&'f dyn ToSql>,
+        alias: Option<TableAlias>,
+    ) -> Self {
+        match filter {
+            Filter::All(filters) => Self::All(
+                filters
+                    .iter()
+                    .map(|filter| Self::from_filter(filter, parameters, alias))
+                    .collect(),
+            ),
+            Filter::Any(filters) => Self::Any(
+                filters
+                    .iter()
+                    .map(|filter| Self::from_filter(filter, parameters, alias))
+                    .collect(),
+            ),
+            Filter::Not(filter) => {
+                Self::Not(Box::new(Self::from_filter(filter, parameters, alias)))
+            }
+            Filter::Equal(lhs, rhs) => Self::Equal(
+                lhs.as_ref()
+                    .map(|value| ConditionValue::from_filter_value(value, parameters, alias)),
+                rhs.as_ref()
+                    .map(|value| ConditionValue::from_filter_value(value, parameters, alias)),
+            ),
+            Filter::NotEqual(lhs, rhs) => Self::NotEqual(
+                lhs.as_ref()
+                    .map(|value| ConditionValue::from_filter_value(value, parameters, alias)),
+                rhs.as_ref()
+                    .map(|value| ConditionValue::from_filter_value(value, parameters, alias)),
+            ),
+        }
+    }
+}
+
+impl Transpile for Condition<'_> {
+    fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Condition::All(conditions) if conditions.is_empty() => fmt.write_str("true"),
+            Condition::Any(conditions) if conditions.is_empty() => fmt.write_str("false"),
+            Condition::All(conditions) | Condition::Any(conditions) => {
+                for (idx, condition) in conditions.iter().enumerate() {
+                    fmt.write_char('(')?;
+                    condition.transpile(fmt)?;
+                    fmt.write_char(')')?;
+                    if idx + 1 < conditions.len() {
+                        if matches!(self, Condition::All(_)) {
+                            fmt.write_str(" AND ")?;
+                        } else {
+                            fmt.write_str(" OR ")?;
+                        }
+                    }
+                }
+                Ok(())
+            }
+            Condition::Not(condition) => {
+                fmt.write_str("NOT(")?;
+                condition.transpile(fmt)?;
+                fmt.write_char(')')
+            }
+            Condition::Equal(value, None) | Condition::Equal(None, value) => {
+                value.transpile(fmt)?;
+                fmt.write_str(" IS NULL")
+            }
+            Condition::Equal(lhs, rhs) => {
+                lhs.transpile(fmt)?;
+                fmt.write_str(" = ")?;
+                rhs.transpile(fmt)
+            }
+            Condition::NotEqual(value, None) | Condition::NotEqual(None, value) => {
+                value.transpile(fmt)?;
+                fmt.write_str(" IS NOT NULL")
+            }
+            Condition::NotEqual(lhs, rhs) => {
+                lhs.transpile(fmt)?;
+                fmt.write_str(" != ")?;
+                rhs.transpile(fmt)
+            }
+        }
+    }
+}
+
+/// A [`FilterValue`] compiled to postgres.
+pub enum ConditionValue<'q> {
+    Column(Column<'q>),
+    Parameter(usize),
+}
+
+impl Transpile for ConditionValue<'_> {
+    fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Column(column) => column.transpile(fmt),
+            Self::Parameter(index) => write!(fmt, "${index}"),
+        }
+    }
+}
+
+impl<'q> ConditionValue<'q> {
+    pub fn from_filter_value<'f: 'q, T: QueryRecord<Path<'q>: Path>>(
+        value: &'f FilterValue<'q, T>,
+        parameters: &mut Vec<&'f dyn ToSql>,
+        alias: Option<TableAlias>,
+    ) -> Self {
+        match value {
+            FilterValue::Path(path) => Self::Column(Column {
+                table: Table {
+                    name: path.table_name(),
+                    alias,
+                },
+                access: path.column_access(),
+            }),
+            FilterValue::Parameter(parameter) => match parameter {
+                Parameter::Number(number) => {
+                    parameters.push(number);
+                    Self::Parameter(parameters.len())
+                }
+                Parameter::Text(text) => {
+                    parameters.push(text);
+                    Self::Parameter(parameters.len())
+                }
+                Parameter::Boolean(bool) => {
+                    parameters.push(bool);
+                    Self::Parameter(parameters.len())
+                }
+            },
+        }
+    }
+}
+
+impl Transpile for Option<ConditionValue<'_>> {
+    fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Some(value) => value.transpile(fmt),
+            None => fmt.write_str("NULL"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use type_system::DataType;
+
+    use super::*;
+    use crate::{ontology::DataTypeQueryPath, store::postgres::query::test_helper::transpile};
+
+    fn test_condition<'q, 'f: 'q>(
+        filter: &'f Filter<'q, DataType>,
+        rendered: &'static str,
+        parameters: &[&'q dyn ToSql],
+    ) {
+        let mut parameter_list = Vec::new();
+        let condition = Condition::from_filter(filter, &mut parameter_list, None);
+
+        assert_eq!(transpile(&condition), rendered);
+
+        let parameter_list = parameter_list
+            .into_iter()
+            .map(|parameter| format!("{parameter:?}"))
+            .collect::<Vec<_>>();
+        let expected_parameters = parameters
+            .iter()
+            .map(|parameter| format!("{parameter:?}"))
+            .collect::<Vec<_>>();
+        assert_eq!(parameter_list, expected_parameters);
+    }
+
+    #[test]
+    fn render_empty_condition() {
+        let filter = Filter::All(vec![]);
+        test_condition(&filter, "true", &[]);
+
+        let filter = Filter::Any(vec![]);
+        test_condition(&filter, "false", &[]);
+    }
+
+    #[test]
+    fn render_null_condition() {
+        test_condition(
+            &Filter::Equal(
+                Some(FilterValue::Path(DataTypeQueryPath::Description)),
+                None,
+            ),
+            r#""data_types"."schema"->>'description' IS NULL"#,
+            &[],
+        );
+
+        test_condition(
+            &Filter::Equal(
+                None,
+                Some(FilterValue::Path(DataTypeQueryPath::Description)),
+            ),
+            r#""data_types"."schema"->>'description' IS NULL"#,
+            &[],
+        );
+
+        test_condition(&Filter::Equal(None, None), "NULL IS NULL", &[]);
+
+        test_condition(
+            &Filter::NotEqual(
+                Some(FilterValue::Path(DataTypeQueryPath::Description)),
+                None,
+            ),
+            r#""data_types"."schema"->>'description' IS NOT NULL"#,
+            &[],
+        );
+
+        test_condition(
+            &Filter::NotEqual(
+                None,
+                Some(FilterValue::Path(DataTypeQueryPath::Description)),
+            ),
+            r#""data_types"."schema"->>'description' IS NOT NULL"#,
+            &[],
+        );
+
+        test_condition(&Filter::NotEqual(None, None), "NULL IS NOT NULL", &[]);
+    }
+
+    #[test]
+    fn render_all_condition() {
+        test_condition(
+            &Filter::All(vec![Filter::Equal(
+                Some(FilterValue::Path(DataTypeQueryPath::VersionedUri)),
+                Some(FilterValue::Parameter(Parameter::Text(Cow::Borrowed(
+                    "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
+                )))),
+            )]),
+            r#"("data_types"."schema"->>'$id' = $1)"#,
+            &[&"https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"],
+        );
+
+        test_condition(
+            &Filter::All(vec![
+                Filter::Equal(
+                    Some(FilterValue::Path(DataTypeQueryPath::BaseUri)),
+                    Some(FilterValue::Parameter(Parameter::Text(Cow::Borrowed(
+                        "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
+                    )))),
+                ),
+                Filter::Equal(
+                    Some(FilterValue::Path(DataTypeQueryPath::Version)),
+                    Some(FilterValue::Parameter(Parameter::Number(1.0))),
+                ),
+            ]),
+            r#"("type_ids"."base_uri" = $1) AND ("type_ids"."version" = $2)"#,
+            &[
+                &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
+                &1.0,
+            ],
+        );
+    }
+
+    #[test]
+    fn render_any_condition() {
+        test_condition(
+            &Filter::Any(vec![Filter::Equal(
+                Some(FilterValue::Path(DataTypeQueryPath::VersionedUri)),
+                Some(FilterValue::Parameter(Parameter::Text(Cow::Borrowed(
+                    "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
+                )))),
+            )]),
+            r#"("data_types"."schema"->>'$id' = $1)"#,
+            &[&"https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"],
+        );
+
+        test_condition(
+            &Filter::Any(vec![
+                Filter::Equal(
+                    Some(FilterValue::Path(DataTypeQueryPath::BaseUri)),
+                    Some(FilterValue::Parameter(Parameter::Text(Cow::Borrowed(
+                        "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
+                    )))),
+                ),
+                Filter::Equal(
+                    Some(FilterValue::Path(DataTypeQueryPath::Version)),
+                    Some(FilterValue::Parameter(Parameter::Number(1.0))),
+                ),
+            ]),
+            r#"("type_ids"."base_uri" = $1) OR ("type_ids"."version" = $2)"#,
+            &[
+                &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
+                &1.0,
+            ],
+        );
+    }
+
+    #[test]
+    fn render_not_condition() {
+        test_condition(
+            &Filter::Not(Box::new(Filter::Equal(
+                Some(FilterValue::Path(DataTypeQueryPath::VersionedUri)),
+                Some(FilterValue::Parameter(Parameter::Text(Cow::Borrowed(
+                    "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
+                )))),
+            ))),
+            r#"NOT("data_types"."schema"->>'$id' = $1)"#,
+            &[&"https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"],
+        );
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
@@ -5,9 +5,9 @@ use postgres_types::ToSql;
 use crate::store::{
     postgres::query::{
         database::{Column, Table, TableAlias},
-        Path, Transpile,
+        Path, PostgresQueryRecord, Transpile,
     },
-    query::{Filter, FilterValue, Parameter, QueryRecord},
+    query::{Filter, FilterValue, Parameter},
 };
 
 /// A [`Filter`] compiled to postgres.
@@ -25,7 +25,7 @@ impl<'q> Condition<'q> {
     /// In addition to the provided [`Filter`], a list of parameters needs to be passed, which will
     /// be populated from [`FilterValue::Parameter`]. Also, [`TableAlias`] is used to populate
     /// [`Table::alias`] inside of [`ConditionValue::Column`].
-    pub fn from_filter<'f: 'q, T: QueryRecord<Path<'q>: Path>>(
+    pub fn from_filter<'f: 'q, T: PostgresQueryRecord<'q>>(
         filter: &'f Filter<'q, T>,
         parameters: &mut Vec<&'f dyn ToSql>,
         alias: Option<TableAlias>,
@@ -116,7 +116,7 @@ pub enum ConditionValue<'q> {
 }
 
 impl<'q> ConditionValue<'q> {
-    pub fn from_filter_value<'f: 'q, T: QueryRecord<Path<'q>: Path>>(
+    pub fn from_filter_value<'f: 'q, T: PostgresQueryRecord<'q>>(
         value: &'f FilterValue<'q, T>,
         parameters: &mut Vec<&'f dyn ToSql>,
         alias: Option<TableAlias>,
@@ -124,7 +124,7 @@ impl<'q> ConditionValue<'q> {
         match value {
             FilterValue::Path(path) => Self::Column(Column {
                 table: Table {
-                    name: path.table_name(),
+                    name: path.terminating_table_name(),
                     alias,
                 },
                 access: path.column_access(),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
@@ -197,11 +197,8 @@ mod tests {
 
     #[test]
     fn render_empty_condition() {
-        let filter = Filter::All(vec![]);
-        test_condition(&filter, "true", &[]);
-
-        let filter = Filter::Any(vec![]);
-        test_condition(&filter, "false", &[]);
+        test_condition(&Filter::All(vec![]), "true", &[]);
+        test_condition(&Filter::Any(vec![]), "false", &[]);
     }
 
     #[test]

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
@@ -115,15 +115,6 @@ pub enum ConditionValue<'q> {
     Parameter(usize),
 }
 
-impl Transpile for ConditionValue<'_> {
-    fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::Column(column) => column.transpile(fmt),
-            Self::Parameter(index) => write!(fmt, "${index}"),
-        }
-    }
-}
-
 impl<'q> ConditionValue<'q> {
     pub fn from_filter_value<'f: 'q, T: QueryRecord<Path<'q>: Path>>(
         value: &'f FilterValue<'q, T>,
@@ -152,6 +143,15 @@ impl<'q> ConditionValue<'q> {
                     Self::Parameter(parameters.len())
                 }
             },
+        }
+    }
+}
+
+impl Transpile for ConditionValue<'_> {
+    fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Column(column) => column.transpile(fmt),
+            Self::Parameter(index) => write!(fmt, "${index}"),
         }
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
@@ -4,18 +4,14 @@ use type_system::DataType;
 
 use crate::{
     ontology::DataTypeQueryPath,
-    store::{
-        postgres::query::{
-            database::{ColumnAccess, TableName},
-            Field, Path, Query,
-        },
-        query::ReadQuery,
+    store::postgres::query::{
+        database::{ColumnAccess, TableName},
+        Field, Path, PostgresQueryRecord,
     },
 };
 
-impl<'q> Query for ReadQuery<'q, DataType> {
+impl<'q> PostgresQueryRecord<'q> for DataType {
     type Field = DataTypeQueryField<'q>;
-    type Record = DataType;
 
     fn base_table() -> TableName {
         TableName::DataTypes

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
@@ -14,10 +14,8 @@ use crate::store::{
     query::QueryRecord,
 };
 
-/// A structural query, which can be compiled into a statement in Postgres.
-pub trait Query {
+pub trait PostgresQueryRecord<'q>: QueryRecord<Path<'q>: Path> {
     type Field: Field;
-    type Record: QueryRecord;
 
     /// The [`TableName`] used for this `Query`.
     fn base_table() -> TableName;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
@@ -23,7 +23,9 @@ pub trait Query {
     fn base_table() -> TableName;
 }
 
-/// An attribute of an ontology type or a knowledge element.
+/// A queryable attribute of an element in the [`graph`].
+///
+/// [`graph`]: crate::graph
 pub trait Field {
     /// The [`TableName`] of the [`Table`] where this field is located.
     ///
@@ -36,7 +38,7 @@ pub trait Field {
     fn column_access(&self) -> ColumnAccess;
 }
 
-/// An absolute path to a [`Field`].
+/// An absolute path inside of a query pointing to a [`Field`]
 pub trait Path {
     /// Returns a list of [`TableName`]s required to traverse this path.
     fn tables(&self) -> Vec<TableName>;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
@@ -21,9 +21,7 @@ pub trait PostgresQueryRecord<'q>: QueryRecord<Path<'q>: Path> {
     fn base_table() -> TableName;
 }
 
-/// A queryable attribute of an element in the [`graph`].
-///
-/// [`graph`]: crate::graph
+/// A queryable attribute of an element in the graph.
 pub trait Field {
     /// The [`TableName`] of the [`Table`] where this field is located.
     ///

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
@@ -2,6 +2,7 @@
 
 //! Postgres implementation to compile queries.
 
+mod condition;
 mod data_type;
 pub mod database;
 

--- a/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
@@ -1,8 +1,6 @@
 mod filter;
 mod old;
 
-use std::marker::PhantomData;
-
 pub use self::{
     filter::{Filter, FilterValue, Parameter},
     old::{
@@ -17,12 +15,4 @@ pub use self::{
 // TODO: Implement for `DataType`, `PropertyType`, etc. when `Path` is implemented
 pub trait QueryRecord {
     type Path<'q>: TryFrom<Path>;
-}
-
-/// A query to read [`QueryRecord`]s from the [`store`].
-///
-/// [`store`]: crate::store
-pub struct ReadQuery<'q, T: QueryRecord> {
-    // TODO: Replace `PhantomData` with filters used for queries
-    _filters: Vec<PhantomData<T::Path<'q>>>,
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This adds the compilation of `Filter` into `Condition` (added in this PR). a `Condition` will be used in `WHERE` statements and differs in a few key points from `Filter` (which is uer-facing):
- Parameters are prepared, so each `Filter::Parameter` will be replaced with `$x` (e.g. `$1`, `$2`)
- `Filter::Path` is resolved to a `Column`

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/0/1203132766663456/f) _(internal)_

## 🚫 Blocked by

- #1209

## 🔍 What does this change?

- Adds `Condition` and `ConditionValue` (similar to `Filter`/`FilterValue` but adjusted to be transpiled to SQL)
- Provide a conversion from `Filter` to `Condition`. The parameter list, which is generated in this step, can directly be passed to `tokio_postgres`.
- Extend `QueryRecord` trait with `base_table` and `Field` via `PostgresQueryRecord` (replaces `Query`)

## 🐾 Next steps

Please see the list of subtasks of the [main Asana task](https://app.asana.com/0/1200211978612931/1203073992606533/f) _(internal)_

## 🛡 What tests cover this?

A bunch of test cases was added

## 🎥  Demo

Please see the input/outputs of the test cases to see the compilation in action

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203198258363022