### PR TITLE
Allow specifying resolve direction on edges in compiled queries

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
@@ -1,12 +1,13 @@
-use std::{borrow::Cow, iter::once, marker::PhantomData};
+use std::{borrow::Cow, marker::PhantomData};
 
 use postgres_types::ToSql;
 
 use crate::store::{
     postgres::query::{
-        Column, ColumnAccess, Condition, EqualityOperator, Expression, Function, JoinExpression,
-        Path, PostgresQueryRecord, SelectExpression, SelectStatement, Table, TableAlias, TableName,
-        Transpile, WhereExpression, WindowStatement, WithExpression,
+        expression::EdgeJoinDirection, Column, ColumnAccess, Condition, EqualityOperator,
+        Expression, Function, JoinExpression, Path, PostgresQueryRecord, SelectExpression,
+        SelectStatement, Table, TableAlias, TableName, Transpile, WhereExpression, WindowStatement,
+        WithExpression,
     },
     query::{Filter, FilterExpression, Parameter},
 };
@@ -66,12 +67,12 @@ impl<'f: 'q, 'q, T: PostgresQueryRecord<'q>> SelectCompiler<'f, 'q, T> {
     }
 
     /// Adds a new path to the selection.
-    pub fn add_selection_path(&mut self, field: &'q T::Path<'q>) {
-        let table = self.add_join_statements(once(field.terminating_table_name()));
+    pub fn add_selection_path(&mut self, path: &'q T::Path<'q>) {
+        let table = self.add_join_statements(path.tables());
         self.statement.selects.push(SelectExpression::from_column(
             Column {
                 table,
-                access: field.column_access(),
+                access: path.column_access(),
             },
             None,
         ));
@@ -276,11 +277,16 @@ impl<'f: 'q, 'q, T: PostgresQueryRecord<'q>> SelectCompiler<'f, 'q, T> {
     ///
     /// Joining the tables attempts to deduplicate [`JoinExpression`]s. As soon as a new filter was
     /// compiled, each subsequent call will result in a new join-chain.
-    fn add_join_statements(&mut self, tables: impl IntoIterator<Item = TableName>) -> Table {
+    fn add_join_statements(
+        &mut self,
+        tables: impl IntoIterator<Item = (TableName, EdgeJoinDirection)>,
+    ) -> Table {
         let mut current_table = T::base_table();
-        for table_name in tables {
+        let mut current_edge_direction = EdgeJoinDirection::SourceOnTarget;
+        for (table_name, edge_direction) in tables {
             if table_name == T::base_table().name && self.artifacts.current_alias.chain_depth == 0 {
                 // Avoid joining the same initial table
+                current_edge_direction = edge_direction;
                 continue;
             }
 
@@ -289,7 +295,7 @@ impl<'f: 'q, 'q, T: PostgresQueryRecord<'q>> SelectCompiler<'f, 'q, T> {
                 alias: Some(self.artifacts.current_alias),
             };
 
-            let join = JoinExpression::from_tables(table, current_table);
+            let join = JoinExpression::from_tables(table, current_table, current_edge_direction);
 
             if let Some(join_statement) = self
                 .statement
@@ -297,12 +303,12 @@ impl<'f: 'q, 'q, T: PostgresQueryRecord<'q>> SelectCompiler<'f, 'q, T> {
                 .iter()
                 .find(|existing| **existing == join)
             {
-                current_table = join_statement.table;
+                current_table = join_statement.join;
             } else {
                 self.statement.joins.push(join);
                 current_table = table;
             }
-
+            current_edge_direction = edge_direction;
             self.artifacts.current_alias.chain_depth += 1;
         }
         self.artifacts.current_alias.chain_depth = 0;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
@@ -3,7 +3,9 @@ use type_system::DataType;
 
 use crate::{
     ontology::DataTypeQueryPath,
-    store::postgres::query::{ColumnAccess, Path, PostgresQueryRecord, Table, TableName},
+    store::postgres::query::{
+        expression::EdgeJoinDirection, ColumnAccess, Path, PostgresQueryRecord, Table, TableName,
+    },
 };
 
 impl<'q> PostgresQueryRecord<'q> for DataType {
@@ -27,8 +29,11 @@ impl<'q> PostgresQueryRecord<'q> for DataType {
 }
 
 impl Path for DataTypeQueryPath {
-    fn tables(&self) -> Vec<TableName> {
-        vec![self.terminating_table_name()]
+    fn tables(&self) -> Vec<(TableName, EdgeJoinDirection)> {
+        vec![(
+            self.terminating_table_name(),
+            EdgeJoinDirection::SourceOnTarget,
+        )]
     }
 
     fn terminating_table_name(&self) -> TableName {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity_type.rs
@@ -5,7 +5,9 @@ use type_system::EntityType;
 
 use crate::{
     ontology::EntityTypeQueryPath,
-    store::postgres::query::{ColumnAccess, Path, PostgresQueryRecord, Table, TableName},
+    store::postgres::query::{
+        expression::EdgeJoinDirection, ColumnAccess, Path, PostgresQueryRecord, Table, TableName,
+    },
 };
 
 impl<'q> PostgresQueryRecord<'q> for EntityType {
@@ -29,15 +31,24 @@ impl<'q> PostgresQueryRecord<'q> for EntityType {
 }
 
 impl Path for EntityTypeQueryPath {
-    fn tables(&self) -> Vec<TableName> {
+    fn tables(&self) -> Vec<(TableName, EdgeJoinDirection)> {
         match self {
-            Self::Properties(path) => once(TableName::EntityTypePropertyTypeReferences)
-                .chain(path.tables())
-                .collect(),
-            Self::Links(path) => once(TableName::EntityTypeLinkTypeReferences)
-                .chain(path.tables())
-                .collect(),
-            _ => vec![self.terminating_table_name()],
+            Self::Properties(path) => once((
+                TableName::EntityTypePropertyTypeReferences,
+                EdgeJoinDirection::SourceOnTarget,
+            ))
+            .chain(path.tables())
+            .collect(),
+            Self::Links(path) => once((
+                TableName::EntityTypeLinkTypeReferences,
+                EdgeJoinDirection::SourceOnTarget,
+            ))
+            .chain(path.tables())
+            .collect(),
+            _ => vec![(
+                self.terminating_table_name(),
+                EdgeJoinDirection::SourceOnTarget,
+            )],
         }
     }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
@@ -7,12 +7,11 @@ pub struct JoinExpression<'q> {
     pub join: Table,
     pub on: Condition<'q>,
 }
-
-/// The direction of how joining happens.
+/// The order in which to join the tables.
 ///
-/// When joining a table, typically, this happens from mapping the source field to the target field.
-/// In some circumstances, for example when resolving a link by it's incoming links, this direction
-/// is reversed.
+/// Typically, when dealing with paths we join from left to right as we encounter elements. In some
+/// circumstances, the direction we join upon is actually reversed, for example with incoming links,
+/// where we want to use the subject (left element) _as_ the target.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum EdgeJoinDirection {
     SourceOnTarget,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
@@ -4,19 +4,38 @@ use crate::store::postgres::query::{Condition, Expression, Table, Transpile};
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct JoinExpression<'q> {
-    pub table: Table,
+    pub join: Table,
     pub on: Condition<'q>,
+}
+
+/// The direction of how joining happens.
+///
+/// When joining a table, typically, this happens from mapping the source field to the target field.
+/// In some circumstances, for example when resolving a link by it's incoming links, this direction
+/// is reversed.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum EdgeJoinDirection {
+    SourceOnTarget,
+    TargetOnSource,
 }
 
 impl<'q> JoinExpression<'q> {
     #[must_use]
-    pub const fn from_tables(table: Table, on: Table) -> Self {
-        Self {
-            table,
-            on: Condition::Equal(
-                Some(Expression::Column(table.source_join_column())),
+    pub const fn from_tables(join: Table, on: Table, direction: EdgeJoinDirection) -> Self {
+        let condition = match direction {
+            EdgeJoinDirection::SourceOnTarget => Condition::Equal(
+                Some(Expression::Column(join.source_join_column())),
                 Some(Expression::Column(on.target_join_column())),
             ),
+            EdgeJoinDirection::TargetOnSource => Condition::Equal(
+                Some(Expression::Column(join.target_join_column())),
+                Some(Expression::Column(on.source_join_column())),
+            ),
+        };
+
+        Self {
+            join,
+            on: condition,
         }
     }
 }
@@ -24,15 +43,15 @@ impl<'q> JoinExpression<'q> {
 impl Transpile for JoinExpression<'_> {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("JOIN ")?;
-        if self.table.alias.is_some() {
+        if self.join.alias.is_some() {
             let unaliased_table = Table {
-                name: self.table.name,
+                name: self.join.name,
                 alias: None,
             };
             unaliased_table.transpile(fmt)?;
             fmt.write_str(" AS ")?;
         }
-        self.table.transpile(fmt)?;
+        self.join.transpile(fmt)?;
 
         fmt.write_str(" ON ")?;
         self.on.transpile(fmt)
@@ -56,6 +75,7 @@ mod tests {
                     name: TableName::DataTypes,
                     alias: None
                 },
+                EdgeJoinDirection::SourceOnTarget,
             )
             .transpile_to_string(),
             r#"JOIN "type_ids" ON "type_ids"."version_id" = "data_types"."version_id""#
@@ -74,6 +94,7 @@ mod tests {
                     name: TableName::DataTypes,
                     alias: None
                 },
+                EdgeJoinDirection::SourceOnTarget,
             )
             .transpile_to_string(),
             r#"JOIN "type_ids" AS "type_ids_0_1" ON "type_ids_0_1"."version_id" = "data_types"."version_id""#
@@ -92,6 +113,7 @@ mod tests {
                         chain_depth: 0
                     })
                 },
+                EdgeJoinDirection::SourceOnTarget,
             )
             .transpile_to_string(),
             r#"JOIN "type_ids" ON "type_ids"."version_id" = "data_types_0_0"."version_id""#
@@ -113,6 +135,7 @@ mod tests {
                         chain_depth: 0
                     })
                 },
+                EdgeJoinDirection::SourceOnTarget,
             )
             .transpile_to_string(),
             r#"JOIN "type_ids" AS "type_ids_0_1" ON "type_ids_0_1"."version_id" = "data_types_0_0"."version_id""#

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/mod.rs
@@ -6,7 +6,7 @@ mod with_clause;
 
 pub use self::{
     conditional::{Expression, Function},
-    join_clause::JoinExpression,
+    join_clause::{EdgeJoinDirection, JoinExpression},
     select_clause::SelectExpression,
     where_clause::WhereExpression,
     with_clause::{CommonTableExpression, WithExpression},

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/link_type.rs
@@ -3,7 +3,9 @@ use type_system::LinkType;
 
 use crate::{
     ontology::LinkTypeQueryPath,
-    store::postgres::query::{ColumnAccess, Path, PostgresQueryRecord, Table, TableName},
+    store::postgres::query::{
+        expression::EdgeJoinDirection, ColumnAccess, Path, PostgresQueryRecord, Table, TableName,
+    },
 };
 
 impl<'q> PostgresQueryRecord<'q> for LinkType {
@@ -27,8 +29,11 @@ impl<'q> PostgresQueryRecord<'q> for LinkType {
 }
 
 impl Path for LinkTypeQueryPath {
-    fn tables(&self) -> Vec<TableName> {
-        vec![self.terminating_table_name()]
+    fn tables(&self) -> Vec<(TableName, EdgeJoinDirection)> {
+        vec![(
+            self.terminating_table_name(),
+            EdgeJoinDirection::SourceOnTarget,
+        )]
     }
 
     fn terminating_table_name(&self) -> TableName {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
@@ -26,7 +26,7 @@ pub use self::{
     statement::{SelectStatement, Statement, WindowStatement},
     table::{Column, ColumnAccess, Table, TableAlias, TableName},
 };
-use crate::store::query::QueryRecord;
+use crate::store::{postgres::query::expression::EdgeJoinDirection, query::QueryRecord};
 
 pub trait PostgresQueryRecord<'q>: QueryRecord<Path<'q>: Path> {
     /// The [`Table`] used for this `Query`.
@@ -39,7 +39,7 @@ pub trait PostgresQueryRecord<'q>: QueryRecord<Path<'q>: Path> {
 /// An absolute path inside of a query pointing to an attribute.
 pub trait Path {
     /// Returns a list of [`TableName`]s required to traverse this path.
-    fn tables(&self) -> Vec<TableName>;
+    fn tables(&self) -> Vec<(TableName, EdgeJoinDirection)>;
 
     /// The [`TableName`] that marks the end of the path.
     fn terminating_table_name(&self) -> TableName;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/property_type.rs
@@ -5,7 +5,9 @@ use type_system::PropertyType;
 
 use crate::{
     ontology::PropertyTypeQueryPath,
-    store::postgres::query::{ColumnAccess, Path, PostgresQueryRecord, Table, TableName},
+    store::postgres::query::{
+        expression::EdgeJoinDirection, ColumnAccess, Path, PostgresQueryRecord, Table, TableName,
+    },
 };
 
 impl<'q> PostgresQueryRecord<'q> for PropertyType {
@@ -29,15 +31,24 @@ impl<'q> PostgresQueryRecord<'q> for PropertyType {
 }
 
 impl Path for PropertyTypeQueryPath {
-    fn tables(&self) -> Vec<TableName> {
+    fn tables(&self) -> Vec<(TableName, EdgeJoinDirection)> {
         match self {
-            Self::DataTypes(path) => once(TableName::PropertyTypeDataTypeReferences)
-                .chain(path.tables())
-                .collect(),
-            Self::PropertyTypes(path) => once(TableName::PropertyTypePropertyTypeReferences)
-                .chain(path.tables())
-                .collect(),
-            _ => vec![self.terminating_table_name()],
+            Self::DataTypes(path) => once((
+                TableName::PropertyTypeDataTypeReferences,
+                EdgeJoinDirection::SourceOnTarget,
+            ))
+            .chain(path.tables())
+            .collect(),
+            Self::PropertyTypes(path) => once((
+                TableName::PropertyTypePropertyTypeReferences,
+                EdgeJoinDirection::SourceOnTarget,
+            ))
+            .chain(path.tables())
+            .collect(),
+            _ => vec![(
+                self.terminating_table_name(),
+                EdgeJoinDirection::SourceOnTarget,
+            )],
         }
     }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

For `Links` (and also other edge types later on), we allow resolving in both directions, from source to target and from target to source.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- preparation for [this Asana task](https://app.asana.com/0/0/1203157447338108/f) _(internal)_

## 🚫 Blocked by

- #1255 
- #1259

## 🔍 What does this change?

- Adds an enumeration for determining the join direction
- Allow joining in both direction specified by the `Path`