### PR TITLE
Add `--report-unused-disable-directives` to `lint:eslint`

### DIFF
--- a/apps/hashdotai/package.json
+++ b/apps/hashdotai/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "exe": "ts-node --transpile-only",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/hashdotdev/package.json
+++ b/apps/hashdotdev/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "dev": "next dev",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "start": "next start"
   },

--- a/blocks/calculation/package.json
+++ b/blocks/calculation/package.json
@@ -17,7 +17,7 @@
     "build": "block-scripts build",
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "serve": "block-scripts serve"
   },

--- a/blocks/callout/package.json
+++ b/blocks/callout/package.json
@@ -14,7 +14,7 @@
     "build": "block-scripts build",
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "serve": "block-scripts serve"
   },

--- a/blocks/chart/package.json
+++ b/blocks/chart/package.json
@@ -12,7 +12,7 @@
     "build": "block-scripts build",
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "serve": "block-scripts serve"
   },

--- a/blocks/code/package.json
+++ b/blocks/code/package.json
@@ -14,7 +14,7 @@
     "build": "block-scripts build",
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "serve": "block-scripts serve"
   },

--- a/blocks/countdown/package.json
+++ b/blocks/countdown/package.json
@@ -17,7 +17,7 @@
     "build": "block-scripts build",
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "serve": "block-scripts serve"
   },

--- a/blocks/divider/package.json
+++ b/blocks/divider/package.json
@@ -14,7 +14,7 @@
     "build": "block-scripts build",
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "serve": "block-scripts serve"
   },

--- a/blocks/drawing/package.json
+++ b/blocks/drawing/package.json
@@ -17,7 +17,7 @@
     "build": "block-scripts build",
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "serve": "block-scripts serve"
   },

--- a/blocks/embed/package.json
+++ b/blocks/embed/package.json
@@ -14,7 +14,7 @@
     "build": "block-scripts build",
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "serve": "block-scripts serve"
   },

--- a/blocks/github-pr-overview/package.json
+++ b/blocks/github-pr-overview/package.json
@@ -19,7 +19,7 @@
     "build": "block-scripts build",
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "serve": "block-scripts serve"
   },

--- a/blocks/header/package.json
+++ b/blocks/header/package.json
@@ -14,7 +14,7 @@
     "build": "block-scripts build",
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "serve": "block-scripts serve"
   },

--- a/blocks/image/package.json
+++ b/blocks/image/package.json
@@ -14,7 +14,7 @@
     "build": "block-scripts build",
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "serve": "block-scripts serve"
   },

--- a/blocks/paragraph/package.json
+++ b/blocks/paragraph/package.json
@@ -14,7 +14,7 @@
     "build": "block-scripts build",
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "serve": "block-scripts serve"
   },

--- a/blocks/person/package.json
+++ b/blocks/person/package.json
@@ -14,7 +14,7 @@
     "build": "block-scripts build",
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "serve": "block-scripts serve"
   },

--- a/blocks/shuffle/package.json
+++ b/blocks/shuffle/package.json
@@ -17,7 +17,7 @@
     "build": "node_modules/.bin/block-scripts build",
     "dev": "node_modules/.bin/block-scripts dev",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "serve": "node_modules/.bin/block-scripts serve"
   },

--- a/blocks/stopwatch/package.json
+++ b/blocks/stopwatch/package.json
@@ -12,7 +12,7 @@
     "build": "block-scripts build",
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "serve": "block-scripts serve"
   },

--- a/blocks/table/package.json
+++ b/blocks/table/package.json
@@ -14,7 +14,7 @@
     "build": "block-scripts build",
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "serve": "block-scripts serve"
   },

--- a/blocks/timer/package.json
+++ b/blocks/timer/package.json
@@ -12,7 +12,7 @@
     "build": "block-scripts build",
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "serve": "block-scripts serve"
   },

--- a/blocks/toggle-item/package.json
+++ b/blocks/toggle-item/package.json
@@ -12,7 +12,7 @@
     "build": "block-scripts build",
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "serve": "block-scripts serve"
   },

--- a/blocks/video/package.json
+++ b/blocks/video/package.json
@@ -14,7 +14,7 @@
     "build": "block-scripts build",
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "serve": "block-scripts serve"
   },

