### PR TITLE
Use Node 16 in CI to align runtime with Vercel lambdas

### DIFF
--- a/.github/actions/warm-up-repo/action.yml
+++ b/.github/actions/warm-up-repo/action.yml
@@ -9,10 +9,11 @@ inputs:
 
 runs:
   using: composite
+
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 16 ## aligned with Node version on Vercel
         cache: yarn
 
     - run: yarn install

--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -105,7 +105,7 @@ jobs:
       # Node is used for migrating the DB
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 16 ## aligned with Node version on Vercel
           cache: yarn
 
       - name: Prepare dev tools for DB migration

--- a/.github/workflows/sync-algolia-index.yml
+++ b/.github/workflows/sync-algolia-index.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 16 ## aligned with Node version on Vercel
           cache: yarn
 
       - name: Install dependencies


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Before re-enabling Playwright tests, I’ve decided to downgrade Node from v18 to v16. This slightly improves our confidence in Vercel deployments based on local tests.

When Vercel enables Node 18, we will upgrade our actions too. This will probably happen in Spring 2023, according to [Node 16 announcement](https://vercel.com/changelog/node-js-16-lts-is-now-available) (May 2022). Vercel lambdas run on top of AWS so they depend on the platform timeline.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201095311341924/1203272958744356/f) _(internal)_

## ❓ How to test this?

Check CI output