### PR TITLE
Make distinct selections explicit

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
@@ -4,10 +4,10 @@ use postgres_types::ToSql;
 
 use crate::store::{
     postgres::query::{
-        Column, ColumnAccess, Condition, EdgeJoinDirection, EqualityOperator, Expression, Function,
-        JoinExpression, OrderByExpression, Ordering, Path, PostgresQueryRecord, SelectExpression,
-        SelectStatement, Table, TableAlias, TableName, Transpile, WhereExpression, WindowStatement,
-        WithExpression,
+        Column, ColumnAccess, Condition, Distinctness, EdgeJoinDirection, EqualityOperator,
+        Expression, Function, JoinExpression, OrderByExpression, Ordering, Path,
+        PostgresQueryRecord, SelectExpression, SelectStatement, Table, TableAlias, TableName,
+        Transpile, WhereExpression, WindowStatement, WithExpression,
     },
     query::{Filter, FilterExpression, Parameter},
 };
@@ -52,7 +52,7 @@ impl<'f: 'q, 'q, T: PostgresQueryRecord<'q>> SelectCompiler<'f, 'q, T> {
     pub fn with_default_selection() -> Self {
         let mut default = Self::new();
         for path in T::default_selection_paths() {
-            default.add_selection_path(path, false, None);
+            default.add_selection_path(path, Distinctness::Indestinct, None);
         }
         default
     }
@@ -74,7 +74,7 @@ impl<'f: 'q, 'q, T: PostgresQueryRecord<'q>> SelectCompiler<'f, 'q, T> {
     pub fn add_selection_path(
         &mut self,
         path: &'q T::Path<'q>,
-        distinct: bool,
+        distinctness: Distinctness,
         ordering: Option<Ordering>,
     ) {
         let table = self.add_join_statements(path.tables());
@@ -82,7 +82,7 @@ impl<'f: 'q, 'q, T: PostgresQueryRecord<'q>> SelectCompiler<'f, 'q, T> {
             table,
             access: path.column_access(),
         };
-        if distinct {
+        if distinctness == Distinctness::Destinct {
             self.statement.distinct.push(column.clone());
         }
         if let Some(ordering) = ordering {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
@@ -69,8 +69,8 @@ impl<'f: 'q, 'q, T: PostgresQueryRecord<'q>> SelectCompiler<'f, 'q, T> {
 
     /// Adds a new path to the selection.
     ///
-    /// Optionally, a path can be ordered by passing an [`Ordering`] alongside the path. Also, when
-    /// `distinct` is `true`, this path will be selected distinctly.
+    /// Optionally, the added selection can be distinct or ordered by providing [`Distinctness`] and
+    /// [`Ordering`].
     pub fn add_selection_path(
         &mut self,
         path: &'q T::Path<'q>,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/with_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/with_clause.rs
@@ -75,7 +75,7 @@ mod tests {
 
         with_clause.add_statement(TableName::TypeIds, SelectStatement {
             with: WithExpression::default(),
-            distinct: false,
+            distinct: Vec::new(),
             selects: vec![
                 SelectExpression::new(Expression::Asterisk, None),
                 SelectExpression::new(
@@ -102,7 +102,7 @@ mod tests {
 
         with_clause.add_statement(TableName::DataTypes, SelectStatement {
             with: WithExpression::default(),
-            distinct: false,
+            distinct: Vec::new(),
             selects: vec![SelectExpression::new(Expression::Asterisk, None)],
             from: Table {
                 name: TableName::DataTypes,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
@@ -25,7 +25,7 @@ pub use self::{
         CommonTableExpression, EdgeJoinDirection, Expression, Function, JoinExpression,
         OrderByExpression, Ordering, SelectExpression, WhereExpression, WithExpression,
     },
-    statement::{SelectStatement, Statement, WindowStatement},
+    statement::{Distinctness, SelectStatement, Statement, WindowStatement},
     table::{Column, ColumnAccess, Table, TableAlias, TableName},
 };
 use crate::store::query::QueryRecord;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
@@ -22,13 +22,13 @@ pub use self::{
     compile::SelectCompiler,
     condition::{Condition, EqualityOperator},
     expression::{
-        CommonTableExpression, Expression, Function, JoinExpression, OrderByExpression, Ordering,
-        SelectExpression, WhereExpression, WithExpression,
+        CommonTableExpression, EdgeJoinDirection, Expression, Function, JoinExpression,
+        OrderByExpression, Ordering, SelectExpression, WhereExpression, WithExpression,
     },
     statement::{SelectStatement, Statement, WindowStatement},
     table::{Column, ColumnAccess, Table, TableAlias, TableName},
 };
-use crate::store::{postgres::query::expression::EdgeJoinDirection, query::QueryRecord};
+use crate::store::query::QueryRecord;
 
 pub trait PostgresQueryRecord<'q>: QueryRecord<Path<'q>: Path> {
     /// The [`Table`] used for this `Query`.

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/mod.rs
@@ -3,7 +3,10 @@ mod window;
 
 use std::fmt;
 
-pub use self::{select::SelectStatement, window::WindowStatement};
+pub use self::{
+    select::{Distinctness, SelectStatement},
+    window::WindowStatement,
+};
 use crate::store::postgres::query::Transpile;
 
 #[derive(Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Having an implicit `DISTINCT` statement does not cover all cases (e.g. when joining multiple links). Also, without an `ON` clause on `DISTINCT` this is error-prone.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203007126736610/1203157447338109/f) _(internal)_

## 🚫 Blocked by

- #1255
- #1267
- #1268
- #1269
- #1271

## 🔍 What does this change?

- Changes the `distinct` field to be an array of columns
- Allow specifying the `distinct` field upon adding a selection