### PR TITLE
Make `alias` non-optional in `AliasedTable` and `AliasedColumn`

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
@@ -132,7 +132,7 @@ mod tests {
                 Some(FilterExpression::Path(DataTypeQueryPath::Description)),
                 None,
             ),
-            r#""data_types"."schema"->>'description' IS NULL"#,
+            r#""data_types_0_0_0"."schema"->>'description' IS NULL"#,
             &[],
         );
 
@@ -141,7 +141,7 @@ mod tests {
                 None,
                 Some(FilterExpression::Path(DataTypeQueryPath::Description)),
             ),
-            r#""data_types"."schema"->>'description' IS NULL"#,
+            r#""data_types_0_0_0"."schema"->>'description' IS NULL"#,
             &[],
         );
 
@@ -152,7 +152,7 @@ mod tests {
                 Some(FilterExpression::Path(DataTypeQueryPath::Description)),
                 None,
             ),
-            r#""data_types"."schema"->>'description' IS NOT NULL"#,
+            r#""data_types_0_0_0"."schema"->>'description' IS NOT NULL"#,
             &[],
         );
 
@@ -161,7 +161,7 @@ mod tests {
                 None,
                 Some(FilterExpression::Path(DataTypeQueryPath::Description)),
             ),
-            r#""data_types"."schema"->>'description' IS NOT NULL"#,
+            r#""data_types_0_0_0"."schema"->>'description' IS NOT NULL"#,
             &[],
         );
 
@@ -177,7 +177,7 @@ mod tests {
                     "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
                 )))),
             )]),
-            r#"("data_types"."schema"->>'$id' = $1)"#,
+            r#"("data_types_0_0_0"."schema"->>'$id' = $1)"#,
             &[&"https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"],
         );
 
@@ -194,7 +194,7 @@ mod tests {
                     Some(FilterExpression::Parameter(Parameter::Number(1.0))),
                 ),
             ]),
-            r#"("type_ids_0_0_0"."base_uri" = $1) AND ("type_ids_0_0_0"."version" = $2)"#,
+            r#"("type_ids_0_1_0"."base_uri" = $1) AND ("type_ids_0_1_0"."version" = $2)"#,
             &[
                 &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
                 &1.0,
@@ -211,7 +211,7 @@ mod tests {
                     "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
                 )))),
             )]),
-            r#"("data_types"."schema"->>'$id' = $1)"#,
+            r#"("data_types_0_0_0"."schema"->>'$id' = $1)"#,
             &[&"https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"],
         );
 
@@ -228,7 +228,7 @@ mod tests {
                     Some(FilterExpression::Parameter(Parameter::Number(1.0))),
                 ),
             ]),
-            r#"(("type_ids_0_0_0"."base_uri" = $1) OR ("type_ids_0_0_0"."version" = $2))"#,
+            r#"(("type_ids_0_1_0"."base_uri" = $1) OR ("type_ids_0_1_0"."version" = $2))"#,
             &[
                 &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
                 &1.0,
@@ -245,7 +245,7 @@ mod tests {
                     "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
                 )))),
             ))),
-            r#"NOT("data_types"."schema"->>'$id' = $1)"#,
+            r#"NOT("data_types_0_0_0"."schema"->>'$id' = $1)"#,
             &[&"https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"],
         );
     }
@@ -257,7 +257,7 @@ mod tests {
                 Some(FilterExpression::Path(DataTypeQueryPath::Description)),
                 Some(FilterExpression::Path(DataTypeQueryPath::Title)),
             )]),
-            r#"("data_types"."schema"->>'description' = "data_types"."schema"->>'title')"#,
+            r#"("data_types_0_0_0"."schema"->>'description' = "data_types_0_0_0"."schema"->>'title')"#,
             &[],
         );
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/conditional.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/conditional.rs
@@ -84,14 +84,14 @@ mod tests {
     use super::*;
     use crate::{
         ontology::DataTypeQueryPath,
-        store::postgres::query::{test_helper::max_version_expression, Path},
+        store::postgres::query::{test_helper::max_version_expression, Alias, Path},
     };
 
     #[test]
     fn transpile_window_expression() {
         assert_eq!(
             max_version_expression().transpile_to_string(),
-            r#"MAX("type_ids"."version") OVER (PARTITION BY "type_ids"."base_uri")"#
+            r#"MAX("type_ids_0_0_0"."version") OVER (PARTITION BY "type_ids_0_0_0"."base_uri")"#
         );
     }
 
@@ -101,10 +101,14 @@ mod tests {
             Expression::Function(Box::new(Function::Min(Expression::Column(
                 DataTypeQueryPath::Version
                     .terminating_column()
-                    .aliased(None)
+                    .aliased(Alias {
+                        condition_index: 1,
+                        chain_depth: 2,
+                        number: 3
+                    })
             ))))
             .transpile_to_string(),
-            r#"MIN("type_ids"."version")"#
+            r#"MIN("type_ids_1_2_3"."version")"#
         );
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
@@ -23,12 +23,10 @@ impl Transpile for JoinExpression<'_> {
             (false, true) => write!(fmt, "RIGHT OUTER JOIN ")?,
             (true, true) => write!(fmt, "FULL OUTER JOIN ")?,
         };
