### PR TITLE
Disable type system package in subgraph lib

### DIFF
--- a/packages/hash/subgraph/src/shared/type-system-patch.ts
+++ b/packages/hash/subgraph/src/shared/type-system-patch.ts
@@ -1,0 +1,63 @@
+import {
+  BaseUri,
+  VersionedUri,
+  validateBaseUri as validateBaseUriGraphApi,
+  validateVersionedUri as validateVersionedUriGraphApi,
+} from "@blockprotocol/type-system-node";
+
+/**
+ * @todo - we are patching these so this package can be used in node and web environments. When we unify the packages
+ *   this will no longer be necessary return types / functionality may differ a bit in the meantime, these are just
+ *   hotfixes.
+ *   https://app.asana.com/0/1201095311341924/1202923896339225/f
+ *
+ * */
+
+export const extractBaseUri = (id: VersionedUri): BaseUri => {
+  return id.match(/(.+\/)v\/(\d+)(.*)/g)![1]!;
+};
+
+export const extractVersion = (id: VersionedUri): number => {
+  return Number(id.match(/(.+\/)v\/(\d+)(.*)/g)![2]!);
+};
+
+export const validateBaseUri = (
+  uri: string,
+): ReturnType<typeof validateBaseUriGraphApi> => {
+  try {
+    const _ = new URL(uri);
+    return {
+      type: "Ok",
+      inner: uri,
+    };
+  } catch {
+    return {
+      type: "Err",
+      inner: { reason: "UrlParseError", inner: "" },
+    };
+  }
+};
+
+export const validateVersionedUri = (
+  uri: string,
+): ReturnType<typeof validateVersionedUriGraphApi> => {
+  try {
+    const _ = new URL(uri);
+
+    if (/(.+)\/v\/(\d+)(.*)/.test(uri)) {
+      return {
+        type: "Ok",
+        inner: uri as VersionedUri,
+      };
+    }
+  } catch {
+    /* return error below */
+  }
+  return {
+    type: "Err",
+    inner: {
+      reason: "InvalidBaseUri",
+      inner: { reason: "UrlParseError", inner: "" },
+    },
+  };
+};

