### PR TITLE
Fix lifetimes for compiler

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -93,7 +93,7 @@ where
     type Query<'q> = Filter<'q, T::Inner>;
 
     async fn read<'f: 'q, 'q>(&self, filter: &'f Self::Query<'q>) -> Result<Vec<T>, QueryError> {
-        let mut compiler = SelectCompiler::new();
+        let mut compiler = SelectCompiler::with_default_selection();
         compiler.add_filter(filter);
         let (statement, parameters) = compiler.compile();
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -83,16 +83,17 @@ impl From<OntologyRecord<EntityType>> for PersistedEntityType {
 impl<C: AsClient, T> Read<T> for PostgresStore<C>
 where
     T: for<'q> PersistedOntologyType<
-            Inner: PostgresQueryRecord<'q, Path<'q>: Debug + Sync>
+            Inner: PostgresQueryRecord<Path<'q>: Debug + Sync>
                        + OntologyDatabaseType
                        + TryFrom<serde_json::Value, Error: Context>
-                       + Send,
+                       + Send
+                       + 'static,
         > + Send,
 {
     type Query<'q> = Filter<'q, T::Inner>;
 
     async fn read<'f: 'q, 'q>(&self, filter: &'f Self::Query<'q>) -> Result<Vec<T>, QueryError> {
-        let mut compiler = SelectCompiler::with_default_selection();
+        let mut compiler = SelectCompiler::new();
         compiler.add_filter(filter);
         let (statement, parameters) = compiler.compile();
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
@@ -13,19 +13,21 @@ use crate::store::{
     query::{Filter, FilterExpression, Parameter},
 };
 
-pub struct CompilerArtifacts<'f> {
-    parameters: Vec<&'f (dyn ToSql + Sync)>,
+pub struct CompilerArtifacts<'param> {
+    parameters: Vec<&'param (dyn ToSql + Sync)>,
     condition_index: usize,
     required_tables: HashSet<Table>,
 }
 
-pub struct SelectCompiler<'f, 'q, T> {
-    statement: SelectStatement<'q>,
-    artifacts: CompilerArtifacts<'f>,
-    _marker: PhantomData<fn(&'f T)>,
+pub struct SelectCompiler<'compiler, 'param, T> {
+    statement: SelectStatement<'compiler>,
+    artifacts: CompilerArtifacts<'param>,
+    _marker: PhantomData<fn(*const T)>,
 }
 
-impl<'f: 'q, 'q, T: PostgresQueryRecord<'q>> SelectCompiler<'f, 'q, T> {
+impl<'compiler, 'param: 'compiler, T: PostgresQueryRecord + 'static>
+    SelectCompiler<'compiler, 'param, T>
+{
     /// Creates a new, empty compiler.
     pub fn new() -> Self {
         Self {
@@ -49,8 +51,8 @@ impl<'f: 'q, 'q, T: PostgresQueryRecord<'q>> SelectCompiler<'f, 'q, T> {
 
     /// Creates a new compiler, which will default to select the paths returned from
     /// [`PostgresQueryRecord::default_selection_paths()`].
-    pub fn with_default_selection() -> Self {
-        let mut default = Self::new();
+    pub fn with_default_selection() -> SelectCompiler<'compiler, 'static, T> {
+        let mut default = SelectCompiler::new();
         for path in T::default_selection_paths() {
             default.add_selection_path(path);
         }
@@ -71,7 +73,10 @@ impl<'f: 'q, 'q, T: PostgresQueryRecord<'q>> SelectCompiler<'f, 'q, T> {
     ///
     /// Optionally, the added selection can be distinct or ordered by providing [`Distinctness`]
     /// and [`Ordering`].
-    pub fn add_selection_path(&mut self, path: &'q T::Path<'q>) -> impl RowIndex + Display + Copy {
+    pub fn add_selection_path<'p: 'compiler>(
+        &mut self,
+        path: &'p T::Path<'param>,
+    ) -> impl RowIndex + Display + Copy {
         let table = self.add_join_statements(path.relations());
         self.statement.selects.push(SelectExpression::from_column(
             Column {
@@ -87,9 +92,9 @@ impl<'f: 'q, 'q, T: PostgresQueryRecord<'q>> SelectCompiler<'f, 'q, T> {
     ///
     /// Optionally, the added selection can be distinct or ordered by providing [`Distinctness`]
     /// and [`Ordering`].
-    pub fn add_distinct_selection_with_ordering(
+    pub fn add_distinct_selection_with_ordering<'p: 'compiler>(
         &mut self,
-        path: &'q T::Path<'q>,
+        path: &'p T::Path<'param>,
         distinctness: Distinctness,
         ordering: Option<Ordering>,
     ) -> impl RowIndex + Display + Copy {
@@ -113,14 +118,14 @@ impl<'f: 'q, 'q, T: PostgresQueryRecord<'q>> SelectCompiler<'f, 'q, T> {
     }
 
     /// Adds a new filter to the selection.
-    pub fn add_filter(&mut self, filter: &'f Filter<'q, T>) {
+    pub fn add_filter<'f: 'param>(&mut self, filter: &'f Filter<'param, T>) {
         let condition = self.compile_filter(filter);
         self.artifacts.condition_index += 1;
         self.statement.where_expression.add_condition(condition);
     }
 
     /// Transpiles the statement into SQL and the parameter to be passed to a prepared statement.
-    pub fn compile(&self) -> (String, &[&'f (dyn ToSql + Sync)]) {
+    pub fn compile(&self) -> (String, &[&'param (dyn ToSql + Sync)]) {
         (
             self.statement.transpile_to_string(),
             &self.artifacts.parameters,
@@ -128,7 +133,10 @@ impl<'f: 'q, 'q, T: PostgresQueryRecord<'q>> SelectCompiler<'f, 'q, T> {
     }
 
     /// Compiles a [`Filter`] to a `Condition`.
-    pub fn compile_filter(&mut self, filter: &'f Filter<'q, T>) -> Condition<'q> {
+    pub fn compile_filter<'f: 'param>(
+        &mut self,
+        filter: &'f Filter<'param, T>,
+    ) -> Condition<'compiler> {
         if let Some(condition) = self.compile_special_filter(filter) {
             return condition;
         }
@@ -169,15 +177,15 @@ impl<'f: 'q, 'q, T: PostgresQueryRecord<'q>> SelectCompiler<'f, 'q, T> {
     //          ensure compatibility
     fn compile_latest_version_filter(
         &mut self,
-        path: &'f T::Path<'q>,
+        path: &T::Path<'param>,
         operator: EqualityOperator,
-    ) -> Condition<'q> {
+    ) -> Condition<'param> {
         let mut version_column = Column {
             table: Table {
                 name: path.terminating_table_name(),
                 alias: None,
             },
-            access: path.column_access(),
+            access: ColumnAccess::Table { column: "version" },
         };
         // Depending on the table name of the path the partition table is selected
         let partition_column = match version_column.table.name {
@@ -246,7 +254,7 @@ impl<'f: 'q, 'q, T: PostgresQueryRecord<'q>> SelectCompiler<'f, 'q, T> {
     ///
     /// The following [`Filter`]s will be special cased:
     /// - Comparing the `"version"` field on [`TableName::TypeIds`] with `"latest"` for equality.
-    fn compile_special_filter(&mut self, filter: &'f Filter<'q, T>) -> Option<Condition<'q>> {
+    fn compile_special_filter(&mut self, filter: &Filter<'param, T>) -> Option<Condition<'param>> {
         match filter {
             Filter::Equal(lhs, rhs) | Filter::NotEqual(lhs, rhs) => match (lhs, rhs) {
                 (
@@ -288,10 +296,10 @@ impl<'f: 'q, 'q, T: PostgresQueryRecord<'q>> SelectCompiler<'f, 'q, T> {
         }
     }
 
-    pub fn compile_filter_expression(
+    pub fn compile_filter_expression<'f: 'param>(
         &mut self,
-        expression: &'f FilterExpression<'q, T>,
-    ) -> Expression<'q> {
+        expression: &'f FilterExpression<'param, T>,
+    ) -> Expression<'compiler> {
         match expression {
             FilterExpression::Path(path) => {
                 let access = if let Some(field) = path.user_provided_path() {
@@ -325,7 +333,7 @@ impl<'f: 'q, 'q, T: PostgresQueryRecord<'q>> SelectCompiler<'f, 'q, T> {
     ///
     /// Joining the tables attempts to deduplicate [`JoinExpression`]s. As soon as a new filter was
     /// compiled, each subsequent call will result in a new join-chain.
-    fn add_join_statements(&mut self, tables: impl IntoIterator<Item = Relation<'q>>) -> Table {
+    fn add_join_statements(&mut self, tables: impl IntoIterator<Item = Relation>) -> Table {
         let mut current_table = T::base_table();
         let mut chain_depth = 0;
         for Relation {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
@@ -6,12 +6,12 @@ use crate::store::postgres::query::{Expression, Transpile};
 ///
 /// [`Filter`]: crate::store::query::Filter
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub enum Condition<'q> {
+pub enum Condition<'p> {
     All(Vec<Self>),
     Any(Vec<Self>),
     Not(Box<Self>),
-    Equal(Option<Expression<'q>>, Option<Expression<'q>>),
-    NotEqual(Option<Expression<'q>>, Option<Expression<'q>>),
+    Equal(Option<Expression<'p>>, Option<Expression<'p>>),
+    NotEqual(Option<Expression<'p>>, Option<Expression<'p>>),
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
@@ -6,7 +6,7 @@ use crate::{
     store::postgres::query::{ColumnAccess, Path, PostgresQueryRecord, Relation, Table, TableName},
 };
 
-impl<'q> PostgresQueryRecord<'q> for DataType {
+impl PostgresQueryRecord for DataType {
     fn base_table() -> Table {
         Table {
             name: TableName::DataTypes,
@@ -14,7 +14,7 @@ impl<'q> PostgresQueryRecord<'q> for DataType {
         }
     }
 
-    fn default_selection_paths() -> &'q [Self::Path<'q>] {
+    fn default_selection_paths() -> &'static [Self::Path<'static>] {
         &[
             DataTypeQueryPath::VersionedUri,
             DataTypeQueryPath::Schema,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity.rs
@@ -8,7 +8,7 @@ use crate::{
     store::postgres::query::{ColumnAccess, Path, PostgresQueryRecord, Relation, Table, TableName},
 };
 
-impl<'q> PostgresQueryRecord<'q> for Entity {
+impl PostgresQueryRecord for Entity {
     fn base_table() -> Table {
         Table {
             name: TableName::Entities,
@@ -16,7 +16,7 @@ impl<'q> PostgresQueryRecord<'q> for Entity {
         }
     }
 
-    fn default_selection_paths() -> &'q [Self::Path<'q>] {
+    fn default_selection_paths() -> &'static [Self::Path<'static>] {
         &[
             EntityQueryPath::Properties(None),
             EntityQueryPath::Id,
@@ -46,7 +46,9 @@ impl Path for EntityQueryPath<'_> {
                     column: "left_entity_id",
                 },
                 join_table_name: TableName::Entities,
-                join_column_access: Self::Id.column_access(),
+                join_column_access: ColumnAccess::Table {
+                    column: "entity_id",
+                },
             })
             .chain(path.relations())
             .collect(),
@@ -55,12 +57,16 @@ impl Path for EntityQueryPath<'_> {
                     column: "right_entity_id",
                 },
                 join_table_name: TableName::Entities,
-                join_column_access: Self::Id.column_access(),
+                join_column_access: ColumnAccess::Table {
+                    column: "entity_id",
+                },
             })
             .chain(path.relations())
             .collect(),
             Self::OutgoingLinks(path) => once(Relation {
-                current_column_access: Self::Id.column_access(),
+                current_column_access: ColumnAccess::Table {
+                    column: "entity_id",
+                },
                 join_table_name: TableName::Entities,
                 join_column_access: ColumnAccess::Table {
                     column: "left_entity_id",
@@ -69,7 +75,9 @@ impl Path for EntityQueryPath<'_> {
             .chain(path.relations())
             .collect(),
             Self::IncomingLinks(path) => once(Relation {
-                current_column_access: Self::Id.column_access(),
+                current_column_access: ColumnAccess::Table {
+                    column: "entity_id",
+                },
                 join_table_name: TableName::Entities,
                 join_column_access: ColumnAccess::Table {
                     column: "right_entity_id",

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity_type.rs
@@ -6,7 +6,7 @@ use crate::{
     store::postgres::query::{ColumnAccess, Path, PostgresQueryRecord, Relation, Table, TableName},
 };
 
-impl<'q> PostgresQueryRecord<'q> for EntityType {
+impl PostgresQueryRecord for EntityType {
     fn base_table() -> Table {
         Table {
             name: TableName::EntityTypes,
@@ -14,7 +14,7 @@ impl<'q> PostgresQueryRecord<'q> for EntityType {
         }
     }
 
-    fn default_selection_paths() -> &'q [Self::Path<'q>] {
+    fn default_selection_paths() -> &'static [Self::Path<'static>] {
         &[
             EntityTypeQueryPath::VersionedUri,
             EntityTypeQueryPath::Schema,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
@@ -2,10 +2,10 @@ use std::fmt;
 
 use crate::store::postgres::query::{Column, ColumnAccess, Table, TableName, Transpile};
 
-pub struct Relation<'q> {
-    pub current_column_access: ColumnAccess<'q>,
+pub struct Relation {
+    pub current_column_access: ColumnAccess<'static>,
     pub join_table_name: TableName,
-    pub join_column_access: ColumnAccess<'q>,
+    pub join_column_access: ColumnAccess<'static>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
@@ -28,12 +28,12 @@ pub use self::{
 };
 use crate::store::query::QueryRecord;
 
-pub trait PostgresQueryRecord<'q>: QueryRecord<Path<'q>: Path> {
+pub trait PostgresQueryRecord: for<'p> QueryRecord<Path<'p>: Path> {
     /// The [`Table`] used for this `Query`.
     fn base_table() -> Table;
 
     /// Default [`Path`]s returned when querying this record.
-    fn default_selection_paths() -> &'q [Self::Path<'q>];
+    fn default_selection_paths() -> &'static [Self::Path<'static>];
 }
 
 /// An absolute path inside of a query pointing to an attribute.

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/property_type.rs
@@ -6,7 +6,7 @@ use crate::{
     store::postgres::query::{ColumnAccess, Path, PostgresQueryRecord, Relation, Table, TableName},
 };
 
-impl<'q> PostgresQueryRecord<'q> for PropertyType {
+impl PostgresQueryRecord for PropertyType {
     fn base_table() -> Table {
         Table {
             name: TableName::PropertyTypes,
@@ -14,7 +14,7 @@ impl<'q> PostgresQueryRecord<'q> for PropertyType {
         }
     }
 
-    fn default_selection_paths() -> &'q [Self::Path<'q>] {
+    fn default_selection_paths() -> &'static [Self::Path<'static>] {
         &[
             PropertyTypeQueryPath::VersionedUri,
             PropertyTypeQueryPath::Schema,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -91,7 +91,7 @@ mod tests {
         },
     };
 
-    fn test_compilation<'f: 'q, 'q, T: PostgresQueryRecord<'q>>(
+    fn test_compilation<'f, 'q: 'f, T: PostgresQueryRecord + 'static>(
         compiler: &SelectCompiler<'f, 'q, T>,
         expected_statement: &'static str,
         expected_parameters: &[&'f dyn ToSql],

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
@@ -87,13 +87,13 @@ impl Transpile for Table {
 
 /// Specifier on how to access a column of a table.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum ColumnAccess<'q> {
+pub enum ColumnAccess<'param> {
     /// Accesses a column of a table directly: `"column"`
     Table { column: &'static str },
     /// Accesses a field of a JSON blob: `"column"->>'field'`
     Json {
         column: &'static str,
-        field: &'q str,
+        field: &'param str,
     },
     /// Accesses the field of a JSON blob by a numbered parameter: e.g. `"column"->>$1`
     JsonParameter { column: &'static str, index: usize },
@@ -121,9 +121,9 @@ impl Transpile for ColumnAccess<'_> {
 
 /// A column available in the database.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Column<'a> {
+pub struct Column<'param> {
     pub table: Table,
-    pub access: ColumnAccess<'a>,
+    pub access: ColumnAccess<'param>,
 }
 
 impl Transpile for Column<'_> {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The lifetimes of the query compilers are suboptimal as they require the compiler to outlive the parameters.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/0/1203324626226283/f) _(internal)_


## 🔍 What does this change?

- Make `Relation<'q>` static
- Return `'static` from default selection fields
- Remove lifetime from `PostgresQueryRecord`
- Reverse lifetime requirements for `SelectCompiler`