### PR TITLE
Make GraphQL API runnable, basic fixes in `Entity`/`EntityType`/`PropertyType`/`DataType` model classes

### DIFF
--- a/packages/hash/api/package.json
+++ b/packages/hash/api/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/s3-presigned-post": "3.38.0",
     "@aws-sdk/s3-request-presigner": "3.38.0",
     "@blockprotocol/core": "0.0.12",
-    "@blockprotocol/type-system-web": "https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?6526c0e",
+    "@blockprotocol/type-system-web": "https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?244d25a",
     "@graphql-tools/schema": "8.5.0",
     "@hashintel/hash-backend-utils": "0.0.0-private",
     "@hashintel/hash-graph-client": "0.0.0-private",

--- a/packages/hash/api/src/graph/system-types.ts
+++ b/packages/hash/api/src/graph/system-types.ts
@@ -1,13 +1,18 @@
+import { VersionedUri } from "@blockprotocol/type-system-web";
 import { Logger } from "@hashintel/hash-backend-utils/logger";
 import { GraphApi } from "@hashintel/hash-graph-client";
 import { types } from "@hashintel/hash-shared/types";
 import { logger } from "../logger";
 
-import { EntityTypeModel, LinkTypeModel, PropertyTypeModel } from "../model";
+import {
+  EntityTypeModel,
+  // LinkTypeModel,
+  PropertyTypeModel,
+} from "../model";
 import {
   propertyTypeInitializer,
   entityTypeInitializer,
-  linkTypeInitializer,
+  // linkTypeInitializer,
   systemAccountId,
 } from "../model/util";
 
@@ -63,44 +68,45 @@ export let SYSTEM_TYPES: {
      */
     dummy: EntityTypeModel;
   };
-  linkType: {
-    // HASHInstance-related
-    admin: LinkTypeModel;
+  /** @todo: bring back link types as entity types */
+  // linkType: {
+  //   // HASHInstance-related
+  //   admin: LinkTypeModel;
 
-    // User-related
-    hasMembership: LinkTypeModel;
+  //   // User-related
+  //   hasMembership: LinkTypeModel;
 
-    // OrgMembership-related
-    ofOrg: LinkTypeModel;
+  //   // OrgMembership-related
+  //   ofOrg: LinkTypeModel;
 
-    // Block-related
-    blockData: LinkTypeModel;
+  //   // Block-related
+  //   blockData: LinkTypeModel;
 
-    // Page-related
-    contains: LinkTypeModel;
-    parent: LinkTypeModel;
+  //   // Page-related
+  //   contains: LinkTypeModel;
+  //   parent: LinkTypeModel;
 
-    // Comment-related
-    hasText: LinkTypeModel;
-    author: LinkTypeModel;
-  };
+  //   // Comment-related
+  //   hasText: LinkTypeModel;
+  //   author: LinkTypeModel;
+  // };
 };
 
-export const adminLinkTypeInitializer = linkTypeInitializer({
-  ...types.linkType.admin,
-  actorId: systemAccountId,
-});
+// export const adminLinkTypeInitializer = linkTypeInitializer({
+//   ...types.linkType.admin,
+//   actorId: systemAccountId,
+// });
 
 export const hashInstanceEntityTypeInitializer = async (graphApi: GraphApi) => {
   /* eslint-disable @typescript-eslint/no-use-before-define */
 
-  const adminLinkTypeModel = await SYSTEM_TYPES_INITIALIZERS.linkType.admin(
-    graphApi,
-  );
+  // const adminLinkTypeModel = await SYSTEM_TYPES_INITIALIZERS.linkType.admin(
+  //   graphApi,
+  // );
 
-  const userEntityTypeModel = await SYSTEM_TYPES_INITIALIZERS.entityType.user(
-    graphApi,
-  );
+  // const userEntityTypeModel = await SYSTEM_TYPES_INITIALIZERS.entityType.user(
+  //   graphApi,
+  // );
 
   /* eslint-enable @typescript-eslint/no-use-before-define */
 
@@ -108,10 +114,10 @@ export const hashInstanceEntityTypeInitializer = async (graphApi: GraphApi) => {
     ...types.entityType.hashInstance,
     properties: [],
     outgoingLinks: [
-      {
-        linkTypeModel: adminLinkTypeModel,
-        destinationEntityTypeModels: [userEntityTypeModel],
-      },
+      // {
+      //   linkTypeModel: adminLinkTypeModel,
+      //   destinationEntityTypeModels: [userEntityTypeModel],
+      // },
     ],
     actorId: systemAccountId,
   })(graphApi);
@@ -181,13 +187,14 @@ const orgMembershipEntityTypeInitializer = async (graphApi: GraphApi) => {
   const responsibilityPropertyTypeModel =
     await SYSTEM_TYPES_INITIALIZERS.propertyType.responsibility(graphApi);
 
-  const orgEntityTypeModel = await SYSTEM_TYPES_INITIALIZERS.entityType.org(
-    graphApi,
-  );
+  // const orgEntityTypeModel = await SYSTEM_TYPES_INITIALIZERS.entityType.org(
+  //   graphApi,
+  // );
 
-  const ofOrgLinkTypeModel = await SYSTEM_TYPES_INITIALIZERS.linkType.ofOrg(
-    graphApi,
-  );
+  // const ofOrgLinkTypeModel = await SYSTEM_TYPES_INITIALIZERS.linkType.ofOrg(
+  //   graphApi,
+  // );
+
   /* eslint-enable @typescript-eslint/no-use-before-define */
 
   return entityTypeInitializer({
@@ -199,11 +206,11 @@ const orgMembershipEntityTypeInitializer = async (graphApi: GraphApi) => {
       },
     ],
     outgoingLinks: [
-      {
-        linkTypeModel: ofOrgLinkTypeModel,
-        destinationEntityTypeModels: [orgEntityTypeModel],
-        required: true,
-      },
+      // {
+      //   linkTypeModel: ofOrgLinkTypeModel,
+      //   destinationEntityTypeModels: [orgEntityTypeModel],
+      //   required: true,
+      // },
     ],
     actorId: systemAccountId,
   })(graphApi);
@@ -251,15 +258,15 @@ const responsibilityPropertyTypeInitializer = propertyTypeInitializer({
   actorId: systemAccountId,
 });
 
-const ofOrgLinkTypeInitializer = linkTypeInitializer({
-  ...types.linkType.ofOrg,
-  actorId: systemAccountId,
-});
+// const ofOrgLinkTypeInitializer = linkTypeInitializer({
+//   ...types.linkType.ofOrg,
+//   actorId: systemAccountId,
+// });
 
