### PR TITLE
Add support for "links" queries in entity types

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/entity_type.rs
@@ -194,7 +194,7 @@ pub enum EntityTypeQueryPath {
     /// As an [`EntityType`] can link to multiple [`EntityType`]s, the deserialized path
     /// requires an additional selector to identify the [`EntityType`] to query. Currently,
     /// only the `*` selector is available, so the path will be deserialized as
-    /// `["inheritsFrom", "*", ...]` where `...` is the path to the desired field of the
+    /// `["links", "*", ...]` where `...` is the path to the desired field of the
     /// [`EntityType`].
     ///
     /// ```rust

--- a/packages/graph/hash_graph/lib/graph/src/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/entity_type.rs
@@ -189,8 +189,26 @@ pub enum EntityTypeQueryPath {
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     Required,
-    // TODO: https://app.asana.com/0/1200211978612931/1203250001255262/f
-    // Links(LinkTypeQueryPath),
+    /// Corresponds to the keys of [`EntityType::link_mappings()`].
+    ///
+    /// As an [`EntityType`] can link to multiple [`EntityType`]s, the deserialized path
+    /// requires an additional selector to identify the [`EntityType`] to query. Currently,
+    /// only the `*` selector is available, so the path will be deserialized as
+    /// `["inheritsFrom", "*", ...]` where `...` is the path to the desired field of the
+    /// [`EntityType`].
+    ///
+    /// ```rust
+    /// # use serde::Deserialize;
+    /// # use serde_json::json;
+    /// # use graph::ontology::EntityTypeQueryPath;
+    /// let path = EntityTypeQueryPath::deserialize(json!(["links", "*", "baseUri"]))?;
+    /// assert_eq!(
+    ///     path,
+    ///     EntityTypeQueryPath::Links(Box::new(EntityTypeQueryPath::BaseUri))
+    /// );
+    /// # Ok::<(), serde_json::Error>(())
+    /// ```
+    Links(Box<Self>),
     /// Corresponds to [`EntityType::required_links()`].
     ///
     /// ```rust
@@ -272,8 +290,7 @@ impl RecordPath for EntityTypeQueryPath {
                 ParameterType::Any
             }
             Self::Properties(path) => path.expected_type(),
-            // TODO: https://app.asana.com/0/1200211978612931/1203250001255262/f
-            // Self::Links(path) => path.expected_type(),
+            Self::Links(path) => path.expected_type(),
             Self::InheritsFrom(path) => path.expected_type(),
         }
     }
@@ -296,8 +313,7 @@ impl fmt::Display for EntityTypeQueryPath {
             Self::Examples => fmt.write_str("examples"),
             Self::Properties(path) => write!(fmt, "properties.{path}"),
             Self::Required => fmt.write_str("required"),
-            // TODO: https://app.asana.com/0/1200211978612931/1203250001255262/f
-            // Self::Links(path) => write!(fmt, "links.{path}"),
+            Self::Links(path) => write!(fmt, "links.{path}"),
             Self::RequiredLinks => fmt.write_str("requiredLinks"),
             Self::InheritsFrom(path) => write!(fmt, "inheritsFrom.{path}"),
         }

--- a/packages/graph/hash_graph/lib/graph/src/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/entity_type.rs
@@ -290,8 +290,7 @@ impl RecordPath for EntityTypeQueryPath {
                 ParameterType::Any
             }
             Self::Properties(path) => path.expected_type(),
-            Self::Links(path) => path.expected_type(),
-            Self::InheritsFrom(path) => path.expected_type(),
+            Self::Links(path) | Self::InheritsFrom(path) => path.expected_type(),
         }
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/entity_type.rs
@@ -391,10 +391,9 @@ impl<'de> Visitor<'de> for EntityTypeQueryPathVisitor {
                     .ok_or_else(|| de::Error::invalid_length(self.position, &self))?;
                 self.position += 1;
 
-                let property_type_query_path =
-                    PropertyTypeQueryPathVisitor::new(self.position).visit_seq(seq)?;
-
-                EntityTypeQueryPath::Properties(property_type_query_path)
+                EntityTypeQueryPath::Properties(
+                    PropertyTypeQueryPathVisitor::new(self.position).visit_seq(seq)?,
+                )
             }
             EntityTypeQueryToken::Required => EntityTypeQueryPath::Required,
             EntityTypeQueryToken::Links => {
@@ -402,12 +401,7 @@ impl<'de> Visitor<'de> for EntityTypeQueryPathVisitor {
                     .ok_or_else(|| de::Error::invalid_length(self.position, &self))?;
                 self.position += 1;
 
-                todo!("https://app.asana.com/0/1200211978612931/1203250001255262/f");
-
-                // let link_type_query_path =
-                //     LinkTypeQueryPathVisitor::new(self.position).visit_seq(seq)?;
-                //
-                // EntityTypeQueryPath::Links(link_type_query_path)
+                EntityTypeQueryPath::Links(Box::new(Self::new(self.position).visit_seq(seq)?))
             }
             EntityTypeQueryToken::RequiredLinks => EntityTypeQueryPath::RequiredLinks,
             EntityTypeQueryToken::InheritsFrom => {
@@ -415,9 +409,9 @@ impl<'de> Visitor<'de> for EntityTypeQueryPathVisitor {
                     .ok_or_else(|| de::Error::invalid_length(self.position, &self))?;
                 self.position += 1;
 
-                let entity_type_query_path = Self::new(self.position).visit_seq(seq)?;
-
-                EntityTypeQueryPath::InheritsFrom(Box::new(entity_type_query_path))
+                EntityTypeQueryPath::InheritsFrom(Box::new(
+                    Self::new(self.position).visit_seq(seq)?,
+                ))
             }
         })
     }

