### PR TITLE
Allow setting depths in BP hooks

### DIFF
--- a/packages/hash/api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -5,7 +5,12 @@ import {
   ForbiddenError,
   UserInputError,
 } from "apollo-server-express";
-import { Entity, splitEntityId, Subgraph } from "@hashintel/hash-subgraph";
+import {
+  Entity,
+  isEntityId,
+  splitEntityId,
+  Subgraph,
+} from "@hashintel/hash-subgraph";
 import {
   EntityModel,
   EntityTypeModel,
@@ -23,7 +28,26 @@ import { mapEntityModelToGQL } from "../model-mapping";
 import { LoggedInGraphQLContext } from "../../../context";
 import { beforeUpdateEntityHooks } from "./before-update-entity-hooks";
 
-/** @todo - rename these and remove "withMetadata" - https://app.asana.com/0/0/1203157172269854/f */
+/**
+ * @todo - Remove this when the Subgraph is appropriately queryable for a timestamp
+ *   at the moment, (not in the roots) all versions of linked entities are returned,
+ *   and with the lack of an `endTime`, this breaks the queryability of the graph to
+ *   find the correct version of an entity.
+ *   https://app.asana.com/0/1201095311341924/1203331904553375/f
+ *
+ */
+const removeNonlatestEntities = (subgraph: Subgraph) => {
+  for (const entityId of Object.keys(subgraph.vertices)) {
+    if (isEntityId(entityId)) {
+      for (const oldVersion of Object.keys(subgraph.vertices[entityId]!)
+        .sort()
+        .slice(0, -1)) {
+        // eslint-disable-next-line no-param-reassign
+        delete subgraph.vertices[entityId]![oldVersion];
+      }
+    }
+  }
+};
 
 export const createEntity: ResolverFn<
   Promise<Entity>,
@@ -145,6 +169,7 @@ export const getAllLatestEntities: ResolverFn<
       );
     });
 
+  removeNonlatestEntities(entitySubgraph as Subgraph);
   return entitySubgraph as Subgraph;
 };
 
@@ -209,6 +234,7 @@ export const getEntity: ResolverFn<
       );
     });
 
+  removeNonlatestEntities(entitySubgraph as Subgraph);
   return entitySubgraph as Subgraph;
 };
 

--- a/packages/hash/api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -36,7 +36,7 @@ import { beforeUpdateEntityHooks } from "./before-update-entity-hooks";
  *   https://app.asana.com/0/1201095311341924/1203331904553375/f
  *
  */
-const removeNonlatestEntities = (subgraph: Subgraph) => {
+const removeNonLatestEntities = (subgraph: Subgraph) => {
   for (const entityId of Object.keys(subgraph.vertices)) {
     if (isEntityId(entityId)) {
       for (const oldVersion of Object.keys(subgraph.vertices[entityId]!)
@@ -169,7 +169,7 @@ export const getAllLatestEntities: ResolverFn<
       );
     });
 
-  removeNonlatestEntities(entitySubgraph as Subgraph);
+  removeNonLatestEntities(entitySubgraph as Subgraph);
   return entitySubgraph as Subgraph;
 };
 
@@ -234,7 +234,7 @@ export const getEntity: ResolverFn<
       );
     });
 
-  removeNonlatestEntities(entitySubgraph as Subgraph);
+  removeNonLatestEntities(entitySubgraph as Subgraph);
   return entitySubgraph as Subgraph;
 };
 

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/knowledge-shim.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/knowledge-shim.ts
@@ -29,9 +29,14 @@ export type KnowledgeCallbacks = {
   archiveEntity: ArchiveEntityMessageCallback;
 };
 
+export type GetEntityRequest = {
+  entityId: EntityId;
+  graphResolveDepths?: Partial<Subgraph["depths"]>;
+};
+
 /* Entity CRU */
 export type GetEntityMessageCallback = MessageCallback<
