### PR TITLE
Temporal versioning: Support selecting of entities

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -164,7 +164,7 @@ impl LinkData {
 }
 
 /// The metadata of an [`Entity`] record.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
 // TODO: deny_unknown_fields on other structs
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct EntityMetadata {

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
@@ -45,7 +45,7 @@ pub enum EntityQueryPath<'q> {
     /// [`Entity`]: crate::knowledge::Entity
     OwnedById,
     // TODO: DOC: https://app.asana.com/0/0/1203505325130325/f
-    EditionId,
+    RecordId,
     // TODO: DOC: https://app.asana.com/0/0/1203505325130325/f
     DecisionTime,
     // TODO: DOC: https://app.asana.com/0/0/1203505325130325/f
@@ -238,7 +238,7 @@ impl fmt::Display for EntityQueryPath<'_> {
             Self::Uuid => fmt.write_str("uuid"),
             Self::OwnedById => fmt.write_str("ownedById"),
             Self::UpdatedById => fmt.write_str("updatedById"),
-            Self::EditionId => fmt.write_str("editionId"),
+            Self::RecordId => fmt.write_str("editionId"),
             Self::DecisionTime => fmt.write_str("decisionTime"),
             Self::TransactionTime => fmt.write_str("transactionTime"),
             Self::LowerTransactionTime => fmt.write_str("transactionTimeFrom"),
@@ -260,14 +260,13 @@ impl RecordPath for EntityQueryPath<'_> {
     fn expected_type(&self) -> ParameterType {
         match self {
             Self::Uuid | Self::OwnedById | Self::UpdatedById => ParameterType::Uuid,
-            Self::EditionId => ParameterType::UnsignedInteger,
+            Self::RecordId => ParameterType::UnsignedInteger,
             Self::LeftEntity(path)
             | Self::RightEntity(path)
             | Self::IncomingLinks(path)
             | Self::OutgoingLinks(path) => path.expected_type(),
-            Self::DecisionTime | Self::TransactionTime | Self::LowerTransactionTime => {
-                ParameterType::Timestamp
-            }
+            Self::DecisionTime | Self::TransactionTime => ParameterType::Timespan,
+            Self::LowerTransactionTime => ParameterType::Timestamp,
             Self::Type(path) => path.expected_type(),
             Self::Properties(_) => ParameterType::Any,
             Self::LeftToRightOrder | Self::RightToLeftOrder => ParameterType::Number,

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
@@ -238,7 +238,7 @@ impl fmt::Display for EntityQueryPath<'_> {
             Self::Uuid => fmt.write_str("uuid"),
             Self::OwnedById => fmt.write_str("ownedById"),
             Self::UpdatedById => fmt.write_str("updatedById"),
-            Self::RecordId => fmt.write_str("editionId"),
+            Self::RecordId => fmt.write_str("recordId"),
             Self::DecisionTime => fmt.write_str("decisionTime"),
             Self::TransactionTime => fmt.write_str("transactionTime"),
             Self::LowerTransactionTime => fmt.write_str("transactionTimeFrom"),

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/mod.rs
@@ -223,7 +223,7 @@ impl ToSchema for GraphElementId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 #[serde(untagged)]
 pub enum GraphElementEditionId {
     Ontology(OntologyTypeEditionId),

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/mod.rs
@@ -50,6 +50,13 @@ impl FromStr for DecisionTimestamp {
 #[postgres(transparent)]
 pub struct TransactionTimestamp(DateTime<Utc>);
 
+impl TransactionTimestamp {
+    #[must_use]
+    pub const fn as_date_time(&self) -> DateTime<Utc> {
+        self.0
+    }
+}
+
 impl fmt::Display for TransactionTimestamp {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         fmt::Display::fmt(&self.0, fmt)

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -25,6 +25,8 @@ use uuid::Uuid;
 
 use self::context::OntologyRecord;
 pub use self::pool::{AsClient, PostgresStorePool};
+#[cfg(feature = "__internal_bench")]
+use crate::knowledge::{EntityProperties, EntityUuid, LinkData};
 use crate::{
     identifier::{account::AccountId, knowledge::EntityEditionId, ontology::OntologyTypeEditionId},
     ontology::OntologyElementMetadata,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
@@ -183,7 +183,7 @@ impl<'c, 'p: 'c, T: PostgresQueryRecord + 'static> SelectCompiler<'c, 'p, T> {
                     SelectExpression::new(Expression::Asterisk, None),
                     SelectExpression::new(
                         Expression::Window(
-                            Box::new(Expression::Function(Box::new(Function::Max(
+                            Box::new(Expression::Function(Function::Max(Box::new(
                                 Expression::Column(version_column),
                             )))),
                             WindowStatement::partition_by(
@@ -221,19 +221,24 @@ impl<'c, 'p: 'c, T: PostgresQueryRecord + 'static> SelectCompiler<'c, 'p, T> {
         path: &T::Path<'p>,
         operator: EqualityOperator,
     ) -> Condition<'c> {
-        let latest_version_expression = Some(Expression::Column(
-            Column::Entities(Entities::LatestVersion).aliased(self.add_join_statements(path)),
-        ));
+        let alias = self.add_join_statements(path);
+        let decision_time_condition = Condition::RangeContains(
+            Expression::Column(Column::Entities(Entities::DecisionTime).aliased(alias)),
+            Expression::Function(Function::Now),
+        );
+        let transaction_time_condition = Condition::RangeContains(
+            Expression::Column(Column::Entities(Entities::TransactionTime).aliased(alias)),
+            Expression::Function(Function::Now),
+        );
 
         match operator {
-            EqualityOperator::Equal => Condition::Equal(
-                latest_version_expression,
-                Some(Expression::Constant(Constant::Boolean(true))),
-            ),
-            EqualityOperator::NotEqual => Condition::Equal(
-                latest_version_expression,
-                Some(Expression::Constant(Constant::Boolean(false))),
-            ),
+            EqualityOperator::Equal => {
+                Condition::All(vec![decision_time_condition, transaction_time_condition])
+            }
+            EqualityOperator::NotEqual => Condition::All(vec![
+                Condition::Not(Box::new(decision_time_condition)),
+                transaction_time_condition,
+            ]),
         }
     }
 
@@ -262,10 +267,18 @@ impl<'c, 'p: 'c, T: PostgresQueryRecord + 'static> SelectCompiler<'c, 'p, T> {
                             EqualityOperator::NotEqual,
                         ))
                     }
-                    (Column::Entities(Entities::Version), Filter::Equal(..), "latest") => Some(
+                    (
+                        Column::Entities(Entities::LowerTransactionTime),
+                        Filter::Equal(..),
+                        "latest",
+                    ) => Some(
                         self.compile_latest_entity_version_filter(path, EqualityOperator::Equal),
                     ),
-                    (Column::Entities(Entities::Version), Filter::NotEqual(..), "latest") => Some(
+                    (
+                        Column::Entities(Entities::LowerTransactionTime),
+                        Filter::NotEqual(..),
+                        "latest",
+                    ) => Some(
                         self.compile_latest_entity_version_filter(path, EqualityOperator::NotEqual),
                     ),
                     _ => None,
@@ -288,7 +301,20 @@ impl<'c, 'p: 'c, T: PostgresQueryRecord + 'static> SelectCompiler<'c, 'p, T> {
                 column
             };
 
-        column.aliased(self.add_join_statements(path))
+        let alias = self.add_join_statements(path);
+
+        // TODO: Remove special casing when adjusting structural queries
+        //   see https://app.asana.com/0/0/1203491211535116/f
+        if matches!(column, Column::Entities(_)) {
+            self.statement
+                .where_expression
+                .add_condition(Condition::RangeContains(
+                    Expression::Column(Column::Entities(Entities::DecisionTime).aliased(alias)),
+                    Expression::Function(Function::Now),
+                ));
+        }
+
+        column.aliased(alias)
     }
 
     pub fn compile_filter_expression<'f: 'p>(
@@ -296,7 +322,16 @@ impl<'c, 'p: 'c, T: PostgresQueryRecord + 'static> SelectCompiler<'c, 'p, T> {
         expression: &'f FilterExpression<'p, T>,
     ) -> Expression<'c> {
         match expression {
-            FilterExpression::Path(path) => Expression::Column(self.compile_path_column(path)),
+            FilterExpression::Path(path) => {
+                // TODO: Remove special casing when adjusting structural queries
+                //   see https://app.asana.com/0/0/1203491211535116/f
+                let column = self.compile_path_column(path);
+                if column.column == Column::Entities(Entities::LowerTransactionTime) {
+                    Expression::Function(Function::Lower(Box::new(Expression::Column(column))))
+                } else {
+                    Expression::Column(column)
+                }
+            }
             FilterExpression::Parameter(parameter) => {
                 match parameter {
                     Parameter::Number(number) => self.artifacts.parameters.push(number),
@@ -328,21 +363,18 @@ impl<'c, 'p: 'c, T: PostgresQueryRecord + 'static> SelectCompiler<'c, 'p, T> {
                 self.statement
                     .where_expression
                     .add_condition(Condition::NotEqual(
-                        Some(Expression::Function(Box::new(Function::JsonExtractPath(
-                            vec![
-                                Expression::Column(
-                                    Column::EntityTypes(EntityTypes::Schema(None))
-                                        .aliased(base_alias),
-                                ),
-                                Expression::Constant(Constant::String("links")),
-                                Expression::Column(
-                                    Column::EntityTypes(EntityTypes::Schema(Some(
-                                        JsonField::Text(&Cow::Borrowed("$id")),
-                                    )))
-                                    .aliased(joined_table.alias),
-                                ),
-                            ],
-                        )))),
+                        Some(Expression::Function(Function::JsonExtractPath(vec![
+                            Expression::Column(
+                                Column::EntityTypes(EntityTypes::Schema(None)).aliased(base_alias),
+                            ),
+                            Expression::Constant(Constant::String("links")),
+                            Expression::Column(
+                                Column::EntityTypes(EntityTypes::Schema(Some(JsonField::Text(
+                                    &Cow::Borrowed("$id"),
+                                ))))
+                                .aliased(joined_table.alias),
+                            ),
+                        ]))),
                         None,
                     ));
             }
@@ -351,15 +383,15 @@ impl<'c, 'p: 'c, T: PostgresQueryRecord + 'static> SelectCompiler<'c, 'p, T> {
                 self.statement
                     .where_expression
                     .add_condition(Condition::NotEqual(
-                        Some(Expression::Function(Box::new(Function::JsonContains(
-                            Expression::Column(
+                        Some(Expression::Function(Function::JsonContains(
+                            Box::new(Expression::Column(
                                 Column::EntityTypes(EntityTypes::Schema(Some(JsonField::Json(
                                     &Cow::Borrowed("allOf"),
                                 ))))
                                 .aliased(base_alias),
-                            ),
-                            Expression::Function(Box::new(Function::JsonBuildArray(vec![
-                                Expression::Function(Box::new(Function::JsonBuildObject(vec![(
+                            )),
+                            Box::new(Expression::Function(Function::JsonBuildArray(vec![
+                                Expression::Function(Function::JsonBuildObject(vec![(
                                     Expression::Constant(Constant::String("$ref")),
                                     Expression::Column(
                                         Column::EntityTypes(EntityTypes::Schema(Some(
@@ -367,9 +399,9 @@ impl<'c, 'p: 'c, T: PostgresQueryRecord + 'static> SelectCompiler<'c, 'p, T> {
                                         )))
                                         .aliased(joined_table.alias),
                                     ),
-                                )]))),
+                                )])),
                             ]))),
-                        )))),
+                        ))),
                         None,
                     ));
             }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashSet, fmt::Display, marker::PhantomData, ops::Bound};
+use std::{borrow::Cow, collections::HashSet, fmt::Display, marker::PhantomData};
 
 use postgres_types::ToSql;
 use tokio_postgres::row::RowIndex;
@@ -339,12 +339,7 @@ impl<'c, 'p: 'c, T: PostgresQueryRecord + 'static> SelectCompiler<'c, 'p, T> {
                     Parameter::Boolean(bool) => self.artifacts.parameters.push(bool),
                     Parameter::Uuid(uuid) => self.artifacts.parameters.push(uuid),
                     Parameter::SignedInteger(integer) => self.artifacts.parameters.push(integer),
-                    Parameter::Timestamp(timestamp) => match timestamp {
-                        Bound::Unbounded => self.artifacts.parameters.push(&"infinity"),
-                        Bound::Included(timestamp) | Bound::Excluded(timestamp) => {
-                            self.artifacts.parameters.push(timestamp);
-                        }
-                    },
+                    Parameter::Timestamp(timestamp) => self.artifacts.parameters.push(timestamp),
                 }
                 Expression::Parameter(self.artifacts.parameters.len())
             }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
@@ -12,6 +12,7 @@ pub enum Condition<'p> {
     Not(Box<Self>),
     Equal(Option<Expression<'p>>, Option<Expression<'p>>),
     NotEqual(Option<Expression<'p>>, Option<Expression<'p>>),
+    RangeContains(Expression<'p>, Expression<'p>),
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -74,6 +75,11 @@ impl Transpile for Condition<'_> {
             Condition::NotEqual(lhs, rhs) => {
                 lhs.transpile(fmt)?;
                 fmt.write_str(" != ")?;
+                rhs.transpile(fmt)
+            }
+            Condition::RangeContains(lhs, rhs) => {
+                lhs.transpile(fmt)?;
+                fmt.write_str(" @> ")?;
                 rhs.transpile(fmt)
             }
         }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity.rs
@@ -42,7 +42,7 @@ impl Path for EntityQueryPath<'_> {
     fn terminating_column(&self) -> Column {
         match self {
             Self::Uuid => Column::Entities(Entities::EntityUuid),
-            Self::EditionId => Column::Entities(Entities::EditionId),
+            Self::RecordId => Column::Entities(Entities::RecordId),
             Self::DecisionTime => Column::Entities(Entities::DecisionTime),
             Self::TransactionTime => Column::Entities(Entities::TransactionTime),
             Self::LowerTransactionTime => Column::Entities(Entities::LowerTransactionTime),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity.rs
@@ -42,7 +42,10 @@ impl Path for EntityQueryPath<'_> {
     fn terminating_column(&self) -> Column {
         match self {
             Self::Uuid => Column::Entities(Entities::EntityUuid),
-            Self::Version => Column::Entities(Entities::Version),
+            Self::EditionId => Column::Entities(Entities::EditionId),
+            Self::DecisionTime => Column::Entities(Entities::DecisionTime),
+            Self::TransactionTime => Column::Entities(Entities::TransactionTime),
+            Self::LowerTransactionTime => Column::Entities(Entities::LowerTransactionTime),
             Self::Archived => Column::Entities(Entities::Archived),
             Self::Type(path) => path.terminating_column(),
             Self::OwnedById => Column::Entities(Entities::OwnedById),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
@@ -9,7 +9,11 @@ pub struct WhereExpression<'q> {
 
 impl<'q> WhereExpression<'q> {
     pub fn add_condition(&mut self, condition: Condition<'q>) {
-        self.conditions.push(condition);
+        // TODO: Remove deduplication when adjusting structural queries
+        //   see https://app.asana.com/0/0/1203491211535116/f
+        if !self.conditions.iter().any(|c| c == &condition) {
+            self.conditions.push(condition);
+        }
     }
 
     pub fn len(&self) -> usize {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
@@ -128,7 +128,7 @@ impl_ontology_column!(EntityTypes);
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Entities<'p> {
     EntityUuid,
-    EditionId,
+    RecordId,
     DecisionTime,
     TransactionTime,
     // TODO: Remove when adjusting structural queries
@@ -151,7 +151,7 @@ impl Entities<'_> {
     pub const fn nullable(self) -> bool {
         match self {
             Self::EntityUuid
-            | Self::EditionId
+            | Self::RecordId
             | Self::DecisionTime
             | Self::TransactionTime
             | Self::LowerTransactionTime
@@ -174,7 +174,7 @@ impl Transpile for Entities<'_> {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let column = match self {
             Self::EntityUuid => "entity_uuid",
-            Self::EditionId => "entity_edition_id",
+            Self::RecordId => "entity_record_id",
             Self::DecisionTime => "decision_time",
             Self::TransactionTime | Self::LowerTransactionTime => "transaction_time",
             Self::Archived => "archived",

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
@@ -128,8 +128,12 @@ impl_ontology_column!(EntityTypes);
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Entities<'p> {
     EntityUuid,
-    Version,
-    LatestVersion,
+    EditionId,
+    DecisionTime,
+    TransactionTime,
+    // TODO: Remove when adjusting structural queries
+    //   see https://app.asana.com/0/0/1203491211535116/f
+    LowerTransactionTime,
     Archived,
     OwnedById,
     UpdatedById,
@@ -147,8 +151,10 @@ impl Entities<'_> {
     pub const fn nullable(self) -> bool {
         match self {
             Self::EntityUuid
-            | Self::Version
-            | Self::LatestVersion
+            | Self::EditionId
+            | Self::DecisionTime
+            | Self::TransactionTime
+            | Self::LowerTransactionTime
             | Self::Archived
             | Self::OwnedById
             | Self::UpdatedById
@@ -168,8 +174,9 @@ impl Transpile for Entities<'_> {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let column = match self {
             Self::EntityUuid => "entity_uuid",
-            Self::Version => "version",
-            Self::LatestVersion => "latest_version",
+            Self::EditionId => "entity_edition_id",
+            Self::DecisionTime => "decision_time",
+            Self::TransactionTime | Self::LowerTransactionTime => "transaction_time",
             Self::Archived => "archived",
             Self::OwnedById => "owned_by_id",
             Self::UpdatedById => "updated_by_id",

--- a/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
@@ -509,6 +509,8 @@ impl Parameter<'_> {
                 // TODO: validate versioned uri
                 //   see https://app.asana.com/0/1202805690238892/1203225514907875/f
             }
+            // TODO: Reevaluate if we need this after https://app.asana.com/0/0/1203491211535116/f
+            //       Most probably, we won't need this anymore
             (Parameter::Text(text), ParameterType::Timestamp) => {
                 if text != "latest" {
                     *self = Parameter::Timestamp(

--- a/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
@@ -25,7 +25,9 @@ pub enum ParameterType {
     Uuid,
     BaseUri,
     VersionedUri,
+    // TODO: Reevaluate if we need this after https://app.asana.com/0/0/1203491211535116/f
     Timestamp,
+    // TODO: Reevaluate if we need this after https://app.asana.com/0/0/1203491211535116/f
     Timespan,
     Any,
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
@@ -26,6 +26,7 @@ pub enum ParameterType {
     BaseUri,
     VersionedUri,
     Timestamp,
+    Timespan,
     Any,
 }
 
@@ -40,6 +41,7 @@ impl fmt::Display for ParameterType {
             Self::BaseUri => fmt.write_str("base URI"),
             Self::VersionedUri => fmt.write_str("versioned URI"),
             Self::Timestamp => fmt.write_str("timestamp"),
+            Self::Timespan => fmt.write_str("timespan"),
             Self::Any => fmt.write_str("any"),
         }
     }

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -4,7 +4,7 @@
 POST http://127.0.0.1:4000/accounts
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
         client.global.set("account_id", response.body.toString());
     });
@@ -14,7 +14,7 @@ POST http://127.0.0.1:4000/accounts
 GET http://127.0.0.1:4000/data-types
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
         client.assert(response.body.length === 6, "Unexpected number of data types"); // The number of primitive data types
     });
@@ -37,7 +37,7 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
     client.global.set("text_data_type_id", encodeURIComponent(`${response.body.editionId.baseId}v/${response.body.editionId.version}`));
@@ -47,7 +47,7 @@ Accept: application/json
 GET http://127.0.0.1:4000/data-types/{{text_data_type_id}}
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
 %}
@@ -69,7 +69,7 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
 %}
@@ -95,7 +95,7 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
     client.global.set("person_property_type_id", encodeURIComponent(`${response.body.editionId.baseId}v/${response.body.editionId.version}`));
@@ -105,7 +105,7 @@ Accept: application/json
 GET http://127.0.0.1:4000/property-types/{{person_property_type_id}}
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
 %}
@@ -130,7 +130,7 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
 %}
@@ -139,7 +139,7 @@ Accept: application/json
 GET http://127.0.0.1:4000/property-types
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
         client.assert(response.body.length === 1, "Unexpected number of property types");
     });
@@ -168,7 +168,7 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
     client.global.set("friendship_link_entity_type_id", `${response.body.editionId.baseId}v/${response.body.editionId.version}`);
@@ -222,7 +222,7 @@ Content-Type: application/json
 }
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
         client.assert(response.body.roots.length === 1, "Unexpected number of entities");
     });
@@ -250,7 +250,7 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
     client.global.set("person_entity_type_id", encodeURIComponent(`${response.body.editionId.baseId}v/${response.body.editionId.version}`));
@@ -261,7 +261,7 @@ Accept: application/json
 GET http://127.0.0.1:4000/entity-types/{{encoded_person_entity_type_id}}
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
 %}
@@ -300,7 +300,7 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
 %}
@@ -309,7 +309,7 @@ Accept: application/json
 GET http://127.0.0.1:4000/entity-types
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
         client.assert(response.body.length === 3, "Unexpected number of entity types");
     });
@@ -365,7 +365,7 @@ Content-Type: application/json
 }
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
         client.assert(response.body.roots.length === 1, "Unexpected number of entities");
     });
@@ -425,7 +425,7 @@ Content-Type: application/json
 }
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
         client.assert(response.body.roots.length === 0, "Unexpected number of entities");
     });
@@ -448,7 +448,7 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
     client.global.set("person_a_entity_id", response.body.editionId.baseId);
@@ -460,12 +460,12 @@ Accept: application/json
 GET http://127.0.0.1:4000/entities/{{encoded_person_a_entity_id}}
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
 %}
 
-#### Update Person entity
+### Update Person entity
 PUT http://127.0.0.1:4000/entities
 Content-Type: application/json
 Accept: application/json
@@ -480,7 +480,7 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
 %}
@@ -500,7 +500,7 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
     client.global.set("person_b_entity_id", response.body.editionId.baseId);
@@ -511,13 +511,13 @@ Accept: application/json
 GET http://127.0.0.1:4000/entities
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
         client.assert(response.body.length === 2, "Unexpected number of entities");
     });
 %}
 
-#### Get all latest entities by using a query
+### Get all latest entities by using a query
 POST http://127.0.0.1:4000/entities/query
 Content-Type: application/json
 
@@ -565,7 +565,7 @@ Content-Type: application/json
 }
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
         client.assert(response.body.roots.length === 2, "Unexpected number of entities");
     });
