### PR TITLE
Fix deduplication to take columns into account

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
@@ -108,9 +108,10 @@ pub struct EntityQueryPathVisitor {
 }
 
 impl EntityQueryPathVisitor {
-    pub const EXPECTING: &'static str =
-        "one of `id`, `ownedById`, `createdById`, `updatedById`, `removedById`, `version`, \
-         `type`, `properties`, `incomingLinks`, `outgoingLinks`, `leftEntity`, `rightEntity`";
+    pub const EXPECTING: &'static str = "one of `id`, `ownedById`, `createdById`, `updatedById`, \
+                                         `removedById`, `version`, `archived`, `type`, \
+                                         `properties`, `incomingLinks`, `outgoingLinks`, \
+                                         `leftEntity`, `rightEntity`";
 
     #[must_use]
     pub const fn new(position: usize) -> Self {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
@@ -420,8 +420,6 @@ impl<'c, 'p: 'c, T: PostgresQueryRecord + 'static> SelectCompiler<'c, 'p, T> {
                     // We already have a join statement for this table, but it's on a different
                     // column. We need to create a new join statement later on with a new, unique
                     // alias.
-                    // TODO: Do we want to allow `unwrap` in those situations? It should never
-                    //       happen, as `alias` is always set.
                     join_column
                         .table
                         .alias

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashSet, fmt::Display, marker::PhantomData, process::exit};
+use std::{borrow::Cow, collections::HashSet, fmt::Display, marker::PhantomData};
 
 use postgres_types::ToSql;
 use tokio_postgres::row::RowIndex;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
@@ -194,7 +194,7 @@ mod tests {
                     Some(FilterExpression::Parameter(Parameter::Number(1.0))),
                 ),
             ]),
-            r#"("type_ids_0_0"."base_uri" = $1) AND ("type_ids_0_0"."version" = $2)"#,
+            r#"("type_ids_0_0_0"."base_uri" = $1) AND ("type_ids_0_0_0"."version" = $2)"#,
             &[
                 &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
                 &1.0,
@@ -228,7 +228,7 @@ mod tests {
                     Some(FilterExpression::Parameter(Parameter::Number(1.0))),
                 ),
             ]),
