### PR TITLE
Use ontology queries in REST endpoints

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -25,7 +25,7 @@ use crate::{
     shared::identifier::GraphElementIdentifier,
     store::{
         error::{BaseUriAlreadyExists, BaseUriDoesNotExist},
-        query::Expression,
+        query::Filter,
         EntityTypeStore, StorePool,
     },
     subgraph::{
@@ -202,7 +202,7 @@ async fn get_entity_types_by_query<P: StorePool + Send>(
 async fn get_latest_entity_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<PersistedEntityType>>, StatusCode> {
-    read_from_store(pool.as_ref(), &Expression::for_latest_version())
+    read_from_store(pool.as_ref(), &Filter::<EntityType>::for_latest_version())
         .await
         .map(Json)
 }
@@ -226,10 +226,13 @@ async fn get_entity_type<P: StorePool + Send>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,
 ) -> Result<Json<PersistedEntityType>, StatusCode> {
-    read_from_store(pool.as_ref(), &Expression::for_versioned_uri(&uri.0))
-        .await
-        .and_then(|mut entity_types| entity_types.pop().ok_or(StatusCode::NOT_FOUND))
-        .map(Json)
+    read_from_store(
+        pool.as_ref(),
+        &Filter::<EntityType>::for_versioned_uri(&uri.0),
+    )
+    .await
+    .and_then(|mut entity_types| entity_types.pop().ok_or(StatusCode::NOT_FOUND))
+    .map(Json)
 }
 
 #[derive(ToSchema, Serialize, Deserialize)]

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -24,9 +24,7 @@ use crate::{
     },
     provenance::{CreatedById, OwnedById, UpdatedById},
     shared::identifier::GraphElementIdentifier,
-    store::{
-        query::Expression, BaseUriAlreadyExists, BaseUriDoesNotExist, LinkTypeStore, StorePool,
-    },
+    store::{query::Filter, BaseUriAlreadyExists, BaseUriDoesNotExist, LinkTypeStore, StorePool},
     subgraph::{
         EdgeKind, Edges, GraphResolveDepths, OutwardEdge, StructuralQuery, Subgraph, Vertex,
     },
@@ -196,7 +194,7 @@ async fn get_link_types_by_query<P: StorePool + Send>(
 async fn get_latest_link_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<PersistedLinkType>>, StatusCode> {
-    read_from_store(pool.as_ref(), &Expression::for_latest_version())
+    read_from_store(pool.as_ref(), &Filter::<LinkType>::for_latest_version())
         .await
         .map(Json)
 }
@@ -220,10 +218,13 @@ async fn get_link_type<P: StorePool + Send>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,
 ) -> Result<Json<PersistedLinkType>, StatusCode> {
-    read_from_store(pool.as_ref(), &Expression::for_versioned_uri(&uri.0))
-        .await
-        .and_then(|mut data_types| data_types.pop().ok_or(StatusCode::NOT_FOUND))
-        .map(Json)
+    read_from_store(
+        pool.as_ref(),
+        &Filter::<LinkType>::for_versioned_uri(&uri.0),
+    )
+    .await
+    .and_then(|mut data_types| data_types.pop().ok_or(StatusCode::NOT_FOUND))
+    .map(Json)
 }
 
 #[derive(ToSchema, Serialize, Deserialize)]

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
@@ -79,9 +79,9 @@ fn report_to_status_code<C>(report: &Report<C>) -> StatusCode {
     status_code
 }
 
-async fn read_from_store<'pool, P, T>(
+async fn read_from_store<'pool, 'q, P, T>(
     pool: &'pool P,
-    query: &<P::Store<'pool> as Read<T>>::Query<'_>,
+    query: &'q <P::Store<'pool> as Read<T>>::Query<'q>,
 ) -> Result<Vec<T>, StatusCode>
 where
     P: StorePool<Store<'pool>: Read<T>>,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -25,7 +25,7 @@ use crate::{
     provenance::{CreatedById, OwnedById, UpdatedById},
     shared::identifier::GraphElementIdentifier,
     store::{
-        query::Expression, BaseUriAlreadyExists, BaseUriDoesNotExist, PropertyTypeStore, StorePool,
+        query::Filter, BaseUriAlreadyExists, BaseUriDoesNotExist, PropertyTypeStore, StorePool,
     },
     subgraph::{
         EdgeKind, Edges, GraphResolveDepths, OutwardEdge, StructuralQuery, Subgraph, Vertex,
@@ -205,7 +205,7 @@ where
 async fn get_latest_property_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<PersistedPropertyType>>, StatusCode> {
-    read_from_store(pool.as_ref(), &Expression::for_latest_version())
+    read_from_store(pool.as_ref(), &Filter::<PropertyType>::for_latest_version())
         .await
         .map(Json)
 }
@@ -229,10 +229,13 @@ async fn get_property_type<P: StorePool + Send>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,
 ) -> Result<Json<PersistedPropertyType>, StatusCode> {
-    read_from_store(pool.as_ref(), &Expression::for_versioned_uri(&uri.0))
-        .await
-        .and_then(|mut property_types| property_types.pop().ok_or(StatusCode::NOT_FOUND))
-        .map(Json)
+    read_from_store(
+        pool.as_ref(),
+        &Filter::<PropertyType>::for_versioned_uri(&uri.0),
+    )
+    .await
+    .and_then(|mut property_types| property_types.pop().ok_or(StatusCode::NOT_FOUND))
+    .map(Json)
 }
 
 #[derive(ToSchema, Serialize, Deserialize)]

--- a/packages/graph/hash_graph/lib/graph/src/store/crud.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/crud.rs
@@ -21,6 +21,7 @@ use crate::store::QueryError;
 #[async_trait]
 pub trait Read<T: Send>: Sync {
     // TODO: Implement `Valuable` for queries and use them directly
+    //   see https://docs.rs/valuable/latest/valuable/trait.Valuable.html
     type Query<'q>: Debug + Sync;
 
     // TODO: Return a stream of `T` instead
@@ -28,7 +29,7 @@ pub trait Read<T: Send>: Sync {
     /// Returns a value from the [`Store`] specified by the passed `query`.
     ///
     /// [`Store`]: crate::store::Store
-    async fn read<'query>(&self, query: &Self::Query<'query>) -> Result<Vec<T>, QueryError>;
+    async fn read<'f: 'q, 'q>(&self, query: &'f Self::Query<'q>) -> Result<Vec<T>, QueryError>;
 
     // TODO: Consider adding additional methods, which defaults to `read` e.g. reading exactly one
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -27,7 +27,10 @@ use crate::{
         PersistedPropertyType,
     },
     provenance::{CreatedById, OwnedById, RemovedById, UpdatedById},
-    store::{error::LinkRemovalError, query::Expression},
+    store::{
+        error::LinkRemovalError,
+        query::{Expression, Filter},
+    },
     subgraph::{StructuralQuery, Subgraph},
 };
 
@@ -203,7 +206,9 @@ pub trait AccountStore {
 
 /// Describes the API of a store implementation for [`DataType`]s.
 #[async_trait]
-pub trait DataTypeStore: for<'q> crud::Read<PersistedDataType, Query<'q> = Expression> {
+pub trait DataTypeStore:
+    for<'q> crud::Read<PersistedDataType, Query<'q> = Filter<'q, DataType>>
+{
     /// Creates a new [`DataType`].
     ///
     /// # Errors:
@@ -241,7 +246,7 @@ pub trait DataTypeStore: for<'q> crud::Read<PersistedDataType, Query<'q> = Expre
 /// Describes the API of a store implementation for [`PropertyType`]s.
 #[async_trait]
 pub trait PropertyTypeStore:
-    for<'q> crud::Read<PersistedPropertyType, Query<'q> = Expression>
+    for<'q> crud::Read<PersistedPropertyType, Query<'q> = Filter<'q, PropertyType>>
 {
     /// Creates a new [`PropertyType`].
     ///
@@ -279,7 +284,9 @@ pub trait PropertyTypeStore:
 
 /// Describes the API of a store implementation for [`EntityType`]s.
 #[async_trait]
-pub trait EntityTypeStore: for<'q> crud::Read<PersistedEntityType, Query<'q> = Expression> {
+pub trait EntityTypeStore:
+    for<'q> crud::Read<PersistedEntityType, Query<'q> = Filter<'q, EntityType>>
+{
     /// Creates a new [`EntityType`].
     ///
     /// # Errors:
@@ -316,7 +323,9 @@ pub trait EntityTypeStore: for<'q> crud::Read<PersistedEntityType, Query<'q> = E
 
 /// Describes the API of a store implementation for [`LinkType`]s.
 #[async_trait]
-pub trait LinkTypeStore: for<'q> crud::Read<PersistedLinkType, Query<'q> = Expression> {
+pub trait LinkTypeStore:
+    for<'q> crud::Read<PersistedLinkType, Query<'q> = Filter<'q, LinkType>>
+{
     /// Creates a new [`LinkType`].
     ///
     /// # Errors:

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -16,9 +16,9 @@ use crate::{
 impl<C: AsClient> crud::Read<PersistedEntity> for PostgresStore<C> {
     type Query<'q> = Expression;
 
-    async fn read<'query>(
+    async fn read<'f: 'q, 'q>(
         &self,
-        query: &Self::Query<'query>,
+        query: &'f Self::Query<'q>,
     ) -> Result<Vec<PersistedEntity>, QueryError> {
         // TODO: We need to work around collecting all records before filtering
         //   related: https://app.asana.com/0/1202805690238892/1202923536131158/f

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/read.rs
@@ -16,9 +16,9 @@ use crate::{
 impl<C: AsClient> crud::Read<PersistedLink> for PostgresStore<C> {
     type Query<'q> = Expression;
 
-    async fn read<'query>(
+    async fn read<'f: 'q, 'q>(
         &self,
-        query: &Self::Query<'query>,
+        query: &'f Self::Query<'q>,
     ) -> Result<Vec<PersistedLink>, QueryError> {
         // TODO: We need to work around collecting all records before filtering
         //   related: https://app.asana.com/0/1202805690238892/1202923536131158/f

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -15,6 +15,7 @@ use crate::{
     store::{
         crud::Read,
         postgres::{context::PostgresContext, DependencyContext, DependencyContextRef},
+        query::Filter,
         AsClient, InsertionError, PostgresStore, PropertyTypeStore, QueryError, UpdateError,
     },
     subgraph::{EdgeKind, GraphResolveDepths, OutwardEdge, StructuralQuery, Subgraph},
@@ -169,7 +170,9 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
             graph_resolve_depths,
         } = *query;
 
-        let subgraphs = stream::iter(Read::<PersistedPropertyType>::read(self, expression).await?)
+        let mut filter = Filter::try_from(expression.clone()).change_context(QueryError)?;
+        filter.convert_parameters().change_context(QueryError)?;
+        let subgraphs = stream::iter(Read::<PersistedPropertyType>::read(self, &filter).await?)
             .then(|property_type| async move {
                 let mut dependency_context = DependencyContext::new(graph_resolve_depths);
 

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -26,10 +26,7 @@ use graph::{
     },
     subgraph::{GraphResolveDepths, StructuralQuery, Vertex},
 };
-use tokio_postgres::{
-    types::{FromSql, ToSql},
-    NoTls, Transaction,
-};
+use tokio_postgres::{NoTls, Transaction};
 use type_system::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType};
 use uuid::Uuid;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203007126736610/1203205825668099/f) _(internal)_

## 🚫 Blocked by

- #1255 
- #1256 
- #1257

## 🔍 What does this change?

- Slightly adjusts the `Read` trait to allow capturing lifetimes
- Use `Filter` instead of `Expression` for reading ontology types
- Convert `Path` to `Filter` for get-by-query endpoints

## 📜 Does this require a change to the docs?

This is an implementation detail

## 🛡 What tests cover this?

All ontology-related tests, which are using the database, will pick this up

## ❓ How to test this?

Test out different queries for the `/query` endpoints of ontology types
