### PR TITLE
Adjust `StructuralQuery` struct to contain a `Filter<T>`

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -1088,7 +1088,7 @@ export interface RemoveLinkRequest {
   targetEntityId: string;
 }
 /**
- * An [`Expression`] to query the datastore, recursively resolving according to the
+ *
  * @export
  * @interface StructuralQuery
  */

--- a/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
@@ -6,8 +6,8 @@ use graph::{
     identifier::AccountId,
     knowledge::{Entity, EntityId},
     provenance::{CreatedById, OwnedById},
-    store::{query::Expression, AccountStore, AsClient, EntityStore, PostgresStore},
-    subgraph::{GraphResolveDepths, StructuralQuery},
+    store::{query::Filter, AccountStore, AsClient, EntityStore, PostgresStore},
+    subgraph::{GraphResolveDepths, NewStructuralQuery},
 };
 use graph_test_data::{data_type, entity, entity_type, link_type, property_type};
 use rand::{prelude::IteratorRandom, thread_rng};
@@ -101,8 +101,8 @@ pub fn bench_get_entity_by_id(
         },
         |entity_id| async move {
             store
-                .get_entity(&StructuralQuery {
-                    expression: Expression::for_latest_entity_id(entity_id),
+                .get_entity(&NewStructuralQuery {
+                    filter: Filter::for_latest_entity_by_entity_id(entity_id),
                     graph_resolve_depths: GraphResolveDepths {
                         data_type_resolve_depth: 0,
                         property_type_resolve_depth: 0,

--- a/packages/graph/hash_graph/bench/benches/representative_read/knowledge/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/knowledge/entity.rs
@@ -1,8 +1,8 @@
 use criterion::{BatchSize::SmallInput, Bencher};
 use graph::{
     knowledge::EntityId,
-    store::{query::Expression, EntityStore},
-    subgraph::{GraphResolveDepths, StructuralQuery},
+    store::{query::Filter, EntityStore},
+    subgraph::{GraphResolveDepths, NewStructuralQuery},
 };
 use rand::{prelude::IteratorRandom, thread_rng};
 use tokio::runtime::Runtime;
@@ -22,8 +22,8 @@ pub fn bench_get_entity_by_id(
         },
         |entity_id| async move {
             store
-                .get_entity(&StructuralQuery {
-                    expression: Expression::for_latest_entity_id(entity_id),
+                .get_entity(&NewStructuralQuery {
+                    filter: Filter::for_latest_entity_by_entity_id(entity_id),
                     graph_resolve_depths: GraphResolveDepths {
                         data_type_resolve_depth: 0,
                         property_type_resolve_depth: 0,

--- a/packages/graph/hash_graph/bench/benches/representative_read/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/ontology/entity_type.rs
@@ -1,7 +1,7 @@
 use criterion::{BatchSize::SmallInput, Bencher};
 use graph::{
-    store::{query::Expression, EntityTypeStore},
-    subgraph::{GraphResolveDepths, StructuralQuery},
+    store::{query::Filter, EntityTypeStore},
+    subgraph::{GraphResolveDepths, NewStructuralQuery},
 };
 use rand::{prelude::IteratorRandom, thread_rng};
 use tokio::runtime::Runtime;
@@ -26,8 +26,8 @@ pub fn bench_get_entity_type_by_id(
         },
         |entity_type_id| async move {
             store
-                .get_entity_type(&StructuralQuery {
-                    expression: Expression::for_versioned_uri(&entity_type_id),
+                .get_entity_type(&NewStructuralQuery {
+                    filter: Filter::for_versioned_uri(&entity_type_id),
                     graph_resolve_depths: GraphResolveDepths {
                         data_type_resolve_depth: 0,
                         property_type_resolve_depth: 0,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use type_system::{uri::VersionedUri, LinkType};
 use utoipa::{OpenApi, ToSchema};
 
-use super::api_resource::RoutedResource;
+use super::{api_resource::RoutedResource, StructuralQuery};
 use crate::{
     api::rest::{read_from_store, report_to_status_code},
     ontology::{
@@ -26,7 +26,7 @@ use crate::{
     shared::identifier::GraphElementIdentifier,
     store::{query::Filter, BaseUriAlreadyExists, BaseUriDoesNotExist, LinkTypeStore, StorePool},
     subgraph::{
-        EdgeKind, Edges, GraphResolveDepths, OutwardEdge, StructuralQuery, Subgraph, Vertex,
+        EdgeKind, Edges, GraphResolveDepths, NewStructuralQuery, OutwardEdge, Subgraph, Vertex,
     },
 };
 
@@ -172,6 +172,14 @@ async fn get_link_types_by_query<P: StorePool + Send>(
             StatusCode::INTERNAL_SERVER_ERROR
         })
         .and_then(|store| async move {
+            let mut query = NewStructuralQuery::try_from(query).map_err(|error| {
+                tracing::error!(?error, "Could not deserialize query");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+            query.filter.convert_parameters().map_err(|error| {
+                tracing::error!(?error, "Could not validate query");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
             store.get_link_type(&query).await.map_err(|report| {
                 tracing::error!(error=?report, ?query, "Could not read link types from the store");
                 report_to_status_code(&report)

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph.rs
@@ -1,19 +1,23 @@
-use std::collections::{
-    hash_map::{IntoIter, RawEntryMut},
-    HashMap, HashSet,
+use std::{
+    collections::{
+        hash_map::{IntoIter, RawEntryMut},
+        HashMap, HashSet,
+    },
+    fmt::{Debug, Formatter},
 };
 
 use serde::{Deserialize, Serialize};
+use type_system::{DataType, EntityType, LinkType, PropertyType};
 use utoipa::{openapi, ToSchema};
 
 use crate::{
-    knowledge::{KnowledgeGraphQueryDepth, PersistedEntity, PersistedLink},
+    knowledge::{Entity, KnowledgeGraphQueryDepth, Link, PersistedEntity, PersistedLink},
     ontology::{
         OntologyQueryDepth, PersistedDataType, PersistedEntityType, PersistedLinkType,
         PersistedPropertyType,
     },
     shared::identifier::GraphElementIdentifier,
-    store::query::Expression,
+    store::query::{Filter, QueryRecord},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -147,14 +151,36 @@ impl Extend<Self> for Subgraph {
     }
 }
 
-/// An [`Expression`] to query the datastore, recursively resolving according to the
-/// [`GraphResolveDepths`]
-#[derive(Debug, Deserialize, ToSchema)]
+/// A [`Filter`] to query the datastore, recursively resolving according to the
+/// [`GraphResolveDepths`].
+#[derive(Deserialize, ToSchema)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
-pub struct StructuralQuery {
-    #[serde(rename = "query")]
-    pub expression: Expression,
+#[aliases(
+    DataTypeStructuralQuery = NewStructuralQuery<'static, DataType>,
+    PropertyTypeStructuralQuery = NewStructuralQuery<'static, PropertyType>,
+    EntityTypeStructuralQuery = NewStructuralQuery<'static, EntityType>,
+    LinkTypeStructuralQuery = NewStructuralQuery<'static, LinkType>,
+    EntityStructuralQuery = NewStructuralQuery<'static, Entity>,
+    LinkStructuralQuery = NewStructuralQuery<'static, Link>,
+)]
+pub struct NewStructuralQuery<'q, T: QueryRecord> {
+    #[serde(bound = "'de: 'q, T::Path<'q>: Deserialize<'de>")]
+    pub filter: Filter<'q, T>,
     pub graph_resolve_depths: GraphResolveDepths,
+}
+
+// TODO: Derive traits when bounds are generated correctly
+//   see https://github.com/rust-lang/rust/issues/26925
+impl<'q, T> Debug for NewStructuralQuery<'q, T>
+where
+    T: QueryRecord<Path<'q>: Debug>,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StructuralQuery")
+            .field("filter", &self.filter)
+            .field("graph_resolve_depths", &self.graph_resolve_depths)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -28,7 +28,7 @@ use crate::{
     },
     provenance::{CreatedById, OwnedById, RemovedById, UpdatedById},
     store::{error::LinkRemovalError, query::Filter},
-    subgraph::{StructuralQuery, Subgraph},
+    subgraph::{NewStructuralQuery, Subgraph},
 };
 
 #[derive(Debug)]
@@ -221,12 +221,15 @@ pub trait DataTypeStore:
         actor_id: CreatedById,
     ) -> Result<PersistedOntologyMetadata, InsertionError>;
 
-    /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
+    /// Get the [`Subgraph`] specified by the [`NewStructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`DataType`] doesn't exist.
-    async fn get_data_type(&self, query: &StructuralQuery) -> Result<Subgraph, QueryError>;
+    async fn get_data_type<'f: 'q, 'q>(
+        &self,
+        query: &'f NewStructuralQuery<'q, DataType>,
+    ) -> Result<Subgraph, QueryError>;
 
     /// Update the definition of an existing [`DataType`].
     ///
@@ -260,12 +263,15 @@ pub trait PropertyTypeStore:
         actor_id: CreatedById,
     ) -> Result<PersistedOntologyMetadata, InsertionError>;
 
-    /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
+    /// Get the [`Subgraph`] specified by the [`NewStructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`PropertyType`] doesn't exist.
-    async fn get_property_type(&self, query: &StructuralQuery) -> Result<Subgraph, QueryError>;
+    async fn get_property_type<'f: 'q, 'q>(
+        &self,
+        query: &'f NewStructuralQuery<'q, PropertyType>,
+    ) -> Result<Subgraph, QueryError>;
 
     /// Update the definition of an existing [`PropertyType`].
     ///
@@ -299,12 +305,15 @@ pub trait EntityTypeStore:
         actor_id: CreatedById,
     ) -> Result<PersistedOntologyMetadata, InsertionError>;
 
-    /// Get the [`Subgraph`]s specified by the [`StructuralQuery`].
+    /// Get the [`Subgraph`]s specified by the [`NewStructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`EntityType`] doesn't exist.
-    async fn get_entity_type(&self, query: &StructuralQuery) -> Result<Subgraph, QueryError>;
+    async fn get_entity_type<'f: 'q, 'q>(
+        &self,
+        query: &'f NewStructuralQuery<'q, EntityType>,
+    ) -> Result<Subgraph, QueryError>;
 
     /// Update the definition of an existing [`EntityType`].
     ///
@@ -338,12 +347,15 @@ pub trait LinkTypeStore:
         actor_id: CreatedById,
     ) -> Result<PersistedOntologyMetadata, InsertionError>;
 
-    /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
+    /// Get the [`Subgraph`] specified by the [`NewStructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`LinkType`] doesn't exist.
-    async fn get_link_type(&self, query: &StructuralQuery) -> Result<Subgraph, QueryError>;
+    async fn get_link_type<'f: 'q, 'q>(
+        &self,
+        query: &'f NewStructuralQuery<'q, LinkType>,
+    ) -> Result<Subgraph, QueryError>;
 
     /// Update the definition of an existing [`LinkType`].
     ///
@@ -406,12 +418,15 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Filter<'q
         actor_id: CreatedById,
     ) -> Result<Vec<EntityId>, InsertionError>;
 
-    /// Get the [`Subgraph`]s specified by the [`StructuralQuery`].
+    /// Get the [`Subgraph`]s specified by the [`NewStructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`Entity`] doesn't exist
-    async fn get_entity(&self, query: &StructuralQuery) -> Result<Subgraph, QueryError>;
+    async fn get_entity<'f: 'q, 'q>(
+        &self,
+        query: &'f NewStructuralQuery<'q, Entity>,
+    ) -> Result<Subgraph, QueryError>;
 
     /// Update an existing [`Entity`].
     ///
@@ -447,14 +462,14 @@ pub trait LinkStore: for<'q> crud::Read<PersistedLink, Query<'q> = Filter<'q, Li
         actor_id: CreatedById,
     ) -> Result<(), InsertionError>;
 
-    /// Get the [`LinkRootedSubgraph`]s specified by the [`StructuralQuery`].
+    /// Get the [`LinkRootedSubgraph`]s specified by the [`NewStructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`Link`]s don't exist.
-    async fn get_links(
+    async fn get_links<'f: 'q, 'q>(
         &self,
-        query: &StructuralQuery,
+        query: &'f NewStructuralQuery<'q, Link>,
     ) -> Result<Vec<LinkRootedSubgraph>, QueryError>;
 
     /// Removes a [`Link`] between a source and target [`Entity`].

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -18,10 +18,9 @@ use crate::{
         crud::Read,
         error::EntityDoesNotExist,
         postgres::{context::PostgresContext, DependencyContext, DependencyContextRef},
-        query::Filter,
         AsClient, EntityStore, InsertionError, PostgresStore, QueryError, UpdateError,
     },
-    subgraph::{EdgeKind, GraphResolveDepths, OutwardEdge, StructuralQuery, Subgraph},
+    subgraph::{EdgeKind, GraphResolveDepths, NewStructuralQuery, OutwardEdge, Subgraph},
 };
 
 impl<C: AsClient> PostgresStore<C> {
@@ -226,15 +225,16 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         Ok(entity_ids)
     }
 
-    async fn get_entity(&self, query: &StructuralQuery) -> Result<Subgraph, QueryError> {
-        let StructuralQuery {
-            ref expression,
+    async fn get_entity<'f: 'q, 'q>(
+        &self,
+        query: &'q NewStructuralQuery<'q, Entity>,
+    ) -> Result<Subgraph, QueryError> {
+        let NewStructuralQuery {
+            ref filter,
             graph_resolve_depths,
         } = *query;
 
-        let mut filter = Filter::try_from(expression.clone()).change_context(QueryError)?;
-        filter.convert_parameters().change_context(QueryError)?;
-        let subgraphs = stream::iter(Read::<PersistedEntity>::read(self, &filter).await?)
+        let subgraphs = stream::iter(Read::<PersistedEntity>::read(self, filter).await?)
             .then(|entity| async move {
                 let mut dependency_context = DependencyContext::new(graph_resolve_depths);
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -13,10 +13,9 @@ use crate::{
     store::{
         crud::Read,
         postgres::{context::PostgresContext, DependencyContext, DependencyContextRef},
-        query::Filter,
         AsClient, DataTypeStore, InsertionError, PostgresStore, QueryError, UpdateError,
     },
-    subgraph::{StructuralQuery, Subgraph},
+    subgraph::{NewStructuralQuery, Subgraph},
 };
 
 impl<C: AsClient> PostgresStore<C> {
@@ -80,15 +79,16 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
         Ok(metadata)
     }
 
-    async fn get_data_type(&self, query: &StructuralQuery) -> Result<Subgraph, QueryError> {
-        let StructuralQuery {
-            ref expression,
+    async fn get_data_type<'f: 'q, 'q>(
+        &self,
+        query: &'f NewStructuralQuery<'q, DataType>,
+    ) -> Result<Subgraph, QueryError> {
+        let NewStructuralQuery {
+            ref filter,
             graph_resolve_depths,
         } = *query;
 
-        let mut filter = Filter::try_from(expression.clone()).change_context(QueryError)?;
-        filter.convert_parameters().change_context(QueryError)?;
-        let subgraphs = stream::iter(Read::<PersistedDataType>::read(self, &filter).await?)
+        let subgraphs = stream::iter(Read::<PersistedDataType>::read(self, filter).await?)
             .then(|data_type| async move {
                 let mut dependency_context = DependencyContext::new(graph_resolve_depths);
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -15,10 +15,9 @@ use crate::{
     store::{
         crud::Read,
         postgres::{context::PostgresContext, DependencyContext, DependencyContextRef},
-        query::Filter,
         AsClient, InsertionError, PostgresStore, PropertyTypeStore, QueryError, UpdateError,
     },
-    subgraph::{EdgeKind, GraphResolveDepths, OutwardEdge, StructuralQuery, Subgraph},
+    subgraph::{EdgeKind, GraphResolveDepths, NewStructuralQuery, OutwardEdge, Subgraph},
 };
 
 impl<C: AsClient> PostgresStore<C> {
@@ -164,15 +163,16 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         Ok(metadata)
     }
 
-    async fn get_property_type(&self, query: &StructuralQuery) -> Result<Subgraph, QueryError> {
-        let StructuralQuery {
-            ref expression,
+    async fn get_property_type<'f: 'q, 'q>(
+        &self,
+        query: &'f NewStructuralQuery<'q, PropertyType>,
+    ) -> Result<Subgraph, QueryError> {
+        let NewStructuralQuery {
+            ref filter,
             graph_resolve_depths,
         } = *query;
 
-        let mut filter = Filter::try_from(expression.clone()).change_context(QueryError)?;
-        filter.convert_parameters().change_context(QueryError)?;
-        let subgraphs = stream::iter(Read::<PersistedPropertyType>::read(self, &filter).await?)
+        let subgraphs = stream::iter(Read::<PersistedPropertyType>::read(self, filter).await?)
             .then(|property_type| async move {
                 let mut dependency_context = DependencyContext::new(graph_resolve_depths);
 

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -418,7 +418,7 @@ impl DatabaseApi<'_> {
         Ok(self
             .store
             .get_links(&NewStructuralQuery {
-                filter: Filter::Any(vec![
+                filter: Filter::All(vec![
                     Filter::for_link_by_latest_source_entity(source_entity_id),
                     Filter::Equal(
                         Some(FilterExpression::Path(LinkQueryPath::Type(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The optimization implementation in Rust is finished, so the next step is to expose the new queries to the backend. To make this reviewable, this task is split up into three parts:
- #1277 (this PR)
- #1278
- #1279

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203007126736610/1203157447721367/f) _(internal)_

## 🚫 Blocked by

- #1267
- #1268
- #1269
- #1271
- #1272 
- #1273 
- #1228 
- #1274
- #1275
- #1276

## 🔍 What does this change?

- Temporarily rename `StructuralQuery` struct to `NewStructuralQuery` struct and make it aware of `Filter<T>`
- Copy "old" `StructuralQuery` struct to be available in the REST API to avoid adjusting the backend in this PR

## 🐾 Next steps

- #1278
- #1279

## 🛡 What tests cover this?

The REST API tests will pick this change up