### PR TITLE
Bump toolchains for `error-stack` and `deer`

### DIFF
--- a/packages/libs/deer/rust-toolchain.toml
+++ b/packages/libs/deer/rust-toolchain.toml
@@ -1,4 +1,3 @@
 [toolchain]
-# Please also update the badges in `README.md`, `src/lib.rs`, and `macros/` when changing this
-channel = "nightly-2022-09-27"
+channel = "nightly-2022-11-14"
 components = ['rust-src', 'clippy', 'rustfmt']

--- a/packages/libs/error-stack/README.md
+++ b/packages/libs/error-stack/README.md
@@ -8,7 +8,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/error-stack)][crates.io]
 [![libs.rs](https://img.shields.io/badge/libs.rs-error--stack-orange)][libs.rs]
-[![rust-version](https://img.shields.io/badge/Rust-1.63.0/nightly--2022--11--02-blue)][rust-version]
+[![rust-version](https://img.shields.io/badge/Rust-1.63.0/nightly--2022--11--14-blue)][rust-version]
 [![documentation](https://img.shields.io/docsrs/error-stack)][documentation]
 [![license](https://img.shields.io/crates/l/error-stack)][license]
 [![discord](https://img.shields.io/discord/840573247803097118)][discord]

--- a/packages/libs/error-stack/macros/rust-toolchain.toml
+++ b/packages/libs/error-stack/macros/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2022-11-02"
+channel = "nightly-2022-11-14"

--- a/packages/libs/error-stack/rust-toolchain.toml
+++ b/packages/libs/error-stack/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # Please also update the badges in `README.md`, `src/lib.rs`, and `macros/`
-channel = "nightly-2022-11-02"
+channel = "nightly-2022-11-14"
 components = ['rust-src', 'miri', 'clippy', 'rustfmt']

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! [![crates.io](https://img.shields.io/crates/v/error-stack)][crates.io]
 //! [![libs.rs](https://img.shields.io/badge/libs.rs-error--stack-orange)][libs.rs]
-//! [![rust-version](https://img.shields.io/badge/Rust-1.63.0/nightly--2022--11--02-blue)][rust-version]
+//! [![rust-version](https://img.shields.io/badge/Rust-1.63.0/nightly--2022--11--14-blue)][rust-version]
 //! [![discord](https://img.shields.io/discord/840573247803097118)][discord]
 //!
 //! [crates.io]: https://crates.io/crates/error-stack


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The new toolchain does not have `llvm-tools-preview` anymore. In order to allow reusing tools across projects in the future, all projects using `llvm-tools` should have at least a toolchain version with `llvm-tools` available.

## 🔗 Related links

- https://github.com/hashintel/hash/pull/1395#discussion_r1022858410