@@ -592,7 +592,7 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
 %}
@@ -664,7 +664,7 @@ Content-Type: application/json
 }
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
         client.assert(response.body.roots.length === 1, "Unexpected number of entities");
     });
@@ -682,12 +682,12 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
 %}
 
-#### Get all latest unarchived entities by using a query
+### Get all latest unarchived entities by using a query
 // Only person_a and the link remains as entities
 POST http://127.0.0.1:4000/entities/query
 Content-Type: application/json
@@ -752,14 +752,14 @@ Content-Type: application/json
 }
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
         client.assert(response.body.roots.length === 2, "Unexpected number of entities");
     });
 %}
 
 
-#### Get all archived entities
+### Get all archived entities
 POST http://127.0.0.1:4000/entities/query
 Content-Type: application/json
 
@@ -807,7 +807,7 @@ Content-Type: application/json
 }
 
 > {%
-    client.test("status", function () {
+    client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
         client.assert(response.body.roots.length === 1, "Unexpected number of entities");
     });

--- a/packages/graph/hash_graph/tests/rest-test.http
+++ b/packages/graph/hash_graph/tests/rest-test.http
@@ -4,7 +4,7 @@
 POST http://127.0.0.1:4000/accounts
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
         client.global.set("account_id", response.body.toString());
     });
