### PR TITLE
Rework Graph Element Metadata

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -87,13 +87,7 @@ export interface ArchiveEntityRequest {
    * @type {string}
    * @memberof ArchiveEntityRequest
    */
-  entityUuid: string;
-  /**
-   *
-   * @type {string}
-   * @memberof ArchiveEntityRequest
-   */
-  ownedById: string;
+  entityId: string;
 }
 /**
  *
@@ -308,6 +302,25 @@ export interface DataTypeStructuralQuery {
 /**
  *
  * @export
+ * @interface DataTypeWithMetadata
+ */
+export interface DataTypeWithMetadata {
+  /**
+   *
+   * @type {DataType}
+   * @memberof DataTypeWithMetadata
+   */
+  inner: DataType;
+  /**
+   *
+   * @type {OntologyElementMetadata}
+   * @memberof DataTypeWithMetadata
+   */
+  metadata: OntologyElementMetadata;
+}
+/**
+ *
+ * @export
  * @enum {string}
  */
 
@@ -338,6 +351,81 @@ export interface EdgesValueInner {
    * @memberof EdgesValueInner
    */
   edgeKind: EdgeKind;
+}
+/**
+ * A record of an [`Entity`] that has been persisted in the datastore, with its associated
+ * @export
+ * @interface Entity
+ */
+export interface Entity {
+  /**
+   *
+   * @type {object}
+   * @memberof Entity
+   */
+  inner: object;
+  /**
+   *
+   * @type {EntityMetadata}
+   * @memberof Entity
+   */
+  metadata: EntityMetadata;
+}
+/**
+ *
+ * @export
+ * @interface EntityEditionId
+ */
+export interface EntityEditionId {
+  /**
+   *
+   * @type {string}
+   * @memberof EntityEditionId
+   */
+  baseId: string;
+  /**
+   *
+   * @type {string}
+   * @memberof EntityEditionId
+   */
+  version: string;
+}
+/**
+ * The metadata of an [`Entity`] record.
+ * @export
+ * @interface EntityMetadata
+ */
+export interface EntityMetadata {
+  /**
+   *
+   * @type {boolean}
+   * @memberof EntityMetadata
+   */
+  archived: boolean;
+  /**
+   *
+   * @type {EntityEditionId}
+   * @memberof EntityMetadata
+   */
+  editionId: EntityEditionId;
+  /**
+   *
+   * @type {string}
+   * @memberof EntityMetadata
+   */
+  entityTypeId: string;
+  /**
+   *
+   * @type {LinkEntityMetadata}
+   * @memberof EntityMetadata
+   */
+  linkMetadata?: LinkEntityMetadata;
+  /**
+   *
+   * @type {ProvenanceMetadata}
+   * @memberof EntityMetadata
+   */
+  provenance: ProvenanceMetadata;
 }
 /**
  * A [`Filter`] to query the datastore, recursively resolving according to the
@@ -473,6 +561,25 @@ export interface EntityTypeStructuralQuery {
 /**
  *
  * @export
+ * @interface EntityTypeWithMetadata
+ */
+export interface EntityTypeWithMetadata {
+  /**
+   *
+   * @type {EntityType}
+   * @memberof EntityTypeWithMetadata
+   */
+  inner: EntityType;
+  /**
+   *
+   * @type {OntologyElementMetadata}
+   * @memberof EntityTypeWithMetadata
+   */
+  metadata: OntologyElementMetadata;
+}
+/**
+ *
+ * @export
  * @interface EqualFilter
  */
 export interface EqualFilter {
@@ -544,6 +651,37 @@ export interface GraphResolveDepths {
   propertyTypeResolveDepth: number;
 }
 /**
+ * The associated information for \'Link\' entities
+ * @export
+ * @interface LinkEntityMetadata
+ */
+export interface LinkEntityMetadata {
+  /**
+   *
+   * @type {string}
+   * @memberof LinkEntityMetadata
+   */
+  leftEntityId: string;
+  /**
+   *
+   * @type {number}
+   * @memberof LinkEntityMetadata
+   */
+  leftOrder?: number;
+  /**
+   *
+   * @type {string}
+   * @memberof LinkEntityMetadata
+   */
+  rightEntityId: string;
+  /**
+   *
+   * @type {number}
+   * @memberof LinkEntityMetadata
+   */
+  rightOrder?: number;
+}
+/**
  *
  * @export
  * @interface NotEqualFilter
@@ -568,6 +706,50 @@ export interface NotFilter {
    * @memberof NotFilter
    */
   not: Filter;
+}
+/**
+ *
+ * @export
+ * @interface OntologyElementMetadata
+ */
+export interface OntologyElementMetadata {
+  /**
+   *
+   * @type {OntologyTypeEditionId}
+   * @memberof OntologyElementMetadata
+   */
+  editionId: OntologyTypeEditionId;
+  /**
+   *
+   * @type {string}
+   * @memberof OntologyElementMetadata
+   */
+  ownedById: string;
+  /**
+   *
+   * @type {ProvenanceMetadata}
+   * @memberof OntologyElementMetadata
+   */
+  provenance: ProvenanceMetadata;
+}
+/**
+ *
+ * @export
+ * @interface OntologyTypeEditionId
+ */
+export interface OntologyTypeEditionId {
+  /**
+   *
+   * @type {string}
+   * @memberof OntologyTypeEditionId
+   */
+  baseId: string;
+  /**
+   *
+   * @type {number}
+   * @memberof OntologyTypeEditionId
+   */
+  version: number;
 }
 /**
  *
@@ -620,7 +802,6 @@ export const PathExpressionPathEnum = {
   OwnedById: "ownedById",
   CreatedById: "createdById",
   UpdatedById: "updatedById",
-  RemovedById: "removedById",
   BaseUri: "baseUri",
   VersionedUri: "versionedUri",
   Version: "version",
@@ -628,7 +809,7 @@ export const PathExpressionPathEnum = {
   Title: "title",
   Description: "description",
   Type: "type",
-  Id: "id",
+  Uuid: "uuid",
   Properties: "properties",
   IncomingLinks: "incomingLinks",
   OutgoingLinks: "outgoingLinks",
@@ -647,200 +828,6 @@ export const PathExpressionPathEnum = {
 export type PathExpressionPathEnum =
   typeof PathExpressionPathEnum[keyof typeof PathExpressionPathEnum];
 
-/**
- *
- * @export
- * @interface PersistedDataType
- */
-export interface PersistedDataType {
-  /**
-   *
-   * @type {DataType}
-   * @memberof PersistedDataType
-   */
-  inner: DataType;
-  /**
-   *
-   * @type {PersistedOntologyMetadata}
-   * @memberof PersistedDataType
-   */
-  metadata: PersistedOntologyMetadata;
-}
-/**
- * A record of an [`Entity`] that has been persisted in the datastore, with its associated
- * @export
- * @interface PersistedEntity
- */
-export interface PersistedEntity {
-  /**
-   *
-   * @type {object}
-   * @memberof PersistedEntity
-   */
-  inner: object;
-  /**
-   *
-   * @type {PersistedEntityMetadata}
-   * @memberof PersistedEntity
-   */
-  metadata: PersistedEntityMetadata;
-}
-/**
- * The metadata required to uniquely identify an instance of an [`Entity`] that has been persisted
- * @export
- * @interface PersistedEntityIdentifier
- */
-export interface PersistedEntityIdentifier {
-  /**
-   *
-   * @type {string}
-   * @memberof PersistedEntityIdentifier
-   */
-  entityUuid: string;
-  /**
-   *
-   * @type {string}
-   * @memberof PersistedEntityIdentifier
-   */
-  ownedById: string;
-  /**
-   *
-   * @type {string}
-   * @memberof PersistedEntityIdentifier
-   */
-  version: string;
-}
-/**
- * The metadata of an [`Entity`] record.
- * @export
- * @interface PersistedEntityMetadata
- */
-export interface PersistedEntityMetadata {
-  /**
-   *
-   * @type {boolean}
-   * @memberof PersistedEntityMetadata
-   */
-  archived: boolean;
-  /**
-   *
-   * @type {string}
-   * @memberof PersistedEntityMetadata
-   */
-  createdById: string;
-  /**
-   *
-   * @type {string}
-   * @memberof PersistedEntityMetadata
-   */
-  entityTypeId: string;
-  /**
-   *
-   * @type {PersistedEntityIdentifier}
-   * @memberof PersistedEntityMetadata
-   */
-  identifier: PersistedEntityIdentifier;
-  /**
-   *
-   * @type {LinkEntityMetadata}
-   * @memberof PersistedEntityMetadata
-   */
-  linkMetadata?: LinkEntityMetadata;
-  /**
-   *
-   * @type {string}
-   * @memberof PersistedEntityMetadata
-   */
-  updatedById: string;
-}
-/**
- *
- * @export
- * @interface PersistedEntityType
- */
-export interface PersistedEntityType {
-  /**
-   *
-   * @type {EntityType}
-   * @memberof PersistedEntityType
-   */
-  inner: EntityType;
-  /**
-   *
-   * @type {PersistedOntologyMetadata}
-   * @memberof PersistedEntityType
-   */
-  metadata: PersistedOntologyMetadata;
-}
-/**
- * The metadata required to uniquely identify an ontology element that has been persisted in the
- * @export
- * @interface PersistedOntologyIdentifier
- */
-export interface PersistedOntologyIdentifier {
-  /**
-   *
-   * @type {string}
-   * @memberof PersistedOntologyIdentifier
-   */
-  ownedById: string;
-  /**
-   *
-   * @type {string}
-   * @memberof PersistedOntologyIdentifier
-   */
-  uri: string;
-}
-/**
- *
- * @export
- * @interface PersistedOntologyMetadata
- */
-export interface PersistedOntologyMetadata {
-  /**
-   *
-   * @type {string}
-   * @memberof PersistedOntologyMetadata
-   */
-  createdById: string;
-  /**
-   *
-   * @type {PersistedOntologyIdentifier}
-   * @memberof PersistedOntologyMetadata
-   */
-  identifier: PersistedOntologyIdentifier;
-  /**
-   *
-   * @type {RemovedById}
-   * @memberof PersistedOntologyMetadata
-   */
-  removedById?: RemovedById;
-  /**
-   *
-   * @type {string}
-   * @memberof PersistedOntologyMetadata
-   */
-  updatedById: string;
-}
-/**
- *
- * @export
- * @interface PersistedPropertyType
- */
-export interface PersistedPropertyType {
-  /**
-   *
-   * @type {PropertyType}
-   * @memberof PersistedPropertyType
-   */
-  inner: PropertyType;
-  /**
-   *
-   * @type {PersistedOntologyMetadata}
-   * @memberof PersistedPropertyType
-   */
-  metadata: PersistedOntologyMetadata;
-}
 /**
  *
  * @export
@@ -1043,6 +1030,25 @@ export interface PropertyTypeStructuralQuery {
   graphResolveDepths: GraphResolveDepths;
 }
 /**
+ *
+ * @export
+ * @interface PropertyTypeWithMetadata
+ */
+export interface PropertyTypeWithMetadata {
+  /**
+   *
+   * @type {PropertyType}
+   * @memberof PropertyTypeWithMetadata
+   */
+  inner: PropertyType;
+  /**
+   *
+   * @type {OntologyElementMetadata}
+   * @memberof PropertyTypeWithMetadata
+   */
+  metadata: OntologyElementMetadata;
+}
+/**
  * @type PropertyValues
  * @export
  */
@@ -1060,6 +1066,25 @@ export type PropertyValuesUpdate =
   | PropertyArrayValueUpdate
   | PropertyObjectValue;
 
+/**
+ *
+ * @export
+ * @interface ProvenanceMetadata
+ */
+export interface ProvenanceMetadata {
+  /**
+   *
+   * @type {string}
+   * @memberof ProvenanceMetadata
+   */
+  createdById: string;
+  /**
+   *
+   * @type {string}
+   * @memberof ProvenanceMetadata
+   */
+  updatedById: string;
+}
 /**
  *
  * @export
@@ -1180,13 +1205,13 @@ export interface UpdateEntityRequest {
    * @type {string}
    * @memberof UpdateEntityRequest
    */
-  entityTypeId: string;
+  entityId: string;
   /**
    *
    * @type {string}
    * @memberof UpdateEntityRequest
    */
-  entityUuid: string;
+  entityTypeId: string;
 }
 /**
  * The contents of an Entity Type update request
@@ -1444,10 +1469,10 @@ export interface VertexOneOf1Inner {
   inner: PropertyType;
   /**
    *
-   * @type {PersistedOntologyMetadata}
+   * @type {OntologyElementMetadata}
    * @memberof VertexOneOf1Inner
    */
-  metadata: PersistedOntologyMetadata;
+  metadata: OntologyElementMetadata;
 }
 /**
  *
@@ -1490,10 +1515,10 @@ export interface VertexOneOf2Inner {
   inner: EntityType;
   /**
    *
-   * @type {PersistedOntologyMetadata}
+   * @type {OntologyElementMetadata}
    * @memberof VertexOneOf2Inner
    */
-  metadata: PersistedOntologyMetadata;
+  metadata: OntologyElementMetadata;
 }
 /**
  *
@@ -1536,10 +1561,10 @@ export interface VertexOneOf3Inner {
   inner: object;
   /**
    *
-   * @type {PersistedEntityMetadata}
+   * @type {EntityMetadata}
    * @memberof VertexOneOf3Inner
    */
-  metadata: PersistedEntityMetadata;
+  metadata: EntityMetadata;
 }
 /**
  *
@@ -1555,10 +1580,10 @@ export interface VertexOneOfInner {
   inner: DataType;
   /**
    *
-   * @type {PersistedOntologyMetadata}
+   * @type {OntologyElementMetadata}
    * @memberof VertexOneOfInner
    */
-  metadata: PersistedOntologyMetadata;
+  metadata: OntologyElementMetadata;
 }
 
 /**
@@ -1972,7 +1997,7 @@ export const DataTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyMetadata>
+      ) => AxiosPromise<OntologyElementMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.createDataType(
         createDataTypeRequest,
@@ -1998,7 +2023,7 @@ export const DataTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedDataType>
+      ) => AxiosPromise<DataTypeWithMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getDataType(
         uri,
@@ -2046,7 +2071,7 @@ export const DataTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<PersistedDataType>>
+      ) => AxiosPromise<Array<DataTypeWithMetadata>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getLatestDataTypes(options);
@@ -2070,7 +2095,7 @@ export const DataTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyMetadata>
+      ) => AxiosPromise<OntologyElementMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.updateDataType(
         updateDataTypeRequest,
@@ -2106,7 +2131,7 @@ export const DataTypeApiFactory = function (
     createDataType(
       createDataTypeRequest: CreateDataTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyMetadata> {
+    ): AxiosPromise<OntologyElementMetadata> {
       return localVarFp
         .createDataType(createDataTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -2117,7 +2142,10 @@ export const DataTypeApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getDataType(uri: string, options?: any): AxiosPromise<PersistedDataType> {
+    getDataType(
+      uri: string,
+      options?: any,
+    ): AxiosPromise<DataTypeWithMetadata> {
       return localVarFp
         .getDataType(uri, options)
         .then((request) => request(axios, basePath));
@@ -2141,7 +2169,9 @@ export const DataTypeApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getLatestDataTypes(options?: any): AxiosPromise<Array<PersistedDataType>> {
+    getLatestDataTypes(
+      options?: any,
+    ): AxiosPromise<Array<DataTypeWithMetadata>> {
       return localVarFp
         .getLatestDataTypes(options)
         .then((request) => request(axios, basePath));
@@ -2155,7 +2185,7 @@ export const DataTypeApiFactory = function (
     updateDataType(
       updateDataTypeRequest: UpdateDataTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyMetadata> {
+    ): AxiosPromise<OntologyElementMetadata> {
       return localVarFp
         .updateDataType(updateDataTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -2179,7 +2209,7 @@ export interface DataTypeApiInterface {
   createDataType(
     createDataTypeRequest: CreateDataTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyMetadata>;
+  ): AxiosPromise<OntologyElementMetadata>;
 
   /**
    *
@@ -2191,7 +2221,7 @@ export interface DataTypeApiInterface {
   getDataType(
     uri: string,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedDataType>;
+  ): AxiosPromise<DataTypeWithMetadata>;
 
   /**
    *
@@ -2213,7 +2243,7 @@ export interface DataTypeApiInterface {
    */
   getLatestDataTypes(
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PersistedDataType>>;
+  ): AxiosPromise<Array<DataTypeWithMetadata>>;
 
   /**
    *
@@ -2225,7 +2255,7 @@ export interface DataTypeApiInterface {
   updateDataType(
     updateDataTypeRequest: UpdateDataTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyMetadata>;
+  ): AxiosPromise<OntologyElementMetadata>;
 }
 
 /**
@@ -2425,19 +2455,19 @@ export const EntityApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {string} entityUuid The UUID of the entity
+     * @param {string} entityId The EntityId
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getEntity: async (
-      entityUuid: string,
+      entityId: string,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'entityUuid' is not null or undefined
-      assertParamExists("getEntity", "entityUuid", entityUuid);
-      const localVarPath = `/entities/{entityUuid}`.replace(
-        `{${"entityUuid"}}`,
-        encodeURIComponent(String(entityUuid)),
+      // verify required parameter 'entityId' is not null or undefined
+      assertParamExists("getEntity", "entityId", entityId);
+      const localVarPath = `/entities/{entityId}`.replace(
+        `{${"entityId"}}`,
+        encodeURIComponent(String(entityId)),
       );
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -2579,10 +2609,7 @@ export const EntityApiFp = function (configuration?: Configuration) {
       createEntityRequest: CreateEntityRequest,
       options?: AxiosRequestConfig,
     ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<PersistedEntityMetadata>
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<EntityMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.createEntity(
         createEntityRequest,
@@ -2621,21 +2648,18 @@ export const EntityApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {string} entityUuid The UUID of the entity
+     * @param {string} entityId The EntityId
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getEntity(
-      entityUuid: string,
+      entityId: string,
       options?: AxiosRequestConfig,
     ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<PersistedEntity>
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Entity>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getEntity(
-        entityUuid,
+        entityId,
         options,
       );
       return createRequestFunction(
@@ -2653,10 +2677,7 @@ export const EntityApiFp = function (configuration?: Configuration) {
     async getLatestEntities(
       options?: AxiosRequestConfig,
     ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<Array<PersistedEntity>>
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Entity>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getLatestEntities(options);
@@ -2677,10 +2698,7 @@ export const EntityApiFp = function (configuration?: Configuration) {
       updateEntityRequest: UpdateEntityRequest,
       options?: AxiosRequestConfig,
     ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<PersistedEntityMetadata>
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<EntityMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.updateEntity(
         updateEntityRequest,
@@ -2716,7 +2734,7 @@ export const EntityApiFactory = function (
     createEntity(
       createEntityRequest: CreateEntityRequest,
       options?: any,
-    ): AxiosPromise<PersistedEntityMetadata> {
+    ): AxiosPromise<EntityMetadata> {
       return localVarFp
         .createEntity(createEntityRequest, options)
         .then((request) => request(axios, basePath));
@@ -2737,16 +2755,13 @@ export const EntityApiFactory = function (
     },
     /**
      *
-     * @param {string} entityUuid The UUID of the entity
+     * @param {string} entityId The EntityId
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getEntity(
-      entityUuid: string,
-      options?: any,
-    ): AxiosPromise<PersistedEntity> {
+    getEntity(entityId: string, options?: any): AxiosPromise<Entity> {
       return localVarFp
-        .getEntity(entityUuid, options)
+        .getEntity(entityId, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -2754,7 +2769,7 @@ export const EntityApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getLatestEntities(options?: any): AxiosPromise<Array<PersistedEntity>> {
+    getLatestEntities(options?: any): AxiosPromise<Array<Entity>> {
       return localVarFp
         .getLatestEntities(options)
         .then((request) => request(axios, basePath));
@@ -2768,7 +2783,7 @@ export const EntityApiFactory = function (
     updateEntity(
       updateEntityRequest: UpdateEntityRequest,
       options?: any,
-    ): AxiosPromise<PersistedEntityMetadata> {
+    ): AxiosPromise<EntityMetadata> {
       return localVarFp
         .updateEntity(updateEntityRequest, options)
         .then((request) => request(axios, basePath));
@@ -2792,7 +2807,7 @@ export interface EntityApiInterface {
   createEntity(
     createEntityRequest: CreateEntityRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedEntityMetadata>;
+  ): AxiosPromise<EntityMetadata>;
 
   /**
    *
@@ -2808,15 +2823,15 @@ export interface EntityApiInterface {
 
   /**
    *
-   * @param {string} entityUuid The UUID of the entity
+   * @param {string} entityId The EntityId
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof EntityApiInterface
    */
   getEntity(
-    entityUuid: string,
+    entityId: string,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedEntity>;
+  ): AxiosPromise<Entity>;
 
   /**
    *
@@ -2824,9 +2839,7 @@ export interface EntityApiInterface {
    * @throws {RequiredError}
    * @memberof EntityApiInterface
    */
