### PR TITLE
Reconfigure Renovate (cover all dependencies)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,5 +8,42 @@
   "ignorePaths": ["packages/engine/**"],
   "postUpdateOptions": ["yarnDedupeFewer"],
   "rangeStrategy": "bump",
-  "rebaseWhen": "conflicted"
+  "rebaseWhen": "conflicted",
+  "packageRules": [
+    {
+      "enabled": true,
+      "groupName": "ESLint",
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": [
+        "^@types/eslint",
+        "^@typescript-eslint/",
+        "^eslint-",
+        "^eslint$"
+      ]
+    },
+    {
+      "enabled": true,
+      "groupName": "Jest",
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["^@types/jest$", "^jest", "^ts-jest$", "^jest-"]
+    },
+    {
+      "enabled": true,
+      "groupName": "Playwright",
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["^@playwright/", "^playwright$", "^playwright-"]
+    },
+    {
+      "enabled": true,
+      "groupName": "ProseMirror",
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["^prosemirror-"]
+    },
+    {
+      "enabled": true,
+      "groupName": "Sentry",
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["^@sentry/"]
+    }
+  ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,75 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+
   "automerge": true,
   "dependencyDashboard": true,
   "dependencyDashboardApproval": true,
-  "enabledManagers": ["github-actions", "npm"],
   "ignorePaths": ["packages/engine/**"],
   "postUpdateOptions": ["yarnDedupeFewer"],
-  "rebaseWhen": "conflicted",
-  "schedule": ["before 5am on Monday", "before 5am on Thursday"],
-  "packageRules": [
-    {
-      "enabled": false,
-      "matchManagers": ["npm"],
-      "rangeStrategy": "bump"
-    },
-    {
-      "enabled": true,
-      "matchManagers": ["npm"],
-      "matchFiles": ["package.json"]
-    },
-    {
-      "enabled": true,
-      "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^cross-env$", "^dotenv-flow$", "^wait-on$"]
-    },
-    {
-      "enabled": true,
-      "groupName": "GraphQL Codegen",
-      "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^@graphql-codegen/"]
-    },
-    {
-      "enabled": true,
-      "groupName": "ESLint",
-      "matchManagers": ["npm"],
-      "matchPackagePatterns": [
-        "^@types/eslint",
-        "^@typescript-eslint/",
-        "^eslint-",
-        "^eslint$"
-      ]
-    },
-    {
-      "enabled": true,
-      "groupName": "Jest",
-      "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^@types/jest$", "^jest", "^ts-jest$", "^jest-"]
-    },
-    {
-      "enabled": true,
-      "groupName": "Playwright",
-      "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^@playwright/", "^playwright$", "^playwright-"]
-    },
-    {
-      "enabled": true,
-      "groupName": "Prettier",
-      "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^prettier$", "^prettier-"]
-    },
-    {
-      "enabled": true,
-      "groupName": "ProseMirror",
-      "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^prosemirror-"]
-    },
-    {
-      "enabled": true,
-      "groupName": "Sentry",
-      "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^@sentry/"]
-    }
-  ]
+  "rangeStrategy": "bump",
+  "rebaseWhen": "conflicted"
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR extends the scope of Renovate, which now covers all dependencies in the repo. As before, new PRs are not created automatically and we need to approve them via Dependency dashboard (#1481) first.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203312852763953/1203464390652052/f) _(internal)_
- https://github.com/blockprotocol/blockprotocol/pull/799

## 🔍 What does this change?

I’ve removed some package rules as they are no longer needed. We extend from a preset named [`config:base`](https://docs.renovatebot.com/presets-config/#configbase) which in turn includes [monorepo presets](https://docs.renovatebot.com/presets-monorepo/). This means that dependencies within well-known monorepos are grouped together without us having to configure anything. For example, `next` is upgraded with `@next/bundle-analyzer` in a single PR. I’ve kept a few rules that span across multiple monorepos (e.g. everything related to ESLint or Jest), but we can revise this later.