### PR TITLE
Fix user-provided fields not being prepared

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
@@ -261,8 +261,8 @@ mod tests {
                     Cow::Borrowed("right"),
                 ))),
             )]),
-            r#"("data_types"."schema"->>'left' = "data_types"."schema"->>'right')"#,
-            &[],
+            r#"("data_types"."schema"->>$1 = "data_types"."schema"->>$2)"#,
+            &[&"left", &"right"],
         );
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
@@ -251,7 +251,7 @@ mod tests {
     }
 
     #[test]
-    fn render_without_parameters() {
+    fn render_json_access() {
         test_condition(
             &Filter::Any(vec![Filter::Equal(
                 Some(FilterExpression::Path(DataTypeQueryPath::Custom(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use postgres_types::ToSql;
 use type_system::DataType;
 
 use crate::{
@@ -39,7 +40,7 @@ pub enum DataTypeQueryField<'q> {
     Custom(Cow<'q, str>),
 }
 
-impl Field for DataTypeQueryField<'_> {
+impl<'q> Field for DataTypeQueryField<'q> {
     fn table_name(&self) -> TableName {
         match self {
             Self::BaseUri | Self::Version => TableName::TypeIds,
@@ -67,23 +68,23 @@ impl Field for DataTypeQueryField<'_> {
             Self::Schema => ColumnAccess::Table { column: "schema" },
             Self::VersionedUri => ColumnAccess::Json {
                 column: "schema",
-                field: Cow::Borrowed("$id"),
+                field: "$id",
             },
             Self::Title => ColumnAccess::Json {
                 column: "schema",
-                field: Cow::Borrowed("title"),
+                field: "title",
             },
             Self::Type => ColumnAccess::Json {
                 column: "schema",
-                field: Cow::Borrowed("type"),
+                field: "type",
             },
             Self::Description => ColumnAccess::Json {
                 column: "schema",
-                field: Cow::Borrowed("description"),
+                field: "description",
             },
             Self::Custom(field) => ColumnAccess::Json {
                 column: "schema",
-                field: field.clone(),
+                field: field.as_ref(),
             },
         }
     }
@@ -115,24 +116,32 @@ impl Path for DataTypeQueryPath<'_> {
             },
             Self::VersionedUri => ColumnAccess::Json {
                 column: "schema",
-                field: Cow::Borrowed("$id"),
+                field: "$id",
             },
             Self::Title => ColumnAccess::Json {
                 column: "schema",
-                field: Cow::Borrowed("title"),
+                field: "title",
             },
             Self::Type => ColumnAccess::Json {
                 column: "schema",
-                field: Cow::Borrowed("type"),
+                field: "type",
             },
             Self::Description => ColumnAccess::Json {
                 column: "schema",
-                field: Cow::Borrowed("description"),
+                field: "description",
             },
             Self::Custom(field) => ColumnAccess::Json {
                 column: "schema",
-                field: field.clone(),
+                field: field.as_ref(),
             },
+        }
+    }
+
+    fn user_provided_field(&self) -> Option<&(dyn ToSql + Sync)> {
+        if let Self::Custom(field) = self {
+            Some(field)
+        } else {
+            None
         }
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
@@ -139,7 +139,7 @@ mod tests {
                 WHERE "type_ids_0_0"."version" = "type_ids_0_0"."latest_version"
                   AND ("type_ids_0_0"."base_uri" = $1) AND ("type_ids_0_0"."version" = $2)
                   AND "data_types"."schema"->>'description' IS NOT NULL
-                  AND (("data_types"."schema"->>'value' = $3) OR ("data_types"."schema"->>'value' = $4))"#
+                  AND (("data_types"."schema"->>$3 = $4) OR ("data_types"."schema"->>$5 = $6))"#
             )
         );
 
@@ -152,7 +152,9 @@ mod tests {
         assert_eq!(parameters, &[
             "\"https://blockprotocol.org/@blockprotocol/types/data-type/text/\"",
             "1.0",
+            "\"value\"",
             "\"something\"",
+            "\"value\"",
             "\"something_else\""
         ]);
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
@@ -11,6 +11,8 @@ mod table;
 
 use std::fmt::{self, Display, Formatter};
 
+use postgres_types::ToSql;
+
 pub use self::{
     compile::SelectCompiler,
     condition::{Condition, EqualityOperator},
@@ -57,6 +59,13 @@ pub trait Path {
     ///
     /// [`terminating_table_name()`]: Self::terminating_table_name
     fn column_access(&self) -> ColumnAccess;
+
+    /// Returns the field if the path is provided by a user.
+    ///
+    /// One example of a user provided path is [`DataTypeQueryPath::Custom("custom string")`]
+    ///
+    /// [`DataTypeQueryPath::Custom("custom string")`]: crate::ontology::DataTypeQueryPath::Custom
+    fn user_provided_field(&self) -> Option<&(dyn ToSql + Sync)>;
 }
 
 /// Renders the object into a Postgres compatible format.

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
@@ -111,7 +111,7 @@ pub enum ColumnAccess<'q> {
         column: &'static str,
         field: &'q str,
     },
-    /// Accesses a field of a JSON blob: `"column"->>'field'`
+    /// Accesses the field of a JSON blob by a numbered parameter: e.g. `"column"->>$1`
     JsonParameter { column: &'static str, index: usize },
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
@@ -1,7 +1,4 @@
-use std::{
-    borrow::Cow,
-    fmt::{self, Write},
-};
+use std::fmt::{self, Write};
 
 use serde::Serialize;
 
@@ -112,14 +109,18 @@ pub enum ColumnAccess<'q> {
     /// Accesses a field of a JSON blob: `"column"->>'field'`
     Json {
         column: &'static str,
-        field: Cow<'q, str>,
+        field: &'q str,
     },
+    /// Accesses a field of a JSON blob: `"column"->>'field'`
+    JsonParameter { column: &'static str, index: usize },
 }
 
 impl ColumnAccess<'_> {
     pub const fn column(&self) -> &'static str {
         match self {
-            Self::Table { column } | Self::Json { column, .. } => column,
+            Self::Table { column }
+            | Self::Json { column, .. }
+            | Self::JsonParameter { column, .. } => column,
         }
     }
 }
@@ -129,6 +130,7 @@ impl Transpile for ColumnAccess<'_> {
         match self {
             Self::Table { column } => write!(fmt, r#""{column}""#),
             Self::Json { column, field } => write!(fmt, r#""{column}"->>'{field}'"#),
+            Self::JsonParameter { column, index } => write!(fmt, r#""{column}"->>${index}"#),
         }
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

It was possible to inject user defined strings into the database query, this provides a fix

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203007126736607/1203205825668112/f) _(internal)_
- https://github.com/hashintel/hash/pull/1217#discussion_r1000583326

## 🚫 Blocked by

- #1218 

## 🔍 What does this change?

- Adds a `Parameter` column access
- Prepare user defined paths

## ❓ How to test this?

A test is picking this change up
