### PR TITLE
Generate OpenAPI specs to make the usage of queries more type-safe

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -815,11 +815,43 @@ export interface ParameterExpression {
 export interface PathExpression {
   /**
    *
-   * @type {Array<string>}
+   * @type {Array<object>}
    * @memberof PathExpression
    */
-  path: Array<string>;
+  path: Array<PathExpressionPathEnum>;
 }
+
+export const PathExpressionPathEnum = {
+  Star: "*",
+  OwnedById: "ownedById",
+  CreatedById: "createdById",
+  UpdatedById: "updatedById",
+  RemovedById: "removedById",
+  BaseUri: "baseUri",
+  VersionedUri: "versionedUri",
+  Version: "version",
+  Title: "title",
+  Description: "description",
+  Type: "type",
+  Id: "id",
+  Properties: "properties",
+  IncomingLinks: "incomingLinks",
+  OutgoingLinks: "outgoingLinks",
+  Default: "default",
+  Examples: "examples",
+  Required: "required",
+  Links: "links",
+  RequiredLinks: "requiredLinks",
+  Source: "source",
+  Target: "target",
+  RelatedKeywords: "relatedKeywords",
+  DataTypes: "dataTypes",
+  PropertyTypes: "propertyTypes",
+} as const;
+
+export type PathExpressionPathEnum =
+  typeof PathExpressionPathEnum[keyof typeof PathExpressionPathEnum];
+
 /**
  *
  * @export

--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -47,6 +47,32 @@ import {
 /**
  *
  * @export
+ * @interface AllFilter
+ */
+export interface AllFilter {
+  /**
+   *
+   * @type {Array<Filter>}
+   * @memberof AllFilter
+   */
+  all: Array<Filter>;
+}
+/**
+ *
+ * @export
+ * @interface AnyFilter
+ */
+export interface AnyFilter {
+  /**
+   *
+   * @type {Array<Filter>}
+   * @memberof AnyFilter
+   */
+  any: Array<Filter>;
+}
+/**
+ *
+ * @export
  * @interface CreateDataTypeRequest
  */
 export interface CreateDataTypeRequest {
@@ -299,10 +325,10 @@ export interface DataTypeReferenceUpdate {
 export interface DataTypeStructuralQuery {
   /**
    *
-   * @type {object}
+   * @type {Filter}
    * @memberof DataTypeStructuralQuery
    */
-  filter: object;
+  filter: Filter;
   /**
    *
    * @type {GraphResolveDepths}
@@ -352,10 +378,10 @@ export interface EdgesValueInner {
 export interface EntityStructuralQuery {
   /**
    *
-   * @type {object}
+   * @type {Filter}
    * @memberof EntityStructuralQuery
    */
-  filter: object;
+  filter: Filter;
   /**
    *
    * @type {GraphResolveDepths}
@@ -464,10 +490,10 @@ export type EntityTypeTypeEnum =
 export interface EntityTypeStructuralQuery {
   /**
    *
-   * @type {object}
+   * @type {Filter}
    * @memberof EntityTypeStructuralQuery
    */
-  filter: object;
+  filter: Filter;
   /**
    *
    * @type {GraphResolveDepths}
@@ -475,6 +501,36 @@ export interface EntityTypeStructuralQuery {
    */
   graphResolveDepths: GraphResolveDepths;
 }
+/**
+ *
+ * @export
+ * @interface EqualFilter
+ */
+export interface EqualFilter {
+  /**
+   *
+   * @type {Array<FilterExpression>}
+   * @memberof EqualFilter
+   */
+  equal: Array<FilterExpression>;
+}
+/**
+ * @type Filter
+ * @export
+ */
+export type Filter =
+  | AllFilter
+  | AnyFilter
+  | EqualFilter
+  | NotEqualFilter
+  | NotFilter;
+
+/**
+ * @type FilterExpression
+ * @export
+ */
+export type FilterExpression = ParameterExpression | PathExpression;
+
 /**
  * @type GraphElementIdentifier
  * @export
@@ -612,10 +668,10 @@ export interface LinkRootedSubgraph {
 export interface LinkStructuralQuery {
   /**
    *
-   * @type {object}
+   * @type {Filter}
    * @memberof LinkStructuralQuery
    */
-  filter: object;
+  filter: Filter;
   /**
    *
    * @type {GraphResolveDepths}
@@ -682,16 +738,42 @@ export type LinkTypeKindEnum =
 export interface LinkTypeStructuralQuery {
   /**
    *
-   * @type {object}
+   * @type {Filter}
    * @memberof LinkTypeStructuralQuery
    */
-  filter: object;
+  filter: Filter;
   /**
    *
    * @type {GraphResolveDepths}
    * @memberof LinkTypeStructuralQuery
    */
   graphResolveDepths: GraphResolveDepths;
+}
+/**
+ *
+ * @export
+ * @interface NotEqualFilter
+ */
+export interface NotEqualFilter {
+  /**
+   *
+   * @type {Array<FilterExpression>}
+   * @memberof NotEqualFilter
+   */
+  notEqual: Array<FilterExpression>;
+}
+/**
+ *
+ * @export
+ * @interface NotFilter
+ */
+export interface NotFilter {
+  /**
+   *
+   * @type {Filter}
+   * @memberof NotFilter
+   */
+  not: Filter;
 }
 /**
  *
@@ -711,6 +793,32 @@ export interface OutwardEdge {
    * @memberof OutwardEdge
    */
   edgeKind: EdgeKind;
+}
+/**
+ *
+ * @export
+ * @interface ParameterExpression
+ */
+export interface ParameterExpression {
+  /**
+   *
+   * @type {boolean | number | string}
+   * @memberof ParameterExpression
+   */
+  parameter: boolean | number | string;
+}
+/**
+ *
+ * @export
+ * @interface PathExpression
+ */
+export interface PathExpression {
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof PathExpression
+   */
+  path: Array<string>;
 }
 /**
  *
@@ -1147,10 +1255,10 @@ export type PropertyTypeKindEnum =
 export interface PropertyTypeStructuralQuery {
   /**
    *
-   * @type {object}
+   * @type {Filter}
    * @memberof PropertyTypeStructuralQuery
    */
-  filter: object;
+  filter: Filter;
   /**
    *
    * @type {GraphResolveDepths}

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
@@ -24,7 +24,10 @@ use error_stack::Report;
 use futures::TryFutureExt;
 use include_dir::{include_dir, Dir};
 use utoipa::{
-    openapi::{self, schema, schema::RefOr, ObjectBuilder},
+    openapi::{
+        self, schema, schema::RefOr, ArrayBuilder, ObjectBuilder, OneOfBuilder, Ref, SchemaFormat,
+        SchemaType,
+    },
     Modify, OpenApi,
 };
 
@@ -33,7 +36,7 @@ use crate::{
     ontology::domain_validator::DomainValidator,
     store::{
         crud::Read,
-        query::{Expression, ExpressionError, ResolveError},
+        query::{ExpressionError, ResolveError},
         StorePool,
     },
 };
@@ -165,7 +168,7 @@ async fn serve_static_schema(Path(path): Path<String>) -> Result<Response, Statu
         tags(
             (name = "Graph", description = "HASH Graph API")
         ),
-        modifiers(&MergeAddon, &ExternalRefAddon, &OperationGraphTagAddon, &FilterObjectAddon)
+        modifiers(&MergeAddon, &ExternalRefAddon, &OperationGraphTagAddon, &FilterSchemaAddon)
     )]
 struct OpenApiDocumentation;
 
@@ -300,23 +303,102 @@ impl Modify for OperationGraphTagAddon {
     }
 }
 
-struct FilterObjectAddon;
+struct FilterSchemaAddon;
 
-impl Modify for FilterObjectAddon {
+impl Modify for FilterSchemaAddon {
     fn modify(&self, openapi: &mut openapi::OpenApi) {
-        openapi.components.as_mut().map(|components| {
+        if let Some(ref mut components) = openapi.components {
             components.schemas.insert(
                 "Filter".to_owned(),
-                schema::Schema::Object(
-                    ObjectBuilder::new()
-                        .example(Some(
-                            serde_json::to_value(Expression::for_latest_version())
-                                .expect("could not serialize expression"),
-                        ))
+                schema::Schema::OneOf(
+                    OneOfBuilder::new()
+                        .item(
+                            ObjectBuilder::new()
+                                .title(Some("AllFilter"))
+                                .property(
+                                    "all",
+                                    ArrayBuilder::new().items(Ref::from_schema_name("Filter")),
+                                )
+                                .required("all"),
+                        )
+                        .item(
+                            ObjectBuilder::new()
+                                .title(Some("AnyFilter"))
+                                .property(
+                                    "any",
+                                    ArrayBuilder::new().items(Ref::from_schema_name("Filter")),
+                                )
+                                .required("any"),
+                        )
+                        .item(
+                            ObjectBuilder::new()
+                                .title(Some("NotFilter"))
+                                .property("not", Ref::from_schema_name("Filter"))
+                                .required("not"),
+                        )
+                        .item(
+                            ObjectBuilder::new()
+                                .title(Some("EqualFilter"))
+                                .property(
+                                    "equal",
+                                    ArrayBuilder::new()
+                                        .items(Ref::from_schema_name("FilterExpression"))
+                                        .min_items(Some(2))
+                                        .max_items(Some(2)),
+                                )
+                                .required("equal"),
+                        )
+                        .item(
+                            ObjectBuilder::new()
+                                .title(Some("NotEqualFilter"))
+                                .property(
+                                    "notEqual",
+                                    ArrayBuilder::new()
+                                        .items(Ref::from_schema_name("FilterExpression"))
+                                        .min_items(Some(2))
+                                        .max_items(Some(2)),
+                                )
+                                .required("notEqual"),
+                        )
                         .build(),
                 )
                 .into(),
-            )
-        });
+            );
+            components.schemas.insert(
+                "FilterExpression".to_owned(),
+                schema::Schema::OneOf(
+                    OneOfBuilder::new()
+                        .item(
+                            ObjectBuilder::new()
+                                .title(Some("PathExpression"))
+                                .property(
+                                    "path",
+                                    ArrayBuilder::new().items(
+                                        ObjectBuilder::new().schema_type(SchemaType::String),
+                                    ),
+                                )
+                                .required("path"),
+                        )
+                        .item(
+                            ObjectBuilder::new()
+                                .title(Some("ParameterExpression"))
+                                .property(
+                                    "parameter",
+                                    OneOfBuilder::new()
+                                        .item(ObjectBuilder::new().schema_type(SchemaType::Boolean))
+                                        .item(
+                                            ObjectBuilder::new()
+                                                .schema_type(SchemaType::Number)
+                                                .format(Some(SchemaFormat::Float)),
+                                        )
+                                        .item(ObjectBuilder::new().schema_type(SchemaType::String)),
+                                )
+                                .required("parameter"),
+                        )
+                        .build(),
+                )
+                .into(),
+            );
+        }
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
@@ -306,6 +306,7 @@ impl Modify for OperationGraphTagAddon {
 struct FilterSchemaAddon;
 
 impl Modify for FilterSchemaAddon {
+    #[expect(clippy::too_many_lines)]
     fn modify(&self, openapi: &mut openapi::OpenApi) {
         if let Some(ref mut components) = openapi.components {
             components.schemas.insert(
@@ -373,9 +374,35 @@ impl Modify for FilterSchemaAddon {
                                 .title(Some("PathExpression"))
                                 .property(
                                     "path",
-                                    ArrayBuilder::new().items(
-                                        ObjectBuilder::new().schema_type(SchemaType::String),
-                                    ),
+                                    ArrayBuilder::new().items(ObjectBuilder::new().enum_values(
+                                        Some([
+                                            "*",
+                                            "ownedById",
+                                            "createdById",
+                                            "updatedById",
+                                            "removedById",
+                                            "baseUri",
+                                            "versionedUri",
+                                            "version",
+                                            "title",
+                                            "description",
+                                            "type",
+                                            "id",
+                                            "properties",
+                                            "incomingLinks",
+                                            "outgoingLinks",
+                                            "default",
+                                            "examples",
+                                            "required",
+                                            "links",
+                                            "requiredLinks",
+                                            "source",
+                                            "target",
+                                            "relatedKeywords",
+                                            "dataTypes",
+                                            "propertyTypes",
+                                        ]),
+                                    )),
                                 )
                                 .required("path"),
                         )

--- a/packages/hash/api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -15,6 +15,7 @@ import {
 } from "../model-mapping";
 import { LoggedInGraphQLContext } from "../../../context";
 import { mapSubgraphToGql } from "../../ontology/model-mapping";
+import { Filter } from "packages/graph/clients/typescript";
 
 /** @todo - rename these and remove "persisted" - https://app.asana.com/0/0/1203157172269854/f */
 
@@ -112,7 +113,7 @@ export const getPersistedEntity: ResolverFn<
 ) => {
   const { graphApi } = dataSources;
 
-  const filter = {
+  const filter: Filter = {
     all: [
       {
         equal: [

--- a/packages/hash/api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -1,3 +1,4 @@
+import { Filter } from "@hashintel/hash-graph-client";
 import { AxiosError } from "axios";
 import { ApolloError } from "apollo-server-express";
 import { EntityModel } from "../../../../model";
@@ -15,7 +16,6 @@ import {
 } from "../model-mapping";
 import { LoggedInGraphQLContext } from "../../../context";
 import { mapSubgraphToGql } from "../../ontology/model-mapping";
-import { Filter } from "packages/graph/clients/typescript";
 
 /** @todo - rename these and remove "persisted" - https://app.asana.com/0/0/1203157172269854/f */
 

--- a/packages/hash/api/src/graphql/resolvers/knowledge/link/link.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/link/link.ts
@@ -1,3 +1,4 @@
+import { Filter } from "packages/graph/clients/typescript";
 import { EntityModel, LinkModel, LinkTypeModel } from "../../../../model";
 import {
   MutationCreatePersistedLinkArgs,
@@ -54,23 +55,26 @@ export const outgoingPersistedLinks: ResolverFn<
   { sourceEntityId, linkTypeId },
   { dataSources: { graphApi } },
 ) => {
-  const linkModels = await LinkModel.getByQuery(graphApi, {
+  const filter: Filter = {
     all: [
       {
         equal: [{ path: ["source", "id"] }, { parameter: sourceEntityId }],
       },
-      linkTypeId
-        ? {
-            equal: [
-              { path: ["type", "versionedUri"] },
-              {
-                parameter: linkTypeId,
-              },
-            ],
-          }
-        : [],
-    ].flat(),
-  });
+    ],
+  };
+
+  if (linkTypeId) {
+    filter.all.push({
+      equal: [
+        { path: ["type", "versionedUri"] },
+        {
+          parameter: linkTypeId,
+        },
+      ],
+    });
+  }
+
+  const linkModels = await LinkModel.getByQuery(graphApi, filter);
 
   return linkModels.map(mapLinkModelToGQL);
 };

--- a/packages/hash/api/src/graphql/resolvers/knowledge/link/link.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/link/link.ts
@@ -1,4 +1,4 @@
-import { Filter } from "packages/graph/clients/typescript";
+import { Filter } from "@hashintel/hash-graph-client";
 import { EntityModel, LinkModel, LinkTypeModel } from "../../../../model";
 import {
   MutationCreatePersistedLinkArgs,

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -4,6 +4,7 @@ import {
   GraphApi,
   Vertex,
   EntityStructuralQuery,
+  Filter,
 } from "@hashintel/hash-graph-client";
 
 import {
@@ -304,7 +305,7 @@ export default class {
 
   static async getByQuery(
     graphApi: GraphApi,
-    filter: object,
+    filter: Filter,
     options?: Omit<Partial<EntityStructuralQuery>, "query">,
   ): Promise<EntityModel[]> {
     const { data: subgraph } = await graphApi.getEntitiesByQuery({

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -306,7 +306,7 @@ export default class {
   static async getByQuery(
     graphApi: GraphApi,
     filter: Filter,
-    options?: Omit<Partial<EntityStructuralQuery>, "query">,
+    options?: Omit<Partial<EntityStructuralQuery>, "filter">,
   ): Promise<EntityModel[]> {
     const { data: subgraph } = await graphApi.getEntitiesByQuery({
       filter,

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -491,23 +491,26 @@ export default class {
     graphApi: GraphApi,
     params?: { linkTypeModel?: LinkTypeModel },
   ): Promise<LinkModel[]> {
-    const incomingLinks = await LinkModel.getByQuery(graphApi, {
+    const filter: Filter = {
       all: [
         {
           equal: [{ path: ["target", "id"] }, { parameter: this.entityId }],
         },
-        params?.linkTypeModel
-          ? {
-              equal: [
-                { path: ["type", "versionedUri"] },
-                {
-                  parameter: params.linkTypeModel.schema.$id,
-                },
-              ],
-            }
-          : [],
-      ].flat(),
-    });
+      ],
+    };
+
+    if (params?.linkTypeModel) {
+      filter.all.push({
+        equal: [
+          { path: ["type", "versionedUri"] },
+          {
+            parameter: params.linkTypeModel.schema.$id,
+          },
+        ],
+      });
+    }
+
+    const incomingLinks = await LinkModel.getByQuery(graphApi, filter);
 
     return incomingLinks;
   }
@@ -521,23 +524,26 @@ export default class {
     graphApi: GraphApi,
     params?: { linkTypeModel?: LinkTypeModel },
   ): Promise<LinkModel[]> {
-    const outgoingLinks = await LinkModel.getByQuery(graphApi, {
+    const filter: Filter = {
       all: [
         {
           equal: [{ path: ["source", "id"] }, { parameter: this.entityId }],
         },
-        params?.linkTypeModel
-          ? {
-              equal: [
-                { path: ["type", "versionedUri"] },
-                {
-                  parameter: params.linkTypeModel.schema.$id,
-                },
-              ],
-            }
-          : [],
-      ].flat(),
-    });
+      ],
+    };
+
+    if (params?.linkTypeModel) {
+      filter.all.push({
+        equal: [
+          { path: ["type", "versionedUri"] },
+          {
+            parameter: params.linkTypeModel.schema.$id,
+          },
+        ],
+      });
+    }
+
+    const outgoingLinks = await LinkModel.getByQuery(graphApi, filter);
 
     return outgoingLinks;
   }

--- a/packages/hash/api/src/model/knowledge/link.model.ts
+++ b/packages/hash/api/src/model/knowledge/link.model.ts
@@ -2,6 +2,7 @@ import {
   LinkStructuralQuery,
   GraphApi,
   PersistedLink,
+  Filter,
 } from "@hashintel/hash-graph-client";
 
 import { EntityModel, LinkModel, LinkTypeModel } from "../index";
@@ -82,7 +83,7 @@ export default class {
 
   static async getByQuery(
     graphApi: GraphApi,
-    filter: object,
+    filter: Filter,
     options?: Omit<Partial<LinkStructuralQuery>, "query">,
   ): Promise<LinkModel[]> {
     const { data: linkRootedSubgraphs } = await graphApi.getLinksByQuery({

--- a/packages/hash/api/src/model/knowledge/link.model.ts
+++ b/packages/hash/api/src/model/knowledge/link.model.ts
@@ -84,7 +84,7 @@ export default class {
   static async getByQuery(
     graphApi: GraphApi,
     filter: Filter,
-    options?: Omit<Partial<LinkStructuralQuery>, "query">,
+    options?: Omit<Partial<LinkStructuralQuery>, "filter">,
   ): Promise<LinkModel[]> {
     const { data: linkRootedSubgraphs } = await graphApi.getLinksByQuery({
       filter,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The optimization implementation in Rust is finished, so the next step is to expose the new queries to the backend. To make this reviewable, this task is split up into three parts:
- #1277
- #1278
- #1279 (this PR)

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203007126736610/1203157447721367/f) _(internal)_

## 🚫 Blocked by

- #1267
- #1268
- #1269
- #1271
- #1272 
- #1273 
- #1228 
- #1274
- #1275
- #1276
- #1277
- #1278

## 🔍 What does this change?

- Manually add `Filter` as schema to the OpenAPI specs resulting in a much more robust interface in TS

## ⚠️  Known issues

- The schema and `Filter` have to be kept in sync, however, if one falls out-of-sync either the tests will fail or the methods are not available in TS
- `Path` cannot be encoded (easily) in TS as the deserialization differs from it's representation. For this, a path builder could be provided.

## 🐾 Next steps

- Generate OpenAPI specs to make the usage of queries more type-safe

## 🛡 What tests cover this?

`tsc` will now check for a correct filter