### PR TITLE
Add united view of latest and historic entities

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -284,7 +284,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             .change_context(UpdateError)?;
 
         let old_entity_metadata = transaction
-            .move_entity_to_histories(entity_id, HistoricMove::ForNewVersion)
+            .move_latest_entity_to_histories(entity_id, HistoricMove::ForNewVersion)
             .await
             .change_context(UpdateError)?;
 
@@ -338,7 +338,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
 
         // Move current latest edition to the historic table
         transaction
-            .move_entity_to_histories(entity_id, HistoricMove::ForNewVersion)
+            .move_latest_entity_to_histories(entity_id, HistoricMove::ForNewVersion)
             .await
             .change_context(ArchivalError)?;
 
@@ -358,7 +358,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
 
         // Archive latest edition, leaving nothing from the entity behind.
         transaction
-            .move_entity_to_histories(entity_id, HistoricMove::ForArchival)
+            .move_latest_entity_to_histories(entity_id, HistoricMove::ForArchival)
             .await
             .change_context(ArchivalError)?;
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -279,7 +279,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         );
 
         transaction
-            .lock_entity_for_update(entity_id)
+            .lock_latest_entity_for_update(entity_id)
             .await
             .change_context(UpdateError)?;
 
@@ -326,7 +326,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         );
 
         transaction
-            .lock_entity_for_update(entity_id)
+            .lock_latest_entity_for_update(entity_id)
             .await
             .change_context(ArchivalError)?;
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -981,7 +981,7 @@ where
     //   This is especially important for making these queries single-shard Citus queries when we
     //   need that.
     //   see: https://app.asana.com/0/1201095311341924/1203214689883091/f
-    async fn move_entity_to_histories(
+    async fn move_latest_entity_to_histories(
         &self,
         entity_id: EntityId,
         historic_move: HistoricMove,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
This PR adds a view combining latest and historic entity entries

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/0/1203325827190276/f) _(internal)_

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->


## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Renames `entities` to `latest_entities`
- Adds a view called `entities` which is a `UNION ALL` of the two existing entities tables
  - the `UNION ALL` is important to use rather than `UNION` as we do not wish to deduplicate anything.

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->


## ⚠️ Known issues

- Querying for latest version through a structural query returns archived entries.
<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->