### PR TITLE
Require Rust setup job to pass in order to merge a PR

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -322,6 +322,9 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      - name: check setup
+        run: |
+          [[ ${{ needs.setup.result }} = success ]]
       - name: check lint
         run: |
           [[ ${{ needs.lint.result }} =~ success|skipped ]]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When the Rust setup-job is failing (e.g. by a spurious http error or a malformed file), the `merging-enabled` job will be green.