### PR TITLE
Support returning archived and versions of entities

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -624,6 +624,7 @@ export const PathExpressionPathEnum = {
   BaseUri: "baseUri",
   VersionedUri: "versionedUri",
   Version: "version",
+  Archived: "archived",
   Title: "title",
   Description: "description",
   Type: "type",

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
@@ -369,6 +369,7 @@ impl Modify for FilterSchemaAddon {
                                             "baseUri",
                                             "versionedUri",
                                             "version",
+                                            "archived",
                                             "title",
                                             "description",
                                             "type",

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
@@ -19,6 +19,7 @@ pub enum EntityQueryPath<'q> {
     UpdatedById,
     RemovedById,
     Version,
+    Archived,
     Type(EntityTypeQueryPath),
     Properties(Option<Cow<'q, str>>),
     IncomingLinks(Box<Self>),
@@ -42,6 +43,7 @@ impl fmt::Display for EntityQueryPath<'_> {
             Self::UpdatedById => fmt.write_str("updatedById"),
             Self::RemovedById => fmt.write_str("removedById"),
             Self::Version => fmt.write_str("version"),
+            Self::Archived => fmt.write_str("archived"),
             Self::Type(path) => write!(fmt, "type.{path}"),
             Self::Properties(Some(property)) => write!(fmt, "properties.{property}"),
             Self::Properties(None) => fmt.write_str("properties"),
@@ -75,6 +77,7 @@ impl RecordPath for EntityQueryPath<'_> {
             Self::Type(path) => path.expected_type(),
             Self::Properties(_) => ParameterType::Any,
             Self::LeftOrder | Self::RightOrder => ParameterType::Number,
+            Self::Archived => ParameterType::Boolean,
         }
     }
 }