-const hasMembershipLinkTypeInitializer = linkTypeInitializer({
-  ...types.linkType.hasMembership,
-  actorId: systemAccountId,
-});
+// const hasMembershipLinkTypeInitializer = linkTypeInitializer({
+//   ...types.linkType.hasMembership,
+//   actorId: systemAccountId,
+// });
 
 const userEntityTypeInitializer = async (graphApi: GraphApi) => {
   /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -275,11 +282,11 @@ const userEntityTypeInitializer = async (graphApi: GraphApi) => {
   const preferredNamePropertyTypeModel =
     await SYSTEM_TYPES_INITIALIZERS.propertyType.preferredName(graphApi);
 
-  const hasMembershipLinkTypeModel =
-    await SYSTEM_TYPES_INITIALIZERS.linkType.hasMembership(graphApi);
+  // const hasMembershipLinkTypeModel =
+  //   await SYSTEM_TYPES_INITIALIZERS.linkType.hasMembership(graphApi);
 
-  const orgMembershipEntityTypeModel =
-    await SYSTEM_TYPES_INITIALIZERS.entityType.orgMembership(graphApi);
+  // const orgMembershipEntityTypeModel =
+  //   await SYSTEM_TYPES_INITIALIZERS.entityType.orgMembership(graphApi);
 
   /* eslint-enable @typescript-eslint/no-use-before-define */
 
@@ -304,10 +311,10 @@ const userEntityTypeInitializer = async (graphApi: GraphApi) => {
       },
     ],
     outgoingLinks: [
-      {
-        linkTypeModel: hasMembershipLinkTypeModel,
-        destinationEntityTypeModels: [orgMembershipEntityTypeModel],
-      },
+      // {
+      //   linkTypeModel: hasMembershipLinkTypeModel,
+      //   destinationEntityTypeModels: [orgMembershipEntityTypeModel],
+      // },
     ],
     actorId: systemAccountId,
   })(graphApi);
@@ -319,10 +326,10 @@ const componentIdPropertyTypeInitializer = propertyTypeInitializer({
   actorId: systemAccountId,
 });
 
-const blockDataLinkTypeInitializer = linkTypeInitializer({
-  ...types.linkType.blockData,
-  actorId: systemAccountId,
-});
+// const blockDataLinkTypeInitializer = linkTypeInitializer({
+//   ...types.linkType.blockData,
+//   actorId: systemAccountId,
+// });
 
 const blockEntityTypeInitializer = async (graphApi: GraphApi) => {
   /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -330,12 +337,12 @@ const blockEntityTypeInitializer = async (graphApi: GraphApi) => {
   const componentIdPropertyTypeModel =
     await SYSTEM_TYPES_INITIALIZERS.propertyType.componentId(graphApi);
 
-  const blockDataLinkTypeModel =
-    await SYSTEM_TYPES_INITIALIZERS.linkType.blockData(graphApi);
+  // const blockDataLinkTypeModel =
+  //   await SYSTEM_TYPES_INITIALIZERS.linkType.blockData(graphApi);
 
-  const dummyEntityTypeModel = await SYSTEM_TYPES_INITIALIZERS.entityType.dummy(
-    graphApi,
-  );
+  // const dummyEntityTypeModel = await SYSTEM_TYPES_INITIALIZERS.entityType.dummy(
+  //   graphApi,
+  // );
 
   /* eslint-enable @typescript-eslint/no-use-before-define */
 
@@ -348,15 +355,15 @@ const blockEntityTypeInitializer = async (graphApi: GraphApi) => {
       },
     ],
     outgoingLinks: [
-      {
-        linkTypeModel: blockDataLinkTypeModel,
-        /**
-         * @todo: unset this when the destination entity type can be undefined
-         * @see https://app.asana.com/0/1202805690238892/1203015527055368/f
-         */
-        destinationEntityTypeModels: [dummyEntityTypeModel],
-        required: true,
-      },
+      // {
+      //   linkTypeModel: blockDataLinkTypeModel,
+      //   /**
+      //    * @todo: unset this when the destination entity type can be undefined
+      //    * @see https://app.asana.com/0/1202805690238892/1203015527055368/f
+      //    */
+      //   destinationEntityTypeModels: [dummyEntityTypeModel],
+      //   required: true,
+      // },
     ],
     actorId: systemAccountId,
   })(graphApi);
@@ -436,15 +443,15 @@ const iconPropertyTypeInitializer = propertyTypeInitializer({
   actorId: systemAccountId,
 });
 
-const containsLinkTypeInitializer = linkTypeInitializer({
-  ...types.linkType.contains,
-  actorId: systemAccountId,
-});
+// const containsLinkTypeInitializer = linkTypeInitializer({
+//   ...types.linkType.contains,
+//   actorId: systemAccountId,
+// });
 
-const parentLinkTypeInitializer = linkTypeInitializer({
-  ...types.linkType.parent,
-  actorId: systemAccountId,
-});
+// const parentLinkTypeInitializer = linkTypeInitializer({
+//   ...types.linkType.parent,
+//   actorId: systemAccountId,
+// });
 
 const pageEntityTypeInitializer = async (graphApi: GraphApi) => {
   /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -464,15 +471,15 @@ const pageEntityTypeInitializer = async (graphApi: GraphApi) => {
   const iconPropertyTypeModel =
     await SYSTEM_TYPES_INITIALIZERS.propertyType.icon(graphApi);
 
-  const containsLinkTypeModel =
-    await SYSTEM_TYPES_INITIALIZERS.linkType.contains(graphApi);
+  // const containsLinkTypeModel =
+  //   await SYSTEM_TYPES_INITIALIZERS.linkType.contains(graphApi);
 
-  const parentLinkTypeTypeModel =
-    await SYSTEM_TYPES_INITIALIZERS.linkType.parent(graphApi);
+  // const parentLinkTypeTypeModel =
+  //   await SYSTEM_TYPES_INITIALIZERS.linkType.parent(graphApi);
 
-  const blockEntityTypeModel = await SYSTEM_TYPES_INITIALIZERS.entityType.block(
-    graphApi,
-  );
+  // const blockEntityTypeModel = await SYSTEM_TYPES_INITIALIZERS.entityType.block(
+  //   graphApi,
+  // );
 
   /* eslint-enable @typescript-eslint/no-use-before-define */
 
@@ -498,17 +505,17 @@ const pageEntityTypeInitializer = async (graphApi: GraphApi) => {
       },
     ],
     outgoingLinks: [
-      {
-        linkTypeModel: containsLinkTypeModel,
-        destinationEntityTypeModels: [blockEntityTypeModel],
-        required: true,
-        array: true,
-        ordered: true,
-      },
-      {
-        linkTypeModel: parentLinkTypeTypeModel,
-        destinationEntityTypeModels: ["SELF_REFERENCE"],
-      },
+      // {
+      //   linkTypeModel: containsLinkTypeModel,
+      //   destinationEntityTypeModels: [blockEntityTypeModel],
+      //   required: true,
+      //   array: true,
+      //   ordered: true,
+      // },
+      // {
+      //   linkTypeModel: parentLinkTypeTypeModel,
+      //   destinationEntityTypeModels: ["SELF_REFERENCE"],
+      // },
     ],
     actorId: systemAccountId,
   })(graphApi);
