### PR TITLE
Add deserialization support for entity queries

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
@@ -74,7 +74,7 @@ impl<'q> TryFrom<Path> for EntityQueryPath<'q> {
     }
 }
 
-/// A single token in a [`DataTypeQueryPath`].
+/// A single token in a [`EntityQueryPath`].
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum EntityQueryToken {

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
@@ -196,7 +196,7 @@ mod tests {
 
         assert_eq!(
             EntityTypeQueryPath::deserialize(
-                de::value::SeqDeserializer::<_, de::value::Error>::new(once("version_id"))
+                de::value::SeqDeserializer::<_, de::value::Error>::new(once("invalid"))
             )
             .expect_err(
                 "managed to convert entity query path with hidden token when it should have \
@@ -204,22 +204,7 @@ mod tests {
             )
             .to_string(),
             format!(
-                "unknown variant `version_id`, expected {}",
-                EntityQueryPathVisitor::EXPECTING
-            )
-        );
-
-        assert_eq!(
-            EntityTypeQueryPath::deserialize(
-                de::value::SeqDeserializer::<_, de::value::Error>::new(once("schema"))
-            )
-            .expect_err(
-                "managed to convert entity query path with hidden token when it should have \
-                 errored"
-            )
-            .to_string(),
-            format!(
-                "unknown variant `schema`, expected {}",
+                "unknown variant `invalid`, expected {}",
                 EntityQueryPathVisitor::EXPECTING
             )
         );

--- a/packages/graph/hash_graph/lib/graph/src/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/data_type.rs
@@ -182,7 +182,7 @@ mod tests {
     use std::iter::once;
 
     use super::*;
-    use crate::ontology::test_utils::create_path;
+    use crate::query::test_utils::create_path;
 
     fn convert_path(segments: impl IntoIterator<Item = &'static str>) -> DataTypeQueryPath {
         DataTypeQueryPath::try_from(create_path(segments)).expect("could not convert path")

--- a/packages/graph/hash_graph/lib/graph/src/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/data_type.rs
@@ -153,6 +153,7 @@ impl<'de> Visitor<'de> for DataTypeQueryPathVisitor {
             .next_element()?
             .ok_or_else(|| de::Error::invalid_length(self.position, &self))?;
         self.position += 1;
+
         Ok(match token {
             DataTypeQueryToken::OwnedById => DataTypeQueryPath::OwnedById,
             DataTypeQueryToken::CreatedById => DataTypeQueryPath::CreatedById,

--- a/packages/graph/hash_graph/lib/graph/src/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/entity_type.rs
@@ -224,7 +224,7 @@ mod tests {
     use std::iter::once;
 
     use super::*;
-    use crate::ontology::test_utils::create_path;
+    use crate::query::test_utils::create_path;
 
     fn convert_path(segments: impl IntoIterator<Item = &'static str>) -> EntityTypeQueryPath {
         EntityTypeQueryPath::try_from(create_path(segments)).expect("could not convert path")

--- a/packages/graph/hash_graph/lib/graph/src/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/entity_type.rs
@@ -172,6 +172,7 @@ impl<'de> Visitor<'de> for EntityTypeQueryPathVisitor {
             .next_element()?
             .ok_or_else(|| de::Error::invalid_length(self.position, &self))?;
         self.position += 1;
+
         Ok(match token {
             EntityTypeQueryToken::OwnedById => EntityTypeQueryPath::OwnedById,
             EntityTypeQueryToken::CreatedById => EntityTypeQueryPath::CreatedById,

--- a/packages/graph/hash_graph/lib/graph/src/ontology/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/link_type.rs
@@ -145,6 +145,7 @@ impl<'de> Visitor<'de> for LinkTypeQueryPathVisitor {
             .next_element()?
             .ok_or_else(|| de::Error::invalid_length(self.position, &self))?;
         self.position += 1;
+
         Ok(match token {
             LinkTypeQueryToken::OwnedById => LinkTypeQueryPath::OwnedById,
             LinkTypeQueryToken::CreatedById => LinkTypeQueryPath::CreatedById,

--- a/packages/graph/hash_graph/lib/graph/src/ontology/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/link_type.rs
@@ -174,7 +174,7 @@ mod tests {
     use std::iter::once;
 
     use super::*;
-    use crate::ontology::test_utils::create_path;
+    use crate::query::test_utils::create_path;
 
     fn convert_path(segments: impl IntoIterator<Item = &'static str>) -> LinkTypeQueryPath {
         LinkTypeQueryPath::try_from(create_path(segments)).expect("could not convert path")

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -20,8 +20,10 @@ use type_system::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyTyp
 use utoipa::ToSchema;
 
 pub use self::{
-    data_type::DataTypeQueryPath, entity_type::EntityTypeQueryPath, link_type::LinkTypeQueryPath,
-    property_type::PropertyTypeQueryPath,
+    data_type::{DataTypeQueryPath, DataTypeQueryPathVisitor},
+    entity_type::{EntityTypeQueryPath, EntityTypeQueryPathVisitor},
+    link_type::{LinkTypeQueryPath, LinkTypeQueryPathVisitor},
+    property_type::{PropertyTypeQueryPath, PropertyTypeQueryPathVisitor},
 };
 use crate::provenance::{CreatedById, OwnedById, RemovedById, UpdatedById};
 
@@ -356,22 +358,6 @@ impl PersistedOntologyType for PersistedEntityType {
         Self {
             inner: record,
             metadata,
-        }
-    }
-}
-
-#[cfg(test)]
-mod test_utils {
-    use crate::store::query::{Path, PathSegment};
-
-    pub fn create_path(segments: impl IntoIterator<Item = &'static str>) -> Path {
-        Path {
-            segments: segments
-                .into_iter()
-                .map(|segment| PathSegment {
-                    identifier: segment.to_owned(),
-                })
-                .collect(),
         }
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/property_type.rs
@@ -199,7 +199,7 @@ mod tests {
     use std::iter::once;
 
     use super::*;
-    use crate::ontology::test_utils::create_path;
+    use crate::query::test_utils::create_path;
 
     fn convert_path(segments: impl IntoIterator<Item = &'static str>) -> PropertyTypeQueryPath {
         PropertyTypeQueryPath::try_from(create_path(segments)).expect("could not convert path")

--- a/packages/graph/hash_graph/lib/graph/src/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/property_type.rs
@@ -153,6 +153,7 @@ impl<'de> Visitor<'de> for PropertyTypeQueryPathVisitor {
             .next_element()?
             .ok_or_else(|| de::Error::invalid_length(self.position, &self))?;
         self.position += 1;
+
         Ok(match token {
             PropertyTypeQueryToken::OwnedById => PropertyTypeQueryPath::OwnedById,
             PropertyTypeQueryToken::CreatedById => PropertyTypeQueryPath::CreatedById,

--- a/packages/graph/hash_graph/lib/graph/src/shared/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/mod.rs
@@ -1,3 +1,4 @@
 pub mod identifier;
 pub mod provenance;
+pub mod query;
 pub mod subgraph;

--- a/packages/graph/hash_graph/lib/graph/src/shared/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/query.rs
@@ -1,0 +1,15 @@
+#[cfg(test)]
+pub mod test_utils {
+    use crate::store::query::{Path, PathSegment};
+
+    pub fn create_path(segments: impl IntoIterator<Item = &'static str>) -> Path {
+        Path {
+            segments: segments
+                .into_iter()
+                .map(|segment| PathSegment {
+                    identifier: segment.to_owned(),
+                })
+                .collect(),
+        }
+    }
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Similar to other deserialization functions, this adds deserialize functionality for entity queries

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203007126736607/1203167266370358/f) _(internal)_

## 🚫 Blocked by

- #1255 
- #1267
- #1268
- #1269

## 🔍 What does this change?

Pretty much the same changes as before: implement `Deserialize` for `EntityQueryPath`