### PR TITLE
Increase `wait-on` timeout for backend in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
         if: ${{ success() || failure() }}
         run: |
           yarn dev:backend 2>&1 | tee var/logs/backend.log & ## ampersand enables background mode
-          yarn wait-on --timeout 30000 http://0.0.0.0:5001
+          yarn wait-on --timeout 60000 http://0.0.0.0:5001
 
       - name: Build and launch frontend
         if: ${{ success() || failure() }}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR helps avoid false-positive CI failures like:
- https://github.com/hashintel/hash/actions/runs/3314781921/jobs/5474512064
- https://github.com/hashintel/hash/actions/runs/3319635516/jobs/5485036060

Backend starts successfully, but may take just above 30 seconds to warm up. If `wait-on` timeout is exhausted, the whole workflow shows ❌ instead of ✅ although all tests pass.

Increasing the timeout to 60 seconds helps avoid false-positive failures. We may revisit it again later if we manage to significantly improve backend warm-up performance.

## ❓ How to test this?

- Check CI examples shared above
- Check CI results in this PR