-
-        if self.join.alias.is_some() {
-            self.join.column.table().transpile(fmt)?;
-            fmt.write_str(" AS ")?;
-        }
-        self.join.table().transpile(fmt)?;
+        let table = self.join.table();
+        table.table.transpile(fmt)?;
+        fmt.write_str(" AS ")?;
+        table.transpile(fmt)?;
 
         fmt.write_str(" ON ")?;
         self.join.transpile(fmt)?;
@@ -41,7 +39,7 @@ impl Transpile for JoinExpression<'_> {
 mod tests {
     use super::*;
     use crate::store::postgres::query::{
-        table::{Column, DataTypes, Entities, TypeIds},
+        table::{Column, DataTypes, TypeIds},
         Alias,
     };
 
@@ -49,24 +47,19 @@ mod tests {
     fn transpile_join_expression() {
         assert_eq!(
             JoinExpression::new(
-                Column::TypeIds(TypeIds::VersionId).aliased(None),
-                Column::DataTypes(DataTypes::VersionId).aliased(None),
-            )
-            .transpile_to_string(),
-            r#"INNER JOIN "type_ids" ON "type_ids"."version_id" = "data_types"."version_id""#
-        );
-
-        assert_eq!(
-            JoinExpression::new(
-                Column::Entities(Entities::LeftEntityUuid).aliased(Alias {
+                Column::TypeIds(TypeIds::VersionId).aliased(Alias {
                     condition_index: 0,
                     chain_depth: 1,
                     number: 2,
                 }),
-                Column::Entities(Entities::EntityUuid).aliased(None),
+                Column::DataTypes(DataTypes::VersionId).aliased(Alias {
+                    condition_index: 1,
+                    chain_depth: 2,
+                    number: 3,
+                }),
             )
             .transpile_to_string(),
-            r#"LEFT OUTER JOIN "entities" AS "entities_0_1_2" ON "entities_0_1_2"."left_entity_uuid" = "entities"."entity_uuid""#
+            r#"INNER JOIN "type_ids" AS "type_ids_0_1_2" ON "type_ids_0_1_2"."version_id" = "data_types_1_2_3"."version_id""#
         );
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/order_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/order_clause.rs
@@ -50,7 +50,7 @@ mod tests {
     use super::*;
     use crate::{
         ontology::DataTypeQueryPath,
-        store::postgres::query::{test_helper::trim_whitespace, Path},
+        store::postgres::query::{test_helper::trim_whitespace, Alias, Path},
     };
 
     #[test]
@@ -59,12 +59,16 @@ mod tests {
         order_by_expression.push(
             DataTypeQueryPath::Version
                 .terminating_column()
-                .aliased(None),
+                .aliased(Alias {
+                    condition_index: 1,
+                    chain_depth: 2,
+                    number: 3,
+                }),
             Ordering::Ascending,
         );
         assert_eq!(
             order_by_expression.transpile_to_string(),
-            r#"ORDER BY "type_ids"."version" ASC"#
+            r#"ORDER BY "type_ids_1_2_3"."version" ASC"#
         );
     }
 
@@ -74,19 +78,27 @@ mod tests {
         order_by_expression.push(
             DataTypeQueryPath::BaseUri
                 .terminating_column()
-                .aliased(None),
+                .aliased(Alias {
+                    condition_index: 1,
+                    chain_depth: 2,
+                    number: 3,
+                }),
             Ordering::Ascending,
         );
         order_by_expression.push(
-            DataTypeQueryPath::Type.terminating_column().aliased(None),
+            DataTypeQueryPath::Type.terminating_column().aliased(Alias {
+                condition_index: 4,
+                chain_depth: 5,
+                number: 6,
+            }),
             Ordering::Descending,
         );
 
         assert_eq!(
             trim_whitespace(order_by_expression.transpile_to_string()),
             trim_whitespace(
-                r#"ORDER BY "type_ids"."base_uri" ASC,
-                "data_types"."schema"->>'type' DESC"#
+                r#"ORDER BY "type_ids_1_2_3"."base_uri" ASC,
+                "data_types_4_5_6"."schema"->>'type' DESC"#
             )
         );
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/select_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/select_clause.rs
@@ -45,22 +45,30 @@ mod tests {
             SelectExpression::from_column(
                 DataTypeQueryPath::BaseUri
                     .terminating_column()
-                    .aliased(None),
-                None,
+                    .aliased(Alias {
+                        condition_index: 1,
+                        chain_depth: 2,
+                        number: 3,
+                    }),
+                None
             )
             .transpile_to_string(),
-            r#""type_ids"."base_uri""#
+            r#""type_ids_1_2_3"."base_uri""#
         );
 
         assert_eq!(
             SelectExpression::from_column(
                 DataTypeQueryPath::VersionedUri
                     .terminating_column()
-                    .aliased(None),
-                Some(Cow::Borrowed("versionedUri")),
+                    .aliased(Alias {
+                        condition_index: 1,
+                        chain_depth: 2,
+                        number: 3,
+                    }),
+                Some(Cow::Borrowed("versionedUri"))
             )
             .transpile_to_string(),
-            r#""data_types"."schema"->>'$id' AS "versionedUri""#
+            r#""data_types_1_2_3"."schema"->>'$id' AS "versionedUri""#
         );
 
         assert_eq!(
@@ -71,26 +79,26 @@ mod tests {
                             DataTypeQueryPath::Version
                                 .terminating_column()
                                 .aliased(Alias {
-                                    condition_index: 0,
-                                    chain_depth: 0,
-                                    number: 0,
-                                }),
+                                    condition_index: 1,
+                                    chain_depth: 2,
+                                    number: 3,
+                                })
                         )
                     )))),
                     WindowStatement::partition_by(
                         DataTypeQueryPath::BaseUri
                             .terminating_column()
                             .aliased(Alias {
-                                condition_index: 0,
-                                chain_depth: 0,
-                                number: 0,
+                                condition_index: 1,
+                                chain_depth: 2,
+                                number: 3,
                             })
-                    ),
+                    )
                 ),
