### PR TITLE
Update to new type system revision and adjust Graph code 

### DIFF
--- a/packages/graph/hash_graph/Cargo.lock
+++ b/packages/graph/hash_graph/Cargo.lock
@@ -2019,7 +2019,7 @@ dependencies = [
 [[package]]
 name = "type-system"
 version = "0.0.0"
-source = "git+https://github.com/blockprotocol/blockprotocol?rev=494d445#494d4453453a481b295dd7d3e90e0a47b58fc6d4"
+source = "git+https://github.com/blockprotocol/blockprotocol?rev=2ea406f#2ea406f632972635cc47aa5a45fd2981533037a7"
 dependencies = [
  "console_error_panic_hook",
  "regex",

--- a/packages/graph/hash_graph/bench/Cargo.toml
+++ b/packages/graph/hash_graph/bench/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.148", features = ["derive"] }
 serde_json = "1.0.89"
 tokio = { version = "1.22.0", features = ["rt-multi-thread", "macros"] }
 tokio-postgres = { version = "0.7.7", default-features = false }
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "494d445" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "2ea406f" }
 uuid = { version = "1.2.2", features = ["v4", "serde"] }
 
 [[bench]]

--- a/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/entity.rs
@@ -12,7 +12,7 @@ use graph::{
 use graph_test_data::{data_type, entity, entity_type, property_type};
 use rand::{prelude::IteratorRandom, thread_rng};
 use tokio::runtime::Runtime;
-use type_system::EntityType;
+use type_system::{repr, EntityType};
 use uuid::Uuid;
 
 use crate::util::{seed, setup, Store, StoreWrapper};
@@ -62,7 +62,9 @@ async fn seed_db(
 
     let properties: EntityProperties =
         serde_json::from_str(entity::BOOK_V1).expect("could not parse entity");
-    let entity_type_id = EntityType::from_str(entity_type::BOOK_V1)
+    let entity_type_repr: repr::EntityType = serde_json::from_str(entity_type::BOOK_V1)
+        .expect("could not parse entity type representation");
+    let entity_type_id = EntityType::try_from(entity_type_repr)
         .expect("could not parse entity type")
         .id()
         .clone();

--- a/packages/graph/hash_graph/bench/benches/representative_read/seed.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/seed.rs
@@ -11,7 +11,7 @@ use graph::{
     store::{AccountStore, AsClient, EntityStore, PostgresStore},
 };
 use graph_test_data::{data_type, entity, entity_type, property_type};
-use type_system::{uri::VersionedUri, EntityType};
+use type_system::{repr, uri::VersionedUri, EntityType};
 use uuid::Uuid;
 
 use crate::util::{seed, StoreWrapper};
@@ -145,7 +145,9 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
     for (entity_type_str, entity_str, quantity) in SEED_ENTITIES {
         let properties: EntityProperties =
             serde_json::from_str(entity_str).expect("could not parse entity");
-        let entity_type_id = EntityType::from_str(entity_type_str)
+        let entity_type_repr: repr::EntityType = serde_json::from_str(entity_type_str)
+            .expect("could not parse entity type representation");
+        let entity_type_id = EntityType::try_from(entity_type_repr)
             .expect("could not parse entity type")
             .id()
             .clone();
@@ -164,7 +166,9 @@ async fn seed_db(account_id: AccountId, store_wrapper: &mut StoreWrapper) {
     }
 
     for (entity_type_str, left_entity_index, right_entity_index) in SEED_LINKS {
-        let entity_type_id = EntityType::from_str(entity_type_str)
+        let entity_type_repr: repr::EntityType = serde_json::from_str(entity_type_str)
+            .expect("could not parse entity type representation");
+        let entity_type_id = EntityType::try_from(entity_type_repr)
             .expect("could not parse entity type")
             .id()
             .clone();
@@ -224,7 +228,9 @@ async fn get_samples(account_id: AccountId, store_wrapper: &mut StoreWrapper) ->
         SEED_ENTITY_TYPES
             .into_iter()
             .map(|entity_type_str| {
-                EntityType::from_str(entity_type_str)
+                let entity_type_repr: repr::EntityType = serde_json::from_str(entity_type_str)
+                    .expect("could not parse entity type representation");
+                EntityType::try_from(entity_type_repr)
                     .expect("could not parse entity type")
                     .id()
                     .clone()
@@ -240,7 +246,9 @@ async fn get_samples(account_id: AccountId, store_wrapper: &mut StoreWrapper) ->
     let sample_map = samples.entities.get_mut(&account_id).unwrap();
 
     for entity_type_id in SEED_ENTITIES.map(|(entity_type_str, ..)| {
-        EntityType::from_str(entity_type_str)
+        let entity_type_repr: repr::EntityType = serde_json::from_str(entity_type_str)
+            .expect("could not parse entity type representation");
+        EntityType::try_from(entity_type_repr)
             .expect("could not parse entity type")
             .id()
             .clone()

--- a/packages/graph/hash_graph/bench/benches/util.rs
+++ b/packages/graph/hash_graph/bench/benches/util.rs
@@ -1,4 +1,4 @@
-use std::{mem::ManuallyDrop, str::FromStr};
+use std::mem::ManuallyDrop;
 
 use graph::{
     identifier::account::AccountId,
@@ -10,7 +10,7 @@ use graph::{
 };
 use tokio::runtime::Runtime;
 use tokio_postgres::NoTls;
-use type_system::{DataType, EntityType, PropertyType};
+use type_system::{repr, DataType, EntityType, PropertyType};
 
 type Pool = PostgresStorePool<NoTls>;
 pub type Store = <Pool as StorePool>::Store<'static>;
@@ -176,7 +176,9 @@ pub async fn seed<D, P, E, C>(
     C: AsClient,
 {
     for data_type_str in data_types {
-        let data_type = DataType::from_str(data_type_str).expect("could not parse data type");
+        let data_type_repr: repr::DataType =
+            serde_json::from_str(data_type_str).expect("could not parse data type representation");
+        let data_type = DataType::try_from(data_type_repr).expect("could not parse data type");
 
         match store
             .create_data_type(
@@ -201,8 +203,10 @@ pub async fn seed<D, P, E, C>(
     }
 
     for property_type_str in property_types {
+        let property_typee_repr: repr::PropertyType = serde_json::from_str(property_type_str)
+            .expect("could not parse property type representation");
         let property_type =
-            PropertyType::from_str(property_type_str).expect("could not parse property type");
+            PropertyType::try_from(property_typee_repr).expect("could not parse property type");
 
         match store
             .create_property_type(
@@ -227,8 +231,10 @@ pub async fn seed<D, P, E, C>(
     }
 
     for entity_type_str in entity_types {
+        let entity_type_repr: repr::EntityType = serde_json::from_str(entity_type_str)
+            .expect("could not parse entity type representation");
         let entity_type =
-            EntityType::from_str(entity_type_str).expect("could not parse entity type");
+            EntityType::try_from(entity_type_repr).expect("could not parse entity type");
 
         match store
             .create_entity_type(

--- a/packages/graph/hash_graph/bin/hash_graph/Cargo.toml
+++ b/packages/graph/hash_graph/bin/hash_graph/Cargo.toml
@@ -18,5 +18,5 @@ serde_json = "1.0.89"
 tokio = { version = "1.22.0", features = ["rt-multi-thread", "macros"] }
 tokio-postgres = { version = "0.7.7", default-features = false }
 tracing = "0.1.37"
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "494d445" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "2ea406f" }
 uuid = "1.2.2"

--- a/packages/graph/hash_graph/lib/graph/Cargo.toml
+++ b/packages/graph/hash_graph/lib/graph/Cargo.toml
@@ -26,7 +26,7 @@ tracing = "0.1.37"
 tracing-appender = "0.2.2"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "json"] }
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "494d445" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "2ea406f" }
 uuid = { version = "1.2.2", features = ["v4", "serde"] }
 utoipa = { version = "2.4.2", features = ["uuid"] }
 include_dir = "0.7.3"

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -11,7 +11,7 @@ use axum::{
 use error_stack::IntoReport;
 use futures::TryFutureExt;
 use serde::{Deserialize, Serialize};
-use type_system::{uri::VersionedUri, DataType};
+use type_system::{repr, uri::VersionedUri, DataType};
 use utoipa::{OpenApi, ToSchema};
 
 use super::api_resource::RoutedResource;
@@ -99,7 +99,7 @@ impl RoutedResource for DataTypeResource {
 #[serde(rename_all = "camelCase")]
 struct CreateDataTypeRequest {
     #[schema(value_type = VAR_DATA_TYPE)]
-    schema: serde_json::Value,
+    schema: repr::DataType,
     owned_by_id: OwnedById,
     actor_id: UpdatedById,
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -11,7 +11,7 @@ use axum::{
 use error_stack::IntoReport;
 use futures::TryFutureExt;
 use serde::{Deserialize, Serialize};
-use type_system::{uri::VersionedUri, EntityType};
+use type_system::{repr, uri::VersionedUri, EntityType};
 use utoipa::{OpenApi, ToSchema};
 
 use crate::{
@@ -109,7 +109,7 @@ impl RoutedResource for EntityTypeResource {
 #[serde(rename_all = "camelCase")]
 struct CreateEntityTypeRequest {
     #[schema(value_type = VAR_ENTITY_TYPE)]
-    schema: serde_json::Value,
+    schema: repr::EntityType,
     owned_by_id: OwnedById,
     actor_id: UpdatedById,
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -11,7 +11,7 @@ use axum::{
 use error_stack::IntoReport;
 use futures::TryFutureExt;
 use serde::{Deserialize, Serialize};
-use type_system::{uri::VersionedUri, PropertyType};
+use type_system::{repr, uri::VersionedUri, PropertyType};
 use utoipa::{OpenApi, ToSchema};
 
 use super::api_resource::RoutedResource;
@@ -102,7 +102,7 @@ impl RoutedResource for PropertyTypeResource {
 #[serde(rename_all = "camelCase")]
 struct CreatePropertyTypeRequest {
     #[schema(value_type = VAR_PROPERTY_TYPE)]
-    schema: serde_json::Value,
+    schema: repr::PropertyType,
     owned_by_id: OwnedById,
     actor_id: UpdatedById,
 }

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -219,7 +219,7 @@ impl OntologyType for EntityType {
     type Representation = repr::EntityType;
 }
 
-pub trait PersistedOntologyType: Sized {
+pub trait PersistedOntologyType {
     type OntologyType: OntologyType;
 
     fn new(record: Self::OntologyType, metadata: OntologyElementMetadata) -> Self;

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/context/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/context/mod.rs
@@ -1,7 +1,7 @@
 mod ontology;
 
 use async_trait::async_trait;
-use error_stack::{Context, Result, ResultExt};
+use error_stack::{Result, ResultExt};
 use type_system::uri::BaseUri;
 
 pub use self::ontology::OntologyRecord;
@@ -21,7 +21,7 @@ pub trait PostgresContext {
         base_uri: &BaseUri,
     ) -> Result<OntologyRecord<T>, QueryError>
     where
-        T: OntologyDatabaseType + TryFrom<serde_json::Value, Error: Context>;
+        T: OntologyDatabaseType;
 }
 
 #[async_trait]
@@ -31,7 +31,7 @@ impl<C: AsClient> PostgresContext for PostgresStore<C> {
         base_uri: &BaseUri,
     ) -> Result<OntologyRecord<T>, QueryError>
     where
-        T: OntologyDatabaseType + TryFrom<serde_json::Value, Error: Context>,
+        T: OntologyDatabaseType,
     {
         ontology::read_latest_type(&self.client, base_uri)
             .await

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -92,8 +92,8 @@ impl<C: AsClient> PostgresStore<C> {
                             .collect::<Vec<_>>()
                     });
 
-                let inherts_from_type_ref_uris = (current_resolve_depth.inherits_from.outgoing > 0)
-                    .then(|| {
+                let inherits_from_type_ref_uris =
+                    (current_resolve_depth.inherits_from.outgoing > 0).then(|| {
                         entity_type
                             .inner()
                             .inherits_from()
@@ -158,21 +158,21 @@ impl<C: AsClient> PostgresStore<C> {
                     }
                 }
 
-                if let Some(inherts_from_type_ref_uris) = inherts_from_type_ref_uris {
-                    for inherts_from_type_ref_uri in inherts_from_type_ref_uris {
+                if let Some(inherits_from_type_ref_uris) = inherits_from_type_ref_uris {
+                    for inherits_from_type_ref_uri in inherits_from_type_ref_uris {
                         subgraph.edges.insert(Edge::Ontology {
                             edition_id: entity_type_id.clone(),
                             outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
                                 kind: OntologyEdgeKind::InheritsFrom,
                                 reversed: false,
                                 right_endpoint: OntologyTypeEditionId::from(
-                                    &inherts_from_type_ref_uri,
+                                    &inherits_from_type_ref_uri,
                                 ),
                             }),
                         });
 
                         self.traverse_entity_type(
-                            &OntologyTypeEditionId::from(&inherts_from_type_ref_uri),
+                            &OntologyTypeEditionId::from(&inherits_from_type_ref_uri),
                             dependency_context,
                             subgraph,
                             GraphResolveDepths {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/mod.rs
@@ -5,10 +5,12 @@ mod read;
 
 use type_system::{uri::VersionedUri, DataType, EntityType, PropertyType};
 
+use crate::ontology::OntologyType;
+
 /// Provides an abstraction over elements of the Type System stored in the Database.
 ///
 /// [`PostgresDatabase`]: crate::store::PostgresDatabase
-pub trait OntologyDatabaseType {
+pub trait OntologyDatabaseType: OntologyType {
     /// Returns the name of the table where this type is stored.
     fn table() -> &'static str;
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -1,14 +1,14 @@
 use std::{fmt::Debug, str::FromStr};
 
 use async_trait::async_trait;
-use error_stack::{Context, IntoReport, Result, ResultExt};
+use error_stack::{IntoReport, Result, ResultExt};
 use futures::{StreamExt, TryStreamExt};
 use tokio_postgres::GenericClient;
 use type_system::uri::VersionedUri;
 
 use crate::{
     identifier::ontology::OntologyTypeEditionId,
-    ontology::{OntologyElementMetadata, PersistedOntologyType},
+    ontology::{OntologyElementMetadata, OntologyType, PersistedOntologyType},
     provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
         crud::Read,
@@ -28,7 +28,7 @@ where
         + for<'q> PostgresQueryRecord<Path<'q>: Debug + Send + Sync + OntologyPath>
         + Send
         + 'static,
-    T::OntologyType: OntologyDatabaseType + TryFrom<serde_json::Value, Error: Context>,
+    T::OntologyType: OntologyDatabaseType,
 {
     async fn read<'f: 'q, 'q>(&self, filter: &'f Filter<'q, T>) -> Result<Vec<T>, QueryError> {
         let versioned_uri_path = <<T as QueryRecord>::Path<'q> as OntologyPath>::versioned_uri();
@@ -60,10 +60,13 @@ where
                 let versioned_uri = VersionedUri::from_str(row.get(versioned_uri_index))
                     .into_report()
                     .change_context(QueryError)?;
-                let record =
-                    <T::OntologyType>::try_from(row.get::<_, serde_json::Value>(schema_index))
+                let record_repr: <T::OntologyType as OntologyType>::Representation =
+                    serde_json::from_value(row.get(schema_index))
                         .into_report()
                         .change_context(QueryError)?;
+                let record = T::OntologyType::try_from(record_repr)
+                    .into_report()
+                    .change_context(QueryError)?;
                 let owned_by_id = OwnedById::new(row.get(owned_by_id_index));
                 let updated_by_id = UpdatedById::new(row.get(updated_by_id_path_index));
 

--- a/packages/graph/hash_graph/tests/integration/postgres/data_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/data_type.rs
@@ -1,13 +1,13 @@
-use std::str::FromStr;
-
-use type_system::DataType;
+use type_system::{repr, DataType};
 
 use crate::postgres::DatabaseTestWrapper;
 
 #[tokio::test]
 async fn insert() {
-    let boolean_dt = DataType::from_str(graph_test_data::data_type::BOOLEAN_V1)
-        .expect("could not parse data type");
+    let data_type_repr: repr::DataType =
+        serde_json::from_str(graph_test_data::data_type::BOOLEAN_V1)
+            .expect("could not parse data type representation");
+    let boolean_dt = DataType::try_from(data_type_repr).expect("could not parse data type");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database
@@ -22,8 +22,10 @@ async fn insert() {
 
 #[tokio::test]
 async fn query() {
-    let empty_list_dt = DataType::from_str(graph_test_data::data_type::EMPTY_LIST_V1)
-        .expect("could not parse data type");
+    let data_type_repr: repr::DataType =
+        serde_json::from_str(graph_test_data::data_type::EMPTY_LIST_V1)
+            .expect("could not parse data type representation");
+    let empty_list_dt = DataType::try_from(data_type_repr).expect("could not parse data type");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database
@@ -45,10 +47,15 @@ async fn query() {
 
 #[tokio::test]
 async fn update() {
-    let object_dt_v1 = DataType::from_str(graph_test_data::data_type::OBJECT_V1)
-        .expect("could not parse data type");
-    let object_dt_v2 = DataType::from_str(graph_test_data::data_type::OBJECT_V2)
-        .expect("could not parse data type");
+    let object_dt_v1_repr: repr::DataType =
+        serde_json::from_str(graph_test_data::data_type::OBJECT_V1)
+            .expect("could not parse data type representation");
+    let object_dt_v1 = DataType::try_from(object_dt_v1_repr).expect("could not parse data type");
+
+    let object_dt_v2_repr: repr::DataType =
+        serde_json::from_str(graph_test_data::data_type::OBJECT_V2)
+            .expect("could not parse data type representation");
+    let object_dt_v2 = DataType::try_from(object_dt_v2_repr).expect("could not parse data type");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database

--- a/packages/graph/hash_graph/tests/integration/postgres/entity_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/entity_type.rs
@@ -1,14 +1,13 @@
-use std::str::FromStr;
-
 use graph_test_data::{data_type, entity_type, property_type};
-use type_system::EntityType;
+use type_system::{repr, EntityType};
 
 use crate::postgres::DatabaseTestWrapper;
 
 #[tokio::test]
 async fn insert() {
-    let person_et =
-        EntityType::from_str(entity_type::PERSON_V1).expect("could not parse entity type");
+    let person_et_repr: repr::EntityType = serde_json::from_str(entity_type::PERSON_V1)
+        .expect("could not parse entity type representation");
+    let person_et = EntityType::try_from(person_et_repr).expect("could not parse entity type");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database
@@ -26,8 +25,10 @@ async fn insert() {
 
 #[tokio::test]
 async fn query() {
+    let organization_et_repr: repr::EntityType = serde_json::from_str(entity_type::ORGANIZATION_V1)
+        .expect("could not parse entity type representation");
     let organization_et =
-        EntityType::from_str(entity_type::ORGANIZATION_V1).expect("could not parse entity type");
+        EntityType::try_from(organization_et_repr).expect("could not parse entity type");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database
@@ -49,10 +50,13 @@ async fn query() {
 
 #[tokio::test]
 async fn update() {
-    let page_et_v1 =
-        EntityType::from_str(entity_type::PAGE_V1).expect("could not parse entity type");
-    let page_et_v2 =
-        EntityType::from_str(entity_type::PAGE_V2).expect("could not parse entity type");
+    let page_et_v1_repr: repr::EntityType = serde_json::from_str(entity_type::PAGE_V1)
+        .expect("could not parse entity type representation");
+    let page_et_v1 = EntityType::try_from(page_et_v1_repr).expect("could not parse entity type");
+
+    let page_et_v2_repr: repr::EntityType = serde_json::from_str(entity_type::PAGE_V2)
+        .expect("could not parse entity type representation");
+    let page_et_v2 = EntityType::try_from(page_et_v2_repr).expect("could not parse entity type");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -36,7 +36,7 @@ use graph::{
     },
 };
 use tokio_postgres::{NoTls, Transaction};
-use type_system::{uri::VersionedUri, DataType, EntityType, PropertyType};
+use type_system::{repr, uri::VersionedUri, DataType, EntityType, PropertyType};
 use uuid::Uuid;
 
 pub struct DatabaseTestWrapper {
@@ -106,30 +106,37 @@ impl DatabaseTestWrapper {
             .await
             .expect("could not insert account id");
 
-        for data_type in data_types {
+        for data_type_str in data_types {
+            let data_type_repr: repr::DataType = serde_json::from_str(data_type_str)
+                .expect("could not parse data type representation");
             store
                 .create_data_type(
-                    DataType::from_str(data_type).expect("could not parse data type"),
+                    DataType::try_from(data_type_repr).expect("could not parse data type"),
                     OwnedById::new(account_id),
                     UpdatedById::new(account_id),
                 )
                 .await?;
         }
 
-        for property_type in property_types {
+        for property_type_str in property_types {
+            let property_type_repr: repr::PropertyType = serde_json::from_str(property_type_str)
+                .expect("could not parse property type representation");
             store
                 .create_property_type(
-                    PropertyType::from_str(property_type).expect("could not parse property type"),
+                    PropertyType::try_from(property_type_repr)
+                        .expect("could not parse property type"),
                     OwnedById::new(account_id),
                     UpdatedById::new(account_id),
                 )
                 .await?;
         }
 
-        for entity_type in entity_types {
+        for entity_type_str in entity_types {
+            let entity_type_repr: repr::EntityType = serde_json::from_str(entity_type_str)
+                .expect("could not parse entity type representation");
             store
                 .create_entity_type(
-                    EntityType::from_str(entity_type).expect("could not parse entity type"),
+                    EntityType::try_from(entity_type_repr).expect("could not parse entity type"),
                     OwnedById::new(account_id),
                     UpdatedById::new(account_id),
                 )

--- a/packages/graph/hash_graph/tests/integration/postgres/property_type.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/property_type.rs
@@ -1,14 +1,13 @@
-use std::str::FromStr;
-
 use graph_test_data::{data_type, property_type};
-use type_system::PropertyType;
+use type_system::{repr, PropertyType};
 
 use crate::postgres::DatabaseTestWrapper;
 
 #[tokio::test]
 async fn insert() {
-    let age_pt =
-        PropertyType::from_str(property_type::AGE_V1).expect("could not parse property type");
+    let age_pt_repr: repr::PropertyType = serde_json::from_str(property_type::AGE_V1)
+        .expect("could not parse property type representation");
+    let age_pt = PropertyType::try_from(age_pt_repr).expect("could not parse property type");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database
@@ -23,8 +22,11 @@ async fn insert() {
 
 #[tokio::test]
 async fn query() {
-    let favorite_quote_pt = PropertyType::from_str(property_type::FAVORITE_QUOTE_V1)
-        .expect("could not parse property type");
+    let favorite_quote_pt_repr: repr::PropertyType =
+        serde_json::from_str(property_type::FAVORITE_QUOTE_V1)
+            .expect("could not parse property type representation");
+    let favorite_quote_pt =
+        PropertyType::try_from(favorite_quote_pt_repr).expect("could not parse property type");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database
@@ -46,11 +48,15 @@ async fn query() {
 
 #[tokio::test]
 async fn update() {
+    let user_id_pt_v1_repr: repr::PropertyType = serde_json::from_str(property_type::USER_ID_V1)
+        .expect("could not parse property type representation");
     let user_id_pt_v1 =
-        PropertyType::from_str(property_type::USER_ID_V1).expect("could not parse property type");
+        PropertyType::try_from(user_id_pt_v1_repr).expect("could not parse property type");
 
+    let user_id_pt_v2_repr: repr::PropertyType = serde_json::from_str(property_type::USER_ID_V2)
+        .expect("could not parse property type representation");
     let user_id_pt_v2 =
-        PropertyType::from_str(property_type::USER_ID_V2).expect("could not parse property type");
+        PropertyType::try_from(user_id_pt_v2_repr).expect("could not parse property type");
 
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = database


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

https://github.com/blockprotocol/blockprotocol/pull/831 exposed the representation for ontology types and removed the hard dependency on `serde_json`. Instead, `serde` is used to (de)serialize from/to the representation, which than can be converted to to the validated representation. This PR adjust the Graph API to use the new changes

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203363157432084/1203449432963809/f) _(internal)_

## 🔍 What does this change?

- Update `type_system` crate
- Add `OntologyType` trait to abstract over ontology type and representation
- Use `TryFrom<repr::*>` over `TryFrom<Value>`