### PR TITLE
Add more benchmarks for structural queries (`dev/links`)

### DIFF
--- a/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
@@ -149,7 +149,7 @@ fn bench_scaling_read_entity(c: &mut Criterion) {
 
         group.bench_with_input(
             BenchmarkId::new(
-                "get_entity_type_by_id",
+                "get_entity_by_id",
                 format!(
                     "Account ID: `{}`, Number Of Entities: `{}`",
                     account_id, size

--- a/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
@@ -74,7 +74,7 @@ async fn seed_db(
 
     let entity_uuids = store
         .insert_entities_batched_by_type(
-            repeat((None, properties)).take(total),
+            repeat((None, properties, None)).take(total),
             entity_type_id,
             OwnedById::new(account_id),
             CreatedById::new(account_id),

--- a/packages/graph/hash_graph/bench/benches/representative_read/knowledge/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/knowledge/entity.rs
@@ -58,14 +58,14 @@ pub fn bench_get_entities_by_property(
                         Cow::Borrowed("https://blockprotocol.org/@alice/types/property-type/name/"),
                     )))),
                     Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                        "Bob",
+                        "Alice",
                     )))),
                 ),
                 graph_resolve_depths,
             })
             .await
             .expect("failed to read entity from store");
-        assert_eq!(subgraph.roots.len(), 1000);
+        assert_eq!(subgraph.roots.len(), 100);
     });
 }
 
@@ -85,13 +85,13 @@ pub fn bench_get_link_by_target_by_property(
                         )))),
                     ))),
                     Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                        "Bob",
+                        "Alice",
                     )))),
                 ),
                 graph_resolve_depths,
             })
             .await
             .expect("failed to read entity from store");
-        assert_eq!(subgraph.roots.len(), 1000);
+        assert_eq!(subgraph.roots.len(), 100);
     });
 }

--- a/packages/graph/hash_graph/bench/benches/representative_read/knowledge/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/knowledge/entity.rs
@@ -1,8 +1,13 @@
+use std::borrow::Cow;
+
 use criterion::{BatchSize::SmallInput, Bencher};
 use graph::{
-    knowledge::EntityUuid,
+    knowledge::{EntityQueryPath, EntityUuid},
     shared::subgraph::{depths::GraphResolveDepths, query::StructuralQuery},
-    store::{query::Filter, EntityStore},
+    store::{
+        query::{Filter, FilterExpression, Parameter},
+        EntityStore,
+    },
 };
 use rand::{prelude::IteratorRandom, thread_rng};
 use tokio::runtime::Runtime;
@@ -21,7 +26,7 @@ pub fn bench_get_entity_by_id(
             *entity_uuids.iter().choose(&mut thread_rng()).unwrap()
         },
         |entity_uuid| async move {
-            store
+            let subgraph = store
                 .get_entity(&StructuralQuery {
                     filter: Filter::for_latest_entity_by_entity_uuid(entity_uuid),
                     graph_resolve_depths: GraphResolveDepths {
@@ -33,7 +38,60 @@ pub fn bench_get_entity_by_id(
                 })
                 .await
                 .expect("failed to read entity from store");
+            assert_eq!(subgraph.roots.len(), 1);
         },
         SmallInput,
     );
+}
+
+pub fn bench_get_entities_by_property(
+    b: &mut Bencher,
+    runtime: &Runtime,
+    store: &Store,
+    graph_resolve_depths: GraphResolveDepths,
+) {
+    b.to_async(runtime).iter(|| async move {
+        let subgraph = store
+            .get_entity(&StructuralQuery {
+                filter: Filter::Equal(
+                    Some(FilterExpression::Path(EntityQueryPath::Properties(Some(
+                        Cow::Borrowed("https://blockprotocol.org/@alice/types/property-type/name/"),
+                    )))),
+                    Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
+                        "Bob",
+                    )))),
+                ),
+                graph_resolve_depths,
+            })
+            .await
+            .expect("failed to read entity from store");
+        assert_eq!(subgraph.roots.len(), 1000);
+    });
+}
+
+pub fn bench_get_link_by_target_by_property(
+    b: &mut Bencher,
+    runtime: &Runtime,
+    store: &Store,
+    graph_resolve_depths: GraphResolveDepths,
+) {
+    b.to_async(runtime).iter(|| async move {
+        let subgraph = store
+            .get_entity(&StructuralQuery {
+                filter: Filter::Equal(
+                    Some(FilterExpression::Path(EntityQueryPath::RightEntity(
+                        Box::new(EntityQueryPath::Properties(Some(Cow::Borrowed(
+                            "https://blockprotocol.org/@alice/types/property-type/name/",
+                        )))),
+                    ))),
+                    Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
+                        "Bob",
+                    )))),
+                ),
+                graph_resolve_depths,
+            })
+            .await
+            .expect("failed to read entity from store");
+        assert_eq!(subgraph.roots.len(), 1000);
+    });
 }

