### PR TITLE
Zack/making macro

### DIFF
--- a/packages/libs/error-stack/macros/Cargo.toml
+++ b/packages/libs/error-stack/macros/Cargo.toml
@@ -13,9 +13,9 @@ keywords = ["errorstack", "error-handling", "macro", "derive", "no_std"]
 categories = ["rust-patterns", "no-std"]
 
 [lib]
-proc-macro = true
+proc-macro = false
 
 [dependencies]
+error-stack = { version = "0.2.4", default-features = false }
 
 [dev-dependencies]
-error-stack = { version = "0.2.4", default-features = false }

--- a/packages/libs/error-stack/macros/Cargo.toml
+++ b/packages/libs/error-stack/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "error-stack-macros"
-version = "0.0.0-reserved"
+version = "0.0.1"
 authors = ["HASH"]
 edition = "2021"
 rust-version = "1.63.0"

--- a/packages/libs/error-stack/macros/src/lib.rs
+++ b/packages/libs/error-stack/macros/src/lib.rs
@@ -1,4 +1,4 @@
-/// # Example:
+/// # impl_error! generates simple error_stack errors.
 /// ```
 /// use error_stack::Report;
 /// use error_stack_macros::impl_error;

--- a/packages/libs/error-stack/macros/src/lib.rs
+++ b/packages/libs/error-stack/macros/src/lib.rs
@@ -1,5 +1,13 @@
 /// # Example:
+/// ```
+/// use error_stack::Report;
+/// use error_stack_macros::impl_error;
 /// impl_error!(MyError, "This is my error!");
+/// assert_eq!(
+///     format!("{}", Report::new(MyError)),
+///     "MyError: This is my error!"
+/// );
+/// ```
 
 #[macro_export]
 macro_rules! impl_error {
@@ -14,17 +22,4 @@ macro_rules! impl_error {
         }
         impl error_stack::Context for $etype {}
     };
-}
-
-#[cfg(test)]
-mod test {
-    use error_stack::Report;
-    #[test]
-    fn test_display() {
-        impl_error!(MyError, "This is my error");
-        assert_eq!(
-            format!("{}", Report::new(MyError)),
-            "MyError: This is my error"
-        );
-    }
 }

--- a/packages/libs/error-stack/macros/src/lib.rs
+++ b/packages/libs/error-stack/macros/src/lib.rs
@@ -1,1 +1,30 @@
-//! Placeholder for future support of macros.
+/// # Example:
+/// impl_error!(MyError, "This is my error!");
+
+#[macro_export]
+macro_rules! impl_error {
+    ($etype:ident, $desc:literal) => {
+        #[derive(Debug)]
+        pub struct $etype;
+
+        impl std::fmt::Display for $etype {
+            fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                fmt.write_str(&format!("{:?}: {}", self, $desc))
+            }
+        }
+        impl error_stack::Context for $etype {}
+    };
+}
+
+#[cfg(test)]
+mod test {
+    use error_stack::Report;
+    #[test]
+    fn test_display() {
+        impl_error!(MyError, "This is my error");
+        assert_eq!(
+            format!("{}", Report::new(MyError)),
+            "MyError: This is my error"
+        );
+    }
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds a simple macro to the error-stack-macros crate.  The point is avoid boilerplate code and make error_stack easier to work with.
## 🔗 Related links


- [Asana task](link) _(internal)_

## 🚫 Blocked by

NA

- [ ] ...

## 🔍 What does this change?
This change just reduces boilerplate using error_stack. 

- ...

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

- I added a small doc/doctest to the lib.rs file. 
## ⚠️ Known issues

NA

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

-

## ❓ How to test this?

cargo test?

