### PR TITLE
Temporal versioning: Fix benchmark seeding logic

### DIFF
--- a/packages/graph/hash_graph/bench/benches/representative_read/seed.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/seed.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use graph::{
-    identifier::{account::AccountId, knowledge::EntityId},
+    identifier::account::AccountId,
     knowledge::{EntityProperties, EntityUuid, LinkData},
     provenance::{OwnedById, UpdatedById},
     store::{AccountStore, AsClient, EntityStore, PostgresStore},
@@ -152,10 +152,9 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
 
         let uuids = store
             .insert_entities_batched_by_type(
-                repeat((None, properties, None)).take(quantity),
-                entity_type_id,
-                OwnedById::new(account_id),
+                repeat((OwnedById::new(account_id), None, properties, None, None)).take(quantity),
                 UpdatedById::new(account_id),
+                &entity_type_id,
             )
             .await
             .expect("failed to create entities");
@@ -175,18 +174,30 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
                 entity_uuids[*left_entity_index]
                     .iter()
                     .zip(&entity_uuids[*right_entity_index])
-                    .map(|(left_uuid, right_uuid)| {
-                        LinkData::new(
-                            EntityId::new(OwnedById::new(account_id), *left_uuid),
-                            EntityId::new(OwnedById::new(account_id), *right_uuid),
+                    .map(
+                        |(
+                            (left_entity_metadata, _left_entity_edition_id),
+                            (right_entity_metadata, _right_entity_edition_id),
+                        )| {
+                            LinkData::new(
+                                left_entity_metadata.edition_id().base_id(),
+                                right_entity_metadata.edition_id().base_id(),
+                                None,
+                                None,
+                            )
+                        },
+                    )
+                    .map(|link_data| {
+                        (
+                            OwnedById::new(account_id),
                             None,
+                            EntityProperties::empty(),
+                            Some(link_data),
                             None,
                         )
-                    })
-                    .map(|link_data| (None, EntityProperties::empty(), Some(link_data))),
-                entity_type_id,
-                OwnedById::new(account_id),
+                    }),
                 UpdatedById::new(account_id),
+                &entity_type_id,
             )
             .await
             .expect("failed to create entities");

--- a/packages/graph/hash_graph/bench/benches/representative_read/seed.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/seed.rs
@@ -174,25 +174,17 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
                 entity_uuids[*left_entity_index]
                     .iter()
                     .zip(&entity_uuids[*right_entity_index])
-                    .map(
-                        |(
-                            (left_entity_metadata, _left_entity_edition_id),
-                            (right_entity_metadata, _right_entity_edition_id),
-                        )| {
-                            LinkData::new(
-                                left_entity_metadata.edition_id().base_id(),
-                                right_entity_metadata.edition_id().base_id(),
-                                None,
-                                None,
-                            )
-                        },
-                    )
-                    .map(|link_data| {
+                    .map(|(left_entity_metadata, right_entity_metadata)| {
                         (
                             OwnedById::new(account_id),
                             None,
                             EntityProperties::empty(),
-                            Some(link_data),
+                            Some(LinkData::new(
+                                left_entity_metadata.edition_id().base_id(),
+                                right_entity_metadata.edition_id().base_id(),
+                                None,
+                                None,
+                            )),
                             None,
                         )
                     }),

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -370,7 +370,7 @@ pub trait EntityStore: crud::Read<Entity> {
         > + Send,
         actor_id: UpdatedById,
         entity_type_id: &VersionedUri,
-    ) -> Result<Vec<(EntityMetadata, i64)>, InsertionError>;
+    ) -> Result<Vec<EntityMetadata>, InsertionError>;
 
     /// Get the [`Subgraph`]s specified by the [`StructuralQuery`].
     ///

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -359,13 +359,18 @@ pub trait EntityStore: crud::Read<Entity> {
     async fn insert_entities_batched_by_type(
         &mut self,
         entities: impl IntoIterator<
-            Item = (Option<EntityUuid>, EntityProperties, Option<LinkData>),
+            Item = (
+                OwnedById,
+                Option<EntityUuid>,
+                EntityProperties,
+                Option<LinkData>,
+                Option<DecisionTimestamp>,
+            ),
             IntoIter: Send,
         > + Send,
-        entity_type_id: VersionedUri,
-        owned_by_id: OwnedById,
         actor_id: UpdatedById,
-    ) -> Result<Vec<EntityUuid>, InsertionError>;
+        entity_type_id: &VersionedUri,
+    ) -> Result<Vec<(EntityMetadata, i64)>, InsertionError>;
 
     /// Get the [`Subgraph`]s specified by the [`StructuralQuery`].
     ///

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -26,11 +26,7 @@ use uuid::Uuid;
 use self::context::OntologyRecord;
 pub use self::pool::{AsClient, PostgresStorePool};
 use crate::{
-    identifier::{
-        account::AccountId,
-        knowledge::{EntityEditionId, EntityRecordId},
-        ontology::OntologyTypeEditionId,
-    },
+    identifier::{account::AccountId, knowledge::EntityEditionId, ontology::OntologyTypeEditionId},
     ontology::OntologyElementMetadata,
     provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
@@ -46,7 +42,7 @@ use crate::{
 #[cfg(feature = "__internal_bench")]
 use crate::{
     identifier::{
-        knowledge::{EntityId, EntityVersion},
+        knowledge::{EntityId, EntityRecordId, EntityVersion},
         DecisionTimespan, DecisionTimestamp, TransactionTimespan,
     },
     knowledge::{EntityProperties, LinkOrder},

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -26,9 +26,15 @@ use uuid::Uuid;
 use self::context::OntologyRecord;
 pub use self::pool::{AsClient, PostgresStorePool};
 #[cfg(feature = "__internal_bench")]
-use crate::knowledge::{EntityProperties, EntityUuid, LinkData};
+use crate::knowledge::EntityProperties;
 use crate::{
-    identifier::{account::AccountId, knowledge::EntityEditionId, ontology::OntologyTypeEditionId},
+    identifier::{
+        account::AccountId,
+        knowledge::{EntityEditionId, EntityId, EntityVersion},
+        ontology::OntologyTypeEditionId,
+        DecisionTimespan, DecisionTimestamp, TransactionTimespan,
+    },
+    knowledge::LinkOrder,
     ontology::OntologyElementMetadata,
     provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
@@ -621,27 +627,53 @@ where
 impl PostgresStore<Transaction<'_>> {
     #[doc(hidden)]
     #[cfg(feature = "__internal_bench")]
-    async fn insert_entity_uuids(
+    async fn insert_entity_ids(
         &self,
-        entity_uuids: impl IntoIterator<Item = EntityUuid, IntoIter: Send> + Send,
+        entity_uuids: impl IntoIterator<
+            Item = (EntityId, Option<EntityId>, Option<EntityId>),
+            IntoIter: Send,
+        > + Send,
     ) -> Result<u64, InsertionError> {
         let sink = self
             .client
-            .copy_in("COPY entity_uuids (entity_uuid) FROM STDIN BINARY")
+            .copy_in(
+                "COPY entity_ids (
+                    owned_by_id,
+                    entity_uuid,
+                    left_owned_by_id,
+                    left_entity_uuid,
+                    right_owned_by_id,
+                    right_entity_uuid
+                ) FROM STDIN BINARY",
+            )
             .await
             .into_report()
             .change_context(InsertionError)?;
-        let writer = BinaryCopyInWriter::new(sink, &[Type::UUID]);
+        let writer = BinaryCopyInWriter::new(sink, &[
+            Type::UUID,
+            Type::UUID,
+            Type::UUID,
+            Type::UUID,
+            Type::UUID,
+            Type::UUID,
+        ]);
 
         futures::pin_mut!(writer);
-        for entity_uuid in entity_uuids {
+        for (entity_id, left_entity_id, right_entity_id) in entity_uuids {
             writer
                 .as_mut()
-                .write(&[&entity_uuid.as_uuid()])
+                .write(&[
+                    &entity_id.owned_by_id(),
+                    &entity_id.entity_uuid(),
+                    &left_entity_id.as_ref().map(EntityId::owned_by_id),
+                    &left_entity_id.as_ref().map(EntityId::entity_uuid),
+                    &right_entity_id.as_ref().map(EntityId::owned_by_id),
+                    &right_entity_id.as_ref().map(EntityId::entity_uuid),
+                ])
                 .await
                 .into_report()
                 .change_context(InsertionError)
-                .attach_printable(entity_uuid)?;
+                .attach_printable(entity_id.entity_uuid())?;
         }
 
         writer
@@ -653,22 +685,147 @@ impl PostgresStore<Transaction<'_>> {
 
     #[doc(hidden)]
     #[cfg(feature = "__internal_bench")]
-    async fn insert_entity_batch_by_type(
+    async fn insert_entity_editions(
         &self,
-        entity_uuids: impl IntoIterator<Item = EntityUuid, IntoIter: Send> + Send,
-        entities: impl IntoIterator<Item = EntityProperties, IntoIter: Send> + Send,
-        link_datas: impl IntoIterator<Item = Option<LinkData>, IntoIter: Send> + Send,
+        entities: impl IntoIterator<
+            Item = (EntityProperties, Option<LinkOrder>, Option<LinkOrder>),
+            IntoIter: Send,
+        > + Send,
         entity_type_version_id: VersionId,
-        owned_by_id: OwnedById,
-        updated_by_id: UpdatedById,
-    ) -> Result<u64, InsertionError> {
+        actor_id: UpdatedById,
+    ) -> Result<Vec<i64>, InsertionError> {
+        self.client
+            .simple_query(
+                "CREATE TEMPORARY TABLE entity_editions_temp (
+                    updated_by_id UUID NOT NULL,
+                    archived BOOLEAN NOT NULL,
+                    entity_type_version_id UUID NOT NULL,
+                    properties JSONB NOT NULL,
+                    left_to_right_order INT,
+                    right_to_left_order INT
+                );",
+            )
+            .await
+            .into_report()
+            .change_context(InsertionError)?;
+
         let sink = self
             .client
             .copy_in(
-                "COPY latest_entities (entity_uuid, entity_type_version_id, properties, \
-                 owned_by_id, updated_by_id, left_owned_by_id, left_entity_uuid, \
-                 right_owned_by_id, right_entity_uuid, left_to_right_order, right_to_left_order) \
-                 FROM STDIN BINARY",
+                "COPY entity_editions_temp (
+                    updated_by_id,
+                    archived,
+                    entity_type_version_id,
+                    properties,
+                    left_to_right_order,
+                    right_to_left_order
+                ) FROM STDIN BINARY",
+            )
+            .await
+            .into_report()
+            .change_context(InsertionError)?;
+        let writer = BinaryCopyInWriter::new(sink, &[
+            Type::UUID,
+            Type::BOOL,
+            Type::UUID,
+            Type::JSONB,
+            Type::INT4,
+            Type::INT4,
+        ]);
+        futures::pin_mut!(writer);
+        for (properties, left_to_right_order, right_to_left_order) in entities {
+            let properties = serde_json::to_value(properties)
+                .into_report()
+                .change_context(InsertionError)?;
+
+            writer
+                .as_mut()
+                .write(&[
+                    &actor_id,
+                    &false,
+                    &entity_type_version_id,
+                    &properties,
+                    &left_to_right_order,
+                    &right_to_left_order,
+                ])
+                .await
+                .into_report()
+                .change_context(InsertionError)?;
+        }
+
+        writer
+            .finish()
+            .await
+            .into_report()
+            .change_context(InsertionError)?;
+
+        let entity_edition_ids = self
+            .client
+            .query(
+                "INSERT INTO entity_editions (
+                    updated_by_id,
+                    archived,
+                    entity_type_version_id,
+                    properties,
+                    left_to_right_order,
+                    right_to_left_order
+                )
+                SELECT
+                    updated_by_id,
+                    archived,
+                    entity_type_version_id,
+                    properties,
+                    left_to_right_order,
+                    right_to_left_order
+                FROM entity_editions_temp
+                RETURNING entity_edition_id;",
+                &[],
+            )
+            .await
+            .into_report()
+            .change_context(InsertionError)?
+            .into_iter()
+            .map(|row| row.get::<_, i64>(0))
+            .collect();
+
+        self.client
+            .simple_query("DROP TABLE entity_editions_temp;")
+            .await
+            .into_report()
+            .change_context(InsertionError)?;
+
+        Ok(entity_edition_ids)
+    }
+
+    #[doc(hidden)]
+    #[cfg(feature = "__internal_bench")]
+    async fn insert_entity_versions(
+        &self,
+        entities: impl IntoIterator<Item = (EntityId, i64, Option<DecisionTimestamp>), IntoIter: Send>
+        + Send,
+    ) -> Result<Vec<EntityVersion>, InsertionError> {
+        self.client
+            .simple_query(
+                "CREATE TEMPORARY TABLE entity_versions_temp (
+                    owned_by_id UUID NOT NULL,
+                    entity_uuid UUID NOT NULL,
+                    entity_edition_id BIGINT NOT NULL,
+                    decision_time TIMESTAMP WITH TIME ZONE
+                );",
+            )
+            .await
+            .into_report()
+            .change_context(InsertionError)?;
+
+        let sink = self
+            .client
+            .copy_in(
+                "COPY entity_versions_temp (
+                    owned_by_id,
+                    entity_uuid,
+                    entity_edition_id,
+                    decision_time
+                ) FROM STDIN BINARY",
             )
             .await
             .into_report()
@@ -676,57 +833,71 @@ impl PostgresStore<Transaction<'_>> {
         let writer = BinaryCopyInWriter::new(sink, &[
             Type::UUID,
             Type::UUID,
-            Type::JSONB,
-            Type::UUID,
-            Type::UUID,
-            Type::UUID,
-            Type::UUID,
-            Type::UUID,
-            Type::UUID,
-            Type::INT4,
-            Type::INT4,
+            Type::INT8,
+            Type::TIMESTAMPTZ,
         ]);
         futures::pin_mut!(writer);
-        for ((entity_uuid, entity), link_data) in
-            entity_uuids.into_iter().zip(entities).zip(link_datas)
-        {
-            let value = serde_json::to_value(entity)
-                .into_report()
-                .change_context(InsertionError)?;
+        for (entity_id, entity_edition_id, decision_time) in entities {
             writer
                 .as_mut()
                 .write(&[
-                    &entity_uuid.as_uuid(),
-                    &entity_type_version_id,
-                    &value,
-                    &owned_by_id.as_account_id(),
-                    &updated_by_id.as_account_id(),
-                    &link_data
-                        .as_ref()
-                        .map(|metadata| metadata.left_entity_id().owned_by_id().as_account_id()),
-                    &link_data
-                        .as_ref()
-                        .map(|metadata| metadata.left_entity_id().entity_uuid().as_uuid()),
-                    &link_data
-                        .as_ref()
-                        .map(|metadata| metadata.right_entity_id().owned_by_id().as_account_id()),
-                    &link_data
-                        .as_ref()
-                        .map(|metadata| metadata.right_entity_id().entity_uuid().as_uuid()),
-                    &link_data.as_ref().and_then(LinkData::left_to_right_order),
-                    &link_data.as_ref().and_then(LinkData::right_to_left_order),
+                    &entity_id.owned_by_id(),
+                    &entity_id.entity_uuid(),
+                    &entity_edition_id,
+                    &decision_time,
                 ])
                 .await
                 .into_report()
-                .change_context(InsertionError)
-                .attach_printable(entity_uuid)?;
+                .change_context(InsertionError)?;
         }
 
         writer
             .finish()
             .await
             .into_report()
-            .change_context(InsertionError)
+            .change_context(InsertionError)?;
+
+        let entity_versions = self
+            .client
+            .query(
+                "INSERT INTO entity_versions (
+                    owned_by_id,
+                    entity_uuid,
+                    entity_edition_id,
+                    decision_time,
+                    transaction_time
+                ) SELECT
+                    owned_by_id,
+                    entity_uuid,
+                    entity_edition_id,
+                    tstzrange(
+                        CASE WHEN decision_time IS NULL THEN now() ELSE decision_time END,
+                        'infinity'
+                    ),
+                    tstzrange(now(), 'infinity')
+                FROM entity_versions_temp
+                RETURNING decision_time, transaction_time;",
+                &[],
+            )
+            .await
+            .into_report()
+            .change_context(InsertionError)?
+            .into_iter()
+            .map(|row| {
+                EntityVersion::new(
+                    DecisionTimespan::new(row.get(0)),
+                    TransactionTimespan::new(row.get(1)),
+                )
+            })
+            .collect();
+
+        self.client
+            .simple_query("DROP TABLE entity_versions_temp;")
+            .await
+            .into_report()
+            .change_context(InsertionError)?;
+
+        Ok(entity_versions)
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -25,16 +25,8 @@ use uuid::Uuid;
 
 use self::context::OntologyRecord;
 pub use self::pool::{AsClient, PostgresStorePool};
-#[cfg(feature = "__internal_bench")]
-use crate::knowledge::EntityProperties;
 use crate::{
-    identifier::{
-        account::AccountId,
-        knowledge::{EntityEditionId, EntityId, EntityVersion},
-        ontology::OntologyTypeEditionId,
-        DecisionTimespan, DecisionTimestamp, TransactionTimespan,
-    },
-    knowledge::LinkOrder,
+    identifier::{account::AccountId, knowledge::EntityEditionId, ontology::OntologyTypeEditionId},
     ontology::OntologyElementMetadata,
     provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
@@ -46,6 +38,14 @@ use crate::{
         UpdateError,
     },
     subgraph::edges::GraphResolveDepths,
+};
+#[cfg(feature = "__internal_bench")]
+use crate::{
+    identifier::{
+        knowledge::{EntityId, EntityVersion},
+        DecisionTimespan, DecisionTimestamp, TransactionTimespan,
+    },
+    knowledge::{EntityProperties, LinkOrder},
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The database layout changed a lot with temporal versioning. The benchmarking code requires a special seeding to insert many entities at once, so this PR adjusts that seeding.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203363157432081/1203505325130328/f) _(internal)_

## 🚫 Blocked by

- #1630 

## 🔍 What does this change?

- Rewrites the seeding logic for benchmarks by using temporary tables to create the autogenerated identifiers