### PR TITLE
Improve generic typing of subgraph roots

### DIFF
--- a/packages/hash/subgraph/src/stdlib/roots.ts
+++ b/packages/hash/subgraph/src/stdlib/roots.ts
@@ -1,11 +1,8 @@
 import {
-  DataTypeWithMetadata,
-  EntityWithMetadata,
-  EntityTypeWithMetadata,
-  GraphElement,
-  PropertyTypeWithMetadata,
-} from "../types/element";
-import { Subgraph } from "../types/subgraph";
+  Subgraph,
+  SubgraphRootType,
+  SubgraphRootTypes,
+} from "../types/subgraph";
 import { getDataTypeByEditionId } from "./element/data-type";
 import {
   isEntityEditionId,
@@ -28,9 +25,9 @@ import { mustBeDefined } from "../shared/invariant";
  *
  * @param subgraph
  */
-export const getRoots = <RootType extends GraphElement>(
+export const getRoots = <RootType extends SubgraphRootType>(
   subgraph: Subgraph<RootType>,
-): RootType[] =>
+): RootType["element"][] =>
   subgraph.roots.map((rootEditionId) => {
     const root = mustBeDefined(
       subgraph.vertices[rootEditionId.baseId]?.[
@@ -45,7 +42,7 @@ export const getRoots = <RootType extends GraphElement>(
       )} was missing`,
     );
 
-    return root.inner as RootType;
+    return root.inner as RootType["element"];
   });
 
 /**
@@ -58,7 +55,7 @@ export const getRoots = <RootType extends GraphElement>(
  */
 export const isDataTypeRootedSubgraph = (
   subgraph: Subgraph,
-): subgraph is Subgraph<DataTypeWithMetadata> => {
+): subgraph is Subgraph<SubgraphRootTypes["dataType"]> => {
   for (const rootEditionId of subgraph.roots) {
     if (!isOntologyTypeEditionId(rootEditionId)) {
       return false;
@@ -85,7 +82,7 @@ export const isDataTypeRootedSubgraph = (
  */
 export const isPropertyTypeRootedSubgraph = (
   subgraph: Subgraph,
-): subgraph is Subgraph<PropertyTypeWithMetadata> => {
+): subgraph is Subgraph<SubgraphRootTypes["propertyType"]> => {
   for (const rootEditionId of subgraph.roots) {
     if (!isOntologyTypeEditionId(rootEditionId)) {
       return false;
@@ -112,7 +109,7 @@ export const isPropertyTypeRootedSubgraph = (
  */
 export const isEntityTypeRootedSubgraph = (
   subgraph: Subgraph,
-): subgraph is Subgraph<EntityTypeWithMetadata> => {
+): subgraph is Subgraph<SubgraphRootTypes["entityType"]> => {
   for (const rootEditionId of subgraph.roots) {
     if (!isOntologyTypeEditionId(rootEditionId)) {
       return false;
@@ -139,7 +136,7 @@ export const isEntityTypeRootedSubgraph = (
  */
 export const isEntityRootedSubgraph = (
   subgraph: Subgraph,
-): subgraph is Subgraph<EntityWithMetadata> => {
+): subgraph is Subgraph<SubgraphRootTypes["entity"]> => {
   for (const rootEditionId of subgraph.roots) {
     if (!isEntityEditionId(rootEditionId)) {
       return false;

--- a/packages/hash/subgraph/src/types/subgraph.ts
+++ b/packages/hash/subgraph/src/types/subgraph.ts
@@ -1,16 +1,40 @@
 import {
-  GraphElementEditionId,
   GraphResolveDepths,
+  OntologyTypeEditionId,
 } from "@hashintel/hash-graph-client";
-import { GraphElement } from "./element";
+import {
+  DataTypeWithMetadata,
+  EntityTypeWithMetadata,
+  EntityWithMetadata,
+  PropertyTypeWithMetadata,
+} from "./element";
 import { Vertices } from "./vertex";
 import { Edges } from "./edge";
+import { EntityEditionId } from "./identifier";
 
-export type Subgraph<
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  RootType extends GraphElement = GraphElement,
-> = {
-  roots: GraphElementEditionId[];
+export type SubgraphRootTypes = {
+  dataType: {
+    editionId: OntologyTypeEditionId;
+    element: DataTypeWithMetadata;
+  };
+  propertyType: {
+    editionId: OntologyTypeEditionId;
+    element: PropertyTypeWithMetadata;
+  };
+  entityType: {
+    editionId: OntologyTypeEditionId;
+    element: EntityTypeWithMetadata;
+  };
+  entity: {
+    editionId: EntityEditionId;
+    element: EntityWithMetadata;
+  };
+};
+
+export type SubgraphRootType = SubgraphRootTypes[keyof SubgraphRootTypes];
+
+export type Subgraph<RootType extends SubgraphRootType = SubgraphRootType> = {
+  roots: RootType["editionId"][];
   vertices: Vertices;
   edges: Edges;
   depths: GraphResolveDepths;

--- a/packages/hash/subgraph/tests/compatibility.test.ts
+++ b/packages/hash/subgraph/tests/compatibility.test.ts
@@ -12,6 +12,7 @@ import { Subgraph as SubgraphGraphApi } from "@hashintel/hash-graph-client";
 import { Subgraph } from "../src";
 import { mapVertices } from "./compatibility.test/map-vertices";
 import { mapEdges } from "./compatibility.test/map-edges";
+import { mapRoots } from "./compatibility.test/map-roots";
 
 test("Graph API subgraph type is compatible with library type", () => {
   // We don't need an actual subgraph, we are just checking for TSC errors
@@ -29,7 +30,7 @@ test("Graph API subgraph type is compatible with library type", () => {
 
   // We just want to check for errors in the type when building the object, no need to use the return value
   const _subgraph: Subgraph = {
-    roots: subgraphGraphApi.roots,
+    roots: mapRoots(subgraphGraphApi.roots),
     vertices: mapVertices(subgraphGraphApi.vertices),
     edges: mapEdges(subgraphGraphApi.edges),
     depths: subgraphGraphApi.depths,

--- a/packages/hash/subgraph/tests/compatibility.test/map-roots.ts
+++ b/packages/hash/subgraph/tests/compatibility.test/map-roots.ts
@@ -1,0 +1,22 @@
+import { Subgraph as SubgraphGraphApi } from "@hashintel/hash-graph-client";
+import {
+  isEntityEditionId,
+  isOntologyTypeEditionId,
+  Subgraph,
+} from "../../src";
+
+export const mapRoots = (
+  roots: SubgraphGraphApi["roots"],
+): Subgraph["roots"] => {
+  return roots.map((root) => {
+    if (isEntityEditionId(root)) {
+      return root;
+    } else if (isOntologyTypeEditionId(root)) {
+      return root;
+    } else {
+      throw new Error(
+        `Unrecognized root edition ID format: ${JSON.stringify(root)}`,
+      );
+    }
+  });
+};


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We can improve the accessor of `subgraph.roots` by some more massaging of the generic type

## 🛡 What tests cover this?

- TSC

## ❓ How to test this?

1.  `yarn workspace @hashintel/hash-subgraph lint:tsc`
