### PR TITLE
Prepare to re-enable `@typescript-eslint/*` rules

### DIFF
--- a/blocks/calculation/.eslintrc.cjs
+++ b/blocks/calculation/.eslintrc.cjs
@@ -1,4 +1,9 @@
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
+  rules: {
+    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+      /* 2022-11-11:   1 */ "@typescript-eslint/no-unsafe-assignment",
+    ]),
+  },
 };

--- a/blocks/calculation/.eslintrc.cjs
+++ b/blocks/calculation/.eslintrc.cjs
@@ -2,7 +2,7 @@
 module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
   rules: {
-    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+    ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
       /* 2022-11-11:   1 */ "@typescript-eslint/no-unsafe-assignment",
     ]),
   },

--- a/blocks/chart/.eslintrc.cjs
+++ b/blocks/chart/.eslintrc.cjs
@@ -2,7 +2,7 @@
 module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
   rules: {
-    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+    ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
       /* 2022-11-11:  2 */ "@typescript-eslint/no-unsafe-call",
       /* 2022-11-11:  7 */ "@typescript-eslint/no-unsafe-member-access",
       /* 2022-11-11:  1 */ "@typescript-eslint/restrict-template-expressions",

--- a/blocks/chart/.eslintrc.cjs
+++ b/blocks/chart/.eslintrc.cjs
@@ -1,4 +1,11 @@
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
+  rules: {
+    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+      /* 2022-11-11:  2 */ "@typescript-eslint/no-unsafe-call",
+      /* 2022-11-11:  7 */ "@typescript-eslint/no-unsafe-member-access",
+      /* 2022-11-11:  1 */ "@typescript-eslint/restrict-template-expressions",
+    ]),
+  },
 };

--- a/blocks/chart/.eslintrc.cjs
+++ b/blocks/chart/.eslintrc.cjs
@@ -3,9 +3,9 @@ module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
   rules: {
     ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
-      /* 2022-11-11:  2 */ "@typescript-eslint/no-unsafe-call",
-      /* 2022-11-11:  7 */ "@typescript-eslint/no-unsafe-member-access",
-      /* 2022-11-11:  1 */ "@typescript-eslint/restrict-template-expressions",
+      /* 2022-11-11:   2 */ "@typescript-eslint/no-unsafe-call",
+      /* 2022-11-11:   7 */ "@typescript-eslint/no-unsafe-member-access",
+      /* 2022-11-11:   1 */ "@typescript-eslint/restrict-template-expressions",
     ]),
   },
 };

--- a/blocks/drawing/.eslintrc.cjs
+++ b/blocks/drawing/.eslintrc.cjs
@@ -3,8 +3,8 @@ module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
   rules: {
     ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
-      /* 2022-11-11:  1 */ "@typescript-eslint/no-unsafe-return",
-      /* 2022-11-11:  1 */ "@typescript-eslint/require-await",
+      /* 2022-11-11:   1 */ "@typescript-eslint/no-unsafe-return",
+      /* 2022-11-11:   1 */ "@typescript-eslint/require-await",
     ]),
   },
 };

--- a/blocks/drawing/.eslintrc.cjs
+++ b/blocks/drawing/.eslintrc.cjs
@@ -1,4 +1,10 @@
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
+  rules: {
+    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+      /* 2022-11-11:  1 */ "@typescript-eslint/no-unsafe-return",
+      /* 2022-11-11:  1 */ "@typescript-eslint/require-await",
+    ]),
+  },
 };

--- a/blocks/drawing/.eslintrc.cjs
+++ b/blocks/drawing/.eslintrc.cjs
@@ -2,7 +2,7 @@
 module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
   rules: {
-    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+    ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
       /* 2022-11-11:  1 */ "@typescript-eslint/no-unsafe-return",
       /* 2022-11-11:  1 */ "@typescript-eslint/require-await",
     ]),

--- a/blocks/embed/.eslintrc.cjs
+++ b/blocks/embed/.eslintrc.cjs
@@ -3,10 +3,10 @@ module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
   rules: {
     ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
-      /* 2022-11-11:  1 */ "@typescript-eslint/no-unsafe-assignment",
-      /* 2022-11-11:  2 */ "@typescript-eslint/no-unsafe-member-access",
-      /* 2022-11-11:  2 */ "@typescript-eslint/no-unsafe-return",
-      /* 2022-11-11:  2 */ "@typescript-eslint/restrict-template-expressions",
+      /* 2022-11-11:   1 */ "@typescript-eslint/no-unsafe-assignment",
+      /* 2022-11-11:   2 */ "@typescript-eslint/no-unsafe-member-access",
+      /* 2022-11-11:   2 */ "@typescript-eslint/no-unsafe-return",
+      /* 2022-11-11:   2 */ "@typescript-eslint/restrict-template-expressions",
     ]),
   },
 };

--- a/blocks/embed/.eslintrc.cjs
+++ b/blocks/embed/.eslintrc.cjs
@@ -2,7 +2,7 @@
 module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
   rules: {
-    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+    ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
       /* 2022-11-11:  1 */ "@typescript-eslint/no-unsafe-assignment",
       /* 2022-11-11:  2 */ "@typescript-eslint/no-unsafe-member-access",
       /* 2022-11-11:  2 */ "@typescript-eslint/no-unsafe-return",

--- a/blocks/embed/.eslintrc.cjs
+++ b/blocks/embed/.eslintrc.cjs
@@ -1,4 +1,12 @@
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
+  rules: {
+    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+      /* 2022-11-11:  1 */ "@typescript-eslint/no-unsafe-assignment",
+      /* 2022-11-11:  2 */ "@typescript-eslint/no-unsafe-member-access",
+      /* 2022-11-11:  2 */ "@typescript-eslint/no-unsafe-return",
+      /* 2022-11-11:  2 */ "@typescript-eslint/restrict-template-expressions",
+    ]),
+  },
 };

