### PR TITLE
Add entity archival endpoint

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -73,6 +73,31 @@ export interface AnyFilter {
 /**
  *
  * @export
+ * @interface ArchiveEntityRequest
+ */
+export interface ArchiveEntityRequest {
+  /**
+   *
+   * @type {string}
+   * @memberof ArchiveEntityRequest
+   */
+  actorId: string;
+  /**
+   *
+   * @type {string}
+   * @memberof ArchiveEntityRequest
+   */
+  entityId: string;
+  /**
+   *
+   * @type {string}
+   * @memberof ArchiveEntityRequest
+   */
+  ownedById: string;
+}
+/**
+ *
+ * @export
  * @interface CreateDataTypeRequest
  */
 export interface CreateDataTypeRequest {
@@ -127,6 +152,12 @@ export interface CreateEntityRequest {
   entityTypeId: string;
   /**
    *
+   * @type {LinkEntityMetadata}
+   * @memberof CreateEntityRequest
+   */
+  linkMetadata?: LinkEntityMetadata;
+  /**
+   *
    * @type {string}
    * @memberof CreateEntityRequest
    */
@@ -156,68 +187,6 @@ export interface CreateEntityTypeRequest {
    * @memberof CreateEntityTypeRequest
    */
   schema: EntityType;
-}
-/**
- *
- * @export
- * @interface CreateLinkRequest
- */
-export interface CreateLinkRequest {
-  /**
-   *
-   * @type {string}
-   * @memberof CreateLinkRequest
-   */
-  actorId: string;
-  /**
-   *
-   * @type {number}
-   * @memberof CreateLinkRequest
-   */
-  index?: number;
-  /**
-   *
-   * @type {string}
-   * @memberof CreateLinkRequest
-   */
-  linkTypeId: string;
-  /**
-   *
-   * @type {string}
-   * @memberof CreateLinkRequest
-   */
-  ownedById: string;
-  /**
-   *
-   * @type {string}
-   * @memberof CreateLinkRequest
-   */
-  targetEntityId: string;
-}
-/**
- *
- * @export
- * @interface CreateLinkTypeRequest
- */
-export interface CreateLinkTypeRequest {
-  /**
-   *
-   * @type {string}
-   * @memberof CreateLinkTypeRequest
-   */
-  actorId: string;
-  /**
-   *
-   * @type {string}
-   * @memberof CreateLinkTypeRequest
-   */
-  ownedById: string;
-  /**
-   *
-   * @type {LinkType}
-   * @memberof CreateLinkTypeRequest
-   */
-  schema: LinkType;
 }
 /**
  *
@@ -572,182 +541,7 @@ export interface GraphResolveDepths {
    * @type {number}
    * @memberof GraphResolveDepths
    */
-  linkTypeResolveDepth: number;
-  /**
-   *
-   * @type {number}
-   * @memberof GraphResolveDepths
-   */
   propertyTypeResolveDepth: number;
-}
-/**
- * A Link between a source and a target entity identified by [`EntityId`]s.
- * @export
- * @interface Link
- */
-export interface Link {
-  /**
-   *
-   * @type {number}
-   * @memberof Link
-   */
-  index?: number;
-  /**
-   *
-   * @type {string}
-   * @memberof Link
-   */
-  linkTypeId: string;
-  /**
-   *
-   * @type {string}
-   * @memberof Link
-   */
-  sourceEntityId: string;
-  /**
-   *
-   * @type {string}
-   * @memberof Link
-   */
-  targetEntityId: string;
-}
-/**
- *
- * @export
- * @interface LinkRootedSubgraph
- */
-export interface LinkRootedSubgraph {
-  /**
-   *
-   * @type {PersistedLink}
-   * @memberof LinkRootedSubgraph
-   */
-  link: PersistedLink;
-  /**
-   *
-   * @type {Array<PersistedEntity>}
-   * @memberof LinkRootedSubgraph
-   */
-  linkedEntities: Array<PersistedEntity>;
-  /**
-   *
-   * @type {Array<PersistedLink>}
-   * @memberof LinkRootedSubgraph
-   */
-  links: Array<PersistedLink>;
-  /**
-   *
-   * @type {Array<PersistedDataType>}
-   * @memberof LinkRootedSubgraph
-   */
-  referencedDataTypes: Array<PersistedDataType>;
-  /**
-   *
-   * @type {Array<PersistedEntityType>}
-   * @memberof LinkRootedSubgraph
-   */
-  referencedEntityTypes: Array<PersistedEntityType>;
-  /**
-   *
-   * @type {Array<PersistedLinkType>}
-   * @memberof LinkRootedSubgraph
-   */
-  referencedLinkTypes: Array<PersistedLinkType>;
-  /**
-   *
-   * @type {Array<PersistedPropertyType>}
-   * @memberof LinkRootedSubgraph
-   */
-  referencedPropertyTypes: Array<PersistedPropertyType>;
-}
-/**
- * A [`Filter`] to query the datastore, recursively resolving according to the
- * @export
- * @interface LinkStructuralQuery
- */
-export interface LinkStructuralQuery {
-  /**
-   *
-   * @type {Filter}
-   * @memberof LinkStructuralQuery
-   */
-  filter: Filter;
-  /**
-   *
-   * @type {GraphResolveDepths}
-   * @memberof LinkStructuralQuery
-   */
-  graphResolveDepths: GraphResolveDepths;
-}
-/**
- * Specifies the structure of a Link Type
- * @export
- * @interface LinkType
- */
-export interface LinkType {
-  /**
-   *
-   * @type {string}
-   * @memberof LinkType
-   */
-  $id: string;
-  /**
-   *
-   * @type {string}
-   * @memberof LinkType
-   */
-  description: string;
-  /**
-   *
-   * @type {object}
-   * @memberof LinkType
-   */
-  kind: LinkTypeKindEnum;
-  /**
-   *
-   * @type {string}
-   * @memberof LinkType
-   */
-  pluralTitle: string;
-  /**
-   *
-   * @type {Array<string>}
-   * @memberof LinkType
-   */
-  relatedKeywords?: Array<string>;
-  /**
-   *
-   * @type {string}
-   * @memberof LinkType
-   */
-  title: string;
-}
-
-export const LinkTypeKindEnum = {
-  LinkType: "linkType",
-} as const;
-
-export type LinkTypeKindEnum =
-  typeof LinkTypeKindEnum[keyof typeof LinkTypeKindEnum];
-
-/**
- * A [`Filter`] to query the datastore, recursively resolving according to the
- * @export
- * @interface LinkTypeStructuralQuery
- */
-export interface LinkTypeStructuralQuery {
-  /**
-   *
-   * @type {Filter}
-   * @memberof LinkTypeStructuralQuery
-   */
-  filter: Filter;
-  /**
-   *
-   * @type {GraphResolveDepths}
-   * @memberof LinkTypeStructuralQuery
-   */
-  graphResolveDepths: GraphResolveDepths;
 }
 /**
  *
@@ -941,10 +735,10 @@ export interface PersistedEntityMetadata {
   identifier: PersistedEntityIdentifier;
   /**
    *
-   * @type {string}
+   * @type {LinkEntityMetadata}
    * @memberof PersistedEntityMetadata
    */
-  removedById?: string;
+  linkMetadata?: LinkEntityMetadata;
   /**
    *
    * @type {string}
@@ -968,63 +762,6 @@ export interface PersistedEntityType {
    *
    * @type {PersistedOntologyMetadata}
    * @memberof PersistedEntityType
-   */
-  metadata: PersistedOntologyMetadata;
-}
-/**
- * A record of a [`Link`] that has been persisted in the datastore, with its associated
- * @export
- * @interface PersistedLink
- */
-export interface PersistedLink {
-  /**
-   *
-   * @type {Link}
-   * @memberof PersistedLink
-   */
-  inner: Link;
-  /**
-   *
-   * @type {PersistedLinkMetadata}
-   * @memberof PersistedLink
-   */
-  metadata: PersistedLinkMetadata;
-}
-/**
- * The metadata of a [`Link`] record.
- * @export
- * @interface PersistedLinkMetadata
- */
-export interface PersistedLinkMetadata {
-  /**
-   *
-   * @type {string}
-   * @memberof PersistedLinkMetadata
-   */
-  createdById: string;
-  /**
-   *
-   * @type {string}
-   * @memberof PersistedLinkMetadata
-   */
-  ownedById: string;
-}
-/**
- *
- * @export
- * @interface PersistedLinkType
- */
-export interface PersistedLinkType {
-  /**
-   *
-   * @type {LinkType}
-   * @memberof PersistedLinkType
-   */
-  inner: LinkType;
-  /**
-   *
-   * @type {PersistedOntologyMetadata}
-   * @memberof PersistedLinkType
    */
   metadata: PersistedOntologyMetadata;
 }
@@ -1067,10 +804,10 @@ export interface PersistedOntologyMetadata {
   identifier: PersistedOntologyIdentifier;
   /**
    *
-   * @type {string}
+   * @type {RemovedById}
    * @memberof PersistedOntologyMetadata
    */
-  removedById?: string;
+  removedById?: RemovedById;
   /**
    *
    * @type {string}
@@ -1319,31 +1056,6 @@ export type PropertyValuesUpdate =
 /**
  *
  * @export
- * @interface RemoveLinkRequest
- */
-export interface RemoveLinkRequest {
-  /**
-   *
-   * @type {string}
-   * @memberof RemoveLinkRequest
-   */
-  actorId: string;
-  /**
-   *
-   * @type {string}
-   * @memberof RemoveLinkRequest
-   */
-  linkTypeId: string;
-  /**
-   *
-   * @type {string}
-   * @memberof RemoveLinkRequest
-   */
-  targetEntityId: string;
-}
-/**
- *
- * @export
  * @interface Subgraph
  */
 export interface Subgraph {
@@ -1582,76 +1294,6 @@ export interface UpdateEntityTypeRequest {
   typeToUpdate: string;
 }
 /**
- * The contents of a Link Type update request
- * @export
- * @interface UpdateLinkType
- */
-export interface UpdateLinkType {
-  /**
-   *
-   * @type {string}
-   * @memberof UpdateLinkType
-   */
-  description: string;
-  /**
-   *
-   * @type {object}
-   * @memberof UpdateLinkType
-   */
-  kind: UpdateLinkTypeKindEnum;
-  /**
-   *
-   * @type {string}
-   * @memberof UpdateLinkType
-   */
-  pluralTitle: string;
-  /**
-   *
-   * @type {Array<string>}
-   * @memberof UpdateLinkType
-   */
-  relatedKeywords?: Array<string>;
-  /**
-   *
-   * @type {string}
-   * @memberof UpdateLinkType
-   */
-  title: string;
-}
-
-export const UpdateLinkTypeKindEnum = {
-  LinkType: "linkType",
-} as const;
-
-export type UpdateLinkTypeKindEnum =
-  typeof UpdateLinkTypeKindEnum[keyof typeof UpdateLinkTypeKindEnum];
-
-/**
- *
- * @export
- * @interface UpdateLinkTypeRequest
- */
-export interface UpdateLinkTypeRequest {
-  /**
-   *
-   * @type {string}
-   * @memberof UpdateLinkTypeRequest
-   */
-  actorId: string;
-  /**
-   *
-   * @type {UpdateLinkType}
-   * @memberof UpdateLinkTypeRequest
-   */
-  schema: UpdateLinkType;
-  /**
-   *
-   * @type {string}
-   * @memberof UpdateLinkTypeRequest
-   */
-  typeToUpdate: string;
-}
-/**
  * The contents of a Property Type update request
  * @export
  * @interface UpdatePropertyType
@@ -1725,13 +1367,7 @@ export interface UpdatePropertyTypeRequest {
  * @type Vertex
  * @export
  */
-export type Vertex =
-  | VertexOneOf
-  | VertexOneOf1
-  | VertexOneOf2
-  | VertexOneOf3
-  | VertexOneOf4
-  | VertexOneOf5;
+export type Vertex = VertexOneOf | VertexOneOf1 | VertexOneOf2 | VertexOneOf3;
 
 /**
  *
@@ -1827,7 +1463,7 @@ export interface VertexOneOf2 {
 }
 
 export const VertexOneOf2KindEnum = {
-  LinkType: "linkType",
+  EntityType: "entityType",
 } as const;
 
 export type VertexOneOf2KindEnum =
@@ -1841,10 +1477,10 @@ export type VertexOneOf2KindEnum =
 export interface VertexOneOf2Inner {
   /**
    *
-   * @type {LinkType}
+   * @type {EntityType}
    * @memberof VertexOneOf2Inner
    */
-  inner: LinkType;
+  inner: EntityType;
   /**
    *
    * @type {PersistedOntologyMetadata}
@@ -1873,122 +1509,30 @@ export interface VertexOneOf3 {
 }
 
 export const VertexOneOf3KindEnum = {
-  EntityType: "entityType",
+  Entity: "entity",
 } as const;
 
 export type VertexOneOf3KindEnum =
   typeof VertexOneOf3KindEnum[keyof typeof VertexOneOf3KindEnum];
 
 /**
- *
+ * A record of an [`Entity`] that has been persisted in the datastore, with its associated
  * @export
  * @interface VertexOneOf3Inner
  */
 export interface VertexOneOf3Inner {
   /**
    *
-   * @type {EntityType}
-   * @memberof VertexOneOf3Inner
-   */
-  inner: EntityType;
-  /**
-   *
-   * @type {PersistedOntologyMetadata}
-   * @memberof VertexOneOf3Inner
-   */
-  metadata: PersistedOntologyMetadata;
-}
-/**
- *
- * @export
- * @interface VertexOneOf4
- */
-export interface VertexOneOf4 {
-  /**
-   *
-   * @type {VertexOneOf4Inner}
-   * @memberof VertexOneOf4
-   */
-  inner: VertexOneOf4Inner;
-  /**
-   *
    * @type {object}
-   * @memberof VertexOneOf4
-   */
-  kind: VertexOneOf4KindEnum;
-}
-
-export const VertexOneOf4KindEnum = {
-  Entity: "entity",
-} as const;
-
-export type VertexOneOf4KindEnum =
-  typeof VertexOneOf4KindEnum[keyof typeof VertexOneOf4KindEnum];
-
-/**
- * A record of an [`Entity`] that has been persisted in the datastore, with its associated
- * @export
- * @interface VertexOneOf4Inner
- */
-export interface VertexOneOf4Inner {
-  /**
-   *
-   * @type {object}
-   * @memberof VertexOneOf4Inner
+   * @memberof VertexOneOf3Inner
    */
   inner: object;
   /**
    *
    * @type {PersistedEntityMetadata}
-   * @memberof VertexOneOf4Inner
+   * @memberof VertexOneOf3Inner
    */
   metadata: PersistedEntityMetadata;
-}
-/**
- *
- * @export
- * @interface VertexOneOf5
- */
-export interface VertexOneOf5 {
-  /**
-   *
-   * @type {VertexOneOf5Inner}
-   * @memberof VertexOneOf5
-   */
-  inner: VertexOneOf5Inner;
-  /**
-   *
-   * @type {object}
-   * @memberof VertexOneOf5
-   */
-  kind: VertexOneOf5KindEnum;
-}
-
-export const VertexOneOf5KindEnum = {
-  Link: "link",
-} as const;
-
-export type VertexOneOf5KindEnum =
-  typeof VertexOneOf5KindEnum[keyof typeof VertexOneOf5KindEnum];
-
-/**
- * A record of a [`Link`] that has been persisted in the datastore, with its associated
- * @export
- * @interface VertexOneOf5Inner
- */
-export interface VertexOneOf5Inner {
-  /**
-   *
-   * @type {Link}
-   * @memberof VertexOneOf5Inner
-   */
-  inner: Link;
-  /**
-   *
-   * @type {PersistedLinkMetadata}
-   * @memberof VertexOneOf5Inner
-   */
-  metadata: PersistedLinkMetadata;
 }
 /**
  *
@@ -4193,115 +3737,6 @@ export const GraphApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {string} entityId The ID of the source entity
-     * @param {CreateLinkRequest} createLinkRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    createLink: async (
-      entityId: string,
-      createLinkRequest: CreateLinkRequest,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'entityId' is not null or undefined
-      assertParamExists("createLink", "entityId", entityId);
-      // verify required parameter 'createLinkRequest' is not null or undefined
-      assertParamExists("createLink", "createLinkRequest", createLinkRequest);
-      const localVarPath = `/entities/{entityId}/links`.replace(
-        `{${"entityId"}}`,
-        encodeURIComponent(String(entityId)),
-      );
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-      let baseOptions;
-      if (configuration) {
-        baseOptions = configuration.baseOptions;
-      }
-
-      const localVarRequestOptions = {
-        method: "POST",
-        ...baseOptions,
-        ...options,
-      };
-      const localVarHeaderParameter = {} as any;
-      const localVarQueryParameter = {} as any;
-
-      localVarHeaderParameter["Content-Type"] = "application/json";
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter);
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {};
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      };
-      localVarRequestOptions.data = serializeDataIfNeeded(
-        createLinkRequest,
-        localVarRequestOptions,
-        configuration,
-      );
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      };
-    },
-    /**
-     *
-     * @param {CreateLinkTypeRequest} createLinkTypeRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    createLinkType: async (
-      createLinkTypeRequest: CreateLinkTypeRequest,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'createLinkTypeRequest' is not null or undefined
-      assertParamExists(
-        "createLinkType",
-        "createLinkTypeRequest",
-        createLinkTypeRequest,
-      );
-      const localVarPath = `/link-types`;
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-      let baseOptions;
-      if (configuration) {
-        baseOptions = configuration.baseOptions;
-      }
-
-      const localVarRequestOptions = {
-        method: "POST",
-        ...baseOptions,
-        ...options,
-      };
-      const localVarHeaderParameter = {} as any;
-      const localVarQueryParameter = {} as any;
-
-      localVarHeaderParameter["Content-Type"] = "application/json";
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter);
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {};
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      };
-      localVarRequestOptions.data = serializeDataIfNeeded(
-        createLinkTypeRequest,
-        localVarRequestOptions,
-        configuration,
-      );
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      };
-    },
-    /**
-     *
      * @param {CreatePropertyTypeRequest} createPropertyTypeRequest
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -4551,51 +3986,6 @@ export const GraphApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {string} entityId The ID of the source entity
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    getEntityLinks: async (
-      entityId: string,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'entityId' is not null or undefined
-      assertParamExists("getEntityLinks", "entityId", entityId);
-      const localVarPath = `/entities/{entityId}/links`.replace(
-        `{${"entityId"}}`,
-        encodeURIComponent(String(entityId)),
-      );
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-      let baseOptions;
-      if (configuration) {
-        baseOptions = configuration.baseOptions;
-      }
-
-      const localVarRequestOptions = {
-        method: "GET",
-        ...baseOptions,
-        ...options,
-      };
-      const localVarHeaderParameter = {} as any;
-      const localVarQueryParameter = {} as any;
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter);
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {};
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      };
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      };
-    },
-    /**
-     *
      * @param {string} uri The URI of the entity type
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -4811,44 +4201,6 @@ export const GraphApiAxiosParamCreator = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getLatestLinkTypes: async (
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      const localVarPath = `/link-types`;
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-      let baseOptions;
-      if (configuration) {
-        baseOptions = configuration.baseOptions;
-      }
-
-      const localVarRequestOptions = {
-        method: "GET",
-        ...baseOptions,
-        ...options,
-      };
-      const localVarHeaderParameter = {} as any;
-      const localVarQueryParameter = {} as any;
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter);
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {};
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      };
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      };
-    },
-    /**
-     *
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
     getLatestPropertyTypes: async (
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
@@ -4876,157 +4228,6 @@ export const GraphApiAxiosParamCreator = function (
         ...headersFromBaseOptions,
         ...options.headers,
       };
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      };
-    },
-    /**
-     *
-     * @param {string} uri The URI of the link type
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    getLinkType: async (
-      uri: string,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'uri' is not null or undefined
-      assertParamExists("getLinkType", "uri", uri);
-      const localVarPath = `/link-types/{uri}`.replace(
-        `{${"uri"}}`,
-        encodeURIComponent(String(uri)),
-      );
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-      let baseOptions;
-      if (configuration) {
-        baseOptions = configuration.baseOptions;
-      }
-
-      const localVarRequestOptions = {
-        method: "GET",
-        ...baseOptions,
-        ...options,
-      };
-      const localVarHeaderParameter = {} as any;
-      const localVarQueryParameter = {} as any;
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter);
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {};
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      };
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      };
-    },
-    /**
-     *
-     * @param {LinkTypeStructuralQuery} linkTypeStructuralQuery
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    getLinkTypesByQuery: async (
-      linkTypeStructuralQuery: LinkTypeStructuralQuery,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'linkTypeStructuralQuery' is not null or undefined
-      assertParamExists(
-        "getLinkTypesByQuery",
-        "linkTypeStructuralQuery",
-        linkTypeStructuralQuery,
-      );
-      const localVarPath = `/link-types/query`;
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-      let baseOptions;
-      if (configuration) {
-        baseOptions = configuration.baseOptions;
-      }
-
-      const localVarRequestOptions = {
-        method: "POST",
-        ...baseOptions,
-        ...options,
-      };
-      const localVarHeaderParameter = {} as any;
-      const localVarQueryParameter = {} as any;
-
-      localVarHeaderParameter["Content-Type"] = "application/json";
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter);
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {};
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      };
-      localVarRequestOptions.data = serializeDataIfNeeded(
-        linkTypeStructuralQuery,
-        localVarRequestOptions,
-        configuration,
-      );
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      };
-    },
-    /**
-     *
-     * @param {LinkStructuralQuery} linkStructuralQuery
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    getLinksByQuery: async (
-      linkStructuralQuery: LinkStructuralQuery,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'linkStructuralQuery' is not null or undefined
-      assertParamExists(
-        "getLinksByQuery",
-        "linkStructuralQuery",
-        linkStructuralQuery,
-      );
-      const localVarPath = `/links/query`;
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-      let baseOptions;
-      if (configuration) {
-        baseOptions = configuration.baseOptions;
-      }
-
-      const localVarRequestOptions = {
-        method: "POST",
-        ...baseOptions,
-        ...options,
-      };
-      const localVarHeaderParameter = {} as any;
-      const localVarQueryParameter = {} as any;
-
-      localVarHeaderParameter["Content-Type"] = "application/json";
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter);
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {};
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      };
-      localVarRequestOptions.data = serializeDataIfNeeded(
-        linkStructuralQuery,
-        localVarRequestOptions,
-        configuration,
-      );
 
       return {
         url: toPathString(localVarUrlObj),
@@ -5122,62 +4323,6 @@ export const GraphApiAxiosParamCreator = function (
       };
       localVarRequestOptions.data = serializeDataIfNeeded(
         propertyTypeStructuralQuery,
-        localVarRequestOptions,
-        configuration,
-      );
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      };
-    },
-    /**
-     *
-     * @param {string} entityId The ID of the source entity
-     * @param {RemoveLinkRequest} removeLinkRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    removeLink: async (
-      entityId: string,
-      removeLinkRequest: RemoveLinkRequest,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'entityId' is not null or undefined
-      assertParamExists("removeLink", "entityId", entityId);
-      // verify required parameter 'removeLinkRequest' is not null or undefined
-      assertParamExists("removeLink", "removeLinkRequest", removeLinkRequest);
-      const localVarPath = `/entities/{entityId}/links`.replace(
-        `{${"entityId"}}`,
-        encodeURIComponent(String(entityId)),
-      );
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-      let baseOptions;
-      if (configuration) {
-        baseOptions = configuration.baseOptions;
-      }
-
-      const localVarRequestOptions = {
-        method: "DELETE",
-        ...baseOptions,
-        ...options,
-      };
-      const localVarHeaderParameter = {} as any;
-      const localVarQueryParameter = {} as any;
-
-      localVarHeaderParameter["Content-Type"] = "application/json";
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter);
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {};
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      };
-      localVarRequestOptions.data = serializeDataIfNeeded(
-        removeLinkRequest,
         localVarRequestOptions,
         configuration,
       );
@@ -5337,59 +4482,6 @@ export const GraphApiAxiosParamCreator = function (
       };
       localVarRequestOptions.data = serializeDataIfNeeded(
         updateEntityTypeRequest,
-        localVarRequestOptions,
-        configuration,
-      );
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      };
-    },
-    /**
-     *
-     * @param {UpdateLinkTypeRequest} updateLinkTypeRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    updateLinkType: async (
-      updateLinkTypeRequest: UpdateLinkTypeRequest,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'updateLinkTypeRequest' is not null or undefined
-      assertParamExists(
-        "updateLinkType",
-        "updateLinkTypeRequest",
-        updateLinkTypeRequest,
-      );
-      const localVarPath = `/link-types`;
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-      let baseOptions;
-      if (configuration) {
-        baseOptions = configuration.baseOptions;
-      }
-
-      const localVarRequestOptions = {
-        method: "PUT",
-        ...baseOptions,
-        ...options,
-      };
-      const localVarHeaderParameter = {} as any;
-      const localVarQueryParameter = {} as any;
-
-      localVarHeaderParameter["Content-Type"] = "application/json";
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter);
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {};
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      };
-      localVarRequestOptions.data = serializeDataIfNeeded(
-        updateLinkTypeRequest,
         localVarRequestOptions,
         configuration,
       );
@@ -5563,58 +4655,6 @@ export const GraphApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {string} entityId The ID of the source entity
-     * @param {CreateLinkRequest} createLinkRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async createLink(
-      entityId: string,
-      createLinkRequest: CreateLinkRequest,
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Link>
-    > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.createLink(
-        entityId,
-        createLinkRequest,
-        options,
-      );
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      );
-    },
-    /**
-     *
-     * @param {CreateLinkTypeRequest} createLinkTypeRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async createLinkType(
-      createLinkTypeRequest: CreateLinkTypeRequest,
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<PersistedOntologyMetadata>
-    > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.createLinkType(
-        createLinkTypeRequest,
-        options,
-      );
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      );
-    },
-    /**
-     *
      * @param {CreatePropertyTypeRequest} createPropertyTypeRequest
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -5730,32 +4770,6 @@ export const GraphApiFp = function (configuration?: Configuration) {
       ) => AxiosPromise<PersistedEntity>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getEntity(
-        entityId,
-        options,
-      );
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      );
-    },
-    /**
-     *
-     * @param {string} entityId The ID of the source entity
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async getEntityLinks(
-      entityId: string,
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<Array<PersistedLink>>
-    > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.getEntityLinks(
         entityId,
         options,
       );
@@ -5887,28 +4901,6 @@ export const GraphApiFp = function (configuration?: Configuration) {
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    async getLatestLinkTypes(
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<Array<PersistedLinkType>>
-    > {
-      const localVarAxiosArgs =
-        await localVarAxiosParamCreator.getLatestLinkTypes(options);
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      );
-    },
-    /**
-     *
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
     async getLatestPropertyTypes(
       options?: AxiosRequestConfig,
     ): Promise<
@@ -5919,82 +4911,6 @@ export const GraphApiFp = function (configuration?: Configuration) {
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getLatestPropertyTypes(options);
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      );
-    },
-    /**
-     *
-     * @param {string} uri The URI of the link type
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async getLinkType(
-      uri: string,
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<PersistedLinkType>
-    > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.getLinkType(
-        uri,
-        options,
-      );
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      );
-    },
-    /**
-     *
-     * @param {LinkTypeStructuralQuery} linkTypeStructuralQuery
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async getLinkTypesByQuery(
-      linkTypeStructuralQuery: LinkTypeStructuralQuery,
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Subgraph>
-    > {
-      const localVarAxiosArgs =
-        await localVarAxiosParamCreator.getLinkTypesByQuery(
-          linkTypeStructuralQuery,
-          options,
-        );
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      );
-    },
-    /**
-     *
-     * @param {LinkStructuralQuery} linkStructuralQuery
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async getLinksByQuery(
-      linkStructuralQuery: LinkStructuralQuery,
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<Array<LinkRootedSubgraph>>
-    > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.getLinksByQuery(
-        linkStructuralQuery,
-        options,
-      );
       return createRequestFunction(
         localVarAxiosArgs,
         globalAxios,
@@ -6045,32 +4961,6 @@ export const GraphApiFp = function (configuration?: Configuration) {
           propertyTypeStructuralQuery,
           options,
         );
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      );
-    },
-    /**
-     *
-     * @param {string} entityId The ID of the source entity
-     * @param {RemoveLinkRequest} removeLinkRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async removeLink(
-      entityId: string,
-      removeLinkRequest: RemoveLinkRequest,
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>
-    > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.removeLink(
-        entityId,
-        removeLinkRequest,
-        options,
-      );
       return createRequestFunction(
         localVarAxiosArgs,
         globalAxios,
@@ -6150,32 +5040,6 @@ export const GraphApiFp = function (configuration?: Configuration) {
           updateEntityTypeRequest,
           options,
         );
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      );
-    },
-    /**
-     *
-     * @param {UpdateLinkTypeRequest} updateLinkTypeRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async updateLinkType(
-      updateLinkTypeRequest: UpdateLinkTypeRequest,
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<PersistedOntologyMetadata>
-    > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.updateLinkType(
-        updateLinkTypeRequest,
-        options,
-      );
       return createRequestFunction(
         localVarAxiosArgs,
         globalAxios,
@@ -6278,36 +5142,6 @@ export const GraphApiFactory = function (
     },
     /**
      *
-     * @param {string} entityId The ID of the source entity
-     * @param {CreateLinkRequest} createLinkRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    createLink(
-      entityId: string,
-      createLinkRequest: CreateLinkRequest,
-      options?: any,
-    ): AxiosPromise<Link> {
-      return localVarFp
-        .createLink(entityId, createLinkRequest, options)
-        .then((request) => request(axios, basePath));
-    },
-    /**
-     *
-     * @param {CreateLinkTypeRequest} createLinkTypeRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    createLinkType(
-      createLinkTypeRequest: CreateLinkTypeRequest,
-      options?: any,
-    ): AxiosPromise<PersistedOntologyMetadata> {
-      return localVarFp
-        .createLinkType(createLinkTypeRequest, options)
-        .then((request) => request(axios, basePath));
-    },
-    /**
-     *
      * @param {CreatePropertyTypeRequest} createPropertyTypeRequest
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -6368,20 +5202,6 @@ export const GraphApiFactory = function (
     getEntity(entityId: string, options?: any): AxiosPromise<PersistedEntity> {
       return localVarFp
         .getEntity(entityId, options)
-        .then((request) => request(axios, basePath));
-    },
-    /**
-     *
-     * @param {string} entityId The ID of the source entity
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    getEntityLinks(
-      entityId: string,
-      options?: any,
-    ): AxiosPromise<Array<PersistedLink>> {
-      return localVarFp
-        .getEntityLinks(entityId, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -6449,60 +5269,11 @@ export const GraphApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getLatestLinkTypes(options?: any): AxiosPromise<Array<PersistedLinkType>> {
-      return localVarFp
-        .getLatestLinkTypes(options)
-        .then((request) => request(axios, basePath));
-    },
-    /**
-     *
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
     getLatestPropertyTypes(
       options?: any,
     ): AxiosPromise<Array<PersistedPropertyType>> {
       return localVarFp
         .getLatestPropertyTypes(options)
-        .then((request) => request(axios, basePath));
-    },
-    /**
-     *
-     * @param {string} uri The URI of the link type
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    getLinkType(uri: string, options?: any): AxiosPromise<PersistedLinkType> {
-      return localVarFp
-        .getLinkType(uri, options)
-        .then((request) => request(axios, basePath));
-    },
-    /**
-     *
-     * @param {LinkTypeStructuralQuery} linkTypeStructuralQuery
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    getLinkTypesByQuery(
-      linkTypeStructuralQuery: LinkTypeStructuralQuery,
-      options?: any,
-    ): AxiosPromise<Subgraph> {
-      return localVarFp
-        .getLinkTypesByQuery(linkTypeStructuralQuery, options)
-        .then((request) => request(axios, basePath));
-    },
-    /**
-     *
-     * @param {LinkStructuralQuery} linkStructuralQuery
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    getLinksByQuery(
-      linkStructuralQuery: LinkStructuralQuery,
-      options?: any,
-    ): AxiosPromise<Array<LinkRootedSubgraph>> {
-      return localVarFp
-        .getLinksByQuery(linkStructuralQuery, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -6531,22 +5302,6 @@ export const GraphApiFactory = function (
     ): AxiosPromise<Subgraph> {
       return localVarFp
         .getPropertyTypesByQuery(propertyTypeStructuralQuery, options)
-        .then((request) => request(axios, basePath));
-    },
-    /**
-     *
-     * @param {string} entityId The ID of the source entity
-     * @param {RemoveLinkRequest} removeLinkRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    removeLink(
-      entityId: string,
-      removeLinkRequest: RemoveLinkRequest,
-      options?: any,
-    ): AxiosPromise<void> {
-      return localVarFp
-        .removeLink(entityId, removeLinkRequest, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -6589,20 +5344,6 @@ export const GraphApiFactory = function (
     ): AxiosPromise<PersistedOntologyMetadata> {
       return localVarFp
         .updateEntityType(updateEntityTypeRequest, options)
-        .then((request) => request(axios, basePath));
-    },
-    /**
-     *
-     * @param {UpdateLinkTypeRequest} updateLinkTypeRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    updateLinkType(
-      updateLinkTypeRequest: UpdateLinkTypeRequest,
-      options?: any,
-    ): AxiosPromise<PersistedOntologyMetadata> {
-      return localVarFp
-        .updateLinkType(updateLinkTypeRequest, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -6674,32 +5415,6 @@ export interface GraphApiInterface {
 
   /**
    *
-   * @param {string} entityId The ID of the source entity
-   * @param {CreateLinkRequest} createLinkRequest
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof GraphApiInterface
-   */
-  createLink(
-    entityId: string,
-    createLinkRequest: CreateLinkRequest,
-    options?: AxiosRequestConfig,
-  ): AxiosPromise<Link>;
-
-  /**
-   *
-   * @param {CreateLinkTypeRequest} createLinkTypeRequest
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof GraphApiInterface
-   */
-  createLinkType(
-    createLinkTypeRequest: CreateLinkTypeRequest,
-    options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyMetadata>;
-
-  /**
-   *
    * @param {CreatePropertyTypeRequest} createPropertyTypeRequest
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
@@ -6757,18 +5472,6 @@ export interface GraphApiInterface {
     entityId: string,
     options?: AxiosRequestConfig,
   ): AxiosPromise<PersistedEntity>;
-
-  /**
-   *
-   * @param {string} entityId The ID of the source entity
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof GraphApiInterface
-   */
-  getEntityLinks(
-    entityId: string,
-    options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PersistedLink>>;
 
   /**
    *
@@ -6830,55 +5533,9 @@ export interface GraphApiInterface {
    * @throws {RequiredError}
    * @memberof GraphApiInterface
    */
-  getLatestLinkTypes(
-    options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PersistedLinkType>>;
-
-  /**
-   *
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof GraphApiInterface
-   */
   getLatestPropertyTypes(
     options?: AxiosRequestConfig,
   ): AxiosPromise<Array<PersistedPropertyType>>;
-
-  /**
-   *
-   * @param {string} uri The URI of the link type
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof GraphApiInterface
-   */
-  getLinkType(
-    uri: string,
-    options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedLinkType>;
-
-  /**
-   *
-   * @param {LinkTypeStructuralQuery} linkTypeStructuralQuery
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof GraphApiInterface
-   */
-  getLinkTypesByQuery(
-    linkTypeStructuralQuery: LinkTypeStructuralQuery,
-    options?: AxiosRequestConfig,
-  ): AxiosPromise<Subgraph>;
-
-  /**
-   *
-   * @param {LinkStructuralQuery} linkStructuralQuery
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof GraphApiInterface
-   */
-  getLinksByQuery(
-    linkStructuralQuery: LinkStructuralQuery,
-    options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<LinkRootedSubgraph>>;
 
   /**
    *
@@ -6903,20 +5560,6 @@ export interface GraphApiInterface {
     propertyTypeStructuralQuery: PropertyTypeStructuralQuery,
     options?: AxiosRequestConfig,
   ): AxiosPromise<Subgraph>;
-
-  /**
-   *
-   * @param {string} entityId The ID of the source entity
-   * @param {RemoveLinkRequest} removeLinkRequest
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof GraphApiInterface
-   */
-  removeLink(
-    entityId: string,
-    removeLinkRequest: RemoveLinkRequest,
-    options?: AxiosRequestConfig,
-  ): AxiosPromise<void>;
 
   /**
    *
@@ -6951,18 +5594,6 @@ export interface GraphApiInterface {
    */
   updateEntityType(
     updateEntityTypeRequest: UpdateEntityTypeRequest,
-    options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyMetadata>;
-
-  /**
-   *
-   * @param {UpdateLinkTypeRequest} updateLinkTypeRequest
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof GraphApiInterface
-   */
-  updateLinkType(
-    updateLinkTypeRequest: UpdateLinkTypeRequest,
     options?: AxiosRequestConfig,
   ): AxiosPromise<PersistedOntologyMetadata>;
 
@@ -7048,40 +5679,6 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
 
   /**
    *
-   * @param {string} entityId The ID of the source entity
-   * @param {CreateLinkRequest} createLinkRequest
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof GraphApi
-   */
-  public createLink(
-    entityId: string,
-    createLinkRequest: CreateLinkRequest,
-    options?: AxiosRequestConfig,
-  ) {
-    return GraphApiFp(this.configuration)
-      .createLink(entityId, createLinkRequest, options)
-      .then((request) => request(this.axios, this.basePath));
-  }
-
-  /**
-   *
-   * @param {CreateLinkTypeRequest} createLinkTypeRequest
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof GraphApi
-   */
-  public createLinkType(
-    createLinkTypeRequest: CreateLinkTypeRequest,
-    options?: AxiosRequestConfig,
-  ) {
-    return GraphApiFp(this.configuration)
-      .createLinkType(createLinkTypeRequest, options)
-      .then((request) => request(this.axios, this.basePath));
-  }
-
-  /**
-   *
    * @param {CreatePropertyTypeRequest} createPropertyTypeRequest
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
@@ -7156,19 +5753,6 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
 
   /**
    *
-   * @param {string} entityId The ID of the source entity
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof GraphApi
-   */
-  public getEntityLinks(entityId: string, options?: AxiosRequestConfig) {
-    return GraphApiFp(this.configuration)
-      .getEntityLinks(entityId, options)
-      .then((request) => request(this.axios, this.basePath));
-  }
-
-  /**
-   *
    * @param {string} uri The URI of the entity type
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
@@ -7238,66 +5822,9 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
    * @throws {RequiredError}
    * @memberof GraphApi
    */
-  public getLatestLinkTypes(options?: AxiosRequestConfig) {
-    return GraphApiFp(this.configuration)
-      .getLatestLinkTypes(options)
-      .then((request) => request(this.axios, this.basePath));
-  }
-
-  /**
-   *
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof GraphApi
-   */
   public getLatestPropertyTypes(options?: AxiosRequestConfig) {
     return GraphApiFp(this.configuration)
       .getLatestPropertyTypes(options)
-      .then((request) => request(this.axios, this.basePath));
-  }
-
-  /**
-   *
-   * @param {string} uri The URI of the link type
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof GraphApi
-   */
-  public getLinkType(uri: string, options?: AxiosRequestConfig) {
-    return GraphApiFp(this.configuration)
-      .getLinkType(uri, options)
-      .then((request) => request(this.axios, this.basePath));
-  }
-
-  /**
-   *
-   * @param {LinkTypeStructuralQuery} linkTypeStructuralQuery
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof GraphApi
-   */
-  public getLinkTypesByQuery(
-    linkTypeStructuralQuery: LinkTypeStructuralQuery,
-    options?: AxiosRequestConfig,
-  ) {
-    return GraphApiFp(this.configuration)
-      .getLinkTypesByQuery(linkTypeStructuralQuery, options)
-      .then((request) => request(this.axios, this.basePath));
-  }
-
-  /**
-   *
-   * @param {LinkStructuralQuery} linkStructuralQuery
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof GraphApi
-   */
-  public getLinksByQuery(
-    linkStructuralQuery: LinkStructuralQuery,
-    options?: AxiosRequestConfig,
-  ) {
-    return GraphApiFp(this.configuration)
-      .getLinksByQuery(linkStructuralQuery, options)
       .then((request) => request(this.axios, this.basePath));
   }
 
@@ -7327,24 +5854,6 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
   ) {
     return GraphApiFp(this.configuration)
       .getPropertyTypesByQuery(propertyTypeStructuralQuery, options)
-      .then((request) => request(this.axios, this.basePath));
-  }
-
-  /**
-   *
-   * @param {string} entityId The ID of the source entity
-   * @param {RemoveLinkRequest} removeLinkRequest
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof GraphApi
-   */
-  public removeLink(
-    entityId: string,
-    removeLinkRequest: RemoveLinkRequest,
-    options?: AxiosRequestConfig,
-  ) {
-    return GraphApiFp(this.configuration)
-      .removeLink(entityId, removeLinkRequest, options)
       .then((request) => request(this.axios, this.basePath));
   }
 
@@ -7398,22 +5907,6 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
 
   /**
    *
-   * @param {UpdateLinkTypeRequest} updateLinkTypeRequest
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof GraphApi
-   */
-  public updateLinkType(
-    updateLinkTypeRequest: UpdateLinkTypeRequest,
-    options?: AxiosRequestConfig,
-  ) {
-    return GraphApiFp(this.configuration)
-      .updateLinkType(updateLinkTypeRequest, options)
-      .then((request) => request(this.axios, this.basePath));
-  }
-
-  /**
-   *
    * @param {UpdatePropertyTypeRequest} updatePropertyTypeRequest
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
@@ -7425,1157 +5918,6 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
   ) {
     return GraphApiFp(this.configuration)
       .updatePropertyType(updatePropertyTypeRequest, options)
-      .then((request) => request(this.axios, this.basePath));
-  }
-}
-
-/**
- * LinkApi - axios parameter creator
- * @export
- */
-export const LinkApiAxiosParamCreator = function (
-  configuration?: Configuration,
-) {
-  return {
-    /**
-     *
-     * @param {string} entityId The ID of the source entity
-     * @param {CreateLinkRequest} createLinkRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    createLink: async (
-      entityId: string,
-      createLinkRequest: CreateLinkRequest,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'entityId' is not null or undefined
-      assertParamExists("createLink", "entityId", entityId);
-      // verify required parameter 'createLinkRequest' is not null or undefined
-      assertParamExists("createLink", "createLinkRequest", createLinkRequest);
-      const localVarPath = `/entities/{entityId}/links`.replace(
-        `{${"entityId"}}`,
-        encodeURIComponent(String(entityId)),
-      );
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-      let baseOptions;
-      if (configuration) {
-        baseOptions = configuration.baseOptions;
-      }
-
-      const localVarRequestOptions = {
-        method: "POST",
-        ...baseOptions,
-        ...options,
-      };
-      const localVarHeaderParameter = {} as any;
-      const localVarQueryParameter = {} as any;
-
-      localVarHeaderParameter["Content-Type"] = "application/json";
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter);
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {};
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      };
-      localVarRequestOptions.data = serializeDataIfNeeded(
-        createLinkRequest,
-        localVarRequestOptions,
-        configuration,
-      );
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      };
-    },
-    /**
-     *
-     * @param {string} entityId The ID of the source entity
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    getEntityLinks: async (
-      entityId: string,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'entityId' is not null or undefined
-      assertParamExists("getEntityLinks", "entityId", entityId);
-      const localVarPath = `/entities/{entityId}/links`.replace(
-        `{${"entityId"}}`,
-        encodeURIComponent(String(entityId)),
-      );
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-      let baseOptions;
-      if (configuration) {
-        baseOptions = configuration.baseOptions;
-      }
-
-      const localVarRequestOptions = {
-        method: "GET",
-        ...baseOptions,
-        ...options,
-      };
-      const localVarHeaderParameter = {} as any;
-      const localVarQueryParameter = {} as any;
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter);
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {};
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      };
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      };
-    },
-    /**
-     *
-     * @param {LinkStructuralQuery} linkStructuralQuery
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    getLinksByQuery: async (
-      linkStructuralQuery: LinkStructuralQuery,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'linkStructuralQuery' is not null or undefined
-      assertParamExists(
-        "getLinksByQuery",
-        "linkStructuralQuery",
-        linkStructuralQuery,
-      );
-      const localVarPath = `/links/query`;
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-      let baseOptions;
-      if (configuration) {
-        baseOptions = configuration.baseOptions;
-      }
-
-      const localVarRequestOptions = {
-        method: "POST",
-        ...baseOptions,
-        ...options,
-      };
-      const localVarHeaderParameter = {} as any;
-      const localVarQueryParameter = {} as any;
-
-      localVarHeaderParameter["Content-Type"] = "application/json";
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter);
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {};
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      };
-      localVarRequestOptions.data = serializeDataIfNeeded(
-        linkStructuralQuery,
-        localVarRequestOptions,
-        configuration,
-      );
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      };
-    },
-    /**
-     *
-     * @param {string} entityId The ID of the source entity
-     * @param {RemoveLinkRequest} removeLinkRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    removeLink: async (
-      entityId: string,
-      removeLinkRequest: RemoveLinkRequest,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'entityId' is not null or undefined
-      assertParamExists("removeLink", "entityId", entityId);
-      // verify required parameter 'removeLinkRequest' is not null or undefined
-      assertParamExists("removeLink", "removeLinkRequest", removeLinkRequest);
-      const localVarPath = `/entities/{entityId}/links`.replace(
-        `{${"entityId"}}`,
-        encodeURIComponent(String(entityId)),
-      );
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-      let baseOptions;
-      if (configuration) {
-        baseOptions = configuration.baseOptions;
-      }
-
-      const localVarRequestOptions = {
-        method: "DELETE",
-        ...baseOptions,
-        ...options,
-      };
-      const localVarHeaderParameter = {} as any;
-      const localVarQueryParameter = {} as any;
-
-      localVarHeaderParameter["Content-Type"] = "application/json";
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter);
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {};
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      };
-      localVarRequestOptions.data = serializeDataIfNeeded(
-        removeLinkRequest,
-        localVarRequestOptions,
-        configuration,
-      );
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      };
-    },
-  };
-};
-
-/**
- * LinkApi - functional programming interface
- * @export
- */
-export const LinkApiFp = function (configuration?: Configuration) {
-  const localVarAxiosParamCreator = LinkApiAxiosParamCreator(configuration);
-  return {
-    /**
-     *
-     * @param {string} entityId The ID of the source entity
-     * @param {CreateLinkRequest} createLinkRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async createLink(
-      entityId: string,
-      createLinkRequest: CreateLinkRequest,
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Link>
-    > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.createLink(
-        entityId,
-        createLinkRequest,
-        options,
-      );
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      );
-    },
-    /**
-     *
-     * @param {string} entityId The ID of the source entity
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async getEntityLinks(
-      entityId: string,
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<Array<PersistedLink>>
-    > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.getEntityLinks(
-        entityId,
-        options,
-      );
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      );
-    },
-    /**
-     *
-     * @param {LinkStructuralQuery} linkStructuralQuery
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async getLinksByQuery(
-      linkStructuralQuery: LinkStructuralQuery,
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<Array<LinkRootedSubgraph>>
-    > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.getLinksByQuery(
-        linkStructuralQuery,
-        options,
-      );
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      );
-    },
-    /**
-     *
-     * @param {string} entityId The ID of the source entity
-     * @param {RemoveLinkRequest} removeLinkRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async removeLink(
-      entityId: string,
-      removeLinkRequest: RemoveLinkRequest,
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>
-    > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.removeLink(
-        entityId,
-        removeLinkRequest,
-        options,
-      );
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      );
-    },
-  };
-};
-
-/**
- * LinkApi - factory interface
- * @export
- */
-export const LinkApiFactory = function (
-  configuration?: Configuration,
-  basePath?: string,
-  axios?: AxiosInstance,
-) {
-  const localVarFp = LinkApiFp(configuration);
-  return {
-    /**
-     *
-     * @param {string} entityId The ID of the source entity
-     * @param {CreateLinkRequest} createLinkRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    createLink(
-      entityId: string,
-      createLinkRequest: CreateLinkRequest,
-      options?: any,
-    ): AxiosPromise<Link> {
-      return localVarFp
-        .createLink(entityId, createLinkRequest, options)
-        .then((request) => request(axios, basePath));
-    },
-    /**
-     *
-     * @param {string} entityId The ID of the source entity
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    getEntityLinks(
-      entityId: string,
-      options?: any,
-    ): AxiosPromise<Array<PersistedLink>> {
-      return localVarFp
-        .getEntityLinks(entityId, options)
-        .then((request) => request(axios, basePath));
-    },
-    /**
-     *
-     * @param {LinkStructuralQuery} linkStructuralQuery
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    getLinksByQuery(
-      linkStructuralQuery: LinkStructuralQuery,
-      options?: any,
-    ): AxiosPromise<Array<LinkRootedSubgraph>> {
-      return localVarFp
-        .getLinksByQuery(linkStructuralQuery, options)
-        .then((request) => request(axios, basePath));
-    },
-    /**
-     *
-     * @param {string} entityId The ID of the source entity
-     * @param {RemoveLinkRequest} removeLinkRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    removeLink(
-      entityId: string,
-      removeLinkRequest: RemoveLinkRequest,
-      options?: any,
-    ): AxiosPromise<void> {
-      return localVarFp
-        .removeLink(entityId, removeLinkRequest, options)
-        .then((request) => request(axios, basePath));
-    },
-  };
-};
-
-/**
- * LinkApi - interface
- * @export
- * @interface LinkApi
- */
-export interface LinkApiInterface {
-  /**
-   *
-   * @param {string} entityId The ID of the source entity
-   * @param {CreateLinkRequest} createLinkRequest
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof LinkApiInterface
-   */
-  createLink(
-    entityId: string,
-    createLinkRequest: CreateLinkRequest,
-    options?: AxiosRequestConfig,
-  ): AxiosPromise<Link>;
-
-  /**
-   *
-   * @param {string} entityId The ID of the source entity
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof LinkApiInterface
-   */
-  getEntityLinks(
-    entityId: string,
-    options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PersistedLink>>;
-
-  /**
-   *
-   * @param {LinkStructuralQuery} linkStructuralQuery
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof LinkApiInterface
-   */
-  getLinksByQuery(
-    linkStructuralQuery: LinkStructuralQuery,
-    options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<LinkRootedSubgraph>>;
-
-  /**
-   *
-   * @param {string} entityId The ID of the source entity
-   * @param {RemoveLinkRequest} removeLinkRequest
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof LinkApiInterface
-   */
-  removeLink(
-    entityId: string,
-    removeLinkRequest: RemoveLinkRequest,
-    options?: AxiosRequestConfig,
-  ): AxiosPromise<void>;
-}
-
-/**
- * LinkApi - object-oriented interface
- * @export
- * @class LinkApi
- * @extends {BaseAPI}
- */
-export class LinkApi extends BaseAPI implements LinkApiInterface {
-  /**
-   *
-   * @param {string} entityId The ID of the source entity
-   * @param {CreateLinkRequest} createLinkRequest
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof LinkApi
-   */
-  public createLink(
-    entityId: string,
-    createLinkRequest: CreateLinkRequest,
-    options?: AxiosRequestConfig,
-  ) {
-    return LinkApiFp(this.configuration)
-      .createLink(entityId, createLinkRequest, options)
-      .then((request) => request(this.axios, this.basePath));
-  }
-
-  /**
-   *
-   * @param {string} entityId The ID of the source entity
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof LinkApi
-   */
-  public getEntityLinks(entityId: string, options?: AxiosRequestConfig) {
-    return LinkApiFp(this.configuration)
-      .getEntityLinks(entityId, options)
-      .then((request) => request(this.axios, this.basePath));
-  }
-
-  /**
-   *
-   * @param {LinkStructuralQuery} linkStructuralQuery
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof LinkApi
-   */
-  public getLinksByQuery(
-    linkStructuralQuery: LinkStructuralQuery,
-    options?: AxiosRequestConfig,
-  ) {
-    return LinkApiFp(this.configuration)
-      .getLinksByQuery(linkStructuralQuery, options)
-      .then((request) => request(this.axios, this.basePath));
-  }
-
-  /**
-   *
-   * @param {string} entityId The ID of the source entity
-   * @param {RemoveLinkRequest} removeLinkRequest
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof LinkApi
-   */
-  public removeLink(
-    entityId: string,
-    removeLinkRequest: RemoveLinkRequest,
-    options?: AxiosRequestConfig,
-  ) {
-    return LinkApiFp(this.configuration)
-      .removeLink(entityId, removeLinkRequest, options)
-      .then((request) => request(this.axios, this.basePath));
-  }
-}
-
-/**
- * LinkTypeApi - axios parameter creator
- * @export
- */
-export const LinkTypeApiAxiosParamCreator = function (
-  configuration?: Configuration,
-) {
-  return {
-    /**
-     *
-     * @param {CreateLinkTypeRequest} createLinkTypeRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    createLinkType: async (
-      createLinkTypeRequest: CreateLinkTypeRequest,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'createLinkTypeRequest' is not null or undefined
-      assertParamExists(
-        "createLinkType",
-        "createLinkTypeRequest",
-        createLinkTypeRequest,
-      );
-      const localVarPath = `/link-types`;
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-      let baseOptions;
-      if (configuration) {
-        baseOptions = configuration.baseOptions;
-      }
-
-      const localVarRequestOptions = {
-        method: "POST",
-        ...baseOptions,
-        ...options,
-      };
-      const localVarHeaderParameter = {} as any;
-      const localVarQueryParameter = {} as any;
-
-      localVarHeaderParameter["Content-Type"] = "application/json";
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter);
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {};
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      };
-      localVarRequestOptions.data = serializeDataIfNeeded(
-        createLinkTypeRequest,
-        localVarRequestOptions,
-        configuration,
-      );
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      };
-    },
-    /**
-     *
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    getLatestLinkTypes: async (
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      const localVarPath = `/link-types`;
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-      let baseOptions;
-      if (configuration) {
-        baseOptions = configuration.baseOptions;
-      }
-
-      const localVarRequestOptions = {
-        method: "GET",
-        ...baseOptions,
-        ...options,
-      };
-      const localVarHeaderParameter = {} as any;
-      const localVarQueryParameter = {} as any;
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter);
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {};
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      };
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      };
-    },
-    /**
-     *
-     * @param {string} uri The URI of the link type
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    getLinkType: async (
-      uri: string,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'uri' is not null or undefined
-      assertParamExists("getLinkType", "uri", uri);
-      const localVarPath = `/link-types/{uri}`.replace(
-        `{${"uri"}}`,
-        encodeURIComponent(String(uri)),
-      );
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-      let baseOptions;
-      if (configuration) {
-        baseOptions = configuration.baseOptions;
-      }
-
-      const localVarRequestOptions = {
-        method: "GET",
-        ...baseOptions,
-        ...options,
-      };
-      const localVarHeaderParameter = {} as any;
-      const localVarQueryParameter = {} as any;
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter);
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {};
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      };
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      };
-    },
-    /**
-     *
-     * @param {LinkTypeStructuralQuery} linkTypeStructuralQuery
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    getLinkTypesByQuery: async (
-      linkTypeStructuralQuery: LinkTypeStructuralQuery,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'linkTypeStructuralQuery' is not null or undefined
-      assertParamExists(
-        "getLinkTypesByQuery",
-        "linkTypeStructuralQuery",
-        linkTypeStructuralQuery,
-      );
-      const localVarPath = `/link-types/query`;
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-      let baseOptions;
-      if (configuration) {
-        baseOptions = configuration.baseOptions;
-      }
-
-      const localVarRequestOptions = {
-        method: "POST",
-        ...baseOptions,
-        ...options,
-      };
-      const localVarHeaderParameter = {} as any;
-      const localVarQueryParameter = {} as any;
-
-      localVarHeaderParameter["Content-Type"] = "application/json";
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter);
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {};
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      };
-      localVarRequestOptions.data = serializeDataIfNeeded(
-        linkTypeStructuralQuery,
-        localVarRequestOptions,
-        configuration,
-      );
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      };
-    },
-    /**
-     *
-     * @param {UpdateLinkTypeRequest} updateLinkTypeRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    updateLinkType: async (
-      updateLinkTypeRequest: UpdateLinkTypeRequest,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'updateLinkTypeRequest' is not null or undefined
-      assertParamExists(
-        "updateLinkType",
-        "updateLinkTypeRequest",
-        updateLinkTypeRequest,
-      );
-      const localVarPath = `/link-types`;
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-      let baseOptions;
-      if (configuration) {
-        baseOptions = configuration.baseOptions;
-      }
-
-      const localVarRequestOptions = {
-        method: "PUT",
-        ...baseOptions,
-        ...options,
-      };
-      const localVarHeaderParameter = {} as any;
-      const localVarQueryParameter = {} as any;
-
-      localVarHeaderParameter["Content-Type"] = "application/json";
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter);
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {};
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      };
-      localVarRequestOptions.data = serializeDataIfNeeded(
-        updateLinkTypeRequest,
-        localVarRequestOptions,
-        configuration,
-      );
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      };
-    },
-  };
-};
-
-/**
- * LinkTypeApi - functional programming interface
- * @export
- */
-export const LinkTypeApiFp = function (configuration?: Configuration) {
-  const localVarAxiosParamCreator = LinkTypeApiAxiosParamCreator(configuration);
-  return {
-    /**
-     *
-     * @param {CreateLinkTypeRequest} createLinkTypeRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async createLinkType(
-      createLinkTypeRequest: CreateLinkTypeRequest,
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<PersistedOntologyMetadata>
-    > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.createLinkType(
-        createLinkTypeRequest,
-        options,
-      );
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      );
-    },
-    /**
-     *
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async getLatestLinkTypes(
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<Array<PersistedLinkType>>
-    > {
-      const localVarAxiosArgs =
-        await localVarAxiosParamCreator.getLatestLinkTypes(options);
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      );
-    },
-    /**
-     *
-     * @param {string} uri The URI of the link type
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async getLinkType(
-      uri: string,
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<PersistedLinkType>
-    > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.getLinkType(
-        uri,
-        options,
-      );
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      );
-    },
-    /**
-     *
-     * @param {LinkTypeStructuralQuery} linkTypeStructuralQuery
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async getLinkTypesByQuery(
-      linkTypeStructuralQuery: LinkTypeStructuralQuery,
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Subgraph>
-    > {
-      const localVarAxiosArgs =
-        await localVarAxiosParamCreator.getLinkTypesByQuery(
-          linkTypeStructuralQuery,
-          options,
-        );
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      );
-    },
-    /**
-     *
-     * @param {UpdateLinkTypeRequest} updateLinkTypeRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async updateLinkType(
-      updateLinkTypeRequest: UpdateLinkTypeRequest,
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<PersistedOntologyMetadata>
-    > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.updateLinkType(
-        updateLinkTypeRequest,
-        options,
-      );
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      );
-    },
-  };
-};
-
-/**
- * LinkTypeApi - factory interface
- * @export
- */
-export const LinkTypeApiFactory = function (
-  configuration?: Configuration,
-  basePath?: string,
-  axios?: AxiosInstance,
-) {
-  const localVarFp = LinkTypeApiFp(configuration);
-  return {
-    /**
-     *
-     * @param {CreateLinkTypeRequest} createLinkTypeRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    createLinkType(
-      createLinkTypeRequest: CreateLinkTypeRequest,
-      options?: any,
-    ): AxiosPromise<PersistedOntologyMetadata> {
-      return localVarFp
-        .createLinkType(createLinkTypeRequest, options)
-        .then((request) => request(axios, basePath));
-    },
-    /**
-     *
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    getLatestLinkTypes(options?: any): AxiosPromise<Array<PersistedLinkType>> {
-      return localVarFp
-        .getLatestLinkTypes(options)
-        .then((request) => request(axios, basePath));
-    },
-    /**
-     *
-     * @param {string} uri The URI of the link type
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    getLinkType(uri: string, options?: any): AxiosPromise<PersistedLinkType> {
-      return localVarFp
-        .getLinkType(uri, options)
-        .then((request) => request(axios, basePath));
-    },
-    /**
-     *
-     * @param {LinkTypeStructuralQuery} linkTypeStructuralQuery
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    getLinkTypesByQuery(
-      linkTypeStructuralQuery: LinkTypeStructuralQuery,
-      options?: any,
-    ): AxiosPromise<Subgraph> {
-      return localVarFp
-        .getLinkTypesByQuery(linkTypeStructuralQuery, options)
-        .then((request) => request(axios, basePath));
-    },
-    /**
-     *
-     * @param {UpdateLinkTypeRequest} updateLinkTypeRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    updateLinkType(
-      updateLinkTypeRequest: UpdateLinkTypeRequest,
-      options?: any,
-    ): AxiosPromise<PersistedOntologyMetadata> {
-      return localVarFp
-        .updateLinkType(updateLinkTypeRequest, options)
-        .then((request) => request(axios, basePath));
-    },
-  };
-};
-
-/**
- * LinkTypeApi - interface
- * @export
- * @interface LinkTypeApi
- */
-export interface LinkTypeApiInterface {
-  /**
-   *
-   * @param {CreateLinkTypeRequest} createLinkTypeRequest
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof LinkTypeApiInterface
-   */
-  createLinkType(
-    createLinkTypeRequest: CreateLinkTypeRequest,
-    options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyMetadata>;
-
-  /**
-   *
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof LinkTypeApiInterface
-   */
-  getLatestLinkTypes(
-    options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PersistedLinkType>>;
-
-  /**
-   *
-   * @param {string} uri The URI of the link type
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof LinkTypeApiInterface
-   */
-  getLinkType(
-    uri: string,
-    options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedLinkType>;
-
-  /**
-   *
-   * @param {LinkTypeStructuralQuery} linkTypeStructuralQuery
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof LinkTypeApiInterface
-   */
-  getLinkTypesByQuery(
-    linkTypeStructuralQuery: LinkTypeStructuralQuery,
-    options?: AxiosRequestConfig,
-  ): AxiosPromise<Subgraph>;
-
-  /**
-   *
-   * @param {UpdateLinkTypeRequest} updateLinkTypeRequest
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof LinkTypeApiInterface
-   */
-  updateLinkType(
-    updateLinkTypeRequest: UpdateLinkTypeRequest,
-    options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyMetadata>;
-}
-
-/**
- * LinkTypeApi - object-oriented interface
- * @export
- * @class LinkTypeApi
- * @extends {BaseAPI}
- */
-export class LinkTypeApi extends BaseAPI implements LinkTypeApiInterface {
-  /**
-   *
-   * @param {CreateLinkTypeRequest} createLinkTypeRequest
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof LinkTypeApi
-   */
-  public createLinkType(
-    createLinkTypeRequest: CreateLinkTypeRequest,
-    options?: AxiosRequestConfig,
-  ) {
-    return LinkTypeApiFp(this.configuration)
-      .createLinkType(createLinkTypeRequest, options)
-      .then((request) => request(this.axios, this.basePath));
-  }
-
-  /**
-   *
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof LinkTypeApi
-   */
-  public getLatestLinkTypes(options?: AxiosRequestConfig) {
-    return LinkTypeApiFp(this.configuration)
-      .getLatestLinkTypes(options)
-      .then((request) => request(this.axios, this.basePath));
-  }
-
-  /**
-   *
-   * @param {string} uri The URI of the link type
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof LinkTypeApi
-   */
-  public getLinkType(uri: string, options?: AxiosRequestConfig) {
-    return LinkTypeApiFp(this.configuration)
-      .getLinkType(uri, options)
-      .then((request) => request(this.axios, this.basePath));
-  }
-
-  /**
-   *
-   * @param {LinkTypeStructuralQuery} linkTypeStructuralQuery
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof LinkTypeApi
-   */
-  public getLinkTypesByQuery(
-    linkTypeStructuralQuery: LinkTypeStructuralQuery,
-    options?: AxiosRequestConfig,
-  ) {
-    return LinkTypeApiFp(this.configuration)
-      .getLinkTypesByQuery(linkTypeStructuralQuery, options)
-      .then((request) => request(this.axios, this.basePath));
-  }
-
-  /**
-   *
-   * @param {UpdateLinkTypeRequest} updateLinkTypeRequest
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof LinkTypeApi
-   */
-  public updateLinkType(
-    updateLinkTypeRequest: UpdateLinkTypeRequest,
-    options?: AxiosRequestConfig,
-  ) {
-    return LinkTypeApiFp(this.configuration)
-      .updateLinkType(updateLinkTypeRequest, options)
       .then((request) => request(this.axios, this.basePath));
   }
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -48,6 +48,7 @@ use crate::{
             UpdatedById,
             CreateEntityRequest,
             UpdateEntityRequest,
+            ArchiveEntityRequest,
             EntityId,
             PersistedEntityIdentifier,
             PersistedEntityMetadata,
@@ -158,6 +159,7 @@ async fn create_entity<P: StorePool + Send>(
 #[serde(rename_all = "camelCase")]
 struct ArchiveEntityRequest {
     entity_id: EntityId,
+    owned_by_id: OwnedById,
     actor_id: UpdatedById,
 }
 
@@ -180,6 +182,7 @@ async fn archive_entity<P: StorePool + Send>(
 ) -> Result<(), StatusCode> {
     let Json(ArchiveEntityRequest {
         entity_id,
+        owned_by_id,
         actor_id,
     }) = body;
 
@@ -189,7 +192,7 @@ async fn archive_entity<P: StorePool + Send>(
     })?;
 
     store
-        .archive_entity(entity_id, actor_id)
+        .archive_entity(entity_id, owned_by_id, actor_id)
         .await
         .map_err(|report| {
             if report.contains::<QueryError>() {

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -19,7 +19,7 @@ use crate::{
         Entity, EntityId, LinkEntityMetadata, PersistedEntity, PersistedEntityIdentifier,
         PersistedEntityMetadata,
     },
-    provenance::{ArchivedById, CreatedById, OwnedById, UpdatedById},
+    provenance::{CreatedById, OwnedById, UpdatedById},
     shared::identifier::GraphElementIdentifier,
     store::{
         error::{EntityDoesNotExist, QueryError},
@@ -158,7 +158,7 @@ async fn create_entity<P: StorePool + Send>(
 #[serde(rename_all = "camelCase")]
 struct ArchiveEntityRequest {
     entity_id: EntityId,
-    actor_id: ArchivedById,
+    actor_id: UpdatedById,
 }
 
 #[utoipa::path(

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -167,7 +167,7 @@ struct ArchiveEntityRequest {
     request_body = ArchiveEntityRequest,
     tag = "Entity",
     responses(
-        (status = 201, content_type = "application/json", description = "No response"),
+        (status = 200, content_type = "application/json", description = "No response"),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Entity could not be found"),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/json_schemas/entity_type.json
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/json_schemas/entity_type.json
@@ -45,10 +45,9 @@
         "format": "uri"
       }
     },
-    // TODO: update this https://app.asana.com/0/1202805690238892/1203260690980368/f
     "links": { "$ref": "#/$defs/linkTypeObject" },
     "requiredLinks": {
-      "$comment": "A list of link-types which are required. This is a separate field to 'required' to avoid breaking standard JSON schema validation",
+      "$comment": "TODO: update this https://app.asana.com/0/1202805690238892/1203260690980368/f. A list of link-types which are required. This is a separate field to 'required' to avoid breaking standard JSON schema validation",
       "type": "array",
       "items": {
         "type": "string"

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/json_schemas/update_entity_type.json
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/json_schemas/update_entity_type.json
@@ -40,10 +40,9 @@
         "format": "uri"
       }
     },
-    // TODO: update this https://app.asana.com/0/1202805690238892/1203260690980368/f
     "links": { "$ref": "#/$defs/linkTypeObject" },
     "requiredLinks": {
-      "$comment": "A list of link-types which are required. This is a separate field to 'required' to avoid breaking standard JSON schema validation",
+      "$comment": "// TODO: update this https://app.asana.com/0/1202805690238892/1203260690980368/f. A list of link-types which are required. This is a separate field to 'required' to avoid breaking standard JSON schema validation",
       "type": "array",
       "items": {
         "type": "string"

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -156,7 +156,6 @@ pub struct PersistedEntityMetadata {
     //  https://app.asana.com/0/1201095311341924/1203227079758117/f
     created_by_id: CreatedById,
     updated_by_id: UpdatedById,
-    removed_by_id: Option<RemovedById>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     link_metadata: Option<LinkEntityMetadata>,
 }
@@ -168,7 +167,6 @@ impl PersistedEntityMetadata {
         entity_type_id: VersionedUri,
         created_by_id: CreatedById,
         updated_by_id: UpdatedById,
-        removed_by_id: Option<RemovedById>,
         link_metadata: Option<LinkEntityMetadata>,
     ) -> Self {
         Self {
@@ -176,7 +174,6 @@ impl PersistedEntityMetadata {
             entity_type_id,
             created_by_id,
             updated_by_id,
-            removed_by_id,
             link_metadata,
         }
     }
@@ -202,11 +199,6 @@ impl PersistedEntityMetadata {
     }
 
     #[must_use]
-    pub const fn removed_by_id(&self) -> Option<RemovedById> {
-        self.removed_by_id
-    }
-
-    #[must_use]
     pub const fn link_metadata(&self) -> &Option<LinkEntityMetadata> {
         &self.link_metadata
     }
@@ -229,7 +221,6 @@ impl PersistedEntity {
         entity_type_id: VersionedUri,
         created_by_id: CreatedById,
         updated_by_id: UpdatedById,
-        removed_by_id: Option<RemovedById>,
         link_metadata: Option<LinkEntityMetadata>,
     ) -> Self {
         Self {
@@ -239,7 +230,6 @@ impl PersistedEntity {
                 entity_type_id,
                 created_by_id,
                 updated_by_id,
-                removed_by_id,
                 link_metadata,
             ),
         }

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -96,7 +96,7 @@ impl PersistedEntityIdentifier {
 }
 
 /// The associated information for 'Link' entities
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct LinkEntityMetadata {
     left_entity_id: EntityId,
@@ -199,8 +199,8 @@ impl PersistedEntityMetadata {
     }
 
     #[must_use]
-    pub const fn link_metadata(&self) -> &Option<LinkEntityMetadata> {
-        &self.link_metadata
+    pub const fn link_metadata(&self) -> Option<LinkEntityMetadata> {
+        self.link_metadata
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -158,6 +158,7 @@ pub struct PersistedEntityMetadata {
     updated_by_id: UpdatedById,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     link_metadata: Option<LinkEntityMetadata>,
+    archived: bool,
 }
 
 impl PersistedEntityMetadata {
@@ -168,6 +169,7 @@ impl PersistedEntityMetadata {
         created_by_id: CreatedById,
         updated_by_id: UpdatedById,
         link_metadata: Option<LinkEntityMetadata>,
+        archived: bool,
     ) -> Self {
         Self {
             identifier,
@@ -175,6 +177,7 @@ impl PersistedEntityMetadata {
             created_by_id,
             updated_by_id,
             link_metadata,
+            archived,
         }
     }
 
@@ -202,6 +205,11 @@ impl PersistedEntityMetadata {
     pub const fn link_metadata(&self) -> Option<LinkEntityMetadata> {
         self.link_metadata
     }
+
+    #[must_use]
+    pub const fn archived(&self) -> bool {
+        self.archived
+    }
 }
 
 /// A record of an [`Entity`] that has been persisted in the datastore, with its associated
@@ -222,6 +230,7 @@ impl PersistedEntity {
         created_by_id: CreatedById,
         updated_by_id: UpdatedById,
         link_metadata: Option<LinkEntityMetadata>,
+        archived: bool,
     ) -> Self {
         Self {
             inner,
@@ -231,6 +240,7 @@ impl PersistedEntity {
                 created_by_id,
                 updated_by_id,
                 link_metadata,
+                archived,
             ),
         }
     }

--- a/packages/graph/hash_graph/lib/graph/src/shared/provenance.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/provenance.rs
@@ -45,3 +45,4 @@ define_provenance_id!(OwnedById);
 define_provenance_id!(CreatedById);
 define_provenance_id!(UpdatedById);
 define_provenance_id!(RemovedById);
+define_provenance_id!(ArchivedById);

--- a/packages/graph/hash_graph/lib/graph/src/shared/provenance.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/provenance.rs
@@ -45,4 +45,3 @@ define_provenance_id!(OwnedById);
 define_provenance_id!(CreatedById);
 define_provenance_id!(UpdatedById);
 define_provenance_id!(RemovedById);
-define_provenance_id!(ArchivedById);

--- a/packages/graph/hash_graph/lib/graph/src/store/error.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/error.rs
@@ -40,6 +40,18 @@ impl Context for UpdateError {}
 
 #[derive(Debug)]
 #[must_use]
+pub struct ArchivalError;
+
+impl fmt::Display for ArchivalError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.write_str("Could not archive entry in store")
+    }
+}
+
+impl Context for ArchivalError {}
+
+#[derive(Debug)]
+#[must_use]
 pub struct BaseUriAlreadyExists;
 
 impl fmt::Display for BaseUriAlreadyExists {

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     ontology::{
         PersistedDataType, PersistedEntityType, PersistedOntologyMetadata, PersistedPropertyType,
     },
-    provenance::{ArchivedById, CreatedById, OwnedById, UpdatedById},
+    provenance::{CreatedById, OwnedById, UpdatedById},
     store::query::Filter,
     subgraph::{StructuralQuery, Subgraph},
 };
@@ -404,6 +404,6 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Filter<'q
     async fn archive_entity(
         &mut self,
         entity_id: EntityId,
-        actor_id: ArchivedById,
+        actor_id: UpdatedById,
     ) -> Result<(), ArchivalError>;
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -405,6 +405,7 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Filter<'q
     async fn archive_entity(
         &mut self,
         entity_id: EntityId,
+        owned_by_id: OwnedById,
         actor_id: UpdatedById,
     ) -> Result<(), ArchivalError>;
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -11,6 +11,7 @@ use async_trait::async_trait;
 use error_stack::{Context, Result};
 use type_system::{uri::VersionedUri, DataType, EntityType, PropertyType};
 
+use self::error::ArchivalError;
 pub use self::{
     error::{BaseUriAlreadyExists, BaseUriDoesNotExist, InsertionError, QueryError, UpdateError},
     pool::StorePool,
@@ -22,7 +23,7 @@ use crate::{
     ontology::{
         PersistedDataType, PersistedEntityType, PersistedOntologyMetadata, PersistedPropertyType,
     },
-    provenance::{CreatedById, OwnedById, RemovedById, UpdatedById},
+    provenance::{ArchivedById, CreatedById, OwnedById, UpdatedById},
     store::query::Filter,
     subgraph::{StructuralQuery, Subgraph},
 };
@@ -384,7 +385,7 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Filter<'q
     /// - if the [`Entity`] doesn't exist
     /// - if the [`EntityType`] doesn't exist
     /// - if the [`Entity`] is not valid with respect to its [`EntityType`]
-    /// - if the account referred to by `updated_by` does not exist
+    /// - if the account referred to by `actor_id` does not exist
     async fn update_entity(
         &mut self,
         entity_id: EntityId,
@@ -392,4 +393,17 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Filter<'q
         entity_type_id: VersionedUri,
         actor_id: UpdatedById,
     ) -> Result<PersistedEntityMetadata, UpdateError>;
+
+    /// Archives an [`Entity`].
+    ///
+    /// # Errors:
+    ///
+    /// - if the [`Entity`] doesn't exist
+    /// - if the [`Entity`] has already been archived
+    /// - if the account referred to by `actor_id` does not exist
+    async fn archive_entity(
+        &mut self,
+        entity_id: EntityId,
+        actor_id: ArchivedById,
+    ) -> Result<(), ArchivalError>;
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -398,8 +398,9 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Filter<'q
     ///
     /// # Errors:
     ///
-    /// - if the [`Entity`] doesn't exist
-    /// - if the [`Entity`] has already been archived
+    /// - if there isn't an [`Entity`] associated with the [`EntityId`] in the latest entities table
+    ///   - this could be because the [`Entity`] doesn't exist, or
+    ///   - the [`Entity`] has already been archived
     /// - if the account referred to by `actor_id` does not exist
     async fn archive_entity(
         &mut self,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -318,6 +318,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
     async fn archive_entity(
         &mut self,
         entity_id: EntityId,
+        _owned_by_id: OwnedById,
         actor_id: UpdatedById,
     ) -> Result<(), ArchivalError> {
         let mut transaction = PostgresStore::new(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -285,20 +285,20 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         //  Note that the race condition may have been sorted out with the links rewrite.
         //  https://app.asana.com/0/1202805690238892/1203201674100967/f
 
-        let archived_entity_version = transaction
+        let old_entity_metadata = transaction
             .move_entity_to_histories(entity_id, false)
             .await
             .change_context(UpdateError)?;
 
-        let metadata = transaction
+        let entity_metadata = transaction
             .insert_entity(
                 entity_id,
                 entity,
                 entity_type_id,
-                archived_entity_version.identifier().owned_by_id(),
-                archived_entity_version.created_by_id(),
+                old_entity_metadata.identifier().owned_by_id(),
+                old_entity_metadata.created_by_id(),
                 updated_by_id,
-                archived_entity_version.link_metadata().clone(),
+                old_entity_metadata.link_metadata().clone(),
             )
             .await
             .change_context(UpdateError)?;
@@ -310,7 +310,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             .into_report()
             .change_context(UpdateError)?;
 
-        Ok(metadata)
+        Ok(entity_metadata)
     }
 
     async fn archive_entity(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -333,7 +333,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 .change_context(ArchivalError)?,
         );
 
-        let _historic_entity = transaction
+        transaction
             .move_entity_to_histories(entity_id, Some(actor_id))
             .await
             .change_context(ArchivalError)?;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     store::{
         crud::Read,
         error::{ArchivalError, EntityDoesNotExist},
-        postgres::{DependencyContext, DependencyContextRef},
+        postgres::{DependencyContext, DependencyContextRef, HistoricMove},
         query::Filter,
         AsClient, EntityStore, InsertionError, PostgresStore, QueryError, UpdateError,
     },
@@ -288,7 +288,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         //  https://app.asana.com/0/1202805690238892/1203201674100967/f
 
         let old_entity_metadata = transaction
-            .move_entity_to_histories(entity_id, false)
+            .move_entity_to_histories(entity_id, HistoricMove::ForNewVersion)
             .await
             .change_context(UpdateError)?;
 
@@ -349,7 +349,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             .change_context(ArchivalError)?;
 
         transaction
-            .move_entity_to_histories(entity_id, true)
+            .move_entity_to_histories(entity_id, HistoricMove::ForArchival)
             .await
             .change_context(ArchivalError)?;
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -298,7 +298,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 old_entity_metadata.identifier().owned_by_id(),
                 old_entity_metadata.created_by_id(),
                 updated_by_id,
-                old_entity_metadata.link_metadata().clone(),
+                old_entity_metadata.link_metadata(),
             )
             .await
             .change_context(UpdateError)?;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -82,7 +82,9 @@ impl<C: AsClient> PostgresStore<C> {
                     .await?;
                 }
 
-                todo!("https://app.asana.com/0/1200211978612931/1203250001255262/f")
+                // TODO: Subgraphs don't support link entities yet
+                //   https://app.asana.com/0/1200211978612931/1203250001255262/f
+
                 // for link_record in self
                 //     .read_links_by_source(entity_id)
                 //     .await?

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -94,7 +94,6 @@ impl<C: AsClient> crud::Read<PersistedEntity> for PostgresStore<C> {
                     entity_type_uri,
                     row.get(created_by_id_index),
                     row.get(updated_by_id_index),
-                    None,
                     link_metadata,
                 ))
             })

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -95,6 +95,9 @@ impl<C: AsClient> crud::Read<PersistedEntity> for PostgresStore<C> {
                     row.get(created_by_id_index),
                     row.get(updated_by_id_index),
                     link_metadata,
+                    // TODO: only the historic table would have an `archived` field.
+                    //   Consider what we should do about that.
+                    false,
                 ))
             })
             .try_collect()

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -945,6 +945,10 @@ where
         ))
     }
 
+    // TODO: We should be querying with an `owned_by_id` as part of the entity identifier.
+    //   This is especially important for making these queries single-shard Citus queries when we
+    //   need that.
+    //   see: https://app.asana.com/0/1201095311341924/1203214689883091/f
     async fn lock_entity_for_update(&self, entity_id: EntityId) -> Result<(), QueryError> {
         self.as_client()
             .query_one(
@@ -966,6 +970,10 @@ where
         Ok(())
     }
 
+    // TODO: We should be querying with an `owned_by_id` as part of the entity identifier.
+    //   This is especially important for making these queries single-shard Citus queries when we
+    //   need that.
+    //   see: https://app.asana.com/0/1201095311341924/1203214689883091/f
     async fn move_entity_to_histories(
         &self,
         entity_id: EntityId,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -1002,13 +1002,17 @@ where
                         owned_by_id, created_by_id, updated_by_id,
                         $2::boolean
                     FROM to_move_to_historic
-                    -- For metadata purposes, we return the entire entity
-                    RETURNING *
+                    -- We only return metadata
+                    RETURNING 
+                        entity_id, version,
+                        entity_type_version_id,
+                        left_order, right_order,
+                        left_entity_id, right_entity_id,
+                        owned_by_id, created_by_id, updated_by_id
                 )
                 SELECT
                     entity_id, inserted_in_historic.version,
                     base_uri, type_ids.version,
-                    properties, -- Unused
                     left_order, right_order,
                     left_entity_id, right_entity_id,
                     owned_by_id, created_by_id, updated_by_id
@@ -1025,10 +1029,10 @@ where
             .change_context(InsertionError)?;
 
         let link_metadata = match (
+            historic_entity.get(4),
             historic_entity.get(5),
             historic_entity.get(6),
             historic_entity.get(7),
-            historic_entity.get(8),
         ) {
             (left_order, right_order, Some(left_entity_id), Some(right_entity_id)) => Some(
                 LinkEntityMetadata::new(left_entity_id, right_entity_id, left_order, right_order),
@@ -1045,11 +1049,11 @@ where
             PersistedEntityIdentifier::new(
                 historic_entity.get(0),
                 historic_entity.get(1),
-                historic_entity.get(9),
+                historic_entity.get(8),
             ),
             entity_type_id,
+            historic_entity.get(9),
             historic_entity.get(10),
-            historic_entity.get(11),
             link_metadata,
         ))
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -990,7 +990,7 @@ where
                         properties,
                         left_order, right_order,
                         left_entity_id, right_entity_id,
-                        owned_by_id, created_by_id, updated_by_id, 
+                        owned_by_id, created_by_id, updated_by_id,
                         archived
                     )
                     SELECT
@@ -1003,7 +1003,7 @@ where
                         $2::boolean
                     FROM to_move_to_historic
                     -- We only return metadata
-                    RETURNING 
+                    RETURNING
                         entity_id, version,
                         entity_type_version_id,
                         left_order, right_order,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -1041,8 +1041,6 @@ where
             .change_context(InsertionError)?;
         let entity_type_id = VersionedUri::new(base_uri, historic_entity.get::<_, i64>(3) as u32);
 
-        // TODO: Consider using `ProvenanceMetadata` instead?
-        //  https://app.asana.com/0/1201095311341924/1203227079758117/f
         Ok(PersistedEntityMetadata::new(
             PersistedEntityIdentifier::new(
                 historic_entity.get(0),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -356,6 +356,7 @@ pub struct PostgresStore<C> {
 }
 
 /// Describes what context the historic move is done in.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum HistoricMove {
     ForNewVersion,
     ForArchival,
@@ -1027,7 +1028,7 @@ where
                 "#,
                 &[
                     &entity_id,
-                    &matches!(historic_move, HistoricMove::ForArchival),
+                    &(historic_move == HistoricMove::ForArchival),
                 ],
             )
             .await

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -966,8 +966,7 @@ where
     }
 
     async fn lock_entity_for_update(&self, entity_id: EntityId) -> Result<(), QueryError> {
-        let _latest_entity_lock = self
-            .as_client()
+        self.as_client()
             .query_one(
                 // TODO: consider if this row locking is problematic with Citus.
                 //   `FOR UPDATE` is only allowed in single-shard queries.
@@ -982,7 +981,7 @@ where
             )
             .await
             .into_report()
-            .change_context(QueryError);
+            .change_context(QueryError)?;
 
         Ok(())
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -942,6 +942,9 @@ where
             created_by_id,
             updated_by_id,
             link_metadata,
+            // TODO: only the historic table would have an `archived` field.
+            //   Consider what we should do about that.
+            false,
         ))
     }
 
@@ -1079,6 +1082,9 @@ where
             historic_entity.get(9),
             historic_entity.get(10),
             link_metadata,
+            // TODO: only the historic table would have an `archived` field.
+            //   Consider what we should do about that.
+            false,
         ))
     }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -355,6 +355,12 @@ pub struct PostgresStore<C> {
     client: C,
 }
 
+/// Describes what context the historic move is done in.
+pub enum HistoricMove {
+    ForNewVersion,
+    ForArchival,
+}
+
 impl<C> PostgresStore<C>
 where
     C: AsClient,
@@ -962,7 +968,7 @@ where
     async fn move_entity_to_histories(
         &self,
         entity_id: EntityId,
-        archived: bool,
+        historic_move: HistoricMove,
     ) -> Result<PersistedEntityMetadata, InsertionError> {
         let historic_entity = self
             .as_client()
@@ -1021,7 +1027,7 @@ where
                 "#,
                 &[
                     &entity_id,
-                    &archived,
+                    &matches!(historic_move, HistoricMove::ForArchival),
                 ],
             )
             .await

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -1078,6 +1078,8 @@ where
             .change_context(InsertionError)?;
         let entity_type_id = VersionedUri::new(base_uri, historic_entity.get::<_, i64>(3) as u32);
 
+        // TODO: Consider using `ProvenanceMetadata` instead?
+        //  https://app.asana.com/0/1201095311341924/1203227079758117/f
         Ok(PersistedEntityMetadata::new(
             PersistedEntityIdentifier::new(
                 historic_entity.get(0),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -1037,7 +1037,10 @@ where
             (left_order, right_order, Some(left_entity_id), Some(right_entity_id)) => Some(
                 LinkEntityMetadata::new(left_entity_id, right_entity_id, left_order, right_order),
             ),
-            _ => None,
+            (None, None, None, None) => None,
+            _ => {
+                unreachable!("incomplete link information was found in the DB table, this is fatal")
+            }
         };
 
         let base_uri = BaseUri::new(historic_entity.get(2))

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -443,32 +443,6 @@ where
         Ok(())
     }
 
-    // /// Checks if the specified [`Entity`] exists in the database.
-    // ///
-    // /// # Errors
-    // ///
-    // /// - if checking for the [`VersionedUri`] failed.
-    // async fn contains_entity(&self, entity_id: EntityId) -> Result<bool, QueryError> {
-    //     Ok(self
-    //         .client
-    //         .as_client()
-    //         .query_one(
-    //             r#"
-    //                 SELECT EXISTS(
-    //                     SELECT 1
-    //                     FROM entity_ids
-    //                     WHERE entity_id = $1
-    //                 );
-    //             "#,
-    //             &[&entity_id],
-    //         )
-    //         .await
-    //         .into_report()
-    //         .change_context(QueryError)
-    //         .attach_printable(entity_id)?
-    //         .get(0))
-    // }
-
     /// Inserts the specified [`VersionedUri`] into the database.
     ///
     /// # Errors

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -950,6 +950,12 @@ where
     //   need that.
     //   see: https://app.asana.com/0/1201095311341924/1203214689883091/f
     async fn lock_entity_for_update(&self, entity_id: EntityId) -> Result<(), QueryError> {
+        // TODO - address potential serializability issue.
+        //   We don't have a data race per se, but the transaction isolation level of postgres would
+        //   make new entries of the `entities` table inaccessible to peer lock-waiters.
+        //   https://www.postgresql.org/docs/9.2/transaction-iso.html#XACT-READ-COMMITTED
+        //   https://app.asana.com/0/1202805690238892/1203201674100967/f
+
         self.as_client()
             .query_one(
                 // TODO: consider if this row locking is problematic with Citus.

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -359,24 +359,24 @@ GET http://127.0.0.1:4000/entities/{{person_a_entity_id}}
 %}
 
 #### Update Person entity
-#PUT http://127.0.0.1:4000/entities
-#Content-Type: application/json
-#Accept: application/json
-#
-#{
-#  "actorId": "{{account_id}}",
-#  "entityId": "{{person_a_entity_id}}",
-#  "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/2",
-#  "entity": {
-#    "http://localhost:3000/@alice/types/property-type/name/": "Alice Allison"
-#  }
-#}
-#
-#> {%
-#    client.test("status", function() {
-#        client.assert(response.status === 200, "Response status is not 200");
-#    });
-#%}
+PUT http://127.0.0.1:4000/entities
+Content-Type: application/json
+Accept: application/json
+
+{
+ "actorId": "{{account_id}}",
+ "entityId": "{{person_a_entity_id}}",
+ "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/2",
+ "entity": {
+   "http://localhost:3000/@alice/types/property-type/name/": "Alice Allison"
+ }
+}
+
+> {%
+   client.test("status", function() {
+       client.assert(response.status === 200, "Response status is not 200");
+   });
+%}
 
 ### Insert second Person entity
 POST http://127.0.0.1:4000/entities

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -475,6 +475,7 @@ Accept: application/json
 
 {
   "entityId": "{{person_b_entity_id}}",
+  "ownedById": "{{account_id}}",
   "actorId": "{{account_id}}"
 }
 

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -483,3 +483,37 @@ Accept: application/json
         client.assert(response.status === 200, "Response status is not 200");
     });
 %}
+
+#### Get all latest entities by using a query
+// Only person_a and the link remains as entities
+POST http://127.0.0.1:4000/entities/query
+Content-Type: application/json
+
+{
+ "filter": {
+   "equal": [
+    {
+      "path": [
+        "version"
+      ]
+    },
+    {
+      "parameter": "latest"
+    }
+  ]
+ },
+ "graphResolveDepths": {
+   "dataTypeResolveDepth": 0,
+   "propertyTypeResolveDepth": 0,
+   "entityTypeResolveDepth": 0,
+   "linkTargetEntityResolveDepth": 0,
+   "linkResolveDepth": 0
+ }
+}
+
+> {%
+   client.test("status", function() {
+       client.assert(response.status === 200, "Response status is not 200");
+       client.assert(response.body.roots.length === 2, "Unexpected number of entities");
+   });
+%}

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -467,3 +467,19 @@ Accept: application/json
         client.assert(response.status === 200, "Response status is not 200");
     });
 %}
+
+### Archive an entity
+POST http://127.0.0.1:4000/entities/archive
+Content-Type: application/json
+Accept: application/json
+
+{
+  "entityId": "{{person_b_entity_id}}",
+  "actorId": "{{account_id}}"
+}
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+    });
+%}

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -505,8 +505,7 @@ DROP TABLE IF EXISTS entity_type_property_type_references CASCADE;
 DROP TABLE IF EXISTS entity_type_entity_type_references CASCADE;
 DROP TABLE IF EXISTS entity_ids CASCADE;
 DROP TABLE IF EXISTS entities CASCADE;
-DROP TABLE IF EXISTS entity_relations CASCADE;
-DROP TABLE IF EXISTS entity_relation_histories CASCADE;
+DROP TABLE IF EXISTS entity_histories CASCADE;
 DROP TABLE IF EXISTS accounts CASCADE;
 DROP TABLE IF EXISTS ids CASCADE;
 */

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -403,6 +403,16 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
           OR left_entity_id IS NOT NULL AND right_entity_id IS NOT NULL`,
   });
 
+  pgm.addConstraint("entities", "entities_relation_order_constraint", {
+    // left_order if (left_entity_id and right_entity_id) OR
+    // right_order if (left_entity_id and right_entity_id)
+    //
+    // which is the same as
+    // (left_entity_id and right_entity_id) or left_order or right_order
+    check: `(left_entity_id IS NOT NULL AND right_entity_id IS NOT NULL)
+            OR left_order IS NOT NULL OR right_order IS NOT NULL`,
+  });
+
   pgm.createTable(
     "entity_histories",
     {

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -410,7 +410,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     // which is the same as
     // (left_entity_id and right_entity_id) or left_order or right_order
     check: `(left_entity_id IS NOT NULL AND right_entity_id IS NOT NULL)
-            OR left_order IS NOT NULL OR right_order IS NOT NULL`,
+            OR left_order IS NULL OR right_order IS NULL`,
   });
 
   pgm.createTable(

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -404,13 +404,8 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   });
 
   pgm.addConstraint("entities", "entities_relation_order_constraint", {
-    // left_order if (left_entity_id and right_entity_id) OR
-    // right_order if (left_entity_id and right_entity_id)
-    //
-    // which is the same as
-    // (left_entity_id and right_entity_id) or left_order or right_order
     check: `(left_entity_id IS NOT NULL AND right_entity_id IS NOT NULL)
-            OR left_order IS NULL OR right_order IS NULL`,
+            OR (left_order IS NULL AND right_order IS NULL)`,
   });
 
   pgm.createTable(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
This PR adds an endpoint for archiving an entity.
This also allowed entity updates to be re-enabled

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1200211978612931/1203250001255275/f) _(internal)_

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->


## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Fixes entity updating (and makes use of historic table)
- Adds new DB methods for moving an entity from `entities` to `entity_histories`
  - Optionally marks the entity as archived
- Adds HTTP POST endpoint for archiving
- Adds HTTP manual test for archiving
- Re-enables HTTP manual test for updates

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->


## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

-

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch / view the deployment
1.  Run manual HTTP tests
1.  Confirm that the database has 2 entities in the latest table, `entities`, and 3 entity versions in the `entity_histories` table (1 for the update, 2 for the archival.)

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
