### PR TITLE
Add representation for `Link` and linked entities

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
@@ -4,7 +4,7 @@ use error_stack::Report;
 use serde::de;
 
 use crate::{
-    knowledge::Entity,
+    knowledge::{Entity, LinkQueryPath},
     ontology::EntityTypeQueryPath,
     store::query::{ParameterType, Path, QueryRecord, RecordPath},
 };
@@ -19,6 +19,8 @@ pub enum EntityQueryPath<'q> {
     Version,
     Type(EntityTypeQueryPath),
     Properties(Option<Cow<'q, str>>),
+    IncomingLinks(Box<LinkQueryPath<'q>>),
+    OutgoingLinks(Box<LinkQueryPath<'q>>),
 }
 
 impl QueryRecord for Entity {
@@ -37,6 +39,8 @@ impl fmt::Display for EntityQueryPath<'_> {
             Self::Type(path) => write!(fmt, "type.{path}"),
             Self::Properties(Some(property)) => write!(fmt, "properties.{property}"),
             Self::Properties(None) => fmt.write_str("properties"),
+            Self::IncomingLinks(link) => write!(fmt, "incomingLinks.{link}"),
+            Self::OutgoingLinks(link) => write!(fmt, "outgoingLinks.{link}"),
         }
     }
 }
@@ -51,6 +55,7 @@ impl RecordPath for EntityQueryPath<'_> {
             Self::Version => ParameterType::Timestamp,
             Self::Type(path) => path.expected_type(),
             Self::Properties(_) => ParameterType::Any,
+            Self::IncomingLinks(path) | Self::OutgoingLinks(path) => path.expected_type(),
         }
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/link/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/link/mod.rs
@@ -1,9 +1,12 @@
+mod query;
+
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
 use type_system::uri::VersionedUri;
 use utoipa::ToSchema;
 
+pub use self::query::LinkQueryPath;
 use super::EntityId;
 use crate::provenance::{CreatedById, OwnedById};
 

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/link/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/link/query.rs
@@ -1,0 +1,60 @@
+use std::fmt;
+
+use error_stack::Report;
+use serde::de;
+
+use crate::{
+    knowledge::{entity::EntityQueryPath, Link},
+    ontology::LinkTypeQueryPath,
+    store::query::{ParameterType, Path, QueryRecord, RecordPath},
+};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum LinkQueryPath<'q> {
+    OwnedById,
+    CreatedById,
+    Type(LinkTypeQueryPath),
+    Source(Option<EntityQueryPath<'q>>),
+    Target(Option<EntityQueryPath<'q>>),
+    Index,
+}
+
+impl QueryRecord for Link {
+    type Path<'q> = LinkQueryPath<'q>;
+}
+
+impl fmt::Display for LinkQueryPath<'_> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::OwnedById => fmt.write_str("ownedById"),
+            Self::CreatedById => fmt.write_str("createdById"),
+            Self::Type(path) => write!(fmt, "type.{path}"),
+            Self::Source(None) => fmt.write_str("source"),
+            Self::Source(Some(path)) => write!(fmt, "source.{path}"),
+            Self::Target(None) => fmt.write_str("target"),
+            Self::Target(Some(path)) => write!(fmt, "target.{path}"),
+            Self::Index => fmt.write_str("index"),
+        }
+    }
+}
+
+impl RecordPath for LinkQueryPath<'_> {
+    fn expected_type(&self) -> ParameterType {
+        match self {
+            Self::OwnedById | Self::CreatedById | Self::Source(None) | Self::Target(None) => {
+                ParameterType::Uuid
+            }
+            Self::Type(path) => path.expected_type(),
+            Self::Source(Some(path)) | Self::Target(Some(path)) => path.expected_type(),
+            Self::Index => ParameterType::Number,
+        }
+    }
+}
+
+impl<'q> TryFrom<Path> for LinkQueryPath<'q> {
+    type Error = Report<de::value::Error>;
+
+    fn try_from(_path: Path) -> Result<Self, Self::Error> {
+        todo!("https://app.asana.com/0/0/1203167266370359/f")
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/mod.rs
@@ -12,7 +12,7 @@ pub use self::{
         Entity, EntityId, EntityQueryPath, PersistedEntity, PersistedEntityIdentifier,
         PersistedEntityMetadata,
     },
-    link::{Link, PersistedLink, PersistedLinkMetadata},
+    link::{Link, LinkQueryPath, PersistedLink, PersistedLinkMetadata},
 };
 use crate::ontology::{
     PersistedDataType, PersistedEntityType, PersistedLinkType, PersistedPropertyType,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity.rs
@@ -35,6 +35,16 @@ impl Path for EntityQueryPath<'_> {
             Self::Type(path) => once((TableName::Entities, EdgeJoinDirection::SourceOnTarget))
                 .chain(path.tables())
                 .collect(),
+            Self::OutgoingLinks(path) => {
+                once((TableName::Entities, EdgeJoinDirection::SourceOnTarget))
+                    .chain(path.tables())
+                    .collect()
+            }
+            Self::IncomingLinks(path) => {
+                once((TableName::Entities, EdgeJoinDirection::TargetOnSource))
+                    .chain(path.tables())
+                    .collect()
+            }
             _ => vec![(
                 self.terminating_table_name(),
                 EdgeJoinDirection::SourceOnTarget,
@@ -52,6 +62,7 @@ impl Path for EntityQueryPath<'_> {
             | Self::Version
             | Self::Properties(_) => TableName::Entities,
             Self::Type(path) => path.terminating_table_name(),
+            Self::IncomingLinks(path) | Self::OutgoingLinks(path) => path.terminating_table_name(),
         }
     }
 
@@ -83,6 +94,7 @@ impl Path for EntityQueryPath<'_> {
                     field: path.as_ref(),
                 },
             ),