--- a/blocks/github-pr-overview/.eslintrc.cjs
+++ b/blocks/github-pr-overview/.eslintrc.cjs
@@ -2,7 +2,7 @@
 module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
   rules: {
-    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+    ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
       /* 2022-11-11:  5 */ "@typescript-eslint/no-unsafe-assignment",
       /* 2022-11-11:  2 */ "@typescript-eslint/no-unsafe-member-access",
       /* 2022-11-11:  1 */ "@typescript-eslint/no-unsafe-return",

--- a/blocks/github-pr-overview/.eslintrc.cjs
+++ b/blocks/github-pr-overview/.eslintrc.cjs
@@ -3,10 +3,10 @@ module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
   rules: {
     ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
-      /* 2022-11-11:  5 */ "@typescript-eslint/no-unsafe-assignment",
-      /* 2022-11-11:  2 */ "@typescript-eslint/no-unsafe-member-access",
-      /* 2022-11-11:  1 */ "@typescript-eslint/no-unsafe-return",
-      /* 2022-11-11:  3 */ "@typescript-eslint/restrict-template-expressions",
+      /* 2022-11-11:   5 */ "@typescript-eslint/no-unsafe-assignment",
+      /* 2022-11-11:   2 */ "@typescript-eslint/no-unsafe-member-access",
+      /* 2022-11-11:   1 */ "@typescript-eslint/no-unsafe-return",
+      /* 2022-11-11:   3 */ "@typescript-eslint/restrict-template-expressions",
     ]),
   },
 };

--- a/blocks/github-pr-overview/.eslintrc.cjs
+++ b/blocks/github-pr-overview/.eslintrc.cjs
@@ -1,4 +1,12 @@
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
+  rules: {
+    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+      /* 2022-11-11:  5 */ "@typescript-eslint/no-unsafe-assignment",
+      /* 2022-11-11:  2 */ "@typescript-eslint/no-unsafe-member-access",
+      /* 2022-11-11:  1 */ "@typescript-eslint/no-unsafe-return",
+      /* 2022-11-11:  3 */ "@typescript-eslint/restrict-template-expressions",
+    ]),
+  },
 };

--- a/blocks/header/.eslintrc.cjs
+++ b/blocks/header/.eslintrc.cjs
@@ -2,7 +2,7 @@
 module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
   rules: {
-    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+    ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
       /* 2022-11-11:  1 */ "@typescript-eslint/no-unsafe-assignment",
     ]),
   },

--- a/blocks/header/.eslintrc.cjs
+++ b/blocks/header/.eslintrc.cjs
@@ -1,4 +1,9 @@
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
+  rules: {
+    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+      /* 2022-11-11:  1 */ "@typescript-eslint/no-unsafe-assignment",
+    ]),
+  },
 };

--- a/blocks/header/.eslintrc.cjs
+++ b/blocks/header/.eslintrc.cjs
@@ -3,7 +3,7 @@ module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
   rules: {
     ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
-      /* 2022-11-11:  1 */ "@typescript-eslint/no-unsafe-assignment",
+      /* 2022-11-11:   1 */ "@typescript-eslint/no-unsafe-assignment",
     ]),
   },
 };

--- a/blocks/stopwatch/.eslintrc.cjs
+++ b/blocks/stopwatch/.eslintrc.cjs
@@ -2,7 +2,7 @@
 module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
   rules: {
-    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+    ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
       /* 2022-11-11:  2 */ "@typescript-eslint/no-unsafe-argument",
     ]),
   },

--- a/blocks/stopwatch/.eslintrc.cjs
+++ b/blocks/stopwatch/.eslintrc.cjs
@@ -3,7 +3,7 @@ module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
   rules: {
     ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
-      /* 2022-11-11:  2 */ "@typescript-eslint/no-unsafe-argument",
+      /* 2022-11-11:   2 */ "@typescript-eslint/no-unsafe-argument",
     ]),
   },
 };

--- a/blocks/stopwatch/.eslintrc.cjs
+++ b/blocks/stopwatch/.eslintrc.cjs
@@ -1,4 +1,9 @@
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
+  rules: {
+    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+      /* 2022-11-11:  2 */ "@typescript-eslint/no-unsafe-argument",
+    ]),
+  },
 };

--- a/blocks/table/.eslintrc.cjs
+++ b/blocks/table/.eslintrc.cjs
@@ -2,7 +2,7 @@
 module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
   rules: {
-    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+    ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
       /* 2022-11-11:   1 */ "@typescript-eslint/no-unsafe-argument",
       /* 2022-11-11:  12 */ "@typescript-eslint/no-unsafe-assignment",
       /* 2022-11-11:   6 */ "@typescript-eslint/no-unsafe-member-access",

--- a/blocks/table/.eslintrc.cjs
+++ b/blocks/table/.eslintrc.cjs
@@ -1,4 +1,12 @@
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
+  rules: {
+    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+      /* 2022-11-11:   1 */ "@typescript-eslint/no-unsafe-argument-",
+      /* 2022-11-11:  12 */ "@typescript-eslint/no-unsafe-assignment",
+      /* 2022-11-11:   6 */ "@typescript-eslint/no-unsafe-member-access",
+      /* 2022-11-11:   6 */ "@typescript-eslint/no-unsafe-return",
+    ]),
+  },
 };

