### PR TITLE
Property type array expected value badges in entity type editor

### DIFF
--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/expected-value-chip.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/expected-value-chip.tsx
@@ -30,6 +30,7 @@ export const ExpectedValueChip = ({
 
   return (
     <Stack
+      width={1}
       direction="row"
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}

--- a/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-expected-values.tsx
+++ b/packages/hash/frontend/src/pages/[account-slug]/types/entity-type/property-expected-values.tsx
@@ -17,14 +17,19 @@ export const PropertyExpectedValues = ({
   property: PropertyType;
 }) => (
   <>
-    {property.oneOf.map((type) => {
-      if ("$ref" in type) {
-        const label = dataTypeIdToTitle[type.$ref];
+    {property.oneOf.map((dataType) => {
+      let label;
 
-        if (label) {
-          return <Chip key={label} label={label} color="gray" />;
-        }
+      if ("$ref" in dataType) {
+        label = dataTypeIdToTitle[dataType.$ref];
+      } else if (dataType.type === "array") {
+        label = "Array";
       }
+
+      if (label) {
+        return <Chip key={label} label={label} color="gray" />;
+      }
+
       return null;
     })}
   </>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR adds the "Array" chip to expected values to properties in the entity type editor (the chips will be expanded on in the future, this is just a placeholder https://hashintel.slack.com/archives/C022217GAHF/p1670006397135869)
It also fixes this [bug](https://github.com/hashintel/hash/pull/1579#discussion_r1038417680) by putting each chip on its own line.

## 📹 Demo

![image](https://user-images.githubusercontent.com/37453800/205369382-66b0b6a6-436c-4516-8565-408e6e898efb.png)

![image](https://user-images.githubusercontent.com/37453800/205369504-a88e4710-c3b1-4a85-a962-1de7d7845fe6.png)