-            r#"(("type_ids_0_0"."base_uri" = $1) OR ("type_ids_0_0"."version" = $2))"#,
+            r#"(("type_ids_0_0_0"."base_uri" = $1) OR ("type_ids_0_0_0"."version" = $2))"#,
             &[
                 &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
                 &1.0,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use crate::store::postgres::query::{Column, ColumnAccess, Table, TableName, Transpile};
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Relation {
     pub current_column_access: ColumnAccess<'static>,
     pub join_table_name: TableName,
@@ -80,7 +81,8 @@ mod tests {
                         name: TableName::TypeIds,
                         alias: Some(TableAlias {
                             condition_index: 0,
-                            chain_depth: 1
+                            chain_depth: 1,
+                            number: 2,
                         }),
                     },
                     access: ColumnAccess::Table {
@@ -98,7 +100,7 @@ mod tests {
                 },
             )
             .transpile_to_string(),
-            r#"INNER JOIN "type_ids" AS "type_ids_0_1" ON "type_ids_0_1"."version_id" = "data_types"."version_id""#
+            r#"INNER JOIN "type_ids" AS "type_ids_0_1_2" ON "type_ids_0_1_2"."version_id" = "data_types"."version_id""#
         );
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
@@ -24,6 +24,7 @@ impl<'q> JoinExpression<'q> {
 
 impl Transpile for JoinExpression<'_> {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        // TODO: https://app.asana.com/0/1202805690238892/1203324626226299/f
         fmt.write_str("LEFT JOIN ")?;
         if self.join.table.alias.is_some() {
             let unaliased_table = Table {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
@@ -24,7 +24,7 @@ impl<'q> JoinExpression<'q> {
 
 impl Transpile for JoinExpression<'_> {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("INNER JOIN ")?;
+        fmt.write_str("LEFT JOIN ")?;
         if self.join.table.alias.is_some() {
             let unaliased_table = Table {
                 name: self.join.table.name,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/select_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/select_clause.rs
@@ -80,7 +80,8 @@ mod tests {
                                 name: DataTypeQueryPath::Version.terminating_table_name(),
                                 alias: Some(TableAlias {
                                     condition_index: 0,
-                                    chain_depth: 0
+                                    chain_depth: 0,
+                                    number: 0,
                                 }),
                             },
                             access: DataTypeQueryPath::Version.column_access(),
@@ -91,7 +92,8 @@ mod tests {
                             name: DataTypeQueryPath::BaseUri.terminating_table_name(),
                             alias: Some(TableAlias {
                                 condition_index: 0,
-                                chain_depth: 0
+                                chain_depth: 0,
+                                number: 0,
                             }),
                         },
                         access: DataTypeQueryPath::BaseUri.column_access(),
@@ -100,7 +102,7 @@ mod tests {
                 Some(Cow::Borrowed("latest_version"))
             )
             .transpile_to_string(),
-            r#"MAX("type_ids_0_0"."version") OVER (PARTITION BY "type_ids_0_0"."base_uri") AS "latest_version""#
+            r#"MAX("type_ids_0_0_0"."version") OVER (PARTITION BY "type_ids_0_0_0"."base_uri") AS "latest_version""#
         );
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
@@ -70,7 +70,7 @@ mod tests {
 
         assert_eq!(
             where_clause.transpile_to_string(),
-            r#"WHERE "type_ids_0_0"."version" = "type_ids_0_0"."latest_version""#
+            r#"WHERE "type_ids_0_0_0"."version" = "type_ids_0_0_0"."latest_version""#
         );
 
         let filter_b = Filter::<DataType>::All(vec![
@@ -91,8 +91,8 @@ mod tests {
             trim_whitespace(where_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WHERE "type_ids_0_0"."version" = "type_ids_0_0"."latest_version"
-                  AND ("type_ids_0_0"."base_uri" = $1) AND ("type_ids_0_0"."version" = $2)"#
+                WHERE "type_ids_0_0_0"."version" = "type_ids_0_0_0"."latest_version"
+                  AND ("type_ids_0_0_0"."base_uri" = $1) AND ("type_ids_0_0_0"."version" = $2)"#
             )
         );
 
@@ -106,8 +106,8 @@ mod tests {
             trim_whitespace(where_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WHERE "type_ids_0_0"."version" = "type_ids_0_0"."latest_version"
-                  AND ("type_ids_0_0"."base_uri" = $1) AND ("type_ids_0_0"."version" = $2)
+                WHERE "type_ids_0_0_0"."version" = "type_ids_0_0_0"."latest_version"
+                  AND ("type_ids_0_0_0"."base_uri" = $1) AND ("type_ids_0_0_0"."version" = $2)
                   AND "data_types"."schema"->>'description' IS NOT NULL"#
             )
         );
@@ -132,8 +132,8 @@ mod tests {
             trim_whitespace(where_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WHERE "type_ids_0_0"."version" = "type_ids_0_0"."latest_version"
-                  AND ("type_ids_0_0"."base_uri" = $1) AND ("type_ids_0_0"."version" = $2)
+                WHERE "type_ids_0_0_0"."version" = "type_ids_0_0_0"."latest_version"
+                  AND ("type_ids_0_0_0"."base_uri" = $1) AND ("type_ids_0_0_0"."version" = $2)
                   AND "data_types"."schema"->>'description' IS NOT NULL
                   AND (("data_types"."schema"->>'title' = $3) OR ("data_types"."schema"->>'description' = $4))"#
             )

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -614,4 +614,39 @@ mod tests {
             &[],
         );
     }
+
+    #[test]
+    fn link_entity_left_right_id() {
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk();
+
+        let filter = Filter::All(vec![
+            Filter::Equal(
+                Some(FilterExpression::Path(EntityQueryPath::LeftEntity(Some(
+                    Box::new(EntityQueryPath::Id),
+                )))),
+                Some(FilterExpression::Parameter(Parameter::Uuid(Uuid::nil()))),
+            ),
+            Filter::Equal(
+                Some(FilterExpression::Path(EntityQueryPath::RightEntity(Some(
+                    Box::new(EntityQueryPath::Id),
+                )))),
+                Some(FilterExpression::Parameter(Parameter::Uuid(Uuid::nil()))),
+            ),
+        ]);
+        compiler.add_filter(&filter);
+
+        test_compilation(
+            &compiler,
+            r#"
+             SELECT *
+             FROM "entities"
+             INNER JOIN "entities" AS "entities_0_0_0"
+               ON "entities_0_0_0"."entity_id" = "entities"."left_entity_id"
+             INNER JOIN "entities" AS "entities_0_0_1"
+               ON "entities_0_0_1"."entity_id" = "entities"."right_entity_id"
+             WHERE ("entities_0_0_0"."entity_id" = $1) AND ("entities_0_0_1"."entity_id" = $2)
+            "#,
+            &[&Uuid::nil(), &Uuid::nil()],
+        );
+    }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -185,9 +185,9 @@ mod tests {
             r#"
             SELECT *
             FROM "data_types"
-            INNER JOIN "type_ids" AS "type_ids_0_0"
-              ON "type_ids_0_0"."version_id" = "data_types"."version_id"
-            WHERE ("type_ids_0_0"."base_uri" = $1) AND ("type_ids_0_0"."version" = $2)
+            INNER JOIN "type_ids" AS "type_ids_0_0_0"
+              ON "type_ids_0_0_0"."version_id" = "data_types"."version_id"
+            WHERE ("type_ids_0_0_0"."base_uri" = $1) AND ("type_ids_0_0_0"."version" = $2)
             "#,
             &[
                 &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
@@ -213,9 +213,9 @@ mod tests {
             WITH "type_ids" AS (SELECT *, MAX("type_ids"."version") OVER (PARTITION BY "type_ids"."base_uri") AS "latest_version" FROM "type_ids")
             SELECT *
             FROM "data_types"
-            INNER JOIN "type_ids" AS "type_ids_0_0"
-              ON "type_ids_0_0"."version_id" = "data_types"."version_id"
-            WHERE "type_ids_0_0"."version" = "type_ids_0_0"."latest_version"
+            INNER JOIN "type_ids" AS "type_ids_0_0_0"
+              ON "type_ids_0_0_0"."version_id" = "data_types"."version_id"
+            WHERE "type_ids_0_0_0"."version" = "type_ids_0_0_0"."latest_version"
             "#,
             &[],
         );
@@ -238,9 +238,9 @@ mod tests {
             WITH "type_ids" AS (SELECT *, MAX("type_ids"."version") OVER (PARTITION BY "type_ids"."base_uri") AS "latest_version" FROM "type_ids")
             SELECT *
             FROM "data_types"
-            INNER JOIN "type_ids" AS "type_ids_0_0"
-              ON "type_ids_0_0"."version_id" = "data_types"."version_id"
-            WHERE "type_ids_0_0"."version" != "type_ids_0_0"."latest_version"
+            INNER JOIN "type_ids" AS "type_ids_0_0_0"
+              ON "type_ids_0_0_0"."version_id" = "data_types"."version_id"
+            WHERE "type_ids_0_0_0"."version" != "type_ids_0_0_0"."latest_version"
             "#,
             &[],
         );
@@ -264,11 +264,11 @@ mod tests {
             r#"
             SELECT *
             FROM "property_types"
-            INNER JOIN "property_type_data_type_references" AS "property_type_data_type_references_0_0"
-              ON "property_type_data_type_references_0_0"."source_property_type_version_id" = "property_types"."version_id"
-            INNER JOIN "data_types" AS "data_types_0_1"
-              ON "data_types_0_1"."version_id" = "property_type_data_type_references_0_0"."target_data_type_version_id"
-            WHERE "data_types_0_1"."schema"->>'title' = $1
+            INNER JOIN "property_type_data_type_references" AS "property_type_data_type_references_0_0_0"
+              ON "property_type_data_type_references_0_0_0"."source_property_type_version_id" = "property_types"."version_id"
+            INNER JOIN "data_types" AS "data_types_0_1_0"
+              ON "data_types_0_1_0"."version_id" = "property_type_data_type_references_0_0_0"."target_data_type_version_id"
+            WHERE "data_types_0_1_0"."schema"->>'title' = $1
             "#,
             &[&"Text"],
         );
@@ -296,16 +296,16 @@ mod tests {
             r#"
             SELECT *
             FROM "property_types"
-            INNER JOIN "property_type_data_type_references" AS "property_type_data_type_references_0_0"
-              ON "property_type_data_type_references_0_0"."source_property_type_version_id" = "property_types"."version_id"
-            INNER JOIN "data_types" AS "data_types_0_1"
-              ON "data_types_0_1"."version_id" = "property_type_data_type_references_0_0"."target_data_type_version_id"
-            INNER JOIN "property_type_data_type_references" AS "property_type_data_type_references_1_0"
-              ON "property_type_data_type_references_1_0"."source_property_type_version_id" = "property_types"."version_id"
-            INNER JOIN "type_ids" AS "type_ids_1_1"
-              ON "type_ids_1_1"."version_id" = "property_type_data_type_references_1_0"."target_data_type_version_id"
-            WHERE "data_types_0_1"."schema"->>'title' = $1
-              AND ("type_ids_1_1"."base_uri" = $2) AND ("type_ids_1_1"."version" = $3)
+            INNER JOIN "property_type_data_type_references" AS "property_type_data_type_references_0_0_0"
+              ON "property_type_data_type_references_0_0_0"."source_property_type_version_id" = "property_types"."version_id"
+            INNER JOIN "data_types" AS "data_types_0_1_0"
+              ON "data_types_0_1_0"."version_id" = "property_type_data_type_references_0_0_0"."target_data_type_version_id"
+            INNER JOIN "property_type_data_type_references" AS "property_type_data_type_references_1_0_0"
+              ON "property_type_data_type_references_1_0_0"."source_property_type_version_id" = "property_types"."version_id"
+            INNER JOIN "type_ids" AS "type_ids_1_1_0"
+              ON "type_ids_1_1_0"."version_id" = "property_type_data_type_references_1_0_0"."target_data_type_version_id"
+            WHERE "data_types_0_1_0"."schema"->>'title' = $1
+              AND ("type_ids_1_1_0"."base_uri" = $2) AND ("type_ids_1_1_0"."version" = $3)
             "#,
             &[
                 &"Text",
@@ -334,11 +334,11 @@ mod tests {
             r#"
             SELECT *
             FROM "property_types"
-            INNER JOIN "property_type_property_type_references" AS "property_type_property_type_references_0_0"
-              ON "property_type_property_type_references_0_0"."source_property_type_version_id" = "property_types"."version_id"
-            INNER JOIN "property_types" AS "property_types_0_1"
-              ON "property_types_0_1"."version_id" = "property_type_property_type_references_0_0"."target_property_type_version_id"
-            WHERE "property_types_0_1"."schema"->>'title' = $1
+            INNER JOIN "property_type_property_type_references" AS "property_type_property_type_references_0_0_0"
+              ON "property_type_property_type_references_0_0_0"."source_property_type_version_id" = "property_types"."version_id"
+            INNER JOIN "property_types" AS "property_types_0_1_0"
+              ON "property_types_0_1_0"."version_id" = "property_type_property_type_references_0_0_0"."target_property_type_version_id"
+            WHERE "property_types_0_1_0"."schema"->>'title' = $1
             "#,
             &[&"Text"],
         );
@@ -363,11 +363,11 @@ mod tests {
             r#"
             SELECT *
             FROM "entity_types"
-            INNER JOIN "entity_type_property_type_references" AS "entity_type_property_type_references_0_0"
-              ON "entity_type_property_type_references_0_0"."source_entity_type_version_id" = "entity_types"."version_id"
-            INNER JOIN "property_types" AS "property_types_0_1"
-              ON "property_types_0_1"."version_id" = "entity_type_property_type_references_0_0"."target_property_type_version_id"
-            WHERE "property_types_0_1"."schema"->>'title' = $1
+            INNER JOIN "entity_type_property_type_references" AS "entity_type_property_type_references_0_0_0"
+              ON "entity_type_property_type_references_0_0_0"."source_entity_type_version_id" = "entity_types"."version_id"
+            INNER JOIN "property_types" AS "property_types_0_1_0"
+              ON "property_types_0_1_0"."version_id" = "entity_type_property_type_references_0_0_0"."target_property_type_version_id"
+            WHERE "property_types_0_1_0"."schema"->>'title' = $1
             "#,
             &[&"Name"],
         );
@@ -423,13 +423,13 @@ mod tests {
                 "entities"."properties",
                 "entities"."entity_id",
                 "entities"."version",
-                "entity_types_0_0"."schema"->>'$id',
+                "entity_types_0_0_0"."schema"->>'$id',
                 "entities"."owned_by_id",
                 "entities"."created_by_id",
                 "entities"."updated_by_id"
             FROM "entities"
-            INNER JOIN "entity_types" AS "entity_types_0_0"
-              ON "entity_types_0_0"."version_id" = "entities"."entity_type_version_id"
+            INNER JOIN "entity_types" AS "entity_types_0_0_0"
+              ON "entity_types_0_0_0"."version_id" = "entities"."entity_type_version_id"
             WHERE "entities"."entity_id" = $1
             "#,
             &[&"12345678-ABCD-4321-5678-ABCD5555DCBA"],
@@ -455,13 +455,13 @@ mod tests {
                 "entities"."properties",
                 "entities"."entity_id",
                 "entities"."version",
-                "entity_types_0_0"."schema"->>'$id',
+                "entity_types_0_0_0"."schema"->>'$id',
                 "entities"."owned_by_id",
                 "entities"."created_by_id",
                 "entities"."updated_by_id"
             FROM "entities"
-            INNER JOIN "entity_types" AS "entity_types_0_0"
-              ON "entity_types_0_0"."version_id" = "entities"."entity_type_version_id"
+            INNER JOIN "entity_types" AS "entity_types_0_0_0"
+              ON "entity_types_0_0_0"."version_id" = "entities"."entity_type_version_id"
             WHERE "entities"."latest_version" = TRUE
             "#,
             &[],
@@ -576,11 +576,11 @@ mod tests {
             r#"
             SELECT *
             FROM "entities"
-            INNER JOIN "entities" AS "entities_0_0"
-              ON "entities_0_0"."left_entity_id" = "entities"."entity_id"
-            INNER JOIN "entities" AS "entities_0_1"
-              ON "entities_0_1"."entity_id" = "entities_0_0"."right_entity_id"
-            WHERE "entities_0_1"."version" IS NULL
+            INNER JOIN "entities" AS "entities_0_0_0"
+              ON "entities_0_0_0"."left_entity_id" = "entities"."entity_id"
+            INNER JOIN "entities" AS "entities_0_1_0"
+              ON "entities_0_1_0"."entity_id" = "entities_0_0_0"."right_entity_id"
+            WHERE "entities_0_1_0"."version" IS NULL
             "#,
             &[],
         );
@@ -605,11 +605,11 @@ mod tests {
             r#"
             SELECT *
             FROM "entities"
-            INNER JOIN "entities" AS "entities_0_0"
-              ON "entities_0_0"."right_entity_id" = "entities"."entity_id"
-            INNER JOIN "entities" AS "entities_0_1"
-              ON "entities_0_1"."entity_id" = "entities_0_0"."left_entity_id"
-            WHERE "entities_0_1"."version" IS NULL
+            INNER JOIN "entities" AS "entities_0_0_0"
+              ON "entities_0_0_0"."right_entity_id" = "entities"."entity_id"
+            INNER JOIN "entities" AS "entities_0_1_0"
+              ON "entities_0_1_0"."entity_id" = "entities_0_0_0"."left_entity_id"
+            WHERE "entities_0_1_0"."version" IS NULL
             "#,
             &[],
         );

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
@@ -66,6 +66,7 @@ impl TableName {
 pub struct TableAlias {
     pub condition_index: usize,
     pub chain_depth: usize,
+    pub number: usize,
 }
 
 /// A table available in a compiled query.
@@ -78,8 +79,12 @@ pub struct Table {
 impl Transpile for Table {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "\"{}", self.name.as_str())?;
-        if let Some(alias) = self.alias {
-            write!(fmt, "_{}_{}", alias.condition_index, alias.chain_depth)?;
+        if let Some(alias) = &self.alias {
+            write!(
+                fmt,
+                "_{}_{}_{}",
+                alias.condition_index, alias.chain_depth, alias.number
+            )?;
         }
         fmt.write_char('"')
     }
@@ -166,11 +171,12 @@ mod tests {
                 name: TableName::TypeIds,
                 alias: Some(TableAlias {
                     condition_index: 1,
-                    chain_depth: 2
+                    chain_depth: 2,
+                    number: 3,
                 })
             }
             .transpile_to_string(),
-            r#""type_ids_1_2""#
+            r#""type_ids_1_2_3""#
         );
     }
 

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -470,6 +470,58 @@ Accept: application/json
     });
 %}
 
+
+### Get link by source and target
+POST http://127.0.0.1:4000/entities/query
+Content-Type: application/json
+
+{
+  "filter": {
+    "all": [
+      {
+        "equal": [
+          {
+            "path": [
+              "leftEntity",
+              "id"
+            ]
+          },
+          {
+            "parameter": "{{person_a_entity_id}}"
+          }
+        ]
+      },
+      {
+        "equal": [
+          {
+            "path": [
+              "rightEntity",
+              "id"
+            ]
+          },
+          {
+            "parameter": "{{person_b_entity_id}}"
+          }
+        ]
+      }
+    ]
+  },
+  "graphResolveDepths": {
+    "dataTypeResolveDepth": 0,
+    "propertyTypeResolveDepth": 0,
+    "entityTypeResolveDepth": 0,
+    "linkTargetEntityResolveDepth": 0,
+    "linkResolveDepth": 0
+  }
+}
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(response.body.roots.length === 1, "Unexpected number of entities");
+    });
+%}
+
 ### Archive an entity
 POST http://127.0.0.1:4000/entities/archive
 Content-Type: application/json


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When joining with different columns on the same table, the table alias will be used twice.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Slack discussion](https://hashintel.slack.com/archives/C03F7V6DU9M/p1667569077479789) _(internal)_

## 🚫 Blocked by

- #1347

## 🔍 What does this change?

- Add a new field to `TableAlias`
- Only reuse the join statement if all fields are matching, if only the joined table is matching, not the column, a new join statement with a unique name is added

## 🛡 What tests cover this?

A test was added to cover the specific scenario mentioned in the slack discussion.