-  EntityId,
+  GetEntityRequest,
   null,
   Subgraph<SubgraphRootTypes["entity"]>,
   ReadOrModifyResourceError
@@ -39,6 +44,7 @@ export type GetEntityMessageCallback = MessageCallback<
 
 export type AggregateEntitiesRequest = {
   rootEntityTypeIds?: VersionedUri[];
+  graphResolveDepths?: Partial<Subgraph["depths"]>;
 };
 
 export type AggregateEntitiesMessageCallback = MessageCallback<

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/useBlockProtocolAggregateEntities.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/useBlockProtocolAggregateEntities.ts
@@ -33,7 +33,7 @@ export const useBlockProtocolAggregateEntities = (): {
         };
       }
 
-      const { rootEntityTypeIds } = data;
+      const { rootEntityTypeIds, graphResolveDepths } = data;
 
       /**
        * @todo Add filtering to this aggregate query using structural querying.
@@ -51,6 +51,7 @@ export const useBlockProtocolAggregateEntities = (): {
           isOfType: { outgoing: 1 },
           hasLeftEntity: { outgoing: 1, incoming: 1 },
           hasRightEntity: { outgoing: 1, incoming: 1 },
+          ...graphResolveDepths,
         },
       });
 

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/useBlockProtocolGetEntity.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/useBlockProtocolGetEntity.ts
@@ -21,8 +21,8 @@ export const useBlockProtocolGetEntity = (): {
   );
 
   const getEntity = useCallback<GetEntityMessageCallback>(
-    async ({ data: entityId }) => {
-      if (!entityId) {
+    async ({ data }) => {
+      if (!data) {
         return {
           errors: [
             {
@@ -32,6 +32,8 @@ export const useBlockProtocolGetEntity = (): {
           ],
         };
       }
+
+      const { entityId, graphResolveDepths } = data;
 
       const { data: response } = await getEntityFn({
         variables: {
@@ -43,6 +45,7 @@ export const useBlockProtocolGetEntity = (): {
           isOfType: { outgoing: 1 },
           hasLeftEntity: { outgoing: 1, incoming: 1 },
           hasRightEntity: { outgoing: 1, incoming: 1 },
+          ...graphResolveDepths,
         },
       });
 

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/ontology-types-shim.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/ontology-types-shim.ts
@@ -23,6 +23,7 @@ import {
   Subgraph,
   SubgraphRootTypes,
 } from "@hashintel/hash-subgraph";
+import { EmptyObject } from "@hashintel/hash-shared/util";
 
 export type OntologyCallbacks = {
   aggregateDataTypes: AggregateDataTypesMessageCallback;
@@ -39,7 +40,7 @@ export type OntologyCallbacks = {
 
 /* Data type CRU */
 export type AggregateDataTypesMessageCallback = MessageCallback<
-  {},
+  EmptyObject,
   null,
   Subgraph<SubgraphRootTypes["dataType"]>,
   ReadOrModifyResourceError
@@ -64,15 +65,28 @@ export type CreatePropertyTypeMessageCallback = MessageCallback<
   CreateResourceError
 >;
 
+export type AggregatePropertyTypesRequest = {
+  graphResolveDepths?: Partial<
+    Pick<Subgraph["depths"], "constrainsValuesOn" | "constrainsPropertiesOn">
+  >;
+};
+
 export type AggregatePropertyTypesMessageCallback = MessageCallback<
-  {},
+  AggregatePropertyTypesRequest,
   null,
   Subgraph<SubgraphRootTypes["propertyType"]>,
   ReadOrModifyResourceError
 >;
 
+export type GetPropertyTypeRequest = {
+  propertyTypeId: VersionedUri;
+  graphResolveDepths?: Partial<
+    Pick<Subgraph["depths"], "constrainsValuesOn" | "constrainsPropertiesOn">
+  >;
+};
+
 export type GetPropertyTypeMessageCallback = MessageCallback<
