### PR TITLE
Adjust `.*ignore` files to include `.idea/` and `.fleet/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,10 @@ target
 .vscode/settings.json
 
 # intellij IDEs config
-/.idea/
+.idea/
+
+# fleet IDEs config
+.fleet/
 
 # Python virtual environment
 venv

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -96,7 +96,10 @@ target
 .vscode/settings.json
 
 # intellij IDEs config
-/.idea/
+.idea/
+
+# fleet IDEs config
+.fleet/
 
 # Python compiled files and package metadata
 __pycache__

--- a/.prettierignore
+++ b/.prettierignore
@@ -109,7 +109,10 @@ target
 .vscode/settings.json
 
 # intellij IDEs config
-/.idea/
+.idea/
+
+# fleet IDEs config
+.fleet/
 
 # Python compiled files and package metadata
 __pycache__


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When opening IDEs from a subfolder, configuration files are currently not captured in `.*ignore` files, this fixes it

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Slack discussion](https://hashintel.slack.com/archives/C02TWBTT3ED/p1671631409909309) _(internal)_