### PR TITLE
Temporal versioning: Fix `owned_by_id` not included in GiST

### DIFF
--- a/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
+++ b/packages/graph/migrations/postgres/migration/1656417312397_initial.ts
@@ -381,7 +381,7 @@ export const up = (pgm: MigrationBuilder): void => {
 
   pgm.addConstraint("entity_versions", "entity_versions_overlapping", {
     exclude:
-      "USING gist (entity_uuid WITH =, decision_time WITH &&, system_time WITH &&)",
+      "USING gist (owned_by_id WITH =, entity_uuid WITH =, decision_time WITH &&, system_time WITH &&)",
     deferrable: true,
   });
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `owned_by_id` is required for identifying an entity, so it *must* be included in the GiST.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/0/1203505325130332/f) _(internal)_