### PR TITLE
New entity type flow improvements (follow up)

### DIFF
--- a/packages/hash/frontend/src/components/hooks/useAuthenticatedUser.ts
+++ b/packages/hash/frontend/src/components/hooks/useAuthenticatedUser.ts
@@ -128,8 +128,8 @@ export const useAuthenticatedUser = (
   return {
     authenticatedUser,
     kratosSession,
-    refetch: () => {
-      return Promise.all([
+    refetch: () =>
+      Promise.all([
         // Until we change the GraphQL query scalars to return constrained Subgraphs, we need to (safely) cast
         // ourselves
         (
@@ -138,8 +138,7 @@ export const useAuthenticatedUser = (
           >
         )(),
         fetchKratosIdentity(forceLogin, true),
-      ]);
-    },
+      ]),
     loading: loadingUser || loadingKratosSession,
   };
 };

--- a/packages/hash/frontend/src/components/hooks/useAuthenticatedUser.ts
+++ b/packages/hash/frontend/src/components/hooks/useAuthenticatedUser.ts
@@ -1,21 +1,14 @@
 import { ApolloQueryResult, QueryHookOptions, useQuery } from "@apollo/client";
-import * as Sentry from "@sentry/nextjs";
-import { useRouter } from "next/router";
-import {
-  useContext,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
 
 import { Subgraph, SubgraphRootTypes } from "@hashintel/hash-subgraph";
-import { meQuery } from "../../graphql/queries/user.queries";
+import * as Sentry from "@sentry/nextjs";
+import { useRouter } from "next/router";
+import { useContext, useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import { MeQuery, MeQueryVariables } from "../../graphql/apiTypes.gen";
-import { oryKratosClient } from "../../pages/shared/ory-kratos";
-import { AuthenticatedUser, constructAuthenticatedUser } from "../../lib/user";
+import { meQuery } from "../../graphql/queries/user.queries";
 import { useInitTypeSystem } from "../../lib/use-init-type-system";
+import { AuthenticatedUser, constructAuthenticatedUser } from "../../lib/user";
+import { oryKratosClient } from "../../pages/shared/ory-kratos";
 import { SessionContext } from "../../pages/shared/session-context";
 
 /**
@@ -30,12 +23,7 @@ import { SessionContext } from "../../pages/shared/session-context";
 export const useAuthenticatedUser = (
   options?: Omit<QueryHookOptions<MeQuery, MeQueryVariables>, "errorPolicy">,
   forceLogin = false,
-  onAuthenticate?: (
-    authenticatedUser: AuthenticatedUser,
-  ) => Promise<void> | void,
 ) => {
-  const [prevAuthenticatedUser, setPrevAuthenticatedUser] =
-    useState<AuthenticatedUser>();
   const loadingTypeSystem = useInitTypeSystem();
   const router = useRouter();
 
@@ -97,7 +85,11 @@ export const useAuthenticatedUser = (
     });
   }, [authenticatedUser]);
 
-  const fetchKratosIdentity = async (login: boolean) => {
+  const fetchKratosIdentity = async (login: boolean, refetch = false) => {
+    if (!refetch && kratosSession) {
+      return;
+    }
+
     setLoadingKratosSession(true);
 
     const session = await oryKratosClient
@@ -105,11 +97,12 @@ export const useAuthenticatedUser = (
       .then(({ data }) => data)
       .catch(() => undefined);
 
+    setLoadingKratosSession(false);
+
     if (!session && login) {
       await router.push("/login");
     } else {
       setKratosSession(session);
-      setLoadingKratosSession(false);
       return session;
     }
   };
@@ -132,16 +125,11 @@ export const useAuthenticatedUser = (
   //   client.writeQuery();
   // };
 
-  if (!prevAuthenticatedUser && authenticatedUser) {
-    setPrevAuthenticatedUser(authenticatedUser);
-    void onAuthenticate?.(authenticatedUser);
-  }
-
   return {
     authenticatedUser,
     kratosSession,
-    refetch: () =>
-      Promise.all([
+    refetch: () => {
+      return Promise.all([
         // Until we change the GraphQL query scalars to return constrained Subgraphs, we need to (safely) cast
         // ourselves
         (
@@ -149,8 +137,9 @@ export const useAuthenticatedUser = (
             ApolloQueryResult<{ me: Subgraph<SubgraphRootTypes["entity"]> }>
           >
         )(),
-        fetchKratosIdentity(forceLogin),
-      ]),
+        fetchKratosIdentity(forceLogin, true),
+      ]);
+    },
     loading: loadingUser || loadingKratosSession,
   };
 };

--- a/packages/hash/frontend/src/pages/[account-slug]/entities/[entity-uuid].page/new-entity-page.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/entities/[entity-uuid].page/new-entity-page.tsx
@@ -3,6 +3,7 @@ import { Button, Chip, FontAwesomeIcon } from "@hashintel/hash-design-system";
 import { Box, Divider, Typography } from "@mui/material";
 import { useRouter } from "next/router";
 import { useState } from "react";
+import { useAuthenticatedUser } from "../../../../components/hooks/useAuthenticatedUser";
 import { useSnackbar } from "../../../../components/hooks/useSnackbar";
 import { SectionWrapper } from "../../shared/section-wrapper";
 import { WhiteCard } from "../../shared/white-card";
@@ -20,6 +21,7 @@ export const NewEntityPage = () => {
   const [isSelectingType, setIsSelectingType] = useState(false);
   const [loading, setLoading] = useState(false);
 
+  const { authenticatedUser } = useAuthenticatedUser();
   const createNewEntityAndRedirect = useCreateNewEntityAndRedirect();
 
   return (
@@ -72,10 +74,17 @@ export const NewEntityPage = () => {
                   onCancel={() => setIsSelectingType(false)}
                   onSelect={async (entityType) => {
                     try {
+                      if (!authenticatedUser) {
+                        throw new Error("user not found");
+                      }
+
                       setIsSelectingType(false);
                       setLoading(true);
 
-                      await createNewEntityAndRedirect(entityType.$id);
+                      await createNewEntityAndRedirect(
+                        authenticatedUser,
+                        entityType.$id,
+                      );
                     } catch (error: any) {
                       snackbar.error(error.message);
                     } finally {

--- a/packages/hash/frontend/src/pages/[account-slug]/entities/[entity-uuid].page/new-entity-page.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/entities/[entity-uuid].page/new-entity-page.tsx
@@ -92,7 +92,7 @@ export const NewEntityPage = () => {
                     }
                   }}
                   onCreateNew={(searchValue) => {
-                    let href = `/${router.query["account-slug"]}/types/new/entity-type`;
+                    let href = `/${router.query["account-slug"]}/new/types/entity-type`;
                     if (searchValue) {
                       href += `?name=${encodeURIComponent(searchValue)}`;
                     }

--- a/packages/hash/frontend/src/pages/[account-slug]/entities/new.page.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/entities/new.page.tsx
@@ -1,9 +1,14 @@
 import { validateVersionedUri } from "@blockprotocol/type-system-web";
 import { useRouter } from "next/router";
-import { useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import { useAuthenticatedUser } from "../../../components/hooks/useAuthenticatedUser";
 import { PageErrorState } from "../../../components/page-error-state";
-import { getPlainLayout, NextPageWithLayout } from "../../../shared/layout";
+import { useInitTypeSystem } from "../../../lib/use-init-type-system";
+import {
+  getLayoutWithSidebar,
+  getPlainLayout,
+  NextPageWithLayout,
+} from "../../../shared/layout";
 import { EntityPageLoadingState } from "./[entity-uuid].page/entity-page-loading-state";
 import { NewEntityPage } from "./[entity-uuid].page/new-entity-page";
 import { useCreateNewEntityAndRedirect } from "./[entity-uuid].page/shared/use-create-new-entity-and-redirect";
@@ -11,51 +16,81 @@ import { useCreateNewEntityAndRedirect } from "./[entity-uuid].page/shared/use-c
 const Page: NextPageWithLayout = () => {
   const router = useRouter();
   const createNewEntityAndRedirect = useCreateNewEntityAndRedirect();
-  const [loading, setLoading] = useState(true);
+  const loadingTypeSystem = useInitTypeSystem();
+  const queryEntityId = router.query["entity-type-id"]?.toString();
+  const entityTypeId =
+    loadingTypeSystem || !queryEntityId
+      ? null
+      : validateVersionedUri(queryEntityId);
+  const { authenticatedUser, loading: authenticatedUserLoading } =
+    useAuthenticatedUser(undefined, true);
+  const shouldBeCreatingEntity = entityTypeId?.type === "Ok";
+  const [creatingEntity, setCreatingEntity] = useState(shouldBeCreatingEntity);
 
-  const entityTypeId = String(router.query["entity-type-id"]);
-  const idResult = validateVersionedUri(entityTypeId);
+  const entityIdInvalid = !!queryEntityId && entityTypeId?.type === "Err";
 
-  const { authenticatedUser } = useAuthenticatedUser(
-    undefined,
-    true,
-    async () => {
-      if (idResult.type === "Ok") {
-        try {
-          await createNewEntityAndRedirect(idResult.inner);
-        } finally {
-          setLoading(false);
-        }
-      } else {
-        setLoading(false);
-      }
-    },
-  );
+  if (shouldBeCreatingEntity && !creatingEntity) {
+    setCreatingEntity(true);
+  } else if (entityIdInvalid && creatingEntity) {
+    setCreatingEntity(false);
+  }
+
+  /**
+   * This shouldn't be an effect, because we're relying on React re-renders after
+   * events, instead of just subscribing to the events. It's difficult to do that
+   * right now because the different pieces are stored in different places. We
+   * should have one component responsible for fetching user data and storing it
+   * in context, and which will also let child components subscribe to
+   * authenticatedUser becoming available
+   *
+   * @todo remove this effect when possible
+   */
+  useEffect(() => {
+    if (entityTypeId?.type === "Ok" && authenticatedUser) {
+      const controller = new AbortController();
+
+      void createNewEntityAndRedirect(
+        authenticatedUser,
+        entityTypeId.inner,
+        true,
+        controller.signal,
+      );
+
+      return () => {
+        controller.abort();
+      };
+    }
+  }, [
+    authenticatedUser,
+    createNewEntityAndRedirect,
+    entityTypeId?.inner,
+    entityTypeId?.type,
+  ]);
 
   const accountSlug = router.query["account-slug"] as string | undefined;
   const shortname = accountSlug?.slice(1);
+
+  if (creatingEntity || authenticatedUserLoading || loadingTypeSystem) {
+    return <EntityPageLoadingState />;
+  }
 
   if (!authenticatedUser) {
     return null;
   }
 
-  if (loading) {
-    return <EntityPageLoadingState />;
-  }
-
   // show error if url slug it's not users shortname, or shortname of one of users orgs
-  const atUsersNamespace = shortname === authenticatedUser?.shortname;
-  const atOrgsNamespace = !!authenticatedUser?.memberOf.find(
+  const atUsersNamespace = shortname === authenticatedUser.shortname;
+  const atOrgsNamespace = authenticatedUser.memberOf.some(
     (val) => val.shortname === shortname,
   );
 
-  if ((!atOrgsNamespace && !atUsersNamespace) || idResult.type === "Err") {
+  if ((!atOrgsNamespace && !atUsersNamespace) || entityIdInvalid) {
     return <PageErrorState />;
   }
 
   return <NewEntityPage />;
 };
 
-Page.getLayout = getPlainLayout;
+Page.getLayout = (page) => getLayoutWithSidebar(page, { fullWidth: true });
 
 export default Page;

--- a/packages/hash/frontend/src/pages/[account-slug]/entities/new.page.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/entities/new.page.tsx
@@ -1,12 +1,11 @@
 import { validateVersionedUri } from "@blockprotocol/type-system-web";
 import { useRouter } from "next/router";
-import { useEffect, useLayoutEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useAuthenticatedUser } from "../../../components/hooks/useAuthenticatedUser";
 import { PageErrorState } from "../../../components/page-error-state";
 import { useInitTypeSystem } from "../../../lib/use-init-type-system";
 import {
   getLayoutWithSidebar,
-  getPlainLayout,
   NextPageWithLayout,
 } from "../../../shared/layout";
 import { EntityPageLoadingState } from "./[entity-uuid].page/entity-page-loading-state";

--- a/packages/hash/frontend/src/pages/[account-slug]/new/entity.page.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/new/entity.page.tsx
@@ -8,9 +8,9 @@ import {
   getLayoutWithSidebar,
   NextPageWithLayout,
 } from "../../../shared/layout";
-import { EntityPageLoadingState } from "./[entity-uuid].page/entity-page-loading-state";
-import { NewEntityPage } from "./[entity-uuid].page/new-entity-page";
-import { useCreateNewEntityAndRedirect } from "./[entity-uuid].page/shared/use-create-new-entity-and-redirect";
+import { EntityPageLoadingState } from "../entities/[entity-uuid].page/entity-page-loading-state";
+import { NewEntityPage } from "../entities/[entity-uuid].page/new-entity-page";
+import { useCreateNewEntityAndRedirect } from "../entities/[entity-uuid].page/shared/use-create-new-entity-and-redirect";
 
 const Page: NextPageWithLayout = () => {
   const router = useRouter();

--- a/packages/hash/frontend/src/pages/[account-slug]/new/types/entity-type.page.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/new/types/entity-type.page.tsx
@@ -29,7 +29,7 @@ import { TopContextBar } from "../../../shared/top-context-bar";
 import { WorkspaceContext } from "../../../shared/workspace-context";
 import { HashOntologyIcon } from "../../shared/hash-ontology-icon";
 import { OntologyChip } from "../../shared/ontology-chip";
-import { useRouteNamespace } from "../entity-type/use-route-namespace";
+import { useRouteNamespace } from "../../types/entity-type/use-route-namespace";
 
 const FormHelperLabel = ({
   children,
@@ -89,7 +89,7 @@ const Page: NextPageWithLayout = () => {
   useEffect(() => {
     if (activeWorkspace && !loadingNamespace && !routeNamespace) {
       void router.replace(
-        `/@${activeWorkspace.shortname}/types/new/entity-type`,
+        `/@${activeWorkspace.shortname}/new/types/entity-type`,
       );
     }
   }, [loadingNamespace, activeWorkspace, routeNamespace, router]);
@@ -166,7 +166,7 @@ const Page: NextPageWithLayout = () => {
                   >
                     {`@${activeWorkspace.shortname}`}
                   </Typography>
-                  /types/new/entity-type
+                  /new/types/entity-type
                 </Typography>
               }
               sx={[{ marginBottom: 2 }]}

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/[entity-type-id].page.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/[entity-type-id].page.tsx
@@ -159,7 +159,7 @@ const Page: NextPageWithLayout = () => {
         `Error: Couldn't find namespace with shortname '${router.query["account-slug"]}'.`,
       );
       void router.replace(
-        `/@${activeWorkspace.shortname}/types/new/entity-type`,
+        `/@${activeWorkspace.shortname}/new/types/entity-type`,
       );
       return;
     }
@@ -170,7 +170,7 @@ const Page: NextPageWithLayout = () => {
         `Error: Couldn't find entity type with id '${router.query["entity-type-id"]}'.`,
       );
       void router.replace(
-        `/@${activeWorkspace.shortname}/types/new/entity-type`,
+        `/@${activeWorkspace.shortname}/new/types/entity-type`,
       );
     }
   }, [
@@ -264,7 +264,7 @@ const Page: NextPageWithLayout = () => {
                       // @todo confirmation of discard when draft
                       isDraft
                         ? {
-                            href: `/${router.query["account-slug"]}/types/new/entity-type`,
+                            href: `/${router.query["account-slug"]}/new/types/entity-type`,
                           }
                         : {
                             onClick() {

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/entity-type-tabs.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/entity-type-tabs.tsx
@@ -85,7 +85,7 @@ export const EntityTypeTabs = () => {
           value="create"
           href={`/@${
             activeWorkspace?.shortname
-          }/entities/new?entity-type-id=${encodeURIComponent(entityType.$id)}`}
+          }/new/entity?entity-type-id=${encodeURIComponent(entityType.$id)}`}
           label="Create new entity"
           sx={(theme) => ({
             ml: "auto",

--- a/packages/hash/frontend/src/pages/index.page.tsx
+++ b/packages/hash/frontend/src/pages/index.page.tsx
@@ -15,7 +15,7 @@ const Page: NextPageWithLayout = () => {
 
   useEffect(() => {
     if (authenticatedUser) {
-      void router.push(`/${authenticatedUser.userAccountId}`);
+      void router.replace(`/${authenticatedUser.userAccountId}`);
     }
   }, [router, authenticatedUser]);
 

--- a/packages/hash/frontend/src/shared/layout/layout-with-header/actions-dropdown.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-header/actions-dropdown.tsx
@@ -123,7 +123,7 @@ export const ActionsDropdownInner: FunctionComponent<{
         </MenuItem> */}
         {activeWorkspace ? (
           <MenuItem
-            href={`/@${activeWorkspace.shortname}/types/new/entity-type`}
+            href={`/@${activeWorkspace.shortname}/new/types/entity-type`}
             onClick={popupState.close}
           >
             <ListItemText primary="Create Entity Type" />

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list.tsx
@@ -176,7 +176,7 @@ export const AccountEntityTypeList: FunctionComponent<
         title="Types"
         endAdornmentProps={{
           tooltipTitle: "Create new entity type",
-          href: `/@${authenticatedUser?.shortname}/types/new/entity-type`,
+          href: `/@${authenticatedUser?.shortname}/new/types/entity-type`,
           "data-testid": "create-entity-type-btn",
         }}
       >

--- a/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list/entity-type-menu.tsx
+++ b/packages/hash/frontend/src/shared/layout/layout-with-sidebar/account-entity-type-list/entity-type-menu.tsx
@@ -44,7 +44,7 @@ export const EntityTypeMenu: FunctionComponent<EntityTypeMenuProps> = ({
       {
         title: `Create new ${pluralize.singular(entityTitle)}`,
         icon: faAdd,
-        href: `/${accountId}/entities/new?entityTypeId=${entityId}`,
+        href: `/${accountId}/new/entity?entity-type-id=${entityId}`,
         faded: false,
       },
       {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Follow up to https://github.com/hashintel/hash/pull/1492 to improve some of the flow around the new entity type stuff (and updating routes) 

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- N/A

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

- [x] https://github.com/hashintel/hash/pull/1492

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- `useAuthenticatedUser`:
	- Removed `onUserAuthenticated` as no way to implement it properly with current authentication state management
	- Kratos fetching is updated to not refetch it for every use of the hook (this fixes a bug)
- Routes for new pages updated – see https://hashintel.slack.com/archives/C022217GAHF/p1669774923256599 (internal)
- `useCreateNewEntityAndRedirect` is substantially updated
  - Instead of calling `useAuthenticatedUser` itself, the callback it returns now takes the user. This is because it's hard to reason about stale closures:
    - The caller of `useCreateNewEntityAndRedirect` isn't supposed to use its callback until the user has authenticated, so it's likely the parent component is also calling `useAuthenticatedUser`
    - Right now, it's possible that the order of `useCreateNewEntityAndRedirect` vs `useAuthenticatedUser` being called matters (and that the callback will be called with a stale closure). This is kinda hard to explain but happy to try on Tandem, but the approach of passing the user in directly avoids this problem
  - The redirect is now cancellable with an abort signal
  - Now able to use `router.replace` for the redirect – which makes the back button from "create new entity" button on entity type editor work
- The different state management on new entity page is updated to make it easier to follow 
- Home redirect to users dashboard now uses `router.replace` to ensure back button isn't broken

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

N/A

## ⚠️ Known issues

We're having to use an effect for something that is not strictly an effect, which is frustrating. 

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

Eventually we'll redo state management of authentication, but it's not a priority

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

N/A

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Confirm behaviour is as before