### PR TITLE
Select types returned from Graph distinctly

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/data_type.rs
@@ -174,12 +174,20 @@ impl OntologyPath for DataTypeQueryPath {
         Self::Version
     }
 
-    fn title() -> Self {
-        Self::Title
+    fn owned_by_id() -> Self {
+        Self::OwnedById
     }
 
-    fn description() -> Self {
-        Self::Description
+    fn created_by_id() -> Self {
+        Self::CreatedById
+    }
+
+    fn updated_by_id() -> Self {
+        Self::UpdatedById
+    }
+
+    fn schema() -> Self {
+        Self::Schema
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/entity_type.rs
@@ -248,12 +248,20 @@ impl OntologyPath for EntityTypeQueryPath {
         Self::Version
     }
 
-    fn title() -> Self {
-        Self::Title
+    fn owned_by_id() -> Self {
+        Self::OwnedById
     }
 
-    fn description() -> Self {
-        Self::Description
+    fn created_by_id() -> Self {
+        Self::CreatedById
+    }
+
+    fn updated_by_id() -> Self {
+        Self::UpdatedById
+    }
+
+    fn schema() -> Self {
+        Self::Schema
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/property_type.rs
@@ -183,12 +183,20 @@ impl OntologyPath for PropertyTypeQueryPath {
         Self::Version
     }
 
-    fn title() -> Self {
-        Self::Title
+    fn owned_by_id() -> Self {
+        Self::OwnedById
     }
 
-    fn description() -> Self {
-        Self::Description
+    fn created_by_id() -> Self {
+        Self::CreatedById
+    }
+
+    fn updated_by_id() -> Self {
+        Self::UpdatedById
+    }
+
+    fn schema() -> Self {
+        Self::Schema
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
@@ -51,16 +51,6 @@ impl<'c, 'p: 'c, T: PostgresQueryRecord + 'static> SelectCompiler<'c, 'p, T> {
         }
     }
 
-    /// Creates a new compiler, which will default to select the paths returned from
-    /// [`PostgresQueryRecord::default_selection_paths()`].
-    pub fn with_default_selection() -> SelectCompiler<'c, 'static, T> {
-        let mut default = SelectCompiler::new();
-        for path in T::default_selection_paths() {
-            default.add_selection_path(path);
-        }
-        default
-    }
-
     /// Creates a new compiler, which will select everything using the asterisk (`*`).
     pub fn with_asterisk() -> Self {
         let mut default = Self::new();

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
@@ -13,16 +13,6 @@ impl PostgresQueryRecord for DataType {
             alias: None,
         }
     }
-
-    fn default_selection_paths() -> &'static [Self::Path<'static>] {
-        &[
-            DataTypeQueryPath::VersionedUri,
-            DataTypeQueryPath::Schema,
-            DataTypeQueryPath::OwnedById,
-            DataTypeQueryPath::CreatedById,
-            DataTypeQueryPath::UpdatedById,
-        ]
-    }
 }
 
 impl Path for DataTypeQueryPath {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity.rs
@@ -15,18 +15,6 @@ impl PostgresQueryRecord for Entity {
             alias: None,
         }
     }
-
-    fn default_selection_paths() -> &'static [Self::Path<'static>] {
-        &[
-            EntityQueryPath::Properties(None),
-            EntityQueryPath::Uuid,
-            EntityQueryPath::Version,
-            EntityQueryPath::Type(EntityTypeQueryPath::VersionedUri),
-            EntityQueryPath::OwnedById,
-            EntityQueryPath::CreatedById,
-            EntityQueryPath::UpdatedById,
-        ]
-    }
 }
 
 impl Path for EntityQueryPath<'_> {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity_type.rs
@@ -13,16 +13,6 @@ impl PostgresQueryRecord for EntityType {
             alias: None,
         }
     }
-
-    fn default_selection_paths() -> &'static [Self::Path<'static>] {
-        &[
-            EntityTypeQueryPath::VersionedUri,
-            EntityTypeQueryPath::Schema,
-            EntityTypeQueryPath::OwnedById,
-            EntityTypeQueryPath::CreatedById,
-            EntityTypeQueryPath::UpdatedById,
-        ]
-    }
 }
 
 impl Path for EntityTypeQueryPath {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/mod.rs
@@ -31,9 +31,6 @@ use crate::store::query::QueryRecord;
 pub trait PostgresQueryRecord: for<'p> QueryRecord<Path<'p>: Path> {
     /// The [`Table`] used for this `Query`.
     fn base_table() -> Table;
-
-    /// Default [`Path`]s returned when querying this record.
-    fn default_selection_paths() -> &'static [Self::Path<'static>];
 }
 
 /// An absolute path inside of a query pointing to an attribute.

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/property_type.rs
@@ -13,16 +13,6 @@ impl PostgresQueryRecord for PropertyType {
             alias: None,
         }
     }
