### PR TITLE
Rename "endpoint" in edges

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -785,8 +785,8 @@ export interface GraphResolveDepths {
  */
 
 export const KnowledgeGraphEdgeKind = {
-  LeftEndpoint: "HAS_LEFT_ENDPOINT",
-  RightEndpoint: "HAS_RIGHT_ENDPOINT",
+  LeftEntity: "HAS_LEFT_ENTITY",
+  RightEntity: "HAS_RIGHT_ENTITY",
 } as const;
 
 export type KnowledgeGraphEdgeKind =
@@ -808,12 +808,6 @@ export type KnowledgeGraphOutwardEdges =
 export interface KnowledgeGraphOutwardEdgesOneOf {
   /**
    *
-   * @type {KnowledgeGraphOutwardEdgesOneOfEndpoint}
-   * @memberof KnowledgeGraphOutwardEdgesOneOf
-   */
-  endpoint: KnowledgeGraphOutwardEdgesOneOfEndpoint;
-  /**
-   *
    * @type {string}
    * @memberof KnowledgeGraphOutwardEdgesOneOf
    */
@@ -824,11 +818,17 @@ export interface KnowledgeGraphOutwardEdgesOneOf {
    * @memberof KnowledgeGraphOutwardEdgesOneOf
    */
   reversed: boolean;
+  /**
+   *
+   * @type {KnowledgeGraphOutwardEdgesOneOfRightEndpoint}
+   * @memberof KnowledgeGraphOutwardEdgesOneOf
+   */
+  rightEndpoint: KnowledgeGraphOutwardEdgesOneOfRightEndpoint;
 }
 
 export const KnowledgeGraphOutwardEdgesOneOfKindEnum = {
-  LeftEndpoint: "HAS_LEFT_ENDPOINT",
-  RightEndpoint: "HAS_RIGHT_ENDPOINT",
+  LeftEntity: "HAS_LEFT_ENTITY",
+  RightEntity: "HAS_RIGHT_ENTITY",
 } as const;
 
 export type KnowledgeGraphOutwardEdgesOneOfKindEnum =
@@ -842,12 +842,6 @@ export type KnowledgeGraphOutwardEdgesOneOfKindEnum =
 export interface KnowledgeGraphOutwardEdgesOneOf1 {
   /**
    *
-   * @type {GraphElementEditionIdOneOf}
-   * @memberof KnowledgeGraphOutwardEdgesOneOf1
-   */
-  endpoint: GraphElementEditionIdOneOf;
-  /**
-   *
    * @type {string}
    * @memberof KnowledgeGraphOutwardEdgesOneOf1
    */
@@ -858,6 +852,12 @@ export interface KnowledgeGraphOutwardEdgesOneOf1 {
    * @memberof KnowledgeGraphOutwardEdgesOneOf1
    */
   reversed: boolean;
+  /**
+   *
+   * @type {GraphElementEditionIdOneOf}
+   * @memberof KnowledgeGraphOutwardEdgesOneOf1
+   */
+  rightEndpoint: GraphElementEditionIdOneOf;
 }
 
 export const KnowledgeGraphOutwardEdgesOneOf1KindEnum = {
@@ -870,19 +870,19 @@ export type KnowledgeGraphOutwardEdgesOneOf1KindEnum =
 /**
  *
  * @export
- * @interface KnowledgeGraphOutwardEdgesOneOfEndpoint
+ * @interface KnowledgeGraphOutwardEdgesOneOfRightEndpoint
  */
-export interface KnowledgeGraphOutwardEdgesOneOfEndpoint {
+export interface KnowledgeGraphOutwardEdgesOneOfRightEndpoint {
   /**
    *
    * @type {string}
-   * @memberof KnowledgeGraphOutwardEdgesOneOfEndpoint
+   * @memberof KnowledgeGraphOutwardEdgesOneOfRightEndpoint
    */
   baseId: string;
   /**
    *
    * @type {string}
-   * @memberof KnowledgeGraphOutwardEdgesOneOfEndpoint
+   * @memberof KnowledgeGraphOutwardEdgesOneOfRightEndpoint
    */
   timestamp: string;
 }
@@ -1088,12 +1088,6 @@ export type OntologyOutwardEdges =
 export interface OntologyOutwardEdgesOneOf {
   /**
    *
-   * @type {GraphElementEditionIdOneOf}
-   * @memberof OntologyOutwardEdgesOneOf
-   */
-  endpoint: GraphElementEditionIdOneOf;
-  /**
-   *
    * @type {string}
    * @memberof OntologyOutwardEdgesOneOf
    */
@@ -1104,6 +1098,12 @@ export interface OntologyOutwardEdgesOneOf {
    * @memberof OntologyOutwardEdgesOneOf
    */
   reversed: boolean;
+  /**
+   *
+   * @type {GraphElementEditionIdOneOf}
+   * @memberof OntologyOutwardEdgesOneOf
+   */
+  rightEndpoint: GraphElementEditionIdOneOf;
 }
 
 export const OntologyOutwardEdgesOneOfKindEnum = {
@@ -1125,12 +1125,6 @@ export type OntologyOutwardEdgesOneOfKindEnum =
 export interface OntologyOutwardEdgesOneOf1 {
   /**
    *
-   * @type {GraphElementEditionIdOneOf1}
-   * @memberof OntologyOutwardEdgesOneOf1
-   */
-  endpoint: GraphElementEditionIdOneOf1;
-  /**
-   *
    * @type {string}
    * @memberof OntologyOutwardEdgesOneOf1
    */
@@ -1141,6 +1135,12 @@ export interface OntologyOutwardEdgesOneOf1 {
    * @memberof OntologyOutwardEdgesOneOf1
    */
   reversed: boolean;
+  /**
+   *
+   * @type {GraphElementEditionIdOneOf1}
+   * @memberof OntologyOutwardEdgesOneOf1
+   */
+  rightEndpoint: GraphElementEditionIdOneOf1;
 }
 
 export const OntologyOutwardEdgesOneOf1KindEnum = {

--- a/packages/graph/hash_graph/bench/benches/representative_read/mod.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/mod.rs
@@ -17,8 +17,6 @@
 //!
 //! [`BenchmarkId`]: criterion::BenchmarkId
 
-use std::time::Duration;
-
 use criterion::{BenchmarkId, Criterion, SamplingMode};
 use criterion_macro::criterion;
 use graph::subgraph::depths::GraphResolveDepths;

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph/edges/edge.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph/edges/edge.rs
@@ -10,13 +10,13 @@ use crate::{
 };
 
 #[derive(Debug, Hash, PartialEq, Eq, Serialize)]
-#[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct GenericOutwardEdge<K, E> {
     pub kind: K,
     /// If true, interpret this as a reversed mapping and the endpoint as the source, that is,
     /// instead of Source-Edge-Target, interpret it as Target-Edge-Source
     pub reversed: bool,
-    pub endpoint: E,
+    pub right_endpoint: E,
 }
 
 // Utoipa doesn't seem to be able to generate sensible interfaces for this, it gets confused by
@@ -35,8 +35,8 @@ where
                 openapi::Object::with_type(openapi::SchemaType::Boolean),
             )
             .required("reversed")
-            .property("endpoint", E::schema())
-            .required("endpoint")
+            .property("rightEndpoint", E::schema())
+            .required("rightEndpoint")
             .into()
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph/edges/kind.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph/edges/kind.rs
@@ -38,11 +38,11 @@ pub enum KnowledgeGraphEdgeKind {
     /// `Link` [`Entity`].
     ///
     /// [`Entity`]: crate::knowledge::Entity
-    HasLeftEndpoint,
+    HasLeftEntity,
     /// This link [`Entity`] has another [`Entity`] on its 'right' endpoint.
     ///
     /// [`Entity`]: crate::knowledge::Entity
-    HasRightEndpoint,
+    HasRightEntity,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, ToSchema)]

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -87,7 +87,7 @@ impl<C: AsClient> PostgresStore<C> {
                         GenericOutwardEdge {
                             kind: SharedEdgeKind::IsOfType,
                             reversed: false,
-                            endpoint: entity_type_id.into(),
+                            right_endpoint: entity_type_id.into(),
                         },
                     )),
                 );
@@ -134,7 +134,7 @@ impl<C: AsClient> PostgresStore<C> {
                             // outgoing `Link` `Entity`
                             kind: KnowledgeGraphEdgeKind::HasLeftEndpoint,
                             reversed: true,
-                            endpoint: EntityIdAndTimestamp::new(
+                            right_endpoint: EntityIdAndTimestamp::new(
                                 outgoing_link_entity.metadata().edition_id().base_id(),
                                 earliest_version.inner(),
                             ),
@@ -180,7 +180,7 @@ impl<C: AsClient> PostgresStore<C> {
                         GenericOutwardEdge {
                             kind: KnowledgeGraphEdgeKind::HasLeftEndpoint,
                             reversed: false,
-                            endpoint: EntityIdAndTimestamp::new(
+                            right_endpoint: EntityIdAndTimestamp::new(
                                 left_entity.metadata().edition_id().base_id(),
                                 earliest_version.inner(),
                             ),
@@ -226,7 +226,7 @@ impl<C: AsClient> PostgresStore<C> {
                         GenericOutwardEdge {
                             kind: KnowledgeGraphEdgeKind::HasRightEndpoint,
                             reversed: false,
-                            endpoint: EntityIdAndTimestamp::new(
+                            right_endpoint: EntityIdAndTimestamp::new(
                                 right_entity.metadata().edition_id().base_id(),
                                 earliest_version.inner(),
                             ),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -132,7 +132,7 @@ impl<C: AsClient> PostgresStore<C> {
                         GenericOutwardEdge {
                             // (HasLeftEndpoint, reversed=true) is equivalent to an
                             // outgoing `Link` `Entity`
-                            kind: KnowledgeGraphEdgeKind::HasLeftEndpoint,
+                            kind: KnowledgeGraphEdgeKind::HasLeftEntity,
                             reversed: true,
                             right_endpoint: EntityIdAndTimestamp::new(
                                 outgoing_link_entity.metadata().edition_id().base_id(),
@@ -178,7 +178,7 @@ impl<C: AsClient> PostgresStore<C> {
                         entity_edition_id,
                         left_entity.metadata().edition_id(),
                         GenericOutwardEdge {
-                            kind: KnowledgeGraphEdgeKind::HasLeftEndpoint,
+                            kind: KnowledgeGraphEdgeKind::HasLeftEntity,
                             reversed: false,
                             right_endpoint: EntityIdAndTimestamp::new(
                                 left_entity.metadata().edition_id().base_id(),
@@ -224,7 +224,7 @@ impl<C: AsClient> PostgresStore<C> {
                         entity_edition_id,
                         right_entity.metadata().edition_id(),
                         GenericOutwardEdge {
-                            kind: KnowledgeGraphEdgeKind::HasRightEndpoint,
+                            kind: KnowledgeGraphEdgeKind::HasRightEntity,
                             reversed: false,
                             right_endpoint: EntityIdAndTimestamp::new(
                                 right_entity.metadata().edition_id().base_id(),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -81,7 +81,7 @@ impl<C: AsClient> PostgresStore<C> {
                             GenericOutwardEdge {
                                 kind: OntologyEdgeKind::ConstrainsPropertiesOn,
                                 reversed: false,
-                                endpoint: property_type_ref.uri().clone().into(),
+                                right_endpoint: property_type_ref.uri().clone().into(),
                             },
                         )),
                     );
@@ -155,7 +155,7 @@ impl<C: AsClient> PostgresStore<C> {
                 OutwardEdge::Ontology(OntologyOutwardEdges::ToOntology(GenericOutwardEdge {
                     kind: edge_kind,
                     reversed: false,
-                    endpoint: dependent_entity_type_id.clone(),
+                    right_endpoint: dependent_entity_type_id.clone(),
                 })),
             );
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -80,7 +80,7 @@ impl<C: AsClient> PostgresStore<C> {
                             GenericOutwardEdge {
                                 kind: OntologyEdgeKind::ConstrainsValuesOn,
                                 reversed: false,
-                                endpoint: data_type_ref.uri().clone().into(),
+                                right_endpoint: data_type_ref.uri().clone().into(),
                             },
                         )),
                     );
@@ -114,7 +114,7 @@ impl<C: AsClient> PostgresStore<C> {
                             GenericOutwardEdge {
                                 kind: OntologyEdgeKind::ConstrainsPropertiesOn,
                                 reversed: false,
-                                endpoint: property_type_ref.uri().clone().into(),
+                                right_endpoint: property_type_ref.uri().clone().into(),
                             },
                         )),
                     );

--- a/packages/hash/subgraph/src/types/edge.ts
+++ b/packages/hash/subgraph/src/types/edge.ts
@@ -18,7 +18,7 @@ const ONTOLOGY_EDGE_KINDS = [
   "CONSTRAINS_LINKS_ON",
   "CONSTRAINS_LINK_DESTINATIONS_ON",
 ];
-const KNOWLEDGE_GRAPH_EDGE_KIND = ["HAS_LEFT_ENDPOINT", "HAS_RIGHT_ENDPOINT"];
+const KNOWLEDGE_GRAPH_EDGE_KIND = ["HAS_LEFT_ENTITY", "HAS_RIGHT_ENTITY"];
 const SHARED_EDGE_KIND = ["IS_OF_TYPE"];
 
 export type OntologyEdgeKind = typeof ONTOLOGY_EDGE_KINDS[number];
@@ -48,7 +48,7 @@ export const isSharedEdgeKind = (kind: string): kind is SharedEdgeKind => {
 type GenericOutwardEdge<K, E> = {
   kind: K;
   reversed: boolean;
-  endpoint: E;
+  rightEndpoint: E;
 };
 
 export type OntologyOutwardEdge =
@@ -66,7 +66,7 @@ export const isOntologyOutwardEdge = (
 ): edge is OntologyOutwardEdge => {
   return (
     isOntologyEdgeKind(edge.kind) ||
-    (isSharedEdgeKind(edge.kind) && isEntityEditionId(edge.endpoint))
+    (isSharedEdgeKind(edge.kind) && isEntityEditionId(edge.rightEndpoint))
   );
 };
 
@@ -75,7 +75,7 @@ export const isKnowledgeGraphOutwardEdge = (
 ): edge is KnowledgeGraphOutwardEdge => {
   return (
     isKnowledgeGraphEdgeKind(edge.kind) ||
-    (isSharedEdgeKind(edge.kind) && isOntologyTypeEditionId(edge.endpoint))
+    (isSharedEdgeKind(edge.kind) && isOntologyTypeEditionId(edge.rightEndpoint))
   );
 };
 

--- a/packages/hash/subgraph/tests/compatibility.test/map-edges.ts
+++ b/packages/hash/subgraph/tests/compatibility.test/map-edges.ts
@@ -26,9 +26,9 @@ export const mapOutwardEdge = (
       return outwardEdge;
     }
     // Knowledge-graph edge-kind cases
-    case "HAS_LEFT_ENDPOINT":
-    case "HAS_RIGHT_ENDPOINT": {
-      if (!isEntityAndTimestamp(outwardEdge.endpoint)) {
+    case "HAS_LEFT_ENTITY":
+    case "HAS_RIGHT_ENTITY": {
+      if (!isEntityAndTimestamp(outwardEdge.rightEndpoint)) {
         throw new Error(
           `Expected an \`EntityAndTimestamp\` for knowledge-graph edge-kind endpoint but found:\n${JSON.stringify(
             outwardEdge,
@@ -38,14 +38,14 @@ export const mapOutwardEdge = (
       return {
         ...outwardEdge,
         endpoint: {
-          baseId: outwardEdge.endpoint.baseId,
-          timestamp: outwardEdge.endpoint.timestamp,
+          baseId: outwardEdge.rightEndpoint.baseId,
+          timestamp: outwardEdge.rightEndpoint.timestamp,
         },
       };
     }
     // Shared edge-kind cases
     case "IS_OF_TYPE": {
-      if (!isOntologyTypeEditionId(outwardEdge.endpoint)) {
+      if (!isOntologyTypeEditionId(outwardEdge.rightEndpoint)) {
         throw new Error(
           `Expected an \`OntologyTypeEditionId\` for knowledge-graph to ontology edge endpoint but found:\n${JSON.stringify(
             outwardEdge,
@@ -55,8 +55,8 @@ export const mapOutwardEdge = (
       return {
         ...outwardEdge,
         endpoint: {
-          baseId: outwardEdge.endpoint.baseId,
-          version: outwardEdge.endpoint.version,
+          baseId: outwardEdge.rightEndpoint.baseId,
+          version: outwardEdge.rightEndpoint.version,
         },
       };
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We were intermittently referring to things as LeftEntity and LeftEndpoint, RightEntity and RightEndpoint. This tries to clarify between them