--- a/blocks/table/.eslintrc.cjs
+++ b/blocks/table/.eslintrc.cjs
@@ -3,7 +3,7 @@ module.exports = {
   ...require("@local/eslint-config/generate-block-config.cjs")(__dirname),
   rules: {
     ...require("@local/eslint-config/disable-until-fixed.cjs")([
-      /* 2022-11-11:   1 */ "@typescript-eslint/no-unsafe-argument-",
+      /* 2022-11-11:   1 */ "@typescript-eslint/no-unsafe-argument",
       /* 2022-11-11:  12 */ "@typescript-eslint/no-unsafe-assignment",
       /* 2022-11-11:   6 */ "@typescript-eslint/no-unsafe-member-access",
       /* 2022-11-11:   6 */ "@typescript-eslint/no-unsafe-return",

--- a/libs/javascript/@local/eslint-config/disable-until-fixed.cjs
+++ b/libs/javascript/@local/eslint-config/disable-until-fixed.cjs
@@ -1,0 +1,16 @@
+/**
+ * @param {string[]} ruleNames
+ * @returns {import("eslint").Linter.RulesRecord}
+ */
+module.exports = (ruleNames) => {
+  const result = {};
+
+  if (process.env.CHECK_DISABLE_UNTIL_FIXED === "true") {
+    return result;
+  }
+
+  for (const ruleName of ruleNames) {
+    result[ruleName] = "off";
+  }
+  return result;
+};

--- a/libs/javascript/@local/eslint-config/legacy-base-eslintrc-to-refactor.cjs
+++ b/libs/javascript/@local/eslint-config/legacy-base-eslintrc-to-refactor.cjs
@@ -373,60 +373,6 @@ module.exports = {
             varsIgnorePattern: "^_+",
           },
         ],
-
-        // yarn workspace @hashintel/hash-integration lint:eslint
-        // total: 180
-        // "@typescript-eslint/no-unsafe-argument": 2
-        // "@typescript-eslint/no-unsafe-assignment": 60
-        // "@typescript-eslint/no-unsafe-call": 31
-        // "@typescript-eslint/no-unsafe-member-access": 76
-        // "@typescript-eslint/no-unsafe-return": 2
-        // "@typescript-eslint/require-await": 2
-        // "@typescript-eslint/restrict-template-expressions": 7
-
-        // yarn workspace @hashintel/hash-frontend lint:eslint
-        // total: 974
-        // "@typescript-eslint/no-unsafe-argument": 105
-        // "@typescript-eslint/no-unsafe-assignment": 303
-        // "@typescript-eslint/no-unsafe-call":
-        // "@typescript-eslint/no-unsafe-member-access":
-        // "@typescript-eslint/no-unsafe-return":
-        // "@typescript-eslint/require-await":
-        // "@typescript-eslint/restrict-template-expressions":
-        // "@typescript-eslint/unbound-method":
-
-        // command (/Users/ak/-/projects/hash/github/hash/packages/hash/backend-utils) yarn run lint:eslint exited (1)
-        // total:
-        // "@typescript-eslint/no-unsafe-argument":
-        // "@typescript-eslint/no-unsafe-assignment":
-        // "@typescript-eslint/no-unsafe-call":
-        // "@typescript-eslint/no-unsafe-member-access":
-        // "@typescript-eslint/no-unsafe-return":
-        // "@typescript-eslint/require-await":
-        // "@typescript-eslint/restrict-template-expressions":
-        // "@typescript-eslint/unbound-method":
-
-        // command (/Users/ak/-/projects/hash/github/hash/blocks/table) yarn run lint:eslint exited (1)
-        // total:
-        // "@typescript-eslint/no-unsafe-argument":
-        // "@typescript-eslint/no-unsafe-assignment":
-        // "@typescript-eslint/no-unsafe-call":
-        // "@typescript-eslint/no-unsafe-member-access":
-        // "@typescript-eslint/no-unsafe-return":
-        // "@typescript-eslint/require-await":
-        // "@typescript-eslint/restrict-template-expressions":
-        // "@typescript-eslint/unbound-method":
-
-        // command (/Users/ak/-/projects/hash/github/hash/packages/hash/shared) yarn run lint:eslint exited (1)
-        // total:
-        // "@typescript-eslint/no-unsafe-argument":
-        // "@typescript-eslint/no-unsafe-assignment":
-        // "@typescript-eslint/no-unsafe-call":
-        // "@typescript-eslint/no-unsafe-member-access":
-        // "@typescript-eslint/no-unsafe-return":
-        // "@typescript-eslint/require-await":
-        // "@typescript-eslint/restrict-template-expressions":
-        // "@typescript-eslint/unbound-method":
       },
     },
     {

--- a/libs/javascript/@local/eslint-config/legacy-base-eslintrc-to-refactor.cjs
+++ b/libs/javascript/@local/eslint-config/legacy-base-eslintrc-to-refactor.cjs
@@ -374,16 +374,59 @@ module.exports = {
           },
         ],
 
-        // Part of @typescript-eslint/recommended-requiring-type-checking
-        // TODO: re-enable
-        "@typescript-eslint/no-unsafe-argument": "off",
-        "@typescript-eslint/no-unsafe-assignment": "off",
-        "@typescript-eslint/no-unsafe-call": "off",
-        "@typescript-eslint/no-unsafe-member-access": "off",
-        "@typescript-eslint/no-unsafe-return": "off",
-        "@typescript-eslint/require-await": "off",
-        "@typescript-eslint/restrict-template-expressions": "off",
-        "@typescript-eslint/unbound-method": "off",
+        // yarn workspace @hashintel/hash-integration lint:eslint
+        // total: 180
+        // "@typescript-eslint/no-unsafe-argument": 2
+        // "@typescript-eslint/no-unsafe-assignment": 60
+        // "@typescript-eslint/no-unsafe-call": 31
+        // "@typescript-eslint/no-unsafe-member-access": 76
+        // "@typescript-eslint/no-unsafe-return": 2
+        // "@typescript-eslint/require-await": 2
+        // "@typescript-eslint/restrict-template-expressions": 7
+
+        // yarn workspace @hashintel/hash-frontend lint:eslint
+        // total: 974
+        // "@typescript-eslint/no-unsafe-argument": 105
+        // "@typescript-eslint/no-unsafe-assignment": 303
+        // "@typescript-eslint/no-unsafe-call":
+        // "@typescript-eslint/no-unsafe-member-access":
+        // "@typescript-eslint/no-unsafe-return":
+        // "@typescript-eslint/require-await":
+        // "@typescript-eslint/restrict-template-expressions":
+        // "@typescript-eslint/unbound-method":
+
+        // command (/Users/ak/-/projects/hash/github/hash/packages/hash/backend-utils) yarn run lint:eslint exited (1)
+        // total:
+        // "@typescript-eslint/no-unsafe-argument":
+        // "@typescript-eslint/no-unsafe-assignment":
+        // "@typescript-eslint/no-unsafe-call":
+        // "@typescript-eslint/no-unsafe-member-access":
+        // "@typescript-eslint/no-unsafe-return":
+        // "@typescript-eslint/require-await":
+        // "@typescript-eslint/restrict-template-expressions":
+        // "@typescript-eslint/unbound-method":
+
+        // command (/Users/ak/-/projects/hash/github/hash/blocks/table) yarn run lint:eslint exited (1)
+        // total:
+        // "@typescript-eslint/no-unsafe-argument":
+        // "@typescript-eslint/no-unsafe-assignment":
+        // "@typescript-eslint/no-unsafe-call":
+        // "@typescript-eslint/no-unsafe-member-access":
+        // "@typescript-eslint/no-unsafe-return":
+        // "@typescript-eslint/require-await":
+        // "@typescript-eslint/restrict-template-expressions":
+        // "@typescript-eslint/unbound-method":
+
+        // command (/Users/ak/-/projects/hash/github/hash/packages/hash/shared) yarn run lint:eslint exited (1)
+        // total:
+        // "@typescript-eslint/no-unsafe-argument":
+        // "@typescript-eslint/no-unsafe-assignment":
+        // "@typescript-eslint/no-unsafe-call":
+        // "@typescript-eslint/no-unsafe-member-access":
+        // "@typescript-eslint/no-unsafe-return":
+        // "@typescript-eslint/require-await":
+        // "@typescript-eslint/restrict-template-expressions":
+        // "@typescript-eslint/unbound-method":
       },
     },
     {

--- a/libs/javascript/@local/eslint-config/temporarily-disable-rules.cjs
+++ b/libs/javascript/@local/eslint-config/temporarily-disable-rules.cjs
@@ -1,11 +1,12 @@
 /**
  * @param {string[]} ruleNames
  * @returns {import("eslint").Linter.RulesRecord}
+ * @see https://github.com/hashintel/hash/pull/1384
  */
 module.exports = (ruleNames) => {
   const result = {};
 
-  if (process.env.CHECK_DISABLE_UNTIL_FIXED === "true") {
+  if (process.env.CHECK_TEMPORARILY_DISABLED_RULES === "true") {
     return result;
   }
 

--- a/packages/graph/migrations/.eslintrc.cjs
+++ b/packages/graph/migrations/.eslintrc.cjs
@@ -5,7 +5,7 @@ module.exports = {
     node: true,
   },
   rules: {
-    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+    ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
       /* 2022-11-11:  1 */ "@typescript-eslint/require-await",
     ]),
   },

--- a/packages/graph/migrations/.eslintrc.cjs
+++ b/packages/graph/migrations/.eslintrc.cjs
@@ -6,7 +6,7 @@ module.exports = {
   },
   rules: {
     ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
-      /* 2022-11-11:  1 */ "@typescript-eslint/require-await",
+      /* 2022-11-11:   1 */ "@typescript-eslint/require-await",
     ]),
   },
 };

