### PR TITLE
Only run coverage on Rust on change

### DIFF
--- a/.github/scripts/rust/setup.py
+++ b/.github/scripts/rust/setup.py
@@ -238,7 +238,7 @@ def main():
     available_crates = find_local_crates()
     changed_crates = filter_for_changed_crates(diffs, available_crates)
     changed_parent_crates = filter_parent_crates(changed_crates)
-    coverage_crates = filter_for_coverage_crates(available_crates)
+    coverage_crates = filter_for_coverage_crates(changed_parent_crates)
     changed_docker_crates = filter_for_docker_crates(changed_parent_crates)
 
     github_output_file = open(os.environ["GITHUB_OUTPUT_FILE_PATH"], "w")


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

With https://github.com/hashintel/hash/pull/1307 it's not required anymore to unconditionally run coverage

## 🔗 Related links

- https://github.com/hashintel/hash/pull/1307

## ⚠️ Known issues

It's probably possible to run the coverage tests within the test task. This PR only changes the condition, when to run coverage, it does not merge the jobs as this is a trivial fix and merging the jobs requires more work.