### PR TITLE
Use `TableName::as_str` instead of serde

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/with_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/with_clause.rs
@@ -40,9 +40,7 @@ impl Transpile for WithExpression<'_> {
 
         fmt.write_str("WITH ")?;
         for (idx, expression) in self.common_table_expressions.iter().enumerate() {
-            fmt.write_char('"')?;
-            expression.table_name.serialize(&mut *fmt)?;
-            fmt.write_str("\" AS (")?;
+            write!(fmt, "\"{}\" AS (", expression.table_name.as_str())?;
             expression.statement.transpile(fmt)?;
             fmt.write_char(')')?;
             if idx + 1 < self.common_table_expressions.len() {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
@@ -1,12 +1,9 @@
 use std::fmt::{self, Write};
 
-use serde::Serialize;
-
 use crate::store::postgres::query::Transpile;
 
 /// The name of a [`Table`] in the Postgres database.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum TableName {
     TypeIds,
     DataTypes,
@@ -58,6 +55,24 @@ impl TableName {
                 | Self::EntityTypePropertyTypeReferences => "target_property_type_version_id",
                 Self::EntityTypeEntityTypeReferences => "target_entity_type_version_id",
             },
+        }
+    }
+}
+
+impl TableName {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::TypeIds => "type_ids",
+            Self::DataTypes => "data_types",
+            Self::PropertyTypes => "property_types",
+            Self::EntityTypes => "entity_types",
+            Self::LinkTypes => "link_types",
+            Self::Entities => "entities",
+            Self::PropertyTypeDataTypeReferences => "property_type_data_type_references",
+            Self::PropertyTypePropertyTypeReferences => "property_type_property_type_references",
+            Self::EntityTypePropertyTypeReferences => "entity_type_property_type_references",
+            Self::EntityTypeEntityTypeReferences => "entity_type_entity_type_references",
+            Self::Links => "links",
         }
     }
 }
@@ -123,8 +138,7 @@ impl Table {
 
 impl Transpile for Table {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_char('"')?;
-        self.name.serialize(&mut *fmt)?;
+        write!(fmt, "\"{}", self.name.as_str())?;
         if let Some(alias) = self.alias {
             write!(fmt, "_{}_{}", alias.condition_index, alias.chain_depth)?;
         }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To be a bit more flexible on table names, this PR don't use `Serialize` anymore but static strings to determine the table names