### PR TITLE
Fix edges not generated for root vertices

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -42,7 +42,7 @@ impl<C: AsClient> PostgresStore<C> {
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
     #[expect(clippy::too_many_lines)]
-    pub(crate) fn get_entity_as_dependency<'a>(
+    pub(crate) fn get_entity_with_dependency<'a>(
         &'a self,
         entity_edition_id: EntityEditionId,
         dependency_context: &'a mut DependencyContext,
@@ -91,7 +91,7 @@ impl<C: AsClient> PostgresStore<C> {
                         });
                     }
 
-                    self.get_entity_type_as_dependency(
+                    self.get_entity_type_with_dependency(
                         &entity_type_id,
                         dependency_context,
                         subgraph,
@@ -159,7 +159,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_entity_as_dependency(
+                        self.get_entity_with_dependency(
                             outgoing_link_entity.metadata().edition_id(),
                             dependency_context,
                             subgraph,
@@ -228,7 +228,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_entity_as_dependency(
+                        self.get_entity_with_dependency(
                             incoming_link_entity.metadata().edition_id(),
                             dependency_context,
                             subgraph,
@@ -293,7 +293,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_entity_as_dependency(
+                        self.get_entity_with_dependency(
                             left_entity.metadata().edition_id(),
                             dependency_context,
                             subgraph,
@@ -358,7 +358,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_entity_as_dependency(
+                        self.get_entity_with_dependency(
                             right_entity.metadata().edition_id(),
                             dependency_context,
                             subgraph,
@@ -510,15 +510,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
 
         for entity in Read::<Entity>::read(self, filter).await? {
             let entity_edition_id = entity.metadata().edition_id();
-            dependency_context
-                .knowledge_dependency_map
-                .insert(&entity_edition_id, None);
-            subgraph
-                .vertices
-                .knowledge_graph
-                .insert(entity_edition_id, KnowledgeGraphVertex::Entity(entity));
 
-            self.get_entity_as_dependency(
+            self.get_entity_with_dependency(
                 entity_edition_id,
                 &mut dependency_context,
                 &mut subgraph,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -52,7 +52,7 @@ impl<C: AsClient> PostgresStore<C> {
         async move {
             let dependency_status = dependency_context
                 .knowledge_dependency_map
-                .insert(&entity_edition_id, Some(current_resolve_depth));
+                .insert(&entity_edition_id, current_resolve_depth);
             let entity: Option<&KnowledgeGraphVertex> = match dependency_status {
                 DependencyStatus::Unknown => {
                     let entity = Read::<Entity>::read_one(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -42,7 +42,7 @@ impl<C: AsClient> PostgresStore<C> {
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
     #[expect(clippy::too_many_lines)]
-    pub(crate) fn get_entity_with_dependency<'a>(
+    pub(crate) fn get_entity_with_dependencies<'a>(
         &'a self,
         entity_edition_id: EntityEditionId,
         dependency_context: &'a mut DependencyContext,
@@ -91,7 +91,7 @@ impl<C: AsClient> PostgresStore<C> {
                         });
                     }
 
-                    self.get_entity_type_with_dependency(
+                    self.get_entity_type_with_dependencies(
                         &entity_type_id,
                         dependency_context,
                         subgraph,
@@ -159,7 +159,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_entity_with_dependency(
+                        self.get_entity_with_dependencies(
                             outgoing_link_entity.metadata().edition_id(),
                             dependency_context,
                             subgraph,
@@ -228,7 +228,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_entity_with_dependency(
+                        self.get_entity_with_dependencies(
                             incoming_link_entity.metadata().edition_id(),
                             dependency_context,
                             subgraph,
@@ -293,7 +293,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_entity_with_dependency(
+                        self.get_entity_with_dependencies(
                             left_entity.metadata().edition_id(),
                             dependency_context,
                             subgraph,
@@ -358,7 +358,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_entity_with_dependency(
+                        self.get_entity_with_dependencies(
                             right_entity.metadata().edition_id(),
                             dependency_context,
                             subgraph,
@@ -511,7 +511,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         for entity in Read::<Entity>::read(self, filter).await? {
             let entity_edition_id = entity.metadata().edition_id();
 
-            self.get_entity_with_dependency(
+            self.get_entity_with_dependencies(
                 entity_edition_id,
                 &mut dependency_context,
                 &mut subgraph,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -42,7 +42,7 @@ impl<C: AsClient> PostgresStore<C> {
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
     #[expect(clippy::too_many_lines)]
-    pub(crate) fn get_entity_with_dependencies<'a>(
+    pub(crate) fn traverse_entity<'a>(
         &'a self,
         entity_edition_id: EntityEditionId,
         dependency_context: &'a mut DependencyContext,
@@ -91,7 +91,7 @@ impl<C: AsClient> PostgresStore<C> {
                         });
                     }
 
-                    self.get_entity_type_with_dependencies(
+                    self.traverse_entity_type(
                         &entity_type_id,
                         dependency_context,
                         subgraph,
@@ -159,7 +159,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_entity_with_dependencies(
+                        self.traverse_entity(
                             outgoing_link_entity.metadata().edition_id(),
                             dependency_context,
                             subgraph,
@@ -228,7 +228,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_entity_with_dependencies(
+                        self.traverse_entity(
                             incoming_link_entity.metadata().edition_id(),
                             dependency_context,
                             subgraph,
@@ -293,7 +293,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_entity_with_dependencies(
+                        self.traverse_entity(
                             left_entity.metadata().edition_id(),
                             dependency_context,
                             subgraph,
@@ -358,7 +358,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_entity_with_dependencies(
+                        self.traverse_entity(
                             right_entity.metadata().edition_id(),
                             dependency_context,
                             subgraph,
@@ -511,7 +511,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         for entity in Read::<Entity>::read(self, filter).await? {
             let entity_edition_id = entity.metadata().edition_id();
 
-            self.get_entity_with_dependencies(
+            self.traverse_entity(
                 entity_edition_id,
                 &mut dependency_context,
                 &mut subgraph,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -53,7 +53,7 @@ pub enum DependencyStatus {
 }
 
 pub struct DependencyMap<K> {
-    resolved: HashMap<K, Option<GraphResolveDepths>>,
+    resolved: HashMap<K, GraphResolveDepths>,
 }
 
 impl<K> Default for DependencyMap<K> {
@@ -82,24 +82,20 @@ where
     pub fn insert(
         &mut self,
         identifier: &K,
-        resolved_depth: Option<GraphResolveDepths>,
+        resolved_depth: GraphResolveDepths,
     ) -> DependencyStatus {
         match self.resolved.raw_entry_mut().from_key(identifier) {
             RawEntryMut::Vacant(entry) => {
                 entry.insert(identifier.clone(), resolved_depth);
                 DependencyStatus::Unknown
             }
-            RawEntryMut::Occupied(entry) => match (entry.into_mut(), resolved_depth) {
-                (None, Some(_)) => DependencyStatus::DependenciesUnresolved,
-                (Some(used_depth), Some(resolved_depth)) => {
-                    if used_depth.update(resolved_depth) {
-                        DependencyStatus::DependenciesUnresolved
-                    } else {
-                        DependencyStatus::Resolved
-                    }
+            RawEntryMut::Occupied(entry) => {
+                if entry.into_mut().update(resolved_depth) {
+                    DependencyStatus::DependenciesUnresolved
+                } else {
+                    DependencyStatus::Resolved
                 }
-                _ => DependencyStatus::Resolved,
-            },
+            }
         }
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -31,7 +31,7 @@ impl<C: AsClient> PostgresStore<C> {
     ) -> Result<(), QueryError> {
         let dependency_status = dependency_context
             .ontology_dependency_map
-            .insert(data_type_id, Some(current_resolve_depth));
+            .insert(data_type_id, current_resolve_depth);
         let data_type: Option<&OntologyVertex> = match dependency_status {
             DependencyStatus::Unknown => {
                 let data_type = Read::<DataTypeWithMetadata>::read_one(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -22,7 +22,7 @@ impl<C: AsClient> PostgresStore<C> {
     /// Internal method to read a [`DataTypeWithMetadata`] into a [`DependencyContext`].
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
-    pub(crate) async fn get_data_type_with_dependencies(
+    pub(crate) async fn traverse_data_type(
         &self,
         data_type_id: &OntologyTypeEditionId,
         dependency_context: &mut DependencyContext,
@@ -108,7 +108,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
         for data_type in Read::<DataTypeWithMetadata>::read(self, filter).await? {
             let data_type_id = data_type.metadata().edition_id().clone();
 
-            self.get_data_type_with_dependencies(
+            self.traverse_data_type(
                 &data_type_id,
                 &mut dependency_context,
                 &mut subgraph,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -22,7 +22,7 @@ impl<C: AsClient> PostgresStore<C> {
     /// Internal method to read a [`DataTypeWithMetadata`] into a [`DependencyContext`].
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
-    pub(crate) async fn get_data_type_as_dependency(
+    pub(crate) async fn get_data_type_with_dependency(
         &self,
         data_type_id: &OntologyTypeEditionId,
         dependency_context: &mut DependencyContext,
@@ -107,15 +107,8 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
 
         for data_type in Read::<DataTypeWithMetadata>::read(self, filter).await? {
             let data_type_id = data_type.metadata().edition_id().clone();
-            dependency_context
-                .ontology_dependency_map
-                .insert(&data_type_id, None);
-            subgraph.vertices.ontology.insert(
-                data_type_id.clone(),
-                OntologyVertex::DataType(Box::new(data_type)),
-            );
 
-            self.get_data_type_as_dependency(
+            self.get_data_type_with_dependency(
                 &data_type_id,
                 &mut dependency_context,
                 &mut subgraph,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -22,7 +22,7 @@ impl<C: AsClient> PostgresStore<C> {
     /// Internal method to read a [`DataTypeWithMetadata`] into a [`DependencyContext`].
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
-    pub(crate) async fn get_data_type_with_dependency(
+    pub(crate) async fn get_data_type_with_dependencies(
         &self,
         data_type_id: &OntologyTypeEditionId,
         dependency_context: &mut DependencyContext,
@@ -108,7 +108,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
         for data_type in Read::<DataTypeWithMetadata>::read(self, filter).await? {
             let data_type_id = data_type.metadata().edition_id().clone();
 
-            self.get_data_type_with_dependency(
+            self.get_data_type_with_dependencies(
                 &data_type_id,
                 &mut dependency_context,
                 &mut subgraph,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -45,7 +45,7 @@ impl<C: AsClient> PostgresStore<C> {
         async move {
             let dependency_status = dependency_context
                 .ontology_dependency_map
-                .insert(entity_type_id, Some(current_resolve_depth));
+                .insert(entity_type_id, current_resolve_depth);
             let entity_type = match dependency_status {
                 DependencyStatus::Unknown => {
                     let entity_type = Read::<EntityTypeWithMetadata>::read_one(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -35,7 +35,7 @@ impl<C: AsClient> PostgresStore<C> {
         clippy::too_many_lines,
         reason = "There is quite a few code duplication, which has to be resolved"
     )]
-    pub(crate) fn get_entity_type_as_dependency<'a>(
+    pub(crate) fn get_entity_type_with_dependency<'a>(
         &'a self,
         entity_type_id: &'a OntologyTypeEditionId,
         dependency_context: &'a mut DependencyContext,
@@ -84,7 +84,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_property_type_as_dependency(
+                        self.get_property_type_with_dependency(
                             &OntologyTypeEditionId::from(property_type_ref.uri()),
                             dependency_context,
                             subgraph,
@@ -118,7 +118,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_entity_type_as_dependency(
+                        self.get_entity_type_with_dependency(
                             &OntologyTypeEditionId::from(entity_type_ref.uri()),
                             dependency_context,
                             subgraph,
@@ -149,7 +149,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_entity_type_as_dependency(
+                        self.get_entity_type_with_dependency(
                             &OntologyTypeEditionId::from(entity_type_ref.uri()),
                             dependency_context,
                             subgraph,
@@ -192,7 +192,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_entity_type_as_dependency(
+                        self.get_entity_type_with_dependency(
                             &OntologyTypeEditionId::from(entity_type_ref.uri()),
                             dependency_context,
                             subgraph,
@@ -277,15 +277,8 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
 
         for entity_type in Read::<EntityTypeWithMetadata>::read(self, filter).await? {
             let entity_type_id = entity_type.metadata().edition_id().clone();
-            dependency_context
-                .ontology_dependency_map
-                .insert(&entity_type_id, None);
-            subgraph.vertices.ontology.insert(
-                entity_type_id.clone(),
-                OntologyVertex::EntityType(Box::new(entity_type)),
-            );
 
-            self.get_entity_type_as_dependency(
+            self.get_entity_type_with_dependency(
                 &entity_type_id,
                 &mut dependency_context,
                 &mut subgraph,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -35,7 +35,7 @@ impl<C: AsClient> PostgresStore<C> {
         clippy::too_many_lines,
         reason = "There is quite a few code duplication, which has to be resolved"
     )]
-    pub(crate) fn get_entity_type_with_dependency<'a>(
+    pub(crate) fn get_entity_type_with_dependencies<'a>(
         &'a self,
         entity_type_id: &'a OntologyTypeEditionId,
         dependency_context: &'a mut DependencyContext,
@@ -84,7 +84,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_property_type_with_dependency(
+                        self.get_property_type_with_dependencies(
                             &OntologyTypeEditionId::from(property_type_ref.uri()),
                             dependency_context,
                             subgraph,
@@ -118,7 +118,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_entity_type_with_dependency(
+                        self.get_entity_type_with_dependencies(
                             &OntologyTypeEditionId::from(entity_type_ref.uri()),
                             dependency_context,
                             subgraph,
@@ -149,7 +149,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_entity_type_with_dependency(
+                        self.get_entity_type_with_dependencies(
                             &OntologyTypeEditionId::from(entity_type_ref.uri()),
                             dependency_context,
                             subgraph,
@@ -192,7 +192,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_entity_type_with_dependency(
+                        self.get_entity_type_with_dependencies(
                             &OntologyTypeEditionId::from(entity_type_ref.uri()),
                             dependency_context,
                             subgraph,
@@ -278,7 +278,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         for entity_type in Read::<EntityTypeWithMetadata>::read(self, filter).await? {
             let entity_type_id = entity_type.metadata().edition_id().clone();
 
-            self.get_entity_type_with_dependency(
+            self.get_entity_type_with_dependencies(
                 &entity_type_id,
                 &mut dependency_context,
                 &mut subgraph,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -35,7 +35,7 @@ impl<C: AsClient> PostgresStore<C> {
         clippy::too_many_lines,
         reason = "There is quite a few code duplication, which has to be resolved"
     )]
-    pub(crate) fn get_entity_type_with_dependencies<'a>(
+    pub(crate) fn traverse_entity_type<'a>(
         &'a self,
         entity_type_id: &'a OntologyTypeEditionId,
         dependency_context: &'a mut DependencyContext,
@@ -84,7 +84,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_property_type_with_dependencies(
+                        self.traverse_property_type(
                             &OntologyTypeEditionId::from(property_type_ref.uri()),
                             dependency_context,
                             subgraph,
@@ -118,7 +118,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_entity_type_with_dependencies(
+                        self.traverse_entity_type(
                             &OntologyTypeEditionId::from(entity_type_ref.uri()),
                             dependency_context,
                             subgraph,
@@ -149,7 +149,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_entity_type_with_dependencies(
+                        self.traverse_entity_type(
                             &OntologyTypeEditionId::from(entity_type_ref.uri()),
                             dependency_context,
                             subgraph,
@@ -192,7 +192,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_entity_type_with_dependencies(
+                        self.traverse_entity_type(
                             &OntologyTypeEditionId::from(entity_type_ref.uri()),
                             dependency_context,
                             subgraph,
@@ -278,7 +278,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         for entity_type in Read::<EntityTypeWithMetadata>::read(self, filter).await? {
             let entity_type_id = entity_type.metadata().edition_id().clone();
 
-            self.get_entity_type_with_dependencies(
+            self.traverse_entity_type(
                 &entity_type_id,
                 &mut dependency_context,
                 &mut subgraph,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -41,7 +41,7 @@ impl<C: AsClient> PostgresStore<C> {
         async move {
             let dependency_status = dependency_context
                 .ontology_dependency_map
-                .insert(property_type_id, Some(current_resolve_depth));
+                .insert(property_type_id, current_resolve_depth);
             let property_type = match dependency_status {
                 DependencyStatus::Unknown => {
                     let property_type = Read::<PropertyTypeWithMetadata>::read_one(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -31,7 +31,7 @@ impl<C: AsClient> PostgresStore<C> {
     /// Internal method to read a [`PropertyTypeWithMetadata`] into two [`DependencyContext`]s.
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
-    pub(crate) fn get_property_type_as_dependency<'a>(
+    pub(crate) fn get_property_type_with_dependency<'a>(
         &'a self,
         property_type_id: &'a OntologyTypeEditionId,
         dependency_context: &'a mut DependencyContext,
@@ -82,7 +82,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_property_type_as_dependency(
+                        self.get_property_type_with_dependency(
                             &OntologyTypeEditionId::from(property_type_ref.uri()),
                             dependency_context,
                             subgraph,
@@ -118,7 +118,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_data_type_as_dependency(
+                        self.get_data_type_with_dependency(
                             &OntologyTypeEditionId::from(data_type_ref.uri()),
                             dependency_context,
                             subgraph,
@@ -201,15 +201,8 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
 
         for property_type in Read::<PropertyTypeWithMetadata>::read(self, filter).await? {
             let property_type_id = property_type.metadata().edition_id().clone();
-            dependency_context
-                .ontology_dependency_map
-                .insert(&property_type_id, None);
-            subgraph.vertices.ontology.insert(
-                property_type_id.clone(),
-                OntologyVertex::PropertyType(Box::new(property_type)),
-            );
 
-            self.get_property_type_as_dependency(
+            self.get_property_type_with_dependency(
                 &property_type_id,
                 &mut dependency_context,
                 &mut subgraph,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -31,7 +31,7 @@ impl<C: AsClient> PostgresStore<C> {
     /// Internal method to read a [`PropertyTypeWithMetadata`] into two [`DependencyContext`]s.
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
-    pub(crate) fn get_property_type_with_dependency<'a>(
+    pub(crate) fn get_property_type_with_dependencies<'a>(
         &'a self,
         property_type_id: &'a OntologyTypeEditionId,
         dependency_context: &'a mut DependencyContext,
@@ -82,7 +82,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_property_type_with_dependency(
+                        self.get_property_type_with_dependencies(
                             &OntologyTypeEditionId::from(property_type_ref.uri()),
                             dependency_context,
                             subgraph,
@@ -118,7 +118,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_data_type_with_dependency(
+                        self.get_data_type_with_dependencies(
                             &OntologyTypeEditionId::from(data_type_ref.uri()),
                             dependency_context,
                             subgraph,
@@ -202,7 +202,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         for property_type in Read::<PropertyTypeWithMetadata>::read(self, filter).await? {
             let property_type_id = property_type.metadata().edition_id().clone();
 
-            self.get_property_type_with_dependency(
+            self.get_property_type_with_dependencies(
                 &property_type_id,
                 &mut dependency_context,
                 &mut subgraph,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -31,7 +31,7 @@ impl<C: AsClient> PostgresStore<C> {
     /// Internal method to read a [`PropertyTypeWithMetadata`] into two [`DependencyContext`]s.
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
-    pub(crate) fn get_property_type_with_dependencies<'a>(
+    pub(crate) fn traverse_property_type<'a>(
         &'a self,
         property_type_id: &'a OntologyTypeEditionId,
         dependency_context: &'a mut DependencyContext,
@@ -82,7 +82,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_property_type_with_dependencies(
+                        self.traverse_property_type(
                             &OntologyTypeEditionId::from(property_type_ref.uri()),
                             dependency_context,
                             subgraph,
@@ -118,7 +118,7 @@ impl<C: AsClient> PostgresStore<C> {
                             });
                         }
 
-                        self.get_data_type_with_dependencies(
+                        self.traverse_data_type(
                             &OntologyTypeEditionId::from(data_type_ref.uri()),
                             dependency_context,
                             subgraph,
@@ -202,7 +202,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         for property_type in Read::<PropertyTypeWithMetadata>::read(self, filter).await? {
             let property_type_id = property_type.metadata().edition_id().clone();
 
-            self.get_property_type_with_dependencies(
+            self.traverse_property_type(
                 &property_type_id,
                 &mut dependency_context,
                 &mut subgraph,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The edges based on the root vertices are not added to the subgraph, this fixes that bug.

## 🔍 What does this change?

- Don't insert the vertices before the resolving logic (results in an `DependencyStatus::DependenciesUnresolved` status instead of `DependencyStatus::Unknown`)
- Rename functions to better reflect this
- Make `GraphResolveDepths` required for dependency maps
