### PR TITLE
Subgraph edge tracking

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -258,19 +258,6 @@ export interface DataTypeReferenceUpdate {
 /**
  *
  * @export
- * @interface DataTypeRootedSubgraph
- */
-export interface DataTypeRootedSubgraph {
-  /**
-   *
-   * @type {PersistedDataType}
-   * @memberof DataTypeRootedSubgraph
-   */
-  dataType: PersistedDataType;
-}
-/**
- *
- * @export
  * @enum {string}
  */
 
@@ -283,6 +270,25 @@ export const EdgeKind = {
 
 export type EdgeKind = typeof EdgeKind[keyof typeof EdgeKind];
 
+/**
+ *
+ * @export
+ * @interface EdgesValueInner
+ */
+export interface EdgesValueInner {
+  /**
+   *
+   * @type {GraphElementIdentifier}
+   * @memberof EdgesValueInner
+   */
+  destination: GraphElementIdentifier;
+  /**
+   *
+   * @type {EdgeKind}
+   * @memberof EdgesValueInner
+   */
+  edgeKind: EdgeKind;
+}
 /**
  *
  * @export
@@ -1135,10 +1141,10 @@ export interface Subgraph {
   depths: GraphResolveDepths;
   /**
    *
-   * @type {{ [key: string]: Array<OutwardEdge>; }}
+   * @type {{ [key: string]: Array<EdgesValueInner>; }}
    * @memberof Subgraph
    */
-  edges: { [key: string]: Array<OutwardEdge> };
+  edges: { [key: string]: Array<EdgesValueInner> };
   /**
    *
    * @type {Array<GraphElementIdentifier>}

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -19,14 +19,14 @@ use crate::{
     api::rest::{read_from_store, report_to_status_code},
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
-        patch_id_and_parse, AccountId, DataTypeRootedSubgraph, PersistedDataType,
-        PersistedOntologyIdentifier, PersistedOntologyMetadata,
+        patch_id_and_parse, AccountId, PersistedDataType, PersistedOntologyIdentifier,
+        PersistedOntologyMetadata,
     },
     store::{
         query::Expression, BaseUriAlreadyExists, BaseUriDoesNotExist, DataTypeStore, StorePool,
     },
     subgraph::{
-        EdgeKind, GraphElementIdentifier, GraphResolveDepths, OutwardEdge, StructuralQuery,
+        EdgeKind, Edges, GraphElementIdentifier, GraphResolveDepths, OutwardEdge, StructuralQuery,
         Subgraph, Vertex,
     },
 };
@@ -49,13 +49,13 @@ use crate::{
             PersistedOntologyMetadata,
             PersistedDataType,
             StructuralQuery,
-            DataTypeRootedSubgraph,
             GraphElementIdentifier,
             Vertex,
             EdgeKind,
             OutwardEdge,
             GraphResolveDepths,
-            Subgraph
+            Subgraph,
+            Edges
         )
     ),
     tags(

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -25,7 +25,10 @@ use crate::{
     store::{
         query::Expression, BaseUriAlreadyExists, BaseUriDoesNotExist, PropertyTypeStore, StorePool,
     },
-    subgraph::{StructuralQuery, Subgraph},
+    subgraph::{
+        EdgeKind, Edges, GraphElementIdentifier, GraphResolveDepths, OutwardEdge, StructuralQuery,
+        Subgraph, Vertex,
+    },
 };
 
 #[derive(OpenApi)]
@@ -46,6 +49,13 @@ use crate::{
             PersistedOntologyMetadata,
             PersistedPropertyType,
             StructuralQuery,
+            GraphElementIdentifier,
+            Vertex,
+            EdgeKind,
+            OutwardEdge,
+            GraphResolveDepths,
+            Subgraph,
+            Edges
         )
     ),
     tags(

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -196,12 +196,6 @@ impl PersistedDataType {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct DataTypeRootedSubgraph {
-    pub data_type: PersistedDataType,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 pub struct PersistedPropertyType {
     #[schema(value_type = VAR_PROPERTY_TYPE)]
     #[serde(serialize_with = "serialize_ontology_type")]

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -1,7 +1,7 @@
 mod read;
 mod resolve;
 
-use std::{collections::HashMap, future::Future, pin::Pin};
+use std::{future::Future, pin::Pin};
 
 use async_trait::async_trait;
 use error_stack::{IntoReport, Report, Result, ResultExt};
@@ -19,7 +19,9 @@ use crate::{
     store::{
         crud::Read,
         error::EntityDoesNotExist,
-        postgres::{context::PostgresContext, DependencyContext, DependencyMap, DependencySet},
+        postgres::{
+            context::PostgresContext, DependencyContext, DependencyMap, DependencySet, Edges,
+        },
         AsClient, EntityStore, InsertionError, PostgresStore, QueryError, UpdateError,
     },
     subgraph::{GraphResolveDepths, StructuralQuery},
@@ -215,7 +217,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
 
         stream::iter(Read::<PersistedEntity>::read(self, expression).await?)
             .then(|entity| async move {
-                let mut edges = HashMap::new();
+                let mut edges = Edges::new();
                 let mut referenced_data_types = DependencyMap::new();
                 let mut referenced_property_types = DependencyMap::new();
                 let mut referenced_link_types = DependencyMap::new();

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -41,9 +41,11 @@ impl<C: AsClient> PostgresStore<C> {
                 .linked_entities
                 .insert_with(
                     &entity_id,
-                    dependency_context
-                        .graph_resolve_depths
-                        .link_target_entity_resolve_depth,
+                    Some(
+                        dependency_context
+                            .graph_resolve_depths
+                            .link_target_entity_resolve_depth,
+                    ),
                     || async {
                         Ok(PersistedEntity::from(
                             self.read_latest_entity_by_id(entity_id).await?,
@@ -230,13 +232,9 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 let mut dependency_context = DependencyContext::new(graph_resolve_depths);
 
                 let entity_id = entity.metadata().identifier().entity_id();
-                dependency_context.linked_entities.insert(
-                    &entity_id,
-                    dependency_context
-                        .graph_resolve_depths
-                        .link_target_entity_resolve_depth,
-                    entity,
-                );
+                dependency_context
+                    .linked_entities
+                    .insert(&entity_id, None, entity);
 
                 self.get_entity_as_dependency(entity_id, dependency_context.as_ref_object())
                     .await?;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 
 impl<C: AsClient> PostgresStore<C> {
-    /// Internal method to read an [`Entity`] into a [`DependencyMap`].
+    /// Internal method to read an [`Entity`] into a [`DependencyContext`].
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
     pub(crate) fn get_entity_as_dependency<'a: 'b, 'b>(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/mod.rs
@@ -1,7 +1,7 @@
 mod read;
 mod resolve;
 
-use std::{collections::HashMap, future::Future, pin::Pin};
+use std::{future::Future, pin::Pin};
 
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
@@ -14,7 +14,7 @@ use crate::{
     store::{
         crud::Read,
         error::LinkRemovalError,
-        postgres::{DependencyContext, DependencyMap, DependencySet},
+        postgres::{DependencyContext, DependencyMap, DependencySet, Edges},
         AsClient, InsertionError, LinkStore, PostgresStore, QueryError,
     },
     subgraph::{GraphResolveDepths, StructuralQuery},
@@ -127,7 +127,7 @@ impl<C: AsClient> LinkStore for PostgresStore<C> {
 
         stream::iter(Read::<PersistedLink>::read(self, expression).await?)
             .then(|link| async move {
-                let mut edges = HashMap::new();
+                let mut edges = Edges::new();
                 let mut referenced_data_types = DependencyMap::new();
                 let mut referenced_property_types = DependencyMap::new();
                 let mut referenced_link_types = DependencyMap::new();

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/mod.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 impl<C: AsClient> PostgresStore<C> {
-    /// Internal method to read a [`Link`] into a [`DependencyMap`].
+    /// Internal method to read a [`Link`] into a [`DependencyContext`].
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
     pub(crate) fn get_link_as_dependency<'a: 'b, 'b>(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/mod.rs
@@ -34,7 +34,7 @@ impl<C: AsClient> PostgresStore<C> {
         async move {
             if let Some(link) = dependency_context.links.insert(
                 link,
-                dependency_context.graph_resolve_depths.link_resolve_depth,
+                Some(dependency_context.graph_resolve_depths.link_resolve_depth),
             ) {
                 // Cloning/copying here avoids multiple borrow errors which would otherwise
                 // require us to clone the Link
@@ -154,10 +154,7 @@ impl<C: AsClient> LinkStore for PostgresStore<C> {
             .then(|link| async move {
                 let mut dependency_context = DependencyContext::new(graph_resolve_depths);
 
-                dependency_context.links.insert(
-                    &link,
-                    dependency_context.graph_resolve_depths.link_resolve_depth,
-                );
+                dependency_context.links.insert(&link, None);
 
                 self.get_link_as_dependency(&link, dependency_context.as_ref_object())
                     .await?;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/mod.rs
@@ -154,6 +154,11 @@ impl<C: AsClient> LinkStore for PostgresStore<C> {
             .then(|link| async move {
                 let mut dependency_context = DependencyContext::new(graph_resolve_depths);
 
+                dependency_context.links.insert(
+                    &link,
+                    dependency_context.graph_resolve_depths.link_resolve_depth,
+                );
+
                 self.get_link_as_dependency(&link, dependency_context.as_ref_object())
                     .await?;
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -184,15 +184,6 @@ impl Edges {
         Self(HashMap::new())
     }
 
-    #[expect(
-        dead_code,
-        reason = "It's going to be a helpful function, saving someone from needing to write it"
-    )]
-    #[must_use]
-    pub fn inner(&self) -> &HashMap<GraphElementIdentifier, HashSet<OutwardEdge>> {
-        &self.0
-    }
-
     pub fn insert(&mut self, identifier: GraphElementIdentifier, edge: OutwardEdge) -> bool {
         match self.0.raw_entry_mut().from_key(&identifier) {
             RawEntryMut::Vacant(entry) => {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -241,13 +241,13 @@ impl<'a> DependencyContextRef<'a> {
     ) -> DependencyContextRef<'_>
 where {
         DependencyContextRef {
-            edges: &mut *self.edges,
-            referenced_data_types: &mut *self.referenced_data_types,
-            referenced_property_types: &mut *self.referenced_property_types,
-            referenced_link_types: &mut *self.referenced_link_types,
-            referenced_entity_types: &mut *self.referenced_entity_types,
-            linked_entities: &mut *self.linked_entities,
-            links: &mut *self.links,
+            edges: self.edges,
+            referenced_data_types: self.referenced_data_types,
+            referenced_property_types: self.referenced_property_types,
+            referenced_link_types: self.referenced_link_types,
+            referenced_entity_types: self.referenced_entity_types,
+            linked_entities: self.linked_entities,
+            links: self.links,
             graph_resolve_depths,
         }
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     store::{
         crud::Read,
         postgres::{
-            context::PostgresContext, DependencyContext, DependencyMap, DependencySet,
+            context::PostgresContext, DependencyContext, DependencyMap, DependencySet, Edges,
             PersistedOntologyType,
         },
         AsClient, DataTypeStore, InsertionError, PostgresStore, QueryError, UpdateError,
@@ -88,7 +88,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
         let roots_and_vertices =
             stream::iter(Read::<PersistedDataType>::read(self, expression).await?)
                 .then(|data_type| async move {
-                    let mut edges = HashMap::new();
+                    let mut edges = Edges::new();
                     let mut referenced_data_types = DependencyMap::new();
                     let mut referenced_property_types = DependencyMap::new();
                     let mut referenced_link_types = DependencyMap::new();

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 impl<C: AsClient> PostgresStore<C> {
-    /// Internal method to read a [`PersistedDataType`] into a [`DependencyMap`].
+    /// Internal method to read a [`PersistedDataType`] into a [`DependencyContext`].
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
     pub(crate) async fn get_data_type_as_dependency(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -37,7 +37,7 @@ impl<C: AsClient> PostgresStore<C> {
         let _unresolved_entity_type = referenced_data_types
             .insert_with(
                 data_type_id,
-                graph_resolve_depths.data_type_resolve_depth,
+                Some(graph_resolve_depths.data_type_resolve_depth),
                 || async {
                     Ok(PersistedDataType::from_record(
                         self.read_versioned_ontology_type(data_type_id).await?,
@@ -88,13 +88,9 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
                 let mut dependency_context = DependencyContext::new(graph_resolve_depths);
 
                 let data_type_id = data_type.metadata().identifier().uri().clone();
-                dependency_context.referenced_data_types.insert(
-                    &data_type_id,
-                    dependency_context
-                        .graph_resolve_depths
-                        .data_type_resolve_depth,
-                    data_type,
-                );
+                dependency_context
+                    .referenced_data_types
+                    .insert(&data_type_id, None, data_type);
 
                 self.get_data_type_as_dependency(&data_type_id, dependency_context.as_ref_object())
                     .await?;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -1,7 +1,5 @@
 pub mod resolve;
 
-use std::collections::HashMap;
-
 use async_trait::async_trait;
 use error_stack::{IntoReport, Report, Result, ResultExt};
 use futures::{stream, StreamExt, TryStreamExt};
@@ -18,7 +16,7 @@ use crate::{
         },
         AsClient, DataTypeStore, InsertionError, PostgresStore, QueryError, UpdateError,
     },
-    subgraph::{Edges, GraphElementIdentifier, StructuralQuery, Subgraph, Vertex},
+    subgraph::{GraphElementIdentifier, StructuralQuery, Subgraph},
 };
 
 impl<C: AsClient> PostgresStore<C> {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -110,7 +110,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
                     dependency_context.edges,
                 ))
             })
-            .try_collect::<Vec<(_, _, _)>>()
+            .try_collect::<Vec<_>>()
             .await?;
 
         let mut edges = Edges::new();

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
@@ -1,6 +1,6 @@
 mod resolve;
 
-use std::{collections::HashMap, future::Future, pin::Pin};
+use std::{future::Future, pin::Pin};
 
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
@@ -15,7 +15,7 @@ use crate::{
     store::{
         crud::Read,
         postgres::{
-            context::PostgresContext, DependencyContext, DependencyMap, DependencySet,
+            context::PostgresContext, DependencyContext, DependencyMap, DependencySet, Edges,
             PersistedOntologyType,
         },
         AsClient, EntityTypeStore, InsertionError, PostgresStore, QueryError, UpdateError,
@@ -213,7 +213,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
 
         stream::iter(Read::<PersistedEntityType>::read(self, expression).await?)
             .then(|entity_type| async move {
-                let mut edges = HashMap::new();
+                let mut edges = Edges::new();
                 let mut referenced_data_types = DependencyMap::new();
                 let mut referenced_property_types = DependencyMap::new();
                 let mut referenced_link_types = DependencyMap::new();

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
@@ -113,59 +113,55 @@ impl<C: AsClient> PostgresStore<C> {
                         },
                     );
 
-                    if context.graph_resolve_depths.link_type_resolve_depth > 0
-                        || context.graph_resolve_depths.entity_type_resolve_depth > 0
-                    {
-                        if graph_resolve_depths.link_type_resolve_depth > 0 {
-                            self.get_link_type_as_dependency(link_type_id, DependencyContext {
-                                graph_resolve_depths: GraphResolveDepths {
-                                    link_type_resolve_depth: graph_resolve_depths
-                                        .link_type_resolve_depth
-                                        - 1,
-                                    ..graph_resolve_depths
-                                },
-                                edges,
-                                referenced_data_types,
-                                referenced_property_types,
-                                referenced_link_types,
-                                referenced_entity_types,
-                                linked_entities,
-                                links,
-                            })
-                            .await?;
-                        }
-                        for referenced_entity_type_id in entity_type_ids {
-                            edges.insert(
-                                GraphElementIdentifier::OntologyElementId(entity_type_id.clone()),
-                                OutwardEdge {
-                                    edge_kind: EdgeKind::References,
-                                    destination: GraphElementIdentifier::OntologyElementId(
-                                        referenced_entity_type_id.uri().clone(),
-                                    ),
-                                },
-                            );
+                    if graph_resolve_depths.link_type_resolve_depth > 0 {
+                        self.get_link_type_as_dependency(link_type_id, DependencyContext {
+                            graph_resolve_depths: GraphResolveDepths {
+                                link_type_resolve_depth: graph_resolve_depths
+                                    .link_type_resolve_depth
+                                    - 1,
+                                ..graph_resolve_depths
+                            },
+                            edges,
+                            referenced_data_types,
+                            referenced_property_types,
+                            referenced_link_types,
+                            referenced_entity_types,
+                            linked_entities,
+                            links,
+                        })
+                        .await?;
+                    }
+                    for referenced_entity_type_id in entity_type_ids {
+                        edges.insert(
+                            GraphElementIdentifier::OntologyElementId(entity_type_id.clone()),
+                            OutwardEdge {
+                                edge_kind: EdgeKind::References,
+                                destination: GraphElementIdentifier::OntologyElementId(
+                                    referenced_entity_type_id.uri().clone(),
+                                ),
+                            },
+                        );
 
-                            if context.graph_resolve_depths.entity_type_resolve_depth > 0 {
-                                self.get_entity_type_as_dependency(
-                                    referenced_entity_type_id.uri(),
-                                    DependencyContext {
-                                        graph_resolve_depths: GraphResolveDepths {
-                                            entity_type_resolve_depth: graph_resolve_depths
-                                                .entity_type_resolve_depth
-                                                - 1,
-                                            ..graph_resolve_depths
-                                        },
-                                        edges,
-                                        referenced_data_types,
-                                        referenced_property_types,
-                                        referenced_link_types,
-                                        referenced_entity_types,
-                                        linked_entities,
-                                        links,
+                        if context.graph_resolve_depths.entity_type_resolve_depth > 0 {
+                            self.get_entity_type_as_dependency(
+                                referenced_entity_type_id.uri(),
+                                DependencyContext {
+                                    graph_resolve_depths: GraphResolveDepths {
+                                        entity_type_resolve_depth: graph_resolve_depths
+                                            .entity_type_resolve_depth
+                                            - 1,
+                                        ..graph_resolve_depths
                                     },
-                                )
-                                .await?;
-                            }
+                                    edges,
+                                    referenced_data_types,
+                                    referenced_property_types,
+                                    referenced_link_types,
+                                    referenced_entity_types,
+                                    linked_entities,
+                                    links,
+                                },
+                            )
+                            .await?;
                         }
                     }
                 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
@@ -31,7 +31,7 @@ impl<C: AsClient> PostgresStore<C> {
         reason = "difficult to shrink the number of lines with destructuring and so many \
                   variables needing to be passed independently"
     )]
-    /// Internal method to read a [`PersistedEntityType`] into four [`DependencyMap`]s.
+    /// Internal method to read a [`PersistedEntityType`] into four [`DependencyContext`]s.
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
     pub(crate) fn get_entity_type_as_dependency<'a: 'b, 'b>(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
@@ -44,9 +44,11 @@ impl<C: AsClient> PostgresStore<C> {
                 .referenced_entity_types
                 .insert_with(
                     entity_type_id,
-                    dependency_context
-                        .graph_resolve_depths
-                        .entity_type_resolve_depth,
+                    Some(
+                        dependency_context
+                            .graph_resolve_depths
+                            .entity_type_resolve_depth,
+                    ),
                     || async {
                         Ok(PersistedEntityType::from_record(
                             self.read_versioned_ontology_type(entity_type_id).await?,
@@ -214,9 +216,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
                 let entity_type_id = entity_type.metadata().identifier().uri().clone();
                 dependency_context.referenced_entity_types.insert(
                     &entity_type_id,
-                    dependency_context
-                        .graph_resolve_depths
-                        .entity_type_resolve_depth,
+                    None,
                     entity_type,
                 );
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
@@ -1,7 +1,5 @@
 mod resolve;
 
-use std::collections::HashMap;
-
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
 use futures::{stream, StreamExt, TryStreamExt};
@@ -13,7 +11,7 @@ use crate::{
     store::{
         crud::Read,
         postgres::{
-            context::PostgresContext, DependencyContext, DependencyMap, DependencySet,
+            context::PostgresContext, DependencyContext, DependencyMap, DependencySet, Edges,
             PersistedOntologyType,
         },
         AsClient, InsertionError, LinkTypeStore, PostgresStore, QueryError, UpdateError,
@@ -85,7 +83,7 @@ impl<C: AsClient> LinkTypeStore for PostgresStore<C> {
 
         stream::iter(Read::<PersistedLinkType>::read(self, expression).await?)
             .then(|link_type| async move {
-                let mut edges = HashMap::new();
+                let mut edges = Edges::new();
                 let mut referenced_data_types = DependencyMap::new();
                 let mut referenced_property_types = DependencyMap::new();
                 let mut referenced_link_types = DependencyMap::new();

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 impl<C: AsClient> PostgresStore<C> {
-    /// Internal method to read a [`PersistedLinkType`] into a [`DependencyMap`].
+    /// Internal method to read a [`PersistedLinkType`] into a [`DependencyContext`].
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
     pub(crate) async fn get_link_type_as_dependency<'a>(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
@@ -32,7 +32,7 @@ impl<C: AsClient> PostgresStore<C> {
             .referenced_link_types
             .insert_with(
                 link_type_id,
-                context.graph_resolve_depths.link_type_resolve_depth,
+                Some(context.graph_resolve_depths.link_type_resolve_depth),
                 || async {
                     Ok(PersistedLinkType::from_record(
                         self.read_versioned_ontology_type(link_type_id).await?,
@@ -86,13 +86,9 @@ impl<C: AsClient> LinkTypeStore for PostgresStore<C> {
                 let mut dependency_context = DependencyContext::new(graph_resolve_depths);
 
                 let link_type_id = link_type.metadata().identifier().uri().clone();
-                dependency_context.referenced_link_types.insert(
-                    &link_type_id,
-                    dependency_context
-                        .graph_resolve_depths
-                        .link_type_resolve_depth,
-                    link_type,
-                );
+                dependency_context
+                    .referenced_link_types
+                    .insert(&link_type_id, None, link_type);
 
                 self.get_link_type_as_dependency(&link_type_id, dependency_context.as_ref_object())
                     .await?;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     store::{
         crud::Read,
         postgres::{
-            context::PostgresContext, DependencyContext, DependencyMap, DependencySet, Edges,
+            context::PostgresContext, DependencyContext, DependencyContextRef,
             PersistedOntologyType,
         },
         AsClient, InsertionError, LinkTypeStore, PostgresStore, QueryError, UpdateError,
@@ -23,10 +23,10 @@ impl<C: AsClient> PostgresStore<C> {
     /// Internal method to read a [`PersistedLinkType`] into a [`DependencyMap`].
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
-    pub(crate) async fn get_link_type_as_dependency(
+    pub(crate) async fn get_link_type_as_dependency<'a>(
         &self,
         link_type_id: &VersionedUri,
-        context: DependencyContext<'_>,
+        context: DependencyContextRef<'a>,
     ) -> Result<(), QueryError> {
         let _unresolved_link_type = context
             .referenced_link_types
@@ -83,30 +83,16 @@ impl<C: AsClient> LinkTypeStore for PostgresStore<C> {
 
         stream::iter(Read::<PersistedLinkType>::read(self, expression).await?)
             .then(|link_type| async move {
-                let mut edges = Edges::new();
-                let mut referenced_data_types = DependencyMap::new();
-                let mut referenced_property_types = DependencyMap::new();
-                let mut referenced_link_types = DependencyMap::new();
-                let mut referenced_entity_types = DependencyMap::new();
-                let mut linked_entities = DependencyMap::new();
-                let mut links = DependencySet::new();
+                let mut dependency_context = DependencyContext::new(graph_resolve_depths);
 
                 self.get_link_type_as_dependency(
                     link_type.metadata().identifier().uri(),
-                    DependencyContext {
-                        edges: &mut edges,
-                        referenced_data_types: &mut referenced_data_types,
-                        referenced_property_types: &mut referenced_property_types,
-                        referenced_link_types: &mut referenced_link_types,
-                        referenced_entity_types: &mut referenced_entity_types,
-                        linked_entities: &mut linked_entities,
-                        links: &mut links,
-                        graph_resolve_depths,
-                    },
+                    dependency_context.as_ref_object(),
                 )
                 .await?;
 
-                let root = referenced_link_types
+                let root = dependency_context
+                    .referenced_link_types
                     .remove(link_type.metadata().identifier().uri())
                     .expect("root was not added to the subgraph");
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     store::{
         crud::Read,
         postgres::{
-            context::PostgresContext, DependencyContext, DependencyMap, DependencySet,
+            context::PostgresContext, DependencyContext, DependencyMap, DependencySet, Edges,
             PersistedOntologyType,
         },
         AsClient, InsertionError, PostgresStore, PropertyTypeStore, QueryError, UpdateError,
@@ -172,7 +172,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         let roots_and_vertices =
             stream::iter(Read::<PersistedPropertyType>::read(self, expression).await?)
                 .then(|property_type| async move {
-                    let mut edges = HashMap::new();
+                    let mut edges = Edges::new();
                     let mut referenced_data_types = DependencyMap::new();
                     let mut referenced_property_types = DependencyMap::new();
                     let mut referenced_link_types = DependencyMap::new();

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -38,9 +38,11 @@ impl<C: AsClient> PostgresStore<C> {
                 .referenced_property_types
                 .insert_with(
                     property_type_id,
-                    dependency_context
-                        .graph_resolve_depths
-                        .property_type_resolve_depth,
+                    Some(
+                        dependency_context
+                            .graph_resolve_depths
+                            .property_type_resolve_depth,
+                    ),
                     || async {
                         Ok(PersistedPropertyType::from_record(
                             self.read_versioned_ontology_type(property_type_id).await?,
@@ -177,9 +179,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                 let property_type_id = property_type.metadata().identifier().uri().clone();
                 dependency_context.referenced_property_types.insert(
                     &property_type_id,
-                    dependency_context
-                        .graph_resolve_depths
-                        .property_type_resolve_depth,
+                    None,
                     property_type,
                 );
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 
 impl<C: AsClient> PostgresStore<C> {
-    /// Internal method to read a [`PersistedPropertyType`] into two [`DependencyMap`]s.
+    /// Internal method to read a [`PersistedPropertyType`] into two [`DependencyContext`]s.
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
     pub(crate) fn get_property_type_as_dependency<'a: 'b, 'b>(
@@ -191,7 +191,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                     );
 
                     Ok::<_, Report<QueryError>>((
-                        identifier.clone(),
+                        identifier,
                         Vertex::PropertyType(property_type),
                         dependency_context.edges,
                     ))

--- a/packages/graph/hash_graph/lib/graph/src/subgraph.rs
+++ b/packages/graph/hash_graph/lib/graph/src/subgraph.rs
@@ -18,10 +18,10 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct LinkId {
-    source_entity_id: EntityId,
-    target_entity_id: EntityId,
+    pub source_entity_id: EntityId,
+    pub target_entity_id: EntityId,
     #[schema(value_type = String)]
-    link_type_id: VersionedUri,
+    pub link_type_id: VersionedUri,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]

--- a/packages/graph/hash_graph/lib/graph/src/subgraph.rs
+++ b/packages/graph/hash_graph/lib/graph/src/subgraph.rs
@@ -93,7 +93,7 @@ impl ToSchema for Vertex {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, ToSchema)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum EdgeKind {
     /// An entity has a link
@@ -106,11 +106,11 @@ pub enum EdgeKind {
     References,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct OutwardEdge {
-    edge_kind: EdgeKind,
-    destination: GraphElementIdentifier,
+    pub edge_kind: EdgeKind,
+    pub destination: GraphElementIdentifier,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]

--- a/packages/graph/hash_graph/lib/graph/src/subgraph.rs
+++ b/packages/graph/hash_graph/lib/graph/src/subgraph.rs
@@ -157,6 +157,28 @@ pub struct Subgraph {
     pub depths: GraphResolveDepths,
 }
 
+impl Subgraph {
+    #[must_use]
+    pub fn new(depths: GraphResolveDepths) -> Self {
+        Self {
+            roots: Vec::new(),
+            vertices: HashMap::new(),
+            edges: Edges::new(),
+            depths,
+        }
+    }
+}
+
+impl Extend<Self> for Subgraph {
+    fn extend<T: IntoIterator<Item = Self>>(&mut self, iter: T) {
+        for subgraph in iter {
+            self.roots.extend(subgraph.roots.into_iter());
+            self.vertices.extend(subgraph.vertices.into_iter());
+            self.edges.extend(subgraph.edges.into_iter());
+        }
+    }
+}
+
 /// An [`Expression`] to query the datastore, recursively resolving according to the
 /// [`GraphResolveDepths`]
 #[derive(Debug, Deserialize, ToSchema)]

--- a/packages/graph/hash_graph/lib/graph/src/subgraph.rs
+++ b/packages/graph/hash_graph/lib/graph/src/subgraph.rs
@@ -5,7 +5,7 @@ use std::collections::{
 
 use serde::{Deserialize, Serialize};
 use type_system::uri::VersionedUri;
-use utoipa::{openapi, ToSchema};
+use utoipa::{openapi, openapi::Schema, ToSchema};
 
 use crate::{
     knowledge::{EntityId, KnowledgeGraphQueryDepth, PersistedEntity, PersistedLink},
@@ -167,7 +167,7 @@ pub struct StructuralQuery {
     pub graph_resolve_depths: GraphResolveDepths,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
 pub struct Edges(HashMap<GraphElementIdentifier, HashSet<OutwardEdge>>);
 
 impl Edges {
@@ -187,6 +187,15 @@ impl Edges {
                 set.insert(edge)
             }
         }
+    }
+}
+
+// Necessary because utoipa can't handle HashSet
+impl ToSchema for Edges {
+    fn schema() -> Schema {
+        openapi::ObjectBuilder::new()
+            .additional_properties(Some(openapi::schema::Array::new(OutwardEdge::schema())))
+            .into()
     }
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#1198 introduced the `Subgraph` type. The combines all of the elements of the graph into a vertex set. The "edge set" represents how those elements depend on one another. This PR populates the `edges` field.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/0/1203176491232123/f) _(internal)_

## 🔍 What does this change?

- Creates the `Edges` struct
- Modifies the `as_dependency` methods to capture edges while resolving dependencies in structural queries.\
  - *It is a conscious design decision* to capture edges even if the dependencies won't be resolved (due to the max depth being encountered). This potentially will help with 'cursor'-based pagination, and will help calling code to know there are more things to be resolved. **It does mean that at the moment, having an identifier in the `Subgraph` object does _not_ mean it will appear in the `Vertices` list. We will need to make this clear in documentation**
- (**TD**): Insert entries to the dependency graph directly to avoid duplicated queries: https://github.com/hashintel/hash/pull/1213/commits/8b78df6fa4a2573cd69e54c75f6d475103bc81ff

## 📜 Does this require a change to the docs?

- This is internal (the OpenAPI spec has not changed).

## ⚠️ Known issues

- We still need some clones that _probably shouldn't_ be needed, but are at the moment due to how the mutable references are behaving in the recursive functions.
- The `LinkId` struct is incredibly temporary and there for completeness. As such, the PR will look a bit strange but that is going to be cleaned up in a follow-up.

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

- Migrate `EntityType` endpoints to use `Subgraph`
- Migrate `LinkType` endpoints to use `Subgraph`
- Migrate `Link` endpoints to use `Subgraph`
- Migrate `Entity` endpoints to use `Subgraph`
- Remove any code that has been made redundant as a result of this work
- Update documentation

## 🛡 What tests cover this?

The changes in this PR aren't really covered by tests at the moment. Various tests should check that this hasn't broken (de)serialization, but we don't test the structural queries appropriately in integration tests at the moment. This is a known issue.

## ❓ How to test this?

- Follow the READMEs for testing guidance
- Create some queries in the frontend
- Look at CI