@@ -14,7 +14,7 @@ POST http://127.0.0.1:4000/accounts
 GET http://127.0.0.1:4000/data-types
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
         client.assert(response.body.length === 6, "Unexpected number of data types"); // The number of primitive data types
     });
@@ -37,7 +37,7 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
     });
     client.global.set("text_data_type_id", encodeURIComponent(`${response.body.editionId.baseId}v/${response.body.editionId.version}`));
@@ -47,7 +47,7 @@ Accept: application/json
 GET http://127.0.0.1:4000/data-types/{{text_data_type_id}}
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
     });
 %}
@@ -69,7 +69,7 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
     });
 %}
@@ -95,7 +95,7 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
     });
     client.global.set("person_property_type_id", encodeURIComponent(`${response.body.editionId.baseId}v/${response.body.editionId.version}`));
@@ -105,7 +105,7 @@ Accept: application/json
 GET http://127.0.0.1:4000/property-types/{{person_property_type_id}}
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
     });
 %}
@@ -130,7 +130,7 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
     });
 %}
@@ -139,7 +139,7 @@ Accept: application/json
 GET http://127.0.0.1:4000/property-types
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
         client.assert(response.body.length === 1, "Unexpected number of property types");
     });
@@ -168,7 +168,7 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
     });
     client.global.set("friendship_link_entity_type_id", `${response.body.editionId.baseId}v/${response.body.editionId.version}`);
