### PR TITLE
Replace custom `ProsemirrorNode` type with standard `Node`

### DIFF
--- a/libs/javascript/@local/eslint-config/legacy-base-eslintrc-to-refactor.cjs
+++ b/libs/javascript/@local/eslint-config/legacy-base-eslintrc-to-refactor.cjs
@@ -136,11 +136,6 @@ module.exports = {
             message: "Please use ./src/tests/testUtils.tsx#render instead",
           },
           {
-            name: "prosemirror-model",
-            importNames: ["Node"],
-            message: "Please import ProsemirrorNode instead",
-          },
-          {
             name: "@mui/material",
             importNames: ["Link"],
             message:

--- a/packages/hash/frontend/src/blocks/page/BlockView.tsx
+++ b/packages/hash/frontend/src/blocks/page/BlockView.tsx
@@ -10,7 +10,7 @@ import {
 } from "@hashintel/hash-shared/prosemirror";
 import { HashBlockMeta } from "@hashintel/hash-shared/blocks";
 import { ProsemirrorManager } from "@hashintel/hash-shared/ProsemirrorManager";
-import { ProsemirrorNode } from "prosemirror-model";
+import { Node } from "prosemirror-model";
 import { NodeSelection, TextSelection } from "prosemirror-state";
 import { EditorView, NodeView } from "prosemirror-view";
 import { createRef } from "react";
@@ -51,7 +51,7 @@ export class BlockView implements NodeView {
   private store: EntityStore;
   private unsubscribe: Function;
 
-  getBlockEntityIdFromNode = (node: ProsemirrorNode) => {
+  getBlockEntityIdFromNode = (node: Node) => {
     const blockEntityNode = node.firstChild;
 
     if (!blockEntityNode || !isEntityNode(blockEntityNode)) {
@@ -85,7 +85,7 @@ export class BlockView implements NodeView {
   };
 
   constructor(
-    public node: ProsemirrorNode,
+    public node: Node,
     public editorView: EditorView,
     public getPos: () => number,
     public renderPortal: RenderPortal,
@@ -161,7 +161,7 @@ export class BlockView implements NodeView {
      * they're handled by React
      */
     return (
-      this.blockHandleRef.current?.contains(evt.target as Node) ||
+      this.blockHandleRef.current?.contains(evt.target as globalThis.Node) ||
       (evt.target === this.blockHandleRef.current && evt.type === "mousedown")
     );
   }
@@ -191,7 +191,7 @@ export class BlockView implements NodeView {
     return false;
   }
 
-  update(blockNode: ProsemirrorNode) {
+  update(blockNode: Node) {
     if (blockNode.type.name !== "block") {
       return false;
     }

--- a/packages/hash/frontend/src/blocks/page/ComponentView.tsx
+++ b/packages/hash/frontend/src/blocks/page/ComponentView.tsx
@@ -22,7 +22,7 @@ import {
 import { ProsemirrorManager } from "@hashintel/hash-shared/ProsemirrorManager";
 import { textBlockNodeToEntityProperties } from "@hashintel/hash-shared/text";
 import * as Sentry from "@sentry/nextjs";
-import { ProsemirrorNode } from "prosemirror-model";
+import { Node } from "prosemirror-model";
 import { TextSelection, Transaction } from "prosemirror-state";
 import { EditorView, NodeView } from "prosemirror-view";
 import { BlockLoader } from "../../components/BlockLoader/BlockLoader";
@@ -88,7 +88,7 @@ export class ComponentView implements NodeView {
   private wasSuggested = false;
 
   constructor(
-    private node: ProsemirrorNode,
+    private node: Node,
     private readonly editorView: EditorView,
     private readonly getPos: () => number | undefined,
     private readonly renderPortal: RenderPortal,
@@ -137,7 +137,7 @@ export class ComponentView implements NodeView {
     this.update(this.node);
   }
 
-  update(node: ProsemirrorNode) {
+  update(node: Node) {
     this.node = node;
 
     /**

--- a/packages/hash/frontend/src/blocks/page/LoadingView.tsx
+++ b/packages/hash/frontend/src/blocks/page/LoadingView.tsx
@@ -1,5 +1,5 @@
 import { Box } from "@mui/material";
-import { ProsemirrorNode } from "prosemirror-model";
+import { Node } from "prosemirror-model";
 import { NodeView } from "prosemirror-view";
 import { BlockLoadingIndicator } from "../../components/RemoteBlock/RemoteBlock";
 
@@ -27,12 +27,12 @@ export const ProsemirrorLoadingState = () => {
 export class LoadingView implements NodeView {
   dom: HTMLDivElement;
 
-  constructor(node: ProsemirrorNode, private renderPortal: RenderPortal) {
+  constructor(node: Node, private renderPortal: RenderPortal) {
     this.dom = document.createElement("div");
     this.update(node);
   }
 
-  update(node: ProsemirrorNode) {
+  update(node: Node) {
     if (node.type.name !== "loading") {
       return false;
     }

--- a/packages/hash/frontend/src/blocks/page/MentionView/MentionNodeView.ts
+++ b/packages/hash/frontend/src/blocks/page/MentionView/MentionNodeView.ts
@@ -1,15 +1,11 @@
-import { ProsemirrorNode } from "prosemirror-model";
+import { Node } from "prosemirror-model";
 import { EditorView } from "prosemirror-view";
 import { RenderPortal } from "../usePortals";
 import { MentionView } from "./MentionView";
 
 export const mentionNodeView =
   (renderPortal: RenderPortal, accountId: string) =>
-  (
-    currentNode: ProsemirrorNode,
-    currentView: EditorView,
-    getPos: () => number,
-  ) => {
+  (currentNode: Node, currentView: EditorView, getPos: () => number) => {
     if (typeof getPos === "boolean") {
       throw new Error("Invalid config for nodeview");
     }

--- a/packages/hash/frontend/src/blocks/page/MentionView/MentionView.tsx
+++ b/packages/hash/frontend/src/blocks/page/MentionView/MentionView.tsx
@@ -1,4 +1,4 @@
-import { ProsemirrorNode } from "prosemirror-model";
+import { Node } from "prosemirror-model";
 import { EditorView, NodeView } from "prosemirror-view";
 import { RenderPortal } from "../usePortals";
 import { MentionDisplay } from "./MentionDisplay";
@@ -7,7 +7,7 @@ export class MentionView implements NodeView {
   dom: HTMLSpanElement;
 
   constructor(
-    public node: ProsemirrorNode,
+    public node: Node,
     public view: EditorView,
     public getPos: () => number,
     public renderPortal: RenderPortal,
@@ -19,7 +19,7 @@ export class MentionView implements NodeView {
     this.update(node);
   }
 
-  update(node: ProsemirrorNode) {
+  update(node: Node) {
     if (node.type.name !== "mention") {
       return false;
     }

--- a/packages/hash/frontend/src/blocks/page/clipboardTextSerializer.ts
+++ b/packages/hash/frontend/src/blocks/page/clipboardTextSerializer.ts
@@ -1,4 +1,4 @@
-import { NodeType, ProsemirrorNode, Slice } from "prosemirror-model";
+import { NodeType, Node, Slice } from "prosemirror-model";
 
 // /**
 //  * Prosemirror doesn't know to convert hard breaks into new line characters
@@ -15,7 +15,7 @@ export const clipboardTextSerializer =
       0,
       slice.content.size,
       "\n\n",
-      (node: ProsemirrorNode) => {
+      (node: Node) => {
         if (node.type === lineBreakNodetype) {
           return "\n";
         }

--- a/packages/hash/frontend/src/blocks/page/collab/EditorConnection.ts
+++ b/packages/hash/frontend/src/blocks/page/collab/EditorConnection.ts
@@ -15,7 +15,7 @@ import {
 import { ProsemirrorManager } from "@hashintel/hash-shared/ProsemirrorManager";
 import { isString } from "lodash";
 import { collab, receiveTransaction, sendableSteps } from "prosemirror-collab";
-import { ProsemirrorNode, Schema } from "prosemirror-model";
+import { Node, Schema } from "prosemirror-model";
 import { EditorState, Plugin, Transaction } from "prosemirror-state";
 import { Step } from "prosemirror-transform";
 import { EditorView } from "prosemirror-view";
@@ -47,7 +47,7 @@ class State {
 type EditorConnectionAction =
   | {
       type: "loaded";
-      doc: ProsemirrorNode;
+      doc: Node;
       store: EntityStore;
       version: number;
     }

--- a/packages/hash/frontend/src/blocks/page/createFormatPlugins/util.ts
+++ b/packages/hash/frontend/src/blocks/page/createFormatPlugins/util.ts
@@ -1,6 +1,6 @@
 import { isComponentNode } from "@hashintel/hash-shared/prosemirror";
 import { InputRule } from "prosemirror-inputrules";
-import { ProsemirrorNode, Mark } from "prosemirror-model";
+import { Node, Mark } from "prosemirror-model";
 import { EditorState, TextSelection } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import urlRegexSafe from "url-regex-safe";
@@ -39,18 +39,16 @@ export function isValidLink(text: string) {
 
 export function getActiveMarksWithAttrs(editorState: EditorState) {
   const activeMarks: { name: string; attrs?: Record<string, string> }[] = [];
-  editorState.selection
-    .content()
-    .content.descendants((node: ProsemirrorNode) => {
-      for (const mark of node.marks) {
-        activeMarks.push({
-          name: mark.type.name,
-          attrs: mark.attrs,
-        });
-      }
+  editorState.selection.content().content.descendants((node: Node) => {
+    for (const mark of node.marks) {
+      activeMarks.push({
+        name: mark.type.name,
+        attrs: mark.attrs,
+      });
+    }
 
-      return true;
-    });
+    return true;
+  });
 
   return activeMarks;
 }
@@ -96,8 +94,8 @@ export function removeLink(editorView: EditorView) {
 
     // For empty selection
     if ($cursor) {
-      const nodesBefore: [number, ProsemirrorNode][] = [];
-      const nodesAfter: [number, ProsemirrorNode][] = [];
+      const nodesBefore: [number, Node][] = [];
+      const nodesAfter: [number, Node][] = [];
 
       // Get sibling nodes to the left/right of the cursor
       $cursor.parent.nodesBetween(0, $cursor.parentOffset, (node, pos) => {

--- a/packages/hash/shared/src/ProsemirrorManager.ts
+++ b/packages/hash/shared/src/ProsemirrorManager.ts
@@ -1,5 +1,5 @@
 import { BlockVariant, JsonObject } from "@blockprotocol/core";
-import { ProsemirrorNode, Schema } from "prosemirror-model";
+import { Node, Schema } from "prosemirror-model";
 import { EditorState, Transaction } from "prosemirror-state";
 import { EditorProps, EditorView } from "prosemirror-view";
 
@@ -239,7 +239,7 @@ export class ProsemirrorManager {
     draftBlockId: string,
     targetComponentId: string,
     targetVariant: BlockVariant,
-    node: ProsemirrorNode,
+    node: Node,
     pos: number,
   ) {
     const { view } = this;
@@ -262,7 +262,7 @@ export class ProsemirrorManager {
   /**
    * @todo consider removing the old block from the entity store
    */
-  async deleteNode(node: ProsemirrorNode, pos: number) {
+  async deleteNode(node: Node, pos: number) {
     const { view } = this;
 
     if (!view) {

--- a/packages/hash/shared/src/createProseMirrorState.ts
+++ b/packages/hash/shared/src/createProseMirrorState.ts
@@ -1,7 +1,7 @@
 import { cloneDeep } from "lodash";
 import { baseKeymap } from "prosemirror-commands";
 import { dropCursor } from "prosemirror-dropcursor";
-import { ProsemirrorNode, Schema } from "prosemirror-model";
+import { Node, Schema } from "prosemirror-model";
 import { EditorState, Plugin } from "prosemirror-state";
 import { createEntityStorePlugin } from "./entityStorePlugin";
 import {
@@ -35,7 +35,7 @@ export const createProseMirrorState = ({
   plugins = [],
 }: {
   accountId: string;
-  doc?: ProsemirrorNode;
+  doc?: Node;
   plugins?: Plugin<unknown>[];
 }) => {
   return EditorState.create({

--- a/packages/hash/shared/src/entityStorePlugin.ts
+++ b/packages/hash/shared/src/entityStorePlugin.ts
@@ -1,6 +1,6 @@
 import { Draft, produce } from "immer";
 import { isEqual } from "lodash";
-import { ProsemirrorNode } from "prosemirror-model";
+import { Node } from "prosemirror-model";
 import { EditorState, Plugin, PluginKey, Transaction } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import { v4 as uuid } from "uuid";
@@ -446,7 +446,7 @@ class ProsemirrorStateChangeHandler {
     return this.tr;
   }
 
-  private handleNode(node: ProsemirrorNode, pos: number) {
+  private handleNode(node: Node, pos: number) {
     if (isComponentNode(node)) {
       this.componentNode(node, pos);
     }

--- a/packages/hash/shared/src/prosemirror.ts
+++ b/packages/hash/shared/src/prosemirror.ts
@@ -1,9 +1,9 @@
 import { toggleMark } from "prosemirror-commands";
-import { NodeSpec, NodeType, ProsemirrorNode, Schema } from "prosemirror-model";
+import { NodeSpec, NodeType, Node, Schema } from "prosemirror-model";
 import { keymap } from "prosemirror-keymap";
 import { paragraphBlockComponentId } from "./blocks";
 
-type NodeWithAttrs<Attrs extends {}> = Omit<ProsemirrorNode, "attrs"> & {
+type NodeWithAttrs<Attrs extends {}> = Omit<Node, "attrs"> & {
   attrs: Attrs;
 };
 
@@ -19,9 +19,8 @@ export type NodeSpecs = {
   [name: string]: NodeSpec;
 };
 
-export const isEntityNode = (
-  node: ProsemirrorNode | null,
-): node is EntityNode => !!node && node.type === node.type.schema.nodes.entity;
+export const isEntityNode = (node: Node | null): node is EntityNode =>
+  !!node && node.type === node.type.schema.nodes.entity;
 
 export const componentNodeGroupName = "componentNode";
 
@@ -234,12 +233,10 @@ export const createSchema = (nodes: NodeSpecs) =>
 export const isComponentNodeType = (nodeType: NodeType) =>
   nodeType.groups?.includes(componentNodeGroupName) ?? false;
 
-export const isComponentNode = (node: ProsemirrorNode): node is ComponentNode =>
+export const isComponentNode = (node: Node): node is ComponentNode =>
   isComponentNodeType(node.type);
 
-export const findComponentNodes = (
-  containingNode: ProsemirrorNode,
-): ComponentNode[] => {
+export const findComponentNodes = (containingNode: Node): ComponentNode[] => {
   const componentNodes: ComponentNode[] = [];
 
   containingNode.descendants((node) => {
@@ -254,7 +251,7 @@ export const findComponentNodes = (
 };
 
 export const findComponentNode = (
-  containingNode: ProsemirrorNode,
+  containingNode: Node,
   containingNodePosition: number,
 ): [ComponentNode, number] | null => {
   let result: [ComponentNode, number] | null = null;
@@ -355,7 +352,7 @@ export const mutateSchema = (
   })(schema.spec);
 };
 
-export const isParagraphNode = (node: ProsemirrorNode) => {
+export const isParagraphNode = (node: Node) => {
   return componentNodeToId(node) === paragraphBlockComponentId;
 };
 

--- a/packages/hash/shared/src/save.ts
+++ b/packages/hash/shared/src/save.ts
@@ -1,6 +1,6 @@
 import { ApolloClient } from "@apollo/client";
 import { isEqual } from "lodash";
-import { ProsemirrorNode } from "prosemirror-model";
+import { Node } from "prosemirror-model";
 import { v4 as uuid } from "uuid";
 
 import { BlockEntity, isDraftTextEntity } from "./entity";
@@ -42,7 +42,7 @@ const calculateSaveActions = async (
   ownedById: string,
   textEntityTypeId: string,
   blocks: BlockEntity[],
-  doc: ProsemirrorNode,
+  doc: Node,
   getEntityTypeForComponent: (
     componentId: string,
   ) => Promise<EntityTypeForComponentResult>,
@@ -380,7 +380,7 @@ export const save = async (
   apolloClient: ApolloClient<unknown>,
   ownedById: string,
   pageEntityId: string,
-  doc: ProsemirrorNode,
+  doc: Node,
   store: EntityStore,
 ) => {
   const blocks = await apolloClient

--- a/packages/hash/shared/src/text.ts
+++ b/packages/hash/shared/src/text.ts
@@ -1,4 +1,4 @@
-import { ProsemirrorNode, Schema } from "prosemirror-model";
+import { Node, Schema } from "prosemirror-model";
 import { ComponentNode } from "./prosemirror";
 import { TextToken } from "./graphql/types";
 import { TextEntityType, TextProperties } from "./entity";
@@ -7,7 +7,7 @@ import { TEXT_TOKEN_PROPERTY_TYPE_BASE_URI } from "./entityStore";
 export const textBlockNodesFromTokens = (
   tokens: TextToken[],
   schema: Schema,
-): ProsemirrorNode[] =>
+): Node[] =>
   // eslint-disable-next-line array-callback-return -- TODO: disable the rule because it’s not aware of TS
   tokens.map((token) => {
     switch (token.tokenType) {
@@ -41,7 +41,7 @@ export const textBlockNodesFromTokens = (
 export const childrenForTextEntity = (
   entity: Pick<TextEntityType, "properties">,
   schema: Schema,
-): ProsemirrorNode[] =>
+): Node[] =>
   textBlockNodesFromTokens(
     entity.properties[TEXT_TOKEN_PROPERTY_TYPE_BASE_URI] ?? [],
     schema,

--- a/packages/hash/shared/src/wrapEntitiesPlugin.ts
+++ b/packages/hash/shared/src/wrapEntitiesPlugin.ts
@@ -9,17 +9,17 @@ import {
   Transaction,
 } from "prosemirror-state";
 import { keymap } from "prosemirror-keymap";
-import { ProsemirrorNode } from "prosemirror-model";
+import { Node } from "prosemirror-model";
 import { Mapping } from "prosemirror-transform";
 import { getBlockChildEntity, isTextEntity } from "./entity";
 import { isComponentNode, isEntityNode } from "./prosemirror";
 
-type WrapperNodes = [number, ProsemirrorNode[]];
+type WrapperNodes = [number, Node[]];
 type WrapperNodesList = WrapperNodes[];
 
 const getRangeForNodeAtMappedPosition = (
   pos: number,
-  node: ProsemirrorNode,
+  node: Node,
   tr: Transaction,
 ) => {
   const $start = tr.doc.resolve(tr.mapping.map(pos));
@@ -185,7 +185,7 @@ const prepareCommandForWrappedEntities =
               throw new Error("Cannot unwrap");
             }
 
-            const wrapperNodes: ProsemirrorNode[] = [];
+            const wrapperNodes: Node[] = [];
             const $originalStart = state.doc.resolve(pos);
 
             for (let depth = $originalStart.depth; depth > 0; depth--) {

--- a/patches/prosemirror-model+1.18.2.patch
+++ b/patches/prosemirror-model+1.18.2.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/prosemirror-model/dist/index.d.ts b/node_modules/prosemirror-model/dist/index.d.ts
-index 196ade9..de6ee69 100644
+index 196ade9..31ef008 100644
 --- a/node_modules/prosemirror-model/dist/index.d.ts
 +++ b/node_modules/prosemirror-model/dist/index.d.ts
 @@ -741,6 +741,10 @@ declare class NodeType {
@@ -13,15 +13,3 @@ index 196ade9..de6ee69 100644
      /**
      The node type's [whitespace](https://prosemirror.net/docs/ref/#model.NodeSpec.whitespace) option.
      */
-@@ -1617,3 +1621,11 @@ declare class Node {
- }
- 
- export { AttributeSpec, Attrs, ContentMatch, DOMOutputSpec, DOMParser, DOMSerializer, Fragment, Mark, MarkSpec, MarkType, Node, NodeRange, NodeSpec, NodeType, ParseOptions, ParseRule, ReplaceError, ResolvedPos, Schema, SchemaSpec, Slice };
-+/**
-+ * The term Node is ambiguous which means we can't enforce the use of the Schema
-+ * generic argument via eslint. To work around that, we disallow the direct
-+ * import of Node from prosemirror-model and enforce the use of this
-+ * ProsemirrorNode alias via eslint which allows to then enforce the use of the
-+ * Schema generic argument.
-+ */
-+export { Node as ProsemirrorNode };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We’ve been using

```js
import { ProsemirrorNode } from "prosemirror-model";
```

instead of

```js
import { Node } from "prosemirror-model";
```

since https://github.com/hashintel/hash/pull/202. This has allowed us to introduce an ESLint rule that requires a generic argument:

```js
❌ ProsemirrorNode // Please provide a generic to avoid implicit `any`

✅ ProsemirrorNode<Schema>
```

Keeping the original type name would trigger false-positive errors for DOM `Node` type.

With ProseMirror typings updated in #1359, `ProsemirrorNode` is no longer generic. We’ve removed custom linting rules and no longer benefit from a customised type name. Replacing `ProsemirrorNode` back to `Node` reduces the patch for `prosemirror-model` and also makes our codebase more aligned with ProseMirror standards.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201095311341924/1203216920361646/f) _(internal)_

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

Global `Node` type from DOM may get shadowed by `Node` from `prosemirror-model`. If the original type needs to be referred, we can use `globalThis.Node`.

## 🐾 Next steps

- Configure automatic dependency updates for ProseMirror
