### PR TITLE
Rename link order fields

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -447,7 +447,7 @@ export interface EntityLinkOrder {
    * @type {number}
    * @memberof EntityLinkOrder
    */
-  leftOrder?: number;
+  leftToRightOrder?: number;
   /**
    *
    * @type {number}
@@ -504,7 +504,7 @@ export const EntityQueryToken = {
   OutgoingLinks: "outgoingLinks",
   LeftEntity: "leftEntity",
   RightEntity: "rightEntity",
-  LeftOrder: "leftOrder",
+  LeftToRightOrder: "leftToRightOrder",
   RightToLeftOrder: "rightToLeftOrder",
 } as const;
 
@@ -1011,7 +1011,7 @@ export interface LinkData {
    * @type {number}
    * @memberof LinkData
    */
-  leftOrder?: number;
+  leftToRightOrder?: number;
   /**
    *
    * @type {number}
@@ -1821,7 +1821,7 @@ export interface UpdateEntityRequest {
    * @type {number}
    * @memberof UpdateEntityRequest
    */
-  leftOrder?: number;
+  leftToRightOrder?: number;
   /**
    *
    * @type {number}

--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -453,7 +453,7 @@ export interface EntityLinkOrder {
    * @type {number}
    * @memberof EntityLinkOrder
    */
-  rightOrder?: number;
+  rightToLeftOrder?: number;
 }
 /**
  * The metadata of an [`Entity`] record.
@@ -505,7 +505,7 @@ export const EntityQueryToken = {
   LeftEntity: "leftEntity",
   RightEntity: "rightEntity",
   LeftOrder: "leftOrder",
-  RightOrder: "rightOrder",
+  RightToLeftOrder: "rightToLeftOrder",
 } as const;
 
 export type EntityQueryToken =
@@ -1017,7 +1017,7 @@ export interface LinkData {
    * @type {number}
    * @memberof LinkData
    */
-  rightOrder?: number;
+  rightToLeftOrder?: number;
   /**
    *
    * @type {string}
@@ -1827,7 +1827,7 @@ export interface UpdateEntityRequest {
    * @type {number}
    * @memberof UpdateEntityRequest
    */
