### PR TITLE
Avoid being too conservative with dependencies

### DIFF
--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -18,10 +18,10 @@ categories = ["rust-patterns", "no-std"]
 
 [dependencies]
 tracing-error = { version = "0.2", optional = true, default_features = false }
-anyhow = { version = "1", default-features = false, optional = true }
+anyhow = { version = "1.0.65", default-features = false, optional = true }
 eyre = { version = "0.6", default-features = false, optional = true }
 owo-colors = { version = "3", default-features = false, optional = true, features = ['supports-colors'] }
-serde = { version = "1.0.147", default-features = false, optional = true }
+serde = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0.137", features = ["derive"] }

--- a/packages/libs/error-stack/src/fmt/hook.rs
+++ b/packages/libs/error-stack/src/fmt/hook.rs
@@ -263,7 +263,7 @@ impl HookContextInner {
 // TODO: ideally we would want to make `HookContextInner` private, as it is an implementation
 //  detail, but "attribute privacy" as outlined in https://github.com/rust-lang/rust/pull/61969
 //  is currently not implemented for repr(transparent).
-#[repr(transparent)]
+#[cfg_attr(not(doc), repr(transparent))]
 pub struct HookContext<T> {
     inner: HookContextInner,
     _marker: PhantomData<fn(&T)>,

--- a/packages/libs/error-stack/src/frame/frame_impl.rs
+++ b/packages/libs/error-stack/src/frame/frame_impl.rs
@@ -92,7 +92,6 @@ impl<A: 'static + fmt::Debug + fmt::Display + Send + Sync> FrameImpl
     }
 }
 
-#[repr(transparent)]
 #[cfg(feature = "anyhow")]
 struct AnyhowContext(anyhow::Error);
 
@@ -141,7 +140,6 @@ impl FrameImpl for AnyhowContext {
     }
 }
 
-#[repr(transparent)]
 #[cfg(feature = "eyre")]
 struct EyreContext(eyre::Report);
 

--- a/packages/libs/error-stack/src/report.rs
+++ b/packages/libs/error-stack/src/report.rs
@@ -191,7 +191,6 @@ use crate::{
 /// # }
 /// ```
 #[must_use]
-#[repr(transparent)]
 pub struct Report<C> {
     // The vector is boxed as this implies a memory footprint equal to a single pointer size
     // instead of three pointer sizes. Even for small `Result::Ok` variants, the `Result` would

--- a/packages/libs/error-stack/src/serde.rs
+++ b/packages/libs/error-stack/src/serde.rs
@@ -88,7 +88,7 @@ impl<'a> Serialize for SerializeContext<'a> {
         } = self;
 
         let mut map = serializer.serialize_map(Some(3))?;
-        map.serialize_entry("context", &format!("{context}"))?;
+        map.serialize_entry("context", &format!("{context}").as_str())?;
         map.serialize_entry("attachments", &SerializeAttachmentList(&attachments[..]))?;
         map.serialize_entry("sources", &SerializeSources(sources))?;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

It's not required to rely on a recent version of `serde`, however, we require `anyhow@1.0.65`.

## 🔍 What does this change?

- set minimum dependency on `serde` to `1.0.0`
- set minimum dependency on `anyhow` to `1.0.65`
- Avoid relying on `String: Serialize`
- Drive-by: Remove unneeded `#[repr(transparent)]` or hide it