+            Self::IncomingLinks(path) | Self::OutgoingLinks(path) => path.column_access(),
         }
     }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
@@ -53,6 +53,34 @@ impl<'q> JoinExpression<'q> {
                     ),
                 };
             }
+            (TableName::Links, TableName::LinkTypes | TableName::TypeIds) => {
+                return Self {
+                    join,
+                    on: Condition::Equal(
+                        Some(Expression::Column(Column {
+                            table: join,
+                            access: ColumnAccess::Table {
+                                column: "link_type_version_id",
+                            },
+                        })),
+                        Some(Expression::Column(on.target_join_column())),
+                    ),
+                };
+            }
+            (TableName::LinkTypes | TableName::TypeIds, TableName::Links) => {
+                return Self {
+                    join,
+                    on: Condition::Equal(
+                        Some(Expression::Column(join.source_join_column())),
+                        Some(Expression::Column(Column {
+                            table: on,
+                            access: ColumnAccess::Table {
+                                column: "link_type_version_id",
+                            },
+                        })),
+                    ),
+                };
+            }
             _ => {}
         }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/link.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/link.rs
@@ -1,0 +1,91 @@
+use std::iter::once;
+
+use postgres_types::ToSql;
+
+use crate::{
+    knowledge::{Link, LinkQueryPath},
+    ontology::LinkTypeQueryPath,
+    store::postgres::query::{
+        expression::EdgeJoinDirection, ColumnAccess, Path, PostgresQueryRecord, Table, TableName,
+    },
+};
+
+impl<'q> PostgresQueryRecord<'q> for Link {
+    fn base_table() -> Table {
+        Table {
+            name: TableName::Links,
+            alias: None,
+        }
+    }
+
+    fn default_selection_paths() -> &'q [Self::Path<'q>] {
+        &[
+            LinkQueryPath::Type(LinkTypeQueryPath::VersionedUri),
+            LinkQueryPath::Source(None),
+            LinkQueryPath::Target(None),
+            LinkQueryPath::Index,
+            LinkQueryPath::OwnedById,
+            LinkQueryPath::CreatedById,
+        ]
+    }
+}
+
+impl Path for LinkQueryPath<'_> {
+    fn tables(&self) -> Vec<(TableName, EdgeJoinDirection)> {
+        match self {
+            Self::OwnedById | Self::CreatedById | Self::Index | Self::Target(None) => {
+                vec![(TableName::Links, EdgeJoinDirection::SourceOnTarget)]
+            }
+            Self::Type(path) => once((TableName::Links, EdgeJoinDirection::SourceOnTarget))
+                .chain(path.tables())
+                .collect(),
+            Self::Source(Some(path)) => once((TableName::Links, EdgeJoinDirection::TargetOnSource))
+                .chain(path.tables())
+                .collect(),
+            Self::Source(None) => {
+                vec![(TableName::Links, EdgeJoinDirection::TargetOnSource)]
+            }
+            Self::Target(Some(path)) => once((TableName::Links, EdgeJoinDirection::SourceOnTarget))
+                .chain(path.tables())
+                .collect(),
+        }
+    }
+
+    fn terminating_table_name(&self) -> TableName {
+        match self {
+            Self::OwnedById
+            | Self::CreatedById
+            | Self::Index
+            | Self::Source(None)
+            | Self::Target(None) => TableName::Links,
+            Self::Type(path) => path.terminating_table_name(),
+            Self::Source(Some(path)) | Self::Target(Some(path)) => path.terminating_table_name(),
+        }
+    }
+
+    fn column_access(&self) -> ColumnAccess {
+        match self {
+            Self::OwnedById => ColumnAccess::Table {
+                column: "owned_by_id",
+            },
+            Self::CreatedById => ColumnAccess::Table {
+                column: "created_by_id",
+            },
+            Self::Type(path) => path.column_access(),
+            Self::Source(Some(path)) | Self::Target(Some(path)) => path.column_access(),
+            Self::Index => ColumnAccess::Table {
+                column: "link_index",
+            },
+            Self::Source(None) => ColumnAccess::Table {
+                column: "source_entity_id",
+            },
+            Self::Target(None) => ColumnAccess::Table {
+                column: "target_entity_id",
+            },
+        }
+    }
+
+    fn user_provided_path(&self) -> Option<&(dyn ToSql + Sync)> {
+        None
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
@@ -8,6 +8,7 @@ mod data_type;
 mod entity;
 mod entity_type;
 mod expression;
+mod link;
 mod link_type;
 mod property_type;
 mod statement;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
@@ -14,6 +14,7 @@ pub enum TableName {
     EntityTypes,
     LinkTypes,
     Entities,
+    Links,
     PropertyTypeDataTypeReferences,
     PropertyTypePropertyTypeReferences,
     EntityTypePropertyTypeReferences,
@@ -30,6 +31,7 @@ impl TableName {
                 | Self::EntityTypes
                 | Self::LinkTypes => "version_id",
                 Self::Entities => "entity_id",
+                Self::Links => "source_entity_id",
                 Self::PropertyTypeDataTypeReferences | Self::PropertyTypePropertyTypeReferences => {
                     "source_property_type_version_id"
                 }
@@ -50,6 +52,7 @@ impl TableName {
                 | Self::EntityTypes
                 | Self::LinkTypes => "version_id",
                 Self::Entities => "entity_id",
+                Self::Links => "target_entity_id",
                 Self::PropertyTypeDataTypeReferences => "target_data_type_version_id",
                 Self::PropertyTypePropertyTypeReferences
                 | Self::EntityTypePropertyTypeReferences => "target_property_type_version_id",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Similar to the `Entity` representation, this adds the representation for `Link`s

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203007126736607/1203157447338099/f) (_internal_)
- [Asana task for links](https://app.asana.com/0/1203007126736610/1203157447338108/f) _(internal)_
- [Asana task for linked entities](https://app.asana.com/0/1203007126736610/1203157447338109/f) _(internal)_

## 🚫 Blocked by

- #1255
- #1259 
- #1267
- #1268

## 🔍 What does this change?

- Add representation for `Link`s without deserialization (follow-up)
- Implement common query traits on `Link` and `LinkQueryPath`
- Special case `Link <-> LinkType` joins
- Add test cases to cover the above
- Add tests for linked entities

## 🛡 What tests cover this?

- A bunch of tests were added to cover the cases of entities