### PR TITLE
Set coverage flags to carry forward

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,5 +8,8 @@ coverage:
     patch:
       default:
         informational: true
+flag_management:
+  default_rules:
+    carryforward: true
 github_checks:
   annotations: false


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, we have to unconditionally run coverage. With this change, the flags can be carried forward from previous commits.

## 🔗 Related links

- [CodeCov documentation](https://docs.codecov.com/docs/flags#recommended-automatic-flag-management)


## 🔍 What does this change?

- Sets all flags to `carryforward = true` by default

## 🐾 Next steps

There are many options for flags (see the documentation), we probably want to further tweak the configuration but this is not required right now. [**Asana Task**](https://app.asana.com/0/1201095311341924/1203264930671957/f) (_internal_)