--- a/packages/graph/hash_graph/lib/graph/src/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/entity_type.rs
@@ -460,11 +460,10 @@ mod tests {
             EntityTypeQueryPath::Properties(PropertyTypeQueryPath::Version)
         );
         assert_eq!(deserialize(["required"]), EntityTypeQueryPath::Required);
-        // TODO: https://app.asana.com/0/1200211978612931/1203250001255262/f
-        // assert_eq!(
-        //     deserialize(["links", "*", "version"]),
-        //     EntityTypeQueryPath::Links(LinkTypeQueryPath::Version)
-        // );
+        assert_eq!(
+            deserialize(["links", "*", "version"]),
+            EntityTypeQueryPath::Links(Box::new(EntityTypeQueryPath::Version))
+        );
         assert_eq!(
             deserialize(["requiredLinks"]),
             EntityTypeQueryPath::RequiredLinks
@@ -528,19 +527,18 @@ mod tests {
             )
         );
 
-        // TODO: https://app.asana.com/0/1200211978612931/1203250001255262/f
-        // assert_eq!(
-        //     EntityTypeQueryPath::deserialize(
-        //         de::value::SeqDeserializer::<_, de::value::Error>::new(
-        //             ["links", "*", "versionedUri", "invalid"].into_iter()
-        //         )
-        //     )
-        //     .expect_err(
-        //         "managed to convert entity type query path with multiple tokens when it should \
-        //          have errored"
-        //     )
-        //     .to_string(),
-        //     "invalid length 4, expected 3 elements in sequence"
-        // );
+        assert_eq!(
+            EntityTypeQueryPath::deserialize(
+                de::value::SeqDeserializer::<_, de::value::Error>::new(
+                    ["links", "*", "versionedUri", "invalid"].into_iter()
+                )
+            )
+            .expect_err(
+                "managed to convert entity type query path with multiple tokens when it should \
+                 have errored"
+            )
+            .to_string(),
+            "invalid length 4, expected 3 elements in sequence"
+        );
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
@@ -324,12 +324,12 @@ impl<'c, 'p: 'c, T: PostgresQueryRecord + 'static> SelectCompiler<'c, 'p, T> {
     fn add_special_relation_conditions(
         &mut self,
         relation: Relation,
-        current_alias: Alias,
-        current_table: AliasedTable,
+        base_alias: Alias,
+        joined_table: AliasedTable,
     ) {
         match relation {
             Relation::EntityTypeLinks => {
-                self.artifacts.required_tables.insert(current_table);
+                self.artifacts.required_tables.insert(joined_table);
                 self.statement
                     .where_expression
                     .add_condition(Condition::NotEqual(
@@ -337,14 +337,14 @@ impl<'c, 'p: 'c, T: PostgresQueryRecord + 'static> SelectCompiler<'c, 'p, T> {
                             vec![
                                 Expression::Column(
                                     Column::EntityTypes(EntityTypes::Schema(None))
-                                        .aliased(current_alias),
+                                        .aliased(base_alias),
                                 ),
                                 Expression::Constant(Constant::String("links")),
                                 Expression::Column(
                                     Column::EntityTypes(EntityTypes::Schema(Some(
                                         JsonField::Text(&Cow::Borrowed("$id")),
                                     )))
-                                    .aliased(current_table.alias),
+                                    .aliased(joined_table.alias),
                                 ),
                             ],
                         )))),
@@ -352,7 +352,7 @@ impl<'c, 'p: 'c, T: PostgresQueryRecord + 'static> SelectCompiler<'c, 'p, T> {
                     ));
             }
             Relation::EntityTypeInheritance => {
-                self.artifacts.required_tables.insert(current_table);
+                self.artifacts.required_tables.insert(joined_table);
                 self.statement
                     .where_expression
                     .add_condition(Condition::NotEqual(
@@ -361,7 +361,7 @@ impl<'c, 'p: 'c, T: PostgresQueryRecord + 'static> SelectCompiler<'c, 'p, T> {
                                 Column::EntityTypes(EntityTypes::Schema(Some(JsonField::Json(
                                     &Cow::Borrowed("allOf"),
                                 ))))
-                                .aliased(current_alias),
+                                .aliased(base_alias),
                             ),
                             Expression::Function(Box::new(Function::JsonBuildArray(vec![
                                 Expression::Function(Box::new(Function::JsonBuildObject(vec![(
@@ -370,7 +370,7 @@ impl<'c, 'p: 'c, T: PostgresQueryRecord + 'static> SelectCompiler<'c, 'p, T> {
                                         Column::EntityTypes(EntityTypes::Schema(Some(
                                             JsonField::Text(&Cow::Borrowed("$id")),
                                         )))
-                                        .aliased(current_table.alias),
+                                        .aliased(joined_table.alias),
                                     ),
                                 )]))),
                             ]))),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity_type.rs
@@ -34,6 +34,9 @@ impl Path for EntityTypeQueryPath {
             Self::Properties(path) => once(Relation::EntityTypePropertyTypeReferences)
                 .chain(path.relations())
                 .collect(),
+            Self::Links(path) => once(Relation::EntityTypeLinks)
+                .chain(path.relations())
+                .collect(),
             Self::InheritsFrom(path) => once(Relation::EntityTypeInheritance)
                 .chain(path.relations())
                 .collect(),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity_type.rs
@@ -71,7 +71,7 @@ impl Path for EntityTypeQueryPath {
             Self::RequiredLinks => Column::EntityTypes(EntityTypes::Schema(Some(JsonField::Text(
                 &Cow::Borrowed("requiredLinks"),
             )))),
-            Self::InheritsFrom(path) => path.terminating_column(),
+            Self::Links(path) | Self::InheritsFrom(path) => path.terminating_column(),
             Self::Properties(path) => path.terminating_column(),
         }
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
@@ -423,6 +423,7 @@ pub enum Relation {
     PropertyTypeDataTypeReferences,
     PropertyTypePropertyTypeReferences,
     EntityTypePropertyTypeReferences,
+    EntityTypeLinks,
     EntityTypeInheritance,
     EntityType,
     LeftEndpoint,
@@ -488,7 +489,7 @@ impl Relation {
                     Column::PropertyTypes(PropertyTypes::VersionId),
                 ),
             ],
-            Self::EntityTypeInheritance => &[
+            Self::EntityTypeLinks | Self::EntityTypeInheritance => &[
                 (
                     Column::EntityTypes(EntityTypes::VersionId),
                     Column::EntityTypeEntityTypeReferences(

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -327,6 +327,45 @@ Content-Type: application/json
     });
 %}
 
+### Get all entity types which links to a link (should be none)
+POST http://127.0.0.1:4000/entity-types/query
+Content-Type: application/json
+
+{
+  "filter": {
+    "all": [
+      {
+        "equal": [
+          {
+            "path": [
+              "links",
+              "*",
+              "baseUri"
+            ]
+          },
+          {
+            "parameter": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/"
+          }
+        ]
+      }
+    ]
+  },
+  "graphResolveDepths": {
+    "dataTypeResolveDepth": 0,
+    "propertyTypeResolveDepth": 0,
+    "entityTypeResolveDepth": 0,
+    "entityResolveDepth": 0
+  }
+}
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(response.body.roots.length === 0, "Unexpected number of entities");
+    });
+%}
+
+
 
 ### Insert Person entity
 POST http://127.0.0.1:4000/entities


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Supports the "links" query in entity types

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202805690238892/1203348428860462/f) _(internal)_

## 🚫 Blocked by

- #1407
- #1411

## 🔍 What does this change?

- Re-add `Links` variant to `EntityTypeQueryPath`
- Support parsing `"links"`
- Add special case for `"links"` and `"inheritsFrom"` to distinguish between different entity type references
- Add test cases for the above

## 📜 Does this require a change to the docs?

The `EntityTypeQueyrPath` documentation were adjusted

## ⚠️ Known issues

We always never use the reference table to get all referenced entity types. If we'd add distinct reference tables, both, this code and the subgraph query would be easier.

## 🛡 What tests cover this?

Test cases were added