### PR TITLE
Allow ordering by path of query results

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/mod.rs
@@ -1,5 +1,6 @@
 mod conditional;
 mod join_clause;
+mod order_clause;
 mod select_clause;
 mod where_clause;
 mod with_clause;
@@ -7,6 +8,7 @@ mod with_clause;
 pub use self::{
     conditional::{Expression, Function},
     join_clause::{EdgeJoinDirection, JoinExpression},
+    order_clause::{OrderByExpression, Ordering},
     select_clause::SelectExpression,
     where_clause::WhereExpression,
     with_clause::{CommonTableExpression, WithExpression},

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/order_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/order_clause.rs
@@ -1,0 +1,107 @@
+use std::fmt;
+
+use crate::store::postgres::query::{Column, Transpile};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum Ordering {
+    Ascending,
+    Descending,
+}
+
+#[derive(Debug, Default, PartialEq, Eq, Hash)]
+pub struct OrderByExpression<'q> {
+    columns: Vec<(Column<'q>, Ordering)>,
+}
+
+impl<'q> OrderByExpression<'q> {
+    pub fn push(&mut self, column: Column<'q>, ordering: Ordering) {
+        self.columns.push((column, ordering));
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.columns.is_empty()
+    }
+}
+
+impl Transpile for OrderByExpression<'_> {
+    fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        if self.columns.is_empty() {
+            return Ok(());
+        }
+
+        fmt.write_str("ORDER BY ")?;
+        for (idx, (column, ordering)) in self.columns.iter().enumerate() {
+            column.transpile(fmt)?;
+            match ordering {
+                Ordering::Ascending => write!(fmt, " ASC")?,
+                Ordering::Descending => write!(fmt, " DESC")?,
+            }
+            if idx + 1 < self.columns.len() {
+                fmt.write_str(",\n         ")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        ontology::DataTypeQueryPath,
+        store::postgres::query::{test_helper::trim_whitespace, Path, Table},
+    };
+
+    #[test]
+    fn order_one() {
+        let mut order_by_expression = OrderByExpression::default();
+        order_by_expression.push(
+            Column {
+                table: Table {
+                    name: DataTypeQueryPath::Version.terminating_table_name(),
+                    alias: None,
+                },
+                access: DataTypeQueryPath::Version.column_access(),
+            },
+            Ordering::Ascending,
+        );
+        assert_eq!(
+            order_by_expression.transpile_to_string(),
+            r#"ORDER BY "type_ids"."version" ASC"#
+        );
+    }
+
+    #[test]
+    fn order_multiple() {
+        let mut order_by_expression = OrderByExpression::default();
+        order_by_expression.push(
+            Column {
+                table: Table {
+                    name: DataTypeQueryPath::BaseUri.terminating_table_name(),
+                    alias: None,
+                },
+                access: DataTypeQueryPath::BaseUri.column_access(),
+            },
+            Ordering::Ascending,
+        );
+        order_by_expression.push(
+            Column {
+                table: Table {
+                    name: DataTypeQueryPath::Type.terminating_table_name(),
+                    alias: None,
+                },
+                access: DataTypeQueryPath::Type.column_access(),
+            },
+            Ordering::Descending,
+        );
+
+        assert_eq!(
+            trim_whitespace(order_by_expression.transpile_to_string()),
+            trim_whitespace(
+                r#"ORDER BY "type_ids"."base_uri" ASC,
+                "data_types"."schema"->>'type' DESC"#
+            )
+        );
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/with_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/with_clause.rs
@@ -62,6 +62,7 @@ mod tests {
     use crate::{
         ontology::DataTypeQueryPath,
         store::postgres::query::{
+            expression::OrderByExpression,
             test_helper::{max_version_expression, trim_whitespace},
             Expression, Path, SelectExpression, SelectStatement, Table, TableName, WhereExpression,
         },
@@ -88,6 +89,7 @@ mod tests {
             },
             joins: vec![],
             where_expression: WhereExpression::default(),
+            order_by_expression: OrderByExpression::default(),
         });
 
         assert_eq!(
@@ -108,6 +110,7 @@ mod tests {
             },
             joins: vec![],
             where_expression: WhereExpression::default(),
+            order_by_expression: OrderByExpression::default(),
         });
 
         assert_eq!(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
@@ -22,8 +22,8 @@ pub use self::{
     compile::SelectCompiler,
     condition::{Condition, EqualityOperator},
     expression::{
-        CommonTableExpression, Expression, Function, JoinExpression, SelectExpression,
-        WhereExpression, WithExpression,
+        CommonTableExpression, Expression, Function, JoinExpression, OrderByExpression, Ordering,
+        SelectExpression, WhereExpression, WithExpression,
     },
     statement::{SelectStatement, Statement, WindowStatement},
     table::{Column, ColumnAccess, Table, TableAlias, TableName},

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -1,7 +1,8 @@
 use std::fmt::{self, Write};
 
 use crate::store::postgres::query::{
-    JoinExpression, SelectExpression, Table, Transpile, WhereExpression, WithExpression,
+    expression::OrderByExpression, JoinExpression, SelectExpression, Table, Transpile,
+    WhereExpression, WithExpression,
 };
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -12,6 +13,7 @@ pub struct SelectStatement<'q> {
     pub from: Table,
     pub joins: Vec<JoinExpression<'q>>,
     pub where_expression: WhereExpression<'q>,
+    pub order_by_expression: OrderByExpression<'q>,
 }
 
 impl Transpile for SelectStatement<'_> {
@@ -44,6 +46,11 @@ impl Transpile for SelectStatement<'_> {
         if !self.where_expression.is_empty() {
             fmt.write_char('\n')?;
             self.where_expression.transpile(fmt)?;
+        }
+
+        if !self.order_by_expression.is_empty() {
+            fmt.write_char('\n')?;
+            self.order_by_expression.transpile(fmt)?;
         }
 
         Ok(())


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

For some endpoints we currently guarantee a specific ordering (e.g. for links). 

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203007126736610/1203157447338109/f) _(internal)_

## 🚫 Blocked by

- #1255
- #1267
- #1268
- #1269

## 🔍 What does this change?

- Adds an ordering clause 
- Allow specifying the ordering when adding a selection

## 🛡 What tests cover this?

A few tests were added to test transpiling 