### PR TITLE
Clean up predefined filters

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
@@ -86,18 +86,8 @@ where
     #[must_use]
     pub fn for_versioned_uri(versioned_uri: &'p VersionedUri) -> Self {
         Self::All(vec![
-            Self::Equal(
-                Some(FilterExpression::Path(<R::QueryPath<'p>>::base_uri())),
-                Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                    versioned_uri.base_uri().as_str(),
-                )))),
-            ),
-            Self::Equal(
-                Some(FilterExpression::Path(<R::QueryPath<'p>>::version())),
-                Some(FilterExpression::Parameter(Parameter::SignedInteger(
-                    versioned_uri.version().into(),
-                ))),
-            ),
+            Self::for_base_uri(versioned_uri.base_uri()),
+            Self::for_version(versioned_uri.version()),
         ])
     }
 
@@ -108,18 +98,8 @@ where
         ontology_type_edition_id: &'p OntologyTypeEditionId,
     ) -> Self {
         Self::All(vec![
-            Self::Equal(
-                Some(FilterExpression::Path(<R::QueryPath<'p>>::base_uri())),
-                Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
-                    ontology_type_edition_id.base_id().as_str(),
-                )))),
-            ),
-            Self::Equal(
-                Some(FilterExpression::Path(<R::QueryPath<'p>>::version())),
-                Some(FilterExpression::Parameter(Parameter::SignedInteger(
-                    ontology_type_edition_id.version().inner().into(),
-                ))),
-            ),
+            Self::for_base_uri(ontology_type_edition_id.base_id()),
+            Self::for_version(ontology_type_edition_id.version().inner()),
         ])
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
@@ -70,6 +70,17 @@ where
         )
     }
 
+    /// Creates a `Filter` to filter by a version.
+    #[must_use]
+    fn for_version(version: u32) -> Self {
+        Self::Equal(
+            Some(FilterExpression::Path(<R::QueryPath<'p>>::version())),
+            Some(FilterExpression::Parameter(Parameter::SignedInteger(
+                version.into(),
+            ))),
+        )
+    }
+
     /// Creates a `Filter` to search for a specific ontology type of kind `R`, identified by its
     /// [`VersionedUri`].
     #[must_use]

--- a/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
@@ -70,7 +70,7 @@ where
         )
     }
 
-    /// Creates a `Filter` to filter by a version.
+    /// Creates a `Filter` to filter by a given version.
     #[must_use]
     fn for_version(version: u32) -> Self {
         Self::Equal(

--- a/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
@@ -8,7 +8,7 @@ use std::{
 use chrono::{DateTime, Utc};
 use error_stack::{bail, ensure, Context, IntoReport, Report, ResultExt};
 use serde::Deserialize;
-use type_system::uri::VersionedUri;
+use type_system::uri::{BaseUri, VersionedUri};
 use uuid::Uuid;
 
 use crate::{
@@ -54,6 +54,18 @@ where
             Some(FilterExpression::Path(<R::QueryPath<'p>>::version())),
             Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
                 "latest",
+            )))),
+        )
+    }
+
+    /// Creates a `Filter` to search for a specific ontology type of kind `R`, identified by its
+    /// [`BaseUri`].
+    #[must_use]
+    pub fn for_base_uri(base_uri: &'p BaseUri) -> Self {
+        Self::Equal(
+            Some(FilterExpression::Path(<R::QueryPath<'p>>::base_uri())),
+            Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
+                base_uri.as_str(),
             )))),
         )
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The version and the base URI are re-used in some places. The base URI filter is also required for a follow-up PR.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203363157432084/1203449432963809/f) _(internal)_

## 🚫 Blocked by

- #1667 

## 🔍 What does this change?

- Add `Filter::for_base_uri`
- Add `Filter::for_version` (implementation detail)
- Reuse the above functions in other filters