### PR TITLE
Handle `null` in Block Schema

### DIFF
--- a/packages/hash/shared/src/blocks.ts
+++ b/packages/hash/shared/src/blocks.ts
@@ -189,7 +189,7 @@ export const fetchBlock = async (
     try {
       schemaUrl = deriveAbsoluteUrl({ baseUrl, path: metadata.schema });
       // @todo needs validation
-      schema = schemaUrl ? await (await fetch(schemaUrl)).json() : {};
+      schema = (schemaUrl && (await (await fetch(schemaUrl)).json())) ?? {};
     } catch (err) {
       blockCache.delete(baseUrl);
       throw new Error(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The goal of this PR is to fix Playwright CI. This is done by supporting `null` in Block Schemas.
<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203301853897838/1203409678848738/f) _(internal)_
- [Slack thread](https://hashintel.slack.com/archives/C022217GAHF/p1669044565345679) _(internal)_
- https://blockprotocol.hashai.workers.dev/blocks/jtewright/latest/block-schema.json

## ⚠️ Known issues

- Schema remains not fully validated (see pre-existing comment next to diff).
