### PR TITLE
Use `next/link` to redirect to the entity's type in the entity editor

### DIFF
--- a/packages/hash/frontend/src/pages/[account-slug]/shared/white-card.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/shared/white-card.tsx
@@ -6,6 +6,28 @@ import {
   CardContent,
   CardContentProps,
 } from "@mui/material";
+import { FunctionComponent, ReactNode } from "react";
+import { Link } from "../../../shared/ui/link";
+
+const WhiteCardActionArea: FunctionComponent<
+  { children: ReactNode } & CardActionAreaProps
+> = ({ children, ...props }) => (
+  <CardActionArea
+    {...props}
+    disableRipple
+    disableTouchRipple
+    sx={[
+      {
+        [`&:hover .${cardActionAreaClasses.focusHighlight}`]: {
+          opacity: 0,
+        },
+      },
+      ...(Array.isArray(props.sx) ? props.sx : [props.sx]),
+    ]}
+  >
+    {children}
+  </CardActionArea>
+);
 
 export const WhiteCard = ({
   onClick,
@@ -43,19 +65,14 @@ export const WhiteCard = ({
           : {},
       ]}
     >
-      {onClick || href ? (
-        <CardActionArea
-          {...(onClick ? { onClick } : { href })}
-          disableRipple
-          disableTouchRipple
-          sx={{
-            [`&:hover .${cardActionAreaClasses.focusHighlight}`]: {
-              opacity: 0,
-            },
-          }}
-        >
+      {onClick ? (
+        <WhiteCardActionArea onClick={onClick}>
           {cardContent}
-        </CardActionArea>
+        </WhiteCardActionArea>
+      ) : href ? (
+        <Link href={href} sx={{ textDecoration: "none" }}>
+          <WhiteCardActionArea>{cardContent}</WhiteCardActionArea>
+        </Link>
       ) : (
         cardContent
       )}

--- a/packages/hash/frontend/src/pages/[account-slug]/shared/white-card.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/shared/white-card.tsx
@@ -6,28 +6,7 @@ import {
   CardContent,
   CardContentProps,
 } from "@mui/material";
-import { FunctionComponent, ReactNode } from "react";
 import { Link } from "../../../shared/ui/link";
-
-const WhiteCardActionArea: FunctionComponent<
-  { children: ReactNode } & CardActionAreaProps
-> = ({ children, ...props }) => (
-  <CardActionArea
-    {...props}
-    disableRipple
-    disableTouchRipple
-    sx={[
-      {
-        [`&:hover .${cardActionAreaClasses.focusHighlight}`]: {
-          opacity: 0,
-        },
-      },
-      ...(Array.isArray(props.sx) ? props.sx : [props.sx]),
-    ]}
-  >
-    {children}
-  </CardActionArea>
-);
 
 export const WhiteCard = ({
   onClick,
@@ -65,14 +44,20 @@ export const WhiteCard = ({
           : {},
       ]}
     >
-      {onClick ? (
-        <WhiteCardActionArea onClick={onClick}>
+      {onClick || href ? (
+        <CardActionArea
+          {...(onClick ? { onClick } : { href })}
+          LinkComponent={Link}
+          disableRipple
+          disableTouchRipple
+          sx={{
+            [`&:hover .${cardActionAreaClasses.focusHighlight}`]: {
+              opacity: 0,
+            },
+          }}
+        >
           {cardContent}
-        </WhiteCardActionArea>
-      ) : href ? (
-        <Link href={href} sx={{ textDecoration: "none" }}>
-          <WhiteCardActionArea>{cardContent}</WhiteCardActionArea>
-        </Link>
+        </CardActionArea>
       ) : (
         cardContent
       )}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR ensures that the Next JS link component is used when redirecting from an entity to it's entity type in the entity editor. This prevents a white screen from flashing between the pages, as the page isn't fully refreshed.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203312852763953/1203468350364504/f) _(internal)_

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

See commits.

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

Not that I'm aware of.

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

- sometimes when clicking on the entity's type, the user is redirected to the create new entity type page

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None, tested manually.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Log in to the frontend
2. Go to the entity editor
3. Click on it's type
4. Ensure the page is not refreshed during the page transition

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

Before:

https://user-images.githubusercontent.com/42802102/205073739-75d044a0-fa8a-4dd7-ba28-070d4a5975f8.mov

After:

https://user-images.githubusercontent.com/42802102/205073245-48d5c99d-942b-408c-a02d-a3cc37fa2806.mov


