### PR TITLE
Frontend fixes: Formatting buttons. User mention caching. Entity labels

### DIFF
--- a/packages/hash/frontend/src/blocks/page/MentionView/MentionDisplay.tsx
+++ b/packages/hash/frontend/src/blocks/page/MentionView/MentionDisplay.tsx
@@ -21,7 +21,7 @@ export const MentionDisplay: FunctionComponent<MentionDisplayProps> = ({
   mentionType,
   accountId,
 }) => {
-  const { users, loading: usersLoading } = useUsers();
+  const { users, loading: usersLoading } = useUsers(true);
   const { data: pages, loading: pagesLoading } = useAccountPages(accountId);
 
   const { title, href, icon } = useMemo(() => {

--- a/packages/hash/frontend/src/blocks/page/createFormatPlugins/MarksTooltip.tsx
+++ b/packages/hash/frontend/src/blocks/page/createFormatPlugins/MarksTooltip.tsx
@@ -67,7 +67,7 @@ export const MarksTooltip: FunctionComponent<MarksTooltipProps> = ({
           <button
             className={tw`flex items-center ${getMarkBtnClass(
               name,
-            )} bg-transparent border-0 cursor-pointer py-1 px-4 border-r-1 last:border-r-0 border-gray-300`}
+            )} border-0 cursor-pointer py-1 px-4 border-r-1 last:border-r-0 border-gray-300`}
             key={name}
             onClick={() => handleToggleMark(name)}
             type="button"

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/use-entities-table.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/use-entities-table.tsx
@@ -73,7 +73,7 @@ export const useEntitiesTable = (
 
     const rows: TypeEntitiesRow[] =
       entities?.map((entity) => {
-        const entityLabel = generateEntityLabel(subgraph);
+        const entityLabel = generateEntityLabel(subgraph, entity);
         const entityNamespace = getEntityByEditionId(
           subgraph,
           entity.metadata.editionId,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A few fixes to things I noticed while playing with the app, in the order they appear in the diff:

### 1. Cache the 'fetch all users' in the user mention hook, to stop loading state every time a mention is displayed

**Before**
![Kapture 2022-12-02 at 15 11 47](https://user-images.githubusercontent.com/37743469/205324905-6c3fb42d-337d-499b-9172-ea9c4cccc845.gif)

**After**
![Kapture 2022-12-02 at 15 12 19](https://user-images.githubusercontent.com/37743469/205324964-df2f55c1-a0c3-4c43-bc2e-8e6bac49a16a.gif)

---

### 2. Remove a background class from the formatting toolbar that was overwriting the class that is meant to apply when the mark is active, making the mark text invisible

**Before**
![Screenshot 2022-12-02 at 15 05 23](https://user-images.githubusercontent.com/37743469/205325271-49a06dff-240c-4803-b5b1-b586c4c71660.png)

**After**
![Screenshot 2022-12-02 at 15 05 38](https://user-images.githubusercontent.com/37743469/205325286-d34e45b4-6f22-40ed-bf54-c6a2bf5e3a88.png)

---

### 3. Fix the labels for entities in the entities tab on the entity type page (i.e. for a type, list entities belonging to it) – this was previously using whatever the root of the subgraph was, rather than the entity in question

**I'm not sure why the root of the subgraph was a `Block` entity?!**

**Before**
![Screenshot 2022-12-02 at 15 04 32](https://user-images.githubusercontent.com/37743469/205325628-de9bdb8c-bb87-49c8-aa06-95650c99128f.png)

**After**
![Screenshot 2022-12-02 at 15 04 40](https://user-images.githubusercontent.com/37743469/205325667-e31d5a5b-54ee-49cb-b120-60b97cab1308.png)
