### PR TITLE
Add deserialization support for Link queries

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -9,7 +9,7 @@ use type_system::uri::{BaseUri, VersionedUri};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-pub use self::query::EntityQueryPath;
+pub use self::query::{EntityQueryPath, EntityQueryPathVisitor};
 use crate::provenance::{CreatedById, OwnedById, RemovedById, UpdatedById};
 
 #[derive(

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
@@ -143,12 +143,22 @@ impl<'de> Visitor<'de> for EntityQueryPathVisitor {
                     .ok_or_else(|| de::Error::invalid_length(self.position, &self))?;
                 EntityQueryPath::Properties(Some(property))
             }
-            EntityQueryToken::OutgoingLinks | EntityQueryToken::IncomingLinks => {
-                todo!("https://app.asana.com/0/0/1203167266370359/f")
+            EntityQueryToken::OutgoingLinks => {
+                let link_query_path = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(self.position, &self))?;
+                EntityQueryPath::OutgoingLinks(link_query_path)
+            }
+            EntityQueryToken::IncomingLinks => {
+                let link_query_path = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(self.position, &self))?;
+                EntityQueryPath::IncomingLinks(link_query_path)
             }
         })
     }
 }
+
 impl<'de: 'q, 'q> Deserialize<'de> for EntityQueryPath<'q> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/link/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/link/mod.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use type_system::uri::VersionedUri;
 use utoipa::ToSchema;
 
-pub use self::query::LinkQueryPath;
+pub use self::query::{LinkQueryPath, LinkQueryPathVisitor};
 use super::EntityId;
 use crate::provenance::{CreatedById, OwnedById};
 

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/link/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/link/query.rs
@@ -1,11 +1,15 @@
 use std::fmt;
 
-use error_stack::Report;
-use serde::de;
+use error_stack::{IntoReport, Report};
+use serde::{
+    de,
+    de::{SeqAccess, Visitor},
+    Deserialize, Deserializer,
+};
 
 use crate::{
-    knowledge::{entity::EntityQueryPath, Link},
-    ontology::LinkTypeQueryPath,
+    knowledge::{entity::EntityQueryPath, EntityQueryPathVisitor, Link},
+    ontology::{LinkTypeQueryPath, LinkTypeQueryPathVisitor},
     store::query::{ParameterType, Path, QueryRecord, RecordPath},
 };
 