--- a/packages/hash/subgraph/src/shared/type-system-patch.ts
+++ b/packages/hash/subgraph/src/shared/type-system-patch.ts
@@ -13,12 +13,14 @@ import {
  *
  * */
 
+const versionedUriGroupsPattern = /(.+\/)v\/(\d+)(.*)/;
+
 export const extractBaseUri = (id: VersionedUri): BaseUri => {
-  return id.match(/(.+\/)v\/(\d+)(.*)/g)![1]!;
+  return id.match(versionedUriGroupsPattern)![1]!;
 };
 
 export const extractVersion = (id: VersionedUri): number => {
-  return Number(id.match(/(.+\/)v\/(\d+)(.*)/g)![2]!);
+  return Number(id.match(versionedUriGroupsPattern)![2]!);
 };
 
 export const validateBaseUri = (
@@ -44,7 +46,7 @@ export const validateVersionedUri = (
   try {
     const _ = new URL(uri);
 
-    if (/(.+)\/v\/(\d+)(.*)/.test(uri)) {
+    if (versionedUriGroupsPattern.test(uri)) {
       return {
         type: "Ok",
         inner: uri as VersionedUri,

--- a/packages/hash/subgraph/src/stdlib/element/data-type.ts
+++ b/packages/hash/subgraph/src/stdlib/element/data-type.ts
@@ -1,13 +1,9 @@
-import {
-  BaseUri,
-  extractBaseUri,
-  extractVersion,
-  VersionedUri,
-} from "@blockprotocol/type-system-node";
+import { BaseUri, VersionedUri } from "@blockprotocol/type-system-node";
 import { OntologyTypeEditionId } from "../../types/identifier";
 import { Subgraph } from "../../types/subgraph";
 import { DataTypeWithMetadata } from "../../types/element";
 import { isDataTypeVertex } from "../../types/vertex";
+import { extractBaseUri, extractVersion } from "../../shared/type-system-patch";
 
 /**
  * Returns all `DataTypeWithMetadata`s within the vertices of the subgraph

--- a/packages/hash/subgraph/src/stdlib/element/entity-type.ts
+++ b/packages/hash/subgraph/src/stdlib/element/entity-type.ts
@@ -1,13 +1,9 @@
-import {
-  BaseUri,
-  extractBaseUri,
-  extractVersion,
-  VersionedUri,
-} from "@blockprotocol/type-system-node";
+import { BaseUri, VersionedUri } from "@blockprotocol/type-system-node";
 import { isEntityTypeVertex } from "../../types/vertex";
 import { Subgraph } from "../../types/subgraph";
 import { EntityTypeWithMetadata } from "../../types/element";
 import { OntologyTypeEditionId } from "../../types/identifier";
+import { extractBaseUri, extractVersion } from "../../shared/type-system-patch";
 
 /**
  * Returns all `EntityTypeWithMetadata`s within the vertices of the subgraph

--- a/packages/hash/subgraph/src/stdlib/element/property-type.ts
+++ b/packages/hash/subgraph/src/stdlib/element/property-type.ts
@@ -1,13 +1,9 @@
-import {
-  BaseUri,
-  extractBaseUri,
-  extractVersion,
-  VersionedUri,
-} from "@blockprotocol/type-system-node";
+import { BaseUri, VersionedUri } from "@blockprotocol/type-system-node";
 import { OntologyTypeEditionId } from "../../types/identifier";
 import { Subgraph } from "../../types/subgraph";
 import { PropertyTypeWithMetadata } from "../../types/element";
 import { isPropertyTypeVertex } from "../../types/vertex";
+import { extractBaseUri, extractVersion } from "../../shared/type-system-patch";
 
 /**
  * Returns all `PropertyTypeWithMetadata`s within the vertices of the subgraph

--- a/packages/hash/subgraph/tests/compatibility.test/map-edges.ts
+++ b/packages/hash/subgraph/tests/compatibility.test/map-edges.ts
@@ -2,7 +2,6 @@ import {
   Edges as EdgesGraphApi,
   OutwardEdge as OutwardEdgeGraphApi,
 } from "@hashintel/hash-graph-client";
-import { validateBaseUri } from "@blockprotocol/type-system-node";
 import {
   Edges,
   isEntityAndTimestamp,
@@ -12,6 +11,7 @@ import {
   isOntologyTypeEditionId,
   OutwardEdge,
 } from "../../src";
+import { validateBaseUri } from "../../src/shared/type-system-patch";
 
 export const mapOutwardEdge = (
   outwardEdge: OutwardEdgeGraphApi,

--- a/packages/hash/subgraph/tests/compatibility.test/map-vertices.ts
+++ b/packages/hash/subgraph/tests/compatibility.test/map-vertices.ts
@@ -12,8 +12,6 @@ import {
   OneOf,
   PropertyType,
   PropertyValues,
-  validateBaseUri,
-  validateVersionedUri,
   VersionedUri,
 } from "@blockprotocol/type-system-node";
 import {
@@ -24,6 +22,10 @@ import {
   PropertyObject,
   EntityId,
 } from "../../src";
+import {
+  validateBaseUri,
+  validateVersionedUri,
+} from "../../src/shared/type-system-patch";
 
 const mapDataType = (dataType: DataTypeGraphApi): DataType => {
   const idResult = validateVersionedUri(dataType.$id);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We haven't unified the type system packages yet, and the subgraph lib is likely to be used in the frontend and backend. To avoid messing around with conflicting WASM definitions and such, we are just patched the handful of functions we need to use at the moment.

## 🐾 Next steps

- Unify the packages [Asana task](https://app.asana.com/0/1201095311341924/1202923896339225/f
) _(internal)_
