### PR TITLE
`error-stack` expose `Frame::type_id`

### DIFF
--- a/packages/libs/error-stack/CHANGELOG.md
+++ b/packages/libs/error-stack/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to `error-stack` will be documented in this file.
 ## Unreleased
 
 - The output of [`Location`](https://doc.rust-lang.org/std/panic/struct.Location.html) is no longer hard-coded and can now be adjusted through hooks. ([#1237](https://github.com/hashintel/hash/pull/1237))
+- The `TypeId` of a value contained in a `Frame` can now be accessed via `Frame::type_id` ([#1289](https://github.com/hashintel/hash/pull/1289))
 
 ## [0.2.3](https://github.com/hashintel/hash/tree/error-stack%400.2.3/packages/libs/error-stack) - 2022-10-12
 

--- a/packages/libs/error-stack/src/frame/mod.rs
+++ b/packages/libs/error-stack/src/frame/mod.rs
@@ -4,7 +4,7 @@ mod kind;
 use alloc::boxed::Box;
 #[cfg(nightly)]
 use core::any::{self, Demand, Provider};
-use core::{fmt, panic::Location};
+use core::{any::TypeId, fmt, panic::Location};
 
 use self::frame_impl::FrameImpl;
 pub use self::kind::{AttachmentKind, FrameKind};
@@ -109,6 +109,12 @@ impl Frame {
     #[must_use]
     pub fn downcast_mut<T: Send + Sync + 'static>(&mut self) -> Option<&mut T> {
         self.frame.as_any_mut().downcast_mut()
+    }
+
+    /// Returns the [`TypeId`] of the held context or attachment by this frame.
+    #[must_use]
+    pub fn type_id(&self) -> TypeId {
+        self.frame.as_any().type_id()
     }
 }
 

--- a/packages/libs/error-stack/tests/test_frame.rs
+++ b/packages/libs/error-stack/tests/test_frame.rs
@@ -3,7 +3,7 @@
 
 mod common;
 
-use std::iter::zip;
+use core::{any::TypeId, iter::zip};
 
 use common::*;
 
@@ -130,4 +130,15 @@ fn context() {
         .downcast_ref::<ContextA>()
         .expect("Wrong source frame");
     assert_eq!(context.0, 20);
+}
+
+#[test]
+fn type_id() {
+    let report = create_report().attach(2u32);
+    let current = &report.current_frames()[0];
+
+    assert_eq!(current.type_id(), TypeId::of::<u32>());
+
+    let context = report.frames().last().unwrap();
+    assert_eq!(context.type_id(), TypeId::of::<RootError>())
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

While developing `deer` (which heavily uses `error-stack` and `Frame`s for errors), I often tried to get the current type contained in a `Frame`, before #1288 `error-stack` had a `pub(crate)` function with the same name (`type_id`). Even though `error-stack` no longer directly uses `TypeId`, I think it is still valuable to add the method for lower-level use cases outside of `error-stack`, to inspect the contained type easily.

This is entirely optional, one can also repeatedly call `Frame::is<T>()` for every expected type, but this isn't ideal, as it isn't very straightforward, nor ergonomic, or as performant as a simple lookup in a `HashSet` (or similar).

## 🔍 What does this change?

* exposes `Frame::type_id`

## 📜 Does this require a change to the docs?

Yes, the newly exposed method is documented.

## ❓ How to test this?

An additional test has been added to verify the behavior.
