### PR TITLE
Adjust backend to use the new `Filter`s 🎉 

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -292,6 +292,25 @@ export interface DataTypeReferenceUpdate {
   $ref: string;
 }
 /**
+ * A [`Filter`] to query the datastore, recursively resolving according to the
+ * @export
+ * @interface DataTypeStructuralQuery
+ */
+export interface DataTypeStructuralQuery {
+  /**
+   *
+   * @type {object}
+   * @memberof DataTypeStructuralQuery
+   */
+  filter: object;
+  /**
+   *
+   * @type {GraphResolveDepths}
+   * @memberof DataTypeStructuralQuery
+   */
+  graphResolveDepths: GraphResolveDepths;
+}
+/**
  *
  * @export
  * @enum {string}
@@ -324,6 +343,25 @@ export interface EdgesValueInner {
    * @memberof EdgesValueInner
    */
   edgeKind: EdgeKind;
+}
+/**
+ * A [`Filter`] to query the datastore, recursively resolving according to the
+ * @export
+ * @interface EntityStructuralQuery
+ */
+export interface EntityStructuralQuery {
+  /**
+   *
+   * @type {object}
+   * @memberof EntityStructuralQuery
+   */
+  filter: object;
+  /**
+   *
+   * @type {GraphResolveDepths}
+   * @memberof EntityStructuralQuery
+   */
+  graphResolveDepths: GraphResolveDepths;
 }
 /**
  * Specifies the structure of an Entity Type
@@ -418,6 +456,25 @@ export const EntityTypeTypeEnum = {
 export type EntityTypeTypeEnum =
   typeof EntityTypeTypeEnum[keyof typeof EntityTypeTypeEnum];
 
+/**
+ * A [`Filter`] to query the datastore, recursively resolving according to the
+ * @export
+ * @interface EntityTypeStructuralQuery
+ */
+export interface EntityTypeStructuralQuery {
+  /**
+   *
+   * @type {object}
+   * @memberof EntityTypeStructuralQuery
+   */
+  filter: object;
+  /**
+   *
+   * @type {GraphResolveDepths}
+   * @memberof EntityTypeStructuralQuery
+   */
+  graphResolveDepths: GraphResolveDepths;
+}
 /**
  * @type GraphElementIdentifier
  * @export
@@ -548,6 +605,25 @@ export interface LinkRootedSubgraph {
   referencedPropertyTypes: Array<PersistedPropertyType>;
 }
 /**
+ * A [`Filter`] to query the datastore, recursively resolving according to the
+ * @export
+ * @interface LinkStructuralQuery
+ */
+export interface LinkStructuralQuery {
+  /**
+   *
+   * @type {object}
+   * @memberof LinkStructuralQuery
+   */
+  filter: object;
+  /**
+   *
+   * @type {GraphResolveDepths}
+   * @memberof LinkStructuralQuery
+   */
+  graphResolveDepths: GraphResolveDepths;
+}
+/**
  * Specifies the structure of a Link Type
  * @export
  * @interface LinkType
@@ -598,6 +674,25 @@ export const LinkTypeKindEnum = {
 export type LinkTypeKindEnum =
   typeof LinkTypeKindEnum[keyof typeof LinkTypeKindEnum];
 
+/**
+ * A [`Filter`] to query the datastore, recursively resolving according to the
+ * @export
+ * @interface LinkTypeStructuralQuery
+ */
+export interface LinkTypeStructuralQuery {
+  /**
+   *
+   * @type {object}
+   * @memberof LinkTypeStructuralQuery
+   */
+  filter: object;
+  /**
+   *
+   * @type {GraphResolveDepths}
+   * @memberof LinkTypeStructuralQuery
+   */
+  graphResolveDepths: GraphResolveDepths;
+}
 /**
  *
  * @export
@@ -1045,6 +1140,25 @@ export type PropertyTypeKindEnum =
   typeof PropertyTypeKindEnum[keyof typeof PropertyTypeKindEnum];
 
 /**
+ * A [`Filter`] to query the datastore, recursively resolving according to the
+ * @export
+ * @interface PropertyTypeStructuralQuery
+ */
+export interface PropertyTypeStructuralQuery {
+  /**
+   *
+   * @type {object}
+   * @memberof PropertyTypeStructuralQuery
+   */
+  filter: object;
+  /**
+   *
+   * @type {GraphResolveDepths}
+   * @memberof PropertyTypeStructuralQuery
+   */
+  graphResolveDepths: GraphResolveDepths;
+}
+/**
  * @type PropertyValues
  * @export
  */
@@ -1086,25 +1200,6 @@ export interface RemoveLinkRequest {
    * @memberof RemoveLinkRequest
    */
   targetEntityId: string;
-}
-/**
- *
- * @export
- * @interface StructuralQuery
- */
-export interface StructuralQuery {
-  /**
-   *
-   * @type {GraphResolveDepths}
-   * @memberof StructuralQuery
-   */
-  graphResolveDepths: GraphResolveDepths;
-  /**
-   *
-   * @type {object}
-   * @memberof StructuralQuery
-   */
-  query: object;
 }
 /**
  *
@@ -2021,19 +2116,19 @@ export const DataTypeApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {DataTypeStructuralQuery} dataTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getDataTypesByQuery: async (
-      structuralQuery: StructuralQuery,
+      dataTypeStructuralQuery: DataTypeStructuralQuery,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'structuralQuery' is not null or undefined
+      // verify required parameter 'dataTypeStructuralQuery' is not null or undefined
       assertParamExists(
         "getDataTypesByQuery",
-        "structuralQuery",
-        structuralQuery,
+        "dataTypeStructuralQuery",
+        dataTypeStructuralQuery,
       );
       const localVarPath = `/data-types/query`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -2062,7 +2157,7 @@ export const DataTypeApiAxiosParamCreator = function (
         ...options.headers,
       };
       localVarRequestOptions.data = serializeDataIfNeeded(
-        structuralQuery,
+        dataTypeStructuralQuery,
         localVarRequestOptions,
         configuration,
       );
@@ -2227,19 +2322,19 @@ export const DataTypeApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {DataTypeStructuralQuery} dataTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getDataTypesByQuery(
-      structuralQuery: StructuralQuery,
+      dataTypeStructuralQuery: DataTypeStructuralQuery,
       options?: AxiosRequestConfig,
     ): Promise<
       (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Subgraph>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getDataTypesByQuery(
-          structuralQuery,
+          dataTypeStructuralQuery,
           options,
         );
       return createRequestFunction(
@@ -2338,16 +2433,16 @@ export const DataTypeApiFactory = function (
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {DataTypeStructuralQuery} dataTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getDataTypesByQuery(
-      structuralQuery: StructuralQuery,
+      dataTypeStructuralQuery: DataTypeStructuralQuery,
       options?: any,
     ): AxiosPromise<Subgraph> {
       return localVarFp
-        .getDataTypesByQuery(structuralQuery, options)
+        .getDataTypesByQuery(dataTypeStructuralQuery, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -2409,13 +2504,13 @@ export interface DataTypeApiInterface {
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {DataTypeStructuralQuery} dataTypeStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof DataTypeApiInterface
    */
   getDataTypesByQuery(
-    structuralQuery: StructuralQuery,
+    dataTypeStructuralQuery: DataTypeStructuralQuery,
     options?: AxiosRequestConfig,
   ): AxiosPromise<Subgraph>;
 
