### PR TITLE
Don't collect into intermediary collection of subgraphs

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph/depths.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph/depths.rs
@@ -54,7 +54,7 @@ pub type SubgraphQueryDepth = u8;
 /// will not be included in the subgraph, because the depth for `entity_resolve_depth` is `2`
 /// and `Link2` is `3` edges away from `Entity1`.
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct GraphResolveDepths {
     #[schema(value_type = i64)]

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph/edges/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph/edges/mod.rs
@@ -135,7 +135,7 @@ impl Edges {
     }
 
     pub fn extend(&mut self, other: Self) {
-        for (key, value) in other.ontology.0.into_iter() {
+        for (key, value) in other.ontology.0 {
             match self.ontology.0.entry(key) {
                 Entry::Occupied(entry) => {
                     entry.into_mut().extend(value);
@@ -145,7 +145,7 @@ impl Edges {
                 }
             }
         }
-        for (key, value) in other.knowledge_graph.0.into_iter() {
+        for (key, value) in other.knowledge_graph.0 {
             match self.knowledge_graph.0.entry(key) {
                 Entry::Occupied(entry) => {
                     entry.into_mut().extend(value);

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph/mod.rs
@@ -18,7 +18,7 @@ pub mod edges;
 pub mod query;
 pub mod vertices;
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Debug, Default, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Subgraph {
     #[schema(value_type = Vec<GraphElementEditionId>)]

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph/vertices/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph/vertices/mod.rs
@@ -47,7 +47,7 @@ impl Vertices {
     }
 
     pub fn extend(&mut self, other: Self) {
-        for (key, value) in other.ontology.0.into_iter() {
+        for (key, value) in other.ontology.0 {
             match self.ontology.0.entry(key) {
                 Entry::Occupied(entry) => {
                     entry.into_mut().extend(value);
@@ -57,7 +57,7 @@ impl Vertices {
                 }
             }
         }
-        for (key, value) in other.knowledge_graph.0.into_iter() {
+        for (key, value) in other.knowledge_graph.0 {
             match self.knowledge_graph.0.entry(key) {
                 Entry::Occupied(entry) => {
                     entry.into_mut().extend(value);

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph/vertices/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph/vertices/mod.rs
@@ -13,11 +13,11 @@ use crate::identifier::{
     GraphElementEditionId,
 };
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Default, Debug, Serialize, ToSchema)]
 #[serde(transparent)]
 pub struct OntologyVertices(pub HashMap<BaseUri, HashMap<OntologyTypeVersion, OntologyVertex>>);
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Default, Debug, Serialize, ToSchema)]
 #[serde(transparent)]
 pub struct KnowledgeGraphVertices(
     // TODO: expose it through methods instead of making this field `pub`
@@ -25,7 +25,7 @@ pub struct KnowledgeGraphVertices(
     pub HashMap<EntityId, HashMap<EntityVersion, KnowledgeGraphVertex>>,
 );
 
-#[derive(Debug, Serialize)]
+#[derive(Default, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Vertices {
     #[serde(flatten)]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We implement `Extend` for `Subgraph` and we were collecting into a `Vec<Subgraph>` before combining them. We should just be able to directly collect into one `Subgraph`, this PR makes it possible.