--- a/packages/graph/migrations/.eslintrc.cjs
+++ b/packages/graph/migrations/.eslintrc.cjs
@@ -4,4 +4,9 @@ module.exports = {
   env: {
     node: true,
   },
+  rules: {
+    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+      /* 2022-11-11:  1 */ "@typescript-eslint/require-await",
+    ]),
+  },
 };

--- a/packages/hash/api/.eslintrc.cjs
+++ b/packages/hash/api/.eslintrc.cjs
@@ -5,7 +5,7 @@ module.exports = {
     // @todo Re-enable these rules once ESLint config is refactored
     "@typescript-eslint/restrict-plus-operands": "off",
     "@typescript-eslint/prefer-nullish-coalescing": "off",
-    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+    ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
       /* 2022-11-11:  60 */ "@typescript-eslint/no-unsafe-argument",
       /* 2022-11-11: 110 */ "@typescript-eslint/no-unsafe-assignment",
       /* 2022-11-11:  26 */ "@typescript-eslint/no-unsafe-call",

--- a/packages/hash/api/.eslintrc.cjs
+++ b/packages/hash/api/.eslintrc.cjs
@@ -5,6 +5,16 @@ module.exports = {
     // @todo Re-enable these rules once ESLint config is refactored
     "@typescript-eslint/restrict-plus-operands": "off",
     "@typescript-eslint/prefer-nullish-coalescing": "off",
+    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+      /* 2022-11-11:  60 */ "@typescript-eslint/no-unsafe-argument",
+      /* 2022-11-11: 110 */ "@typescript-eslint/no-unsafe-assignment",
+      /* 2022-11-11:  26 */ "@typescript-eslint/no-unsafe-call",
+      /* 2022-11-11: 103 */ "@typescript-eslint/no-unsafe-member-access",
+      /* 2022-11-11:  40 */ "@typescript-eslint/no-unsafe-return",
+      /* 2022-11-11:  11 */ "@typescript-eslint/require-await",
+      /* 2022-11-11:  64 */ "@typescript-eslint/restrict-template-expressions",
+      /* 2022-11-11:   7 */ "@typescript-eslint/unbound-method",
+    ]),
   },
   ignorePatterns: [
     ...require("@local/eslint-config/generate-ignore-patterns.cjs")(__dirname),

--- a/packages/hash/backend-utils/.eslintrc.cjs
+++ b/packages/hash/backend-utils/.eslintrc.cjs
@@ -1,4 +1,16 @@
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   ...require("@local/eslint-config/generate-workspace-config.cjs")(__dirname),
+  rules: {
+    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+      /* 2022-11-11:   1 */ "@typescript-eslint/no-unsafe-argument",
+      /* 2022-11-11:  10 */ "@typescript-eslint/no-unsafe-assignment",
+      /* 2022-11-11:   3 */ "@typescript-eslint/no-unsafe-call",
+      /* 2022-11-11:  21 */ "@typescript-eslint/no-unsafe-member-access",
+      /* 2022-11-11:   1 */ "@typescript-eslint/no-unsafe-return",
+      /* 2022-11-11:   1 */ "@typescript-eslint/require-await",
+      /* 2022-11-11:   4 */ "@typescript-eslint/restrict-template-expressions",
+      /* 2022-11-11:  11 */ "@typescript-eslint/unbound-method",
+    ]),
+  },
 };

