### PR TITLE
new `append-vec` crate

### DIFF
--- a/packages/libs/deer/append-vec/Cargo.toml
+++ b/packages/libs/deer/append-vec/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[target.'cfg(loom)'.dependencies]
+loom = "0.5"

--- a/packages/libs/deer/append-vec/Cargo.toml
+++ b/packages/libs/deer/append-vec/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "deer-append-vec"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/packages/libs/deer/append-vec/Cargo.toml
+++ b/packages/libs/deer/append-vec/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 [dependencies]
 
 [target.'cfg(loom)'.dependencies]
-loom = "0.5"
+loom = { version = "0.5", features = ['checkpoint'] }

--- a/packages/libs/deer/append-vec/Cargo.toml
+++ b/packages/libs/deer/append-vec/Cargo.toml
@@ -7,5 +7,19 @@ edition = "2021"
 
 [dependencies]
 
+[dev-dependencies]
+criterion = { version = "0.4.0", features = ['html_reports'] }
+
+# Benchmark targets
+sharded-slab = "0.1.4"
+scc = "0.11.2"
+appendlist = "1.4.0"
+intrusive-collections = "0.9.4"
+im = "15.1.0"
+
 [target.'cfg(loom)'.dependencies]
 loom = { version = "0.5", features = ['checkpoint'] }
+
+[[bench]]
+name = "bench"
+harness = false