@@ -222,7 +222,7 @@ Content-Type: application/json
 }
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
         client.assert(response.body.roots.length === 1, "Unexpected number of entities");
     });
@@ -250,7 +250,7 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
     });
     client.global.set("person_entity_type_id", encodeURIComponent(`${response.body.editionId.baseId}v/${response.body.editionId.version}`));
@@ -261,7 +261,7 @@ Accept: application/json
 GET http://127.0.0.1:4000/entity-types/{{encoded_person_entity_type_id}}
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
     });
 %}
@@ -300,7 +300,7 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
     });
 %}
@@ -309,7 +309,7 @@ Accept: application/json
 GET http://127.0.0.1:4000/entity-types
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
         client.assert(response.body.length === 3, "Unexpected number of entity types");
     });
@@ -365,7 +365,7 @@ Content-Type: application/json
 }
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
         client.assert(response.body.roots.length === 1, "Unexpected number of entities");
     });
@@ -425,7 +425,7 @@ Content-Type: application/json
 }
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
         client.assert(response.body.roots.length === 0, "Unexpected number of entities");
     });
@@ -448,7 +448,7 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
     });
     client.global.set("person_a_entity_id", response.body.editionId.baseId);
@@ -460,7 +460,7 @@ Accept: application/json
 GET http://127.0.0.1:4000/entities/{{encoded_person_a_entity_id}}
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
     });
 %}
