### PR TITLE
Support link ordering in updateEntity endpoint

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -1690,6 +1690,18 @@ export interface UpdateDataTypeRequest {
 export interface UpdateEntityRequest {
   /**
    *
+   * @type {number}
+   * @memberof UpdateEntityRequest
+   */
+  leftOrder?: number;
+  /**
+   *
+   * @type {number}
+   * @memberof UpdateEntityRequest
+   */
+  rightOrder?: number;
+  /**
+   *
    * @type {string}
    * @memberof UpdateEntityRequest
    */
@@ -1710,6 +1722,37 @@ export interface UpdateEntityRequest {
    *
    * @type {object}
    * @memberof UpdateEntityRequest
+   */
+  properties: object;
+}
+/**
+ *
+ * @export
+ * @interface UpdateEntityRequestAllOf
+ */
+export interface UpdateEntityRequestAllOf {
+  /**
+   *
+   * @type {string}
+   * @memberof UpdateEntityRequestAllOf
+   */
+  actorId: string;
+  /**
+   *
+   * @type {string}
+   * @memberof UpdateEntityRequestAllOf
+   */
+  entityId: string;
+  /**
+   *
+   * @type {string}
+   * @memberof UpdateEntityRequestAllOf
+   */
+  entityTypeId: string;
+  /**
+   *
+   * @type {object}
+   * @memberof UpdateEntityRequestAllOf
    */
   properties: object;
 }

--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -392,6 +392,25 @@ export interface EntityIdAndTimestamp {
   timestamp: string;
 }
 /**
+ *
+ * @export
+ * @interface EntityLinkOrder
+ */
+export interface EntityLinkOrder {
+  /**
+   *
+   * @type {number}
+   * @memberof EntityLinkOrder
+   */
+  leftOrder?: number;
+  /**
+   *
+   * @type {number}
+   * @memberof EntityLinkOrder
+   */
+  rightOrder?: number;
+}
+/**
  * The metadata of an [`Entity`] record.
  * @export
  * @interface EntityMetadata
@@ -869,28 +888,47 @@ export interface KnowledgeGraphVertices {
 export interface LinkEntityMetadata {
   /**
    *
-   * @type {string}
-   * @memberof LinkEntityMetadata
-   */
-  leftEntityId: string;
-  /**
-   *
    * @type {number}
    * @memberof LinkEntityMetadata
    */
   leftOrder?: number;
   /**
    *
-   * @type {string}
-   * @memberof LinkEntityMetadata
-   */
-  rightEntityId: string;
-  /**
-   *
    * @type {number}
    * @memberof LinkEntityMetadata
    */
   rightOrder?: number;
+  /**
+   *
+   * @type {string}
+   * @memberof LinkEntityMetadata
+   */
+  leftEntityId: string;
+  /**
+   *
+   * @type {string}
+   * @memberof LinkEntityMetadata
+   */
+  rightEntityId: string;
+}
+/**
+ *
+ * @export
+ * @interface LinkEntityMetadataAllOf
+ */
+export interface LinkEntityMetadataAllOf {
+  /**
+   *
+   * @type {string}
+   * @memberof LinkEntityMetadataAllOf
+   */
+  leftEntityId: string;
+  /**
+   *
+   * @type {string}
+   * @memberof LinkEntityMetadataAllOf
+   */
+  rightEntityId: string;
 }
 /**
  *

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -331,6 +331,8 @@ struct UpdateEntityRequest {
     #[schema(value_type = String)]
     entity_type_id: VersionedUri,
     actor_id: UpdatedById,
+    #[serde(flatten)]
+    order: EntityLinkOrder,
 }
 
 #[utoipa::path(
@@ -355,6 +357,7 @@ async fn update_entity<P: StorePool + Send>(
         entity_id,
         entity_type_id,
         actor_id,
+        order,
     }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
@@ -363,7 +366,7 @@ async fn update_entity<P: StorePool + Send>(
     })?;
 
     store
-        .update_entity(entity_id, properties, entity_type_id, actor_id)
+        .update_entity(entity_id, properties, entity_type_id, actor_id, order)
         .await
         .map_err(|report| {
             tracing::error!(error=?report, "Could not update entity");

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -16,7 +16,8 @@ use utoipa::{OpenApi, ToSchema};
 use crate::{
     api::rest::{api_resource::RoutedResource, read_from_store, report_to_status_code},
     knowledge::{
-        Entity, EntityMetadata, EntityProperties, EntityUuid, LinkEntityMetadata, LinkOrder,
+        Entity, EntityLinkOrder, EntityMetadata, EntityProperties, EntityUuid, LinkEntityMetadata,
+        LinkOrder,
     },
     provenance::{CreatedById, OwnedById, ProvenanceMetadata, UpdatedById},
     shared::{
@@ -70,6 +71,7 @@ use crate::{
             EntityIdAndTimestamp,
             EntityMetadata,
             Entity,
+            EntityLinkOrder,
             EntityProperties,
             EntityVersion,
             EntityStructuralQuery,

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -73,16 +73,43 @@ impl EntityProperties {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct EntityLinkOrder {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    left_order: Option<LinkOrder>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    right_order: Option<LinkOrder>,
+}
+
+impl EntityLinkOrder {
+    #[must_use]
+    pub fn new(left_order: Option<LinkOrder>, right_order: Option<LinkOrder>) -> Self {
+        Self {
+            left_order,
+            right_order,
+        }
+    }
+
+    #[must_use]
+    pub const fn left(&self) -> Option<LinkOrder> {
+        self.left_order
+    }
+
+    #[must_use]
+    pub const fn right(&self) -> Option<LinkOrder> {
+        self.right_order
+    }
+}
+
 /// The associated information for 'Link' entities
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct LinkEntityMetadata {
     left_entity_id: EntityId,
     right_entity_id: EntityId,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    left_order: Option<LinkOrder>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    right_order: Option<LinkOrder>,
+    #[serde(flatten)]
+    order: EntityLinkOrder,
 }
 
 impl LinkEntityMetadata {
@@ -96,8 +123,10 @@ impl LinkEntityMetadata {
         Self {
             left_entity_id,
             right_entity_id,
-            left_order,
-            right_order,
+            order: EntityLinkOrder {
+                left_order,
+                right_order,
+            },
         }
     }
 
@@ -113,12 +142,12 @@ impl LinkEntityMetadata {
 
     #[must_use]
     pub const fn left_order(&self) -> Option<LinkOrder> {
-        self.left_order
+        self.order.left_order
     }
 
     #[must_use]
     pub const fn right_order(&self) -> Option<LinkOrder> {
-        self.right_order
+        self.order.right_order
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -84,7 +84,7 @@ pub struct EntityLinkOrder {
 
 impl EntityLinkOrder {
     #[must_use]
-    pub fn new(left_order: Option<LinkOrder>, right_order: Option<LinkOrder>) -> Self {
+    pub const fn new(left_order: Option<LinkOrder>, right_order: Option<LinkOrder>) -> Self {
         Self {
             left_order,
             right_order,
@@ -123,10 +123,7 @@ impl LinkEntityMetadata {
         Self {
             left_entity_id,
             right_entity_id,
-            order: EntityLinkOrder {
-                left_order,
-                right_order,
-            },
+            order: EntityLinkOrder::new(left_order, right_order),
         }
     }
 

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/mod.rs
@@ -4,6 +4,6 @@
 mod entity;
 
 pub use self::entity::{
-    Entity, EntityMetadata, EntityProperties, EntityQueryPath, EntityQueryPathVisitor, EntityUuid,
-    LinkEntityMetadata, LinkOrder,
+    Entity, EntityLinkOrder, EntityMetadata, EntityProperties, EntityQueryPath,
+    EntityQueryPathVisitor, EntityUuid, LinkEntityMetadata, LinkOrder,
 };

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -19,7 +19,9 @@ pub use self::{
 };
 use crate::{
     identifier::knowledge::EntityId,
-    knowledge::{Entity, EntityMetadata, EntityProperties, EntityUuid, LinkEntityMetadata},
+    knowledge::{
+        Entity, EntityLinkOrder, EntityMetadata, EntityProperties, EntityUuid, LinkEntityMetadata,
+    },
     ontology::{
         DataTypeWithMetadata, EntityTypeWithMetadata, OntologyElementMetadata,
         PropertyTypeWithMetadata,
@@ -395,6 +397,7 @@ pub trait EntityStore: for<'q> crud::Read<Entity, Query<'q> = Filter<'q, Entity>
         properties: EntityProperties,
         entity_type_id: VersionedUri,
         actor_id: UpdatedById,
+        order: EntityLinkOrder,
     ) -> Result<EntityMetadata, UpdateError>;
 
     /// Archives an [`Entity`].

--- a/packages/graph/hash_graph/tests/integration/postgres/entity.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/entity.rs
@@ -1,4 +1,4 @@
-use graph::knowledge::EntityProperties;
+use graph::knowledge::{EntityLinkOrder, EntityProperties};
 use graph_test_data::{data_type, entity, entity_type, property_type};
 use type_system::uri::{BaseUri, VersionedUri};
 
@@ -115,6 +115,7 @@ async fn update() {
                     .expect("couldn't construct Base URI"),
                 1,
             ),
+            EntityLinkOrder::new(None, None),
         )
         .await
         .expect("could not update entity");

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -10,7 +10,8 @@ use error_stack::Result;
 use graph::{
     identifier::knowledge::{EntityEditionId, EntityId},
     knowledge::{
-        Entity, EntityMetadata, EntityProperties, EntityQueryPath, EntityUuid, LinkEntityMetadata,
+        Entity, EntityLinkOrder, EntityMetadata, EntityProperties, EntityQueryPath, EntityUuid,
+        LinkEntityMetadata,
     },
     ontology::{
         DataTypeWithMetadata, EntityTypeQueryPath, EntityTypeWithMetadata, OntologyElementMetadata,
@@ -306,6 +307,7 @@ impl DatabaseApi<'_> {
         entity_id: EntityId,
         properties: EntityProperties,
         entity_type_id: VersionedUri,
+        order: EntityLinkOrder,
     ) -> Result<EntityMetadata, UpdateError> {
         self.store
             .update_entity(
@@ -313,6 +315,7 @@ impl DatabaseApi<'_> {
                 properties,
                 entity_type_id,
                 UpdatedById::new(self.account_id),
+                order,
             )
             .await
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We currently don't have a way to update link ordering of entities. This exposes `leftOrder` and `rightOrder` in the `updateEntity` endpoint.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202805690238892/1203384069111429/f) _(internal)_

## 🔍 What does this change?

- Split `left_order` and `right_order` from `LinkEntityMetadata`
- Add logic for updating the orders:
    - Update if, and only if, the order previously existed and a new order was passed
    - error otherwise
- Expose functionality to the OpenAPI specs