### PR TITLE
Remove `twind` from blocks

### DIFF
--- a/blocks/embed/package.json
+++ b/blocks/embed/package.json
@@ -20,8 +20,7 @@
   },
   "dependencies": {
     "blockprotocol": "0.0.12",
-    "lodash": "4.17.21",
-    "twind": "0.16.17"
+    "lodash": "4.17.21"
   },
   "devDependencies": {
     "@local/eslint-config": "0.0.0-private",

--- a/blocks/embed/src/app.tsx
+++ b/blocks/embed/src/app.tsx
@@ -314,7 +314,7 @@ export const App: BlockComponent<BlockEntityProperties> = ({
       !!embedType && PROVIDER_NAMES_THAT_CANT_BE_RESIZED.has(embedType);
 
     return (
-      <div className={tw`flex justify-center`}>
+      <div style={{ display: "flex", justifyContent: "center" }}>
         <div>
           {shouldNotBeResized ? (
             <HtmlBlock
@@ -336,7 +336,19 @@ export const App: BlockComponent<BlockEntityProperties> = ({
         <button
           onClick={resetData}
           type="button"
-          className={tw`border-solid bg-gray-100 w-10 h-10 flex items-center justify-center ml-1 border-1 border-gray-300 rounded-sm self-start`}
+          style={{
+            alignItems: "center",
+            alignSelf: "flex-start",
+            backgroundColor: "#F3F4F6",
+            borderColor: "#D1D5DB",
+            borderRadius: "0.125rem",
+            borderStyle: "solid",
+            display: "flex",
+            height: "2.5rem",
+            justifyContent: "center",
+            marginLeft: "0.25rem",
+            width: "2.5rem",
+          }}
         >
           <Pencil />
         </button>
@@ -345,7 +357,14 @@ export const App: BlockComponent<BlockEntityProperties> = ({
   };
 
   return (
-    <div className={tw`w-full font-sans`} ref={containerRef}>
+    <div
+      style={{
+        fontFamily:
+          'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+        width: "100%",
+      }}
+      ref={containerRef}
+    >
       {renderContent()}
     </div>
   );

--- a/blocks/embed/src/app.tsx
+++ b/blocks/embed/src/app.tsx
@@ -7,8 +7,6 @@ import {
   Reducer,
 } from "react";
 
-import { tw, setup } from "twind";
-
 import { BlockComponent } from "blockprotocol/react";
 
 import { BlockProtocolUpdateEntitiesAction } from "blockprotocol";
@@ -79,8 +77,6 @@ const reducer = (state: AppState, action: Actions): AppState => {
       return state;
   }
 };
-
-setup({ preflight: false });
 
 export const App: BlockComponent<BlockEntityProperties> = ({
   accountId,

--- a/blocks/embed/src/components/edit-view.tsx
+++ b/blocks/embed/src/components/edit-view.tsx
@@ -1,5 +1,4 @@
 import { FormEvent, FunctionComponent } from "react";
-import { tw } from "twind";
 import Cross from "../svgs/cross";
 import Loader from "../svgs/loader";
 

--- a/blocks/embed/src/components/edit-view.tsx
+++ b/blocks/embed/src/components/edit-view.tsx
@@ -34,18 +34,33 @@ export const EditView: FunctionComponent<EditViewProps> = ({
     <>
       {errorString && (
         <div
-          className={tw`w-96 mx-auto mb-4 bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative`}
-          style={{ overflowWrap: "anywhere" }}
+          style={{
+            backgroundColor: "#FEE2E2",
+            borderColor: "#F87171",
+            borderRadius: "0.25rem",
+            borderWidth: "1px",
+            color: "#B91C1C",
+            marginBottom: "1rem",
+            marginLeft: "auto",
+            marginRight: "auto",
+            overflowWrap: "anywhere",
+            paddingBottom: "0.75rem",
+            paddingLeft: "1rem",
+            paddingRight: "1rem",
+            paddingTop: "0.75rem",
+            position: "relative",
+            width: "24rem",
+          }}
           role="alert"
         >
-          <div className={tw`mr-5`}>
-            <strong className={tw`font-bold`}>Error</strong>
-            <span className={tw`block sm:inline ml-2 `}>{errorString}</span>
+          <div style={{ marginRight: "1.25rem" }}>
+            <strong style={{ fontWeight: "700" }}>Error</strong>
+            <span style={tw`block sm:inline ml-2 `}>{errorString}</span>
           </div>
           <button
             onClick={() => setErrorString("")}
             type="button"
-            className={tw`absolute focus:outline-none top-0 bottom-0 right-0 px-4 py-3`}
+            style={tw`absolute focus:outline-none top-0 bottom-0 right-0 px-4 py-3`}
           >
             <Cross />
           </button>
@@ -53,29 +68,38 @@ export const EditView: FunctionComponent<EditViewProps> = ({
       )}
 
       <div
-        className={tw`w-96 mx-auto bg-white rounded-sm shadow-md overflow-hidden text-center p-4 border-2 border-gray-200`}
+        style={tw`w-96 mx-auto bg-white rounded-sm shadow-md overflow-hidden text-center p-4 border-2 border-gray-200`}
       >
-        <form className={tw`mb-0`} onSubmit={handleSubmit}>
+        <form style={{ marginBottom: "0" }} onSubmit={handleSubmit}>
           <div>
             <input
               required
-              className={tw`border-solid text-base px-1.5 py-1 rounded-sm border-2 border-gray-200 bg-gray-50 focus:outline-none focus:ring focus:border-blue-300 w-full`}
+              style={tw`border-solid text-base px-1.5 py-1 rounded-sm border-2 border-gray-200 bg-gray-50 focus:outline-none focus:ring focus:border-blue-300 w-full`}
               onChange={(event) => onChangeEmbedUrl(event.target.value)}
               value={embedUrl}
               type="url"
               placeholder={placeholderText}
             />
           </div>
-          <div className={tw`mt-4`}>
+          <div style={{ marginTop: "1rem" }}>
             <button
-              className={tw`border-none text-base bg-blue-400 rounded-sm hover:bg-blue-500 focus:bg-blue-600 py-1 text-white w-full flex items-center justify-center`}
+              style={tw`border-none text-base bg-blue-400 rounded-sm hover:bg-blue-500 focus:bg-blue-600 py-1 text-white w-full flex items-center justify-center`}
               type="submit"
             >
               {loading && <Loader />}
               {buttonText}
             </button>
           </div>
-          <div className={tw`text-sm text-gray-400 mt-4`}>{bottomText}</div>
+          <div
+            style={{
+              marginTop: "1rem",
+              color: "#9CA3AF",
+              fontSize: "0.875rem",
+              lineHeight: "1.25rem",
+            }}
+          >
+            {bottomText}
+          </div>
         </form>
       </div>
     </>

--- a/blocks/embed/src/components/edit-view.tsx
+++ b/blocks/embed/src/components/edit-view.tsx
@@ -55,12 +55,12 @@ export const EditView: FunctionComponent<EditViewProps> = ({
         >
           <div style={{ marginRight: "1.25rem" }}>
             <strong style={{ fontWeight: "700" }}>Error</strong>
-            <span style={tw`block sm:inline ml-2 `}>{errorString}</span>
+            <span className={tw`block sm:inline ml-2 `}>{errorString}</span>
           </div>
           <button
             onClick={() => setErrorString("")}
             type="button"
-            style={tw`absolute focus:outline-none top-0 bottom-0 right-0 px-4 py-3`}
+            className={tw`absolute focus:outline-none top-0 bottom-0 right-0 px-4 py-3`}
           >
             <Cross />
           </button>
@@ -68,13 +68,13 @@ export const EditView: FunctionComponent<EditViewProps> = ({
       )}
 
       <div
-        style={tw`w-96 mx-auto bg-white rounded-sm shadow-md overflow-hidden text-center p-4 border-2 border-gray-200`}
+        className={tw`w-96 mx-auto bg-white rounded-sm shadow-md overflow-hidden text-center p-4 border-2 border-gray-200`}
       >
         <form style={{ marginBottom: "0" }} onSubmit={handleSubmit}>
           <div>
             <input
               required
-              style={tw`border-solid text-base px-1.5 py-1 rounded-sm border-2 border-gray-200 bg-gray-50 focus:outline-none focus:ring focus:border-blue-300 w-full`}
+              className={tw`border-solid text-base px-1.5 py-1 rounded-sm border-2 border-gray-200 bg-gray-50 focus:outline-none focus:ring focus:border-blue-300 w-full`}
               onChange={(event) => onChangeEmbedUrl(event.target.value)}
               value={embedUrl}
               type="url"
@@ -83,7 +83,7 @@ export const EditView: FunctionComponent<EditViewProps> = ({
           </div>
           <div style={{ marginTop: "1rem" }}>
             <button
-              style={tw`border-none text-base bg-blue-400 rounded-sm hover:bg-blue-500 focus:bg-blue-600 py-1 text-white w-full flex items-center justify-center`}
+              className={tw`border-none text-base bg-blue-400 rounded-sm hover:bg-blue-500 focus:bg-blue-600 py-1 text-white w-full flex items-center justify-center`}
               type="submit"
             >
               {loading && <Loader />}

--- a/blocks/embed/src/components/resize-block.tsx
+++ b/blocks/embed/src/components/resize-block.tsx
@@ -209,9 +209,15 @@ export const ResizeBlock: FunctionComponent<ResizeBlockProps> = ({
   );
 
   return (
-    <div ref={divRef} className={tw`relative flex group`}>
+    <div ref={divRef} style={{ display: "flex", position: "relative" }}>
       <div
-        className={tw`absolute top-0 left-0 w-full h-full`}
+        style={{
+          position: "absolute",
+          top: "0",
+          left: "0",
+          width: "100%",
+          height: "100%",
+        }}
         ref={childrenWrapperRef}
       >
         {children}
@@ -222,7 +228,7 @@ export const ResizeBlock: FunctionComponent<ResizeBlockProps> = ({
             <button
               key={position}
               type="button"
-              className={tw`transition-all absolute z-10 opacity-0 group-hover:opacity-100 focus:outline-none ${className}`}
+              style={tw`transition-all absolute z-10 opacity-0 group-hover:opacity-100 focus:outline-none ${className}`}
               onMouseDown={(evt) => handleResize(evt, position)}
             >
               <CornerResize position={position} />
@@ -236,7 +242,7 @@ export const ResizeBlock: FunctionComponent<ResizeBlockProps> = ({
             style={{ maxHeight: "50%" }}
             aria-label={`${position} resize button`}
             type="button"
-            className={tw`transition-all absolute border-1 border-white rounded-full bg-black bg-opacity-70 z-10 opacity-0 focus:outline-none group-hover:opacity-100 ${className}`}
+            style={tw`transition-all absolute border-1 border-white rounded-full bg-black bg-opacity-70 z-10 opacity-0 focus:outline-none group-hover:opacity-100 ${className}`}
             onMouseDown={(evt) => handleResize(evt, position)}
           />
         );

--- a/blocks/embed/src/components/resize-block.tsx
+++ b/blocks/embed/src/components/resize-block.tsx
@@ -228,7 +228,7 @@ export const ResizeBlock: FunctionComponent<ResizeBlockProps> = ({
             <button
               key={position}
               type="button"
-              style={tw`transition-all absolute z-10 opacity-0 group-hover:opacity-100 focus:outline-none ${className}`}
+              className={tw`transition-all absolute z-10 opacity-0 group-hover:opacity-100 focus:outline-none ${className}`}
               onMouseDown={(evt) => handleResize(evt, position)}
             >
               <CornerResize position={position} />
@@ -242,7 +242,7 @@ export const ResizeBlock: FunctionComponent<ResizeBlockProps> = ({
             style={{ maxHeight: "50%" }}
             aria-label={`${position} resize button`}
             type="button"
-            style={tw`transition-all absolute border-1 border-white rounded-full bg-black bg-opacity-70 z-10 opacity-0 focus:outline-none group-hover:opacity-100 ${className}`}
+            className={tw`transition-all absolute border-1 border-white rounded-full bg-black bg-opacity-70 z-10 opacity-0 focus:outline-none group-hover:opacity-100 ${className}`}
             onMouseDown={(evt) => handleResize(evt, position)}
           />
         );

--- a/blocks/embed/src/components/resize-block.tsx
+++ b/blocks/embed/src/components/resize-block.tsx
@@ -7,7 +7,6 @@ import {
   useRef,
   MouseEvent,
 } from "react";
-import { tw } from "twind";
 import { throttle } from "lodash";
 import { MIN_WIDTH, MIN_HEIGHT } from "../constants";
 import { CornerResize } from "../svgs/corner-resize";

--- a/blocks/embed/src/dev.tsx
+++ b/blocks/embed/src/dev.tsx
@@ -65,9 +65,22 @@ const AppComponent: FunctionComponent = () => {
     useState(initialVariantIndex);
 
   return (
-    <div className={tw`mt-4 w-1/2 mx-auto`}>
+    <div
+      style={{
+        marginLeft: "auto",
+        marginRight: "auto",
+        marginTop: "1rem",
+        width: "50%",
+      }}
+    >
       <select
-        className={tw`text-base border-1 border-gray-300 rounded-md p-1`}
+        style={{
+          borderColor: "#D1D5DB",
+          borderRadius: "0.375rem",
+          fontSize: "1rem",
+          lineHeight: "1.5rem",
+          padding: "0.25rem",
+        }}
         value={selectedVariantIndex}
         onChange={(event) =>
           setSelectedVariantIndex(parseInt(event.target.value, 10))

--- a/blocks/embed/src/dev.tsx
+++ b/blocks/embed/src/dev.tsx
@@ -4,7 +4,6 @@
  */
 import { FunctionComponent, useState } from "react";
 import { render } from "react-dom";
-import { tw } from "twind";
 import { MockBlockDock } from "mock-block-dock";
 
 import Component from "./index";

--- a/blocks/embed/src/html-block.tsx
+++ b/blocks/embed/src/html-block.tsx
@@ -38,11 +38,20 @@ export const HtmlBlock: FunctionComponent<HtmlBlockProps> = ({
   return (
     <div
       ref={divRef}
-      className={tw`${
-        !dimensions ? "absolute top-0 left-0 h-full w-full" : "relative"
-      }`}
       style={
-        dimensions ? { width: dimensions.width, height: dimensions.height } : {}
+        dimensions
+          ? {
+              position: "relative",
+              width: dimensions.width,
+              height: dimensions.height,
+            }
+          : {
+              height: "100%",
+              left: "0",
+              position: "absolute",
+              top: "0",
+              width: "100%",
+            }
       }
       {...props}
     />

--- a/blocks/embed/src/html-block.tsx
+++ b/blocks/embed/src/html-block.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, FunctionComponent } from "react";
-import { tw } from "twind";
 import { toCSSText } from "./utils";
 
 type HtmlBlockProps = {

--- a/blocks/embed/src/svgs/corner-resize.tsx
+++ b/blocks/embed/src/svgs/corner-resize.tsx
@@ -12,9 +12,14 @@ export const CornerResize: FunctionComponent<CornerResizeProps> = ({
       viewBox="0 0 16 16"
       stroke="rgba(255,255,255,0.6)"
       strokeLinecap="round"
-      className={tw`h-5 w-5 fill-current text-black text-opacity-70 ${
-        position === "bottom-left" ? "rotate-90" : ""
-      }`}
+      style={{
+        color: "#000000",
+        opacity: "0.7",
+        width: "1.25rem",
+        height: "1.25rem",
+        fill: "currentColor",
+        ...(position === "bottom-left" ? { transform: "rotate(90deg)" } : {}),
+      }}
     >
       <path
         fillRule="evenodd"

--- a/blocks/embed/src/svgs/corner-resize.tsx
+++ b/blocks/embed/src/svgs/corner-resize.tsx
@@ -1,5 +1,4 @@
 import { FunctionComponent } from "react";
-import { tw } from "twind";
 
 type CornerResizeProps = {
   position: string;

--- a/blocks/embed/src/svgs/cross.tsx
+++ b/blocks/embed/src/svgs/cross.tsx
@@ -3,7 +3,12 @@ import { FunctionComponent } from "react";
 const Cross: FunctionComponent = () => {
   return (
     <svg
-      className={tw`fill-current h-6 w-6 text-red-500`}
+      style={{
+        color: "#EF4444",
+        width: "1.5rem",
+        height: "1.5rem",
+        fill: "currentColor",
+      }}
       role="button"
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 20 20"

--- a/blocks/embed/src/svgs/cross.tsx
+++ b/blocks/embed/src/svgs/cross.tsx
@@ -1,5 +1,4 @@
 import { FunctionComponent } from "react";
-import { tw } from "twind";
 
 const Cross: FunctionComponent = () => {
   return (

--- a/blocks/embed/src/svgs/loader.tsx
+++ b/blocks/embed/src/svgs/loader.tsx
@@ -1,5 +1,4 @@
 import { FunctionComponent } from "react";
-import { tw } from "twind";
 
 const Loader: FunctionComponent = () => {
   return (

--- a/blocks/embed/src/svgs/loader.tsx
+++ b/blocks/embed/src/svgs/loader.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent } from "react";
 const Loader: FunctionComponent = () => {
   return (
     <svg
-      style={tw`animate-spin h-4 text-white mr-2`}
+      className={tw`animate-spin h-4 text-white mr-2`}
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"

--- a/blocks/embed/src/svgs/loader.tsx
+++ b/blocks/embed/src/svgs/loader.tsx
@@ -3,13 +3,13 @@ import { FunctionComponent } from "react";
 const Loader: FunctionComponent = () => {
   return (
     <svg
-      className={tw`animate-spin h-4 text-white mr-2`}
+      style={tw`animate-spin h-4 text-white mr-2`}
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
     >
       <circle
-        className={tw`opacity-25`}
+        style={{ opacity: "0.25" }}
         cx="12"
         cy="12"
         r="10"
@@ -17,7 +17,7 @@ const Loader: FunctionComponent = () => {
         strokeWidth="4"
       />
       <path
-        className={tw`opacity-75`}
+        style={{ opacity: "0.75" }}
         fill="currentColor"
         d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
       />

--- a/blocks/image/package.json
+++ b/blocks/image/package.json
@@ -20,8 +20,7 @@
   },
   "dependencies": {
     "@blockprotocol/graph": "0.0.18",
-    "@blockprotocol/hook": "0.0.8",
-    "twind": "0.16.17"
+    "@blockprotocol/hook": "0.0.8"
   },
   "devDependencies": {
     "@local/eslint-config": "0.0.0-private",

--- a/blocks/image/src/components/error-alert.tsx
+++ b/blocks/image/src/components/error-alert.tsx
@@ -29,13 +29,13 @@ export const ErrorAlert: FunctionComponent<ImageErrorAlertProps> = ({
   >
     <div style={{ marginRight: "1.25rem" }}>
       <strong style={{ fontWeight: "700" }}>Error</strong>
-      <span style={tw`block sm:inline ml-2 `}>{error}</span>
+      <span className={tw`block sm:inline ml-2 `}>{error}</span>
     </div>
 
     <button
       type="button"
       onClick={onClearError}
-      style={tw`absolute top-0 bottom-0 right-0 px-4 py-3 border-0 focus:outline-none bg-transparent box-border cursor-pointer`}
+      className={tw`absolute top-0 bottom-0 right-0 px-4 py-3 border-0 focus:outline-none bg-transparent box-border cursor-pointer`}
     >
       <Cross />
     </button>

--- a/blocks/image/src/components/error-alert.tsx
+++ b/blocks/image/src/components/error-alert.tsx
@@ -8,18 +8,34 @@ export const ErrorAlert: FunctionComponent<ImageErrorAlertProps> = ({
   onClearError,
 }) => (
   <div
-    className={tw`w-96 mx-auto mb-4 bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative border-solid`}
+    style={{
+      position: "relative",
+      paddingTop: "0.75rem",
+      paddingBottom: "0.75rem",
+      paddingLeft: "1rem",
+      paddingRight: "1rem",
+      marginLeft: "auto",
+      marginRight: "auto",
+      marginBottom: "1rem",
+      backgroundColor: "#FEE2E2",
+      color: "#B91C1C",
+      width: "24rem",
+      borderRadius: "0.25rem",
+      borderWidth: "1px",
+      borderColor: "#F87171",
+      borderStyle: "solid",
+    }}
     role="alert"
   >
-    <div className={tw`mr-5`}>
-      <strong className={tw`font-bold`}>Error</strong>
-      <span className={tw`block sm:inline ml-2 `}>{error}</span>
+    <div style={{ marginRight: "1.25rem" }}>
+      <strong style={{ fontWeight: "700" }}>Error</strong>
+      <span style={tw`block sm:inline ml-2 `}>{error}</span>
     </div>
 
     <button
       type="button"
       onClick={onClearError}
-      className={tw`absolute top-0 bottom-0 right-0 px-4 py-3 border-0 focus:outline-none bg-transparent box-border cursor-pointer`}
+      style={tw`absolute top-0 bottom-0 right-0 px-4 py-3 border-0 focus:outline-none bg-transparent box-border cursor-pointer`}
     >
       <Cross />
     </button>

--- a/blocks/image/src/components/error-alert.tsx
+++ b/blocks/image/src/components/error-alert.tsx
@@ -1,5 +1,4 @@
 import { FunctionComponent } from "react";
-import { tw } from "twind";
 import Cross from "../svgs/cross";
 
 type ImageErrorAlertProps = { error: string | null; onClearError: () => void };

--- a/blocks/image/src/components/media-with-caption.tsx
+++ b/blocks/image/src/components/media-with-caption.tsx
@@ -1,5 +1,4 @@
 import { FunctionComponent } from "react";
-import { tw } from "twind";
 import Pencil from "../svgs/pencil";
 import { ResizeImageBlock } from "./resize-image-block";
 

--- a/blocks/image/src/components/media-with-caption.tsx
+++ b/blocks/image/src/components/media-with-caption.tsx
@@ -33,7 +33,7 @@ export const MediaWithCaption: FunctionComponent<MediaWithCaptionProps> = ({
   const captionNode = (
     <input
       placeholder="Add a caption"
-      className={tw`border-none bg-transparent focus:outline-none text-center mt-3`}
+      style={tw`border-none bg-transparent focus:outline-none text-center mt-3`}
       type="text"
       value={caption}
       disabled={readonly}
@@ -42,9 +42,16 @@ export const MediaWithCaption: FunctionComponent<MediaWithCaptionProps> = ({
     />
   );
   return (
-    <div className={tw`flex justify-center text-center w-full`}>
+    <div
+      style={{
+        display: "flex",
+        textAlign: "center",
+        justifyContent: "center",
+        width: "100%",
+      }}
+    >
       {props.type === "image" ? (
-        <div className={tw`flex flex-col`}>
+        <div style={{ display: "flex", flexDirection: "column" }}>
           <ResizeImageBlock
             imageSrc={src}
             width={props.width}
@@ -54,7 +61,7 @@ export const MediaWithCaption: FunctionComponent<MediaWithCaptionProps> = ({
           {captionNode}
         </div>
       ) : (
-        <div className={tw`max-w-full`}>
+        <div style={{ maxWidth: "100%" }}>
           {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
           <video
             controls
@@ -70,7 +77,15 @@ export const MediaWithCaption: FunctionComponent<MediaWithCaptionProps> = ({
         <button
           type="button"
           onClick={onReset}
-          className={tw`ml-2 bg-gray-100 p-1.5 border-1 border-gray-300 rounded-sm self-start border-solid`}
+          style={{
+            padding: "0.375rem",
+            marginLeft: "0.5rem",
+            backgroundColor: "#F3F4F6",
+            alignSelf: "flex-start",
+            borderRadius: "0.125rem",
+            borderColor: "#D1D5DB",
+            borderStyle: "solid",
+          }}
         >
           <Pencil />
         </button>

--- a/blocks/image/src/components/media-with-caption.tsx
+++ b/blocks/image/src/components/media-with-caption.tsx
@@ -33,7 +33,7 @@ export const MediaWithCaption: FunctionComponent<MediaWithCaptionProps> = ({
   const captionNode = (
     <input
       placeholder="Add a caption"
-      style={tw`border-none bg-transparent focus:outline-none text-center mt-3`}
+      className={tw`border-none bg-transparent focus:outline-none text-center mt-3`}
       type="text"
       value={caption}
       disabled={readonly}

--- a/blocks/image/src/components/resize-image-block.tsx
+++ b/blocks/image/src/components/resize-image-block.tsx
@@ -75,10 +75,10 @@ export const ResizeImageBlock: FunctionComponent<ResizeBlockProps> = ({
   };
 
   return (
-    <div className={tw`relative flex group`}>
+    <div style={{ display: "flex", position: "relative" }}>
       {/* eslint-disable-next-line jsx-a11y/img-redundant-alt */}
       <img
-        className={tw`mx-auto max-w-full`}
+        style={{ marginLeft: "auto", marginRight: "auto", maxWidth: "100%" }}
         ref={imageRef}
         src={imageSrc}
         alt="Image block"
@@ -88,7 +88,7 @@ export const ResizeImageBlock: FunctionComponent<ResizeBlockProps> = ({
         <div
           key={position}
           style={{ maxHeight: "50%" }}
-          className={tw`transition-all absolute ${
+          style={tw`transition-all absolute ${
             position === "left" ? "left-1" : "right-1"
           } top-1/2 -translate-y-1/2 h-12 w-1.5 rounded-full bg-black bg-opacity-70 cursor-col-resize opacity-0 group-hover:opacity-100`}
           onMouseDown={(evt) => handleResize(evt, position)}

--- a/blocks/image/src/components/resize-image-block.tsx
+++ b/blocks/image/src/components/resize-image-block.tsx
@@ -88,7 +88,7 @@ export const ResizeImageBlock: FunctionComponent<ResizeBlockProps> = ({
         <div
           key={position}
           style={{ maxHeight: "50%" }}
-          style={tw`transition-all absolute ${
+          className={tw`transition-all absolute ${
             position === "left" ? "left-1" : "right-1"
           } top-1/2 -translate-y-1/2 h-12 w-1.5 rounded-full bg-black bg-opacity-70 cursor-col-resize opacity-0 group-hover:opacity-100`}
           onMouseDown={(evt) => handleResize(evt, position)}

--- a/blocks/image/src/components/resize-image-block.tsx
+++ b/blocks/image/src/components/resize-image-block.tsx
@@ -1,5 +1,4 @@
 import { FunctionComponent, MouseEvent, useLayoutEffect, useRef } from "react";
-import { tw } from "twind";
 
 type ResizeBlockProps = {
   imageSrc: string;

--- a/blocks/image/src/components/upload-media-form.tsx
+++ b/blocks/image/src/components/upload-media-form.tsx
@@ -1,5 +1,4 @@
 import { ChangeEvent, FunctionComponent } from "react";
-import { tw } from "twind";
 import Loader from "../svgs/loader";
 
 type UploadMediaFormProps = {

--- a/blocks/image/src/components/upload-media-form.tsx
+++ b/blocks/image/src/components/upload-media-form.tsx
@@ -31,7 +31,7 @@ export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
 
   return (
     <div
-      className={tw`w-96 mx-auto bg-white rounded-sm shadow-md overflow-hidden text-center p-4 border-2 border-gray-200`}
+      style={tw`w-96 mx-auto bg-white rounded-sm shadow-md overflow-hidden text-center p-4 border-2 border-gray-200`}
       onDragOver={(event) => {
         event.stopPropagation();
         event.preventDefault();
@@ -44,7 +44,7 @@ export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
       }}
     >
       <form
-        className={tw`mb-0`}
+        style={{ marginBottom: "0" }}
         onSubmit={(event) => {
           event.preventDefault();
 
@@ -54,7 +54,7 @@ export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
         <div>
           {/** @todo need to make this controlled */}
           <input
-            className={tw`box-border text-base border-solid px-1.5 py-1 rounded-sm border-2 border-gray-200 bg-gray-50 focus:outline-none focus:ring focus:border-blue-300 w-full`}
+            style={tw`box-border text-base border-solid px-1.5 py-1 rounded-sm border-2 border-gray-200 bg-gray-50 focus:outline-none focus:ring focus:border-blue-300 w-full`}
             onChange={(event) => onUrlChange(event.target.value)}
             type="url"
             placeholder={`Enter ${capitalisedType} URL`}
@@ -64,7 +64,7 @@ export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
         <div>
           <label>
             <div
-              className={tw`text-base my-4 bg-gray-50 border-2 border-dashed border-gray-200 py-4 text-sm text-gray-400 ${
+              style={tw`text-base my-4 bg-gray-50 border-2 border-dashed border-gray-200 py-4 text-sm text-gray-400 ${
                 !readonly ? "cursor-pointer" : ""
               }`}
             >
@@ -72,7 +72,7 @@ export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
             </div>
 
             <input
-              className={tw`hidden`}
+              style={{ display: "none" }}
               disabled={readonly}
               type="file"
               accept={`${type}/*`}
@@ -82,10 +82,10 @@ export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
             />
           </label>
         </div>
-        <div className={tw`mt-4`}>
+        <div style={{ marginTop: "1rem" }}>
           {!readonly && (
             <button
-              className={tw`text-base border-none bg-blue-400 rounded-sm hover:bg-blue-500 focus:bg-blue-600 py-1 text-white w-full flex items-center justify-center`}
+              style={tw`text-base border-none bg-blue-400 rounded-sm hover:bg-blue-500 focus:bg-blue-600 py-1 text-white w-full flex items-center justify-center`}
               type="submit"
             >
               {loading && <Loader />}
@@ -93,7 +93,14 @@ export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
             </button>
           )}
         </div>
-        <div className={tw`text-sm text-gray-400 mt-4`}>
+        <div
+          style={{
+            marginTop: "1rem",
+            color: "#9CA3AF",
+            fontSize: "0.875rem",
+            lineHeight: "1.25rem",
+          }}
+        >
           Works with web-supported {type} formats
         </div>
       </form>

--- a/blocks/image/src/components/upload-media-form.tsx
+++ b/blocks/image/src/components/upload-media-form.tsx
@@ -31,7 +31,7 @@ export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
 
   return (
     <div
-      style={tw`w-96 mx-auto bg-white rounded-sm shadow-md overflow-hidden text-center p-4 border-2 border-gray-200`}
+      className={tw`w-96 mx-auto bg-white rounded-sm shadow-md overflow-hidden text-center p-4 border-2 border-gray-200`}
       onDragOver={(event) => {
         event.stopPropagation();
         event.preventDefault();
@@ -54,7 +54,7 @@ export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
         <div>
           {/** @todo need to make this controlled */}
           <input
-            style={tw`box-border text-base border-solid px-1.5 py-1 rounded-sm border-2 border-gray-200 bg-gray-50 focus:outline-none focus:ring focus:border-blue-300 w-full`}
+            className={tw`box-border text-base border-solid px-1.5 py-1 rounded-sm border-2 border-gray-200 bg-gray-50 focus:outline-none focus:ring focus:border-blue-300 w-full`}
             onChange={(event) => onUrlChange(event.target.value)}
             type="url"
             placeholder={`Enter ${capitalisedType} URL`}
@@ -64,7 +64,7 @@ export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
         <div>
           <label>
             <div
-              style={tw`text-base my-4 bg-gray-50 border-2 border-dashed border-gray-200 py-4 text-sm text-gray-400 ${
+              className={tw`text-base my-4 bg-gray-50 border-2 border-dashed border-gray-200 py-4 text-sm text-gray-400 ${
                 !readonly ? "cursor-pointer" : ""
               }`}
             >
@@ -85,7 +85,7 @@ export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
         <div style={{ marginTop: "1rem" }}>
           {!readonly && (
             <button
-              style={tw`text-base border-none bg-blue-400 rounded-sm hover:bg-blue-500 focus:bg-blue-600 py-1 text-white w-full flex items-center justify-center`}
+              className={tw`text-base border-none bg-blue-400 rounded-sm hover:bg-blue-500 focus:bg-blue-600 py-1 text-white w-full flex items-center justify-center`}
               type="submit"
             >
               {loading && <Loader />}

--- a/blocks/image/src/image.tsx
+++ b/blocks/image/src/image.tsx
@@ -25,7 +25,14 @@ export const Image: BlockComponent<BlockEntityProperties> = (props) => {
   );
 
   return (
-    <div ref={blockRef} className={tw`font-sans box-border`}>
+    <div
+      ref={blockRef}
+      style={{
+        boxSizing: "border-box",
+        fontFamily:
+          'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+      }}
+    >
       {showFallback && (
         <Media {...props} blockRef={blockRef} mediaType="image" />
       )}

--- a/blocks/image/src/image.tsx
+++ b/blocks/image/src/image.tsx
@@ -1,12 +1,9 @@
 import { BlockComponent } from "@blockprotocol/graph/react";
 import { useRef, useState } from "react";
 import { useHook, useHookBlockService } from "@blockprotocol/hook/react";
-import { tw, setup } from "twind";
 import { Media, MediaEntityProperties } from "./components/media";
 
 export type BlockEntityProperties = MediaEntityProperties;
-
-setup({ preflight: false });
 
 export const Image: BlockComponent<BlockEntityProperties> = (props) => {
   const [showFallback, setShowFallback] = useState(false);

--- a/blocks/image/src/svgs/cross.tsx
+++ b/blocks/image/src/svgs/cross.tsx
@@ -3,7 +3,12 @@ import { FunctionComponent } from "react";
 const Cross: FunctionComponent = () => {
   return (
     <svg
-      className={tw`fill-current h-6 w-6 text-red-500`}
+      style={{
+        color: "#EF4444",
+        width: "1.5rem",
+        height: "1.5rem",
+        fill: "currentColor",
+      }}
       role="button"
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 20 20"

--- a/blocks/image/src/svgs/cross.tsx
+++ b/blocks/image/src/svgs/cross.tsx
@@ -1,5 +1,4 @@
 import { FunctionComponent } from "react";
-import { tw } from "twind";
 
 const Cross: FunctionComponent = () => {
   return (

--- a/blocks/image/src/svgs/loader.tsx
+++ b/blocks/image/src/svgs/loader.tsx
@@ -1,5 +1,4 @@
 import { FunctionComponent } from "react";
-import { tw } from "twind";
 
 const Loader: FunctionComponent = () => {
   return (

--- a/blocks/image/src/svgs/loader.tsx
+++ b/blocks/image/src/svgs/loader.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent } from "react";
 const Loader: FunctionComponent = () => {
   return (
     <svg
-      style={tw`animate-spin h-4 text-white mr-2`}
+      className={tw`animate-spin h-4 text-white mr-2`}
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"

--- a/blocks/image/src/svgs/loader.tsx
+++ b/blocks/image/src/svgs/loader.tsx
@@ -3,13 +3,13 @@ import { FunctionComponent } from "react";
 const Loader: FunctionComponent = () => {
   return (
     <svg
-      className={tw`animate-spin h-4 text-white mr-2`}
+      style={tw`animate-spin h-4 text-white mr-2`}
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
     >
       <circle
-        className={tw`opacity-25`}
+        style={{ opacity: "0.25" }}
         cx="12"
         cy="12"
         r="10"
@@ -17,7 +17,7 @@ const Loader: FunctionComponent = () => {
         strokeWidth="4"
       />
       <path
-        className={tw`opacity-75`}
+        style={{ opacity: "0.75" }}
         fill="currentColor"
         d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
       />

--- a/blocks/video/package.json
+++ b/blocks/video/package.json
@@ -19,8 +19,7 @@
     "serve": "block-scripts serve"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.18",
-    "twind": "0.16.17"
+    "@blockprotocol/graph": "0.0.18"
   },
   "devDependencies": {
     "@local/eslint-config": "0.0.0-private",

--- a/blocks/video/src/components/error-alert.tsx
+++ b/blocks/video/src/components/error-alert.tsx
@@ -29,13 +29,13 @@ export const ErrorAlert: FunctionComponent<ImageErrorAlertProps> = ({
   >
     <div style={{ marginRight: "1.25rem" }}>
       <strong style={{ fontWeight: "700" }}>Error</strong>
-      <span style={tw`block sm:inline ml-2 `}>{error}</span>
+      <span className={tw`block sm:inline ml-2 `}>{error}</span>
     </div>
 
     <button
       type="button"
       onClick={onClearError}
-      style={tw`absolute top-0 bottom-0 right-0 px-4 py-3 border-0 focus:outline-none bg-transparent box-border cursor-pointer`}
+      className={tw`absolute top-0 bottom-0 right-0 px-4 py-3 border-0 focus:outline-none bg-transparent box-border cursor-pointer`}
     >
       <Cross />
     </button>

--- a/blocks/video/src/components/error-alert.tsx
+++ b/blocks/video/src/components/error-alert.tsx
@@ -8,18 +8,34 @@ export const ErrorAlert: FunctionComponent<ImageErrorAlertProps> = ({
   onClearError,
 }) => (
   <div
-    className={tw`w-96 mx-auto mb-4 bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative border-solid`}
+    style={{
+      position: "relative",
+      paddingTop: "0.75rem",
+      paddingBottom: "0.75rem",
+      paddingLeft: "1rem",
+      paddingRight: "1rem",
+      marginLeft: "auto",
+      marginRight: "auto",
+      marginBottom: "1rem",
+      backgroundColor: "#FEE2E2",
+      color: "#B91C1C",
+      width: "24rem",
+      borderRadius: "0.25rem",
+      borderWidth: "1px",
+      borderColor: "#F87171",
+      borderStyle: "solid",
+    }}
     role="alert"
   >
-    <div className={tw`mr-5`}>
-      <strong className={tw`font-bold`}>Error</strong>
-      <span className={tw`block sm:inline ml-2 `}>{error}</span>
+    <div style={{ marginRight: "1.25rem" }}>
+      <strong style={{ fontWeight: "700" }}>Error</strong>
+      <span style={tw`block sm:inline ml-2 `}>{error}</span>
     </div>
 
     <button
       type="button"
       onClick={onClearError}
-      className={tw`absolute top-0 bottom-0 right-0 px-4 py-3 border-0 focus:outline-none bg-transparent box-border cursor-pointer`}
+      style={tw`absolute top-0 bottom-0 right-0 px-4 py-3 border-0 focus:outline-none bg-transparent box-border cursor-pointer`}
     >
       <Cross />
     </button>

--- a/blocks/video/src/components/error-alert.tsx
+++ b/blocks/video/src/components/error-alert.tsx
@@ -1,5 +1,4 @@
 import { FunctionComponent } from "react";
-import { tw } from "twind";
 import Cross from "../svgs/cross";
 
 type ImageErrorAlertProps = { error: string | null; onClearError: () => void };

--- a/blocks/video/src/components/media-with-caption.tsx
+++ b/blocks/video/src/components/media-with-caption.tsx
@@ -1,5 +1,4 @@
 import { FunctionComponent } from "react";
-import { tw } from "twind";
 import Pencil from "../svgs/pencil";
 import { ResizeImageBlock } from "./resize-image-block";
 

--- a/blocks/video/src/components/media-with-caption.tsx
+++ b/blocks/video/src/components/media-with-caption.tsx
@@ -33,7 +33,7 @@ export const MediaWithCaption: FunctionComponent<MediaWithCaptionProps> = ({
   const captionNode = (
     <input
       placeholder="Add a caption"
-      className={tw`border-none bg-transparent focus:outline-none text-center mt-3`}
+      style={tw`border-none bg-transparent focus:outline-none text-center mt-3`}
       type="text"
       value={caption}
       disabled={readonly}
@@ -42,9 +42,16 @@ export const MediaWithCaption: FunctionComponent<MediaWithCaptionProps> = ({
     />
   );
   return (
-    <div className={tw`flex justify-center text-center w-full`}>
+    <div
+      style={{
+        display: "flex",
+        textAlign: "center",
+        justifyContent: "center",
+        width: "100%",
+      }}
+    >
       {props.type === "image" ? (
-        <div className={tw`flex flex-col`}>
+        <div style={{ display: "flex", flexDirection: "column" }}>
           <ResizeImageBlock
             imageSrc={src}
             width={props.width}
@@ -54,7 +61,7 @@ export const MediaWithCaption: FunctionComponent<MediaWithCaptionProps> = ({
           {captionNode}
         </div>
       ) : (
-        <div className={tw`max-w-full`}>
+        <div style={{ maxWidth: "100%" }}>
           {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
           <video
             controls
@@ -70,7 +77,15 @@ export const MediaWithCaption: FunctionComponent<MediaWithCaptionProps> = ({
         <button
           type="button"
           onClick={onReset}
-          className={tw`ml-2 bg-gray-100 p-1.5 border-1 border-gray-300 rounded-sm self-start border-solid`}
+          style={{
+            padding: "0.375rem",
+            marginLeft: "0.5rem",
+            backgroundColor: "#F3F4F6",
+            alignSelf: "flex-start",
+            borderRadius: "0.125rem",
+            borderColor: "#D1D5DB",
+            borderStyle: "solid",
+          }}
         >
           <Pencil />
         </button>

--- a/blocks/video/src/components/media-with-caption.tsx
+++ b/blocks/video/src/components/media-with-caption.tsx
@@ -33,7 +33,7 @@ export const MediaWithCaption: FunctionComponent<MediaWithCaptionProps> = ({
   const captionNode = (
     <input
       placeholder="Add a caption"
-      style={tw`border-none bg-transparent focus:outline-none text-center mt-3`}
+      className={tw`border-none bg-transparent focus:outline-none text-center mt-3`}
       type="text"
       value={caption}
       disabled={readonly}

--- a/blocks/video/src/components/media.tsx
+++ b/blocks/video/src/components/media.tsx
@@ -14,7 +14,6 @@ import {
   UpdateEntityData,
 } from "@blockprotocol/graph";
 import { useGraphBlockService } from "@blockprotocol/graph/react";
-import { tw } from "twind";
 import {
   Dispatch,
   SetStateAction,

--- a/blocks/video/src/components/media.tsx
+++ b/blocks/video/src/components/media.tsx
@@ -335,7 +335,14 @@ export const Media: FunctionComponent<
   };
 
   return (
-    <div ref={blockRef} className={tw`font-sans box-border`}>
+    <div
+      ref={blockRef}
+      style={{
+        boxSizing: "border-box",
+        fontFamily:
+          'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+      }}
+    >
       {draftSrc ? (
         <MediaWithCaption
           src={draftSrc}

--- a/blocks/video/src/components/resize-image-block.tsx
+++ b/blocks/video/src/components/resize-image-block.tsx
@@ -75,10 +75,10 @@ export const ResizeImageBlock: FunctionComponent<ResizeBlockProps> = ({
   };
 
   return (
-    <div className={tw`relative flex group`}>
+    <div style={{ display: "flex", position: "relative" }}>
       {/* eslint-disable-next-line jsx-a11y/img-redundant-alt */}
       <img
-        className={tw`mx-auto max-w-full`}
+        style={{ marginLeft: "auto", marginRight: "auto", maxWidth: "100%" }}
         ref={imageRef}
         src={imageSrc}
         alt="Image block"
@@ -88,7 +88,7 @@ export const ResizeImageBlock: FunctionComponent<ResizeBlockProps> = ({
         <div
           key={position}
           style={{ maxHeight: "50%" }}
-          className={tw`transition-all absolute ${
+          style={tw`transition-all absolute ${
             position === "left" ? "left-1" : "right-1"
           } top-1/2 -translate-y-1/2 h-12 w-1.5 rounded-full bg-black bg-opacity-70 cursor-col-resize opacity-0 group-hover:opacity-100`}
           onMouseDown={(evt) => handleResize(evt, position)}

--- a/blocks/video/src/components/resize-image-block.tsx
+++ b/blocks/video/src/components/resize-image-block.tsx
@@ -88,7 +88,7 @@ export const ResizeImageBlock: FunctionComponent<ResizeBlockProps> = ({
         <div
           key={position}
           style={{ maxHeight: "50%" }}
-          style={tw`transition-all absolute ${
+          className={tw`transition-all absolute ${
             position === "left" ? "left-1" : "right-1"
           } top-1/2 -translate-y-1/2 h-12 w-1.5 rounded-full bg-black bg-opacity-70 cursor-col-resize opacity-0 group-hover:opacity-100`}
           onMouseDown={(evt) => handleResize(evt, position)}

--- a/blocks/video/src/components/resize-image-block.tsx
+++ b/blocks/video/src/components/resize-image-block.tsx
@@ -1,5 +1,4 @@
 import { FunctionComponent, MouseEvent, useLayoutEffect, useRef } from "react";
-import { tw } from "twind";
 
 type ResizeBlockProps = {
   imageSrc: string;

--- a/blocks/video/src/components/upload-media-form.tsx
+++ b/blocks/video/src/components/upload-media-form.tsx
@@ -1,5 +1,4 @@
 import { ChangeEvent, FunctionComponent } from "react";
-import { tw } from "twind";
 import Loader from "../svgs/loader";
 
 type UploadMediaFormProps = {

--- a/blocks/video/src/components/upload-media-form.tsx
+++ b/blocks/video/src/components/upload-media-form.tsx
@@ -31,7 +31,7 @@ export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
 
   return (
     <div
-      style={tw`w-96 mx-auto bg-white rounded-sm shadow-md overflow-hidden text-center p-4 border-2 border-gray-200`}
+      className={tw`w-96 mx-auto bg-white rounded-sm shadow-md overflow-hidden text-center p-4 border-2 border-gray-200`}
       onDragOver={(event) => {
         event.stopPropagation();
         event.preventDefault();
@@ -53,7 +53,7 @@ export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
         <div>
           {/** @todo need to make this controlled */}
           <input
-            style={tw`box-border text-base border-solid px-1.5 py-1 rounded-sm border-2 border-gray-200 bg-gray-50 focus:outline-none focus:ring focus:border-blue-300 w-full`}
+            className={tw`box-border text-base border-solid px-1.5 py-1 rounded-sm border-2 border-gray-200 bg-gray-50 focus:outline-none focus:ring focus:border-blue-300 w-full`}
             onChange={(event) => onUrlChange(event.target.value)}
             type="url"
             placeholder={`Enter ${capitalisedType} URL`}
@@ -63,7 +63,7 @@ export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
         <div>
           <label>
             <div
-              style={tw`text-base my-4 bg-gray-50 border-2 border-dashed border-gray-200 py-4 text-sm text-gray-400 ${
+              className={tw`text-base my-4 bg-gray-50 border-2 border-dashed border-gray-200 py-4 text-sm text-gray-400 ${
                 !readonly ? "cursor-pointer" : ""
               }`}
             >
@@ -84,7 +84,7 @@ export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
         <div style={{ marginTop: "1rem" }}>
           {!readonly && (
             <button
-              style={tw`text-base border-none bg-blue-400 rounded-sm hover:bg-blue-500 focus:bg-blue-600 py-1 text-white w-full flex items-center justify-center`}
+              className={tw`text-base border-none bg-blue-400 rounded-sm hover:bg-blue-500 focus:bg-blue-600 py-1 text-white w-full flex items-center justify-center`}
               type="submit"
             >
               {loading && <Loader />}

--- a/blocks/video/src/components/upload-media-form.tsx
+++ b/blocks/video/src/components/upload-media-form.tsx
@@ -31,7 +31,7 @@ export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
 
   return (
     <div
-      className={tw`w-96 mx-auto bg-white rounded-sm shadow-md overflow-hidden text-center p-4 border-2 border-gray-200`}
+      style={tw`w-96 mx-auto bg-white rounded-sm shadow-md overflow-hidden text-center p-4 border-2 border-gray-200`}
       onDragOver={(event) => {
         event.stopPropagation();
         event.preventDefault();
@@ -44,7 +44,7 @@ export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
       }}
     >
       <form
-        className={tw`mb-0`}
+        style={{ marginBottom: "0" }}
         onSubmit={(event) => {
           event.preventDefault();
           onUrlConfirm();
@@ -53,7 +53,7 @@ export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
         <div>
           {/** @todo need to make this controlled */}
           <input
-            className={tw`box-border text-base border-solid px-1.5 py-1 rounded-sm border-2 border-gray-200 bg-gray-50 focus:outline-none focus:ring focus:border-blue-300 w-full`}
+            style={tw`box-border text-base border-solid px-1.5 py-1 rounded-sm border-2 border-gray-200 bg-gray-50 focus:outline-none focus:ring focus:border-blue-300 w-full`}
             onChange={(event) => onUrlChange(event.target.value)}
             type="url"
             placeholder={`Enter ${capitalisedType} URL`}
@@ -63,7 +63,7 @@ export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
         <div>
           <label>
             <div
-              className={tw`text-base my-4 bg-gray-50 border-2 border-dashed border-gray-200 py-4 text-sm text-gray-400 ${
+              style={tw`text-base my-4 bg-gray-50 border-2 border-dashed border-gray-200 py-4 text-sm text-gray-400 ${
                 !readonly ? "cursor-pointer" : ""
               }`}
             >
@@ -71,7 +71,7 @@ export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
             </div>
 
             <input
-              className={tw`hidden`}
+              style={{ display: "none" }}
               disabled={readonly}
               type="file"
               accept={`${type}/*`}
@@ -81,10 +81,10 @@ export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
             />
           </label>
         </div>
-        <div className={tw`mt-4`}>
+        <div style={{ marginTop: "1rem" }}>
           {!readonly && (
             <button
-              className={tw`text-base border-none bg-blue-400 rounded-sm hover:bg-blue-500 focus:bg-blue-600 py-1 text-white w-full flex items-center justify-center`}
+              style={tw`text-base border-none bg-blue-400 rounded-sm hover:bg-blue-500 focus:bg-blue-600 py-1 text-white w-full flex items-center justify-center`}
               type="submit"
             >
               {loading && <Loader />}
@@ -92,7 +92,14 @@ export const UploadMediaForm: FunctionComponent<UploadMediaFormProps> = ({
             </button>
           )}
         </div>
-        <div className={tw`text-sm text-gray-400 mt-4`}>
+        <div
+          style={{
+            marginTop: "1rem",
+            color: "#9CA3AF",
+            fontSize: "0.875rem",
+            lineHeight: "1.25rem",
+          }}
+        >
           Works with web-supported {type} formats
         </div>
       </form>

--- a/blocks/video/src/svgs/cross.tsx
+++ b/blocks/video/src/svgs/cross.tsx
@@ -3,7 +3,12 @@ import { FunctionComponent } from "react";
 const Cross: FunctionComponent = () => {
   return (
     <svg
-      className={tw`fill-current h-6 w-6 text-red-500`}
+      style={{
+        color: "#EF4444",
+        width: "1.5rem",
+        height: "1.5rem",
+        fill: "currentColor",
+      }}
       role="button"
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 20 20"

--- a/blocks/video/src/svgs/cross.tsx
+++ b/blocks/video/src/svgs/cross.tsx
@@ -1,5 +1,4 @@
 import { FunctionComponent } from "react";
-import { tw } from "twind";
 
 const Cross: FunctionComponent = () => {
   return (

--- a/blocks/video/src/svgs/loader.tsx
+++ b/blocks/video/src/svgs/loader.tsx
@@ -1,5 +1,4 @@
 import { FunctionComponent } from "react";
-import { tw } from "twind";
 
 const Loader: FunctionComponent = () => {
   return (

--- a/blocks/video/src/svgs/loader.tsx
+++ b/blocks/video/src/svgs/loader.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent } from "react";
 const Loader: FunctionComponent = () => {
   return (
     <svg
-      style={tw`animate-spin h-4 text-white mr-2`}
+      className={tw`animate-spin h-4 text-white mr-2`}
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"

--- a/blocks/video/src/svgs/loader.tsx
+++ b/blocks/video/src/svgs/loader.tsx
@@ -3,13 +3,13 @@ import { FunctionComponent } from "react";
 const Loader: FunctionComponent = () => {
   return (
     <svg
-      className={tw`animate-spin h-4 text-white mr-2`}
+      style={tw`animate-spin h-4 text-white mr-2`}
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
     >
       <circle
-        className={tw`opacity-25`}
+        style={{ opacity: "0.25" }}
         cx="12"
         cy="12"
         r="10"
@@ -17,7 +17,7 @@ const Loader: FunctionComponent = () => {
         strokeWidth="4"
       />
       <path
-        className={tw`opacity-75`}
+        style={{ opacity: "0.75" }}
         fill="currentColor"
         d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
       />

--- a/blocks/video/src/video.tsx
+++ b/blocks/video/src/video.tsx
@@ -1,10 +1,7 @@
 import { BlockComponent } from "@blockprotocol/graph/react";
-import { setup } from "twind";
 import { Media, MediaEntityProperties } from "./components/media";
 
 export type BlockEntityProperties = MediaEntityProperties;
-
-setup({ preflight: false });
 
 export const Video: BlockComponent<BlockEntityProperties> = (props) => (
   <Media {...props} mediaType="video" />


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The purpose of this PR is to remove `twind` dependency from three blocks (`embed`, `image` and `video`). Simple tailwind classes are converted into inline styles via [Tailwind to CSS](https://tailwind-to-css.vercel.app/). Classes with hover state etc. are meant to be converted into css modules.

It has been decided to abandon this PR after an internal discussion. We will upgrade `twind` instead and clean up its usage.
 
<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201095311341924/1201543651334388/f) _(internal)_
- [Tailwind to CSS](https://tailwind-to-css.vercel.app/)