-  rightOrder?: number;
+  rightToLeftOrder?: number;
   /**
    *
    * @type {string}

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -77,7 +77,7 @@ impl EntityProperties {
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct EntityLinkOrder {
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    left_order: Option<LinkOrder>,
+    left_to_right_order: Option<LinkOrder>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     right_to_left_order: Option<LinkOrder>,
 }
@@ -85,18 +85,18 @@ pub struct EntityLinkOrder {
 impl EntityLinkOrder {
     #[must_use]
     pub const fn new(
-        left_order: Option<LinkOrder>,
+        left_to_right_order: Option<LinkOrder>,
         right_to_left_order: Option<LinkOrder>,
     ) -> Self {
         Self {
-            left_order,
+            left_to_right_order,
             right_to_left_order,
         }
     }
 
     #[must_use]
     pub const fn left(&self) -> Option<LinkOrder> {
-        self.left_order
+        self.left_to_right_order
     }
 
     #[must_use]
@@ -120,13 +120,13 @@ impl LinkData {
     pub const fn new(
         left_entity_id: EntityId,
         right_entity_id: EntityId,
-        left_order: Option<LinkOrder>,
+        left_to_right_order: Option<LinkOrder>,
         right_to_left_order: Option<LinkOrder>,
     ) -> Self {
         Self {
             left_entity_id,
             right_entity_id,
-            order: EntityLinkOrder::new(left_order, right_to_left_order),
+            order: EntityLinkOrder::new(left_to_right_order, right_to_left_order),
         }
     }
 
@@ -141,8 +141,8 @@ impl LinkData {
     }
 
     #[must_use]
-    pub const fn left_order(&self) -> Option<LinkOrder> {
-        self.order.left_order
+    pub const fn left_to_right_order(&self) -> Option<LinkOrder> {
+        self.order.left_to_right_order
     }
 
     #[must_use]

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -79,15 +79,18 @@ pub struct EntityLinkOrder {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     left_order: Option<LinkOrder>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    right_order: Option<LinkOrder>,
+    right_to_left_order: Option<LinkOrder>,
 }
 
 impl EntityLinkOrder {
     #[must_use]
-    pub const fn new(left_order: Option<LinkOrder>, right_order: Option<LinkOrder>) -> Self {
+    pub const fn new(
+        left_order: Option<LinkOrder>,
+        right_to_left_order: Option<LinkOrder>,
+    ) -> Self {
         Self {
             left_order,
-            right_order,
+            right_to_left_order,
         }
     }
 
@@ -98,7 +101,7 @@ impl EntityLinkOrder {
 
     #[must_use]
     pub const fn right(&self) -> Option<LinkOrder> {
-        self.right_order
+        self.right_to_left_order
     }
 }
 
@@ -118,12 +121,12 @@ impl LinkData {
         left_entity_id: EntityId,
         right_entity_id: EntityId,
         left_order: Option<LinkOrder>,
-        right_order: Option<LinkOrder>,
+        right_to_left_order: Option<LinkOrder>,
     ) -> Self {
         Self {
             left_entity_id,
             right_entity_id,
-            order: EntityLinkOrder::new(left_order, right_order),
+            order: EntityLinkOrder::new(left_order, right_to_left_order),
         }
     }
 
@@ -143,8 +146,8 @@ impl LinkData {
     }
 
     #[must_use]
-    pub const fn right_order(&self) -> Option<LinkOrder> {
-        self.order.right_order
+    pub const fn right_to_left_order(&self) -> Option<LinkOrder> {
+        self.order.right_to_left_order
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
@@ -228,19 +228,19 @@ pub enum EntityQueryPath<'q> {
     ///
     /// [`LinkData::left_order()`]: crate::knowledge::LinkData::left_order
     LeftOrder,
-    /// Corresponds to [`LinkData::right_order()`].
+    /// Corresponds to [`LinkData::right_to_left_order()`].
     ///
     /// ```rust
     /// # use serde::Deserialize;
     /// # use serde_json::json;
     /// # use graph::knowledge::EntityQueryPath;
-    /// let path = EntityQueryPath::deserialize(json!(["rightOrder"]))?;
-    /// assert_eq!(path, EntityQueryPath::RightOrder);
+    /// let path = EntityQueryPath::deserialize(json!(["rightToLeftOrder"]))?;
+    /// assert_eq!(path, EntityQueryPath::RightToLeftOrder);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     ///
-    /// [`LinkData::right_order()`]: crate::knowledge::LinkData::right_order
-    RightOrder,
+    /// [`LinkData::right_to_left_order()`]: crate::knowledge::LinkData::right_to_left_order
+    RightToLeftOrder,
     /// Corresponds to [`Entity::properties()`].
     ///
     /// Deserializes from `["properties", ...]` where `...` is a path to a property URI of an
@@ -289,7 +289,7 @@ impl fmt::Display for EntityQueryPath<'_> {
             Self::LeftEntity(path) => write!(fmt, "leftEntityUuid.{path}"),
             Self::RightEntity(path) => write!(fmt, "rightEntityUuid.{path}"),
             Self::LeftOrder => fmt.write_str("leftOrder"),
-            Self::RightOrder => fmt.write_str("rightOrder"),
+            Self::RightToLeftOrder => fmt.write_str("rightToLeftOrder"),
         }
     }
 }
@@ -305,7 +305,7 @@ impl RecordPath for EntityQueryPath<'_> {
             Self::Version => ParameterType::Timestamp,
             Self::Type(path) => path.expected_type(),
             Self::Properties(_) => ParameterType::Any,
-            Self::LeftOrder | Self::RightOrder => ParameterType::Number,
+            Self::LeftOrder | Self::RightToLeftOrder => ParameterType::Number,
             Self::Archived => ParameterType::Boolean,
         }
     }
@@ -328,7 +328,7 @@ pub enum EntityQueryToken {
     LeftEntity,
     RightEntity,
     LeftOrder,
-    RightOrder,
+    RightToLeftOrder,
 }
 
 /// Deserializes an [`EntityQueryPath`] from a string sequence.
@@ -338,9 +338,10 @@ pub struct EntityQueryPathVisitor {
 }
 
 impl EntityQueryPathVisitor {
-    pub const EXPECTING: &'static str =
-        "one of `uuid`, `version`, `archived`, `ownedById`, `updatedById`, `type`, `properties`, \
-         `incomingLinks`, `outgoingLinks`, `leftEntity`, `rightEntity`, `leftOrder`, `rightOrder`";
+    pub const EXPECTING: &'static str = "one of `uuid`, `version`, `archived`, `ownedById`, \
+                                         `updatedById`, `type`, `properties`, `incomingLinks`, \
+                                         `outgoingLinks`, `leftEntity`, `rightEntity`, \
+                                         `leftOrder`, `rightToLeftOrder`";
 
     #[must_use]
     pub const fn new(position: usize) -> Self {
@@ -392,7 +393,7 @@ impl<'de> Visitor<'de> for EntityQueryPathVisitor {
                 EntityQueryPath::RightEntity(Box::new(Self::new(self.position).visit_seq(seq)?))
             }
             EntityQueryToken::LeftOrder => EntityQueryPath::LeftOrder,
-            EntityQueryToken::RightOrder => EntityQueryPath::RightOrder,
+            EntityQueryToken::RightToLeftOrder => EntityQueryPath::RightToLeftOrder,
         })
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
@@ -215,19 +215,19 @@ pub enum EntityQueryPath<'q> {
     /// [`Entity`]: crate::knowledge::Entity
     /// [`LinkData::right_entity_id()`]: crate::knowledge::LinkData::right_entity_id
     RightEntity(Box<Self>),
-    /// Corresponds to [`LinkData::left_order()`].
+    /// Corresponds to [`LinkData::left_to_right_order()`].
     ///
     /// ```rust
     /// # use serde::Deserialize;
     /// # use serde_json::json;
     /// # use graph::knowledge::EntityQueryPath;
-    /// let path = EntityQueryPath::deserialize(json!(["leftOrder"]))?;
-    /// assert_eq!(path, EntityQueryPath::LeftOrder);
+    /// let path = EntityQueryPath::deserialize(json!(["leftToRightOrder"]))?;
+    /// assert_eq!(path, EntityQueryPath::LeftToRightOrder);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     ///
-    /// [`LinkData::left_order()`]: crate::knowledge::LinkData::left_order
-    LeftOrder,
+    /// [`LinkData::left_to_right_order()`]: crate::knowledge::LinkData::left_to_right_order
+    LeftToRightOrder,
     /// Corresponds to [`LinkData::right_to_left_order()`].
     ///
     /// ```rust
@@ -288,7 +288,7 @@ impl fmt::Display for EntityQueryPath<'_> {
             Self::OutgoingLinks(link) => write!(fmt, "outgoingLinks.{link}"),
             Self::LeftEntity(path) => write!(fmt, "leftEntityUuid.{path}"),
             Self::RightEntity(path) => write!(fmt, "rightEntityUuid.{path}"),
-            Self::LeftOrder => fmt.write_str("leftOrder"),
+            Self::LeftToRightOrder => fmt.write_str("leftToRightOrder"),
             Self::RightToLeftOrder => fmt.write_str("rightToLeftOrder"),
         }
     }
@@ -305,7 +305,7 @@ impl RecordPath for EntityQueryPath<'_> {
             Self::Version => ParameterType::Timestamp,
             Self::Type(path) => path.expected_type(),
             Self::Properties(_) => ParameterType::Any,
-            Self::LeftOrder | Self::RightToLeftOrder => ParameterType::Number,
+            Self::LeftToRightOrder | Self::RightToLeftOrder => ParameterType::Number,
             Self::Archived => ParameterType::Boolean,
         }
     }
@@ -327,7 +327,7 @@ pub enum EntityQueryToken {
     OutgoingLinks,
     LeftEntity,
     RightEntity,
-    LeftOrder,
+    LeftToRightOrder,
     RightToLeftOrder,
 }
 
@@ -341,7 +341,7 @@ impl EntityQueryPathVisitor {
     pub const EXPECTING: &'static str = "one of `uuid`, `version`, `archived`, `ownedById`, \
                                          `updatedById`, `type`, `properties`, `incomingLinks`, \
                                          `outgoingLinks`, `leftEntity`, `rightEntity`, \
-                                         `leftOrder`, `rightToLeftOrder`";
+                                         `leftToRightOrder`, `rightToLeftOrder`";
 
     #[must_use]
     pub const fn new(position: usize) -> Self {
@@ -392,7 +392,7 @@ impl<'de> Visitor<'de> for EntityQueryPathVisitor {
             EntityQueryToken::RightEntity => {
                 EntityQueryPath::RightEntity(Box::new(Self::new(self.position).visit_seq(seq)?))
             }
-            EntityQueryToken::LeftOrder => EntityQueryPath::LeftOrder,
+            EntityQueryToken::LeftToRightOrder => EntityQueryPath::LeftToRightOrder,
             EntityQueryToken::RightToLeftOrder => EntityQueryPath::RightToLeftOrder,
         })
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -553,7 +553,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                     .attach_printable("cannot update link order of an entity that is not a link")
             ),
             (Some(link_data), left, right) => {
-                let new_left_order = match (link_data.left_order(), left) {
+                let new_left_order = match (link_data.left_to_right_order(), left) {
                     (None, None) => None,
                     (Some(_), None) => bail!(Report::new(UpdateError).attach_printable(
                         "left order was set on entity but new order was not provided"

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -553,30 +553,32 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                     .attach_printable("cannot update link order of an entity that is not a link")
             ),
             (Some(link_data), left, right) => {
-                let new_left_order = match (link_data.left_to_right_order(), left) {
+                let new_left_to_right_order = match (link_data.left_to_right_order(), left) {
                     (None, None) => None,
                     (Some(_), None) => bail!(Report::new(UpdateError).attach_printable(
-                        "left order was set on entity but new order was not provided"
+                        "left to right order was set on entity but new order was not provided"
                     )),
                     (None, Some(_)) => bail!(Report::new(UpdateError).attach_printable(
-                        "cannot set left order of a link that does not have a left order"
+                        "cannot set left to right order of a link that does not have a left to \
+                         right order"
                     )),
                     (Some(_), Some(new_left)) => Some(new_left),
                 };
                 let new_right_to_left_order = match (link_data.right_to_left_order(), right) {
                     (None, None) => None,
                     (Some(_), None) => bail!(Report::new(UpdateError).attach_printable(
-                        "right order was set on entity but new order was not provided"
+                        "right to left order was set on entity but new order was not provided"
                     )),
                     (None, Some(_)) => bail!(Report::new(UpdateError).attach_printable(
-                        "cannot set right order of a link that does not have a right order"
+                        "cannot set right to left order of a link that does not have a right to \
+                         left order"
                     )),
                     (Some(_), Some(new_right)) => Some(new_right),
                 };
                 Some(LinkData::new(
                     link_data.left_entity_id(),
                     link_data.right_entity_id(),
-                    new_left_order,
+                    new_left_to_right_order,
                     new_right_to_left_order,
                 ))
             }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -563,7 +563,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                     )),
                     (Some(_), Some(new_left)) => Some(new_left),
                 };
-                let new_right_order = match (link_data.right_order(), right) {
+                let new_right_to_left_order = match (link_data.right_to_left_order(), right) {
                     (None, None) => None,
                     (Some(_), None) => bail!(Report::new(UpdateError).attach_printable(
                         "right order was set on entity but new order was not provided"
@@ -577,7 +577,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                     link_data.left_entity_id(),
                     link_data.right_entity_id(),
                     new_left_order,
-                    new_right_order,
+                    new_right_to_left_order,
                 ))
             }
         };

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -63,7 +63,8 @@ impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
         let right_entity_uuid_index = compiler.add_selection_path(&right_entity_uuid_path);
         let right_entity_owned_by_id_index =
             compiler.add_selection_path(&right_owned_by_id_query_path);
-        let left_order_index = compiler.add_selection_path(&EntityQueryPath::LeftOrder);
+        let left_to_right_order_index =
+            compiler.add_selection_path(&EntityQueryPath::LeftToRightOrder);
         let right_to_left_order_index =
             compiler.add_selection_path(&EntityQueryPath::RightToLeftOrder);
 
@@ -116,7 +117,7 @@ impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
                                 OwnedById::new(right_owned_by_id),
                                 EntityUuid::new(right_entity_uuid),
                             ),
-                            row.get(left_order_index),
+                            row.get(left_to_right_order_index),
                             row.get(right_to_left_order_index),
                         )),
                         (None, None, None, None) => None,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -64,7 +64,8 @@ impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
         let right_entity_owned_by_id_index =
             compiler.add_selection_path(&right_owned_by_id_query_path);
         let left_order_index = compiler.add_selection_path(&EntityQueryPath::LeftOrder);
-        let right_order_index = compiler.add_selection_path(&EntityQueryPath::RightOrder);
+        let right_to_left_order_index =
+            compiler.add_selection_path(&EntityQueryPath::RightToLeftOrder);
 
         let updated_by_id_index = compiler.add_selection_path(&EntityQueryPath::UpdatedById);
 
@@ -116,7 +117,7 @@ impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
                                 EntityUuid::new(right_entity_uuid),
                             ),
                             row.get(left_order_index),
-                            row.get(right_order_index),
+                            row.get(right_to_left_order_index),
                         )),
                         (None, None, None, None) => None,
                         _ => unreachable!(

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -649,7 +649,7 @@ where
                     properties,
                     left_owned_by_id, left_entity_uuid,
                     right_owned_by_id, right_entity_uuid,
-                    left_order, right_order,
+                    left_order, right_to_left_order,
                     updated_by_id
                 )
                 VALUES ($1, $2, clock_timestamp(), $3, $4, $5, $6, $7, $8, $9, $10, $11)
@@ -673,7 +673,7 @@ where
                         .as_ref()
                         .map(|metadata| metadata.right_entity_id().entity_uuid().as_uuid()),
                     &link_data.as_ref().map(LinkData::left_order),
-                    &link_data.as_ref().map(LinkData::right_order),
+                    &link_data.as_ref().map(LinkData::right_to_left_order),
                     &updated_by_id.as_account_id(),
                 ],
             )
@@ -745,7 +745,7 @@ where
                         properties,
                         left_owned_by_id, left_entity_uuid,
                         right_owned_by_id, right_entity_uuid,
-                        left_order, right_order,
+                        left_order, right_to_left_order,
                         updated_by_id
                 ),
                 inserted_in_historic AS (
@@ -758,7 +758,7 @@ where
                         properties,
                         left_owned_by_id, left_entity_uuid,
                         right_owned_by_id, right_entity_uuid,
-                        left_order, right_order,
+                        left_order, right_to_left_order,
                         updated_by_id,
                         archived
                     )
@@ -768,7 +768,7 @@ where
                         properties,
                         left_owned_by_id, left_entity_uuid,
                         right_owned_by_id, right_entity_uuid,
-                        left_order, right_order,
+                        left_order, right_to_left_order,
                         updated_by_id,
                         $3::boolean
                     FROM to_move_to_historic
@@ -778,7 +778,7 @@ where
                         entity_type_version_id,
                         left_owned_by_id, left_entity_uuid,
                         right_owned_by_id, right_entity_uuid,
-                        left_order, right_order,
+                        left_order, right_to_left_order,
                         updated_by_id
                 )
                 SELECT
@@ -786,7 +786,7 @@ where
                     base_uri, type_ids.version,
                     left_owned_by_id, left_entity_uuid,
                     right_owned_by_id, right_entity_uuid,
-                    left_order, right_order,
+                    left_order, right_to_left_order,
                     updated_by_id
                 FROM inserted_in_historic
                 INNER JOIN type_ids ON inserted_in_historic.entity_type_version_id = type_ids.version_id;
@@ -815,7 +815,7 @@ where
                 Some(right_owned_by_id),
                 Some(right_entity_uuid),
                 left_order,
-                right_order,
+                right_to_left_order,
             ) => Some(LinkData::new(
                 EntityId::new(
                     OwnedById::new(left_owned_by_id),
@@ -826,7 +826,7 @@ where
                     EntityUuid::new(right_entity_uuid),
                 ),
                 left_order,
-                right_order,
+                right_to_left_order,
             )),
             (None, None, None, None, None, None) => None,
             _ => {
@@ -918,7 +918,8 @@ impl PostgresStore<Transaction<'_>> {
             .copy_in(
                 "COPY latest_entities (entity_uuid, entity_type_version_id, properties, \
                  owned_by_id, updated_by_id, left_owned_by_id, left_entity_uuid, \
-                 right_owned_by_id, right_entity_uuid, left_order, right_order) FROM STDIN BINARY",
+                 right_owned_by_id, right_entity_uuid, left_order, right_to_left_order) FROM \
+                 STDIN BINARY",
             )
             .await
             .into_report()
@@ -964,7 +965,7 @@ impl PostgresStore<Transaction<'_>> {
                         .as_ref()
                         .map(|metadata| metadata.right_entity_id().entity_uuid().as_uuid()),
                     &link_data.as_ref().and_then(LinkData::left_order),
-                    &link_data.as_ref().and_then(LinkData::right_order),
+                    &link_data.as_ref().and_then(LinkData::right_to_left_order),
                 ])
                 .await
                 .into_report()

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -649,7 +649,7 @@ where
                     properties,
                     left_owned_by_id, left_entity_uuid,
                     right_owned_by_id, right_entity_uuid,
-                    left_order, right_to_left_order,
+                    left_to_right_order, right_to_left_order,
                     updated_by_id
                 )
                 VALUES ($1, $2, clock_timestamp(), $3, $4, $5, $6, $7, $8, $9, $10, $11)
@@ -672,7 +672,7 @@ where
                     &link_data
                         .as_ref()
                         .map(|metadata| metadata.right_entity_id().entity_uuid().as_uuid()),
-                    &link_data.as_ref().map(LinkData::left_order),
+                    &link_data.as_ref().map(LinkData::left_to_right_order),
                     &link_data.as_ref().map(LinkData::right_to_left_order),
                     &updated_by_id.as_account_id(),
                 ],
@@ -745,7 +745,7 @@ where
                         properties,
                         left_owned_by_id, left_entity_uuid,
                         right_owned_by_id, right_entity_uuid,
-                        left_order, right_to_left_order,
+                        left_to_right_order, right_to_left_order,
                         updated_by_id
                 ),
                 inserted_in_historic AS (
@@ -758,7 +758,7 @@ where
                         properties,
                         left_owned_by_id, left_entity_uuid,
                         right_owned_by_id, right_entity_uuid,
-                        left_order, right_to_left_order,
+                        left_to_right_order, right_to_left_order,
                         updated_by_id,
                         archived
                     )
@@ -768,7 +768,7 @@ where
                         properties,
                         left_owned_by_id, left_entity_uuid,
                         right_owned_by_id, right_entity_uuid,
-                        left_order, right_to_left_order,
+                        left_to_right_order, right_to_left_order,
                         updated_by_id,
                         $3::boolean
                     FROM to_move_to_historic
@@ -778,7 +778,7 @@ where
                         entity_type_version_id,
                         left_owned_by_id, left_entity_uuid,
                         right_owned_by_id, right_entity_uuid,
-                        left_order, right_to_left_order,
+                        left_to_right_order, right_to_left_order,
                         updated_by_id
                 )
                 SELECT
@@ -786,7 +786,7 @@ where
                     base_uri, type_ids.version,
                     left_owned_by_id, left_entity_uuid,
                     right_owned_by_id, right_entity_uuid,
-                    left_order, right_to_left_order,
+                    left_to_right_order, right_to_left_order,
                     updated_by_id
                 FROM inserted_in_historic
                 INNER JOIN type_ids ON inserted_in_historic.entity_type_version_id = type_ids.version_id;
@@ -814,7 +814,7 @@ where
                 Some(left_entity_uuid),
                 Some(right_owned_by_id),
                 Some(right_entity_uuid),
-                left_order,
+                left_to_right_order,
                 right_to_left_order,
             ) => Some(LinkData::new(
                 EntityId::new(
@@ -825,7 +825,7 @@ where
                     OwnedById::new(right_owned_by_id),
                     EntityUuid::new(right_entity_uuid),
                 ),
-                left_order,
+                left_to_right_order,
                 right_to_left_order,
             )),
             (None, None, None, None, None, None) => None,
@@ -918,8 +918,8 @@ impl PostgresStore<Transaction<'_>> {
             .copy_in(
                 "COPY latest_entities (entity_uuid, entity_type_version_id, properties, \
                  owned_by_id, updated_by_id, left_owned_by_id, left_entity_uuid, \
-                 right_owned_by_id, right_entity_uuid, left_order, right_to_left_order) FROM \
-                 STDIN BINARY",
+                 right_owned_by_id, right_entity_uuid, left_to_right_order, right_to_left_order) \
+                 FROM STDIN BINARY",
             )
             .await
             .into_report()
@@ -964,7 +964,7 @@ impl PostgresStore<Transaction<'_>> {
                     &link_data
                         .as_ref()
                         .map(|metadata| metadata.right_entity_id().entity_uuid().as_uuid()),
-                    &link_data.as_ref().and_then(LinkData::left_order),
+                    &link_data.as_ref().and_then(LinkData::left_to_right_order),
                     &link_data.as_ref().and_then(LinkData::right_to_left_order),
                 ])
                 .await

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity.rs
@@ -64,7 +64,7 @@ impl Path for EntityQueryPath<'_> {
             | Self::IncomingLinks(path)
             | Self::OutgoingLinks(path) => path.terminating_column(),
             Self::LeftOrder => Column::Entities(Entities::LeftOrder),
-            Self::RightOrder => Column::Entities(Entities::RightOrder),
+            Self::RightToLeftOrder => Column::Entities(Entities::RightToLeftOrder),
             Self::Properties(path) => path
                 .as_ref()
                 .map_or(Column::Entities(Entities::Properties(None)), |path| {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity.rs
@@ -63,7 +63,7 @@ impl Path for EntityQueryPath<'_> {
             | Self::RightEntity(path)
             | Self::IncomingLinks(path)
             | Self::OutgoingLinks(path) => path.terminating_column(),
-            Self::LeftOrder => Column::Entities(Entities::LeftOrder),
+            Self::LeftToRightOrder => Column::Entities(Entities::LeftToRightOrder),
             Self::RightToLeftOrder => Column::Entities(Entities::RightToLeftOrder),
             Self::Properties(path) => path
                 .as_ref()

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
@@ -136,7 +136,7 @@ pub enum Entities<'p> {
     EntityTypeVersionId,
     Properties(Option<JsonField<'p>>),
     LeftOrder,
-    RightOrder,
+    RightToLeftOrder,
     LeftEntityUuid,
     RightEntityUuid,
     LeftEntityOwnedById,
@@ -159,7 +159,7 @@ impl Entities<'_> {
             | Self::LeftEntityOwnedById
             | Self::RightEntityOwnedById
             | Self::LeftOrder
-            | Self::RightOrder => true,
+            | Self::RightToLeftOrder => true,
         }
     }
 }
@@ -189,7 +189,7 @@ impl Transpile for Entities<'_> {
                 };
             }
             Self::LeftOrder => "left_order",
-            Self::RightOrder => "right_order",
+            Self::RightToLeftOrder => "right_to_left_order",
             Self::LeftEntityUuid => "left_entity_uuid",
             Self::RightEntityUuid => "right_entity_uuid",
             Self::LeftEntityOwnedById => "left_owned_by_id",

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
@@ -135,7 +135,7 @@ pub enum Entities<'p> {
     UpdatedById,
     EntityTypeVersionId,
     Properties(Option<JsonField<'p>>),
-    LeftOrder,
+    LeftToRightOrder,
     RightToLeftOrder,
     LeftEntityUuid,
     RightEntityUuid,
@@ -158,7 +158,7 @@ impl Entities<'_> {
             | Self::RightEntityUuid
             | Self::LeftEntityOwnedById
             | Self::RightEntityOwnedById
-            | Self::LeftOrder
+            | Self::LeftToRightOrder
             | Self::RightToLeftOrder => true,
         }
     }
@@ -188,7 +188,7 @@ impl Transpile for Entities<'_> {
                     }
                 };
             }
-            Self::LeftOrder => "left_order",
+            Self::LeftToRightOrder => "left_to_right_order",
             Self::RightToLeftOrder => "right_to_left_order",
             Self::LeftEntityUuid => "left_entity_uuid",
             Self::RightEntityUuid => "right_entity_uuid",

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -330,7 +330,7 @@ export const up = (pgm: MigrationBuilder): void => {
         type: "integer",
         notNull: false,
       },
-      right_order: {
+      right_to_left_order: {
         // TODO: this is where we could do fractional indexing
         //  https://app.asana.com/0/1200211978612931/1202085856561975/f
         type: "integer",
@@ -368,7 +368,7 @@ export const up = (pgm: MigrationBuilder): void => {
     {
       // Because of the "entities_relation_constraint", we can check any one of the required link columns
       check: `(left_entity_uuid IS NOT NULL)
-            OR (left_order IS NULL AND right_order IS NULL)`,
+            OR (left_order IS NULL AND right_to_left_order IS NULL)`,
     },
   );
 
@@ -425,7 +425,7 @@ export const up = (pgm: MigrationBuilder): void => {
         type: "integer",
         notNull: false,
       },
-      right_order: {
+      right_to_left_order: {
         // TODO: this is where we could do fractional indexing
         //  https://app.asana.com/0/1200211978612931/1202085856561975/f
         type: "integer",
@@ -472,7 +472,7 @@ export const up = (pgm: MigrationBuilder): void => {
     {
       // Because of the "entities_histories_relation_constraint", we can check any one of the required link columns
       check: `(left_entity_uuid IS NOT NULL)
-            OR (left_order IS NULL AND right_order IS NULL)`,
+            OR (left_order IS NULL AND right_to_left_order IS NULL)`,
     },
   );
 
@@ -493,15 +493,15 @@ export const up = (pgm: MigrationBuilder): void => {
         "right_owned_by_id",
         "right_entity_uuid",
         "left_order",
-        "right_order",
+        "right_to_left_order",
         "archived",
         "updated_by_id",
       ],
     },
     `
-    SELECT owned_by_id, entity_uuid, version, TRUE as latest_version, entity_type_version_id, properties, left_owned_by_id, left_entity_uuid, right_owned_by_id, right_entity_uuid, left_order, right_order, FALSE AS archived, updated_by_id FROM latest_entities
+    SELECT owned_by_id, entity_uuid, version, TRUE as latest_version, entity_type_version_id, properties, left_owned_by_id, left_entity_uuid, right_owned_by_id, right_entity_uuid, left_order, right_to_left_order, FALSE AS archived, updated_by_id FROM latest_entities
     UNION ALL
-    SELECT owned_by_id, entity_uuid, version, FALSE as latest_version, entity_type_version_id, properties, left_owned_by_id, left_entity_uuid, right_owned_by_id, right_entity_uuid, left_order, right_order, archived, updated_by_id FROM entity_histories`,
+    SELECT owned_by_id, entity_uuid, version, FALSE as latest_version, entity_type_version_id, properties, left_owned_by_id, left_entity_uuid, right_owned_by_id, right_entity_uuid, left_order, right_to_left_order, archived, updated_by_id FROM entity_histories`,
   );
 };
 

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -324,7 +324,7 @@ export const up = (pgm: MigrationBuilder): void => {
         notNull: false,
         references: "entity_uuids",
       },
-      left_order: {
+      left_to_right_order: {
         // TODO: this is where we could do fractional indexing
         //  https://app.asana.com/0/1200211978612931/1202085856561975/f
         type: "integer",
@@ -368,7 +368,7 @@ export const up = (pgm: MigrationBuilder): void => {
     {
       // Because of the "entities_relation_constraint", we can check any one of the required link columns
       check: `(left_entity_uuid IS NOT NULL)
-            OR (left_order IS NULL AND right_to_left_order IS NULL)`,
+            OR (left_to_right_order IS NULL AND right_to_left_order IS NULL)`,
     },
   );
 
@@ -419,7 +419,7 @@ export const up = (pgm: MigrationBuilder): void => {
         notNull: false,
         references: "entity_uuids",
       },
-      left_order: {
+      left_to_right_order: {
         // TODO: this is where we could do fractional indexing
         //  https://app.asana.com/0/1200211978612931/1202085856561975/f
         type: "integer",
@@ -472,7 +472,7 @@ export const up = (pgm: MigrationBuilder): void => {
     {
       // Because of the "entities_histories_relation_constraint", we can check any one of the required link columns
       check: `(left_entity_uuid IS NOT NULL)
-            OR (left_order IS NULL AND right_to_left_order IS NULL)`,
+            OR (left_to_right_order IS NULL AND right_to_left_order IS NULL)`,
     },
   );
 
@@ -492,16 +492,16 @@ export const up = (pgm: MigrationBuilder): void => {
         "left_entity_uuid",
         "right_owned_by_id",
         "right_entity_uuid",
-        "left_order",
+        "left_to_right_order",
         "right_to_left_order",
         "archived",
         "updated_by_id",
       ],
     },
     `
-    SELECT owned_by_id, entity_uuid, version, TRUE as latest_version, entity_type_version_id, properties, left_owned_by_id, left_entity_uuid, right_owned_by_id, right_entity_uuid, left_order, right_to_left_order, FALSE AS archived, updated_by_id FROM latest_entities
+    SELECT owned_by_id, entity_uuid, version, TRUE as latest_version, entity_type_version_id, properties, left_owned_by_id, left_entity_uuid, right_owned_by_id, right_entity_uuid, left_to_right_order, right_to_left_order, FALSE AS archived, updated_by_id FROM latest_entities
     UNION ALL
-    SELECT owned_by_id, entity_uuid, version, FALSE as latest_version, entity_type_version_id, properties, left_owned_by_id, left_entity_uuid, right_owned_by_id, right_entity_uuid, left_order, right_to_left_order, archived, updated_by_id FROM entity_histories`,
+    SELECT owned_by_id, entity_uuid, version, FALSE as latest_version, entity_type_version_id, properties, left_owned_by_id, left_entity_uuid, right_owned_by_id, right_entity_uuid, left_to_right_order, right_to_left_order, archived, updated_by_id FROM entity_histories`,
   );
 };
 

--- a/packages/hash/api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -69,7 +69,8 @@ export const createEntity: ResolverFn<
   let entityModel: EntityModel | LinkEntityModel;
 
   if (linkData) {
-    const { leftEntityId, leftOrder, rightEntityId, rightOrder } = linkData;
+    const { leftEntityId, leftOrder, rightEntityId, rightToLeftOrder } =
+      linkData;
 
     const [leftEntityModel, rightEntityModel, linkEntityTypeModel] =
       await Promise.all([
@@ -86,7 +87,7 @@ export const createEntity: ResolverFn<
       leftEntityModel,
       leftOrder: leftOrder ?? undefined,
       rightEntityModel,
-      rightOrder: rightOrder ?? undefined,
+      rightToLeftOrder: rightToLeftOrder ?? undefined,
       properties,
       linkEntityTypeModel,
       ownedById: ownedById ?? userModel.getEntityUuid(),
@@ -247,7 +248,7 @@ export const updateEntity: ResolverFn<
   MutationUpdateEntityArgs
 > = async (
   _,
-  { entityId, updatedProperties, leftOrder, rightOrder },
+  { entityId, updatedProperties, leftOrder, rightToLeftOrder },
   { dataSources: { graphApi }, userModel },
 ) => {
   // The user needs to be signed up if they aren't updating their own user entity
@@ -282,10 +283,10 @@ export const updateEntity: ResolverFn<
       properties: updatedProperties,
       actorId: userModel.getEntityUuid(),
       leftOrder: leftOrder ?? undefined,
-      rightOrder: rightOrder ?? undefined,
+      rightToLeftOrder: rightToLeftOrder ?? undefined,
     });
   } else {
-    if (leftOrder || rightOrder) {
+    if (leftOrder || rightToLeftOrder) {
       throw new UserInputError(
         `Cannot update the left order or right order of entity with ID ${entityModel.getBaseId()} because it isn't a link.`,
       );

--- a/packages/hash/api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -288,7 +288,7 @@ export const updateEntity: ResolverFn<
   } else {
     if (leftToRightOrder || rightToLeftOrder) {
       throw new UserInputError(
-        `Cannot update the left order or right order of entity with ID ${entityModel.getBaseId()} because it isn't a link.`,
+        `Cannot update the left to right order or right to left order of entity with ID ${entityModel.getBaseId()} because it isn't a link.`,
       );
     }
 

--- a/packages/hash/api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -69,7 +69,7 @@ export const createEntity: ResolverFn<
   let entityModel: EntityModel | LinkEntityModel;
 
   if (linkData) {
-    const { leftEntityId, leftOrder, rightEntityId, rightToLeftOrder } =
+    const { leftEntityId, leftToRightOrder, rightEntityId, rightToLeftOrder } =
       linkData;
 
     const [leftEntityModel, rightEntityModel, linkEntityTypeModel] =
@@ -85,7 +85,7 @@ export const createEntity: ResolverFn<
 
     entityModel = await LinkEntityModel.createLinkEntity(graphApi, {
       leftEntityModel,
-      leftOrder: leftOrder ?? undefined,
+      leftToRightOrder: leftToRightOrder ?? undefined,
       rightEntityModel,
       rightToLeftOrder: rightToLeftOrder ?? undefined,
       properties,
@@ -248,7 +248,7 @@ export const updateEntity: ResolverFn<
   MutationUpdateEntityArgs
 > = async (
   _,
-  { entityId, updatedProperties, leftOrder, rightToLeftOrder },
+  { entityId, updatedProperties, leftToRightOrder, rightToLeftOrder },
   { dataSources: { graphApi }, userModel },
 ) => {
   // The user needs to be signed up if they aren't updating their own user entity
@@ -282,11 +282,11 @@ export const updateEntity: ResolverFn<
     updatedEntityModel = await entityModel.update(graphApi, {
       properties: updatedProperties,
       actorId: userModel.getEntityUuid(),
-      leftOrder: leftOrder ?? undefined,
+      leftToRightOrder: leftToRightOrder ?? undefined,
       rightToLeftOrder: rightToLeftOrder ?? undefined,
     });
   } else {
-    if (leftOrder || rightToLeftOrder) {
+    if (leftToRightOrder || rightToLeftOrder) {
       throw new UserInputError(
         `Cannot update the left order or right order of entity with ID ${entityModel.getBaseId()} because it isn't a link.`,
       );

--- a/packages/hash/api/src/graphql/typeDefs/knowledge/entity.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/knowledge/entity.typedef.ts
@@ -125,7 +125,7 @@ export const entityTypedef = gql`
       """
       The updated right order of the link entity (if updating a link entity).
       """
-      rightOrder: Int
+      rightToLeftOrder: Int
     ): Entity!
 
     """

--- a/packages/hash/api/src/graphql/typeDefs/knowledge/entity.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/knowledge/entity.typedef.ts
@@ -119,11 +119,11 @@ export const entityTypedef = gql`
       """
       updatedProperties: PropertyObject!
       """
-      The updated left order of the link entity (if updating a link entity).
+      The updated left to right order of the link entity (if updating a link entity).
       """
       leftToRightOrder: Int
       """
-      The updated right order of the link entity (if updating a link entity).
+      The updated right to left order of the link entity (if updating a link entity).
       """
       rightToLeftOrder: Int
     ): Entity!

--- a/packages/hash/api/src/graphql/typeDefs/knowledge/entity.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/knowledge/entity.typedef.ts
@@ -121,7 +121,7 @@ export const entityTypedef = gql`
       """
       The updated left order of the link entity (if updating a link entity).
       """
-      leftOrder: Int
+      leftToRightOrder: Int
       """
       The updated right order of the link entity (if updating a link entity).
       """

--- a/packages/hash/api/src/model/knowledge/entity.model.ts
+++ b/packages/hash/api/src/model/knowledge/entity.model.ts
@@ -226,7 +226,7 @@ export default class {
           await parentEntity.entity.createOutgoingLink(graphApi, {
             linkEntityTypeModel,
             rightEntityModel: entity,
-            leftOrder: link.meta.index ?? undefined,
+            leftToRightOrder: link.meta.index ?? undefined,
             ownedById,
             actorId,
           });

--- a/packages/hash/api/src/model/knowledge/linkEntity.model.ts
+++ b/packages/hash/api/src/model/knowledge/linkEntity.model.ts
@@ -27,7 +27,7 @@ export type LinkModelCreateParams = {
   properties?: PropertyObject;
   linkEntityTypeModel: EntityTypeModel;
   leftEntityModel: EntityModel;
-  leftOrder?: number;
+  leftToRightOrder?: number;
   rightEntityModel: EntityModel;
   rightToLeftOrder?: number;
   actorId: string;
@@ -122,7 +122,7 @@ export default class extends EntityModel {
    * @param params.ownedById - the id of the account who owns the new link entity
    * @param params.linkEntityTypeModel - the link entity type of the link entity
    * @param params.leftEntityModel - the left entity of the link
-   * @param params.leftOrder (optional) - the left order of the link entity
+   * @param params.leftToRightOrder (optional) - the left order of the link entity
    * @param params.rightEntityModel - the right entity of the link
    * @param params.rightToLeftOrder (optional) - the right order of the link entity
    * @param params.actorId - the id of the account that is creating the link
@@ -136,7 +136,7 @@ export default class extends EntityModel {
       linkEntityTypeModel,
       actorId,
       leftEntityModel,
-      leftOrder,
+      leftToRightOrder,
       rightEntityModel,
       rightToLeftOrder,
       properties = {},
@@ -152,7 +152,7 @@ export default class extends EntityModel {
 
     const linkData = {
       leftEntityId: leftEntityModel.getBaseId(),
-      leftOrder,
+      leftToRightOrder,
       rightEntityId: rightEntityModel.getBaseId(),
       rightToLeftOrder,
     };
@@ -181,19 +181,19 @@ export default class extends EntityModel {
     graphApi: GraphApi,
     params: {
       properties: PropertyObject;
-      leftOrder?: number;
+      leftToRightOrder?: number;
       rightToLeftOrder?: number;
       actorId: string;
     },
   ): Promise<EntityModel> {
-    const { properties, actorId, leftOrder, rightToLeftOrder } = params;
+    const { properties, actorId, leftToRightOrder, rightToLeftOrder } = params;
 
     const { data: metadata } = await graphApi.updateEntity({
       actorId,
       entityId: this.getBaseId(),
       entityTypeId: this.entityTypeModel.getSchema().$id,
       properties,
-      leftOrder,
+      leftToRightOrder,
       rightToLeftOrder,
     });
 
@@ -202,7 +202,7 @@ export default class extends EntityModel {
       properties,
       linkData: {
         leftEntityId: this.entity.linkData!.leftEntityId,
-        leftOrder,
+        leftToRightOrder,
         rightEntityId: this.entity.linkData!.rightEntityId,
         rightToLeftOrder,
       },
@@ -230,7 +230,7 @@ export default class extends EntityModel {
       entityId: this.getBaseId(),
       entityTypeId: this.entityTypeModel.getSchema().$id,
       properties,
-      leftOrder: linkOrder.leftOrder,
+      leftToRightOrder: linkOrder.leftToRightOrder,
       rightToLeftOrder: linkOrder.rightToLeftOrder,
     });
 
@@ -239,7 +239,7 @@ export default class extends EntityModel {
       properties,
       linkData: {
         leftEntityId: this.entity.linkData!.leftEntityId,
-        leftOrder: linkOrder.leftOrder,
+        leftToRightOrder: linkOrder.leftToRightOrder,
         rightEntityId: this.entity.linkData!.rightEntityId,
         rightToLeftOrder: linkOrder.rightToLeftOrder,
       },

--- a/packages/hash/api/src/model/knowledge/linkEntity.model.ts
+++ b/packages/hash/api/src/model/knowledge/linkEntity.model.ts
@@ -122,9 +122,9 @@ export default class extends EntityModel {
    * @param params.ownedById - the id of the account who owns the new link entity
    * @param params.linkEntityTypeModel - the link entity type of the link entity
    * @param params.leftEntityModel - the left entity of the link
-   * @param params.leftToRightOrder (optional) - the left order of the link entity
+   * @param params.leftToRightOrder (optional) - the left to right order of the link entity
    * @param params.rightEntityModel - the right entity of the link
-   * @param params.rightToLeftOrder (optional) - the right order of the link entity
+   * @param params.rightToLeftOrder (optional) - the right to left order of the link entity
    * @param params.actorId - the id of the account that is creating the link
    */
   static async createLinkEntity(

--- a/packages/hash/api/src/model/knowledge/linkEntity.model.ts
+++ b/packages/hash/api/src/model/knowledge/linkEntity.model.ts
@@ -29,7 +29,7 @@ export type LinkModelCreateParams = {
   leftEntityModel: EntityModel;
   leftOrder?: number;
   rightEntityModel: EntityModel;
-  rightOrder?: number;
+  rightToLeftOrder?: number;
   actorId: string;
 };
 
@@ -124,7 +124,7 @@ export default class extends EntityModel {
    * @param params.leftEntityModel - the left entity of the link
    * @param params.leftOrder (optional) - the left order of the link entity
    * @param params.rightEntityModel - the right entity of the link
-   * @param params.rightOrder (optional) - the right order of the link entity
+   * @param params.rightToLeftOrder (optional) - the right order of the link entity
    * @param params.actorId - the id of the account that is creating the link
    */
   static async createLinkEntity(
@@ -138,7 +138,7 @@ export default class extends EntityModel {
       leftEntityModel,
       leftOrder,
       rightEntityModel,
-      rightOrder,
+      rightToLeftOrder,
       properties = {},
     } = params;
 
@@ -154,7 +154,7 @@ export default class extends EntityModel {
       leftEntityId: leftEntityModel.getBaseId(),
       leftOrder,
       rightEntityId: rightEntityModel.getBaseId(),
-      rightOrder,
+      rightToLeftOrder,
     };
     const { data: linkEntityMetadata } = await graphApi.createEntity({
       ownedById,
@@ -182,11 +182,11 @@ export default class extends EntityModel {
     params: {
       properties: PropertyObject;
       leftOrder?: number;
-      rightOrder?: number;
+      rightToLeftOrder?: number;
       actorId: string;
     },
   ): Promise<EntityModel> {
-    const { properties, actorId, leftOrder, rightOrder } = params;
+    const { properties, actorId, leftOrder, rightToLeftOrder } = params;
 
     const { data: metadata } = await graphApi.updateEntity({
       actorId,
@@ -194,7 +194,7 @@ export default class extends EntityModel {
       entityTypeId: this.entityTypeModel.getSchema().$id,
       properties,
       leftOrder,
-      rightOrder,
+      rightToLeftOrder,
     });
 
     return LinkEntityModel.fromEntity(graphApi, {
@@ -204,7 +204,7 @@ export default class extends EntityModel {
         leftEntityId: this.entity.linkData!.leftEntityId,
         leftOrder,
         rightEntityId: this.entity.linkData!.rightEntityId,
-        rightOrder,
+        rightToLeftOrder,
       },
     });
   }
@@ -231,7 +231,7 @@ export default class extends EntityModel {
       entityTypeId: this.entityTypeModel.getSchema().$id,
       properties,
       leftOrder: linkOrder.leftOrder,
-      rightOrder: linkOrder.rightOrder,
+      rightToLeftOrder: linkOrder.rightToLeftOrder,
     });
 
     return LinkEntityModel.fromEntity(graphApi, {
@@ -241,7 +241,7 @@ export default class extends EntityModel {
         leftEntityId: this.entity.linkData!.leftEntityId,
         leftOrder: linkOrder.leftOrder,
         rightEntityId: this.entity.linkData!.rightEntityId,
-        rightOrder: linkOrder.rightOrder,
+        rightToLeftOrder: linkOrder.rightToLeftOrder,
       },
     });
   }

--- a/packages/hash/api/src/model/knowledge/page.model.ts
+++ b/packages/hash/api/src/model/knowledge/page.model.ts
@@ -381,7 +381,8 @@ export default class extends EntityModel {
     return outgoingBlockDataLinks
       .sort(
         (a, b) =>
-          (a.getLinkData().leftOrder ?? 0) - (b.getLinkData().leftOrder ?? 0) ||
+          (a.getLinkData().leftToRightOrder ?? 0) -
+            (b.getLinkData().leftToRightOrder ?? 0) ||
           a.getBaseId().localeCompare(b.getBaseId()) ||
           a.getVersion().localeCompare(b.getVersion()),
       )
@@ -427,7 +428,7 @@ export default class extends EntityModel {
     await this.createOutgoingLink(graphApi, {
       rightEntityModel: block,
       linkEntityTypeModel: SYSTEM_TYPES.linkEntityType.contains,
-      leftOrder:
+      leftToRightOrder:
         specifiedPosition ??
         // if position is not specified and there are no blocks currently in the page, specify the index of the link is `0`
         ((await this.getBlocks(graphApi)).length === 0 ? 0 : undefined),
@@ -469,7 +470,7 @@ export default class extends EntityModel {
 
     const link = contentLinks.find(
       (linkEntityModel) =>
-        linkEntityModel.getLinkData().leftOrder === currentPosition,
+        linkEntityModel.getLinkData().leftToRightOrder === currentPosition,
     );
 
     if (!link) {
@@ -480,7 +481,7 @@ export default class extends EntityModel {
 
     await link.updateOrder(graphApi, {
       linkOrder: {
-        leftOrder: newPosition,
+        leftToRightOrder: newPosition,
       },
       actorId,
     });
@@ -516,7 +517,7 @@ export default class extends EntityModel {
 
     const linkEntityModel = contentLinkEntityModels.find(
       (contentLinkEntityModel) =>
-        contentLinkEntityModel.getLinkData().leftOrder === position,
+        contentLinkEntityModel.getLinkData().leftToRightOrder === position,
     );
 
     if (!linkEntityModel) {

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/knowledge-shim.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/knowledge-shim.ts
@@ -71,7 +71,7 @@ export type CreateEntityMessageCallback = MessageCallback<
 export type UpdateEntityRequest = {
   entityId: EntityId;
   updatedProperties: PropertyObject;
-  leftOrder?: number;
+  leftToRightOrder?: number;
   rightToLeftOrder?: number;
 };
 

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/knowledge-shim.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/knowledge-shim.ts
@@ -72,7 +72,7 @@ export type UpdateEntityRequest = {
   entityId: EntityId;
   updatedProperties: PropertyObject;
   leftOrder?: number;
-  rightOrder?: number;
+  rightToLeftOrder?: number;
 };
 
 export type UpdateEntityMessageCallback = MessageCallback<

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/useBlockProtocolUpdateEntity.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/useBlockProtocolUpdateEntity.ts
@@ -45,13 +45,18 @@ export const useBlockProtocolUpdateEntity = (
         };
       }
 
-      const { entityId, updatedProperties, leftOrder, rightToLeftOrder } = data;
+      const {
+        entityId,
+        updatedProperties,
+        leftToRightOrder,
+        rightToLeftOrder,
+      } = data;
 
       const { data: updateEntityResponseData } = await updateFn({
         variables: {
           entityId,
           updatedProperties,
-          leftOrder,
+          leftToRightOrder,
           rightToLeftOrder,
         },
       });

--- a/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/useBlockProtocolUpdateEntity.ts
+++ b/packages/hash/frontend/src/components/hooks/blockProtocolFunctions/knowledge/useBlockProtocolUpdateEntity.ts
@@ -45,14 +45,14 @@ export const useBlockProtocolUpdateEntity = (
         };
       }
 
-      const { entityId, updatedProperties, leftOrder, rightOrder } = data;
+      const { entityId, updatedProperties, leftOrder, rightToLeftOrder } = data;
 
       const { data: updateEntityResponseData } = await updateFn({
         variables: {
           entityId,
           updatedProperties,
           leftOrder,
-          rightOrder,
+          rightToLeftOrder,
         },
       });
 

--- a/packages/hash/frontend/src/graphql/queries/knowledge/entity.queries.ts
+++ b/packages/hash/frontend/src/graphql/queries/knowledge/entity.queries.ts
@@ -78,14 +78,14 @@ export const updateEntityMutation = gql`
   mutation updateEntity(
     $entityId: EntityId!
     $updatedProperties: PropertyObject!
-    $leftOrder: Int
+    $leftToRightOrder: Int
     $rightToLeftOrder: Int
   ) {
     # This is a scalar, which has no selection.
     updateEntity(
       entityId: $entityId
       updatedProperties: $updatedProperties
-      leftOrder: $leftOrder
+      leftToRightOrder: $leftToRightOrder
       rightToLeftOrder: $rightToLeftOrder
     )
   }

--- a/packages/hash/frontend/src/graphql/queries/knowledge/entity.queries.ts
+++ b/packages/hash/frontend/src/graphql/queries/knowledge/entity.queries.ts
@@ -79,14 +79,14 @@ export const updateEntityMutation = gql`
     $entityId: EntityId!
     $updatedProperties: PropertyObject!
     $leftOrder: Int
-    $rightOrder: Int
+    $rightToLeftOrder: Int
   ) {
     # This is a scalar, which has no selection.
     updateEntity(
       entityId: $entityId
       updatedProperties: $updatedProperties
       leftOrder: $leftOrder
-      rightOrder: $rightOrder
+      rightToLeftOrder: $rightToLeftOrder
     )
   }
 `;

--- a/packages/hash/subgraph/src/types/element.ts
+++ b/packages/hash/subgraph/src/types/element.ts
@@ -50,7 +50,7 @@ export type PropertyObject = {
 
 export type LinkData = {
   leftOrder?: number;
-  rightOrder?: number;
+  rightToLeftOrder?: number;
   leftEntityId: EntityId;
   rightEntityId: EntityId;
 };

--- a/packages/hash/subgraph/src/types/element.ts
+++ b/packages/hash/subgraph/src/types/element.ts
@@ -49,7 +49,7 @@ export type PropertyObject = {
 };
 
 export type LinkData = {
-  leftOrder?: number;
+  leftToRightOrder?: number;
   rightToLeftOrder?: number;
   leftEntityId: EntityId;
   rightEntityId: EntityId;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Links have been designed with the hope of supporting bi-directional links in the future. As such, a link might need an order (list index) for both directions. We had called this `left_order` and `right_order` to avoid accidental implication of order with `source` and `target`. The choice of the order names was deemed somewhat confusing, and `left_to_right_order` and `right_to_left_order` seems to be more explicit, albeit slightly wordy.

This PR renames all occurrences (I believe). It involves changing the DB so the volume will need to be wiped in between runs.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201095311341924/1203401244553571/f) _(internal)_

## 🔍 What does this change?

See commits

## 📜 Does this require a change to the docs?

- At the moment these fields aren't captured in standalone docs, however doc comments and such should have been successfully updated as part of this.

## 🛡 What tests cover this?

Any tests (E2E, integration, unit) that interact with link entities.

## ❓ How to test this?

1.  Checkout the branch / view the deployment
1.  Test out the app as usual, noting features that depend on links.

