### PR TITLE
Avoid multiple queries for the same row

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -71,16 +71,18 @@ impl<C: AsClient> PostgresStore<C> {
             if let Some(OntologyVertex::EntityType(entity_type)) = entity_type {
                 for property_type_ref in entity_type.inner().property_type_references() {
                     if current_resolve_depth.constrains_properties_on.outgoing > 0 {
-                        subgraph.edges.insert(Edge::Ontology {
-                            edition_id: entity_type_id.clone(),
-                            outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
-                                kind: OntologyEdgeKind::ConstrainsPropertiesOn,
-                                reversed: false,
-                                right_endpoint: OntologyTypeEditionId::from(
-                                    property_type_ref.uri(),
-                                ),
-                            }),
-                        });
+                        if dependency_status == DependencyStatus::Unknown {
+                            subgraph.edges.insert(Edge::Ontology {
+                                edition_id: entity_type_id.clone(),
+                                outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
+                                    kind: OntologyEdgeKind::ConstrainsPropertiesOn,
+                                    reversed: false,
+                                    right_endpoint: OntologyTypeEditionId::from(
+                                        property_type_ref.uri(),
+                                    ),
+                                }),
+                            });
+                        }
 
                         self.get_property_type_as_dependency(
                             &OntologyTypeEditionId::from(property_type_ref.uri()),
@@ -103,14 +105,18 @@ impl<C: AsClient> PostgresStore<C> {
 
                 for entity_type_ref in entity_type.inner().inherits_from().all_of() {
                     if current_resolve_depth.inherits_from.outgoing > 0 {
-                        subgraph.edges.insert(Edge::Ontology {
-                            edition_id: entity_type_id.clone(),
-                            outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
-                                kind: OntologyEdgeKind::InheritsFrom,
-                                reversed: false,
-                                right_endpoint: OntologyTypeEditionId::from(entity_type_ref.uri()),
-                            }),
-                        });
+                        if dependency_status == DependencyStatus::Unknown {
+                            subgraph.edges.insert(Edge::Ontology {
+                                edition_id: entity_type_id.clone(),
+                                outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
+                                    kind: OntologyEdgeKind::InheritsFrom,
+                                    reversed: false,
+                                    right_endpoint: OntologyTypeEditionId::from(
+                                        entity_type_ref.uri(),
+                                    ),
+                                }),
+                            });
+                        }
 
                         self.get_entity_type_as_dependency(
                             &OntologyTypeEditionId::from(entity_type_ref.uri()),
@@ -130,14 +136,18 @@ impl<C: AsClient> PostgresStore<C> {
 
                 for entity_type_ref in entity_type.inner().link_mappings().into_keys() {
                     if current_resolve_depth.constrains_links_on.outgoing > 0 {
-                        subgraph.edges.insert(Edge::Ontology {
-                            edition_id: entity_type_id.clone(),
-                            outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
-                                kind: OntologyEdgeKind::ConstrainsLinksOn,
-                                reversed: false,
-                                right_endpoint: OntologyTypeEditionId::from(entity_type_ref.uri()),
-                            }),
-                        });
+                        if dependency_status == DependencyStatus::Unknown {
+                            subgraph.edges.insert(Edge::Ontology {
+                                edition_id: entity_type_id.clone(),
+                                outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
+                                    kind: OntologyEdgeKind::ConstrainsLinksOn,
+                                    reversed: false,
+                                    right_endpoint: OntologyTypeEditionId::from(
+                                        entity_type_ref.uri(),
+                                    ),
+                                }),
+                            });
+                        }
 
                         self.get_entity_type_as_dependency(
                             &OntologyTypeEditionId::from(entity_type_ref.uri()),
@@ -169,14 +179,18 @@ impl<C: AsClient> PostgresStore<C> {
                         .outgoing
                         > 0
                     {
-                        subgraph.edges.insert(Edge::Ontology {
-                            edition_id: entity_type_id.clone(),
-                            outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
-                                kind: OntologyEdgeKind::ConstrainsLinkDestinationsOn,
-                                reversed: false,
-                                right_endpoint: OntologyTypeEditionId::from(entity_type_ref.uri()),
-                            }),
-                        });
+                        if dependency_status == DependencyStatus::Unknown {
+                            subgraph.edges.insert(Edge::Ontology {
+                                edition_id: entity_type_id.clone(),
+                                outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
+                                    kind: OntologyEdgeKind::ConstrainsLinkDestinationsOn,
+                                    reversed: false,
+                                    right_endpoint: OntologyTypeEditionId::from(
+                                        entity_type_ref.uri(),
+                                    ),
+                                }),
+                            });
+                        }
 
                         self.get_entity_type_as_dependency(
                             &OntologyTypeEditionId::from(entity_type_ref.uri()),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -69,16 +69,18 @@ impl<C: AsClient> PostgresStore<C> {
                 //   see https://app.asana.com/0/0/1202884883200942/f
                 for property_type_ref in property_type.inner().property_type_references() {
                     if current_resolve_depth.constrains_properties_on.outgoing > 0 {
-                        subgraph.edges.insert(Edge::Ontology {
-                            edition_id: property_type_id.clone(),
-                            outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
-                                kind: OntologyEdgeKind::ConstrainsPropertiesOn,
-                                reversed: false,
-                                right_endpoint: OntologyTypeEditionId::from(
-                                    property_type_ref.uri(),
-                                ),
-                            }),
-                        });
+                        if dependency_status == DependencyStatus::Unknown {
+                            subgraph.edges.insert(Edge::Ontology {
+                                edition_id: property_type_id.clone(),
+                                outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
+                                    kind: OntologyEdgeKind::ConstrainsPropertiesOn,
+                                    reversed: false,
+                                    right_endpoint: OntologyTypeEditionId::from(
+                                        property_type_ref.uri(),
+                                    ),
+                                }),
+                            });
+                        }
 
                         self.get_property_type_as_dependency(
                             &OntologyTypeEditionId::from(property_type_ref.uri()),
@@ -103,14 +105,18 @@ impl<C: AsClient> PostgresStore<C> {
                 //   see https://app.asana.com/0/0/1202884883200942/f
                 for data_type_ref in property_type.inner().data_type_references() {
                     if current_resolve_depth.constrains_values_on.outgoing > 0 {
-                        subgraph.edges.insert(Edge::Ontology {
-                            edition_id: property_type_id.clone(),
-                            outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
-                                kind: OntologyEdgeKind::ConstrainsValuesOn,
-                                reversed: false,
-                                right_endpoint: OntologyTypeEditionId::from(data_type_ref.uri()),
-                            }),
-                        });
+                        if dependency_status == DependencyStatus::Unknown {
+                            subgraph.edges.insert(Edge::Ontology {
+                                edition_id: property_type_id.clone(),
+                                outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
+                                    kind: OntologyEdgeKind::ConstrainsValuesOn,
+                                    reversed: false,
+                                    right_endpoint: OntologyTypeEditionId::from(
+                                        data_type_ref.uri(),
+                                    ),
+                                }),
+                            });
+                        }
 
                         self.get_data_type_as_dependency(
                             &OntologyTypeEditionId::from(data_type_ref.uri()),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When the resolve depth is high enough, the entities may get resolved multiple times, this solves this issue.

This change speeds up the performance by about 50%.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202805690238892/1203358665695493/f) _(internal)_

## 🚫 Blocked by

- #1488 

## 🔍 What does this change?

- ~~Insert edges before resolving the edge~~ (applied in #1488)
- Only resolve entities if the edge is unresolve