### PR TITLE
Allow filter creation from records

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -12,7 +12,7 @@ pub use self::query::{EntityQueryPath, EntityQueryPathVisitor, EntityQueryToken}
 use crate::{
     identifier::knowledge::{EntityEditionId, EntityId},
     provenance::ProvenanceMetadata,
-    store::Record,
+    store::{query::Filter, Record},
 };
 
 #[derive(
@@ -269,6 +269,10 @@ impl Record for Entity {
 
     fn edition_id(&self) -> &Self::EditionId {
         &self.metadata.edition_id
+    }
+
+    fn create_filter_for_edition_id(edition_id: &Self::EditionId) -> Filter<Self> {
+        Filter::for_entity_by_edition_id(*edition_id)
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -24,7 +24,7 @@ pub use self::{
 use crate::{
     identifier::ontology::OntologyTypeEditionId,
     provenance::{OwnedById, ProvenanceMetadata},
-    store::Record,
+    store::{query::Filter, Record},
 };
 
 #[derive(Deserialize, ToSchema)]
@@ -203,6 +203,10 @@ impl Record for DataTypeWithMetadata {
     fn edition_id(&self) -> &Self::EditionId {
         self.metadata().edition_id()
     }
+
+    fn create_filter_for_edition_id(edition_id: &Self::EditionId) -> Filter<Self> {
+        Filter::for_ontology_type_edition_id(edition_id)
+    }
 }
 
 impl OntologyTypeWithMetadata for DataTypeWithMetadata {
@@ -239,6 +243,10 @@ impl Record for PropertyTypeWithMetadata {
     fn edition_id(&self) -> &Self::EditionId {
         self.metadata().edition_id()
     }
+
+    fn create_filter_for_edition_id(edition_id: &Self::EditionId) -> Filter<Self> {
+        Filter::for_ontology_type_edition_id(edition_id)
+    }
 }
 
 impl OntologyTypeWithMetadata for PropertyTypeWithMetadata {
@@ -274,6 +282,10 @@ impl Record for EntityTypeWithMetadata {
 
     fn edition_id(&self) -> &Self::EditionId {
         self.metadata().edition_id()
+    }
+
+    fn create_filter_for_edition_id(edition_id: &Self::EditionId) -> Filter<Self> {
+        Filter::for_ontology_type_edition_id(edition_id)
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -24,7 +24,7 @@ use crate::{
         PropertyTypeWithMetadata,
     },
     provenance::{OwnedById, UpdatedById},
-    store::query::QueryPath,
+    store::query::{Filter, QueryPath},
     subgraph::{query::StructuralQuery, Subgraph},
 };
 
@@ -36,6 +36,8 @@ pub trait Record {
     type QueryPath<'p>: QueryPath;
 
     fn edition_id(&self) -> &Self::EditionId;
+
+    fn create_filter_for_edition_id(edition_id: &Self::EditionId) -> Filter<Self>;
 }
 
 #[derive(Debug)]

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -62,7 +62,7 @@ impl<C: AsClient> PostgresStore<C> {
                         Entry::Vacant(entry) => {
                             let entity = Read::<Entity>::read_one(
                                 self,
-                                &Filter::for_entity_by_edition_id(entity_edition_id),
+                                &Entity::create_filter_for_edition_id(&entity_edition_id),
                             )
                             .await?;
                             Some(entry.insert(entity))

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -12,8 +12,7 @@ use crate::{
     store::{
         crud::Read,
         postgres::{DependencyContext, DependencyStatus},
-        query::Filter,
-        AsClient, DataTypeStore, InsertionError, PostgresStore, QueryError, UpdateError,
+        AsClient, DataTypeStore, InsertionError, PostgresStore, QueryError, Record, UpdateError,
     },
     subgraph::{edges::GraphResolveDepths, query::StructuralQuery, Subgraph},
 };
@@ -47,7 +46,7 @@ impl<C: AsClient> PostgresStore<C> {
                     RawEntryMut::Vacant(entry) => {
                         let data_type = Read::<DataTypeWithMetadata>::read_one(
                             self,
-                            &Filter::for_ontology_type_edition_id(data_type_id),
+                            &DataTypeWithMetadata::create_filter_for_edition_id(data_type_id),
                         )
                         .await?;
                         Some(entry.insert(data_type_id.clone(), data_type).1)

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -13,8 +13,7 @@ use crate::{
     store::{
         crud::Read,
         postgres::{DependencyContext, DependencyStatus},
-        query::Filter,
-        AsClient, EntityTypeStore, InsertionError, PostgresStore, QueryError, UpdateError,
+        AsClient, EntityTypeStore, InsertionError, PostgresStore, QueryError, Record, UpdateError,
     },
     subgraph::{
         edges::{
@@ -60,7 +59,9 @@ impl<C: AsClient> PostgresStore<C> {
                         RawEntryMut::Vacant(entry) => {
                             let entity_type = Read::<EntityTypeWithMetadata>::read_one(
                                 self,
-                                &Filter::for_ontology_type_edition_id(entity_type_id),
+                                &EntityTypeWithMetadata::create_filter_for_edition_id(
+                                    entity_type_id,
+                                ),
                             )
                             .await?;
                             Some(entry.insert(entity_type_id.clone(), entity_type).1)

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -13,8 +13,8 @@ use crate::{
     store::{
         crud::Read,
         postgres::{DependencyContext, DependencyStatus},
-        query::Filter,
-        AsClient, InsertionError, PostgresStore, PropertyTypeStore, QueryError, UpdateError,
+        AsClient, InsertionError, PostgresStore, PropertyTypeStore, QueryError, Record,
+        UpdateError,
     },
     subgraph::{
         edges::{
@@ -60,7 +60,9 @@ impl<C: AsClient> PostgresStore<C> {
                         RawEntryMut::Vacant(entry) => {
                             let property_type = Read::<PropertyTypeWithMetadata>::read_one(
                                 self,
-                                &Filter::for_ontology_type_edition_id(property_type_id),
+                                &PropertyTypeWithMetadata::create_filter_for_edition_id(
+                                    property_type_id,
+                                ),
                             )
                             .await?;
                             Some(entry.insert(property_type_id.clone(), property_type).1)

--- a/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
@@ -29,7 +29,7 @@ use crate::{
     rename_all = "camelCase",
     bound = "'de: 'p, R::QueryPath<'p>: Deserialize<'de>"
 )]
-pub enum Filter<'p, R: Record> {
+pub enum Filter<'p, R: Record + ?Sized> {
     All(Vec<Self>),
     Any(Vec<Self>),
     Not(Box<Self>),
@@ -410,7 +410,7 @@ where
     rename_all = "camelCase",
     bound = "'de: 'p, R::QueryPath<'p>: Deserialize<'de>"
 )]
-pub enum FilterExpression<'p, R: Record> {
+pub enum FilterExpression<'p, R: Record + ?Sized> {
     Path(R::QueryPath<'p>),
     Parameter(Parameter<'p>),
 }

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -27,7 +27,7 @@ use graph::{
         query::{Filter, FilterExpression, Parameter},
         AccountStore, AsClient, DataTypeStore, DatabaseConnectionInfo, DatabaseType, EntityStore,
         EntityTypeStore, InsertionError, PostgresStore, PostgresStorePool, PropertyTypeStore,
-        QueryError, StorePool, UpdateError,
+        QueryError, Record, StorePool, UpdateError,
     },
     subgraph::{edges::GraphResolveDepths, query::StructuralQuery},
 };
@@ -289,7 +289,7 @@ impl DatabaseApi<'_> {
         Ok(self
             .store
             .get_entity(&StructuralQuery {
-                filter: Filter::for_entity_by_edition_id(entity_edition_id),
+                filter: Entity::create_filter_for_edition_id(&entity_edition_id),
                 graph_resolve_depths: GraphResolveDepths::default(),
             })
             .await?


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To read data from the store into the subgraph in a generic context, a filter for `Record`s has to be created. This adds a small function to allow creation for filters used in a structural query to filter by a specific edition id.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- Part of [this Asana task](https://app.asana.com/0/1203363157432084/1203444301722127/f) _(internal)_

## 🚫 Blocked by

- #1679 
- #1677