@@ -526,15 +533,15 @@ const deletedAtPropertyTypeInitializer = propertyTypeInitializer({
   actorId: systemAccountId,
 });
 
-const hasTextLinkTypeInitializer = linkTypeInitializer({
-  ...types.linkType.hasText,
-  actorId: systemAccountId,
-});
+// const hasTextLinkTypeInitializer = linkTypeInitializer({
+//   ...types.linkType.hasText,
+//   actorId: systemAccountId,
+// });
 
-const authorLinkTypeInitializer = linkTypeInitializer({
-  ...types.linkType.author,
-  actorId: systemAccountId,
-});
+// const authorLinkTypeInitializer = linkTypeInitializer({
+//   ...types.linkType.author,
+//   actorId: systemAccountId,
+// });
 
 const commentEntityTypeInitializer = async (graphApi: GraphApi) => {
   /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -545,27 +552,27 @@ const commentEntityTypeInitializer = async (graphApi: GraphApi) => {
   const deletedAtPropertyTypeModel =
     await SYSTEM_TYPES_INITIALIZERS.propertyType.deletedAt(graphApi);
 
-  const hasTextLinkTypeModel = await SYSTEM_TYPES_INITIALIZERS.linkType.hasText(
-    graphApi,
-  );
+  // const hasTextLinkTypeModel = await SYSTEM_TYPES_INITIALIZERS.linkType.hasText(
+  //   graphApi,
+  // );
 
-  const parentLinkTypeTypeModel =
-    await SYSTEM_TYPES_INITIALIZERS.linkType.parent(graphApi);
+  // const parentLinkTypeTypeModel =
+  //   await SYSTEM_TYPES_INITIALIZERS.linkType.parent(graphApi);
 
-  const authorLinkTypeTypeModel =
-    await SYSTEM_TYPES_INITIALIZERS.linkType.author(graphApi);
+  // const authorLinkTypeTypeModel =
+  //   await SYSTEM_TYPES_INITIALIZERS.linkType.author(graphApi);
 
-  const userEntityTypeModel = await SYSTEM_TYPES_INITIALIZERS.entityType.user(
-    graphApi,
-  );
+  // const userEntityTypeModel = await SYSTEM_TYPES_INITIALIZERS.entityType.user(
+  //   graphApi,
+  // );
 
-  const textEntityTypeModel = await SYSTEM_TYPES_INITIALIZERS.entityType.text(
-    graphApi,
-  );
+  // const textEntityTypeModel = await SYSTEM_TYPES_INITIALIZERS.entityType.text(
+  //   graphApi,
+  // );
 
-  const blockEntityTypeModel = await SYSTEM_TYPES_INITIALIZERS.entityType.block(
-    graphApi,
-  );
+  // const blockEntityTypeModel = await SYSTEM_TYPES_INITIALIZERS.entityType.block(
+  //   graphApi,
+  // );
 
   /* eslint-enable @typescript-eslint/no-use-before-define */
 
@@ -580,21 +587,21 @@ const commentEntityTypeInitializer = async (graphApi: GraphApi) => {
       },
     ],
     outgoingLinks: [
-      {
-        linkTypeModel: hasTextLinkTypeModel,
-        destinationEntityTypeModels: [textEntityTypeModel],
-        required: true,
-      },
-      {
-        linkTypeModel: parentLinkTypeTypeModel,
-        destinationEntityTypeModels: ["SELF_REFERENCE", blockEntityTypeModel],
-        required: true,
-      },
-      {
-        linkTypeModel: authorLinkTypeTypeModel,
-        destinationEntityTypeModels: [userEntityTypeModel],
-        required: true,
-      },
+      // {
+      //   linkTypeModel: hasTextLinkTypeModel,
+      //   destinationEntityTypeModels: [textEntityTypeModel],
+      //   required: true,
+      // },
+      // {
+      //   linkTypeModel: parentLinkTypeTypeModel,
+      //   destinationEntityTypeModels: ["SELF_REFERENCE", blockEntityTypeModel],
+      //   required: true,
+      // },
+      // {
+      //   linkTypeModel: authorLinkTypeTypeModel,
+      //   destinationEntityTypeModels: [userEntityTypeModel],
+      //   required: true,
+      // },
     ],
     actorId: systemAccountId,
   })(graphApi);
@@ -649,16 +656,16 @@ export const SYSTEM_TYPES_INITIALIZERS: FlattenAndPromisify<
     text: textEntityTypeInitializer,
     dummy: dummyEntityTypeInitializer,
   },
-  linkType: {
-    admin: adminLinkTypeInitializer,
-    ofOrg: ofOrgLinkTypeInitializer,
-    hasMembership: hasMembershipLinkTypeInitializer,
-    blockData: blockDataLinkTypeInitializer,
-    contains: containsLinkTypeInitializer,
-    parent: parentLinkTypeInitializer,
-    hasText: hasTextLinkTypeInitializer,
-    author: authorLinkTypeInitializer,
-  },
+  // linkType: {
+  //   admin: adminLinkTypeInitializer,
+  //   ofOrg: ofOrgLinkTypeInitializer,
+  //   hasMembership: hasMembershipLinkTypeInitializer,
+  //   blockData: blockDataLinkTypeInitializer,
+  //   contains: containsLinkTypeInitializer,
+  //   parent: parentLinkTypeInitializer,
+  //   hasText: hasTextLinkTypeInitializer,
+  //   author: authorLinkTypeInitializer,
+  // },
 };
 
 /**

--- a/packages/hash/api/src/graph/system-types.ts
+++ b/packages/hash/api/src/graph/system-types.ts
@@ -68,7 +68,10 @@ export let SYSTEM_TYPES: {
      */
     dummy: EntityTypeModel;
   };
-  /** @todo: bring back link types as entity types */
+  /**
+   * @todo: bring back link types as entity types
+   * @see https://app.asana.com/0/1202805690238892/1203361844133477/f
+   */
   // linkType: {
   //   // HASHInstance-related
   //   admin: LinkTypeModel;

