### PR TITLE
Test `error-stack` with Rust 1.65

### DIFF
--- a/.github/scripts/rust/setup.py
+++ b/.github/scripts/rust/setup.py
@@ -24,7 +24,7 @@ ALWAYS_RUN_PATTERNS = [".github/**"]
 # Toolchains used for the specified crates in addition to the toolchain which is defined in
 # rust-toolchain.toml
 TOOLCHAINS = {
-    "packages/libs/error-stack": ["1.63", "beta-2022-09-25"],
+    "packages/libs/error-stack": ["1.63", "1.65"],
     "packages/libs/deer": ["1.63"]
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Rust 1.65 released today with backtrace being stabilized. Instead of testing `error-stack` with the beta branch, we should test it with a stable release
