### PR TITLE
Remove keyboard shortcuts starting with Alt / Opt

### DIFF
--- a/packages/hash/frontend/src/pages/[account-slug]/entities/[entity-id].page/entity-page-wrapper/entity-page-header.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/entities/[entity-id].page/entity-page-wrapper/entity-page-header.tsx
@@ -24,7 +24,7 @@ export const EntityPageHeader = ({ entity }: { entity: EntityResponse }) => {
         crumbs={[
           {
             title: "Entities",
-            href: `${accountSlug}/entities`,
+            href: `/${accountSlug}/entities`,
             id: "entities",
           },
           {

--- a/packages/hash/frontend/src/shared/layout/layout-with-header/actions-dropdown.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-header/actions-dropdown.tsx
@@ -2,13 +2,10 @@ import { useState, useCallback, FunctionComponent, useMemo } from "react";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import {
   Box,
-  ListItemSecondaryAction,
   listItemSecondaryActionClasses,
   ListItemText,
   useTheme,
 } from "@mui/material";
-import { useKeys } from "rooks";
-import { useRouter } from "next/router";
 
 import {
   usePopupState,
@@ -25,7 +22,6 @@ import { useRouteAccountInfo } from "../../routing";
 export const ActionsDropdownInner: FunctionComponent<{
   accountId: string;
 }> = ({ accountId }) => {
-  const router = useRouter();
   const theme = useTheme();
   const [loading, setLoading] = useState(false);
   const { data } = useAccountPages(accountId);
@@ -64,9 +60,6 @@ export const ActionsDropdownInner: FunctionComponent<{
 
   const newEntityTypeRoute = `/${accountId}/types/new`;
 
-  useKeys(["AltLeft", "KeyP"], addPage);
-  useKeys(["AltLeft", "KeyT"], () => router.push(newEntityTypeRoute));
-
   return (
     <Box>
       <HeaderIconButton
@@ -97,7 +90,6 @@ export const ActionsDropdownInner: FunctionComponent<{
         PaperProps={{
           elevation: 4,
           sx: {
-            width: 225,
             borderRadius: "6px",
             marginTop: 1,
             border: `1px solid ${theme.palette.gray["20"]}`,
@@ -115,7 +107,6 @@ export const ActionsDropdownInner: FunctionComponent<{
           }}
         >
           <ListItemText primary="Create page" />
-          <ListItemSecondaryAction>Opt + P</ListItemSecondaryAction>
         </MenuItem>
         {/*  
           Commented out menu items whose functionality have not been implemented yet
@@ -123,11 +114,9 @@ export const ActionsDropdownInner: FunctionComponent<{
         */}
         {/* <MenuItem onClick={popupState.close}>
           <ListItemText primary="Create entity" />
-          <ListItemSecondaryAction>Opt + E</ListItemSecondaryAction>
         </MenuItem> */}
         <MenuItem href={newEntityTypeRoute} onClick={popupState.close}>
           <ListItemText primary="Create Type" />
-          <ListItemSecondaryAction>Opt + T</ListItemSecondaryAction>
         </MenuItem>
       </Menu>
     </Box>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR removes two keyboard shortcuts that interfere with other user interactions. For example, pressing 't' in the editor was causing the type editor to appear.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203007126736604/1203150072758523/f) _(internal)_

## 🐾 Next steps

We'll want to re-introduce shorcuts in a coherent way throughout the app later. That's not on a critical path to market.

## 🛡 What tests cover this?

- Manual

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch / view the deployment
1.  Open a page
1.  Press Alt + t / Alt + p

## 📹 Demo

### Before

<img width="295" alt="Screenshot 2022-10-21 at 13 19 58" src="https://user-images.githubusercontent.com/608862/197196966-dde05249-d0c9-4e4d-ac76-bdb5e9bfc292.png">

### After

<img width="196" alt="Screenshot 2022-10-21 at 13 22 45" src="https://user-images.githubusercontent.com/608862/197196983-0d29635f-b0a6-4c56-b43d-1ab01215998f.png">
