### PR TITLE
Add query representation for `PropertyType`

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -2,6 +2,7 @@
 
 mod data_type;
 pub mod domain_validator;
+mod property_type;
 
 use core::fmt;
 
@@ -13,7 +14,7 @@ use type_system::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyTyp
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-pub use self::data_type::DataTypeQueryPath;
+pub use self::{data_type::DataTypeQueryPath, property_type::PropertyTypeQueryPath};
 
 // TODO - find a good place for AccountId, perhaps it will become redundant in a future design
 

--- a/packages/graph/hash_graph/lib/graph/src/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/property_type.rs
@@ -1,0 +1,32 @@
+use error_stack::Report;
+use serde::de;
+use type_system::PropertyType;
+
+use crate::{
+    ontology::DataTypeQueryPath,
+    store::query::{Path, QueryRecord},
+};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum PropertyTypeQueryPath<'q> {
+    OwnedById,
+    BaseUri,
+    VersionedUri,
+    Version,
+    Title,
+    Description,
+    DataTypes(DataTypeQueryPath<'q>),
+    PropertyTypes(Box<Self>),
+}
+
+impl QueryRecord for PropertyType {
+    type Path<'q> = PropertyTypeQueryPath<'q>;
+}
+
+impl<'q> TryFrom<Path> for PropertyTypeQueryPath<'q> {
+    type Error = Report<de::value::Error>;
+
+    fn try_from(_path: Path) -> Result<Self, Self::Error> {
+        todo!("https://app.asana.com/0/1203007126736607/1203167266370354/f")
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
@@ -150,7 +150,7 @@ impl<'f: 'q, 'q, T: PostgresQueryRecord<'q>> SelectCompiler<'f, 'q, T> {
                 table: version_column.table,
                 access: ColumnAccess::Table { column: "base_uri" },
             },
-            TableName::DataTypes => unreachable!(),
+            _ => unreachable!(),
         };
 
         // Add a WITH expression selecting the partitioned version

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
@@ -120,13 +120,13 @@ mod tests {
     }
 
     #[test]
-    fn render_empty_condition() {
+    fn transpile_empty_condition() {
         test_condition(&Filter::All(vec![]), "TRUE", &[]);
         test_condition(&Filter::Any(vec![]), "FALSE", &[]);
     }
 
     #[test]
-    fn render_null_condition() {
+    fn transpile_null_condition() {
         test_condition(
             &Filter::Equal(
                 Some(FilterExpression::Path(DataTypeQueryPath::Description)),
@@ -169,7 +169,7 @@ mod tests {
     }
 
     #[test]
-    fn render_all_condition() {
+    fn transpile_all_condition() {
         test_condition(
             &Filter::All(vec![Filter::Equal(
                 Some(FilterExpression::Path(DataTypeQueryPath::VersionedUri)),
@@ -203,7 +203,7 @@ mod tests {
     }
 
     #[test]
-    fn render_any_condition() {
+    fn transpile_any_condition() {
         test_condition(
             &Filter::Any(vec![Filter::Equal(
                 Some(FilterExpression::Path(DataTypeQueryPath::VersionedUri)),
@@ -237,7 +237,7 @@ mod tests {
     }
 
     #[test]
-    fn render_not_condition() {
+    fn transpile_not_condition() {
         test_condition(
             &Filter::Not(Box::new(Filter::Equal(
                 Some(FilterExpression::Path(DataTypeQueryPath::VersionedUri)),
@@ -251,7 +251,7 @@ mod tests {
     }
 
     #[test]
-    fn render_json_access() {
+    fn transpile_json_access() {
         test_condition(
             &Filter::Any(vec![Filter::Equal(
                 Some(FilterExpression::Path(DataTypeQueryPath::Custom(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/conditional.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/conditional.rs
@@ -103,7 +103,7 @@ mod tests {
     };
 
     #[test]
-    fn render_window_expression() {
+    fn transpile_window_expression() {
         assert_eq!(
             max_version_expression().transpile_to_string(),
             r#"MAX("type_ids"."version") OVER (PARTITION BY "type_ids"."base_uri")"#
@@ -111,7 +111,7 @@ mod tests {
     }
 
     #[test]
-    fn render_function_expression() {
+    fn transpile_function_expression() {
         assert_eq!(
             Expression::Function(Box::new(Function::Min(Expression::Column(Column {
                 table: Table {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
@@ -45,7 +45,7 @@ mod tests {
     use crate::store::postgres::query::{TableAlias, TableName};
 
     #[test]
-    fn transpile_join() {
+    fn transpile_join_expression() {
         assert_eq!(
             JoinExpression::from_tables(
                 Table {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
@@ -45,7 +45,7 @@ mod tests {
     use crate::store::postgres::query::{TableAlias, TableName};
 
     #[test]
-    fn render_join() {
+    fn transpile_join() {
         assert_eq!(
             JoinExpression::from_tables(
                 Table {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/select_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/select_clause.rs
@@ -39,7 +39,7 @@ mod tests {
     };
 
     #[test]
-    fn render_select_expression() {
+    fn transpile_select_expression() {
         assert_eq!(
             SelectExpression::from_column(
                 Column {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
@@ -55,7 +55,7 @@ mod tests {
     };
 
     #[test]
-    fn render_where_expression() {
+    fn transpile_where_expression() {
         let mut compiler = SelectCompiler::<DataType>::new();
         let mut where_clause = WhereExpression::default();
         assert_eq!(where_clause.transpile_to_string(), "");

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/with_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/with_clause.rs
@@ -66,7 +66,7 @@ mod tests {
     };
 
     #[test]
-    fn render_with_clause() {
+    fn transpile_with_clause() {
         let mut with_clause = WithExpression::default();
         assert_eq!(with_clause.transpile_to_string(), "");
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/with_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/with_clause.rs
@@ -66,7 +66,7 @@ mod tests {
     };
 
     #[test]
-    fn transpile_with_clause() {
+    fn transpile_with_expression() {
         let mut with_clause = WithExpression::default();
         assert_eq!(with_clause.transpile_to_string(), "");
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
@@ -6,6 +6,7 @@ mod compile;
 mod condition;
 mod data_type;
 mod expression;
+mod property_type;
 mod statement;
 mod table;
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/property_type.rs
@@ -1,0 +1,132 @@
+use std::iter::once;
+
+use postgres_types::ToSql;
+use type_system::PropertyType;
+
+use crate::{
+    ontology::PropertyTypeQueryPath,
+    store::postgres::query::{ColumnAccess, Field, Path, PostgresQueryRecord, Table, TableName},
+};
+
+impl<'q> PostgresQueryRecord<'q> for PropertyType {
+    type Field = PropertyTypeField;
+
+    fn base_table() -> Table {
+        Table {
+            name: TableName::PropertyTypes,
+            alias: None,
+        }
+    }
+
+    fn default_fields() -> &'q [Self::Field] {
+        &[PropertyTypeField::Schema, PropertyTypeField::OwnedById]
+    }
+}
+
+/// A [`Field`] available in [`PropertyType`]s.
+///
+/// [`PropertyType`]: type_system::PropertyType
+#[derive(Debug, PartialEq, Eq)]
+pub enum PropertyTypeField {
+    BaseUri,
+    Version,
+    VersionId,
+    OwnedById,
+    Schema,
+    VersionedUri,
+    Title,
+    Description,
+}
+
+impl Field for PropertyTypeField {
+    fn table_name(&self) -> TableName {
+        match self {
+            Self::BaseUri | Self::Version => TableName::TypeIds,
+            Self::VersionId
+            | Self::OwnedById
+            | Self::Schema
+            | Self::VersionedUri
+            | Self::Title
+            | Self::Description => TableName::PropertyTypes,
+        }
+    }
+
+    fn column_access(&self) -> ColumnAccess {
+        match self {
+            Self::BaseUri => ColumnAccess::Table { column: "base_uri" },
+            Self::Version => ColumnAccess::Table { column: "version" },
+            Self::VersionId => ColumnAccess::Table {
+                column: "version_id",
+            },
+            Self::OwnedById => ColumnAccess::Table {
+                column: "owned_by_id",
+            },
+            Self::Schema => ColumnAccess::Table { column: "schema" },
+            Self::VersionedUri => ColumnAccess::Json {
+                column: "schema",
+                field: "$id",
+            },
+            Self::Title => ColumnAccess::Json {
+                column: "schema",
+                field: "title",
+            },
+            Self::Description => ColumnAccess::Json {
+                column: "schema",
+                field: "description",
+            },
+        }
+    }
+}
+
+impl Path for PropertyTypeQueryPath<'_> {
+    fn tables(&self) -> Vec<TableName> {
+        match self {
+            Self::DataTypes(path) => once(TableName::PropertyTypeDataTypeReferences)
+                .chain(path.tables())
+                .collect(),
+            Self::PropertyTypes(path) => once(TableName::PropertyTypePropertyTypeReferences)
+                .chain(path.tables())
+                .collect(),
+            _ => vec![self.terminating_table_name()],
+        }
+    }
+
+    fn terminating_table_name(&self) -> TableName {
+        match self {
+            Self::BaseUri | Self::Version => TableName::TypeIds,
+            Self::OwnedById | Self::VersionedUri | Self::Title | Self::Description => {
+                TableName::PropertyTypes
+            }
+            Self::DataTypes(path) => path.terminating_table_name(),
+            Self::PropertyTypes(path) => path.terminating_table_name(),
+        }
+    }
+
+    fn column_access(&self) -> ColumnAccess {
+        match self {
+            Self::BaseUri => ColumnAccess::Table { column: "base_uri" },
+            Self::Version => ColumnAccess::Table { column: "version" },
+            Self::OwnedById => ColumnAccess::Table {
+                column: "owned_by_id",
+            },
+            Self::VersionedUri => ColumnAccess::Json {
+                column: "schema",
+                field: "$id",
+            },
+            Self::Title => ColumnAccess::Json {
+                column: "schema",
+                field: "title",
+            },
+            Self::Description => ColumnAccess::Json {
+                column: "schema",
+                field: "description",
+            },
+            Self::DataTypes(path) => path.column_access(),
+            Self::PropertyTypes(path) => path.column_access(),
+        }
+    }
+
+    fn user_provided_field(&self) -> Option<&(dyn ToSql + Sync)> {
+        None
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -55,10 +55,10 @@ mod tests {
     use std::borrow::Cow;
 
     use postgres_types::ToSql;
-    use type_system::DataType;
+    use type_system::{DataType, PropertyType};
 
     use crate::{
-        ontology::DataTypeQueryPath,
+        ontology::{DataTypeQueryPath, PropertyTypeQueryPath},
         store::{
             postgres::query::{test_helper::trim_whitespace, PostgresQueryRecord, SelectCompiler},
             query::{Filter, FilterExpression, Parameter},
@@ -211,6 +211,101 @@ mod tests {
             WHERE "type_ids_0_0"."version" != "type_ids_0_0"."latest_version"
             "#,
             &[],
+        );
+    }
+
+    #[test]
+    fn property_type_to_data_type() {
+        let mut compiler = SelectCompiler::<PropertyType>::with_asterisk();
+
+        compiler.add_filter(&Filter::Equal(
+            Some(FilterExpression::Path(PropertyTypeQueryPath::DataTypes(
+                DataTypeQueryPath::Title,
+            ))),
+            Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
+                "Text",
+            )))),
+        ));
+
+        test_compilation(
+            &compiler,
+            r#"
+            SELECT *
+            FROM "property_types"
+            JOIN "property_type_data_type_references" AS "property_type_data_type_references_0_0"
+              ON "property_type_data_type_references_0_0"."source_property_type_version_id" = "property_types"."version_id"
+            JOIN "data_types" AS "data_types_0_1" ON "data_types_0_1"."version_id" = "property_type_data_type_references_0_0"."target_data_type_version_id"
+            WHERE "data_types_0_1"."schema"->>'title' = $1
+            "#,
+            &[&"Text"],
+        );
+
+        let filter = Filter::All(vec![
+            Filter::Equal(
+                Some(FilterExpression::Path(PropertyTypeQueryPath::DataTypes(
+                    DataTypeQueryPath::BaseUri,
+                ))),
+                Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
+                    "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
+                )))),
+            ),
+            Filter::Equal(
+                Some(FilterExpression::Path(PropertyTypeQueryPath::DataTypes(
+                    DataTypeQueryPath::Version,
+                ))),
+                Some(FilterExpression::Parameter(Parameter::Number(1.0))),
+            ),
+        ]);
+        compiler.add_filter(&filter);
+
+        test_compilation(
+            &compiler,
+            r#"
+            SELECT *
+            FROM "property_types"
+            JOIN "property_type_data_type_references" AS "property_type_data_type_references_0_0"
+              ON "property_type_data_type_references_0_0"."source_property_type_version_id" = "property_types"."version_id"
+            JOIN "data_types" AS "data_types_0_1" ON "data_types_0_1"."version_id" = "property_type_data_type_references_0_0"."target_data_type_version_id"
+            JOIN "property_type_data_type_references" AS "property_type_data_type_references_1_0"
+              ON "property_type_data_type_references_1_0"."source_property_type_version_id" = "property_types"."version_id"
+            JOIN "type_ids" AS "type_ids_1_1"
+              ON "type_ids_1_1"."version_id" = "property_type_data_type_references_1_0"."target_data_type_version_id"
+            WHERE "data_types_0_1"."schema"->>'title' = $1
+              AND ("type_ids_1_1"."base_uri" = $2) AND ("type_ids_1_1"."version" = $3)
+            "#,
+            &[
+                &"Text",
+                &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
+                &1.0,
+            ],
+        );
+    }
+
+    #[test]
+    fn property_type_to_property_type() {
+        let mut compiler = SelectCompiler::<PropertyType>::with_asterisk();
+
+        let filter = Filter::Equal(
+            Some(FilterExpression::Path(
+                PropertyTypeQueryPath::PropertyTypes(Box::new(PropertyTypeQueryPath::Title)),
+            )),
+            Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
+                "Text",
+            )))),
+        );
+        compiler.add_filter(&filter);
+
+        test_compilation(
+            &compiler,
+            r#"
+            SELECT *
+            FROM "property_types"
+            JOIN "property_type_property_type_references" AS "property_type_property_type_references_0_0"
+              ON "property_type_property_type_references_0_0"."source_property_type_version_id" = "property_types"."version_id"
+            JOIN "property_types" AS "property_types_0_1" ON "property_types_0_1"."version_id" = "property_type_property_type_references_0_0"."target_property_type_version_id"
+            WHERE "property_types_0_1"."schema"->>'title' = $1
+            "#,
+            &[&"Text"],
         );
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -215,7 +215,7 @@ mod tests {
     }
 
     #[test]
-    fn property_type_to_data_type() {
+    fn property_type_by_referenced_data_types() {
         let mut compiler = SelectCompiler::<PropertyType>::with_asterisk();
 
         compiler.add_filter(&Filter::Equal(
@@ -282,7 +282,7 @@ mod tests {
     }
 
     #[test]
-    fn property_type_to_property_type() {
+    fn property_type_by_referenced_property_types() {
         let mut compiler = SelectCompiler::<PropertyType>::with_asterisk();
 
         let filter = Filter::Equal(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
@@ -10,13 +10,19 @@ use crate::store::postgres::query::Transpile;
 pub enum TableName {
     TypeIds,
     DataTypes,
+    PropertyTypes,
+    PropertyTypeDataTypeReferences,
+    PropertyTypePropertyTypeReferences,
 }
 
 impl TableName {
     const fn source_join_column_access(self) -> ColumnAccess<'static> {
         ColumnAccess::Table {
             column: match self {
-                Self::TypeIds | Self::DataTypes => "version_id",
+                Self::TypeIds | Self::DataTypes | Self::PropertyTypes => "version_id",
+                Self::PropertyTypeDataTypeReferences | Self::PropertyTypePropertyTypeReferences => {
+                    "source_property_type_version_id"
+                }
             },
         }
     }
@@ -25,7 +31,9 @@ impl TableName {
     const fn target_join_column_access(self) -> ColumnAccess<'static> {
         ColumnAccess::Table {
             column: match self {
-                Self::TypeIds | Self::DataTypes => "version_id",
+                Self::TypeIds | Self::DataTypes | Self::PropertyTypes => "version_id",
+                Self::PropertyTypeDataTypeReferences => "target_data_type_version_id",
+                Self::PropertyTypePropertyTypeReferences => "target_property_type_version_id",
             },
         }
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
@@ -196,7 +196,7 @@ mod tests {
     }
 
     #[test]
-    fn render_table() {
+    fn transpile_table() {
         assert_eq!(
             Table {
                 name: TableName::TypeIds,
@@ -216,7 +216,7 @@ mod tests {
     }
 
     #[test]
-    fn render_table_alias() {
+    fn transpile_table_alias() {
         assert_eq!(
             Table {
                 name: TableName::TypeIds,
@@ -231,7 +231,7 @@ mod tests {
     }
 
     #[test]
-    fn render_column_access() {
+    fn transpile_column_access() {
         assert_eq!(
             DataTypeQueryField::VersionId
                 .column_access()
@@ -247,7 +247,7 @@ mod tests {
     }
 
     #[test]
-    fn render_column() {
+    fn transpile_column() {
         assert_eq!(
             Column {
                 table: Table {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Similar to `DataType`s, this adds the representation for `PropertyType`

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203007126736607/1203157447338104/f) _(internal)_

## 🚫 Blocked by

- #1218 
- #1230

## 🔍 What does this change?

- Add `PropertyTypeQueryPath` and implement traits
- Add `PropertyTypeQueryField` and implement traits

## 🛡 What tests cover this?

A set of tests were added to test property-type queries