### PR TITLE
Fix mentions properly

### DIFF
--- a/packages/hash/frontend/src/blocks/page/MentionView/MentionDisplay.tsx
+++ b/packages/hash/frontend/src/blocks/page/MentionView/MentionDisplay.tsx
@@ -5,10 +5,10 @@ import {
   EntityId,
   extractEntityUuidFromEntityId,
 } from "@hashintel/hash-subgraph";
+import { SYSTEM_ACCOUNT_SHORTNAME } from "@hashintel/hash-shared/environment";
 import { useUsers } from "../../../components/hooks/useUsers";
 import { useAccountPages } from "../../../components/hooks/useAccountPages";
 import { Link } from "../../../shared/ui";
-import { SYSTEM_ACCOUNT_SHORTNAME } from "@hashintel/hash-shared/environment";
 
 interface MentionDisplayProps {
   entityId: EntityId;
@@ -28,7 +28,7 @@ export const MentionDisplay: FunctionComponent<MentionDisplayProps> = ({
     switch (mentionType) {
       case "user": {
         // User entities are stored on the system account
-        const href = `/@${SYSTEM_ACCOUNT_SHORTNAME}/entities/${extractEntityUuidFromEntityId(
+        const userHref = `/@${SYSTEM_ACCOUNT_SHORTNAME}/entities/${extractEntityUuidFromEntityId(
           entityId,
         )}`;
 
@@ -37,7 +37,7 @@ export const MentionDisplay: FunctionComponent<MentionDisplayProps> = ({
           /** @todo - What should the href be here? */
           return {
             title: "User",
-            href,
+            href: userHref,
             icon: "@",
           };
         } else {
@@ -49,7 +49,7 @@ export const MentionDisplay: FunctionComponent<MentionDisplayProps> = ({
           if (matchingUser) {
             return {
               title: matchingUser.preferredName,
-              href,
+              href: userHref,
               icon: "@",
             };
           } else {

--- a/packages/hash/frontend/src/blocks/page/MentionView/MentionDisplay.tsx
+++ b/packages/hash/frontend/src/blocks/page/MentionView/MentionDisplay.tsx
@@ -8,6 +8,7 @@ import {
 import { useUsers } from "../../../components/hooks/useUsers";
 import { useAccountPages } from "../../../components/hooks/useAccountPages";
 import { Link } from "../../../shared/ui";
+import { SYSTEM_ACCOUNT_SHORTNAME } from "@hashintel/hash-shared/environment";
 
 interface MentionDisplayProps {
   entityId: EntityId;
@@ -26,12 +27,17 @@ export const MentionDisplay: FunctionComponent<MentionDisplayProps> = ({
   const { title, href, icon } = useMemo(() => {
     switch (mentionType) {
       case "user": {
-        // Only set the title to "Page" if the query hasn't returned yet
+        // User entities are stored on the system account
+        const href = `/@${SYSTEM_ACCOUNT_SHORTNAME}/entities/${extractEntityUuidFromEntityId(
+          entityId,
+        )}`;
+
+        // Only set the title to "User" if the query hasn't returned yet
         if (!users || (usersLoading && !users.length)) {
           /** @todo - What should the href be here? */
           return {
             title: "User",
-            href: `#`,
+            href,
             icon: "@",
           };
         } else {
@@ -43,9 +49,7 @@ export const MentionDisplay: FunctionComponent<MentionDisplayProps> = ({
           if (matchingUser) {
             return {
               title: matchingUser.preferredName,
-              href: `@${
-                matchingUser.shortname
-              }/entities/${extractEntityUuidFromEntityId(entityId)}`,
+              href,
               icon: "@",
             };
           } else {
@@ -73,7 +77,7 @@ export const MentionDisplay: FunctionComponent<MentionDisplayProps> = ({
 
         return {
           title: pageTitle,
-          href: `/${accountId}/${entityId}`,
+          href: `/${accountId}/${extractEntityUuidFromEntityId(entityId)}`,
           icon: <ArticleIcon style={{ fontSize: "1em" }} />,
         };
       }

--- a/packages/hash/frontend/src/blocks/page/createSuggester/MentionSuggester.tsx
+++ b/packages/hash/frontend/src/blocks/page/createSuggester/MentionSuggester.tsx
@@ -7,18 +7,19 @@ import { useAccountPages } from "../../../components/hooks/useAccountPages";
 import { fuzzySearchBy } from "./fuzzySearchBy";
 import { Suggester } from "./Suggester";
 import { useRouteAccountInfo } from "../../../shared/routing";
+import { EntityId } from "@hashintel/hash-subgraph";
 
 export interface MentionSuggesterProps {
   search?: string;
-  onChange(entityId: string, title: string): void;
+  onChange(entityId: EntityId, mentionType: "user" | "page"): void;
   accountId: string;
 }
 
 type SearchableItem = {
   shortname?: string;
   name: string;
-  entityId: string;
-  type: "user" | "page";
+  entityId: EntityId;
+  mentionType: "user" | "page";
   isActiveOrgMember?: boolean;
 };
 
@@ -40,7 +41,7 @@ export const MentionSuggester: FunctionComponent<MentionSuggesterProps> = ({
         shortname: user.shortname,
         name: user.preferredName ?? user.shortname ?? "User",
         entityId: user.entityEditionId.baseId,
-        type: "user",
+        mentionType: "user",
         isActiveOrgMember: user.memberOf.some(
           ({ orgAccountId }) => orgAccountId === routeAccountId,
         ),
@@ -49,7 +50,7 @@ export const MentionSuggester: FunctionComponent<MentionSuggesterProps> = ({
     const iterablePages: Array<SearchableItem> = pages.map((page) => ({
       name: page.title,
       entityId: page.entityId,
-      type: "page",
+      mentionType: "page",
     }));
 
     const peopleSearch = fuzzySearchBy(iterableAccounts, search, (option) =>
@@ -78,7 +79,7 @@ export const MentionSuggester: FunctionComponent<MentionSuggesterProps> = ({
       options={options}
       renderItem={(option) => (
         <div className={tw`flex items-center py-1 px-2`}>
-          {option.type === "user" ? (
+          {option.mentionType === "user" ? (
             <div
               className={tw`w-6 h-6 flex items-center justify-center text-sm rounded-full bg-gray-200 mr-2`}
             >
@@ -94,7 +95,7 @@ export const MentionSuggester: FunctionComponent<MentionSuggesterProps> = ({
         </div>
       )}
       itemKey={(option) => option.entityId}
-      onChange={(option) => onChange(option.entityId, option.type)}
+      onChange={(option) => onChange(option.entityId, option.mentionType)}
       loading={loading}
     />
   );

--- a/packages/hash/frontend/src/blocks/page/createSuggester/MentionSuggester.tsx
+++ b/packages/hash/frontend/src/blocks/page/createSuggester/MentionSuggester.tsx
@@ -2,12 +2,12 @@ import { useMemo, FunctionComponent } from "react";
 import { tw } from "twind";
 import ArticleIcon from "@mui/icons-material/Article";
 
+import { EntityId } from "@hashintel/hash-subgraph";
 import { useUsers } from "../../../components/hooks/useUsers";
 import { useAccountPages } from "../../../components/hooks/useAccountPages";
 import { fuzzySearchBy } from "./fuzzySearchBy";
 import { Suggester } from "./Suggester";
 import { useRouteAccountInfo } from "../../../shared/routing";
-import { EntityId } from "@hashintel/hash-subgraph";
 
 export interface MentionSuggesterProps {
   search?: string;

--- a/packages/hash/frontend/src/blocks/page/createSuggester/createSuggester.tsx
+++ b/packages/hash/frontend/src/blocks/page/createSuggester/createSuggester.tsx
@@ -10,11 +10,11 @@ import {
   Transaction,
 } from "prosemirror-state";
 import { ReactElement } from "react";
+import { EntityId } from "@hashintel/hash-subgraph";
 import { ensureMounted } from "../../../lib/dom";
 import { RenderPortal } from "../usePortals";
 import { BlockSuggester } from "./BlockSuggester";
 import { MentionSuggester } from "./MentionSuggester";
-import { EntityId } from "@hashintel/hash-subgraph";
 
 interface Trigger {
   char: "@" | "/";

--- a/packages/hash/frontend/src/blocks/page/createSuggester/createSuggester.tsx
+++ b/packages/hash/frontend/src/blocks/page/createSuggester/createSuggester.tsx
@@ -14,6 +14,7 @@ import { ensureMounted } from "../../../lib/dom";
 import { RenderPortal } from "../usePortals";
 import { BlockSuggester } from "./BlockSuggester";
 import { MentionSuggester } from "./MentionSuggester";
+import { EntityId } from "@hashintel/hash-subgraph";
 
 interface Trigger {
   char: "@" | "/";
@@ -285,7 +286,10 @@ export const createSuggester = (
               });
           };
 
-          const onMentionChange = (entityId: string, mentionType: string) => {
+          const onMentionChange = (
+            entityId: EntityId,
+            mentionType: "page" | "user",
+          ) => {
             const { tr } = view.state;
 
             const mentionNode = view.state.schema.nodes.mention!.create({


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#1495 partly fixed mentions, but it turns out there were more breakages (or previous oversights). This PR fixes the mentions menu and improves typings on a number of props.

Now when clicking on a user mention, it links to the associated entity editor page, and when clicking on a page mention it correctly redirects.

## 🔍 What does this change?

See commits, small PR 

## 📜 Does this require a change to the docs?

No

## ⚠️ Known issues

We currently query for all entities quite a lot in the process of rendering a page. It takes many seconds for the users to populate the mentions drop-down (possibly because resolving a user always also resolves its orgs)

## 🛡 What tests cover this?

None

## ❓ How to test this?

1.  Checkout the branch / view the deployment
1.  Run the app
1.  Type "@" on a page

## 📹 Demo

Demo'd live, but: 
<img width="475" alt="image" src="https://user-images.githubusercontent.com/25749103/204029283-060e4076-f4a9-490c-9911-de9944f0b19d.png">

