### PR TITLE
Fix Entity definitions in REST API

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -128,12 +128,6 @@ export interface CreateEntityRequest {
   actorId: string;
   /**
    *
-   * @type {object}
-   * @memberof CreateEntityRequest
-   */
-  entity: object;
-  /**
-   *
    * @type {string}
    * @memberof CreateEntityRequest
    */
@@ -156,6 +150,12 @@ export interface CreateEntityRequest {
    * @memberof CreateEntityRequest
    */
   ownedById: string;
+  /**
+   *
+   * @type {object}
+   * @memberof CreateEntityRequest
+   */
+  properties: object;
 }
 /**
  *
@@ -1658,12 +1658,6 @@ export interface UpdateEntityRequest {
   actorId: string;
   /**
    *
-   * @type {object}
-   * @memberof UpdateEntityRequest
-   */
-  entity: object;
-  /**
-   *
    * @type {string}
    * @memberof UpdateEntityRequest
    */
@@ -1674,6 +1668,12 @@ export interface UpdateEntityRequest {
    * @memberof UpdateEntityRequest
    */
   entityTypeId: string;
+  /**
+   *
+   * @type {object}
+   * @memberof UpdateEntityRequest
+   */
+  properties: object;
 }
 /**
  * The contents of an Entity Type update request

--- a/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
@@ -65,7 +65,7 @@ async fn seed_db(
     )
     .await;
 
-    let entity: EntityProperties =
+    let properties: EntityProperties =
         serde_json::from_str(entity::BOOK_V1).expect("could not parse entity");
     let entity_type_id = EntityType::from_str(entity_type::BOOK_V1)
         .expect("could not parse entity type")
@@ -74,7 +74,7 @@ async fn seed_db(
 
     let entity_uuids = store
         .insert_entities_batched_by_type(
-            repeat((None, entity)).take(total),
+            repeat((None, properties)).take(total),
             entity_type_id,
             OwnedById::new(account_id),
             CreatedById::new(account_id),

--- a/packages/graph/hash_graph/bench/benches/representative_read/seed.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/seed.rs
@@ -128,7 +128,7 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
 
     let mut total_entities = 0;
     for (entity_type_str, entity_str, quantity) in SEED_ENTITIES {
-        let entity: EntityProperties =
+        let properties: EntityProperties =
             serde_json::from_str(entity_str).expect("could not parse entity");
         let entity_type_id = EntityType::from_str(entity_type_str)
             .expect("could not parse entity type")
@@ -137,7 +137,7 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
 
         store
             .insert_entities_batched_by_type(
-                repeat((None, entity)).take(quantity),
+                repeat((None, properties)).take(quantity),
                 entity_type_id,
                 OwnedById::new(account_id),
                 CreatedById::new(account_id),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -125,7 +125,7 @@ impl RoutedResource for EntityResource {
 #[derive(Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 struct CreateEntityRequest {
-    entity: EntityProperties,
+    properties: EntityProperties,
     #[schema(value_type = String)]
     entity_type_id: VersionedUri,
     owned_by_id: OwnedById,
@@ -155,7 +155,7 @@ async fn create_entity<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<EntityMetadata>, StatusCode> {
     let Json(CreateEntityRequest {
-        entity,
+        properties,
         entity_type_id,
         owned_by_id,
         entity_uuid,
@@ -170,7 +170,7 @@ async fn create_entity<P: StorePool + Send>(
 
     store
         .create_entity(
-            entity,
+            properties,
             entity_type_id,
             owned_by_id,
             entity_uuid,
@@ -323,7 +323,7 @@ async fn get_entity<P: StorePool + Send>(
 #[derive(ToSchema, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct UpdateEntityRequest {
-    entity: EntityProperties,
+    properties: EntityProperties,
     entity_id: EntityId,
     #[schema(value_type = String)]
     entity_type_id: VersionedUri,
@@ -348,7 +348,7 @@ async fn update_entity<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<EntityMetadata>, StatusCode> {
     let Json(UpdateEntityRequest {
-        entity,
+        properties,
         entity_id,
         entity_type_id,
         actor_id,
@@ -360,7 +360,7 @@ async fn update_entity<P: StorePool + Send>(
     })?;
 
     store
-        .update_entity(entity_id, entity, entity_type_id, actor_id)
+        .update_entity(entity_id, properties, entity_type_id, actor_id)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not update entity");

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -230,11 +230,11 @@ mod tests {
     fn test_entity(json: &str) {
         let json_value: serde_json::Value = serde_json::from_str(json).expect("invalid JSON");
 
-        let entity: EntityProperties =
+        let properties: EntityProperties =
             serde_json::from_value(json_value.clone()).expect("invalid entity");
 
         assert_eq!(
-            serde_json::to_value(entity.clone()).expect("could not serialize"),
+            serde_json::to_value(properties.clone()).expect("could not serialize"),
             json_value,
             "{entity:#?}"
         );

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -236,7 +236,7 @@ mod tests {
         assert_eq!(
             serde_json::to_value(properties.clone()).expect("could not serialize"),
             json_value,
-            "{entity:#?}"
+            "{properties:#?}"
         );
     }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -330,12 +330,12 @@ pub trait EntityStore: for<'q> crud::Read<Entity, Query<'q> = Filter<'q, Entity>
     /// # Errors:
     ///
     /// - if the [`EntityType`] doesn't exist
-    /// - if the [`Entity`] is not valid with respect to the specified [`EntityType`]
+    /// - if the [`EntityProperties`] is not valid with respect to the specified [`EntityType`]
     /// - if the account referred to by `owned_by_id` does not exist
     /// - if an [`EntityUuid`] was supplied and already exists in the store
     async fn create_entity(
         &mut self,
-        entity: EntityProperties,
+        properties: EntityProperties,
         entity_type_id: VersionedUri,
         owned_by_id: OwnedById,
         entity_uuid: Option<EntityUuid>,
@@ -392,7 +392,7 @@ pub trait EntityStore: for<'q> crud::Read<Entity, Query<'q> = Filter<'q, Entity>
     async fn update_entity(
         &mut self,
         entity_id: EntityId,
-        entity: EntityProperties,
+        properties: EntityProperties,
         entity_type_id: VersionedUri,
         actor_id: UpdatedById,
     ) -> Result<EntityMetadata, UpdateError>;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -272,7 +272,7 @@ impl<C: AsClient> PostgresStore<C> {
 impl<C: AsClient> EntityStore for PostgresStore<C> {
     async fn create_entity(
         &mut self,
-        entity: EntityProperties,
+        properties: EntityProperties,
         entity_type_id: VersionedUri,
         owned_by_id: OwnedById,
         entity_uuid: Option<EntityUuid>,
@@ -296,7 +296,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         let metadata = transaction
             .insert_entity(
                 entity_id,
-                entity,
+                properties,
                 entity_type_id,
                 created_by_id,
                 UpdatedById::new(created_by_id.as_account_id()),
@@ -416,7 +416,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
     async fn update_entity(
         &mut self,
         entity_id: EntityId,
-        entity: EntityProperties,
+        properties: EntityProperties,
         entity_type_id: VersionedUri,
         updated_by_id: UpdatedById,
     ) -> Result<EntityMetadata, UpdateError> {
@@ -441,7 +441,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         let entity_metadata = transaction
             .insert_entity(
                 entity_id,
-                entity,
+                properties,
                 entity_type_id,
                 old_entity_metadata.provenance_metadata().created_by_id(),
                 updated_by_id,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -71,7 +71,7 @@ impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
             .change_context(QueryError)?
             .map(|row| row.into_report().change_context(QueryError))
             .and_then(|row| async move {
-                let entity: EntityProperties = serde_json::from_value(row.get(properties_index))
+                let properties: EntityProperties = serde_json::from_value(row.get(properties_index))
                     .into_report()
                     .change_context(QueryError)?;
                 let entity_type_uri = VersionedUri::from_str(row.get(type_id_index))
@@ -122,7 +122,7 @@ impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
                 let updated_by_id = UpdatedById::new(row.get(updated_by_id_index));
 
                 Ok(Entity::new(
-                    entity,
+                    properties,
                     EntityEditionId::new(
                         EntityId::new(owned_by_id, entity_uuid),
                         row.get(version_index),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -843,7 +843,7 @@ where
     async fn insert_entity(
         &self,
         entity_id: EntityId,
-        entity: EntityProperties,
+        properties: EntityProperties,
         entity_type_id: VersionedUri,
         created_by_id: CreatedById,
         updated_by_id: UpdatedById,
@@ -857,7 +857,7 @@ where
         // TODO: Validate entity against entity type
         //  https://app.asana.com/0/0/1202629282579257/f
 
-        let value = serde_json::to_value(entity)
+        let value = serde_json::to_value(properties)
             .into_report()
             .change_context(InsertionError)?;
         let version = self

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -265,13 +265,13 @@ impl DatabaseApi<'_> {
 
     pub async fn create_entity(
         &mut self,
-        entity: EntityProperties,
+        properties: EntityProperties,
         entity_type_id: VersionedUri,
         entity_uuid: Option<EntityUuid>,
     ) -> Result<EntityMetadata, InsertionError> {
         self.store
             .create_entity(
-                entity,
+                properties,
                 entity_type_id,
                 OwnedById::new(self.account_id),
                 entity_uuid,
@@ -304,13 +304,13 @@ impl DatabaseApi<'_> {
     pub async fn update_entity(
         &mut self,
         entity_id: EntityId,
-        entity: EntityProperties,
+        properties: EntityProperties,
         entity_type_id: VersionedUri,
     ) -> Result<EntityMetadata, UpdateError> {
         self.store
             .update_entity(
                 entity_id,
-                entity,
+                properties,
                 entity_type_id,
                 UpdatedById::new(self.account_id),
             )
@@ -319,7 +319,7 @@ impl DatabaseApi<'_> {
 
     async fn create_link_entity(
         &mut self,
-        entity: EntityProperties,
+        properties: EntityProperties,
         entity_type_id: VersionedUri,
         entity_uuid: Option<EntityUuid>,
         left_entity_id: EntityId,
@@ -327,7 +327,7 @@ impl DatabaseApi<'_> {
     ) -> Result<EntityMetadata, InsertionError> {
         self.store
             .create_entity(
-                entity,
+                properties,
                 entity_type_id,
                 OwnedById::new(self.account_id),
                 entity_uuid,

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -336,7 +336,7 @@ Accept: application/json
 {
   "ownedById": "{{account_id}}",
   "actorId": "{{account_id}}",
-  "entity": {
+  "properties": {
     "http://localhost:3000/@alice/types/property-type/name/": "Alice"
   },
   "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/1"
@@ -369,7 +369,7 @@ Accept: application/json
  "actorId": "{{account_id}}",
  "entityId": "{{person_a_entity_id}}",
  "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/2",
- "entity": {
+ "properties": {
    "http://localhost:3000/@alice/types/property-type/name/": "Alice Allison"
  }
 }
@@ -388,7 +388,7 @@ Accept: application/json
 {
   "ownedById": "{{account_id}}",
   "actorId": "{{account_id}}",
-  "entity": {
+  "properties": {
     "http://localhost:3000/@alice/types/property-type/name/": "Bob"
   },
   "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/1"
@@ -456,7 +456,7 @@ Accept: application/json
 {
   "ownedById": "{{account_id}}",
   "actorId": "{{account_id}}",
-  "entity": {},
+  "properties": {},
   "entityTypeId": "{{friendship_link_entity_type_id}}",
   "linkMetadata": {
     "leftEntityId": "{{person_a_entity_id}}",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Prior to this branch we had incorrectly had an `Entity` type in the Rust side of the code which was actually just the `EntityProperties` of the `Entity`. When we fixed this, we had some stray fields and variable names that were still incorrect. This PR cleans them up.

## 🛡 What tests cover this?

- All tests within the HASH Graph README

## ❓ How to test this?

1.  Follow the README