--- a/packages/hash/backend-utils/.eslintrc.cjs
+++ b/packages/hash/backend-utils/.eslintrc.cjs
@@ -2,7 +2,7 @@
 module.exports = {
   ...require("@local/eslint-config/generate-workspace-config.cjs")(__dirname),
   rules: {
-    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+    ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
       /* 2022-11-11:   1 */ "@typescript-eslint/no-unsafe-argument",
       /* 2022-11-11:  10 */ "@typescript-eslint/no-unsafe-assignment",
       /* 2022-11-11:   3 */ "@typescript-eslint/no-unsafe-call",

--- a/packages/hash/design-system/.eslintrc.cjs
+++ b/packages/hash/design-system/.eslintrc.cjs
@@ -3,6 +3,9 @@ module.exports = {
   ...require("@local/eslint-config/generate-workspace-config.cjs")(__dirname),
   plugins: ["@typescript-eslint", "canonical", "unicorn"],
   rules: {
+    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+      /* 2022-11-11:  14 */ "@typescript-eslint/no-unsafe-assignment",
+    ]),
     "jsx-a11y/label-has-associated-control": "off",
     "import/no-default-export": "error",
     "no-restricted-imports": [

--- a/packages/hash/design-system/.eslintrc.cjs
+++ b/packages/hash/design-system/.eslintrc.cjs
@@ -3,7 +3,7 @@ module.exports = {
   ...require("@local/eslint-config/generate-workspace-config.cjs")(__dirname),
   plugins: ["@typescript-eslint", "canonical", "unicorn"],
   rules: {
-    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+    ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
       /* 2022-11-11:  14 */ "@typescript-eslint/no-unsafe-assignment",
     ]),
     "jsx-a11y/label-has-associated-control": "off",

--- a/packages/hash/frontend/.eslintrc.cjs
+++ b/packages/hash/frontend/.eslintrc.cjs
@@ -3,8 +3,17 @@ module.exports = {
   ...require("@local/eslint-config/generate-workspace-config.cjs")(__dirname),
   plugins: ["@typescript-eslint", "canonical", "unicorn"],
   rules: {
-    // @todo Re-enable this rule once ESLint config is refactored
-    "@typescript-eslint/restrict-plus-operands": "off",
+    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+      /* 2022-11-11: 105 */ "@typescript-eslint/no-unsafe-argument",
+      /* 2022-11-11: 303 */ "@typescript-eslint/no-unsafe-assignment",
+      /* 2022-11-11: 103 */ "@typescript-eslint/no-unsafe-call",
+      /* 2022-11-11: 326 */ "@typescript-eslint/no-unsafe-member-access",
+      /* 2022-11-11:  74 */ "@typescript-eslint/no-unsafe-return",
+      /* 2022-11-11:   5 */ "@typescript-eslint/require-await",
+      /* 2022-11-11:   1 */ "@typescript-eslint/restrict-plus-operands",
+      /* 2022-11-11:  53 */ "@typescript-eslint/restrict-template-expressions",
+      /* 2022-11-11:   5 */ "@typescript-eslint/unbound-method",
+    ]),
     "jsx-a11y/label-has-associated-control": "off",
     "import/no-default-export": "error",
     "no-restricted-imports": [

--- a/packages/hash/frontend/.eslintrc.cjs
+++ b/packages/hash/frontend/.eslintrc.cjs
@@ -3,7 +3,7 @@ module.exports = {
   ...require("@local/eslint-config/generate-workspace-config.cjs")(__dirname),
   plugins: ["@typescript-eslint", "canonical", "unicorn"],
   rules: {
-    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+    ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
       /* 2022-11-11: 105 */ "@typescript-eslint/no-unsafe-argument",
       /* 2022-11-11: 303 */ "@typescript-eslint/no-unsafe-assignment",
       /* 2022-11-11: 103 */ "@typescript-eslint/no-unsafe-call",

--- a/packages/hash/integration/.eslintrc.cjs
+++ b/packages/hash/integration/.eslintrc.cjs
@@ -1,6 +1,17 @@
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   ...require("@local/eslint-config/generate-workspace-config.cjs")(__dirname),
+  rules: {
+    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+      /* 2022-11-11:   2 */ "@typescript-eslint/no-unsafe-argument",
+      /* 2022-11-11:  60 */ "@typescript-eslint/no-unsafe-assignment",
+      /* 2022-11-11:  31 */ "@typescript-eslint/no-unsafe-call",
+      /* 2022-11-11:  76 */ "@typescript-eslint/no-unsafe-member-access",
+      /* 2022-11-11:   2 */ "@typescript-eslint/no-unsafe-return",
+      /* 2022-11-11:   2 */ "@typescript-eslint/require-await",
+      /* 2022-11-11:   7 */ "@typescript-eslint/restrict-template-expressions",
+    ]),
+  },
   env: {
     node: true,
   },

--- a/packages/hash/integration/.eslintrc.cjs
+++ b/packages/hash/integration/.eslintrc.cjs
@@ -2,7 +2,7 @@
 module.exports = {
   ...require("@local/eslint-config/generate-workspace-config.cjs")(__dirname),
   rules: {
-    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+    ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
       /* 2022-11-11:   2 */ "@typescript-eslint/no-unsafe-argument",
       /* 2022-11-11:  60 */ "@typescript-eslint/no-unsafe-assignment",
       /* 2022-11-11:  31 */ "@typescript-eslint/no-unsafe-call",

--- a/packages/hash/playwright/.eslintrc.cjs
+++ b/packages/hash/playwright/.eslintrc.cjs
@@ -1,6 +1,12 @@
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   ...require("@local/eslint-config/generate-workspace-config.cjs")(__dirname),
+  rules: {
+    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+      /* 2022-11-11:  21 */ "@typescript-eslint/no-unsafe-call",
+      /* 2022-11-11:  3 */ "@typescript-eslint/restrict-template-expressions",
+    ]),
+  },
   overrides: [
     {
       files: ["**/*.{spec,test}.ts"],

--- a/packages/hash/playwright/.eslintrc.cjs
+++ b/packages/hash/playwright/.eslintrc.cjs
@@ -2,7 +2,7 @@
 module.exports = {
   ...require("@local/eslint-config/generate-workspace-config.cjs")(__dirname),
   rules: {
-    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+    ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
       /* 2022-11-11:  21 */ "@typescript-eslint/no-unsafe-call",
       /* 2022-11-11:  3 */ "@typescript-eslint/restrict-template-expressions",
     ]),

--- a/packages/hash/playwright/.eslintrc.cjs
+++ b/packages/hash/playwright/.eslintrc.cjs
@@ -4,7 +4,7 @@ module.exports = {
   rules: {
     ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
       /* 2022-11-11:  21 */ "@typescript-eslint/no-unsafe-call",
-      /* 2022-11-11:  3 */ "@typescript-eslint/restrict-template-expressions",
+      /* 2022-11-11:   3 */ "@typescript-eslint/restrict-template-expressions",
     ]),
   },
   overrides: [

--- a/packages/hash/realtime/.eslintrc.cjs
+++ b/packages/hash/realtime/.eslintrc.cjs
@@ -3,8 +3,8 @@ module.exports = {
   ...require("@local/eslint-config/generate-workspace-config.cjs")(__dirname),
   rules: {
     ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
-      /* 2022-11-11:  1 */ "@typescript-eslint/no-unsafe-assignment",
-      /* 2022-11-11:  1 */ "@typescript-eslint/no-unsafe-member-access",
+      /* 2022-11-11:   1 */ "@typescript-eslint/no-unsafe-assignment",
+      /* 2022-11-11:   1 */ "@typescript-eslint/no-unsafe-member-access",
     ]),
   },
   env: {

--- a/packages/hash/realtime/.eslintrc.cjs
+++ b/packages/hash/realtime/.eslintrc.cjs
@@ -2,7 +2,7 @@
 module.exports = {
   ...require("@local/eslint-config/generate-workspace-config.cjs")(__dirname),
   rules: {
-    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+    ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
       /* 2022-11-11:  1 */ "@typescript-eslint/no-unsafe-assignment",
       /* 2022-11-11:  1 */ "@typescript-eslint/no-unsafe-member-access",
     ]),

--- a/packages/hash/realtime/.eslintrc.cjs
+++ b/packages/hash/realtime/.eslintrc.cjs
@@ -1,6 +1,12 @@
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   ...require("@local/eslint-config/generate-workspace-config.cjs")(__dirname),
+  rules: {
+    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+      /* 2022-11-11:  1 */ "@typescript-eslint/no-unsafe-assignment",
+      /* 2022-11-11:  1 */ "@typescript-eslint/no-unsafe-member-access",
+    ]),
+  },
   env: {
     node: true,
   },

--- a/packages/hash/search-loader/.eslintrc.cjs
+++ b/packages/hash/search-loader/.eslintrc.cjs
@@ -5,7 +5,7 @@ module.exports = {
     node: true,
   },
   rules: {
-    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+    ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
       /* 2022-11-11:  11 */ "@typescript-eslint/no-unsafe-assignment",
       /* 2022-11-11:   5 */ "@typescript-eslint/no-unsafe-call",
       /* 2022-11-11:  17 */ "@typescript-eslint/no-unsafe-member-access",

--- a/packages/hash/search-loader/.eslintrc.cjs
+++ b/packages/hash/search-loader/.eslintrc.cjs
@@ -4,4 +4,15 @@ module.exports = {
   env: {
     node: true,
   },
+  rules: {
+    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+      /* 2022-11-11:  11 */ "@typescript-eslint/no-unsafe-assignment",
+      /* 2022-11-11:   5 */ "@typescript-eslint/no-unsafe-call",
+      /* 2022-11-11:  17 */ "@typescript-eslint/no-unsafe-member-access",
+      /* 2022-11-11:   2 */ "@typescript-eslint/no-unsafe-return",
+      /* 2022-11-11:   1 */ "@typescript-eslint/require-await",
+      /* 2022-11-11:   2 */ "@typescript-eslint/restrict-template-expressions",
+      /* 2022-11-11:   1 */ "@typescript-eslint/unbound-method",
+    ]),
+  },
 };

--- a/packages/hash/shared/.eslintrc.cjs
+++ b/packages/hash/shared/.eslintrc.cjs
@@ -2,7 +2,7 @@
 module.exports = {
   ...require("@local/eslint-config/generate-workspace-config.cjs")(__dirname),
   rules: {
-    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+    ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
       /* 2022-11-11:   9 */ "@typescript-eslint/no-unsafe-argument",
       /* 2022-11-11:  18 */ "@typescript-eslint/no-unsafe-assignment",
       /* 2022-11-11:   6 */ "@typescript-eslint/no-unsafe-call",

--- a/packages/hash/shared/.eslintrc.cjs
+++ b/packages/hash/shared/.eslintrc.cjs
@@ -2,6 +2,15 @@
 module.exports = {
   ...require("@local/eslint-config/generate-workspace-config.cjs")(__dirname),
   rules: {
+    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+      /* 2022-11-11:   9 */ "@typescript-eslint/no-unsafe-argument",
+      /* 2022-11-11:  18 */ "@typescript-eslint/no-unsafe-assignment",
+      /* 2022-11-11:   6 */ "@typescript-eslint/no-unsafe-call",
+      /* 2022-11-11:   7 */ "@typescript-eslint/no-unsafe-member-access",
+      /* 2022-11-11:   6 */ "@typescript-eslint/no-unsafe-return",
+      /* 2022-11-11:   3 */ "@typescript-eslint/require-await",
+      /* 2022-11-11:   5 */ "@typescript-eslint/restrict-template-expressions",
+    ]),
     "import/no-extraneous-dependencies": ["error", { devDependencies: true }],
   },
 };

--- a/packages/hash/task-executor/.eslintrc.cjs
+++ b/packages/hash/task-executor/.eslintrc.cjs
@@ -6,5 +6,12 @@ module.exports = {
   },
   rules: {
     "no-console": "off",
+    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+      /* 2022-11-11:   2 */ "@typescript-eslint/no-unsafe-argument",
+      /* 2022-11-11:   8 */ "@typescript-eslint/no-unsafe-assignment",
+      /* 2022-11-11:   5 */ "@typescript-eslint/no-unsafe-call",
+      /* 2022-11-11:   5 */ "@typescript-eslint/no-unsafe-member-access",
+      /* 2022-11-11:   2 */ "@typescript-eslint/no-unsafe-return",
+    ]),
   },
 };

