### PR TITLE
Use outer joins when joining on nullable columns

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -575,7 +575,7 @@ mod tests {
             r#"
             SELECT *
             FROM "entities"
-            INNER JOIN "entities" AS "entities_0_0_0"
+            LEFT OUTER JOIN "entities" AS "entities_0_0_0"
               ON "entities_0_0_0"."left_entity_uuid" = "entities"."entity_uuid"
             WHERE "entities_0_0_0"."right_entity_uuid" IS NULL
             "#,
@@ -604,9 +604,9 @@ mod tests {
             r#"
             SELECT *
             FROM "entities"
-            INNER JOIN "entities" AS "entities_0_0_0"
+            LEFT OUTER JOIN "entities" AS "entities_0_0_0"
               ON "entities_0_0_0"."right_entity_uuid" = "entities"."entity_uuid"
-            INNER JOIN "entities" AS "entities_0_1_0"
+            RIGHT OUTER JOIN "entities" AS "entities_0_1_0"
               ON "entities_0_1_0"."entity_uuid" = "entities_0_0_0"."left_entity_uuid"
             WHERE "entities_0_1_0"."latest_version" = TRUE
             "#,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
@@ -88,6 +88,18 @@ macro_rules! impl_ontology_column {
                 Schema(Option<JsonField<'static>>),
             }
 
+            impl $name {
+                pub const fn nullable(self) -> bool {
+                    match self {
+                        Self::VersionId
+                        | Self::OwnedById
+                        | Self::CreatedById
+                        | Self::UpdatedById => false,
+                        Self::Schema(_) => true,
+                    }
+                }
+            }
+
             impl Transpile for $name {
                 fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
                     let column = match self {
@@ -136,6 +148,28 @@ pub enum Entities<'p> {
     RightEntityUuid,
     LeftEntityOwnedById,
     RightEntityOwnedById,
+}
+
+impl Entities<'_> {
+    pub const fn nullable(self) -> bool {
+        match self {
+            Self::EntityUuid
+            | Self::Version
+            | Self::LatestVersion
+            | Self::Archived
+            | Self::OwnedById
+            | Self::CreatedById
+            | Self::UpdatedById
+            | Self::EntityTypeVersionId
+            | Self::LeftOrder
+            | Self::RightOrder => false,
+            Self::Properties(_)
+            | Self::LeftEntityUuid
+            | Self::RightEntityUuid
+            | Self::LeftEntityOwnedById
+            | Self::RightEntityOwnedById => true,
+        }
+    }
 }
 
 impl Transpile for Entities<'_> {
@@ -261,6 +295,16 @@ impl<'p> Column<'p> {
             }
             Self::EntityTypePropertyTypeReferences(_) => Table::EntityTypePropertyTypeReferences,
             Self::EntityTypeEntityTypeReferences(_) => Table::EntityTypeEntityTypeReferences,
+        }
+    }
+
+    pub const fn nullable(self) -> bool {
+        match self {
+            Self::DataTypes(column) => column.nullable(),
+            Self::PropertyTypes(column) => column.nullable(),
+            Self::EntityTypes(column) => column.nullable(),
+            Self::Entities(column) => column.nullable(),
+            _ => false,
         }
     }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
@@ -160,14 +160,14 @@ impl Entities<'_> {
             | Self::OwnedById
             | Self::CreatedById
             | Self::UpdatedById
-            | Self::EntityTypeVersionId
-            | Self::LeftOrder
-            | Self::RightOrder => false,
+            | Self::EntityTypeVersionId => false,
             Self::Properties(_)
             | Self::LeftEntityUuid
             | Self::RightEntityUuid
             | Self::LeftEntityOwnedById
-            | Self::RightEntityOwnedById => true,
+            | Self::RightEntityOwnedById
+            | Self::LeftOrder
+            | Self::RightOrder => true,
         }
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Inner joins with the column being joined is `NULL`, the result is empty. This is fine for the majority of cases as the result of the query is expected to be empty, but this is not the case for more compilcated queries like "Give me entities which either has the left entity being bar **or** the name property being baz".

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202805690238892/1203324626226299/f) _(internal)_
- https://github.com/hashintel/hash/pull/1387#discussion_r1020401037

## 🚫 Blocked by

- #1407

## 🔍 What does this change?

- Add a `nullable()` method to `Column`
- Decide on join type depending on `nullable()` return value