### PR TITLE
Run Rust CI on dev-branches

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - dev/**
 
 defaults:
   run:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Dev-branches require a review so they are special-cased. In order to profit from caching and upload proper coverage support, the CI should run on pushes to  `dev/**` branches as well.