### PR TITLE
`error-stack` support `Debug` hooks in `no-std` contexts

### DIFF
--- a/packages/libs/error-stack/CHANGELOG.md
+++ b/packages/libs/error-stack/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to `error-stack` will be documented in this file.
 ### Features
 
 - Add serializing support using [`serde`](https://serde.rs) ([#1290](https://github.com/hashintel/hash/pull/1290))
+- Support `Debug` hooks on `no-std` platforms via the `hooks` feature ([#1556](https://github.com/hashintel/hash/pull/1556))
 
 ## [0.2.4](https://github.com/hashintel/hash/tree/error-stack%400.2.4/packages/libs/error-stack) - 2022-11-04
 

--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -22,7 +22,7 @@ anyhow = { version = "1.0.65", default-features = false, optional = true }
 eyre = { version = "0.6", default-features = false, optional = true }
 owo-colors = { version = "3", default-features = false, optional = true, features = ['supports-colors'] }
 serde = { version = "1", default-features = false, optional = true }
-spin = { version = "0.9.4", default-features = false, optional = true, features = ['rwlock', 'once'] }
+spin = { version = "0.9", default-features = false, optional = true, features = ['rwlock', 'once'] }
 
 [dev-dependencies]
 serde = { version = "1.0.148", features = ["derive"] }

--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -22,6 +22,7 @@ anyhow = { version = "1.0.65", default-features = false, optional = true }
 eyre = { version = "0.6", default-features = false, optional = true }
 owo-colors = { version = "3", default-features = false, optional = true, features = ['supports-colors'] }
 serde = { version = "1", default-features = false, optional = true }
+spin = { version = "0.9.4", default-features = false, optional = true, features = ['rwlock', 'once'] }
 
 [dev-dependencies]
 serde = { version = "1.0.148", features = ["derive"] }
@@ -47,6 +48,7 @@ spantrace = ["dep:tracing-error", "std"]
 std = ["anyhow?/std"]
 eyre = ["dep:eyre", "std"]
 serde = ["dep:serde"]
+hooks = ['dep:spin']
 
 [package.metadata.docs.rs]
 all-features = true

--- a/packages/libs/error-stack/Makefile.toml
+++ b/packages/libs/error-stack/Makefile.toml
@@ -6,9 +6,9 @@ CARGO_TEST_HACK_FLAGS = "--workspace --optional-deps --feature-powerset --exclud
 CARGO_INSTA_TEST_FLAGS = "--no-fail-fast"
 CARGO_RUSTDOC_HACK_FLAGS = ""
 CARGO_DOC_HACK_FLAGS = ""
-# The only features that are of relevance are: spantrace, pretty-print, std
+# The only features that are of relevance are: spantrace, pretty-print, std, hooks
 # all others do not change the output
-CARGO_INSTA_TEST_HACK_FLAGS = "--keep-going --feature-powerset --include-features spantrace,pretty-print,std"
+CARGO_INSTA_TEST_HACK_FLAGS = "--keep-going --feature-powerset --include-features spantrace,pretty-print,std,hooks"
 
 
 [tasks.test]

--- a/packages/libs/error-stack/src/fmt/hook.rs
+++ b/packages/libs/error-stack/src/fmt/hook.rs
@@ -755,9 +755,7 @@ impl Hooks {
 mod default {
     #![allow(unused_imports)]
 
-    #[cfg(any(rust_1_65, feature = "spantrace"))]
-    use alloc::format;
-    use alloc::{vec, vec::Vec};
+    use alloc::{format, vec, vec::Vec};
     use core::{
         any::TypeId,
         panic::Location,

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -475,11 +475,11 @@ mod report;
 mod result;
 
 mod context;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "hooks"))]
 pub mod fmt;
-#[cfg(not(feature = "std"))]
+#[cfg(not(any(feature = "std", feature = "hooks")))]
 mod fmt;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "hooks"))]
 mod hook;
 #[cfg(feature = "serde")]
 mod serde;

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -415,9 +415,10 @@
 //!
 //!  Feature       | Description                                                        | default
 //! ---------------|--------------------------------------------------------------------|----------
-//! `std`          | Enables support for [`Error`] and, on nightly, [`Backtrace`]       | enabled
+//! `std`          | Enables support for [`Error`], and, on Rust 1.65+, [`Backtrace`]   | enabled
 //! `pretty-print` | Provide color[^color] and use of unicode in [`Debug`] output       | enabled
 //! `spantrace`    | Enables automatic capturing of [`SpanTrace`]s                      | disabled
+//! `hooks`        | Enables hooks on `no-std` platforms using spin locks               | disabled
 //! `anyhow`       | Provides `into_report` to convert [`anyhow::Error`] to [`Report`]  | disabled
 //! `eyre`         | Provides `into_report` to convert [`eyre::Report`] to [`Report`]   | disabled
 //!

--- a/packages/libs/error-stack/tests/test_debug.rs
+++ b/packages/libs/error-stack/tests/test_debug.rs
@@ -238,7 +238,7 @@ fn sources_nested_alternate() {
 
 #[cfg(all(
     rust_1_65,
-    feature = "std",
+    any(feature = "std", feature = "hooks"),
     feature = "spantrace",
     feature = "pretty-print"
 ))]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

While exploring #1399 we found the [spin crate](https://crates.io/crates/spin), which implements a `no-std` equivalent for `std::sync` types, like `RwLock` based on spin locks. This PR adds a new feature, `hooks`, which - if enabled - will replace the `RwLock` with the spin variant.

Note: while we expect a majority of calls to be read-only, there's still a chance of priority inversion, this is why if both `std` and `hooks` features are enabled, we will instead use the `std` `RwLock`.

> Must read for spin locks and their application: https://matklad.github.io/2020/01/02/spinlocks-considered-harmful.html

I consider using a spinlock okay for `error-stack` hooks, as we expect hooks to only be initialized very, very infrequently, and most operations are reads. A read is simply a `fetch_add` + `fetch_sub` without any spinning.

An alternative approach would be using [`critical-section`](https://crates.io/crates/critical-section) instead, which acts like a `Mutex`, but because we mostly only read, we do not need to hold the hooks exclusively, and `critical-section` is only available on single thread embedded microprocessors.

> **Note:** this increases our test permutation count to 81!

## 🔗 Related links

- https://matklad.github.io/2020/01/02/spinlocks-considered-harmful.html

## 🚫 Blocked by

## 🔍 What does this change?

- new feature `hook`

## 📋 TODO

- [x] Documentation
- [x] Changelog

## 📜 Does this require a change to the docs?

We need to mention the new feature in our table and the consequences.