### PR TITLE
Avoid unnecessary lookups and traversals in Subgraph generation

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -200,7 +200,7 @@ impl EntityMetadata {
 
 /// A record of an [`Entity`] that has been persisted in the datastore, with its associated
 /// metadata.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Entity {
     properties: EntityProperties,

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -96,7 +96,7 @@ where
     serde_json::Value::from(ontology_type.clone()).serialize(serializer)
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
+#[derive(Debug, PartialEq, Eq, Serialize, ToSchema)]
 pub struct DataTypeWithMetadata {
     #[schema(value_type = VAR_DATA_TYPE)]
     #[serde(rename = "schema", serialize_with = "serialize_ontology_type")]
@@ -116,7 +116,7 @@ impl DataTypeWithMetadata {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
+#[derive(Debug, PartialEq, Eq, Serialize, ToSchema)]
 pub struct PropertyTypeWithMetadata {
     #[schema(value_type = VAR_PROPERTY_TYPE)]
     #[serde(rename = "schema", serialize_with = "serialize_ontology_type")]
@@ -175,7 +175,7 @@ impl OntologyElementMetadata {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
+#[derive(Debug, PartialEq, Eq, Serialize, ToSchema)]
 pub struct EntityTypeWithMetadata {
     #[schema(value_type = VAR_ENTITY_TYPE)]
     #[serde(rename = "schema", serialize_with = "serialize_ontology_type")]

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph/vertices/vertex.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph/vertices/vertex.rs
@@ -6,7 +6,7 @@ use crate::{
     ontology::{DataTypeWithMetadata, EntityTypeWithMetadata, PropertyTypeWithMetadata},
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 #[serde(tag = "kind", content = "inner")]
 #[serde(rename_all = "camelCase")]
 pub enum OntologyVertex {
@@ -48,7 +48,7 @@ impl ToSchema for OntologyVertex {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 #[serde(tag = "kind", content = "inner")]
 #[serde(rename_all = "camelCase")]
 pub enum KnowledgeGraphVertex {
@@ -81,7 +81,7 @@ impl ToSchema for KnowledgeGraphVertex {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
 pub enum Vertex {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -51,7 +51,7 @@ impl<C: AsClient> PostgresStore<C> {
             let dependency_status = dependency_context
                 .knowledge_dependency_map
                 .insert(&entity_edition_id, current_resolve_depth);
-            let entity = match dependency_status {
+            let entity: Option<&KnowledgeGraphVertex> = match dependency_status {
                 DependencyStatus::Unresolved => {
                     match subgraph.vertices.knowledge_graph.entry(entity_edition_id) {
                         Entry::Occupied(entry) => Some(entry.into_mut()),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -51,6 +51,9 @@ impl<C: AsClient> PostgresStore<C> {
             let dependency_status = dependency_context
                 .knowledge_dependency_map
                 .insert(&entity_edition_id, current_resolve_depth);
+
+            // Explicitly converting the unique reference to a shared reference to the vertex to
+            // avoid mutating it by accident
             let entity: Option<&KnowledgeGraphVertex> = match dependency_status {
                 DependencyStatus::Unresolved => {
                     match subgraph.vertices.knowledge_graph.entry(entity_edition_id) {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -47,8 +47,7 @@ use crate::{
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum DependencyStatus {
-    Unknown,
-    DependenciesUnresolved,
+    Unresolved,
     Resolved,
 }
 
@@ -87,11 +86,11 @@ where
         match self.resolved.raw_entry_mut().from_key(identifier) {
             RawEntryMut::Vacant(entry) => {
                 entry.insert(identifier.clone(), resolved_depth);
-                DependencyStatus::Unknown
+                DependencyStatus::Unresolved
             }
             RawEntryMut::Occupied(entry) => {
                 if entry.into_mut().update(resolved_depth) {
-                    DependencyStatus::DependenciesUnresolved
+                    DependencyStatus::Unresolved
                 } else {
                     DependencyStatus::Resolved
                 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -34,7 +34,7 @@ impl<C: AsClient> PostgresStore<C> {
         let dependency_status = dependency_context
             .ontology_dependency_map
             .insert(data_type_id, current_resolve_depth);
-        let data_type = match dependency_status {
+        let data_type: Option<&OntologyVertex> = match dependency_status {
             DependencyStatus::Unresolved => {
                 match subgraph
                     .vertices

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -34,6 +34,9 @@ impl<C: AsClient> PostgresStore<C> {
         let dependency_status = dependency_context
             .ontology_dependency_map
             .insert(data_type_id, current_resolve_depth);
+
+        // Explicitly converting the unique reference to a shared reference to the vertex to
+        // avoid mutating it by accident
         let data_type: Option<&OntologyVertex> = match dependency_status {
             DependencyStatus::Unresolved => {
                 match subgraph

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -1,3 +1,5 @@
+use std::collections::hash_map::RawEntryMut;
+
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
 use tokio_postgres::GenericClient;
@@ -32,27 +34,31 @@ impl<C: AsClient> PostgresStore<C> {
         let dependency_status = dependency_context
             .ontology_dependency_map
             .insert(data_type_id, current_resolve_depth);
-        let data_type: Option<&OntologyVertex> = match dependency_status {
-            DependencyStatus::Unknown => {
-                if let Some(data_type) = subgraph.vertices.ontology.get(data_type_id) {
-                    Some(data_type)
-                } else {
-                    let data_type = Read::<DataTypeWithMetadata>::read_one(
-                        self,
-                        &Filter::<DataType>::for_ontology_type_edition_id(data_type_id),
-                    )
-                    .await?;
-                    Some(
-                        subgraph
-                            .vertices
-                            .ontology
-                            .entry(data_type_id.clone())
-                            .or_insert(OntologyVertex::DataType(Box::new(data_type))),
-                    )
+        let data_type = match dependency_status {
+            DependencyStatus::Unresolved => {
+                match subgraph
+                    .vertices
+                    .ontology
+                    .raw_entry_mut()
+                    .from_key(data_type_id)
+                {
+                    RawEntryMut::Occupied(entry) => Some(entry.into_mut()),
+                    RawEntryMut::Vacant(entry) => {
+                        let data_type = Read::<DataTypeWithMetadata>::read_one(
+                            self,
+                            &Filter::<DataType>::for_ontology_type_edition_id(data_type_id),
+                        )
+                        .await?;
+                        Some(
+                            entry
+                                .insert(
+                                    data_type_id.clone(),
+                                    OntologyVertex::DataType(Box::new(data_type)),
+                                )
+                                .1,
+                        )
+                    }
                 }
-            }
-            DependencyStatus::DependenciesUnresolved => {
-                subgraph.vertices.ontology.get(data_type_id)
             }
             DependencyStatus::Resolved => None,
         };

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -46,7 +46,7 @@ impl<C: AsClient> PostgresStore<C> {
             let dependency_status = dependency_context
                 .ontology_dependency_map
                 .insert(entity_type_id, current_resolve_depth);
-            let entity_type = match dependency_status {
+            let entity_type: Option<&OntologyVertex> = match dependency_status {
                 DependencyStatus::Unresolved => {
                     match subgraph
                         .vertices

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -46,6 +46,9 @@ impl<C: AsClient> PostgresStore<C> {
             let dependency_status = dependency_context
                 .ontology_dependency_map
                 .insert(entity_type_id, current_resolve_depth);
+
+            // Explicitly converting the unique reference to a shared reference to the vertex to
+            // avoid mutating it by accident
             let entity_type: Option<&OntologyVertex> = match dependency_status {
                 DependencyStatus::Unresolved => {
                     match subgraph

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -79,6 +79,8 @@ impl<C: AsClient> PostgresStore<C> {
             };
 
             if let Some(OntologyVertex::EntityType(entity_type)) = entity_type {
+                // Collecting references before traversing further to avoid having a shared
+                // reference to the subgraph when borrowing it mutably
                 let property_type_ref_uris =
                     (current_resolve_depth.constrains_properties_on.outgoing > 0).then(|| {
                         entity_type

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -42,7 +42,7 @@ impl<C: AsClient> PostgresStore<C> {
             let dependency_status = dependency_context
                 .ontology_dependency_map
                 .insert(property_type_id, current_resolve_depth);
-            let property_type = match dependency_status {
+            let property_type: Option<&OntologyVertex> = match dependency_status {
                 DependencyStatus::Unresolved => {
                     match subgraph
                         .vertices

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -81,6 +81,8 @@ impl<C: AsClient> PostgresStore<C> {
             };
 
             if let Some(OntologyVertex::PropertyType(property_type)) = property_type {
+                // Collecting references before traversing further to avoid having a shared
+                // reference to the subgraph when borrowing it mutably
                 let data_type_ref_uris = (current_resolve_depth.constrains_values_on.outgoing > 0)
                     .then(|| {
                         property_type

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -46,6 +46,9 @@ impl<C: AsClient> PostgresStore<C> {
             let dependency_status = dependency_context
                 .ontology_dependency_map
                 .insert(property_type_id, current_resolve_depth);
+
+            // Explicitly converting the unique reference to a shared reference to the vertex to
+            // avoid mutating it by accident
             let property_type: Option<&OntologyVertex> = match dependency_status {
                 DependencyStatus::Unresolved => {
                     match subgraph

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -410,10 +410,10 @@ impl DatabaseApi<'_> {
             })
             .collect::<Vec<_>>();
 
-        match roots.as_slice() {
-            [] => panic!("no entity found"),
-            [entity] => Ok(entity.clone()),
-            [..] => panic!("more than one entity was found"),
+        match roots.len() {
+            0 => panic!("no entity found"),
+            1 => Ok(roots.into_iter().next().unwrap()),
+            _ => panic!("more than one entity was found"),
         }
     }
 

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -411,9 +411,8 @@ impl DatabaseApi<'_> {
             .collect::<Vec<_>>();
 
         match roots.len() {
-            0 => panic!("no entity found"),
             1 => Ok(roots.into_iter().next().unwrap()),
-            _ => panic!("more than one entity was found"),
+            len => panic!("unexpected number of entities found, expected 1 but received {len}"),
         }
     }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We currently look up each type (knowledge + ontology) twice, this reduces the amount of lookups by using the entry API. Also, don't traverse the ontology types (on the Rust side, not on PSQL) if not needed.
Additionally, this avoids iterating through the link mappings twice.