@@ -2480,17 +2575,17 @@ export class DataTypeApi extends BaseAPI implements DataTypeApiInterface {
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {DataTypeStructuralQuery} dataTypeStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof DataTypeApi
    */
   public getDataTypesByQuery(
-    structuralQuery: StructuralQuery,
+    dataTypeStructuralQuery: DataTypeStructuralQuery,
     options?: AxiosRequestConfig,
   ) {
     return DataTypeApiFp(this.configuration)
-      .getDataTypesByQuery(structuralQuery, options)
+      .getDataTypesByQuery(dataTypeStructuralQuery, options)
       .then((request) => request(this.axios, this.basePath));
   }
 
@@ -2586,19 +2681,19 @@ export const EntityApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {EntityStructuralQuery} entityStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getEntitiesByQuery: async (
-      structuralQuery: StructuralQuery,
+      entityStructuralQuery: EntityStructuralQuery,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'structuralQuery' is not null or undefined
+      // verify required parameter 'entityStructuralQuery' is not null or undefined
       assertParamExists(
         "getEntitiesByQuery",
-        "structuralQuery",
-        structuralQuery,
+        "entityStructuralQuery",
+        entityStructuralQuery,
       );
       const localVarPath = `/entities/query`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -2627,7 +2722,7 @@ export const EntityApiAxiosParamCreator = function (
         ...options.headers,
       };
       localVarRequestOptions.data = serializeDataIfNeeded(
-        structuralQuery,
+        entityStructuralQuery,
         localVarRequestOptions,
         configuration,
       );
@@ -2811,19 +2906,19 @@ export const EntityApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {EntityStructuralQuery} entityStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getEntitiesByQuery(
-      structuralQuery: StructuralQuery,
+      entityStructuralQuery: EntityStructuralQuery,
       options?: AxiosRequestConfig,
     ): Promise<
       (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Subgraph>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getEntitiesByQuery(
-          structuralQuery,
+          entityStructuralQuery,
           options,
         );
       return createRequestFunction(
@@ -2937,16 +3032,16 @@ export const EntityApiFactory = function (
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {EntityStructuralQuery} entityStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getEntitiesByQuery(
-      structuralQuery: StructuralQuery,
+      entityStructuralQuery: EntityStructuralQuery,
       options?: any,
     ): AxiosPromise<Subgraph> {
       return localVarFp
-        .getEntitiesByQuery(structuralQuery, options)
+        .getEntitiesByQuery(entityStructuralQuery, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -3007,13 +3102,13 @@ export interface EntityApiInterface {
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {EntityStructuralQuery} entityStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof EntityApiInterface
    */
   getEntitiesByQuery(
-    structuralQuery: StructuralQuery,
+    entityStructuralQuery: EntityStructuralQuery,
     options?: AxiosRequestConfig,
   ): AxiosPromise<Subgraph>;
 
@@ -3077,17 +3172,17 @@ export class EntityApi extends BaseAPI implements EntityApiInterface {
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {EntityStructuralQuery} entityStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof EntityApi
    */
   public getEntitiesByQuery(
-    structuralQuery: StructuralQuery,
+    entityStructuralQuery: EntityStructuralQuery,
     options?: AxiosRequestConfig,
   ) {
     return EntityApiFp(this.configuration)
-      .getEntitiesByQuery(structuralQuery, options)
+      .getEntitiesByQuery(entityStructuralQuery, options)
       .then((request) => request(this.axios, this.basePath));
   }
 
@@ -3241,19 +3336,19 @@ export const EntityTypeApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {EntityTypeStructuralQuery} entityTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getEntityTypesByQuery: async (
-      structuralQuery: StructuralQuery,
+      entityTypeStructuralQuery: EntityTypeStructuralQuery,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'structuralQuery' is not null or undefined
+      // verify required parameter 'entityTypeStructuralQuery' is not null or undefined
       assertParamExists(
         "getEntityTypesByQuery",
-        "structuralQuery",
-        structuralQuery,
+        "entityTypeStructuralQuery",
+        entityTypeStructuralQuery,
       );
       const localVarPath = `/entity-types/query`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -3282,7 +3377,7 @@ export const EntityTypeApiAxiosParamCreator = function (
         ...options.headers,
       };
       localVarRequestOptions.data = serializeDataIfNeeded(
-        structuralQuery,
+        entityTypeStructuralQuery,
         localVarRequestOptions,
         configuration,
       );
@@ -3449,19 +3544,19 @@ export const EntityTypeApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {EntityTypeStructuralQuery} entityTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getEntityTypesByQuery(
-      structuralQuery: StructuralQuery,
+      entityTypeStructuralQuery: EntityTypeStructuralQuery,
       options?: AxiosRequestConfig,
     ): Promise<
       (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Subgraph>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getEntityTypesByQuery(
-          structuralQuery,
+          entityTypeStructuralQuery,
           options,
         );
       return createRequestFunction(
@@ -3564,16 +3659,16 @@ export const EntityTypeApiFactory = function (
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {EntityTypeStructuralQuery} entityTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getEntityTypesByQuery(
-      structuralQuery: StructuralQuery,
+      entityTypeStructuralQuery: EntityTypeStructuralQuery,
       options?: any,
     ): AxiosPromise<Subgraph> {
       return localVarFp
-        .getEntityTypesByQuery(structuralQuery, options)
+        .getEntityTypesByQuery(entityTypeStructuralQuery, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -3637,13 +3732,13 @@ export interface EntityTypeApiInterface {
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {EntityTypeStructuralQuery} entityTypeStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof EntityTypeApiInterface
    */
   getEntityTypesByQuery(
-    structuralQuery: StructuralQuery,
+    entityTypeStructuralQuery: EntityTypeStructuralQuery,
     options?: AxiosRequestConfig,
   ): AxiosPromise<Subgraph>;
 
@@ -3708,17 +3803,17 @@ export class EntityTypeApi extends BaseAPI implements EntityTypeApiInterface {
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {EntityTypeStructuralQuery} entityTypeStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof EntityTypeApi
    */
   public getEntityTypesByQuery(
-    structuralQuery: StructuralQuery,
+    entityTypeStructuralQuery: EntityTypeStructuralQuery,
     options?: AxiosRequestConfig,
   ) {
     return EntityTypeApiFp(this.configuration)
-      .getEntityTypesByQuery(structuralQuery, options)
+      .getEntityTypesByQuery(entityTypeStructuralQuery, options)
       .then((request) => request(this.axios, this.basePath));
   }
 
@@ -4165,19 +4260,19 @@ export const GraphApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {DataTypeStructuralQuery} dataTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getDataTypesByQuery: async (
-      structuralQuery: StructuralQuery,
+      dataTypeStructuralQuery: DataTypeStructuralQuery,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'structuralQuery' is not null or undefined
+      // verify required parameter 'dataTypeStructuralQuery' is not null or undefined
       assertParamExists(
         "getDataTypesByQuery",
-        "structuralQuery",
-        structuralQuery,
+        "dataTypeStructuralQuery",
+        dataTypeStructuralQuery,
       );
       const localVarPath = `/data-types/query`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -4206,7 +4301,7 @@ export const GraphApiAxiosParamCreator = function (
         ...options.headers,
       };
       localVarRequestOptions.data = serializeDataIfNeeded(
-        structuralQuery,
+        dataTypeStructuralQuery,
         localVarRequestOptions,
         configuration,
       );
@@ -4218,19 +4313,19 @@ export const GraphApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {EntityStructuralQuery} entityStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getEntitiesByQuery: async (
-      structuralQuery: StructuralQuery,
+      entityStructuralQuery: EntityStructuralQuery,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'structuralQuery' is not null or undefined
+      // verify required parameter 'entityStructuralQuery' is not null or undefined
       assertParamExists(
         "getEntitiesByQuery",
-        "structuralQuery",
-        structuralQuery,
+        "entityStructuralQuery",
+        entityStructuralQuery,
       );
       const localVarPath = `/entities/query`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -4259,7 +4354,7 @@ export const GraphApiAxiosParamCreator = function (
         ...options.headers,
       };
       localVarRequestOptions.data = serializeDataIfNeeded(
-        structuralQuery,
+        entityStructuralQuery,
         localVarRequestOptions,
         configuration,
       );
@@ -4406,19 +4501,19 @@ export const GraphApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {EntityTypeStructuralQuery} entityTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getEntityTypesByQuery: async (
-      structuralQuery: StructuralQuery,
+      entityTypeStructuralQuery: EntityTypeStructuralQuery,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'structuralQuery' is not null or undefined
+      // verify required parameter 'entityTypeStructuralQuery' is not null or undefined
       assertParamExists(
         "getEntityTypesByQuery",
-        "structuralQuery",
-        structuralQuery,
+        "entityTypeStructuralQuery",
+        entityTypeStructuralQuery,
       );
       const localVarPath = `/entity-types/query`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -4447,7 +4542,7 @@ export const GraphApiAxiosParamCreator = function (
         ...options.headers,
       };
       localVarRequestOptions.data = serializeDataIfNeeded(
-        structuralQuery,
+        entityTypeStructuralQuery,
         localVarRequestOptions,
         configuration,
       );
@@ -4694,19 +4789,19 @@ export const GraphApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {LinkTypeStructuralQuery} linkTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getLinkTypesByQuery: async (
-      structuralQuery: StructuralQuery,
+      linkTypeStructuralQuery: LinkTypeStructuralQuery,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'structuralQuery' is not null or undefined
+      // verify required parameter 'linkTypeStructuralQuery' is not null or undefined
       assertParamExists(
         "getLinkTypesByQuery",
-        "structuralQuery",
-        structuralQuery,
+        "linkTypeStructuralQuery",
+        linkTypeStructuralQuery,
       );
       const localVarPath = `/link-types/query`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -4735,7 +4830,7 @@ export const GraphApiAxiosParamCreator = function (
         ...options.headers,
       };
       localVarRequestOptions.data = serializeDataIfNeeded(
-        structuralQuery,
+        linkTypeStructuralQuery,
         localVarRequestOptions,
         configuration,
       );
@@ -4747,16 +4842,20 @@ export const GraphApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {LinkStructuralQuery} linkStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getLinksByQuery: async (
-      structuralQuery: StructuralQuery,
+      linkStructuralQuery: LinkStructuralQuery,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'structuralQuery' is not null or undefined
-      assertParamExists("getLinksByQuery", "structuralQuery", structuralQuery);
+      // verify required parameter 'linkStructuralQuery' is not null or undefined
+      assertParamExists(
+        "getLinksByQuery",
+        "linkStructuralQuery",
+        linkStructuralQuery,
+      );
       const localVarPath = `/links/query`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -4784,7 +4883,7 @@ export const GraphApiAxiosParamCreator = function (
         ...options.headers,
       };
       localVarRequestOptions.data = serializeDataIfNeeded(
-        structuralQuery,
+        linkStructuralQuery,
         localVarRequestOptions,
         configuration,
       );
@@ -4841,19 +4940,19 @@ export const GraphApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {PropertyTypeStructuralQuery} propertyTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getPropertyTypesByQuery: async (
-      structuralQuery: StructuralQuery,
+      propertyTypeStructuralQuery: PropertyTypeStructuralQuery,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'structuralQuery' is not null or undefined
+      // verify required parameter 'propertyTypeStructuralQuery' is not null or undefined
       assertParamExists(
         "getPropertyTypesByQuery",
-        "structuralQuery",
-        structuralQuery,
+        "propertyTypeStructuralQuery",
+        propertyTypeStructuralQuery,
       );
       const localVarPath = `/property-types/query`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -4882,7 +4981,7 @@ export const GraphApiAxiosParamCreator = function (
         ...options.headers,
       };
       localVarRequestOptions.data = serializeDataIfNeeded(
-        structuralQuery,
+        propertyTypeStructuralQuery,
         localVarRequestOptions,
         configuration,
       );
@@ -5429,19 +5528,19 @@ export const GraphApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {DataTypeStructuralQuery} dataTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getDataTypesByQuery(
-      structuralQuery: StructuralQuery,
+      dataTypeStructuralQuery: DataTypeStructuralQuery,
       options?: AxiosRequestConfig,
     ): Promise<
       (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Subgraph>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getDataTypesByQuery(
-          structuralQuery,
+          dataTypeStructuralQuery,
           options,
         );
       return createRequestFunction(
@@ -5453,19 +5552,19 @@ export const GraphApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {EntityStructuralQuery} entityStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getEntitiesByQuery(
-      structuralQuery: StructuralQuery,
+      entityStructuralQuery: EntityStructuralQuery,
       options?: AxiosRequestConfig,
     ): Promise<
       (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Subgraph>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getEntitiesByQuery(
-          structuralQuery,
+          entityStructuralQuery,
           options,
         );
       return createRequestFunction(
@@ -5555,19 +5654,19 @@ export const GraphApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {EntityTypeStructuralQuery} entityTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getEntityTypesByQuery(
-      structuralQuery: StructuralQuery,
+      entityTypeStructuralQuery: EntityTypeStructuralQuery,
       options?: AxiosRequestConfig,
     ): Promise<
       (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Subgraph>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getEntityTypesByQuery(
-          structuralQuery,
+          entityTypeStructuralQuery,
           options,
         );
       return createRequestFunction(
@@ -5715,19 +5814,19 @@ export const GraphApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {LinkTypeStructuralQuery} linkTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getLinkTypesByQuery(
-      structuralQuery: StructuralQuery,
+      linkTypeStructuralQuery: LinkTypeStructuralQuery,
       options?: AxiosRequestConfig,
     ): Promise<
       (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Subgraph>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getLinkTypesByQuery(
-          structuralQuery,
+          linkTypeStructuralQuery,
           options,
         );
       return createRequestFunction(
@@ -5739,12 +5838,12 @@ export const GraphApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {LinkStructuralQuery} linkStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getLinksByQuery(
-      structuralQuery: StructuralQuery,
+      linkStructuralQuery: LinkStructuralQuery,
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -5753,7 +5852,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       ) => AxiosPromise<Array<LinkRootedSubgraph>>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getLinksByQuery(
-        structuralQuery,
+        linkStructuralQuery,
         options,
       );
       return createRequestFunction(
@@ -5791,19 +5890,19 @@ export const GraphApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {PropertyTypeStructuralQuery} propertyTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getPropertyTypesByQuery(
-      structuralQuery: StructuralQuery,
+      propertyTypeStructuralQuery: PropertyTypeStructuralQuery,
       options?: AxiosRequestConfig,
     ): Promise<
       (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Subgraph>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getPropertyTypesByQuery(
-          structuralQuery,
+          propertyTypeStructuralQuery,
           options,
         );
       return createRequestFunction(
@@ -6094,30 +6193,30 @@ export const GraphApiFactory = function (
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {DataTypeStructuralQuery} dataTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getDataTypesByQuery(
-      structuralQuery: StructuralQuery,
+      dataTypeStructuralQuery: DataTypeStructuralQuery,
       options?: any,
     ): AxiosPromise<Subgraph> {
       return localVarFp
-        .getDataTypesByQuery(structuralQuery, options)
+        .getDataTypesByQuery(dataTypeStructuralQuery, options)
         .then((request) => request(axios, basePath));
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {EntityStructuralQuery} entityStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getEntitiesByQuery(
-      structuralQuery: StructuralQuery,
+      entityStructuralQuery: EntityStructuralQuery,
       options?: any,
     ): AxiosPromise<Subgraph> {
       return localVarFp
-        .getEntitiesByQuery(structuralQuery, options)
+        .getEntitiesByQuery(entityStructuralQuery, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -6161,16 +6260,16 @@ export const GraphApiFactory = function (
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {EntityTypeStructuralQuery} entityTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getEntityTypesByQuery(
-      structuralQuery: StructuralQuery,
+      entityTypeStructuralQuery: EntityTypeStructuralQuery,
       options?: any,
     ): AxiosPromise<Subgraph> {
       return localVarFp
-        .getEntityTypesByQuery(structuralQuery, options)
+        .getEntityTypesByQuery(entityTypeStructuralQuery, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -6240,30 +6339,30 @@ export const GraphApiFactory = function (
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {LinkTypeStructuralQuery} linkTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getLinkTypesByQuery(
-      structuralQuery: StructuralQuery,
+      linkTypeStructuralQuery: LinkTypeStructuralQuery,
       options?: any,
     ): AxiosPromise<Subgraph> {
       return localVarFp
-        .getLinkTypesByQuery(structuralQuery, options)
+        .getLinkTypesByQuery(linkTypeStructuralQuery, options)
         .then((request) => request(axios, basePath));
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {LinkStructuralQuery} linkStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getLinksByQuery(
-      structuralQuery: StructuralQuery,
+      linkStructuralQuery: LinkStructuralQuery,
       options?: any,
     ): AxiosPromise<Array<LinkRootedSubgraph>> {
       return localVarFp
-        .getLinksByQuery(structuralQuery, options)
+        .getLinksByQuery(linkStructuralQuery, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -6282,16 +6381,16 @@ export const GraphApiFactory = function (
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {PropertyTypeStructuralQuery} propertyTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getPropertyTypesByQuery(
-      structuralQuery: StructuralQuery,
+      propertyTypeStructuralQuery: PropertyTypeStructuralQuery,
       options?: any,
     ): AxiosPromise<Subgraph> {
       return localVarFp
-        .getPropertyTypesByQuery(structuralQuery, options)
+        .getPropertyTypesByQuery(propertyTypeStructuralQuery, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -6485,25 +6584,25 @@ export interface GraphApiInterface {
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {DataTypeStructuralQuery} dataTypeStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof GraphApiInterface
    */
   getDataTypesByQuery(
-    structuralQuery: StructuralQuery,
+    dataTypeStructuralQuery: DataTypeStructuralQuery,
     options?: AxiosRequestConfig,
   ): AxiosPromise<Subgraph>;
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {EntityStructuralQuery} entityStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof GraphApiInterface
    */
   getEntitiesByQuery(
-    structuralQuery: StructuralQuery,
+    entityStructuralQuery: EntityStructuralQuery,
     options?: AxiosRequestConfig,
   ): AxiosPromise<Subgraph>;
 
@@ -6545,13 +6644,13 @@ export interface GraphApiInterface {
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {EntityTypeStructuralQuery} entityTypeStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof GraphApiInterface
    */
   getEntityTypesByQuery(
-    structuralQuery: StructuralQuery,
+    entityTypeStructuralQuery: EntityTypeStructuralQuery,
     options?: AxiosRequestConfig,
   ): AxiosPromise<Subgraph>;
 
@@ -6619,25 +6718,25 @@ export interface GraphApiInterface {
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {LinkTypeStructuralQuery} linkTypeStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof GraphApiInterface
    */
   getLinkTypesByQuery(
-    structuralQuery: StructuralQuery,
+    linkTypeStructuralQuery: LinkTypeStructuralQuery,
     options?: AxiosRequestConfig,
   ): AxiosPromise<Subgraph>;
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {LinkStructuralQuery} linkStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof GraphApiInterface
    */
   getLinksByQuery(
-    structuralQuery: StructuralQuery,
+    linkStructuralQuery: LinkStructuralQuery,
     options?: AxiosRequestConfig,
   ): AxiosPromise<Array<LinkRootedSubgraph>>;
 
@@ -6655,13 +6754,13 @@ export interface GraphApiInterface {
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {PropertyTypeStructuralQuery} propertyTypeStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof GraphApiInterface
    */
   getPropertyTypesByQuery(
-    structuralQuery: StructuralQuery,
+    propertyTypeStructuralQuery: PropertyTypeStructuralQuery,
     options?: AxiosRequestConfig,
   ): AxiosPromise<Subgraph>;
 
@@ -6872,33 +6971,33 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {DataTypeStructuralQuery} dataTypeStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof GraphApi
    */
   public getDataTypesByQuery(
-    structuralQuery: StructuralQuery,
+    dataTypeStructuralQuery: DataTypeStructuralQuery,
     options?: AxiosRequestConfig,
   ) {
     return GraphApiFp(this.configuration)
-      .getDataTypesByQuery(structuralQuery, options)
+      .getDataTypesByQuery(dataTypeStructuralQuery, options)
       .then((request) => request(this.axios, this.basePath));
   }
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {EntityStructuralQuery} entityStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof GraphApi
    */
   public getEntitiesByQuery(
-    structuralQuery: StructuralQuery,
+    entityStructuralQuery: EntityStructuralQuery,
     options?: AxiosRequestConfig,
   ) {
     return GraphApiFp(this.configuration)
-      .getEntitiesByQuery(structuralQuery, options)
+      .getEntitiesByQuery(entityStructuralQuery, options)
       .then((request) => request(this.axios, this.basePath));
   }
 
@@ -6943,17 +7042,17 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {EntityTypeStructuralQuery} entityTypeStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof GraphApi
    */
   public getEntityTypesByQuery(
-    structuralQuery: StructuralQuery,
+    entityTypeStructuralQuery: EntityTypeStructuralQuery,
     options?: AxiosRequestConfig,
   ) {
     return GraphApiFp(this.configuration)
-      .getEntityTypesByQuery(structuralQuery, options)
+      .getEntityTypesByQuery(entityTypeStructuralQuery, options)
       .then((request) => request(this.axios, this.basePath));
   }
 
@@ -7032,33 +7131,33 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {LinkTypeStructuralQuery} linkTypeStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof GraphApi
    */
   public getLinkTypesByQuery(
-    structuralQuery: StructuralQuery,
+    linkTypeStructuralQuery: LinkTypeStructuralQuery,
     options?: AxiosRequestConfig,
   ) {
     return GraphApiFp(this.configuration)
-      .getLinkTypesByQuery(structuralQuery, options)
+      .getLinkTypesByQuery(linkTypeStructuralQuery, options)
       .then((request) => request(this.axios, this.basePath));
   }
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {LinkStructuralQuery} linkStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof GraphApi
    */
   public getLinksByQuery(
-    structuralQuery: StructuralQuery,
+    linkStructuralQuery: LinkStructuralQuery,
     options?: AxiosRequestConfig,
   ) {
     return GraphApiFp(this.configuration)
-      .getLinksByQuery(structuralQuery, options)
+      .getLinksByQuery(linkStructuralQuery, options)
       .then((request) => request(this.axios, this.basePath));
   }
 
@@ -7077,17 +7176,17 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {PropertyTypeStructuralQuery} propertyTypeStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof GraphApi
    */
   public getPropertyTypesByQuery(
-    structuralQuery: StructuralQuery,
+    propertyTypeStructuralQuery: PropertyTypeStructuralQuery,
     options?: AxiosRequestConfig,
   ) {
     return GraphApiFp(this.configuration)
-      .getPropertyTypesByQuery(structuralQuery, options)
+      .getPropertyTypesByQuery(propertyTypeStructuralQuery, options)
       .then((request) => request(this.axios, this.basePath));
   }
 
@@ -7301,16 +7400,20 @@ export const LinkApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {LinkStructuralQuery} linkStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getLinksByQuery: async (
-      structuralQuery: StructuralQuery,
+      linkStructuralQuery: LinkStructuralQuery,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'structuralQuery' is not null or undefined
-      assertParamExists("getLinksByQuery", "structuralQuery", structuralQuery);
+      // verify required parameter 'linkStructuralQuery' is not null or undefined
+      assertParamExists(
+        "getLinksByQuery",
+        "linkStructuralQuery",
+        linkStructuralQuery,
+      );
       const localVarPath = `/links/query`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -7338,7 +7441,7 @@ export const LinkApiAxiosParamCreator = function (
         ...options.headers,
       };
       localVarRequestOptions.data = serializeDataIfNeeded(
-        structuralQuery,
+        linkStructuralQuery,
         localVarRequestOptions,
         configuration,
       );
@@ -7468,12 +7571,12 @@ export const LinkApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {LinkStructuralQuery} linkStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getLinksByQuery(
-      structuralQuery: StructuralQuery,
+      linkStructuralQuery: LinkStructuralQuery,
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -7482,7 +7585,7 @@ export const LinkApiFp = function (configuration?: Configuration) {
       ) => AxiosPromise<Array<LinkRootedSubgraph>>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getLinksByQuery(
-        structuralQuery,
+        linkStructuralQuery,
         options,
       );
       return createRequestFunction(
@@ -7564,16 +7667,16 @@ export const LinkApiFactory = function (
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {LinkStructuralQuery} linkStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getLinksByQuery(
-      structuralQuery: StructuralQuery,
+      linkStructuralQuery: LinkStructuralQuery,
       options?: any,
     ): AxiosPromise<Array<LinkRootedSubgraph>> {
       return localVarFp
-        .getLinksByQuery(structuralQuery, options)
+        .getLinksByQuery(linkStructuralQuery, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -7629,13 +7732,13 @@ export interface LinkApiInterface {
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {LinkStructuralQuery} linkStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof LinkApiInterface
    */
   getLinksByQuery(
-    structuralQuery: StructuralQuery,
+    linkStructuralQuery: LinkStructuralQuery,
     options?: AxiosRequestConfig,
   ): AxiosPromise<Array<LinkRootedSubgraph>>;
 
@@ -7694,17 +7797,17 @@ export class LinkApi extends BaseAPI implements LinkApiInterface {
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {LinkStructuralQuery} linkStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof LinkApi
    */
   public getLinksByQuery(
-    structuralQuery: StructuralQuery,
+    linkStructuralQuery: LinkStructuralQuery,
     options?: AxiosRequestConfig,
   ) {
     return LinkApiFp(this.configuration)
-      .getLinksByQuery(structuralQuery, options)
+      .getLinksByQuery(linkStructuralQuery, options)
       .then((request) => request(this.axios, this.basePath));
   }
 
@@ -7873,19 +7976,19 @@ export const LinkTypeApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {LinkTypeStructuralQuery} linkTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getLinkTypesByQuery: async (
-      structuralQuery: StructuralQuery,
+      linkTypeStructuralQuery: LinkTypeStructuralQuery,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'structuralQuery' is not null or undefined
+      // verify required parameter 'linkTypeStructuralQuery' is not null or undefined
       assertParamExists(
         "getLinkTypesByQuery",
-        "structuralQuery",
-        structuralQuery,
+        "linkTypeStructuralQuery",
+        linkTypeStructuralQuery,
       );
       const localVarPath = `/link-types/query`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -7914,7 +8017,7 @@ export const LinkTypeApiAxiosParamCreator = function (
         ...options.headers,
       };
       localVarRequestOptions.data = serializeDataIfNeeded(
-        structuralQuery,
+        linkTypeStructuralQuery,
         localVarRequestOptions,
         configuration,
       );
@@ -8063,19 +8166,19 @@ export const LinkTypeApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {LinkTypeStructuralQuery} linkTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getLinkTypesByQuery(
-      structuralQuery: StructuralQuery,
+      linkTypeStructuralQuery: LinkTypeStructuralQuery,
       options?: AxiosRequestConfig,
     ): Promise<
       (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Subgraph>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getLinkTypesByQuery(
-          structuralQuery,
+          linkTypeStructuralQuery,
           options,
         );
       return createRequestFunction(
@@ -8162,16 +8265,16 @@ export const LinkTypeApiFactory = function (
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {LinkTypeStructuralQuery} linkTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getLinkTypesByQuery(
-      structuralQuery: StructuralQuery,
+      linkTypeStructuralQuery: LinkTypeStructuralQuery,
       options?: any,
     ): AxiosPromise<Subgraph> {
       return localVarFp
-        .getLinkTypesByQuery(structuralQuery, options)
+        .getLinkTypesByQuery(linkTypeStructuralQuery, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -8233,13 +8336,13 @@ export interface LinkTypeApiInterface {
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {LinkTypeStructuralQuery} linkTypeStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof LinkTypeApiInterface
    */
   getLinkTypesByQuery(
-    structuralQuery: StructuralQuery,
+    linkTypeStructuralQuery: LinkTypeStructuralQuery,
     options?: AxiosRequestConfig,
   ): AxiosPromise<Subgraph>;
 
@@ -8306,17 +8409,17 @@ export class LinkTypeApi extends BaseAPI implements LinkTypeApiInterface {
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {LinkTypeStructuralQuery} linkTypeStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof LinkTypeApi
    */
   public getLinkTypesByQuery(
-    structuralQuery: StructuralQuery,
+    linkTypeStructuralQuery: LinkTypeStructuralQuery,
     options?: AxiosRequestConfig,
   ) {
     return LinkTypeApiFp(this.configuration)
-      .getLinkTypesByQuery(structuralQuery, options)
+      .getLinkTypesByQuery(linkTypeStructuralQuery, options)
       .then((request) => request(this.axios, this.basePath));
   }
 
@@ -8483,19 +8586,19 @@ export const PropertyTypeApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {PropertyTypeStructuralQuery} propertyTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getPropertyTypesByQuery: async (
-      structuralQuery: StructuralQuery,
+      propertyTypeStructuralQuery: PropertyTypeStructuralQuery,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'structuralQuery' is not null or undefined
+      // verify required parameter 'propertyTypeStructuralQuery' is not null or undefined
       assertParamExists(
         "getPropertyTypesByQuery",
-        "structuralQuery",
-        structuralQuery,
+        "propertyTypeStructuralQuery",
+        propertyTypeStructuralQuery,
       );
       const localVarPath = `/property-types/query`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -8524,7 +8627,7 @@ export const PropertyTypeApiAxiosParamCreator = function (
         ...options.headers,
       };
       localVarRequestOptions.data = serializeDataIfNeeded(
-        structuralQuery,
+        propertyTypeStructuralQuery,
         localVarRequestOptions,
         configuration,
       );
@@ -8675,19 +8778,19 @@ export const PropertyTypeApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {PropertyTypeStructuralQuery} propertyTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getPropertyTypesByQuery(
-      structuralQuery: StructuralQuery,
+      propertyTypeStructuralQuery: PropertyTypeStructuralQuery,
       options?: AxiosRequestConfig,
     ): Promise<
       (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Subgraph>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getPropertyTypesByQuery(
-          structuralQuery,
+          propertyTypeStructuralQuery,
           options,
         );
       return createRequestFunction(
@@ -8780,16 +8883,16 @@ export const PropertyTypeApiFactory = function (
     },
     /**
      *
-     * @param {StructuralQuery} structuralQuery
+     * @param {PropertyTypeStructuralQuery} propertyTypeStructuralQuery
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getPropertyTypesByQuery(
-      structuralQuery: StructuralQuery,
+      propertyTypeStructuralQuery: PropertyTypeStructuralQuery,
       options?: any,
     ): AxiosPromise<Subgraph> {
       return localVarFp
-        .getPropertyTypesByQuery(structuralQuery, options)
+        .getPropertyTypesByQuery(propertyTypeStructuralQuery, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -8851,13 +8954,13 @@ export interface PropertyTypeApiInterface {
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {PropertyTypeStructuralQuery} propertyTypeStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof PropertyTypeApiInterface
    */
   getPropertyTypesByQuery(
-    structuralQuery: StructuralQuery,
+    propertyTypeStructuralQuery: PropertyTypeStructuralQuery,
     options?: AxiosRequestConfig,
   ): AxiosPromise<Subgraph>;
 
@@ -8927,17 +9030,17 @@ export class PropertyTypeApi
 
   /**
    *
-   * @param {StructuralQuery} structuralQuery
+   * @param {PropertyTypeStructuralQuery} propertyTypeStructuralQuery
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof PropertyTypeApi
    */
   public getPropertyTypesByQuery(
-    structuralQuery: StructuralQuery,
+    propertyTypeStructuralQuery: PropertyTypeStructuralQuery,
     options?: AxiosRequestConfig,
   ) {
     return PropertyTypeApiFp(this.configuration)
-      .getPropertyTypesByQuery(structuralQuery, options)
+      .getPropertyTypesByQuery(propertyTypeStructuralQuery, options)
       .then((request) => request(this.axios, this.basePath));
   }
 

--- a/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
@@ -7,7 +7,7 @@ use graph::{
     knowledge::{Entity, EntityId},
     provenance::{CreatedById, OwnedById},
     store::{query::Filter, AccountStore, AsClient, EntityStore, PostgresStore},
-    subgraph::{GraphResolveDepths, NewStructuralQuery},
+    subgraph::{GraphResolveDepths, StructuralQuery},
 };
 use graph_test_data::{data_type, entity, entity_type, link_type, property_type};
 use rand::{prelude::IteratorRandom, thread_rng};
@@ -101,7 +101,7 @@ pub fn bench_get_entity_by_id(
         },
         |entity_id| async move {
             store
-                .get_entity(&NewStructuralQuery {
+                .get_entity(&StructuralQuery {
                     filter: Filter::for_latest_entity_by_entity_id(entity_id),
                     graph_resolve_depths: GraphResolveDepths {
                         data_type_resolve_depth: 0,

--- a/packages/graph/hash_graph/bench/benches/representative_read/knowledge/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/knowledge/entity.rs
@@ -2,7 +2,7 @@ use criterion::{BatchSize::SmallInput, Bencher};
 use graph::{
     knowledge::EntityId,
     store::{query::Filter, EntityStore},
-    subgraph::{GraphResolveDepths, NewStructuralQuery},
+    subgraph::{GraphResolveDepths, StructuralQuery},
 };
 use rand::{prelude::IteratorRandom, thread_rng};
 use tokio::runtime::Runtime;
@@ -22,7 +22,7 @@ pub fn bench_get_entity_by_id(
         },
         |entity_id| async move {
             store
-                .get_entity(&NewStructuralQuery {
+                .get_entity(&StructuralQuery {
                     filter: Filter::for_latest_entity_by_entity_id(entity_id),
                     graph_resolve_depths: GraphResolveDepths {
                         data_type_resolve_depth: 0,

--- a/packages/graph/hash_graph/bench/benches/representative_read/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/ontology/entity_type.rs
@@ -1,7 +1,7 @@
 use criterion::{BatchSize::SmallInput, Bencher};
 use graph::{
     store::{query::Filter, EntityTypeStore},
-    subgraph::{GraphResolveDepths, NewStructuralQuery},
+    subgraph::{GraphResolveDepths, StructuralQuery},
 };
 use rand::{prelude::IteratorRandom, thread_rng};
 use tokio::runtime::Runtime;
@@ -26,7 +26,7 @@ pub fn bench_get_entity_type_by_id(
         },
         |entity_type_id| async move {
             store
-                .get_entity_type(&NewStructuralQuery {
+                .get_entity_type(&StructuralQuery {
                     filter: Filter::for_versioned_uri(&entity_type_id),
                     graph_resolve_depths: GraphResolveDepths {
                         data_type_resolve_depth: 0,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use type_system::{uri::VersionedUri, DataType};
 use utoipa::{OpenApi, ToSchema};
 
-use super::{api_resource::RoutedResource, StructuralQuery};
+use super::api_resource::RoutedResource;
 use crate::{
     api::rest::{read_from_store, report_to_status_code},
     ontology::{
@@ -26,7 +26,8 @@ use crate::{
     shared::identifier::GraphElementIdentifier,
     store::{query::Filter, BaseUriAlreadyExists, BaseUriDoesNotExist, DataTypeStore, StorePool},
     subgraph::{
-        EdgeKind, Edges, GraphResolveDepths, NewStructuralQuery, OutwardEdge, Subgraph, Vertex,
+        DataTypeStructuralQuery, EdgeKind, Edges, GraphResolveDepths, OutwardEdge, StructuralQuery,
+        Subgraph, Vertex,
     },
 };
 
@@ -49,7 +50,7 @@ use crate::{
             PersistedOntologyIdentifier,
             PersistedOntologyMetadata,
             PersistedDataType,
-            StructuralQuery,
+            DataTypeStructuralQuery,
             GraphElementIdentifier,
             Vertex,
             EdgeKind,
@@ -155,7 +156,7 @@ async fn create_data_type<P: StorePool + Send>(
 #[utoipa::path(
     post,
     path = "/data-types/query",
-    request_body = StructuralQuery,
+    request_body = DataTypeStructuralQuery,
     tag = "DataType",
     responses(
         (status = 200, content_type = "application/json", body = Subgraph, description = "Gets a subgraph rooted at all data types that satisfy the given query, each resolved to the requested depth."),
@@ -166,7 +167,7 @@ async fn create_data_type<P: StorePool + Send>(
 )]
 async fn get_data_types_by_query<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
-    Json(query): Json<StructuralQuery>,
+    Json(query): Json<serde_json::Value>,
 ) -> Result<Json<Subgraph>, StatusCode> {
     pool.acquire()
         .map_err(|error| {
@@ -174,7 +175,7 @@ async fn get_data_types_by_query<P: StorePool + Send>(
             StatusCode::INTERNAL_SERVER_ERROR
         })
         .and_then(|store| async move {
-            let mut query = NewStructuralQuery::try_from(query).map_err(|error| {
+            let mut query = StructuralQuery::deserialize(&query).map_err(|error| {
                 tracing::error!(?error, "Could not deserialize query");
                 StatusCode::INTERNAL_SERVER_ERROR
             })?;

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -13,7 +13,6 @@ use serde::{Deserialize, Serialize};
 use type_system::uri::VersionedUri;
 use utoipa::{OpenApi, ToSchema};
 
-use super::StructuralQuery;
 use crate::{
     api::rest::{api_resource::RoutedResource, read_from_store, report_to_status_code},
     knowledge::{
@@ -27,7 +26,8 @@ use crate::{
         EntityStore, StorePool,
     },
     subgraph::{
-        EdgeKind, Edges, GraphResolveDepths, NewStructuralQuery, OutwardEdge, Subgraph, Vertex,
+        EdgeKind, Edges, EntityStructuralQuery, GraphResolveDepths, OutwardEdge, StructuralQuery,
+        Subgraph, Vertex,
     },
 };
 
@@ -52,7 +52,7 @@ use crate::{
             PersistedEntityMetadata,
             PersistedEntity,
             Entity,
-            StructuralQuery,
+            EntityStructuralQuery,
             GraphElementIdentifier,
             Vertex,
             EdgeKind,
@@ -144,7 +144,7 @@ async fn create_entity<P: StorePool + Send>(
 #[utoipa::path(
     post,
     path = "/entities/query",
-    request_body = StructuralQuery,
+    request_body = EntityStructuralQuery,
     tag = "Entity",
     responses(
         (status = 200, content_type = "application/json", body = Subgraph, description = "A subgraph rooted at entities that satisfy the given query, each resolved to the requested depth."),
@@ -154,7 +154,7 @@ async fn create_entity<P: StorePool + Send>(
 )]
 async fn get_entities_by_query<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
-    Json(query): Json<StructuralQuery>,
+    Json(query): Json<serde_json::Value>,
 ) -> Result<Json<Subgraph>, StatusCode> {
     pool.acquire()
         .map_err(|error| {
@@ -162,7 +162,7 @@ async fn get_entities_by_query<P: StorePool + Send>(
             StatusCode::INTERNAL_SERVER_ERROR
         })
         .and_then(|store| async move {
-            let mut query = NewStructuralQuery::try_from(query).map_err(|error| {
+            let mut query = StructuralQuery::deserialize(&query).map_err(|error| {
                 tracing::error!(?error, "Could not deserialize query");
                 StatusCode::INTERNAL_SERVER_ERROR
             })?;

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/link_type.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use type_system::{uri::VersionedUri, LinkType};
 use utoipa::{OpenApi, ToSchema};
 
-use super::{api_resource::RoutedResource, StructuralQuery};
+use super::api_resource::RoutedResource;
 use crate::{
     api::rest::{read_from_store, report_to_status_code},
     ontology::{
@@ -26,7 +26,8 @@ use crate::{
     shared::identifier::GraphElementIdentifier,
     store::{query::Filter, BaseUriAlreadyExists, BaseUriDoesNotExist, LinkTypeStore, StorePool},
     subgraph::{
-        EdgeKind, Edges, GraphResolveDepths, NewStructuralQuery, OutwardEdge, Subgraph, Vertex,
+        EdgeKind, Edges, GraphResolveDepths, LinkTypeStructuralQuery, OutwardEdge, StructuralQuery,
+        Subgraph, Vertex,
     },
 };
 
@@ -49,7 +50,7 @@ use crate::{
             PersistedOntologyIdentifier,
             PersistedOntologyMetadata,
             PersistedLinkType,
-            StructuralQuery,
+            LinkTypeStructuralQuery,
             GraphElementIdentifier,
             Vertex,
             EdgeKind,
@@ -154,7 +155,7 @@ async fn create_link_type<P: StorePool + Send>(
 #[utoipa::path(
     post,
     path = "/link-types/query",
-    request_body = StructuralQuery,
+    request_body = LinkTypeStructuralQuery,
     tag = "LinkType",
     responses(
         (status = 200, content_type = "application/json", body = Subgraph, description = "A subgraph rooted at link types that satisfy the given query, each resolved to the requested depth."),
@@ -164,7 +165,7 @@ async fn create_link_type<P: StorePool + Send>(
 )]
 async fn get_link_types_by_query<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
-    Json(query): Json<StructuralQuery>,
+    Json(query): Json<serde_json::Value>,
 ) -> Result<Json<Subgraph>, StatusCode> {
     pool.acquire()
         .map_err(|error| {
@@ -172,7 +173,7 @@ async fn get_link_types_by_query<P: StorePool + Send>(
             StatusCode::INTERNAL_SERVER_ERROR
         })
         .and_then(|store| async move {
-            let mut query = NewStructuralQuery::try_from(query).map_err(|error| {
+            let mut query = StructuralQuery::deserialize(&query).map_err(|error| {
                 tracing::error!(?error, "Could not deserialize query");
                 StatusCode::INTERNAL_SERVER_ERROR
             })?;

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use type_system::{uri::VersionedUri, PropertyType};
 use utoipa::{OpenApi, ToSchema};
 
-use super::{api_resource::RoutedResource, StructuralQuery};
+use super::api_resource::RoutedResource;
 use crate::{
     api::rest::{read_from_store, report_to_status_code},
     ontology::{
@@ -28,7 +28,8 @@ use crate::{
         query::Filter, BaseUriAlreadyExists, BaseUriDoesNotExist, PropertyTypeStore, StorePool,
     },
     subgraph::{
-        EdgeKind, Edges, GraphResolveDepths, NewStructuralQuery, OutwardEdge, Subgraph, Vertex,
+        EdgeKind, Edges, GraphResolveDepths, OutwardEdge, PropertyTypeStructuralQuery,
+        StructuralQuery, Subgraph, Vertex,
     },
 };
 
@@ -51,7 +52,7 @@ use crate::{
             PersistedOntologyIdentifier,
             PersistedOntologyMetadata,
             PersistedPropertyType,
-            StructuralQuery,
+            PropertyTypeStructuralQuery,
             GraphElementIdentifier,
             Vertex,
             EdgeKind,
@@ -158,7 +159,7 @@ async fn create_property_type<P: StorePool + Send>(
 #[utoipa::path(
     post,
     path = "/property-types/query",
-    request_body = StructuralQuery,
+    request_body = PropertyTypeStructuralQuery,
     tag = "PropertyType",
     responses(
         (status = 200, content_type = "application/json", body = Subgraph, description = "A subgraph rooted at property types that satisfy the given query, each resolved to the requested depth."),
@@ -167,20 +168,17 @@ async fn create_property_type<P: StorePool + Send>(
         (status = 500, description = "Store error occurred"),
     )
 )]
-async fn get_property_types_by_query<P>(
+async fn get_property_types_by_query<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
-    Json(query): Json<StructuralQuery>,
-) -> Result<Json<Subgraph>, StatusCode>
-where
-    for<'pool> P: StorePool<Store<'pool>: PropertyTypeStore> + Send,
-{
+    Json(query): Json<serde_json::Value>,
+) -> Result<Json<Subgraph>, StatusCode> {
     pool.acquire()
         .map_err(|error| {
             tracing::error!(?error, "Could not acquire access to the store");
             StatusCode::INTERNAL_SERVER_ERROR
         })
         .and_then(|store| async move {
-            let mut query = NewStructuralQuery::try_from(query).map_err(|error| {
+            let mut query = StructuralQuery::deserialize(&query).map_err(|error| {
                 tracing::error!(?error, "Could not deserialize query");
                 StatusCode::INTERNAL_SERVER_ERROR
             })?;

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph.rs
@@ -156,14 +156,14 @@ impl Extend<Self> for Subgraph {
 #[derive(Deserialize, ToSchema)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[aliases(
-    DataTypeStructuralQuery = NewStructuralQuery<'static, DataType>,
-    PropertyTypeStructuralQuery = NewStructuralQuery<'static, PropertyType>,
-    EntityTypeStructuralQuery = NewStructuralQuery<'static, EntityType>,
-    LinkTypeStructuralQuery = NewStructuralQuery<'static, LinkType>,
-    EntityStructuralQuery = NewStructuralQuery<'static, Entity>,
-    LinkStructuralQuery = NewStructuralQuery<'static, Link>,
+    DataTypeStructuralQuery = StructuralQuery<'static, DataType>,
+    PropertyTypeStructuralQuery = StructuralQuery<'static, PropertyType>,
+    EntityTypeStructuralQuery = StructuralQuery<'static, EntityType>,
+    LinkTypeStructuralQuery = StructuralQuery<'static, LinkType>,
+    EntityStructuralQuery = StructuralQuery<'static, Entity>,
+    LinkStructuralQuery = StructuralQuery<'static, Link>,
 )]
-pub struct NewStructuralQuery<'q, T: QueryRecord> {
+pub struct StructuralQuery<'q, T: QueryRecord> {
     #[serde(bound = "'de: 'q, T::Path<'q>: Deserialize<'de>")]
     pub filter: Filter<'q, T>,
     pub graph_resolve_depths: GraphResolveDepths,
@@ -171,7 +171,7 @@ pub struct NewStructuralQuery<'q, T: QueryRecord> {
 
 // TODO: Derive traits when bounds are generated correctly
 //   see https://github.com/rust-lang/rust/issues/26925
-impl<'q, T> Debug for NewStructuralQuery<'q, T>
+impl<'q, T> Debug for StructuralQuery<'q, T>
 where
     T: QueryRecord<Path<'q>: Debug>,
 {

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -28,7 +28,7 @@ use crate::{
     },
     provenance::{CreatedById, OwnedById, RemovedById, UpdatedById},
     store::{error::LinkRemovalError, query::Filter},
-    subgraph::{NewStructuralQuery, Subgraph},
+    subgraph::{StructuralQuery, Subgraph},
 };
 
 #[derive(Debug)]
@@ -221,14 +221,14 @@ pub trait DataTypeStore:
         actor_id: CreatedById,
     ) -> Result<PersistedOntologyMetadata, InsertionError>;
 
-    /// Get the [`Subgraph`] specified by the [`NewStructuralQuery`].
+    /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`DataType`] doesn't exist.
     async fn get_data_type<'f: 'q, 'q>(
         &self,
-        query: &'f NewStructuralQuery<'q, DataType>,
+        query: &'f StructuralQuery<'q, DataType>,
     ) -> Result<Subgraph, QueryError>;
 
     /// Update the definition of an existing [`DataType`].
@@ -263,14 +263,14 @@ pub trait PropertyTypeStore:
         actor_id: CreatedById,
     ) -> Result<PersistedOntologyMetadata, InsertionError>;
 
-    /// Get the [`Subgraph`] specified by the [`NewStructuralQuery`].
+    /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`PropertyType`] doesn't exist.
     async fn get_property_type<'f: 'q, 'q>(
         &self,
-        query: &'f NewStructuralQuery<'q, PropertyType>,
+        query: &'f StructuralQuery<'q, PropertyType>,
     ) -> Result<Subgraph, QueryError>;
 
     /// Update the definition of an existing [`PropertyType`].
@@ -305,14 +305,14 @@ pub trait EntityTypeStore:
         actor_id: CreatedById,
     ) -> Result<PersistedOntologyMetadata, InsertionError>;
 
-    /// Get the [`Subgraph`]s specified by the [`NewStructuralQuery`].
+    /// Get the [`Subgraph`]s specified by the [`StructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`EntityType`] doesn't exist.
     async fn get_entity_type<'f: 'q, 'q>(
         &self,
-        query: &'f NewStructuralQuery<'q, EntityType>,
+        query: &'f StructuralQuery<'q, EntityType>,
     ) -> Result<Subgraph, QueryError>;
 
     /// Update the definition of an existing [`EntityType`].
@@ -347,14 +347,14 @@ pub trait LinkTypeStore:
         actor_id: CreatedById,
     ) -> Result<PersistedOntologyMetadata, InsertionError>;
 
-    /// Get the [`Subgraph`] specified by the [`NewStructuralQuery`].
+    /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`LinkType`] doesn't exist.
     async fn get_link_type<'f: 'q, 'q>(
         &self,
-        query: &'f NewStructuralQuery<'q, LinkType>,
+        query: &'f StructuralQuery<'q, LinkType>,
     ) -> Result<Subgraph, QueryError>;
 
     /// Update the definition of an existing [`LinkType`].
@@ -418,14 +418,14 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Filter<'q
         actor_id: CreatedById,
     ) -> Result<Vec<EntityId>, InsertionError>;
 
-    /// Get the [`Subgraph`]s specified by the [`NewStructuralQuery`].
+    /// Get the [`Subgraph`]s specified by the [`StructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`Entity`] doesn't exist
     async fn get_entity<'f: 'q, 'q>(
         &self,
-        query: &'f NewStructuralQuery<'q, Entity>,
+        query: &'f StructuralQuery<'q, Entity>,
     ) -> Result<Subgraph, QueryError>;
 
     /// Update an existing [`Entity`].
@@ -462,14 +462,14 @@ pub trait LinkStore: for<'q> crud::Read<PersistedLink, Query<'q> = Filter<'q, Li
         actor_id: CreatedById,
     ) -> Result<(), InsertionError>;
 
-    /// Get the [`LinkRootedSubgraph`]s specified by the [`NewStructuralQuery`].
+    /// Get the [`LinkRootedSubgraph`]s specified by the [`StructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`Link`]s don't exist.
     async fn get_links<'f: 'q, 'q>(
         &self,
-        query: &'f NewStructuralQuery<'q, Link>,
+        query: &'f StructuralQuery<'q, Link>,
     ) -> Result<Vec<LinkRootedSubgraph>, QueryError>;
 
     /// Removes a [`Link`] between a source and target [`Entity`].

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -20,7 +20,7 @@ use crate::{
         postgres::{context::PostgresContext, DependencyContext, DependencyContextRef},
         AsClient, EntityStore, InsertionError, PostgresStore, QueryError, UpdateError,
     },
-    subgraph::{EdgeKind, GraphResolveDepths, NewStructuralQuery, OutwardEdge, Subgraph},
+    subgraph::{EdgeKind, GraphResolveDepths, OutwardEdge, StructuralQuery, Subgraph},
 };
 
 impl<C: AsClient> PostgresStore<C> {
@@ -227,9 +227,9 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
 
     async fn get_entity<'f: 'q, 'q>(
         &self,
-        query: &'q NewStructuralQuery<'q, Entity>,
+        query: &'q StructuralQuery<'q, Entity>,
     ) -> Result<Subgraph, QueryError> {
-        let NewStructuralQuery {
+        let StructuralQuery {
             ref filter,
             graph_resolve_depths,
         } = *query;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/link/mod.rs
@@ -18,7 +18,7 @@ use crate::{
         postgres::{DependencyContext, DependencyContextRef},
         AsClient, InsertionError, LinkStore, PostgresStore, QueryError,
     },
-    subgraph::{EdgeKind, GraphResolveDepths, NewStructuralQuery, OutwardEdge},
+    subgraph::{EdgeKind, GraphResolveDepths, OutwardEdge, StructuralQuery},
 };
 
 impl<C: AsClient> PostgresStore<C> {
@@ -145,9 +145,9 @@ impl<C: AsClient> LinkStore for PostgresStore<C> {
 
     async fn get_links<'f: 'q, 'q>(
         &self,
-        query: &'f NewStructuralQuery<'q, Link>,
+        query: &'f StructuralQuery<'q, Link>,
     ) -> Result<Vec<LinkRootedSubgraph>, QueryError> {
-        let NewStructuralQuery {
+        let StructuralQuery {
             ref filter,
             graph_resolve_depths,
         } = *query;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type/mod.rs
@@ -15,7 +15,7 @@ use crate::{
         postgres::{context::PostgresContext, DependencyContext, DependencyContextRef},
         AsClient, DataTypeStore, InsertionError, PostgresStore, QueryError, UpdateError,
     },
-    subgraph::{NewStructuralQuery, Subgraph},
+    subgraph::{StructuralQuery, Subgraph},
 };
 
 impl<C: AsClient> PostgresStore<C> {
@@ -81,9 +81,9 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
 
     async fn get_data_type<'f: 'q, 'q>(
         &self,
-        query: &'f NewStructuralQuery<'q, DataType>,
+        query: &'f StructuralQuery<'q, DataType>,
     ) -> Result<Subgraph, QueryError> {
-        let NewStructuralQuery {
+        let StructuralQuery {
             ref filter,
             graph_resolve_depths,
         } = *query;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         postgres::{context::PostgresContext, DependencyContext, DependencyContextRef},
         AsClient, EntityTypeStore, InsertionError, PostgresStore, QueryError, UpdateError,
     },
-    subgraph::{EdgeKind, GraphResolveDepths, NewStructuralQuery, OutwardEdge, Subgraph},
+    subgraph::{EdgeKind, GraphResolveDepths, OutwardEdge, StructuralQuery, Subgraph},
 };
 
 impl<C: AsClient> PostgresStore<C> {
@@ -200,9 +200,9 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
 
     async fn get_entity_type<'f: 'q, 'q>(
         &self,
-        query: &'f NewStructuralQuery<'q, EntityType>,
+        query: &'f StructuralQuery<'q, EntityType>,
     ) -> Result<Subgraph, QueryError> {
-        let NewStructuralQuery {
+        let StructuralQuery {
             ref filter,
             graph_resolve_depths,
         } = *query;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/link_type/mod.rs
@@ -15,7 +15,7 @@ use crate::{
         postgres::{context::PostgresContext, DependencyContext, DependencyContextRef},
         AsClient, InsertionError, LinkTypeStore, PostgresStore, QueryError, UpdateError,
     },
-    subgraph::{NewStructuralQuery, Subgraph},
+    subgraph::{StructuralQuery, Subgraph},
 };
 
 impl<C: AsClient> PostgresStore<C> {
@@ -76,9 +76,9 @@ impl<C: AsClient> LinkTypeStore for PostgresStore<C> {
 
     async fn get_link_type<'f: 'q, 'q>(
         &self,
-        query: &'f NewStructuralQuery<'q, LinkType>,
+        query: &'f StructuralQuery<'q, LinkType>,
     ) -> Result<Subgraph, QueryError> {
-        let NewStructuralQuery {
+        let StructuralQuery {
             ref filter,
             graph_resolve_depths,
         } = *query;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         postgres::{context::PostgresContext, DependencyContext, DependencyContextRef},
         AsClient, InsertionError, PostgresStore, PropertyTypeStore, QueryError, UpdateError,
     },
-    subgraph::{EdgeKind, GraphResolveDepths, NewStructuralQuery, OutwardEdge, Subgraph},
+    subgraph::{EdgeKind, GraphResolveDepths, OutwardEdge, StructuralQuery, Subgraph},
 };
 
 impl<C: AsClient> PostgresStore<C> {
@@ -165,9 +165,9 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
 
     async fn get_property_type<'f: 'q, 'q>(
         &self,
-        query: &'f NewStructuralQuery<'q, PropertyType>,
+        query: &'f StructuralQuery<'q, PropertyType>,
     ) -> Result<Subgraph, QueryError> {
-        let NewStructuralQuery {
+        let StructuralQuery {
             ref filter,
             graph_resolve_depths,
         } = *query;

--- a/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
@@ -364,6 +364,9 @@ impl Parameter<'_> {
             | (Parameter::Text(_), ParameterType::Text) => {
                 // no action needed, exact match
             }
+            (Parameter::Text(text), ParameterType::UnsignedInteger) if text == "latest" => {
+                // Special case for checking `version == "latest"
+            }
             (Parameter::Text(_base_uri), ParameterType::BaseUri) => {
                 // TODO: validate base uri
                 //   see https://app.asana.com/0/1202805690238892/1203225514907875/f

--- a/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
@@ -364,9 +364,6 @@ impl Parameter<'_> {
             | (Parameter::Text(_), ParameterType::Text) => {
                 // no action needed, exact match
             }
-            (Parameter::Text(text), ParameterType::UnsignedInteger) if text == "latest" => {
-                // Special case for checking `version == "latest"
-            }
             (Parameter::Text(_base_uri), ParameterType::BaseUri) => {
                 // TODO: validate base uri
                 //   see https://app.asana.com/0/1202805690238892/1203225514907875/f
@@ -395,6 +392,9 @@ impl Parameter<'_> {
                     expected: ParameterType::UnsignedInteger
                 });
                 *self = Parameter::SignedInteger(number);
+            }
+            (Parameter::Text(text), ParameterType::UnsignedInteger) if text == "latest" => {
+                // Special case for checking `version == "latest"
             }
             (actual, expected) => {
                 bail!(ParameterConversionError {

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -27,7 +27,7 @@ use graph::{
         EntityTypeStore, InsertionError, LinkStore, LinkTypeStore, PostgresStore,
         PostgresStorePool, PropertyTypeStore, QueryError, StorePool, UpdateError,
     },
-    subgraph::{GraphResolveDepths, NewStructuralQuery, Vertex},
+    subgraph::{GraphResolveDepths, StructuralQuery, Vertex},
 };
 use tokio_postgres::{NoTls, Transaction};
 use type_system::{uri::VersionedUri, DataType, EntityType, LinkType, PropertyType};
@@ -168,7 +168,7 @@ impl DatabaseApi<'_> {
     ) -> Result<PersistedDataType, QueryError> {
         let vertex = self
             .store
-            .get_data_type(&NewStructuralQuery {
+            .get_data_type(&StructuralQuery {
                 filter: Filter::for_versioned_uri(uri),
                 graph_resolve_depths: GraphResolveDepths::zeroed(),
             })
@@ -211,7 +211,7 @@ impl DatabaseApi<'_> {
     ) -> Result<PersistedPropertyType, QueryError> {
         let vertex = self
             .store
-            .get_property_type(&NewStructuralQuery {
+            .get_property_type(&StructuralQuery {
                 filter: Filter::for_versioned_uri(uri),
                 graph_resolve_depths: GraphResolveDepths::zeroed(),
             })
@@ -254,7 +254,7 @@ impl DatabaseApi<'_> {
     ) -> Result<PersistedEntityType, QueryError> {
         let vertex = self
             .store
-            .get_entity_type(&NewStructuralQuery {
+            .get_entity_type(&StructuralQuery {
                 filter: Filter::for_versioned_uri(uri),
                 graph_resolve_depths: GraphResolveDepths::zeroed(),
             })
@@ -297,7 +297,7 @@ impl DatabaseApi<'_> {
     ) -> Result<PersistedLinkType, QueryError> {
         let vertex = self
             .store
-            .get_link_type(&NewStructuralQuery {
+            .get_link_type(&StructuralQuery {
                 filter: Filter::for_versioned_uri(uri),
                 graph_resolve_depths: GraphResolveDepths::zeroed(),
             })
@@ -341,7 +341,7 @@ impl DatabaseApi<'_> {
     pub async fn get_entity(&mut self, entity_id: EntityId) -> Result<PersistedEntity, QueryError> {
         let vertex = self
             .store
-            .get_entity(&NewStructuralQuery {
+            .get_entity(&StructuralQuery {
                 filter: Filter::for_latest_entity_by_entity_id(entity_id),
                 graph_resolve_depths: GraphResolveDepths::zeroed(),
             })
@@ -417,7 +417,7 @@ impl DatabaseApi<'_> {
     ) -> Result<PersistedLink, QueryError> {
         Ok(self
             .store
-            .get_links(&NewStructuralQuery {
+            .get_links(&StructuralQuery {
                 filter: Filter::All(vec![
                     Filter::for_link_by_latest_source_entity(source_entity_id),
                     Filter::Equal(
@@ -452,7 +452,7 @@ impl DatabaseApi<'_> {
     ) -> Result<Vec<PersistedLink>, QueryError> {
         Ok(self
             .store
-            .get_links(&NewStructuralQuery {
+            .get_links(&StructuralQuery {
                 filter: Filter::for_link_by_latest_source_entity(source_entity_id),
                 graph_resolve_depths: GraphResolveDepths::zeroed(),
             })

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -392,15 +392,15 @@ POST http://127.0.0.1:4000/entities/query
 Content-Type: application/json
 
 {
-  "query": {
-    "eq": [
+  "filter": {
+    "equal": [
       {
         "path": [
           "version"
         ]
       },
       {
-        "literal": "latest"
+        "parameter": "latest"
       }
     ]
   },

--- a/packages/hash/api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -68,7 +68,9 @@ export const getAllLatestPersistedEntities: ResolverFn<
 
   const { data: entitySubgraph } = await graphApi
     .getEntitiesByQuery({
-      query: { eq: [{ path: ["version"] }, { literal: "latest" }] },
+      filter: {
+        equal: [{ path: ["version"] }, { parameter: "latest" }],
+      },
       graphResolveDepths: {
         dataTypeResolveDepth,
         propertyTypeResolveDepth,
@@ -110,16 +112,21 @@ export const getPersistedEntity: ResolverFn<
 ) => {
   const { graphApi } = dataSources;
 
-  const query = {
+  const filter = {
     all: [
-      { eq: [{ path: ["version"] }, { literal: entityVersion ?? "latest" }] },
-      { eq: [{ path: ["id"] }, { literal: entityId }] },
+      {
+        equal: [
+          { path: ["version"] },
+          { parameter: entityVersion ?? "latest" },
+        ],
+      },
+      { equal: [{ path: ["id"] }, { parameter: entityId }] },
     ],
   };
 
   const { data: entitySubgraph } = await graphApi
     .getEntitiesByQuery({
-      query,
+      filter,
       graphResolveDepths: {
         dataTypeResolveDepth,
         propertyTypeResolveDepth,

--- a/packages/hash/api/src/graphql/resolvers/knowledge/link/link.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/link/link.ts
@@ -56,13 +56,15 @@ export const outgoingPersistedLinks: ResolverFn<
 ) => {
   const linkModels = await LinkModel.getByQuery(graphApi, {
     all: [
-      { eq: [{ path: ["source", "id"] }, { literal: sourceEntityId }] },
+      {
+        equal: [{ path: ["source", "id"] }, { parameter: sourceEntityId }],
+      },
       linkTypeId
         ? {
-            eq: [
+            equal: [
               { path: ["type", "versionedUri"] },
               {
-                literal: linkTypeId,
+                parameter: linkTypeId,
               },
             ],
           }

--- a/packages/hash/api/src/graphql/resolvers/ontology/data-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/data-type.ts
@@ -20,7 +20,9 @@ export const getAllLatestDataTypes: ResolverFn<
 
   const { data: dataTypeSubgraph } = await graphApi
     .getDataTypesByQuery({
-      query: { eq: [{ path: ["version"] }, { literal: "latest" }] },
+      filter: {
+        equal: [{ path: ["version"] }, { parameter: "latest" }],
+      },
       graphResolveDepths: {
         dataTypeResolveDepth,
         propertyTypeResolveDepth: 0,
@@ -50,8 +52,8 @@ export const getDataType: ResolverFn<
 
   const { data: dataTypeSubgraph } = await graphApi
     .getDataTypesByQuery({
-      query: {
-        eq: [{ path: ["versionedUri"] }, { literal: dataTypeId }],
+      filter: {
+        equal: [{ path: ["versionedUri"] }, { parameter: dataTypeId }],
       },
       /** @todo - make these configurable once non-primitive data types are a thing https://app.asana.com/0/1200211978612931/1202464168422955/f */
       graphResolveDepths: {

--- a/packages/hash/api/src/graphql/resolvers/ontology/entity-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/entity-type.ts
@@ -54,7 +54,9 @@ export const getAllLatestEntityTypes: ResolverFn<
 
   const { data: entityTypeSubgraph } = await graphApi
     .getEntityTypesByQuery({
-      query: { eq: [{ path: ["version"] }, { literal: "latest" }] },
+      filter: {
+        equal: [{ path: ["version"] }, { parameter: "latest" }],
+      },
       graphResolveDepths: {
         dataTypeResolveDepth,
         propertyTypeResolveDepth,
@@ -95,8 +97,8 @@ export const getEntityType: ResolverFn<
 
   const { data: entityTypeSubgraph } = await graphApi
     .getEntityTypesByQuery({
-      query: {
-        eq: [{ path: ["versionedUri"] }, { literal: entityTypeId }],
+      filter: {
+        equal: [{ path: ["versionedUri"] }, { parameter: entityTypeId }],
       },
       graphResolveDepths: {
         dataTypeResolveDepth,

--- a/packages/hash/api/src/graphql/resolvers/ontology/link-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/link-type.ts
@@ -43,7 +43,9 @@ export const getAllLatestLinkTypes: ResolverFn<
 
   const { data: linkTypeSubgraph } = await graphApi
     .getLinkTypesByQuery({
-      query: { eq: [{ path: ["version"] }, { literal: "latest" }] },
+      filter: {
+        equal: [{ path: ["version"] }, { parameter: "latest" }],
+      },
       graphResolveDepths: {
         dataTypeResolveDepth: 0,
         propertyTypeResolveDepth: 0,
@@ -73,8 +75,8 @@ export const getLinkType: ResolverFn<
 
   const { data: linkTypeSubgraph } = await graphApi
     .getLinkTypesByQuery({
-      query: {
-        eq: [{ path: ["versionedUri"] }, { literal: linkTypeId }],
+      filter: {
+        equal: [{ path: ["versionedUri"] }, { parameter: linkTypeId }],
       },
       graphResolveDepths: {
         dataTypeResolveDepth: 0,

--- a/packages/hash/api/src/graphql/resolvers/ontology/property-type.ts
+++ b/packages/hash/api/src/graphql/resolvers/ontology/property-type.ts
@@ -55,7 +55,9 @@ export const getAllLatestPropertyTypes: ResolverFn<
    */
   const { data: propertyTypeSubgraph } = await graphApi
     .getPropertyTypesByQuery({
-      query: { eq: [{ path: ["version"] }, { literal: "latest" }] },
+      filter: {
+        equal: [{ path: ["version"] }, { parameter: "latest" }],
+      },
       graphResolveDepths: {
         dataTypeResolveDepth,
         propertyTypeResolveDepth,
@@ -90,8 +92,8 @@ export const getPropertyType: ResolverFn<
 
   const { data: propertyTypeSubgraph } = await graphApi
     .getDataTypesByQuery({
-      query: {
-        eq: [{ path: ["versionedUri"] }, { literal: propertyTypeId }],
+      filter: {
+        equal: [{ path: ["versionedUri"] }, { parameter: propertyTypeId }],
       },
       graphResolveDepths: {
         dataTypeResolveDepth,

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -2,8 +2,8 @@ import { ApolloError } from "apollo-server-errors";
 import {
   PersistedEntity,
   GraphApi,
-  StructuralQuery,
   Vertex,
+  EntityStructuralQuery,
 } from "@hashintel/hash-graph-client";
 
 import {
@@ -304,11 +304,11 @@ export default class {
 
   static async getByQuery(
     graphApi: GraphApi,
-    query: object,
-    options?: Omit<Partial<StructuralQuery>, "query">,
+    filter: object,
+    options?: Omit<Partial<EntityStructuralQuery>, "query">,
   ): Promise<EntityModel[]> {
     const { data: subgraph } = await graphApi.getEntitiesByQuery({
-      query,
+      filter,
       graphResolveDepths: {
         dataTypeResolveDepth:
           options?.graphResolveDepths?.dataTypeResolveDepth ?? 0,
@@ -493,14 +493,14 @@ export default class {
     const incomingLinks = await LinkModel.getByQuery(graphApi, {
       all: [
         {
-          eq: [{ path: ["target", "id"] }, { literal: this.entityId }],
+          equal: [{ path: ["target", "id"] }, { parameter: this.entityId }],
         },
         params?.linkTypeModel
           ? {
-              eq: [
+              equal: [
                 { path: ["type", "versionedUri"] },
                 {
-                  literal: params.linkTypeModel.schema.$id,
+                  parameter: params.linkTypeModel.schema.$id,
                 },
               ],
             }
@@ -523,14 +523,14 @@ export default class {
     const outgoingLinks = await LinkModel.getByQuery(graphApi, {
       all: [
         {
-          eq: [{ path: ["source", "id"] }, { literal: this.entityId }],
+          equal: [{ path: ["source", "id"] }, { parameter: this.entityId }],
         },
         params?.linkTypeModel
           ? {
-              eq: [
+              equal: [
                 { path: ["type", "versionedUri"] },
                 {
-                  literal: params.linkTypeModel.schema.$id,
+                  parameter: params.linkTypeModel.schema.$id,
                 },
               ],
             }

--- a/packages/hash/api/src/model/knowledge/link.model.ts
+++ b/packages/hash/api/src/model/knowledge/link.model.ts
@@ -1,5 +1,5 @@
 import {
-  StructuralQuery,
+  LinkStructuralQuery,
   GraphApi,
   PersistedLink,
 } from "@hashintel/hash-graph-client";
@@ -82,11 +82,11 @@ export default class {
 
   static async getByQuery(
     graphApi: GraphApi,
-    query: object,
-    options?: Omit<Partial<StructuralQuery>, "query">,
+    filter: object,
+    options?: Omit<Partial<LinkStructuralQuery>, "query">,
   ): Promise<LinkModel[]> {
     const { data: linkRootedSubgraphs } = await graphApi.getLinksByQuery({
-      query,
+      filter,
       graphResolveDepths: {
         dataTypeResolveDepth:
           options?.graphResolveDepths?.dataTypeResolveDepth ?? 0,
@@ -121,13 +121,17 @@ export default class {
 
     const linkModels = await LinkModel.getByQuery(graphApi, {
       all: [
-        { eq: [{ path: ["source", "id"] }, { literal: sourceEntityId }] },
-        { eq: [{ path: ["target", "id"] }, { literal: targetEntityId }] },
         {
-          eq: [
+          equal: [{ path: ["source", "id"] }, { parameter: sourceEntityId }],
+        },
+        {
+          equal: [{ path: ["target", "id"] }, { parameter: targetEntityId }],
+        },
+        {
+          equal: [
             { path: ["type", "versionedUri"] },
             {
-              literal: linkTypeId,
+              parameter: linkTypeId,
             },
           ],
         },

--- a/packages/hash/api/src/model/knowledge/org.model.ts
+++ b/packages/hash/api/src/model/knowledge/org.model.ts
@@ -116,11 +116,11 @@ export default class extends EntityModel {
     /** @todo: use upcoming Graph API method to filter entities in the datastore */
     const orgEntities = await EntityModel.getByQuery(graphApi, {
       all: [
-        { eq: [{ path: ["version"] }, { literal: "latest" }] },
+        { equal: [{ path: ["version"] }, { parameter: "latest" }] },
         {
-          eq: [
+          equal: [
             { path: ["type", "versionedUri"] },
-            { literal: WORKSPACE_TYPES.entityType.org.schema.$id },
+            { parameter: WORKSPACE_TYPES.entityType.org.schema.$id },
           ],
         },
       ],

--- a/packages/hash/api/src/model/knowledge/orgMembership.model.ts
+++ b/packages/hash/api/src/model/knowledge/orgMembership.model.ts
@@ -93,13 +93,13 @@ export default class extends EntityModel {
     const outgoingOrgLinks = await LinkModel.getByQuery(graphApi, {
       all: [
         {
-          eq: [{ path: ["source", "id"] }, { literal: this.entityId }],
+          equal: [{ path: ["source", "id"] }, { parameter: this.entityId }],
         },
         {
-          eq: [
+          equal: [
             { path: ["type", "versionedUri"] },
             {
-              literal: WORKSPACE_TYPES.linkType.ofOrg.schema.$id,
+              parameter: WORKSPACE_TYPES.linkType.ofOrg.schema.$id,
             },
           ],
         },
@@ -130,16 +130,16 @@ export default class extends EntityModel {
   async getUser(graphApi: GraphApi) {
     const { data: incomingOrgMembershipLinks } = await graphApi.getLinksByQuery(
       {
-        query: {
+        filter: {
           all: [
             {
-              eq: [{ path: ["target", "id"] }, { literal: this.entityId }],
+              equal: [{ path: ["target", "id"] }, { parameter: this.entityId }],
             },
             {
-              eq: [
+              equal: [
                 { path: ["type", "versionedUri"] },
                 {
-                  literal: WORKSPACE_TYPES.linkType.hasMembership.schema.$id,
+                  parameter: WORKSPACE_TYPES.linkType.hasMembership.schema.$id,
                 },
               ],
             },

--- a/packages/hash/api/src/model/knowledge/page.model.ts
+++ b/packages/hash/api/src/model/knowledge/page.model.ts
@@ -134,11 +134,11 @@ export default class extends EntityModel {
   ): Promise<PageModel[]> {
     const pageEntityModels = await EntityModel.getByQuery(graphApi, {
       all: [
-        { eq: [{ path: ["version"] }, { literal: "latest" }] },
+        { equal: [{ path: ["version"] }, { parameter: "latest" }] },
         {
-          eq: [
+          equal: [
             { path: ["type", "versionedUri"] },
-            { literal: WORKSPACE_TYPES.entityType.page.schema.$id },
+            { parameter: WORKSPACE_TYPES.entityType.page.schema.$id },
           ],
         },
       ],
@@ -365,13 +365,13 @@ export default class extends EntityModel {
     const outgoingBlockDataLinks = await LinkModel.getByQuery(graphApi, {
       all: [
         {
-          eq: [{ path: ["source", "id"] }, { literal: this.entityId }],
+          equal: [{ path: ["source", "id"] }, { parameter: this.entityId }],
         },
         {
-          eq: [
+          equal: [
             { path: ["type", "versionedUri"] },
             {
-              literal: WORKSPACE_TYPES.linkType.contains.schema.$id,
+              parameter: WORKSPACE_TYPES.linkType.contains.schema.$id,
             },
           ],
         },

--- a/packages/hash/api/src/model/knowledge/user.model.ts
+++ b/packages/hash/api/src/model/knowledge/user.model.ts
@@ -73,11 +73,11 @@ export default class extends EntityModel {
      */
     const userEntities = await EntityModel.getByQuery(graphApi, {
       all: [
-        { eq: [{ path: ["version"] }, { literal: "latest" }] },
+        { equal: [{ path: ["version"] }, { parameter: "latest" }] },
         {
-          eq: [
+          equal: [
             { path: ["type", "versionedUri"] },
-            { literal: WORKSPACE_TYPES.entityType.user.schema.$id },
+            { parameter: WORKSPACE_TYPES.entityType.user.schema.$id },
           ],
         },
       ],
@@ -105,11 +105,11 @@ export default class extends EntityModel {
      */
     const userEntities = await EntityModel.getByQuery(graphApi, {
       all: [
-        { eq: [{ path: ["version"] }, { literal: "latest" }] },
+        { equal: [{ path: ["version"] }, { parameter: "latest" }] },
         {
-          eq: [
+          equal: [
             { path: ["type", "versionedUri"] },
-            { literal: WORKSPACE_TYPES.entityType.user.schema.$id },
+            { parameter: WORKSPACE_TYPES.entityType.user.schema.$id },
           ],
         },
       ],
@@ -391,16 +391,16 @@ export default class extends EntityModel {
   async getOrgMemberships(graphApi: GraphApi): Promise<OrgMembershipModel[]> {
     const { data: outgoingOrgMembershipLinkRootedSubgraphs } =
       await graphApi.getLinksByQuery({
-        query: {
+        filter: {
           all: [
             {
-              eq: [{ path: ["source", "id"] }, { literal: this.entityId }],
+              equal: [{ path: ["source", "id"] }, { parameter: this.entityId }],
             },
             {
-              eq: [
+              equal: [
                 { path: ["type", "versionedUri"] },
                 {
-                  literal: WORKSPACE_TYPES.linkType.hasMembership.schema.$id,
+                  parameter: WORKSPACE_TYPES.linkType.hasMembership.schema.$id,
                 },
               ],
             },

--- a/packages/hash/integration/src/tests/model/knowledge/entity.model.test.ts
+++ b/packages/hash/integration/src/tests/model/knowledge/entity.model.test.ts
@@ -181,7 +181,7 @@ describe("Entity CRU", () => {
   it("can read all latest entities", async () => {
     const allEntityModels = (
       await EntityModel.getByQuery(graphApi, {
-        all: [{ eq: [{ path: ["version"] }, { literal: "latest" }] }],
+        all: [{ equal: [{ path: ["version"] }, { parameter: "latest" }] }],
       })
     ).filter((entity) => entity.ownedById === testUser.entityId);
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The optimization implementation in Rust is finished, so the next step is to expose the new queries to the backend. To make this reviewable, this task is split up into three parts:
- #1277
- #1278 (this PR)
- #1279

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203007126736610/1203157447721367/f) _(internal)_

## 🚫 Blocked by

- #1267
- #1268
- #1269
- #1271
- #1272 
- #1273 
- #1228 
- #1274
- #1275
- #1276
- #1277

## 🔍 What does this change?

- Revert the renaming done in #1277
- Generated new OpenAPI specs with new queries
- Adjusted the backend to use new queries 🎉 

## 🐾 Next steps

- #1279

## 🛡 What tests cover this?

The backend integration test are now testing implicitly the new optimized queries 🎉 