### PR TITLE
`deer` use new built-in errors in visitor and deserializer defaults

### DIFF
--- a/packages/libs/deer/src/error/mod.rs
+++ b/packages/libs/deer/src/error/mod.rs
@@ -105,7 +105,15 @@ impl Id {
 }
 
 // TODO: most likely (in 0.2) we want to actually have a proper schema
+<<<<<<< HEAD
 #[derive(serde::Serialize)]
+=======
+// TODO: this is currently completely untyped, we might want to adhere to a standard, like
+//  JSON-Schema or OpenAPI
+//  The problem here mainly is: which crate to use, one can use utoipa (but that has significant
+//  overhead)  there's no real library out there that properly just provides the types
+//  necessary.
+>>>>>>> b4c42669e (feat: implement (most) Visitor errors using new errors)
 pub struct Schema {
     #[serde(rename = "type")]
     ty: String,

--- a/packages/libs/deer/src/error/mod.rs
+++ b/packages/libs/deer/src/error/mod.rs
@@ -105,15 +105,12 @@ impl Id {
 }
 
 // TODO: most likely (in 0.2) we want to actually have a proper schema
-<<<<<<< HEAD
-#[derive(serde::Serialize)]
-=======
 // TODO: this is currently completely untyped, we might want to adhere to a standard, like
 //  JSON-Schema or OpenAPI
 //  The problem here mainly is: which crate to use, one can use utoipa (but that has significant
 //  overhead)  there's no real library out there that properly just provides the types
 //  necessary.
->>>>>>> b4c42669e (feat: implement (most) Visitor errors using new errors)
+#[derive(serde::Serialize)]
 pub struct Schema {
     #[serde(rename = "type")]
     ty: String,

--- a/packages/libs/deer/src/error/mod.rs
+++ b/packages/libs/deer/src/error/mod.rs
@@ -69,7 +69,7 @@ pub use unknown::{
     ExpectedField, ExpectedVariant, ReceivedField, ReceivedVariant, UnknownFieldError,
     UnknownVariantError,
 };
-pub use value::{ReceivedValue, ValueError};
+pub use value::{MissingError, ReceivedValue, ValueError};
 
 use crate::error::macros::impl_error;
 

--- a/packages/libs/deer/src/lib.rs
+++ b/packages/libs/deer/src/lib.rs
@@ -53,9 +53,8 @@ pub trait ArrayAccess<'de> {
     fn finish(self) -> Result<(), ArrayAccessError>;
 }
 
-// TODO: Error PR: attach the expected and received type
-// Reason: this definition is used by all other visitors, we provide fallbacks, which **currently**
-//  do not take into account the value provided. This will change with the error PR.
+// Reason: We error out on every `visit_*`, which means we do not use the value, but(!) IDEs like to
+// use the name to make autocomplete, therefore names for unused parameters are required.
 #[allow(unused_variables)]
 pub trait Visitor<'de>: Sized {
     type Value;

--- a/packages/libs/deer/src/lib.rs
+++ b/packages/libs/deer/src/lib.rs
@@ -23,8 +23,8 @@ use error_stack::{Report, Result, ResultExt};
 use num_traits::ToPrimitive;
 
 use crate::error::{
-    ArrayAccessError, DeserializeError, DeserializerError, ExpectedType, ObjectAccessError,
-    ReceivedType, ReceivedValue, Schema, TypeError, ValueError, VisitorError,
+    ArrayAccessError, DeserializeError, DeserializerError, ExpectedType, MissingError,
+    ObjectAccessError, ReceivedType, ReceivedValue, Schema, TypeError, ValueError, VisitorError,
 };
 pub use crate::number::Number;
 
@@ -63,10 +63,9 @@ pub trait Visitor<'de>: Sized {
     fn expecting(&self) -> Schema;
 
     fn visit_none(self) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected missing value",
-        // )))
-        todo!()
+        Err(Report::new(MissingError)
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     fn visit_null(self) -> Result<Self::Value, VisitorError> {

--- a/packages/libs/deer/src/lib.rs
+++ b/packages/libs/deer/src/lib.rs
@@ -17,17 +17,14 @@
 #![allow(clippy::missing_errors_doc)]
 #![forbid(unsafe_code)]
 
-use alloc::{
-    collections::BTreeMap,
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{string::String, vec::Vec};
 
-use error_stack::{IntoReport, Result, ResultExt};
+use error_stack::{Report, Result, ResultExt};
 use num_traits::ToPrimitive;
 
 use crate::error::{
-    ArrayAccessError, DeserializeError, DeserializerError, ObjectAccessError, VisitorError,
+    ArrayAccessError, DeserializeError, DeserializerError, ExpectedType, ObjectAccessError,
+    ReceivedType, ReceivedValue, Schema, TypeError, ValueError, VisitorError,
 };
 pub use crate::number::Number;
 
@@ -63,16 +60,7 @@ pub trait ArrayAccess<'de> {
 pub trait Visitor<'de>: Sized {
     type Value;
 
-    fn expecting_display(&self) -> String;
-
-    // TODO: this is currently completely untyped, we might want to adhere to a standard, like
-    //  JSON-Schema or OpenAPI
-    //  The problem here mainly is: which crate to use, one can use utoipa (but that has significant
-    //  overhead)  there's no real library out there that properly just provides the types
-    //  necessary.
-    fn expecting_schema(&self) -> BTreeMap<String, String> {
-        BTreeMap::new()
-    }
+    fn expecting(&self) -> Schema;
 
     fn visit_none(self) -> Result<Self::Value, VisitorError> {
         // Err(Report::new(Self::Error::message(
@@ -82,191 +70,254 @@ pub trait Visitor<'de>: Sized {
     }
 
     fn visit_null(self) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type null",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(Schema::new("null")))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     fn visit_bool(self, v: bool) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type bool",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(Schema::new("boolean")))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     // TODO: should this auto-delegate to one of the other visit functions?!
     //  ~> experimentation is needed
     fn visit_number(self, v: Number) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type number",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(Schema::new("number")))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
-    fn visit_char(self, v: String) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type char",
-        // )))
-        todo!()
+    fn visit_char(self, v: char) -> Result<Self::Value, VisitorError> {
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(
+                Schema::new("string")
+                    .with("minLength", 1)
+                    .with("maxLength", 1),
+            ))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     fn visit_string(self, v: String) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type string",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(Schema::new("string")))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
+
     fn visit_str(self, v: &str) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type string",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(Schema::new("string")))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
+
     fn visit_borrowed_str(self, v: &'de str) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type string",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(Schema::new("string")))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     fn visit_bytes_buffer(self, v: Vec<u8>) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type string",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(
+                // TODO: binary is not a valid json-schema type
+                Schema::new("binary"),
+            ))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     fn visit_bytes(self, v: &[u8]) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type string",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(
+                // TODO: binary is not a valid json-schema type
+                Schema::new("binary"),
+            ))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     fn visit_borrowed_bytes(self, v: &'de [u8]) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type string",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(
+                // TODO: binary is not a valid json-schema type
+                Schema::new("binary"),
+            ))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     fn visit_array<T>(self, v: T) -> Result<Self::Value, VisitorError>
     where
         T: ArrayAccess<'de>,
     {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type array",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(Schema::new("array")))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     fn visit_object<T>(self, v: T) -> Result<Self::Value, VisitorError>
     where
         T: ObjectAccess<'de>,
     {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type object",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(Schema::new("object")))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     fn visit_i8(self, v: i8) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type i8",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(
+                Schema::new("integer")
+                    .with("minimum", i8::MIN)
+                    .with("maximum", i8::MAX),
+            ))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     fn visit_i16(self, v: i16) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type i16",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(
+                Schema::new("integer")
+                    .with("minimum", i16::MIN)
+                    .with("maximum", i16::MAX),
+            ))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     fn visit_i32(self, v: i32) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type i32",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(
+                Schema::new("integer")
+                    .with("minimum", i32::MIN)
+                    .with("maximum", i32::MAX),
+            ))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     fn visit_i64(self, v: i64) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type i64",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(
+                Schema::new("integer")
+                    .with("minimum", i64::MIN)
+                    .with("maximum", i64::MAX),
+            ))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     fn visit_i128(self, v: i128) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type i128",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(
+                Schema::new("integer")
+                    .with("minimum", i128::MIN)
+                    .with("maximum", i128::MAX),
+            ))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     fn visit_isize(self, v: isize) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type isize",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(
+                Schema::new("integer")
+                    .with("minimum", isize::MIN)
+                    .with("maximum", isize::MAX),
+            ))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     fn visit_u8(self, v: u8) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type u8",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(
+                Schema::new("integer")
+                    .with("minimum", u8::MIN)
+                    .with("maximum", u8::MAX),
+            ))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     fn visit_u16(self, v: u16) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type u16",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(
+                Schema::new("integer")
+                    .with("minimum", u16::MIN)
+                    .with("maximum", u16::MAX),
+            ))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     fn visit_u32(self, v: u32) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type u32",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(
+                Schema::new("integer")
+                    .with("minimum", u32::MIN)
+                    .with("maximum", u32::MAX),
+            ))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     fn visit_u64(self, v: u64) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type u64",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(
+                Schema::new("integer")
+                    .with("minimum", u64::MIN)
+                    .with("maximum", u64::MAX),
+            ))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     fn visit_u128(self, v: u128) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type u128",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(
+                Schema::new("integer")
+                    .with("minimum", u128::MIN)
+                    .with("maximum", u128::MAX),
+            ))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     fn visit_usize(self, v: usize) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type usize",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(
+                Schema::new("integer")
+                    .with("minimum", usize::MIN)
+                    .with("maximum", usize::MAX),
+            ))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     fn visit_f32(self, v: f32) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type f32",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(Schema::new("number")))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 
     fn visit_f64(self, v: f64) -> Result<Self::Value, VisitorError> {
-        // Err(Report::new(Self::Error::message(
-        //     "unexpected value of type f64",
-        // )))
-        todo!()
+        Err(Report::new(TypeError)
+            .attach(ReceivedType::new(Schema::new("number")))
+            .attach(ExpectedType::new(self.expecting()))
+            .change_context(VisitorError))
     }
 }
 