@@ -54,7 +58,141 @@ impl RecordPath for LinkQueryPath<'_> {
 impl<'q> TryFrom<Path> for LinkQueryPath<'q> {
     type Error = Report<de::value::Error>;
 
-    fn try_from(_path: Path) -> Result<Self, Self::Error> {
-        todo!("https://app.asana.com/0/0/1203167266370359/f")
+    fn try_from(path: Path) -> Result<Self, Self::Error> {
+        Self::deserialize(de::value::SeqDeserializer::new(
+            path.segments.into_iter().map(|segment| segment.identifier),
+        ))
+        .into_report()
+    }
+}
+
+/// A single token in a [`LinkQueryPath`].
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum LinkQueryToken {
+    OwnedById,
+    Type,
+    Source,
+    Target,
+}
+
+/// Deserializes a [`LinkQueryPath`] from a string sequence.
+pub struct LinkQueryPathVisitor {
+    /// The current position in the sequence when deserializing.
+    position: usize,
+}
+
+impl LinkQueryPathVisitor {
+    #[must_use]
+    pub const fn new(position: usize) -> Self {
+        Self { position }
+    }
+}
+
+impl<'de> Visitor<'de> for LinkQueryPathVisitor {
+    type Value = LinkQueryPath<'de>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a sequence consisting of `ownedById`, `type`, `source`, or `target`")
+    }
+
+    fn visit_seq<A>(mut self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let token = seq
+            .next_element()?
+            .ok_or_else(|| de::Error::invalid_length(self.position, &self))?;
+        self.position += 1;
+        Ok(match token {
+            LinkQueryToken::OwnedById => LinkQueryPath::OwnedById,
+            LinkQueryToken::Type => {
+                let link_type_query_path =
+                    LinkTypeQueryPathVisitor::new(self.position).visit_seq(seq)?;
+
+                LinkQueryPath::Type(link_type_query_path)
+            }
+            LinkQueryToken::Source => {
+                let entity_type_query_path =
+                    EntityQueryPathVisitor::new(self.position).visit_seq(seq)?;
+
+                LinkQueryPath::Source(Some(entity_type_query_path))
+            }
+            LinkQueryToken::Target => {
+                let entity_type_query_path =
+                    EntityQueryPathVisitor::new(self.position).visit_seq(seq)?;
+
+                LinkQueryPath::Target(Some(entity_type_query_path))
+            }
+        })
+    }
+}
+
+impl<'de: 'k, 'k> Deserialize<'de> for LinkQueryPath<'k> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_seq(LinkQueryPathVisitor::new(0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::test_utils::create_path;
+
+    fn convert_path(segments: impl IntoIterator<Item = &'static str>) -> LinkQueryPath<'static> {
+        LinkQueryPath::try_from(create_path(segments)).expect("Could not convert path")
+    }
+
+    fn deserialize<'q>(segments: impl IntoIterator<Item = &'q str>) -> LinkQueryPath<'q> {
+        LinkQueryPath::deserialize(de::value::SeqDeserializer::<_, de::value::Error>::new(
+            segments.into_iter(),
+        ))
+        .expect("Could not deserialize path")
+    }
+
+    #[test]
+    fn deserialization() {
+        assert_eq!(deserialize(["ownedById"]), LinkQueryPath::OwnedById);
+        assert_eq!(
+            deserialize(["type", "version"]),
+            LinkQueryPath::Type(LinkTypeQueryPath::Version)
+        );
+        assert_eq!(
+            deserialize(["source", "version"]),
+            LinkQueryPath::Source(Some(EntityQueryPath::Version))
+        );
+        assert_eq!(
+            deserialize(["target", "version"]),
+            LinkQueryPath::Target(Some(EntityQueryPath::Version))
+        );
+
+        assert_eq!(
+            LinkQueryPath::deserialize(de::value::SeqDeserializer::<_, de::value::Error>::new(
+                ["ownedById", "test"].into_iter()
+            ))
+            .expect_err("Could convert link query path with multiple tokens")
+            .to_string(),
+            "invalid length 2, expected 1 element in sequence"
+        );
+    }
+
+    #[test]
+    fn path_conversion() {
+        assert_eq!(convert_path(["ownedById"]), LinkQueryPath::OwnedById);
+        assert_eq!(
+            convert_path(["type", "version"]),
+            LinkQueryPath::Type(LinkTypeQueryPath::Version)
+        );
+        assert_eq!(
+            convert_path(["source", "version"]),
+            LinkQueryPath::Source(Some(EntityQueryPath::Version))
+        );
+        assert_eq!(
+            convert_path(["target", "version"]),
+            LinkQueryPath::Target(Some(EntityQueryPath::Version))
+        );
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/mod.rs
@@ -9,10 +9,10 @@ use utoipa::ToSchema;
 
 pub use self::{
     entity::{
-        Entity, EntityId, EntityQueryPath, PersistedEntity, PersistedEntityIdentifier,
-        PersistedEntityMetadata,
+        Entity, EntityId, EntityQueryPath, EntityQueryPathVisitor, PersistedEntity,
+        PersistedEntityIdentifier, PersistedEntityMetadata,
     },
-    link::{Link, LinkQueryPath, PersistedLink, PersistedLinkMetadata},
+    link::{Link, LinkQueryPath, LinkQueryPathVisitor, PersistedLink, PersistedLinkMetadata},
 };
 use crate::ontology::{
     PersistedDataType, PersistedEntityType, PersistedLinkType, PersistedPropertyType,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Supporting deserializing links, similar to entities in #1273

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203007126736610/1203167266370359/f) _(internal)_

## 🚫 Blocked by

- #1255 
- #1267
- #1268
- #1269
- #1273

## 🔍 What does this change?

Similar changes as in #1273, but for links