-  VersionedUri,
+  GetPropertyTypeRequest,
   null,
   Subgraph<SubgraphRootTypes["propertyType"]>,
   ReadOrModifyResourceError
@@ -101,15 +115,40 @@ export type CreateEntityTypeMessageCallback = MessageCallback<
   CreateResourceError
 >;
 
+export type AggregateEntityTypesRequest = {
+  graphResolveDepths?: Partial<
+    Pick<
+      Subgraph["depths"],
+      | "constrainsValuesOn"
+      | "constrainsPropertiesOn"
+      | "constrainsLinksOn"
+      | "constrainsLinkDestinationsOn"
+    >
+  >;
+};
+
 export type AggregateEntityTypesMessageCallback = MessageCallback<
-  {},
+  AggregateEntityTypesRequest,
   null,
   Subgraph<SubgraphRootTypes["entityType"]>,
   ReadOrModifyResourceError
 >;
 
+export type GetEntityTypeRequest = {
+  entityTypeId: VersionedUri;
+  graphResolveDepths?: Partial<
+    Pick<
+      Subgraph["depths"],
+      | "constrainsValuesOn"
+      | "constrainsPropertiesOn"
+      | "constrainsLinksOn"
+      | "constrainsLinkDestinationsOn"
+    >
+  >;
+};
+
 export type GetEntityTypeMessageCallback = MessageCallback<
-  VersionedUri,
+  GetEntityTypeRequest,
   null,
   Subgraph<SubgraphRootTypes["entityType"]>,
   ReadOrModifyResourceError

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolAggregateEntityTypes.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolAggregateEntityTypes.ts
@@ -33,6 +33,8 @@ export const useBlockProtocolAggregateEntityTypes = (): {
         };
       }
 
