### PR TITLE
Add Log middleware to Graph Rest API

### DIFF
--- a/packages/graph/hash_graph/Cargo.lock
+++ b/packages/graph/hash_graph/Cargo.lock
@@ -671,6 +671,7 @@ dependencies = [
  "error-stack",
  "futures",
  "graph-test-data",
+ "hyper",
  "include_dir",
  "postgres-types",
  "regex",
@@ -678,6 +679,8 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-postgres",
+ "tower",
+ "tower-http",
  "tracing",
  "tracing-appender",
  "tracing-error",
@@ -805,9 +808,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1540,9 +1543,9 @@ checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10c98bba371b9b22a71a9414e420f92ddeb2369239af08200816169d5e2dd7aa"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
@@ -1799,6 +1802,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/packages/graph/hash_graph/lib/graph/Cargo.toml
+++ b/packages/graph/hash_graph/lib/graph/Cargo.toml
@@ -14,11 +14,14 @@ clap = { version = "4.0.13", features = ["derive", "env"], optional = true }
 chrono = { version = "0.4.22", features = ["serde"] }
 error-stack = { version = "0.2.3", features = ["spantrace"] }
 futures = "0.3.24"
+hyper = "0.14.22"
 postgres-types = { version = "0.2.4", default-features = false, features = ["derive", "with-uuid-1", "with-serde_json-1", "with-chrono-0_4"] }
 regex = "1.6.0"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.86"
 tokio-postgres = { version = "0.7.7", default-features = false }
+tower = "0.4.13"
+tower-http = { version = "0.3.4", features = ["trace"] }
 tracing = "0.1.37"
 tracing-appender = "0.2.2"
 tracing-error = "0.2.0"

--- a/packages/graph/hash_graph/lib/graph/Cargo.toml
+++ b/packages/graph/hash_graph/lib/graph/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 publish = false
 description = "HASH Graph API"
 
-
 [dependencies]
 async-trait = "0.1.57"
 axum = "0.5.16"

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/middleware.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/middleware.rs
@@ -1,0 +1,73 @@
+use axum::{
+    body::{Body, Bytes, HttpBody},
+    http::{Request, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use tracing::{enabled, Level};
+
+// *Heavily* inspired by
+// https://github.com/tokio-rs/axum/blob/main/examples/print-request-response/src/main.rs
+
+/// A development-environment-focused Axum Handler function to buffer the body of requests and
+/// responses and log them. Overhead should be minimal when not in `Level::Trace`
+pub(super) async fn log_request_and_response(
+    request: Request<Body>,
+    next: Next<Body>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let mut request = request;
+    if enabled!(Level::TRACE) {
+        // Destructure the request and pass the stream buffer
+        let (parts, body) = request.into_parts();
+        let bytes = buffer_and_log("request", body, None).await?;
+        request = Request::from_parts(parts, Body::from(bytes));
+    }
+
+    // Run the rest of the layers
+    let response = next.run(request).await;
+
+    if enabled!(Level::TRACE) {
+        // Destructure the response and pass the stream buffer
+        let (parts, body) = response.into_parts();
+        let bytes = buffer_and_log("response", body, Some(parts.status)).await?;
+        let new_response = Response::from_parts(parts, Body::from(bytes));
+        Ok(new_response.into_response())
+    } else {
+        Ok(response)
+    }
+}
+
+async fn buffer_and_log<B>(
+    direction: &str,
+    body: B,
+    status_code: Option<StatusCode>,
+) -> Result<Bytes, (StatusCode, String)>
+where
+    B: HttpBody<Data = Bytes> + Send,
+    B::Error: std::fmt::Display,
+{
+    let bytes = match hyper::body::to_bytes(body).await {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!("failed to read {} body: {}", direction, err),
+            ));
+        }
+    };
+
+    if let Ok(body) = std::str::from_utf8(&bytes) {
+        // would be nice to use `let_guard`s here
+        if let Some(status_code) = status_code {
+            if !(status_code.is_success()) {
+                tracing::error!("{} body = {:?}", direction, body);
+            } else {
+                tracing::trace!("{} body = {:?}", direction, body);
+            }
+        } else {
+            tracing::trace!("{} body = {:?}", direction, body);
+        }
+    }
+
+    Ok(bytes)
+}

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/middleware.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/middleware.rs
@@ -9,7 +9,7 @@ use tracing::{enabled, Level};
 // *Heavily* inspired by
 // https://github.com/tokio-rs/axum/blob/main/examples/print-request-response/src/main.rs
 
