### PR TITLE
Upgrade hook service in text blocks, upgrade other block deps

### DIFF
--- a/blocks/calculation/package.json
+++ b/blocks/calculation/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "block-scripts": "0.0.14",
-    "mock-block-dock": "0.0.26",
+    "mock-block-dock": "0.0.35",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/blocks/callout/package.json
+++ b/blocks/callout/package.json
@@ -19,13 +19,13 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.16",
-    "@blockprotocol/hook": "0.0.4"
+    "@blockprotocol/graph": "0.0.18",
+    "@blockprotocol/hook": "0.0.7"
   },
   "devDependencies": {
     "block-scripts": "0.0.14",
     "eslint": "8.20.0",
-    "mock-block-dock": "0.0.26",
+    "mock-block-dock": "0.0.35",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "4.7.4"

--- a/blocks/callout/src/app.tsx
+++ b/blocks/callout/src/app.tsx
@@ -24,7 +24,7 @@ export const App: BlockComponent<BlockEntityProperties> = ({
   const { graphService } = useGraphBlockService(blockRef);
   const { hookService } = useHookBlockService(blockRef);
 
-  useHook(hookService, editableRef, "text", "$.text", (node) => {
+  useHook(hookService, editableRef, "text", entityId, "$.text", (node) => {
     // eslint-disable-next-line no-param-reassign
     node.innerText = text ?? "";
 

--- a/blocks/callout/src/dev.tsx
+++ b/blocks/callout/src/dev.tsx
@@ -20,6 +20,7 @@ const App = () => (
       entityId: "test-block-1",
       properties: calloutProperties,
     }}
+    debug
   />
 );
 

--- a/blocks/code/package.json
+++ b/blocks/code/package.json
@@ -19,7 +19,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.16",
+    "@blockprotocol/graph": "0.0.18",
     "prismjs": "1.28.0",
     "styled-components": "5.3.5"
   },
@@ -27,7 +27,7 @@
     "@types/prismjs": "1.26.0",
     "@types/styled-components": "5.1.25",
     "block-scripts": "0.0.14",
-    "mock-block-dock": "0.0.26",
+    "mock-block-dock": "0.0.35",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sass": "1.52.3",

--- a/blocks/countdown/package.json
+++ b/blocks/countdown/package.json
@@ -22,14 +22,14 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.16",
+    "@blockprotocol/graph": "0.0.18",
     "date-fns": "2.28.0",
     "react-datepicker": "4.7.0"
   },
   "devDependencies": {
     "@types/react-datepicker": "^4.4.1",
     "block-scripts": "0.0.14",
-    "mock-block-dock": "0.0.26",
+    "mock-block-dock": "0.0.35",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/blocks/drawing/package.json
+++ b/blocks/drawing/package.json
@@ -22,7 +22,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.16",
+    "@blockprotocol/graph": "0.0.18",
     "@tldraw/tldraw": "1.16.0",
     "@types/react-resizable": "1.7.4",
     "react-resizable": "^3.0.4"
@@ -30,7 +30,7 @@
   "devDependencies": {
     "block-scripts": "0.0.14",
     "mobx": "6.5.0",
-    "mock-block-dock": "0.0.26",
+    "mock-block-dock": "0.0.35",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/blocks/github-pr-overview/package.json
+++ b/blocks/github-pr-overview/package.json
@@ -24,7 +24,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.16",
+    "@blockprotocol/graph": "0.0.18",
     "@hashintel/hash-design-system": "0.0.0",
     "@mui/icons-material": "5.10.6",
     "@mui/lab": "5.0.0-alpha.100",
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "block-scripts": "0.0.14",
-    "mock-block-dock": "0.0.26",
+    "mock-block-dock": "0.0.35",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/blocks/header/package.json
+++ b/blocks/header/package.json
@@ -19,14 +19,14 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.16",
-    "@blockprotocol/hook": "0.0.4",
+    "@blockprotocol/graph": "0.0.18",
+    "@blockprotocol/hook": "0.0.7",
     "@rooks/use-fork-ref": "4.11.2"
   },
   "devDependencies": {
     "block-scripts": "0.0.14",
     "eslint": "8.20.0",
-    "mock-block-dock": "0.0.26",
+    "mock-block-dock": "0.0.35",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "4.7.4"

--- a/blocks/header/src/app.tsx
+++ b/blocks/header/src/app.tsx
@@ -11,6 +11,7 @@ type BlockEntityProperties = {
 export const App: BlockComponent<BlockEntityProperties> = ({
   graph: {
     blockEntity: {
+      entityId,
       properties: { color, level = 1, text },
     },
   },
@@ -19,7 +20,7 @@ export const App: BlockComponent<BlockEntityProperties> = ({
   const headerRef = useRef<HTMLHeadingElement>(null);
   const { hookService } = useHookBlockService(containerRef);
 
-  useHook(hookService, headerRef, "text", "$.text", (node) => {
+  useHook(hookService, headerRef, "text", entityId, "$.text", (node) => {
     // eslint-disable-next-line no-param-reassign
     node.innerText = text ?? "";
 

--- a/blocks/header/src/dev.tsx
+++ b/blocks/header/src/dev.tsx
@@ -22,6 +22,7 @@ const App = () => (
       entityId: "test-header-1",
       properties: headerProperties,
     }}
+    debug
   />
 );
 

--- a/blocks/image/package.json
+++ b/blocks/image/package.json
@@ -19,12 +19,12 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.16"
+    "@blockprotocol/graph": "0.0.18"
   },
   "devDependencies": {
     "block-scripts": "0.0.14",
     "eslint": "8.20.0",
-    "mock-block-dock": "0.0.26",
+    "mock-block-dock": "0.0.35",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "twind": "0.16.17",

--- a/blocks/paragraph/package.json
+++ b/blocks/paragraph/package.json
@@ -19,13 +19,13 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.16",
-    "@blockprotocol/hook": "0.0.4"
+    "@blockprotocol/graph": "0.0.18",
+    "@blockprotocol/hook": "0.0.7"
   },
   "devDependencies": {
     "block-scripts": "0.0.14",
     "eslint": "8.20.0",
-    "mock-block-dock": "0.0.26",
+    "mock-block-dock": "0.0.35",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "4.7.4",

--- a/blocks/paragraph/src/app.tsx
+++ b/blocks/paragraph/src/app.tsx
@@ -9,6 +9,7 @@ type BlockEntityProperties = {
 export const App: BlockComponent<BlockEntityProperties> = ({
   graph: {
     blockEntity: {
+      entityId,
       properties: { text },
     },
   },
@@ -16,7 +17,7 @@ export const App: BlockComponent<BlockEntityProperties> = ({
   const ref = useRef<HTMLHeadingElement>(null);
   const { hookService } = useHookBlockService(ref);
 
-  useHook(hookService, ref, "text", "$.text", (node) => {
+  useHook(hookService, ref, "text", entityId, "$.text", (node) => {
     // eslint-disable-next-line no-param-reassign
     node.innerText = text ?? "";
 
@@ -26,5 +27,5 @@ export const App: BlockComponent<BlockEntityProperties> = ({
     };
   });
 
-  return <p ref={ref} />;
+  return <div ref={ref} />;
 };

--- a/blocks/paragraph/src/dev.tsx
+++ b/blocks/paragraph/src/dev.tsx
@@ -20,6 +20,7 @@ const App = () => (
       entityId: "test-para-1",
       properties: paragraphProperties,
     }}
+    debug
   />
 );
 

--- a/blocks/person/package.json
+++ b/blocks/person/package.json
@@ -19,14 +19,14 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.16",
+    "@blockprotocol/graph": "0.0.18",
     "dompurify": "2.3.6"
   },
   "devDependencies": {
     "@types/dompurify": "2.3.3",
     "block-scripts": "0.0.14",
     "eslint": "8.20.0",
-    "mock-block-dock": "0.0.26",
+    "mock-block-dock": "0.0.35",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "4.7.4"

--- a/blocks/shuffle/package.json
+++ b/blocks/shuffle/package.json
@@ -22,7 +22,7 @@
     "serve": "node_modules/.bin/block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.16",
+    "@blockprotocol/graph": "0.0.18",
     "@dnd-kit/core": "6.0.5",
     "@dnd-kit/modifiers": "6.0.0",
     "@dnd-kit/sortable": "7.0.1",
@@ -39,7 +39,7 @@
     "@types/lodash.isequal": "4.5.6",
     "@types/react-beautiful-dnd": "13.1.2",
     "block-scripts": "0.0.14",
-    "mock-block-dock": "0.0.26",
+    "mock-block-dock": "0.0.35",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/blocks/table/package.json
+++ b/blocks/table/package.json
@@ -19,7 +19,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.16",
+    "@blockprotocol/graph": "0.0.18",
     "@headlessui/react": "1.4.1",
     "immer": "9.0.6",
     "lodash": "4.17.21",
@@ -30,7 +30,7 @@
     "@types/react-table": "7.7.1",
     "block-scripts": "0.0.14",
     "eslint": "8.20.0",
-    "mock-block-dock": "0.0.26",
+    "mock-block-dock": "0.0.35",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "twind": "0.16.17",

--- a/blocks/timer/package.json
+++ b/blocks/timer/package.json
@@ -17,13 +17,13 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.16",
+    "@blockprotocol/graph": "0.0.18",
     "date-fns": "2.28.0",
     "duration-fns": "3.0.1"
   },
   "devDependencies": {
     "block-scripts": "0.0.14",
-    "mock-block-dock": "0.0.26",
+    "mock-block-dock": "0.0.35",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/blocks/video/package.json
+++ b/blocks/video/package.json
@@ -19,12 +19,12 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.16"
+    "@blockprotocol/graph": "0.0.18"
   },
   "devDependencies": {
     "block-scripts": "0.0.14",
     "eslint": "8.20.0",
-    "mock-block-dock": "0.0.26",
+    "mock-block-dock": "0.0.35",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "twind": "0.16.17",

--- a/packages/hash/api/package.json
+++ b/packages/hash/api/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/credential-provider-node": "3.41.0",
     "@aws-sdk/s3-presigned-post": "3.38.0",
     "@aws-sdk/s3-request-presigner": "3.38.0",
-    "@blockprotocol/core": "0.0.11",
+    "@blockprotocol/core": "0.0.12",
     "@blockprotocol/type-system-web": "https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?6526c0e",
     "@graphql-tools/schema": "8.5.0",
     "@hashintel/hash-backend-utils": "0.0.0",

--- a/packages/hash/backend-utils/package.json
+++ b/packages/hash/backend-utils/package.json
@@ -21,7 +21,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@blockprotocol/core": "0.0.11",
+    "@blockprotocol/core": "0.0.12",
     "@opensearch-project/opensearch": "1.1.0",
     "apollo-datasource": "3.3.2",
     "dotenv-flow": "3.2.0",

--- a/packages/hash/frontend/package.json
+++ b/packages/hash/frontend/package.json
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@apollo/client": "3.6.9",
-    "@blockprotocol/core": "0.0.11",
-    "@blockprotocol/graph": "0.0.16",
-    "@blockprotocol/hook": "0.0.4",
+    "@blockprotocol/core": "0.0.12",
+    "@blockprotocol/graph": "0.0.18",
+    "@blockprotocol/hook": "0.0.7",
     "@blockprotocol/type-system-web": "https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?6526c0e",
     "@dnd-kit/core": "6.0.5",
     "@dnd-kit/modifiers": "6.0.0",

--- a/packages/hash/frontend/src/blocks/page/collab/EditorConnection.ts
+++ b/packages/hash/frontend/src/blocks/page/collab/EditorConnection.ts
@@ -258,7 +258,7 @@ export class EditorConnection {
       })
       .catch((err) => {
         this.closeRequest();
-        // eslint-disable-next-line no-console -- TODO: consider using logger
+
         console.error(err);
         this.dispatch({ type: "error", error: err });
       });
@@ -378,7 +378,7 @@ export class EditorConnection {
         if (err.status === 410 || badVersion(err)) {
           // Too far behind. Revert to server state
           // @todo use logger
-          // eslint-disable-next-line no-console
+
           console.warn(err);
           this.dispatch({ type: "restart" });
         } else if (err) {

--- a/packages/hash/shared/package.json
+++ b/packages/hash/shared/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@apollo/client": "3.6.9",
-    "@blockprotocol/core": "0.0.11",
+    "@blockprotocol/core": "0.0.12",
     "@hashintel/hash-graph-client": "0.0.0",
     "@sentry/browser": "7.10.0",
     "graphql-tag": "2.12.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3073,10 +3073,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@blockprotocol/core@0.0.11":
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/@blockprotocol/core/-/core-0.0.11.tgz#3a874001e1b954324031db2819f32dea9086a232"
-  integrity sha512-A2mPDzYxWOANNc5wJIlhODxux78MzIndFVnLJh60bw3uk/zlQe45xm3/iJd0eKWyMUvpK0qYy3bvJlqS2kPQcQ==
+"@blockprotocol/core@0.0.12":
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@blockprotocol/core/-/core-0.0.12.tgz#11ccdf72a636e0bb38d41222fe23fbb9c6218cff"
+  integrity sha512-9GGxSQq1DDCQkPR9WGCHxU6ngXuFXjEQMEr9sXfmwgXrkqQtmmhuo7RmJSjPF1lrrt2TTb2RXsJ8Aset5vZTwA==
   dependencies:
     es-module-lexer "^0.10.5"
     uuid "^8.3.2"
@@ -3104,20 +3104,20 @@
     "@blockprotocol/core" "0.0.9"
     lit "^2.2.5"
 
-"@blockprotocol/graph@0.0.16":
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/@blockprotocol/graph/-/graph-0.0.16.tgz#1a1026633df9ea8bfdf2f763cb124441d392cb3e"
-  integrity sha512-mR+tIXnitEXQ65IX4H6J/bZ0sW6XyDU6pbcDjYv/Ur9oddY4g7ufhgUAWVNPoQyXly84VMb6jNAlyAKVLVV0lQ==
+"@blockprotocol/graph@0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@blockprotocol/graph/-/graph-0.0.18.tgz#4b1634196329ff1a590725767bac5c8dbb38e721"
+  integrity sha512-CGpwoVGe1aH2ZKKrYIik5oKhyBjQNbMoYsLTt4pBOm8r67YMSHpeUn7prWNtrdiTBY30PWQPnPY6A4uer8tVHg==
   dependencies:
-    "@blockprotocol/core" "0.0.11"
+    "@blockprotocol/core" "0.0.12"
     lit "^2.2.5"
 
-"@blockprotocol/hook@0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@blockprotocol/hook/-/hook-0.0.4.tgz#da1f64bb87c805ad1681efb65abd58bfff769a54"
-  integrity sha512-SCWyp/6BopRFkwHckVUrAo7Vxx/NRclJsNl3GLdrGLX0awzUIDoMBfdarVc8aIZaMocXDN/Rp4wZf/iV3FoY6w==
+"@blockprotocol/hook@0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@blockprotocol/hook/-/hook-0.0.7.tgz#56ea49f4c25fa756fab7acefff171cc2f1d3df86"
+  integrity sha512-d5GK5yusWqzQlM9NsRonIMsWDIc7Hq9y8W121mt5MYhsHlPl54ivhQTk9jJNV+bZVcGPM652zejlkFQgMXLdLQ==
   dependencies:
-    "@blockprotocol/core" "0.0.11"
+    "@blockprotocol/core" "0.0.12"
 
 "@blockprotocol/type-system-web@https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?6526c0e":
   version "0.0.1"
@@ -5868,6 +5868,11 @@
   resolved "https://registry.yarnpkg.com/@types/iframe-resizer/-/iframe-resizer-3.5.9.tgz#75c4cda33cee5f4da4c7693a0d9ad1ccb0c5ee98"
   integrity sha512-RQUBI75F+uXruB95BFpC/8V8lPgJg4MQ6HxOCtAZYBB/h0FNCfrFfb4I+u2pZJIV7sKeszZbFqy1UnGeBMrvsA==
 
+"@types/is-hotkey@^0.1.1":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@types/is-hotkey/-/is-hotkey-0.1.7.tgz#30ec6d4234895230b576728ef77e70a52962f3b3"
+  integrity sha512-yB5C7zcOM7idwYZZ1wKQ3pTfjA9BbvFqRWvKB46GFddxnJtHwi/b9y84ykQtxQPg5qhdpg4Q/kWU3EGoCTmLzQ==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
@@ -5957,7 +5962,7 @@
   dependencies:
     "@types/lodash" "*"
 
-"@types/lodash@*", "@types/lodash@4.14.175":
+"@types/lodash@*", "@types/lodash@4.14.175", "@types/lodash@^4.14.149":
   version "4.14.175"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.175.tgz#b78dfa959192b01fae0ad90e166478769b215f45"
   integrity sha512-XmdEOrKQ8a1Y/yxQFOMbC47G/V2VDO1GvMRnl4O75M4GW/abC5tnfzadQYkqEveqRM1dEJGFFegfPNA2vvx2iw==
@@ -8640,6 +8645,11 @@ compute-lcm@^1.1.0:
     validate.io-function "^1.0.2"
     validate.io-integer-array "^1.0.0"
 
+compute-scroll-into-view@^1.0.17:
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz#6a88f18acd9d42e9cf4baa6bec7e0522607ab7ab"
+  integrity sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -9351,6 +9361,11 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+direction@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/direction/-/direction-1.0.4.tgz#2b86fb686967e987088caf8b89059370d4837442"
+  integrity sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==
+
 discontinuous-range@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
@@ -9552,13 +9567,13 @@ ecdsa-sig-formatter@1.0.11:
   dependencies:
     safe-buffer "^5.0.1"
 
-echarts@^5.3.2:
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.3.2.tgz#0a7b3be8c48a48b2e7cb1b82121df0c208d42d2c"
-  integrity sha512-LWCt7ohOKdJqyiBJ0OGBmE9szLdfA9sGcsMEi+GGoc6+Xo75C+BkcT/6NNGRHAWtnQl2fNow05AQjznpap28TQ==
+echarts@^5.3.2, echarts@^5.3.3:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.4.0.tgz#a9a8e5367293a397408d3bf3e2638b869249ce04"
+  integrity sha512-uPsO9VRUIKAdFOoH3B0aNg7NRVdN7aM39/OjovjO9MwmWsAkfGyeXJhK+dbRi51iDrQWliXV60/XwLA7kg3z0w==
   dependencies:
     tslib "2.3.0"
-    zrender "5.3.1"
+    zrender "5.4.0"
 
 edit-json-file@^1.7.0:
   version "1.7.0"
@@ -11705,7 +11720,7 @@ immediate@~3.0.5:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
   integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
 
-immer@9.0.6:
+immer@9.0.6, immer@^9.0.6:
   version "9.0.6"
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.6.tgz#7a96bf2674d06c8143e327cbf73539388ddf1a73"
   integrity sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==
@@ -12121,6 +12136,11 @@ is-hexadecimal@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz#86b5bf668fca307498d319dfc03289d781a90027"
   integrity sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==
+
+is-hotkey@^0.1.6:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/is-hotkey/-/is-hotkey-0.1.8.tgz#6b1f4b2d0e5639934e20c05ed24d623a21d36d25"
+  integrity sha512-qs3NZ1INIS+H+yeo7cD9pDfwYV/jqRh1JG9S9zYrNudkoUQg7OL7ziXqRKu+InFjUIDoP2o6HIkLYMh1pcWgyQ==
 
 is-installed-globally@^0.4.0:
   version "0.4.0"
@@ -14512,20 +14532,25 @@ mock-block-dock@0.0.21:
     react-json-view "^1.21.3"
     uuid "^8.3.2"
 
-mock-block-dock@0.0.26:
-  version "0.0.26"
-  resolved "https://registry.yarnpkg.com/mock-block-dock/-/mock-block-dock-0.0.26.tgz#feb6e81f074000bf3f512ddaaa8204379daae1b4"
-  integrity sha512-zhTBxBGpBXCS9+HssDgz+bnaztjoV/KJhCMSBBheSRcDbG/vZCbJuzXY0eO4777j9e45SF0t+rHRGL3eqHT4dA==
+mock-block-dock@0.0.35:
+  version "0.0.35"
+  resolved "https://registry.yarnpkg.com/mock-block-dock/-/mock-block-dock-0.0.35.tgz#a6603551b618c96a11a73c61ce0aef6cb389fe47"
+  integrity sha512-hZaIkeg3PAvFgssS39/a0Nz8lcTh2OvVrna9+IgaqdiDEgGqT0l5C9omEydKTKtkzF1IqMimD0SDc23oXoUceg==
   dependencies:
-    "@blockprotocol/core" "0.0.11"
-    "@blockprotocol/graph" "0.0.16"
+    "@blockprotocol/core" "0.0.12"
+    "@blockprotocol/graph" "0.0.18"
+    "@blockprotocol/hook" "0.0.7"
     "@emotion/react" "^11.10.0"
     "@emotion/styled" "^11.10.0"
     "@lit-labs/react" "^1.0.4"
     "@mui/material" "^5.10.4"
     ajv "^8.9.0"
+    echarts "^5.3.3"
     react-json-view "^1.21.3"
     react-resizable "^3.0.4"
+    slate "^0.82.1"
+    slate-react "^0.83.1"
+    styled-jsx "5.0.7"
     use-local-storage-state "^18.1.1"
     uuid "^8.3.2"
 
@@ -17205,6 +17230,13 @@ schema-utils@^4.0.0:
     ajv-formats "^2.1.1"
     ajv-keywords "^5.0.0"
 
+scroll-into-view-if-needed@^2.2.20:
+  version "2.2.29"
+  resolved "https://registry.yarnpkg.com/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.29.tgz#551791a84b7e2287706511f8c68161e4990ab885"
+  integrity sha512-hxpAR6AN+Gh53AdAimHM6C8oTN1ppwVZITihix+WqalywBeFcQ6LdQP5ABNl26nX8GTEL7VT+b8lKpdqq65wXg==
+  dependencies:
+    compute-scroll-into-view "^1.0.17"
+
 scuid@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/scuid/-/scuid-1.1.0.tgz#d3f9f920956e737a60f72d0e4ad280bf324d5dab"
@@ -17557,6 +17589,29 @@ slash@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
   integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
+
+slate-react@^0.83.1:
+  version "0.83.2"
+  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.83.2.tgz#7099db1607b79c95cc2a41e2df1e04982b7e26a5"
+  integrity sha512-V5qtPsCOiDVCMU3ovj/CWndxx9/as5/wGJxnbJDRVzuazSh+NVw/YuGTlus1fCt+Nlt6UHOhFvM7C9pXYaftPA==
+  dependencies:
+    "@types/is-hotkey" "^0.1.1"
+    "@types/lodash" "^4.14.149"
+    direction "^1.0.3"
+    is-hotkey "^0.1.6"
+    is-plain-object "^5.0.0"
+    lodash "^4.17.4"
+    scroll-into-view-if-needed "^2.2.20"
+    tiny-invariant "1.0.6"
+
+slate@^0.82.1:
+  version "0.82.1"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.82.1.tgz#cf43cb828c980734dab01c9bbb517fd4d20892f7"
+  integrity sha512-3mdRdq7U3jSEoyFrGvbeb28hgrvrr4NdFCtJX+IjaNvSFozY0VZd/CGHF0zf/JDx7aEov864xd5uj0HQxxEWTQ==
+  dependencies:
+    immer "^9.0.6"
+    is-plain-object "^5.0.0"
+    tiny-warning "^1.0.3"
 
 slice-ansi@0.0.4:
   version "0.0.4"
@@ -18190,6 +18245,11 @@ styled-jsx@5.0.2:
   resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.0.2.tgz#ff230fd593b737e9e68b630a694d460425478729"
   integrity sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==
 
+styled-jsx@5.0.7:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.0.7.tgz#be44afc53771b983769ac654d355ca8d019dff48"
+  integrity sha512-b3sUzamS086YLRuvnaDigdAewz1/EFYlHpYBP5mZovKEdQQOIIYq8lApylub3HHZ6xFjV051kkGU7cudJmrXEA==
+
 stylis@4.0.13:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.13.tgz#f5db332e376d13cc84ecfe5dace9a2a51d954c91"
@@ -18429,6 +18489,16 @@ thunky@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
+
+tiny-invariant@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.6.tgz#b3f9b38835e36a41c843a3b0907a5a7b3755de73"
+  integrity sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==
+
+tiny-warning@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
 title-case@^3.0.3:
   version "3.0.3"
@@ -19996,10 +20066,10 @@ zen-observable@0.8.15:
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
 
-zrender@5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.3.1.tgz#fa8e63ac7e719cfd563831fe8c42a9756c5af384"
-  integrity sha512-7olqIjy0gWfznKr6vgfnGBk7y4UtdMvdwFmK92vVQsQeDPyzkHW1OlrLEKg6GHz1W5ePf0FeN1q2vkl/HFqhXw==
+zrender@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.4.0.tgz#d4f76e527b2e3bbd7add2bdaf27a16af85785576"
+  integrity sha512-rOS09Z2HSVGFs2dn/TuYk5BlCaZcVe8UDLLjj1ySYF828LATKKdxuakSZMvrDz54yiKPDYVfjdKqcX8Jky3BIA==
   dependencies:
     tslib "2.3.0"
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Now that `mock-block-dock` supports the hook service, we can re-enable the text blocks using it on the [Hub](https://blockprotocol.org/hub).

This PR upgrades the version used of `mock-block-dock` and `@blockprotocol/hook `in text blocks.

It also takes the opportunity to upgrade the versions of `@blockprotocol/graph`

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203007126736607/1203214182073173/f) _(internal)_

## 🐾 Next steps

- After merging, open a PR in the `blockprotocol` repo to use the new text block versions.
