### PR TITLE
Remove validateVersionedUri from json type middleware

### DIFF
--- a/packages/hash/frontend/src/middleware/return-types-as-json/generate-query-args.ts
+++ b/packages/hash/frontend/src/middleware/return-types-as-json/generate-query-args.ts
@@ -24,7 +24,7 @@ const queryStringFromNode = (node: DocumentNode) => {
 
 const zeroDepth = { outgoing: 0 };
 
-type OntologyType = "data" | "entity" | "property";
+type OntologyType = "data-type" | "entity-type" | "property-type";
 
 export const generateQueryArgs = (
   versionedUri: VersionedUri,
@@ -37,7 +37,7 @@ export const generateQueryArgs = (
     | GetPropertyTypeQueryVariables;
 } => {
   switch (ontologyType) {
-    case "data":
+    case "data-type":
       return {
         query: queryStringFromNode(getDataTypeQuery),
         variables: {
@@ -45,7 +45,7 @@ export const generateQueryArgs = (
           constrainsValuesOn: zeroDepth,
         },
       };
-    case "entity":
+    case "entity-type":
       return {
         query: queryStringFromNode(getEntityTypeQuery),
         variables: {
@@ -56,7 +56,7 @@ export const generateQueryArgs = (
           constrainsValuesOn: zeroDepth,
         },
       };
-    case "property":
+    case "property-type":
       return {
         query: queryStringFromNode(getPropertyTypeQuery),
         variables: {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

I introduced middleware in #1612 without realising that the [NextJS Edge runtime](https://nextjs.org/docs/api-reference/edge-runtime) does not support how it uses WASM. 

While there are ways around this (e.g. using the `experimental-edge`), it seems simplest just to replace the one function requiring WASM with something local.

This also makes a driveby change [suggested](https://github.com/hashintel/hash/pull/1612#discussion_r1043182381) in that PR. 

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Check that the requests work as they should

