### PR TITLE
Return `Subgraph` from Entity endpoints in the Graph API

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -326,55 +326,6 @@ export interface EdgesValueInner {
   edgeKind: EdgeKind;
 }
 /**
- *
- * @export
- * @interface EntityRootedSubgraph
- */
-export interface EntityRootedSubgraph {
-  /**
-   *
-   * @type {PersistedEntity}
-   * @memberof EntityRootedSubgraph
-   */
-  entity: PersistedEntity;
-  /**
-   *
-   * @type {Array<PersistedEntity>}
-   * @memberof EntityRootedSubgraph
-   */
-  linkedEntities: Array<PersistedEntity>;
-  /**
-   *
-   * @type {Array<PersistedLink>}
-   * @memberof EntityRootedSubgraph
-   */
-  links: Array<PersistedLink>;
-  /**
-   *
-   * @type {Array<PersistedDataType>}
-   * @memberof EntityRootedSubgraph
-   */
-  referencedDataTypes: Array<PersistedDataType>;
-  /**
-   *
-   * @type {Array<PersistedEntityType>}
-   * @memberof EntityRootedSubgraph
-   */
-  referencedEntityTypes: Array<PersistedEntityType>;
-  /**
-   *
-   * @type {Array<PersistedLinkType>}
-   * @memberof EntityRootedSubgraph
-   */
-  referencedLinkTypes: Array<PersistedLinkType>;
-  /**
-   *
-   * @type {Array<PersistedPropertyType>}
-   * @memberof EntityRootedSubgraph
-   */
-  referencedPropertyTypes: Array<PersistedPropertyType>;
-}
-/**
  * Specifies the structure of an Entity Type
  * @export
  * @interface EntityType
@@ -2868,10 +2819,7 @@ export const EntityApiFp = function (configuration?: Configuration) {
       structuralQuery: StructuralQuery,
       options?: AxiosRequestConfig,
     ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<Array<EntityRootedSubgraph>>
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Subgraph>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getEntitiesByQuery(
@@ -2996,7 +2944,7 @@ export const EntityApiFactory = function (
     getEntitiesByQuery(
       structuralQuery: StructuralQuery,
       options?: any,
-    ): AxiosPromise<Array<EntityRootedSubgraph>> {
+    ): AxiosPromise<Subgraph> {
       return localVarFp
         .getEntitiesByQuery(structuralQuery, options)
         .then((request) => request(axios, basePath));
@@ -3067,7 +3015,7 @@ export interface EntityApiInterface {
   getEntitiesByQuery(
     structuralQuery: StructuralQuery,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<EntityRootedSubgraph>>;
+  ): AxiosPromise<Subgraph>;
 
   /**
    *
@@ -5513,10 +5461,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       structuralQuery: StructuralQuery,
       options?: AxiosRequestConfig,
     ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<Array<EntityRootedSubgraph>>
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Subgraph>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getEntitiesByQuery(
@@ -6170,7 +6115,7 @@ export const GraphApiFactory = function (
     getEntitiesByQuery(
       structuralQuery: StructuralQuery,
       options?: any,
-    ): AxiosPromise<Array<EntityRootedSubgraph>> {
+    ): AxiosPromise<Subgraph> {
       return localVarFp
         .getEntitiesByQuery(structuralQuery, options)
         .then((request) => request(axios, basePath));
@@ -6560,7 +6505,7 @@ export interface GraphApiInterface {
   getEntitiesByQuery(
     structuralQuery: StructuralQuery,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<EntityRootedSubgraph>>;
+  ): AxiosPromise<Subgraph>;
 
   /**
    *

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -22,12 +22,12 @@ use crate::{
         patch_id_and_parse, AccountId, PersistedDataType, PersistedOntologyIdentifier,
         PersistedOntologyMetadata,
     },
+    shared::identifier::GraphElementIdentifier,
     store::{
         query::Expression, BaseUriAlreadyExists, BaseUriDoesNotExist, DataTypeStore, StorePool,
     },
     subgraph::{
-        EdgeKind, Edges, GraphElementIdentifier, GraphResolveDepths, OutwardEdge, StructuralQuery,
-        Subgraph, Vertex,
+        EdgeKind, Edges, GraphResolveDepths, OutwardEdge, StructuralQuery, Subgraph, Vertex,
     },
 };
 

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -19,14 +19,14 @@ use crate::{
         Entity, EntityId, PersistedEntity, PersistedEntityIdentifier, PersistedEntityMetadata,
     },
     ontology::AccountId,
+    shared::identifier::GraphElementIdentifier,
     store::{
         error::{EntityDoesNotExist, QueryError},
         query::Expression,
         EntityStore, StorePool,
     },
     subgraph::{
-        EdgeKind, Edges, GraphElementIdentifier, GraphResolveDepths, OutwardEdge, StructuralQuery,
-        Subgraph, Vertex,
+        EdgeKind, Edges, GraphResolveDepths, OutwardEdge, StructuralQuery, Subgraph, Vertex,
     },
 };
 

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -21,14 +21,14 @@ use crate::{
         patch_id_and_parse, AccountId, PersistedEntityType, PersistedOntologyIdentifier,
         PersistedOntologyMetadata,
     },
+    shared::identifier::GraphElementIdentifier,
     store::{
         error::{BaseUriAlreadyExists, BaseUriDoesNotExist},
         query::Expression,
         EntityTypeStore, StorePool,
     },
     subgraph::{
-        EdgeKind, Edges, GraphElementIdentifier, GraphResolveDepths, OutwardEdge, StructuralQuery,
-        Subgraph, Vertex,
+        EdgeKind, Edges, GraphResolveDepths, OutwardEdge, StructuralQuery, Subgraph, Vertex,
     },
 };
 

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -26,7 +26,10 @@ use crate::{
         query::Expression,
         EntityTypeStore, StorePool,
     },
-    subgraph::{StructuralQuery, Subgraph},
+    subgraph::{
+        EdgeKind, Edges, GraphElementIdentifier, GraphResolveDepths, OutwardEdge, StructuralQuery,
+        Subgraph, Vertex,
+    },
 };
 
 #[derive(OpenApi)]
@@ -47,6 +50,12 @@ use crate::{
             PersistedOntologyMetadata,
             PersistedEntityType,
             StructuralQuery,
+            GraphElementIdentifier,
+            Vertex,
+            EdgeKind,
+            OutwardEdge,
+            GraphResolveDepths,
+            Edges,
             Subgraph,
         )
     ),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -22,12 +22,12 @@ use crate::{
         patch_id_and_parse, AccountId, PersistedLinkType, PersistedOntologyIdentifier,
         PersistedOntologyMetadata,
     },
+    shared::identifier::GraphElementIdentifier,
     store::{
         query::Expression, BaseUriAlreadyExists, BaseUriDoesNotExist, LinkTypeStore, StorePool,
     },
     subgraph::{
-        EdgeKind, Edges, GraphElementIdentifier, GraphResolveDepths, OutwardEdge, StructuralQuery,
-        Subgraph, Vertex,
+        EdgeKind, Edges, GraphResolveDepths, OutwardEdge, StructuralQuery, Subgraph, Vertex,
     },
 };
 

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -25,7 +25,10 @@ use crate::{
     store::{
         query::Expression, BaseUriAlreadyExists, BaseUriDoesNotExist, LinkTypeStore, StorePool,
     },
-    subgraph::{StructuralQuery, Subgraph},
+    subgraph::{
+        EdgeKind, Edges, GraphElementIdentifier, GraphResolveDepths, OutwardEdge, StructuralQuery,
+        Subgraph, Vertex,
+    },
 };
 
 #[derive(OpenApi)]
@@ -46,6 +49,12 @@ use crate::{
             PersistedOntologyMetadata,
             PersistedLinkType,
             StructuralQuery,
+            GraphElementIdentifier,
+            Vertex,
+            EdgeKind,
+            OutwardEdge,
+            GraphResolveDepths,
+            Edges,
             Subgraph,
         )
     ),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -54,8 +54,8 @@ use crate::{
             EdgeKind,
             OutwardEdge,
             GraphResolveDepths,
+            Edges,
             Subgraph,
-            Edges
         )
     ),
     tags(

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -22,12 +22,12 @@ use crate::{
         patch_id_and_parse, AccountId, PersistedOntologyIdentifier, PersistedOntologyMetadata,
         PersistedPropertyType,
     },
+    shared::identifier::GraphElementIdentifier,
     store::{
         query::Expression, BaseUriAlreadyExists, BaseUriDoesNotExist, PropertyTypeStore, StorePool,
     },
     subgraph::{
-        EdgeKind, Edges, GraphElementIdentifier, GraphResolveDepths, OutwardEdge, StructuralQuery,
-        Subgraph, Vertex,
+        EdgeKind, Edges, GraphResolveDepths, OutwardEdge, StructuralQuery, Subgraph, Vertex,
     },
 };
 

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/mod.rs
@@ -49,18 +49,6 @@ pub type KnowledgeGraphQueryDepth = u8;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct EntityRootedSubgraph {
-    pub entity: PersistedEntity,
-    pub referenced_data_types: Vec<PersistedDataType>,
-    pub referenced_property_types: Vec<PersistedPropertyType>,
-    pub referenced_link_types: Vec<PersistedLinkType>,
-    pub referenced_entity_types: Vec<PersistedEntityType>,
-    pub linked_entities: Vec<PersistedEntity>,
-    pub links: Vec<PersistedLink>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
-#[serde(rename_all = "camelCase")]
 pub struct LinkRootedSubgraph {
     pub link: PersistedLink,
     pub referenced_data_types: Vec<PersistedDataType>,

--- a/packages/graph/hash_graph/lib/graph/src/lib.rs
+++ b/packages/graph/hash_graph/lib/graph/src/lib.rs
@@ -74,8 +74,10 @@ pub mod api;
 
 pub mod knowledge;
 pub mod ontology;
+pub mod shared;
 
 pub mod store;
 
 pub mod logging;
-pub mod subgraph;
+
+pub use shared::*;

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -44,7 +44,7 @@ impl fmt::Display for AccountId {
 pub struct PersistedOntologyIdentifier {
     #[schema(value_type = String)]
     uri: VersionedUri,
-    // TODO: owned_by_id is not required to identify an ontology element 
+    // TODO: owned_by_id is not required to identify an ontology element
     //  https://app.asana.com/0/1202805690238892/1203214689883091/f
     owned_by_id: AccountId,
 }

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -44,6 +44,8 @@ impl fmt::Display for AccountId {
 pub struct PersistedOntologyIdentifier {
     #[schema(value_type = String)]
     uri: VersionedUri,
+    // TODO: owned_by_id is not required to identify an ontology element 
+    //  https://app.asana.com/0/1202805690238892/1203214689883091/f
     owned_by_id: AccountId,
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier.rs
@@ -19,6 +19,8 @@ pub struct LinkId {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum GraphElementIdentifier {
     OntologyElementId(VersionedUri),
+    // TODO: owned_by_id and version are required to identify a specific instance of an entity
+    //  https://app.asana.com/0/1202805690238892/1203214689883091/f
     KnowledgeGraphElementId(EntityId),
     Temporary(LinkId),
 }

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier.rs
@@ -1,0 +1,37 @@
+use serde::{Deserialize, Serialize};
+use type_system::uri::VersionedUri;
+use utoipa::{openapi, ToSchema};
+
+use crate::knowledge::EntityId;
+
+// TODO - This is temporary and introduced for consistency, we need to introduce actual IDs for
+//  links, should be revisited as part of https://app.asana.com/0/0/1203157172269853/f
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct LinkId {
+    pub source_entity_id: EntityId,
+    pub target_entity_id: EntityId,
+    #[schema(value_type = String)]
+    pub link_type_id: VersionedUri,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "camelCase", untagged)]
+pub enum GraphElementIdentifier {
+    OntologyElementId(VersionedUri),
+    KnowledgeGraphElementId(EntityId),
+    Temporary(LinkId),
+}
+
+// TODO: We have to do this because utoipa doesn't understand serde untagged
+//  https://github.com/juhaku/utoipa/issues/320
+impl ToSchema for GraphElementIdentifier {
+    fn schema() -> openapi::Schema {
+        openapi::OneOfBuilder::new()
+            .item(openapi::Object::with_type(openapi::SchemaType::String))
+            .example(Some(serde_json::json!(
+                "6013145d-7392-4630-ab16-e99c59134cb6"
+            )))
+            .into()
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/shared/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/mod.rs
@@ -1,0 +1,2 @@
+pub mod identifier;
+pub mod subgraph;

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph.rs
@@ -4,49 +4,17 @@ use std::collections::{
 };
 
 use serde::{Deserialize, Serialize};
-use type_system::uri::VersionedUri;
 use utoipa::{openapi, ToSchema};
 
 use crate::{
-    knowledge::{EntityId, KnowledgeGraphQueryDepth, PersistedEntity, PersistedLink},
+    knowledge::{KnowledgeGraphQueryDepth, PersistedEntity, PersistedLink},
     ontology::{
         OntologyQueryDepth, PersistedDataType, PersistedEntityType, PersistedLinkType,
         PersistedPropertyType,
     },
+    shared::identifier::GraphElementIdentifier,
     store::query::Expression,
 };
-
-// TODO - This is temporary and introduced for consistency, we need to introduce actual IDs for
-//  links, should be revisited as part of https://app.asana.com/0/0/1203157172269853/f
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct LinkId {
-    pub source_entity_id: EntityId,
-    pub target_entity_id: EntityId,
-    #[schema(value_type = String)]
-    pub link_type_id: VersionedUri,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
-#[serde(rename_all = "camelCase", untagged)]
-pub enum GraphElementIdentifier {
-    OntologyElementId(VersionedUri),
-    KnowledgeGraphElementId(EntityId),
-    Temporary(LinkId),
-}
-
-// TODO: We have to do this because utoipa doesn't understand serde untagged
-//  https://github.com/juhaku/utoipa/issues/320
-impl ToSchema for GraphElementIdentifier {
-    fn schema() -> openapi::Schema {
-        openapi::OneOfBuilder::new()
-            .item(openapi::Object::with_type(openapi::SchemaType::String))
-            .example(Some(serde_json::json!(
-                "6013145d-7392-4630-ab16-e99c59134cb6"
-            )))
-            .into()
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -18,8 +18,8 @@ pub use self::{
 };
 use crate::{
     knowledge::{
-        Entity, EntityId, EntityRootedSubgraph, Link, LinkRootedSubgraph, PersistedEntity,
-        PersistedEntityMetadata, PersistedLink,
+        Entity, EntityId, Link, LinkRootedSubgraph, PersistedEntity, PersistedEntityMetadata,
+        PersistedLink,
     },
     ontology::{
         AccountId, PersistedDataType, PersistedEntityType, PersistedLinkType,
@@ -397,15 +397,12 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Expressio
         owned_by_id: AccountId,
     ) -> Result<Vec<EntityId>, InsertionError>;
 
-    /// Get the [`EntityRootedSubgraph`]s specified by the [`StructuralQuery`].
+    /// Get the [`Subgraph`]s specified by the [`StructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`Entity`] doesn't exist
-    async fn get_entity(
-        &self,
-        query: &StructuralQuery,
-    ) -> Result<Vec<EntityRootedSubgraph>, QueryError>;
+    async fn get_entity(&self, query: &StructuralQuery) -> Result<Subgraph, QueryError>;
 
     /// Update an existing [`Entity`].
     ///

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -11,6 +11,7 @@ use type_system::uri::VersionedUri;
 use uuid::Uuid;
 
 use crate::{
+    identifier::{GraphElementIdentifier, LinkId},
     knowledge::{Entity, EntityId, PersistedEntity, PersistedEntityMetadata, PersistedLink},
     ontology::AccountId,
     store::{
@@ -19,10 +20,7 @@ use crate::{
         postgres::{context::PostgresContext, DependencyContext, DependencyContextRef},
         AsClient, EntityStore, InsertionError, PostgresStore, QueryError, UpdateError,
     },
-    subgraph::{
-        EdgeKind, GraphElementIdentifier, GraphResolveDepths, LinkId, OutwardEdge, StructuralQuery,
-        Subgraph,
-    },
+    subgraph::{EdgeKind, GraphResolveDepths, OutwardEdge, StructuralQuery, Subgraph},
 };
 
 impl<C: AsClient> PostgresStore<C> {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -11,10 +11,7 @@ use type_system::uri::VersionedUri;
 use uuid::Uuid;
 
 use crate::{
-    knowledge::{
-        Entity, EntityId, EntityRootedSubgraph, PersistedEntity, PersistedEntityMetadata,
-        PersistedLink,
-    },
+    knowledge::{Entity, EntityId, PersistedEntity, PersistedEntityMetadata, PersistedLink},
     ontology::AccountId,
     store::{
         crud::Read,
@@ -24,6 +21,7 @@ use crate::{
     },
     subgraph::{
         EdgeKind, GraphElementIdentifier, GraphResolveDepths, LinkId, OutwardEdge, StructuralQuery,
+        Subgraph,
     },
 };
 
@@ -226,16 +224,13 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         Ok(entity_ids)
     }
 
-    async fn get_entity(
-        &self,
-        query: &StructuralQuery,
-    ) -> Result<Vec<EntityRootedSubgraph>, QueryError> {
+    async fn get_entity(&self, query: &StructuralQuery) -> Result<Subgraph, QueryError> {
         let StructuralQuery {
             ref expression,
             graph_resolve_depths,
         } = *query;
 
-        stream::iter(Read::<PersistedEntity>::read(self, expression).await?)
+        let subgraphs = stream::iter(Read::<PersistedEntity>::read(self, expression).await?)
             .then(|entity| async move {
                 let mut dependency_context = DependencyContext::new(graph_resolve_depths);
 
@@ -247,25 +242,17 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 self.get_entity_as_dependency(entity_id, dependency_context.as_ref_object())
                     .await?;
 
-                let root = dependency_context
-                    .linked_entities
-                    .remove(&entity_id)
-                    .expect("root was not added to the subgraph");
+                let root = GraphElementIdentifier::KnowledgeGraphElementId(entity_id);
 
-                Ok(EntityRootedSubgraph {
-                    entity: root,
-                    referenced_data_types: dependency_context.referenced_data_types.into_vec(),
-                    referenced_property_types: dependency_context
-                        .referenced_property_types
-                        .into_vec(),
-                    referenced_link_types: dependency_context.referenced_link_types.into_vec(),
-                    referenced_entity_types: dependency_context.referenced_entity_types.into_vec(),
-                    linked_entities: dependency_context.linked_entities.into_vec(),
-                    links: dependency_context.links.into_vec(),
-                })
+                Ok::<_, Report<QueryError>>(dependency_context.into_subgraph(vec![root]))
             })
-            .try_collect()
-            .await
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        let mut subgraph = Subgraph::new(graph_resolve_depths);
+        subgraph.extend(subgraphs);
+
+        Ok(subgraph)
     }
 
     async fn update_entity(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/mod.rs
@@ -11,15 +11,14 @@ use tokio_postgres::GenericClient;
 use crate::{
     knowledge::{Link, LinkRootedSubgraph, PersistedLink},
     ontology::AccountId,
+    shared::identifier::{GraphElementIdentifier, LinkId},
     store::{
         crud::Read,
         error::LinkRemovalError,
         postgres::{DependencyContext, DependencyContextRef},
         AsClient, InsertionError, LinkStore, PostgresStore, QueryError,
     },
-    subgraph::{
-        EdgeKind, GraphElementIdentifier, GraphResolveDepths, LinkId, OutwardEdge, StructuralQuery,
-    },
+    subgraph::{EdgeKind, GraphResolveDepths, OutwardEdge, StructuralQuery},
 };
 
 impl<C: AsClient> PostgresStore<C> {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -39,13 +39,14 @@ use crate::{
         AccountId, OntologyQueryDepth, PersistedDataType, PersistedEntityType, PersistedLinkType,
         PersistedOntologyIdentifier, PersistedOntologyMetadata, PersistedPropertyType,
     },
+    shared::identifier::{GraphElementIdentifier, LinkId},
     store::{
         error::VersionedUriAlreadyExists,
         postgres::{ontology::OntologyDatabaseType, version_id::VersionId},
         AccountStore, BaseUriAlreadyExists, BaseUriDoesNotExist, InsertionError, QueryError,
         UpdateError,
     },
-    subgraph::{Edges, GraphElementIdentifier, GraphResolveDepths, LinkId, Subgraph, Vertex},
+    subgraph::{Edges, GraphResolveDepths, Subgraph, Vertex},
 };
 
 pub struct DependencyMap<V, T, D> {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -147,10 +147,6 @@ where
     pub fn into_vec(self) -> Vec<T> {
         self.into_values().collect()
     }
-
-    pub fn remove(&mut self, identifier: &V) -> Option<T> {
-        self.resolved.remove(identifier).map(|(value, _)| value)
-    }
 }
 
 pub struct DependencySet<T, D> {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -8,6 +8,7 @@ use type_system::{uri::VersionedUri, DataType};
 
 use crate::{
     ontology::{AccountId, PersistedDataType, PersistedOntologyMetadata},
+    shared::identifier::GraphElementIdentifier,
     store::{
         crud::Read,
         postgres::{
@@ -16,7 +17,7 @@ use crate::{
         },
         AsClient, DataTypeStore, InsertionError, PostgresStore, QueryError, UpdateError,
     },
-    subgraph::{GraphElementIdentifier, StructuralQuery, Subgraph},
+    subgraph::{StructuralQuery, Subgraph},
 };
 
 impl<C: AsClient> PostgresStore<C> {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
@@ -10,6 +10,7 @@ use type_system::{uri::VersionedUri, EntityType};
 
 use crate::{
     ontology::{AccountId, PersistedEntityType, PersistedOntologyMetadata},
+    shared::identifier::GraphElementIdentifier,
     store::{
         crud::Read,
         postgres::{
@@ -18,10 +19,7 @@ use crate::{
         },
         AsClient, EntityTypeStore, InsertionError, PostgresStore, QueryError, UpdateError,
     },
-    subgraph::{
-        EdgeKind, GraphElementIdentifier, GraphResolveDepths, OutwardEdge, StructuralQuery,
-        Subgraph,
-    },
+    subgraph::{EdgeKind, GraphResolveDepths, OutwardEdge, StructuralQuery, Subgraph},
 };
 
 impl<C: AsClient> PostgresStore<C> {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
@@ -8,6 +8,7 @@ use type_system::{uri::VersionedUri, LinkType};
 
 use crate::{
     ontology::{AccountId, PersistedLinkType, PersistedOntologyMetadata},
+    shared::identifier::GraphElementIdentifier,
     store::{
         crud::Read,
         postgres::{
@@ -16,7 +17,7 @@ use crate::{
         },
         AsClient, InsertionError, LinkTypeStore, PostgresStore, QueryError, UpdateError,
     },
-    subgraph::{GraphElementIdentifier, StructuralQuery, Subgraph},
+    subgraph::{StructuralQuery, Subgraph},
 };
 
 impl<C: AsClient> PostgresStore<C> {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -10,6 +10,7 @@ use type_system::{uri::VersionedUri, PropertyType};
 
 use crate::{
     ontology::{AccountId, PersistedOntologyMetadata, PersistedPropertyType},
+    shared::identifier::GraphElementIdentifier,
     store::{
         crud::Read,
         postgres::{
@@ -18,10 +19,7 @@ use crate::{
         },
         AsClient, InsertionError, PostgresStore, PropertyTypeStore, QueryError, UpdateError,
     },
-    subgraph::{
-        EdgeKind, GraphElementIdentifier, GraphResolveDepths, OutwardEdge, StructuralQuery,
-        Subgraph,
-    },
+    subgraph::{EdgeKind, GraphResolveDepths, OutwardEdge, StructuralQuery, Subgraph},
 };
 
 impl<C: AsClient> PostgresStore<C> {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/version_id.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/version_id.rs
@@ -7,6 +7,7 @@ use uuid::Uuid;
 
 // TODO: rename this to TypeInternalVersionId or something to distinguish it from versioned
 //  URIs and from entity ids
+//  https://app.asana.com/0/1202805690238892/1203214689883089/f
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema, FromSql, ToSql)]
 #[repr(transparent)]
 #[postgres(transparent)]

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/version_id.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/version_id.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
+// TODO: rename this to TypeInternalVersionId or something to distinguish it from versioned
+//  URIs and from entity ids
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema, FromSql, ToSql)]
 #[repr(transparent)]
 #[postgres(transparent)]

--- a/packages/graph/hash_graph/lib/graph/src/subgraph.rs
+++ b/packages/graph/hash_graph/lib/graph/src/subgraph.rs
@@ -5,7 +5,7 @@ use std::collections::{
 
 use serde::{Deserialize, Serialize};
 use type_system::uri::VersionedUri;
-use utoipa::{openapi, openapi::Schema, ToSchema};
+use utoipa::{openapi, ToSchema};
 
 use crate::{
     knowledge::{EntityId, KnowledgeGraphQueryDepth, PersistedEntity, PersistedLink},
@@ -214,7 +214,7 @@ impl Edges {
 
 // Necessary because utoipa can't handle HashSet
 impl ToSchema for Edges {
-    fn schema() -> Schema {
+    fn schema() -> openapi::Schema {
         openapi::ObjectBuilder::new()
             .additional_properties(Some(openapi::schema::Array::new(OutwardEdge::schema())))
             .into()

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -317,16 +317,21 @@ impl DatabaseApi<'_> {
     }
 
     pub async fn get_entity(&mut self, entity_id: EntityId) -> Result<PersistedEntity, QueryError> {
-        Ok(self
+        let vertex = self
             .store
             .get_entity(&StructuralQuery {
                 expression: Expression::for_latest_entity_id(entity_id),
                 graph_resolve_depths: GraphResolveDepths::zeroed(),
             })
             .await?
-            .pop()
-            .expect("no entity found")
-            .entity)
+            .vertices
+            .remove(&GraphElementIdentifier::KnowledgeGraphElementId(entity_id))
+            .expect("no entity found");
+
+        match vertex {
+            Vertex::Entity(persisted_entity) => Ok(persisted_entity),
+            _ => unreachable!(),
+        }
     }
 
     pub async fn update_entity(

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -14,6 +14,7 @@ use graph::{
         AccountId, PersistedDataType, PersistedEntityType, PersistedLinkType,
         PersistedOntologyMetadata, PersistedPropertyType,
     },
+    shared::identifier::GraphElementIdentifier,
     store::{
         error::LinkRemovalError,
         query::{Expression, Literal, Path, PathSegment},
@@ -21,7 +22,7 @@ use graph::{
         EntityTypeStore, InsertionError, LinkStore, LinkTypeStore, PostgresStore,
         PostgresStorePool, PropertyTypeStore, QueryError, StorePool, UpdateError,
     },
-    subgraph::{GraphElementIdentifier, GraphResolveDepths, StructuralQuery, Vertex},
+    subgraph::{GraphResolveDepths, StructuralQuery, Vertex},
 };
 use tokio_postgres::{NoTls, Transaction};
 use type_system::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType};

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -417,7 +417,7 @@ Content-Type: application/json
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
-        client.assert(response.body.length === 2, "Unexpected number of entities");
+        client.assert(response.body.roots.length === 2, "Unexpected number of entities");
     });
 %}
 

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -32,7 +32,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
 
   /**
    * @todo - rename this to type_internal_version_ids or something to distinguish it from versioned URIs and from
-   *   entity ids
+   *   entity ids - https://app.asana.com/0/1202805690238892/1203214689883089/f
    */
   pgm.createTable(
     "version_ids",

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -30,6 +30,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     },
   );
 
