### PR TITLE
Deduplicate dependency resolution - part 2: Generalizes the subgraph insertions

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/mod.rs
@@ -248,6 +248,18 @@ pub enum GraphElementEditionId {
     KnowledgeGraph(EntityEditionId),
 }
 
+impl From<OntologyTypeEditionId> for GraphElementEditionId {
+    fn from(id: OntologyTypeEditionId) -> Self {
+        Self::Ontology(id)
+    }
+}
+
+impl From<EntityEditionId> for GraphElementEditionId {
+    fn from(id: EntityEditionId) -> Self {
+        Self::KnowledgeGraph(id)
+    }
+}
+
 // WARNING: This MUST be kept up to date with the enum variants.
 //   We have to do this because utoipa doesn't understand serde untagged:
 //   https://github.com/juhaku/utoipa/issues/320

--- a/packages/graph/hash_graph/lib/graph/src/store/crud.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/crud.rs
@@ -39,12 +39,11 @@ pub trait Read<R: Record + Send>: Sync {
                 records.len(),
             ))
         );
-        let record = records.pop().ok_or_else(|| {
+        records.pop().ok_or_else(|| {
             Report::new(QueryError).attach_printable(
                 "Expected exactly one record to be returned from the query but none was returned",
             )
-        })?;
-        Ok(record)
+        })
     }
 
     /// Looks up a single [`Record`] in the subgraph or reads it from the [`Store`] and inserts it

--- a/packages/graph/hash_graph/lib/graph/src/store/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/mod.rs
@@ -21,7 +21,9 @@ pub use self::{
     postgres::{AsClient, PostgresStore, PostgresStorePool},
 };
 use crate::{
-    identifier::{account::AccountId, knowledge::EntityId, DecisionTimestamp},
+    identifier::{
+        account::AccountId, knowledge::EntityId, DecisionTimestamp, GraphElementEditionId,
+    },
     knowledge::{Entity, EntityLinkOrder, EntityMetadata, EntityProperties, EntityUuid, LinkData},
     ontology::{
         DataTypeWithMetadata, EntityTypeWithMetadata, OntologyElementMetadata,
@@ -35,8 +37,8 @@ use crate::{
 /// A record stored in the [`store`].
 ///
 /// [`store`]: crate::store
-pub trait Record: Sized {
-    type EditionId: Clone + PartialEq + Eq + Hash + Send + Sync;
+pub trait Record: Sized + Send {
+    type EditionId: Clone + PartialEq + Eq + Hash + Send + Sync + Into<GraphElementEditionId>;
     type QueryPath<'p>: QueryPath + Send + Sync;
 
     fn edition_id(&self) -> &Self::EditionId;
@@ -47,6 +49,21 @@ pub trait Record: Sized {
         subgraph: &'s mut Subgraph,
         edition_id: &Self::EditionId,
     ) -> RawEntryMut<'s, Self::EditionId, Self, RandomState>;
+
+    fn insert_into_subgraph(self, subgraph: &mut Subgraph) -> &Self {
+        let edition_id = self.edition_id();
+        Self::subgraph_entry(subgraph, edition_id)
+            .or_insert(edition_id.clone(), self)
+            .1
+    }
+
+    fn insert_into_subgraph_as_root(self, subgraph: &mut Subgraph) -> &Self {
+        let edition_id = self.edition_id();
+        subgraph.roots.insert(edition_id.clone().into());
+        Self::subgraph_entry(subgraph, edition_id)
+            .or_insert(edition_id.clone(), self)
+            .1
+    }
 }
 
 #[derive(Debug)]

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/mod.rs
@@ -5,12 +5,12 @@ mod read;
 
 use type_system::{DataType, EntityType, PropertyType};
 
-use crate::ontology::OntologyType;
+use crate::{ontology::OntologyType, store::postgres::query::PostgresRecord};
 
 /// Provides an abstraction over elements of the Type System stored in the Database.
 ///
 /// [`PostgresDatabase`]: crate::store::PostgresDatabase
-pub trait OntologyDatabaseType: OntologyType {
+pub trait OntologyDatabaseType: OntologyType<WithMetadata: PostgresRecord> {
     /// Returns the name of the table where this type is stored.
     fn table() -> &'static str;
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -12,10 +12,7 @@ use crate::{
     provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
         crud::Read,
-        postgres::{
-            ontology::OntologyDatabaseType,
-            query::{Distinctness, PostgresRecord, SelectCompiler},
-        },
+        postgres::query::{Distinctness, PostgresRecord, SelectCompiler},
         query::{Filter, OntologyQueryPath},
         AsClient, PostgresStore, QueryError,
     },
@@ -24,9 +21,8 @@ use crate::{
 #[async_trait]
 impl<C: AsClient, T> Read<T> for PostgresStore<C>
 where
-    T: OntologyTypeWithMetadata + PostgresRecord + Send,
-    T::OntologyType: OntologyDatabaseType,
-    for<'p> T::QueryPath<'p>: Send + Sync + OntologyQueryPath,
+    T: OntologyTypeWithMetadata + PostgresRecord,
+    for<'p> T::QueryPath<'p>: OntologyQueryPath,
 {
     async fn read(&self, filter: &Filter<T>) -> Result<Vec<T>, QueryError> {
         let versioned_uri_path = <T::QueryPath<'static> as OntologyQueryPath>::versioned_uri();


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The next step towards deduplicating of dependency resolution. It's required, that the insertion of records is aware of the `Record` type being inserted, so the deduplicated resolution can just call those function.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203363157432084/1203444301722127/f) _(internal)_

## 🚫 Blocked by

- #1677 
- #1679 
- #1680 
- #1682 



## 🔍 What does this change?

- Add method to `Record` to allow inserting of themself to the provided subgraph
- Added a similar method, but add it as a root as well
- Use the above functions to simplify dependency resolution logic
- Drive-by: Simplify some trait bounds