### PR TITLE
Remove debug statement of previous PR

### DIFF
--- a/packages/libs/error-stack/src/fmt/hook.rs
+++ b/packages/libs/error-stack/src/fmt/hook.rs
@@ -812,7 +812,6 @@ mod default {
     }
 
     fn location(location: &Location<'static>, context: &mut HookContext<Location<'static>>) {
-        println!("location");
         #[cfg(feature = "pretty-print")]
         context.push_body(format!(
             "{}",

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -445,7 +445,10 @@
     unreachable_pub,
     clippy::pedantic,
     clippy::nursery,
-    clippy::undocumented_unsafe_blocks
+    clippy::undocumented_unsafe_blocks,
+    clippy::dbg_macro,
+    clippy::print_stdout,
+    clippy::print_stderr
 )]
 #![allow(clippy::redundant_pub_crate)] // This would otherwise clash with `unreachable_pub`
 #![allow(clippy::missing_errors_doc)] // This is an error handling library producing Results, not Errors


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A previous PR introduced a debug statement, which should not exist

## 🔍 What does this change?

- Remove the `println`
- Add lints to avoid this kind of mistakes in the future