### PR TITLE
Tweak `A-infra` labeling to include top level configurations

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,8 +4,10 @@ A-infra:
   - ".github/**/*"
   - ".github/**/.*"
   - "*.md"
+  - "*.yml"
+  - "*.json"
   - ".markdownlint*"
-  - ".gitignore"
+  - ".*ignore"
 
 A-blocks:
   - "blocks/*"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Top level configuration files are infra-configurations. This adds these files to the `A-infra` label

## 🔍 What does this change?

- Add `*.yml` and `*.json` files
- Include other `*ignore` files