### PR TITLE
Temporal versioning: Support updating of entities

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -1836,6 +1836,12 @@ export interface UpdateEntityRequest {
   actorId: string;
   /**
    *
+   * @type {boolean}
+   * @memberof UpdateEntityRequest
+   */
+  archived?: boolean;
+  /**
+   *
    * @type {string}
    * @memberof UpdateEntityRequest
    */
@@ -1865,6 +1871,12 @@ export interface UpdateEntityRequestAllOf {
    * @memberof UpdateEntityRequestAllOf
    */
   actorId: string;
+  /**
+   *
+   * @type {boolean}
+   * @memberof UpdateEntityRequestAllOf
+   */
+  archived?: boolean;
   /**
    *
    * @type {string}
@@ -2839,6 +2851,7 @@ export const EntityApiAxiosParamCreator = function (
      *
      * @param {ArchiveEntityRequest} archiveEntityRequest
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     archiveEntity: async (
@@ -3144,6 +3157,7 @@ export const EntityApiFp = function (configuration?: Configuration) {
      *
      * @param {ArchiveEntityRequest} archiveEntityRequest
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     async archiveEntity(
@@ -3293,6 +3307,7 @@ export const EntityApiFactory = function (
      *
      * @param {ArchiveEntityRequest} archiveEntityRequest
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     archiveEntity(
@@ -3379,6 +3394,7 @@ export interface EntityApiInterface {
    *
    * @param {ArchiveEntityRequest} archiveEntityRequest
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof EntityApiInterface
    */
@@ -3455,6 +3471,7 @@ export class EntityApi extends BaseAPI implements EntityApiInterface {
    *
    * @param {ArchiveEntityRequest} archiveEntityRequest
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof EntityApi
    */
@@ -4171,6 +4188,7 @@ export const GraphApiAxiosParamCreator = function (
      *
      * @param {ArchiveEntityRequest} archiveEntityRequest
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     archiveEntity: async (
@@ -5240,6 +5258,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
      *
      * @param {ArchiveEntityRequest} archiveEntityRequest
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     async archiveEntity(
@@ -5785,6 +5804,7 @@ export const GraphApiFactory = function (
      *
      * @param {ArchiveEntityRequest} archiveEntityRequest
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     archiveEntity(
@@ -6085,6 +6105,7 @@ export interface GraphApiInterface {
    *
    * @param {ArchiveEntityRequest} archiveEntityRequest
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof GraphApiInterface
    */
@@ -6343,6 +6364,7 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
    *
    * @param {ArchiveEntityRequest} archiveEntityRequest
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof GraphApi
    */

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -377,6 +377,7 @@ struct UpdateEntityRequest {
     responses(
         (status = 200, content_type = "application/json", description = "The metadata of the updated entity", body = EntityMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
+        (status = 423, content_type = "text/plain", description = "The entity that should be updated was unexpectedly updated at the same time"),
 
         (status = 404, description = "Entity ID or Entity Type URI was not found"),
         (status = 500, description = "Store error occurred"),

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -107,12 +107,12 @@ impl EntityLinkOrder {
     }
 
     #[must_use]
-    pub const fn left(&self) -> Option<LinkOrder> {
+    pub const fn left_to_right(&self) -> Option<LinkOrder> {
         self.left_to_right_order
     }
 
     #[must_use]
-    pub const fn right(&self) -> Option<LinkOrder> {
+    pub const fn right_to_left(&self) -> Option<LinkOrder> {
         self.right_to_left_order
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/error.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/error.rs
@@ -80,7 +80,7 @@ pub struct RaceConditionOnUpdate;
 
 impl fmt::Display for RaceConditionOnUpdate {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.write_str("A race condition happened when updating the entity")
+        fmt.write_str("The entity that should be updated was unexpectedly updated at the same time")
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/error.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/error.rs
@@ -76,6 +76,18 @@ impl Context for EntityDoesNotExist {}
 
 #[derive(Debug)]
 #[must_use]
+pub struct RaceConditionOnUpdate;
+
+impl fmt::Display for RaceConditionOnUpdate {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.write_str("A race condition happened when updating the entity")
+    }
+}
+
+impl Context for RaceConditionOnUpdate {}
+
+#[derive(Debug)]
+#[must_use]
 pub struct VersionedUriAlreadyExists;
 
 impl fmt::Display for VersionedUriAlreadyExists {

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -324,6 +324,7 @@ pub trait EntityStore: crud::Read<Entity> {
     /// - if the [`EntityProperties`] is not valid with respect to the specified [`EntityType`]
     /// - if the account referred to by `owned_by_id` does not exist
     /// - if an [`EntityUuid`] was supplied and already exists in the store
+    #[expect(clippy::too_many_arguments)]
     async fn create_entity(
         &mut self,
         owned_by_id: OwnedById,
@@ -384,12 +385,15 @@ pub trait EntityStore: crud::Read<Entity> {
     /// - if the [`EntityType`] doesn't exist
     /// - if the [`Entity`] is not valid with respect to its [`EntityType`]
     /// - if the account referred to by `actor_id` does not exist
+    #[expect(clippy::too_many_arguments)]
     async fn update_entity(
         &mut self,
         entity_id: EntityId,
-        properties: EntityProperties,
+        decision_time: Option<Timestamp>,
+        updated_by_id: UpdatedById,
+        archived: bool,
         entity_type_id: VersionedUri,
-        actor_id: UpdatedById,
-        order: EntityLinkOrder,
+        properties: EntityProperties,
+        link_order: EntityLinkOrder,
     ) -> Result<EntityMetadata, UpdateError>;
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -630,7 +630,10 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         if transaction
             .as_client()
             .query_opt(
-                "SELECT 1 FROM entity_ids WHERE owned_by_id = $1 AND entity_uuid = $2;",
+                r#"
+                 SELECT EXISTS (
+                    SELECT 1 FROM entity_ids WHERE owned_by_id = $1 AND entity_uuid = $2
+                 );"#,
                 &[&entity_id.owned_by_id(), &entity_id.entity_uuid()],
             )
             .await

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -26,12 +26,7 @@ use uuid::Uuid;
 use self::context::OntologyRecord;
 pub use self::pool::{AsClient, PostgresStorePool};
 use crate::{
-    identifier::{
-        account::AccountId,
-        knowledge::{EntityEditionId, EntityId},
-        ontology::OntologyTypeEditionId,
-    },
-    knowledge::{EntityMetadata, EntityProperties, EntityUuid, LinkData},
+    identifier::{account::AccountId, knowledge::EntityEditionId, ontology::OntologyTypeEditionId},
     ontology::OntologyElementMetadata,
     provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
@@ -173,29 +168,6 @@ where
             .change_context(QueryError)
             .attach_printable_lazy(|| uri.clone())?
             .get(0))
-    }
-
-    /// Inserts the specified [`EntityUuid`] into the database.
-    ///
-    /// # Errors
-    ///
-    /// - if inserting the [`EntityUuid`] failed.
-    async fn insert_entity_uuid(&self, entity_uuid: EntityUuid) -> Result<(), InsertionError> {
-        self.as_client()
-            .query_one(
-                r#"
-                    INSERT INTO entity_uuids (entity_uuid)
-                    VALUES ($1)
-                    RETURNING entity_uuid;
-                "#,
-                &[&entity_uuid.as_uuid()],
-            )
-            .await
-            .into_report()
-            .change_context(InsertionError)
-            .attach_printable(entity_uuid)?;
-
-        Ok(())
     }
 
     /// Inserts the specified [`VersionedUri`] into the database.

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -472,7 +472,7 @@ Accept: application/json
 
 {
  "actorId": "{{account_id}}",
- "entityId": "{{person_a_entity_id}}",
+ "entityId": "f2d1062c-b774-42e5-bfb9-be6344bc9977%df572e43-3b3b-4d8e-b661-a572f034688d",
  "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/2",
  "properties": {
    "http://localhost:3000/@alice/types/property-type/name/": "Alice Allison"

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -472,7 +472,7 @@ Accept: application/json
 
 {
  "actorId": "{{account_id}}",
- "entityId": "f2d1062c-b774-42e5-bfb9-be6344bc9977%df572e43-3b3b-4d8e-b661-a572f034688d",
+ "entityId": "df572e43-3b3b-4d8e-b661-a572f034688d%f2d1062c-b774-42e5-bfb9-be6344bc9977",
  "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/2",
  "properties": {
    "http://localhost:3000/@alice/types/property-type/name/": "Alice Allison"

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -472,7 +472,7 @@ Accept: application/json
 
 {
  "actorId": "{{account_id}}",
- "entityId": "df572e43-3b3b-4d8e-b661-a572f034688d%f2d1062c-b774-42e5-bfb9-be6344bc9977",
+ "entityId": "{{person_a_entity_id}}",
  "entityTypeId": "http://localhost:3000/@alice/types/entity-type/person/v/2",
  "properties": {
    "http://localhost:3000/@alice/types/property-type/name/": "Alice Allison"

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -609,8 +609,6 @@ export const up = (pgm: MigrationBuilder): void => {
       )
       RETURNING entity_editions.entity_edition_id INTO _new_entity_edition_id;
   
-      -- It's not possible to re-use the query from the \`PERFORM\` statement above, as the \`WHERE\` clause may select
-      -- a different row.
       RETURN QUERY
       UPDATE entity_versions
       SET decision_time = tstzrange(_decision_time, upper(entity_versions.decision_time)),

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -485,7 +485,6 @@ export const up = (pgm: MigrationBuilder): void => {
     DECLARE
       _entity_edition_id BIGINT;
     BEGIN
-      -- If the decision time is not specified, use the current time.
       IF _decision_time IS NULL THEN _decision_time := now(); END IF;
   
       INSERT INTO entity_ids (
@@ -589,7 +588,6 @@ export const up = (pgm: MigrationBuilder): void => {
     DECLARE
       _new_entity_edition_id BIGINT;
     BEGIN
-      -- If the decision time is not specified, use the current time.
       IF _decision_time IS NULL THEN _decision_time := now(); END IF;
 
       INSERT INTO entity_editions (


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Similar to #1604, this PR uses the `update_entity` method in SQL to update an entity.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203363157432081/1203464975244303/f) _(internal)_

## 🚫 Blocked by

- #1604 

## 🔍 What does this change?

- Use the SQL function `update_entity` to ... update an entity 👁️ 👁️ 
- Remove unused error structs
- Fallback to get-entity + update entity for archiving. 

## ⚠️ Known issues

The fallback in the `/entities/archive` endpoint will result in data races if the same entity is updated at the same time, but I don't consider this as an issue as I'm going to remove this function as part of [this Asana task](https://app.asana.com/0/0/1203444301722133/f) _(internal)_ and the chance, that this will happen is very very unlikely. If it would happen, there would still be an error.
