### PR TITLE
Reuse subgraph from previous iterations to avoid unnecessary lookups

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph/mod.rs
@@ -11,7 +11,7 @@ pub mod edges;
 pub mod query;
 pub mod vertices;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Subgraph {
     pub roots: HashSet<GraphElementEditionId>,
     pub vertices: Vertices,
@@ -27,16 +27,6 @@ impl Subgraph {
             vertices: Vertices::default(),
             edges: Edges::default(),
             depths,
-        }
-    }
-}
-
-impl Extend<Self> for Subgraph {
-    fn extend<T: IntoIterator<Item = Self>>(&mut self, iter: T) {
-        for subgraph in iter {
-            self.roots.extend(subgraph.roots.into_iter());
-            self.vertices.extend(subgraph.vertices);
-            self.edges.extend(subgraph.edges);
         }
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -4,7 +4,7 @@ use std::{future::Future, pin::Pin};
 
 use async_trait::async_trait;
 use error_stack::{bail, IntoReport, Report, Result, ResultExt};
-use futures::{stream, FutureExt, StreamExt, TryStreamExt};
+use futures::FutureExt;
 use tokio_postgres::GenericClient;
 use type_system::uri::VersionedUri;
 use uuid::Uuid;
@@ -497,38 +497,31 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             graph_resolve_depths,
         } = *query;
 
-        let mut subgraph = stream::iter(Read::<Entity>::read(self, filter).await?)
-            .then(|entity| async move {
-                let mut subgraph = Subgraph::new(graph_resolve_depths);
-                let mut dependency_context = DependencyContext::default();
+        let mut subgraph = Subgraph::new(graph_resolve_depths);
+        let mut dependency_context = DependencyContext::default();
 
-                let entity_edition_id = entity.metadata().edition_id();
-                dependency_context
-                    .knowledge_dependency_map
-                    .insert(&entity_edition_id, None);
-                subgraph
-                    .vertices
-                    .knowledge_graph
-                    .insert(entity_edition_id, KnowledgeGraphVertex::Entity(entity));
+        for entity in Read::<Entity>::read(self, filter).await? {
+            let entity_edition_id = entity.metadata().edition_id();
+            dependency_context
+                .knowledge_dependency_map
+                .insert(&entity_edition_id, None);
+            subgraph
+                .vertices
+                .knowledge_graph
+                .insert(entity_edition_id, KnowledgeGraphVertex::Entity(entity));
 
-                self.get_entity_as_dependency(
-                    entity_edition_id,
-                    &mut dependency_context,
-                    &mut subgraph,
-                    graph_resolve_depths,
-                )
-                .await?;
-
-                subgraph
-                    .roots
-                    .insert(GraphElementEditionId::KnowledgeGraph(entity_edition_id));
-
-                Ok::<_, Report<QueryError>>(subgraph)
-            })
-            .try_collect::<Subgraph>()
+            self.get_entity_as_dependency(
+                entity_edition_id,
+                &mut dependency_context,
+                &mut subgraph,
+                graph_resolve_depths,
+            )
             .await?;
 
-        subgraph.depths = graph_resolve_depths;
+            subgraph
+                .roots
+                .insert(GraphElementEditionId::KnowledgeGraph(entity_edition_id));
+        }
 
         Ok(subgraph)
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -1,8 +1,8 @@
 use std::{future::Future, pin::Pin};
 
 use async_trait::async_trait;
-use error_stack::{IntoReport, Report, Result, ResultExt};
-use futures::{stream, FutureExt, StreamExt, TryStreamExt};
+use error_stack::{IntoReport, Result, ResultExt};
+use futures::FutureExt;
 use tokio_postgres::GenericClient;
 use type_system::EntityType;
 
@@ -258,38 +258,31 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
             graph_resolve_depths,
         } = *query;
 