--- a/libs/javascript/@local/eslint-config/package.json
+++ b/libs/javascript/@local/eslint-config/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint ."
+    "lint:eslint": "eslint --report-unused-disable-directives ."
   },
   "dependencies": {
     "@babel/eslint-parser": "7.19.1",

--- a/packages/graph/clients/typescript/package.json
+++ b/packages/graph/clients/typescript/package.json
@@ -7,7 +7,7 @@
   "main": "./index.ts",
   "scripts": {
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint ."
+    "lint:eslint": "eslint --report-unused-disable-directives ."
   },
   "dependencies": {
     "axios": "0.27.2"

--- a/packages/graph/clients/typescript/package.json
+++ b/packages/graph/clients/typescript/package.json
@@ -7,7 +7,7 @@
   "main": "./index.ts",
   "scripts": {
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint --report-unused-disable-directives ."
+    "lint:eslint": "eslint ."
   },
   "dependencies": {
     "axios": "0.27.2"

--- a/packages/graph/migrations/package.json
+++ b/packages/graph/migrations/package.json
@@ -8,7 +8,7 @@
     "fix:eslint": "eslint --fix .",
     "graph:migrate": "ts-node node_modules/.bin/node-pg-migrate -d HASH_GRAPH_PG_MIGRATION_URL -f ./postgres/migration-config.json",
     "graph:recreate-db": "ts-node postgres/scripts/recreate-graph-db.ts",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/hash/api/package.json
+++ b/packages/hash/api/package.json
@@ -8,7 +8,7 @@
     "codegen": "rimraf './src/**/*.gen.*'; graphql-codegen --config codegen.yml",
     "dev": "node --max-old-space-size=2048 ./node_modules/.bin/ts-node-dev --respawn --transpile-only ./src/index.ts",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "start": "cross-env NODE_ENV=production node --max-old-space-size=2048 ./node_modules/.bin/ts-node --transpile-only ./src/index.ts",
     "test": "jest"

--- a/packages/hash/backend-utils/package.json
+++ b/packages/hash/backend-utils/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "test": "jest"
   },

--- a/packages/hash/design-system/package.json
+++ b/packages/hash/design-system/package.json
@@ -8,7 +8,7 @@
   "types": "./src/ui.ts",
   "scripts": {
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "test": "jest"
   },

--- a/packages/hash/frontend/package.json
+++ b/packages/hash/frontend/package.json
@@ -9,7 +9,7 @@
     "codegen": "rimraf './src/**/*.gen.*'; graphql-codegen --config codegen.yml",
     "dev": "next dev",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "start": "next start",
     "test": "jest"

--- a/packages/hash/integration/package.json
+++ b/packages/hash/integration/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "codegen": "rimraf './src/**/*.gen.*'; graphql-codegen --config codegen.yml",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "test": "jest --runInBand"
   },

--- a/packages/hash/playwright/package.json
+++ b/packages/hash/playwright/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "test": "playwright test page-readonly-mode --project chromium"
   },

--- a/packages/hash/realtime/package.json
+++ b/packages/hash/realtime/package.json
@@ -8,7 +8,7 @@
     "clear-redis": "ts-node ./src/scripts/clear-redis.ts",
     "dev": "node --max-old-space-size=2048 ./node_modules/.bin/ts-node-dev --respawn --transpile-only ./src/index.ts",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "start": "cross-env NODE_ENV=production node --max-old-space-size=2048 ./node_modules/.bin/ts-node --transpile-only ./src/index.ts"
   },

--- a/packages/hash/search-loader/package.json
+++ b/packages/hash/search-loader/package.json
@@ -8,7 +8,7 @@
     "clear-opensearch": "yarn ts-node ./src/scripts/clear-opensearch.ts",
     "dev": "echo 'Opensearch currently disabled'",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "start": "cross-env NODE_ENV=production node --max-old-space-size=2048 ./node_modules/.bin/ts-node --transpile-only ./src/index.ts"
   },

--- a/packages/hash/shared/package.json
+++ b/packages/hash/shared/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "codegen": "rimraf './src/**/*.gen.*'; graphql-codegen --config codegen.yml",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "test": "jest"
   },

--- a/packages/hash/subgraph/package.json
+++ b/packages/hash/subgraph/package.json
@@ -5,7 +5,7 @@
   "types": "./src/index.ts",
   "scripts": {
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "test": "jest"
   },

--- a/packages/hash/task-executor/package.json
+++ b/packages/hash/task-executor/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "start": "nodemon ./src/index.ts --transpile-only"
   },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR makes sure that `yarn lint:eslint` does not exits with 0 if there are unused ESLint disable comments left in the codebase. These comments should be automatically removed on save because we have `reportUnusedDisableDirectives: true`  [in our base ESLint config](https://github.com/blockprotocol/blockprotocol/blob/e5a1e7df730596b0e93e420703ca70cdee314c58/packages/%40local/eslint-config/index.js#L5). However, when we do bulk-edits, unused directives may remain as warnings and not fail the CI.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203363157432081/1203452982053233/f) (internal)
- https://github.com/blockprotocol/blockprotocol/pull/812 
- [Docs](https://eslint.org/docs/latest/user-guide/command-line-interface#--report-unused-disable-directives)
<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

## ⚠️ Known issues

- I had to remove `--report-unused-disable-directives` from `packages/graph/clients/typescript/package.json`. This package contains auto-generated files like [`index.ts`](https://github.com/hashintel/hash/blob/bd03642e06ace7a5dc53cd0907528da82f6b8d7c/packages/graph/clients/typescript/index.ts) because of which we need to make an exception. Local `.eslintrc.cjs` [is already aware](https://github.com/hashintel/hash/blob/147c277740cfd86abc9254d8f6eaef966c7019ed/packages/graph/clients/typescript/.eslintrc.cjs#L8) of this edge case, but unfortunately this config property is not yet synced with the CLI arg. Hope this [can be fixed upstream](https://github.com/eslint/eslint/issues/15466#issuecomment-1339837916) via an RFC + PR.

## 🐾 Next steps

If there is support for ``reportUnusedDisableDirectives: "error"`` [upstream](https://github.com/eslint/eslint/issues/15466#issuecomment-1339759506), we can remove the CLI option.

## 🛡 What tests cover this?

I tested the option manually by adding `// eslint-disable-next-line` in a random place. `yarn fix:eslint` worked equally with and without the CLI option so I only added it for `lint:eslint`.
