### PR TITLE
Simplify `Read` trait and consistently use `*WithMetadata` for trait filters

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -215,9 +215,12 @@ async fn get_data_types_by_query<P: StorePool + Send>(
 async fn get_latest_data_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<DataTypeWithMetadata>>, StatusCode> {
-    read_from_store(pool.as_ref(), &Filter::<DataType>::for_latest_version())
-        .await
-        .map(Json)
+    read_from_store(
+        pool.as_ref(),
+        &Filter::<DataTypeWithMetadata>::for_latest_version(),
+    )
+    .await
+    .map(Json)
 }
 
 #[utoipa::path(
@@ -241,7 +244,7 @@ async fn get_data_type<P: StorePool + Send>(
 ) -> Result<Json<DataTypeWithMetadata>, StatusCode> {
     read_from_store(
         pool.as_ref(),
-        &Filter::<DataType>::for_versioned_uri(&uri.0),
+        &Filter::<DataTypeWithMetadata>::for_versioned_uri(&uri.0),
     )
     .await
     .and_then(|mut data_types| data_types.pop().ok_or(StatusCode::NOT_FOUND))

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -215,12 +215,9 @@ async fn get_data_types_by_query<P: StorePool + Send>(
 async fn get_latest_data_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<DataTypeWithMetadata>>, StatusCode> {
-    read_from_store(
-        pool.as_ref(),
-        &Filter::<DataTypeWithMetadata>::for_latest_version(),
-    )
-    .await
-    .map(Json)
+    read_from_store(pool.as_ref(), &Filter::for_latest_version())
+        .await
+        .map(Json)
 }
 
 #[utoipa::path(
@@ -242,13 +239,10 @@ async fn get_data_type<P: StorePool + Send>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,
 ) -> Result<Json<DataTypeWithMetadata>, StatusCode> {
-    read_from_store(
-        pool.as_ref(),
-        &Filter::<DataTypeWithMetadata>::for_versioned_uri(&uri.0),
-    )
-    .await
-    .and_then(|mut data_types| data_types.pop().ok_or(StatusCode::NOT_FOUND))
-    .map(Json)
+    read_from_store(pool.as_ref(), &Filter::for_versioned_uri(&uri.0))
+        .await
+        .and_then(|mut data_types| data_types.pop().ok_or(StatusCode::NOT_FOUND))
+        .map(Json)
 }
 
 #[derive(ToSchema, Serialize, Deserialize)]

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -317,7 +317,7 @@ async fn get_entity<P: StorePool + Send>(
 ) -> Result<Json<Entity>, StatusCode> {
     read_from_store(
         pool.as_ref(),
-        &Filter::<Entity>::for_latest_entity_by_entity_id(entity_id),
+        &Filter::for_latest_entity_by_entity_id(entity_id),
     )
     .await
     .and_then(|mut entities| entities.pop().ok_or(StatusCode::NOT_FOUND))

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -228,12 +228,9 @@ async fn get_entity_types_by_query<P: StorePool + Send>(
 async fn get_latest_entity_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<EntityTypeWithMetadata>>, StatusCode> {
-    read_from_store(
-        pool.as_ref(),
-        &Filter::<EntityTypeWithMetadata>::for_latest_version(),
-    )
-    .await
-    .map(Json)
+    read_from_store(pool.as_ref(), &Filter::for_latest_version())
+        .await
+        .map(Json)
 }
 
 #[utoipa::path(
@@ -255,13 +252,10 @@ async fn get_entity_type<P: StorePool + Send>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,
 ) -> Result<Json<EntityTypeWithMetadata>, StatusCode> {
-    read_from_store(
-        pool.as_ref(),
-        &Filter::<EntityTypeWithMetadata>::for_versioned_uri(&uri.0),
-    )
-    .await
-    .and_then(|mut entity_types| entity_types.pop().ok_or(StatusCode::NOT_FOUND))
-    .map(Json)
+    read_from_store(pool.as_ref(), &Filter::for_versioned_uri(&uri.0))
+        .await
+        .and_then(|mut entity_types| entity_types.pop().ok_or(StatusCode::NOT_FOUND))
+        .map(Json)
 }
 
 #[derive(ToSchema, Serialize, Deserialize)]

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -228,9 +228,12 @@ async fn get_entity_types_by_query<P: StorePool + Send>(
 async fn get_latest_entity_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<EntityTypeWithMetadata>>, StatusCode> {
-    read_from_store(pool.as_ref(), &Filter::<EntityType>::for_latest_version())
-        .await
-        .map(Json)
+    read_from_store(
+        pool.as_ref(),
+        &Filter::<EntityTypeWithMetadata>::for_latest_version(),
+    )
+    .await
+    .map(Json)
 }
 
 #[utoipa::path(
@@ -254,7 +257,7 @@ async fn get_entity_type<P: StorePool + Send>(
 ) -> Result<Json<EntityTypeWithMetadata>, StatusCode> {
     read_from_store(
         pool.as_ref(),
-        &Filter::<EntityType>::for_versioned_uri(&uri.0),
+        &Filter::<EntityTypeWithMetadata>::for_versioned_uri(&uri.0),
     )
     .await
     .and_then(|mut entity_types| entity_types.pop().ok_or(StatusCode::NOT_FOUND))

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -222,12 +222,9 @@ async fn get_property_types_by_query<P: StorePool + Send>(
 async fn get_latest_property_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<PropertyTypeWithMetadata>>, StatusCode> {
-    read_from_store(
-        pool.as_ref(),
-        &Filter::<PropertyTypeWithMetadata>::for_latest_version(),
-    )
-    .await
-    .map(Json)
+    read_from_store(pool.as_ref(), &Filter::for_latest_version())
+        .await
+        .map(Json)
 }
 
 #[utoipa::path(
@@ -249,13 +246,10 @@ async fn get_property_type<P: StorePool + Send>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,
 ) -> Result<Json<PropertyTypeWithMetadata>, StatusCode> {
-    read_from_store(
-        pool.as_ref(),
-        &Filter::<PropertyTypeWithMetadata>::for_versioned_uri(&uri.0),
-    )
-    .await
-    .and_then(|mut property_types| property_types.pop().ok_or(StatusCode::NOT_FOUND))
-    .map(Json)
+    read_from_store(pool.as_ref(), &Filter::for_versioned_uri(&uri.0))
+        .await
+        .and_then(|mut property_types| property_types.pop().ok_or(StatusCode::NOT_FOUND))
+        .map(Json)
 }
 
 #[derive(ToSchema, Serialize, Deserialize)]

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -222,9 +222,12 @@ async fn get_property_types_by_query<P: StorePool + Send>(
 async fn get_latest_property_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<PropertyTypeWithMetadata>>, StatusCode> {
-    read_from_store(pool.as_ref(), &Filter::<PropertyType>::for_latest_version())
-        .await
-        .map(Json)
+    read_from_store(
+        pool.as_ref(),
+        &Filter::<PropertyTypeWithMetadata>::for_latest_version(),
+    )
+    .await
+    .map(Json)
 }
 
 #[utoipa::path(
@@ -248,7 +251,7 @@ async fn get_property_type<P: StorePool + Send>(
 ) -> Result<Json<PropertyTypeWithMetadata>, StatusCode> {
     read_from_store(
         pool.as_ref(),
-        &Filter::<PropertyType>::for_versioned_uri(&uri.0),
+        &Filter::<PropertyTypeWithMetadata>::for_versioned_uri(&uri.0),
     )
     .await
     .and_then(|mut property_types| property_types.pop().ok_or(StatusCode::NOT_FOUND))

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
@@ -77,12 +77,12 @@ pub enum EntityQueryPath<'q> {
     /// # use std::borrow::Cow;
     /// # use serde::Deserialize;
     /// # use serde_json::json;
-    /// # use type_system::DataType;
-    /// # use graph::{store::query::{Filter, FilterExpression, Parameter}, ontology::DataTypeQueryPath};
+    /// # use graph::{store::query::{Filter, FilterExpression, Parameter}};
+    /// # use graph::knowledge::{Entity, EntityQueryPath};
     /// let filter_value = json!({ "equal": [{ "path": ["version"] }, { "parameter": "latest" }] });
-    /// let path = Filter::<DataType>::deserialize(filter_value)?;
+    /// let path = Filter::<Entity>::deserialize(filter_value)?;
     /// assert_eq!(path, Filter::Equal(
-    ///     Some(FilterExpression::Path(DataTypeQueryPath::Version)),
+    ///     Some(FilterExpression::Path(EntityQueryPath::Version)),
     ///     Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed("latest")))))
     /// );
     /// # Ok::<(), serde_json::Error>(())

--- a/packages/graph/hash_graph/lib/graph/src/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/data_type.rs
@@ -4,10 +4,12 @@ use serde::{
     de::{self, Deserializer, SeqAccess, Visitor},
     Deserialize,
 };
-use type_system::DataType;
 use utoipa::ToSchema;
 
-use crate::store::query::{OntologyPath, ParameterType, QueryRecord, RecordPath};
+use crate::{
+    ontology::DataTypeWithMetadata,
+    store::query::{OntologyPath, ParameterType, QueryRecord, RecordPath},
+};
 
 /// A path to a [`DataType`] field.
 ///
@@ -31,6 +33,7 @@ pub enum DataTypeQueryPath {
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     ///
+    /// [`DataType`]: type_system::DataType
     /// [`BaseUri`]: type_system::uri::BaseUri
     BaseUri,
     /// The version of the [`DataType`].
@@ -52,16 +55,18 @@ pub enum DataTypeQueryPath {
     /// # use std::borrow::Cow;
     /// # use serde::Deserialize;
     /// # use serde_json::json;
-    /// # use type_system::DataType;
-    /// # use graph::{store::query::{Filter, FilterExpression, Parameter}, ontology::DataTypeQueryPath};
+    /// # use graph::{store::query::{Filter, FilterExpression, Parameter}};
+    /// # use graph::{ontology::{DataTypeQueryPath, DataTypeWithMetadata}};
     /// let filter_value = json!({ "equal": [{ "path": ["version"] }, { "parameter": "latest" }] });
-    /// let path = Filter::<DataType>::deserialize(filter_value)?;
+    /// let path = Filter::<DataTypeWithMetadata>::deserialize(filter_value)?;
     /// assert_eq!(path, Filter::Equal(
     ///     Some(FilterExpression::Path(DataTypeQueryPath::Version)),
     ///     Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed("latest")))))
     /// );
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    ///
+    /// [`DataType`]: type_system::DataType
     Version,
     /// The [`VersionedUri`] of the [`DataType`].
     ///
@@ -75,6 +80,7 @@ pub enum DataTypeQueryPath {
     /// ```
     ///
     /// [`VersionedUri`]: type_system::uri::VersionedUri
+    /// [`DataType`]: type_system::DataType
     VersionedUri,
     /// The [`OwnedById`] of the [`OntologyElementMetadata`] belonging to the [`DataType`].
     ///
@@ -87,6 +93,7 @@ pub enum DataTypeQueryPath {
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     ///
+    /// [`DataType`]: type_system::DataType
     /// [`OwnedById`]: crate::provenance::OwnedById
     /// [`OntologyElementMetadata`]: crate::ontology::OntologyElementMetadata
     OwnedById,
@@ -101,6 +108,7 @@ pub enum DataTypeQueryPath {
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     ///
+    /// [`DataType`]: type_system::DataType
     /// [`UpdatedById`]: crate::provenance::UpdatedById
     /// [`ProvenanceMetadata`]: crate::provenance::ProvenanceMetadata
     UpdatedById,
@@ -114,6 +122,8 @@ pub enum DataTypeQueryPath {
     /// assert_eq!(path, DataTypeQueryPath::Title);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    ///
+    /// [`DataType::title()`]: type_system::DataType::title
     Title,
     /// Corresponds to [`DataType::description()`]
     ///
@@ -125,6 +135,8 @@ pub enum DataTypeQueryPath {
     /// assert_eq!(path, DataTypeQueryPath::Description);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    ///
+    /// [`DataType::description()`]: type_system::DataType::description
     Description,
     /// Corresponds to [`DataType::json_type()`].
     ///
@@ -136,6 +148,8 @@ pub enum DataTypeQueryPath {
     /// assert_eq!(path, DataTypeQueryPath::Type);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    ///
+    /// [`DataType::json_type()`]: type_system::DataType::json_type
     Type,
     /// Only used internally and not available for deserialization.
     VersionId,
@@ -143,7 +157,7 @@ pub enum DataTypeQueryPath {
     Schema,
 }
 
-impl QueryRecord for DataType {
+impl QueryRecord for DataTypeWithMetadata {
     type Path<'q> = DataTypeQueryPath;
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/entity_type.rs
@@ -4,15 +4,19 @@ use serde::{
     de::{self, Deserializer, SeqAccess, Visitor},
     Deserialize,
 };
-use type_system::EntityType;
 use utoipa::ToSchema;
 
 use crate::{
-    ontology::{property_type::PropertyTypeQueryPathVisitor, PropertyTypeQueryPath, Selector},
+    ontology::{
+        property_type::PropertyTypeQueryPathVisitor, EntityTypeWithMetadata, PropertyTypeQueryPath,
+        Selector,
+    },
     store::query::{OntologyPath, ParameterType, QueryRecord, RecordPath},
 };
 
 /// A path to a [`EntityType`] field.
+///
+/// [`EntityType`]: type_system::EntityType
 #[derive(Debug, PartialEq, Eq)]
 pub enum EntityTypeQueryPath {
     /// The [`BaseUri`] of the [`EntityType`].
@@ -26,6 +30,7 @@ pub enum EntityTypeQueryPath {
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     ///
+    /// [`EntityType`]: type_system::EntityType
     /// [`BaseUri`]: type_system::uri::BaseUri
     BaseUri,
     /// The version of the [`EntityType`].
@@ -47,16 +52,18 @@ pub enum EntityTypeQueryPath {
     /// # use std::borrow::Cow;
     /// # use serde::Deserialize;
     /// # use serde_json::json;
-    /// # use type_system::EntityType;
-    /// # use graph::{store::query::{Filter, FilterExpression, Parameter}, ontology::EntityTypeQueryPath};
+    /// # use graph::{store::query::{Filter, FilterExpression, Parameter}};
+    /// # use graph::{ontology::{EntityTypeQueryPath, EntityTypeWithMetadata}};
     /// let filter_value = json!({ "equal": [{ "path": ["version"] }, { "parameter": "latest" }] });
-    /// let path = Filter::<EntityType>::deserialize(filter_value)?;
+    /// let path = Filter::<EntityTypeWithMetadata>::deserialize(filter_value)?;
     /// assert_eq!(path, Filter::Equal(
     ///     Some(FilterExpression::Path(EntityTypeQueryPath::Version)),
     ///     Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed("latest")))))
     /// );
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    ///
+    /// [`EntityType`]: type_system::EntityType
     Version,
     /// The [`VersionedUri`] of the [`EntityType`].
     ///
@@ -69,6 +76,7 @@ pub enum EntityTypeQueryPath {
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     ///
+    /// [`EntityType`]: type_system::EntityType
     /// [`VersionedUri`]: type_system::uri::VersionedUri
     VersionedUri,
     /// The [`OwnedById`] of the [`OntologyElementMetadata`] belonging to the [`EntityType`].
@@ -82,6 +90,7 @@ pub enum EntityTypeQueryPath {
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     ///
+    /// [`EntityType`]: type_system::EntityType
     /// [`OwnedById`]: crate::provenance::OwnedById
     /// [`OntologyElementMetadata`]: crate::ontology::OntologyElementMetadata
     OwnedById,
@@ -96,6 +105,7 @@ pub enum EntityTypeQueryPath {
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     ///
+    /// [`EntityType`]: type_system::EntityType
     /// [`UpdatedById`]: crate::provenance::UpdatedById
     /// [`ProvenanceMetadata`]: crate::provenance::ProvenanceMetadata
     UpdatedById,
@@ -109,6 +119,8 @@ pub enum EntityTypeQueryPath {
     /// assert_eq!(path, EntityTypeQueryPath::Title);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    ///
+    /// [`EntityType::title()`]: type_system::EntityType::title
     Title,
     /// Corresponds to [`EntityType::description()`]
     ///
@@ -120,6 +132,8 @@ pub enum EntityTypeQueryPath {
     /// assert_eq!(path, EntityTypeQueryPath::Description);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    ///
+    /// [`EntityType::description()`]: type_system::EntityType::description
     Description,
     /// Corresponds to [`EntityType::default()`].
     ///
@@ -131,6 +145,8 @@ pub enum EntityTypeQueryPath {
     /// assert_eq!(path, EntityTypeQueryPath::Default);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    ///
+    /// [`EntityType::default()`]: type_system::EntityType::default
     Default,
     /// Corresponds to [`EntityType::examples()`].
     ///
@@ -142,6 +158,8 @@ pub enum EntityTypeQueryPath {
     /// assert_eq!(path, EntityTypeQueryPath::Examples);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    ///
+    /// [`EntityType::examples()`]: type_system::EntityType::examples
     Examples,
     /// Corresponds to [`EntityType::property_type_references()`].
     ///
@@ -162,6 +180,8 @@ pub enum EntityTypeQueryPath {
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     ///
+    /// [`EntityType`]: type_system::EntityType
+    /// [`EntityType::property_type_references()`]: type_system::EntityType::property_type_references
     /// [`PropertyType`]: type_system::PropertyType
     Properties(PropertyTypeQueryPath),
     /// Corresponds to [`EntityType::required()`].
@@ -174,6 +194,8 @@ pub enum EntityTypeQueryPath {
     /// assert_eq!(path, EntityTypeQueryPath::Required);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    ///
+    /// [`EntityType::required()`]: type_system::EntityType::required
     Required,
     /// Corresponds to the keys of [`EntityType::link_mappings()`].
     ///
@@ -194,6 +216,9 @@ pub enum EntityTypeQueryPath {
     /// );
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    ///
+    /// [`EntityType`]: type_system::EntityType
+    /// [`EntityType::link_mappings()`]: type_system::EntityType::link_mappings
     Links(Box<Self>),
     /// Corresponds to [`EntityType::required_links()`].
     ///
@@ -205,6 +230,8 @@ pub enum EntityTypeQueryPath {
     /// assert_eq!(path, EntityTypeQueryPath::RequiredLinks);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    ///
+    /// [`EntityType::required_links()`]: type_system::EntityType::required_links
     RequiredLinks,
     /// Currently, does not correspond to any field of [`EntityType`].
     ///
@@ -228,6 +255,9 @@ pub enum EntityTypeQueryPath {
     /// );
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    ///
+    /// [`EntityType`]: type_system::EntityType
+    /// [`EntityType::inherits_from()`]: type_system::EntityType::inherits_from
     InheritsFrom(Box<Self>),
     /// Only used internally and not available for deserialization.
     VersionId,
@@ -235,7 +265,7 @@ pub enum EntityTypeQueryPath {
     Schema,
 }
 
-impl QueryRecord for EntityType {
+impl QueryRecord for EntityTypeWithMetadata {
     type Path<'q> = EntityTypeQueryPath;
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -196,15 +196,15 @@ impl EntityTypeWithMetadata {
 }
 
 pub trait PersistedOntologyType {
-    type Inner;
+    type OntologyType;
 
-    fn new(record: Self::Inner, metadata: OntologyElementMetadata) -> Self;
+    fn new(record: Self::OntologyType, metadata: OntologyElementMetadata) -> Self;
 }
 
 impl PersistedOntologyType for DataTypeWithMetadata {
-    type Inner = DataType;
+    type OntologyType = DataType;
 
-    fn new(record: Self::Inner, metadata: OntologyElementMetadata) -> Self {
+    fn new(record: Self::OntologyType, metadata: OntologyElementMetadata) -> Self {
         Self {
             inner: record,
             metadata,
@@ -213,9 +213,9 @@ impl PersistedOntologyType for DataTypeWithMetadata {
 }
 
 impl PersistedOntologyType for PropertyTypeWithMetadata {
-    type Inner = PropertyType;
+    type OntologyType = PropertyType;
 
-    fn new(record: Self::Inner, metadata: OntologyElementMetadata) -> Self {
+    fn new(record: Self::OntologyType, metadata: OntologyElementMetadata) -> Self {
         Self {
             inner: record,
             metadata,
@@ -224,9 +224,9 @@ impl PersistedOntologyType for PropertyTypeWithMetadata {
 }
 
 impl PersistedOntologyType for EntityTypeWithMetadata {
-    type Inner = EntityType;
+    type OntologyType = EntityType;
 
-    fn new(record: Self::Inner, metadata: OntologyElementMetadata) -> Self {
+    fn new(record: Self::OntologyType, metadata: OntologyElementMetadata) -> Self {
         Self {
             inner: record,
             metadata,

--- a/packages/graph/hash_graph/lib/graph/src/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/property_type.rs
@@ -4,15 +4,18 @@ use serde::{
     de::{self, Deserializer, SeqAccess, Visitor},
     Deserialize,
 };
-use type_system::PropertyType;
 use utoipa::ToSchema;
 
 use crate::{
-    ontology::{data_type::DataTypeQueryPathVisitor, DataTypeQueryPath, Selector},
+    ontology::{
+        data_type::DataTypeQueryPathVisitor, DataTypeQueryPath, PropertyTypeWithMetadata, Selector,
+    },
     store::query::{OntologyPath, ParameterType, QueryRecord, RecordPath},
 };
 
 /// A path to a [`PropertyType`] field.
+///
+/// [`PropertyType`]: type_system::PropertyType
 #[derive(Debug, PartialEq, Eq)]
 pub enum PropertyTypeQueryPath {
     /// The [`BaseUri`] of the [`PropertyType`].
@@ -26,6 +29,7 @@ pub enum PropertyTypeQueryPath {
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     ///
+    /// [`PropertyType`]: type_system::PropertyType
     /// [`BaseUri`]: type_system::uri::BaseUri
     BaseUri,
     /// The version of the [`PropertyType`].
@@ -42,6 +46,8 @@ pub enum PropertyTypeQueryPath {
     /// In addition to specifying the version directly, it's also possible to compare the version
     /// with a `"latest"` parameter, which will only match the latest version of the
     /// [`PropertyType`].
+    ///
+    /// [`PropertyType`]: type_system::PropertyType
     Version,
     /// The [`VersionedUri`] of the [`PropertyType`].
     ///
@@ -54,6 +60,7 @@ pub enum PropertyTypeQueryPath {
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     ///
+    /// [`PropertyType`]: type_system::PropertyType
     /// [`VersionedUri`]: type_system::uri::VersionedUri
     VersionedUri,
     /// The [`OwnedById`] of the [`OntologyElementMetadata`] belonging to the [`PropertyType`].
@@ -67,10 +74,13 @@ pub enum PropertyTypeQueryPath {
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     ///
+    /// [`PropertyType`]: type_system::PropertyType
     /// [`OwnedById`]: crate::provenance::OwnedById
     /// [`OntologyElementMetadata`]: crate::ontology::OntologyElementMetadata
     OwnedById,
     /// The [`UpdatedById`] of the [`ProvenanceMetadata`] belonging to the [`PropertyType`].
+    ///
+    /// [`PropertyType`]: type_system::PropertyType
     ///
     /// ```rust
     /// # use serde::Deserialize;
@@ -86,6 +96,8 @@ pub enum PropertyTypeQueryPath {
     UpdatedById,
     /// Corresponds to [`PropertyType::title()`].
     ///
+    /// [`PropertyType::title()`]: type_system::PropertyType::title
+    ///
     /// ```rust
     /// # use serde::Deserialize;
     /// # use serde_json::json;
@@ -96,6 +108,8 @@ pub enum PropertyTypeQueryPath {
     /// ```
     Title,
     /// Corresponds to [`PropertyType::description()`]
+    ///
+    /// [`PropertyType::description()`]: type_system::PropertyType::description
     ///
     /// ```rust
     /// # use serde::Deserialize;
@@ -112,6 +126,9 @@ pub enum PropertyTypeQueryPath {
     /// additional selector to identify the [`DataType`] to query. Currently, only the `*` selector
     /// is available, so the path will be deserialized as `["dataTypes", "*", ...]` where `...` is
     /// the path to the desired field of the [`DataType`].
+    ///
+    /// [`PropertyType::data_type_references()`]: type_system::PropertyType::data_type_references
+    /// [`PropertyType`]: type_system::PropertyType
     ///
     /// ```rust
     /// # use serde::Deserialize;
@@ -145,6 +162,9 @@ pub enum PropertyTypeQueryPath {
     /// );
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    ///
+    /// [`PropertyType`]: type_system::PropertyType
+    /// [`PropertyType::property_type_references()`]: type_system::PropertyType::property_type_references
     PropertyTypes(Box<Self>),
     /// Only used internally and not available for deserialization.
     VersionId,
@@ -152,7 +172,7 @@ pub enum PropertyTypeQueryPath {
     Schema,
 }
 
-impl QueryRecord for PropertyType {
+impl QueryRecord for PropertyTypeWithMetadata {
     type Path<'q> = PropertyTypeQueryPath;
 }
 
@@ -293,6 +313,7 @@ impl<'de> Visitor<'de> for PropertyTypeQueryPathVisitor {
         })
     }
 }
+
 impl<'de> Deserialize<'de> for PropertyTypeQueryPath {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph/edges/kind.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph/edges/kind.rs
@@ -63,7 +63,6 @@ pub struct EdgeResolveDepths {
 }
 
 impl EdgeResolveDepths {
-    /// Update the depths to be at least as deep as the given depths provided by `other`.
     #[expect(
         clippy::useless_let_if_seq,
         reason = "Using a mutable variable is more readable"
@@ -95,7 +94,6 @@ pub struct OutgoingEdgeResolveDepth {
 }
 
 impl OutgoingEdgeResolveDepth {
-    /// Update the depths to be at least as deep as the given depths provided by `other`.
     #[expect(
         clippy::useless_let_if_seq,
         reason = "Be consistent with `EdgeResolveDepths`"
@@ -125,7 +123,6 @@ pub struct GraphResolveDepths {
 }
 
 impl GraphResolveDepths {
-    /// Update the depths to be at least as deep as the given depths provided by `other`.
     #[expect(
         clippy::useless_let_if_seq,
         reason = "Using a mutable variable is more readable"

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph/query.rs
@@ -1,11 +1,11 @@
 use std::fmt::{Debug, Formatter};
 
 use serde::Deserialize;
-use type_system::{DataType, EntityType, PropertyType};
 use utoipa::ToSchema;
 
 use crate::{
     knowledge::Entity,
+    ontology::{DataTypeWithMetadata, EntityTypeWithMetadata, PropertyTypeWithMetadata},
     store::query::{Filter, QueryRecord},
     subgraph::edges::GraphResolveDepths,
 };
@@ -153,9 +153,9 @@ use crate::{
 #[derive(Deserialize, ToSchema)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[aliases(
-    DataTypeStructuralQuery = StructuralQuery<'static, DataType>,
-    PropertyTypeStructuralQuery = StructuralQuery<'static, PropertyType>,
-    EntityTypeStructuralQuery = StructuralQuery<'static, EntityType>,
+    DataTypeStructuralQuery = StructuralQuery<'static, DataTypeWithMetadata>,
+    PropertyTypeStructuralQuery = StructuralQuery<'static, PropertyTypeWithMetadata>,
+    EntityTypeStructuralQuery = StructuralQuery<'static, EntityTypeWithMetadata>,
     EntityStructuralQuery = StructuralQuery<'static, Entity>,
 )]
 pub struct StructuralQuery<'q, T: QueryRecord> {

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -27,7 +27,6 @@ use crate::{
         PropertyTypeWithMetadata,
     },
     provenance::{OwnedById, UpdatedById},
-    store::query::Filter,
     subgraph::{query::StructuralQuery, Subgraph},
 };
 
@@ -197,9 +196,7 @@ pub trait AccountStore {
 
 /// Describes the API of a store implementation for [`DataType`]s.
 #[async_trait]
-pub trait DataTypeStore:
-    for<'q> crud::Read<DataTypeWithMetadata, Query<'q> = Filter<'q, DataType>>
-{
+pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     /// Creates a new [`DataType`].
     ///
     /// # Errors:
@@ -222,7 +219,7 @@ pub trait DataTypeStore:
     /// - if the requested [`DataType`] doesn't exist.
     async fn get_data_type<'f: 'q, 'q>(
         &self,
-        query: &'f StructuralQuery<'q, DataType>,
+        query: &'f StructuralQuery<'q, DataTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError>;
 
     /// Update the definition of an existing [`DataType`].
@@ -239,9 +236,7 @@ pub trait DataTypeStore:
 
 /// Describes the API of a store implementation for [`PropertyType`]s.
 #[async_trait]
-pub trait PropertyTypeStore:
-    for<'q> crud::Read<PropertyTypeWithMetadata, Query<'q> = Filter<'q, PropertyType>>
-{
+pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     /// Creates a new [`PropertyType`].
     ///
     /// # Errors:
@@ -264,7 +259,7 @@ pub trait PropertyTypeStore:
     /// - if the requested [`PropertyType`] doesn't exist.
     async fn get_property_type<'f: 'q, 'q>(
         &self,
-        query: &'f StructuralQuery<'q, PropertyType>,
+        query: &'f StructuralQuery<'q, PropertyTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError>;
 
     /// Update the definition of an existing [`PropertyType`].
@@ -281,9 +276,7 @@ pub trait PropertyTypeStore:
 
 /// Describes the API of a store implementation for [`EntityType`]s.
 #[async_trait]
-pub trait EntityTypeStore:
-    for<'q> crud::Read<EntityTypeWithMetadata, Query<'q> = Filter<'q, EntityType>>
-{
+pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     /// Creates a new [`EntityType`].
     ///
     /// # Errors:
@@ -306,7 +299,7 @@ pub trait EntityTypeStore:
     /// - if the requested [`EntityType`] doesn't exist.
     async fn get_entity_type<'f: 'q, 'q>(
         &self,
-        query: &'f StructuralQuery<'q, EntityType>,
+        query: &'f StructuralQuery<'q, EntityTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError>;
 
     /// Update the definition of an existing [`EntityType`].
@@ -325,7 +318,7 @@ pub trait EntityTypeStore:
 ///
 /// [Entities]: crate::knowledge::Entity
 #[async_trait]
-pub trait EntityStore: for<'q> crud::Read<Entity, Query<'q> = Filter<'q, Entity>> {
+pub trait EntityStore: crud::Read<Entity> {
     /// Creates a new [`Entity`].
     ///
     /// # Errors:

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -25,12 +25,10 @@ use crate::{
 
 #[async_trait]
 impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
-    type Query<'q> = Filter<'q, Entity>;
-
     #[expect(clippy::too_many_lines)]
     async fn read<'f: 'q, 'q>(
         &self,
-        filter: &'f Self::Query<'q>,
+        filter: &'f Filter<'q, Entity>,
     ) -> Result<Vec<Entity>, QueryError> {
         // We can't define these inline otherwise we'll drop while borrowed
         let left_entity_uuid_path = EntityQueryPath::LeftEntity(Box::new(EntityQueryPath::Uuid));

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -39,7 +39,7 @@ impl<C: AsClient> PostgresStore<C> {
                 } else {
                     let data_type = Read::<DataTypeWithMetadata>::read_one(
                         self,
-                        &Filter::<DataTypeWithMetadata>::for_ontology_type_edition_id(data_type_id),
+                        &Filter::for_ontology_type_edition_id(data_type_id),
                     )
                     .await?;
                     Some(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -39,7 +39,7 @@ impl<C: AsClient> PostgresStore<C> {
                 } else {
                     let data_type = Read::<DataTypeWithMetadata>::read_one(
                         self,
-                        &Filter::<DataType>::for_ontology_type_edition_id(data_type_id),
+                        &Filter::<DataTypeWithMetadata>::for_ontology_type_edition_id(data_type_id),
                     )
                     .await?;
                     Some(
@@ -99,7 +99,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
 
     async fn get_data_type<'f: 'q, 'q>(
         &self,
-        query: &'f StructuralQuery<'q, DataType>,
+        query: &'f StructuralQuery<'q, DataTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError> {
         let StructuralQuery {
             ref filter,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -255,7 +255,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
 
     async fn get_entity_type<'f: 'q, 'q>(
         &self,
-        query: &'f StructuralQuery<'q, EntityType>,
+        query: &'f StructuralQuery<'q, EntityTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError> {
         let StructuralQuery {
             ref filter,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -187,7 +187,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
 
     async fn get_property_type<'f: 'q, 'q>(
         &self,
-        query: &'f StructuralQuery<'q, PropertyType>,
+        query: &'f StructuralQuery<'q, PropertyTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError> {
         let StructuralQuery {
             ref filter,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -28,7 +28,7 @@ where
         + for<'q> PostgresQueryRecord<Path<'q>: Debug + Send + Sync + OntologyPath>
         + Send
         + 'static,
-    T::Inner: OntologyDatabaseType + TryFrom<serde_json::Value, Error: Context>,
+    T::OntologyType: OntologyDatabaseType + TryFrom<serde_json::Value, Error: Context>,
 {
     async fn read<'f: 'q, 'q>(&self, filter: &'f Filter<'q, T>) -> Result<Vec<T>, QueryError> {
         let versioned_uri_path = <<T as QueryRecord>::Path<'q> as OntologyPath>::versioned_uri();
@@ -60,9 +60,10 @@ where
                 let versioned_uri = VersionedUri::from_str(row.get(versioned_uri_index))
                     .into_report()
                     .change_context(QueryError)?;
-                let record = <T::Inner>::try_from(row.get::<_, serde_json::Value>(schema_index))
-                    .into_report()
-                    .change_context(QueryError)?;
+                let record =
+                    <T::OntologyType>::try_from(row.get::<_, serde_json::Value>(schema_index))
+                        .into_report()
+                        .change_context(QueryError)?;
                 let owned_by_id = OwnedById::new(row.get(owned_by_id_index));
                 let updated_by_id = UpdatedById::new(row.get(updated_by_id_path_index));
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -24,11 +24,11 @@ use crate::{
 #[async_trait]
 impl<C: AsClient, T> Read<T> for PostgresStore<C>
 where
-    for<'q> T: PersistedOntologyType<
-            Inner: OntologyDatabaseType + TryFrom<serde_json::Value, Error: Context>,
-        > + PostgresQueryRecord<Path<'q>: Debug + Send + Sync + OntologyPath>
+    T: PersistedOntologyType
+        + for<'q> PostgresQueryRecord<Path<'q>: Debug + Send + Sync + OntologyPath>
         + Send
         + 'static,
+    T::Inner: OntologyDatabaseType + TryFrom<serde_json::Value, Error: Context>,
 {
     async fn read<'f: 'q, 'q>(&self, filter: &'f Filter<'q, T>) -> Result<Vec<T>, QueryError> {
         let versioned_uri_path = <<T as QueryRecord>::Path<'q> as OntologyPath>::versioned_uri();

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -24,23 +24,17 @@ use crate::{
 #[async_trait]
 impl<C: AsClient, T> Read<T> for PostgresStore<C>
 where
-    T: for<'q> PersistedOntologyType<
-            Inner: PostgresQueryRecord<Path<'q>: Debug + Send + Sync + OntologyPath>
-                       + OntologyDatabaseType
-                       + TryFrom<serde_json::Value, Error: Context>
-                       + Send
-                       + 'static,
-        > + Send,
+    for<'q> T: PersistedOntologyType<
+            Inner: OntologyDatabaseType + TryFrom<serde_json::Value, Error: Context>,
+        > + PostgresQueryRecord<Path<'q>: Debug + Send + Sync + OntologyPath>
+        + Send
+        + 'static,
 {
-    type Query<'q> = Filter<'q, T::Inner>;
-
-    async fn read<'f: 'q, 'q>(&self, filter: &'f Self::Query<'q>) -> Result<Vec<T>, QueryError> {
-        let versioned_uri_path =
-            <<T::Inner as QueryRecord>::Path<'q> as OntologyPath>::versioned_uri();
-        let schema_path = <<T::Inner as QueryRecord>::Path<'q> as OntologyPath>::schema();
-        let owned_by_id_path = <<T::Inner as QueryRecord>::Path<'q> as OntologyPath>::owned_by_id();
-        let updated_by_id_path =
-            <<T::Inner as QueryRecord>::Path<'q> as OntologyPath>::updated_by_id();
+    async fn read<'f: 'q, 'q>(&self, filter: &'f Filter<'q, T>) -> Result<Vec<T>, QueryError> {
+        let versioned_uri_path = <<T as QueryRecord>::Path<'q> as OntologyPath>::versioned_uri();
+        let schema_path = <<T as QueryRecord>::Path<'q> as OntologyPath>::schema();
+        let owned_by_id_path = <<T as QueryRecord>::Path<'q> as OntologyPath>::owned_by_id();
+        let updated_by_id_path = <<T as QueryRecord>::Path<'q> as OntologyPath>::updated_by_id();
 
         let mut compiler = SelectCompiler::new();
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
@@ -85,10 +85,9 @@ mod tests {
     use std::borrow::Cow;
 
     use postgres_types::ToSql;
-    use type_system::DataType;
 
     use crate::{
-        ontology::DataTypeQueryPath,
+        ontology::{DataTypeQueryPath, DataTypeWithMetadata},
         store::{
             postgres::query::{SelectCompiler, Transpile},
             query::{Filter, FilterExpression, Parameter},
@@ -96,7 +95,7 @@ mod tests {
     };
 
     fn test_condition<'q, 'f: 'q>(
-        filter: &'f Filter<'q, DataType>,
+        filter: &'f Filter<'q, DataTypeWithMetadata>,
         rendered: &'static str,
         parameters: &[&'q dyn ToSql],
     ) {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
@@ -1,16 +1,14 @@
 use std::borrow::Cow;
 
-use type_system::DataType;
-
 use crate::{
-    ontology::DataTypeQueryPath,
+    ontology::{DataTypeQueryPath, DataTypeWithMetadata},
     store::postgres::query::{
         table::{Column, DataTypes, JsonField, Relation, TypeIds},
         Path, PostgresQueryRecord, Table,
     },
 };
 
-impl PostgresQueryRecord for DataType {
+impl PostgresQueryRecord for DataTypeWithMetadata {
     fn base_table() -> Table {
         Table::DataTypes
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity_type.rs
@@ -1,16 +1,14 @@
 use std::{borrow::Cow, iter::once};
 
-use type_system::EntityType;
-
 use crate::{
-    ontology::EntityTypeQueryPath,
+    ontology::{EntityTypeQueryPath, EntityTypeWithMetadata},
     store::postgres::query::{
         table::{Column, EntityTypes, JsonField, Relation, TypeIds},
         Path, PostgresQueryRecord, Table,
     },
 };
 
-impl PostgresQueryRecord for EntityType {
+impl PostgresQueryRecord for EntityTypeWithMetadata {
     fn base_table() -> Table {
         Table::EntityTypes
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
@@ -43,11 +43,9 @@ impl Transpile for WhereExpression<'_> {
 mod tests {
     use std::borrow::Cow;
 
-    use type_system::DataType;
-
     use super::*;
     use crate::{
-        ontology::DataTypeQueryPath,
+        ontology::{DataTypeQueryPath, DataTypeWithMetadata},
         store::{
             postgres::query::{test_helper::trim_whitespace, SelectCompiler},
             query::{Filter, FilterExpression, Parameter},
@@ -56,11 +54,11 @@ mod tests {
 
     #[test]
     fn transpile_where_expression() {
-        let mut compiler = SelectCompiler::<DataType>::new();
+        let mut compiler = SelectCompiler::<DataTypeWithMetadata>::new();
         let mut where_clause = WhereExpression::default();
         assert_eq!(where_clause.transpile_to_string(), "");
 
-        let filter_a = Filter::<DataType>::Equal(
+        let filter_a = Filter::<DataTypeWithMetadata>::Equal(
             Some(FilterExpression::Path(DataTypeQueryPath::Version)),
             Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
                 "latest",
@@ -73,7 +71,7 @@ mod tests {
             r#"WHERE "type_ids_0_1_0"."version" = "type_ids_0_1_0"."latest_version""#
         );
 
-        let filter_b = Filter::<DataType>::All(vec![
+        let filter_b = Filter::<DataTypeWithMetadata>::All(vec![
             Filter::Equal(
                 Some(FilterExpression::Path(DataTypeQueryPath::BaseUri)),
                 Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
@@ -96,7 +94,7 @@ mod tests {
             )
         );
 
-        let filter_c = Filter::<DataType>::NotEqual(
+        let filter_c = Filter::<DataTypeWithMetadata>::NotEqual(
             Some(FilterExpression::Path(DataTypeQueryPath::Description)),
             None,
         );
@@ -112,7 +110,7 @@ mod tests {
             )
         );
 
-        let filter_d = Filter::<DataType>::Any(vec![
+        let filter_d = Filter::<DataTypeWithMetadata>::Any(vec![
             Filter::Equal(
                 Some(FilterExpression::Path(DataTypeQueryPath::Title)),
                 Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
@@ -58,7 +58,7 @@ mod tests {
         let mut where_clause = WhereExpression::default();
         assert_eq!(where_clause.transpile_to_string(), "");
 
-        let filter_a = Filter::<DataTypeWithMetadata>::Equal(
+        let filter_a = Filter::Equal(
             Some(FilterExpression::Path(DataTypeQueryPath::Version)),
             Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
                 "latest",
@@ -71,7 +71,7 @@ mod tests {
             r#"WHERE "type_ids_0_1_0"."version" = "type_ids_0_1_0"."latest_version""#
         );
 
-        let filter_b = Filter::<DataTypeWithMetadata>::All(vec![
+        let filter_b = Filter::All(vec![
             Filter::Equal(
                 Some(FilterExpression::Path(DataTypeQueryPath::BaseUri)),
                 Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
@@ -94,7 +94,7 @@ mod tests {
             )
         );
 
-        let filter_c = Filter::<DataTypeWithMetadata>::NotEqual(
+        let filter_c = Filter::NotEqual(
             Some(FilterExpression::Path(DataTypeQueryPath::Description)),
             None,
         );
@@ -110,7 +110,7 @@ mod tests {
             )
         );
 
-        let filter_d = Filter::<DataTypeWithMetadata>::Any(vec![
+        let filter_d = Filter::Any(vec![
             Filter::Equal(
                 Some(FilterExpression::Path(DataTypeQueryPath::Title)),
                 Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/property_type.rs
@@ -1,16 +1,14 @@
 use std::{borrow::Cow, iter::once};
 
-use type_system::PropertyType;
-
 use crate::{
-    ontology::PropertyTypeQueryPath,
+    ontology::{PropertyTypeQueryPath, PropertyTypeWithMetadata},
     store::postgres::query::{
         table::{Column, JsonField, PropertyTypes, Relation, TypeIds},
         Path, PostgresQueryRecord, Table,
     },
 };
 
-impl PostgresQueryRecord for PropertyType {
+impl PostgresQueryRecord for PropertyTypeWithMetadata {
     fn base_table() -> Table {
         Table::PropertyTypes
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -78,12 +78,14 @@ mod tests {
     use std::borrow::Cow;
 
     use postgres_types::ToSql;
-    use type_system::{DataType, EntityType, PropertyType};
     use uuid::Uuid;
 
     use crate::{
         knowledge::{Entity, EntityQueryPath},
-        ontology::{DataTypeQueryPath, EntityTypeQueryPath, PropertyTypeQueryPath},
+        ontology::{
+            DataTypeQueryPath, DataTypeWithMetadata, EntityTypeQueryPath, EntityTypeWithMetadata,
+            PropertyTypeQueryPath, PropertyTypeWithMetadata,
+        },
         store::{
             postgres::query::{
                 test_helper::trim_whitespace, Distinctness, Ordering, PostgresQueryRecord,
@@ -120,7 +122,7 @@ mod tests {
     #[test]
     fn asterisk() {
         test_compilation(
-            &SelectCompiler::<DataType>::with_asterisk(),
+            &SelectCompiler::<DataTypeWithMetadata>::with_asterisk(),
             r#"SELECT * FROM "data_types" AS "data_types_0_0_0""#,
             &[],
         );
@@ -128,7 +130,7 @@ mod tests {
 
     #[test]
     fn simple_expression() {
-        let mut compiler = SelectCompiler::<DataType>::with_asterisk();
+        let mut compiler = SelectCompiler::<DataTypeWithMetadata>::with_asterisk();
         compiler.add_filter(&Filter::Equal(
             Some(FilterExpression::Path(DataTypeQueryPath::VersionedUri)),
             Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
@@ -148,7 +150,7 @@ mod tests {
 
     #[test]
     fn specific_version() {
-        let mut compiler = SelectCompiler::<DataType>::with_asterisk();
+        let mut compiler = SelectCompiler::<DataTypeWithMetadata>::with_asterisk();
 
         let filter = Filter::All(vec![
             Filter::Equal(
@@ -182,7 +184,7 @@ mod tests {
 
     #[test]
     fn latest_version() {
-        let mut compiler = SelectCompiler::<DataType>::with_asterisk();
+        let mut compiler = SelectCompiler::<DataTypeWithMetadata>::with_asterisk();
 
         compiler.add_filter(&Filter::Equal(
             Some(FilterExpression::Path(DataTypeQueryPath::Version)),
@@ -207,7 +209,7 @@ mod tests {
 
     #[test]
     fn not_latest_version() {
-        let mut compiler = SelectCompiler::<DataType>::with_asterisk();
+        let mut compiler = SelectCompiler::<DataTypeWithMetadata>::with_asterisk();
 
         compiler.add_filter(&Filter::NotEqual(
             Some(FilterExpression::Path(DataTypeQueryPath::Version)),
@@ -232,7 +234,7 @@ mod tests {
 
     #[test]
     fn property_type_by_referenced_data_types() {
-        let mut compiler = SelectCompiler::<PropertyType>::with_asterisk();
+        let mut compiler = SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk();
 
         compiler.add_filter(&Filter::Equal(
             Some(FilterExpression::Path(PropertyTypeQueryPath::DataTypes(
@@ -301,7 +303,7 @@ mod tests {
 
     #[test]
     fn property_type_by_referenced_property_types() {
-        let mut compiler = SelectCompiler::<PropertyType>::with_asterisk();
+        let mut compiler = SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk();
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(
@@ -330,7 +332,7 @@ mod tests {
 
     #[test]
     fn entity_type_by_referenced_property_types() {
-        let mut compiler = SelectCompiler::<EntityType>::with_asterisk();
+        let mut compiler = SelectCompiler::<EntityTypeWithMetadata>::with_asterisk();
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityTypeQueryPath::Properties(
@@ -359,7 +361,7 @@ mod tests {
 
     #[test]
     fn entity_type_by_referenced_link_types() {
-        let mut compiler = SelectCompiler::<EntityType>::with_asterisk();
+        let mut compiler = SelectCompiler::<EntityTypeWithMetadata>::with_asterisk();
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityTypeQueryPath::Links(
@@ -396,7 +398,7 @@ mod tests {
 
     #[test]
     fn entity_type_by_inheritance() {
-        let mut compiler = SelectCompiler::<EntityType>::with_asterisk();
+        let mut compiler = SelectCompiler::<EntityTypeWithMetadata>::with_asterisk();
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityTypeQueryPath::InheritsFrom(
@@ -680,7 +682,7 @@ mod tests {
 
         #[test]
         fn for_latest_version() {
-            let mut compiler = SelectCompiler::<DataType>::with_asterisk();
+            let mut compiler = SelectCompiler::<DataTypeWithMetadata>::with_asterisk();
 
             let filter = Filter::for_latest_version();
             compiler.add_filter(&filter);
@@ -709,7 +711,7 @@ mod tests {
                 1,
             );
 
-            let mut compiler = SelectCompiler::<DataType>::with_asterisk();
+            let mut compiler = SelectCompiler::<DataTypeWithMetadata>::with_asterisk();
 
             let filter = Filter::for_versioned_uri(&uri);
             compiler.add_filter(&filter);
@@ -737,7 +739,7 @@ mod tests {
                 OntologyTypeVersion::new(1),
             );
 
-            let mut compiler = SelectCompiler::<DataType>::with_asterisk();
+            let mut compiler = SelectCompiler::<DataTypeWithMetadata>::with_asterisk();
 
             let filter = Filter::for_ontology_type_edition_id(&uri);
             compiler.add_filter(&filter);

--- a/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
@@ -553,12 +553,12 @@ impl fmt::Display for Parameter<'_> {
 #[cfg(test)]
 mod tests {
     use serde_json::json;
-    use type_system::{uri::BaseUri, DataType};
+    use type_system::uri::BaseUri;
 
     use super::*;
     use crate::{
         identifier::{account::AccountId, knowledge::EntityVersion, ontology::OntologyTypeVersion},
-        ontology::DataTypeQueryPath,
+        ontology::{DataTypeQueryPath, DataTypeWithMetadata},
         provenance::OwnedById,
     };
 
@@ -581,7 +581,10 @@ mod tests {
           ]
         }};
 
-        test_filter_representation(&Filter::<DataType>::for_latest_version(), &expected);
+        test_filter_representation(
+            &Filter::<DataTypeWithMetadata>::for_latest_version(),
+            &expected,
+        );
     }
 
     #[test]
@@ -607,7 +610,10 @@ mod tests {
           ]
         }};
 
-        test_filter_representation(&Filter::<DataType>::for_versioned_uri(&uri), &expected);
+        test_filter_representation(
+            &Filter::<DataTypeWithMetadata>::for_versioned_uri(&uri),
+            &expected,
+        );
     }
 
     #[test]
@@ -634,7 +640,7 @@ mod tests {
         }};
 
         test_filter_representation(
-            &Filter::<DataType>::for_ontology_type_edition_id(&uri),
+            &Filter::<DataTypeWithMetadata>::for_ontology_type_edition_id(&uri),
             &expected,
         );
     }
@@ -870,7 +876,7 @@ mod tests {
 
         test_filter_representation(
             &Filter::NotEqual(
-                Some(FilterExpression::<DataType>::Path(
+                Some(FilterExpression::<DataTypeWithMetadata>::Path(
                     DataTypeQueryPath::Description,
                 )),
                 None,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, we use `DataType`, `PropertyType`, `EntityType`, and `Entity` for the query filters. This is inconsistent, as `Entity` contains metadata, the ontology types does not.
To deduplicated a very big chunk of code in the dependency resolution, those should be unified, thus, this PR is using `DataTypeWithMetadata` etc. in `Filters` instead. This also simplifies the `Read` trait in general to allow less bounds to be used in callers

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/0/1203444301722130/f) _(internal)_

## 🚫 Blocked by

- #1493

## 🔍 What does this change?

- Simplify `Read` trait to always use `Filter`
- Consistently use the type containing the `MetaData` in `Filters`