### PR TITLE
Fix references in create entity type

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -803,7 +803,6 @@ where
                 .change_context(InsertionError)?;
         }
 
-        // TODO: should we check that the `link_entity_type_ref` is a link entity type?
         let entity_type_references = entity_type
             .link_mappings()
             .keys()

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -298,6 +298,25 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   );
 
   pgm.createTable(
+    "entity_type_entity_type_references",
+    {
+      source_entity_type_version_id: {
+        type: "UUID",
+        notNull: true,
+        references: "entity_types",
+      },
+      target_entity_type_version_id: {
+        type: "UUID",
+        notNull: true,
+        references: "entity_types",
+      },
+    },
+    {
+      ifNotExists: true,
+    },
+  );
+
+  pgm.createTable(
     "entity_ids",
     {
       entity_id: {
@@ -478,7 +497,7 @@ DROP TABLE IF EXISTS property_type_property_type_references CASCADE;
 DROP TABLE IF EXISTS property_type_data_type_references CASCADE;
 DROP TABLE IF EXISTS entity_types CASCADE;
 DROP TABLE IF EXISTS entity_type_property_type_references CASCADE;
-DROP TABLE IF EXISTS link_types CASCADE;
+DROP TABLE IF EXISTS entity_type_entity_type_references CASCADE;
 DROP TABLE IF EXISTS entity_ids CASCADE;
 DROP TABLE IF EXISTS entities CASCADE;
 DROP TABLE IF EXISTS entity_relations CASCADE;


### PR DESCRIPTION
> Duplicate of #1303, GitHub made a mistake

## 🌟 What is the purpose of this PR?

When we create the objects in the DB we store index tables about their references (e.g. this entity type references this property type). The logic to store those references when creating an entity type was broken, this PR fixes it.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203007126736613/1203273212930210/f) _(internal)_

## 🔍 What does this change?

- Reintroduces the `entity_type_entity_type_references` table as it went missing
- Reimplements the entity type references logic to use the new API from the Type System crate

## ⚠️ Known issues

- We don't currently check that a referenced entity type _is_ a link entity type when used as one

## 🛡 What tests cover this?

- The HTTP tests should check this doesn't error

## ❓ How to test this?

1. Checkout the branch
2. Follow instructions on how to run the HTTP tests
