### PR TITLE
Fix nested hashmap extension

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph/edges/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph/edges/mod.rs
@@ -140,12 +140,29 @@ impl Edges {
         }
     }
 
-    // TODO: Implement `Extend` trait instead
     pub fn extend(&mut self, other: Self) {
-        self.ontology.0.extend(other.ontology.0.into_iter());
-        self.knowledge_graph
-            .0
-            .extend(other.knowledge_graph.0.into_iter());
+        for (key, value) in other.ontology.0.into_iter() {
+            match self.ontology.0.entry(key) {
+                Entry::Occupied(entry) => {
+                    let inner_map = entry.into_mut();
+                    inner_map.extend(value);
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(value);
+                }
+            }
+        }
+        for (key, value) in other.knowledge_graph.0.into_iter() {
+            match self.knowledge_graph.0.entry(key) {
+                Entry::Occupied(entry) => {
+                    let inner_map = entry.into_mut();
+                    inner_map.extend(value);
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(value);
+                }
+            }
+        }
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph/edges/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph/edges/mod.rs
@@ -100,10 +100,7 @@ impl Edges {
                     .or_default();
 
                 match map.entry(ontology_edition_id.version()) {
-                    Entry::Occupied(entry) => {
-                        let set = entry.into_mut();
-                        set.insert(outward_edge)
-                    }
+                    Entry::Occupied(entry) => entry.into_mut().insert(outward_edge),
                     Entry::Vacant(entry) => {
                         entry.insert(HashSet::from([outward_edge]));
                         true
@@ -121,10 +118,7 @@ impl Edges {
                     .or_default();
 
                 match map.entry(entity_edition_id.version()) {
-                    Entry::Occupied(entry) => {
-                        let set = entry.into_mut();
-                        set.insert(outward_edge)
-                    }
+                    Entry::Occupied(entry) => entry.into_mut().insert(outward_edge),
                     Entry::Vacant(entry) => {
                         entry.insert(HashSet::from([outward_edge]));
                         true
@@ -144,8 +138,7 @@ impl Edges {
         for (key, value) in other.ontology.0.into_iter() {
             match self.ontology.0.entry(key) {
                 Entry::Occupied(entry) => {
-                    let inner_map = entry.into_mut();
-                    inner_map.extend(value);
+                    entry.into_mut().extend(value);
                 }
                 Entry::Vacant(entry) => {
                     entry.insert(value);
@@ -155,8 +148,7 @@ impl Edges {
         for (key, value) in other.knowledge_graph.0.into_iter() {
             match self.knowledge_graph.0.entry(key) {
                 Entry::Occupied(entry) => {
-                    let inner_map = entry.into_mut();
-                    inner_map.extend(value);
+                    entry.into_mut().extend(value);
                 }
                 Entry::Vacant(entry) => {
                     entry.insert(value);

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph/vertices/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph/vertices/mod.rs
@@ -50,8 +50,7 @@ impl Vertices {
         for (key, value) in other.ontology.0.into_iter() {
             match self.ontology.0.entry(key) {
                 Entry::Occupied(entry) => {
-                    let inner_map = entry.into_mut();
-                    inner_map.extend(value);
+                    entry.into_mut().extend(value);
                 }
                 Entry::Vacant(entry) => {
                     entry.insert(value);
@@ -61,8 +60,7 @@ impl Vertices {
         for (key, value) in other.knowledge_graph.0.into_iter() {
             match self.knowledge_graph.0.entry(key) {
                 Entry::Occupied(entry) => {
-                    let inner_map = entry.into_mut();
-                    inner_map.extend(value);
+                    entry.into_mut().extend(value);
                 }
                 Entry::Vacant(entry) => {
                     entry.insert(value);

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph/vertices/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph/vertices/mod.rs
@@ -1,6 +1,6 @@
 mod vertex;
 
-use std::collections::HashMap;
+use std::collections::{hash_map::Entry, HashMap};
 
 use serde::Serialize;
 use type_system::uri::BaseUri;
@@ -47,10 +47,28 @@ impl Vertices {
     }
 
     pub fn extend(&mut self, other: Self) {
-        self.ontology.0.extend(other.ontology.0.into_iter());
-        self.knowledge_graph
-            .0
-            .extend(other.knowledge_graph.0.into_iter());
+        for (key, value) in other.ontology.0.into_iter() {
+            match self.ontology.0.entry(key) {
+                Entry::Occupied(entry) => {
+                    let inner_map = entry.into_mut();
+                    inner_map.extend(value);
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(value);
+                }
+            }
+        }
+        for (key, value) in other.knowledge_graph.0.into_iter() {
+            match self.knowledge_graph.0.entry(key) {
+                Entry::Occupied(entry) => {
+                    let inner_map = entry.into_mut();
+                    inner_map.extend(value);
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(value);
+                }
+            }
+        }
     }
 
     #[must_use]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When combining intermediary HashMaps, we were using the extend trait, but this doesn't use `extend` in a nested fashion, which means we were dropping vertices and edges that have the same BaseId. This fixes it