-                Some(Cow::Borrowed("latest_version")),
+                Some(Cow::Borrowed("latest_version"))
             )
             .transpile_to_string(),
-            r#"MAX("type_ids_0_0_0"."version") OVER (PARTITION BY "type_ids_0_0_0"."base_uri") AS "latest_version""#
+            r#"MAX("type_ids_1_2_3"."version") OVER (PARTITION BY "type_ids_1_2_3"."base_uri") AS "latest_version""#
         );
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
@@ -70,7 +70,7 @@ mod tests {
 
         assert_eq!(
             where_clause.transpile_to_string(),
-            r#"WHERE "type_ids_0_0_0"."version" = "type_ids_0_0_0"."latest_version""#
+            r#"WHERE "type_ids_0_1_0"."version" = "type_ids_0_1_0"."latest_version""#
         );
 
         let filter_b = Filter::<DataType>::All(vec![
@@ -91,8 +91,8 @@ mod tests {
             trim_whitespace(where_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WHERE "type_ids_0_0_0"."version" = "type_ids_0_0_0"."latest_version"
-                  AND ("type_ids_0_0_0"."base_uri" = $1) AND ("type_ids_0_0_0"."version" = $2)"#
+                WHERE "type_ids_0_1_0"."version" = "type_ids_0_1_0"."latest_version"
+                  AND ("type_ids_0_1_0"."base_uri" = $1) AND ("type_ids_0_1_0"."version" = $2)"#
             )
         );
 
@@ -106,9 +106,9 @@ mod tests {
             trim_whitespace(where_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WHERE "type_ids_0_0_0"."version" = "type_ids_0_0_0"."latest_version"
-                  AND ("type_ids_0_0_0"."base_uri" = $1) AND ("type_ids_0_0_0"."version" = $2)
-                  AND "data_types"."schema"->>'description' IS NOT NULL"#
+                WHERE "type_ids_0_1_0"."version" = "type_ids_0_1_0"."latest_version"
+                  AND ("type_ids_0_1_0"."base_uri" = $1) AND ("type_ids_0_1_0"."version" = $2)
+                  AND "data_types_0_0_0"."schema"->>'description' IS NOT NULL"#
             )
         );
 
@@ -132,10 +132,10 @@ mod tests {
             trim_whitespace(where_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WHERE "type_ids_0_0_0"."version" = "type_ids_0_0_0"."latest_version"
-                  AND ("type_ids_0_0_0"."base_uri" = $1) AND ("type_ids_0_0_0"."version" = $2)
-                  AND "data_types"."schema"->>'description' IS NOT NULL
-                  AND (("data_types"."schema"->>'title' = $3) OR ("data_types"."schema"->>'description' = $4))"#
+                WHERE "type_ids_0_1_0"."version" = "type_ids_0_1_0"."latest_version"
+                  AND ("type_ids_0_1_0"."base_uri" = $1) AND ("type_ids_0_1_0"."version" = $2)
+                  AND "data_types_0_0_0"."schema"->>'description' IS NOT NULL
+                  AND (("data_types_0_0_0"."schema"->>'title' = $3) OR ("data_types_0_0_0"."schema"->>'description' = $4))"#
             )
         );
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/with_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/with_clause.rs
@@ -56,13 +56,10 @@ mod tests {
     use std::borrow::Cow;
 
     use super::*;
-    use crate::{
-        ontology::DataTypeQueryPath,
-        store::postgres::query::{
-            expression::OrderByExpression,
-            test_helper::{max_version_expression, trim_whitespace},
-            Expression, Path, SelectExpression, SelectStatement, Table, WhereExpression,
-        },
+    use crate::store::postgres::query::{
+        expression::OrderByExpression,
+        test_helper::{max_version_expression, trim_whitespace},
+        Alias, Expression, SelectExpression, SelectStatement, Table, WhereExpression,
     };
 
     #[test]
@@ -80,7 +77,11 @@ mod tests {
                     Some(Cow::Borrowed("latest_version")),
                 ),
             ],
-            from: DataTypeQueryPath::Version.terminating_column().table(),
+            from: Table::TypeIds.aliased(Alias {
+                condition_index: 0,
+                chain_depth: 0,
+                number: 0,
+            }),
             joins: vec![],
             where_expression: WhereExpression::default(),
             order_by_expression: OrderByExpression::default(),
@@ -90,7 +91,7 @@ mod tests {
             trim_whitespace(with_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WITH "type_ids" AS (SELECT *, MAX("type_ids"."version") OVER (PARTITION BY "type_ids"."base_uri") AS "latest_version" FROM "type_ids")"#
+                WITH "type_ids" AS (SELECT *, MAX("type_ids_0_0_0"."version") OVER (PARTITION BY "type_ids_0_0_0"."base_uri") AS "latest_version" FROM "type_ids" AS "type_ids_0_0_0")"#
             )
         );
 
@@ -98,7 +99,11 @@ mod tests {
             with: WithExpression::default(),
             distinct: Vec::new(),
             selects: vec![SelectExpression::new(Expression::Asterisk, None)],
-            from: Table::DataTypes,
+            from: Table::DataTypes.aliased(Alias {
+                condition_index: 3,
+                chain_depth: 4,
+                number: 5,
+            }),
             joins: vec![],
             where_expression: WhereExpression::default(),
             order_by_expression: OrderByExpression::default(),
@@ -108,8 +113,8 @@ mod tests {
             trim_whitespace(with_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WITH "type_ids" AS (SELECT *, MAX("type_ids"."version") OVER (PARTITION BY "type_ids"."base_uri") AS "latest_version" FROM "type_ids"),
-                     "data_types" AS (SELECT * FROM "data_types")"#
+                WITH "type_ids" AS (SELECT *, MAX("type_ids_0_0_0"."version") OVER (PARTITION BY "type_ids_0_0_0"."base_uri") AS "latest_version" FROM "type_ids" AS "type_ids_0_0_0"),
+                     "data_types" AS (SELECT * FROM "data_types" AS "data_types_3_4_5")"#
             )
         );
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
@@ -67,7 +67,7 @@ pub trait Transpile {
 mod test_helper {
     use crate::{
         ontology::DataTypeQueryPath,
-        store::postgres::query::{Expression, Function, Path, WindowStatement},
+        store::postgres::query::{Alias, Expression, Function, Path, WindowStatement},
     };
 
     pub fn trim_whitespace(string: impl Into<String>) -> String {
@@ -81,17 +81,21 @@ mod test_helper {
     pub fn max_version_expression() -> Expression<'static> {
         Expression::Window(
             Box::new(Expression::Function(Box::new(Function::Max(
-                Expression::Column(
-                    DataTypeQueryPath::Version
-                        .terminating_column()
-                        .aliased(None),
-                ),
+                Expression::Column(DataTypeQueryPath::Version.terminating_column().aliased(
+                    Alias {
+                        condition_index: 0,
+                        chain_depth: 0,
+                        number: 0,
+                    },
+                )),
             )))),
-            WindowStatement::partition_by(
-                DataTypeQueryPath::BaseUri
-                    .terminating_column()
-                    .aliased(None),
-            ),
+            WindowStatement::partition_by(DataTypeQueryPath::BaseUri.terminating_column().aliased(
+                Alias {
+                    condition_index: 0,
+                    chain_depth: 0,
+                    number: 0,
+                },
+            )),
         )
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

For further features, `AliasedColumns` without an alias (which is already a contradiction) needs to be treated specially when generating join expressions. Always requiring an alias makes this easier and less error-prone.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203271043333970/1203363980182352/f) _(internal)_

## 🔍 What does this change?

- Make `alias` non-optional in `AliasedTable` and `AliasedColumn`

## 🚫  Blockers

- #1407 

## ⚠️ Known issues

Using an alias in the tests is annoying but a fair trade-off for more robust code. This is the majority of the diff of this PR.