-/// A development-environment-focused Axum Handler function to buffer the body of requests and
+/// A development-environment-focused `axum` Handler function to buffer the body of requests and
 /// responses and log them. Overhead should be minimal when not in `Level::Trace`
 pub(super) async fn log_request_and_response(
     request: Request<Body>,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/middleware.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/middleware.rs
@@ -59,10 +59,10 @@ where
     if let Ok(body) = std::str::from_utf8(&bytes) {
         // would be nice to use `let_guard`s here
         if let Some(status_code) = status_code {
-            if !(status_code.is_success()) {
-                tracing::error!("{} body = {:?}", direction, body);
-            } else {
+            if status_code.is_success() {
                 tracing::trace!("{} body = {:?}", direction, body);
+            } else {
+                tracing::error!("{} body = {:?}", direction, body);
             }
         } else {
             tracing::trace!("{} body = {:?}", direction, body);

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
@@ -2,8 +2,10 @@
 //!
 //! Handler methods are grouped by routes that make up the REST API.
 
-mod account;
 mod api_resource;
+mod middleware;
+
+mod account;
 mod data_type;
 mod entity;
 mod entity_type;
@@ -21,6 +23,8 @@ use axum::{
 use error_stack::Report;
 use futures::TryFutureExt;
 use include_dir::{include_dir, Dir};
+use tower::ServiceBuilder;
+use tower_http::trace::TraceLayer;
 use utoipa::{
     openapi::{
         self, schema, schema::RefOr, ArrayBuilder, ObjectBuilder, OneOfBuilder, Ref, SchemaFormat,
@@ -31,6 +35,7 @@ use utoipa::{
 
 use self::api_resource::RoutedResource;
 use crate::{
+    api::rest::middleware::log_request_and_response,
     ontology::domain_validator::DomainValidator,
     store::{crud::Read, QueryError, StorePool},
 };
@@ -113,6 +118,16 @@ pub fn rest_api_router<P: StorePool + Send + 'static>(
     merged_routes
         .layer(Extension(store))
         .layer(Extension(domain_regex))
+        .layer(
+            axum::middleware::from_fn(log_request_and_response)
+        )
+        .layer(
+            ServiceBuilder::new()
+                .layer(
+                    TraceLayer::new_for_http()
+                )
+        )
+        // We don't want any layers or handlers for the api-doc
         .nest(
             "/api-doc",
             Router::new()


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We currently get very little log information for requests. This is especially infuriating in development when searching for bugs identified by the HTTP tests or workspace and we're unable to see which request failed, or why.

This PR adds middleware, so that when in TRACE logging we log much more information.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201095311341924/1203331904553379/f) _(internal)_

## 🔍 What does this change?

- Adds the `TraceLayer` to the OpenAPI services setup, this will ensure that logs happen within tracing spans that can associate things like the route and headers of the request
- Adds custom middleware when in trace logging to log the bodies of HTTP requests/responses

## 📜 Does this require a change to the docs?

- Not currently

## ⚠️ Known issues

- The `remove_link` integration test is currently broken
- The final HTTP test is currently broken

## 🛡 What tests cover this?

No tests explicitly check this functionality, but the existing test suite should continue to behave as normal

## ❓ How to test this?

1.  Checkout the branch and follow instructions to run the graph with trace logging
1.  Make requests (can do this by running HTTP requests)
1.  Look at output

## 📹 Demo

<img width="1798" alt="image" src="https://user-images.githubusercontent.com/25749103/200842140-9db33135-cbae-4fc3-94ff-48f00576c9cc.png">
