### PR TITLE
`error-stack` warn about new lints

### DIFF
--- a/packages/libs/error-stack/src/fmt/hook.rs
+++ b/packages/libs/error-stack/src/fmt/hook.rs
@@ -759,16 +759,14 @@ mod default {
     #[cfg(any(rust_1_65, feature = "spantrace"))]
     use alloc::format;
     use alloc::{vec, vec::Vec};
-    use core::any::TypeId;
+    use core::{
+        any::TypeId,
+        panic::Location,
+        sync::atomic::{AtomicBool, Ordering},
+    };
     #[cfg(rust_1_65)]
     use std::backtrace::Backtrace;
-    use std::{
-        panic::Location,
-        sync::{
-            atomic::{AtomicBool, Ordering},
-            Once,
-        },
-    };
+    use std::sync::Once;
 
     #[cfg(feature = "pretty-print")]
     use owo_colors::{OwoColorize, Stream};

--- a/packages/libs/error-stack/src/hook.rs
+++ b/packages/libs/error-stack/src/hook.rs
@@ -1,4 +1,5 @@
-use std::{error::Error, fmt, sync::RwLock};
+use alloc::fmt;
+use std::{error::Error, sync::RwLock};
 
 use crate::{
     fmt::{install_builtin_hooks, HookContext, Hooks},

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -447,12 +447,12 @@
     clippy::nursery,
     clippy::undocumented_unsafe_blocks,
     clippy::dbg_macro,
+    clippy::print_stdout,
+    clippy::print_stderr,
     clippy::alloc_instead_of_core,
     clippy::std_instead_of_alloc,
     clippy::std_instead_of_core,
-    clippy::if_then_some_else_none,
-    clippy::print_stdout,
-    clippy::print_stderr
+    clippy::if_then_some_else_none
 )]
 #![allow(clippy::redundant_pub_crate)] // This would otherwise clash with `unreachable_pub`
 #![allow(clippy::missing_errors_doc)] // This is an error handling library producing Results, not Errors

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -450,6 +450,7 @@
     clippy::alloc_instead_of_core,
     clippy::std_instead_of_alloc,
     clippy::std_instead_of_core,
+    clippy::if_then_some_else_none,
     clippy::print_stdout,
     clippy::print_stderr
 )]

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -447,6 +447,9 @@
     clippy::nursery,
     clippy::undocumented_unsafe_blocks,
     clippy::dbg_macro,
+    clippy::alloc_instead_of_core,
+    clippy::std_instead_of_alloc,
+    clippy::std_instead_of_core,
     clippy::print_stdout,
     clippy::print_stderr
 )]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Enable the following new lints;
* [`clippy::alloc_instead_of_core`](https://rust-lang.github.io/rust-clippy/master/#alloc_instead_of_core)
* [`clippy::std_instead_of_alloc`](https://rust-lang.github.io/rust-clippy/master/#std_instead_of_alloc)
* [`clippy::std_instead_of_core`](https://rust-lang.github.io/rust-clippy/master/#std_instead_of_core)
* [`clippy::if_then_some_else_none`](https://rust-lang.github.io/rust-clippy/master/#if_then_some_else_none)

The `*_instead_of_*` help us identify `std` and `alloc` imports which can also be imported using `core` or `alloc`. This helps during development, as Clippy will now complain in CLion (if enabled) if something has been accidentally imported over `std` in `no-std` code.

The benefit for `std` is not immediate, but using `alloc` and `core` where possible enables a developer or reviewer during development (and version changes) if it might be possible to turn `std` code into `no-std` code and makes this transition easier.

An example for this can be found in `src/hook.rs`:

```
use std::{error::Error, fmt, sync::RwLock};
```

```
use alloc::fmt;
use std::{error::Error, sync::RwLock};
```

Just from looking at the imports, it is now evident that the use of `fmt` isn't the problem for turning this `no-std`, but the `std::error::Error` trait (which is solved by the move of the error trait into `core` in nightly) and `std::sync::RwLock` (`no-std` does not provide any synchronization primitives) currently make the transition to `no-std` impossible.

The `if_then_some_else_none` lint is merely a personal taste, as I often see myself using the pattern, where `.then()` might be more appropriate, I am happy to remove the added lint if requested.

## 📜 Does this require a change to the docs?

This is only internal.