--- a/packages/graph/hash_graph/bench/benches/representative_read/mod.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/mod.rs
@@ -65,11 +65,6 @@ fn bench_representative_read_multiple_entities(c: &mut Criterion) {
     let (runtime, store_wrapper) = setup(DB_NAME, false, false);
     group.sample_size(10);
     group.sampling_mode(SamplingMode::Flat);
-    // Set the warm_up and measurement times to try and encourage Criterion to run as few iterations
-    // as possible as these benchmarks run a *lot* longer than the intended Criterion benchmark,
-    // by a few orders of magnitude
-    group.warm_up_time(Duration::from_nanos(1));
-    group.measurement_time(Duration::from_millis(100));
 
     let graph_resolve_depths = [
         GraphResolveDepths {
@@ -159,7 +154,7 @@ fn bench_representative_read_multiple_entities(c: &mut Criterion) {
     }
 }
 
-// #[criterion]
+#[criterion]
 fn bench_representative_read_entity_type(c: &mut Criterion) {
     let mut group = c.benchmark_group("representative_read_entity_type");
     let (runtime, mut store_wrapper) = setup(DB_NAME, false, false);

--- a/packages/graph/hash_graph/bench/benches/representative_read/mod.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/mod.rs
@@ -76,20 +76,20 @@ fn bench_representative_read_multiple_entities(c: &mut Criterion) {
         GraphResolveDepths {
             data_type_resolve_depth: 0,
             property_type_resolve_depth: 0,
+            entity_type_resolve_depth: 0,
+            entity_resolve_depth: 2,
+        },
+        GraphResolveDepths {
+            data_type_resolve_depth: 0,
+            property_type_resolve_depth: 0,
             entity_type_resolve_depth: 2,
-            entity_resolve_depth: 0,
+            entity_resolve_depth: 2,
         },
         GraphResolveDepths {
             data_type_resolve_depth: 0,
             property_type_resolve_depth: 2,
             entity_type_resolve_depth: 2,
-            entity_resolve_depth: 0,
-        },
-        GraphResolveDepths {
-            data_type_resolve_depth: 2,
-            property_type_resolve_depth: 2,
-            entity_type_resolve_depth: 2,
-            entity_resolve_depth: 0,
+            entity_resolve_depth: 2,
         },
         GraphResolveDepths {
             data_type_resolve_depth: 2,

--- a/packages/graph/hash_graph/bench/benches/representative_read/mod.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/mod.rs
@@ -17,8 +17,11 @@
 //!
 //! [`BenchmarkId`]: criterion::BenchmarkId
 
-use criterion::{BenchmarkId, Criterion};
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, SamplingMode};
 use criterion_macro::criterion;
+use graph::subgraph::depths::GraphResolveDepths;
 
 use crate::{representative_read::seed::setup_and_extract_samples, util::setup};
 
@@ -41,7 +44,7 @@ fn bench_representative_read_entity(c: &mut Criterion) {
         for (entity_type_id, entity_uuids) in type_ids_and_entity_uuids {
             group.bench_with_input(
                 BenchmarkId::new(
-                    "get_entity_by_id",
+                    "entity_by_id",
                     format!(
                         "Account ID: `{}`, Entity Type ID: `{}`",
                         account_id, entity_type_id
@@ -57,6 +60,106 @@ fn bench_representative_read_entity(c: &mut Criterion) {
 }
 
 #[criterion]
+fn bench_representative_read_multiple_entities(c: &mut Criterion) {
+    let mut group = c.benchmark_group("representative_read_multiple_entities");
+    let (runtime, store_wrapper) = setup(DB_NAME, false, false);
+    group.sample_size(10);
+    group.sampling_mode(SamplingMode::Flat);
+    // Set the warm_up and measurement times to try and encourage Criterion to run as few iterations
+    // as possible as these benchmarks run a *lot* longer than the intended Criterion benchmark,
+    // by a few orders of magnitude
+    group.warm_up_time(Duration::from_nanos(1));
+    group.measurement_time(Duration::from_millis(100));
+
+    let graph_resolve_depths = [
+        GraphResolveDepths {
+            data_type_resolve_depth: 0,
+            property_type_resolve_depth: 0,
+            entity_type_resolve_depth: 0,
+            entity_resolve_depth: 0,
+        },
+        GraphResolveDepths {
+            data_type_resolve_depth: 0,
+            property_type_resolve_depth: 0,
+            entity_type_resolve_depth: 2,
+            entity_resolve_depth: 0,
+        },
+        GraphResolveDepths {
+            data_type_resolve_depth: 0,
+            property_type_resolve_depth: 2,
+            entity_type_resolve_depth: 2,
+            entity_resolve_depth: 0,
+        },
+        GraphResolveDepths {
+            data_type_resolve_depth: 2,
+            property_type_resolve_depth: 2,
+            entity_type_resolve_depth: 2,
+            entity_resolve_depth: 0,
+        },
+        GraphResolveDepths {
+            data_type_resolve_depth: 2,
+            property_type_resolve_depth: 2,
+            entity_type_resolve_depth: 2,
+            entity_resolve_depth: 2,
+        },
+        GraphResolveDepths {
+            data_type_resolve_depth: 255,
+            property_type_resolve_depth: 255,
+            entity_type_resolve_depth: 255,
+            entity_resolve_depth: 255,
+        },
+    ];
+
+    for graph_resolve_depth in graph_resolve_depths {
+        group.bench_with_input(
+            BenchmarkId::new(
+                "entity_by_property",
+                format!(
+                    "depths: DT={}, PT={}, ET={}, E={}",
+                    graph_resolve_depth.data_type_resolve_depth,
+                    graph_resolve_depth.property_type_resolve_depth,
+                    graph_resolve_depth.entity_type_resolve_depth,
+                    graph_resolve_depth.entity_resolve_depth,
+                ),
+            ),
+            &graph_resolve_depth,
+            |b, graph_resolve_depth| {
+                knowledge::entity::bench_get_entities_by_property(
+                    b,
+                    &runtime,
+                    &store_wrapper.store,
+                    *graph_resolve_depth,
+                );
+            },
+        );
+    }
+
+    for graph_resolve_depth in graph_resolve_depths {
+        group.bench_with_input(
+            BenchmarkId::new(
+                "link_by_source_by_property",
+                format!(
+                    "depths: DT={}, PT={}, ET={}, E={}",
+                    graph_resolve_depth.data_type_resolve_depth,
+                    graph_resolve_depth.property_type_resolve_depth,
+                    graph_resolve_depth.entity_type_resolve_depth,
+                    graph_resolve_depth.entity_resolve_depth,
+                ),
+            ),
+            &graph_resolve_depth,
+            |b, graph_resolve_depth| {
+                knowledge::entity::bench_get_link_by_target_by_property(
+                    b,
+                    &runtime,
+                    &store_wrapper.store,
+                    *graph_resolve_depth,
+                );
+            },
+        );
+    }
+}
+
+// #[criterion]
 fn bench_representative_read_entity_type(c: &mut Criterion) {
     let mut group = c.benchmark_group("representative_read_entity_type");
     let (runtime, mut store_wrapper) = setup(DB_NAME, false, false);

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -366,8 +366,14 @@ pub trait EntityStore: for<'q> crud::Read<Entity, Query<'q> = Filter<'q, Entity>
     #[cfg(feature = "__internal_bench")]
     async fn insert_entities_batched_by_type(
         &mut self,
-        entities: impl IntoIterator<Item = (Option<EntityUuid>, EntityProperties), IntoIter: Send>
-        + Send,
+        entities: impl IntoIterator<
+            Item = (
+                Option<EntityUuid>,
+                EntityProperties,
+                Option<LinkEntityMetadata>,
+            ),
+            IntoIter: Send,
+        > + Send,
         entity_type_id: VersionedUri,
         owned_by_id: OwnedById,
         actor_id: CreatedById,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds two new benchmarks testing two different structural queries with various resolve depths. This is the same implementation as in #1436, but targeting the `dev/links` branch

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/0/1203384240596319/f) _(internal)_

## 🚫 Blocked by

- #1432

## 🔍 What does this change?

- Adds two new benchmarks:
    - Get entity specified by a property
    - Get link to an entity, where the entity has a specified property
- Varies over the resolve depth of these filters