-
-    fn default_selection_paths() -> &'static [Self::Path<'static>] {
-        &[
-            PropertyTypeQueryPath::VersionedUri,
-            PropertyTypeQueryPath::Schema,
-            PropertyTypeQueryPath::OwnedById,
-            PropertyTypeQueryPath::CreatedById,
-            PropertyTypeQueryPath::UpdatedById,
-        ]
-    }
 }
 
 impl Path for PropertyTypeQueryPath {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -127,14 +127,9 @@ mod tests {
     #[test]
     fn default_selection() {
         test_compilation(
-            &SelectCompiler::<DataType>::with_default_selection(),
+            &SelectCompiler::<DataType>::with_asterisk(),
             r#"
-            SELECT
-                "data_types"."schema"->>'$id',
-                "data_types"."schema",
-                "data_types"."owned_by_id",
-                "data_types"."created_by_id",
-                "data_types"."updated_by_id"
+            SELECT *
             FROM "data_types"
             "#,
             &[],
@@ -405,7 +400,7 @@ mod tests {
 
     #[test]
     fn entity_simple_query() {
-        let mut compiler = SelectCompiler::<Entity>::with_default_selection();
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk();
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityQueryPath::Uuid)),
@@ -418,14 +413,7 @@ mod tests {
         test_compilation(
             &compiler,
             r#"
-            SELECT
-                "entities"."properties",
-                "entities"."entity_uuid",
-                "entities"."version",
-                "entity_types_0_0_0"."schema"->>'$id',
-                "entities"."owned_by_id",
-                "entities"."created_by_id",
-                "entities"."updated_by_id"
+            SELECT *
             FROM "entities"
             INNER JOIN "entity_types" AS "entity_types_0_0_0"
               ON "entity_types_0_0_0"."version_id" = "entities"."entity_type_version_id"
@@ -437,7 +425,7 @@ mod tests {
 
     #[test]
     fn entity_latest_version_query() {
-        let mut compiler = SelectCompiler::<Entity>::with_default_selection();
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk();
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityQueryPath::Version)),
@@ -450,14 +438,7 @@ mod tests {
         test_compilation(
             &compiler,
             r#"
-            SELECT
-                "entities"."properties",
-                "entities"."entity_uuid",
-                "entities"."version",
-                "entity_types_0_0_0"."schema"->>'$id',
-                "entities"."owned_by_id",
-                "entities"."created_by_id",
-                "entities"."updated_by_id"
+            SELECT *
             FROM "entities"
             INNER JOIN "entity_types" AS "entity_types_0_0_0"
               ON "entity_types_0_0_0"."version_id" = "entities"."entity_type_version_id"

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -127,18 +127,6 @@ mod tests {
     }
 
     #[test]
-    fn default_selection() {
-        test_compilation(
-            &SelectCompiler::<DataType>::with_asterisk(),
-            r#"
-            SELECT *
-            FROM "data_types" AS "data_types_0_0_0"
-            "#,
-            &[],
-        );
-    }
-
-    #[test]
     fn simple_expression() {
         let mut compiler = SelectCompiler::<DataType>::with_asterisk();
         compiler.add_filter(&Filter::Equal(

--- a/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
@@ -56,9 +56,9 @@ pub trait OntologyPath: 'static {
     /// [`VersionedUri`]: type_system::uri::VersionedUri
     fn versioned_uri() -> Self;
 
-    /// Returns the path identifying the [`OntologyVersion`].
+    /// Returns the path identifying the [`OntologyTypeVersion`].
     ///
-    /// [`OntologyVersion`]: crate::ontology::OntologyVersion
+    /// [`OntologyTypeVersion`]: crate::identifier::ontology::OntologyTypeVersion
     fn version() -> Self;
 
     /// Returns the path identifying the [`OwnedById`].

--- a/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
@@ -46,19 +46,37 @@ impl fmt::Display for ParameterType {
     }
 }
 
-pub trait OntologyPath {
-    /// Returns the path identifying the base URI.
+pub trait OntologyPath: 'static {
+    /// Returns the path identifying the [`BaseUri`].
+    ///
+    /// [`BaseUri`]: type_system::uri::BaseUri
     fn base_uri() -> Self;
 
-    /// Returns the path identifying the versioned URI.
+    /// Returns the path identifying the [`VersionedUri`].
+    ///
+    /// [`VersionedUri`]: type_system::uri::VersionedUri
     fn versioned_uri() -> Self;
 
-    /// Returns the path identifying the version
+    /// Returns the path identifying the [`OntologyVersion`].
+    ///
+    /// [`OntologyVersion`]: crate::ontology::OntologyVersion
     fn version() -> Self;
 
-    /// Returns the path identifying the title.
-    fn title() -> Self;
+    /// Returns the path identifying the [`OwnedById`].
+    ///
+    /// [`OwnedById`]: crate::provenance::OwnedById
+    fn owned_by_id() -> Self;
 
-    /// Returns the path identifying the description.
-    fn description() -> Self;
+    /// Returns the path identifying the [`CreatedById`].
+    ///
+    /// [`CreatedById`]: crate::provenance::CreatedById
+    fn created_by_id() -> Self;
+
+    /// Returns the path identifying the [`UpdatedById`].
+    ///
+    /// [`UpdatedById`]: crate::provenance::UpdatedById
+    fn updated_by_id() -> Self;
+
+    /// Returns the path identifying the schema.
+    fn schema() -> Self;
 }

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -557,10 +557,10 @@ Content-Type: application/json
     ]
   },
   "graphResolveDepths": {
-    "dataTypeResolveDepth": 0,
-    "propertyTypeResolveDepth": 0,
-    "entityTypeResolveDepth": 0,
-    "entityResolveDepth": 0
+    "dataTypeResolveDepth": 10,
+    "propertyTypeResolveDepth": 10,
+    "entityTypeResolveDepth": 10,
+    "entityResolveDepth": 10
   }
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When joining tables, the same row may be selected multiple times, but some methods require exactly one row to be returned.
This PR changes the database query to select distinctly on the primary keys.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202805690238892/1203358665695497/f) _(internal)_

## 🔍 What does this change?

- Add required methods to the `OntologyPath` trait
- Replace `Compiler::with_default_selection` to pick the columns manually