### PR TITLE
Don't implement `ToSql` and `FromSql` for provenance records

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -10,7 +10,7 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 pub use self::query::{EntityQueryPath, EntityQueryPathVisitor};
-use crate::provenance::{CreatedById, OwnedById, RemovedById, UpdatedById};
+use crate::provenance::{CreatedById, OwnedById, UpdatedById};
 
 #[derive(
     Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema, FromSql, ToSql,

--- a/packages/graph/hash_graph/lib/graph/src/shared/provenance.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/provenance.rs
@@ -1,6 +1,5 @@
 use core::fmt;
 
-use postgres_types::{FromSql, ToSql};
 use serde::{Deserialize, Serialize};
 use utoipa::{openapi::Schema, ToSchema};
 
@@ -8,11 +7,8 @@ use crate::identifier::AccountId;
 
 macro_rules! define_provenance_id {
     ($name:tt) => {
-        #[derive(
-            Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, FromSql, ToSql,
-        )]
+        #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
         #[repr(transparent)]
-        #[postgres(transparent)]
         pub struct $name(AccountId);
 
         impl $name {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/context/ontology.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/context/ontology.rs
@@ -3,6 +3,7 @@ use tokio_postgres::GenericClient;
 use type_system::uri::{BaseUri, VersionedUri};
 
 use crate::{
+    identifier::AccountId,
     provenance::{CreatedById, OwnedById, RemovedById, UpdatedById},
     store::{postgres::ontology::OntologyDatabaseType, AsClient, QueryError},
 };
@@ -54,10 +55,10 @@ where
     let record = T::try_from(row.get(0))
         .into_report()
         .change_context(QueryError)?;
-    let owned_by_id = row.get(1);
-    let created_by_id = row.get(2);
-    let updated_by_id = row.get(3);
-    let removed_by_id = row.get(4);
+    let owned_by_id = OwnedById::new(row.get(1));
+    let created_by_id = CreatedById::new(row.get(2));
+    let updated_by_id = UpdatedById::new(row.get(3));
+    let removed_by_id = row.get::<_, Option<AccountId>>(5).map(RemovedById::new);
 
     Ok(OntologyRecord {
         record,
@@ -102,11 +103,11 @@ where
     let record = T::try_from(row.get(0))
         .into_report()
         .change_context(QueryError)?;
-    let owned_by_id = row.get(1);
+    let owned_by_id = OwnedById::new(row.get(1));
     let latest: i64 = row.get(2);
-    let created_by_id = row.get(3);
-    let updated_by_id = row.get(4);
-    let removed_by_id = row.get(5);
+    let created_by_id = CreatedById::new(row.get(3));
+    let updated_by_id = UpdatedById::new(row.get(4));
+    let removed_by_id = row.get::<_, Option<AccountId>>(5).map(RemovedById::new);
 
     Ok(OntologyRecord {
         record,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     provenance::{CreatedById, OwnedById, UpdatedById},
     store::{
         crud::Read,
-        error::{ArchivalError, EntityDoesNotExist},
+        error::ArchivalError,
         postgres::{DependencyContext, DependencyContextRef, HistoricMove},
         query::Filter,
         AsClient, EntityStore, InsertionError, PostgresStore, QueryError, UpdateError,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -12,6 +12,7 @@ use crate::{
         PersistedEntityIdentifier,
     },
     ontology::EntityTypeQueryPath,
+    provenance::{CreatedById, OwnedById, UpdatedById},
     store::{
         crud, postgres::query::SelectCompiler, query::Filter, AsClient, PostgresStore, QueryError,
     },
@@ -82,16 +83,20 @@ impl<C: AsClient> crud::Read<PersistedEntity> for PostgresStore<C> {
                     }
                 };
 
+                let owned_by_id = OwnedById::new(row.get(owned_by_id_index));
+                let created_by_id = CreatedById::new(row.get(created_by_id_index));
+                let updated_by_id = UpdatedById::new(row.get(updated_by_id_index));
+
                 Ok(PersistedEntity::new(
                     entity,
                     PersistedEntityIdentifier::new(
                         row.get(entity_id_index),
                         row.get(version_index),
-                        row.get(owned_by_id_index),
+                        owned_by_id,
                     ),
                     entity_type_uri,
-                    row.get(created_by_id_index),
-                    row.get(updated_by_id_index),
+                    created_by_id,
+                    updated_by_id,
                     link_metadata,
                     // TODO: only the historic table would have an `archived` field.
                     //   Consider what we should do about that.

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -10,8 +10,6 @@ use std::{
     collections::{hash_map::RawEntryMut, HashMap},
     future::Future,
     hash::Hash,
-    iter,
-    str::FromStr,
 };
 
 use async_trait::async_trait;
@@ -703,7 +701,7 @@ where
                     "#,
                     T::table()
                 ),
-                &[&version_id, &value, &owned_by_id, &created_by_id, &updated_by_id],
+                &[&version_id, &value, &owned_by_id.as_account_id(), &created_by_id.as_account_id(), &updated_by_id.as_account_id()],
             )
             .await
             .into_report()
@@ -926,9 +924,9 @@ where
                     &link_metadata
                         .as_ref()
                         .map(LinkEntityMetadata::right_entity_id),
-                    &owned_by_id,
-                    &created_by_id,
-                    &updated_by_id,
+                    &owned_by_id.as_account_id(),
+                    &created_by_id.as_account_id(),
+                    &updated_by_id.as_account_id(),
                 ],
             )
             .await
@@ -1076,11 +1074,11 @@ where
             PersistedEntityIdentifier::new(
                 historic_entity.get(0),
                 historic_entity.get(1),
-                historic_entity.get(8),
+                OwnedById::new(historic_entity.get(8)),
             ),
             entity_type_id,
-            historic_entity.get(9),
-            historic_entity.get(10),
+            CreatedById::new(historic_entity.get(9)),
+            UpdatedById::new(historic_entity.get(10)),
             link_metadata,
             // TODO: only the historic table would have an `archived` field.
             //   Consider what we should do about that.
@@ -1192,9 +1190,9 @@ impl PostgresStore<Transaction<'_>> {
                     &entity_id,
                     &entity_type_version_id,
                     &value,
-                    &owned_by_id,
-                    &created_by,
-                    &updated_by_id,
+                    &owned_by_id.as_account_id(),
+                    &created_by.as_account_id(),
+                    &updated_by_id.as_account_id(),
                 ])
                 .await
                 .into_report()

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/with_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/with_clause.rs
@@ -1,7 +1,5 @@
 use std::fmt::{self, Write};
 
-use serde::Serialize;
-
 use crate::store::postgres::query::{Statement, TableName, Transpile};
 
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
@@ -18,7 +18,7 @@ pub enum TableName {
 }
 
 impl TableName {
-    pub const fn as_str(&self) -> &'static str {
+    pub const fn as_str(self) -> &'static str {
         match self {
             Self::TypeIds => "type_ids",
             Self::DataTypes => "data_types",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

with #1254 we added the provenance module, but we don't want to implement `ToSql` and `FromSql` for these types. This PR removes the implementation and makes the code explicit about that.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202805690238892/1203264930671943/f) _(internal)_