### PR TITLE
Bump toolchain to 2022-11-14 (`main`)

### DIFF
--- a/packages/graph/hash_graph/rust-toolchain.toml
+++ b/packages/graph/hash_graph/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-09-27"
+channel = "nightly-2022-11-14"
 components = ['rust-src', 'clippy', 'rustfmt']


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The same as https://github.com/hashintel/hash/pull/1395, but targeting the main branch