--- a/packages/hash/task-executor/.eslintrc.cjs
+++ b/packages/hash/task-executor/.eslintrc.cjs
@@ -6,7 +6,7 @@ module.exports = {
   },
   rules: {
     "no-console": "off",
-    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+    ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
       /* 2022-11-11:   2 */ "@typescript-eslint/no-unsafe-argument",
       /* 2022-11-11:   8 */ "@typescript-eslint/no-unsafe-assignment",
       /* 2022-11-11:   5 */ "@typescript-eslint/no-unsafe-call",

--- a/sites/hashai/.eslintrc.cjs
+++ b/sites/hashai/.eslintrc.cjs
@@ -2,7 +2,7 @@
 module.exports = {
   ...require("@local/eslint-config/generate-workspace-config.cjs")(__dirname),
   rules: {
-    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+    ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
       /* 2022-11-11:   2 */ "@typescript-eslint/restrict-template-expressions",
     ]),
   },

--- a/sites/hashai/.eslintrc.cjs
+++ b/sites/hashai/.eslintrc.cjs
@@ -1,4 +1,9 @@
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   ...require("@local/eslint-config/generate-workspace-config.cjs")(__dirname),
+  rules: {
+    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+      /* 2022-11-11:   2 */ "@typescript-eslint/restrict-template-expressions",
+    ]),
+  },
 };

