### PR TITLE
Return incoming links by default

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
@@ -204,6 +204,37 @@ impl<'q> Filter<'q, Entity> {
 
     /// TODO
     #[must_use]
+    pub fn for_incoming_link_by_source_entity_edition_id(edition_id: EntityEditionId) -> Self {
+        Self::All(vec![
+            Self::Equal(
+                Some(FilterExpression::Path(EntityQueryPath::RightEntity(
+                    Box::new(EntityQueryPath::OwnedById),
+                ))),
+                Some(FilterExpression::Parameter(Parameter::Uuid(
+                    edition_id.base_id().owned_by_id().as_uuid(),
+                ))),
+            ),
+            Self::Equal(
+                Some(FilterExpression::Path(EntityQueryPath::RightEntity(
+                    Box::new(EntityQueryPath::Uuid),
+                ))),
+                Some(FilterExpression::Parameter(Parameter::Uuid(
+                    edition_id.base_id().entity_uuid().as_uuid(),
+                ))),
+            ),
+            Self::Equal(
+                Some(FilterExpression::Path(EntityQueryPath::RightEntity(
+                    Box::new(EntityQueryPath::Version),
+                ))),
+                Some(FilterExpression::Parameter(Parameter::Timestamp(
+                    edition_id.version().inner(),
+                ))),
+            ),
+        ])
+    }
+
+    /// TODO
+    #[must_use]
     pub fn for_left_entity_by_entity_edition_id(edition_id: EntityEditionId) -> Self {
         Self::All(vec![
             Self::Equal(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We require incoming link edges to be present in the subgraph.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/0/1203426166281269/f) _(internal)_
- [Slack discussion](https://hashintel.slack.com/archives/C03F7V6DU9M/p1669200140528029) _(internal)_

## 🚫 Blocked by

- #1474

## 🔍 What does this change?

- Add a predefined filter to return incoming links by the right entity edition id
- Add edges and linked entities based on that filter

## 🛡 What tests cover this?

None

## ❓ How to test this?

Run the REST endpoint tests and check for the correct edges to be present when querying a person-entity