--- a/packages/hash/api/src/index.ts
+++ b/packages/hash/api/src/index.ts
@@ -45,7 +45,7 @@ import { setupTelemetry } from "./telemetry/snowplow-setup";
 import { connectToTaskExecutor } from "./task-execution";
 import { createGraphClient } from "./graph";
 import { seedOrgsAndUsers } from "./seed-data";
-import { ensureSystemEntitiesExists } from "./graph/system-entities";
+// import { ensureSystemEntitiesExists } from "./graph/system-entities";
 
 const shutdown = new GracefulShutdown(logger, "SIGINT", "SIGTERM");
 
@@ -132,7 +132,8 @@ const main = async () => {
 
   await ensureSystemTypesExist({ graphApi, logger });
 
-  await ensureSystemEntitiesExists({ graphApi, logger });
+  /** @todo: bring back when links are working */
+  // await ensureSystemEntitiesExists({ graphApi, logger });
 
   // Set sensible default security headers: https://www.npmjs.com/package/helmet
   // Temporarily disable contentSecurityPolicy for the GraphQL playground

--- a/packages/hash/api/src/index.ts
+++ b/packages/hash/api/src/index.ts
@@ -132,7 +132,10 @@ const main = async () => {
 
   await ensureSystemTypesExist({ graphApi, logger });
 
-  /** @todo: bring back when links are working */
+  /**
+   * @todo: fix this when links are working
+   * @see https://app.asana.com/0/1202805690238892/1203361844133479/f
+   */
   // await ensureSystemEntitiesExists({ graphApi, logger });
 
   // Set sensible default security headers: https://www.npmjs.com/package/helmet

--- a/packages/hash/api/src/index.ts
+++ b/packages/hash/api/src/index.ts
@@ -44,7 +44,7 @@ import { getAwsRegion } from "./lib/aws-config";
 import { setupTelemetry } from "./telemetry/snowplow-setup";
 import { connectToTaskExecutor } from "./task-execution";
 import { createGraphClient } from "./graph";
-import { seedOrgsAndUsers } from "./seed-data";
+// import { seedOrgsAndUsers } from "./seed-data";
 // import { ensureSystemEntitiesExists } from "./graph/system-entities";
 
 const shutdown = new GracefulShutdown(logger, "SIGINT", "SIGTERM");
@@ -149,7 +149,11 @@ const main = async () => {
 
   if (isDevEnv) {
     // This will seed users, an org and pages.
-    await seedOrgsAndUsers({ graphApi, logger });
+    /**
+     * @todo: fix this when links are working
+     * @see https://app.asana.com/0/1202805690238892/1203361844133479/f
+     */
+    // await seedOrgsAndUsers({ graphApi, logger });
   }
 
   // Create an email transporter

--- a/packages/hash/api/src/model/knowledge/block.model.ts
+++ b/packages/hash/api/src/model/knowledge/block.model.ts
@@ -26,13 +26,13 @@ export default class extends EntityModel {
       SYSTEM_TYPES.entityType.block.schema.$id
     ) {
       throw new EntityTypeMismatchError(
-        entity.entityId,
+        entity.baseId,
         SYSTEM_TYPES.entityType.block.schema.$id,
         entity.entityTypeModel.schema.$id,
       );
     }
 
-    return new BlockModel(entity);
+    return new BlockModel({ entity, entityTypeModel: entity.entityTypeModel });
   }
 
   /**

--- a/packages/hash/api/src/model/knowledge/comment.model.ts
+++ b/packages/hash/api/src/model/knowledge/comment.model.ts
@@ -28,13 +28,16 @@ export default class extends EntityModel {
       SYSTEM_TYPES.entityType.comment.schema.$id
     ) {
       throw new EntityTypeMismatchError(
-        entity.entityId,
+        entity.baseId,
         SYSTEM_TYPES.entityType.comment.schema.$id,
         entity.entityTypeModel.schema.$id,
       );
     }
 
-    return new CommentModel(entity);
+    return new CommentModel({
+      entity,
+      entityTypeModel: entity.entityTypeModel,
+    });
   }
 
   /**

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -6,6 +6,7 @@ import {
   Subgraph,
   EntityStructuralQuery,
   Filter,
+  EntityMetadata,
 } from "@hashintel/hash-graph-client";
 
 import {
@@ -22,12 +23,8 @@ import {
 import { exactlyOne, linkedTreeFlatten } from "../../util";
 
 export type EntityModelConstructorParams = {
-  entityId: string;
-  version: string;
+  entity: Entity;
   entityTypeModel: EntityTypeModel;
-  properties: object;
-  createdById: string;
-  updatedById: string;
 };
 
 export type EntityModelCreateParams = {
@@ -42,41 +39,36 @@ export type EntityModelCreateParams = {
  * @class {@link EntityModel}
  */
 export default class {
-  entityId: string;
-  version: string;
+  private entity: Entity;
+
   entityTypeModel: EntityTypeModel;
-  properties: object;
 
-  createdById: string;
-  updatedById: string;
+  /** @todo: get rid of `entityId` accessor */
+  get entityId(): string {
+    return this.entity.metadata.editionId.baseId;
+  }
 
-  constructor({
-    entityId,
-    version,
-    entityTypeModel,
-    properties,
-    createdById,
-    updatedById,
-  }: EntityModelConstructorParams) {
-    this.entityId = entityId;
-    this.version = version;
+  get metadata(): EntityMetadata {
+    return this.entity.metadata;
+  }
+
+  get properties(): object {
+    return this.entity.properties;
+  }
+
+  constructor({ entity, entityTypeModel }: EntityModelConstructorParams) {
+    this.entity = entity;
     this.entityTypeModel = entityTypeModel;
-    this.properties = properties;
-
-    this.createdById = createdById;
-    this.updatedById = updatedById;
   }
 
   private static async fromEntity(
     graphApi: GraphApi,
-    { metadata, properties }: Entity,
+    entity: Entity,
     cachedEntityTypeModels?: Map<string, EntityTypeModel>,
   ): Promise<EntityModel> {
     const {
-      editionId,
-      entityTypeId,
-      provenance: { createdById, updatedById },
-    } = metadata;
+      metadata: { entityTypeId },
+    } = entity;
 
     const cachedEntityTypeModel = cachedEntityTypeModels?.get(entityTypeId);
 
@@ -91,14 +83,7 @@ export default class {
       }
     }
 
-    return new EntityModel({
-      entityId: editionId.baseId,
-      version: editionId.version,
-      entityTypeModel,
-      properties,
-      createdById,
-      updatedById,
-    });
+    return new EntityModel({ entity, entityTypeModel });
   }
 
   /**

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -42,17 +42,20 @@ export default class {
 
   entityTypeModel: EntityTypeModel;
 
-  get entityId(): string {
-    return this.entity.metadata.editionId.baseId;
+  get baseId(): string {
+    return this.metadata.editionId.baseId;
   }
 
   get entityUuid(): string {
-    const [entityId] = this.entity.metadata.editionId.baseId.split("%") as [
-      string,
-      string,
-    ];
+    const [_, entityUuid] = this.baseId.split("%") as [string, string];
 
-    return entityId;
+    return entityUuid;
+  }
+
+  get ownedById(): string {
+    const [ownedById, _] = this.baseId.split("%") as [string, string];
+
+    return ownedById;
   }
 
   get metadata(): EntityMetadata {
@@ -373,11 +376,11 @@ export default class {
     },
   ): Promise<EntityModel> {
     const { properties, actorId } = params;
-    const { entityId, entityTypeModel } = this;
+    const { baseId, entityTypeModel } = this;
 
     const { data: metadata } = await graphApi.updateEntity({
       actorId,
-      entityId,
+      entityId: baseId,
       /** @todo: make this argument optional */
       entityTypeId: entityTypeModel.schema.$id,
       entity: properties,
@@ -443,9 +446,9 @@ export default class {
    * Get the latest version of this entity.
    */
   async getLatestVersion(graphApi: GraphApi) {
-    const { entityId } = this;
+    const { baseId } = this;
 
-    return await EntityModel.getLatest(graphApi, { entityId });
+    return await EntityModel.getLatest(graphApi, { entityId: baseId });
   }
 
   /** @see {@link LinkModel.create} */

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -308,9 +308,6 @@ export default class {
           options?.graphResolveDepths?.entityTypeResolveDepth ?? 0,
         entityResolveDepth:
           options?.graphResolveDepths?.entityResolveDepth ?? 0,
-        // linkResolveDepth: options?.graphResolveDepths?.linkResolveDepth ?? 0,
-        // linkTargetEntityResolveDepth:
-        //   options?.graphResolveDepths?.linkTargetEntityResolveDepth ?? 0,
       },
     });
 

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -555,7 +555,6 @@ export default class {
         dataTypeResolveDepth: 0,
         propertyTypeResolveDepth: 0,
         entityResolveDepth: 0,
-        // linkTypeResolveDepth: 0,
         entityTypeResolveDepth: 0,
         ...params,
       },

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -42,9 +42,17 @@ export default class {
 
   entityTypeModel: EntityTypeModel;
 
-  /** @todo: get rid of `entityId` accessor */
   get entityId(): string {
     return this.entity.metadata.editionId.baseId;
+  }
+
+  get entityUuid(): string {
+    const [entityId] = this.entity.metadata.editionId.baseId.split("%") as [
+      string,
+      string,
+    ];
+
+    return entityId;
   }
 
   get metadata(): EntityMetadata {
@@ -474,7 +482,7 @@ export default class {
     const filter: Filter = {
       all: [
         {
-          equal: [{ path: ["target", "uuid"] }, { parameter: this.entityId }],
+          equal: [{ path: ["target", "uuid"] }, { parameter: this.entityUuid }],
         },
       ],
     };
@@ -507,7 +515,7 @@ export default class {
     const filter: Filter = {
       all: [
         {
-          equal: [{ path: ["source", "uuid"] }, { parameter: this.entityId }],
+          equal: [{ path: ["source", "uuid"] }, { parameter: this.entityUuid }],
         },
       ],
     };
@@ -542,7 +550,7 @@ export default class {
       filter: {
         all: [
           { equal: [{ path: ["version"] }, { parameter: "latest" }] },
-          { equal: [{ path: ["uuid"] }, { parameter: this.entityId }] },
+          { equal: [{ path: ["uuid"] }, { parameter: this.entityUuid }] },
         ],
       },
       graphResolveDepths: {

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -302,8 +302,6 @@ export default class {
           options?.graphResolveDepths?.dataTypeResolveDepth ?? 0,
         propertyTypeResolveDepth:
           options?.graphResolveDepths?.propertyTypeResolveDepth ?? 0,
-        // linkTypeResolveDepth:
-        //   options?.graphResolveDepths?.linkTypeResolveDepth ?? 0,
         entityTypeResolveDepth:
           options?.graphResolveDepths?.entityTypeResolveDepth ?? 0,
         entityResolveDepth:

--- a/packages/hash/api/src/model/knowledge/org.model.ts
+++ b/packages/hash/api/src/model/knowledge/org.model.ts
@@ -81,13 +81,13 @@ export default class extends EntityModel {
       SYSTEM_TYPES.entityType.org.schema.$id
     ) {
       throw new EntityTypeMismatchError(
-        entity.entityId,
+        entity.baseId,
         SYSTEM_TYPES.entityType.org.schema.$id,
         entity.entityTypeModel.schema.$id,
       );
     }
 
-    return new OrgModel(entity);
+    return new OrgModel({ entity, entityTypeModel: entity.entityTypeModel });
   }
 
   /**
@@ -172,7 +172,7 @@ export default class extends EntityModel {
       propertyTypeBaseUri: SYSTEM_TYPES.propertyType.shortName.baseUri,
       value: updatedShortname,
       actorId,
-    }).then((updatedEntity) => new OrgModel(updatedEntity));
+    }).then((updatedEntity) => OrgModel.fromEntityModel(updatedEntity));
   }
 
   getOrgName(): string {

--- a/packages/hash/api/src/model/knowledge/orgMembership.model.ts
+++ b/packages/hash/api/src/model/knowledge/orgMembership.model.ts
@@ -29,13 +29,16 @@ export default class extends EntityModel {
       SYSTEM_TYPES.entityType.orgMembership.schema.$id
     ) {
       throw new EntityTypeMismatchError(
-        entity.entityId,
+        entity.baseId,
         SYSTEM_TYPES.entityType.orgMembership.schema.$id,
         entity.entityTypeModel.schema.$id,
       );
     }
 
-    return new OrgMembershipModel(entity);
+    return new OrgMembershipModel({
+      entity,
+      entityTypeModel: entity.entityTypeModel,
+    });
   }
 
   /**

--- a/packages/hash/api/src/model/knowledge/page.model.ts
+++ b/packages/hash/api/src/model/knowledge/page.model.ts
@@ -34,13 +34,13 @@ export default class extends EntityModel {
       SYSTEM_TYPES.entityType.page.schema.$id
     ) {
       throw new EntityTypeMismatchError(
-        entity.entityId,
+        entity.baseId,
         SYSTEM_TYPES.entityType.page.schema.$id,
         entity.entityTypeModel.schema.$id,
       );
     }
 
-    return new PageModel(entity);
+    return new PageModel({ entity, entityTypeModel: entity.entityTypeModel });
   }
 
   /**
@@ -152,7 +152,7 @@ export default class extends EntityModel {
        * @todo: filter the pages by their ownedById in the query instead once it's supported
        * @see https://app.asana.com/0/1202805690238892/1203015527055374/f
        */
-      .filter(({ ownedById }) => ownedById === params.accountModel.entityId)
+      .filter(({ ownedById }) => ownedById === params.accountModel.entityUuid)
       .map(PageModel.fromEntityModel);
 
     return await Promise.all(

--- a/packages/hash/api/src/model/knowledge/user.model.ts
+++ b/packages/hash/api/src/model/knowledge/user.model.ts
@@ -40,13 +40,13 @@ export default class extends EntityModel {
       SYSTEM_TYPES.entityType.user.schema.$id
     ) {
       throw new EntityTypeMismatchError(
-        entity.entityId,
+        entity.baseId,
         SYSTEM_TYPES.entityType.user.schema.$id,
         entity.entityTypeModel.schema.$id,
       );
     }
 
-    return new UserModel(entity);
+    return new UserModel({ entity, entityTypeModel: entity.entityTypeModel });
   }
 
   /**
@@ -327,7 +327,7 @@ export default class extends EntityModel {
       propertyTypeBaseUri: SYSTEM_TYPES.propertyType.shortName.baseUri,
       value: updatedShortname,
       actorId,
-    }).then((updatedEntity) => new UserModel(updatedEntity));
+    }).then((updatedEntity) => UserModel.fromEntityModel(updatedEntity));
 
     await this.updateKratosIdentityTraits({
       shortname: updatedShortname,
@@ -374,7 +374,7 @@ export default class extends EntityModel {
       actorId,
     });
 
-    return new UserModel(updatedEntity);
+    return UserModel.fromEntityModel(updatedEntity);
   }
 
   getKratosIdentityId(): string {
@@ -475,7 +475,7 @@ export default class extends EntityModel {
 
   async isMemberOfOrg(
     graphApi: GraphApi,
-    params: { orgEntityId: string },
+    params: { orgEntityUuid: string },
   ): Promise<boolean> {
     const orgMemberships = await this.getOrgMemberships(graphApi);
 
@@ -483,7 +483,7 @@ export default class extends EntityModel {
       orgMemberships.map((orgMembership) => orgMembership.getOrg(graphApi)),
     );
 
-    return !!orgs.find(({ entityId }) => entityId === params.orgEntityId);
+    return !!orgs.find(({ entityUuid }) => entityUuid === params.orgEntityUuid);
   }
 
   isAccountSignupComplete(): boolean {

--- a/packages/hash/api/src/model/ontology/data-type.model.ts
+++ b/packages/hash/api/src/model/ontology/data-type.model.ts
@@ -4,66 +4,42 @@ import {
   GraphApi,
   DataTypeWithMetadata,
   UpdateDataTypeRequest,
+  OntologyElementMetadata,
 } from "@hashintel/hash-graph-client";
 import { generateTypeId } from "@hashintel/hash-shared/types";
 import { DataTypeModel } from "../index";
 import { getNamespaceOfAccountOwner } from "./util";
 
 type DataTypeModelConstructorArgs = {
-  ownedById: string;
-  schema: DataType;
-  createdById: string;
-  updatedById: string;
+  dataType: DataTypeWithMetadata;
 };
 
 /**
  * @class {@link DataTypeModel}
  */
 export default class {
-  ownedById: string;
+  private dataType: DataTypeWithMetadata;
 
-  schema: DataType;
-
-  createdById: string;
-  updatedById: string;
-
-  constructor({
-    schema,
-    ownedById,
-    createdById,
-    updatedById,
-  }: DataTypeModelConstructorArgs) {
-    this.ownedById = ownedById;
-    this.schema = schema;
-
-    this.createdById = createdById;
-    this.updatedById = updatedById;
+  get schema(): DataType {
+    /**
+     * @todo: remove this casting when we update the type system package
+     * @see https://app.asana.com/0/1201095311341924/1203259817761581/f
+     */
+    return this.dataType.schema as DataType;
   }
 
-  static fromDataTypeWithMetadata({
-    schema,
-    metadata: {
-      ownedById,
-      provenance: { createdById, updatedById },
-    },
-  }: DataTypeWithMetadata): DataTypeModel {
-    /**
-     * @todo and a warning, these type casts are here to compensate for
-     *   the differences between the Graph API package and the
-     *   type system package.
-     *
-     *   The type system package can be considered the source of truth in
-     *   terms of the shape of values returned from the API, but the API
-     *   client is unable to be given as type package types - it generates
-     *   its own types.
-     *   https://app.asana.com/0/1202805690238892/1202892835843657/f
-     */
-    return new DataTypeModel({
-      schema: schema as DataType,
-      ownedById,
-      createdById,
-      updatedById,
-    });
+  get metadata(): OntologyElementMetadata {
+    return this.dataType.metadata;
+  }
+
+  constructor({ dataType }: DataTypeModelConstructorArgs) {
+    this.dataType = dataType;
+  }
+
+  static fromDataTypeWithMetadata(
+    dataType: DataTypeWithMetadata,
+  ): DataTypeModel {
+    return new DataTypeModel({ dataType });
   }
 
   /**

--- a/packages/hash/api/src/model/ontology/data-type.model.ts
+++ b/packages/hash/api/src/model/ontology/data-type.model.ts
@@ -22,8 +22,15 @@ export default class {
 
   get schema(): DataType {
     /**
-     * @todo: remove this casting when we update the type system package
-     * @see https://app.asana.com/0/1201095311341924/1203259817761581/f
+     * @todo and a warning, these type casts are here to compensate for
+     *   the differences between the Graph API package and the
+     *   type system package.
+     *
+     *   The type system package can be considered the source of truth in
+     *   terms of the shape of values returned from the API, but the API
+     *   client is unable to be given as type package types - it generates
+     *   its own types.
+     *   https://app.asana.com/0/1202805690238892/1202892835843657/f
      */
     return this.dataType.schema as DataType;
   }

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -28,10 +28,6 @@ export type EntityTypeModelCreateParams = {
 export default class {
   private entityType: EntityTypeWithMetadata;
 
-  get ownedById(): string {
-    return this.entityType.metadata.ownedById;
-  }
-
   get schema(): EntityType {
     /**
      * @todo: remove this casting when we update the type system package

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -1,10 +1,11 @@
 import { AxiosError } from "axios";
 
-import { VersionedUri, EntityType } from "@blockprotocol/type-system-web";
+import { EntityType } from "@blockprotocol/type-system-web";
 import {
   GraphApi,
   UpdateEntityTypeRequest,
   EntityTypeWithMetadata,
+  OntologyElementMetadata,
 } from "@hashintel/hash-graph-client";
 import { generateTypeId, types } from "@hashintel/hash-shared/types";
 import { EntityTypeModel, PropertyTypeModel, LinkTypeModel } from "../index";
@@ -12,10 +13,7 @@ import { getNamespaceOfAccountOwner } from "./util";
 import { SYSTEM_TYPES } from "../../graph/system-types";
 
 export type EntityTypeModelConstructorParams = {
-  ownedById: string;
-  schema: EntityType;
-  createdById: string;
-  updatedById: string;
+  entityType: EntityTypeWithMetadata;
 };
 
 export type EntityTypeModelCreateParams = {
@@ -28,54 +26,32 @@ export type EntityTypeModelCreateParams = {
  * @class {@link EntityTypeModel}
  */
 export default class {
-  ownedById: string;
+  private entityType: EntityTypeWithMetadata;
 
-  schema: EntityType;
+  get ownedById(): string {
+    return this.entityType.metadata.ownedById;
+  }
 
-  createdById: string;
-  updatedById: string;
-
-  constructor({
-    schema,
-    ownedById,
-    createdById,
-    updatedById,
-  }: EntityTypeModelConstructorParams) {
-    this.ownedById = ownedById;
+  get schema(): EntityType {
     /**
      * @todo: remove this casting when we update the type system package
      * @see https://app.asana.com/0/1201095311341924/1203259817761581/f
      */
-    this.schema = schema as EntityType & { $id: VersionedUri };
-
-    this.createdById = createdById;
-    this.updatedById = updatedById;
+    return this.entityType.schema as EntityType;
   }
 
-  static fromEntityTypeWithMetadata({
-    schema,
-    metadata: {
-      ownedById,
-      provenance: { createdById, updatedById },
-    },
-  }: EntityTypeWithMetadata): EntityTypeModel {
-    /**
-     * @todo and a warning, these type casts are here to compensate for
-     *   the differences between the Graph API package and the
-     *   type system package.
-     *
-     *   The type system package can be considered the source of truth in
-     *   terms of the shape of values returned from the API, but the API
-     *   client is unable to be given as type package types - it generates
-     *   its own types.
-     *   https://app.asana.com/0/1202805690238892/1202892835843657/f
-     */
-    return new EntityTypeModel({
-      schema: schema as EntityType,
-      ownedById,
-      createdById,
-      updatedById,
-    });
+  get metadata(): OntologyElementMetadata {
+    return this.entityType.metadata;
+  }
+
+  constructor({ entityType }: EntityTypeModelConstructorParams) {
+    this.entityType = entityType;
+  }
+
+  static fromEntityTypeWithMetadata(
+    entityType: EntityTypeWithMetadata,
+  ): EntityTypeModel {
+    return new EntityTypeModel({ entityType });
   }
 
   /**

--- a/packages/hash/api/src/model/ontology/entity-type.model.ts
+++ b/packages/hash/api/src/model/ontology/entity-type.model.ts
@@ -30,8 +30,15 @@ export default class {
 
   get schema(): EntityType {
     /**
-     * @todo: remove this casting when we update the type system package
-     * @see https://app.asana.com/0/1201095311341924/1203259817761581/f
+     * @todo and a warning, these type casts are here to compensate for
+     *   the differences between the Graph API package and the
+     *   type system package.
+     *
+     *   The type system package can be considered the source of truth in
+     *   terms of the shape of values returned from the API, but the API
+     *   client is unable to be given as type package types - it generates
+     *   its own types.
+     *   https://app.asana.com/0/1202805690238892/1202892835843657/f
      */
     return this.entityType.schema as EntityType;
   }

--- a/packages/hash/api/src/model/ontology/property-type.model.ts
+++ b/packages/hash/api/src/model/ontology/property-type.model.ts
@@ -2,6 +2,7 @@ import { AxiosError } from "axios";
 
 import {
   GraphApi,
+  OntologyElementMetadata,
   PropertyTypeWithMetadata,
   UpdatePropertyTypeRequest,
 } from "@hashintel/hash-graph-client";
@@ -12,57 +13,35 @@ import { extractBaseUri } from "../util";
 import { getNamespaceOfAccountOwner } from "./util";
 
 type PropertyTypeModelConstructorParams = {
-  ownedById: string;
-  schema: PropertyType;
-  createdById: string;
-  updatedById: string;
+  propertyType: PropertyTypeWithMetadata;
 };
 
 /**
  * @class {@link PropertyTypeModel}
  */
 export default class {
-  ownedById: string;
+  private propertyType: PropertyTypeWithMetadata;
 
-  schema: PropertyType;
-
-  createdById: string;
-  updatedById: string;
-  removedById: string | undefined;
-
-  constructor({
-    schema,
-    ownedById,
-    createdById,
-    updatedById,
-  }: PropertyTypeModelConstructorParams) {
-    this.ownedById = ownedById;
-    this.schema = schema;
-    this.createdById = createdById;
-    this.updatedById = updatedById;
+  get schema(): PropertyType {
+    /**
+     * @todo: remove this casting when we update the type system package
+     * @see https://app.asana.com/0/1201095311341924/1203259817761581/f
+     */
+    return this.propertyType.schema as PropertyType;
   }
 
-  static fromPropertyTypeWithMetadata({
-    schema,
-    metadata: { ownedById, provenance },
-  }: PropertyTypeWithMetadata): PropertyTypeModel {
-    /**
-     * @todo and a warning, these type casts are here to compensate for
-     *   the differences between the Graph API package and the
-     *   type system package.
-     *
-     *   The type system package can be considered the source of truth in
-     *   terms of the shape of values returned from the API, but the API
-     *   client is unable to be given as type package types - it generates
-     *   its own types.
-     *   https://app.asana.com/0/1202805690238892/1202892835843657/f
-     */
-    return new PropertyTypeModel({
-      schema: schema as PropertyType,
-      ownedById,
-      createdById: provenance.createdById,
-      updatedById: provenance.updatedById,
-    });
+  get metadata(): OntologyElementMetadata {
+    return this.propertyType.metadata;
+  }
+
+  constructor({ propertyType }: PropertyTypeModelConstructorParams) {
+    this.propertyType = propertyType;
+  }
+
+  static fromPropertyTypeWithMetadata(
+    propertyType: PropertyTypeWithMetadata,
+  ): PropertyTypeModel {
+    return new PropertyTypeModel({ propertyType });
   }
 
   /**

--- a/packages/hash/api/src/model/ontology/property-type.model.ts
+++ b/packages/hash/api/src/model/ontology/property-type.model.ts
@@ -24,8 +24,15 @@ export default class {
 
   get schema(): PropertyType {
     /**
-     * @todo: remove this casting when we update the type system package
-     * @see https://app.asana.com/0/1201095311341924/1203259817761581/f
+     * @todo and a warning, these type casts are here to compensate for
+     *   the differences between the Graph API package and the
+     *   type system package.
+     *
+     *   The type system package can be considered the source of truth in
+     *   terms of the shape of values returned from the API, but the API
+     *   client is unable to be given as type package types - it generates
+     *   its own types.
+     *   https://app.asana.com/0/1202805690238892/1202892835843657/f
      */
     return this.propertyType.schema as PropertyType;
   }

--- a/packages/hash/api/src/model/util.ts
+++ b/packages/hash/api/src/model/util.ts
@@ -388,6 +388,10 @@ export type LinkTypeCreatorParams = {
   actorId: string;
 };
 
+/**
+ * @todo: remove or refactor this method when link types equivalent is working
+ * @see https://app.asana.com/0/1202805690238892/1203361844133477/f
+ */
 // /**
 //  * Helper method for generating a link type schema for the Graph API.
 //  *

--- a/packages/hash/api/src/seed-data/dev-users.ts
+++ b/packages/hash/api/src/seed-data/dev-users.ts
@@ -18,7 +18,10 @@ const devUsers: readonly DevelopmentUser[] = [
     email: "admin@example.com",
     shortname: "instance-admin",
     preferredName: "Instance Admin",
-    /** @todo: bring back instance admins when links are working again */
+    /**
+     * @todo: bring back instance admins when links are working again
+     * @see https://app.asana.com/0/1202805690238892/1203361844133479/f
+     */
     // isInstanceAdmin: true,
   },
   {

--- a/packages/hash/api/src/seed-data/dev-users.ts
+++ b/packages/hash/api/src/seed-data/dev-users.ts
@@ -18,7 +18,8 @@ const devUsers: readonly DevelopmentUser[] = [
     email: "admin@example.com",
     shortname: "instance-admin",
     preferredName: "Instance Admin",
-    isInstanceAdmin: true,
+    /** @todo: bring back instance admins when links are working again */
+    // isInstanceAdmin: true,
   },
   {
     email: "alice@example.com",

--- a/packages/hash/api/src/seed-data/index.ts
+++ b/packages/hash/api/src/seed-data/index.ts
@@ -41,7 +41,7 @@ const seedOrg = async (params: {
     },
   ];
 
-  await seedPages(pageTitles, sharedOrgModel.entityId, params);
+  await seedPages(pageTitles, sharedOrgModel.entityUuid, params);
 
   logger.info(
     `Development Org with shortname = "${sharedOrgModel.getShortname()}" now has seeded pages.`,
@@ -93,7 +93,7 @@ export const seedOrgsAndUsers = async (params: {
         },
       ];
 
-      await seedPages(pageTitles, user.entityId, params);
+      await seedPages(pageTitles, user.entityUuid, params);
       logger.info(
         `Development User with shortname = "${user.getShortname()}" now has seeded pages.`,
       );

--- a/packages/hash/frontend/package.json
+++ b/packages/hash/frontend/package.json
@@ -19,7 +19,7 @@
     "@blockprotocol/core": "0.0.12",
     "@blockprotocol/graph": "0.0.18",
     "@blockprotocol/hook": "0.0.8",
-    "@blockprotocol/type-system-web": "https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?6526c0e",
+    "@blockprotocol/type-system-web": "https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?244d25a",
     "@dnd-kit/core": "6.0.5",
     "@dnd-kit/modifiers": "6.0.0",
     "@dnd-kit/sortable": "7.0.1",

--- a/packages/hash/integration/package.json
+++ b/packages/hash/integration/package.json
@@ -12,7 +12,7 @@
     "test": "jest --runInBand"
   },
   "dependencies": {
-    "@blockprotocol/type-system-web": "https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?6526c0e",
+    "@blockprotocol/type-system-web": "https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?244d25a",
     "@hashintel/hash-api": "0.0.0-private",
     "@hashintel/hash-backend-utils": "0.0.0-private",
     "@hashintel/hash-graph-client": "0.0.0-private",

--- a/packages/hash/shared/package.json
+++ b/packages/hash/shared/package.json
@@ -39,7 +39,7 @@
     "uuid": "8.3.2"
   },
   "devDependencies": {
-    "@blockprotocol/type-system-web": "https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?6526c0e",
+    "@blockprotocol/type-system-web": "https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?244d25a",
     "@graphql-codegen/cli": "2.13.11",
     "@graphql-codegen/fragment-matcher": "3.3.1",
     "@graphql-codegen/typescript": "2.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3120,6 +3120,10 @@
   dependencies:
     "@blockprotocol/core" "0.0.12"
 
+"@blockprotocol/type-system-web@https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?244d25a":
+  version "0.0.2"
+  resolved "https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?244d25a#2d34f812c2528ab2da63574a2f12495eb4fe60e9"
+
 "@blockprotocol/type-system-web@https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?6526c0e":
   version "0.0.1"
   resolved "https://gitpkg.vercel.app/blockprotocol/blockprotocol/packages/%40blockprotocol/type-system-web?6526c0e#dfb41fbd251e6ef8f13839ef9f7dda5f0f1369ae"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR makes the GraphQL API runnable again, by removing references to the deprecated link type model, and refactoring the `Entity`/`EntityType`/`PropertyType`/`DataType` model classes.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203150072758509/1203329839349722/f) _(internal)_
- [Update to the new Type System package in the Workspace](https://app.asana.com/0/1201095311341924/1203259817761581/f)

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

See commits.

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

- [Replace link types with entity types in the HASH App on the `dev/links` branch](https://app.asana.com/0/0/1203361844133477/f)
- [Fix links in the HASH App on the `dev/links` branch](https://app.asana.com/0/0/1203361844133479/f)
- [Replace uses of `entityId` in the codebase with `entityUuid` and `baseId`
](https://app.asana.com/0/0/1203361740074435/f)
- [Rework the TS/GraphQL types to be consistent across the codebase](https://app.asana.com/0/1201095311341924/1203227079758117/f)

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Checkout the branch
2. Run the external services using `yarn external-services up`
3. Run the GraphApi using `yarn dev` in a separate terminal window
4. Go to `localhost:5001/graphql` to see the running GQL playground