-  getLatestEntities(
-    options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PersistedEntity>>;
+  getLatestEntities(options?: AxiosRequestConfig): AxiosPromise<Array<Entity>>;
 
   /**
    *
@@ -2838,7 +2851,7 @@ export interface EntityApiInterface {
   updateEntity(
     updateEntityRequest: UpdateEntityRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedEntityMetadata>;
+  ): AxiosPromise<EntityMetadata>;
 }
 
 /**
@@ -2882,14 +2895,14 @@ export class EntityApi extends BaseAPI implements EntityApiInterface {
 
   /**
    *
-   * @param {string} entityUuid The UUID of the entity
+   * @param {string} entityId The EntityId
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof EntityApi
    */
-  public getEntity(entityUuid: string, options?: AxiosRequestConfig) {
+  public getEntity(entityId: string, options?: AxiosRequestConfig) {
     return EntityApiFp(this.configuration)
-      .getEntity(entityUuid, options)
+      .getEntity(entityId, options)
       .then((request) => request(this.axios, this.basePath));
   }
 
@@ -3196,7 +3209,7 @@ export const EntityTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyMetadata>
+      ) => AxiosPromise<OntologyElementMetadata>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.createEntityType(
@@ -3223,7 +3236,7 @@ export const EntityTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedEntityType>
+      ) => AxiosPromise<EntityTypeWithMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getEntityType(
         uri,
@@ -3271,7 +3284,7 @@ export const EntityTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<PersistedEntityType>>
+      ) => AxiosPromise<Array<EntityTypeWithMetadata>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getLatestEntityTypes(options);
@@ -3295,7 +3308,7 @@ export const EntityTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyMetadata>
+      ) => AxiosPromise<OntologyElementMetadata>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.updateEntityType(
@@ -3332,7 +3345,7 @@ export const EntityTypeApiFactory = function (
     createEntityType(
       createEntityTypeRequest: CreateEntityTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyMetadata> {
+    ): AxiosPromise<OntologyElementMetadata> {
       return localVarFp
         .createEntityType(createEntityTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -3346,7 +3359,7 @@ export const EntityTypeApiFactory = function (
     getEntityType(
       uri: string,
       options?: any,
-    ): AxiosPromise<PersistedEntityType> {
+    ): AxiosPromise<EntityTypeWithMetadata> {
       return localVarFp
         .getEntityType(uri, options)
         .then((request) => request(axios, basePath));
@@ -3372,7 +3385,7 @@ export const EntityTypeApiFactory = function (
      */
     getLatestEntityTypes(
       options?: any,
-    ): AxiosPromise<Array<PersistedEntityType>> {
+    ): AxiosPromise<Array<EntityTypeWithMetadata>> {
       return localVarFp
         .getLatestEntityTypes(options)
         .then((request) => request(axios, basePath));
@@ -3386,7 +3399,7 @@ export const EntityTypeApiFactory = function (
     updateEntityType(
       updateEntityTypeRequest: UpdateEntityTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyMetadata> {
+    ): AxiosPromise<OntologyElementMetadata> {
       return localVarFp
         .updateEntityType(updateEntityTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -3410,7 +3423,7 @@ export interface EntityTypeApiInterface {
   createEntityType(
     createEntityTypeRequest: CreateEntityTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyMetadata>;
+  ): AxiosPromise<OntologyElementMetadata>;
 
   /**
    *
@@ -3422,7 +3435,7 @@ export interface EntityTypeApiInterface {
   getEntityType(
     uri: string,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedEntityType>;
+  ): AxiosPromise<EntityTypeWithMetadata>;
 
   /**
    *
@@ -3444,7 +3457,7 @@ export interface EntityTypeApiInterface {
    */
   getLatestEntityTypes(
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PersistedEntityType>>;
+  ): AxiosPromise<Array<EntityTypeWithMetadata>>;
 
   /**
    *
@@ -3456,7 +3469,7 @@ export interface EntityTypeApiInterface {
   updateEntityType(
     updateEntityTypeRequest: UpdateEntityTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyMetadata>;
+  ): AxiosPromise<OntologyElementMetadata>;
 }
 
 /**
@@ -3951,19 +3964,19 @@ export const GraphApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {string} entityUuid The UUID of the entity
+     * @param {string} entityId The EntityId
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getEntity: async (
-      entityUuid: string,
+      entityId: string,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'entityUuid' is not null or undefined
-      assertParamExists("getEntity", "entityUuid", entityUuid);
-      const localVarPath = `/entities/{entityUuid}`.replace(
-        `{${"entityUuid"}}`,
-        encodeURIComponent(String(entityUuid)),
+      // verify required parameter 'entityId' is not null or undefined
+      assertParamExists("getEntity", "entityId", entityId);
+      const localVarPath = `/entities/{entityId}`.replace(
+        `{${"entityId"}}`,
+        encodeURIComponent(String(entityId)),
       );
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -4597,7 +4610,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyMetadata>
+      ) => AxiosPromise<OntologyElementMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.createDataType(
         createDataTypeRequest,
@@ -4620,10 +4633,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       createEntityRequest: CreateEntityRequest,
       options?: AxiosRequestConfig,
     ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<PersistedEntityMetadata>
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<EntityMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.createEntity(
         createEntityRequest,
@@ -4649,7 +4659,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyMetadata>
+      ) => AxiosPromise<OntologyElementMetadata>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.createEntityType(
@@ -4676,7 +4686,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyMetadata>
+      ) => AxiosPromise<OntologyElementMetadata>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.createPropertyType(
@@ -4703,7 +4713,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedDataType>
+      ) => AxiosPromise<DataTypeWithMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getDataType(
         uri,
@@ -4766,21 +4776,18 @@ export const GraphApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {string} entityUuid The UUID of the entity
+     * @param {string} entityId The EntityId
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getEntity(
-      entityUuid: string,
+      entityId: string,
       options?: AxiosRequestConfig,
     ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<PersistedEntity>
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Entity>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getEntity(
-        entityUuid,
+        entityId,
         options,
       );
       return createRequestFunction(
@@ -4803,7 +4810,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedEntityType>
+      ) => AxiosPromise<EntityTypeWithMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getEntityType(
         uri,
@@ -4851,7 +4858,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<PersistedDataType>>
+      ) => AxiosPromise<Array<DataTypeWithMetadata>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getLatestDataTypes(options);
@@ -4870,10 +4877,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
     async getLatestEntities(
       options?: AxiosRequestConfig,
     ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<Array<PersistedEntity>>
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Entity>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getLatestEntities(options);
@@ -4895,7 +4899,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<PersistedEntityType>>
+      ) => AxiosPromise<Array<EntityTypeWithMetadata>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getLatestEntityTypes(options);
@@ -4917,7 +4921,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<PersistedPropertyType>>
+      ) => AxiosPromise<Array<PropertyTypeWithMetadata>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getLatestPropertyTypes(options);
@@ -4941,7 +4945,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedPropertyType>
+      ) => AxiosPromise<PropertyTypeWithMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getPropertyType(
         uri,
@@ -4991,7 +4995,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyMetadata>
+      ) => AxiosPromise<OntologyElementMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.updateDataType(
         updateDataTypeRequest,
@@ -5014,10 +5018,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       updateEntityRequest: UpdateEntityRequest,
       options?: AxiosRequestConfig,
     ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<PersistedEntityMetadata>
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<EntityMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.updateEntity(
         updateEntityRequest,
@@ -5043,7 +5044,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyMetadata>
+      ) => AxiosPromise<OntologyElementMetadata>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.updateEntityType(
@@ -5070,7 +5071,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyMetadata>
+      ) => AxiosPromise<OntologyElementMetadata>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.updatePropertyType(
@@ -5117,7 +5118,7 @@ export const GraphApiFactory = function (
     createDataType(
       createDataTypeRequest: CreateDataTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyMetadata> {
+    ): AxiosPromise<OntologyElementMetadata> {
       return localVarFp
         .createDataType(createDataTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -5131,7 +5132,7 @@ export const GraphApiFactory = function (
     createEntity(
       createEntityRequest: CreateEntityRequest,
       options?: any,
-    ): AxiosPromise<PersistedEntityMetadata> {
+    ): AxiosPromise<EntityMetadata> {
       return localVarFp
         .createEntity(createEntityRequest, options)
         .then((request) => request(axios, basePath));
@@ -5145,7 +5146,7 @@ export const GraphApiFactory = function (
     createEntityType(
       createEntityTypeRequest: CreateEntityTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyMetadata> {
+    ): AxiosPromise<OntologyElementMetadata> {
       return localVarFp
         .createEntityType(createEntityTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -5159,7 +5160,7 @@ export const GraphApiFactory = function (
     createPropertyType(
       createPropertyTypeRequest: CreatePropertyTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyMetadata> {
+    ): AxiosPromise<OntologyElementMetadata> {
       return localVarFp
         .createPropertyType(createPropertyTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -5170,7 +5171,10 @@ export const GraphApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getDataType(uri: string, options?: any): AxiosPromise<PersistedDataType> {
+    getDataType(
+      uri: string,
+      options?: any,
+    ): AxiosPromise<DataTypeWithMetadata> {
       return localVarFp
         .getDataType(uri, options)
         .then((request) => request(axios, basePath));
@@ -5205,16 +5209,13 @@ export const GraphApiFactory = function (
     },
     /**
      *
-     * @param {string} entityUuid The UUID of the entity
+     * @param {string} entityId The EntityId
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getEntity(
-      entityUuid: string,
-      options?: any,
-    ): AxiosPromise<PersistedEntity> {
+    getEntity(entityId: string, options?: any): AxiosPromise<Entity> {
       return localVarFp
-        .getEntity(entityUuid, options)
+        .getEntity(entityId, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -5226,7 +5227,7 @@ export const GraphApiFactory = function (
     getEntityType(
       uri: string,
       options?: any,
-    ): AxiosPromise<PersistedEntityType> {
+    ): AxiosPromise<EntityTypeWithMetadata> {
       return localVarFp
         .getEntityType(uri, options)
         .then((request) => request(axios, basePath));
@@ -5250,7 +5251,9 @@ export const GraphApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getLatestDataTypes(options?: any): AxiosPromise<Array<PersistedDataType>> {
+    getLatestDataTypes(
+      options?: any,
+    ): AxiosPromise<Array<DataTypeWithMetadata>> {
       return localVarFp
         .getLatestDataTypes(options)
         .then((request) => request(axios, basePath));
@@ -5260,7 +5263,7 @@ export const GraphApiFactory = function (
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getLatestEntities(options?: any): AxiosPromise<Array<PersistedEntity>> {
+    getLatestEntities(options?: any): AxiosPromise<Array<Entity>> {
       return localVarFp
         .getLatestEntities(options)
         .then((request) => request(axios, basePath));
@@ -5272,7 +5275,7 @@ export const GraphApiFactory = function (
      */
     getLatestEntityTypes(
       options?: any,
-    ): AxiosPromise<Array<PersistedEntityType>> {
+    ): AxiosPromise<Array<EntityTypeWithMetadata>> {
       return localVarFp
         .getLatestEntityTypes(options)
         .then((request) => request(axios, basePath));
@@ -5284,7 +5287,7 @@ export const GraphApiFactory = function (
      */
     getLatestPropertyTypes(
       options?: any,
-    ): AxiosPromise<Array<PersistedPropertyType>> {
+    ): AxiosPromise<Array<PropertyTypeWithMetadata>> {
       return localVarFp
         .getLatestPropertyTypes(options)
         .then((request) => request(axios, basePath));
@@ -5298,7 +5301,7 @@ export const GraphApiFactory = function (
     getPropertyType(
       uri: string,
       options?: any,
-    ): AxiosPromise<PersistedPropertyType> {
+    ): AxiosPromise<PropertyTypeWithMetadata> {
       return localVarFp
         .getPropertyType(uri, options)
         .then((request) => request(axios, basePath));
@@ -5326,7 +5329,7 @@ export const GraphApiFactory = function (
     updateDataType(
       updateDataTypeRequest: UpdateDataTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyMetadata> {
+    ): AxiosPromise<OntologyElementMetadata> {
       return localVarFp
         .updateDataType(updateDataTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -5340,7 +5343,7 @@ export const GraphApiFactory = function (
     updateEntity(
       updateEntityRequest: UpdateEntityRequest,
       options?: any,
-    ): AxiosPromise<PersistedEntityMetadata> {
+    ): AxiosPromise<EntityMetadata> {
       return localVarFp
         .updateEntity(updateEntityRequest, options)
         .then((request) => request(axios, basePath));
@@ -5354,7 +5357,7 @@ export const GraphApiFactory = function (
     updateEntityType(
       updateEntityTypeRequest: UpdateEntityTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyMetadata> {
+    ): AxiosPromise<OntologyElementMetadata> {
       return localVarFp
         .updateEntityType(updateEntityTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -5368,7 +5371,7 @@ export const GraphApiFactory = function (
     updatePropertyType(
       updatePropertyTypeRequest: UpdatePropertyTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyMetadata> {
+    ): AxiosPromise<OntologyElementMetadata> {
       return localVarFp
         .updatePropertyType(updatePropertyTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -5400,7 +5403,7 @@ export interface GraphApiInterface {
   createDataType(
     createDataTypeRequest: CreateDataTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyMetadata>;
+  ): AxiosPromise<OntologyElementMetadata>;
 
   /**
    *
@@ -5412,7 +5415,7 @@ export interface GraphApiInterface {
   createEntity(
     createEntityRequest: CreateEntityRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedEntityMetadata>;
+  ): AxiosPromise<EntityMetadata>;
 
   /**
    *
@@ -5424,7 +5427,7 @@ export interface GraphApiInterface {
   createEntityType(
     createEntityTypeRequest: CreateEntityTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyMetadata>;
+  ): AxiosPromise<OntologyElementMetadata>;
 
   /**
    *
@@ -5436,7 +5439,7 @@ export interface GraphApiInterface {
   createPropertyType(
     createPropertyTypeRequest: CreatePropertyTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyMetadata>;
+  ): AxiosPromise<OntologyElementMetadata>;
 
   /**
    *
@@ -5448,7 +5451,7 @@ export interface GraphApiInterface {
   getDataType(
     uri: string,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedDataType>;
+  ): AxiosPromise<DataTypeWithMetadata>;
 
   /**
    *
@@ -5476,15 +5479,15 @@ export interface GraphApiInterface {
 
   /**
    *
-   * @param {string} entityUuid The UUID of the entity
+   * @param {string} entityId The EntityId
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof GraphApiInterface
    */
   getEntity(
-    entityUuid: string,
+    entityId: string,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedEntity>;
+  ): AxiosPromise<Entity>;
 
   /**
    *
@@ -5496,7 +5499,7 @@ export interface GraphApiInterface {
   getEntityType(
     uri: string,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedEntityType>;
+  ): AxiosPromise<EntityTypeWithMetadata>;
 
   /**
    *
@@ -5518,7 +5521,7 @@ export interface GraphApiInterface {
    */
   getLatestDataTypes(
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PersistedDataType>>;
+  ): AxiosPromise<Array<DataTypeWithMetadata>>;
 
   /**
    *
@@ -5526,9 +5529,7 @@ export interface GraphApiInterface {
    * @throws {RequiredError}
    * @memberof GraphApiInterface
    */
-  getLatestEntities(
-    options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PersistedEntity>>;
+  getLatestEntities(options?: AxiosRequestConfig): AxiosPromise<Array<Entity>>;
 
   /**
    *
@@ -5538,7 +5539,7 @@ export interface GraphApiInterface {
    */
   getLatestEntityTypes(
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PersistedEntityType>>;
+  ): AxiosPromise<Array<EntityTypeWithMetadata>>;
 
   /**
    *
@@ -5548,7 +5549,7 @@ export interface GraphApiInterface {
    */
   getLatestPropertyTypes(
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PersistedPropertyType>>;
+  ): AxiosPromise<Array<PropertyTypeWithMetadata>>;
 
   /**
    *
@@ -5560,7 +5561,7 @@ export interface GraphApiInterface {
   getPropertyType(
     uri: string,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedPropertyType>;
+  ): AxiosPromise<PropertyTypeWithMetadata>;
 
   /**
    *
@@ -5584,7 +5585,7 @@ export interface GraphApiInterface {
   updateDataType(
     updateDataTypeRequest: UpdateDataTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyMetadata>;
+  ): AxiosPromise<OntologyElementMetadata>;
 
   /**
    *
@@ -5596,7 +5597,7 @@ export interface GraphApiInterface {
   updateEntity(
     updateEntityRequest: UpdateEntityRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedEntityMetadata>;
+  ): AxiosPromise<EntityMetadata>;
 
   /**
    *
@@ -5608,7 +5609,7 @@ export interface GraphApiInterface {
   updateEntityType(
     updateEntityTypeRequest: UpdateEntityTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyMetadata>;
+  ): AxiosPromise<OntologyElementMetadata>;
 
   /**
    *
@@ -5620,7 +5621,7 @@ export interface GraphApiInterface {
   updatePropertyType(
     updatePropertyTypeRequest: UpdatePropertyTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyMetadata>;
+  ): AxiosPromise<OntologyElementMetadata>;
 }
 
 /**
@@ -5753,14 +5754,14 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
 
   /**
    *
-   * @param {string} entityUuid The UUID of the entity
+   * @param {string} entityId The EntityId
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof GraphApi
    */
-  public getEntity(entityUuid: string, options?: AxiosRequestConfig) {
+  public getEntity(entityId: string, options?: AxiosRequestConfig) {
     return GraphApiFp(this.configuration)
-      .getEntity(entityUuid, options)
+      .getEntity(entityId, options)
       .then((request) => request(this.axios, this.basePath));
   }
 
@@ -6209,7 +6210,7 @@ export const PropertyTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyMetadata>
+      ) => AxiosPromise<OntologyElementMetadata>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.createPropertyType(
@@ -6234,7 +6235,7 @@ export const PropertyTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<Array<PersistedPropertyType>>
+      ) => AxiosPromise<Array<PropertyTypeWithMetadata>>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.getLatestPropertyTypes(options);
@@ -6258,7 +6259,7 @@ export const PropertyTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedPropertyType>
+      ) => AxiosPromise<PropertyTypeWithMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getPropertyType(
         uri,
@@ -6308,7 +6309,7 @@ export const PropertyTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PersistedOntologyMetadata>
+      ) => AxiosPromise<OntologyElementMetadata>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.updatePropertyType(
@@ -6345,7 +6346,7 @@ export const PropertyTypeApiFactory = function (
     createPropertyType(
       createPropertyTypeRequest: CreatePropertyTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyMetadata> {
+    ): AxiosPromise<OntologyElementMetadata> {
       return localVarFp
         .createPropertyType(createPropertyTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -6357,7 +6358,7 @@ export const PropertyTypeApiFactory = function (
      */
     getLatestPropertyTypes(
       options?: any,
-    ): AxiosPromise<Array<PersistedPropertyType>> {
+    ): AxiosPromise<Array<PropertyTypeWithMetadata>> {
       return localVarFp
         .getLatestPropertyTypes(options)
         .then((request) => request(axios, basePath));
@@ -6371,7 +6372,7 @@ export const PropertyTypeApiFactory = function (
     getPropertyType(
       uri: string,
       options?: any,
-    ): AxiosPromise<PersistedPropertyType> {
+    ): AxiosPromise<PropertyTypeWithMetadata> {
       return localVarFp
         .getPropertyType(uri, options)
         .then((request) => request(axios, basePath));
@@ -6399,7 +6400,7 @@ export const PropertyTypeApiFactory = function (
     updatePropertyType(
       updatePropertyTypeRequest: UpdatePropertyTypeRequest,
       options?: any,
-    ): AxiosPromise<PersistedOntologyMetadata> {
+    ): AxiosPromise<OntologyElementMetadata> {
       return localVarFp
         .updatePropertyType(updatePropertyTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -6423,7 +6424,7 @@ export interface PropertyTypeApiInterface {
   createPropertyType(
     createPropertyTypeRequest: CreatePropertyTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyMetadata>;
+  ): AxiosPromise<OntologyElementMetadata>;
 
   /**
    *
@@ -6433,7 +6434,7 @@ export interface PropertyTypeApiInterface {
    */
   getLatestPropertyTypes(
     options?: AxiosRequestConfig,
-  ): AxiosPromise<Array<PersistedPropertyType>>;
+  ): AxiosPromise<Array<PropertyTypeWithMetadata>>;
 
   /**
    *
@@ -6445,7 +6446,7 @@ export interface PropertyTypeApiInterface {
   getPropertyType(
     uri: string,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedPropertyType>;
+  ): AxiosPromise<PropertyTypeWithMetadata>;
 
   /**
    *
@@ -6469,7 +6470,7 @@ export interface PropertyTypeApiInterface {
   updatePropertyType(
     updatePropertyTypeRequest: UpdatePropertyTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<PersistedOntologyMetadata>;
+  ): AxiosPromise<OntologyElementMetadata>;
 }
 
 /**

--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -341,10 +341,10 @@ export type EdgeKind = typeof EdgeKind[keyof typeof EdgeKind];
 export interface EdgesValueInner {
   /**
    *
-   * @type {GraphElementIdentifier}
+   * @type {GraphElementId}
    * @memberof EdgesValueInner
    */
-  destination: GraphElementIdentifier;
+  destination: GraphElementId;
   /**
    *
    * @type {EdgeKind}
@@ -608,10 +608,10 @@ export type Filter =
 export type FilterExpression = ParameterExpression | PathExpression;
 
 /**
- * @type GraphElementIdentifier
+ * @type GraphElementId
  * @export
  */
-export type GraphElementIdentifier = string;
+export type GraphElementId = string;
 
 /**
  *
@@ -759,10 +759,10 @@ export interface OntologyTypeEditionId {
 export interface OutwardEdge {
   /**
    *
-   * @type {GraphElementIdentifier}
+   * @type {GraphElementId}
    * @memberof OutwardEdge
    */
-  destination: GraphElementIdentifier;
+  destination: GraphElementId;
   /**
    *
    * @type {EdgeKind}
@@ -1105,10 +1105,10 @@ export interface Subgraph {
   edges: { [key: string]: Array<EdgesValueInner> };
   /**
    *
-   * @type {Array<GraphElementIdentifier>}
+   * @type {Array<GraphElementId>}
    * @memberof Subgraph
    */
-  roots: Array<GraphElementIdentifier>;
+  roots: Array<GraphElementId>;
   /**
    *
    * @type {{ [key: string]: Vertex; }}

--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -307,16 +307,16 @@ export interface DataTypeStructuralQuery {
 export interface DataTypeWithMetadata {
   /**
    *
-   * @type {DataType}
-   * @memberof DataTypeWithMetadata
-   */
-  inner: DataType;
-  /**
-   *
    * @type {OntologyElementMetadata}
    * @memberof DataTypeWithMetadata
    */
   metadata: OntologyElementMetadata;
+  /**
+   *
+   * @type {DataType}
+   * @memberof DataTypeWithMetadata
+   */
+  schema: DataType;
 }
 /**
  *
@@ -360,16 +360,16 @@ export interface EdgesValueInner {
 export interface Entity {
   /**
    *
-   * @type {object}
-   * @memberof Entity
-   */
-  inner: object;
-  /**
-   *
    * @type {EntityMetadata}
    * @memberof Entity
    */
   metadata: EntityMetadata;
+  /**
+   *
+   * @type {object}
+   * @memberof Entity
+   */
+  properties: object;
 }
 /**
  *
@@ -566,16 +566,16 @@ export interface EntityTypeStructuralQuery {
 export interface EntityTypeWithMetadata {
   /**
    *
-   * @type {EntityType}
-   * @memberof EntityTypeWithMetadata
-   */
-  inner: EntityType;
-  /**
-   *
    * @type {OntologyElementMetadata}
    * @memberof EntityTypeWithMetadata
    */
   metadata: OntologyElementMetadata;
+  /**
+   *
+   * @type {EntityType}
+   * @memberof EntityTypeWithMetadata
+   */
+  schema: EntityType;
 }
 /**
  *
@@ -1037,16 +1037,16 @@ export interface PropertyTypeStructuralQuery {
 export interface PropertyTypeWithMetadata {
   /**
    *
-   * @type {PropertyType}
-   * @memberof PropertyTypeWithMetadata
-   */
-  inner: PropertyType;
-  /**
-   *
    * @type {OntologyElementMetadata}
    * @memberof PropertyTypeWithMetadata
    */
   metadata: OntologyElementMetadata;
+  /**
+   *
+   * @type {PropertyType}
+   * @memberof PropertyTypeWithMetadata
+   */
+  schema: PropertyType;
 }
 /**
  * @type PropertyValues
@@ -1463,16 +1463,16 @@ export type VertexOneOf1KindEnum =
 export interface VertexOneOf1Inner {
   /**
    *
-   * @type {PropertyType}
-   * @memberof VertexOneOf1Inner
-   */
-  inner: PropertyType;
-  /**
-   *
    * @type {OntologyElementMetadata}
    * @memberof VertexOneOf1Inner
    */
   metadata: OntologyElementMetadata;
+  /**
+   *
+   * @type {PropertyType}
+   * @memberof VertexOneOf1Inner
+   */
+  schema: PropertyType;
 }
 /**
  *
@@ -1509,16 +1509,16 @@ export type VertexOneOf2KindEnum =
 export interface VertexOneOf2Inner {
   /**
    *
-   * @type {EntityType}
-   * @memberof VertexOneOf2Inner
-   */
-  inner: EntityType;
-  /**
-   *
    * @type {OntologyElementMetadata}
    * @memberof VertexOneOf2Inner
    */
   metadata: OntologyElementMetadata;
+  /**
+   *
+   * @type {EntityType}
+   * @memberof VertexOneOf2Inner
+   */
+  schema: EntityType;
 }
 /**
  *
@@ -1555,16 +1555,16 @@ export type VertexOneOf3KindEnum =
 export interface VertexOneOf3Inner {
   /**
    *
-   * @type {object}
-   * @memberof VertexOneOf3Inner
-   */
-  inner: object;
-  /**
-   *
    * @type {EntityMetadata}
    * @memberof VertexOneOf3Inner
    */
   metadata: EntityMetadata;
+  /**
+   *
+   * @type {object}
+   * @memberof VertexOneOf3Inner
+   */
+  properties: object;
 }
 /**
  *
@@ -1574,16 +1574,16 @@ export interface VertexOneOf3Inner {
 export interface VertexOneOfInner {
   /**
    *
-   * @type {DataType}
-   * @memberof VertexOneOfInner
-   */
-  inner: DataType;
-  /**
-   *
    * @type {OntologyElementMetadata}
    * @memberof VertexOneOfInner
    */
   metadata: OntologyElementMetadata;
+  /**
+   *
+   * @type {DataType}
+   * @memberof VertexOneOfInner
+   */
+  schema: DataType;
 }
 
 /**

--- a/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
@@ -3,7 +3,7 @@ use std::{iter::repeat, str::FromStr};
 use criterion::{BatchSize::SmallInput, Bencher, BenchmarkId, Criterion};
 use criterion_macro::criterion;
 use graph::{
-    knowledge::{Entity, EntityUuid},
+    knowledge::{EntityProperties, EntityUuid},
     provenance::{CreatedById, OwnedById},
     shared::identifier::account::AccountId,
     store::{query::Filter, AccountStore, AsClient, EntityStore, PostgresStore},
@@ -54,7 +54,8 @@ async fn seed_db(
     )
     .await;
 
-    let entity: Entity = serde_json::from_str(entity::BOOK_V1).expect("could not parse entity");
+    let entity: EntityProperties =
+        serde_json::from_str(entity::BOOK_V1).expect("could not parse entity");
     let entity_type_id = EntityType::from_str(entity_type::BOOK_V1)
         .expect("could not parse entity type")
         .id()

--- a/packages/graph/hash_graph/bench/benches/representative_read/seed.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/seed.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use graph::{
-    knowledge::{Entity, EntityUuid},
+    knowledge::{EntityProperties, EntityUuid},
     provenance::{CreatedById, OwnedById},
     shared::identifier::account::AccountId,
     store::{AccountStore, AsClient, EntityStore, PostgresStore},
@@ -119,7 +119,8 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
 
     let mut total_entities = 0;
     for (entity_type_str, entity_str, quantity) in SEED_ENTITIES {
-        let entity: Entity = serde_json::from_str(entity_str).expect("could not parse entity");
+        let entity: EntityProperties =
+            serde_json::from_str(entity_str).expect("could not parse entity");
         let entity_type_id = EntityType::from_str(entity_type_str)
             .expect("could not parse entity type")
             .id()

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -17,10 +17,10 @@ use utoipa::{OpenApi, ToSchema};
 use super::api_resource::RoutedResource;
 use crate::{
     api::rest::{read_from_store, report_to_status_code},
+    identifier::ontology::OntologyTypeEditionId,
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
         patch_id_and_parse, DataTypeWithMetadata, OntologyElementMetadata,
-        PersistedOntologyIdentifier,
     },
     provenance::{CreatedById, OwnedById, UpdatedById},
     shared::identifier::GraphElementIdentifier,
@@ -47,7 +47,7 @@ use crate::{
             OwnedById,
             CreatedById,
             UpdatedById,
-            PersistedOntologyIdentifier,
+            OntologyTypeEditionId,
             OntologyElementMetadata,
             DataTypeWithMetadata,
             DataTypeStructuralQuery,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -19,7 +19,7 @@ use crate::{
     api::rest::{read_from_store, report_to_status_code},
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
-        patch_id_and_parse, PersistedDataType, PersistedOntologyIdentifier,
+        patch_id_and_parse, DataTypeWithMetadata, PersistedOntologyIdentifier,
         PersistedOntologyMetadata,
     },
     provenance::{CreatedById, OwnedById, UpdatedById},
@@ -49,7 +49,7 @@ use crate::{
             UpdatedById,
             PersistedOntologyIdentifier,
             PersistedOntologyMetadata,
-            PersistedDataType,
+            DataTypeWithMetadata,
             DataTypeStructuralQuery,
             GraphElementIdentifier,
             Vertex,
@@ -197,14 +197,14 @@ async fn get_data_types_by_query<P: StorePool + Send>(
     path = "/data-types",
     tag = "DataType",
     responses(
-        (status = 200, content_type = "application/json", description = "List of all data types at their latest versions", body = [PersistedDataType]),
+        (status = 200, content_type = "application/json", description = "List of all data types at their latest versions", body = [DataTypeWithMetadata]),
 
         (status = 500, description = "Store error occurred"),
     )
 )]
 async fn get_latest_data_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
-) -> Result<Json<Vec<PersistedDataType>>, StatusCode> {
+) -> Result<Json<Vec<DataTypeWithMetadata>>, StatusCode> {
     read_from_store(pool.as_ref(), &Filter::<DataType>::for_latest_version())
         .await
         .map(Json)
@@ -215,7 +215,7 @@ async fn get_latest_data_types<P: StorePool + Send>(
     path = "/data-types/{uri}",
     tag = "DataType",
     responses(
-        (status = 200, content_type = "application/json", description = "The schema of the requested data type", body = PersistedDataType),
+        (status = 200, content_type = "application/json", description = "The schema of the requested data type", body = DataTypeWithMetadata),
         (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 404, description = "Data type was not found"),
@@ -228,7 +228,7 @@ async fn get_latest_data_types<P: StorePool + Send>(
 async fn get_data_type<P: StorePool + Send>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<PersistedDataType>, StatusCode> {
+) -> Result<Json<DataTypeWithMetadata>, StatusCode> {
     read_from_store(
         pool.as_ref(),
         &Filter::<DataType>::for_versioned_uri(&uri.0),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -23,7 +23,7 @@ use crate::{
         patch_id_and_parse, DataTypeWithMetadata, OntologyElementMetadata,
     },
     provenance::{CreatedById, OwnedById, UpdatedById},
-    shared::identifier::GraphElementIdentifier,
+    shared::identifier::GraphElementId,
     store::{query::Filter, BaseUriAlreadyExists, BaseUriDoesNotExist, DataTypeStore, StorePool},
     subgraph::{
         DataTypeStructuralQuery, EdgeKind, Edges, GraphResolveDepths, OutwardEdge, StructuralQuery,
@@ -51,7 +51,7 @@ use crate::{
             OntologyElementMetadata,
             DataTypeWithMetadata,
             DataTypeStructuralQuery,
-            GraphElementIdentifier,
+            GraphElementId,
             Vertex,
             EdgeKind,
             OutwardEdge,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -19,8 +19,8 @@ use crate::{
     api::rest::{read_from_store, report_to_status_code},
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
-        patch_id_and_parse, DataTypeWithMetadata, PersistedOntologyIdentifier,
-        PersistedOntologyMetadata,
+        patch_id_and_parse, DataTypeWithMetadata, OntologyElementMetadata,
+        PersistedOntologyIdentifier,
     },
     provenance::{CreatedById, OwnedById, UpdatedById},
     shared::identifier::GraphElementIdentifier,
@@ -48,7 +48,7 @@ use crate::{
             CreatedById,
             UpdatedById,
             PersistedOntologyIdentifier,
-            PersistedOntologyMetadata,
+            OntologyElementMetadata,
             DataTypeWithMetadata,
             DataTypeStructuralQuery,
             GraphElementIdentifier,
@@ -100,7 +100,7 @@ struct CreateDataTypeRequest {
     request_body = CreateDataTypeRequest,
     tag = "DataType",
     responses(
-        (status = 201, content_type = "application/json", description = "The metadata of the created data type", body = PersistedOntologyMetadata),
+        (status = 201, content_type = "application/json", description = "The metadata of the created data type", body = OntologyElementMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 409, description = "Unable to create data type in the store as the base data type URI already exists"),
@@ -112,7 +112,7 @@ async fn create_data_type<P: StorePool + Send>(
     body: Json<CreateDataTypeRequest>,
     pool: Extension<Arc<P>>,
     domain_validator: Extension<DomainValidator>,
-) -> Result<Json<PersistedOntologyMetadata>, StatusCode> {
+) -> Result<Json<OntologyElementMetadata>, StatusCode> {
     let Json(CreateDataTypeRequest {
         schema,
         owned_by_id,
@@ -253,7 +253,7 @@ struct UpdateDataTypeRequest {
     path = "/data-types",
     tag = "DataType",
     responses(
-        (status = 200, content_type = "application/json", description = "The metadata of the updated data type", body = PersistedOntologyMetadata),
+        (status = 200, content_type = "application/json", description = "The metadata of the updated data type", body = OntologyElementMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Base data type ID was not found"),
@@ -264,7 +264,7 @@ struct UpdateDataTypeRequest {
 async fn update_data_type<P: StorePool + Send>(
     body: Json<UpdateDataTypeRequest>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<PersistedOntologyMetadata>, StatusCode> {
+) -> Result<Json<OntologyElementMetadata>, StatusCode> {
     let Json(UpdateDataTypeRequest {
         schema,
         type_to_update,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -276,7 +276,7 @@ async fn get_latest_entities<P: StorePool + Send>(
         (status = 500, description = "Store error occurred"),
     ),
     params(
-        ("entityUuid" = Uuid, Path, description = "The UUID of the entity"),
+        ("entityId" = EntityId, Path, description = "The EntityId"),
     )
 )]
 async fn get_entity<P: StorePool + Send>(

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -21,7 +21,7 @@ use crate::{
     provenance::{CreatedById, OwnedById, ProvenanceMetadata, UpdatedById},
     shared::identifier::{
         knowledge::{EntityEditionId, EntityId, EntityVersion},
-        GraphElementIdentifier,
+        GraphElementId,
     },
     store::{
         error::{EntityDoesNotExist, QueryError},
@@ -62,7 +62,7 @@ use crate::{
             LinkEntityMetadata,
             LinkOrder,
             ProvenanceMetadata,
-            GraphElementIdentifier,
+            GraphElementId,
             Vertex,
             EdgeKind,
             OutwardEdge,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -15,9 +15,7 @@ use utoipa::{OpenApi, ToSchema};
 
 use crate::{
     api::rest::{api_resource::RoutedResource, read_from_store, report_to_status_code},
-    knowledge::{
-        EntityProperties, EntityUuid, LinkEntityMetadata, PersistedEntity, PersistedEntityMetadata,
-    },
+    knowledge::{Entity, EntityMetadata, EntityProperties, EntityUuid, LinkEntityMetadata},
     provenance::{CreatedById, OwnedById, UpdatedById},
     shared::identifier::{
         knowledge::{EntityEditionId, EntityId},
@@ -54,9 +52,9 @@ use crate::{
             EntityUuid,
             EntityId,
             EntityEditionId,
-            PersistedEntityMetadata,
-            PersistedEntity,
+            EntityMetadata,
             Entity,
+            EntityProperties,
             EntityStructuralQuery,
             GraphElementIdentifier,
             Vertex,
@@ -114,7 +112,7 @@ struct CreateEntityRequest {
     request_body = CreateEntityRequest,
     tag = "Entity",
     responses(
-        (status = 201, content_type = "application/json", description = "The metadata of the created entity", body = PersistedEntityMetadata),
+        (status = 201, content_type = "application/json", description = "The metadata of the created entity", body = EntityMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Entity Type URI was not found"),
@@ -124,7 +122,7 @@ struct CreateEntityRequest {
 async fn create_entity<P: StorePool + Send>(
     body: Json<CreateEntityRequest>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<PersistedEntityMetadata>, StatusCode> {
+) -> Result<Json<EntityMetadata>, StatusCode> {
     let Json(CreateEntityRequest {
         entity,
         entity_type_id,
@@ -250,14 +248,14 @@ async fn get_entities_by_query<P: StorePool + Send>(
     path = "/entities",
     tag = "Entity",
     responses(
-        (status = 200, content_type = "application/json", description = "List of all entities", body = [PersistedEntity]),
+        (status = 200, content_type = "application/json", description = "List of all entities", body = [Entity]),
 
         (status = 500, description = "Store error occurred"),
     )
 )]
 async fn get_latest_entities<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
-) -> Result<Json<Vec<PersistedEntity>>, StatusCode> {
+) -> Result<Json<Vec<Entity>>, StatusCode> {
     read_from_store(
         pool.as_ref(),
         &Filter::<EntityProperties>::for_all_latest_entities(),
@@ -271,7 +269,7 @@ async fn get_latest_entities<P: StorePool + Send>(
     path = "/entities/{entityId}",
     tag = "Entity",
     responses(
-        (status = 200, content_type = "application/json", description = "The requested entity", body = PersistedEntity),
+        (status = 200, content_type = "application/json", description = "The requested entity", body = Entity),
 
         (status = 400, content_type = "text/plain", description = "Provided entity id is invalid"),
         (status = 404, description = "Entity was not found"),
@@ -284,7 +282,7 @@ async fn get_latest_entities<P: StorePool + Send>(
 async fn get_entity<P: StorePool + Send>(
     Path(entity_id): Path<EntityId>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<PersistedEntity>, StatusCode> {
+) -> Result<Json<Entity>, StatusCode> {
     read_from_store(
         pool.as_ref(),
         &Filter::<EntityProperties>::for_latest_entity_by_entity_id(entity_id),
@@ -309,7 +307,7 @@ struct UpdateEntityRequest {
     path = "/entities",
     tag = "Entity",
     responses(
-        (status = 200, content_type = "application/json", description = "The metadata of the updated entity", body = PersistedEntityMetadata),
+        (status = 200, content_type = "application/json", description = "The metadata of the updated entity", body = EntityMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Entity ID or Entity Type URI was not found"),
@@ -320,7 +318,7 @@ struct UpdateEntityRequest {
 async fn update_entity<P: StorePool + Send>(
     body: Json<UpdateEntityRequest>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<PersistedEntityMetadata>, StatusCode> {
+) -> Result<Json<EntityMetadata>, StatusCode> {
     let Json(UpdateEntityRequest {
         entity,
         entity_id,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -15,10 +15,12 @@ use utoipa::{OpenApi, ToSchema};
 
 use crate::{
     api::rest::{api_resource::RoutedResource, read_from_store, report_to_status_code},
-    knowledge::{Entity, EntityMetadata, EntityProperties, EntityUuid, LinkEntityMetadata},
-    provenance::{CreatedById, OwnedById, UpdatedById},
+    knowledge::{
+        Entity, EntityMetadata, EntityProperties, EntityUuid, LinkEntityMetadata, LinkOrder,
+    },
+    provenance::{CreatedById, OwnedById, ProvenanceMetadata, UpdatedById},
     shared::identifier::{
-        knowledge::{EntityEditionId, EntityId},
+        knowledge::{EntityEditionId, EntityId, EntityVersion},
         GraphElementIdentifier,
     },
     store::{
@@ -55,7 +57,11 @@ use crate::{
             EntityMetadata,
             Entity,
             EntityProperties,
+            EntityVersion,
             EntityStructuralQuery,
+            LinkEntityMetadata,
+            LinkOrder,
+            ProvenanceMetadata,
             GraphElementIdentifier,
             Vertex,
             EdgeKind,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -19,10 +19,9 @@ use crate::{
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
         patch_id_and_parse, EntityTypeWithMetadata, OntologyElementMetadata,
-        PersistedOntologyIdentifier,
     },
     provenance::{CreatedById, OwnedById, UpdatedById},
-    shared::identifier::GraphElementIdentifier,
+    shared::identifier::{ontology::OntologyTypeEditionId, GraphElementIdentifier},
     store::{
         error::{BaseUriAlreadyExists, BaseUriDoesNotExist},
         query::Filter,
@@ -50,7 +49,7 @@ use crate::{
             OwnedById,
             CreatedById,
             UpdatedById,
-            PersistedOntologyIdentifier,
+            OntologyTypeEditionId,
             OntologyElementMetadata,
             EntityTypeWithMetadata,
             EntityTypeStructuralQuery,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -18,7 +18,7 @@ use crate::{
     api::rest::{api_resource::RoutedResource, read_from_store, report_to_status_code},
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
-        patch_id_and_parse, PersistedEntityType, PersistedOntologyIdentifier,
+        patch_id_and_parse, EntityTypeWithMetadata, PersistedOntologyIdentifier,
         PersistedOntologyMetadata,
     },
     provenance::{CreatedById, OwnedById, UpdatedById},
@@ -52,7 +52,7 @@ use crate::{
             UpdatedById,
             PersistedOntologyIdentifier,
             PersistedOntologyMetadata,
-            PersistedEntityType,
+            EntityTypeWithMetadata,
             EntityTypeStructuralQuery,
             GraphElementIdentifier,
             Vertex,
@@ -203,14 +203,14 @@ async fn get_entity_types_by_query<P: StorePool + Send>(
     path = "/entity-types",
     tag = "EntityType",
     responses(
-        (status = 200, content_type = "application/json", description = "List of all entity types at their latest versions", body = [PersistedEntityType]),
+        (status = 200, content_type = "application/json", description = "List of all entity types at their latest versions", body = [EntityTypeWithMetadata]),
 
         (status = 500, description = "Store error occurred"),
     )
 )]
 async fn get_latest_entity_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
-) -> Result<Json<Vec<PersistedEntityType>>, StatusCode> {
+) -> Result<Json<Vec<EntityTypeWithMetadata>>, StatusCode> {
     read_from_store(pool.as_ref(), &Filter::<EntityType>::for_latest_version())
         .await
         .map(Json)
@@ -221,7 +221,7 @@ async fn get_latest_entity_types<P: StorePool + Send>(
     path = "/entity-types/{uri}",
     tag = "EntityType",
     responses(
-        (status = 200, content_type = "application/json", description = "The schema of the requested entity type", body = PersistedEntityType),
+        (status = 200, content_type = "application/json", description = "The schema of the requested entity type", body = EntityTypeWithMetadata),
         (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 404, description = "Entity type was not found"),
@@ -234,7 +234,7 @@ async fn get_latest_entity_types<P: StorePool + Send>(
 async fn get_entity_type<P: StorePool + Send>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<PersistedEntityType>, StatusCode> {
+) -> Result<Json<EntityTypeWithMetadata>, StatusCode> {
     read_from_store(
         pool.as_ref(),
         &Filter::<EntityType>::for_versioned_uri(&uri.0),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -21,7 +21,7 @@ use crate::{
         patch_id_and_parse, EntityTypeWithMetadata, OntologyElementMetadata,
     },
     provenance::{CreatedById, OwnedById, ProvenanceMetadata, UpdatedById},
-    shared::identifier::{ontology::OntologyTypeEditionId, GraphElementIdentifier},
+    shared::identifier::{ontology::OntologyTypeEditionId, GraphElementId},
     store::{
         error::{BaseUriAlreadyExists, BaseUriDoesNotExist},
         query::Filter,
@@ -53,7 +53,7 @@ use crate::{
             OntologyElementMetadata,
             EntityTypeWithMetadata,
             EntityTypeStructuralQuery,
-            GraphElementIdentifier,
+            GraphElementId,
             ProvenanceMetadata,
             Vertex,
             EdgeKind,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -18,8 +18,8 @@ use crate::{
     api::rest::{api_resource::RoutedResource, read_from_store, report_to_status_code},
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
-        patch_id_and_parse, EntityTypeWithMetadata, PersistedOntologyIdentifier,
-        PersistedOntologyMetadata,
+        patch_id_and_parse, EntityTypeWithMetadata, OntologyElementMetadata,
+        PersistedOntologyIdentifier,
     },
     provenance::{CreatedById, OwnedById, UpdatedById},
     shared::identifier::GraphElementIdentifier,
@@ -51,7 +51,7 @@ use crate::{
             CreatedById,
             UpdatedById,
             PersistedOntologyIdentifier,
-            PersistedOntologyMetadata,
+            OntologyElementMetadata,
             EntityTypeWithMetadata,
             EntityTypeStructuralQuery,
             GraphElementIdentifier,
@@ -103,7 +103,7 @@ struct CreateEntityTypeRequest {
     request_body = CreateEntityTypeRequest,
     tag = "EntityType",
     responses(
-        (status = 201, content_type = "application/json", description = "The metadata of the created entity type", body = PersistedOntologyMetadata),
+        (status = 201, content_type = "application/json", description = "The metadata of the created entity type", body = OntologyElementMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 409, description = "Unable to create entity type in the datastore as the base entity type ID already exists"),
@@ -115,7 +115,7 @@ async fn create_entity_type<P: StorePool + Send>(
     body: Json<CreateEntityTypeRequest>,
     pool: Extension<Arc<P>>,
     domain_validator: Extension<DomainValidator>,
-) -> Result<Json<PersistedOntologyMetadata>, StatusCode> {
+) -> Result<Json<OntologyElementMetadata>, StatusCode> {
     let Json(CreateEntityTypeRequest {
         schema,
         owned_by_id,
@@ -259,7 +259,7 @@ struct UpdateEntityTypeRequest {
     path = "/entity-types",
     tag = "EntityType",
     responses(
-        (status = 200, content_type = "application/json", description = "The metadata of the updated entity type", body = PersistedOntologyMetadata),
+        (status = 200, content_type = "application/json", description = "The metadata of the updated entity type", body = OntologyElementMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Base entity type ID was not found"),
@@ -270,7 +270,7 @@ struct UpdateEntityTypeRequest {
 async fn update_entity_type<P: StorePool + Send>(
     body: Json<UpdateEntityTypeRequest>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<PersistedOntologyMetadata>, StatusCode> {
+) -> Result<Json<OntologyElementMetadata>, StatusCode> {
     let Json(UpdateEntityTypeRequest {
         schema,
         type_to_update,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -20,7 +20,7 @@ use crate::{
         domain_validator::{DomainValidator, ValidateOntologyType},
         patch_id_and_parse, EntityTypeWithMetadata, OntologyElementMetadata,
     },
-    provenance::{CreatedById, OwnedById, UpdatedById},
+    provenance::{CreatedById, OwnedById, ProvenanceMetadata, UpdatedById},
     shared::identifier::{ontology::OntologyTypeEditionId, GraphElementIdentifier},
     store::{
         error::{BaseUriAlreadyExists, BaseUriDoesNotExist},
@@ -54,6 +54,7 @@ use crate::{
             EntityTypeWithMetadata,
             EntityTypeStructuralQuery,
             GraphElementIdentifier,
+            ProvenanceMetadata,
             Vertex,
             EdgeKind,
             OutwardEdge,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
@@ -380,7 +380,6 @@ impl Modify for FilterSchemaAddon {
                                             "ownedById",
                                             "createdById",
                                             "updatedById",
-                                            "removedById",
                                             "baseUri",
                                             "versionedUri",
                                             "version",

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -20,7 +20,7 @@ use crate::{
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
         patch_id_and_parse, PersistedOntologyIdentifier, PersistedOntologyMetadata,
-        PersistedPropertyType,
+        PropertyTypeWithMetadata,
     },
     provenance::{CreatedById, OwnedById, UpdatedById},
     shared::identifier::GraphElementIdentifier,
@@ -51,7 +51,7 @@ use crate::{
             UpdatedById,
             PersistedOntologyIdentifier,
             PersistedOntologyMetadata,
-            PersistedPropertyType,
+            PropertyTypeWithMetadata,
             PropertyTypeStructuralQuery,
             GraphElementIdentifier,
             Vertex,
@@ -203,14 +203,14 @@ async fn get_property_types_by_query<P: StorePool + Send>(
     path = "/property-types",
     tag = "PropertyType",
     responses(
-        (status = 200, content_type = "application/json", description = "List of all property types at their latest versions", body = [PersistedPropertyType]),
+        (status = 200, content_type = "application/json", description = "List of all property types at their latest versions", body = [PropertyTypeWithMetadata]),
 
         (status = 500, description = "Store error occurred"),
     )
 )]
 async fn get_latest_property_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
-) -> Result<Json<Vec<PersistedPropertyType>>, StatusCode> {
+) -> Result<Json<Vec<PropertyTypeWithMetadata>>, StatusCode> {
     read_from_store(pool.as_ref(), &Filter::<PropertyType>::for_latest_version())
         .await
         .map(Json)
@@ -221,7 +221,7 @@ async fn get_latest_property_types<P: StorePool + Send>(
     path = "/property-types/{uri}",
     tag = "PropertyType",
     responses(
-        (status = 200, content_type = "application/json", description = "The schema of the requested property type", body = PersistedPropertyType),
+        (status = 200, content_type = "application/json", description = "The schema of the requested property type", body = PropertyTypeWithMetadata),
         (status = 422, content_type = "text/plain", description = "Provided URI is invalid"),
 
         (status = 404, description = "Property type was not found"),
@@ -234,7 +234,7 @@ async fn get_latest_property_types<P: StorePool + Send>(
 async fn get_property_type<P: StorePool + Send>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<PersistedPropertyType>, StatusCode> {
+) -> Result<Json<PropertyTypeWithMetadata>, StatusCode> {
     read_from_store(
         pool.as_ref(),
         &Filter::<PropertyType>::for_versioned_uri(&uri.0),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -22,7 +22,7 @@ use crate::{
         patch_id_and_parse, OntologyElementMetadata, PropertyTypeWithMetadata,
     },
     provenance::{CreatedById, OwnedById, UpdatedById},
-    shared::identifier::{ontology::OntologyTypeEditionId, GraphElementIdentifier},
+    shared::identifier::{ontology::OntologyTypeEditionId, GraphElementId},
     store::{
         query::Filter, BaseUriAlreadyExists, BaseUriDoesNotExist, PropertyTypeStore, StorePool,
     },
@@ -52,7 +52,7 @@ use crate::{
             OntologyElementMetadata,
             PropertyTypeWithMetadata,
             PropertyTypeStructuralQuery,
-            GraphElementIdentifier,
+            GraphElementId,
             Vertex,
             EdgeKind,
             OutwardEdge,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -19,11 +19,10 @@ use crate::{
     api::rest::{read_from_store, report_to_status_code},
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
-        patch_id_and_parse, OntologyElementMetadata, PersistedOntologyIdentifier,
-        PropertyTypeWithMetadata,
+        patch_id_and_parse, OntologyElementMetadata, PropertyTypeWithMetadata,
     },
     provenance::{CreatedById, OwnedById, UpdatedById},
-    shared::identifier::GraphElementIdentifier,
+    shared::identifier::{ontology::OntologyTypeEditionId, GraphElementIdentifier},
     store::{
         query::Filter, BaseUriAlreadyExists, BaseUriDoesNotExist, PropertyTypeStore, StorePool,
     },
@@ -49,7 +48,7 @@ use crate::{
             OwnedById,
             CreatedById,
             UpdatedById,
-            PersistedOntologyIdentifier,
+            OntologyTypeEditionId,
             OntologyElementMetadata,
             PropertyTypeWithMetadata,
             PropertyTypeStructuralQuery,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -19,7 +19,7 @@ use crate::{
     api::rest::{read_from_store, report_to_status_code},
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
-        patch_id_and_parse, PersistedOntologyIdentifier, PersistedOntologyMetadata,
+        patch_id_and_parse, OntologyElementMetadata, PersistedOntologyIdentifier,
         PropertyTypeWithMetadata,
     },
     provenance::{CreatedById, OwnedById, UpdatedById},
@@ -50,7 +50,7 @@ use crate::{
             CreatedById,
             UpdatedById,
             PersistedOntologyIdentifier,
-            PersistedOntologyMetadata,
+            OntologyElementMetadata,
             PropertyTypeWithMetadata,
             PropertyTypeStructuralQuery,
             GraphElementIdentifier,
@@ -102,7 +102,7 @@ struct CreatePropertyTypeRequest {
     request_body = CreatePropertyTypeRequest,
     tag = "PropertyType",
     responses(
-        (status = 201, content_type = "application/json", description = "The metadata of the created property type", body = PersistedOntologyMetadata),
+        (status = 201, content_type = "application/json", description = "The metadata of the created property type", body = OntologyElementMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 409, description = "Unable to create property type in the store as the base property type ID already exists"),
@@ -114,7 +114,7 @@ async fn create_property_type<P: StorePool + Send>(
     body: Json<CreatePropertyTypeRequest>,
     pool: Extension<Arc<P>>,
     domain_validator: Extension<DomainValidator>,
-) -> Result<Json<PersistedOntologyMetadata>, StatusCode> {
+) -> Result<Json<OntologyElementMetadata>, StatusCode> {
     let Json(CreatePropertyTypeRequest {
         schema,
         owned_by_id,
@@ -259,7 +259,7 @@ struct UpdatePropertyTypeRequest {
     path = "/property-types",
     tag = "PropertyType",
     responses(
-        (status = 200, content_type = "application/json", description = "The metadata of the updated property type", body = PersistedOntologyMetadata),
+        (status = 200, content_type = "application/json", description = "The metadata of the updated property type", body = OntologyElementMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Base property type ID was not found"),
@@ -270,7 +270,7 @@ struct UpdatePropertyTypeRequest {
 async fn update_property_type<P: StorePool + Send>(
     body: Json<UpdatePropertyTypeRequest>,
     pool: Extension<Arc<P>>,
-) -> Result<Json<PersistedOntologyMetadata>, StatusCode> {
+) -> Result<Json<OntologyElementMetadata>, StatusCode> {
     let Json(UpdatePropertyTypeRequest {
         schema,
         type_to_update,

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -39,17 +39,7 @@ impl fmt::Display for EntityUuid {
 }
 
 #[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    Serialize,
-    Deserialize,
-    ToSchema,
-    FromSql,
-    ToSql,
+    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema, FromSql, ToSql,
 )]
 #[repr(transparent)]
 #[postgres(transparent)]
@@ -196,14 +186,14 @@ impl EntityMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Entity {
-    inner: EntityProperties,
+    properties: EntityProperties,
     metadata: EntityMetadata,
 }
 
 impl Entity {
     #[must_use]
     pub const fn new(
-        inner: EntityProperties,
+        properties: EntityProperties,
         identifier: EntityEditionId,
         entity_type_id: VersionedUri,
         provenance_metadata: ProvenanceMetadata,
@@ -211,7 +201,7 @@ impl Entity {
         archived: bool,
     ) -> Self {
         Self {
-            inner,
+            properties,
             metadata: EntityMetadata::new(
                 identifier,
                 entity_type_id,
@@ -223,8 +213,8 @@ impl Entity {
     }
 
     #[must_use]
-    pub const fn inner(&self) -> &EntityProperties {
-        &self.inner
+    pub const fn properties(&self) -> &EntityProperties {
+        &self.properties
     }
 
     #[must_use]

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 pub use self::query::{EntityQueryPath, EntityQueryPathVisitor};
 use crate::{
     identifier::knowledge::{EntityEditionId, EntityId},
-    provenance::{CreatedById, UpdatedById},
+    provenance::ProvenanceMetadata,
 };
 
 #[derive(
@@ -130,10 +130,8 @@ pub struct EntityMetadata {
     identifier: EntityEditionId,
     #[schema(value_type = String)]
     entity_type_id: VersionedUri,
-    // TODO: encapsulate these in a `ProvenanceMetadata` struct?
-    //  https://app.asana.com/0/1201095311341924/1203227079758117/f
-    created_by_id: CreatedById,
-    updated_by_id: UpdatedById,
+    #[serde(rename = "provenance")]
+    provenance_metadata: ProvenanceMetadata,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     link_metadata: Option<LinkEntityMetadata>,
     archived: bool,
@@ -144,16 +142,14 @@ impl EntityMetadata {
     pub const fn new(
         identifier: EntityEditionId,
         entity_type_id: VersionedUri,
-        created_by_id: CreatedById,
-        updated_by_id: UpdatedById,
+        provenance_metadata: ProvenanceMetadata,
         link_metadata: Option<LinkEntityMetadata>,
         archived: bool,
     ) -> Self {
         Self {
             identifier,
             entity_type_id,
-            created_by_id,
-            updated_by_id,
+            provenance_metadata,
             link_metadata,
             archived,
         }
@@ -170,13 +166,8 @@ impl EntityMetadata {
     }
 
     #[must_use]
-    pub const fn created_by_id(&self) -> CreatedById {
-        self.created_by_id
-    }
-
-    #[must_use]
-    pub const fn updated_by_id(&self) -> UpdatedById {
-        self.updated_by_id
+    pub const fn provenance_metadata(&self) -> ProvenanceMetadata {
+        self.provenance_metadata
     }
 
     #[must_use]
@@ -205,8 +196,7 @@ impl Entity {
         inner: EntityProperties,
         identifier: EntityEditionId,
         entity_type_id: VersionedUri,
-        created_by_id: CreatedById,
-        updated_by_id: UpdatedById,
+        provenance_metadata: ProvenanceMetadata,
         link_metadata: Option<LinkEntityMetadata>,
         archived: bool,
     ) -> Self {
@@ -215,8 +205,7 @@ impl Entity {
             metadata: EntityMetadata::new(
                 identifier,
                 entity_type_id,
-                created_by_id,
-                updated_by_id,
+                provenance_metadata,
                 link_metadata,
                 archived,
             ),

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -127,7 +127,7 @@ impl LinkEntityMetadata {
 // TODO: deny_unknown_fields on other structs
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct EntityMetadata {
-    identifier: EntityEditionId,
+    edition_id: EntityEditionId,
     #[schema(value_type = String)]
     entity_type_id: VersionedUri,
     #[serde(rename = "provenance")]
@@ -140,14 +140,14 @@ pub struct EntityMetadata {
 impl EntityMetadata {
     #[must_use]
     pub const fn new(
-        identifier: EntityEditionId,
+        edition_id: EntityEditionId,
         entity_type_id: VersionedUri,
         provenance_metadata: ProvenanceMetadata,
         link_metadata: Option<LinkEntityMetadata>,
         archived: bool,
     ) -> Self {
         Self {
-            identifier,
+            edition_id,
             entity_type_id,
             provenance_metadata,
             link_metadata,
@@ -156,8 +156,8 @@ impl EntityMetadata {
     }
 
     #[must_use]
-    pub const fn identifier(&self) -> &EntityEditionId {
-        &self.identifier
+    pub const fn edition_id(&self) -> &EntityEditionId {
+        &self.edition_id
     }
 
     #[must_use]

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -126,7 +126,7 @@ impl LinkEntityMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 // TODO: deny_unknown_fields on other structs
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
-pub struct PersistedEntityMetadata {
+pub struct EntityMetadata {
     identifier: EntityEditionId,
     #[schema(value_type = String)]
     entity_type_id: VersionedUri,
@@ -139,7 +139,7 @@ pub struct PersistedEntityMetadata {
     archived: bool,
 }
 
-impl PersistedEntityMetadata {
+impl EntityMetadata {
     #[must_use]
     pub const fn new(
         identifier: EntityEditionId,
@@ -194,12 +194,12 @@ impl PersistedEntityMetadata {
 /// metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct PersistedEntity {
+pub struct Entity {
     inner: EntityProperties,
-    metadata: PersistedEntityMetadata,
+    metadata: EntityMetadata,
 }
 
-impl PersistedEntity {
+impl Entity {
     #[must_use]
     pub const fn new(
         inner: EntityProperties,
@@ -212,7 +212,7 @@ impl PersistedEntity {
     ) -> Self {
         Self {
             inner,
-            metadata: PersistedEntityMetadata::new(
+            metadata: EntityMetadata::new(
                 identifier,
                 entity_type_id,
                 created_by_id,
@@ -229,7 +229,7 @@ impl PersistedEntity {
     }
 
     #[must_use]
-    pub const fn metadata(&self) -> &PersistedEntityMetadata {
+    pub const fn metadata(&self) -> &EntityMetadata {
         &self.metadata
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -39,7 +39,17 @@ impl fmt::Display for EntityUuid {
 }
 
 #[derive(
-    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema, FromSql, ToSql,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    ToSchema,
+    FromSql,
+    ToSql,
 )]
 #[repr(transparent)]
 #[postgres(transparent)]

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -52,21 +52,21 @@ impl LinkOrder {
     }
 }
 
-/// An entity.
+/// The properties of an entity.
 ///
 /// When expressed as JSON, this should validate against its respective entity type(s).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[schema(value_type = Object)]
-pub struct Entity(HashMap<BaseUri, serde_json::Value>);
+pub struct EntityProperties(HashMap<BaseUri, serde_json::Value>);
 
-impl Entity {
+impl EntityProperties {
     #[must_use]
     pub fn empty() -> Self {
         Self(HashMap::new())
     }
 }
 
-impl Entity {
+impl EntityProperties {
     #[must_use]
     pub const fn properties(&self) -> &HashMap<BaseUri, serde_json::Value> {
         &self.0
@@ -195,14 +195,14 @@ impl PersistedEntityMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PersistedEntity {
-    inner: Entity,
+    inner: EntityProperties,
     metadata: PersistedEntityMetadata,
 }
 
 impl PersistedEntity {
     #[must_use]
     pub const fn new(
-        inner: Entity,
+        inner: EntityProperties,
         identifier: EntityEditionId,
         entity_type_id: VersionedUri,
         created_by_id: CreatedById,
@@ -224,7 +224,7 @@ impl PersistedEntity {
     }
 
     #[must_use]
-    pub const fn inner(&self) -> &Entity {
+    pub const fn inner(&self) -> &EntityProperties {
         &self.inner
     }
 
@@ -241,7 +241,8 @@ mod tests {
     fn test_entity(json: &str) {
         let json_value: serde_json::Value = serde_json::from_str(json).expect("invalid JSON");
 
-        let entity: Entity = serde_json::from_value(json_value.clone()).expect("invalid entity");
+        let entity: EntityProperties =
+            serde_json::from_value(json_value.clone()).expect("invalid entity");
 
         assert_eq!(
             serde_json::to_value(entity.clone()).expect("could not serialize"),

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
@@ -17,7 +17,6 @@ pub enum EntityQueryPath<'q> {
     OwnedById,
     CreatedById,
     UpdatedById,
-    RemovedById,
     Version,
     Archived,
     Type(EntityTypeQueryPath),
@@ -41,7 +40,6 @@ impl fmt::Display for EntityQueryPath<'_> {
             Self::OwnedById => fmt.write_str("ownedById"),
             Self::CreatedById => fmt.write_str("createdById"),
             Self::UpdatedById => fmt.write_str("updatedById"),
-            Self::RemovedById => fmt.write_str("removedById"),
             Self::Version => fmt.write_str("version"),
             Self::Archived => fmt.write_str("archived"),
             Self::Type(path) => write!(fmt, "type.{path}"),
@@ -66,7 +64,6 @@ impl RecordPath for EntityQueryPath<'_> {
             | Self::OwnedById
             | Self::CreatedById
             | Self::UpdatedById
-            | Self::RemovedById
             | Self::LeftEntity(None)
             | Self::RightEntity(None) => ParameterType::Uuid,
             Self::LeftEntity(Some(path))
@@ -91,7 +88,6 @@ pub enum EntityQueryToken {
     OwnedById,
     CreatedById,
     UpdatedById,
-    RemovedById,
     Version,
     Archived,
     Type,
@@ -109,10 +105,9 @@ pub struct EntityQueryPathVisitor {
 }
 
 impl EntityQueryPathVisitor {
-    pub const EXPECTING: &'static str = "one of `uuid`, `ownedById`, `createdById`, \
-                                         `updatedById`, `removedById`, `version`, `archived`, \
-                                         `type`, `properties`, `incomingLinks`, `outgoingLinks`, \
-                                         `leftEntity`, `rightEntity`";
+    pub const EXPECTING: &'static str =
+        "one of `uuid`, `ownedById`, `createdById`, `updatedById`, `version`, `archived`, `type`, \
+         `properties`, `incomingLinks`, `outgoingLinks`, `leftEntity`, `rightEntity`";
 
     #[must_use]
     pub const fn new(position: usize) -> Self {
@@ -141,7 +136,6 @@ impl<'de> Visitor<'de> for EntityQueryPathVisitor {
             EntityQueryToken::OwnedById => EntityQueryPath::OwnedById,
             EntityQueryToken::CreatedById => EntityQueryPath::CreatedById,
             EntityQueryToken::UpdatedById => EntityQueryPath::UpdatedById,
-            EntityQueryToken::RemovedById => EntityQueryPath::RemovedById,
             EntityQueryToken::Version => EntityQueryPath::Version,
             EntityQueryToken::Archived => EntityQueryPath::Archived,
             EntityQueryToken::Type => EntityQueryPath::Type(

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
@@ -6,7 +6,7 @@ use serde::{
 };
 
 use crate::{
-    knowledge::Entity,
+    knowledge::EntityProperties,
     ontology::{EntityTypeQueryPath, EntityTypeQueryPathVisitor},
     store::query::{ParameterType, QueryRecord, RecordPath},
 };
@@ -30,7 +30,7 @@ pub enum EntityQueryPath<'q> {
     RightOrder,
 }
 
-impl QueryRecord for Entity {
+impl QueryRecord for EntityProperties {
     type Path<'q> = EntityQueryPath<'q>;
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/mod.rs
@@ -4,8 +4,8 @@
 mod entity;
 
 pub use self::entity::{
-    EntityProperties, EntityQueryPath, EntityQueryPathVisitor, EntityUuid, LinkEntityMetadata,
-    LinkOrder, PersistedEntity, PersistedEntityMetadata,
+    Entity, EntityMetadata, EntityProperties, EntityQueryPath, EntityQueryPathVisitor, EntityUuid,
+    LinkEntityMetadata, LinkOrder,
 };
 
 // TODO: update this doc: https://app.asana.com/0/1200211978612931/1203250001255262/f

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/mod.rs
@@ -4,8 +4,8 @@
 mod entity;
 
 pub use self::entity::{
-    Entity, EntityQueryPath, EntityQueryPathVisitor, EntityUuid, LinkEntityMetadata, LinkOrder,
-    PersistedEntity, PersistedEntityMetadata,
+    EntityProperties, EntityQueryPath, EntityQueryPathVisitor, EntityUuid, LinkEntityMetadata,
+    LinkOrder, PersistedEntity, PersistedEntityMetadata,
 };
 
 // TODO: update this doc: https://app.asana.com/0/1200211978612931/1203250001255262/f

--- a/packages/graph/hash_graph/lib/graph/src/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/data_type.rs
@@ -22,7 +22,6 @@ pub enum DataTypeQueryPath {
     OwnedById,
     CreatedById,
     UpdatedById,
-    RemovedById,
     Schema,
     BaseUri,
     VersionedUri,
@@ -64,7 +63,6 @@ impl RecordPath for DataTypeQueryPath {
             Self::VersionId | Self::OwnedById | Self::CreatedById | Self::UpdatedById => {
                 ParameterType::Uuid
             }
-            Self::RemovedById => ParameterType::Uuid,
             Self::Schema => ParameterType::Any,
             Self::BaseUri => ParameterType::BaseUri,
             Self::VersionedUri => ParameterType::VersionedUri,
@@ -81,7 +79,6 @@ impl fmt::Display for DataTypeQueryPath {
             Self::OwnedById => fmt.write_str("ownedById"),
             Self::CreatedById => fmt.write_str("createdById"),
             Self::UpdatedById => fmt.write_str("updatedById"),
-            Self::RemovedById => fmt.write_str("removedById"),
             Self::Schema => fmt.write_str("schema"),
             Self::BaseUri => fmt.write_str("baseUri"),
             Self::VersionedUri => fmt.write_str("versionedUri"),
@@ -100,7 +97,6 @@ enum DataTypeQueryToken {
     OwnedById,
     CreatedById,
     UpdatedById,
-    RemovedById,
     BaseUri,
     VersionedUri,
     Version,
@@ -117,8 +113,8 @@ pub struct DataTypeQueryPathVisitor {
 
 impl DataTypeQueryPathVisitor {
     pub const EXPECTING: &'static str = "one of `ownedById`, `createdById`, `updatedById`, \
-                                         `removedById`, `baseUri`, `versionedUri`, `version`, \
-                                         `title`, `description`, `type`";
+                                         `baseUri`, `versionedUri`, `version`, `title`, \
+                                         `description`, `type`";
 
     #[must_use]
     pub const fn new(position: usize) -> Self {
@@ -146,7 +142,6 @@ impl<'de> Visitor<'de> for DataTypeQueryPathVisitor {
             DataTypeQueryToken::OwnedById => DataTypeQueryPath::OwnedById,
             DataTypeQueryToken::CreatedById => DataTypeQueryPath::CreatedById,
             DataTypeQueryToken::UpdatedById => DataTypeQueryPath::UpdatedById,
-            DataTypeQueryToken::RemovedById => DataTypeQueryPath::RemovedById,
             DataTypeQueryToken::BaseUri => DataTypeQueryPath::BaseUri,
             DataTypeQueryToken::VersionedUri => DataTypeQueryPath::VersionedUri,
             DataTypeQueryToken::Version => DataTypeQueryPath::Version,

--- a/packages/graph/hash_graph/lib/graph/src/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/entity_type.rs
@@ -17,7 +17,6 @@ pub enum EntityTypeQueryPath {
     OwnedById,
     CreatedById,
     UpdatedById,
-    RemovedById,
     Schema,
     BaseUri,
     VersionedUri,
@@ -66,7 +65,6 @@ impl RecordPath for EntityTypeQueryPath {
             Self::VersionId | Self::OwnedById | Self::CreatedById | Self::UpdatedById => {
                 ParameterType::Uuid
             }
-            Self::RemovedById => ParameterType::Uuid,
             Self::Schema => ParameterType::Any,
             Self::BaseUri => ParameterType::BaseUri,
             Self::VersionedUri => ParameterType::VersionedUri,
@@ -90,7 +88,6 @@ impl fmt::Display for EntityTypeQueryPath {
             Self::OwnedById => fmt.write_str("ownedById"),
             Self::CreatedById => fmt.write_str("createdById"),
             Self::UpdatedById => fmt.write_str("updatedById"),
-            Self::RemovedById => fmt.write_str("removedById"),
             Self::Schema => fmt.write_str("schema"),
             Self::BaseUri => fmt.write_str("baseUri"),
             Self::VersionedUri => fmt.write_str("versionedUri"),
@@ -116,7 +113,6 @@ pub enum EntityTypeQueryToken {
     OwnedById,
     CreatedById,
     UpdatedById,
-    RemovedById,
     BaseUri,
     VersionedUri,
     Version,
@@ -138,10 +134,10 @@ pub struct EntityTypeQueryPathVisitor {
 }
 
 impl EntityTypeQueryPathVisitor {
-    pub const EXPECTING: &'static str =
-        "one of `ownedById`, `createdById`, `updatedById`, `removedById`, `baseUri`, \
-         `versionedUri`, `version`, `title`, `description`, `default`, `examples`, `properties`, \
-         `required`, `links`, `requiredLinks`, `inheritsFrom`";
+    pub const EXPECTING: &'static str = "one of `ownedById`, `createdById`, `updatedById`, \
+                                         `baseUri`, `versionedUri`, `version`, `title`, \
+                                         `description`, `default`, `examples`, `properties`, \
+                                         `required`, `links`, `requiredLinks`, `inheritsFrom`";
 
     #[must_use]
     pub const fn new(position: usize) -> Self {
@@ -169,7 +165,6 @@ impl<'de> Visitor<'de> for EntityTypeQueryPathVisitor {
             EntityTypeQueryToken::OwnedById => EntityTypeQueryPath::OwnedById,
             EntityTypeQueryToken::CreatedById => EntityTypeQueryPath::CreatedById,
             EntityTypeQueryToken::UpdatedById => EntityTypeQueryPath::UpdatedById,
-            EntityTypeQueryToken::RemovedById => EntityTypeQueryPath::RemovedById,
             EntityTypeQueryToken::BaseUri => EntityTypeQueryPath::BaseUri,
             EntityTypeQueryToken::VersionedUri => EntityTypeQueryPath::VersionedUri,
             EntityTypeQueryToken::Version => EntityTypeQueryPath::Version,

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -69,25 +69,17 @@ impl<'de> Deserialize<'de> for Selector {
 pub struct PersistedOntologyIdentifier {
     #[schema(value_type = String)]
     uri: VersionedUri,
-    // TODO: owned_by_id is not required to identify an ontology element
-    //  https://app.asana.com/0/1202805690238892/1203214689883091/f
-    owned_by_id: OwnedById,
 }
 
 impl PersistedOntologyIdentifier {
     #[must_use]
-    pub const fn new(uri: VersionedUri, owned_by_id: OwnedById) -> Self {
-        Self { uri, owned_by_id }
+    pub const fn new(uri: VersionedUri) -> Self {
+        Self { uri }
     }
 
     #[must_use]
     pub const fn uri(&self) -> &VersionedUri {
         &self.uri
-    }
-
-    #[must_use]
-    pub const fn owned_by_id(&self) -> OwnedById {
-        self.owned_by_id
     }
 }
 
@@ -243,6 +235,7 @@ pub struct OntologyElementMetadata {
     identifier: PersistedOntologyIdentifier,
     #[serde(rename = "provenance")]
     provenance_metadata: ProvenanceMetadata,
+    owned_by_id: OwnedById,
 }
 
 impl OntologyElementMetadata {
@@ -250,10 +243,12 @@ impl OntologyElementMetadata {
     pub const fn new(
         identifier: PersistedOntologyIdentifier,
         provenance_metadata: ProvenanceMetadata,
+        owned_by_id: OwnedById,
     ) -> Self {
         Self {
             identifier,
             provenance_metadata,
+            owned_by_id,
         }
     }
 
@@ -265,6 +260,11 @@ impl OntologyElementMetadata {
     #[must_use]
     pub const fn provenance_metadata(&self) -> ProvenanceMetadata {
         self.provenance_metadata
+    }
+
+    #[must_use]
+    pub const fn owned_by_id(&self) -> OwnedById {
+        self.owned_by_id
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -23,7 +23,10 @@ pub use self::{
     entity_type::{EntityTypeQueryPath, EntityTypeQueryPathVisitor},
     property_type::{PropertyTypeQueryPath, PropertyTypeQueryPathVisitor},
 };
-use crate::provenance::{OwnedById, ProvenanceMetadata};
+use crate::{
+    identifier::ontology::OntologyTypeEditionId,
+    provenance::{OwnedById, ProvenanceMetadata},
+};
 
 pub enum Selector {
     Asterisk,
@@ -59,27 +62,6 @@ impl<'de> Deserialize<'de> for Selector {
         }
 
         deserializer.deserialize_str(SelectorVisitor)
-    }
-}
-
-/// The metadata required to uniquely identify an ontology element that has been persisted in the
-/// datastore.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct PersistedOntologyIdentifier {
-    #[schema(value_type = String)]
-    uri: VersionedUri,
-}
-
-impl PersistedOntologyIdentifier {
-    #[must_use]
-    pub const fn new(uri: VersionedUri) -> Self {
-        Self { uri }
-    }
-
-    #[must_use]
-    pub const fn uri(&self) -> &VersionedUri {
-        &self.uri
     }
 }
 
@@ -232,7 +214,7 @@ impl PropertyTypeWithMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct OntologyElementMetadata {
-    identifier: PersistedOntologyIdentifier,
+    identifier: OntologyTypeEditionId,
     #[serde(rename = "provenance")]
     provenance_metadata: ProvenanceMetadata,
     owned_by_id: OwnedById,
@@ -241,7 +223,7 @@ pub struct OntologyElementMetadata {
 impl OntologyElementMetadata {
     #[must_use]
     pub const fn new(
-        identifier: PersistedOntologyIdentifier,
+        identifier: OntologyTypeEditionId,
         provenance_metadata: ProvenanceMetadata,
         owned_by_id: OwnedById,
     ) -> Self {
@@ -253,7 +235,7 @@ impl OntologyElementMetadata {
     }
 
     #[must_use]
-    pub const fn identifier(&self) -> &PersistedOntologyIdentifier {
+    pub const fn edition_id(&self) -> &OntologyTypeEditionId {
         &self.identifier
     }
 

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -214,7 +214,7 @@ impl PropertyTypeWithMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct OntologyElementMetadata {
-    identifier: OntologyTypeEditionId,
+    edition_id: OntologyTypeEditionId,
     #[serde(rename = "provenance")]
     provenance_metadata: ProvenanceMetadata,
     owned_by_id: OwnedById,
@@ -223,12 +223,12 @@ pub struct OntologyElementMetadata {
 impl OntologyElementMetadata {
     #[must_use]
     pub const fn new(
-        identifier: OntologyTypeEditionId,
+        edition_id: OntologyTypeEditionId,
         provenance_metadata: ProvenanceMetadata,
         owned_by_id: OwnedById,
     ) -> Self {
         Self {
-            identifier,
+            edition_id,
             provenance_metadata,
             owned_by_id,
         }
@@ -236,7 +236,7 @@ impl OntologyElementMetadata {
 
     #[must_use]
     pub const fn edition_id(&self) -> &OntologyTypeEditionId {
-        &self.identifier
+        &self.edition_id
     }
 
     #[must_use]

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -198,14 +198,14 @@ where
 pub type OntologyQueryDepth = u8;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
-pub struct PersistedDataType {
+pub struct DataTypeWithMetadata {
     #[schema(value_type = VAR_DATA_TYPE)]
     #[serde(serialize_with = "serialize_ontology_type")]
     inner: DataType,
     metadata: PersistedOntologyMetadata,
 }
 
-impl PersistedDataType {
+impl DataTypeWithMetadata {
     #[must_use]
     pub const fn inner(&self) -> &DataType {
         &self.inner
@@ -218,14 +218,14 @@ impl PersistedDataType {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
-pub struct PersistedPropertyType {
+pub struct PropertyTypeWithMetadata {
     #[schema(value_type = VAR_PROPERTY_TYPE)]
     #[serde(serialize_with = "serialize_ontology_type")]
     inner: PropertyType,
     metadata: PersistedOntologyMetadata,
 }
 
-impl PersistedPropertyType {
+impl PropertyTypeWithMetadata {
     #[must_use]
     pub const fn inner(&self) -> &PropertyType {
         &self.inner
@@ -269,14 +269,14 @@ impl PersistedOntologyMetadata {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
-pub struct PersistedEntityType {
+pub struct EntityTypeWithMetadata {
     #[schema(value_type = VAR_ENTITY_TYPE)]
     #[serde(serialize_with = "serialize_ontology_type")]
     inner: EntityType,
     metadata: PersistedOntologyMetadata,
 }
 
-impl PersistedEntityType {
+impl EntityTypeWithMetadata {
     #[must_use]
     pub const fn inner(&self) -> &EntityType {
         &self.inner
@@ -294,7 +294,7 @@ pub trait PersistedOntologyType {
     fn new(record: Self::Inner, metadata: PersistedOntologyMetadata) -> Self;
 }
 
-impl PersistedOntologyType for PersistedDataType {
+impl PersistedOntologyType for DataTypeWithMetadata {
     type Inner = DataType;
 
     fn new(record: Self::Inner, metadata: PersistedOntologyMetadata) -> Self {
@@ -305,7 +305,7 @@ impl PersistedOntologyType for PersistedDataType {
     }
 }
 
-impl PersistedOntologyType for PersistedPropertyType {
+impl PersistedOntologyType for PropertyTypeWithMetadata {
     type Inner = PropertyType;
 
     fn new(record: Self::Inner, metadata: PersistedOntologyMetadata) -> Self {
@@ -316,7 +316,7 @@ impl PersistedOntologyType for PersistedPropertyType {
     }
 }
 
-impl PersistedOntologyType for PersistedEntityType {
+impl PersistedOntologyType for EntityTypeWithMetadata {
     type Inner = EntityType;
 
     fn new(record: Self::Inner, metadata: PersistedOntologyMetadata) -> Self {

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -23,7 +23,7 @@ pub use self::{
     entity_type::{EntityTypeQueryPath, EntityTypeQueryPathVisitor},
     property_type::{PropertyTypeQueryPath, PropertyTypeQueryPathVisitor},
 };
-use crate::provenance::{CreatedById, OwnedById, RemovedById, UpdatedById};
+use crate::provenance::{OwnedById, ProvenanceMetadata};
 
 pub enum Selector {
     Asterisk,
@@ -241,30 +241,30 @@ impl PropertyTypeWithMetadata {
 #[serde(rename_all = "camelCase")]
 pub struct PersistedOntologyMetadata {
     identifier: PersistedOntologyIdentifier,
-    created_by_id: CreatedById,
-    updated_by_id: UpdatedById,
-    removed_by_id: Option<RemovedById>,
+    #[serde(rename = "provenance")]
+    provenance_metadata: ProvenanceMetadata,
 }
 
 impl PersistedOntologyMetadata {
     #[must_use]
     pub const fn new(
         identifier: PersistedOntologyIdentifier,
-        created_by_id: CreatedById,
-        updated_by_id: UpdatedById,
-        removed_by_id: Option<RemovedById>,
+        provenance_metadata: ProvenanceMetadata,
     ) -> Self {
         Self {
             identifier,
-            created_by_id,
-            updated_by_id,
-            removed_by_id,
+            provenance_metadata,
         }
     }
 
     #[must_use]
     pub const fn identifier(&self) -> &PersistedOntologyIdentifier {
         &self.identifier
+    }
+
+    #[must_use]
+    pub const fn provenance_metadata(&self) -> ProvenanceMetadata {
+        self.provenance_metadata
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -202,7 +202,7 @@ pub struct DataTypeWithMetadata {
     #[schema(value_type = VAR_DATA_TYPE)]
     #[serde(serialize_with = "serialize_ontology_type")]
     inner: DataType,
-    metadata: PersistedOntologyMetadata,
+    metadata: OntologyElementMetadata,
 }
 
 impl DataTypeWithMetadata {
@@ -212,7 +212,7 @@ impl DataTypeWithMetadata {
     }
 
     #[must_use]
-    pub const fn metadata(&self) -> &PersistedOntologyMetadata {
+    pub const fn metadata(&self) -> &OntologyElementMetadata {
         &self.metadata
     }
 }
@@ -222,7 +222,7 @@ pub struct PropertyTypeWithMetadata {
     #[schema(value_type = VAR_PROPERTY_TYPE)]
     #[serde(serialize_with = "serialize_ontology_type")]
     inner: PropertyType,
-    metadata: PersistedOntologyMetadata,
+    metadata: OntologyElementMetadata,
 }
 
 impl PropertyTypeWithMetadata {
@@ -232,20 +232,20 @@ impl PropertyTypeWithMetadata {
     }
 
     #[must_use]
-    pub const fn metadata(&self) -> &PersistedOntologyMetadata {
+    pub const fn metadata(&self) -> &OntologyElementMetadata {
         &self.metadata
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct PersistedOntologyMetadata {
+pub struct OntologyElementMetadata {
     identifier: PersistedOntologyIdentifier,
     #[serde(rename = "provenance")]
     provenance_metadata: ProvenanceMetadata,
 }
 
-impl PersistedOntologyMetadata {
+impl OntologyElementMetadata {
     #[must_use]
     pub const fn new(
         identifier: PersistedOntologyIdentifier,
@@ -273,7 +273,7 @@ pub struct EntityTypeWithMetadata {
     #[schema(value_type = VAR_ENTITY_TYPE)]
     #[serde(serialize_with = "serialize_ontology_type")]
     inner: EntityType,
-    metadata: PersistedOntologyMetadata,
+    metadata: OntologyElementMetadata,
 }
 
 impl EntityTypeWithMetadata {
@@ -283,7 +283,7 @@ impl EntityTypeWithMetadata {
     }
 
     #[must_use]
-    pub const fn metadata(&self) -> &PersistedOntologyMetadata {
+    pub const fn metadata(&self) -> &OntologyElementMetadata {
         &self.metadata
     }
 }
@@ -291,13 +291,13 @@ impl EntityTypeWithMetadata {
 pub trait PersistedOntologyType {
     type Inner;
 
-    fn new(record: Self::Inner, metadata: PersistedOntologyMetadata) -> Self;
+    fn new(record: Self::Inner, metadata: OntologyElementMetadata) -> Self;
 }
 
 impl PersistedOntologyType for DataTypeWithMetadata {
     type Inner = DataType;
 
-    fn new(record: Self::Inner, metadata: PersistedOntologyMetadata) -> Self {
+    fn new(record: Self::Inner, metadata: OntologyElementMetadata) -> Self {
         Self {
             inner: record,
             metadata,
@@ -308,7 +308,7 @@ impl PersistedOntologyType for DataTypeWithMetadata {
 impl PersistedOntologyType for PropertyTypeWithMetadata {
     type Inner = PropertyType;
 
-    fn new(record: Self::Inner, metadata: PersistedOntologyMetadata) -> Self {
+    fn new(record: Self::Inner, metadata: OntologyElementMetadata) -> Self {
         Self {
             inner: record,
             metadata,
@@ -319,7 +319,7 @@ impl PersistedOntologyType for PropertyTypeWithMetadata {
 impl PersistedOntologyType for EntityTypeWithMetadata {
     type Inner = EntityType;
 
-    fn new(record: Self::Inner, metadata: PersistedOntologyMetadata) -> Self {
+    fn new(record: Self::Inner, metadata: OntologyElementMetadata) -> Self {
         Self {
             inner: record,
             metadata,

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -174,7 +174,7 @@ pub type OntologyQueryDepth = u8;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 pub struct DataTypeWithMetadata {
     #[schema(value_type = VAR_DATA_TYPE)]
-    #[serde(serialize_with = "serialize_ontology_type")]
+    #[serde(rename = "schema", serialize_with = "serialize_ontology_type")]
     inner: DataType,
     metadata: OntologyElementMetadata,
 }
@@ -194,7 +194,7 @@ impl DataTypeWithMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 pub struct PropertyTypeWithMetadata {
     #[schema(value_type = VAR_PROPERTY_TYPE)]
-    #[serde(serialize_with = "serialize_ontology_type")]
+    #[serde(rename = "schema", serialize_with = "serialize_ontology_type")]
     inner: PropertyType,
     metadata: OntologyElementMetadata,
 }
@@ -253,7 +253,7 @@ impl OntologyElementMetadata {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 pub struct EntityTypeWithMetadata {
     #[schema(value_type = VAR_ENTITY_TYPE)]
-    #[serde(serialize_with = "serialize_ontology_type")]
+    #[serde(rename = "schema", serialize_with = "serialize_ontology_type")]
     inner: EntityType,
     metadata: OntologyElementMetadata,
 }

--- a/packages/graph/hash_graph/lib/graph/src/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/property_type.rs
@@ -17,7 +17,6 @@ pub enum PropertyTypeQueryPath {
     OwnedById,
     CreatedById,
     UpdatedById,
-    RemovedById,
     Schema,
     BaseUri,
     VersionedUri,
@@ -60,7 +59,6 @@ impl RecordPath for PropertyTypeQueryPath {
             Self::VersionId | Self::OwnedById | Self::CreatedById | Self::UpdatedById => {
                 ParameterType::Uuid
             }
-            Self::RemovedById => ParameterType::Uuid,
             Self::Schema => ParameterType::Any,
             Self::BaseUri => ParameterType::BaseUri,
             Self::VersionedUri => ParameterType::VersionedUri,
@@ -79,7 +77,6 @@ impl fmt::Display for PropertyTypeQueryPath {
             Self::OwnedById => fmt.write_str("ownedById"),
             Self::CreatedById => fmt.write_str("createdById"),
             Self::UpdatedById => fmt.write_str("updatedById"),
-            Self::RemovedById => fmt.write_str("removedById"),
             Self::Schema => fmt.write_str("schema"),
             Self::BaseUri => fmt.write_str("baseUri"),
             Self::VersionedUri => fmt.write_str("versionedUri"),
@@ -99,7 +96,6 @@ pub enum PropertyTypeQueryToken {
     OwnedById,
     CreatedById,
     UpdatedById,
-    RemovedById,
     BaseUri,
     VersionedUri,
     Version,
@@ -117,8 +113,8 @@ pub struct PropertyTypeQueryPathVisitor {
 
 impl PropertyTypeQueryPathVisitor {
     pub const EXPECTING: &'static str = "one of `ownedById`, `createdById`, `updatedById`, \
-                                         `removedById`, `baseUri`, `versionedUri`, `version`, \
-                                         `title`, `description`, `dataTypes`, `propertyTypes`";
+                                         `baseUri`, `versionedUri`, `version`, `title`, \
+                                         `description`, `dataTypes`, `propertyTypes`";
 
     #[must_use]
     pub const fn new(position: usize) -> Self {
@@ -146,7 +142,6 @@ impl<'de> Visitor<'de> for PropertyTypeQueryPathVisitor {
             PropertyTypeQueryToken::OwnedById => PropertyTypeQueryPath::OwnedById,
             PropertyTypeQueryToken::CreatedById => PropertyTypeQueryPath::CreatedById,
             PropertyTypeQueryToken::UpdatedById => PropertyTypeQueryPath::UpdatedById,
-            PropertyTypeQueryToken::RemovedById => PropertyTypeQueryPath::RemovedById,
             PropertyTypeQueryToken::BaseUri => PropertyTypeQueryPath::BaseUri,
             PropertyTypeQueryToken::VersionedUri => PropertyTypeQueryPath::VersionedUri,
             PropertyTypeQueryToken::Version => PropertyTypeQueryPath::Version,

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/knowledge.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/knowledge.rs
@@ -50,7 +50,7 @@ impl<'de> Deserialize<'de> for EntityId {
     where
         D: Deserializer<'de>,
     {
-        // TODO: we can be more efficient than this, we know the byte sizes of all the elements
+        // We can be more efficient than this, we know the byte sizes of all the elements
         let as_string = String::deserialize(deserializer)?;
         let mut parts = as_string.split('%');
 

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/mod.rs
@@ -1,10 +1,9 @@
 use chrono::{DateTime, Utc};
 use serde::{Serialize, Serializer};
 use serde_json;
-use type_system::uri::VersionedUri;
 use utoipa::{openapi, ToSchema};
 
-use crate::identifier::knowledge::EntityId;
+use crate::identifier::{knowledge::EntityId, ontology::OntologyTypeEditionId};
 
 pub mod account;
 pub mod knowledge;
@@ -14,7 +13,7 @@ pub type Timestamp = DateTime<Utc>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum GraphElementIdentifier {
-    OntologyElementId(VersionedUri),
+    OntologyElementId(OntologyTypeEditionId),
     KnowledgeGraphElementId(EntityId),
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/mod.rs
@@ -12,12 +12,12 @@ pub mod ontology;
 pub type Timestamp = DateTime<Utc>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum GraphElementIdentifier {
+pub enum GraphElementId {
     OntologyElementId(OntologyTypeEditionId),
     KnowledgeGraphElementId(EntityId),
 }
 
-impl Serialize for GraphElementIdentifier {
+impl Serialize for GraphElementId {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -31,7 +31,7 @@ impl Serialize for GraphElementIdentifier {
 
 // TODO: We have to do this because utoipa doesn't understand serde untagged
 //  https://github.com/juhaku/utoipa/issues/320
-impl ToSchema for GraphElementIdentifier {
+impl ToSchema for GraphElementId {
     fn schema() -> openapi::Schema {
         openapi::OneOfBuilder::new()
             .item(openapi::Object::with_type(openapi::SchemaType::String))

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/ontology.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/ontology.rs
@@ -37,6 +37,7 @@ impl ToSchema for OntologyTypeVersion {
 pub struct OntologyTypeEditionId {
     #[schema(value_type = String)]
     base_id: BaseUri,
+    #[schema(value_type = number)]
     version: OntologyTypeVersion,
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/ontology.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/ontology.rs
@@ -64,7 +64,7 @@ impl Display for OntologyTypeEditionId {
     }
 }
 
-// TODO: The Type System crate doesn't let us destructure so we need to clone base_uri
+// The Type System crate doesn't let us destructure so we need to clone base_uri
 impl From<VersionedUri> for OntologyTypeEditionId {
     fn from(versioned_uri: VersionedUri) -> Self {
         Self {
@@ -76,7 +76,7 @@ impl From<VersionedUri> for OntologyTypeEditionId {
 
 impl From<OntologyTypeEditionId> for VersionedUri {
     fn from(edition_id: OntologyTypeEditionId) -> Self {
-        // TODO: we should make it possible to destructure to avoid the clone
+        // We should make it possible to destructure to avoid the clone
         Self::new(edition_id.base_id().clone(), edition_id.version.inner())
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/ontology.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/ontology.rs
@@ -33,6 +33,7 @@ impl ToSchema for OntologyTypeVersion {
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct OntologyTypeEditionId {
     #[schema(value_type = String)]
     base_id: BaseUri,

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/ontology.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/ontology.rs
@@ -1,3 +1,5 @@
+use std::{fmt, fmt::Display};
+
 use postgres_types::{FromSql, ToSql};
 use serde::{Deserialize, Serialize};
 use type_system::uri::{BaseUri, VersionedUri};
@@ -51,6 +53,12 @@ impl OntologyTypeEditionId {
     #[must_use]
     pub const fn version(&self) -> OntologyTypeVersion {
         self.version
+    }
+}
+
+impl Display for OntologyTypeEditionId {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}v/{}", self.base_id.as_str(), self.version.inner())
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/shared/provenance.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/provenance.rs
@@ -48,7 +48,6 @@ macro_rules! define_provenance_id {
 define_provenance_id!(OwnedById);
 define_provenance_id!(CreatedById);
 define_provenance_id!(UpdatedById);
-define_provenance_id!(RemovedById);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]

--- a/packages/graph/hash_graph/lib/graph/src/shared/provenance.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/provenance.rs
@@ -49,3 +49,30 @@ define_provenance_id!(OwnedById);
 define_provenance_id!(CreatedById);
 define_provenance_id!(UpdatedById);
 define_provenance_id!(RemovedById);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct ProvenanceMetadata {
+    created_by_id: CreatedById,
+    updated_by_id: UpdatedById,
+}
+
+impl ProvenanceMetadata {
+    #[must_use]
+    pub const fn new(created_by_id: CreatedById, updated_by_id: UpdatedById) -> Self {
+        Self {
+            created_by_id,
+            updated_by_id,
+        }
+    }
+
+    #[must_use]
+    pub const fn created_by_id(&self) -> CreatedById {
+        self.created_by_id
+    }
+
+    #[must_use]
+    pub const fn updated_by_id(&self) -> UpdatedById {
+        self.updated_by_id
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph.rs
@@ -116,6 +116,7 @@ impl GraphResolveDepths {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Subgraph {
+    #[schema(value_type = Vec<GraphElementIdentifier>)]
     pub roots: HashSet<GraphElementIdentifier>,
     pub vertices: HashMap<GraphElementIdentifier, Vertex>,
     pub edges: Edges,

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph.rs
@@ -12,7 +12,9 @@ use utoipa::{openapi, ToSchema};
 
 use crate::{
     knowledge::{Entity, KnowledgeGraphQueryDepth, PersistedEntity},
-    ontology::{OntologyQueryDepth, PersistedDataType, PersistedEntityType, PersistedPropertyType},
+    ontology::{
+        DataTypeWithMetadata, EntityTypeWithMetadata, OntologyQueryDepth, PropertyTypeWithMetadata,
+    },
     shared::identifier::GraphElementIdentifier,
     store::query::{Filter, QueryRecord},
 };
@@ -21,9 +23,9 @@ use crate::{
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "kind", content = "inner")]
 pub enum Vertex {
-    DataType(PersistedDataType),
-    PropertyType(PersistedPropertyType),
-    EntityType(PersistedEntityType),
+    DataType(DataTypeWithMetadata),
+    PropertyType(PropertyTypeWithMetadata),
+    EntityType(EntityTypeWithMetadata),
     Entity(PersistedEntity),
 }
 
@@ -36,9 +38,9 @@ impl ToSchema for Vertex {
             openapi::OneOfBuilder::new().discriminator(Some(openapi::Discriminator::new("kind")));
 
         for (kind, schema) in [
-            ("dataType", PersistedDataType::schema()),
-            ("propertyType", PersistedPropertyType::schema()),
-            ("entityType", PersistedEntityType::schema()),
+            ("dataType", DataTypeWithMetadata::schema()),
+            ("propertyType", PropertyTypeWithMetadata::schema()),
+            ("entityType", EntityTypeWithMetadata::schema()),
             ("entity", PersistedEntity::schema()),
         ] {
             builder = builder.item(

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph.rs
@@ -11,7 +11,7 @@ use type_system::{DataType, EntityType, PropertyType};
 use utoipa::{openapi, ToSchema};
 
 use crate::{
-    knowledge::{EntityProperties, KnowledgeGraphQueryDepth, PersistedEntity},
+    knowledge::{Entity, EntityProperties, KnowledgeGraphQueryDepth},
     ontology::{
         DataTypeWithMetadata, EntityTypeWithMetadata, OntologyQueryDepth, PropertyTypeWithMetadata,
     },
@@ -26,7 +26,7 @@ pub enum Vertex {
     DataType(DataTypeWithMetadata),
     PropertyType(PropertyTypeWithMetadata),
     EntityType(EntityTypeWithMetadata),
-    Entity(PersistedEntity),
+    Entity(Entity),
 }
 
 // WARNING: This MUST be kept up to date with the enum names and serde attribute, as utoipa does
@@ -41,7 +41,7 @@ impl ToSchema for Vertex {
             ("dataType", DataTypeWithMetadata::schema()),
             ("propertyType", PropertyTypeWithMetadata::schema()),
             ("entityType", EntityTypeWithMetadata::schema()),
-            ("entity", PersistedEntity::schema()),
+            ("entity", Entity::schema()),
         ] {
             builder = builder.item(
                 openapi::ObjectBuilder::new()

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph.rs
@@ -11,7 +11,7 @@ use type_system::{DataType, EntityType, PropertyType};
 use utoipa::{openapi, ToSchema};
 
 use crate::{
-    knowledge::{Entity, KnowledgeGraphQueryDepth, PersistedEntity},
+    knowledge::{EntityProperties, KnowledgeGraphQueryDepth, PersistedEntity},
     ontology::{
         DataTypeWithMetadata, EntityTypeWithMetadata, OntologyQueryDepth, PropertyTypeWithMetadata,
     },
@@ -152,7 +152,7 @@ impl Extend<Self> for Subgraph {
     DataTypeStructuralQuery = StructuralQuery<'static, DataType>,
     PropertyTypeStructuralQuery = StructuralQuery<'static, PropertyType>,
     EntityTypeStructuralQuery = StructuralQuery<'static, EntityType>,
-    EntityStructuralQuery = StructuralQuery<'static, Entity>,
+    EntityStructuralQuery = StructuralQuery<'static, EntityProperties>,
 )]
 pub struct StructuralQuery<'q, T: QueryRecord> {
     #[serde(bound = "'de: 'q, T::Path<'q>: Deserialize<'de>")]

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph.rs
@@ -15,7 +15,7 @@ use crate::{
     ontology::{
         DataTypeWithMetadata, EntityTypeWithMetadata, OntologyQueryDepth, PropertyTypeWithMetadata,
     },
-    shared::identifier::GraphElementIdentifier,
+    shared::identifier::GraphElementId,
     store::query::{Filter, QueryRecord},
 };
 
@@ -80,7 +80,7 @@ pub enum EdgeKind {
 #[serde(rename_all = "camelCase")]
 pub struct OutwardEdge {
     pub edge_kind: EdgeKind,
-    pub destination: GraphElementIdentifier,
+    pub destination: GraphElementId,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
@@ -116,9 +116,9 @@ impl GraphResolveDepths {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Subgraph {
-    #[schema(value_type = Vec<GraphElementIdentifier>)]
-    pub roots: HashSet<GraphElementIdentifier>,
-    pub vertices: HashMap<GraphElementIdentifier, Vertex>,
+    #[schema(value_type = Vec<GraphElementId>)]
+    pub roots: HashSet<GraphElementId>,
+    pub vertices: HashMap<GraphElementId, Vertex>,
     pub edges: Edges,
     pub depths: GraphResolveDepths,
 }
@@ -176,7 +176,7 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
-pub struct Edges(HashMap<GraphElementIdentifier, HashSet<OutwardEdge>>);
+pub struct Edges(HashMap<GraphElementId, HashSet<OutwardEdge>>);
 
 impl Edges {
     #[must_use]
@@ -184,7 +184,7 @@ impl Edges {
         Self(HashMap::new())
     }
 
-    pub fn insert(&mut self, identifier: GraphElementIdentifier, edge: OutwardEdge) -> bool {
+    pub fn insert(&mut self, identifier: GraphElementId, edge: OutwardEdge) -> bool {
         match self.0.raw_entry_mut().from_key(&identifier) {
             RawEntryMut::Vacant(entry) => {
                 entry.insert(identifier, HashSet::from([edge]));
@@ -208,19 +208,16 @@ impl ToSchema for Edges {
 }
 
 impl IntoIterator for Edges {
-    type IntoIter = IntoIter<GraphElementIdentifier, HashSet<OutwardEdge>>;
-    type Item = (GraphElementIdentifier, HashSet<OutwardEdge>);
+    type IntoIter = IntoIter<GraphElementId, HashSet<OutwardEdge>>;
+    type Item = (GraphElementId, HashSet<OutwardEdge>);
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
     }
 }
 
-impl Extend<(GraphElementIdentifier, HashSet<OutwardEdge>)> for Edges {
-    fn extend<T: IntoIterator<Item = (GraphElementIdentifier, HashSet<OutwardEdge>)>>(
-        &mut self,
-        other: T,
-    ) {
+impl Extend<(GraphElementId, HashSet<OutwardEdge>)> for Edges {
+    fn extend<T: IntoIterator<Item = (GraphElementId, HashSet<OutwardEdge>)>>(&mut self, other: T) {
         self.0.extend(other);
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -19,7 +19,9 @@ pub use self::{
 };
 use crate::{
     identifier::knowledge::EntityId,
-    knowledge::{Entity, EntityUuid, LinkEntityMetadata, PersistedEntity, PersistedEntityMetadata},
+    knowledge::{
+        EntityProperties, EntityUuid, LinkEntityMetadata, PersistedEntity, PersistedEntityMetadata,
+    },
     ontology::{
         DataTypeWithMetadata, EntityTypeWithMetadata, PersistedOntologyMetadata,
         PropertyTypeWithMetadata,
@@ -324,7 +326,9 @@ pub trait EntityTypeStore:
 ///
 /// [Entities]: crate::knowledge::Entity
 #[async_trait]
-pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Filter<'q, Entity>> {
+pub trait EntityStore:
+    for<'q> crud::Read<PersistedEntity, Query<'q> = Filter<'q, EntityProperties>>
+{
     /// Creates a new [`Entity`].
     ///
     /// # Errors:
@@ -335,7 +339,7 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Filter<'q
     /// - if an [`EntityUuid`] was supplied and already exists in the store
     async fn create_entity(
         &mut self,
-        entity: Entity,
+        entity: EntityProperties,
         entity_type_id: VersionedUri,
         owned_by_id: OwnedById,
         entity_uuid: Option<EntityUuid>,
@@ -364,7 +368,8 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Filter<'q
     #[cfg(feature = "__internal_bench")]
     async fn insert_entities_batched_by_type(
         &mut self,
-        entities: impl IntoIterator<Item = (Option<EntityUuid>, Entity), IntoIter: Send> + Send,
+        entities: impl IntoIterator<Item = (Option<EntityUuid>, EntityProperties), IntoIter: Send>
+        + Send,
         entity_type_id: VersionedUri,
         owned_by_id: OwnedById,
         actor_id: CreatedById,
@@ -377,7 +382,7 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Filter<'q
     /// - if the requested [`Entity`] doesn't exist
     async fn get_entity<'f: 'q, 'q>(
         &self,
-        query: &'f StructuralQuery<'q, Entity>,
+        query: &'f StructuralQuery<'q, EntityProperties>,
     ) -> Result<Subgraph, QueryError>;
 
     /// Update an existing [`Entity`].
@@ -391,7 +396,7 @@ pub trait EntityStore: for<'q> crud::Read<PersistedEntity, Query<'q> = Filter<'q
     async fn update_entity(
         &mut self,
         entity_id: EntityId,
-        entity: Entity,
+        entity: EntityProperties,
         entity_type_id: VersionedUri,
         actor_id: UpdatedById,
     ) -> Result<PersistedEntityMetadata, UpdateError>;

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     identifier::knowledge::EntityId,
     knowledge::{Entity, EntityMetadata, EntityProperties, EntityUuid, LinkEntityMetadata},
     ontology::{
-        DataTypeWithMetadata, EntityTypeWithMetadata, PersistedOntologyMetadata,
+        DataTypeWithMetadata, EntityTypeWithMetadata, OntologyElementMetadata,
         PropertyTypeWithMetadata,
     },
     provenance::{CreatedById, OwnedById, UpdatedById},
@@ -212,7 +212,7 @@ pub trait DataTypeStore:
         data_type: DataType,
         owned_by_id: OwnedById,
         actor_id: CreatedById,
-    ) -> Result<PersistedOntologyMetadata, InsertionError>;
+    ) -> Result<OntologyElementMetadata, InsertionError>;
 
     /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
     ///
@@ -233,7 +233,7 @@ pub trait DataTypeStore:
         &mut self,
         data_type: DataType,
         actor_id: UpdatedById,
-    ) -> Result<PersistedOntologyMetadata, UpdateError>;
+    ) -> Result<OntologyElementMetadata, UpdateError>;
 }
 
 /// Describes the API of a store implementation for [`PropertyType`]s.
@@ -254,7 +254,7 @@ pub trait PropertyTypeStore:
         property_type: PropertyType,
         owned_by_id: OwnedById,
         actor_id: CreatedById,
-    ) -> Result<PersistedOntologyMetadata, InsertionError>;
+    ) -> Result<OntologyElementMetadata, InsertionError>;
 
     /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
     ///
@@ -275,7 +275,7 @@ pub trait PropertyTypeStore:
         &mut self,
         property_type: PropertyType,
         actor_id: UpdatedById,
-    ) -> Result<PersistedOntologyMetadata, UpdateError>;
+    ) -> Result<OntologyElementMetadata, UpdateError>;
 }
 
 /// Describes the API of a store implementation for [`EntityType`]s.
@@ -296,7 +296,7 @@ pub trait EntityTypeStore:
         entity_type: EntityType,
         owned_by_id: OwnedById,
         actor_id: CreatedById,
-    ) -> Result<PersistedOntologyMetadata, InsertionError>;
+    ) -> Result<OntologyElementMetadata, InsertionError>;
 
     /// Get the [`Subgraph`]s specified by the [`StructuralQuery`].
     ///
@@ -317,7 +317,7 @@ pub trait EntityTypeStore:
         &mut self,
         entity_type: EntityType,
         actor_id: UpdatedById,
-    ) -> Result<PersistedOntologyMetadata, UpdateError>;
+    ) -> Result<OntologyElementMetadata, UpdateError>;
 }
 
 /// Describes the API of a store implementation for [Entities].

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -21,7 +21,8 @@ use crate::{
     identifier::knowledge::EntityId,
     knowledge::{Entity, EntityUuid, LinkEntityMetadata, PersistedEntity, PersistedEntityMetadata},
     ontology::{
-        PersistedDataType, PersistedEntityType, PersistedOntologyMetadata, PersistedPropertyType,
+        DataTypeWithMetadata, EntityTypeWithMetadata, PersistedOntologyMetadata,
+        PropertyTypeWithMetadata,
     },
     provenance::{CreatedById, OwnedById, UpdatedById},
     shared::identifier::account::AccountId,
@@ -196,7 +197,7 @@ pub trait AccountStore {
 /// Describes the API of a store implementation for [`DataType`]s.
 #[async_trait]
 pub trait DataTypeStore:
-    for<'q> crud::Read<PersistedDataType, Query<'q> = Filter<'q, DataType>>
+    for<'q> crud::Read<DataTypeWithMetadata, Query<'q> = Filter<'q, DataType>>
 {
     /// Creates a new [`DataType`].
     ///
@@ -238,7 +239,7 @@ pub trait DataTypeStore:
 /// Describes the API of a store implementation for [`PropertyType`]s.
 #[async_trait]
 pub trait PropertyTypeStore:
-    for<'q> crud::Read<PersistedPropertyType, Query<'q> = Filter<'q, PropertyType>>
+    for<'q> crud::Read<PropertyTypeWithMetadata, Query<'q> = Filter<'q, PropertyType>>
 {
     /// Creates a new [`PropertyType`].
     ///
@@ -280,7 +281,7 @@ pub trait PropertyTypeStore:
 /// Describes the API of a store implementation for [`EntityType`]s.
 #[async_trait]
 pub trait EntityTypeStore:
-    for<'q> crud::Read<PersistedEntityType, Query<'q> = Filter<'q, EntityType>>
+    for<'q> crud::Read<EntityTypeWithMetadata, Query<'q> = Filter<'q, EntityType>>
 {
     /// Creates a new [`EntityType`].
     ///

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -19,9 +19,7 @@ pub use self::{
 };
 use crate::{
     identifier::knowledge::EntityId,
-    knowledge::{
-        EntityProperties, EntityUuid, LinkEntityMetadata, PersistedEntity, PersistedEntityMetadata,
-    },
+    knowledge::{Entity, EntityMetadata, EntityProperties, EntityUuid, LinkEntityMetadata},
     ontology::{
         DataTypeWithMetadata, EntityTypeWithMetadata, PersistedOntologyMetadata,
         PropertyTypeWithMetadata,
@@ -327,7 +325,7 @@ pub trait EntityTypeStore:
 /// [Entities]: crate::knowledge::Entity
 #[async_trait]
 pub trait EntityStore:
-    for<'q> crud::Read<PersistedEntity, Query<'q> = Filter<'q, EntityProperties>>
+    for<'q> crud::Read<Entity, Query<'q> = Filter<'q, EntityProperties>>
 {
     /// Creates a new [`Entity`].
     ///
@@ -345,7 +343,7 @@ pub trait EntityStore:
         entity_uuid: Option<EntityUuid>,
         actor_id: CreatedById,
         link_metadata: Option<LinkEntityMetadata>,
-    ) -> Result<PersistedEntityMetadata, InsertionError>;
+    ) -> Result<EntityMetadata, InsertionError>;
 
     /// Inserts the entities with the specified [`EntityType`] into the `Store`.
     ///
@@ -399,7 +397,7 @@ pub trait EntityStore:
         entity: EntityProperties,
         entity_type_id: VersionedUri,
         actor_id: UpdatedById,
-    ) -> Result<PersistedEntityMetadata, UpdateError>;
+    ) -> Result<EntityMetadata, UpdateError>;
 
     /// Archives an [`Entity`].
     ///

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -59,7 +59,7 @@ impl<C: AsClient> PostgresStore<C> {
                     OutwardEdge {
                         edge_kind: EdgeKind::HasType,
                         destination: GraphElementIdentifier::OntologyElementId(
-                            entity_type_id.clone(),
+                            entity_type_id.clone().into(),
                         ),
                     },
                 );
@@ -70,7 +70,7 @@ impl<C: AsClient> PostgresStore<C> {
                     > 0
                 {
                     self.get_entity_type_as_dependency(
-                        &entity_type_id,
+                        &entity_type_id.into(),
                         dependency_context.change_depth(GraphResolveDepths {
                             entity_type_resolve_depth: dependency_context
                                 .graph_resolve_depths

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -248,7 +248,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             .then(|entity| async move {
                 let mut dependency_context = DependencyContext::new(graph_resolve_depths);
 
-                let entity_id = entity.metadata().identifier().base_id();
+                let entity_id = entity.metadata().edition_id().base_id();
                 dependency_context
                     .linked_entities
                     .insert(&entity_id, None, entity);

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -299,7 +299,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 entity_id,
                 entity,
                 entity_type_id,
-                old_entity_metadata.created_by_id(),
+                old_entity_metadata.provenance_metadata().created_by_id(),
                 updated_by_id,
                 old_entity_metadata.link_metadata(),
             )
@@ -352,7 +352,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 entity_id,
                 old_entity.inner().clone(),
                 old_entity.metadata().entity_type_id().clone(),
-                old_entity.metadata().created_by_id(),
+                old_entity.metadata().provenance_metadata().created_by_id(),
                 actor_id,
                 old_entity.metadata().link_metadata(),
             )

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -350,7 +350,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         transaction
             .insert_entity(
                 entity_id,
-                old_entity.inner().clone(),
+                old_entity.properties().clone(),
                 old_entity.metadata().entity_type_id().clone(),
                 old_entity.metadata().provenance_metadata().created_by_id(),
                 actor_id,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -11,7 +11,9 @@ use uuid::Uuid;
 
 use crate::{
     identifier::{knowledge::EntityId, GraphElementIdentifier},
-    knowledge::{Entity, EntityUuid, LinkEntityMetadata, PersistedEntity, PersistedEntityMetadata},
+    knowledge::{
+        EntityProperties, EntityUuid, LinkEntityMetadata, PersistedEntity, PersistedEntityMetadata,
+    },
     provenance::{CreatedById, OwnedById, UpdatedById},
     store::{
         crud::Read,
@@ -131,7 +133,7 @@ impl<C: AsClient> PostgresStore<C> {
 impl<C: AsClient> EntityStore for PostgresStore<C> {
     async fn create_entity(
         &mut self,
-        entity: Entity,
+        entity: EntityProperties,
         entity_type_id: VersionedUri,
         owned_by_id: OwnedById,
         entity_uuid: Option<EntityUuid>,
@@ -177,7 +179,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
     #[cfg(feature = "__internal_bench")]
     async fn insert_entities_batched_by_type(
         &mut self,
-        entities: impl IntoIterator<Item = (Option<EntityUuid>, Entity), IntoIter: Send> + Send,
+        entities: impl IntoIterator<Item = (Option<EntityUuid>, EntityProperties), IntoIter: Send>
+        + Send,
         entity_type_id: VersionedUri,
         owned_by_id: OwnedById,
         actor_id: CreatedById,
@@ -236,7 +239,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
 
     async fn get_entity<'f: 'q, 'q>(
         &self,
-        query: &'f StructuralQuery<'q, Entity>,
+        query: &'f StructuralQuery<'q, EntityProperties>,
     ) -> Result<Subgraph, QueryError> {
         let StructuralQuery {
             ref filter,
@@ -271,7 +274,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
     async fn update_entity(
         &mut self,
         entity_id: EntityId,
-        entity: Entity,
+        entity: EntityProperties,
         entity_type_id: VersionedUri,
         updated_by_id: UpdatedById,
     ) -> Result<PersistedEntityMetadata, UpdateError> {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -10,7 +10,7 @@ use type_system::uri::VersionedUri;
 use uuid::Uuid;
 
 use crate::{
-    identifier::{knowledge::EntityId, GraphElementIdentifier},
+    identifier::{knowledge::EntityId, GraphElementId},
     knowledge::{Entity, EntityMetadata, EntityProperties, EntityUuid, LinkEntityMetadata},
     provenance::{CreatedById, OwnedById, UpdatedById},
     store::{
@@ -55,10 +55,10 @@ impl<C: AsClient> PostgresStore<C> {
                 let entity_type_id = entity.metadata().entity_type_id().clone();
 
                 dependency_context.edges.insert(
-                    GraphElementIdentifier::KnowledgeGraphElementId(entity_id),
+                    GraphElementId::KnowledgeGraphElementId(entity_id),
                     OutwardEdge {
                         edge_kind: EdgeKind::HasType,
-                        destination: GraphElementIdentifier::OntologyElementId(
+                        destination: GraphElementId::OntologyElementId(
                             entity_type_id.clone().into(),
                         ),
                     },
@@ -92,10 +92,10 @@ impl<C: AsClient> PostgresStore<C> {
                 //     .await?
                 // {
                 //     dependency_context.edges.insert(
-                //         GraphElementIdentifier::KnowledgeGraphElementId(entity_uuid),
+                //         GraphElementId::KnowledgeGraphElementId(entity_uuid),
                 //         OutwardEdge {
                 //             edge_kind: EdgeKind::HasLink,
-                //             destination: GraphElementIdentifier::Temporary(LinkId {
+                //             destination: GraphElementId::Temporary(LinkId {
                 //                 source_entity_uuid: link_record.source_entity_uuid,
                 //                 target_entity_uuid: link_record.target_entity_uuid,
                 //                 link_type_id: link_record.link_type_id.clone(),
@@ -256,7 +256,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 self.get_entity_as_dependency(entity_id, dependency_context.as_ref_object())
                     .await?;
 
-                let root = GraphElementIdentifier::KnowledgeGraphElementId(entity_id);
+                let root = GraphElementId::KnowledgeGraphElementId(entity_id);
 
                 Ok::<_, Report<QueryError>>(dependency_context.into_subgraph(HashSet::from([root])))
             })

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -12,7 +12,9 @@ use crate::{
         account::AccountId,
         knowledge::{EntityEditionId, EntityId},
     },
-    knowledge::{Entity, EntityQueryPath, EntityUuid, LinkEntityMetadata, PersistedEntity},
+    knowledge::{
+        EntityProperties, EntityQueryPath, EntityUuid, LinkEntityMetadata, PersistedEntity,
+    },
     ontology::EntityTypeQueryPath,
     provenance::{CreatedById, OwnedById, UpdatedById},
     store::{
@@ -22,7 +24,7 @@ use crate::{
 
 #[async_trait]
 impl<C: AsClient> crud::Read<PersistedEntity> for PostgresStore<C> {
-    type Query<'q> = Filter<'q, Entity>;
+    type Query<'q> = Filter<'q, EntityProperties>;
 
     async fn read<'f: 'q, 'q>(
         &self,
@@ -71,7 +73,7 @@ impl<C: AsClient> crud::Read<PersistedEntity> for PostgresStore<C> {
             .change_context(QueryError)?
             .map(|row| row.into_report().change_context(QueryError))
             .and_then(|row| async move {
-                let entity: Entity = serde_json::from_value(row.get(properties_index))
+                let entity: EntityProperties = serde_json::from_value(row.get(properties_index))
                     .into_report()
                     .change_context(QueryError)?;
                 let entity_type_uri = VersionedUri::from_str(row.get(type_id_index))

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -12,9 +12,7 @@ use crate::{
         account::AccountId,
         knowledge::{EntityEditionId, EntityId},
     },
-    knowledge::{
-        EntityProperties, EntityQueryPath, EntityUuid, LinkEntityMetadata, PersistedEntity,
-    },
+    knowledge::{Entity, EntityProperties, EntityQueryPath, EntityUuid, LinkEntityMetadata},
     ontology::EntityTypeQueryPath,
     provenance::{CreatedById, OwnedById, UpdatedById},
     store::{
@@ -23,13 +21,13 @@ use crate::{
 };
 
 #[async_trait]
-impl<C: AsClient> crud::Read<PersistedEntity> for PostgresStore<C> {
+impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
     type Query<'q> = Filter<'q, EntityProperties>;
 
     async fn read<'f: 'q, 'q>(
         &self,
         filter: &'f Self::Query<'q>,
-    ) -> Result<Vec<PersistedEntity>, QueryError> {
+    ) -> Result<Vec<Entity>, QueryError> {
         // We can't define these inline otherwise we'll drop while borrowed
         let left_owned_by_id_query_path =
             EntityQueryPath::LeftEntity(Some(Box::new(EntityQueryPath::OwnedById)));
@@ -123,7 +121,7 @@ impl<C: AsClient> crud::Read<PersistedEntity> for PostgresStore<C> {
                 let created_by_id = CreatedById::new(row.get(created_by_id_index));
                 let updated_by_id = UpdatedById::new(row.get(updated_by_id_index));
 
-                Ok(PersistedEntity::new(
+                Ok(Entity::new(
                     entity,
                     EntityEditionId::new(
                         EntityId::new(owned_by_id, entity_uuid),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     knowledge::{Entity, EntityProperties, EntityQueryPath, EntityUuid, LinkEntityMetadata},
     ontology::EntityTypeQueryPath,
-    provenance::{CreatedById, OwnedById, UpdatedById},
+    provenance::{CreatedById, OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
         crud, postgres::query::SelectCompiler, query::Filter, AsClient, PostgresStore, QueryError,
     },
@@ -128,8 +128,7 @@ impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
                         row.get(version_index),
                     ),
                     entity_type_uri,
-                    created_by_id,
-                    updated_by_id,
+                    ProvenanceMetadata::new(created_by_id, updated_by_id),
                     link_metadata,
                     // TODO: only the historic table would have an `archived` field.
                     //   Consider what we should do about that.

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -585,11 +585,12 @@ where
         Ok((
             version_id,
             OntologyElementMetadata::new(
-                PersistedOntologyIdentifier::new(uri, owned_by_id),
+                PersistedOntologyIdentifier::new(uri),
                 ProvenanceMetadata::new(
                     created_by_id,
                     UpdatedById::new(created_by_id.as_account_id()),
                 ),
+                owned_by_id,
             ),
         ))
     }
@@ -664,8 +665,9 @@ where
         Ok((
             version_id,
             OntologyElementMetadata::new(
-                PersistedOntologyIdentifier::new(uri, owned_by_id),
+                PersistedOntologyIdentifier::new(uri),
                 ProvenanceMetadata::new(created_by_id, updated_by_id),
+                owned_by_id,
             ),
         ))
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -28,8 +28,8 @@ pub use self::pool::{AsClient, PostgresStorePool};
 use crate::{
     identifier::knowledge::{EntityEditionId, EntityId},
     knowledge::{
-        EntityProperties, EntityUuid, KnowledgeGraphQueryDepth, LinkEntityMetadata,
-        PersistedEntity, PersistedEntityMetadata,
+        Entity, EntityMetadata, EntityProperties, EntityUuid, KnowledgeGraphQueryDepth,
+        LinkEntityMetadata,
     },
     ontology::{
         DataTypeWithMetadata, EntityTypeWithMetadata, OntologyQueryDepth,
@@ -235,7 +235,7 @@ pub struct DependencyContext {
         DependencyMap<VersionedUri, PropertyTypeWithMetadata, OntologyQueryDepth>,
     pub referenced_entity_types:
         DependencyMap<VersionedUri, EntityTypeWithMetadata, OntologyQueryDepth>,
-    pub linked_entities: DependencyMap<EntityId, PersistedEntity, KnowledgeGraphQueryDepth>,
+    pub linked_entities: DependencyMap<EntityId, Entity, KnowledgeGraphQueryDepth>,
     pub graph_resolve_depths: GraphResolveDepths,
 }
 
@@ -328,7 +328,7 @@ pub struct DependencyContextRef<'a> {
         &'a mut DependencyMap<VersionedUri, PropertyTypeWithMetadata, OntologyQueryDepth>,
     pub referenced_entity_types:
         &'a mut DependencyMap<VersionedUri, EntityTypeWithMetadata, OntologyQueryDepth>,
-    pub linked_entities: &'a mut DependencyMap<EntityId, PersistedEntity, KnowledgeGraphQueryDepth>,
+    pub linked_entities: &'a mut DependencyMap<EntityId, Entity, KnowledgeGraphQueryDepth>,
     pub graph_resolve_depths: GraphResolveDepths,
 }
 
@@ -885,7 +885,7 @@ where
         created_by_id: CreatedById,
         updated_by_id: UpdatedById,
         link_metadata: Option<LinkEntityMetadata>,
-    ) -> Result<PersistedEntityMetadata, InsertionError> {
+    ) -> Result<EntityMetadata, InsertionError> {
         let entity_type_version_id = self
             .version_id_by_uri(&entity_type_id)
             .await
@@ -941,7 +941,7 @@ where
             .change_context(InsertionError)?
             .get(0);
 
-        Ok(PersistedEntityMetadata::new(
+        Ok(EntityMetadata::new(
             EntityEditionId::new(entity_id, version),
             entity_type_id,
             created_by_id,
@@ -987,7 +987,7 @@ where
         &self,
         entity_id: EntityId,
         historic_move: HistoricMove,
-    ) -> Result<PersistedEntityMetadata, InsertionError> {
+    ) -> Result<EntityMetadata, InsertionError> {
         let historic_entity = self
             .as_client()
             .query_one(
@@ -1096,7 +1096,7 @@ where
             .change_context(InsertionError)?;
         let entity_type_id = VersionedUri::new(base_uri, historic_entity.get::<_, i64>(4) as u32);
 
-        Ok(PersistedEntityMetadata::new(
+        Ok(EntityMetadata::new(
             EntityEditionId::new(
                 EntityId::new(
                     OwnedById::new(historic_entity.get(0)),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -39,7 +39,7 @@ use crate::{
         PropertyTypeWithMetadata,
     },
     provenance::{CreatedById, OwnedById, ProvenanceMetadata, UpdatedById},
-    shared::identifier::{account::AccountId, GraphElementIdentifier},
+    shared::identifier::{account::AccountId, GraphElementId},
     store::{
         error::VersionedUriAlreadyExists,
         postgres::{ontology::OntologyDatabaseType, version_id::VersionId},
@@ -268,15 +268,13 @@ impl DependencyContext {
     }
 
     #[must_use]
-    pub fn into_subgraph(self, roots: HashSet<GraphElementIdentifier>) -> Subgraph {
+    pub fn into_subgraph(self, roots: HashSet<GraphElementId>) -> Subgraph {
         let vertices = self
             .referenced_data_types
             .into_values()
             .map(|data_type| {
                 (
-                    GraphElementIdentifier::OntologyElementId(
-                        data_type.metadata().edition_id().clone(),
-                    ),
+                    GraphElementId::OntologyElementId(data_type.metadata().edition_id().clone()),
                     Vertex::DataType(data_type),
                 )
             })
@@ -285,7 +283,7 @@ impl DependencyContext {
                     .into_values()
                     .map(|property_type| {
                         (
-                            GraphElementIdentifier::OntologyElementId(
+                            GraphElementId::OntologyElementId(
                                 property_type.metadata().edition_id().clone(),
                             ),
                             Vertex::PropertyType(property_type),
@@ -297,7 +295,7 @@ impl DependencyContext {
                     .into_values()
                     .map(|entity_type| {
                         (
-                            GraphElementIdentifier::OntologyElementId(
+                            GraphElementId::OntologyElementId(
                                 entity_type.metadata().edition_id().clone(),
                             ),
                             Vertex::EntityType(entity_type),
@@ -306,7 +304,7 @@ impl DependencyContext {
             )
             .chain(self.linked_entities.into_values().map(|entity| {
                 (
-                    GraphElementIdentifier::KnowledgeGraphElementId(
+                    GraphElementId::KnowledgeGraphElementId(
                         entity.metadata().edition_id().base_id(),
                     ),
                     Vertex::Entity(entity),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -35,7 +35,7 @@ use crate::{
         DataTypeWithMetadata, EntityTypeWithMetadata, OntologyQueryDepth,
         PersistedOntologyIdentifier, PersistedOntologyMetadata, PropertyTypeWithMetadata,
     },
-    provenance::{CreatedById, OwnedById, UpdatedById},
+    provenance::{CreatedById, OwnedById, ProvenanceMetadata, UpdatedById},
     shared::identifier::{account::AccountId, GraphElementIdentifier},
     store::{
         error::VersionedUriAlreadyExists,
@@ -944,8 +944,7 @@ where
         Ok(EntityMetadata::new(
             EntityEditionId::new(entity_id, version),
             entity_type_id,
-            created_by_id,
-            updated_by_id,
+            ProvenanceMetadata::new(created_by_id, updated_by_id),
             link_metadata,
             // TODO: only the historic table would have an `archived` field.
             //   Consider what we should do about that.
@@ -1105,8 +1104,10 @@ where
                 historic_entity.get(2),
             ),
             entity_type_id,
-            CreatedById::new(historic_entity.get(11)),
-            UpdatedById::new(historic_entity.get(12)),
+            ProvenanceMetadata::new(
+                CreatedById::new(historic_entity.get(11)),
+                UpdatedById::new(historic_entity.get(12)),
+            ),
             link_metadata,
             // TODO: only the historic table would have an `archived` field.
             //   Consider what we should do about that.

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -32,8 +32,8 @@ use crate::{
         PersistedEntityMetadata,
     },
     ontology::{
-        OntologyQueryDepth, PersistedDataType, PersistedEntityType, PersistedOntologyIdentifier,
-        PersistedOntologyMetadata, PersistedPropertyType,
+        DataTypeWithMetadata, EntityTypeWithMetadata, OntologyQueryDepth,
+        PersistedOntologyIdentifier, PersistedOntologyMetadata, PropertyTypeWithMetadata,
     },
     provenance::{CreatedById, OwnedById, UpdatedById},
     shared::identifier::{account::AccountId, GraphElementIdentifier},
@@ -229,11 +229,12 @@ where
 
 pub struct DependencyContext {
     pub edges: Edges,
-    pub referenced_data_types: DependencyMap<VersionedUri, PersistedDataType, OntologyQueryDepth>,
+    pub referenced_data_types:
+        DependencyMap<VersionedUri, DataTypeWithMetadata, OntologyQueryDepth>,
     pub referenced_property_types:
-        DependencyMap<VersionedUri, PersistedPropertyType, OntologyQueryDepth>,
+        DependencyMap<VersionedUri, PropertyTypeWithMetadata, OntologyQueryDepth>,
     pub referenced_entity_types:
-        DependencyMap<VersionedUri, PersistedEntityType, OntologyQueryDepth>,
+        DependencyMap<VersionedUri, EntityTypeWithMetadata, OntologyQueryDepth>,
     pub linked_entities: DependencyMap<EntityId, PersistedEntity, KnowledgeGraphQueryDepth>,
     pub graph_resolve_depths: GraphResolveDepths,
 }
@@ -322,11 +323,11 @@ impl DependencyContext {
 pub struct DependencyContextRef<'a> {
     pub edges: &'a mut Edges,
     pub referenced_data_types:
-        &'a mut DependencyMap<VersionedUri, PersistedDataType, OntologyQueryDepth>,
+        &'a mut DependencyMap<VersionedUri, DataTypeWithMetadata, OntologyQueryDepth>,
     pub referenced_property_types:
-        &'a mut DependencyMap<VersionedUri, PersistedPropertyType, OntologyQueryDepth>,
+        &'a mut DependencyMap<VersionedUri, PropertyTypeWithMetadata, OntologyQueryDepth>,
     pub referenced_entity_types:
-        &'a mut DependencyMap<VersionedUri, PersistedEntityType, OntologyQueryDepth>,
+        &'a mut DependencyMap<VersionedUri, EntityTypeWithMetadata, OntologyQueryDepth>,
     pub linked_entities: &'a mut DependencyMap<EntityId, PersistedEntity, KnowledgeGraphQueryDepth>,
     pub graph_resolve_depths: GraphResolveDepths,
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -32,8 +32,8 @@ use crate::{
         LinkEntityMetadata,
     },
     ontology::{
-        DataTypeWithMetadata, EntityTypeWithMetadata, OntologyQueryDepth,
-        PersistedOntologyIdentifier, PersistedOntologyMetadata, PropertyTypeWithMetadata,
+        DataTypeWithMetadata, EntityTypeWithMetadata, OntologyElementMetadata, OntologyQueryDepth,
+        PersistedOntologyIdentifier, PropertyTypeWithMetadata,
     },
     provenance::{CreatedById, OwnedById, ProvenanceMetadata, UpdatedById},
     shared::identifier::{account::AccountId, GraphElementIdentifier},
@@ -541,7 +541,7 @@ where
         database_type: T,
         owned_by_id: OwnedById,
         created_by_id: CreatedById,
-    ) -> Result<(VersionId, PersistedOntologyMetadata), InsertionError>
+    ) -> Result<(VersionId, OntologyElementMetadata), InsertionError>
     where
         T: OntologyDatabaseType + Send + Sync + Into<serde_json::Value>,
     {
@@ -584,7 +584,7 @@ where
 
         Ok((
             version_id,
-            PersistedOntologyMetadata::new(
+            OntologyElementMetadata::new(
                 PersistedOntologyIdentifier::new(uri, owned_by_id),
                 ProvenanceMetadata::new(
                     created_by_id,
@@ -608,7 +608,7 @@ where
         &self,
         database_type: T,
         updated_by_id: UpdatedById,
-    ) -> Result<(VersionId, PersistedOntologyMetadata), UpdateError>
+    ) -> Result<(VersionId, OntologyElementMetadata), UpdateError>
     where
         T: OntologyDatabaseType
             + Send
@@ -663,7 +663,7 @@ where
 
         Ok((
             version_id,
-            PersistedOntologyMetadata::new(
+            OntologyElementMetadata::new(
                 PersistedOntologyIdentifier::new(uri, owned_by_id),
                 ProvenanceMetadata::new(created_by_id, updated_by_id),
             ),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -28,8 +28,8 @@ pub use self::pool::{AsClient, PostgresStorePool};
 use crate::{
     identifier::knowledge::{EntityEditionId, EntityId},
     knowledge::{
-        Entity, EntityUuid, KnowledgeGraphQueryDepth, LinkEntityMetadata, PersistedEntity,
-        PersistedEntityMetadata,
+        EntityProperties, EntityUuid, KnowledgeGraphQueryDepth, LinkEntityMetadata,
+        PersistedEntity, PersistedEntityMetadata,
     },
     ontology::{
         DataTypeWithMetadata, EntityTypeWithMetadata, OntologyQueryDepth,
@@ -880,7 +880,7 @@ where
     async fn insert_entity(
         &self,
         entity_id: EntityId,
-        entity: Entity,
+        entity: EntityProperties,
         entity_type_id: VersionedUri,
         created_by_id: CreatedById,
         updated_by_id: UpdatedById,
@@ -1184,7 +1184,7 @@ impl PostgresStore<Transaction<'_>> {
     async fn insert_entity_batch_by_type(
         &self,
         entity_uuids: impl IntoIterator<Item = EntityUuid, IntoIter: Send> + Send,
-        entities: impl IntoIterator<Item = Entity, IntoIter: Send> + Send,
+        entities: impl IntoIterator<Item = EntityProperties, IntoIter: Send> + Send,
         entity_type_version_id: VersionId,
         owned_by_id: OwnedById,
         created_by: CreatedById,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -586,9 +586,10 @@ where
             version_id,
             PersistedOntologyMetadata::new(
                 PersistedOntologyIdentifier::new(uri, owned_by_id),
-                created_by_id,
-                UpdatedById::new(created_by_id.as_account_id()),
-                None,
+                ProvenanceMetadata::new(
+                    created_by_id,
+                    UpdatedById::new(created_by_id.as_account_id()),
+                ),
             ),
         ))
     }
@@ -664,9 +665,7 @@ where
             version_id,
             PersistedOntologyMetadata::new(
                 PersistedOntologyIdentifier::new(uri, owned_by_id),
-                created_by_id,
-                updated_by_id,
-                None,
+                ProvenanceMetadata::new(created_by_id, updated_by_id),
             ),
         ))
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -307,7 +307,7 @@ impl DependencyContext {
             .chain(self.linked_entities.into_values().map(|entity| {
                 (
                     GraphElementIdentifier::KnowledgeGraphElementId(
-                        entity.metadata().identifier().base_id(),
+                        entity.metadata().edition_id().base_id(),
                     ),
                     Vertex::Entity(entity),
                 )

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -4,9 +4,10 @@ use async_trait::async_trait;
 use error_stack::{IntoReport, Report, Result, ResultExt};
 use futures::{stream, StreamExt, TryStreamExt};
 use tokio_postgres::GenericClient;
-use type_system::{uri::VersionedUri, DataType};
+use type_system::DataType;
 
 use crate::{
+    identifier::ontology::OntologyTypeEditionId,
     ontology::{DataTypeWithMetadata, OntologyElementMetadata},
     provenance::{CreatedById, OwnedById, UpdatedById},
     shared::identifier::GraphElementIdentifier,
@@ -24,7 +25,7 @@ impl<C: AsClient> PostgresStore<C> {
     /// This is used to recursively resolve a type, so the result can be reused.
     pub(crate) async fn get_data_type_as_dependency(
         &self,
-        data_type_id: &VersionedUri,
+        data_type_id: &OntologyTypeEditionId,
         context: DependencyContextRef<'_>,
     ) -> Result<(), QueryError> {
         let DependencyContextRef {
@@ -92,7 +93,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
             .then(|data_type| async move {
                 let mut dependency_context = DependencyContext::new(graph_resolve_depths);
 
-                let data_type_id = data_type.metadata().identifier().uri().clone();
+                let data_type_id = data_type.metadata().edition_id().clone();
                 dependency_context
                     .referenced_data_types
                     .insert(&data_type_id, None, data_type);

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -7,7 +7,7 @@ use tokio_postgres::GenericClient;
 use type_system::{uri::VersionedUri, DataType};
 
 use crate::{
-    ontology::{PersistedDataType, PersistedOntologyMetadata},
+    ontology::{DataTypeWithMetadata, PersistedOntologyMetadata},
     provenance::{CreatedById, OwnedById, UpdatedById},
     shared::identifier::GraphElementIdentifier,
     store::{
@@ -19,7 +19,7 @@ use crate::{
 };
 
 impl<C: AsClient> PostgresStore<C> {
-    /// Internal method to read a [`PersistedDataType`] into a [`DependencyContext`].
+    /// Internal method to read a [`DataTypeWithMetadata`] into a [`DependencyContext`].
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
     pub(crate) async fn get_data_type_as_dependency(
@@ -38,7 +38,7 @@ impl<C: AsClient> PostgresStore<C> {
                 data_type_id,
                 Some(graph_resolve_depths.data_type_resolve_depth),
                 || async {
-                    Ok(PersistedDataType::from(
+                    Ok(DataTypeWithMetadata::from(
                         self.read_versioned_ontology_type(data_type_id).await?,
                     ))
                 },
@@ -88,7 +88,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
             graph_resolve_depths,
         } = *query;
 
-        let subgraphs = stream::iter(Read::<PersistedDataType>::read(self, filter).await?)
+        let subgraphs = stream::iter(Read::<DataTypeWithMetadata>::read(self, filter).await?)
             .then(|data_type| async move {
                 let mut dependency_context = DependencyContext::new(graph_resolve_depths);
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -10,7 +10,7 @@ use crate::{
     identifier::ontology::OntologyTypeEditionId,
     ontology::{DataTypeWithMetadata, OntologyElementMetadata},
     provenance::{CreatedById, OwnedById, UpdatedById},
-    shared::identifier::GraphElementIdentifier,
+    shared::identifier::GraphElementId,
     store::{
         crud::Read,
         postgres::{context::PostgresContext, DependencyContext, DependencyContextRef},
@@ -101,7 +101,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
                 self.get_data_type_as_dependency(&data_type_id, dependency_context.as_ref_object())
                     .await?;
 
-                let root = GraphElementIdentifier::OntologyElementId(data_type_id);
+                let root = GraphElementId::OntologyElementId(data_type_id);
 
                 Ok::<_, Report<QueryError>>(dependency_context.into_subgraph(HashSet::from([root])))
             })

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -7,7 +7,7 @@ use tokio_postgres::GenericClient;
 use type_system::{uri::VersionedUri, DataType};
 
 use crate::{
-    ontology::{DataTypeWithMetadata, PersistedOntologyMetadata},
+    ontology::{DataTypeWithMetadata, OntologyElementMetadata},
     provenance::{CreatedById, OwnedById, UpdatedById},
     shared::identifier::GraphElementIdentifier,
     store::{
@@ -56,7 +56,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
         data_type: DataType,
         owned_by_id: OwnedById,
         created_by_id: CreatedById,
-    ) -> Result<PersistedOntologyMetadata, InsertionError> {
+    ) -> Result<OntologyElementMetadata, InsertionError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
                 .transaction()
@@ -117,7 +117,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
         &mut self,
         data_type: DataType,
         updated_by_id: UpdatedById,
-    ) -> Result<PersistedOntologyMetadata, UpdateError> {
+    ) -> Result<OntologyElementMetadata, UpdateError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
                 .transaction()

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -7,7 +7,7 @@ use tokio_postgres::GenericClient;
 use type_system::{uri::VersionedUri, EntityType, EntityTypeReference};
 
 use crate::{
-    ontology::{EntityTypeWithMetadata, PersistedOntologyMetadata},
+    ontology::{EntityTypeWithMetadata, OntologyElementMetadata},
     provenance::{CreatedById, OwnedById, UpdatedById},
     shared::identifier::GraphElementIdentifier,
     store::{
@@ -139,7 +139,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         entity_type: EntityType,
         owned_by_id: OwnedById,
         created_by_id: CreatedById,
-    ) -> Result<PersistedOntologyMetadata, InsertionError> {
+    ) -> Result<OntologyElementMetadata, InsertionError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
                 .transaction()
@@ -220,7 +220,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         &mut self,
         entity_type: EntityType,
         updated_by: UpdatedById,
-    ) -> Result<PersistedOntologyMetadata, UpdateError> {
+    ) -> Result<OntologyElementMetadata, UpdateError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
                 .transaction()

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -10,7 +10,7 @@ use crate::{
     identifier::ontology::OntologyTypeEditionId,
     ontology::{EntityTypeWithMetadata, OntologyElementMetadata},
     provenance::{CreatedById, OwnedById, UpdatedById},
-    shared::identifier::GraphElementIdentifier,
+    shared::identifier::GraphElementId,
     store::{
         crud::Read,
         postgres::{context::PostgresContext, DependencyContext, DependencyContextRef},
@@ -49,10 +49,10 @@ impl<C: AsClient> PostgresStore<C> {
             if let Some(entity_type) = unresolved_entity_type.cloned() {
                 for property_type_ref in entity_type.inner().property_type_references() {
                     dependency_context.edges.insert(
-                        GraphElementIdentifier::OntologyElementId(entity_type_id.clone()),
+                        GraphElementId::OntologyElementId(entity_type_id.clone()),
                         OutwardEdge {
                             edge_kind: EdgeKind::References,
-                            destination: GraphElementIdentifier::OntologyElementId(
+                            destination: GraphElementId::OntologyElementId(
                                 property_type_ref.uri().clone().into(),
                             ),
                         },
@@ -99,10 +99,10 @@ impl<C: AsClient> PostgresStore<C> {
                 //   see https://app.asana.com/0/0/1202884883200942/f
                 for entity_type_id in entity_type_ids {
                     dependency_context.edges.insert(
-                        GraphElementIdentifier::OntologyElementId(entity_type_id.clone().into()),
+                        GraphElementId::OntologyElementId(entity_type_id.clone().into()),
                         OutwardEdge {
                             edge_kind: EdgeKind::References,
-                            destination: GraphElementIdentifier::OntologyElementId(
+                            destination: GraphElementId::OntologyElementId(
                                 entity_type_id.clone().into(),
                             ),
                         },
@@ -206,7 +206,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
                 )
                 .await?;
 
-                let root = GraphElementIdentifier::OntologyElementId(entity_type_id);
+                let root = GraphElementId::OntologyElementId(entity_type_id);
 
                 Ok::<_, Report<QueryError>>(dependency_context.into_subgraph(HashSet::from([root])))
             })

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -7,7 +7,7 @@ use tokio_postgres::GenericClient;
 use type_system::{uri::VersionedUri, EntityType, EntityTypeReference};
 
 use crate::{
-    ontology::{PersistedEntityType, PersistedOntologyMetadata},
+    ontology::{EntityTypeWithMetadata, PersistedOntologyMetadata},
     provenance::{CreatedById, OwnedById, UpdatedById},
     shared::identifier::GraphElementIdentifier,
     store::{
@@ -19,7 +19,7 @@ use crate::{
 };
 
 impl<C: AsClient> PostgresStore<C> {
-    /// Internal method to read a [`PersistedEntityType`] into four [`DependencyContext`]s.
+    /// Internal method to read a [`EntityTypeWithMetadata`] into four [`DependencyContext`]s.
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
     pub(crate) fn get_entity_type_as_dependency<'a: 'b, 'b>(
@@ -38,7 +38,7 @@ impl<C: AsClient> PostgresStore<C> {
                             .entity_type_resolve_depth,
                     ),
                     || async {
-                        Ok(PersistedEntityType::from(
+                        Ok(EntityTypeWithMetadata::from(
                             self.read_versioned_ontology_type(entity_type_id).await?,
                         ))
                     },
@@ -186,7 +186,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
             graph_resolve_depths,
         } = *query;
 
-        let subgraphs = stream::iter(Read::<PersistedEntityType>::read(self, filter).await?)
+        let subgraphs = stream::iter(Read::<EntityTypeWithMetadata>::read(self, filter).await?)
             .then(|entity_type| async move {
                 let mut dependency_context = DependencyContext::new(graph_resolve_depths);
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -66,7 +66,7 @@ impl<C: AsClient> PostgresStore<C> {
                         // TODO: Use relation tables
                         //   see https://app.asana.com/0/0/1202884883200942/f
                         self.get_property_type_as_dependency(
-                            // TODO: we have to clone here because we can't call `Into` on the ref
+                            // We have to clone here because we can't call `Into` on the ref
                             &property_type_ref.uri().clone().into(),
                             dependency_context.change_depth(GraphResolveDepths {
                                 property_type_resolve_depth: dependency_context
@@ -114,7 +114,7 @@ impl<C: AsClient> PostgresStore<C> {
                         > 0
                     {
                         self.get_entity_type_as_dependency(
-                            // TODO: we have to clone here because we can't call `Into` on the ref
+                            // We have to clone here because we can't call `Into` on the ref
                             &entity_type_id.clone().into(),
                             dependency_context.change_depth(GraphResolveDepths {
                                 entity_type_resolve_depth: dependency_context

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -7,7 +7,7 @@ use tokio_postgres::GenericClient;
 use type_system::{uri::VersionedUri, PropertyType};
 
 use crate::{
-    ontology::{PersistedOntologyMetadata, PersistedPropertyType},
+    ontology::{PersistedOntologyMetadata, PropertyTypeWithMetadata},
     provenance::{CreatedById, OwnedById, UpdatedById},
     shared::identifier::GraphElementIdentifier,
     store::{
@@ -19,7 +19,7 @@ use crate::{
 };
 
 impl<C: AsClient> PostgresStore<C> {
-    /// Internal method to read a [`PersistedPropertyType`] into two [`DependencyContext`]s.
+    /// Internal method to read a [`PropertyTypeWithMetadata`] into two [`DependencyContext`]s.
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
     pub(crate) fn get_property_type_as_dependency<'a: 'b, 'b>(
@@ -38,7 +38,7 @@ impl<C: AsClient> PostgresStore<C> {
                             .property_type_resolve_depth,
                     ),
                     || async {
-                        Ok(PersistedPropertyType::from(
+                        Ok(PropertyTypeWithMetadata::from(
                             self.read_versioned_ontology_type(property_type_id).await?,
                         ))
                     },
@@ -170,7 +170,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
             graph_resolve_depths,
         } = *query;
 
-        let subgraphs = stream::iter(Read::<PersistedPropertyType>::read(self, filter).await?)
+        let subgraphs = stream::iter(Read::<PropertyTypeWithMetadata>::read(self, filter).await?)
             .then(|property_type| async move {
                 let mut dependency_context = DependencyContext::new(graph_resolve_depths);
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -65,7 +65,7 @@ impl<C: AsClient> PostgresStore<C> {
                         > 0
                     {
                         self.get_data_type_as_dependency(
-                            // TODO: we have to clone here because we can't call `Into` on the ref
+                            // We have to clone here because we can't call `Into` on the ref
                             &data_type_ref.uri().clone().into(),
                             dependency_context.change_depth(GraphResolveDepths {
                                 data_type_resolve_depth: dependency_context
@@ -98,7 +98,7 @@ impl<C: AsClient> PostgresStore<C> {
                         > 0
                     {
                         self.get_property_type_as_dependency(
-                            // TODO: we have to clone here because we can't call `Into` on the ref
+                            // We have to clone here because we can't call `Into` on the ref
                             &property_type_ref.uri().clone().into(),
                             dependency_context.change_depth(GraphResolveDepths {
                                 property_type_resolve_depth: dependency_context

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -7,7 +7,7 @@ use tokio_postgres::GenericClient;
 use type_system::{uri::VersionedUri, PropertyType};
 
 use crate::{
-    ontology::{PersistedOntologyMetadata, PropertyTypeWithMetadata},
+    ontology::{OntologyElementMetadata, PropertyTypeWithMetadata},
     provenance::{CreatedById, OwnedById, UpdatedById},
     shared::identifier::GraphElementIdentifier,
     store::{
@@ -123,7 +123,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         property_type: PropertyType,
         owned_by_id: OwnedById,
         created_by_id: CreatedById,
-    ) -> Result<PersistedOntologyMetadata, InsertionError> {
+    ) -> Result<OntologyElementMetadata, InsertionError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
                 .transaction()
@@ -204,7 +204,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         &mut self,
         property_type: PropertyType,
         updated_by: UpdatedById,
-    ) -> Result<PersistedOntologyMetadata, UpdateError> {
+    ) -> Result<OntologyElementMetadata, UpdateError> {
         let transaction = PostgresStore::new(
             self.as_mut_client()
                 .transaction()

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -4,9 +4,10 @@ use async_trait::async_trait;
 use error_stack::{IntoReport, Report, Result, ResultExt};
 use futures::{stream, FutureExt, StreamExt, TryStreamExt};
 use tokio_postgres::GenericClient;
-use type_system::{uri::VersionedUri, PropertyType};
+use type_system::PropertyType;
 
 use crate::{
+    identifier::ontology::OntologyTypeEditionId,
     ontology::{OntologyElementMetadata, PropertyTypeWithMetadata},
     provenance::{CreatedById, OwnedById, UpdatedById},
     shared::identifier::GraphElementIdentifier,
@@ -24,7 +25,7 @@ impl<C: AsClient> PostgresStore<C> {
     /// This is used to recursively resolve a type, so the result can be reused.
     pub(crate) fn get_property_type_as_dependency<'a: 'b, 'b>(
         &'a self,
-        property_type_id: &'b VersionedUri,
+        property_type_id: &'b OntologyTypeEditionId,
         mut dependency_context: DependencyContextRef<'b>,
     ) -> Pin<Box<dyn Future<Output = Result<(), QueryError>> + Send + 'b>> {
         async move {
@@ -50,11 +51,11 @@ impl<C: AsClient> PostgresStore<C> {
                 //   see https://app.asana.com/0/0/1202884883200942/f
                 for data_type_ref in property_type.inner().data_type_references() {
                     dependency_context.edges.insert(
-                        GraphElementIdentifier::OntologyElementId(property_type_id.clone()),
+                        GraphElementIdentifier::OntologyElementId(property_type_id.clone().into()),
                         OutwardEdge {
                             edge_kind: EdgeKind::References,
                             destination: GraphElementIdentifier::OntologyElementId(
-                                data_type_ref.uri().clone(),
+                                data_type_ref.uri().clone().into(),
                             ),
                         },
                     );
@@ -64,7 +65,8 @@ impl<C: AsClient> PostgresStore<C> {
                         > 0
                     {
                         self.get_data_type_as_dependency(
-                            data_type_ref.uri(),
+                            // TODO: we have to clone here because we can't call `Into` on the ref
+                            &data_type_ref.uri().clone().into(),
                             dependency_context.change_depth(GraphResolveDepths {
                                 data_type_resolve_depth: dependency_context
                                     .graph_resolve_depths
@@ -85,7 +87,7 @@ impl<C: AsClient> PostgresStore<C> {
                         OutwardEdge {
                             edge_kind: EdgeKind::References,
                             destination: GraphElementIdentifier::OntologyElementId(
-                                property_type_ref.uri().clone(),
+                                property_type_ref.uri().clone().into(),
                             ),
                         },
                     );
@@ -96,7 +98,8 @@ impl<C: AsClient> PostgresStore<C> {
                         > 0
                     {
                         self.get_property_type_as_dependency(
-                            property_type_ref.uri(),
+                            // TODO: we have to clone here because we can't call `Into` on the ref
+                            &property_type_ref.uri().clone().into(),
                             dependency_context.change_depth(GraphResolveDepths {
                                 property_type_resolve_depth: dependency_context
                                     .graph_resolve_depths
@@ -174,7 +177,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
             .then(|property_type| async move {
                 let mut dependency_context = DependencyContext::new(graph_resolve_depths);
 
-                let property_type_id = property_type.metadata().identifier().uri().clone();
+                let property_type_id = property_type.metadata().edition_id().clone();
                 dependency_context.referenced_property_types.insert(
                     &property_type_id,
                     None,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -10,7 +10,7 @@ use crate::{
     identifier::ontology::OntologyTypeEditionId,
     ontology::{OntologyElementMetadata, PropertyTypeWithMetadata},
     provenance::{CreatedById, OwnedById, UpdatedById},
-    shared::identifier::GraphElementIdentifier,
+    shared::identifier::GraphElementId,
     store::{
         crud::Read,
         postgres::{context::PostgresContext, DependencyContext, DependencyContextRef},
@@ -51,10 +51,10 @@ impl<C: AsClient> PostgresStore<C> {
                 //   see https://app.asana.com/0/0/1202884883200942/f
                 for data_type_ref in property_type.inner().data_type_references() {
                     dependency_context.edges.insert(
-                        GraphElementIdentifier::OntologyElementId(property_type_id.clone().into()),
+                        GraphElementId::OntologyElementId(property_type_id.clone().into()),
                         OutwardEdge {
                             edge_kind: EdgeKind::References,
-                            destination: GraphElementIdentifier::OntologyElementId(
+                            destination: GraphElementId::OntologyElementId(
                                 data_type_ref.uri().clone().into(),
                             ),
                         },
@@ -83,10 +83,10 @@ impl<C: AsClient> PostgresStore<C> {
                 //   see https://app.asana.com/0/0/1202884883200942/f
                 for property_type_ref in property_type.inner().property_type_references() {
                     dependency_context.edges.insert(
-                        GraphElementIdentifier::OntologyElementId(property_type_id.clone()),
+                        GraphElementId::OntologyElementId(property_type_id.clone()),
                         OutwardEdge {
                             edge_kind: EdgeKind::References,
-                            destination: GraphElementIdentifier::OntologyElementId(
+                            destination: GraphElementId::OntologyElementId(
                                 property_type_ref.uri().clone().into(),
                             ),
                         },
@@ -190,7 +190,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                 )
                 .await?;
 
-                let root = GraphElementIdentifier::OntologyElementId(property_type_id);
+                let root = GraphElementId::OntologyElementId(property_type_id);
 
                 Ok::<_, Report<QueryError>>(dependency_context.into_subgraph(HashSet::from([root])))
             })

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -8,8 +8,8 @@ use type_system::{uri::VersionedUri, DataType, EntityType, PropertyType};
 
 use crate::{
     ontology::{
-        PersistedDataType, PersistedEntityType, PersistedOntologyIdentifier,
-        PersistedOntologyMetadata, PersistedOntologyType, PersistedPropertyType,
+        DataTypeWithMetadata, EntityTypeWithMetadata, PersistedOntologyIdentifier,
+        PersistedOntologyMetadata, PersistedOntologyType, PropertyTypeWithMetadata,
     },
     provenance::{CreatedById, OwnedById, RemovedById, UpdatedById},
     shared::identifier::account::AccountId,
@@ -25,7 +25,7 @@ use crate::{
     },
 };
 
-impl From<OntologyRecord<DataType>> for PersistedDataType {
+impl From<OntologyRecord<DataType>> for DataTypeWithMetadata {
     fn from(data_type: OntologyRecord<DataType>) -> Self {
         let identifier =
             PersistedOntologyIdentifier::new(data_type.record.id().clone(), data_type.owned_by_id);
@@ -42,7 +42,7 @@ impl From<OntologyRecord<DataType>> for PersistedDataType {
     }
 }
 
-impl From<OntologyRecord<PropertyType>> for PersistedPropertyType {
+impl From<OntologyRecord<PropertyType>> for PropertyTypeWithMetadata {
     fn from(property_type: OntologyRecord<PropertyType>) -> Self {
         let identifier = PersistedOntologyIdentifier::new(
             property_type.record.id().clone(),
@@ -61,7 +61,7 @@ impl From<OntologyRecord<PropertyType>> for PersistedPropertyType {
     }
 }
 
-impl From<OntologyRecord<EntityType>> for PersistedEntityType {
+impl From<OntologyRecord<EntityType>> for EntityTypeWithMetadata {
     fn from(entity_type: OntologyRecord<EntityType>) -> Self {
         let identifier = PersistedOntologyIdentifier::new(
             entity_type.record.id().clone(),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -8,8 +8,8 @@ use type_system::{uri::VersionedUri, DataType, EntityType, PropertyType};
 
 use crate::{
     ontology::{
-        DataTypeWithMetadata, EntityTypeWithMetadata, PersistedOntologyIdentifier,
-        PersistedOntologyMetadata, PersistedOntologyType, PropertyTypeWithMetadata,
+        DataTypeWithMetadata, EntityTypeWithMetadata, OntologyElementMetadata,
+        PersistedOntologyIdentifier, PersistedOntologyType, PropertyTypeWithMetadata,
     },
     provenance::{CreatedById, OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
@@ -31,7 +31,7 @@ impl From<OntologyRecord<DataType>> for DataTypeWithMetadata {
 
         Self::new(
             data_type.record,
-            PersistedOntologyMetadata::new(
+            OntologyElementMetadata::new(
                 identifier,
                 ProvenanceMetadata::new(data_type.created_by_id, data_type.updated_by_id),
             ),
@@ -48,7 +48,7 @@ impl From<OntologyRecord<PropertyType>> for PropertyTypeWithMetadata {
 
         Self::new(
             property_type.record,
-            PersistedOntologyMetadata::new(
+            OntologyElementMetadata::new(
                 identifier,
                 ProvenanceMetadata::new(property_type.created_by_id, property_type.updated_by_id),
             ),
@@ -64,7 +64,7 @@ impl From<OntologyRecord<EntityType>> for EntityTypeWithMetadata {
         );
         Self::new(
             entity_type.record,
-            PersistedOntologyMetadata::new(
+            OntologyElementMetadata::new(
                 identifier,
                 ProvenanceMetadata::new(entity_type.created_by_id, entity_type.updated_by_id),
             ),
@@ -110,7 +110,7 @@ where
                 let identifier = PersistedOntologyIdentifier::new(versioned_uri, owned_by_id);
                 Ok(T::new(
                     record,
-                    PersistedOntologyMetadata::new(
+                    OntologyElementMetadata::new(
                         identifier,
                         ProvenanceMetadata::new(created_by_id, updated_by_id),
                     ),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -9,7 +9,7 @@ use type_system::{uri::VersionedUri, DataType, EntityType, PropertyType};
 use crate::{
     ontology::{
         DataTypeWithMetadata, EntityTypeWithMetadata, OntologyElementMetadata,
-        PersistedOntologyIdentifier, PersistedOntologyType, PropertyTypeWithMetadata,
+        PersistedOntologyType, PropertyTypeWithMetadata,
     },
     provenance::{CreatedById, OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
@@ -26,7 +26,7 @@ use crate::{
 
 impl From<OntologyRecord<DataType>> for DataTypeWithMetadata {
     fn from(data_type: OntologyRecord<DataType>) -> Self {
-        let identifier = PersistedOntologyIdentifier::new(data_type.record.id().clone());
+        let identifier = data_type.record.id().clone().into();
 
         Self::new(
             data_type.record,
@@ -41,7 +41,7 @@ impl From<OntologyRecord<DataType>> for DataTypeWithMetadata {
 
 impl From<OntologyRecord<PropertyType>> for PropertyTypeWithMetadata {
     fn from(property_type: OntologyRecord<PropertyType>) -> Self {
-        let identifier = PersistedOntologyIdentifier::new(property_type.record.id().clone());
+        let identifier = property_type.record.id().clone().into();
 
         Self::new(
             property_type.record,
@@ -56,7 +56,7 @@ impl From<OntologyRecord<PropertyType>> for PropertyTypeWithMetadata {
 
 impl From<OntologyRecord<EntityType>> for EntityTypeWithMetadata {
     fn from(entity_type: OntologyRecord<EntityType>) -> Self {
-        let identifier = PersistedOntologyIdentifier::new(entity_type.record.id().clone());
+        let identifier = entity_type.record.id().clone().into();
         Self::new(
             entity_type.record,
             OntologyElementMetadata::new(
@@ -103,11 +103,11 @@ where
                 let created_by_id = CreatedById::new(row.get(3));
                 let updated_by_id = UpdatedById::new(row.get(4));
 
-                let identifier = PersistedOntologyIdentifier::new(versioned_uri);
+                let edition_identifier = versioned_uri.into();
                 Ok(T::new(
                     record,
                     OntologyElementMetadata::new(
-                        identifier,
+                        edition_identifier,
                         ProvenanceMetadata::new(created_by_id, updated_by_id),
                         owned_by_id,
                     ),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -26,14 +26,14 @@ use crate::{
 
 impl From<OntologyRecord<DataType>> for DataTypeWithMetadata {
     fn from(data_type: OntologyRecord<DataType>) -> Self {
-        let identifier =
-            PersistedOntologyIdentifier::new(data_type.record.id().clone(), data_type.owned_by_id);
+        let identifier = PersistedOntologyIdentifier::new(data_type.record.id().clone());
 
         Self::new(
             data_type.record,
             OntologyElementMetadata::new(
                 identifier,
                 ProvenanceMetadata::new(data_type.created_by_id, data_type.updated_by_id),
+                data_type.owned_by_id,
             ),
         )
     }
@@ -41,16 +41,14 @@ impl From<OntologyRecord<DataType>> for DataTypeWithMetadata {
 
 impl From<OntologyRecord<PropertyType>> for PropertyTypeWithMetadata {
     fn from(property_type: OntologyRecord<PropertyType>) -> Self {
-        let identifier = PersistedOntologyIdentifier::new(
-            property_type.record.id().clone(),
-            property_type.owned_by_id,
-        );
+        let identifier = PersistedOntologyIdentifier::new(property_type.record.id().clone());
 
         Self::new(
             property_type.record,
             OntologyElementMetadata::new(
                 identifier,
                 ProvenanceMetadata::new(property_type.created_by_id, property_type.updated_by_id),
+                property_type.owned_by_id,
             ),
         )
     }
@@ -58,15 +56,13 @@ impl From<OntologyRecord<PropertyType>> for PropertyTypeWithMetadata {
 
 impl From<OntologyRecord<EntityType>> for EntityTypeWithMetadata {
     fn from(entity_type: OntologyRecord<EntityType>) -> Self {
-        let identifier = PersistedOntologyIdentifier::new(
-            entity_type.record.id().clone(),
-            entity_type.owned_by_id,
-        );
+        let identifier = PersistedOntologyIdentifier::new(entity_type.record.id().clone());
         Self::new(
             entity_type.record,
             OntologyElementMetadata::new(
                 identifier,
                 ProvenanceMetadata::new(entity_type.created_by_id, entity_type.updated_by_id),
+                entity_type.owned_by_id,
             ),
         )
     }
@@ -107,12 +103,13 @@ where
                 let created_by_id = CreatedById::new(row.get(3));
                 let updated_by_id = UpdatedById::new(row.get(4));
 
-                let identifier = PersistedOntologyIdentifier::new(versioned_uri, owned_by_id);
+                let identifier = PersistedOntologyIdentifier::new(versioned_uri);
                 Ok(T::new(
                     record,
                     OntologyElementMetadata::new(
                         identifier,
                         ProvenanceMetadata::new(created_by_id, updated_by_id),
+                        owned_by_id,
                     ),
                 ))
             })

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -11,8 +11,7 @@ use crate::{
         DataTypeWithMetadata, EntityTypeWithMetadata, PersistedOntologyIdentifier,
         PersistedOntologyMetadata, PersistedOntologyType, PropertyTypeWithMetadata,
     },
-    provenance::{CreatedById, OwnedById, RemovedById, UpdatedById},
-    shared::identifier::account::AccountId,
+    provenance::{CreatedById, OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
         crud::Read,
         postgres::{
@@ -34,9 +33,7 @@ impl From<OntologyRecord<DataType>> for DataTypeWithMetadata {
             data_type.record,
             PersistedOntologyMetadata::new(
                 identifier,
-                data_type.created_by_id,
-                data_type.updated_by_id,
-                data_type.removed_by_id,
+                ProvenanceMetadata::new(data_type.created_by_id, data_type.updated_by_id),
             ),
         )
     }
@@ -53,9 +50,7 @@ impl From<OntologyRecord<PropertyType>> for PropertyTypeWithMetadata {
             property_type.record,
             PersistedOntologyMetadata::new(
                 identifier,
-                property_type.created_by_id,
-                property_type.updated_by_id,
-                property_type.removed_by_id,
+                ProvenanceMetadata::new(property_type.created_by_id, property_type.updated_by_id),
             ),
         )
     }
@@ -71,9 +66,7 @@ impl From<OntologyRecord<EntityType>> for EntityTypeWithMetadata {
             entity_type.record,
             PersistedOntologyMetadata::new(
                 identifier,
-                entity_type.created_by_id,
-                entity_type.updated_by_id,
-                entity_type.removed_by_id,
+                ProvenanceMetadata::new(entity_type.created_by_id, entity_type.updated_by_id),
             ),
         )
     }
@@ -113,16 +106,13 @@ where
                 let owned_by_id = OwnedById::new(row.get(2));
                 let created_by_id = CreatedById::new(row.get(3));
                 let updated_by_id = UpdatedById::new(row.get(4));
-                let removed_by_id = row.get::<_, Option<AccountId>>(5).map(RemovedById::new);
 
                 let identifier = PersistedOntologyIdentifier::new(versioned_uri, owned_by_id);
                 Ok(T::new(
                     record,
                     PersistedOntologyMetadata::new(
                         identifier,
-                        created_by_id,
-                        updated_by_id,
-                        removed_by_id,
+                        ProvenanceMetadata::new(created_by_id, updated_by_id),
                     ),
                 ))
             })

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
@@ -21,7 +21,6 @@ impl PostgresQueryRecord for DataType {
             DataTypeQueryPath::OwnedById,
             DataTypeQueryPath::CreatedById,
             DataTypeQueryPath::UpdatedById,
-            DataTypeQueryPath::RemovedById,
         ]
     }
 }
@@ -47,7 +46,6 @@ impl Path for DataTypeQueryPath {
             | Self::OwnedById
             | Self::CreatedById
             | Self::UpdatedById
-            | Self::RemovedById
             | Self::Schema
             | Self::VersionedUri
             | Self::Title
@@ -71,9 +69,6 @@ impl Path for DataTypeQueryPath {
             },
             Self::UpdatedById => ColumnAccess::Table {
                 column: "updated_by_id",
-            },
-            Self::RemovedById => ColumnAccess::Table {
-                column: "removed_by_id",
             },
             Self::Schema => ColumnAccess::Table { column: "schema" },
             Self::VersionedUri => ColumnAccess::Json {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity.rs
@@ -3,12 +3,12 @@ use std::iter::once;
 use postgres_types::ToSql;
 
 use crate::{
-    knowledge::{Entity, EntityQueryPath},
+    knowledge::{EntityProperties, EntityQueryPath},
     ontology::EntityTypeQueryPath,
     store::postgres::query::{ColumnAccess, Path, PostgresQueryRecord, Relation, Table, TableName},
 };
 
-impl PostgresQueryRecord for Entity {
+impl PostgresQueryRecord for EntityProperties {
     fn base_table() -> Table {
         Table {
             name: TableName::Entities,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity.rs
@@ -95,7 +95,6 @@ impl Path for EntityQueryPath<'_> {
             | Self::OwnedById
             | Self::CreatedById
             | Self::UpdatedById
-            | Self::RemovedById
             | Self::Version
             | Self::Archived
             | Self::LeftEntity(None)
@@ -127,9 +126,6 @@ impl Path for EntityQueryPath<'_> {
             },
             Self::UpdatedById => ColumnAccess::Table {
                 column: "updated_by_id",
-            },
-            Self::RemovedById => ColumnAccess::Table {
-                column: "removed_by_id",
             },
             Self::LeftEntity(None) => ColumnAccess::Table {
                 column: "left_entity_uuid",

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity_type.rs
@@ -21,7 +21,6 @@ impl PostgresQueryRecord for EntityType {
             EntityTypeQueryPath::OwnedById,
             EntityTypeQueryPath::CreatedById,
             EntityTypeQueryPath::UpdatedById,
-            EntityTypeQueryPath::RemovedById,
         ]
     }
 }
@@ -87,7 +86,6 @@ impl Path for EntityTypeQueryPath {
             | Self::OwnedById
             | Self::CreatedById
             | Self::UpdatedById
-            | Self::RemovedById
             | Self::Schema
             | Self::VersionedUri
             | Self::Title
@@ -118,9 +116,6 @@ impl Path for EntityTypeQueryPath {
             },
             Self::UpdatedById => ColumnAccess::Table {
                 column: "updated_by_id",
-            },
-            Self::RemovedById => ColumnAccess::Table {
-                column: "removed_by_id",
             },
             Self::Schema => ColumnAccess::Table { column: "schema" },
             Self::VersionedUri => ColumnAccess::Json {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/property_type.rs
@@ -21,7 +21,6 @@ impl PostgresQueryRecord for PropertyType {
             PropertyTypeQueryPath::OwnedById,
             PropertyTypeQueryPath::CreatedById,
             PropertyTypeQueryPath::UpdatedById,
-            PropertyTypeQueryPath::RemovedById,
         ]
     }
 }
@@ -83,7 +82,6 @@ impl Path for PropertyTypeQueryPath {
             | Self::OwnedById
             | Self::CreatedById
             | Self::UpdatedById
-            | Self::RemovedById
             | Self::Schema
             | Self::VersionedUri
             | Self::Title
@@ -108,9 +106,6 @@ impl Path for PropertyTypeQueryPath {
             },
             Self::UpdatedById => ColumnAccess::Table {
                 column: "updated_by_id",
-            },
-            Self::RemovedById => ColumnAccess::Table {
-                column: "removed_by_id",
             },
             Self::Schema => ColumnAccess::Table { column: "schema" },
             Self::VersionedUri => ColumnAccess::Json {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -134,8 +134,7 @@ mod tests {
                 "data_types"."schema",
                 "data_types"."owned_by_id",
                 "data_types"."created_by_id",
-                "data_types"."updated_by_id",
-                "data_types"."removed_by_id"
+                "data_types"."updated_by_id"
             FROM "data_types"
             "#,
             &[],

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -80,7 +80,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::{
-        knowledge::{Entity, EntityQueryPath},
+        knowledge::{EntityProperties, EntityQueryPath},
         ontology::{DataTypeQueryPath, EntityTypeQueryPath, PropertyTypeQueryPath},
         store::{
             postgres::query::{
@@ -406,7 +406,7 @@ mod tests {
 
     #[test]
     fn entity_simple_query() {
-        let mut compiler = SelectCompiler::<Entity>::with_default_selection();
+        let mut compiler = SelectCompiler::<EntityProperties>::with_default_selection();
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityQueryPath::Uuid)),
@@ -438,7 +438,7 @@ mod tests {
 
     #[test]
     fn entity_latest_version_query() {
-        let mut compiler = SelectCompiler::<Entity>::with_default_selection();
+        let mut compiler = SelectCompiler::<EntityProperties>::with_default_selection();
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityQueryPath::Version)),
@@ -470,7 +470,7 @@ mod tests {
 
     #[test]
     fn entity_with_manual_selection() {
-        let mut compiler = SelectCompiler::<Entity>::new();
+        let mut compiler = SelectCompiler::<EntityProperties>::new();
         compiler.add_distinct_selection_with_ordering(
             &EntityQueryPath::Uuid,
             Distinctness::Distinct,
@@ -508,7 +508,7 @@ mod tests {
 
     #[test]
     fn entity_property_query() {
-        let mut compiler = SelectCompiler::<Entity>::with_asterisk();
+        let mut compiler = SelectCompiler::<EntityProperties>::with_asterisk();
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityQueryPath::Properties(Some(
@@ -536,7 +536,7 @@ mod tests {
 
     #[test]
     fn entity_property_null_query() {
-        let mut compiler = SelectCompiler::<Entity>::with_asterisk();
+        let mut compiler = SelectCompiler::<EntityProperties>::with_asterisk();
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityQueryPath::Properties(Some(
@@ -559,7 +559,7 @@ mod tests {
 
     #[test]
     fn entity_outgoing_link_query() {
-        let mut compiler = SelectCompiler::<Entity>::with_asterisk();
+        let mut compiler = SelectCompiler::<EntityProperties>::with_asterisk();
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityQueryPath::OutgoingLinks(
@@ -588,7 +588,7 @@ mod tests {
 
     #[test]
     fn entity_incoming_link_query() {
-        let mut compiler = SelectCompiler::<Entity>::with_asterisk();
+        let mut compiler = SelectCompiler::<EntityProperties>::with_asterisk();
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityQueryPath::IncomingLinks(
@@ -617,7 +617,7 @@ mod tests {
 
     #[test]
     fn link_entity_left_right_id() {
-        let mut compiler = SelectCompiler::<Entity>::with_asterisk();
+        let mut compiler = SelectCompiler::<EntityProperties>::with_asterisk();
 
         let filter = Filter::All(vec![
             Filter::Equal(

--- a/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 
 use crate::{
     identifier::knowledge::EntityId,
-    knowledge::{Entity, EntityQueryPath},
+    knowledge::{EntityProperties, EntityQueryPath},
     store::query::{OntologyPath, ParameterType, QueryRecord, RecordPath},
 };
 
@@ -73,7 +73,7 @@ where
     }
 }
 
-impl<'q> Filter<'q, Entity> {
+impl<'q> Filter<'q, EntityProperties> {
     /// Creates a `Filter` to search for all entities at their latest version.
     #[must_use]
     pub const fn for_all_latest_entities() -> Self {

--- a/packages/graph/hash_graph/tests/integration/postgres/entity.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/entity.rs
@@ -39,7 +39,7 @@ async fn insert() {
         .await
         .expect("could not get entity");
 
-    assert_eq!(entity.inner(), &person);
+    assert_eq!(entity.properties(), &person);
 }
 
 #[tokio::test]
@@ -75,7 +75,7 @@ async fn query() {
         .await
         .expect("could not get entity");
 
-    assert_eq!(&organization, queried_organization.inner());
+    assert_eq!(&organization, queried_organization.properties());
 }
 
 #[tokio::test]
@@ -123,5 +123,5 @@ async fn update() {
         .await
         .expect("could not get entity");
 
-    assert_eq!(entity.inner(), &page_v2);
+    assert_eq!(entity.properties(), &page_v2);
 }

--- a/packages/graph/hash_graph/tests/integration/postgres/entity.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/entity.rs
@@ -34,12 +34,12 @@ async fn insert() {
         .await
         .expect("could not create entity");
 
-    let persisted_entity = api
+    let entity = api
         .get_entity(metadata.identifier().base_id())
         .await
         .expect("could not get entity");
 
-    assert_eq!(persisted_entity.inner(), &person);
+    assert_eq!(entity.inner(), &person);
 }
 
 #[tokio::test]
@@ -118,10 +118,10 @@ async fn update() {
     .await
     .expect("could not update entity");
 
-    let persisted_entity = api
+    let entity = api
         .get_entity(metadata.identifier().base_id())
         .await
         .expect("could not get entity");
 
-    assert_eq!(persisted_entity.inner(), &page_v2);
+    assert_eq!(entity.inner(), &page_v2);
 }

--- a/packages/graph/hash_graph/tests/integration/postgres/entity.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/entity.rs
@@ -35,7 +35,7 @@ async fn insert() {
         .expect("could not create entity");
 
     let entity = api
-        .get_entity(metadata.identifier().base_id())
+        .get_entity(metadata.edition_id().base_id())
         .await
         .expect("could not get entity");
 
@@ -71,7 +71,7 @@ async fn query() {
         .expect("could not create entity");
 
     let queried_organization = api
-        .get_entity(metadata.identifier().base_id())
+        .get_entity(metadata.edition_id().base_id())
         .await
         .expect("could not get entity");
 
@@ -107,7 +107,7 @@ async fn update() {
         .expect("could not create entity");
 
     api.update_entity(
-        metadata.identifier().base_id(),
+        metadata.edition_id().base_id(),
         page_v2.clone(),
         VersionedUri::new(
             BaseUri::new("https://blockprotocol.org/@alice/types/entity-type/page/".to_owned())
@@ -119,7 +119,7 @@ async fn update() {
     .expect("could not update entity");
 
     let entity = api
-        .get_entity(metadata.identifier().base_id())
+        .get_entity(metadata.edition_id().base_id())
         .await
         .expect("could not get entity");
 

--- a/packages/graph/hash_graph/tests/integration/postgres/entity.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/entity.rs
@@ -1,4 +1,4 @@
-use graph::knowledge::Entity;
+use graph::knowledge::EntityProperties;
 use graph_test_data::{data_type, entity, entity_type, property_type};
 use type_system::uri::{BaseUri, VersionedUri};
 
@@ -6,7 +6,8 @@ use crate::postgres::DatabaseTestWrapper;
 
 #[tokio::test]
 async fn insert() {
-    let person: Entity = serde_json::from_str(entity::PERSON_A_V1).expect("could not parse entity");
+    let person: EntityProperties =
+        serde_json::from_str(entity::PERSON_A_V1).expect("could not parse entity");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database
@@ -43,7 +44,7 @@ async fn insert() {
 
 #[tokio::test]
 async fn query() {
-    let organization: Entity =
+    let organization: EntityProperties =
         serde_json::from_str(entity::ORGANIZATION_V1).expect("could not parse entity");
 
     let mut database = DatabaseTestWrapper::new().await;
@@ -79,8 +80,10 @@ async fn query() {
 
 #[tokio::test]
 async fn update() {
-    let page_v1: Entity = serde_json::from_str(entity::PAGE_V1).expect("could not parse entity");
-    let page_v2: Entity = serde_json::from_str(entity::PAGE_V2).expect("could not parse entity");
+    let page_v1: EntityProperties =
+        serde_json::from_str(entity::PAGE_V1).expect("could not parse entity");
+    let page_v2: EntityProperties =
+        serde_json::from_str(entity::PAGE_V2).expect("could not parse entity");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database

--- a/packages/graph/hash_graph/tests/integration/postgres/links.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/links.rs
@@ -1,4 +1,4 @@
-use graph::knowledge::Entity;
+use graph::knowledge::EntityProperties;
 use graph_test_data::{data_type, entity, entity_type, property_type};
 use type_system::uri::{BaseUri, VersionedUri};
 
@@ -8,7 +8,7 @@ use crate::postgres::DatabaseTestWrapper;
 async fn insert() {
     let person_a = serde_json::from_str(entity::PERSON_A_V1).expect("could not parse entity");
     let person_b = serde_json::from_str(entity::PERSON_B_V1).expect("could not parse entity");
-    let friend_of = Entity::empty();
+    let friend_of = EntityProperties::empty();
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database
@@ -127,7 +127,7 @@ async fn get_entity_links() {
         .expect("could not create entity");
 
     api.create_link_entity(
-        Entity::empty(),
+        EntityProperties::empty(),
         friend_link_type_id.clone(),
         None,
         person_a_metadata.identifier().base_id(),
@@ -137,7 +137,7 @@ async fn get_entity_links() {
     .expect("could not create link");
 
     api.create_link_entity(
-        Entity::empty(),
+        EntityProperties::empty(),
         acquaintance_entity_link_type_id.clone(),
         None,
         person_a_metadata.identifier().base_id(),
@@ -236,7 +236,7 @@ async fn remove_link() {
 
     let link_entity_metadata = api
         .create_link_entity(
-            Entity::empty(),
+            EntityProperties::empty(),
             friend_link_type_id,
             None,
             person_a_metadata.identifier().base_id(),

--- a/packages/graph/hash_graph/tests/integration/postgres/links.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/links.rs
@@ -46,15 +46,15 @@ async fn insert() {
         friend_of,
         friend_of_type_id.clone(),
         None,
-        person_a_metadata.identifier().base_id(),
-        person_b_metadata.identifier().base_id(),
+        person_a_metadata.edition_id().base_id(),
+        person_b_metadata.edition_id().base_id(),
     )
     .await
     .expect("could not create link");
 
     let link_entity = api
         .get_link_entity_target(
-            person_a_metadata.identifier().base_id().entity_uuid(),
+            person_a_metadata.edition_id().base_id().entity_uuid(),
             friend_of_type_id,
         )
         .await
@@ -66,11 +66,11 @@ async fn insert() {
 
     assert_eq!(
         link_metadata.left_entity_id(),
-        person_a_metadata.identifier().base_id()
+        person_a_metadata.edition_id().base_id()
     );
     assert_eq!(
         link_metadata.right_entity_id(),
-        person_b_metadata.identifier().base_id()
+        person_b_metadata.edition_id().base_id()
     );
 }
 
@@ -130,8 +130,8 @@ async fn get_entity_links() {
         EntityProperties::empty(),
         friend_link_type_id.clone(),
         None,
-        person_a_metadata.identifier().base_id(),
-        person_b_metadata.identifier().base_id(),
+        person_a_metadata.edition_id().base_id(),
+        person_b_metadata.edition_id().base_id(),
     )
     .await
     .expect("could not create link");
@@ -140,14 +140,14 @@ async fn get_entity_links() {
         EntityProperties::empty(),
         acquaintance_entity_link_type_id.clone(),
         None,
-        person_a_metadata.identifier().base_id(),
-        person_c_metadata.identifier().base_id(),
+        person_a_metadata.edition_id().base_id(),
+        person_c_metadata.edition_id().base_id(),
     )
     .await
     .expect("could not create link");
 
     let links_from_source = api
-        .get_latest_entity_links(person_a_metadata.identifier().base_id())
+        .get_latest_entity_links(person_a_metadata.edition_id().base_id())
         .await
         .expect("could not fetch link");
 
@@ -178,21 +178,21 @@ async fn get_entity_links() {
         link_metadatas
             .iter()
             .find(|link_metadata| link_metadata.left_entity_id()
-                == person_a_metadata.identifier().base_id())
+                == person_a_metadata.edition_id().base_id())
             .is_some()
     );
     assert!(
         link_metadatas
             .iter()
             .find(|link_metadata| link_metadata.right_entity_id()
-                == person_b_metadata.identifier().base_id())
+                == person_b_metadata.edition_id().base_id())
             .is_some()
     );
     assert!(
         link_metadatas
             .iter()
             .find(|link_metadata| link_metadata.right_entity_id()
-                == person_c_metadata.identifier().base_id())
+                == person_c_metadata.edition_id().base_id())
             .is_some()
     );
 }
@@ -239,25 +239,25 @@ async fn remove_link() {
             EntityProperties::empty(),
             friend_link_type_id,
             None,
-            person_a_metadata.identifier().base_id(),
-            person_b_metadata.identifier().base_id(),
+            person_a_metadata.edition_id().base_id(),
+            person_b_metadata.edition_id().base_id(),
         )
         .await
         .expect("could not create link");
 
     assert!(
-        !api.get_latest_entity_links(person_a_metadata.identifier().base_id())
+        !api.get_latest_entity_links(person_a_metadata.edition_id().base_id())
             .await
             .expect("could not fetch links")
             .is_empty()
     );
 
-    api.archive_entity(link_entity_metadata.identifier().base_id())
+    api.archive_entity(link_entity_metadata.edition_id().base_id())
         .await
         .expect("could not remove link");
 
     assert!(
-        api.get_latest_entity_links(person_a_metadata.identifier().base_id())
+        api.get_latest_entity_links(person_a_metadata.edition_id().base_id())
             .await
             .expect("could not fetch links")
             .is_empty()

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -159,7 +159,9 @@ impl DatabaseApi<'_> {
             })
             .await?
             .vertices
-            .remove(&GraphElementIdentifier::OntologyElementId(uri.clone()))
+            .remove(&GraphElementIdentifier::OntologyElementId(
+                uri.clone().into(),
+            ))
             .expect("no data type found");
 
         match vertex {
@@ -202,7 +204,9 @@ impl DatabaseApi<'_> {
             })
             .await?
             .vertices
-            .remove(&GraphElementIdentifier::OntologyElementId(uri.clone()))
+            .remove(&GraphElementIdentifier::OntologyElementId(
+                uri.clone().into(),
+            ))
             .expect("no property type found");
 
         match vertex {
@@ -245,7 +249,9 @@ impl DatabaseApi<'_> {
             })
             .await?
             .vertices
-            .remove(&GraphElementIdentifier::OntologyElementId(uri.clone()))
+            .remove(&GraphElementIdentifier::OntologyElementId(
+                uri.clone().into(),
+            ))
             .expect("no entity type found");
 
         match vertex {

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -10,7 +10,7 @@ use error_stack::Result;
 use graph::{
     identifier::knowledge::EntityId,
     knowledge::{
-        Entity, EntityQueryPath, EntityUuid, LinkEntityMetadata, PersistedEntity,
+        EntityProperties, EntityQueryPath, EntityUuid, LinkEntityMetadata, PersistedEntity,
         PersistedEntityMetadata,
     },
     ontology::{
@@ -266,7 +266,7 @@ impl DatabaseApi<'_> {
 
     pub async fn create_entity(
         &mut self,
-        entity: Entity,
+        entity: EntityProperties,
         entity_type_id: VersionedUri,
         entity_uuid: Option<EntityUuid>,
     ) -> Result<PersistedEntityMetadata, InsertionError> {
@@ -303,7 +303,7 @@ impl DatabaseApi<'_> {
     pub async fn update_entity(
         &mut self,
         entity_id: EntityId,
-        entity: Entity,
+        entity: EntityProperties,
         entity_type_id: VersionedUri,
     ) -> Result<PersistedEntityMetadata, UpdateError> {
         self.store
@@ -318,7 +318,7 @@ impl DatabaseApi<'_> {
 
     async fn create_link_entity(
         &mut self,
-        entity: Entity,
+        entity: EntityProperties,
         entity_type_id: VersionedUri,
         entity_uuid: Option<EntityUuid>,
         left_entity_id: EntityId,

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -14,8 +14,8 @@ use graph::{
         PersistedEntityMetadata,
     },
     ontology::{
-        EntityTypeQueryPath, PersistedDataType, PersistedEntityType, PersistedOntologyMetadata,
-        PersistedPropertyType,
+        DataTypeWithMetadata, EntityTypeQueryPath, EntityTypeWithMetadata,
+        PersistedOntologyMetadata, PropertyTypeWithMetadata,
     },
     provenance::{CreatedById, OwnedById, UpdatedById},
     shared::identifier::{account::AccountId, GraphElementIdentifier},
@@ -151,7 +151,7 @@ impl DatabaseApi<'_> {
     pub async fn get_data_type(
         &mut self,
         uri: &VersionedUri,
-    ) -> Result<PersistedDataType, QueryError> {
+    ) -> Result<DataTypeWithMetadata, QueryError> {
         let vertex = self
             .store
             .get_data_type(&StructuralQuery {
@@ -164,7 +164,7 @@ impl DatabaseApi<'_> {
             .expect("no data type found");
 
         match vertex {
-            Vertex::DataType(persisted_data_type) => Ok(persisted_data_type),
+            Vertex::DataType(data_type_with_metadata) => Ok(data_type_with_metadata),
             _ => unreachable!(),
         }
     }
@@ -194,7 +194,7 @@ impl DatabaseApi<'_> {
     pub async fn get_property_type(
         &mut self,
         uri: &VersionedUri,
-    ) -> Result<PersistedPropertyType, QueryError> {
+    ) -> Result<PropertyTypeWithMetadata, QueryError> {
         let vertex = self
             .store
             .get_property_type(&StructuralQuery {
@@ -207,7 +207,7 @@ impl DatabaseApi<'_> {
             .expect("no property type found");
 
         match vertex {
-            Vertex::PropertyType(persisted_property_type) => Ok(persisted_property_type),
+            Vertex::PropertyType(property_type_with_metadata) => Ok(property_type_with_metadata),
             _ => unreachable!(),
         }
     }
@@ -237,7 +237,7 @@ impl DatabaseApi<'_> {
     pub async fn get_entity_type(
         &mut self,
         uri: &VersionedUri,
-    ) -> Result<PersistedEntityType, QueryError> {
+    ) -> Result<EntityTypeWithMetadata, QueryError> {
         let vertex = self
             .store
             .get_entity_type(&StructuralQuery {

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -17,7 +17,7 @@ use graph::{
         PropertyTypeWithMetadata,
     },
     provenance::{CreatedById, OwnedById, UpdatedById},
-    shared::identifier::{account::AccountId, GraphElementIdentifier},
+    shared::identifier::{account::AccountId, GraphElementId},
     store::{
         error::ArchivalError,
         query::{Filter, FilterExpression, Parameter},
@@ -159,9 +159,7 @@ impl DatabaseApi<'_> {
             })
             .await?
             .vertices
-            .remove(&GraphElementIdentifier::OntologyElementId(
-                uri.clone().into(),
-            ))
+            .remove(&GraphElementId::OntologyElementId(uri.clone().into()))
             .expect("no data type found");
 
         match vertex {
@@ -204,9 +202,7 @@ impl DatabaseApi<'_> {
             })
             .await?
             .vertices
-            .remove(&GraphElementIdentifier::OntologyElementId(
-                uri.clone().into(),
-            ))
+            .remove(&GraphElementId::OntologyElementId(uri.clone().into()))
             .expect("no property type found");
 
         match vertex {
@@ -249,9 +245,7 @@ impl DatabaseApi<'_> {
             })
             .await?
             .vertices
-            .remove(&GraphElementIdentifier::OntologyElementId(
-                uri.clone().into(),
-            ))
+            .remove(&GraphElementId::OntologyElementId(uri.clone().into()))
             .expect("no entity type found");
 
         match vertex {
@@ -296,7 +290,7 @@ impl DatabaseApi<'_> {
             })
             .await?
             .vertices
-            .remove(&GraphElementIdentifier::KnowledgeGraphElementId(entity_id))
+            .remove(&GraphElementId::KnowledgeGraphElementId(entity_id))
             .expect("no entity found");
 
         match vertex {

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -13,8 +13,8 @@ use graph::{
         Entity, EntityMetadata, EntityProperties, EntityQueryPath, EntityUuid, LinkEntityMetadata,
     },
     ontology::{
-        DataTypeWithMetadata, EntityTypeQueryPath, EntityTypeWithMetadata,
-        PersistedOntologyMetadata, PropertyTypeWithMetadata,
+        DataTypeWithMetadata, EntityTypeQueryPath, EntityTypeWithMetadata, OntologyElementMetadata,
+        PropertyTypeWithMetadata,
     },
     provenance::{CreatedById, OwnedById, UpdatedById},
     shared::identifier::{account::AccountId, GraphElementIdentifier},
@@ -137,7 +137,7 @@ impl DatabaseApi<'_> {
     pub async fn create_data_type(
         &mut self,
         data_type: DataType,
-    ) -> Result<PersistedOntologyMetadata, InsertionError> {
+    ) -> Result<OntologyElementMetadata, InsertionError> {
         self.store
             .create_data_type(
                 data_type,
@@ -171,7 +171,7 @@ impl DatabaseApi<'_> {
     pub async fn update_data_type(
         &mut self,
         data_type: DataType,
-    ) -> Result<PersistedOntologyMetadata, UpdateError> {
+    ) -> Result<OntologyElementMetadata, UpdateError> {
         self.store
             .update_data_type(data_type, UpdatedById::new(self.account_id))
             .await
@@ -180,7 +180,7 @@ impl DatabaseApi<'_> {
     pub async fn create_property_type(
         &mut self,
         property_type: PropertyType,
-    ) -> Result<PersistedOntologyMetadata, InsertionError> {
+    ) -> Result<OntologyElementMetadata, InsertionError> {
         self.store
             .create_property_type(
                 property_type,
@@ -214,7 +214,7 @@ impl DatabaseApi<'_> {
     pub async fn update_property_type(
         &mut self,
         property_type: PropertyType,
-    ) -> Result<PersistedOntologyMetadata, UpdateError> {
+    ) -> Result<OntologyElementMetadata, UpdateError> {
         self.store
             .update_property_type(property_type, UpdatedById::new(self.account_id))
             .await
@@ -223,7 +223,7 @@ impl DatabaseApi<'_> {
     pub async fn create_entity_type(
         &mut self,
         entity_type: EntityType,
-    ) -> Result<PersistedOntologyMetadata, InsertionError> {
+    ) -> Result<OntologyElementMetadata, InsertionError> {
         self.store
             .create_entity_type(
                 entity_type,
@@ -257,7 +257,7 @@ impl DatabaseApi<'_> {
     pub async fn update_entity_type(
         &mut self,
         entity_type: EntityType,
-    ) -> Result<PersistedOntologyMetadata, UpdateError> {
+    ) -> Result<OntologyElementMetadata, UpdateError> {
         self.store
             .update_entity_type(entity_type, UpdatedById::new(self.account_id))
             .await

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -10,8 +10,7 @@ use error_stack::Result;
 use graph::{
     identifier::knowledge::EntityId,
     knowledge::{
-        EntityProperties, EntityQueryPath, EntityUuid, LinkEntityMetadata, PersistedEntity,
-        PersistedEntityMetadata,
+        Entity, EntityMetadata, EntityProperties, EntityQueryPath, EntityUuid, LinkEntityMetadata,
     },
     ontology::{
         DataTypeWithMetadata, EntityTypeQueryPath, EntityTypeWithMetadata,
@@ -250,7 +249,7 @@ impl DatabaseApi<'_> {
             .expect("no entity type found");
 
         match vertex {
-            Vertex::EntityType(persisted_entity_type) => Ok(persisted_entity_type),
+            Vertex::EntityType(entity_type) => Ok(entity_type),
             _ => unreachable!(),
         }
     }
@@ -269,7 +268,7 @@ impl DatabaseApi<'_> {
         entity: EntityProperties,
         entity_type_id: VersionedUri,
         entity_uuid: Option<EntityUuid>,
-    ) -> Result<PersistedEntityMetadata, InsertionError> {
+    ) -> Result<EntityMetadata, InsertionError> {
         self.store
             .create_entity(
                 entity,
@@ -282,7 +281,7 @@ impl DatabaseApi<'_> {
             .await
     }
 
-    pub async fn get_entity(&self, entity_id: EntityId) -> Result<PersistedEntity, QueryError> {
+    pub async fn get_entity(&self, entity_id: EntityId) -> Result<Entity, QueryError> {
         let vertex = self
             .store
             .get_entity(&StructuralQuery {
@@ -295,7 +294,7 @@ impl DatabaseApi<'_> {
             .expect("no entity found");
 
         match vertex {
-            Vertex::Entity(persisted_entity) => Ok(persisted_entity),
+            Vertex::Entity(entity) => Ok(entity),
             _ => unreachable!(),
         }
     }
@@ -305,7 +304,7 @@ impl DatabaseApi<'_> {
         entity_id: EntityId,
         entity: EntityProperties,
         entity_type_id: VersionedUri,
-    ) -> Result<PersistedEntityMetadata, UpdateError> {
+    ) -> Result<EntityMetadata, UpdateError> {
         self.store
             .update_entity(
                 entity_id,
@@ -323,7 +322,7 @@ impl DatabaseApi<'_> {
         entity_uuid: Option<EntityUuid>,
         left_entity_id: EntityId,
         right_entity_id: EntityId,
-    ) -> Result<PersistedEntityMetadata, InsertionError> {
+    ) -> Result<EntityMetadata, InsertionError> {
         self.store
             .create_entity(
                 entity,
@@ -345,7 +344,7 @@ impl DatabaseApi<'_> {
         &self,
         source_entity_uuid: EntityUuid,
         link_type_id: VersionedUri,
-    ) -> Result<PersistedEntity, QueryError> {
+    ) -> Result<Entity, QueryError> {
         let filter = Filter::All(vec![
             Filter::Equal(
                 Some(FilterExpression::Path(EntityQueryPath::LeftEntity(Some(
@@ -382,7 +381,7 @@ impl DatabaseApi<'_> {
             .vertices
             .into_iter()
             .map(|(_, vertex)| match vertex {
-                Vertex::Entity(persisted_entity) => Ok(persisted_entity),
+                Vertex::Entity(entity) => Ok(entity),
                 _ => unreachable!(),
             })
             .next()
@@ -392,7 +391,7 @@ impl DatabaseApi<'_> {
     pub async fn get_latest_entity_links(
         &self,
         source_entity_id: EntityId,
-    ) -> Result<Vec<PersistedEntity>, QueryError> {
+    ) -> Result<Vec<Entity>, QueryError> {
         let filter = Filter::All(vec![
             Filter::Equal(
                 Some(FilterExpression::Path(EntityQueryPath::LeftEntity(None))),
@@ -426,7 +425,7 @@ impl DatabaseApi<'_> {
             .vertices
             .into_iter()
             .map(|(_, vertex)| match vertex {
-                Vertex::Entity(persisted_entity) => persisted_entity,
+                Vertex::Entity(entity) => entity,
                 _ => unreachable!(),
             })
             .collect())

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -40,7 +40,7 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("text_data_type_id", encodeURIComponent(response.body.identifier.uri));
+    client.global.set("text_data_type_id", encodeURIComponent(`${response.body.editionId.baseId}v/${response.body.editionId.version}`));
 %}
 
 ### Get Text data type
@@ -98,7 +98,7 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("person_property_type_id", encodeURIComponent(response.body.identifier.uri));
+    client.global.set("person_property_type_id", encodeURIComponent(`${response.body.editionId.baseId}v/${response.body.editionId.version}`));
 %}
 
 ### Get Name property type
@@ -171,7 +171,7 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("friendship_link_entity_type_id", response.body.identifier.uri);
+    client.global.set("friendship_link_entity_type_id", `${response.body.editionId.baseId}v/${response.body.editionId.version}`);
 %}
 
 ### Get Friendship entity type
@@ -232,8 +232,8 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("person_entity_type_id", encodeURIComponent(response.body.identifier.uri));
-    client.global.set("encoded_person_entity_type_id", encodeURIComponent(response.body.identifier.uri));
+    client.global.set("person_entity_type_id", encodeURIComponent(`${response.body.editionId.baseId}v/${response.body.editionId.version}`));
+    client.global.set("encoded_person_entity_type_id", encodeURIComponent(`${response.body.editionId.baseId}v/${response.body.editionId.version}`));
 %}
 
 ### Get Person entity type
@@ -348,9 +348,9 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("person_a_entity_id", response.body.identifier.baseId);
-    client.global.set("person_a_entity_uuid", response.body.identifier.baseId.split("%")[1])
-    client.global.set("encoded_person_a_entity_id", encodeURIComponent(response.body.identifier.baseId));
+    client.global.set("person_a_entity_id", response.body.editionId.baseId);
+    client.global.set("person_a_entity_uuid", response.body.editionId.baseId.split("%")[1])
+    client.global.set("encoded_person_a_entity_id", encodeURIComponent(response.body.editionId.baseId));
 %}
 
 ### Get Person entity
@@ -400,8 +400,8 @@ Accept: application/json
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("person_b_entity_id", response.body.identifier.baseId);
-    client.global.set("person_b_entity_uuid", response.body.identifier.baseId.split("%")[1])
+    client.global.set("person_b_entity_id", response.body.editionId.baseId);
+    client.global.set("person_b_entity_uuid", response.body.editionId.baseId.split("%")[1])
 %}
 
 ### Get all latest entities

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -103,14 +103,6 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         notNull: true,
         references: "accounts",
       },
-      /**
-       * @todo: remove this column if we introduce a delete table similar to links
-       * @see https://app.asana.com/0/1201095311341924/1202697596928142/f
-       */
-      removed_by_id: {
-        type: "UUID",
-        references: "accounts",
-      },
     },
     {
       ifNotExists: true,
@@ -142,14 +134,6 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       updated_by_id: {
         type: "UUID",
         notNull: true,
-        references: "accounts",
-      },
-      /**
-       * @todo: remove this column if we introduce a delete table similar to links
-       * @see https://app.asana.com/0/1201095311341924/1202697596928142/f
-       */
-      removed_by_id: {
-        type: "UUID",
         references: "accounts",
       },
     },
@@ -185,14 +169,6 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
         notNull: true,
         references: "accounts",
       },
-      /**
-       * @todo: remove this column if we introduce a delete table similar to links
-       * @see https://app.asana.com/0/1201095311341924/1202697596928142/f
-       */
-      removed_by_id: {
-        type: "UUID",
-        references: "accounts",
-      },
     },
     {
       ifNotExists: true,
@@ -224,14 +200,6 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       updated_by_id: {
         type: "UUID",
         notNull: true,
-        references: "accounts",
-      },
-      /**
-       * @todo: remove this column if we introduce a delete table similar to links
-       * @see https://app.asana.com/0/1201095311341924/1202697596928142/f
-       */
-      removed_by_id: {
-        type: "UUID",
         references: "accounts",
       },
     },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We have records, and their associated metadata (e.g. a Property Type, and its associated owned_by_id). These were being haphazardly joined together in various places, and inconsistently across the element types. 

This PR reworks the structure of the elements to group related things, to better encapsulate the necessary information to _uniquely identify_ something, and to have more similar APIs.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201095311341924/1203331904553386/f) _(internal)_

## 🚫 Blocked by

- [x] #1374 

## 🔍 What does this change?

See commit list, effort has been made to keep it clean (and independent commits revertable for the most part)

## 📜 Does this require a change to the docs?

When `dev/links` is merged it will do.

## ⚠️ Known issues

- OntologyTypeEditionId can have a `From` and `Into` for `VersionedUri`, but because `VersionedUri` can't currently be deconstructed, we need to clone. This also causes problems for references of either type, if we stick `repr(C)` we can probably safely transmute. There is a question of if we even need the `OntologyTypeEditionId` struct though
- The subgraph currently tries to put an `OntologyTypeEditionId` in the keys of the object, this breaks because you can't have an object as a key. This means this PR breaks 2 HTTP tests. They will be fixed as a follow-up.

## 🐾 Next steps

- Migrate the `Subgraph`

## 🛡 What tests cover this?

- Unit Tests
- Integration Tests
- HTTP tests

## ❓ How to test this?

1.  Follow the README
