### PR TITLE
Move `EntityVersion` from `EntityEditionId` to `EntityMetadata`

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -781,7 +781,7 @@ export interface GraphElementVertexIdOneOf1 {
    * @type {string}
    * @memberof GraphElementVertexIdOneOf1
    */
-  base_id: string;
+  baseId: string;
   /**
    *
    * @type {string}

--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -1209,10 +1209,10 @@ export interface OntologyOutwardEdgesOneOf1 {
   reversed: boolean;
   /**
    *
-   * @type {OntologyOutwardEdgesOneOf1RightEndpoint}
+   * @type {GraphElementVertexIdOneOf1}
    * @memberof OntologyOutwardEdgesOneOf1
    */
-  rightEndpoint: OntologyOutwardEdgesOneOf1RightEndpoint;
+  rightEndpoint: GraphElementVertexIdOneOf1;
 }
 
 export const OntologyOutwardEdgesOneOf1KindEnum = {
@@ -1222,25 +1222,6 @@ export const OntologyOutwardEdgesOneOf1KindEnum = {
 export type OntologyOutwardEdgesOneOf1KindEnum =
   typeof OntologyOutwardEdgesOneOf1KindEnum[keyof typeof OntologyOutwardEdgesOneOf1KindEnum];
 
-/**
- *
- * @export
- * @interface OntologyOutwardEdgesOneOf1RightEndpoint
- */
-export interface OntologyOutwardEdgesOneOf1RightEndpoint {
-  /**
-   *
-   * @type {string}
-   * @memberof OntologyOutwardEdgesOneOf1RightEndpoint
-   */
-  baseId: string;
-  /**
-   *
-   * @type {number}
-   * @memberof OntologyOutwardEdgesOneOf1RightEndpoint
-   */
-  recordId: number;
-}
 /**
  *
  * @export

--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -416,12 +416,6 @@ export interface EntityEditionId {
    * @memberof EntityEditionId
    */
   recordId: number;
-  /**
-   *
-   * @type {EntityVersion}
-   * @memberof EntityEditionId
-   */
-  version: EntityVersion;
 }
 /**
  *
@@ -491,6 +485,12 @@ export interface EntityMetadata {
    * @memberof EntityMetadata
    */
   provenance: ProvenanceMetadata;
+  /**
+   *
+   * @type {EntityVersion}
+   * @memberof EntityMetadata
+   */
+  version: EntityVersion;
 }
 /**
  * A single token in an [`EntityQueryPath`].
@@ -738,63 +738,57 @@ export type Filter =
 export type FilterExpression = ParameterExpression | PathExpression;
 
 /**
- * @type GraphElementEditionId
+ * @type GraphElementId
  * @export
  */
-export type GraphElementEditionId =
-  | GraphElementEditionIdOneOf
-  | GraphElementEditionIdOneOf1;
+export type GraphElementId = string;
+
+/**
+ * @type GraphElementVertexId
+ * @export
+ */
+export type GraphElementVertexId =
+  | GraphElementVertexIdOneOf
+  | GraphElementVertexIdOneOf1;
 
 /**
  *
  * @export
- * @interface GraphElementEditionIdOneOf
+ * @interface GraphElementVertexIdOneOf
  */
