### PR TITLE
Create database structure for temporal versioning

### DIFF
--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -161,34 +161,6 @@ export const up = (pgm: MigrationBuilder): void => {
   );
 
   pgm.createTable(
-    "link_types",
-    {
-      version_id: {
-        type: "UUID",
-        primaryKey: true,
-        references: "version_ids",
-      },
-      schema: {
-        type: "JSONB",
-        notNull: true,
-      },
-      owned_by_id: {
-        type: "UUID",
-        notNull: true,
-        references: "accounts",
-      },
-      updated_by_id: {
-        type: "UUID",
-        notNull: true,
-        references: "accounts",
-      },
-    },
-    {
-      ifNotExists: true,
-    },
-  );
-
-  pgm.createTable(
     "property_type_property_type_references",
     {
       source_property_type_version_id: {
@@ -265,20 +237,7 @@ export const up = (pgm: MigrationBuilder): void => {
   );
 
   pgm.createTable(
-    "entity_uuids",
-    {
-      entity_uuid: {
-        type: "UUID",
-        primaryKey: true,
-      },
-    },
-    {
-      ifNotExists: true,
-    },
-  );
-
-  pgm.createTable(
-    "latest_entities",
+    "entity_ids",
     {
       owned_by_id: {
         type: "UUID",
@@ -287,13 +246,63 @@ export const up = (pgm: MigrationBuilder): void => {
       },
       entity_uuid: {
         type: "UUID",
-        references: "entity_uuids",
         notNull: true,
       },
-      version: {
-        type: "TIMESTAMP WITH TIME ZONE",
+      left_owned_by_id: {
+        type: "UUID",
+        notNull: false,
+      },
+      left_entity_uuid: {
+        type: "UUID",
+        notNull: false,
+      },
+      right_owned_by_id: {
+        type: "UUID",
+        notNull: false,
+      },
+      right_entity_uuid: {
+        type: "UUID",
+        notNull: false,
+      },
+    },
+    {
+      ifNotExists: true,
+    },
+  );
+
+  pgm.addConstraint("entity_ids", "entity_ids_primary_key", {
+    primaryKey: ["owned_by_id", "entity_uuid"],
+  });
+  pgm.addConstraint("entity_ids", "entity_ids_left_reference", {
+    foreignKeys: {
+      references: "entity_ids",
+      columns: ["left_owned_by_id", "left_entity_uuid"],
+    },
+  });
+  pgm.addConstraint("entity_ids", "entity_ids_right_reference", {
+    foreignKeys: {
+      references: "entity_ids",
+      columns: ["right_owned_by_id", "right_entity_uuid"],
+    },
+  });
+  pgm.addConstraint("entity_ids", "entity_ids_relation_constraint", {
+    check: `
+      left_entity_uuid IS NULL AND right_entity_uuid IS NULL AND left_owned_by_id IS NULL AND right_owned_by_id IS NULL
+    OR 
+      left_entity_uuid IS NOT NULL AND right_entity_uuid IS NOT NULL AND left_owned_by_id IS NOT NULL AND right_owned_by_id IS NOT NULL
+    `,
+  });
+
+  pgm.createTable(
+    "entity_editions",
+    {
+      entity_edition_id: {
+        type: "BIGINT",
+        primaryKey: true,
         notNull: true,
-        default: pgm.func("clock_timestamp()"),
+        sequenceGenerated: {
+          precedence: "ALWAYS",
+        },
       },
       entity_type_version_id: {
         type: "UUID",
@@ -304,33 +313,13 @@ export const up = (pgm: MigrationBuilder): void => {
         type: "JSONB",
         notNull: true,
       },
-      left_owned_by_id: {
-        type: "UUID",
-        notNull: false,
-        references: "accounts",
-      },
-      left_entity_uuid: {
-        type: "UUID",
-        notNull: false,
-        references: "entity_uuids",
-      },
-      right_owned_by_id: {
-        type: "UUID",
-        notNull: false,
-        references: "accounts",
-      },
-      right_entity_uuid: {
-        type: "UUID",
-        notNull: false,
-        references: "entity_uuids",
-      },
-      left_to_right_order: {
+      left_order: {
         // TODO: this is where we could do fractional indexing
         //  https://app.asana.com/0/1200211978612931/1202085856561975/f
         type: "integer",
         notNull: false,
       },
-      right_to_left_order: {
+      right_order: {
         // TODO: this is where we could do fractional indexing
         //  https://app.asana.com/0/1200211978612931/1202085856561975/f
         type: "integer",
@@ -340,139 +329,59 @@ export const up = (pgm: MigrationBuilder): void => {
         type: "UUID",
         notNull: true,
         references: "accounts",
-      },
-    },
-    {
-      ifNotExists: true,
-    },
-  );
-  // Only allow a single version of an entity in this table.
-  pgm.addConstraint("latest_entities", "latest_entities_primary_key", {
-    primaryKey: ["entity_uuid"],
-  });
-
-  pgm.addConstraint("latest_entities", "latest_entities_relation_constraint", {
-    check: `(
-      left_entity_uuid IS NULL AND left_owned_by_id IS NULL
-        AND right_entity_uuid IS NULL AND right_owned_by_id IS NULL
-    ) 
-    OR (
-      left_entity_uuid IS NOT NULL AND left_owned_by_id IS NOT NULL
-       AND right_entity_uuid IS NOT NULL AND right_owned_by_id IS NOT NULL
-    )`,
-  });
-
-  pgm.addConstraint(
-    "latest_entities",
-    "latest_entities_relation_order_constraint",
-    {
-      // Because of the "entities_relation_constraint", we can check any one of the required link columns
-      check: `(left_entity_uuid IS NOT NULL)
-            OR (left_to_right_order IS NULL AND right_to_left_order IS NULL)`,
-    },
-  );
-
-  pgm.createTable(
-    "entity_histories",
-    {
-      owned_by_id: {
-        type: "UUID",
-        notNull: true,
-        references: "accounts",
-      },
-      entity_uuid: {
-        type: "UUID",
-        references: "entity_uuids",
-        notNull: true,
-      },
-      version: {
-        type: "TIMESTAMP WITH TIME ZONE",
-        notNull: true,
-        default: pgm.func("clock_timestamp()"),
-      },
-      entity_type_version_id: {
-        type: "UUID",
-        notNull: true,
-        references: "entity_types",
-      },
-      properties: {
-        type: "JSONB",
-        notNull: true,
-      },
-      left_owned_by_id: {
-        type: "UUID",
-        notNull: false,
-        references: "accounts",
-      },
-      left_entity_uuid: {
-        type: "UUID",
-        notNull: false,
-        references: "entity_uuids",
-      },
-      right_owned_by_id: {
-        type: "UUID",
-        notNull: false,
-        references: "accounts",
-      },
-      right_entity_uuid: {
-        type: "UUID",
-        notNull: false,
-        references: "entity_uuids",
-      },
-      left_to_right_order: {
-        // TODO: this is where we could do fractional indexing
-        //  https://app.asana.com/0/1200211978612931/1202085856561975/f
-        type: "integer",
-        notNull: false,
-      },
-      right_to_left_order: {
-        // TODO: this is where we could do fractional indexing
-        //  https://app.asana.com/0/1200211978612931/1202085856561975/f
-        type: "integer",
-        notNull: false,
       },
       archived: {
-        // We may be able to reclaim some space here by using nullability.
-        type: "boolean",
+        type: "BOOLEAN",
         notNull: true,
-        default: "FALSE",
-      },
-      updated_by_id: {
-        type: "UUID",
-        notNull: true,
-        references: "accounts",
       },
     },
     {
       ifNotExists: true,
     },
   );
-  pgm.addConstraint("entity_histories", "entity_histories_primary_key", {
-    primaryKey: ["entity_uuid", "version"],
-  });
 
-  pgm.addConstraint(
-    "entity_histories",
-    "entity_histories_relation_constraint",
+  pgm.createTable(
+    "entity_versions",
     {
-      check: `(
-      left_entity_uuid IS NULL AND left_owned_by_id IS NULL
-        AND right_entity_uuid IS NULL AND right_owned_by_id IS NULL
-    ) 
-    OR (
-      left_entity_uuid IS NOT NULL AND left_owned_by_id IS NOT NULL
-       AND right_entity_uuid IS NOT NULL AND right_owned_by_id IS NOT NULL
-    )`,
+      owned_by_id: {
+        type: "UUID",
+        notNull: true,
+      },
+      entity_uuid: {
+        type: "UUID",
+        notNull: true,
+      },
+      entity_edition_id: {
+        type: "BIGINT",
+        notNull: true,
+        references: "entity_editions",
+      },
+      decision_time: {
+        type: "tstzrange",
+        notNull: true,
+      },
+      system_time: {
+        type: "tstzrange",
+        notNull: true,
+      },
+    },
+    {
+      ifNotExists: true,
     },
   );
 
+  pgm.addConstraint("entity_versions", "entity_versions_reference", {
+    foreignKeys: {
+      references: "entity_ids",
+      columns: ["owned_by_id", "entity_uuid"],
+    },
+  });
+
   pgm.addConstraint(
-    "entity_histories",
-    "entities_histories_relation_order_constraint",
+    "entity_versions",
+    "entity_versions_decision_time_validation",
     {
-      // Because of the "entities_histories_relation_constraint", we can check any one of the required link columns
-      check: `(left_entity_uuid IS NOT NULL)
-            OR (left_to_right_order IS NULL AND right_to_left_order IS NULL)`,
+      check: `lower(decision_time) <= lower(system_time)`,
     },
   );
 
@@ -480,29 +389,294 @@ export const up = (pgm: MigrationBuilder): void => {
   // The latest entities come first when querying the view.
   pgm.createView(
     "entities",
+    {},
+    `
+    SELECT
+      entity_versions.entity_edition_id,
+      entity_versions.owned_by_id,
+      entity_versions.entity_uuid,
+      entity_versions.decision_time,
+      entity_versions.system_time,
+      entity_editions.entity_type_version_id,
+      entity_editions.updated_by_id,
+      entity_editions.properties,
+      entity_editions.archived,
+      entity_ids.left_owned_by_id,
+      entity_ids.left_entity_uuid,
+      entity_editions.left_order,
+      entity_ids.right_owned_by_id,
+      entity_ids.right_entity_uuid,
+      entity_editions.right_order
+    FROM entity_versions
+    JOIN entity_editions ON entity_versions.entity_edition_id = entity_editions.entity_edition_id
+    JOIN entity_ids ON entity_versions.owned_by_id = entity_ids.owned_by_id AND entity_versions.entity_uuid = entity_ids.entity_uuid
+    `,
+  );
+
+  pgm.createFunction(
+    "create_entity",
+    [
+      {
+        name: "_owned_by_id",
+        type: "UUID",
+      },
+      {
+        name: "_entity_uuid",
+        type: "UUID",
+      },
+      {
+        name: "_decision_time",
+        type: "TIMESTAMP WITH TIME ZONE",
+      },
+      {
+        name: "_updated_by_id",
+        type: "UUID",
+      },
+      {
+        name: "_archived",
+        type: "BOOLEAN",
+      },
+      {
+        name: "_entity_type_version_id",
+        type: "UUID",
+      },
+      {
+        name: "_properties",
+        type: "JSONB",
+      },
+      {
+        name: "_left_owned_by_id",
+        type: "UUID",
+      },
+      {
+        name: "_left_entity_uuid",
+        type: "UUID",
+      },
+      {
+        name: "_right_owned_by_id",
+        type: "UUID",
+      },
+      {
+        name: "_right_entity_uuid",
+        type: "UUID",
+      },
+      {
+        name: "_left_order",
+        type: "INTEGER",
+      },
+      {
+        name: "_right_order",
+        type: "INTEGER",
+      },
+    ],
     {
-      columns: [
-        "owned_by_id",
-        "entity_uuid",
-        "version",
-        "latest_version",
-        "entity_type_version_id",
-        "properties",
-        "left_owned_by_id",
-        "left_entity_uuid",
-        "right_owned_by_id",
-        "right_entity_uuid",
-        "left_to_right_order",
-        "right_to_left_order",
-        "archived",
-        "updated_by_id",
-      ],
+      returns:
+        "TABLE (entity_edition_id BIGINT, decision_time tstzrange, system_time tstzrange)",
+      language: "plpgsql",
+      replace: true,
     },
     `
-    SELECT owned_by_id, entity_uuid, version, TRUE as latest_version, entity_type_version_id, properties, left_owned_by_id, left_entity_uuid, right_owned_by_id, right_entity_uuid, left_to_right_order, right_to_left_order, FALSE AS archived, updated_by_id FROM latest_entities
-    UNION ALL
-    SELECT owned_by_id, entity_uuid, version, FALSE as latest_version, entity_type_version_id, properties, left_owned_by_id, left_entity_uuid, right_owned_by_id, right_entity_uuid, left_to_right_order, right_to_left_order, archived, updated_by_id FROM entity_histories`,
+    DECLARE
+      _entity_edition_id BIGINT;
+    BEGIN
+      -- If the decision time is not specified, use the current time.
+      IF _decision_time IS NULL THEN _decision_time := now(); END IF;
+  
+      INSERT INTO entity_ids (
+        owned_by_id,
+        entity_uuid,
+        left_owned_by_id,
+        left_entity_uuid,
+        right_owned_by_id,
+        right_entity_uuid
+      ) VALUES (
+        _owned_by_id,
+        _entity_uuid,
+        _left_owned_by_id,
+        _left_entity_uuid,
+        _right_owned_by_id,
+        _right_entity_uuid
+      );
+
+      -- insert the data of the entity
+      INSERT INTO entity_editions (
+        updated_by_id,
+        archived,
+        entity_type_version_id,
+        properties,
+        left_order,
+        right_order
+      ) VALUES (
+        _updated_by_id,
+        _archived,
+        _entity_type_version_id,
+        _properties,
+        _left_order,
+        _right_order
+      ) RETURNING entity_editions.entity_edition_id INTO _entity_edition_id;
+
+      RETURN QUERY
+      INSERT INTO entity_versions (
+        owned_by_id,
+        entity_uuid,
+        entity_edition_id,
+        decision_time,
+        system_time
+      ) VALUES (
+        _owned_by_id,
+        _entity_uuid,
+        _entity_edition_id,
+        tstzrange(_decision_time, 'infinity'),
+        tstzrange(now(), 'infinity')
+      ) RETURNING entity_versions.entity_edition_id, entity_versions.decision_time, entity_versions.system_time;
+    END
+    `,
   );
+
+  pgm.createFunction(
+    "update_entity",
+    [
+      {
+        name: "_owned_by_id",
+        type: "UUID",
+      },
+      {
+        name: "_entity_uuid",
+        type: "UUID",
+      },
+      {
+        name: "_decision_time",
+        type: "TIMESTAMP WITH TIME ZONE",
+      },
+      {
+        name: "_updated_by_id",
+        type: "UUID",
+      },
+      {
+        name: "_archived",
+        type: "BOOLEAN",
+      },
+      {
+        name: "_entity_type_version_id",
+        type: "UUID",
+      },
+      {
+        name: "_properties",
+        type: "JSONB",
+      },
+      {
+        name: "_left_order",
+        type: "INTEGER",
+      },
+      {
+        name: "_right_order",
+        type: "INTEGER",
+      },
+    ],
+    {
+      returns:
+        "TABLE (entity_edition_id BIGINT, decision_time tstzrange, system_time tstzrange)",
+      language: "plpgsql",
+      replace: true,
+    },
+    `
+    DECLARE
+      _new_entity_edition_id BIGINT;
+    BEGIN
+      -- If the decision time is not specified, use the current time.
+      IF _decision_time IS NULL THEN _decision_time := now(); END IF;
+  
+      -- ensure, that the row, we are going to update, is locked
+      -- this is required as \`UPDATE\` will not reevaluate the \`WHERE\` clause
+      PERFORM FROM entity_versions
+      WHERE entity_versions.owned_by_id = _owned_by_id
+        AND entity_versions.entity_uuid = _entity_uuid
+        AND entity_versions.decision_time @> _decision_time
+        AND entity_versions.system_time @> now()
+      FOR UPDATE;
+
+      INSERT INTO entity_editions (
+        updated_by_id,
+        archived,
+        entity_type_version_id,
+        properties,
+        left_order,
+        right_order
+      ) VALUES (
+        _updated_by_id,
+        _archived,
+        _entity_type_version_id,
+        _properties,
+        _left_order,
+        _right_order
+      )
+      RETURNING entity_editions.entity_edition_id INTO _new_entity_edition_id;
+  
+      -- It's not possible to re-use the query from the \`PERFORM\` statement above, as the \`WHERE\` clause may select
+      -- a different row.
+      RETURN QUERY
+      UPDATE entity_versions
+      SET decision_time = tstzrange(_decision_time, upper(entity_versions.decision_time)),
+          system_time = tstzrange(now(), 'infinity'),
+          entity_edition_id = _new_entity_edition_id
+      WHERE entity_versions.owned_by_id = _owned_by_id
+        AND entity_versions.entity_uuid = _entity_uuid
+        AND entity_versions.decision_time @> _decision_time
+        AND entity_versions.system_time @> now()
+      RETURNING entity_versions.entity_edition_id, entity_versions.decision_time, entity_versions.system_time;
+    END
+    `,
+  );
+
+  pgm.createFunction(
+    "update_entity_version_trigger",
+    [],
+    {
+      returns: "TRIGGER",
+      language: "plpgsql",
+    },
+    `
+    BEGIN
+      -- Insert a new version with the old decision time and the system time up until now
+      INSERT INTO entity_versions (
+        owned_by_id,
+        entity_uuid,
+        entity_edition_id,
+        decision_time,
+        system_time
+      ) VALUES (
+        OLD.owned_by_id,
+        OLD.entity_uuid,
+        OLD.entity_edition_id,
+        OLD.decision_time,
+        tstzrange(lower(OLD.system_time),lower(NEW.system_time))
+      );
+
+      -- Insert a new version with the previous decision time until the new decision time
+      INSERT INTO entity_versions (
+        owned_by_id,
+        entity_uuid,
+        entity_edition_id,
+        decision_time,
+        system_time
+      ) VALUES (
+        OLD.owned_by_id,
+        OLD.entity_uuid,
+        OLD.entity_edition_id,
+        tstzrange(lower(OLD.decision_time), lower(NEW.decision_time)),
+        NEW.system_time
+      );
+
+      RETURN NEW;
+    END`,
+  );
+
+  pgm.createTrigger("entity_versions", "update_entity_version_trigger", {
+    when: "BEFORE",
+    operation: "UPDATE",
+    level: "ROW",
+    function: "update_entity_version_trigger",
+  });
 };
 
 // A down migration would cause data loss.
@@ -516,9 +690,17 @@ DROP TABLE IF EXISTS property_type_data_type_references CASCADE;
 DROP TABLE IF EXISTS entity_types CASCADE;
 DROP TABLE IF EXISTS entity_type_property_type_references CASCADE;
 DROP TABLE IF EXISTS entity_type_entity_type_references CASCADE;
-DROP TABLE IF EXISTS entity_uuids CASCADE;
-DROP TABLE IF EXISTS entities CASCADE;
-DROP TABLE IF EXISTS entity_histories CASCADE;
+DROP TABLE IF EXISTS entity_ids CASCADE;
+DROP TABLE IF EXISTS entity_editions CASCADE;
+DROP TABLE IF EXISTS entity_versions CASCADE;
 DROP TABLE IF EXISTS accounts CASCADE;
-DROP TABLE IF EXISTS ids CASCADE;
+DROP TABLE IF EXISTS base_uris CASCADE;
+DROP TABLE IF EXISTS type_ids CASCADE;
+DROP TABLE IF EXISTS version_ids CASCADE;
 */
+
+/* Drop all functions:
+DROP FUNCTION IF EXISTS update_entity_version_trigger;
+DROP FUNCTION IF EXISTS update_entity;
+DROP FUNCTION IF EXISTS create_entity;
+ */

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -4,6 +4,8 @@ import { stripNewLines } from "../util";
 export const shorthands: ColumnDefinitions | undefined = undefined;
 
 export const up = (pgm: MigrationBuilder): void => {
+  pgm.createExtension("btree_gist", { ifNotExists: true });
+
   pgm.createTable(
     "accounts",
     {
@@ -375,6 +377,12 @@ export const up = (pgm: MigrationBuilder): void => {
       references: "entity_ids",
       columns: ["owned_by_id", "entity_uuid"],
     },
+  });
+
+  pgm.addConstraint("entity_versions", "entity_versions_overlapping", {
+    exclude:
+      "USING gist (entity_uuid WITH =, decision_time WITH &&, system_time WITH &&)",
+    deferrable: true,
   });
 
   pgm.addConstraint(

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -416,7 +416,7 @@ export const up = (pgm: MigrationBuilder): void => {
     [
       {
         name: "_owned_by_id",
-        type: "UUID NOT NULL",
+        type: "UUID",
       },
       {
         name: "_entity_uuid",

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -313,13 +313,13 @@ export const up = (pgm: MigrationBuilder): void => {
         type: "JSONB",
         notNull: true,
       },
-      left_order: {
+      left_to_right_order: {
         // TODO: this is where we could do fractional indexing
         //  https://app.asana.com/0/1200211978612931/1202085856561975/f
         type: "integer",
         notNull: false,
       },
-      right_order: {
+      right_to_left_order: {
         // TODO: this is where we could do fractional indexing
         //  https://app.asana.com/0/1200211978612931/1202085856561975/f
         type: "integer",
@@ -403,10 +403,10 @@ export const up = (pgm: MigrationBuilder): void => {
       entity_editions.archived,
       entity_ids.left_owned_by_id,
       entity_ids.left_entity_uuid,
-      entity_editions.left_order,
+      entity_editions.left_to_right_order,
       entity_ids.right_owned_by_id,
       entity_ids.right_entity_uuid,
-      entity_editions.right_order
+      entity_editions.right_to_left_order
     FROM entity_versions
     JOIN entity_editions ON entity_versions.entity_edition_id = entity_editions.entity_edition_id
     JOIN entity_ids ON entity_versions.owned_by_id = entity_ids.owned_by_id AND entity_versions.entity_uuid = entity_ids.entity_uuid
@@ -461,11 +461,11 @@ export const up = (pgm: MigrationBuilder): void => {
         type: "UUID",
       },
       {
-        name: "_left_order",
+        name: "_left_to_right_order",
         type: "INTEGER",
       },
       {
-        name: "_right_order",
+        name: "_right_to_left_order",
         type: "INTEGER",
       },
     ],
@@ -504,15 +504,15 @@ export const up = (pgm: MigrationBuilder): void => {
         archived,
         entity_type_version_id,
         properties,
-        left_order,
-        right_order
+        left_to_right_order,
+        right_to_left_order
       ) VALUES (
         _updated_by_id,
         _archived,
         _entity_type_version_id,
         _properties,
-        _left_order,
-        _right_order
+        _left_to_right_order,
+        _right_to_left_order
       ) RETURNING entity_editions.entity_edition_id INTO _entity_edition_id;
 
       RETURN QUERY
@@ -565,11 +565,11 @@ export const up = (pgm: MigrationBuilder): void => {
         type: "JSONB",
       },
       {
-        name: "_left_order",
+        name: "_left_to_right_order",
         type: "INTEGER",
       },
       {
-        name: "_right_order",
+        name: "_right_to_left_order",
         type: "INTEGER",
       },
     ],
@@ -600,15 +600,15 @@ export const up = (pgm: MigrationBuilder): void => {
         archived,
         entity_type_version_id,
         properties,
-        left_order,
-        right_order
+        left_to_right_order,
+        right_to_left_order
       ) VALUES (
         _updated_by_id,
         _archived,
         _entity_type_version_id,
         _properties,
-        _left_order,
-        _right_order
+        _left_to_right_order,
+        _right_to_left_order
       )
       RETURNING entity_editions.entity_edition_id INTO _new_entity_edition_id;
   

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -385,8 +385,6 @@ export const up = (pgm: MigrationBuilder): void => {
     },
   );
 
-  // This view contains the union of both latest and historic table.
-  // The latest entities come first when querying the view.
   pgm.createView(
     "entities",
     {},
@@ -418,7 +416,7 @@ export const up = (pgm: MigrationBuilder): void => {
     [
       {
         name: "_owned_by_id",
-        type: "UUID",
+        type: "UUID NOT NULL",
       },
       {
         name: "_entity_uuid",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Initial PR to implement temporal versioning.
This adjusts the database to store entities in a bi-temporal table: decision-time and system-time.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203363157432081/1203444301722131/f) _(internal)_

## 🔍 What does this change?

- Split the `entities` table into three: `entity_ids`, `entity_versions`, and `entity_editions`
    - `entity_ids` holds the identifier for an entity and parameters, which must not change over the lifetime of an entity (left/right entity id for links)
    - `entity_editions` holds the data of the entities, uniquely identified by `entity_edition_id`
    - `entity_versions` holds the bi-temporal logic and points to the entity editions
- The `entities` view were adjusted to join the three table from above
- Two functions were created to appropriately handle the creation and updating of an entity
- Drive-by: Remove old, unused `link_types` table

## ⚠️ Known issues

Dealing with `pgm` is pretty hard as their own syntax is required. It's nice to have autocompletion for the functions, but almost every IDE also has auto-completion for raw SQL. We should switch to a migration tool, which is supporting raw `*.sql` files at one point.