### PR TITLE
Codegen Hotfix

### DIFF
--- a/packages/hash/api/codegen.yml
+++ b/packages/hash/api/codegen.yml
@@ -39,6 +39,6 @@ generates:
         EntityId: "@hashintel/hash-subgraph#EntityId"
         EntityEditionId: "@hashintel/hash-subgraph#EntityEditionId"
         EntityMetadata: "@hashintel/hash-subgraph#EntityMetadata"
-        EntityWithMetadata: "@hashintel/hash-subgraph#Entity"
+        EntityWithMetadata: "@hashintel/hash-subgraph#EntityWithMetadata"
         Edges: "@hashintel/hash-shared/graphql/types#Edges"
         Vertices: "@hashintel/hash-shared/graphql/types#Vertices"

--- a/packages/hash/frontend/codegen.yml
+++ b/packages/hash/frontend/codegen.yml
@@ -26,7 +26,7 @@ generates:
         EntityId: "@hashintel/hash-subgraph#EntityId"
         EntityEditionId: "@hashintel/hash-subgraph#EntityEditionId"
         EntityMetadata: "@hashintel/hash-subgraph#EntityMetadata"
-        EntityWithMetadata: "@hashintel/hash-subgraph#Entity"
+        EntityWithMetadata: "@hashintel/hash-subgraph#EntityWithMetadata"
         Edges: "@hashintel/hash-shared/graphql/types#Edges"
         Vertices: "@hashintel/hash-shared/graphql/types#Vertices"
     documents:

--- a/packages/hash/integration/codegen.yml
+++ b/packages/hash/integration/codegen.yml
@@ -26,7 +26,7 @@ generates:
         EntityId: "@hashintel/hash-graph#EntityId"
         EntityEditionId: "@hashintel/hash-subgraph#EntityEditionId"
         EntityMetadata: "@hashintel/hash-subgraph#EntityMetadata"
-        EntityWithMetadata: "@hashintel/hash-subgraph#Entity"
+        EntityWithMetadata: "@hashintel/hash-subgraph#EntityWithMetadata"
         Edges: "@hashintel/hash-shared/subgraphql/types#Edges"
         Vertices: "@hashintel/hash-shared/graphql/types#Vertices"
     documents: ./src/graphql/queries/**/*.ts

--- a/packages/hash/shared/codegen.yml
+++ b/packages/hash/shared/codegen.yml
@@ -26,7 +26,7 @@ generates:
         EntityId: "@hashintel/hash-subgraph#EntityId"
         EntityEditionId: "@hashintel/hash-subgraph#EntityEditionId"
         EntityMetadata: "@hashintel/hash-subgraph#EntityMetadata"
-        EntityWithMetadata: "@hashintel/hash-subgraph#Entity"
+        EntityWithMetadata: "@hashintel/hash-subgraph#EntityWithMetadata"
         Edges: "@hashintel/hash-shared/graphql/types#Edges"
         Vertices: "@hashintel/hash-shared/graphql/types#Vertices"
     documents:

--- a/packages/hash/subgraph/src/stdlib/edge/link.ts
+++ b/packages/hash/subgraph/src/stdlib/edge/link.ts
@@ -1,6 +1,6 @@
 import { Subgraph } from "../../types/subgraph";
 import { EntityId } from "../../types/identifier";
-import { Entity } from "../../types/element";
+import { EntityWithMetadata } from "../../types/element";
 import { getEntityAtTimestamp } from "../element/entity";
 import {
   isOutwardLinkEdge,
@@ -21,7 +21,7 @@ export const getOutgoingLinksForEntityAtMoment = (
   entityId: EntityId,
   timestamp: Date | string,
   includeArchived: boolean = false,
-): Entity[] => {
+): EntityWithMetadata[] => {
   const timestampString =
     typeof timestamp === "string" ? timestamp : timestamp.toISOString();
 
@@ -59,7 +59,7 @@ export const getOutgoingLinksForEntityAtMoment = (
 
         return linkEntity;
       })
-      .filter((x): x is Entity => x !== undefined)
+      .filter((x): x is EntityWithMetadata => x !== undefined)
   );
 };
 