-        let mut subgraph = stream::iter(Read::<EntityTypeWithMetadata>::read(self, filter).await?)
-            .then(|entity_type| async move {
-                let mut subgraph = Subgraph::new(graph_resolve_depths);
-                let mut dependency_context = DependencyContext::default();
+        let mut subgraph = Subgraph::new(graph_resolve_depths);
+        let mut dependency_context = DependencyContext::default();
 
-                let entity_type_id = entity_type.metadata().edition_id().clone();
-                dependency_context
-                    .ontology_dependency_map
-                    .insert(&entity_type_id, None);
-                subgraph.vertices.ontology.insert(
-                    entity_type_id.clone(),
-                    OntologyVertex::EntityType(Box::new(entity_type)),
-                );
+        for entity_type in Read::<EntityTypeWithMetadata>::read(self, filter).await? {
+            let entity_type_id = entity_type.metadata().edition_id().clone();
+            dependency_context
+                .ontology_dependency_map
+                .insert(&entity_type_id, None);
+            subgraph.vertices.ontology.insert(
+                entity_type_id.clone(),
+                OntologyVertex::EntityType(Box::new(entity_type)),
+            );
 
-                self.get_entity_type_as_dependency(
-                    &entity_type_id,
-                    &mut dependency_context,
-                    &mut subgraph,
-                    graph_resolve_depths,
-                )
-                .await?;
-
-                subgraph
-                    .roots
-                    .insert(GraphElementEditionId::Ontology(entity_type_id));
-
-                Ok::<_, Report<QueryError>>(subgraph)
-            })
-            .try_collect::<Subgraph>()
+            self.get_entity_type_as_dependency(
+                &entity_type_id,
+                &mut dependency_context,
+                &mut subgraph,
+                graph_resolve_depths,
+            )
             .await?;
 
-        subgraph.depths = graph_resolve_depths;
+            subgraph
+                .roots
+                .insert(GraphElementEditionId::Ontology(entity_type_id));
+        }
 
         Ok(subgraph)
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -1,8 +1,8 @@
 use std::{future::Future, pin::Pin};
 
 use async_trait::async_trait;
-use error_stack::{IntoReport, Report, Result, ResultExt};
-use futures::{stream, FutureExt, StreamExt, TryStreamExt};
+use error_stack::{IntoReport, Result, ResultExt};
+use futures::FutureExt;
 use tokio_postgres::GenericClient;
 use type_system::PropertyType;
 
@@ -190,39 +190,32 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
             graph_resolve_depths,
         } = *query;
 
-        let mut subgraph =
-            stream::iter(Read::<PropertyTypeWithMetadata>::read(self, filter).await?)
-                .then(|property_type| async move {
-                    let mut subgraph = Subgraph::new(graph_resolve_depths);
-                    let mut dependency_context = DependencyContext::default();
+        let mut subgraph = Subgraph::new(graph_resolve_depths);
+        let mut dependency_context = DependencyContext::default();
 
-                    let property_type_id = property_type.metadata().edition_id().clone();
-                    dependency_context
-                        .ontology_dependency_map
-                        .insert(&property_type_id, None);
-                    subgraph.vertices.ontology.insert(
-                        property_type_id.clone(),
-                        OntologyVertex::PropertyType(Box::new(property_type)),
-                    );
+        for property_type in Read::<PropertyTypeWithMetadata>::read(self, filter).await? {
+            let property_type_id = property_type.metadata().edition_id().clone();
+            dependency_context
+                .ontology_dependency_map
+                .insert(&property_type_id, None);
+            subgraph.vertices.ontology.insert(
+                property_type_id.clone(),
+                OntologyVertex::PropertyType(Box::new(property_type)),
+            );
 
-                    self.get_property_type_as_dependency(
-                        &property_type_id,
-                        &mut dependency_context,
-                        &mut subgraph,
-                        graph_resolve_depths,
-                    )
-                    .await?;
+            self.get_property_type_as_dependency(
+                &property_type_id,
+                &mut dependency_context,
+                &mut subgraph,
+                graph_resolve_depths,
+            )
+            .await?;
 
-                    subgraph
-                        .roots
-                        .insert(GraphElementEditionId::Ontology(property_type_id));
+            subgraph
+                .roots
+                .insert(GraphElementEditionId::Ontology(property_type_id));
+        }
 
-                    Ok::<_, Report<QueryError>>(subgraph)
-                })
-                .try_collect::<Subgraph>()
-                .await?;
-
-        subgraph.depths = graph_resolve_depths;
         Ok(subgraph)
     }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

As a follow-up of #1491 this also avoids unnecessary lookups across multiple roots.

With these changes, the performance was increased by up to 50% (as many queries can be avoided).

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202805690238892/1203358665695493/f) _(internal)_

## 🚫 Blocked by

- ~~#1491~~ 

## 🔍 What does this change?

- Reuse the same subgraph for multiple roots
- Remove `Extend` and `Default` implementation of `Subgraph`