### PR TITLE
Fix expected query param account-slug

### DIFF
--- a/packages/hash/frontend/src/pages/[shortname]/types/entity-type/[entity-type-id].page/definition-tab/shared/type-form.tsx
+++ b/packages/hash/frontend/src/pages/[shortname]/types/entity-type/[entity-type-id].page/definition-tab/shared/type-form.tsx
@@ -236,7 +236,7 @@ export const generateInitialTypeUri = (baseUri: string) =>
 
 export const useGenerateTypeBaseUri = (kind: SchemaKind) => {
   const router = useRouter();
-  const shortname = router.query["account-slug"]?.toString().slice(1) ?? "";
+  const shortname = router.query.shortname?.toString().slice(1) ?? "";
 
   return (value: string) => {
     if (!shortname) {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#1705 updated the name of a param for a route, but missed an occurence of the old name. This PR fixes it.
