### PR TITLE
Seed links in benchmarks (`dev/links`)

### DIFF
--- a/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
@@ -74,7 +74,7 @@ async fn seed_db(
 
     let entity_uuids = store
         .insert_entities_batched_by_type(
-            repeat((None, properties)).take(total),
+            repeat((None, properties, None)).take(total),
             entity_type_id,
             OwnedById::new(account_id),
             CreatedById::new(account_id),

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -366,8 +366,14 @@ pub trait EntityStore: for<'q> crud::Read<Entity, Query<'q> = Filter<'q, Entity>
     #[cfg(feature = "__internal_bench")]
     async fn insert_entities_batched_by_type(
         &mut self,
-        entities: impl IntoIterator<Item = (Option<EntityUuid>, EntityProperties), IntoIter: Send>
-        + Send,
+        entities: impl IntoIterator<
+            Item = (
+                Option<EntityUuid>,
+                EntityProperties,
+                Option<LinkEntityMetadata>,
+            ),
+            IntoIter: Send,
+        > + Send,
         entity_type_id: VersionedUri,
         owned_by_id: OwnedById,
         actor_id: CreatedById,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To allow comparing benchmarks between `main` and `dev/links`, we want more data to be queried.
This adds the same functionality as #1431, but targeting the `dev/links` branch

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/0/1203384240596317/f) _(internal)_

## 🔍 What does this change?

- Update entity batch insertion method to support links
- Seed links based on existing entities


## 🐾 Next steps

[Add new benchmarks to `main`](https://app.asana.com/0/0/1203384240596318/f) (_internal_)