### PR TITLE
Rebuild on `deployment-up` in Graph Makefile

### DIFF
--- a/packages/graph/Makefile.toml
+++ b/packages/graph/Makefile.toml
@@ -27,7 +27,7 @@ private = false
 category = "Deploy"
 description = "Spins up the deployment environment"
 extend = "docker"
-args = ["compose", "--env-file", "../.env", "up", "--wait"]
+args = ["compose", "--env-file", "../.env", "up", "--wait", "--build"]
 cwd = "${REPO_ROOT}/packages/graph/deployment"
 
 [tasks.deployment-down]

--- a/packages/graph/hash_graph/Makefile.toml
+++ b/packages/graph/hash_graph/Makefile.toml
@@ -18,6 +18,7 @@ run_task = [
     { name = ["test-task"] }
 ]
 
+
 [tasks.miri]
 clear = true
 command = "echo"

--- a/packages/graph/hash_graph/Makefile.toml
+++ b/packages/graph/hash_graph/Makefile.toml
@@ -18,7 +18,6 @@ run_task = [
     { name = ["test-task"] }
 ]
 
-
 [tasks.miri]
 clear = true
 command = "echo"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

If the DB changes, at the moment devs have to manually call `docker compose` with the build arg`, or temporarily add `--build` to the `deployment-up` task in the graph's Makefile. 

It's not possible (or at least not easy) to pass in parameters to the task (e.g. with `${@}` because they get passed to all tasks, and this breaks CI as we have a `cargo make test` task which requires parameters such as `--no-fail-fast`).

Adding `--build` barely adds overhead as it benefits heavily from docker's caching, so this has minimal impact on local dev, and CI was already building fresh so this should be fine.

## ❓ How to test this?

1. Run `cargo make test` in the graph
2. Watch CI
