### PR TITLE
Add empty "Properties" state on entity page

### DIFF
--- a/packages/hash/frontend/src/pages/[account-slug]/entities/[entity-id].page/entity-editor/links-section.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/entities/[entity-id].page/entity-editor/links-section.tsx
@@ -13,8 +13,7 @@ const EmptyState = () => (
   <EntitySectionEmptyState
     title="This entity currently has no links"
     titleIcon={<LinksIcon />}
-    description="Links contain information about connections or relationships between
-different entities"
+    description="Links contain information about connections or relationships between different entities"
   />
 );
 
@@ -33,7 +32,11 @@ export const LinksSection = () => {
   return (
     <EntitySection
       title="Links"
-      titleTooltip="The links on an entity are determined by its type. To add a new link to this entity, specify an additional type or edit an existing one."
+      titleTooltip={
+        isEmpty
+          ? ""
+          : "The links on an entity are determined by its type. To add a new link to this entity, specify an additional type or edit an existing one."
+      }
       titleStartContent={
         isEmpty ? (
           <Chip label="No links" />

--- a/packages/hash/frontend/src/pages/[account-slug]/entities/[entity-id].page/entity-editor/properties-section.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/entities/[entity-id].page/entity-editor/properties-section.tsx
@@ -4,11 +4,21 @@ import { FontAwesomeIcon } from "@hashintel/hash-design-system/fontawesome-icon"
 import { IconButton } from "@hashintel/hash-design-system/icon-button";
 import { Paper, Stack } from "@mui/material";
 import { useState } from "react";
+import { LinksIcon } from "../../../../../shared/icons";
 import { useEntityEditor } from "./entity-editor-context";
 import { getPropertyCountSummary } from "./properties-section/get-property-count-summary";
 import { PropertyTable } from "./properties-section/property-table";
 import { EntitySection } from "./shared/entity-section";
+import { EntitySectionEmptyState } from "./shared/entity-section-empty-state";
 import { WhiteChip } from "./shared/white-chip";
+
+const EmptyState = () => (
+  <EntitySectionEmptyState
+    title="This entity currently has no properties"
+    titleIcon={<LinksIcon />}
+    description="Properties contain data about entities, and are inherited from types"
+  />
+);
 
 export const PropertiesSection = () => {
   const { rootEntityAndSubgraph } = useEntityEditor();
@@ -24,36 +34,50 @@ export const PropertiesSection = () => {
     entity.properties,
   );
 
+  const isEmpty = emptyCount + notEmptyCount === 0;
+
   return (
     <EntitySection
       title="Properties"
-      titleTooltip="The properties on an entity are determined by its type. To add a new property to this entity, specify an additional type or edit an existing one."
+      titleTooltip={
+        isEmpty
+          ? ""
+          : "The properties on an entity are determined by its type. To add a new property to this entity, specify an additional type or edit an existing one."
+      }
       titleStartContent={
-        <Stack direction="row" spacing={1.5}>
-          {notEmptyCount > 0 && (
-            <Chip size="xs" label={`${notEmptyCount} values`} />
-          )}
-          {emptyCount > 0 && (
-            <WhiteChip size="xs" label={`${emptyCount} empty`} />
-          )}
-          <Stack direction="row" spacing={0.5}>
-            <IconButton
-              rounded
-              onClick={() => setShowSearch(true)}
-              sx={{ color: ({ palette }) => palette.gray[60] }}
-            >
-              <FontAwesomeIcon icon={faMagnifyingGlass} />
-            </IconButton>
+        isEmpty ? (
+          <Chip label="No properties" />
+        ) : (
+          <Stack direction="row" spacing={1.5}>
+            {notEmptyCount > 0 && (
+              <Chip size="xs" label={`${notEmptyCount} values`} />
+            )}
+            {emptyCount > 0 && (
+              <WhiteChip size="xs" label={`${emptyCount} empty`} />
+            )}
+            <Stack direction="row" spacing={0.5}>
+              <IconButton
+                rounded
+                onClick={() => setShowSearch(true)}
+                sx={{ color: ({ palette }) => palette.gray[60] }}
+              >
+                <FontAwesomeIcon icon={faMagnifyingGlass} />
+              </IconButton>
+            </Stack>
           </Stack>
-        </Stack>
+        )
       }
     >
-      <Paper sx={{ overflow: "hidden" }}>
-        <PropertyTable
-          onSearchClose={() => setShowSearch(false)}
-          showSearch={showSearch}
-        />
-      </Paper>
+      {isEmpty ? (
+        <EmptyState />
+      ) : (
+        <Paper sx={{ overflow: "hidden" }}>
+          <PropertyTable
+            onSearchClose={() => setShowSearch(false)}
+            showSearch={showSearch}
+          />
+        </Paper>
+      )}
     </EntitySection>
   );
 };

--- a/packages/hash/frontend/src/pages/[account-slug]/entities/[entity-id].page/entity-editor/types-section.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/entities/[entity-id].page/entity-editor/types-section.tsx
@@ -50,7 +50,7 @@ export const TypesSection = () => {
 
   return (
     <EntitySection
-      title="Type"
+      title="Types"
       titleTooltip="Types describe what an entity is, allowing information to be associated with it. Entities can have an unlimited number of types."
     >
       <Box display="flex" gap={2}>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

- This PR adds an empty state for "properties" section on the entity page. So if an entity has no properties defined, we inform the users about this to prevent confusion.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201095311341924/1203199644802780/f) _(internal)_
- [Design] (https://www.figma.com/file/gydVGka9FjNEg9E2STwhi2/HASH-App?node-id=5438%3A244733) _(internal)_

## ❓ How to test this?

1.  Checkout the branch / view the deployment
1.  Open entity editor for an entity with no properties defined (this could be achieved by DB manipulation right now)
1.  Confirm that properties section renders an empty state

## 📹 Demo

![properties empty state](https://user-images.githubusercontent.com/39553853/199914044-e10ab8da-1c1f-4364-8a66-d4681635c86a.png)