@@ -74,7 +74,7 @@ export const getRightEntityForLinkEntityAtMoment = (
   subgraph: Subgraph,
   entityId: EntityId,
   timestamp: Date | string,
-): Entity => {
+): EntityWithMetadata => {
   const linkEntityEdges = mustBeDefined(
     subgraph.edges[entityId],
     "link entities must have right endpoints and therefore must have edges",
@@ -105,7 +105,7 @@ export const getOutgoingLinkAndTargetEntitiesAtMoment = (
   entityId: EntityId,
   timestamp: Date | string,
   includeArchived: boolean = false,
-): { linkEntity: Entity; rightEntity: Entity }[] => {
+): { linkEntity: EntityWithMetadata; rightEntity: EntityWithMetadata }[] => {
   return getOutgoingLinksForEntityAtMoment(
     subgraph,
     entityId,

--- a/packages/hash/subgraph/src/stdlib/element/entity.ts
+++ b/packages/hash/subgraph/src/stdlib/element/entity.ts
@@ -5,7 +5,7 @@ import {
   isEntityEditionId,
 } from "../../types/identifier";
 import { isEntityVertex } from "../../types/vertex";
-import { Entity } from "../../types/element";
+import { EntityWithMetadata } from "../../types/element";
 import { mustBeDefined } from "../../shared/invariant";
 
 /**
@@ -13,7 +13,7 @@ import { mustBeDefined } from "../../shared/invariant";
  *
  * @param subgraph
  */
-export const getEntities = (subgraph: Subgraph): Entity[] => {
+export const getEntities = (subgraph: Subgraph): EntityWithMetadata[] => {
   return Object.values(
     Object.values(subgraph.vertices).flatMap((versionObject) =>
       Object.values(versionObject)
@@ -34,7 +34,7 @@ export const getEntities = (subgraph: Subgraph): Entity[] => {
 export const getEntityByEditionId = (
   subgraph: Subgraph,
   entityEditionId: EntityEditionId,
-): Entity | undefined => {
+): EntityWithMetadata | undefined => {
   const { baseId: entityId, version } = entityEditionId;
   const vertex = subgraph.vertices[entityId]?.[version];
 
@@ -54,7 +54,7 @@ export const getEntityByEditionId = (
 export const getEntityEditionsByEntityId = (
   subgraph: Subgraph,
   entityId: EntityId,
-): Entity[] => {
+): EntityWithMetadata[] => {
   const versionObject = subgraph.vertices[entityId];
 
   if (!versionObject) {
@@ -78,7 +78,7 @@ export const getEntityAtTimestamp = (
   subgraph: Subgraph,
   entityId: EntityId,
   timestamp: Date | string,
-): Entity | undefined => {
+): EntityWithMetadata | undefined => {
   const timestampString =
     typeof timestamp === "string" ? timestamp : timestamp.toISOString();
 
@@ -114,7 +114,7 @@ export const getEntityAtTimestamp = (
  * @throws if the roots aren't all `EntityEditionId`s
  * @throws if the subgraph is malformed and there isn't a vertex associated with the root ID
  */
-export const getRootsAsEntities = (subgraph: Subgraph): Entity[] => {
+export const getRootsAsEntities = (subgraph: Subgraph): EntityWithMetadata[] => {
   return subgraph.roots.map((rootEditionId) => {
     if (!isEntityEditionId(rootEditionId)) {
       throw new Error(

--- a/packages/hash/subgraph/src/stdlib/roots.ts
+++ b/packages/hash/subgraph/src/stdlib/roots.ts
@@ -1,6 +1,6 @@
 import {
   DataTypeWithMetadata,
-  Entity,
+  EntityWithMetadata,
   EntityTypeWithMetadata,
   GraphElement,
   PropertyTypeWithMetadata,
@@ -139,7 +139,7 @@ export const isEntityTypeRootedSubgraph = (
  */
 export const isEntityRootedSubgraph = (
   subgraph: Subgraph,
-): subgraph is Subgraph<Entity> => {
+): subgraph is Subgraph<EntityWithMetadata> => {
   for (const rootEditionId of subgraph.roots) {
     if (!isEntityEditionId(rootEditionId)) {
       return false;

--- a/packages/hash/subgraph/src/types/element.ts
+++ b/packages/hash/subgraph/src/types/element.ts
@@ -63,7 +63,11 @@ export type EntityMetadata = {
   provenance: ProvenanceMetadataGraphApi;
 };
 
-export type Entity = {
+/**
+ * @todo - Rename this when we delete the old entity GraphQL types
+ *   https://app.asana.com/0/1202805690238892/1203157172269854/f
+ * */
+export type EntityWithMetadata = {
   properties: PropertyObject;
   metadata: EntityMetadata;
 };
@@ -72,4 +76,4 @@ export type GraphElement =
   | DataTypeWithMetadata
   | PropertyTypeWithMetadata
   | EntityTypeWithMetadata
-  | Entity;
+  | EntityWithMetadata;

--- a/packages/hash/subgraph/src/types/vertex.ts
+++ b/packages/hash/subgraph/src/types/vertex.ts
@@ -1,7 +1,7 @@
 import { BaseUri } from "@blockprotocol/type-system-node";
 import {
   DataTypeWithMetadata,
-  Entity,
+  EntityWithMetadata,
   EntityTypeWithMetadata,
   PropertyTypeWithMetadata,
 } from "./element";
@@ -21,7 +21,7 @@ export type EntityTypeVertex = {
   inner: EntityTypeWithMetadata;
 };
 
-export type EntityVertex = { kind: "entity"; inner: Entity };
+export type EntityVertex = { kind: "entity"; inner: EntityWithMetadata };
 
 export type OntologyVertex =
   | DataTypeVertex


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We have an old `Entity` typedef lying around in GraphQL. Removing it would be quite difficult to do now (although we intend to very soon). We were using `EntityWithMetadata` as a temporary alias for the actual up-to-date `Entity` type in GraphQL. Unfortunately, importing `Entity` from the subgraph package caused the generated ts types file to be invalid due to name conflicts on the import.

This PR temporary renames `Entity` in the subgraph package to `EntityWithMetadata` for consistency
