### PR TITLE
Deprecate old endpoints

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -2302,6 +2302,7 @@ export const DataTypeApiAxiosParamCreator = function (
      *
      * @param {string} uri The URI of the data type
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getDataType: async (
@@ -2399,6 +2400,7 @@ export const DataTypeApiAxiosParamCreator = function (
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getLatestDataTypes: async (
@@ -2527,6 +2529,7 @@ export const DataTypeApiFp = function (configuration?: Configuration) {
      *
      * @param {string} uri The URI of the data type
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     async getDataType(
@@ -2576,6 +2579,7 @@ export const DataTypeApiFp = function (configuration?: Configuration) {
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     async getLatestDataTypes(
@@ -2653,6 +2657,7 @@ export const DataTypeApiFactory = function (
      *
      * @param {string} uri The URI of the data type
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getDataType(
@@ -2680,6 +2685,7 @@ export const DataTypeApiFactory = function (
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getLatestDataTypes(
@@ -2728,6 +2734,7 @@ export interface DataTypeApiInterface {
    *
    * @param {string} uri The URI of the data type
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof DataTypeApiInterface
    */
@@ -2751,6 +2758,7 @@ export interface DataTypeApiInterface {
   /**
    *
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof DataTypeApiInterface
    */
@@ -2798,6 +2806,7 @@ export class DataTypeApi extends BaseAPI implements DataTypeApiInterface {
    *
    * @param {string} uri The URI of the data type
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof DataTypeApi
    */
@@ -2826,6 +2835,7 @@ export class DataTypeApi extends BaseAPI implements DataTypeApiInterface {
   /**
    *
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof DataTypeApi
    */
@@ -3024,6 +3034,7 @@ export const EntityApiAxiosParamCreator = function (
      *
      * @param {string} entityId The EntityId
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getEntity: async (
@@ -3068,6 +3079,7 @@ export const EntityApiAxiosParamCreator = function (
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getLatestEntities: async (
@@ -3241,6 +3253,7 @@ export const EntityApiFp = function (configuration?: Configuration) {
      *
      * @param {string} entityId The EntityId
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     async getEntity(
@@ -3263,6 +3276,7 @@ export const EntityApiFp = function (configuration?: Configuration) {
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     async getLatestEntities(
@@ -3363,6 +3377,7 @@ export const EntityApiFactory = function (
      *
      * @param {string} entityId The EntityId
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getEntity(entityId: string, options?: any): AxiosPromise<Entity> {
@@ -3373,6 +3388,7 @@ export const EntityApiFactory = function (
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getLatestEntities(options?: any): AxiosPromise<Array<Entity>> {
@@ -3444,6 +3460,7 @@ export interface EntityApiInterface {
    *
    * @param {string} entityId The EntityId
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof EntityApiInterface
    */
@@ -3455,6 +3472,7 @@ export interface EntityApiInterface {
   /**
    *
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof EntityApiInterface
    */
@@ -3533,6 +3551,7 @@ export class EntityApi extends BaseAPI implements EntityApiInterface {
    *
    * @param {string} entityId The EntityId
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof EntityApi
    */
@@ -3545,6 +3564,7 @@ export class EntityApi extends BaseAPI implements EntityApiInterface {
   /**
    *
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof EntityApi
    */
@@ -3636,6 +3656,7 @@ export const EntityTypeApiAxiosParamCreator = function (
      *
      * @param {string} uri The URI of the entity type
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getEntityType: async (
@@ -3733,6 +3754,7 @@ export const EntityTypeApiAxiosParamCreator = function (
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getLatestEntityTypes: async (
@@ -3863,6 +3885,7 @@ export const EntityTypeApiFp = function (configuration?: Configuration) {
      *
      * @param {string} uri The URI of the entity type
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     async getEntityType(
@@ -3912,6 +3935,7 @@ export const EntityTypeApiFp = function (configuration?: Configuration) {
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     async getLatestEntityTypes(
@@ -3990,6 +4014,7 @@ export const EntityTypeApiFactory = function (
      *
      * @param {string} uri The URI of the entity type
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getEntityType(
@@ -4017,6 +4042,7 @@ export const EntityTypeApiFactory = function (
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getLatestEntityTypes(
@@ -4065,6 +4091,7 @@ export interface EntityTypeApiInterface {
    *
    * @param {string} uri The URI of the entity type
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof EntityTypeApiInterface
    */
@@ -4088,6 +4115,7 @@ export interface EntityTypeApiInterface {
   /**
    *
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof EntityTypeApiInterface
    */
@@ -4135,6 +4163,7 @@ export class EntityTypeApi extends BaseAPI implements EntityTypeApiInterface {
    *
    * @param {string} uri The URI of the entity type
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof EntityTypeApi
    */
@@ -4163,6 +4192,7 @@ export class EntityTypeApi extends BaseAPI implements EntityTypeApiInterface {
   /**
    *
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof EntityTypeApi
    */
@@ -4505,6 +4535,7 @@ export const GraphApiAxiosParamCreator = function (
      *
      * @param {string} uri The URI of the data type
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getDataType: async (
@@ -4656,6 +4687,7 @@ export const GraphApiAxiosParamCreator = function (
      *
      * @param {string} entityId The EntityId
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getEntity: async (
@@ -4701,6 +4733,7 @@ export const GraphApiAxiosParamCreator = function (
      *
      * @param {string} uri The URI of the entity type
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getEntityType: async (
@@ -4798,6 +4831,7 @@ export const GraphApiAxiosParamCreator = function (
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getLatestDataTypes: async (
@@ -4836,6 +4870,7 @@ export const GraphApiAxiosParamCreator = function (
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getLatestEntities: async (
@@ -4874,6 +4909,7 @@ export const GraphApiAxiosParamCreator = function (
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getLatestEntityTypes: async (
@@ -4912,6 +4948,7 @@ export const GraphApiAxiosParamCreator = function (
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getLatestPropertyTypes: async (
@@ -4951,6 +4988,7 @@ export const GraphApiAxiosParamCreator = function (
      *
      * @param {string} uri The URI of the property type
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getPropertyType: async (
@@ -5418,6 +5456,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
      *
      * @param {string} uri The URI of the data type
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     async getDataType(
@@ -5492,6 +5531,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
      *
      * @param {string} entityId The EntityId
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     async getEntity(
@@ -5515,6 +5555,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
      *
      * @param {string} uri The URI of the entity type
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     async getEntityType(
@@ -5564,6 +5605,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     async getLatestDataTypes(
@@ -5586,6 +5628,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     async getLatestEntities(
@@ -5605,6 +5648,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     async getLatestEntityTypes(
@@ -5627,6 +5671,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     async getLatestPropertyTypes(
@@ -5650,6 +5695,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
      *
      * @param {string} uri The URI of the property type
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     async getPropertyType(
@@ -5898,6 +5944,7 @@ export const GraphApiFactory = function (
      *
      * @param {string} uri The URI of the data type
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getDataType(
@@ -5940,6 +5987,7 @@ export const GraphApiFactory = function (
      *
      * @param {string} entityId The EntityId
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getEntity(entityId: string, options?: any): AxiosPromise<Entity> {
@@ -5951,6 +5999,7 @@ export const GraphApiFactory = function (
      *
      * @param {string} uri The URI of the entity type
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getEntityType(
@@ -5978,6 +6027,7 @@ export const GraphApiFactory = function (
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getLatestDataTypes(
@@ -5990,6 +6040,7 @@ export const GraphApiFactory = function (
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getLatestEntities(options?: any): AxiosPromise<Array<Entity>> {
@@ -6000,6 +6051,7 @@ export const GraphApiFactory = function (
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getLatestEntityTypes(
@@ -6012,6 +6064,7 @@ export const GraphApiFactory = function (
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getLatestPropertyTypes(
@@ -6025,6 +6078,7 @@ export const GraphApiFactory = function (
      *
      * @param {string} uri The URI of the property type
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getPropertyType(
@@ -6187,6 +6241,7 @@ export interface GraphApiInterface {
    *
    * @param {string} uri The URI of the data type
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof GraphApiInterface
    */
@@ -6223,6 +6278,7 @@ export interface GraphApiInterface {
    *
    * @param {string} entityId The EntityId
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof GraphApiInterface
    */
@@ -6235,6 +6291,7 @@ export interface GraphApiInterface {
    *
    * @param {string} uri The URI of the entity type
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof GraphApiInterface
    */
@@ -6258,6 +6315,7 @@ export interface GraphApiInterface {
   /**
    *
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof GraphApiInterface
    */
@@ -6268,6 +6326,7 @@ export interface GraphApiInterface {
   /**
    *
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof GraphApiInterface
    */
@@ -6276,6 +6335,7 @@ export interface GraphApiInterface {
   /**
    *
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof GraphApiInterface
    */
@@ -6286,6 +6346,7 @@ export interface GraphApiInterface {
   /**
    *
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof GraphApiInterface
    */
@@ -6297,6 +6358,7 @@ export interface GraphApiInterface {
    *
    * @param {string} uri The URI of the property type
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof GraphApiInterface
    */
@@ -6470,6 +6532,7 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
    *
    * @param {string} uri The URI of the data type
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof GraphApi
    */
@@ -6515,6 +6578,7 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
    *
    * @param {string} entityId The EntityId
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof GraphApi
    */
@@ -6528,6 +6592,7 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
    *
    * @param {string} uri The URI of the entity type
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof GraphApi
    */
@@ -6556,6 +6621,7 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
   /**
    *
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof GraphApi
    */
@@ -6568,6 +6634,7 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
   /**
    *
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof GraphApi
    */
@@ -6580,6 +6647,7 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
   /**
    *
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof GraphApi
    */
@@ -6592,6 +6660,7 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
   /**
    *
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof GraphApi
    */
@@ -6605,6 +6674,7 @@ export class GraphApi extends BaseAPI implements GraphApiInterface {
    *
    * @param {string} uri The URI of the property type
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof GraphApi
    */
@@ -6759,6 +6829,7 @@ export const PropertyTypeApiAxiosParamCreator = function (
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getLatestPropertyTypes: async (
@@ -6798,6 +6869,7 @@ export const PropertyTypeApiAxiosParamCreator = function (
      *
      * @param {string} uri The URI of the property type
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getPropertyType: async (
@@ -6986,6 +7058,7 @@ export const PropertyTypeApiFp = function (configuration?: Configuration) {
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     async getLatestPropertyTypes(
@@ -7009,6 +7082,7 @@ export const PropertyTypeApiFp = function (configuration?: Configuration) {
      *
      * @param {string} uri The URI of the property type
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     async getPropertyType(
@@ -7113,6 +7187,7 @@ export const PropertyTypeApiFactory = function (
     /**
      *
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getLatestPropertyTypes(
@@ -7126,6 +7201,7 @@ export const PropertyTypeApiFactory = function (
      *
      * @param {string} uri The URI of the property type
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     getPropertyType(
@@ -7188,6 +7264,7 @@ export interface PropertyTypeApiInterface {
   /**
    *
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof PropertyTypeApiInterface
    */
@@ -7199,6 +7276,7 @@ export interface PropertyTypeApiInterface {
    *
    * @param {string} uri The URI of the property type
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof PropertyTypeApiInterface
    */
@@ -7261,6 +7339,7 @@ export class PropertyTypeApi
   /**
    *
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof PropertyTypeApi
    */
@@ -7274,6 +7353,7 @@ export class PropertyTypeApi
    *
    * @param {string} uri The URI of the property type
    * @param {*} [options] Override http request option.
+   * @deprecated
    * @throws {RequiredError}
    * @memberof PropertyTypeApi
    */

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -78,6 +78,7 @@ pub struct DataTypeResource;
 
 impl RoutedResource for DataTypeResource {
     /// Create routes for interacting with data types.
+    #[expect(deprecated)]
     fn routes<P: StorePool + Send + 'static>() -> Router {
         // TODO: The URL format here is preliminary and will have to change.
         Router::new().nest(
@@ -212,6 +213,7 @@ async fn get_data_types_by_query<P: StorePool + Send>(
         (status = 500, description = "Store error occurred"),
     )
 )]
+#[deprecated = "use `/data-types/query` instead"]
 async fn get_latest_data_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<DataTypeWithMetadata>>, StatusCode> {
@@ -235,6 +237,7 @@ async fn get_latest_data_types<P: StorePool + Send>(
         ("uri" = String, Path, description = "The URI of the data type"),
     )
 )]
+#[deprecated = "use `/data-types/query` instead"]
 async fn get_data_type<P: StorePool + Send>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -111,6 +111,7 @@ pub struct EntityResource;
 
 impl RoutedResource for EntityResource {
     /// Create routes for interacting with entities.
+    #[expect(deprecated)]
     fn routes<P: StorePool + Send + 'static>() -> Router {
         // TODO: The URL format here is preliminary and will have to change.
         Router::new().nest(
@@ -122,11 +123,7 @@ impl RoutedResource for EntityResource {
                         .get(get_latest_entities::<P>)
                         .put(update_entity::<P>),
                 )
-                .route(
-                    "/archive",
-                    #[expect(deprecated)]
-                    post(archive_entity::<P>),
-                )
+                .route("/archive", post(archive_entity::<P>))
                 .route("/query", post(get_entities_by_query::<P>))
                 .route("/:entity_uuid", get(get_entity::<P>)),
         )
@@ -321,6 +318,7 @@ async fn get_entities_by_query<P: StorePool + Send>(
         (status = 500, description = "Store error occurred"),
     )
 )]
+#[deprecated = "use `/entities/query` instead"]
 async fn get_latest_entities<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<Entity>>, StatusCode> {
@@ -344,6 +342,7 @@ async fn get_latest_entities<P: StorePool + Send>(
         ("entityId" = EntityId, Path, description = "The EntityId"),
     )
 )]
+#[deprecated = "use `/entities/query` instead"]
 async fn get_entity<P: StorePool + Send>(
     Path(entity_id): Path<EntityId>,
     pool: Extension<Arc<P>>,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -88,6 +88,7 @@ pub struct EntityTypeResource;
 
 impl RoutedResource for EntityTypeResource {
     /// Create routes for interacting with entity types.
+    #[expect(deprecated)]
     fn routes<P: StorePool + Send + 'static>() -> Router {
         // TODO: The URL format here is preliminary and will have to change.
         Router::new().nest(
@@ -225,6 +226,7 @@ async fn get_entity_types_by_query<P: StorePool + Send>(
         (status = 500, description = "Store error occurred"),
     )
 )]
+#[deprecated = "use `/entity-types/query` instead"]
 async fn get_latest_entity_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<EntityTypeWithMetadata>>, StatusCode> {
@@ -248,6 +250,7 @@ async fn get_latest_entity_types<P: StorePool + Send>(
         ("uri" = String, Path, description = "The URI of the entity type"),
     )
 )]
+#[deprecated = "use `/entity-types/query` instead"]
 async fn get_entity_type<P: StorePool + Send>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -81,6 +81,7 @@ pub struct PropertyTypeResource;
 
 impl RoutedResource for PropertyTypeResource {
     /// Create routes for interacting with property types.
+    #[expect(deprecated)]
     fn routes<P: StorePool + Send + 'static>() -> Router {
         // TODO: The URL format here is preliminary and will have to change.
         Router::new().nest(
@@ -219,6 +220,7 @@ async fn get_property_types_by_query<P: StorePool + Send>(
         (status = 500, description = "Store error occurred"),
     )
 )]
+#[deprecated = "use `/property-types/query` instead"]
 async fn get_latest_property_types<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
 ) -> Result<Json<Vec<PropertyTypeWithMetadata>>, StatusCode> {
@@ -242,6 +244,7 @@ async fn get_latest_property_types<P: StorePool + Send>(
         ("uri" = String, Path, description = "The URI of the property type"),
     )
 )]
+#[deprecated = "use `/property-types/query` instead"]
 async fn get_property_type<P: StorePool + Send>(
     uri: Path<VersionedUri>,
     pool: Extension<Arc<P>>,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In order to notify the TS backend, that the old endpoints are going to be removed, we annotate them with a `deprecated` attribute

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201095311341924/1202979057056095/f) _(internal)_