### PR TITLE
Expose `EntityRecordId` as `"recordId"`

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -412,6 +412,12 @@ export interface EntityEditionId {
   baseId: string;
   /**
    *
+   * @type {number}
+   * @memberof EntityEditionId
+   */
+  recordId: number;
+  /**
+   *
    * @type {string}
    * @memberof EntityEditionId
    */
@@ -495,6 +501,7 @@ export interface EntityMetadata {
 export const EntityQueryToken = {
   Uuid: "uuid",
   Version: "version",
+  RecordId: "recordId",
   Archived: "archived",
   OwnedById: "ownedById",
   UpdatedById: "updatedById",
@@ -750,6 +757,12 @@ export interface GraphElementEditionIdOneOf1 {
    * @memberof GraphElementEditionIdOneOf1
    */
   baseId: string;
+  /**
+   *
+   * @type {number}
+   * @memberof GraphElementEditionIdOneOf1
+   */
+  recordId: number;
   /**
    *
    * @type {string}

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -23,7 +23,9 @@ use crate::{
         },
     },
     identifier::{
-        knowledge::{EntityEditionId, EntityId, EntityIdAndTimestamp, EntityVersion},
+        knowledge::{
+            EntityEditionId, EntityId, EntityIdAndTimestamp, EntityRecordId, EntityVersion,
+        },
         GraphElementEditionId, GraphElementId,
     },
     knowledge::{
@@ -72,6 +74,7 @@ use crate::{
             Entity,
             EntityLinkOrder,
             EntityProperties,
+            EntityRecordId,
             EntityVersion,
             EntityStructuralQuery,
             EntityQueryToken,

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
@@ -282,6 +282,7 @@ pub enum EntityQueryToken {
     // TODO: we want to expose `EntityId` here instead
     Uuid,
     Version,
+    RecordId,
     Archived,
     OwnedById,
     UpdatedById,
@@ -302,10 +303,10 @@ pub struct EntityQueryPathVisitor {
 }
 
 impl EntityQueryPathVisitor {
-    pub const EXPECTING: &'static str = "one of `uuid`, `version`, `archived`, `ownedById`, \
-                                         `updatedById`, `type`, `properties`, `incomingLinks`, \
-                                         `outgoingLinks`, `leftEntity`, `rightEntity`, \
-                                         `leftToRightOrder`, `rightToLeftOrder`";
+    pub const EXPECTING: &'static str = "one of `uuid`, `version`, `recordId`, `archived`, \
+                                         `ownedById`, `updatedById`, `type`, `properties`, \
+                                         `incomingLinks`, `outgoingLinks`, `leftEntity`, \
+                                         `rightEntity`, `leftToRightOrder`, `rightToLeftOrder`";
 
     #[must_use]
     pub const fn new(position: usize) -> Self {
@@ -331,6 +332,7 @@ impl<'de> Visitor<'de> for EntityQueryPathVisitor {
 
         Ok(match token {
             EntityQueryToken::Uuid => EntityQueryPath::Uuid,
+            EntityQueryToken::RecordId => EntityQueryPath::RecordId,
             EntityQueryToken::OwnedById => EntityQueryPath::OwnedById,
             EntityQueryToken::UpdatedById => EntityQueryPath::UpdatedById,
             EntityQueryToken::Version => EntityQueryPath::LowerTransactionTime,

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/knowledge.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/knowledge.rs
@@ -135,7 +135,7 @@ impl EntityVersion {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, ToSql)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, ToSql, ToSchema)]
 #[postgres(transparent)]
 #[repr(transparent)]
 pub struct EntityRecordId(i64);
@@ -156,7 +156,6 @@ impl EntityRecordId {
 #[serde(rename_all = "camelCase")]
 pub struct EntityEditionId {
     base_id: EntityId,
-    #[serde(skip)]
     record_id: EntityRecordId,
     version: EntityVersion,
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
@@ -748,7 +748,7 @@ mod tests {
 
     #[test]
     fn for_entity_by_edition_id() {
-        let _entity_edition_id = EntityEditionId::new(
+        let entity_edition_id = EntityEditionId::new(
             EntityId::new(
                 OwnedById::new(AccountId::new(Uuid::new_v4())),
                 EntityUuid::new(Uuid::new_v4()),
@@ -760,35 +760,32 @@ mod tests {
             ),
         );
 
-        // TODO: `EntityRecordId` is not exposed in the public API, so we can't
-        //       use it in the expected filter.
-        //   see https://app.asana.com/0/0/1203491211535116/f
-        // let expected = json! {{
-        //   "all": [
-        //     { "equal": [
-        //       { "path": ["ownedById"] },
-        //       { "parameter": entity_edition_id.base_id().owned_by_id() }
-        //     ]},
-        //     { "equal": [
-        //       { "path": ["uuid"] },
-        //       { "parameter": entity_edition_id.base_id().entity_uuid() }
-        //     ]},
-        //     { "equal": [
-        //       { "path": ["recordId"] },
-        //       { "parameter": entity_edition_id.record_id() }
-        //     ]}
-        //   ]
-        // }};
-        //
-        // test_filter_representation(
-        //     &Filter::for_entity_by_edition_id(entity_edition_id),
-        //     &expected,
-        // );
+        let expected = json! {{
+          "all": [
+            { "equal": [
+              { "path": ["ownedById"] },
+              { "parameter": entity_edition_id.base_id().owned_by_id() }
+            ]},
+            { "equal": [
+              { "path": ["uuid"] },
+              { "parameter": entity_edition_id.base_id().entity_uuid() }
+            ]},
+            { "equal": [
+              { "path": ["recordId"] },
+              { "parameter": entity_edition_id.record_id() }
+            ]}
+          ]
+        }};
+
+        test_filter_representation(
+            &Filter::for_entity_by_edition_id(entity_edition_id),
+            &expected,
+        );
     }
 
     #[test]
     fn for_outgoing_link_by_source_entity_edition_id() {
-        let _entity_edition_id = EntityEditionId::new(
+        let entity_edition_id = EntityEditionId::new(
             EntityId::new(
                 OwnedById::new(AccountId::new(Uuid::new_v4())),
                 EntityUuid::new(Uuid::new_v4()),
@@ -800,35 +797,32 @@ mod tests {
             ),
         );
 
-        // TODO: `EntityRecordId` is not exposed in the public API, so we can't
-        //       use it in the expected filter.
-        //   see https://app.asana.com/0/0/1203491211535116/f
-        // let expected = json! {{
-        //   "all": [
-        //     { "equal": [
-        //       { "path": ["leftEntity", "ownedById"] },
-        //       { "parameter": entity_edition_id.base_id().owned_by_id() }
-        //     ]},
-        //     { "equal": [
-        //       { "path": ["leftEntity", "uuid"] },
-        //       { "parameter": entity_edition_id.base_id().entity_uuid() }
-        //     ]},
-        //     { "equal": [
-        //       { "path": ["leftEntity", "recordId"] },
-        //       { "parameter": entity_edition_id.record_id() }
-        //     ]}
-        //   ]
-        // }};
-        //
-        // test_filter_representation(
-        //     &Filter::for_outgoing_link_by_source_entity_edition_id(entity_edition_id),
-        //     &expected,
-        // );
+        let expected = json! {{
+          "all": [
+            { "equal": [
+              { "path": ["leftEntity", "ownedById"] },
+              { "parameter": entity_edition_id.base_id().owned_by_id() }
+            ]},
+            { "equal": [
+              { "path": ["leftEntity", "uuid"] },
+              { "parameter": entity_edition_id.base_id().entity_uuid() }
+            ]},
+            { "equal": [
+              { "path": ["leftEntity", "recordId"] },
+              { "parameter": entity_edition_id.record_id() }
+            ]}
+          ]
+        }};
+
+        test_filter_representation(
+            &Filter::for_outgoing_link_by_source_entity_edition_id(entity_edition_id),
+            &expected,
+        );
     }
 
     #[test]
     fn for_left_entity_by_entity_edition_id() {
-        let _entity_edition_id = EntityEditionId::new(
+        let entity_edition_id = EntityEditionId::new(
             EntityId::new(
                 OwnedById::new(AccountId::new(Uuid::new_v4())),
                 EntityUuid::new(Uuid::new_v4()),
@@ -840,35 +834,32 @@ mod tests {
             ),
         );
 
-        // TODO: `EntityRecordId` is not exposed in the public API, so we can't
-        //       use it in the expected filter.
-        //   see https://app.asana.com/0/0/1203491211535116/f
-        // let expected = json! {{
-        //   "all": [
-        //     { "equal": [
-        //       { "path": ["outgoingLinks", "ownedById"] },
-        //       { "parameter": entity_edition_id.base_id().owned_by_id() }
-        //     ]},
-        //     { "equal": [
-        //       { "path": ["outgoingLinks", "uuid"] },
-        //       { "parameter": entity_edition_id.base_id().entity_uuid() }
-        //     ]},
-        //     { "equal": [
-        //       { "path": ["outgoingLinks", "recordId"] },
-        //       { "parameter": entity_edition_id.record_id() }
-        //     ]}
-        //   ]
-        // }};
-        //
-        // test_filter_representation(
-        //     &Filter::for_left_entity_by_entity_edition_id(entity_edition_id),
-        //     &expected,
-        // );
+        let expected = json! {{
+          "all": [
+            { "equal": [
+              { "path": ["outgoingLinks", "ownedById"] },
+              { "parameter": entity_edition_id.base_id().owned_by_id() }
+            ]},
+            { "equal": [
+              { "path": ["outgoingLinks", "uuid"] },
+              { "parameter": entity_edition_id.base_id().entity_uuid() }
+            ]},
+            { "equal": [
+              { "path": ["outgoingLinks", "recordId"] },
+              { "parameter": entity_edition_id.record_id() }
+            ]}
+          ]
+        }};
+
+        test_filter_representation(
+            &Filter::for_left_entity_by_entity_edition_id(entity_edition_id),
+            &expected,
+        );
     }
 
     #[test]
     fn for_right_entity_by_entity_edition_id() {
-        let _entity_edition_id = EntityEditionId::new(
+        let entity_edition_id = EntityEditionId::new(
             EntityId::new(
                 OwnedById::new(AccountId::new(Uuid::new_v4())),
                 EntityUuid::new(Uuid::new_v4()),
@@ -880,30 +871,27 @@ mod tests {
             ),
         );
 
-        // TODO: `EntityRecordId` is not exposed in the public API, so we can't
-        //       use it in the expected filter.
-        //   see https://app.asana.com/0/0/1203491211535116/f
-        // let expected = json! {{
-        //   "all": [
-        //     { "equal": [
-        //       { "path": ["incomingLinks", "ownedById"] },
-        //       { "parameter": entity_edition_id.base_id().owned_by_id() }
-        //     ]},
-        //     { "equal": [
-        //       { "path": ["incomingLinks", "uuid"] },
-        //       { "parameter": entity_edition_id.base_id().entity_uuid() }
-        //     ]},
-        //     { "equal": [
-        //       { "path": ["incomingLinks", "recordId"] },
-        //       { "parameter": entity_edition_id.record_id() }
-        //     ]}
-        //   ]
-        // }};
-        //
-        // test_filter_representation(
-        //     &Filter::for_right_entity_by_entity_edition_id(entity_edition_id),
-        //     &expected,
-        // );
+        let expected = json! {{
+          "all": [
+            { "equal": [
+              { "path": ["incomingLinks", "ownedById"] },
+              { "parameter": entity_edition_id.base_id().owned_by_id() }
+            ]},
+            { "equal": [
+              { "path": ["incomingLinks", "uuid"] },
+              { "parameter": entity_edition_id.base_id().entity_uuid() }
+            ]},
+            { "equal": [
+              { "path": ["incomingLinks", "recordId"] },
+              { "parameter": entity_edition_id.record_id() }
+            ]}
+          ]
+        }};
+
+        test_filter_representation(
+            &Filter::for_right_entity_by_entity_edition_id(entity_edition_id),
+            &expected,
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This exposes the opaque `EntityRecordId` to be available for queries.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/0/1203505325130368/f) _(internal)_