@@ -480,9 +480,9 @@ Accept: application/json
 }
 
 > {%
-   client.test("status", function() {
-       client.assert(response.status === 200, "Response status is not 200");
-   });
+    client.test("status", function () {
+        client.assert(response.status === 200, "Response status is not 200");
+    });
 %}
 
 ### Insert second Person entity
@@ -500,7 +500,7 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
     });
     client.global.set("person_b_entity_id", response.body.editionId.baseId);
@@ -511,7 +511,7 @@ Accept: application/json
 GET http://127.0.0.1:4000/entities
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
         client.assert(response.body.length === 2, "Unexpected number of entities");
     });
@@ -565,7 +565,7 @@ Content-Type: application/json
 }
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
         client.assert(response.body.roots.length === 2, "Unexpected number of entities");
     });
@@ -592,7 +592,7 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
     });
 %}
@@ -664,7 +664,7 @@ Content-Type: application/json
 }
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
         client.assert(response.body.roots.length === 1, "Unexpected number of entities");
     });
@@ -682,26 +682,42 @@ Accept: application/json
 }
 
 > {%
-    client.test("status", function() {
+    client.test("status", function () {
         client.assert(response.status === 200, "Response status is not 200");
     });
 %}
 
-#### Get all latest entities by using a query
+#### Get all latest unarchived entities by using a query
 // Only person_a and the link remains as entities
 POST http://127.0.0.1:4000/entities/query
 Content-Type: application/json
 
 {
   "filter": {
-    "equal": [
+    "all": [
       {
-        "path": [
-          "version"
+        "equal": [
+          {
+            "path": [
+              "version"
+            ]
+          },
+          {
+            "parameter": "latest"
+          }
         ]
       },
       {
-        "parameter": "latest"
+        "equal": [
+          {
+            "path": [
+              "archived"
+            ]
+          },
+          {
+            "parameter": false
+          }
+        ]
       }
     ]
   },
@@ -736,10 +752,10 @@ Content-Type: application/json
 }
 
 > {%
-   client.test("status", function() {
-       client.assert(response.status === 200, "Response status is not 200");
-       client.assert(response.body.roots.length === 2, "Unexpected number of entities");
-   });
+    client.test("status", function () {
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(response.body.roots.length === 2, "Unexpected number of entities");
+    });
 %}
 
 
@@ -791,8 +807,8 @@ Content-Type: application/json
 }
 
 > {%
-   client.test("status", function() {
-       client.assert(response.status === 200, "Response status is not 200");
-       client.assert(response.body.roots.length === 1, "Unexpected number of entities");
-   });
+    client.test("status", function () {
+        client.assert(response.status === 200, "Response status is not 200");
+        client.assert(response.body.roots.length === 1, "Unexpected number of entities");
+    });
 %}

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -298,7 +298,7 @@ export const up = (pgm: MigrationBuilder): void => {
   pgm.createTable(
     "entity_editions",
     {
-      entity_edition_id: {
+      entity_record_id: {
         type: "BIGINT",
         primaryKey: true,
         notNull: true,
@@ -353,7 +353,7 @@ export const up = (pgm: MigrationBuilder): void => {
         type: "UUID",
         notNull: true,
       },
-      entity_edition_id: {
+      entity_record_id: {
         type: "BIGINT",
         notNull: true,
         references: "entity_editions",
@@ -398,7 +398,7 @@ export const up = (pgm: MigrationBuilder): void => {
     {},
     `
     SELECT
-      entity_versions.entity_edition_id,
+      entity_versions.entity_record_id,
       entity_versions.owned_by_id,
       entity_versions.entity_uuid,
       entity_versions.decision_time,
@@ -414,7 +414,7 @@ export const up = (pgm: MigrationBuilder): void => {
       entity_ids.right_entity_uuid,
       entity_editions.right_to_left_order
     FROM entity_versions
-    JOIN entity_editions ON entity_versions.entity_edition_id = entity_editions.entity_edition_id
+    JOIN entity_editions ON entity_versions.entity_record_id = entity_editions.entity_record_id
     JOIN entity_ids ON entity_versions.owned_by_id = entity_ids.owned_by_id AND entity_versions.entity_uuid = entity_ids.entity_uuid
     `,
   );
@@ -477,13 +477,13 @@ export const up = (pgm: MigrationBuilder): void => {
     ],
     {
       returns:
-        "TABLE (entity_edition_id BIGINT, decision_time tstzrange, transaction_time tstzrange)",
+        "TABLE (entity_record_id BIGINT, decision_time tstzrange, transaction_time tstzrange)",
       language: "plpgsql",
       replace: true,
     },
     `
     DECLARE
-      _entity_edition_id BIGINT;
+      _entity_record_id BIGINT;
     BEGIN
       IF _decision_time IS NULL THEN _decision_time := now(); END IF;
   
@@ -518,22 +518,22 @@ export const up = (pgm: MigrationBuilder): void => {
         _properties,
         _left_to_right_order,
         _right_to_left_order
-      ) RETURNING entity_editions.entity_edition_id INTO _entity_edition_id;
+      ) RETURNING entity_editions.entity_record_id INTO _entity_record_id;
 
       RETURN QUERY
       INSERT INTO entity_versions (
         owned_by_id,
         entity_uuid,
-        entity_edition_id,
+        entity_record_id,
         decision_time,
         transaction_time
       ) VALUES (
         _owned_by_id,
         _entity_uuid,
-        _entity_edition_id,
+        _entity_record_id,
         tstzrange(_decision_time, 'infinity', '[)'),
         tstzrange(now(), 'infinity', '[)')
-      ) RETURNING entity_versions.entity_edition_id, entity_versions.decision_time, entity_versions.transaction_time;
+      ) RETURNING entity_versions.entity_record_id, entity_versions.decision_time, entity_versions.transaction_time;
     END
     `,
   );
@@ -580,13 +580,13 @@ export const up = (pgm: MigrationBuilder): void => {
     ],
     {
       returns:
-        "TABLE (entity_edition_id BIGINT, decision_time tstzrange, transaction_time tstzrange)",
+        "TABLE (entity_record_id BIGINT, decision_time tstzrange, transaction_time tstzrange)",
       language: "plpgsql",
       replace: true,
     },
     `
     DECLARE
-      _new_entity_edition_id BIGINT;
+      _new_entity_record_id BIGINT;
     BEGIN
       IF _decision_time IS NULL THEN _decision_time := now(); END IF;
 
@@ -605,18 +605,18 @@ export const up = (pgm: MigrationBuilder): void => {
         _left_to_right_order,
         _right_to_left_order
       )
-      RETURNING entity_editions.entity_edition_id INTO _new_entity_edition_id;
+      RETURNING entity_editions.entity_record_id INTO _new_entity_record_id;
   
       RETURN QUERY
       UPDATE entity_versions
       SET decision_time = tstzrange(_decision_time, upper(entity_versions.decision_time), '[)'),
           transaction_time = tstzrange(now(), 'infinity', '[)'),
-          entity_edition_id = _new_entity_edition_id
+          entity_record_id = _new_entity_record_id
       WHERE entity_versions.owned_by_id = _owned_by_id
         AND entity_versions.entity_uuid = _entity_uuid
         AND entity_versions.decision_time @> _decision_time
         AND entity_versions.transaction_time @> now()
-      RETURNING entity_versions.entity_edition_id, entity_versions.decision_time, entity_versions.transaction_time;
+      RETURNING entity_versions.entity_record_id, entity_versions.decision_time, entity_versions.transaction_time;
     END
     `,
   );
@@ -636,13 +636,13 @@ export const up = (pgm: MigrationBuilder): void => {
       INSERT INTO entity_versions (
         owned_by_id,
         entity_uuid,
-        entity_edition_id,
+        entity_record_id,
         decision_time,
         transaction_time
       ) VALUES (
         OLD.owned_by_id,
         OLD.entity_uuid,
-        OLD.entity_edition_id,
+        OLD.entity_record_id,
         OLD.decision_time,
         tstzrange(lower(OLD.transaction_time),lower(NEW.transaction_time), '[)')
       );
@@ -651,13 +651,13 @@ export const up = (pgm: MigrationBuilder): void => {
       INSERT INTO entity_versions (
         owned_by_id,
         entity_uuid,
-        entity_edition_id,
+        entity_record_id,
         decision_time,
         transaction_time
       ) VALUES (
         OLD.owned_by_id,
         OLD.entity_uuid,
-        OLD.entity_edition_id,
+        OLD.entity_record_id,
         tstzrange(lower(OLD.decision_time), lower(NEW.decision_time), '[)'),
         NEW.transaction_time
       );

--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -298,6 +298,8 @@ export const up = (pgm: MigrationBuilder): void => {
   pgm.createTable(
     "entity_editions",
     {
+      // TODO: Consider changing this to XIDs
+      //   see https://app.asana.com/0/1202805690238892/1203505325130365/f
       entity_record_id: {
         type: "BIGINT",
         primaryKey: true,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adjusts the query logic for the `Read` methods and the corresponding `EntityQueryPath` to allow querying of entities as before.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/0/1203505325130329/f) _(internal)_

## 🚫 Blocked by

- #1624 

## 🔍 What does this change?

- Replaces `EntityQueryPath::Version` with `EntityQueryPath::LowerTransactionTime` (to be removed as part of [Adjust structural queries for temporal versioning](https://app.asana.com/0/0/1203491211535116/f) (_internal_))
- Adds `EntityQueryPath::{EditionId, DecisionTime, TransactionTime}`
- Adds `Lower`, `Upper`, and `Now` functions
- Uses `Now` function as `"latest"` special case
- Adjust `Read` implementation
- Sets the correct filter for getting archived entities