@@ -89,6 +92,7 @@ pub enum EntityQueryToken {
     UpdatedById,
     RemovedById,
     Version,
+    Archived,
     Type,
     Properties,
     IncomingLinks,
@@ -104,8 +108,8 @@ pub struct EntityQueryPathVisitor {
 impl EntityQueryPathVisitor {
     pub const EXPECTING: &'static str =
         "one of `ownedById`, `createdById`, `updatedById`, `removedById`, `baseUri`, \
-         `versionedUri`, `version`, `title`, `description`, `default`, `examples`, `properties`, \
-         `required`, `links`, `requiredLinks`, `inheritsFrom`";
+         `versionedUri`, `version`, `archived`, `title`, `description`, `default`, `examples`, \
+         `properties`, `required`, `links`, `requiredLinks`, `inheritsFrom`";
 
     #[must_use]
     pub const fn new(position: usize) -> Self {
@@ -136,6 +140,7 @@ impl<'de> Visitor<'de> for EntityQueryPathVisitor {
             EntityQueryToken::UpdatedById => EntityQueryPath::UpdatedById,
             EntityQueryToken::RemovedById => EntityQueryPath::RemovedById,
             EntityQueryToken::Version => EntityQueryPath::Version,
+            EntityQueryToken::Archived => EntityQueryPath::Archived,
             EntityQueryToken::Type => {
                 let entity_type_query_path =
                     EntityTypeQueryPathVisitor::new(self.position).visit_seq(seq)?;

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
@@ -106,10 +106,9 @@ pub struct EntityQueryPathVisitor {
 }
 
 impl EntityQueryPathVisitor {
-    pub const EXPECTING: &'static str =
-        "one of `ownedById`, `createdById`, `updatedById`, `removedById`, `baseUri`, \
-         `versionedUri`, `version`, `archived`, `title`, `description`, `default`, `examples`, \
-         `properties`, `required`, `links`, `requiredLinks`, `inheritsFrom`";
+    pub const EXPECTING: &'static str = "one of `id`, `ownedById`, `createdById`, `updatedById`, \
+                                         `removedById`, `version`, `archived`, `type`, \
+                                         `properties`, `incomingLinks`, `outgoingLinks`";
 
     #[must_use]
     pub const fn new(position: usize) -> Self {
@@ -210,9 +209,9 @@ mod tests {
         );
 
         assert_eq!(
-            EntityTypeQueryPath::deserialize(
-                de::value::SeqDeserializer::<_, de::value::Error>::new(once("invalid"))
-            )
+            EntityQueryPath::deserialize(de::value::SeqDeserializer::<_, de::value::Error>::new(
+                once("invalid")
+            ))
             .expect_err(
                 "managed to convert entity query path with hidden token when it should have \
                  errored"
@@ -225,11 +224,9 @@ mod tests {
         );
 
         assert_eq!(
-            EntityTypeQueryPath::deserialize(
-                de::value::SeqDeserializer::<_, de::value::Error>::new(
-                    ["version", "test"].into_iter()
-                )
-            )
+            EntityQueryPath::deserialize(de::value::SeqDeserializer::<_, de::value::Error>::new(
+                ["version", "test"].into_iter()
+            ))
             .expect_err(
                 "managed to convert entity query path with multiple tokens when it should have \
                  errored"

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -31,6 +31,7 @@ impl<C: AsClient> crud::Read<PersistedEntity> for PostgresStore<C> {
         let properties_index = compiler.add_selection_path(&EntityQueryPath::Properties(None));
         let entity_id_index = compiler.add_selection_path(&EntityQueryPath::Id);
         let version_index = compiler.add_selection_path(&EntityQueryPath::Version);
+        let archived_index = compiler.add_selection_path(&EntityQueryPath::Archived);
         let type_id_index =
             compiler.add_selection_path(&EntityQueryPath::Type(EntityTypeQueryPath::VersionedUri));
         let owned_by_id_index = compiler.add_selection_path(&EntityQueryPath::OwnedById);
@@ -100,7 +101,7 @@ impl<C: AsClient> crud::Read<PersistedEntity> for PostgresStore<C> {
                     link_metadata,
                     // TODO: only the historic table would have an `archived` field.
                     //   Consider what we should do about that.
-                    false,
+                    row.get(archived_index),
                 ))
             })
             .try_collect()

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity.rs
@@ -97,6 +97,7 @@ impl Path for EntityQueryPath<'_> {
             | Self::UpdatedById
             | Self::RemovedById
             | Self::Version
+            | Self::Archived
             | Self::LeftEntity(None)
             | Self::RightEntity(None)
             | Self::LeftOrder
@@ -116,6 +117,7 @@ impl Path for EntityQueryPath<'_> {
                 column: "entity_id",
             },
             Self::Version => ColumnAccess::Table { column: "version" },
+            Self::Archived => ColumnAccess::Table { column: "archived" },
             Self::Type(path) => path.column_access(),
             Self::OwnedById => ColumnAccess::Table {
                 column: "owned_by_id",

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/conditional.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/conditional.rs
@@ -43,7 +43,10 @@ impl Transpile for Constant {
 pub enum Expression<'q> {
     Asterisk,
     Column(Column<'q>),
+    /// A parameter are transpiled as a placeholder, e.g. `$1`, in order to prevent SQL injection.
     Parameter(usize),
+    /// [`Constant`]s are directly transpiled into the SQL query. Caution has to be taken to
+    /// prevent SQL injection and no user input should ever be used as a [`Constant`].
     Constant(Constant),
     Function(Box<Function<'q>>),
     Window(Box<Self>, WindowStatement<'q>),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/mod.rs
@@ -6,7 +6,7 @@ mod where_clause;
 mod with_clause;
 
 pub use self::{
-    conditional::{Expression, Function},
+    conditional::{Constant, Expression, Function},
     join_clause::{JoinExpression, Relation},
     order_clause::{OrderByExpression, Ordering},
     select_clause::SelectExpression,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -451,7 +451,6 @@ mod tests {
         test_compilation(
             &compiler,
             r#"
-            WITH "entities" AS (SELECT *, MAX("entities"."version") OVER (PARTITION BY "entities"."entity_id") AS "latest_version" FROM "entities")
             SELECT
                 "entities"."properties",
                 "entities"."entity_id",
@@ -463,7 +462,7 @@ mod tests {
             FROM "entities"
             INNER JOIN "entity_types" AS "entity_types_0_0"
               ON "entity_types_0_0"."version_id" = "entities"."entity_type_version_id"
-            WHERE "entities"."version" = "entities"."latest_version"
+            WHERE "entities"."latest_version" = TRUE
             "#,
             &[],
         );

--- a/packages/graph/hash_graph/tests/integration/postgres/links.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/links.rs
@@ -147,7 +147,7 @@ async fn get_entity_links() {
     .expect("could not create link");
 
     let links_from_source = api
-        .get_entity_links(person_a_metadata.identifier().entity_id())
+        .get_latest_entity_links(person_a_metadata.identifier().entity_id())
         .await
         .expect("could not fetch link");
 
@@ -246,7 +246,7 @@ async fn remove_link() {
         .expect("could not create link");
 
     assert!(
-        !api.get_entity_links(person_a_metadata.identifier().entity_id())
+        !api.get_latest_entity_links(person_a_metadata.identifier().entity_id())
             .await
             .expect("could not fetch links")
             .is_empty()
@@ -257,7 +257,7 @@ async fn remove_link() {
         .expect("could not remove link");
 
     assert!(
-        api.get_entity_links(person_a_metadata.identifier().entity_id())
+        api.get_latest_entity_links(person_a_metadata.identifier().entity_id())
             .await
             .expect("could not fetch links")
             .is_empty()

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -389,16 +389,24 @@ impl DatabaseApi<'_> {
             .expect("no entity found")
     }
 
-    pub async fn get_entity_links(
+    pub async fn get_latest_entity_links(
         &self,
         source_entity_id: EntityId,
     ) -> Result<Vec<PersistedEntity>, QueryError> {
-        let filter = Filter::Equal(
-            Some(FilterExpression::Path(EntityQueryPath::LeftEntity(None))),
-            Some(FilterExpression::Parameter(Parameter::Uuid(
-                source_entity_id.as_uuid(),
-            ))),
-        );
+        let filter = Filter::All(vec![
+            Filter::Equal(
+                Some(FilterExpression::Path(EntityQueryPath::LeftEntity(None))),
+                Some(FilterExpression::Parameter(Parameter::Uuid(
+                    source_entity_id.as_uuid(),
+                ))),
+            ),
+            Filter::Equal(
+                Some(FilterExpression::Path(EntityQueryPath::Version)),
+                Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
+                    "latest",
+                )))),
+            ),
+        ]);
 
         Ok(self
             .store

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -303,7 +303,9 @@ Content-Type: application/json
     "equal": [
       {
         "path": [
-          "inheritsFrom", "*", "versionedUri"
+          "inheritsFrom",
+          "*",
+          "versionedUri"
         ]
       },
       {
@@ -491,30 +493,64 @@ POST http://127.0.0.1:4000/entities/query
 Content-Type: application/json
 
 {
- "filter": {
-   "equal": [
-    {
-      "path": [
-        "version"
-      ]
-    },
-    {
-      "parameter": "latest"
-    }
-  ]
- },
- "graphResolveDepths": {
-   "dataTypeResolveDepth": 0,
-   "propertyTypeResolveDepth": 0,
-   "entityTypeResolveDepth": 0,
-   "linkTargetEntityResolveDepth": 0,
-   "linkResolveDepth": 0
- }
+  "filter": {
+    "equal": [
+      {
+        "path": [
+          "version"
+        ]
+      },
+      {
+        "parameter": "latest"
+      }
+    ]
+  },
+  "graphResolveDepths": {
+    "dataTypeResolveDepth": 0,
+    "propertyTypeResolveDepth": 0,
+    "entityTypeResolveDepth": 0,
+    "linkTargetEntityResolveDepth": 0,
+    "linkResolveDepth": 0
+  }
 }
 
 > {%
    client.test("status", function() {
        client.assert(response.status === 200, "Response status is not 200");
        client.assert(response.body.roots.length === 2, "Unexpected number of entities");
+   });
+%}
+
+
+#### Get all archived entities
+POST http://127.0.0.1:4000/entities/query
+Content-Type: application/json
+
+{
+  "filter": {
+    "equal": [
+      {
+        "path": [
+          "archived"
+        ]
+      },
+      {
+        "parameter": true
+      }
+    ]
+  },
+  "graphResolveDepths": {
+    "dataTypeResolveDepth": 0,
+    "propertyTypeResolveDepth": 0,
+    "entityTypeResolveDepth": 0,
+    "linkTargetEntityResolveDepth": 0,
+    "linkResolveDepth": 0
+  }
+}
+
+> {%
+   client.test("status", function() {
+       client.assert(response.status === 200, "Response status is not 200");
+       client.assert(response.body.roots.length === 1, "Unexpected number of entities");
    });
 %}

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -499,11 +499,27 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   // The latest entities come first when querying the view.
   pgm.createView(
     "entities",
-    {},
+    {
+      columns: [
+        "entity_id",
+        "version",
+        "latest_version",
+        "entity_type_version_id",
+        "properties",
+        "left_order",
+        "right_order",
+        "left_entity_id",
+        "right_entity_id",
+        "archived",
+        "owned_by_id",
+        "created_by_id",
+        "updated_by_id",
+      ],
+    },
     `
-    SELECT entity_id, version, entity_type_version_id, properties, left_order, right_order, left_entity_id, right_entity_id, FALSE AS archived, owned_by_id, created_by_id, updated_by_id FROM latest_entities
+    SELECT entity_id, version, TRUE as latest_version, entity_type_version_id, properties, left_order, right_order, left_entity_id, right_entity_id, FALSE AS archived, owned_by_id, created_by_id, updated_by_id FROM latest_entities
     UNION ALL
-    SELECT entity_id, version, entity_type_version_id, properties, left_order, right_order, left_entity_id, right_entity_id, archived, owned_by_id, created_by_id, updated_by_id FROM entity_histories`,
+    SELECT entity_id, version, FALSE as latest_version, entity_type_version_id, properties, left_order, right_order, left_entity_id, right_entity_id, archived, owned_by_id, created_by_id, updated_by_id FROM entity_histories`,
   );
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We previously split up the entities table into `entity_histories` and `latest_entities`. An `entities` view exists combining these two. The `entities` view almost behave like the table before, but it is also returning archived entities, so this PR treats getting entity versions differently.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201095311341924/1203190454879638/f) _(internal)_

## 🔍 What does this change?

- Change the view to return `latest_version` depending on the table: `TRUE` for `latest_entities` and `FALSE` for `entity_histories`.
- Remove the CTE when asking for `version = "latest"` and use the new column instead
- In order to implement the above, a `Constant` expression was added to the compiler (not exposed to the API) which skips statement preparation
- Allow `entity.archived` to be set in filters, so one could explicitly ask for only entities, which are not archived (this has to be explicit)
- Adjust integration test to only return latest entities. Previously, also archived entities were returned.

## 📜 Does this require a change to the docs?

The OpenAPI specs were updated to support `"archived"`

## 🛡 What tests cover this?

- A new REST test was added to read archived entitites