### PR TITLE
Add more benchmarks for structural queries (`main`)

### DIFF
--- a/packages/graph/hash_graph/bench/benches/representative_read/knowledge/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/knowledge/entity.rs
@@ -1,7 +1,12 @@
+use std::borrow::Cow;
+
 use criterion::{BatchSize::SmallInput, Bencher};
 use graph::{
-    knowledge::EntityId,
-    store::{query::Filter, EntityStore},
+    knowledge::{EntityId, EntityQueryPath, LinkQueryPath},
+    store::{
+        query::{Filter, FilterExpression, Parameter},
+        EntityStore, LinkStore,
+    },
     subgraph::{GraphResolveDepths, StructuralQuery},
 };
 use rand::{prelude::IteratorRandom, thread_rng};
@@ -21,7 +26,7 @@ pub fn bench_get_entity_by_id(
             *entity_ids.iter().choose(&mut thread_rng()).unwrap()
         },
         |entity_id| async move {
-            store
+            let subgraph = store
                 .get_entity(&StructuralQuery {
                     filter: Filter::for_latest_entity_by_entity_id(entity_id),
                     graph_resolve_depths: GraphResolveDepths {
@@ -35,7 +40,60 @@ pub fn bench_get_entity_by_id(
                 })
                 .await
                 .expect("failed to read entity from store");
+            assert_eq!(subgraph.roots.len(), 1);
         },
         SmallInput,
     );
+}
+
+pub fn bench_get_entities_by_property(
+    b: &mut Bencher,
+    runtime: &Runtime,
+    store: &Store,
+    graph_resolve_depths: GraphResolveDepths,
+) {
+    b.to_async(runtime).iter(|| async move {
+        let subgraph = store
+            .get_entity(&StructuralQuery {
+                filter: Filter::Equal(
+                    Some(FilterExpression::Path(EntityQueryPath::Properties(Some(
+                        Cow::Borrowed("https://blockprotocol.org/@alice/types/property-type/name/"),
+                    )))),
+                    Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
+                        "Alice",
+                    )))),
+                ),
+                graph_resolve_depths,
+            })
+            .await
+            .expect("failed to read entity from store");
+        assert_eq!(subgraph.roots.len(), 100);
+    });
+}
+
+pub fn bench_get_link_by_target_by_property(
+    b: &mut Bencher,
+    runtime: &Runtime,
+    store: &Store,
+    graph_resolve_depths: GraphResolveDepths,
+) {
+    b.to_async(runtime).iter(|| async move {
+        let subgraph = store
+            .get_links(&StructuralQuery {
+                filter: Filter::Equal(
+                    Some(FilterExpression::Path(LinkQueryPath::Target(Some(
+                        EntityQueryPath::Properties(Some(Cow::Borrowed(
+                            "https://blockprotocol.org/@alice/types/property-type/name/",
+                        ))),
+                    )))),
+                    Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
+                        "Alice",
+                    )))),
+                ),
+                graph_resolve_depths,
+            })
+            .await
+            .expect("failed to read entity from store");
+        assert_eq!(subgraph.len(), 100);
+    });
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds two new benchmarks testing two different structural queries with various resolve depths

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/0/1203384240596318/f) _(internal)_

## 🚫 Blocked by

- #1431

## 🔍 What does this change?

- Adds two new benchmarks:
    - Get entity specified by a property
    - Get link to an entity, where the entity has a specified property
- Varies over the resolve depth of these filters