### PR TITLE
Fix unescaped chars in `entities` glossary entry

### DIFF
--- a/apps/hashdotai/resources/glossary/entities.mdx
+++ b/apps/hashdotai/resources/glossary/entities.mdx
@@ -8,7 +8,7 @@ tags: ["Graphs", "Simulation Modeling"]
 
 ## What are entities?
 
-Entities are individual ‘things’ with a distinct, independent existence.
+Entities are individual “things” with a distinct, independent existence.
 
 Every entity in HASH has:
 
@@ -16,19 +16,19 @@ Every entity in HASH has:
 - one or more [entity types](https://hash.ai/glossary/entity-type) which describe the entity’s expected properties;
 - [properties](https://hash.ai/glossary/properties), infered from its entity type(s), which may in turn contain [values](https://hash.ai/glossary/values).
 
-The ‘entity type’ tells you what kind of thing an entity is expected to be (e.g. a `Book`, which is expected to have properties such as `author`, `title` and `publisher`).
+The _entity type_ tells you what kind of thing an entity is expected to be (e.g. a `Book`, which is expected to have properties such as `author`, `title` and `publisher`).
 
 The values of an entity’s properties tell you about that instance of the entity itself, for example what its `title` actually is (e.g. “Brave New World”).
 
-Sometimes the values of a property may contain [links](https://hash.ai/glossary/links). In such cases, we would describe an entity as a ‘linked entity’.
+Sometimes the values of a property may contain [links](https://hash.ai/glossary/links). In such cases, we would describe an entity as a _linked entity_.
 
 ## What are linked entities?
 
-In the real world, entities are often connected to other entities -- often by some directional relationship.
+In the real world, entities are often connected to other entities, and these connections are described as _relationships_.
 
-Sometimes these connections take the form of social relationships (e.g. “Mother", "Child”, or “Friend") occurring between entities of the same [entity type] (in this case `Person`).
+Sometimes these connections take the form of social relationships (e.g. “Mother", "Child”, or “Friend") occurring between entities of the same [entity type] (in this example `Person`).
 
-However, entities of completely different entity types can also be linked. For example, connections between entities may sometimes be legal or procedural, such as “Employee \<> Employer” or “Politician \<> Political Party”, which may both link a `Person` with an `Organization`.
+However, entities of completely different entity types can also be linked. For example, connections between entities may sometimes be legal or procedural, such as “Employee \<\> Employer” or “Politician \<\> Political Party”, which may both link a `Person` with an `Organization`.
 
 A network of entities which are connected to other entities is sometimes called a [graph](https://hash.ai/glossary/graphs). We call these entities with links ‘linked entities’.
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Copy update and escaping of rogue characters.