### PR TITLE
Add provenance fields for ontology query types

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/data_type.rs
@@ -20,6 +20,9 @@ use crate::store::query::{Path, QueryRecord};
 #[derive(Debug, PartialEq, Eq)]
 pub enum DataTypeQueryPath {
     OwnedById,
+    CreatedById,
+    UpdatedById,
+    RemovedById,
     BaseUri,
     VersionedUri,
     Version,
@@ -48,6 +51,9 @@ impl TryFrom<Path> for DataTypeQueryPath {
 #[serde(rename_all = "camelCase")]
 enum DataTypeQueryToken {
     OwnedById,
+    CreatedById,
+    UpdatedById,
+    RemovedById,
     BaseUri,
     VersionedUri,
     Version,
@@ -90,6 +96,9 @@ impl<'de> Visitor<'de> for DataTypeQueryPathVisitor {
         self.position += 1;
         Ok(match token {
             DataTypeQueryToken::OwnedById => DataTypeQueryPath::OwnedById,
+            DataTypeQueryToken::CreatedById => DataTypeQueryPath::CreatedById,
+            DataTypeQueryToken::UpdatedById => DataTypeQueryPath::UpdatedById,
+            DataTypeQueryToken::RemovedById => DataTypeQueryPath::RemovedById,
             DataTypeQueryToken::BaseUri => DataTypeQueryPath::BaseUri,
             DataTypeQueryToken::VersionedUri => DataTypeQueryPath::VersionedUri,
             DataTypeQueryToken::Version => DataTypeQueryPath::Version,

--- a/packages/graph/hash_graph/lib/graph/src/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/entity_type.rs
@@ -18,6 +18,9 @@ use crate::{
 #[derive(Debug, PartialEq, Eq)]
 pub enum EntityTypeQueryPath {
     OwnedById,
+    CreatedById,
+    UpdatedById,
+    RemovedById,
     BaseUri,
     VersionedUri,
     Version,
@@ -51,6 +54,9 @@ impl TryFrom<Path> for EntityTypeQueryPath {
 #[serde(rename_all = "camelCase")]
 pub enum EntityTypeQueryToken {
     OwnedById,
+    CreatedById,
+    UpdatedById,
+    RemovedById,
     BaseUri,
     VersionedUri,
     Version,
@@ -71,8 +77,9 @@ pub struct EntityTypeQueryPathVisitor {
 }
 
 impl EntityTypeQueryPathVisitor {
-    pub const EXPECTING: &'static str = "one of `ownedById`, `baseUri`, `versionedUri`, \
-                                         `version`, `title, `description`, `default`, `examples`, \
+    pub const EXPECTING: &'static str = "one of `ownedById`, `createdById`, `updatedById`, \
+                                         `removedById`, `baseUri`, `versionedUri`, `version`, \
+                                         `title, `description`, `default`, `examples`, \
                                          `properties`, `required`, `links`, or `requiredLinks`";
 
     #[must_use]
@@ -98,6 +105,9 @@ impl<'de> Visitor<'de> for EntityTypeQueryPathVisitor {
         self.position += 1;
         Ok(match token {
             EntityTypeQueryToken::OwnedById => EntityTypeQueryPath::OwnedById,
+            EntityTypeQueryToken::CreatedById => EntityTypeQueryPath::CreatedById,
+            EntityTypeQueryToken::UpdatedById => EntityTypeQueryPath::UpdatedById,
+            EntityTypeQueryToken::RemovedById => EntityTypeQueryPath::RemovedById,
             EntityTypeQueryToken::BaseUri => EntityTypeQueryPath::BaseUri,
             EntityTypeQueryToken::VersionedUri => EntityTypeQueryPath::VersionedUri,
             EntityTypeQueryToken::Version => EntityTypeQueryPath::Version,
@@ -207,8 +217,10 @@ mod tests {
             )
             .expect_err("managed to convert entity type query path with missing tokens")
             .to_string(),
-            "invalid length 2, expected one of `ownedById`, `baseUri`, `versionedUri`, `version`, \
-             `title, `description`, `dataTypes`, or `propertyTypes`"
+            format!(
+                "invalid length 2, expected {}",
+                PropertyTypeQueryPathVisitor::EXPECTING
+            )
         );
 
         assert_eq!(

--- a/packages/graph/hash_graph/lib/graph/src/ontology/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/link_type.rs
@@ -12,6 +12,9 @@ use crate::store::query::{Path, QueryRecord};
 #[derive(Debug, PartialEq, Eq)]
 pub enum LinkTypeQueryPath {
     OwnedById,
+    CreatedById,
+    UpdatedById,
+    RemovedById,
     BaseUri,
     VersionedUri,
     Version,
@@ -40,6 +43,9 @@ impl TryFrom<Path> for LinkTypeQueryPath {
 #[serde(rename_all = "camelCase")]
 pub enum LinkTypeQueryToken {
     OwnedById,
+    CreatedById,
+    UpdatedById,
+    RemovedById,
     BaseUri,
     VersionedUri,
     Version,
@@ -55,8 +61,9 @@ pub struct LinkTypeQueryPathVisitor {
 }
 
 impl LinkTypeQueryPathVisitor {
-    pub const EXPECTING: &'static str = "one of `ownedById`, `baseUri`, `versionedUri`, \
-                                         `version`, `title, `description`, or `relatedKeywords`";
+    pub const EXPECTING: &'static str = "one of `ownedById`, `createdById`, `updatedById`, \
+                                         `removedById`, `baseUri`, `versionedUri`, `version`, \
+                                         `title, `description`, or `relatedKeywords`";
 
     #[must_use]
     pub const fn new(position: usize) -> Self {
@@ -81,6 +88,9 @@ impl<'de> Visitor<'de> for LinkTypeQueryPathVisitor {
         self.position += 1;
         Ok(match token {
             LinkTypeQueryToken::OwnedById => LinkTypeQueryPath::OwnedById,
+            LinkTypeQueryToken::CreatedById => LinkTypeQueryPath::CreatedById,
+            LinkTypeQueryToken::UpdatedById => LinkTypeQueryPath::UpdatedById,
+            LinkTypeQueryToken::RemovedById => LinkTypeQueryPath::RemovedById,
             LinkTypeQueryToken::BaseUri => LinkTypeQueryPath::BaseUri,
             LinkTypeQueryToken::VersionedUri => LinkTypeQueryPath::VersionedUri,
             LinkTypeQueryToken::Version => LinkTypeQueryPath::Version,

--- a/packages/graph/hash_graph/lib/graph/src/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/property_type.rs
@@ -15,6 +15,9 @@ use crate::{
 #[derive(Debug, PartialEq, Eq)]
 pub enum PropertyTypeQueryPath {
     OwnedById,
+    CreatedById,
+    UpdatedById,
+    RemovedById,
     BaseUri,
     VersionedUri,
     Version,
@@ -44,6 +47,9 @@ impl TryFrom<Path> for PropertyTypeQueryPath {
 #[serde(rename_all = "camelCase")]
 pub enum PropertyTypeQueryToken {
     OwnedById,
+    CreatedById,
+    UpdatedById,
+    RemovedById,
     BaseUri,
     VersionedUri,
     Version,
@@ -60,9 +66,9 @@ pub struct PropertyTypeQueryPathVisitor {
 }
 
 impl PropertyTypeQueryPathVisitor {
-    pub const EXPECTING: &'static str = "one of `ownedById`, `baseUri`, `versionedUri`, \
-                                         `version`, `title, `description`, `dataTypes`, or \
-                                         `propertyTypes`";
+    pub const EXPECTING: &'static str = "one of `ownedById`, `createdById`, `updatedById`, \
+                                         `removedById`, `baseUri`, `versionedUri`, `version`, \
+                                         `title, `description`, `dataTypes`, or `propertyTypes`";
 
     #[must_use]
     pub const fn new(position: usize) -> Self {
@@ -87,6 +93,9 @@ impl<'de> Visitor<'de> for PropertyTypeQueryPathVisitor {
         self.position += 1;
         Ok(match token {
             PropertyTypeQueryToken::OwnedById => PropertyTypeQueryPath::OwnedById,
+            PropertyTypeQueryToken::CreatedById => PropertyTypeQueryPath::CreatedById,
+            PropertyTypeQueryToken::UpdatedById => PropertyTypeQueryPath::UpdatedById,
+            PropertyTypeQueryToken::RemovedById => PropertyTypeQueryPath::RemovedById,
             PropertyTypeQueryToken::BaseUri => PropertyTypeQueryPath::BaseUri,
             PropertyTypeQueryToken::VersionedUri => PropertyTypeQueryPath::VersionedUri,
             PropertyTypeQueryToken::Version => PropertyTypeQueryPath::Version,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
@@ -17,7 +17,14 @@ impl<'q> PostgresQueryRecord<'q> for DataType {
     }
 
     fn default_fields() -> &'q [Self::Field] {
-        &[DataTypeQueryField::Schema, DataTypeQueryField::OwnedById]
+        &[
+            DataTypeQueryField::VersionedUri,
+            DataTypeQueryField::Schema,
+            DataTypeQueryField::OwnedById,
+            DataTypeQueryField::CreatedById,
+            DataTypeQueryField::UpdatedById,
+            DataTypeQueryField::RemovedById,
+        ]
     }
 }
 
@@ -30,6 +37,9 @@ pub enum DataTypeQueryField {
     Version,
     VersionId,
     OwnedById,
+    CreatedById,
+    UpdatedById,
+    RemovedById,
     Schema,
     VersionedUri,
     Title,
@@ -43,6 +53,9 @@ impl Field for DataTypeQueryField {
             Self::BaseUri | Self::Version => TableName::TypeIds,
             Self::VersionId
             | Self::OwnedById
+            | Self::CreatedById
+            | Self::UpdatedById
+            | Self::RemovedById
             | Self::Schema
             | Self::VersionedUri
             | Self::Title
@@ -60,6 +73,15 @@ impl Field for DataTypeQueryField {
             },
             Self::OwnedById => ColumnAccess::Table {
                 column: "owned_by_id",
+            },
+            Self::CreatedById => ColumnAccess::Table {
+                column: "created_by_id",
+            },
+            Self::UpdatedById => ColumnAccess::Table {
+                column: "updated_by_id",
+            },
+            Self::RemovedById => ColumnAccess::Table {
+                column: "removed_by_id",
             },
             Self::Schema => ColumnAccess::Table { column: "schema" },
             Self::VersionedUri => ColumnAccess::Json {
@@ -90,9 +112,14 @@ impl Path for DataTypeQueryPath {
     fn terminating_table_name(&self) -> TableName {
         match self {
             Self::BaseUri | Self::Version => TableName::TypeIds,
-            Self::OwnedById | Self::VersionedUri | Self::Title | Self::Type | Self::Description => {
-                TableName::DataTypes
-            }
+            Self::OwnedById
+            | Self::CreatedById
+            | Self::UpdatedById
+            | Self::RemovedById
+            | Self::VersionedUri
+            | Self::Title
+            | Self::Type
+            | Self::Description => TableName::DataTypes,
         }
     }
 
@@ -102,6 +129,15 @@ impl Path for DataTypeQueryPath {
             Self::Version => ColumnAccess::Table { column: "version" },
             Self::OwnedById => ColumnAccess::Table {
                 column: "owned_by_id",
+            },
+            Self::CreatedById => ColumnAccess::Table {
+                column: "created_by_id",
+            },
+            Self::UpdatedById => ColumnAccess::Table {
+                column: "updated_by_id",
+            },
+            Self::RemovedById => ColumnAccess::Table {
+                column: "removed_by_id",
             },
             Self::VersionedUri => ColumnAccess::Json {
                 column: "schema",

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity_type.rs
@@ -19,7 +19,14 @@ impl<'q> PostgresQueryRecord<'q> for EntityType {
     }
 
     fn default_fields() -> &'q [Self::Field] {
-        &[EntityTypeField::Schema, EntityTypeField::OwnedById]
+        &[
+            EntityTypeField::VersionedUri,
+            EntityTypeField::Schema,
+            EntityTypeField::OwnedById,
+            EntityTypeField::CreatedById,
+            EntityTypeField::UpdatedById,
+            EntityTypeField::RemovedById,
+        ]
     }
 }
 
@@ -32,6 +39,9 @@ pub enum EntityTypeField {
     Version,
     VersionId,
     OwnedById,
+    CreatedById,
+    UpdatedById,
+    RemovedById,
     Schema,
     VersionedUri,
     Title,
@@ -50,6 +60,9 @@ impl Field for EntityTypeField {
             Self::BaseUri | Self::Version => TableName::TypeIds,
             Self::VersionId
             | Self::OwnedById
+            | Self::CreatedById
+            | Self::UpdatedById
+            | Self::RemovedById
             | Self::Schema
             | Self::VersionedUri
             | Self::Title
@@ -72,6 +85,15 @@ impl Field for EntityTypeField {
             },
             Self::OwnedById => ColumnAccess::Table {
                 column: "owned_by_id",
+            },
+            Self::CreatedById => ColumnAccess::Table {
+                column: "created_by_id",
+            },
+            Self::UpdatedById => ColumnAccess::Table {
+                column: "updated_by_id",
+            },
+            Self::RemovedById => ColumnAccess::Table {
+                column: "removed_by_id",
             },
             Self::Schema => ColumnAccess::Table { column: "schema" },
             Self::VersionedUri => ColumnAccess::Json {
@@ -131,6 +153,9 @@ impl Path for EntityTypeQueryPath {
         match self {
             Self::BaseUri | Self::Version => TableName::TypeIds,
             Self::OwnedById
+            | Self::CreatedById
+            | Self::UpdatedById
+            | Self::RemovedById
             | Self::VersionedUri
             | Self::Title
             | Self::Description
@@ -149,6 +174,15 @@ impl Path for EntityTypeQueryPath {
             Self::Version => ColumnAccess::Table { column: "version" },
             Self::OwnedById => ColumnAccess::Table {
                 column: "owned_by_id",
+            },
+            Self::CreatedById => ColumnAccess::Table {
+                column: "created_by_id",
+            },
+            Self::UpdatedById => ColumnAccess::Table {
+                column: "updated_by_id",
+            },
+            Self::RemovedById => ColumnAccess::Table {
+                column: "removed_by_id",
             },
             Self::VersionedUri => ColumnAccess::Json {
                 column: "schema",

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/link_type.rs
@@ -17,7 +17,14 @@ impl<'q> PostgresQueryRecord<'q> for LinkType {
     }
 
     fn default_fields() -> &'q [Self::Field] {
-        &[LinkTypeQueryField::Schema, LinkTypeQueryField::OwnedById]
+        &[
+            LinkTypeQueryField::VersionedUri,
+            LinkTypeQueryField::Schema,
+            LinkTypeQueryField::OwnedById,
+            LinkTypeQueryField::CreatedById,
+            LinkTypeQueryField::UpdatedById,
+            LinkTypeQueryField::RemovedById,
+        ]
     }
 }
 
@@ -30,6 +37,9 @@ pub enum LinkTypeQueryField {
     Version,
     VersionId,
     OwnedById,
+    CreatedById,
+    UpdatedById,
+    RemovedById,
     Schema,
     VersionedUri,
     Title,
@@ -43,6 +53,9 @@ impl Field for LinkTypeQueryField {
             Self::BaseUri | Self::Version => TableName::TypeIds,
             Self::VersionId
             | Self::OwnedById
+            | Self::CreatedById
+            | Self::UpdatedById
+            | Self::RemovedById
             | Self::Schema
             | Self::VersionedUri
             | Self::Title
@@ -60,6 +73,15 @@ impl Field for LinkTypeQueryField {
             },
             Self::OwnedById => ColumnAccess::Table {
                 column: "owned_by_id",
+            },
+            Self::CreatedById => ColumnAccess::Table {
+                column: "created_by_id",
+            },
+            Self::UpdatedById => ColumnAccess::Table {
+                column: "updated_by_id",
+            },
+            Self::RemovedById => ColumnAccess::Table {
+                column: "removed_by_id",
             },
             Self::Schema => ColumnAccess::Table { column: "schema" },
             Self::VersionedUri => ColumnAccess::Json {
@@ -91,6 +113,9 @@ impl Path for LinkTypeQueryPath {
         match self {
             Self::BaseUri | Self::Version => TableName::TypeIds,
             Self::OwnedById
+            | Self::CreatedById
+            | Self::UpdatedById
+            | Self::RemovedById
             | Self::VersionedUri
             | Self::Title
             | Self::Description
@@ -104,6 +129,15 @@ impl Path for LinkTypeQueryPath {
             Self::Version => ColumnAccess::Table { column: "version" },
             Self::OwnedById => ColumnAccess::Table {
                 column: "owned_by_id",
+            },
+            Self::CreatedById => ColumnAccess::Table {
+                column: "created_by_id",
+            },
+            Self::UpdatedById => ColumnAccess::Table {
+                column: "updated_by_id",
+            },
+            Self::RemovedById => ColumnAccess::Table {
+                column: "removed_by_id",
             },
             Self::VersionedUri => ColumnAccess::Json {
                 column: "schema",

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/property_type.rs
@@ -19,7 +19,14 @@ impl<'q> PostgresQueryRecord<'q> for PropertyType {
     }
 
     fn default_fields() -> &'q [Self::Field] {
-        &[PropertyTypeField::Schema, PropertyTypeField::OwnedById]
+        &[
+            PropertyTypeField::VersionedUri,
+            PropertyTypeField::Schema,
+            PropertyTypeField::OwnedById,
+            PropertyTypeField::CreatedById,
+            PropertyTypeField::UpdatedById,
+            PropertyTypeField::RemovedById,
+        ]
     }
 }
 
@@ -32,6 +39,9 @@ pub enum PropertyTypeField {
     Version,
     VersionId,
     OwnedById,
+    CreatedById,
+    UpdatedById,
+    RemovedById,
     Schema,
     VersionedUri,
     Title,
@@ -44,6 +54,9 @@ impl Field for PropertyTypeField {
             Self::BaseUri | Self::Version => TableName::TypeIds,
             Self::VersionId
             | Self::OwnedById
+            | Self::CreatedById
+            | Self::UpdatedById
+            | Self::RemovedById
             | Self::Schema
             | Self::VersionedUri
             | Self::Title
@@ -60,6 +73,15 @@ impl Field for PropertyTypeField {
             },
             Self::OwnedById => ColumnAccess::Table {
                 column: "owned_by_id",
+            },
+            Self::CreatedById => ColumnAccess::Table {
+                column: "created_by_id",
+            },
+            Self::UpdatedById => ColumnAccess::Table {
+                column: "updated_by_id",
+            },
+            Self::RemovedById => ColumnAccess::Table {
+                column: "removed_by_id",
             },
             Self::Schema => ColumnAccess::Table { column: "schema" },
             Self::VersionedUri => ColumnAccess::Json {
@@ -94,9 +116,13 @@ impl Path for PropertyTypeQueryPath {
     fn terminating_table_name(&self) -> TableName {
         match self {
             Self::BaseUri | Self::Version => TableName::TypeIds,
-            Self::OwnedById | Self::VersionedUri | Self::Title | Self::Description => {
-                TableName::PropertyTypes
-            }
+            Self::OwnedById
+            | Self::CreatedById
+            | Self::UpdatedById
+            | Self::RemovedById
+            | Self::VersionedUri
+            | Self::Title
+            | Self::Description => TableName::PropertyTypes,
             Self::DataTypes(path) => path.terminating_table_name(),
             Self::PropertyTypes(path) => path.terminating_table_name(),
         }
@@ -108,6 +134,15 @@ impl Path for PropertyTypeQueryPath {
             Self::Version => ColumnAccess::Table { column: "version" },
             Self::OwnedById => ColumnAccess::Table {
                 column: "owned_by_id",
+            },
+            Self::CreatedById => ColumnAccess::Table {
+                column: "created_by_id",
+            },
+            Self::UpdatedById => ColumnAccess::Table {
+                column: "updated_by_id",
+            },
+            Self::RemovedById => ColumnAccess::Table {
+                column: "removed_by_id",
             },
             Self::VersionedUri => ColumnAccess::Json {
                 column: "schema",

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -105,7 +105,13 @@ mod tests {
         test_compilation(
             &SelectCompiler::<DataType>::with_default_fields(),
             r#"
-            SELECT "data_types"."schema", "data_types"."owned_by_id"
+            SELECT
+                "data_types"."schema"->>'$id',
+                "data_types"."schema",
+                "data_types"."owned_by_id",
+                "data_types"."created_by_id",
+                "data_types"."updated_by_id",
+                "data_types"."removed_by_id"
             FROM "data_types"
             "#,
             &[],


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

With #1197 the provenance fields were introduced. In order to use the structural queries in the REST API, it's required, that the fields can be selected.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203007126736607/1203157447338099/f) _(internal)_

## 🚫 Blocked by

- #1223 

## 🔍 What does this change?

Adds `CreatedById`, `UpdatedById`, and `RemovedById` to query parameters