-export interface GraphElementEditionIdOneOf {
+export interface GraphElementVertexIdOneOf {
   /**
    *
    * @type {string}
-   * @memberof GraphElementEditionIdOneOf
+   * @memberof GraphElementVertexIdOneOf
    */
   baseId: string;
   /**
    *
    * @type {number}
-   * @memberof GraphElementEditionIdOneOf
+   * @memberof GraphElementVertexIdOneOf
    */
   version: number;
 }
 /**
  *
  * @export
- * @interface GraphElementEditionIdOneOf1
+ * @interface GraphElementVertexIdOneOf1
  */
-export interface GraphElementEditionIdOneOf1 {
+export interface GraphElementVertexIdOneOf1 {
   /**
    *
    * @type {string}
-   * @memberof GraphElementEditionIdOneOf1
+   * @memberof GraphElementVertexIdOneOf1
    */
-  baseId: string;
+  base_id: string;
   /**
    *
-   * @type {number}
-   * @memberof GraphElementEditionIdOneOf1
+   * @type {string}
+   * @memberof GraphElementVertexIdOneOf1
    */
-  recordId: number;
-  /**
-   *
-   * @type {EntityVersion}
-   * @memberof GraphElementEditionIdOneOf1
-   */
-  version: EntityVersion;
+  version: string;
 }
-/**
- * @type GraphElementId
- * @export
- */
-export type GraphElementId = string;
-
 /**
  * TODO: DOC - <https://app.asana.com/0/0/1203438518991188/f>
  * @export
@@ -926,10 +920,10 @@ export interface KnowledgeGraphOutwardEdgesOneOf1 {
   reversed: boolean;
   /**
    *
-   * @type {GraphElementEditionIdOneOf}
+   * @type {GraphElementVertexIdOneOf}
    * @memberof KnowledgeGraphOutwardEdgesOneOf1
    */
-  rightEndpoint: GraphElementEditionIdOneOf;
+  rightEndpoint: GraphElementVertexIdOneOf;
 }
 
 export const KnowledgeGraphOutwardEdgesOneOf1KindEnum = {
@@ -1178,10 +1172,10 @@ export interface OntologyOutwardEdgesOneOf {
   reversed: boolean;
   /**
    *
-   * @type {GraphElementEditionIdOneOf}
+   * @type {GraphElementVertexIdOneOf}
    * @memberof OntologyOutwardEdgesOneOf
    */
-  rightEndpoint: GraphElementEditionIdOneOf;
+  rightEndpoint: GraphElementVertexIdOneOf;
 }
 
 export const OntologyOutwardEdgesOneOfKindEnum = {
@@ -1215,10 +1209,10 @@ export interface OntologyOutwardEdgesOneOf1 {
   reversed: boolean;
   /**
    *
-   * @type {GraphElementEditionIdOneOf1}
+   * @type {OntologyOutwardEdgesOneOf1RightEndpoint}
    * @memberof OntologyOutwardEdgesOneOf1
    */
-  rightEndpoint: GraphElementEditionIdOneOf1;
+  rightEndpoint: OntologyOutwardEdgesOneOf1RightEndpoint;
 }
 
 export const OntologyOutwardEdgesOneOf1KindEnum = {
@@ -1228,6 +1222,25 @@ export const OntologyOutwardEdgesOneOf1KindEnum = {
 export type OntologyOutwardEdgesOneOf1KindEnum =
   typeof OntologyOutwardEdgesOneOf1KindEnum[keyof typeof OntologyOutwardEdgesOneOf1KindEnum];
 
+/**
+ *
+ * @export
+ * @interface OntologyOutwardEdgesOneOf1RightEndpoint
+ */
+export interface OntologyOutwardEdgesOneOf1RightEndpoint {
+  /**
+   *
+   * @type {string}
+   * @memberof OntologyOutwardEdgesOneOf1RightEndpoint
+   */
+  baseId: string;
+  /**
+   *
+   * @type {number}
+   * @memberof OntologyOutwardEdgesOneOf1RightEndpoint
+   */
+  recordId: number;
+}
 /**
  *
  * @export
@@ -1766,10 +1779,10 @@ export interface Subgraph {
   edges: Edges;
   /**
    *
-   * @type {Array<GraphElementEditionId>}
+   * @type {Array<GraphElementVertexId>}
    * @memberof Subgraph
    */
-  roots: Array<GraphElementEditionId>;
+  roots: Array<GraphElementVertexId>;
   /**
    *
    * @type {Vertices}

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/data_type.rs
@@ -15,7 +15,7 @@ use crate::{
         report_to_status_code,
         utoipa_typedef::subgraph::{Edges, Subgraph, Vertex, Vertices},
     },
-    identifier::{ontology::OntologyTypeEditionId, GraphElementEditionId, GraphElementId},
+    identifier::{ontology::OntologyTypeEditionId, GraphElementId, GraphElementVertexId},
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
         patch_id_and_parse, DataTypeQueryToken, DataTypeWithMetadata, OntologyElementMetadata,
@@ -50,7 +50,7 @@ use crate::{
             DataTypeStructuralQuery,
             DataTypeQueryToken,
             GraphElementId,
-            GraphElementEditionId,
+            GraphElementVertexId,
             Vertices,
             Vertex,
             OntologyEdgeKind,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -24,7 +24,7 @@ use crate::{
     identifier::{
         knowledge::{EntityEditionId, EntityId, EntityRecordId, EntityVersion},
         time::{DecisionTimeVersionTimespan, TransactionTimeVersionTimespan, TransactionTimestamp},
-        GraphElementEditionId, GraphElementId,
+        GraphElementId, GraphElementVertexId,
     },
     knowledge::{
         Entity, EntityLinkOrder, EntityMetadata, EntityProperties, EntityQueryToken, EntityUuid,
@@ -76,7 +76,7 @@ use crate::{
             LinkOrder,
             ProvenanceMetadata,
             GraphElementId,
-            GraphElementEditionId,
+            GraphElementVertexId,
             OntologyVertex,
             KnowledgeGraphVertex,
             Vertex,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity_type.rs
@@ -17,7 +17,7 @@ use crate::{
             Edges, OntologyRootedEdges, OntologyVertices, Subgraph, Vertex, Vertices,
         },
     },
-    identifier::{ontology::OntologyTypeEditionId, GraphElementEditionId, GraphElementId},
+    identifier::{ontology::OntologyTypeEditionId, GraphElementId, GraphElementVertexId},
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
         patch_id_and_parse, EntityTypeQueryToken, EntityTypeWithMetadata, OntologyElementMetadata,
@@ -55,7 +55,7 @@ use crate::{
             EntityTypeStructuralQuery,
             EntityTypeQueryToken,
             GraphElementId,
-            GraphElementEditionId,
+            GraphElementVertexId,
             ProvenanceMetadata,
             OntologyVertices,
             Vertices,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/property_type.rs
@@ -15,7 +15,7 @@ use crate::{
         report_to_status_code,
         utoipa_typedef::subgraph::{Edges, Subgraph, Vertex, Vertices},
     },
-    identifier::{ontology::OntologyTypeEditionId, GraphElementEditionId, GraphElementId},
+    identifier::{ontology::OntologyTypeEditionId, GraphElementId, GraphElementVertexId},
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
         patch_id_and_parse, OntologyElementMetadata, PropertyTypeQueryToken,
@@ -51,7 +51,7 @@ use crate::{
             PropertyTypeStructuralQuery,
             PropertyTypeQueryToken,
             GraphElementId,
-            GraphElementEditionId,
+            GraphElementVertexId,
             Vertices,
             Vertex,
             OntologyEdgeKind,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/edges.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/edges.rs
@@ -115,10 +115,8 @@ impl Edges {
                                     vertices.earliest_entity_by_id(&id.base_id())
                                 }
                                     .expect("entity must exist in subgraph")
-                                    .edition_id()
-                                    .version()
-                                    .transaction_time()
-                                    .start;
+                                    .vertex_id()
+                                    .version();
 
                                 KnowledgeGraphOutwardEdges::ToKnowledgeGraph(OutwardEdge {
                                     kind: edge.kind,
@@ -134,13 +132,13 @@ impl Edges {
                     match map.entry(id.base_id()) {
                         Entry::Occupied(entry) => {
                             entry.into_mut().insert(
-                                id.version().transaction_time().start,
+                                id.version(),
                                 edges
                             );
                         }
                         Entry::Vacant(entry) => {
                             entry.insert(BTreeMap::from([(
-                                id.version().transaction_time().start,
+                                id.version(),
                                 edges
                             )]));
                         }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/mod.rs
@@ -11,12 +11,12 @@ pub use self::{
         Vertices,
     },
 };
-use crate::{identifier::GraphElementEditionId, subgraph::edges::GraphResolveDepths};
+use crate::{identifier::GraphElementVertexId, subgraph::edges::GraphResolveDepths};
 
 #[derive(Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Subgraph {
-    roots: Vec<GraphElementEditionId>,
+    roots: Vec<GraphElementVertexId>,
     vertices: Vertices,
     edges: Edges,
     depths: GraphResolveDepths,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/vertices/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/vertices/mod.rs
@@ -78,14 +78,13 @@ impl From<crate::subgraph::vertices::Vertices> for Vertices {
                 |mut map, (id, vertex)| {
                     match map.entry(id.base_id()) {
                         Entry::Occupied(entry) => {
-                            entry.into_mut().insert(
-                                id.version().transaction_time().start,
-                                KnowledgeGraphVertex::Entity(vertex),
-                            );
+                            entry
+                                .into_mut()
+                                .insert(id.version(), KnowledgeGraphVertex::Entity(vertex));
                         }
                         Entry::Vacant(entry) => {
                             entry.insert(BTreeMap::from([(
-                                id.version().transaction_time().start,
+                                id.version(),
                                 KnowledgeGraphVertex::Entity(vertex),
                             )]));
                         }

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 pub use self::query::{EntityQueryPath, EntityQueryPathVisitor, EntityQueryToken};
 use crate::{
     identifier::{
-        knowledge::{EntityEditionId, EntityId},
+        knowledge::{EntityEditionId, EntityId, EntityVersion},
         EntityVertexId,
     },
     provenance::ProvenanceMetadata,
@@ -180,6 +180,7 @@ impl LinkData {
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct EntityMetadata {
     edition_id: EntityEditionId,
+    version: EntityVersion,
     #[schema(value_type = String)]
     entity_type_id: VersionedUri,
     #[serde(rename = "provenance")]
@@ -191,12 +192,14 @@ impl EntityMetadata {
     #[must_use]
     pub const fn new(
         edition_id: EntityEditionId,
+        version: EntityVersion,
         entity_type_id: VersionedUri,
         provenance_metadata: ProvenanceMetadata,
         archived: bool,
     ) -> Self {
         Self {
             edition_id,
+            version,
             entity_type_id,
             provenance_metadata,
             archived,
@@ -206,6 +209,11 @@ impl EntityMetadata {
     #[must_use]
     pub const fn edition_id(&self) -> EntityEditionId {
         self.edition_id
+    }
+
+    #[must_use]
+    pub const fn version(&self) -> &EntityVersion {
+        &self.version
     }
 
     #[must_use]
@@ -241,6 +249,7 @@ impl Entity {
         properties: EntityProperties,
         link_data: Option<LinkData>,
         identifier: EntityEditionId,
+        version: EntityVersion,
         entity_type_id: VersionedUri,
         provenance_metadata: ProvenanceMetadata,
         archived: bool,
@@ -250,6 +259,7 @@ impl Entity {
             link_data,
             metadata: EntityMetadata::new(
                 identifier,
+                version,
                 entity_type_id,
                 provenance_metadata,
                 archived,
@@ -285,7 +295,7 @@ impl Record for Entity {
     fn vertex_id(&self) -> Self::VertexId {
         EntityVertexId::new(
             self.edition_id().base_id(),
-            self.edition_id().version().transaction_time().start,
+            self.metadata().version().transaction_time().start,
         )
     }
 

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -201,24 +201,29 @@ pub struct DataTypeWithMetadata {
 impl Record for DataTypeWithMetadata {
     type EditionId = OntologyTypeEditionId;
     type QueryPath<'p> = DataTypeQueryPath;
+    type VertexId = Self::EditionId;
 
     fn edition_id(&self) -> &Self::EditionId {
         self.metadata().edition_id()
     }
 
-    fn create_filter_for_edition_id(edition_id: &Self::EditionId) -> Filter<Self> {
-        Filter::for_ontology_type_edition_id(edition_id)
+    fn vertex_id(&self) -> Self::VertexId {
+        self.edition_id().clone()
+    }
+
+    fn create_filter_for_vertex_id(vertex_id: &Self::VertexId) -> Filter<Self> {
+        Filter::for_ontology_type_edition_id(vertex_id)
     }
 
     fn subgraph_entry<'s>(
         subgraph: &'s mut Subgraph,
-        edition_id: &Self::EditionId,
-    ) -> RawEntryMut<'s, Self::EditionId, Self, RandomState> {
+        vertex_id: &Self::VertexId,
+    ) -> RawEntryMut<'s, Self::VertexId, Self, RandomState> {
         subgraph
             .vertices
             .data_types
             .raw_entry_mut()
-            .from_key(edition_id)
+            .from_key(vertex_id)
     }
 }
 
@@ -252,24 +257,29 @@ pub struct PropertyTypeWithMetadata {
 impl Record for PropertyTypeWithMetadata {
     type EditionId = OntologyTypeEditionId;
     type QueryPath<'p> = PropertyTypeQueryPath;
+    type VertexId = Self::EditionId;
 
     fn edition_id(&self) -> &Self::EditionId {
         self.metadata().edition_id()
     }
 
-    fn create_filter_for_edition_id(edition_id: &Self::EditionId) -> Filter<Self> {
-        Filter::for_ontology_type_edition_id(edition_id)
+    fn vertex_id(&self) -> Self::VertexId {
+        self.edition_id().clone()
+    }
+
+    fn create_filter_for_vertex_id(vertex_id: &Self::VertexId) -> Filter<Self> {
+        Filter::for_ontology_type_edition_id(vertex_id)
     }
 
     fn subgraph_entry<'s>(
         subgraph: &'s mut Subgraph,
-        edition_id: &Self::EditionId,
-    ) -> RawEntryMut<'s, Self::EditionId, Self, RandomState> {
+        vertex_id: &Self::VertexId,
+    ) -> RawEntryMut<'s, Self::VertexId, Self, RandomState> {
         subgraph
             .vertices
             .property_types
             .raw_entry_mut()
-            .from_key(edition_id)
+            .from_key(vertex_id)
     }
 }
 
@@ -303,24 +313,29 @@ pub struct EntityTypeWithMetadata {
 impl Record for EntityTypeWithMetadata {
     type EditionId = OntologyTypeEditionId;
     type QueryPath<'p> = EntityTypeQueryPath;
+    type VertexId = Self::EditionId;
 
     fn edition_id(&self) -> &Self::EditionId {
         self.metadata().edition_id()
     }
 
-    fn create_filter_for_edition_id(edition_id: &Self::EditionId) -> Filter<Self> {
-        Filter::for_ontology_type_edition_id(edition_id)
+    fn vertex_id(&self) -> Self::VertexId {
+        self.edition_id().clone()
+    }
+
+    fn create_filter_for_vertex_id(vertex_id: &Self::VertexId) -> Filter<Self> {
+        Filter::for_ontology_type_edition_id(vertex_id)
     }
 
     fn subgraph_entry<'s>(
         subgraph: &'s mut Subgraph,
-        edition_id: &Self::EditionId,
-    ) -> RawEntryMut<'s, Self::EditionId, Self, RandomState> {
+        vertex_id: &Self::VertexId,
+    ) -> RawEntryMut<'s, Self::VertexId, Self, RandomState> {
         subgraph
             .vertices
             .entity_types
             .raw_entry_mut()
-            .from_key(edition_id)
+            .from_key(vertex_id)
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/knowledge.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/knowledge.rs
@@ -134,20 +134,14 @@ impl EntityRecordId {
 pub struct EntityEditionId {
     base_id: EntityId,
     record_id: EntityRecordId,
-    version: EntityVersion,
 }
 
 impl EntityEditionId {
     #[must_use]
-    pub const fn new(
-        entity_id: EntityId,
-        record_id: EntityRecordId,
-        version: EntityVersion,
-    ) -> Self {
+    pub const fn new(entity_id: EntityId, record_id: EntityRecordId) -> Self {
         Self {
             base_id: entity_id,
             record_id,
-            version,
         }
     }
 
@@ -159,10 +153,5 @@ impl EntityEditionId {
     #[must_use]
     pub const fn record_id(&self) -> EntityRecordId {
         self.record_id
-    }
-
-    #[must_use]
-    pub const fn version(&self) -> EntityVersion {
-        self.version
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/mod.rs
@@ -9,8 +9,7 @@ use type_system::uri::BaseUri;
 use utoipa::{openapi, ToSchema};
 
 use crate::identifier::{
-    knowledge::{EntityEditionId, EntityId},
-    ontology::OntologyTypeEditionId,
+    knowledge::EntityId, ontology::OntologyTypeEditionId, time::TransactionTimestamp,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -34,21 +33,44 @@ impl ToSchema for GraphElementId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
-#[serde(untagged)]
-pub enum GraphElementEditionId {
-    Ontology(OntologyTypeEditionId),
-    KnowledgeGraph(EntityEditionId),
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, ToSchema)]
+pub struct EntityVertexId {
+    base_id: EntityId,
+    version: TransactionTimestamp,
 }
 
-impl From<OntologyTypeEditionId> for GraphElementEditionId {
+impl EntityVertexId {
+    #[must_use]
+    pub const fn new(base_id: EntityId, version: TransactionTimestamp) -> Self {
+        Self { base_id, version }
+    }
+
+    #[must_use]
+    pub const fn base_id(&self) -> EntityId {
+        self.base_id
+    }
+
+    #[must_use]
+    pub const fn version(&self) -> TransactionTimestamp {
+        self.version
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(untagged)]
+pub enum GraphElementVertexId {
+    Ontology(OntologyTypeEditionId),
+    KnowledgeGraph(EntityVertexId),
+}
+
+impl From<OntologyTypeEditionId> for GraphElementVertexId {
     fn from(id: OntologyTypeEditionId) -> Self {
         Self::Ontology(id)
     }
 }
 
-impl From<EntityEditionId> for GraphElementEditionId {
-    fn from(id: EntityEditionId) -> Self {
+impl From<EntityVertexId> for GraphElementVertexId {
+    fn from(id: EntityVertexId) -> Self {
         Self::KnowledgeGraph(id)
     }
 }
@@ -56,11 +78,11 @@ impl From<EntityEditionId> for GraphElementEditionId {
 // WARNING: This MUST be kept up to date with the enum variants.
 //   We have to do this because utoipa doesn't understand serde untagged:
 //   https://github.com/juhaku/utoipa/issues/320
-impl ToSchema for GraphElementEditionId {
+impl ToSchema for GraphElementVertexId {
     fn schema() -> openapi::Schema {
         openapi::OneOfBuilder::new()
             .item(OntologyTypeEditionId::schema())
-            .item(EntityEditionId::schema())
+            .item(EntityVertexId::schema())
             .into()
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/mod.rs
@@ -34,6 +34,7 @@ impl ToSchema for GraphElementId {
 }
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct EntityVertexId {
     base_id: EntityId,
     version: TransactionTimestamp,

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/timestamp.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/timestamp.rs
@@ -1,5 +1,5 @@
 use core::fmt;
-use std::{any::type_name, error::Error, marker::PhantomData, time::SystemTime};
+use std::{any::type_name, error::Error, marker::PhantomData, str::FromStr, time::SystemTime};
 
 use chrono::{DateTime, Utc};
 use derivative::Derivative;
@@ -40,6 +40,12 @@ impl<A> fmt::Debug for Timestamp<A> {
     }
 }
 
+impl<A> fmt::Display for Timestamp<A> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.time, fmt)
+    }
+}
+
 impl<A> Timestamp<A> {
     #[must_use]
     pub fn now() -> Self {
@@ -63,6 +69,17 @@ impl<A> Timestamp<A> {
             axis: PhantomData,
             time: time.time,
         }
+    }
+}
+
+impl<A> FromStr for Timestamp<A> {
+    type Err = chrono::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self {
+            axis: PhantomData,
+            time: DateTime::from_str(s)?,
+        })
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph/edges/edge.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph/edges/edge.rs
@@ -2,10 +2,7 @@ use serde::Serialize;
 use utoipa::{openapi, ToSchema};
 
 use crate::{
-    identifier::{
-        knowledge::{EntityEditionId, EntityId},
-        ontology::OntologyTypeEditionId,
-    },
+    identifier::{knowledge::EntityId, ontology::OntologyTypeEditionId, EntityVertexId},
     subgraph::edges::{KnowledgeGraphEdgeKind, OntologyEdgeKind, SharedEdgeKind},
 };
 
@@ -45,7 +42,7 @@ where
 #[serde(untagged)]
 pub enum OntologyOutwardEdges {
     ToOntology(OutwardEdge<OntologyEdgeKind, OntologyTypeEditionId>),
-    ToKnowledgeGraph(OutwardEdge<SharedEdgeKind, EntityEditionId>),
+    ToKnowledgeGraph(OutwardEdge<SharedEdgeKind, EntityVertexId>),
 }
 
 // WARNING: This MUST be kept up to date with the enum variants.
@@ -55,7 +52,7 @@ impl ToSchema for OntologyOutwardEdges {
     fn schema() -> openapi::Schema {
         openapi::OneOfBuilder::new()
             .item(<OutwardEdge<OntologyEdgeKind, OntologyTypeEditionId>>::schema())
-            .item(<OutwardEdge<SharedEdgeKind, EntityEditionId>>::schema())
+            .item(<OutwardEdge<SharedEdgeKind, EntityVertexId>>::schema())
             .into()
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph/edges/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph/edges/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::{hash_map::Entry, HashMap, HashSet};
 
-use crate::identifier::{knowledge::EntityEditionId, ontology::OntologyTypeEditionId};
+use crate::identifier::{ontology::OntologyTypeEditionId, EntityVertexId};
 
 mod edge;
 mod kind;
@@ -16,16 +16,16 @@ pub use self::{
 #[derive(Default, Debug)]
 pub struct Edges {
     pub ontology: HashMap<OntologyTypeEditionId, HashSet<OntologyOutwardEdges>>,
-    pub knowledge_graph: HashMap<EntityEditionId, HashSet<KnowledgeGraphOutwardEdges>>,
+    pub knowledge_graph: HashMap<EntityVertexId, HashSet<KnowledgeGraphOutwardEdges>>,
 }
 
 pub enum Edge {
     Ontology {
-        edition_id: OntologyTypeEditionId,
+        vertex_id: OntologyTypeEditionId,
         outward_edge: OntologyOutwardEdges,
     },
     KnowledgeGraph {
-        edition_id: EntityEditionId,
+        vertex_id: EntityVertexId,
         outward_edge: KnowledgeGraphOutwardEdges,
     },
 }
@@ -45,9 +45,9 @@ impl Edges {
     pub fn insert(&mut self, edge: Edge) -> bool {
         match edge {
             Edge::Ontology {
-                edition_id,
+                vertex_id,
                 outward_edge,
-            } => match self.ontology.entry(edition_id) {
+            } => match self.ontology.entry(vertex_id) {
                 Entry::Occupied(entry) => entry.into_mut().insert(outward_edge),
                 Entry::Vacant(entry) => {
                     entry.insert(HashSet::from([outward_edge]));
@@ -55,9 +55,9 @@ impl Edges {
                 }
             },
             Edge::KnowledgeGraph {
-                edition_id,
+                vertex_id,
                 outward_edge,
-            } => match self.knowledge_graph.entry(edition_id) {
+            } => match self.knowledge_graph.entry(vertex_id) {
                 Entry::Occupied(entry) => entry.into_mut().insert(outward_edge),
                 Entry::Vacant(entry) => {
                     entry.insert(HashSet::from([outward_edge]));
@@ -68,8 +68,8 @@ impl Edges {
     }
 
     pub fn extend(&mut self, other: Self) {
-        for (edition_id, edges) in other.ontology {
-            match self.ontology.entry(edition_id) {
+        for (vertex_id, edges) in other.ontology {
+            match self.ontology.entry(vertex_id) {
                 Entry::Occupied(entry) => entry.into_mut().extend(edges),
                 Entry::Vacant(entry) => {
                     entry.insert(edges);
@@ -77,8 +77,8 @@ impl Edges {
             }
         }
 
-        for (edition_id, edges) in other.knowledge_graph {
-            match self.knowledge_graph.entry(edition_id) {
+        for (vertex_id, edges) in other.knowledge_graph {
+            match self.knowledge_graph.entry(vertex_id) {
                 Entry::Occupied(entry) => entry.into_mut().extend(edges),
                 Entry::Vacant(entry) => {
                     entry.insert(edges);

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph/mod.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, fmt::Debug};
 use edges::Edges;
 
 use crate::{
-    shared::identifier::GraphElementEditionId,
+    shared::identifier::GraphElementVertexId,
     subgraph::{edges::GraphResolveDepths, vertices::Vertices},
 };
 
@@ -13,7 +13,7 @@ pub mod vertices;
 
 #[derive(Debug)]
 pub struct Subgraph {
-    pub roots: HashSet<GraphElementEditionId>,
+    pub roots: HashSet<GraphElementVertexId>,
     pub vertices: Vertices,
     pub edges: Edges,
     pub depths: GraphResolveDepths,

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph/vertices/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph/vertices/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::{
-    identifier::{knowledge::EntityEditionId, ontology::OntologyTypeEditionId},
+    identifier::{ontology::OntologyTypeEditionId, EntityVertexId},
     knowledge::Entity,
     ontology::{DataTypeWithMetadata, EntityTypeWithMetadata, PropertyTypeWithMetadata},
 };
@@ -11,5 +11,5 @@ pub struct Vertices {
     pub data_types: HashMap<OntologyTypeEditionId, DataTypeWithMetadata>,
     pub property_types: HashMap<OntologyTypeEditionId, PropertyTypeWithMetadata>,
     pub entity_types: HashMap<OntologyTypeEditionId, EntityTypeWithMetadata>,
-    pub entities: HashMap<EntityEditionId, Entity>,
+    pub entities: HashMap<EntityVertexId, Entity>,
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/crud.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/crud.rs
@@ -54,15 +54,15 @@ pub trait Read<R: Record + Send>: Sync {
     async fn read_into_subgraph<'r>(
         &self,
         subgraph: &'r mut Subgraph,
-        edition_id: &R::EditionId,
+        vertex_id: &R::VertexId,
     ) -> Result<&'r R, QueryError> {
-        Ok(match R::subgraph_entry(subgraph, edition_id) {
+        Ok(match R::subgraph_entry(subgraph, vertex_id) {
             RawEntryMut::Occupied(entry) => entry.into_mut(),
             RawEntryMut::Vacant(entry) => {
                 entry
                     .insert(
-                        edition_id.clone(),
-                        self.read_one(&R::create_filter_for_edition_id(edition_id))
+                        vertex_id.clone(),
+                        self.read_one(&R::create_filter_for_vertex_id(vertex_id))
                             .await?,
                     )
                     .1

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -324,13 +324,10 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             .change_context(InsertionError)?;
 
         Ok(EntityMetadata::new(
-            EntityEditionId::new(
-                entity_id,
-                EntityRecordId::new(row.get(0)),
-                EntityVersion::new(
-                    DecisionTimeVersionTimespan::from_anonymous(row.get(1)),
-                    TransactionTimeVersionTimespan::from_anonymous(row.get(2)),
-                ),
+            EntityEditionId::new(entity_id, EntityRecordId::new(row.get(0))),
+            EntityVersion::new(
+                DecisionTimeVersionTimespan::from_anonymous(row.get(1)),
+                TransactionTimeVersionTimespan::from_anonymous(row.get(2)),
             ),
             entity_type_id,
             ProvenanceMetadata::new(updated_by_id),
@@ -428,7 +425,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             .zip(entity_record_ids)
             .map(|(((entity_id, ..), entity_version), entity_record_id)| {
                 EntityMetadata::new(
-                    EntityEditionId::new(entity_id, entity_record_id, entity_version),
+                    EntityEditionId::new(entity_id, entity_record_id),
+                    entity_version,
                     entity_type_id.clone(),
                     ProvenanceMetadata::new(actor_id),
                     false,
@@ -564,13 +562,10 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             .change_context(UpdateError)?;
 
         Ok(EntityMetadata::new(
-            EntityEditionId::new(
-                entity_id,
-                EntityRecordId::new(row.get(0)),
-                EntityVersion::new(
-                    DecisionTimeVersionTimespan::from_anonymous(row.get(1)),
-                    TransactionTimeVersionTimespan::from_anonymous(row.get(2)),
-                ),
+            EntityEditionId::new(entity_id, EntityRecordId::new(row.get(0))),
+            EntityVersion::new(
+                DecisionTimeVersionTimespan::from_anonymous(row.get(1)),
+                TransactionTimeVersionTimespan::from_anonymous(row.get(2)),
             ),
             entity_type_id,
             ProvenanceMetadata::new(updated_by_id),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -134,13 +134,11 @@ impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
                     EntityEditionId::new(
                         EntityId::new(owned_by_id, entity_uuid),
                         EntityRecordId::new(row.get(record_id_index)),
-                        EntityVersion::new(
-                            DecisionTimeVersionTimespan::from_anonymous(
-                                row.get(decision_time_index),
-                            ),
-                            TransactionTimeVersionTimespan::from_anonymous(
-                                row.get(transaction_time_index),
-                            ),
+                    ),
+                    EntityVersion::new(
+                        DecisionTimeVersionTimespan::from_anonymous(row.get(decision_time_index)),
+                        TransactionTimeVersionTimespan::from_anonymous(
+                            row.get(transaction_time_index),
                         ),
                     ),
                     entity_type_uri,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -32,7 +32,7 @@ use crate::{
     knowledge::{EntityProperties, LinkOrder},
 };
 use crate::{
-    identifier::{account::AccountId, knowledge::EntityEditionId, ontology::OntologyTypeEditionId},
+    identifier::{account::AccountId, ontology::OntologyTypeEditionId, EntityVertexId},
     ontology::{OntologyElementMetadata, OntologyTypeWithMetadata},
     provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
@@ -103,7 +103,7 @@ where
 #[derive(Default)]
 pub struct DependencyContext {
     pub ontology_dependency_map: DependencyMap<OntologyTypeEditionId>,
-    pub knowledge_dependency_map: DependencyMap<EntityEditionId>,
+    pub knowledge_dependency_map: DependencyMap<EntityVertexId>,
 }
 
 /// A Postgres-backed store

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -5,7 +5,7 @@ use type_system::DataType;
 
 use crate::{
     identifier::ontology::OntologyTypeEditionId,
-    ontology::{DataTypeWithMetadata, OntologyElementMetadata, OntologyTypeWithMetadata},
+    ontology::{DataTypeWithMetadata, OntologyElementMetadata},
     provenance::{OwnedById, UpdatedById},
     store::{
         crud::Read,
@@ -100,7 +100,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
             let data_type = data_type.insert_into_subgraph_as_root(&mut subgraph);
 
             self.traverse_data_type(
-                &data_type.metadata().edition_id().clone(),
+                &data_type.vertex_id().clone(),
                 &mut dependency_context,
                 &mut subgraph,
                 graph_resolve_depths,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -106,7 +106,7 @@ impl<C: AsClient> PostgresStore<C> {
             if let Some(property_type_ref_uris) = property_type_ref_uris {
                 for property_type_ref_uri in property_type_ref_uris {
                     subgraph.edges.insert(Edge::Ontology {
-                        edition_id: entity_type_id.clone(),
+                        vertex_id: entity_type_id.clone(),
                         outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
                             kind: OntologyEdgeKind::ConstrainsPropertiesOn,
                             reversed: false,
@@ -134,7 +134,7 @@ impl<C: AsClient> PostgresStore<C> {
             if let Some(inherits_from_type_ref_uris) = inherits_from_type_ref_uris {
                 for inherits_from_type_ref_uri in inherits_from_type_ref_uris {
                     subgraph.edges.insert(Edge::Ontology {
-                        edition_id: entity_type_id.clone(),
+                        vertex_id: entity_type_id.clone(),
                         outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
                             kind: OntologyEdgeKind::InheritsFrom,
                             reversed: false,
@@ -164,7 +164,7 @@ impl<C: AsClient> PostgresStore<C> {
                 for (link_type_uri, destination_type_uris) in link_mappings {
                     if current_resolve_depth.constrains_links_on.outgoing > 0 {
                         subgraph.edges.insert(Edge::Ontology {
-                            edition_id: entity_type_id.clone(),
+                            vertex_id: entity_type_id.clone(),
                             outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
                                 kind: OntologyEdgeKind::ConstrainsLinksOn,
                                 reversed: false,
@@ -194,7 +194,7 @@ impl<C: AsClient> PostgresStore<C> {
                         {
                             for destination_type_uri in destination_type_uris {
                                 subgraph.edges.insert(Edge::Ontology {
-                                    edition_id: entity_type_id.clone(),
+                                    vertex_id: entity_type_id.clone(),
                                     outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
                                         kind: OntologyEdgeKind::ConstrainsLinkDestinationsOn,
                                         reversed: false,
@@ -295,7 +295,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
             let entity_type = entity_type.insert_into_subgraph_as_root(&mut subgraph);
 
             self.traverse_entity_type(
-                &entity_type.metadata().edition_id().clone(),
+                &entity_type.vertex_id().clone(),
                 &mut dependency_context,
                 &mut subgraph,
                 graph_resolve_depths,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -82,7 +82,7 @@ impl<C: AsClient> PostgresStore<C> {
             if let Some(data_type_ref_uris) = data_type_ref_uris {
                 for data_type_ref in data_type_ref_uris {
                     subgraph.edges.insert(Edge::Ontology {
-                        edition_id: property_type_id.clone(),
+                        vertex_id: property_type_id.clone(),
                         outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
                             kind: OntologyEdgeKind::ConstrainsValuesOn,
                             reversed: false,
@@ -109,7 +109,7 @@ impl<C: AsClient> PostgresStore<C> {
             if let Some(property_type_ref_uris) = property_type_ref_uris {
                 for property_type_ref_uri in property_type_ref_uris {
                     subgraph.edges.insert(Edge::Ontology {
-                        edition_id: property_type_id.clone(),
+                        vertex_id: property_type_id.clone(),
                         outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
                             kind: OntologyEdgeKind::ConstrainsPropertiesOn,
                             reversed: false,
@@ -204,7 +204,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
             let property_type = property_type.insert_into_subgraph_as_root(&mut subgraph);
 
             self.traverse_property_type(
-                &property_type.metadata().edition_id().clone(),
+                &property_type.vertex_id().clone(),
                 &mut dependency_context,
                 &mut subgraph,
                 graph_resolve_depths,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -692,12 +692,10 @@ mod tests {
         use crate::{
             identifier::{
                 account::AccountId,
-                knowledge::{EntityEditionId, EntityId, EntityRecordId, EntityVersion},
+                knowledge::EntityId,
                 ontology::{OntologyTypeEditionId, OntologyTypeVersion},
-                time::{
-                    DecisionTimeVersionTimespan, DecisionTimestamp, TransactionTimeVersionTimespan,
-                    TransactionTimestamp,
-                },
+                time::TransactionTimestamp,
+                EntityVertexId,
             },
             knowledge::EntityUuid,
             provenance::OwnedById,
@@ -789,21 +787,17 @@ mod tests {
 
         #[test]
         fn for_entity_by_edition_id() {
-            let entity_edition_id = EntityEditionId::new(
+            let entity_vertex_id = EntityVertexId::new(
                 EntityId::new(
                     OwnedById::new(AccountId::new(Uuid::new_v4())),
                     EntityUuid::new(Uuid::new_v4()),
                 ),
-                EntityRecordId::new(0),
-                EntityVersion::new(
-                    DecisionTimeVersionTimespan::new(DecisionTimestamp::now(), None),
-                    TransactionTimeVersionTimespan::new(TransactionTimestamp::now(), None),
-                ),
+                TransactionTimestamp::now(),
             );
 
             let mut compiler = SelectCompiler::<Entity>::with_asterisk();
 
-            let filter = Filter::for_entity_by_edition_id(entity_edition_id);
+            let filter = Filter::for_entity_by_vertex_id(entity_vertex_id);
             compiler.add_filter(&filter);
 
             test_compilation(
@@ -814,33 +808,29 @@ mod tests {
                 WHERE "entities_0_0_0"."decision_time" @> now()
                   AND ("entities_0_0_0"."owned_by_id" = $1)
                   AND ("entities_0_0_0"."entity_uuid" = $2)
-                  AND ("entities_0_0_0"."entity_record_id" = $3)
+                  AND (lower("entities_0_0_0"."transaction_time") = $3)
                 "#,
                 &[
-                    &entity_edition_id.base_id().owned_by_id().as_uuid(),
-                    &entity_edition_id.base_id().entity_uuid().as_uuid(),
-                    &entity_edition_id.record_id().as_i64(),
+                    &entity_vertex_id.base_id().owned_by_id().as_uuid(),
+                    &entity_vertex_id.base_id().entity_uuid().as_uuid(),
+                    &entity_vertex_id.version(),
                 ],
             );
         }
 
         #[test]
-        fn for_outgoing_link_by_source_entity_edition_id() {
-            let entity_edition_id = EntityEditionId::new(
+        fn for_outgoing_link_by_source_entity_vertex_id() {
+            let entity_vertex_id = EntityVertexId::new(
                 EntityId::new(
                     OwnedById::new(AccountId::new(Uuid::new_v4())),
                     EntityUuid::new(Uuid::new_v4()),
                 ),
-                EntityRecordId::new(0),
-                EntityVersion::new(
-                    DecisionTimeVersionTimespan::new(DecisionTimestamp::now(), None),
-                    TransactionTimeVersionTimespan::new(TransactionTimestamp::now(), None),
-                ),
+                TransactionTimestamp::now(),
             );
 
             let mut compiler = SelectCompiler::<Entity>::with_asterisk();
 
-            let filter = Filter::for_outgoing_link_by_source_entity_edition_id(entity_edition_id);
+            let filter = Filter::for_outgoing_link_by_source_entity_vertex_id(entity_vertex_id);
             compiler.add_filter(&filter);
 
             test_compilation(
@@ -854,33 +844,29 @@ mod tests {
                   AND "entities_0_1_0"."decision_time" @> now()
                   AND ("entities_0_0_0"."left_owned_by_id" = $1)
                   AND ("entities_0_0_0"."left_entity_uuid" = $2)
-                  AND ("entities_0_1_0"."entity_record_id" = $3)
+                  AND (lower("entities_0_1_0"."transaction_time") = $3)
                 "#,
                 &[
-                    &entity_edition_id.base_id().owned_by_id().as_uuid(),
-                    &entity_edition_id.base_id().entity_uuid().as_uuid(),
-                    &entity_edition_id.record_id().as_i64(),
+                    &entity_vertex_id.base_id().owned_by_id().as_uuid(),
+                    &entity_vertex_id.base_id().entity_uuid().as_uuid(),
+                    &entity_vertex_id.version(),
                 ],
             );
         }
 
         #[test]
-        fn for_left_entity_by_entity_edition_id() {
-            let entity_edition_id = EntityEditionId::new(
+        fn for_left_entity_by_entity_vertex_id() {
+            let entity_vertex_id = EntityVertexId::new(
                 EntityId::new(
                     OwnedById::new(AccountId::new(Uuid::new_v4())),
                     EntityUuid::new(Uuid::new_v4()),
                 ),
-                EntityRecordId::new(0),
-                EntityVersion::new(
-                    DecisionTimeVersionTimespan::new(DecisionTimestamp::now(), None),
-                    TransactionTimeVersionTimespan::new(TransactionTimestamp::now(), None),
-                ),
+                TransactionTimestamp::now(),
             );
 
             let mut compiler = SelectCompiler::<Entity>::with_asterisk();
 
-            let filter = Filter::for_left_entity_by_entity_edition_id(entity_edition_id);
+            let filter = Filter::for_left_entity_by_entity_vertex_id(entity_vertex_id);
             compiler.add_filter(&filter);
 
             test_compilation(
@@ -894,33 +880,29 @@ mod tests {
                   AND "entities_0_1_0"."decision_time" @> now()
                   AND ("entities_0_1_0"."owned_by_id" = $1)
                   AND ("entities_0_1_0"."entity_uuid" = $2)
-                  AND ("entities_0_1_0"."entity_record_id" = $3)
+                  AND (lower("entities_0_1_0"."transaction_time") = $3)
                 "#,
                 &[
-                    &entity_edition_id.base_id().owned_by_id().as_uuid(),
-                    &entity_edition_id.base_id().entity_uuid().as_uuid(),
-                    &entity_edition_id.record_id().as_i64(),
+                    &entity_vertex_id.base_id().owned_by_id().as_uuid(),
+                    &entity_vertex_id.base_id().entity_uuid().as_uuid(),
+                    &entity_vertex_id.version(),
                 ],
             );
         }
 
         #[test]
-        fn for_right_entity_by_entity_edition_id() {
-            let entity_edition_id = EntityEditionId::new(
+        fn for_right_entity_by_entity_vertex_id() {
+            let entity_vertex_id = EntityVertexId::new(
                 EntityId::new(
                     OwnedById::new(AccountId::new(Uuid::new_v4())),
                     EntityUuid::new(Uuid::new_v4()),
                 ),
-                EntityRecordId::new(0),
-                EntityVersion::new(
-                    DecisionTimeVersionTimespan::new(DecisionTimestamp::now(), None),
-                    TransactionTimeVersionTimespan::new(TransactionTimestamp::now(), None),
-                ),
+                TransactionTimestamp::now(),
             );
 
             let mut compiler = SelectCompiler::<Entity>::with_asterisk();
 
-            let filter = Filter::for_right_entity_by_entity_edition_id(entity_edition_id);
+            let filter = Filter::for_right_entity_by_entity_vertex_id(entity_vertex_id);
             compiler.add_filter(&filter);
 
             test_compilation(
@@ -934,12 +916,12 @@ mod tests {
                   AND "entities_0_1_0"."decision_time" @> now()
                   AND ("entities_0_1_0"."owned_by_id" = $1)
                   AND ("entities_0_1_0"."entity_uuid" = $2)
-                  AND ("entities_0_1_0"."entity_record_id" = $3)
+                  AND (lower("entities_0_1_0"."transaction_time") = $3)
                 "#,
                 &[
-                    &entity_edition_id.base_id().owned_by_id().as_uuid(),
-                    &entity_edition_id.base_id().entity_uuid().as_uuid(),
-                    &entity_edition_id.record_id().as_i64(),
+                    &entity_vertex_id.base_id().owned_by_id().as_uuid(),
+                    &entity_vertex_id.base_id().entity_uuid().as_uuid(),
+                    &entity_vertex_id.version(),
                 ],
             );
         }

--- a/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
@@ -1,6 +1,5 @@
 use std::{borrow::Cow, fmt, str::FromStr};
 
-use chrono::{DateTime, Utc};
 use derivative::Derivative;
 use error_stack::{bail, ensure, Context, IntoReport, Report, ResultExt};
 use serde::Deserialize;
@@ -9,8 +8,8 @@ use uuid::Uuid;
 
 use crate::{
     identifier::{
-        knowledge::{EntityEditionId, EntityId},
-        ontology::OntologyTypeEditionId,
+        knowledge::EntityId, ontology::OntologyTypeEditionId, time::TransactionTimestamp,
+        EntityVertexId,
     },
     knowledge::{Entity, EntityQueryPath},
     store::{
@@ -114,28 +113,30 @@ impl<'p> Filter<'p, Entity> {
     }
 
     /// Creates a `Filter` to search for a specific entity edition, identified by its
-    /// [`EntityEditionId`].
+    /// [`EntityVertexId`].
     #[must_use]
-    pub fn for_entity_by_edition_id(edition_id: EntityEditionId) -> Self {
+    pub fn for_entity_by_vertex_id(vertex_id: EntityVertexId) -> Self {
         // TODO: Adjust structural queries for temporal versioning
         //   see https://app.asana.com/0/0/1203491211535116/f
         Self::All(vec![
             Self::Equal(
                 Some(FilterExpression::Path(EntityQueryPath::OwnedById)),
                 Some(FilterExpression::Parameter(Parameter::Uuid(
-                    edition_id.base_id().owned_by_id().as_uuid(),
+                    vertex_id.base_id().owned_by_id().as_uuid(),
                 ))),
             ),
             Self::Equal(
                 Some(FilterExpression::Path(EntityQueryPath::Uuid)),
                 Some(FilterExpression::Parameter(Parameter::Uuid(
-                    edition_id.base_id().entity_uuid().as_uuid(),
+                    vertex_id.base_id().entity_uuid().as_uuid(),
                 ))),
             ),
             Self::Equal(
-                Some(FilterExpression::Path(EntityQueryPath::RecordId)),
-                Some(FilterExpression::Parameter(Parameter::SignedInteger(
-                    edition_id.record_id().as_i64(),
+                Some(FilterExpression::Path(
+                    EntityQueryPath::LowerTransactionTime,
+                )),
+                Some(FilterExpression::Parameter(Parameter::Timestamp(
+                    vertex_id.version(),
                 ))),
             ),
         ])
@@ -143,7 +144,7 @@ impl<'p> Filter<'p, Entity> {
 
     /// TODO
     #[must_use]
-    pub fn for_outgoing_link_by_source_entity_edition_id(edition_id: EntityEditionId) -> Self {
+    pub fn for_outgoing_link_by_source_entity_vertex_id(vertex_id: EntityVertexId) -> Self {
         // TODO: Adjust structural queries for temporal versioning
         //   see https://app.asana.com/0/0/1203491211535116/f
         Self::All(vec![
@@ -152,7 +153,7 @@ impl<'p> Filter<'p, Entity> {
                     Box::new(EntityQueryPath::OwnedById),
                 ))),
                 Some(FilterExpression::Parameter(Parameter::Uuid(
-                    edition_id.base_id().owned_by_id().as_uuid(),
+                    vertex_id.base_id().owned_by_id().as_uuid(),
                 ))),
             ),
             Self::Equal(
@@ -160,15 +161,15 @@ impl<'p> Filter<'p, Entity> {
                     Box::new(EntityQueryPath::Uuid),
                 ))),
                 Some(FilterExpression::Parameter(Parameter::Uuid(
-                    edition_id.base_id().entity_uuid().as_uuid(),
+                    vertex_id.base_id().entity_uuid().as_uuid(),
                 ))),
             ),
             Self::Equal(
                 Some(FilterExpression::Path(EntityQueryPath::LeftEntity(
-                    Box::new(EntityQueryPath::RecordId),
+                    Box::new(EntityQueryPath::LowerTransactionTime),
                 ))),
-                Some(FilterExpression::Parameter(Parameter::SignedInteger(
-                    edition_id.record_id().as_i64(),
+                Some(FilterExpression::Parameter(Parameter::Timestamp(
+                    vertex_id.version(),
                 ))),
             ),
         ])
@@ -176,7 +177,7 @@ impl<'p> Filter<'p, Entity> {
 
     /// TODO
     #[must_use]
-    pub fn for_incoming_link_by_source_entity_edition_id(edition_id: EntityEditionId) -> Self {
+    pub fn for_incoming_link_by_source_entity_vertex_id(vertex_id: EntityVertexId) -> Self {
         // TODO: Adjust structural queries for temporal versioning
         //   see https://app.asana.com/0/0/1203491211535116/f
         Self::All(vec![
@@ -185,7 +186,7 @@ impl<'p> Filter<'p, Entity> {
                     Box::new(EntityQueryPath::OwnedById),
                 ))),
                 Some(FilterExpression::Parameter(Parameter::Uuid(
-                    edition_id.base_id().owned_by_id().as_uuid(),
+                    vertex_id.base_id().owned_by_id().as_uuid(),
                 ))),
             ),
             Self::Equal(
@@ -193,15 +194,15 @@ impl<'p> Filter<'p, Entity> {
                     Box::new(EntityQueryPath::Uuid),
                 ))),
                 Some(FilterExpression::Parameter(Parameter::Uuid(
-                    edition_id.base_id().entity_uuid().as_uuid(),
+                    vertex_id.base_id().entity_uuid().as_uuid(),
                 ))),
             ),
             Self::Equal(
                 Some(FilterExpression::Path(EntityQueryPath::RightEntity(
-                    Box::new(EntityQueryPath::RecordId),
+                    Box::new(EntityQueryPath::LowerTransactionTime),
                 ))),
-                Some(FilterExpression::Parameter(Parameter::SignedInteger(
-                    edition_id.record_id().as_i64(),
+                Some(FilterExpression::Parameter(Parameter::Timestamp(
+                    vertex_id.version(),
                 ))),
             ),
         ])
@@ -209,7 +210,7 @@ impl<'p> Filter<'p, Entity> {
 
     /// TODO
     #[must_use]
-    pub fn for_left_entity_by_entity_edition_id(edition_id: EntityEditionId) -> Self {
+    pub fn for_left_entity_by_entity_vertex_id(vertex_id: EntityVertexId) -> Self {
         // TODO: Adjust structural queries for temporal versioning
         //   see https://app.asana.com/0/0/1203491211535116/f
         Self::All(vec![
@@ -218,7 +219,7 @@ impl<'p> Filter<'p, Entity> {
                     Box::new(EntityQueryPath::OwnedById),
                 ))),
                 Some(FilterExpression::Parameter(Parameter::Uuid(
-                    edition_id.base_id().owned_by_id().as_uuid(),
+                    vertex_id.base_id().owned_by_id().as_uuid(),
                 ))),
             ),
             Self::Equal(
@@ -226,15 +227,15 @@ impl<'p> Filter<'p, Entity> {
                     Box::new(EntityQueryPath::Uuid),
                 ))),
                 Some(FilterExpression::Parameter(Parameter::Uuid(
-                    edition_id.base_id().entity_uuid().as_uuid(),
+                    vertex_id.base_id().entity_uuid().as_uuid(),
                 ))),
             ),
             Self::Equal(
                 Some(FilterExpression::Path(EntityQueryPath::OutgoingLinks(
-                    Box::new(EntityQueryPath::RecordId),
+                    Box::new(EntityQueryPath::LowerTransactionTime),
                 ))),
-                Some(FilterExpression::Parameter(Parameter::SignedInteger(
-                    edition_id.record_id().as_i64(),
+                Some(FilterExpression::Parameter(Parameter::Timestamp(
+                    vertex_id.version(),
                 ))),
             ),
         ])
@@ -242,7 +243,7 @@ impl<'p> Filter<'p, Entity> {
 
     /// TODO
     #[must_use]
-    pub fn for_right_entity_by_entity_edition_id(edition_id: EntityEditionId) -> Self {
+    pub fn for_right_entity_by_entity_vertex_id(vertex_id: EntityVertexId) -> Self {
         // TODO: Adjust structural queries for temporal versioning
         //   see https://app.asana.com/0/0/1203491211535116/f
         Self::All(vec![
@@ -251,7 +252,7 @@ impl<'p> Filter<'p, Entity> {
                     Box::new(EntityQueryPath::OwnedById),
                 ))),
                 Some(FilterExpression::Parameter(Parameter::Uuid(
-                    edition_id.base_id().owned_by_id().as_uuid(),
+                    vertex_id.base_id().owned_by_id().as_uuid(),
                 ))),
             ),
             Self::Equal(
@@ -259,15 +260,15 @@ impl<'p> Filter<'p, Entity> {
                     Box::new(EntityQueryPath::Uuid),
                 ))),
                 Some(FilterExpression::Parameter(Parameter::Uuid(
-                    edition_id.base_id().entity_uuid().as_uuid(),
+                    vertex_id.base_id().entity_uuid().as_uuid(),
                 ))),
             ),
             Self::Equal(
                 Some(FilterExpression::Path(EntityQueryPath::IncomingLinks(
-                    Box::new(EntityQueryPath::RecordId),
+                    Box::new(EntityQueryPath::LowerTransactionTime),
                 ))),
-                Some(FilterExpression::Parameter(Parameter::SignedInteger(
-                    edition_id.record_id().as_i64(),
+                Some(FilterExpression::Parameter(Parameter::Timestamp(
+                    vertex_id.version(),
                 ))),
             ),
         ])
@@ -332,7 +333,7 @@ pub enum Parameter<'p> {
     #[serde(skip)]
     SignedInteger(i64),
     #[serde(skip)]
-    Timestamp(DateTime<Utc>),
+    Timestamp(TransactionTimestamp),
 }
 
 impl Parameter<'_> {
@@ -397,7 +398,7 @@ impl Parameter<'_> {
             (Parameter::Text(text), ParameterType::Timestamp) => {
                 if text != "latest" {
                     *self = Parameter::Timestamp(
-                        DateTime::from_str(&*text)
+                        TransactionTimestamp::from_str(&*text)
                             .into_report()
                             .change_context_lazy(|| ParameterConversionError {
                                 actual: self.to_owned(),
@@ -447,13 +448,7 @@ mod tests {
     use super::*;
     use crate::{
         identifier::{
-            account::AccountId,
-            knowledge::{EntityRecordId, EntityVersion},
-            ontology::OntologyTypeVersion,
-            time::{
-                DecisionTimeVersionTimespan, DecisionTimestamp, TransactionTimeVersionTimespan,
-                TransactionTimestamp,
-            },
+            account::AccountId, ontology::OntologyTypeVersion, time::TransactionTimestamp,
         },
         knowledge::EntityUuid,
         ontology::{DataTypeQueryPath, DataTypeWithMetadata},
@@ -552,149 +547,137 @@ mod tests {
     }
 
     #[test]
-    fn for_entity_by_edition_id() {
-        let entity_edition_id = EntityEditionId::new(
+    #[ignore = "TODO: Reevaluate if we need this after https://app.asana.com/0/0/1203491211535116/f"]
+    fn for_entity_by_vertex_id() {
+        let entity_vertex_id = EntityVertexId::new(
             EntityId::new(
                 OwnedById::new(AccountId::new(Uuid::new_v4())),
                 EntityUuid::new(Uuid::new_v4()),
             ),
-            EntityRecordId::new(0),
-            EntityVersion::new(
-                DecisionTimeVersionTimespan::new(DecisionTimestamp::now(), None),
-                TransactionTimeVersionTimespan::new(TransactionTimestamp::now(), None),
-            ),
+            TransactionTimestamp::now(),
         );
 
         let expected = json! {{
           "all": [
             { "equal": [
               { "path": ["ownedById"] },
-              { "parameter": entity_edition_id.base_id().owned_by_id() }
+              { "parameter": entity_vertex_id.base_id().owned_by_id() }
             ]},
             { "equal": [
               { "path": ["uuid"] },
-              { "parameter": entity_edition_id.base_id().entity_uuid() }
+              { "parameter": entity_vertex_id.base_id().entity_uuid() }
             ]},
             { "equal": [
-              { "path": ["recordId"] },
-              { "parameter": entity_edition_id.record_id() }
+              { "path": ["lowerTransactionTime"] },
+              { "parameter": entity_vertex_id.version() }
             ]}
           ]
         }};
 
         test_filter_representation(
-            &Filter::for_entity_by_edition_id(entity_edition_id),
+            &Filter::for_entity_by_vertex_id(entity_vertex_id),
             &expected,
         );
     }
 
     #[test]
-    fn for_outgoing_link_by_source_entity_edition_id() {
-        let entity_edition_id = EntityEditionId::new(
+    #[ignore = "TODO: Reevaluate if we need this after https://app.asana.com/0/0/1203491211535116/f"]
+    fn for_outgoing_link_by_source_entity_vertex_id() {
+        let entity_vertex_id = EntityVertexId::new(
             EntityId::new(
                 OwnedById::new(AccountId::new(Uuid::new_v4())),
                 EntityUuid::new(Uuid::new_v4()),
             ),
-            EntityRecordId::new(0),
-            EntityVersion::new(
-                DecisionTimeVersionTimespan::new(DecisionTimestamp::now(), None),
-                TransactionTimeVersionTimespan::new(TransactionTimestamp::now(), None),
-            ),
+            TransactionTimestamp::now(),
         );
 
         let expected = json! {{
           "all": [
             { "equal": [
               { "path": ["leftEntity", "ownedById"] },
-              { "parameter": entity_edition_id.base_id().owned_by_id() }
+              { "parameter": entity_vertex_id.base_id().owned_by_id() }
             ]},
             { "equal": [
               { "path": ["leftEntity", "uuid"] },
-              { "parameter": entity_edition_id.base_id().entity_uuid() }
+              { "parameter": entity_vertex_id.base_id().entity_uuid() }
             ]},
             { "equal": [
-              { "path": ["leftEntity", "recordId"] },
-              { "parameter": entity_edition_id.record_id() }
+              { "path": ["leftEntity", "lowerTransactionTime"] },
+              { "parameter": entity_vertex_id.version() }
             ]}
           ]
         }};
 
         test_filter_representation(
-            &Filter::for_outgoing_link_by_source_entity_edition_id(entity_edition_id),
+            &Filter::for_outgoing_link_by_source_entity_vertex_id(entity_vertex_id),
             &expected,
         );
     }
 
     #[test]
-    fn for_left_entity_by_entity_edition_id() {
-        let entity_edition_id = EntityEditionId::new(
+    #[ignore = "TODO: Reevaluate if we need this after https://app.asana.com/0/0/1203491211535116/f"]
+    fn for_left_entity_by_entity_vertex_id() {
+        let entity_vertex_id = EntityVertexId::new(
             EntityId::new(
                 OwnedById::new(AccountId::new(Uuid::new_v4())),
                 EntityUuid::new(Uuid::new_v4()),
             ),
-            EntityRecordId::new(0),
-            EntityVersion::new(
-                DecisionTimeVersionTimespan::new(DecisionTimestamp::now(), None),
-                TransactionTimeVersionTimespan::new(TransactionTimestamp::now(), None),
-            ),
+            TransactionTimestamp::now(),
         );
 
         let expected = json! {{
           "all": [
             { "equal": [
               { "path": ["outgoingLinks", "ownedById"] },
-              { "parameter": entity_edition_id.base_id().owned_by_id() }
+              { "parameter": entity_vertex_id.base_id().owned_by_id() }
             ]},
             { "equal": [
               { "path": ["outgoingLinks", "uuid"] },
-              { "parameter": entity_edition_id.base_id().entity_uuid() }
+              { "parameter": entity_vertex_id.base_id().entity_uuid() }
             ]},
             { "equal": [
-              { "path": ["outgoingLinks", "recordId"] },
-              { "parameter": entity_edition_id.record_id() }
+              { "path": ["outgoingLinks", "lowerTransactionTime"] },
+              { "parameter": entity_vertex_id.version() }
             ]}
           ]
         }};
 
         test_filter_representation(
-            &Filter::for_left_entity_by_entity_edition_id(entity_edition_id),
+            &Filter::for_left_entity_by_entity_vertex_id(entity_vertex_id),
             &expected,
         );
     }
 
     #[test]
-    fn for_right_entity_by_entity_edition_id() {
-        let entity_edition_id = EntityEditionId::new(
+    #[ignore = "TODO: Reevaluate if we need this after https://app.asana.com/0/0/1203491211535116/f"]
+    fn for_right_entity_by_entity_vertex_id() {
+        let entity_vertex_id = EntityVertexId::new(
             EntityId::new(
                 OwnedById::new(AccountId::new(Uuid::new_v4())),
                 EntityUuid::new(Uuid::new_v4()),
             ),
-            EntityRecordId::new(0),
-            EntityVersion::new(
-                DecisionTimeVersionTimespan::new(DecisionTimestamp::now(), None),
-                TransactionTimeVersionTimespan::new(TransactionTimestamp::now(), None),
-            ),
+            TransactionTimestamp::now(),
         );
 
         let expected = json! {{
           "all": [
             { "equal": [
               { "path": ["incomingLinks", "ownedById"] },
-              { "parameter": entity_edition_id.base_id().owned_by_id() }
+              { "parameter": entity_vertex_id.base_id().owned_by_id() }
             ]},
             { "equal": [
               { "path": ["incomingLinks", "uuid"] },
-              { "parameter": entity_edition_id.base_id().entity_uuid() }
+              { "parameter": entity_vertex_id.base_id().entity_uuid() }
             ]},
             { "equal": [
-              { "path": ["incomingLinks", "recordId"] },
-              { "parameter": entity_edition_id.record_id() }
+              { "path": ["incomingLinks", "lowerTransactionTime"] },
+              { "parameter": entity_vertex_id.version() }
             ]}
           ]
         }};
 
         test_filter_representation(
-            &Filter::for_right_entity_by_entity_edition_id(entity_edition_id),
+            &Filter::for_right_entity_by_entity_vertex_id(entity_vertex_id),
             &expected,
         );
     }

--- a/packages/graph/hash_graph/lib/graph/src/store/record.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/record.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{
-    identifier::GraphElementEditionId,
+    identifier::GraphElementVertexId,
     store::query::{Filter, QueryPath},
     subgraph::Subgraph,
 };
@@ -13,30 +13,33 @@ use crate::{
 ///
 /// [`store`]: crate::store
 pub trait Record: Sized + Send {
-    type EditionId: Clone + PartialEq + Eq + Hash + Send + Sync + Into<GraphElementEditionId>;
+    type EditionId: Clone + PartialEq + Eq + Hash + Send + Sync;
+    type VertexId: Clone + PartialEq + Eq + Hash + Send + Sync + Into<GraphElementVertexId>;
     type QueryPath<'p>: QueryPath + Send + Sync;
 
     fn edition_id(&self) -> &Self::EditionId;
 
-    fn create_filter_for_edition_id(edition_id: &Self::EditionId) -> Filter<Self>;
+    fn vertex_id(&self) -> Self::VertexId;
+
+    fn create_filter_for_vertex_id(vertex_id: &Self::VertexId) -> Filter<Self>;
 
     fn subgraph_entry<'s>(
         subgraph: &'s mut Subgraph,
-        edition_id: &Self::EditionId,
-    ) -> RawEntryMut<'s, Self::EditionId, Self, RandomState>;
+        vertex_id: &Self::VertexId,
+    ) -> RawEntryMut<'s, Self::VertexId, Self, RandomState>;
 
     fn insert_into_subgraph(self, subgraph: &mut Subgraph) -> &Self {
-        let edition_id = self.edition_id();
-        Self::subgraph_entry(subgraph, edition_id)
-            .or_insert(edition_id.clone(), self)
+        let vertex_id = self.vertex_id();
+        Self::subgraph_entry(subgraph, &vertex_id)
+            .or_insert(vertex_id, self)
             .1
     }
 
     fn insert_into_subgraph_as_root(self, subgraph: &mut Subgraph) -> &Self {
-        let edition_id = self.edition_id();
-        subgraph.roots.insert(edition_id.clone().into());
-        Self::subgraph_entry(subgraph, edition_id)
-            .or_insert(edition_id.clone(), self)
+        let vertex_id = self.vertex_id();
+        subgraph.roots.insert(vertex_id.clone().into());
+        Self::subgraph_entry(subgraph, &vertex_id)
+            .or_insert(vertex_id, self)
             .1
     }
 }

--- a/packages/graph/hash_graph/tests/integration/postgres/entity.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/entity.rs
@@ -35,7 +35,10 @@ async fn insert() {
         .expect("could not create entity");
 
     let entity = api
-        .get_entity(metadata.edition_id())
+        .get_entity(
+            metadata.edition_id().base_id(),
+            metadata.version().transaction_time().start,
+        )
         .await
         .expect("could not get entity");
 
@@ -71,7 +74,10 @@ async fn query() {
         .expect("could not create entity");
 
     let queried_organization = api
-        .get_entity(metadata.edition_id())
+        .get_entity(
+            metadata.edition_id().base_id(),
+            metadata.version().transaction_time().start,
+        )
         .await
         .expect("could not get entity");
 
@@ -121,7 +127,10 @@ async fn update() {
         .expect("could not update entity");
 
     let entity_v2 = api
-        .get_entity(v2_metadata.edition_id())
+        .get_entity(
+            v2_metadata.edition_id().base_id(),
+            v2_metadata.version().transaction_time().start,
+        )
         .await
         .expect("could not get entity");
 

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -12,7 +12,7 @@ use graph::{
         account::AccountId,
         knowledge::{EntityEditionId, EntityId},
         ontology::OntologyTypeEditionId,
-        GraphElementEditionId,
+        GraphElementVertexId,
     },
     knowledge::{
         Entity, EntityLinkOrder, EntityMetadata, EntityProperties, EntityQueryPath, EntityUuid,
@@ -289,7 +289,7 @@ impl DatabaseApi<'_> {
         Ok(self
             .store
             .get_entity(&StructuralQuery {
-                filter: Entity::create_filter_for_edition_id(&entity_edition_id),
+                filter: Entity::create_filter_for_vertex_id(&entity_edition_id),
                 graph_resolve_depths: GraphResolveDepths::default(),
             })
             .await?
@@ -393,8 +393,8 @@ impl DatabaseApi<'_> {
             .roots
             .into_iter()
             .filter_map(|edition_id| match edition_id {
-                GraphElementEditionId::Ontology(_) => None,
-                GraphElementEditionId::KnowledgeGraph(edition_id) => {
+                GraphElementVertexId::Ontology(_) => None,
+                GraphElementVertexId::KnowledgeGraph(edition_id) => {
                     subgraph.vertices.entities.remove(&edition_id)
                 }
             })
@@ -453,8 +453,8 @@ impl DatabaseApi<'_> {
             .roots
             .into_iter()
             .filter_map(|edition_id| match edition_id {
-                GraphElementEditionId::Ontology(_) => None,
-                GraphElementEditionId::KnowledgeGraph(edition_id) => {
+                GraphElementVertexId::Ontology(_) => None,
+                GraphElementVertexId::KnowledgeGraph(edition_id) => {
                     subgraph.vertices.entities.remove(&edition_id)
                 }
             })

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -9,10 +9,8 @@ use std::borrow::Cow;
 use error_stack::Result;
 use graph::{
     identifier::{
-        account::AccountId,
-        knowledge::{EntityEditionId, EntityId},
-        ontology::OntologyTypeEditionId,
-        GraphElementVertexId,
+        account::AccountId, knowledge::EntityId, ontology::OntologyTypeEditionId,
+        time::TransactionTimestamp, EntityVertexId, GraphElementVertexId,
     },
     knowledge::{
         Entity, EntityLinkOrder, EntityMetadata, EntityProperties, EntityQueryPath, EntityUuid,
@@ -284,18 +282,20 @@ impl DatabaseApi<'_> {
 
     pub async fn get_entity(
         &self,
-        entity_edition_id: EntityEditionId,
+        entity_id: EntityId,
+        timestamp: TransactionTimestamp,
     ) -> Result<Entity, QueryError> {
+        let entity_vertex_id = EntityVertexId::new(entity_id, timestamp);
         Ok(self
             .store
             .get_entity(&StructuralQuery {
-                filter: Entity::create_filter_for_vertex_id(&entity_edition_id),
+                filter: Entity::create_filter_for_vertex_id(&entity_vertex_id),
                 graph_resolve_depths: GraphResolveDepths::default(),
             })
             .await?
             .vertices
             .entities
-            .remove(&entity_edition_id)
+            .remove(&entity_vertex_id)
             .expect("no entity found"))
     }
 

--- a/packages/hash/api/src/graph/knowledge/system-types/page.ts
+++ b/packages/hash/api/src/graph/knowledge/system-types/page.ts
@@ -451,8 +451,8 @@ export const getPageBlocks: ImpureGraphFunction<
           a.metadata.editionId.baseId.localeCompare(
             b.metadata.editionId.baseId,
           ) ||
-          a.metadata.editionId.version.decisionTime.start.localeCompare(
-            b.metadata.editionId.version.decisionTime.start,
+          a.metadata.version.decisionTime.start.localeCompare(
+            b.metadata.version.decisionTime.start,
           ),
       )
       .map((linkEntity) => getLinkEntityRightEntity(ctx, { linkEntity })),

--- a/packages/hash/api/src/graphql/resolvers/knowledge/comment/text-updated-at.ts
+++ b/packages/hash/api/src/graphql/resolvers/knowledge/comment/text-updated-at.ts
@@ -21,5 +21,5 @@ export const commentTextUpdatedAtResolver: ResolverFn<
   );
   const textEntity = await getCommentText({ graphApi }, { comment });
 
-  return textEntity.metadata.editionId.version;
+  return textEntity.metadata.version;
 };

--- a/packages/hash/api/src/graphql/typeDefs/subgraph.typedef.ts
+++ b/packages/hash/api/src/graphql/typeDefs/subgraph.typedef.ts
@@ -3,7 +3,7 @@ import { gql } from "apollo-server-express";
 /** @todo - docs */
 
 export const subgraphTypedef = gql`
-  scalar GraphElementEditionId
+  scalar GraphElementVertexId
   scalar VersionedUri
   scalar Vertices
   scalar Edges
@@ -39,7 +39,7 @@ export const subgraphTypedef = gql`
   }
 
   type Subgraph {
-    roots: [GraphElementEditionId!]!
+    roots: [GraphElementVertexId!]!
     vertices: Vertices!
     edges: Edges!
     depths: ResolveDepths!

--- a/packages/hash/frontend/src/blocks/page/Comments/CommentThread.tsx
+++ b/packages/hash/frontend/src/blocks/page/Comments/CommentThread.tsx
@@ -62,8 +62,8 @@ export const CommentThread: FunctionComponent<CommentThreadProps> = ({
 
   const [collapsedReplies, uncollapsibleReplies] = useMemo(() => {
     const replies = [...comment.replies].sort((replyA, replyB) =>
-      replyA.metadata.editionId.version.decisionTime.start.localeCompare(
-        replyB.metadata.editionId.version.decisionTime.start,
+      replyA.metadata.version.decisionTime.start.localeCompare(
+        replyB.metadata.version.decisionTime.start,
       ),
     );
     const lastItems = replies.splice(

--- a/packages/hash/frontend/src/components/hooks/useOrgs.ts
+++ b/packages/hash/frontend/src/components/hooks/useOrgs.ts
@@ -51,10 +51,10 @@ export const useOrgs = (
 
     /** @todo - Is there a way we can ergonomically encode this in the GraphQL type? */
     return getRoots(subgraph as Subgraph<SubgraphRootTypes["entity"]>).map(
-      ({ metadata: { editionId } }) =>
+      (orgEntity) =>
         constructOrg({
           subgraph,
-          orgEntityEditionId: editionId,
+          orgEntity,
           resolvedUsers,
           resolvedOrgs,
         }),

--- a/packages/hash/frontend/src/components/hooks/useUsers.ts
+++ b/packages/hash/frontend/src/components/hooks/useUsers.ts
@@ -47,10 +47,10 @@ export const useUsers = (
 
     /** @todo - Is there a way we can ergonomically encode this in the GraphQL type? */
     return getRoots(subgraph as Subgraph<SubgraphRootTypes["entity"]>).map(
-      ({ metadata: { editionId } }) =>
+      (userEntity) =>
         constructUser({
           subgraph,
-          userEntityEditionId: editionId,
+          userEntity,
           resolvedUsers,
           resolvedOrgs,
         }),

--- a/packages/hash/frontend/src/lib/user-and-org.ts
+++ b/packages/hash/frontend/src/lib/user-and-org.ts
@@ -10,8 +10,8 @@ import {
   EntityEditionId,
   EntityEditionIdString,
   entityEditionIdToString,
+  Entity,
 } from "@hashintel/hash-subgraph";
-import { getEntityByEditionId } from "@hashintel/hash-subgraph/src/stdlib/element/entity";
 import {
   getOutgoingLinksForEntityAtMoment,
   getRightEntityForLinkEntityAtMoment,
@@ -30,24 +30,15 @@ export type MinimalUser = {
 };
 
 export const constructMinimalUser = (params: {
-  subgraph: Subgraph;
-  userEntityEditionId: EntityEditionId;
+  userEntity: Entity;
 }): MinimalUser => {
-  const { subgraph, userEntityEditionId } = params;
+  const { userEntity } = params;
 
-  const { metadata, properties } =
-    getEntityByEditionId(subgraph, userEntityEditionId) ?? {};
-  if (!properties || !metadata) {
-    throw new Error(
-      `Could not find entity edition with ID ${userEntityEditionId} in subgraph`,
-    );
-  }
-
-  const shortname: string = properties[
+  const shortname: string = userEntity.properties[
     extractBaseUri(types.propertyType.shortName.propertyTypeId)
   ] as string;
 
-  const preferredName: string = properties[
+  const preferredName: string = userEntity.properties[
     extractBaseUri(types.propertyType.preferredName.propertyTypeId)
   ] as string;
 
@@ -55,9 +46,11 @@ export const constructMinimalUser = (params: {
 
   return {
     kind: "user",
-    entityEditionId: userEntityEditionId,
+    entityEditionId: userEntity.metadata.editionId,
     // Cast reason: The EntityUuid of a User's baseId is an AccountId
-    accountId: extractAccountId(userEntityEditionId.baseId as AccountEntityId),
+    accountId: extractAccountId(
+      userEntity.metadata.editionId.baseId as AccountEntityId,
+    ),
     shortname,
     preferredName,
     accountSignupComplete,
@@ -70,18 +63,18 @@ export type User = MinimalUser & {
 
 export const constructUser = (params: {
   subgraph: Subgraph;
-  userEntityEditionId: EntityEditionId;
+  userEntity: Entity;
   resolvedUsers?: Record<EntityEditionIdString, User>;
   resolvedOrgs?: Record<EntityEditionIdString, Org>;
 }): User => {
-  const { userEntityEditionId, subgraph } = params;
+  const { userEntity, subgraph } = params;
 
   const resolvedUsers = params.resolvedUsers ?? {};
   const resolvedOrgs = params.resolvedOrgs ?? {};
 
   const orgMemberships = getOutgoingLinksForEntityAtMoment(
     subgraph,
-    userEntityEditionId.baseId,
+    userEntity.metadata.editionId.baseId,
     new Date(),
   ).filter(
     (linkEntity) =>
@@ -89,7 +82,7 @@ export const constructUser = (params: {
       types.linkEntityType.orgMembership.linkEntityTypeId,
   );
 
-  const user = constructMinimalUser({ userEntityEditionId, subgraph }) as User;
+  const user = constructMinimalUser({ userEntity }) as User;
 
   // We add it to resolved users *before* fully creating so that when we're traversing we know
   // we already encountered it and avoid infinite recursion
@@ -116,7 +109,7 @@ export const constructUser = (params: {
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
       org = constructOrg({
         subgraph,
-        orgEntityEditionId: orgEntity.metadata.editionId,
+        orgEntity,
         resolvedUsers,
         resolvedOrgs,
       });
@@ -139,22 +132,13 @@ export type AuthenticatedUser = User & {
 };
 
 export const constructAuthenticatedUser = (params: {
-  userEntityEditionId: EntityEditionId;
+  userEntity: Entity;
   subgraph: Subgraph;
   kratosSession: Session;
 }): AuthenticatedUser => {
-  const { userEntityEditionId, subgraph } = params;
+  const { userEntity, subgraph } = params;
 
-  const { metadata, properties } =
-    getEntityByEditionId(subgraph, userEntityEditionId) ?? {};
-
-  if (!properties || !metadata) {
-    throw new Error(
-      `Could not find entity with ID ${userEntityEditionId.baseId} in subgraph`,
-    );
-  }
-
-  const primaryEmailAddress: string = properties[
+  const primaryEmailAddress: string = userEntity.properties[
     extractBaseUri(types.propertyType.email.propertyTypeId)
   ] as string;
 
@@ -173,7 +157,7 @@ export const constructAuthenticatedUser = (params: {
 
   const user = constructUser({
     subgraph,
-    userEntityEditionId: metadata.editionId,
+    userEntity,
   });
 
   return {
@@ -198,31 +182,24 @@ export type MinimalOrg = {
 };
 
 export const constructMinimalOrg = (params: {
-  subgraph: Subgraph;
-  orgEntityEditionId: EntityEditionId;
+  orgEntity: Entity;
 }): MinimalOrg => {
-  const { subgraph, orgEntityEditionId } = params;
+  const { orgEntity } = params;
 
-  const { metadata, properties } =
-    getEntityByEditionId(subgraph, orgEntityEditionId) ?? {};
-  if (!properties || !metadata) {
-    throw new Error(
-      `Could not find entity edition with ID ${orgEntityEditionId} in subgraph`,
-    );
-  }
-
-  const shortname: string = properties[
+  const shortname: string = orgEntity.properties[
     extractBaseUri(types.propertyType.shortName.propertyTypeId)
   ] as string;
 
-  const name: string = properties[
+  const name: string = orgEntity.properties[
     extractBaseUri(types.propertyType.orgName.propertyTypeId)
   ] as string;
 
   return {
     kind: "org",
-    entityEditionId: orgEntityEditionId,
-    accountId: extractAccountId(orgEntityEditionId.baseId as AccountEntityId),
+    entityEditionId: orgEntity.metadata.editionId,
+    accountId: extractAccountId(
+      orgEntity.metadata.editionId.baseId as AccountEntityId,
+    ),
     shortname,
     name,
   };
@@ -234,18 +211,18 @@ export type Org = MinimalOrg & {
 
 export const constructOrg = (params: {
   subgraph: Subgraph;
-  orgEntityEditionId: EntityEditionId;
+  orgEntity: Entity;
   resolvedUsers?: Record<EntityEditionIdString, User>;
   resolvedOrgs?: Record<EntityEditionIdString, Org>;
 }): Org => {
-  const { subgraph, orgEntityEditionId } = params;
+  const { subgraph, orgEntity } = params;
 
   const resolvedUsers = params.resolvedUsers ?? {};
   const resolvedOrgs = params.resolvedOrgs ?? {};
 
   const orgMemberships = getIncomingLinksForEntityAtMoment(
     subgraph,
-    orgEntityEditionId.baseId,
+    orgEntity.metadata.editionId.baseId,
     new Date(),
   ).filter(
     (linkEntity) =>
@@ -254,8 +231,7 @@ export const constructOrg = (params: {
   );
 
   const org = constructMinimalOrg({
-    subgraph,
-    orgEntityEditionId,
+    orgEntity,
   }) as Org;
 
   // We add it to resolved orgs *before* fully creating so that when we're traversing we know
@@ -282,7 +258,7 @@ export const constructOrg = (params: {
     if (!user) {
       user = constructUser({
         subgraph,
-        userEntityEditionId: userEntity.metadata.editionId,
+        userEntity,
         resolvedOrgs,
         resolvedUsers,
       });

--- a/packages/hash/frontend/src/pages/[shortname]/[page-slug].page.tsx
+++ b/packages/hash/frontend/src/pages/[shortname]/[page-slug].page.tsx
@@ -148,12 +148,10 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
   const workspaces = getRootsAsEntities(workspacesSubgraph).map((entity) =>
     entity.metadata.entityTypeId === types.entityType.user.entityTypeId
       ? constructMinimalUser({
-          userEntityEditionId: entity.metadata.editionId,
-          subgraph: workspacesSubgraph,
+          userEntity: entity,
         })
       : constructMinimalOrg({
-          orgEntityEditionId: entity.metadata.editionId,
-          subgraph: workspacesSubgraph,
+          orgEntity: entity,
         }),
   );
 

--- a/packages/hash/frontend/src/pages/[shortname]/entities/[entity-uuid].page.tsx
+++ b/packages/hash/frontend/src/pages/[shortname]/entities/[entity-uuid].page.tsx
@@ -146,13 +146,18 @@ const Page: NextPageWithLayout = () => {
                  */
                 const newEntity = JSON.parse(JSON.stringify(entity)) as Entity;
                 const newEntityVersion = new Date().toISOString();
-                newEntity.metadata.editionId.version.decisionTime.start =
+                newEntity.metadata.version.decisionTime.start =
                   newEntityVersion;
 
                 return entityAndSubgraph
                   ? ({
                       ...entityAndSubgraph,
-                      roots: [newEntity.metadata.editionId],
+                      roots: [
+                        {
+                          baseId: newEntity.metadata.editionId.baseId,
+                          version: newEntityVersion,
+                        },
+                      ],
                       vertices: {
                         ...entityAndSubgraph.vertices,
                         [newEntity.metadata.editionId.baseId]: {

--- a/packages/hash/frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/link-table/cells/linked-with-cell/entity-selector.tsx
+++ b/packages/hash/frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/link-table/cells/linked-with-cell/entity-selector.tsx
@@ -61,8 +61,8 @@ export const EntitySelector = ({
           !entityIdsToFilterOut?.includes(entity.metadata.editionId.baseId),
       )
       .sort((a, b) =>
-        a.metadata.editionId.version.decisionTime.start.localeCompare(
-          b.metadata.editionId.version.decisionTime.start,
+        a.metadata.version.decisionTime.start.localeCompare(
+          b.metadata.version.decisionTime.start,
         ),
       );
   }, [entities, entityIdsToFilterOut]);

--- a/packages/hash/frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/link-table/cells/sort-link-and-target-entities.ts
+++ b/packages/hash/frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/link-table/cells/sort-link-and-target-entities.ts
@@ -7,8 +7,8 @@ export const sortLinkAndTargetEntities = (
   }[],
 ) => {
   return [...linkAndTargetEntities].sort((a, b) =>
-    a.linkEntity.metadata.editionId.version.decisionTime.start.localeCompare(
-      b.linkEntity.metadata.editionId.version.decisionTime.start,
+    a.linkEntity.metadata.version.decisionTime.start.localeCompare(
+      b.linkEntity.metadata.version.decisionTime.start,
     ),
   );
 };

--- a/packages/hash/frontend/src/pages/_app.page.tsx
+++ b/packages/hash/frontend/src/pages/_app.page.tsx
@@ -5,6 +5,7 @@ require("setimmediate");
 import { ApolloProvider } from "@apollo/client/react";
 import { TypeSystemInitializer } from "@blockprotocol/type-system";
 import { Subgraph, SubgraphRootTypes } from "@hashintel/hash-subgraph";
+import { getRoots } from "@hashintel/hash-subgraph/src/stdlib/roots";
 import { FunctionComponent, useEffect, useState } from "react";
 import { ModalProvider } from "react-modal-hook";
 import { configureScope } from "@sentry/nextjs";
@@ -168,15 +169,15 @@ AppWithTypeSystemContextProvider.getInitialProps = async (appContext) => {
     return {};
   }
 
-  const userEntityEditionId = (
-    subgraph as Subgraph<SubgraphRootTypes["entity"]>
-  ).roots[0]!;
+  const userEntity = getRoots(
+    subgraph as Subgraph<SubgraphRootTypes["entity"]>,
+  )[0]!;
 
   // The type system package needs to be initialized before calling `constructAuthenticatedUser`
   await TypeSystemInitializer.initialize();
 
   const initialAuthenticatedUser = constructAuthenticatedUser({
-    userEntityEditionId,
+    userEntity,
     subgraph,
     kratosSession,
   });

--- a/packages/hash/frontend/src/pages/shared/auth-info-context.tsx
+++ b/packages/hash/frontend/src/pages/shared/auth-info-context.tsx
@@ -1,5 +1,6 @@
 import { useLazyQuery } from "@apollo/client";
 import { Subgraph, SubgraphRootTypes } from "@hashintel/hash-subgraph";
+import { getRoots } from "@hashintel/hash-subgraph/src/stdlib/roots";
 import {
   createContext,
   FunctionComponent,
@@ -62,12 +63,12 @@ export const AuthInfoProvider: FunctionComponent<AuthInfoProviderProps> = ({
       setAuthenticatedUser(undefined);
       return {};
     }
-    const userEntityEditionId = (
-      subgraph as Subgraph<SubgraphRootTypes["entity"]>
-    ).roots[0]!;
+    const userEntity = getRoots(
+      subgraph as Subgraph<SubgraphRootTypes["entity"]>,
+    )[0]!;
 
     const latestAuthenticatedUser = constructAuthenticatedUser({
-      userEntityEditionId,
+      userEntity,
       subgraph,
       kratosSession,
     });

--- a/packages/hash/integration/src/tests/graph/knowledge/primitive/entity.test.ts
+++ b/packages/hash/integration/src/tests/graph/knowledge/primitive/entity.test.ts
@@ -184,8 +184,8 @@ describe("Entity CRU", () => {
     expect(fetchedEntity.metadata.editionId.baseId).toEqual(
       createdEntity.metadata.editionId.baseId,
     );
-    expect(fetchedEntity.metadata.editionId.version).toEqual(
-      createdEntity.metadata.editionId.version,
+    expect(fetchedEntity.metadata.editionId.recordId).toEqual(
+      createdEntity.metadata.editionId.recordId,
     );
   });
 
@@ -241,8 +241,8 @@ describe("Entity CRU", () => {
     expect(allEntitys.length).toBeGreaterThanOrEqual(1);
     expect(newlyUpdated).toBeDefined();
 
-    expect(newlyUpdated?.metadata.editionId.version).toEqual(
-      updatedEntity.metadata.editionId.version,
+    expect(newlyUpdated?.metadata.editionId.recordId).toEqual(
+      updatedEntity.metadata.editionId.recordId,
     );
     expect(
       newlyUpdated?.properties[namePropertyType.metadata.editionId.baseId],

--- a/packages/hash/shared/src/ProsemirrorManager.ts
+++ b/packages/hash/shared/src/ProsemirrorManager.ts
@@ -436,8 +436,8 @@ export class ProsemirrorManager {
     if (
       targetChildEntity.metadata.editionId.baseId ===
         childEntity.metadata.editionId.baseId &&
-      targetChildEntity.metadata.editionId.version ===
-        childEntity.metadata.editionId.version
+      targetChildEntity.metadata.editionId.recordId ===
+        childEntity.metadata.editionId.recordId
     ) {
       return;
     }

--- a/packages/hash/shared/src/graphql/scalar-mapping.ts
+++ b/packages/hash/shared/src/graphql/scalar-mapping.ts
@@ -23,7 +23,7 @@ export const scalars = {
   EntityMetadata: "@hashintel/hash-subgraph#EntityMetadata",
   PropertyObject: "@hashintel/hash-subgraph#PropertyObject",
 
-  GraphElementEditionId: "@hashintel/hash-subgraph#GraphElementEditionId",
+  GraphElementVertexId: "@hashintel/hash-subgraph#GraphElementVertexId",
   Edges: "@hashintel/hash-subgraph#Edges",
   Vertices: "@hashintel/hash-subgraph#Vertices",
   LinkData: "@hashintel/hash-subgraph#LinkData",

--- a/packages/hash/subgraph/src/stdlib/element/entity.ts
+++ b/packages/hash/subgraph/src/stdlib/element/entity.ts
@@ -1,8 +1,8 @@
 import { Subgraph } from "../../types/subgraph";
 import {
-  EntityEditionId,
+  EntityVertexId,
   EntityId,
-  isEntityEditionId,
+  isEntityVertexId,
 } from "../../types/identifier";
 import { isEntityVertex } from "../../types/vertex";
 import { Entity } from "../../types/element";
@@ -31,12 +31,12 @@ export const getEntities = (subgraph: Subgraph): Entity[] => {
  * @param entityEditionId
  * @throws if the vertex isn't an `EntityVertex`
  */
-export const getEntityByEditionId = (
+export const getEntityByVertexId = (
   subgraph: Subgraph,
-  entityEditionId: EntityEditionId,
+  entityVertexId: EntityVertexId,
 ): Entity | undefined => {
-  const { baseId: entityId, version } = entityEditionId;
-  const vertex = subgraph.vertices[entityId]?.[version.transactionTime.start];
+  const { baseId: entityId, version } = entityVertexId;
+  const vertex = subgraph.vertices[entityId]?.[version];
 
   if (!vertex) {
     return undefined;
@@ -115,20 +115,18 @@ export const getEntityAtTimestamp = (
  * @throws if the subgraph is malformed and there isn't a vertex associated with the root ID
  */
 export const getRootsAsEntities = (subgraph: Subgraph): Entity[] => {
-  return subgraph.roots.map((rootEditionId) => {
-    if (!isEntityEditionId(rootEditionId)) {
+  return subgraph.roots.map((rootVertexId) => {
+    if (!isEntityVertexId(rootVertexId)) {
       throw new Error(
-        `expected roots to be \`EntityEditionId\`s but found:\n${JSON.stringify(
-          rootEditionId,
+        `expected roots to be \`EntityVertexId\`s but found:\n${JSON.stringify(
+          rootVertexId,
         )}`,
       );
     }
     const rootVertex = mustBeDefined(
-      subgraph.vertices[rootEditionId.baseId]?.[
-        rootEditionId.version.transactionTime.start
-      ],
+      subgraph.vertices[rootVertexId.baseId]?.[rootVertexId.version],
       `roots should have corresponding vertices but ${JSON.stringify(
-        rootEditionId,
+        rootVertexId,
       )} was missing`,
     );
 

--- a/packages/hash/subgraph/src/stdlib/roots.ts
+++ b/packages/hash/subgraph/src/stdlib/roots.ts
@@ -4,15 +4,10 @@ import {
   SubgraphRootTypes,
 } from "../types/subgraph";
 import { getDataTypeByEditionId } from "./element/data-type";
-import {
-  EntityEditionId,
-  isEntityEditionId,
-  isOntologyTypeEditionId,
-  OntologyTypeEditionId,
-} from "../types/identifier";
+import { isEntityVertexId, isOntologyTypeEditionId } from "../types/identifier";
 import { getPropertyTypeByEditionId } from "./element/property-type";
 import { getEntityTypeByEditionId } from "./element/entity-type";
-import { getEntityByEditionId } from "./element/entity";
+import { getEntityByVertexId } from "./element/entity";
 import { Vertex } from "../types/vertex";
 import { mustBeDefined } from "../shared/invariant";
 
@@ -30,24 +25,17 @@ import { mustBeDefined } from "../shared/invariant";
 export const getRoots = <RootType extends SubgraphRootType>(
   subgraph: Subgraph<RootType>,
 ): RootType["element"][] =>
-  subgraph.roots.map((rootEditionId) => {
-    let rootVersion;
-    if (typeof rootEditionId.version === "object") {
-      rootVersion = (rootEditionId as EntityEditionId).version.transactionTime
-        .start;
-    } else {
-      rootVersion = (rootEditionId as OntologyTypeEditionId).version;
-    }
+  subgraph.roots.map((rootVertexId) => {
     const root = mustBeDefined(
-      subgraph.vertices[rootEditionId.baseId]?.[
+      subgraph.vertices[rootVertexId.baseId]?.[
         // We could use type-guards here to convince TS that it's safe, but that would be slower, it's currently not
         // smart enough to realise this can produce a value of type `Vertex` as it struggles with discriminating
         // `EntityId` and `BaseUri`
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        rootVersion as any
+        rootVertexId.version as any
       ] as Vertex,
       `roots should have corresponding vertices but ${JSON.stringify(
-        rootEditionId,
+        rootVertexId,
       )} was missing`,
     );
 
@@ -146,15 +134,15 @@ export const isEntityTypeRootedSubgraph = (
 export const isEntityRootedSubgraph = (
   subgraph: Subgraph,
 ): subgraph is Subgraph<SubgraphRootTypes["entity"]> => {
-  for (const rootEditionId of subgraph.roots) {
-    if (!isEntityEditionId(rootEditionId)) {
+  for (const rootVertexId of subgraph.roots) {
+    if (!isEntityVertexId(rootVertexId)) {
       return false;
     }
 
     mustBeDefined(
-      getEntityByEditionId(subgraph, rootEditionId),
+      getEntityByVertexId(subgraph, rootVertexId),
       `roots should have corresponding vertices but ${JSON.stringify(
-        rootEditionId,
+        rootVertexId,
       )} was missing`,
     );
   }

--- a/packages/hash/subgraph/src/types/edge.ts
+++ b/packages/hash/subgraph/src/types/edge.ts
@@ -1,10 +1,10 @@
 import { BaseUri } from "@blockprotocol/type-system";
 import {
-  isEntityEditionId,
+  isEntityVertexId,
   isOntologyTypeEditionId,
   EntityId,
   Timestamp,
-  EntityEditionId,
+  EntityVertexId,
   EntityIdAndTimestamp,
   OntologyTypeEditionId,
 } from "./identifier";
@@ -56,7 +56,7 @@ type GenericOutwardEdge<K, E> = {
 
 export type OntologyOutwardEdge =
   | GenericOutwardEdge<OntologyEdgeKind, OntologyTypeEditionId>
-  | GenericOutwardEdge<SharedEdgeKind, EntityEditionId>;
+  | GenericOutwardEdge<SharedEdgeKind, EntityVertexId>;
 
 export type KnowledgeGraphOutwardEdge =
   | GenericOutwardEdge<KnowledgeGraphEdgeKind, EntityIdAndTimestamp>
@@ -69,7 +69,7 @@ export const isOntologyOutwardEdge = (
 ): edge is OntologyOutwardEdge => {
   return (
     isOntologyEdgeKind(edge.kind) ||
-    (isSharedEdgeKind(edge.kind) && isEntityEditionId(edge.rightEndpoint))
+    (isSharedEdgeKind(edge.kind) && isEntityVertexId(edge.rightEndpoint))
   );
 };
 

--- a/packages/hash/subgraph/src/types/element.ts
+++ b/packages/hash/subgraph/src/types/element.ts
@@ -11,7 +11,7 @@ import {
   PropertyType,
   VersionedUri,
 } from "@blockprotocol/type-system";
-import { EntityEditionId, EntityId } from "./identifier";
+import { EntityEditionId, EntityId, EntityVersion } from "./identifier";
 
 // Due to restrictions with how much OpenAPI can express, we patch the schemas with the better-typed ones from the
 // type-system package.
@@ -58,6 +58,7 @@ export type LinkData = {
 export type EntityMetadata = {
   archived: boolean;
   editionId: EntityEditionId;
+  version: EntityVersion;
   entityTypeId: VersionedUri;
   provenance: ProvenanceMetadataGraphApi;
 };

--- a/packages/hash/subgraph/src/types/identifier.ts
+++ b/packages/hash/subgraph/src/types/identifier.ts
@@ -54,7 +54,11 @@ export type EntityRecordId = number;
 export type EntityEditionId = {
   baseId: EntityId;
   recordId: EntityRecordId;
-  version: EntityVersion;
+};
+
+export type EntityVertexId = {
+  baseId: EntityId;
+  version: Timestamp;
 };
 
 /**
@@ -80,7 +84,7 @@ export type EntityIdAndTimestamp = {
 
 export type { OntologyTypeEditionId };
 
-export type GraphElementEditionId = EntityEditionId | OntologyTypeEditionId;
+export type GraphElementVertexId = EntityVertexId | OntologyTypeEditionId;
 
 export const ontologyTypeEditionIdToVersionedUri = (
   ontologyTypeEditionId: OntologyTypeEditionId,
@@ -98,16 +102,16 @@ export const isEntityId = (entityId: string): entityId is EntityId => {
   );
 };
 
-export const isEntityEditionId = (
-  editionId: object,
-): editionId is EntityEditionId => {
+export const isEntityVertexId = (
+  vertexId: object,
+): vertexId is EntityVertexId => {
   return (
-    "baseId" in editionId &&
-    typeof editionId.baseId === "string" &&
-    isEntityId(editionId.baseId) &&
-    "recordId" in editionId &&
-    typeof editionId.recordId === "number" &&
-    Number.isInteger(editionId.recordId)
+    "baseId" in vertexId &&
+    typeof vertexId.baseId === "string" &&
+    isEntityId(vertexId.baseId) &&
+    "version" in vertexId &&
+    typeof vertexId.version === "string" &&
+    !Number.isNaN(Date.parse(vertexId.version))
   );
 };
 
@@ -124,15 +128,15 @@ export const isOntologyTypeEditionId = (
   );
 };
 
-export const isEntityAndTimestamp = (
-  editionId: object,
-): editionId is EntityIdAndTimestamp => {
+export const isEntityIdAndTimestamp = (
+  entityIdAndTimestamp: object,
+): entityIdAndTimestamp is EntityIdAndTimestamp => {
   return (
-    "baseId" in editionId &&
-    typeof editionId.baseId === "string" &&
-    isEntityId(editionId.baseId) &&
-    "timestamp" in editionId &&
-    typeof editionId.timestamp === "string" &&
-    !Number.isNaN(Date.parse(editionId.timestamp))
+    "baseId" in entityIdAndTimestamp &&
+    typeof entityIdAndTimestamp.baseId === "string" &&
+    isEntityId(entityIdAndTimestamp.baseId) &&
+    "timestamp" in entityIdAndTimestamp &&
+    typeof entityIdAndTimestamp.timestamp === "string" &&
+    !Number.isNaN(Date.parse(entityIdAndTimestamp.timestamp))
   );
 };

--- a/packages/hash/subgraph/src/types/subgraph.ts
+++ b/packages/hash/subgraph/src/types/subgraph.ts
@@ -10,23 +10,23 @@ import {
 } from "./element";
 import { Vertices } from "./vertex";
 import { Edges } from "./edge";
-import { EntityEditionId } from "./identifier";
+import { EntityVertexId } from "./identifier";
 
 export type SubgraphRootTypes = {
   dataType: {
-    editionId: OntologyTypeEditionId;
+    vertexId: OntologyTypeEditionId;
     element: DataTypeWithMetadata;
   };
   propertyType: {
-    editionId: OntologyTypeEditionId;
+    vertexId: OntologyTypeEditionId;
     element: PropertyTypeWithMetadata;
   };
   entityType: {
-    editionId: OntologyTypeEditionId;
+    vertexId: OntologyTypeEditionId;
     element: EntityTypeWithMetadata;
   };
   entity: {
-    editionId: EntityEditionId;
+    vertexId: EntityVertexId;
     element: Entity;
   };
 };
@@ -34,7 +34,7 @@ export type SubgraphRootTypes = {
 export type SubgraphRootType = SubgraphRootTypes[keyof SubgraphRootTypes];
 
 export type Subgraph<RootType extends SubgraphRootType = SubgraphRootType> = {
-  roots: RootType["editionId"][];
+  roots: RootType["vertexId"][];
   vertices: Vertices;
   edges: Edges;
   depths: GraphResolveDepths;

--- a/packages/hash/subgraph/tests/compatibility.test/map-edges.ts
+++ b/packages/hash/subgraph/tests/compatibility.test/map-edges.ts
@@ -6,7 +6,7 @@ import {
 import { validateBaseUri } from "@blockprotocol/type-system";
 import {
   Edges,
-  isEntityAndTimestamp,
+  isEntityIdAndTimestamp,
   isEntityId,
   isKnowledgeGraphOutwardEdge,
   isOntologyOutwardEdge,
@@ -29,7 +29,7 @@ export const mapOutwardEdge = (
     // Knowledge-graph edge-kind cases
     case "HAS_LEFT_ENTITY":
     case "HAS_RIGHT_ENTITY": {
-      if (!isEntityAndTimestamp(outwardEdge.rightEndpoint)) {
+      if (!isEntityIdAndTimestamp(outwardEdge.rightEndpoint)) {
         throw new Error(
           `Expected an \`EntityAndTimestamp\` for knowledge-graph edge-kind endpoint but found:\n${JSON.stringify(
             outwardEdge,

--- a/packages/hash/subgraph/tests/compatibility.test/map-roots.ts
+++ b/packages/hash/subgraph/tests/compatibility.test/map-roots.ts
@@ -1,15 +1,11 @@
 import { Subgraph as SubgraphGraphApi } from "@hashintel/hash-graph-client";
-import {
-  isEntityEditionId,
-  isOntologyTypeEditionId,
-  Subgraph,
-} from "../../src";
+import { isEntityVertexId, isOntologyTypeEditionId, Subgraph } from "../../src";
 
 export const mapRoots = (
   roots: SubgraphGraphApi["roots"],
 ): Subgraph["roots"] => {
   return roots.map((root) => {
-    if (isEntityEditionId(root)) {
+    if (isEntityVertexId(root)) {
       return root;
     } else if (isOntologyTypeEditionId(root)) {
       return root;

--- a/packages/hash/subgraph/tests/compatibility.test/map-vertices.ts
+++ b/packages/hash/subgraph/tests/compatibility.test/map-vertices.ts
@@ -123,8 +123,8 @@ const mapKnowledgeGraphVertex = (
         editionId: {
           baseId: vertex.inner.metadata.editionId.baseId as EntityId,
           recordId: vertex.inner.metadata.editionId.recordId,
-          version: vertex.inner.metadata.editionId.version as EntityVersion,
         },
+        version: vertex.inner.metadata.version as EntityVersion,
         entityTypeId: vertex.inner.metadata.entityTypeId as VersionedUri,
       },
     },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The subgraph should not use the entity version as roots, so this changed the roots struct of the subgraph to return a newly introduced `EntityVertexId`.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201095311341924/1203596975031422/f) _(internal)_

## 🚫 Blocked by

- #1703 
- #1717 
- #1715 
- #1718 

## 🔍 What does this change?

- Introduce `EntityVertexId` in the subgraph
- Move `EntityVersion` from `EntityEditionId` to `EntityMetadata`
- Adjust the backend to use those changes. In the frontend I encountered an issue as it passed the entity edition id from the subgraph root to a function, which then looks up the entity by edition id again. I changed this to just take the entity directly.