@@ -277,8 +328,8 @@ struct NumberVisitor;
 impl Visitor<'_> for NumberVisitor {
     type Value = Number;
 
-    fn expecting_display(&self) -> String {
-        "number".to_string()
+    fn expecting(&self) -> Schema {
+        Schema::new("number")
     }
 
     fn visit_number(self, v: Number) -> Result<Self::Value, VisitorError> {
@@ -287,11 +338,11 @@ impl Visitor<'_> for NumberVisitor {
 }
 
 macro_rules! derive_from_number {
-    [$($method:ident ($to:ident) -> $visit:ident,)*] => {
-        $(derive_from_number!(#internal, $method; $to, $visit);)*
+    [$($method:ident ($primitive:ident via $to:ident) -> $visit:ident,)*] => {
+        $(derive_from_number!(#internal, $method; $primitive, $to, $visit);)*
     };
 
-    (#internal, $method:ident; $to:ident, $visit:ident) => {
+    (#internal, $method:ident; $primitive:ident, $to:ident, $visit:ident) => {
         /// Automatically implemented convenience method, which uses [`Self::deserialize_number`]
         /// to extract a value of the primitive type, will otherwise error out.
         ///
@@ -305,10 +356,16 @@ macro_rules! derive_from_number {
             let n = self.deserialize_number(NumberVisitor)?;
             let v = n
                 .$to()
-                // TODO: change with the actual error type
-                .ok_or_else(|| DeserializerError)
-                // .ok_or_else(|| Self::Error::message("provided value too large or too small"))
-                .into_report()?;
+                .ok_or_else(||
+                    Report::new(ValueError)
+                        .attach(ExpectedType::new(
+                            Schema::new("integer")
+                                .with("minimum", $primitive::MIN)
+                                .with("maximum", $primitive::MAX)
+                        ))
+                        .attach(ReceivedValue::new(n))
+                )
+                .change_context(DeserializerError)?;
 
             visitor.$visit(v).change_context(DeserializerError)
         }
@@ -467,22 +524,22 @@ pub trait Deserializer<'de>: Sized {
         V: Visitor<'de>;
 
     derive_from_number![
-        deserialize_i8(to_i8) -> visit_i8,
-        deserialize_i16(to_i16) -> visit_i16,
-        deserialize_i32(to_i32) -> visit_i32,
-        deserialize_i64(to_i64) -> visit_i64,
-        deserialize_i128(to_i128) -> visit_i128,
-        deserialize_isize(to_isize) -> visit_isize,
+        deserialize_i8(i8 via to_i8) -> visit_i8,
+        deserialize_i16(i16 via to_i16) -> visit_i16,
+        deserialize_i32(i32 via to_i32) -> visit_i32,
+        deserialize_i64(i64 via to_i64) -> visit_i64,
+        deserialize_i128(i128 via to_i128) -> visit_i128,
+        deserialize_isize(isize via to_isize) -> visit_isize,
 
-        deserialize_u8(to_u8) -> visit_u8,
-        deserialize_u16(to_u16) -> visit_u16,
-        deserialize_u32(to_u32) -> visit_u32,
-        deserialize_u64(to_u64) -> visit_u64,
-        deserialize_u128(to_u128) -> visit_u128,
-        deserialize_usize(to_usize) -> visit_usize,
+        deserialize_u8(u8 via to_u8) -> visit_u8,
+        deserialize_u16(u16 via to_u16) -> visit_u16,
+        deserialize_u32(u32 via to_u32) -> visit_u32,
+        deserialize_u64(u64 via to_u64) -> visit_u64,
+        deserialize_u128(u128 via to_u128) -> visit_u128,
+        deserialize_usize(usize via to_usize) -> visit_usize,
 
-        deserialize_f32(to_f32) -> visit_f32,
-        deserialize_f64(to_f64) -> visit_f64,
+        deserialize_f32(f32 via to_f32) -> visit_f32,
+        deserialize_f64(f64 via to_f64) -> visit_f64,
     ];
 }
 

--- a/packages/libs/deer/src/number.rs
+++ b/packages/libs/deer/src/number.rs
@@ -327,7 +327,7 @@ impl Serialize for Number {
                 if let Ok(value) = i64::try_from(value) {
                     serializer.serialize_i64(-value)
                 } else {
-                    serializer.serialize_i128(-(value as i128))
+                    serializer.serialize_i128(-i128::from(value))
                 }
             }
             OpaqueNumber::Float(value) => serializer.serialize_f64(value),
@@ -338,7 +338,7 @@ impl Serialize for Number {
 // compatability shim, this could be $deer::private::Number instead, but by using the token
 // from `serde_json` we're able to also allow deserialization and serialization of the existing
 // `serde_json` `Number` type
-#[cfg(feature = "arbitrary_precision")]
+#[cfg(feature = "arbitrary-precision")]
 pub(crate) const TOKEN: &str = "$serde_json::private::Number";
 
 #[cfg(feature = "arbitrary-precision")]
@@ -350,7 +350,7 @@ impl Serialize for Number {
         use serde::ser::SerializeStruct;
 
         let mut s = serializer.serialize_struct(TOKEN, 1)?;
-        s.serialize_field(TOKEN, &self.n)?;
+        s.serialize_field(TOKEN, &self.0)?;
         s.end()
     }
 }

--- a/packages/libs/deer/src/number.rs
+++ b/packages/libs/deer/src/number.rs
@@ -5,6 +5,7 @@ use core::fmt::{Display, Formatter};
 use core::ops::Neg;
 
 use num_traits::{FromPrimitive, ToPrimitive};
+use serde::{Serialize, Serializer};
 
 // This indirection helps us to "disguise" the underlying storage, enabling us to seamlessly convert
 // and change the underlying storage at a later point in time, if required.
@@ -309,5 +310,47 @@ impl Display for Number {
     #[cfg(feature = "arbitrary-precision")]
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.write_str(&self.0)
+    }
+}
+
+#[cfg(not(feature = "arbitrary-precision"))]
+impl Serialize for Number {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self.0 {
+            OpaqueNumber::PosInt(value) => serializer.serialize_u64(value),
+            OpaqueNumber::NegInt(value) => {
+                // in most cases the value will be compatible with i64, but in some cases we need to
+                // "escalate" to i128, which not every serializer might support
+                if let Ok(value) = i64::try_from(value) {
+                    serializer.serialize_i64(-value)
+                } else {
+                    serializer.serialize_i128(-(value as i128))
+                }
+            }
+            OpaqueNumber::Float(value) => serializer.serialize_f64(value),
+        }
+    }
+}
+
+// compatability shim, this could be $deer::private::Number instead, but by using the token
+// from `serde_json` we're able to also allow deserialization and serialization of the existing
+// `serde_json` `Number` type
+#[cfg(feature = "arbitrary_precision")]
+pub(crate) const TOKEN: &str = "$serde_json::private::Number";
+
+#[cfg(feature = "arbitrary-precision")]
+impl Serialize for Number {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeStruct;
+
+        let mut s = serializer.serialize_struct(TOKEN, 1)?;
+        s.serialize_field(TOKEN, &self.n)?;
+        s.end()
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The previous PR (#1375) created the types for all built-in errors inspired by `serde::ser::Error`. This PR adds them to the default implementation of functions in `Visitor` and `Deserializer`. Additionally, this PR adds a new error `MissingError`, which is a "child" of the `ValueError` and is only emitted during `visit_none` (unexpected missing value)

## 🔗 Related links

- [Asana task](https://app.asana.com/0/0/1203363157432059) _(internal)_

## 🚫 Blocked By

* #1375 