### PR TITLE
remove headlessui from hash

### DIFF
--- a/packages/hash/frontend/package.json
+++ b/packages/hash/frontend/package.json
@@ -32,7 +32,6 @@
     "@hashintel/hash-design-system": "0.0.0-private",
     "@hashintel/hash-shared": "0.0.0-private",
     "@hashintel/hash-subgraph": "0.0.0-private",
-    "@headlessui/react": "1.4.1",
     "@lit-labs/react": "1.0.6",
     "@mui/icons-material": "5.10.6",
     "@mui/material": "5.10.6",

--- a/packages/hash/frontend/src/pages/shared/auth-modal-layout.tsx
+++ b/packages/hash/frontend/src/pages/shared/auth-modal-layout.tsx
@@ -1,4 +1,4 @@
-import { Dialog } from "@headlessui/react";
+import { Dialog } from "@mui/material";
 import { ReactNode, FunctionComponent } from "react";
 import { AuthLayout } from "./auth-layout";
 
@@ -16,7 +16,6 @@ export const AuthModalLayout: FunctionComponent<AuthModalLayoutProps> = ({
   loading,
 }) => (
   <Dialog
-    as="div"
     open={show}
     onClose={onClose ?? (() => {})}
     style={{


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR removes `@headlessui/react` from `packages/hash/frontend` and uses MUI's `Dialog` instead.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201095311341924/1203419488743023/f) _(internal)_

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch / view the deployment
1.  Try rendering `auth-modal-layout` on this branch, and confirm that it works as expected (looks same as it's on `main` branch)