--- a/packages/libs/deer/append-vec/benches/bench.rs
+++ b/packages/libs/deer/append-vec/benches/bench.rs
@@ -1,0 +1,285 @@
+//! Benchmark usecases against:
+//! * (std) sharded-slab
+//! * (std) scc
+//! * (std) appendlist
+//! * (std) intrusive-collections
+//! * (std) im
+use std::{
+    cell::Cell,
+    sync::{Arc, Barrier, Mutex, RwLock},
+    thread,
+    time::{Duration, Instant},
+};
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use deer_append_vec::AppendOnlyVec;
+use intrusive_collections::{intrusive_adapter, LinkedListLink};
+
+const N_INSERTIONS: &[usize] = &[100, 300, 500];
+
+// TODO: iter (single, multi)
+
+#[derive(Clone)]
+struct MultithreadedBench<T, const N: usize = 5> {
+    start: Arc<Barrier>,
+    end: Arc<Barrier>,
+    value: Arc<T>,
+}
+
+impl<T: Send + Sync + 'static, const N: usize> MultithreadedBench<T, N> {
+    fn new(slab: Arc<T>) -> Self {
+        Self {
+            start: Arc::new(Barrier::new(N)),
+            end: Arc::new(Barrier::new(N)),
+            value: slab,
+        }
+    }
+
+    fn run(self, f: impl Fn(&Barrier, &T) + Clone + Send + 'static) -> Duration {
+        for _ in 0..N - 1 {
+            let start = self.start.clone();
+            let end = self.end.clone();
+            let slab = self.value.clone();
+            let f = f.clone();
+
+            thread::spawn(move || {
+                f(&start, &*slab);
+                end.wait();
+            });
+        }
+
+        self.start.wait();
+        let t0 = Instant::now();
+        self.end.wait();
+        t0.elapsed()
+    }
+}
+
+struct Entry {
+    link: LinkedListLink,
+    value: Cell<usize>,
+}
+
+intrusive_adapter!(EntryAdapter = Box<Entry>: Entry {link: LinkedListLink});
+
+fn push_multi_thread(c: &mut Criterion) {
+    let mut group = c.benchmark_group("group_multi_thread");
+
+    for i in N_INSERTIONS {
+        group.bench_with_input(BenchmarkId::new("sharded_slab", i), i, |b, &i| {
+            b.iter_custom(|iters| {
+                let mut total = Duration::from_secs(0);
+
+                for _ in 0..iters {
+                    let slab = sharded_slab::Slab::<usize>::new();
+                    let bench = MultithreadedBench::<_, 5>::new(Arc::new(slab));
+
+                    let elapsed = bench.run(move |start, slab| {
+                        start.wait();
+
+                        for idx in 0..i {
+                            slab.insert(idx);
+                        }
+                    });
+
+                    total += elapsed;
+                }
+
+                total
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("scc", i), i, |b, &i| {
+            b.iter_custom(|iters| {
+                let mut total = Duration::from_secs(0);
+
+                for _ in 0..iters {
+                    let slab = scc::Queue::<usize>::default();
+                    let bench = MultithreadedBench::<_, 5>::new(Arc::new(slab));
+
+                    let elapsed = bench.run(move |start, slab| {
+                        start.wait();
+
+                        for idx in 0..i {
+                            slab.push(idx);
+                        }
+                    });
+
+                    total += elapsed;
+                }
+
+                total
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("appendlist", i), i, |b, &i| {
+            b.iter_custom(|iters| {
+                let mut total = Duration::from_secs(0);
+
+                for _ in 0..iters {
+                    let slab = Mutex::new(appendlist::AppendList::new());
+                    let bench = MultithreadedBench::<_, 5>::new(Arc::new(slab));
+
+                    let elapsed = bench.run(move |start, slab| {
+                        start.wait();
+
+                        for idx in 0..i {
+                            let guard = slab.lock().unwrap();
+
+                            guard.push(Box::new(Entry {
+                                link: LinkedListLink::new(),
+                                value: Cell::new(idx),
+                            }));
+                        }
+                    });
+
+                    total += elapsed;
+                }
+
+                total
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("intrusive-collections", i), i, |b, &i| {
+            b.iter_custom(|iters| {
+                let mut total = Duration::from_secs(0);
+
+                for _ in 0..iters {
+                    let slab =
+                        Mutex::new(intrusive_collections::LinkedList::new(EntryAdapter::new()));
+                    let bench = MultithreadedBench::<_, 5>::new(Arc::new(slab));
+
+                    let elapsed = bench.run(move |start, slab| {
+                        start.wait();
+
+                        for idx in 0..i {
+                            let mut guard = slab.lock().unwrap();
+
+                            guard.push_back(Box::new(Entry {
+                                link: LinkedListLink::new(),
+                                value: Cell::new(idx),
+                            }));
+                        }
+                    });
+
+                    total += elapsed;
+                }
+
+                total
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("im", i), i, |b, &i| {
+            b.iter_custom(|iters| {
+                let mut total = Duration::from_secs(0);
+
+                for _ in 0..iters {
+                    let slab = RwLock::new(im::Vector::new());
+                    let bench = MultithreadedBench::<_, 5>::new(Arc::new(slab));
+
+                    let elapsed = bench.run(move |start, slab| {
+                        start.wait();
+
+                        for idx in 0..i {
+                            let mut guard = slab.write().unwrap();
+
+                            guard.push_back(idx);
+                        }
+                    });
+
+                    total += elapsed;
+                }
+
+                total
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("deer-append-vec", i), i, |b, &i| {
+            b.iter_custom(|iters| {
+                let mut total = Duration::from_secs(0);
+
+                for _ in 0..iters {
+                    let slab = AppendOnlyVec::<usize>::new();
+                    let bench = MultithreadedBench::<_, 5>::new(Arc::new(slab));
+
+                    let elapsed = bench.run(move |start, slab| {
+                        start.wait();
+
+                        for idx in 0..i {
+                            slab.push(idx);
+                        }
+                    });
+
+                    total += elapsed;
+                }
+
+                total
+            });
+        });
+    }
+}
+
+fn push_single_thread(c: &mut Criterion) {
+    let mut group = c.benchmark_group("push_single_thread");
+
+    for i in N_INSERTIONS {
+        group.bench_with_input(BenchmarkId::new("sharded_slab", i), i, |b, &i| {
+            b.iter_with_setup(sharded_slab::Slab::<usize>::new, |slab| {
+                for idx in 0..i {
+                    slab.insert(idx);
+                }
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("scc", i), i, |b, &i| {
+            b.iter_with_setup(scc::Queue::<usize>::default, |slab| {
+                for idx in 0..i {
+                    slab.push(idx);
+                }
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("appendlist", i), i, |b, &i| {
+            b.iter_with_setup(appendlist::AppendList::<usize>::new, |slab| {
+                for idx in 0..i {
+                    slab.push(idx);
+                }
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("intrusive-collections", i), i, |b, &i| {
+            b.iter_with_setup(
+                || intrusive_collections::LinkedList::new(EntryAdapter::new()),
+                |mut slab| {
+                    for idx in 0..i {
+                        let entry = Box::new(Entry {
+                            link: LinkedListLink::new(),
+                            value: Cell::new(idx),
+                        });
+
+                        slab.push_back(entry)
+                    }
+                },
+            );
+        });
+
+        group.bench_with_input(BenchmarkId::new("im", i), i, |b, &i| {
+            b.iter_with_setup(im::Vector::<usize>::default, |mut slab| {
+                for idx in 0..i {
+                    slab.push_back(idx);
+                }
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("deer-append-vec", i), i, |b, &i| {
+            b.iter_with_setup(AppendOnlyVec::<usize>::default, |slab| {
+                for idx in 0..i {
+                    slab.push(idx);
+                }
+            });
+        });
+    }
+}
+
+criterion_group!(benches, push_single_thread, push_multi_thread);
+criterion_main!(benches);

--- a/packages/libs/deer/append-vec/src/lib.rs
+++ b/packages/libs/deer/append-vec/src/lib.rs
@@ -1,3 +1,135 @@
 #![no_std]
 
+extern crate alloc;
+
+use alloc::{alloc::alloc, boxed::Box};
+use core::{
+    alloc::Layout,
+    array,
+    cell::UnsafeCell,
+    marker::PhantomData,
+    mem::MaybeUninit,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use crate::lock::AtomicLock;
+
 mod lock;
+pub(crate) mod sync;
+
+pub struct AppendOnlyVec<T, const N: usize> {
+    length: AtomicUsize,
+    lock: AtomicLock,
+
+    head: UnsafeCell<Node<T, N>>,
+}
+
+impl<T, const N: usize> AppendOnlyVec<T, N> {
+    fn indices(&self, length: usize) -> (usize, usize) {
+        (length / N, length % N)
+    }
+
+    pub fn push(&self, value: T) {
+        let _guard = self.lock.lock();
+
+        let length = self.length.fetch_add(1, Ordering::Relaxed);
+        let (node, offset) = self.indices(length);
+
+        unsafe {
+            let head = &mut *self.head.get();
+            head.set(node, offset, value);
+        }
+    }
+
+    pub fn iter(&self) -> Iter<'_, T, N> {
+        Iter::new(self)
+    }
+}
+
+struct Node<T, const N: usize> {
+    store: [MaybeUninit<T>; N],
+
+    next: Box<MaybeUninit<Node<T, N>>>,
+}
+
+fn uninit_box<T>() -> Box<MaybeUninit<T>> {
+    let layout = Layout::new::<MaybeUninit<T>>();
+
+    unsafe {
+        let ptr = alloc(layout) as *mut MaybeUninit<T>;
+
+        Box::from_raw(ptr)
+    }
+}
+
+impl<T, const N: usize> Node<T, N> {
+    fn new() -> Self {
+        Self {
+            // this is the same as MaybeUninit::uninit_array()
+            store: unsafe { MaybeUninit::<[MaybeUninit<T>; N]>::uninit().assume_init() },
+            // this is the same as Box::new_uninit()
+            next: uninit_box(),
+        }
+    }
+
+    // SAFETY: The following invariants must be upheld:
+    // 1) keys are only set sequentially
+    // 2) offset < N
+    unsafe fn set(&mut self, node: usize, offset: usize, value: T) {
+        if node == 1 && offset == 0 {
+            // the next node is empty, and therefore needs to be allocated before we can use it
+            self.next.write(Node::new());
+        }
+
+        if node == 0 {
+            // we need to set our specific entry
+            let entry = &mut self.store[offset];
+            entry.write(value);
+        } else {
+            // the invariants ensure that the next node **always** exists, and the previous
+            // statement will allocate a new node if necessary, therefore this recursion into the
+            // next node is "safe"
+            self.next.assume_init_mut().set(node - 1, offset, value);
+        }
+    }
+}
+
+pub struct Iter<'a, T, const N: usize> {
+    node: &'a Node<T, N>,
+    length: usize,
+    offset: usize,
+}
+
+impl<'a, T, const N: usize> Iter<'a, T, N> {
+    fn new(vec: &'a AppendOnlyVec<T, N>) -> Self {
+        Self {
+            node: unsafe { &*vec.head.get() },
+            length: vec.length.load(Ordering::Relaxed),
+            offset: 0,
+        }
+    }
+}
+
+impl<'a, T, const N: usize> Iterator for Iter<'a, T, N> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.offset >= self.length {
+            return None;
+        }
+
+        if self.offset == N {
+            // we reached a new node, therefore we need to switch our ptr to it and substract N from
+            // the length and offset
+            self.offset -= N;
+            self.length -= N;
+
+            self.node = unsafe { self.node.next.assume_init_ref() };
+        }
+
+        let item = unsafe { self.node.store[self.offset].assume_init_ref() };
+        self.offset += 1;
+
+        Some(item)
+    }
+}

--- a/packages/libs/deer/append-vec/src/lib.rs
+++ b/packages/libs/deer/append-vec/src/lib.rs
@@ -283,7 +283,7 @@ mod tests {
             let v = Arc::new(AppendOnlyVec::<usize>::new());
             let mut threads = Vec::new();
 
-            const N: usize = 8;
+            const N: usize = 4;
 
             let v1 = Arc::clone(&v);
             threads.push(loom::thread::spawn(move || {

--- a/packages/libs/deer/append-vec/src/lib.rs
+++ b/packages/libs/deer/append-vec/src/lib.rs
@@ -3,24 +3,42 @@
 extern crate alloc;
 
 use alloc::boxed::Box;
-use core::mem::MaybeUninit;
+use core::mem::{ManuallyDrop, MaybeUninit};
 
 use crate::{
     lock::AtomicLock,
-    sync::{alloc, AtomicUsize, Layout, Ordering, UnsafeCell},
+    sync::{alloc, AtomicBool, AtomicUsize, Layout, Ordering, UnsafeCell},
 };
 
 mod lock;
 pub(crate) mod sync;
 
-pub struct AppendOnlyVec<T, const N: usize> {
+pub struct AppendOnlyVec<T, const N: usize = 16> {
     length: AtomicUsize,
     lock: AtomicLock,
 
     head: UnsafeCell<Node<T, N>>,
 }
 
+impl<T, const N: usize> Drop for AppendOnlyVec<T, N> {
+    fn drop(&mut self) {
+        let head = self.head.get_mut();
+        unsafe { head.uninit() };
+    }
+}
+
+unsafe impl<T: Send, const N: usize> Send for AppendOnlyVec<T, N> {}
+unsafe impl<T: Send + Sync, const N: usize> Sync for AppendOnlyVec<T, N> {}
+
 impl<T, const N: usize> AppendOnlyVec<T, N> {
+    pub fn new() -> Self {
+        Self {
+            length: AtomicUsize::new(0),
+            lock: AtomicLock::new(),
+            head: UnsafeCell::new(Node::new()),
+        }
+    }
+
     fn indices(&self, length: usize) -> (usize, usize) {
         (length / N, length % N)
     }
@@ -45,7 +63,8 @@ impl<T, const N: usize> AppendOnlyVec<T, N> {
 struct Node<T, const N: usize> {
     store: [MaybeUninit<T>; N],
 
-    next: Box<MaybeUninit<Node<T, N>>>,
+    has_next: AtomicBool,
+    next: ManuallyDrop<Box<MaybeUninit<Node<T, N>>>>,
 }
 
 fn uninit_box<T>() -> Box<MaybeUninit<T>> {
@@ -64,8 +83,17 @@ impl<T, const N: usize> Node<T, N> {
             // this is the same as MaybeUninit::uninit_array()
             store: unsafe { MaybeUninit::<[MaybeUninit<T>; N]>::uninit().assume_init() },
             // this is the same as Box::new_uninit()
-            next: uninit_box(),
+            next: ManuallyDrop::new(uninit_box()),
+            has_next: AtomicBool::new(false),
         }
+    }
+
+    unsafe fn uninit(&mut self) {
+        if self.has_next.load(Ordering::Relaxed) {
+            self.next.assume_init_mut().uninit();
+        }
+
+        ManuallyDrop::drop(&mut self.next)
     }
 
     // SAFETY: The following invariants must be upheld:
@@ -75,6 +103,7 @@ impl<T, const N: usize> Node<T, N> {
         if node == 1 && offset == 0 {
             // the next node is empty, and therefore needs to be allocated before we can use it
             self.next.write(Node::new());
+            self.has_next.store(true, Ordering::Relaxed);
         }
 
         if node == 0 {
@@ -127,5 +156,61 @@ impl<'a, T, const N: usize> Iterator for Iter<'a, T, N> {
         self.offset += 1;
 
         Some(item)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{sync::Arc, vec, vec::Vec};
+
+    use super::AppendOnlyVec;
+
+    #[test]
+    fn push_single() {
+        let vec = AppendOnlyVec::<u8, 4>::new();
+        vec.push(1);
+
+        let vec: Vec<_> = vec.iter().copied().collect();
+        assert_eq!(vec, vec![1]);
+    }
+
+    #[test]
+    fn push_many() {
+        let vec = AppendOnlyVec::<u8, 4>::new();
+        let range = u8::MIN..u8::MAX;
+
+        for i in range.clone() {
+            vec.push(i);
+        }
+
+        let vec: Vec<_> = vec.iter().copied().collect();
+        assert_eq!(vec, range.collect::<Vec<_>>());
+    }
+
+    #[test]
+    #[cfg(loom)]
+    fn push_loom() {
+        loom::model(|| {
+            let v = Arc::new(AppendOnlyVec::<u64>::new());
+
+            let mut threads = Vec::new();
+            const N: u64 = 2;
+
+            for thread_num in 0..N {
+                let v = v.clone();
+                threads.push(loom::thread::spawn(move || {
+                    v.push(thread_num);
+                    v.push(thread_num);
+                }));
+            }
+
+            for t in threads {
+                t.join().expect("all threads could join")
+            }
+
+            for thread_num in 0..N {
+                assert_eq!(2, v.iter().copied().filter(|&x| x == thread_num).count());
+            }
+        })
     }
 }

--- a/packages/libs/deer/append-vec/src/lib.rs
+++ b/packages/libs/deer/append-vec/src/lib.rs
@@ -2,17 +2,13 @@
 
 extern crate alloc;
 
-use alloc::{alloc::alloc, boxed::Box};
-use core::{
-    alloc::Layout,
-    array,
-    cell::UnsafeCell,
-    marker::PhantomData,
-    mem::MaybeUninit,
-    sync::atomic::{AtomicUsize, Ordering},
-};
+use alloc::boxed::Box;
+use core::mem::MaybeUninit;
 
-use crate::lock::AtomicLock;
+use crate::{
+    lock::AtomicLock,
+    sync::{alloc, AtomicUsize, Layout, Ordering, UnsafeCell},
+};
 
 mod lock;
 pub(crate) mod sync;

--- a/packages/libs/deer/append-vec/src/lib.rs
+++ b/packages/libs/deer/append-vec/src/lib.rs
@@ -52,7 +52,7 @@ unsafe impl<T: Send, const N: usize> Send for AppendOnlyVec<T, N> {}
 unsafe impl<T: Send + Sync, const N: usize> Sync for AppendOnlyVec<T, N> {}
 
 impl<T, const N: usize> AppendOnlyVec<T, N> {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             length: AtomicUsize::new(0),
             lock: AtomicLock::new(),
@@ -89,7 +89,7 @@ struct Node<T, const N: usize> {
 }
 
 impl<T, const N: usize> Node<T, N> {
-    fn new() -> Self {
+    const fn new() -> Self {
         Self {
             // this is the same as MaybeUninit::uninit_array()
             store: unsafe { MaybeUninit::<[MaybeUninit<T>; N]>::uninit().assume_init() },

--- a/packages/libs/deer/append-vec/src/lib.rs
+++ b/packages/libs/deer/append-vec/src/lib.rs
@@ -211,7 +211,7 @@ mod tests {
             let v = Arc::new(AppendOnlyVec::<u64>::new());
 
             let mut threads = Vec::new();
-            const N: u64 = 3;
+            const N: u64 = 2;
 
             for thread_num in 0..N {
                 let v = v.clone();

--- a/packages/libs/deer/append-vec/src/lib.rs
+++ b/packages/libs/deer/append-vec/src/lib.rs
@@ -1,0 +1,3 @@
+#![no_std]
+
+mod lock;

--- a/packages/libs/deer/append-vec/src/lock.rs
+++ b/packages/libs/deer/append-vec/src/lock.rs
@@ -23,7 +23,15 @@ pub(crate) struct AtomicLock {
 }
 
 impl AtomicLock {
+    #[cfg(not(loom))]
     pub const fn new() -> Self {
+        Self {
+            flag: AtomicBool::new(false),
+        }
+    }
+
+    #[cfg(loom)]
+    pub fn new() -> Self {
         Self {
             flag: AtomicBool::new(false),
         }

--- a/packages/libs/deer/append-vec/src/lock.rs
+++ b/packages/libs/deer/append-vec/src/lock.rs
@@ -1,0 +1,55 @@
+//! Implementation of a light-weight lock guard, which is guarded by an atomic boolean.
+//!
+//! Most efficient when contention is low, acquiring the lock is a single atomic swap, and releasing
+//! is just one more atomic swap.
+//!
+//! This is heavily inspired from the excellent [try-lock](https://crates.io/crates/try-lock)
+//! crate, but without requiring a value to be guarded.
+
+use core::{
+    hint::spin_loop,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+pub(crate) struct LockGuard<'a> {
+    lock: &'a AtomicLock,
+}
+
+impl Drop for LockGuard<'_> {
+    fn drop(&mut self) {
+        self.lock.locked.store(false, Ordering::Release);
+    }
+}
+
+pub(crate) struct AtomicLock {
+    locked: AtomicBool,
+}
+
+impl AtomicLock {
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            locked: AtomicBool::new(false),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn lock(&self) -> LockGuard {
+        loop {
+            if let Some(lock) = self.try_lock() {
+                return lock;
+            }
+
+            spin_loop()
+        }
+    }
+
+    #[inline]
+    pub(crate) fn try_lock(&self) -> Option<LockGuard> {
+        if !self.locked.swap(true, Ordering::Acquire) {
+            Some(LockGuard { lock: self })
+        } else {
+            None
+        }
+    }
+}

--- a/packages/libs/deer/append-vec/src/lock.rs
+++ b/packages/libs/deer/append-vec/src/lock.rs
@@ -3,10 +3,9 @@
 //! Most efficient when contention is low, acquiring the lock is a single atomic swap, and releasing
 //! is just one more atomic swap.
 //!
-//! This is heavily inspired from the excellent [try-lock](https://crates.io/crates/try-lock)
-//! crate, but without requiring a value to be guarded.
+//! This is adapted from the function outlined in the [std](https://doc.rust-lang.org/std/sync/atomic/fn.fence.html) documentation
 
-use crate::sync::{spin_loop, AtomicBool, Ordering};
+use crate::sync::{fence, spin_loop, AtomicBool, Ordering};
 
 pub(crate) struct LockGuard<'a> {
     lock: &'a AtomicLock,
@@ -14,48 +13,85 @@ pub(crate) struct LockGuard<'a> {
 
 impl Drop for LockGuard<'_> {
     fn drop(&mut self) {
-        self.lock.locked.store(false, Ordering::Release);
+        self.lock.unlock();
     }
 }
 
+// A mutual exclusion primitive based on spinlock.
 pub(crate) struct AtomicLock {
-    locked: AtomicBool,
+    flag: AtomicBool,
 }
 
 impl AtomicLock {
-    #[cfg(not(loom))]
-    #[inline]
-    pub const fn new() -> Self {
-        Self {
-            locked: AtomicBool::new(false),
-        }
-    }
-
-    #[cfg(loom)]
-    #[inline]
     pub fn new() -> Self {
         Self {
-            locked: AtomicBool::new(false),
+            flag: AtomicBool::new(false),
         }
     }
 
-    #[inline]
     pub(crate) fn lock(&self) -> LockGuard {
-        loop {
-            if let Some(lock) = self.try_lock() {
-                return lock;
-            }
-
-            spin_loop()
+        // Wait until the old value is `false`.
+        while self
+            .flag
+            .compare_exchange_weak(false, true, Ordering::Relaxed, Ordering::Relaxed)
+            .is_err()
+        {
+            spin_loop();
         }
+
+        // This fence synchronizes-with store in `unlock`.
+        fence(Ordering::Acquire);
+
+        LockGuard { lock: self }
     }
 
-    #[inline]
-    pub(crate) fn try_lock(&self) -> Option<LockGuard> {
-        if !self.locked.swap(true, Ordering::Acquire) {
-            Some(LockGuard { lock: self })
-        } else {
-            None
-        }
+    fn unlock(&self) {
+        self.flag.store(false, Ordering::Release);
     }
 }
+//
+// pub(crate) struct AtomicLock {
+//     locked: AtomicBool,
+// }
+//
+// impl AtomicLock {
+//     #[cfg(not(loom))]
+//     #[inline]
+//     pub const fn new() -> Self {
+//         Self {
+//             locked: AtomicBool::new(false),
+//         }
+//     }
+//
+//     #[cfg(loom)]
+//     #[inline]
+//     pub fn new() -> Self {
+//         Self {
+//             locked: AtomicBool::new(false),
+//         }
+//     }
+//
+//     #[inline]
+//     pub(crate) fn lock(&self) -> LockGuard {
+//         loop {
+//             if let Some(lock) = self.try_lock() {
+//                 fence(Ordering::Acquire);
+//
+//                 return lock;
+//             }
+//
+//             warn!("D:");
+//
+//             spin_loop();
+//         }
+//     }
+//
+//     #[inline]
+//     pub(crate) fn try_lock(&self) -> Option<LockGuard> {
+//         if !self.locked.swap(true, Ordering::Relaxed) {
+//             Some(LockGuard { lock: self })
+//         } else {
+//             None
+//         }
+//     }
+// }

--- a/packages/libs/deer/append-vec/src/lock.rs
+++ b/packages/libs/deer/append-vec/src/lock.rs
@@ -23,8 +23,17 @@ pub(crate) struct AtomicLock {
 }
 
 impl AtomicLock {
+    #[cfg(not(loom))]
     #[inline]
     pub const fn new() -> Self {
+        Self {
+            locked: AtomicBool::new(false),
+        }
+    }
+
+    #[cfg(loom)]
+    #[inline]
+    pub fn new() -> Self {
         Self {
             locked: AtomicBool::new(false),
         }

--- a/packages/libs/deer/append-vec/src/lock.rs
+++ b/packages/libs/deer/append-vec/src/lock.rs
@@ -6,10 +6,7 @@
 //! This is heavily inspired from the excellent [try-lock](https://crates.io/crates/try-lock)
 //! crate, but without requiring a value to be guarded.
 
-use core::{
-    hint::spin_loop,
-    sync::atomic::{AtomicBool, Ordering},
-};
+use crate::sync::{spin_loop, AtomicBool, Ordering};
 
 pub(crate) struct LockGuard<'a> {
     lock: &'a AtomicLock,

--- a/packages/libs/deer/append-vec/src/lock.rs
+++ b/packages/libs/deer/append-vec/src/lock.rs
@@ -23,7 +23,7 @@ pub(crate) struct AtomicLock {
 }
 
 impl AtomicLock {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             flag: AtomicBool::new(false),
         }

--- a/packages/libs/deer/append-vec/src/sync.rs
+++ b/packages/libs/deer/append-vec/src/sync.rs
@@ -1,0 +1,11 @@
+#[cfg(not(loom))]
+pub(crate) use core::{
+    hint::spin_loop,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+#[cfg(loom)]
+pub(crate) use loom::{
+    hint::spin_loop,
+    sync::atomic::{AtomicBool, Ordering},
+};

--- a/packages/libs/deer/append-vec/src/sync.rs
+++ b/packages/libs/deer/append-vec/src/sync.rs
@@ -1,11 +1,17 @@
 #[cfg(not(loom))]
+pub(crate) use alloc::alloc::alloc;
+#[cfg(not(loom))]
 pub(crate) use core::{
+    alloc::Layout,
+    cell::UnsafeCell,
     hint::spin_loop,
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
 #[cfg(loom)]
 pub(crate) use loom::{
+    alloc::{alloc, Layout},
+    cell::UnsafeCell,
     hint::spin_loop,
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };

--- a/packages/libs/deer/append-vec/src/sync.rs
+++ b/packages/libs/deer/append-vec/src/sync.rs
@@ -3,7 +3,6 @@ pub(crate) use alloc::alloc::alloc;
 #[cfg(not(loom))]
 pub(crate) use core::{
     alloc::Layout,
-    cell::UnsafeCell,
     hint::spin_loop,
     sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };
@@ -11,7 +10,6 @@ pub(crate) use core::{
 #[cfg(loom)]
 pub(crate) use loom::{
     alloc::{alloc, Layout},
-    cell::UnsafeCell,
     hint::spin_loop,
     sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };

--- a/packages/libs/deer/append-vec/src/sync.rs
+++ b/packages/libs/deer/append-vec/src/sync.rs
@@ -1,15 +1,11 @@
 #[cfg(not(loom))]
-pub(crate) use alloc::alloc::alloc;
-#[cfg(not(loom))]
 pub(crate) use core::{
-    alloc::Layout,
     hint::spin_loop,
-    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    sync::atomic::{fence, AtomicBool, AtomicUsize, Ordering},
 };
 
 #[cfg(loom)]
 pub(crate) use loom::{
-    alloc::{alloc, Layout},
     hint::spin_loop,
-    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    sync::atomic::{fence, AtomicBool, AtomicUsize, Ordering},
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR introduces a new crate `append-vec`, a read optimized concurrently accessible (for reads) vector that can only be pushed to.

### Reasoning

This crate originates from the needs of `deer` for a thoroughly tested and verified append only vector that is available on no-std systems. Previous crates like `scc`, `appendlist`, `intrusive-collections`, `sento`, or `append-only-vec` do not fit those requirements as they are only available on `std`, are not concurrently accessible or are poorly tested. This crate tries to remedy all those problems.

## 🔗 Related links

- [Asana task](link) _(internal)_

## 🚫 Blocked by

## 🔍 What does this change?

* introduce a new crate, `append-vec`

## 📜 Does this require a change to the docs?

Documentation is still needed, as this is a completely new crate.

## ⚠️ Known issues

Currently `append-vec` has no `std` option and uses spinlock either way, one could remove the spinlock and replace it with a fully blown `Mutex` on `std`, tho benchmarks have shown that due to speed of push, impact due to spinning is small.

## 🐾 Next steps

* Documentation
* Tests
* Infrastructure (CI)

> The commits are cherry-picked from #1396 via `git format-patch -k --stdout bm/deer/error-visitor...bm/deer/error-hooks -- append-vec | git am -3 -k`
> See https://stackoverflow.com/a/63745988/9077988 for more information.

## 📹 Demo

Coming Soon™