+    /**
+     * @todo - rename this to type_internal_version_ids or something to distinguish it from versioned URIs and from
+     *   entity ids
+     */
   pgm.createTable(
     "version_ids",
     {

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -30,10 +30,10 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     },
   );
 
-    /**
-     * @todo - rename this to type_internal_version_ids or something to distinguish it from versioned URIs and from
-     *   entity ids
-     */
+  /**
+   * @todo - rename this to type_internal_version_ids or something to distinguish it from versioned URIs and from
+   *   entity ids
+   */
   pgm.createTable(
     "version_ids",
     {

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -1,5 +1,5 @@
 import { ApolloError } from "apollo-server-errors";
-
+import { EntityVertex } from "@hashintel/hash-shared/graphql/types";
 import {
   PersistedEntity,
   GraphApi,
@@ -307,7 +307,7 @@ export default class {
     query: object,
     options?: Omit<Partial<StructuralQuery>, "query">,
   ): Promise<EntityModel[]> {
-    const { data: entityRootedSubgraphs } = await graphApi.getEntitiesByQuery({
+    const { data: subgraph } = await graphApi.getEntitiesByQuery({
       query,
       graphResolveDepths: {
         dataTypeResolveDepth:
@@ -325,9 +325,10 @@ export default class {
     });
 
     return await Promise.all(
-      entityRootedSubgraphs.map(({ entity }) =>
-        EntityModel.fromPersistedEntity(graphApi, entity),
-      ),
+      subgraph.roots.map((entityId) => {
+        const entityVertex = subgraph.vertices[entityId] as EntityVertex;
+        return EntityModel.fromPersistedEntity(graphApi, entityVertex.inner);
+      }),
     );
   }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This is similar to a number of previous PRs [#1198, #1205, #1220, #1227] however it is _not_ a full-stack change. This returns `Subgraph` from entity endpoints in the Graph API only, and applies a temporary hotfix in the entity model class to allow TypeScript to compile (without breaking functionality).

Migrating the workspace to use the new subgraph will require substantial changes as the concept of `Entity` is ingrained into the BP, and we use the types, hooks, etc. all over the place.

A bug was discovered in development regarding the identifiers, as such some driveby's have been added around this.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203007126736607/1203214689883085/f) _(internal)_

## 🔍 What does this change?

- Changes `get_entities_by_query` to return a `Subgraph`
- Regenerates the OpenAPI spec
- Driveby's on some of the REST api components
- Introduces the `shared` module to encapsulate `subgraph`
- Adds an `identifier` module in `shared` to encapsulate identifiers for elements of the graph
  -  This contains `GraphElementIdentifier`
- Adds a manual `Serialize` implementation to `GraphElementIdentifier` for the issue described below in "Known Issues"

## 📜 Does this require a change to the docs?

It probably will, this will happen as a follow-up (tracked in this [asana task](https://app.asana.com/0/0/1203160372638987/f) _(internal)_)

## ⚠️ Known issues

- The ones established in previous PRs
- The significant amount of code related to deprecated and old definitions that will need to be deleted in follow-up
- `LinkId`s and `Link`s in general are fairly broken. They are not uniquely identifiable by the structs we are using (there is no concept of the version of a link for example). Their `source` and `target` is defined through `EntityId`s rather than using `(entity_id, owned_by_id)` which is _not_ going to be good enough to uniquely identify an entity when we start to shard the DB by account. 
- `GraphElementIdentifier` uses an `EntityId` for the identifier of an entity, this is incorrect, but fixing it will require wider spanning changes (`owned_by_id` is not available in a lot of the structural querying logic at the moment, we'll need to fix that)

## 🐾 Next steps

- Migrate the frontend to use the new `Subgraph` objects for entities
- Improve/Fix Links
- Fix `GraphElementIdentifier` to uniquely identifier elements
- Migrate `Link` endpoints to use `Subgraph`
- Remove any code that has been made redundant as a result of this work
- Update documentation

## 🛡 What tests cover this?

This was a a Graph API only change, but that has impact on the workspace code, so all the tests of HASH should be checked. These include the ones outlined in the Graph README, as well as workspace integration tests, and manual testing of the application.

## ❓ How to test this?

- Follow the READMEs for the graph and for HASH to run tests
- Look at CI
- Run `yarn external-services up --build` and `yarn dev`
  - Test things manually