--- a/sites/hashdev/.eslintrc.cjs
+++ b/sites/hashdev/.eslintrc.cjs
@@ -2,7 +2,7 @@
 module.exports = {
   ...require("@local/eslint-config/generate-workspace-config.cjs")(__dirname),
   rules: {
-    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+    ...require("@local/eslint-config/temporarily-disable-rules.cjs")([
       /* 2022-11-11:  19 */ "@typescript-eslint/no-unsafe-assignment",
       /* 2022-11-11:   5 */ "@typescript-eslint/no-unsafe-call",
       /* 2022-11-11:  21 */ "@typescript-eslint/no-unsafe-member-access",

--- a/sites/hashdev/.eslintrc.cjs
+++ b/sites/hashdev/.eslintrc.cjs
@@ -2,6 +2,15 @@
 module.exports = {
   ...require("@local/eslint-config/generate-workspace-config.cjs")(__dirname),
   rules: {
+    ...require("@local/eslint-config/disable-until-fixed.cjs")([
+      /* 2022-11-11:  19 */ "@typescript-eslint/no-unsafe-assignment",
+      /* 2022-11-11:   5 */ "@typescript-eslint/no-unsafe-call",
+      /* 2022-11-11:  21 */ "@typescript-eslint/no-unsafe-member-access",
+      /* 2022-11-11:   1 */ "@typescript-eslint/no-unsafe-return",
+      /* 2022-11-11:   2 */ "@typescript-eslint/require-await",
+      /* 2022-11-11:  11 */ "@typescript-eslint/restrict-template-expressions",
+      /* 2022-11-11:   1 */ "@typescript-eslint/unbound-method",
+    ]),
     "jsx-a11y/label-has-associated-control": "off",
     "import/no-default-export": "error",
   },

--- a/turbo.json
+++ b/turbo.json
@@ -12,6 +12,7 @@
       "cache": false
     },
     "lint:eslint": {
+      "env": ["CHECK_DISABLE_UNTIL_FIXED"],
       "outputs": []
     },
     "lint:tsc": {

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,7 @@
       "cache": false
     },
     "lint:eslint": {
-      "env": ["CHECK_DISABLE_UNTIL_FIXED"],
+      "env": ["CHECK_TEMPORARILY_DISABLED_RULES"],
       "outputs": []
     },
     "lint:tsc": {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We enabled a set of [`@typescript-eslint/recommended-requiring-type-checking`](https://typescript-eslint.io/docs/linting/typed-linting/) rules in https://github.com/hashintel/hash/commit/6ebf9bf5c4db28b2cc7a92fe35e73429dd3a8229. Because this revealed hundreds of linting errors, some rules [were disabled in the whole repository](https://github.com/hashintel/hash/commit/6ebf9bf5c4db28b2cc7a92fe35e73429dd3a8229#diff-cfa10afa41baa07528e8f8b7dd0c9e3efc83dfadd7a2a9eecb020326225411bcR176-R183).

We want to re-enable all `@typescript-eslint/*` rules to avoid some types of bugs in the future. This PR makes the first step in this direction. Instead of disabling the selected rules everywhere, we now do this only in workspaces where they actually occur. This saves from introducing new instances of linting errors in various parts of the codebase and also makes it easier to progress towards enabling all rules.

Fixing rule violations is out of scope for this PR.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201095311341924/1203294246816677/f) _(internal)_

## 🔍 What does this change?

- Formerly disabled `@typescript-eslint/*` rules are removed from `@local/eslint-config/legacy-base-eslintrc-to-refactor.cjs`

- A new helper function is created in `@local/eslint-config/temporarily-disable-rules.cjs`

- Errors in `yarn lint:eslint` are inventoried with these bash commands:

  ```sh
  export RULES=(
  @typescript-eslint/no-unsafe-argument
  @typescript-eslint/no-unsafe-assignment
  @typescript-eslint/no-unsafe-call
  @typescript-eslint/no-unsafe-member-access
  @typescript-eslint/no-unsafe-return
  @typescript-eslint/prefer-nullish-coalescing
  @typescript-eslint/require-await
  @typescript-eslint/restrict-plus-operands
  @typescript-eslint/restrict-template-expressions
  @typescript-eslint/unbound-method
  )

  export CHECK_TEMPORARILY_DISABLED_RULES=false
  export CHECK_TEMPORARILY_DISABLED_RULES=true

  export TURBO_FILTER=
  export TURBO_FILTER=./blocks/calculation
  export TURBO_FILTER=./blocks/chart
  export TURBO_FILTER=./blocks/drawing
  export TURBO_FILTER=./blocks/embed
  export TURBO_FILTER=./blocks/github-pr-overview
  export TURBO_FILTER=./blocks/header
  export TURBO_FILTER=./blocks/stopwatch
  export TURBO_FILTER=./blocks/table
  export TURBO_FILTER=./packages/graph/migrations
  export TURBO_FILTER=./packages/hash/backend-utils
  export TURBO_FILTER=./packages/hash/design-system
  export TURBO_FILTER=./packages/hash/frontend
  export TURBO_FILTER=./packages/hash/integration
  export TURBO_FILTER=./packages/hash/playwright
  export TURBO_FILTER=./packages/hash/realtime
  export TURBO_FILTER=./packages/hash/search-loader
  export TURBO_FILTER=./packages/hash/shared
  export TURBO_FILTER=./sites/hashai
  export TURBO_FILTER=./sites/hashdev

  yarn turbo run --filter=${TURBO_FILTER} --continue lint:eslint >/tmp/eslint-output.txt

  echo "// $TURBO_FILTER" &&
  for RULE in "${RULES[@]}"; do
    echo "/* 2022-11-11:  $(grep -w -c $RULE /tmp/eslint-output.txt) */ \"$RULE\",";
  done
  ```

- Rules with >0 occurrences are listed in individual `.eslintrc.cjs` files. Using `@local/eslint-config/temporarily-disable-rules.cjs` provides distinction between permanent and temporary rules. This function also allows us to re-run the inventory if needed.

## 📜 Does this require a change to the docs?

- No

## 🐾 Next steps

- Fix errors and remove `@local/eslint-config/temporarily-disable-rules.cjs` (to be done in a series of small PRs)

## 🛡 What tests cover this?

- CI

## ❓ How to test this?

Check CI