### PR TITLE
Enable Renovate Dependency Dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "dependencyDashboard": true,
   "enabledManagers": ["github-actions", "npm"],
   "ignorePaths": ["packages/engine/**"],
   "postUpdateOptions": ["yarnDedupeFewer"],
@@ -11,8 +12,7 @@
       "automerge": true,
       "enabled": false,
       "matchManagers": ["npm"],
-      "rangeStrategy": "bump",
-      "stabilityDays": 3
+      "rangeStrategy": "bump"
     },
     {
       "enabled": true,

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,10 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "automerge": true,
   "dependencyDashboard": true,
+  "dependencyDashboardApproval": true,
   "enabledManagers": ["github-actions", "npm"],
   "ignorePaths": ["packages/engine/**"],
   "postUpdateOptions": ["yarnDedupeFewer"],
-  "prConcurrentLimit": 5,
   "rebaseWhen": "conflicted",
   "schedule": ["before 5am on Monday", "before 5am on Thursday"],
   "packageRules": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "automerge": true,
   "dependencyDashboard": true,
   "enabledManagers": ["github-actions", "npm"],
   "ignorePaths": ["packages/engine/**"],
@@ -9,7 +10,6 @@
   "schedule": ["before 5am on Monday", "before 5am on Thursday"],
   "packageRules": [
     {
-      "automerge": true,
       "enabled": false,
       "matchManagers": ["npm"],
       "rangeStrategy": "bump"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR enables Dependency Dashboard with pre-approval which would be interesting to try. It also unsets `stabilityDays": 3` as discussed. `automerge` has already been enabled, I've just moved it up.  
 

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203301853897838/1203414492513792/f) (internal)
- [Slack link](https://hashintel.slack.com/archives/C02TWBTT3ED/p1669137989160599) (internal)
- [Dependency dashboard docs](https://docs.renovatebot.com/key-concepts/dashboard/)
- https://github.com/blockprotocol/blockprotocol/pull/782