+      const { graphResolveDepths } = data;
+
       /**
        * @todo Add filtering to this aggregate query using structural querying.
        *   This may mean having the backend use structural querying and relaying
@@ -45,6 +47,7 @@ export const useBlockProtocolAggregateEntityTypes = (): {
           constrainsPropertiesOn: { outgoing: 255 },
           constrainsLinksOn: { outgoing: 1 },
           constrainsLinkDestinationsOn: { outgoing: 1 },
+          ...graphResolveDepths,
         },
       });
 

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolAggregatePropertyTypes.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolAggregatePropertyTypes.ts
@@ -34,6 +34,7 @@ export const useBlockProtocolAggregatePropertyTypes = (): {
           };
         }
 
+        const { graphResolveDepths } = data;
         /**
          * @todo Add filtering to this aggregate query using structural querying.
          *   This may mean having the backend use structural querying and relaying
@@ -44,6 +45,7 @@ export const useBlockProtocolAggregatePropertyTypes = (): {
           variables: {
             constrainsValuesOn: { outgoing: 255 },
             constrainsPropertiesOn: { outgoing: 255 },
+            ...graphResolveDepths,
           },
         });
 

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolGetEntityType.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolGetEntityType.ts
@@ -27,8 +27,8 @@ export const useBlockProtocolGetEntityType = (): {
   );
 
   const getEntityType = useCallback<GetEntityTypeMessageCallback>(
-    async ({ data: entityTypeId }) => {
-      if (!entityTypeId) {
+    async ({ data }) => {
+      if (!data) {
         return {
           errors: [
             {
@@ -39,6 +39,8 @@ export const useBlockProtocolGetEntityType = (): {
         };
       }
 
+      const { entityTypeId, graphResolveDepths } = data;
+
       const response = await getFn({
         query: getEntityTypeQuery,
         variables: {
@@ -47,6 +49,7 @@ export const useBlockProtocolGetEntityType = (): {
           constrainsPropertiesOn: { outgoing: 255 },
           constrainsLinksOn: { outgoing: 1 },
           constrainsLinkDestinationsOn: { outgoing: 1 },
+          ...graphResolveDepths,
         },
       });
 

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolGetPropertyType.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/ontology/useBlockProtocolGetPropertyType.ts
@@ -27,8 +27,8 @@ export const useBlockProtocolGetPropertyType = (): {
   });
 
   const getPropertyType = useCallback<GetPropertyTypeMessageCallback>(
-    async ({ data: propertyTypeId }) => {
-      if (!propertyTypeId) {
+    async ({ data }) => {
+      if (!data) {
         return {
           errors: [
             {
@@ -39,11 +39,14 @@ export const useBlockProtocolGetPropertyType = (): {
         };
       }
 
+      const { propertyTypeId, graphResolveDepths } = data;
+
       const response = await getFn({
         variables: {
           propertyTypeId,
           constrainsValuesOn: { outgoing: 255 },
           constrainsPropertiesOn: { outgoing: 255 },
+          ...graphResolveDepths,
         },
       });
 

--- a/packages/hash/frontend/src/pages/[account-slug]/entities/[entity-uuid].page.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/entities/[entity-uuid].page.tsx
@@ -36,10 +36,12 @@ const Page: NextPageWithLayout = () => {
           const entityUuid = router.query["entity-uuid"] as string;
 
           const { data: subgraph } = await getEntity({
-            data: entityIdFromOwnedByIdAndEntityUuid(
-              namespace.accountId,
-              entityUuid,
-            ),
+            data: {
+              entityId: entityIdFromOwnedByIdAndEntityUuid(
+                namespace.accountId,
+                entityUuid,
+              ),
+            },
           });
 
           if (subgraph) {

--- a/packages/hash/frontend/src/pages/[account-slug]/entities/[entity-uuid].page/shared/use-create-new-entity-and-redirect.ts
+++ b/packages/hash/frontend/src/pages/[account-slug]/entities/[entity-uuid].page/shared/use-create-new-entity-and-redirect.ts
@@ -93,7 +93,15 @@ export const useCreateNewEntityAndRedirect = () => {
   const createNewEntityAndRedirect = useCallback(
     async (entityTypeId: VersionedUri) => {
       const { data: subgraph } = await getEntityType({
-        data: entityTypeId,
+        data: {
+          entityTypeId,
+          graphResolveDepths: {
+            constrainsValuesOn: { outgoing: 0 },
+            constrainsLinksOn: { outgoing: 0 },
+            constrainsLinkDestinationsOn: { outgoing: 0 },
+            constrainsPropertiesOn: { outgoing: 1 },
+          },
+        },
       });
 
       const accountSlug = router.query["account-slug"];

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-type-form.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-type-form.tsx
@@ -183,7 +183,15 @@ export const PropertyTypeForm = ({
                 generatePropertyTypeBaseUriForUser(value),
               );
 
-              const res = await getPropertyType({ data: propertyTypeId });
+              const res = await getPropertyType({
+                data: {
+                  propertyTypeId,
+                  graphResolveDepths: {
+                    constrainsValuesOn: { outgoing: 0 },
+                    constrainsPropertiesOn: { outgoing: 0 },
+                  },
+                },
+              });
 
               const exists =
                 !res.data || !!getPropertyTypeById(res.data, propertyTypeId);

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/use-entity-type-entities.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/use-entity-type-entities.tsx
@@ -2,6 +2,7 @@ import {
   EntityType,
   PropertyType,
   extractBaseUri,
+  BaseUri,
 } from "@blockprotocol/type-system-web";
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { Entity, Subgraph, SubgraphRootTypes } from "@hashintel/hash-subgraph";
@@ -18,14 +19,25 @@ export type EntityTypeEntitiesContextValue = {
 };
 
 export const useEntityTypeEntitiesContextValue = (
-  typeBaseUri: string | null,
+  typeBaseUri: BaseUri | null,
 ): EntityTypeEntitiesContextValue => {
   const [subgraph, setSubgraph] =
     useState<Subgraph<SubgraphRootTypes["entity"]>>();
   const { aggregateEntities } = useBlockProtocolAggregateEntities();
 
   useEffect(() => {
-    void aggregateEntities({ data: {} }).then((res) => {
+    void aggregateEntities({
+      data: {
+        graphResolveDepths: {
+          constrainsValuesOn: { outgoing: 0 },
+          constrainsPropertiesOn: { outgoing: 1 },
+          constrainsLinksOn: { outgoing: 0 },
+          isOfType: { outgoing: 1 },
+          hasLeftEntity: { incoming: 0, outgoing: 0 },
+          hasRightEntity: { incoming: 0, outgoing: 0 },
+        },
+      },
+    }).then((res) => {
       if (res.data) {
         setSubgraph(res.data);
       }

--- a/packages/hash/frontend/src/pages/[account-slug]/types/new/entity-type.page.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/new/entity-type.page.tsx
@@ -219,9 +219,17 @@ const Page: NextPageWithLayout = () => {
                   },
                   async validate(value) {
                     const res = await getEntityType({
-                      data: generateInitialEntityTypeId(
-                        generateEntityTypeBaseUriForUser(value),
-                      ),
+                      data: {
+                        entityTypeId: generateInitialEntityTypeId(
+                          generateEntityTypeBaseUriForUser(value),
+                        ),
+                        graphResolveDepths: {
+                          constrainsValuesOn: { outgoing: 0 },
+                          constrainsPropertiesOn: { outgoing: 0 },
+                          constrainsLinksOn: { outgoing: 0 },
+                          constrainsLinkDestinationsOn: { outgoing: 0 },
+                        },
+                      },
                     });
 
                     return res.data?.roots.length

--- a/packages/hash/frontend/src/pages/entity-editor.page.tsx
+++ b/packages/hash/frontend/src/pages/entity-editor.page.tsx
@@ -39,7 +39,7 @@ const ExampleUsage = ({ ownedById }: { ownedById: string }) => {
       // As an example entity, we are going to use the currently logged in user's entity ID
       const entityId = authenticatedUser.entityEditionId.baseId;
 
-      void getEntity({ data: entityId }).then(({ data }) => {
+      void getEntity({ data: { entityId } }).then(({ data }) => {
         setUserSubgraph(data);
       });
     }

--- a/packages/hash/shared/src/util.ts
+++ b/packages/hash/shared/src/util.ts
@@ -1,6 +1,10 @@
 // @todo this should be defined elsewhere
-
 import { uniq } from "lodash";
+
+/**
+ * This behaves differently from the type `{}`, and will error if you set more properties on it.
+ */
+export type EmptyObject = Record<any, never>;
 
 export type DistributiveOmit<T, K extends keyof any> = T extends any
   ? Omit<T, K>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Previously we selected "sensible" defaults for the hooks. It makes sense to expose the GraphResolveDepths to them so consumers can be opinionated if they want. This leads to substantial performance improvements for the frontend.

This work also discovered the bug fixed in #1530.

It also fixes bugs in the application where `Org`s weren't appearing in the workspace switcher.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203312852763953/1203458586282756/f) _(internal)_

## 🔍 What does this change?

See commit list please

## 📜 Does this require a change to the docs?

No

## ⚠️ Known issues

The Subgraph has started returning multiple versions of linked entities. We will fix this as part of the on-going versioning changes, but because the queries aren't actually temporal based at the moment (you can't ask for the graph at a given timestamp), it is easier to manually patch in a single place in the resolvers to maintain the invariant.

## 🛡 What tests cover this?

- None cover the specific code I've touched, to my knowledge

## ❓ How to test this?

1.  Checkout the branch / view the deployment
1.  Run the app
1.  Try the various routes..

## 📹 Demo
The org appearing again
<img width="264" alt="image" src="https://user-images.githubusercontent.com/25749103/204585879-09d33de5-5906-4efa-ab69-0ddba78e3956.png">
