### PR TITLE
Add time projection interface to structural queries and subgraph at the Graph

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -299,6 +299,12 @@ export interface DataTypeStructuralQuery {
    * @memberof DataTypeStructuralQuery
    */
   graphResolveDepths: GraphResolveDepths;
+  /**
+   *
+   * @type {UnresolvedTimeProjection}
+   * @memberof DataTypeStructuralQuery
+   */
+  timeProjection?: UnresolvedTimeProjection;
 }
 /**
  *
@@ -318,6 +324,113 @@ export interface DataTypeWithMetadata {
    * @memberof DataTypeWithMetadata
    */
   schema: DataType;
+}
+/**
+ * Time axis for the decision time.  This is used as the generic argument to time-related structs and can be used as tag value.
+ * @export
+ * @enum {string}
+ */
+
+export const DecisionTime = {
+  Decision: "decision",
+} as const;
+
+export type DecisionTime = typeof DecisionTime[keyof typeof DecisionTime];
+
+/**
+ *
+ * @export
+ * @interface DecisionTimeImage
+ */
+export interface DecisionTimeImage {
+  /**
+   *
+   * @type {DecisionTime}
+   * @memberof DecisionTimeImage
+   */
+  axis: DecisionTime;
+  /**
+   *
+   * @type {TimespanBound}
+   * @memberof DecisionTimeImage
+   */
+  end: TimespanBound;
+  /**
+   *
+   * @type {TimespanBound}
+   * @memberof DecisionTimeImage
+   */
+  start: TimespanBound;
+}
+/**
+ *
+ * @export
+ * @interface DecisionTimeImageAllOf
+ */
+export interface DecisionTimeImageAllOf {
+  /**
+   *
+   * @type {DecisionTime}
+   * @memberof DecisionTimeImageAllOf
+   */
+  axis: DecisionTime;
+}
+/**
+ *
+ * @export
+ * @interface DecisionTimeImageAllOf1
+ */
+export interface DecisionTimeImageAllOf1 {
+  /**
+   *
+   * @type {TimespanBound}
+   * @memberof DecisionTimeImageAllOf1
+   */
+  end: TimespanBound;
+  /**
+   *
+   * @type {TimespanBound}
+   * @memberof DecisionTimeImageAllOf1
+   */
+  start: TimespanBound;
+}
+/**
+ *
+ * @export
+ * @interface DecisionTimeKernel
+ */
+export interface DecisionTimeKernel {
+  /**
+   *
+   * @type {DecisionTime}
+   * @memberof DecisionTimeKernel
+   */
+  axis: DecisionTime;
+  /**
+   *
+   * @type {string}
+   * @memberof DecisionTimeKernel
+   */
+  timestamp: string;
+}
+/**
+ *
+ * @export
+ * @interface DecisionTimeProjection
+ */
+export interface DecisionTimeProjection {
+  /**
+   *
+   * @type {DecisionTimeImage}
+   * @memberof DecisionTimeProjection
+   */
+  image: DecisionTimeImage;
+  /**
+   *
+   * @type {TransactionTimeKernel}
+   * @memberof DecisionTimeProjection
+   */
+  kernel: TransactionTimeKernel;
 }
 /**
  *
@@ -517,6 +630,12 @@ export interface EntityStructuralQuery {
    * @memberof EntityStructuralQuery
    */
   graphResolveDepths: GraphResolveDepths;
+  /**
+   *
+   * @type {UnresolvedTimeProjection}
+   * @memberof EntityStructuralQuery
+   */
+  timeProjection?: UnresolvedTimeProjection;
 }
 /**
  * Specifies the structure of an Entity Type
@@ -649,6 +768,12 @@ export interface EntityTypeStructuralQuery {
    * @memberof EntityTypeStructuralQuery
    */
   graphResolveDepths: GraphResolveDepths;
+  /**
+   *
+   * @type {UnresolvedTimeProjection}
+   * @memberof EntityTypeStructuralQuery
+   */
+  timeProjection?: UnresolvedTimeProjection;
 }
 /**
  *
@@ -1663,6 +1788,12 @@ export interface PropertyTypeStructuralQuery {
    * @memberof PropertyTypeStructuralQuery
    */
   graphResolveDepths: GraphResolveDepths;
+  /**
+   *
+   * @type {UnresolvedTimeProjection}
+   * @memberof PropertyTypeStructuralQuery
+   */
+  timeProjection?: UnresolvedTimeProjection;
 }
 /**
  *
@@ -1758,16 +1889,331 @@ export interface Subgraph {
   edges: Edges;
   /**
    *
+   * @type {TimeProjection}
+   * @memberof Subgraph
+   */
+  resolvedTimeProjection: TimeProjection;
+  /**
+   *
    * @type {Array<GraphElementVertexId>}
    * @memberof Subgraph
    */
   roots: Array<GraphElementVertexId>;
   /**
    *
+   * @type {UnresolvedTimeProjection}
+   * @memberof Subgraph
+   */
+  timeProjection: UnresolvedTimeProjection;
+  /**
+   *
    * @type {Vertices}
    * @memberof Subgraph
    */
   vertices: Vertices;
+}
+/**
+ * @type TimeProjection
+ * @export
+ */
+export type TimeProjection = DecisionTimeProjection | TransactionTimeProjection;
+
+/**
+ * @type TimespanBound
+ * @export
+ */
+export type TimespanBound = TimespanBoundOneOf | TimespanBoundOneOf1;
+
+/**
+ *
+ * @export
+ * @interface TimespanBoundOneOf
+ */
+export interface TimespanBoundOneOf {
+  /**
+   *
+   * @type {object}
+   * @memberof TimespanBoundOneOf
+   */
+  bound: TimespanBoundOneOfBoundEnum;
+}
+
+export const TimespanBoundOneOfBoundEnum = {
+  Unbounded: "unbounded",
+} as const;
+
+export type TimespanBoundOneOfBoundEnum =
+  typeof TimespanBoundOneOfBoundEnum[keyof typeof TimespanBoundOneOfBoundEnum];
+
+/**
+ *
+ * @export
+ * @interface TimespanBoundOneOf1
+ */
+export interface TimespanBoundOneOf1 {
+  /**
+   *
+   * @type {object}
+   * @memberof TimespanBoundOneOf1
+   */
+  bound: TimespanBoundOneOf1BoundEnum;
+  /**
+   *
+   * @type {string}
+   * @memberof TimespanBoundOneOf1
+   */
+  timestamp: string;
+}
+
+export const TimespanBoundOneOf1BoundEnum = {
+  Included: "included",
+  Excluded: "excluded",
+} as const;
+
+export type TimespanBoundOneOf1BoundEnum =
+  typeof TimespanBoundOneOf1BoundEnum[keyof typeof TimespanBoundOneOf1BoundEnum];
+
+/**
+ * Time axis for the transaction time.  This is used as the generic argument to time-related structs and can be used as tag value.
+ * @export
+ * @enum {string}
+ */
+
+export const TransactionTime = {
+  Transaction: "transaction",
+} as const;
+
+export type TransactionTime =
+  typeof TransactionTime[keyof typeof TransactionTime];
+
+/**
+ *
+ * @export
+ * @interface TransactionTimeImage
+ */
+export interface TransactionTimeImage {
+  /**
+   *
+   * @type {TransactionTime}
+   * @memberof TransactionTimeImage
+   */
+  axis: TransactionTime;
+  /**
+   *
+   * @type {TimespanBound}
+   * @memberof TransactionTimeImage
+   */
+  end: TimespanBound;
+  /**
+   *
+   * @type {TimespanBound}
+   * @memberof TransactionTimeImage
+   */
+  start: TimespanBound;
+}
+/**
+ *
+ * @export
+ * @interface TransactionTimeImageAllOf
+ */
+export interface TransactionTimeImageAllOf {
+  /**
+   *
+   * @type {TransactionTime}
+   * @memberof TransactionTimeImageAllOf
+   */
+  axis: TransactionTime;
+}
+/**
+ *
+ * @export
+ * @interface TransactionTimeKernel
+ */
+export interface TransactionTimeKernel {
+  /**
+   *
+   * @type {TransactionTime}
+   * @memberof TransactionTimeKernel
+   */
+  axis: TransactionTime;
+  /**
+   *
+   * @type {string}
+   * @memberof TransactionTimeKernel
+   */
+  timestamp: string;
+}
+/**
+ *
+ * @export
+ * @interface TransactionTimeProjection
+ */
+export interface TransactionTimeProjection {
+  /**
+   *
+   * @type {TransactionTimeImage}
+   * @memberof TransactionTimeProjection
+   */
+  image: TransactionTimeImage;
+  /**
+   *
+   * @type {DecisionTimeKernel}
+   * @memberof TransactionTimeProjection
+   */
+  kernel: DecisionTimeKernel;
+}
+/**
+ *
+ * @export
+ * @interface UnresolvedDecisionTimeImage
+ */
+export interface UnresolvedDecisionTimeImage {
+  /**
+   *
+   * @type {DecisionTime}
+   * @memberof UnresolvedDecisionTimeImage
+   */
+  axis: DecisionTime;
+  /**
+   *
+   * @type {TimespanBound}
+   * @memberof UnresolvedDecisionTimeImage
+   */
+  end?: TimespanBound;
+  /**
+   *
+   * @type {TimespanBound}
+   * @memberof UnresolvedDecisionTimeImage
+   */
+  start?: TimespanBound;
+}
+/**
+ *
+ * @export
+ * @interface UnresolvedDecisionTimeImageAllOf
+ */
+export interface UnresolvedDecisionTimeImageAllOf {
+  /**
+   *
+   * @type {TimespanBound}
+   * @memberof UnresolvedDecisionTimeImageAllOf
+   */
+  end?: TimespanBound;
+  /**
+   *
+   * @type {TimespanBound}
+   * @memberof UnresolvedDecisionTimeImageAllOf
+   */
+  start?: TimespanBound;
+}
+/**
+ *
+ * @export
+ * @interface UnresolvedDecisionTimeKernel
+ */
+export interface UnresolvedDecisionTimeKernel {
+  /**
+   *
+   * @type {DecisionTime}
+   * @memberof UnresolvedDecisionTimeKernel
+   */
+  axis: DecisionTime;
+  /**
+   *
+   * @type {string}
+   * @memberof UnresolvedDecisionTimeKernel
+   */
+  timestamp?: string;
+}
+/**
+ *
+ * @export
+ * @interface UnresolvedDecisionTimeProjection
+ */
+export interface UnresolvedDecisionTimeProjection {
+  /**
+   *
+   * @type {UnresolvedDecisionTimeImage}
+   * @memberof UnresolvedDecisionTimeProjection
+   */
+  image: UnresolvedDecisionTimeImage;
+  /**
+   *
+   * @type {UnresolvedTransactionTimeKernel}
+   * @memberof UnresolvedDecisionTimeProjection
+   */
+  kernel: UnresolvedTransactionTimeKernel;
+}
+/**
+ * @type UnresolvedTimeProjection
+ * @export
+ */
+export type UnresolvedTimeProjection =
+  | UnresolvedDecisionTimeProjection
+  | UnresolvedTransactionTimeProjection;
+
+/**
+ *
+ * @export
+ * @interface UnresolvedTransactionTimeImage
+ */
+export interface UnresolvedTransactionTimeImage {
+  /**
+   *
+   * @type {TransactionTime}
+   * @memberof UnresolvedTransactionTimeImage
+   */
+  axis: TransactionTime;
+  /**
+   *
+   * @type {TimespanBound}
+   * @memberof UnresolvedTransactionTimeImage
+   */
+  end?: TimespanBound;
+  /**
+   *
+   * @type {TimespanBound}
+   * @memberof UnresolvedTransactionTimeImage
+   */
+  start?: TimespanBound;
+}
+/**
+ *
+ * @export
+ * @interface UnresolvedTransactionTimeKernel
+ */
+export interface UnresolvedTransactionTimeKernel {
+  /**
+   *
+   * @type {TransactionTime}
+   * @memberof UnresolvedTransactionTimeKernel
+   */
+  axis: TransactionTime;
+  /**
+   *
+   * @type {string}
+   * @memberof UnresolvedTransactionTimeKernel
+   */
+  timestamp?: string;
+}
+/**
+ *
+ * @export
+ * @interface UnresolvedTransactionTimeProjection
+ */
+export interface UnresolvedTransactionTimeProjection {
+  /**
+   *
+   * @type {UnresolvedTransactionTimeImage}
+   * @memberof UnresolvedTransactionTimeProjection
+   */
+  image: UnresolvedTransactionTimeImage;
+  /**
+   *
+   * @type {UnresolvedDecisionTimeKernel}
+   * @memberof UnresolvedTransactionTimeProjection
+   */
+  kernel: UnresolvedDecisionTimeKernel;
 }
 /**
  * The contents of a Data Type update request

--- a/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/complete/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/complete/entity.rs
@@ -3,7 +3,10 @@ use std::{iter::repeat, str::FromStr};
 use criterion::{BatchSize::SmallInput, Bencher, BenchmarkId, Criterion, SamplingMode};
 use criterion_macro::criterion;
 use graph::{
-    identifier::account::AccountId,
+    identifier::{
+        account::AccountId,
+        time::{UnresolvedImage, UnresolvedProjection, TimespanBound, UnresolvedKernel, UnresolvedTimeProjection},
+    },
     knowledge::{EntityMetadata, EntityProperties, LinkData},
     provenance::{OwnedById, UpdatedById},
     store::{query::Filter, AccountStore, EntityStore, Store as _, Transaction},
@@ -157,6 +160,13 @@ pub fn bench_get_entity_by_id(
                 .get_entity(&StructuralQuery {
                     filter: Filter::for_entity_by_entity_id(entity_edition_id.base_id()),
                     graph_resolve_depths,
+                    time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
+                        kernel: UnresolvedKernel::new(None),
+                        image: UnresolvedImage::new(
+                            Some(TimespanBound::Unbounded),
+                            Some(TimespanBound::Unbounded),
+                        ),
+                    }),
                 })
                 .await
                 .expect("failed to read entity from store");

--- a/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/complete/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/complete/entity.rs
@@ -5,7 +5,10 @@ use criterion_macro::criterion;
 use graph::{
     identifier::{
         account::AccountId,
-        time::{UnresolvedImage, UnresolvedProjection, TimespanBound, UnresolvedKernel, UnresolvedTimeProjection},
+        time::{
+            TimespanBound, UnresolvedImage, UnresolvedKernel, UnresolvedProjection,
+            UnresolvedTimeProjection,
+        },
     },
     knowledge::{EntityMetadata, EntityProperties, LinkData},
     provenance::{OwnedById, UpdatedById},

--- a/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/linkless/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/linkless/entity.rs
@@ -3,7 +3,10 @@ use std::{iter::repeat, str::FromStr};
 use criterion::{BatchSize::SmallInput, Bencher, BenchmarkId, Criterion};
 use criterion_macro::criterion;
 use graph::{
-    identifier::account::AccountId,
+    identifier::{
+        account::AccountId,
+        time::{UnresolvedImage, UnresolvedProjection, TimespanBound, UnresolvedKernel, UnresolvedTimeProjection},
+    },
     knowledge::{EntityMetadata, EntityProperties},
     provenance::{OwnedById, UpdatedById},
     store::{query::Filter, AccountStore, EntityStore, Store as _, Transaction},
@@ -111,6 +114,13 @@ pub fn bench_get_entity_by_id(
                 .get_entity(&StructuralQuery {
                     filter: Filter::for_entity_by_entity_id(entity_edition_id.base_id()),
                     graph_resolve_depths: GraphResolveDepths::default(),
+                    time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
+                        kernel: UnresolvedKernel::new(None),
+                        image: UnresolvedImage::new(
+                            Some(TimespanBound::Unbounded),
+                            Some(TimespanBound::Unbounded),
+                        ),
+                    }),
                 })
                 .await
                 .expect("failed to read entity from store");

--- a/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/linkless/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/linkless/entity.rs
@@ -5,7 +5,10 @@ use criterion_macro::criterion;
 use graph::{
     identifier::{
         account::AccountId,
-        time::{UnresolvedImage, UnresolvedProjection, TimespanBound, UnresolvedKernel, UnresolvedTimeProjection},
+        time::{
+            TimespanBound, UnresolvedImage, UnresolvedKernel, UnresolvedProjection,
+            UnresolvedTimeProjection,
+        },
     },
     knowledge::{EntityMetadata, EntityProperties},
     provenance::{OwnedById, UpdatedById},

--- a/packages/graph/hash_graph/bench/benches/representative_read/knowledge/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/knowledge/entity.rs
@@ -3,7 +3,8 @@ use std::borrow::Cow;
 use criterion::{BatchSize::SmallInput, Bencher};
 use graph::{
     identifier::time::{
-        UnresolvedImage, UnresolvedProjection, TimespanBound, UnresolvedKernel, UnresolvedTimeProjection,
+        TimespanBound, UnresolvedImage, UnresolvedKernel, UnresolvedProjection,
+        UnresolvedTimeProjection,
     },
     knowledge::{EntityQueryPath, EntityUuid},
     store::{

--- a/packages/graph/hash_graph/bench/benches/representative_read/knowledge/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/knowledge/entity.rs
@@ -2,6 +2,9 @@ use std::borrow::Cow;
 
 use criterion::{BatchSize::SmallInput, Bencher};
 use graph::{
+    identifier::time::{
+        UnresolvedImage, UnresolvedProjection, TimespanBound, UnresolvedKernel, UnresolvedTimeProjection,
+    },
     knowledge::{EntityQueryPath, EntityUuid},
     store::{
         query::{Filter, FilterExpression, Parameter},
@@ -45,6 +48,13 @@ pub fn bench_get_entity_by_id(
                         ),
                     ]),
                     graph_resolve_depths: GraphResolveDepths::default(),
+                    time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
+                        kernel: UnresolvedKernel::new(None),
+                        image: UnresolvedImage::new(
+                            Some(TimespanBound::Unbounded),
+                            Some(TimespanBound::Unbounded),
+                        ),
+                    }),
                 })
                 .await
                 .expect("failed to read entity from store");
@@ -72,6 +82,13 @@ pub fn bench_get_entities_by_property(
                     )))),
                 ),
                 graph_resolve_depths,
+                time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
+                    kernel: UnresolvedKernel::new(None),
+                    image: UnresolvedImage::new(
+                        Some(TimespanBound::Unbounded),
+                        Some(TimespanBound::Unbounded),
+                    ),
+                }),
             })
             .await
             .expect("failed to read entity from store");
@@ -99,6 +116,13 @@ pub fn bench_get_link_by_target_by_property(
                     )))),
                 ),
                 graph_resolve_depths,
+                time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
+                    kernel: UnresolvedKernel::new(None),
+                    image: UnresolvedImage::new(
+                        Some(TimespanBound::Unbounded),
+                        Some(TimespanBound::Unbounded),
+                    ),
+                }),
             })
             .await
             .expect("failed to read entity from store");

--- a/packages/graph/hash_graph/bench/benches/representative_read/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/ontology/entity_type.rs
@@ -1,7 +1,8 @@
 use criterion::{BatchSize::SmallInput, Bencher};
 use graph::{
     identifier::time::{
-        UnresolvedImage, UnresolvedProjection, TimespanBound, UnresolvedKernel, UnresolvedTimeProjection,
+        TimespanBound, UnresolvedImage, UnresolvedKernel, UnresolvedProjection,
+        UnresolvedTimeProjection,
     },
     store::{query::Filter, EntityTypeStore},
     subgraph::{edges::GraphResolveDepths, query::StructuralQuery},

--- a/packages/graph/hash_graph/bench/benches/representative_read/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/ontology/entity_type.rs
@@ -1,5 +1,8 @@
 use criterion::{BatchSize::SmallInput, Bencher};
 use graph::{
+    identifier::time::{
+        UnresolvedImage, UnresolvedProjection, TimespanBound, UnresolvedKernel, UnresolvedTimeProjection,
+    },
     store::{query::Filter, EntityTypeStore},
     subgraph::{edges::GraphResolveDepths, query::StructuralQuery},
 };
@@ -29,6 +32,13 @@ pub fn bench_get_entity_type_by_id(
                 .get_entity_type(&StructuralQuery {
                     filter: Filter::for_versioned_uri(&entity_type_id),
                     graph_resolve_depths: GraphResolveDepths::default(),
+                    time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
+                        kernel: UnresolvedKernel::new(None),
+                        image: UnresolvedImage::new(
+                            Some(TimespanBound::Unbounded),
+                            Some(TimespanBound::Unbounded),
+                        ),
+                    }),
                 })
                 .await
                 .expect("failed to read entity type from store");

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/entity.rs
@@ -14,10 +14,7 @@ use crate::{
         report_to_status_code,
         utoipa_typedef::{subgraph::Subgraph, EntityIdAndTimestamp},
     },
-    identifier::{
-        knowledge::{EntityEditionId, EntityId, EntityRecordId, EntityVersion},
-        time::TransactionTimestamp,
-    },
+    identifier::knowledge::{EntityEditionId, EntityId, EntityRecordId, EntityVersion},
     knowledge::{
         Entity, EntityLinkOrder, EntityMetadata, EntityProperties, EntityQueryToken, EntityUuid,
         LinkData, LinkOrder,
@@ -56,7 +53,6 @@ use crate::{
             EntityVersion,
             EntityStructuralQuery,
             EntityQueryToken,
-            TransactionTimestamp,
             LinkData,
             LinkOrder,
         )

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
@@ -44,7 +44,14 @@ use crate::{
     },
     identifier::{
         ontology::OntologyTypeEditionId,
-        time::{Timestamp, TransactionTimestamp, VersionTimespan},
+        time::{
+            DecisionTime, DecisionTimeImage, DecisionTimeKernel, DecisionTimeProjection,
+            TimeProjection, TimespanBound, Timestamp, TransactionTime, TransactionTimeImage,
+            TransactionTimeKernel, TransactionTimeProjection, UnresolvedDecisionTimeImage,
+            UnresolvedDecisionTimeKernel, UnresolvedDecisionTimeProjection,
+            UnresolvedTimeProjection, UnresolvedTransactionTimeImage,
+            UnresolvedTransactionTimeKernel, UnresolvedTransactionTimeProjection, VersionTimespan,
+        },
         EntityVertexId, GraphElementId, GraphElementVertexId,
     },
     ontology::{domain_validator::DomainValidator, OntologyElementMetadata, Selector},
@@ -161,7 +168,6 @@ async fn serve_static_schema(Path(path): Path<String>) -> Result<Response, Statu
 
             GraphElementId,
             GraphElementVertexId,
-            TransactionTimestamp,
             OntologyVertex,
             KnowledgeGraphVertex,
             Vertex,
@@ -180,6 +186,23 @@ async fn serve_static_schema(Path(path): Path<String>) -> Result<Response, Statu
             EdgeResolveDepths,
             OutgoingEdgeResolveDepth,
             Subgraph,
+
+            DecisionTime,
+            TransactionTime,
+            TimeProjection,
+            UnresolvedTimeProjection,
+            UnresolvedDecisionTimeProjection,
+            UnresolvedDecisionTimeImage,
+            UnresolvedDecisionTimeKernel,
+            UnresolvedTransactionTimeProjection,
+            UnresolvedTransactionTimeImage,
+            UnresolvedTransactionTimeKernel,
+            DecisionTimeProjection,
+            DecisionTimeImage,
+            DecisionTimeKernel,
+            TransactionTimeProjection,
+            TransactionTimeImage,
+            TransactionTimeKernel,
         )
     ),
 )]
@@ -443,6 +466,10 @@ impl Modify for TimeSchemaAddon {
             components.schemas.insert(
                 "VersionTimespan".to_owned(),
                 VersionTimespan::<()>::schema().into(),
+            );
+            components.schemas.insert(
+                "TimespanBound".to_owned(),
+                TimespanBound::<()>::schema().into(),
             );
         }
     }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/utoipa_typedef/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/utoipa_typedef/mod.rs
@@ -1,7 +1,10 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::identifier::{knowledge::EntityId, time::TransactionTimestamp};
+use crate::identifier::{
+    knowledge::EntityId,
+    time::{Timestamp, TransactionTime},
+};
 
 pub mod subgraph;
 
@@ -9,5 +12,5 @@ pub mod subgraph;
 #[serde(rename_all = "camelCase")]
 pub struct EntityIdAndTimestamp {
     pub base_id: EntityId,
-    pub timestamp: TransactionTimestamp,
+    pub timestamp: Timestamp<TransactionTime>,
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/edges.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/edges.rs
@@ -12,7 +12,7 @@ use crate::{
     identifier::{
         knowledge::EntityId,
         ontology::{OntologyTypeEditionId, OntologyTypeVersion},
-        time::TransactionTimestamp,
+        time::{Timestamp, TransactionTime},
     },
     store::Record,
     subgraph::edges::{KnowledgeGraphEdgeKind, OntologyOutwardEdges, OutwardEdge, SharedEdgeKind},
@@ -40,7 +40,7 @@ impl ToSchema for KnowledgeGraphOutwardEdges {
 #[derive(Default, Debug, Serialize, ToSchema)]
 #[serde(transparent)]
 pub struct KnowledgeGraphRootedEdges(
-    pub HashMap<EntityId, BTreeMap<TransactionTimestamp, Vec<KnowledgeGraphOutwardEdges>>>,
+    pub HashMap<EntityId, BTreeMap<Timestamp<TransactionTime>, Vec<KnowledgeGraphOutwardEdges>>>,
 );
 
 #[derive(Default, Debug, Serialize, ToSchema)]

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/mod.rs
@@ -11,7 +11,13 @@ pub use self::{
         Vertices,
     },
 };
-use crate::{identifier::GraphElementVertexId, subgraph::edges::GraphResolveDepths};
+use crate::{
+    identifier::{
+        time::{TimeProjection, UnresolvedTimeProjection},
+        GraphElementVertexId,
+    },
+    subgraph::edges::GraphResolveDepths,
+};
 
 #[derive(Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
@@ -20,6 +26,8 @@ pub struct Subgraph {
     vertices: Vertices,
     edges: Edges,
     depths: GraphResolveDepths,
+    time_projection: UnresolvedTimeProjection,
+    resolved_time_projection: TimeProjection,
 }
 
 impl From<crate::subgraph::Subgraph> for Subgraph {
@@ -31,6 +39,8 @@ impl From<crate::subgraph::Subgraph> for Subgraph {
             vertices,
             edges,
             depths: subgraph.depths,
+            time_projection: subgraph.time_projection,
+            resolved_time_projection: subgraph.resolved_time_projection,
         }
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/vertices/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/vertices/mod.rs
@@ -9,7 +9,11 @@ use utoipa::{
 
 pub use self::vertex::*;
 use crate::{
-    identifier::{knowledge::EntityId, ontology::OntologyTypeVersion, time::TransactionTimestamp},
+    identifier::{
+        knowledge::EntityId,
+        ontology::OntologyTypeVersion,
+        time::{Timestamp, TransactionTime},
+    },
     knowledge::Entity,
 };
 
@@ -22,7 +26,7 @@ pub struct OntologyVertices(pub HashMap<BaseUri, BTreeMap<OntologyTypeVersion, O
 #[derive(Serialize, ToSchema)]
 #[serde(transparent)]
 pub struct KnowledgeGraphVertices(
-    HashMap<EntityId, BTreeMap<TransactionTimestamp, KnowledgeGraphVertex>>,
+    HashMap<EntityId, BTreeMap<Timestamp<TransactionTime>, KnowledgeGraphVertex>>,
 );
 
 #[derive(Serialize)]

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/knowledge.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/knowledge.rs
@@ -10,7 +10,7 @@ use utoipa::{openapi, ToSchema};
 use crate::{
     identifier::{
         account::AccountId,
-        time::{DecisionTimeVersionTimespan, TransactionTimeVersionTimespan},
+        time::{DecisionTime, TransactionTime, VersionTimespan},
         EntityVertexId,
     },
     knowledge::{Entity, EntityUuid},
@@ -90,8 +90,8 @@ impl ToSchema for EntityId {
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EntityVersion {
-    decision_time: DecisionTimeVersionTimespan,
-    transaction_time: TransactionTimeVersionTimespan,
+    decision_time: VersionTimespan<DecisionTime>,
+    transaction_time: VersionTimespan<TransactionTime>,
 }
 
 impl ToSchema for EntityVersion {
@@ -115,8 +115,8 @@ impl ToSchema for EntityVersion {
 impl EntityVersion {
     #[must_use]
     pub const fn new(
-        decision_time: DecisionTimeVersionTimespan,
-        transaction_time: TransactionTimeVersionTimespan,
+        decision_time: VersionTimespan<DecisionTime>,
+        transaction_time: VersionTimespan<TransactionTime>,
     ) -> Self {
         Self {
             decision_time,
@@ -125,12 +125,12 @@ impl EntityVersion {
     }
 
     #[must_use]
-    pub const fn decision_time(&self) -> DecisionTimeVersionTimespan {
+    pub const fn decision_time(&self) -> VersionTimespan<DecisionTime> {
         self.decision_time
     }
 
     #[must_use]
-    pub const fn transaction_time(&self) -> TransactionTimeVersionTimespan {
+    pub const fn transaction_time(&self) -> VersionTimespan<TransactionTime> {
         self.transaction_time
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/mod.rs
@@ -9,7 +9,9 @@ use type_system::uri::BaseUri;
 use utoipa::{openapi, ToSchema};
 
 use crate::identifier::{
-    knowledge::EntityId, ontology::OntologyTypeEditionId, time::TransactionTimestamp,
+    knowledge::EntityId,
+    ontology::OntologyTypeEditionId,
+    time::{Timestamp, TransactionTime},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -37,12 +39,12 @@ impl ToSchema for GraphElementId {
 #[serde(rename_all = "camelCase")]
 pub struct EntityVertexId {
     base_id: EntityId,
-    version: TransactionTimestamp,
+    version: Timestamp<TransactionTime>,
 }
 
 impl EntityVertexId {
     #[must_use]
-    pub const fn new(base_id: EntityId, version: TransactionTimestamp) -> Self {
+    pub const fn new(base_id: EntityId, version: Timestamp<TransactionTime>) -> Self {
         Self { base_id, version }
     }
 
@@ -52,7 +54,7 @@ impl EntityVertexId {
     }
 
     #[must_use]
-    pub const fn version(&self) -> TransactionTimestamp {
+    pub const fn version(&self) -> Timestamp<TransactionTime> {
         self.version
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/axis.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/axis.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
+use utoipa::{openapi, openapi::Schema, ToSchema};
 
-use crate::identifier::time::{timestamp::Timestamp, version::VersionTimespan};
+use crate::identifier::time::{
+    projection::Projection, TimespanBound, UnresolvedImage, UnresolvedKernel, UnresolvedProjection,
+};
 
 /// Time axis for the decision time.
 ///
@@ -23,5 +25,62 @@ pub enum TransactionTime {
     Transaction,
 }
 
-pub type TransactionTimestamp = Timestamp<TransactionTime>;
-pub type TransactionTimeVersionTimespan = VersionTimespan<TransactionTime>;
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum UnresolvedTimeProjection {
+    DecisionTime(UnresolvedProjection<TransactionTime, DecisionTime>),
+    TransactionTime(UnresolvedProjection<DecisionTime, TransactionTime>),
+}
+
+impl Default for UnresolvedTimeProjection {
+    fn default() -> Self {
+        Self::DecisionTime(UnresolvedProjection {
+            kernel: UnresolvedKernel::new(None),
+            image: UnresolvedImage::new(
+                Some(TimespanBound::Unbounded),
+                Some(TimespanBound::Unbounded),
+            ),
+        })
+    }
+}
+
+impl UnresolvedTimeProjection {
+    #[must_use]
+    pub fn resolve(self) -> TimeProjection {
+        match self {
+            Self::DecisionTime(projection) => TimeProjection::DecisionTime(projection.resolve()),
+            Self::TransactionTime(projection) => {
+                TimeProjection::TransactionTime(projection.resolve())
+            }
+        }
+    }
+}
+
+impl ToSchema for UnresolvedTimeProjection {
+    fn schema() -> Schema {
+        openapi::OneOfBuilder::new()
+            .item(openapi::Ref::from_schema_name(
+                "UnresolvedDecisionTimeProjection",
+            ))
+            .item(openapi::Ref::from_schema_name(
+                "UnresolvedTransactionTimeProjection",
+            ))
+            .into()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TimeProjection {
+    DecisionTime(Projection<TransactionTime, DecisionTime>),
+    TransactionTime(Projection<DecisionTime, TransactionTime>),
+}
+
+impl ToSchema for TimeProjection {
+    fn schema() -> Schema {
+        openapi::OneOfBuilder::new()
+            .item(openapi::Ref::from_schema_name("DecisionTimeProjection"))
+            .item(openapi::Ref::from_schema_name("TransactionTimeProjection"))
+            .into()
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/axis.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/axis.rs
@@ -13,9 +13,6 @@ pub enum DecisionTime {
     Decision,
 }
 
-pub type DecisionTimestamp = Timestamp<DecisionTime>;
-pub type DecisionTimeVersionTimespan = VersionTimespan<DecisionTime>;
-
 /// Time axis for the transaction time.
 ///
 /// This is used as the generic argument to time-related structs and can be used as tag value.

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/mod.rs
@@ -1,16 +1,25 @@
 mod axis;
+mod projection;
+mod timespan;
 mod timestamp;
 mod version;
+
 use std::{error::Error, ops::Bound};
 
 use postgres_protocol::types::timestamp_from_sql;
 use postgres_types::{FromSql, Type};
 
 pub use self::{
-    axis::{
-        DecisionTime, DecisionTimeVersionTimespan, DecisionTimestamp, TransactionTime,
-        TransactionTimeVersionTimespan, TransactionTimestamp,
+    axis::{DecisionTime, TimeProjection, TransactionTime, UnresolvedTimeProjection},
+    projection::{
+        DecisionTimeImage, DecisionTimeKernel, DecisionTimeProjection, Image, Kernel,
+        TransactionTimeImage, TransactionTimeKernel, TransactionTimeProjection,
+        UnresolvedDecisionTimeImage, UnresolvedDecisionTimeKernel,
+        UnresolvedDecisionTimeProjection, UnresolvedImage, UnresolvedKernel, UnresolvedProjection,
+        UnresolvedTransactionTimeImage, UnresolvedTransactionTimeKernel,
+        UnresolvedTransactionTimeProjection,
     },
+    timespan::{Timespan, TimespanBound, UnresolvedTimespan},
     timestamp::Timestamp,
     version::VersionTimespan,
 };

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/projection.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/projection.rs
@@ -1,0 +1,291 @@
+use serde::{Deserialize, Serialize};
+use utoipa::{openapi, ToSchema};
+
+use crate::identifier::time::{
+    DecisionTime, Timespan, TimespanBound, Timestamp, TransactionTime, UnresolvedTimespan,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct UnresolvedKernel<A> {
+    pub axis: A,
+    pub timestamp: Option<Timestamp<A>>,
+}
+
+impl<A: Default> UnresolvedKernel<A> {
+    #[must_use]
+    pub fn new(timestamp: Option<Timestamp<A>>) -> Self {
+        Self {
+            axis: A::default(),
+            timestamp,
+        }
+    }
+}
+
+pub type UnresolvedDecisionTimeKernel = UnresolvedKernel<DecisionTime>;
+
+impl ToSchema for UnresolvedDecisionTimeKernel {
+    fn schema() -> openapi::Schema {
+        openapi::ObjectBuilder::new()
+            .property("axis", openapi::Ref::from_schema_name("DecisionTime"))
+            .required("axis")
+            .property("timestamp", openapi::Ref::from_schema_name("Timestamp"))
+            .build()
+            .into()
+    }
+}
+
+pub type UnresolvedTransactionTimeKernel = UnresolvedKernel<TransactionTime>;
+
+impl ToSchema for UnresolvedTransactionTimeKernel {
+    fn schema() -> openapi::Schema {
+        openapi::ObjectBuilder::new()
+            .property("axis", openapi::Ref::from_schema_name("TransactionTime"))
+            .required("axis")
+            .property("timestamp", openapi::Ref::from_schema_name("Timestamp"))
+            .build()
+            .into()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct UnresolvedImage<A> {
+    pub axis: A,
+    #[serde(flatten)]
+    pub span: UnresolvedTimespan<A>,
+}
+
+impl<A: Default> UnresolvedImage<A> {
+    #[must_use]
+    pub fn new(start: Option<TimespanBound<A>>, end: Option<TimespanBound<A>>) -> Self {
+        Self {
+            axis: A::default(),
+            span: UnresolvedTimespan { start, end },
+        }
+    }
+}
+
+pub type UnresolvedDecisionTimeImage = UnresolvedImage<DecisionTime>;
+
+impl ToSchema for UnresolvedDecisionTimeImage {
+    fn schema() -> openapi::Schema {
+        openapi::AllOfBuilder::new()
+            .item(
+                openapi::ObjectBuilder::new()
+                    .property("axis", openapi::Ref::from_schema_name("DecisionTime"))
+                    .required("axis"),
+            )
+            .item(UnresolvedTimespan::<DecisionTime>::schema())
+            .build()
+            .into()
+    }
+}
+
+pub type UnresolvedTransactionTimeImage = UnresolvedImage<TransactionTime>;
+
+impl ToSchema for UnresolvedTransactionTimeImage {
+    fn schema() -> openapi::Schema {
+        openapi::AllOfBuilder::new()
+            .item(
+                openapi::ObjectBuilder::new()
+                    .property("axis", openapi::Ref::from_schema_name("TransactionTime"))
+                    .required("axis"),
+            )
+            .item(UnresolvedTimespan::<DecisionTime>::schema())
+            .build()
+            .into()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct UnresolvedProjection<K, I> {
+    pub kernel: UnresolvedKernel<K>,
+    pub image: UnresolvedImage<I>,
+}
+
+impl<K, I> UnresolvedProjection<K, I> {
+    pub fn resolve(self) -> Projection<K, I> {
+        let now = Timestamp::now();
+        Projection {
+            kernel: Kernel {
+                axis: self.kernel.axis,
+                timestamp: self
+                    .kernel
+                    .timestamp
+                    .unwrap_or_else(|| Timestamp::from_anonymous(now)),
+            },
+            image: Image {
+                axis: self.image.axis,
+                span: Timespan {
+                    start: self
+                        .image
+                        .span
+                        .start
+                        .unwrap_or_else(|| TimespanBound::Included(Timestamp::from_anonymous(now))),
+                    end: self
+                        .image
+                        .span
+                        .end
+                        .unwrap_or_else(|| TimespanBound::Included(Timestamp::from_anonymous(now))),
+                },
+            },
+        }
+    }
+}
+
+pub type UnresolvedDecisionTimeProjection = UnresolvedProjection<TransactionTime, DecisionTime>;
+
+impl ToSchema for UnresolvedDecisionTimeProjection {
+    fn schema() -> openapi::Schema {
+        openapi::ObjectBuilder::new()
+            .property(
+                "kernel",
+                openapi::Ref::from_schema_name("UnresolvedTransactionTimeKernel"),
+            )
+            .required("kernel")
+            .property(
+                "image",
+                openapi::Ref::from_schema_name("UnresolvedDecisionTimeImage"),
+            )
+            .required("image")
+            .into()
+    }
+}
+
+pub type UnresolvedTransactionTimeProjection = UnresolvedProjection<DecisionTime, TransactionTime>;
+
+impl ToSchema for UnresolvedTransactionTimeProjection {
+    fn schema() -> openapi::Schema {
+        openapi::ObjectBuilder::new()
+            .property(
+                "kernel",
+                openapi::Ref::from_schema_name("UnresolvedDecisionTimeKernel"),
+            )
+            .required("kernel")
+            .property(
+                "image",
+                openapi::Ref::from_schema_name("UnresolvedTransactionTimeImage"),
+            )
+            .required("image")
+            .into()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Kernel<A> {
+    pub axis: A,
+    pub timestamp: Timestamp<A>,
+}
+
+pub type DecisionTimeKernel = Kernel<DecisionTime>;
+
+impl ToSchema for DecisionTimeKernel {
+    fn schema() -> openapi::Schema {
+        openapi::ObjectBuilder::new()
+            .property("axis", openapi::Ref::from_schema_name("DecisionTime"))
+            .required("axis")
+            .property("timestamp", openapi::Ref::from_schema_name("Timestamp"))
+            .required("timestamp")
+            .build()
+            .into()
+    }
+}
+
+pub type TransactionTimeKernel = Kernel<TransactionTime>;
+
+impl ToSchema for TransactionTimeKernel {
+    fn schema() -> openapi::Schema {
+        openapi::ObjectBuilder::new()
+            .property("axis", openapi::Ref::from_schema_name("TransactionTime"))
+            .required("axis")
+            .property("timestamp", openapi::Ref::from_schema_name("Timestamp"))
+            .required("timestamp")
+            .build()
+            .into()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Image<A> {
+    pub axis: A,
+    #[serde(flatten)]
+    pub span: Timespan<A>,
+}
+
+pub type DecisionTimeImage = Image<DecisionTime>;
+
+impl ToSchema for DecisionTimeImage {
+    fn schema() -> openapi::Schema {
+        openapi::AllOfBuilder::new()
+            .item(
+                openapi::ObjectBuilder::new()
+                    .property("axis", openapi::Ref::from_schema_name("DecisionTime"))
+                    .required("axis"),
+            )
+            .item(Timespan::<DecisionTime>::schema())
+            .build()
+            .into()
+    }
+}
+
+pub type TransactionTimeImage = Image<TransactionTime>;
+
+impl ToSchema for TransactionTimeImage {
+    fn schema() -> openapi::Schema {
+        openapi::AllOfBuilder::new()
+            .item(
+                openapi::ObjectBuilder::new()
+                    .property("axis", openapi::Ref::from_schema_name("TransactionTime"))
+                    .required("axis"),
+            )
+            .item(Timespan::<DecisionTime>::schema())
+            .build()
+            .into()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Projection<K, I> {
+    pub kernel: Kernel<K>,
+    pub image: Image<I>,
+}
+
+pub type DecisionTimeProjection = Projection<TransactionTime, DecisionTime>;
+
+impl ToSchema for DecisionTimeProjection {
+    fn schema() -> openapi::Schema {
+        openapi::ObjectBuilder::new()
+            .property(
+                "kernel",
+                openapi::Ref::from_schema_name("TransactionTimeKernel"),
+            )
+            .required("kernel")
+            .property("image", openapi::Ref::from_schema_name("DecisionTimeImage"))
+            .required("image")
+            .into()
+    }
+}
+
+pub type TransactionTimeProjection = Projection<DecisionTime, TransactionTime>;
+
+impl ToSchema for TransactionTimeProjection {
+    fn schema() -> openapi::Schema {
+        openapi::ObjectBuilder::new()
+            .property(
+                "kernel",
+                openapi::Ref::from_schema_name("DecisionTimeKernel"),
+            )
+            .required("kernel")
+            .property(
+                "image",
+                openapi::Ref::from_schema_name("TransactionTimeImage"),
+            )
+            .required("image")
+            .into()
+    }
+}

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/timespan.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/timespan.rs
@@ -1,0 +1,79 @@
+use derivative::Derivative;
+use serde::{Deserialize, Serialize};
+use utoipa::{openapi, ToSchema};
+
+use crate::identifier::time::Timestamp;
+
+#[derive(Derivative, Serialize, Deserialize)]
+#[derivative(
+    Debug(bound = ""),
+    Clone(bound = ""),
+    PartialEq(bound = ""),
+    Eq(bound = ""),
+    Hash(bound = "")
+)]
+#[serde(
+    rename_all = "camelCase",
+    bound = "",
+    tag = "bound",
+    content = "timestamp"
+)]
+pub enum TimespanBound<A> {
+    Unbounded,
+    Included(Timestamp<A>),
+    Excluded(Timestamp<A>),
+}
+
+impl<A> ToSchema for TimespanBound<A> {
+    fn schema() -> openapi::Schema {
+        openapi::OneOfBuilder::new()
+            .item(
+                openapi::ObjectBuilder::new()
+                    .property(
+                        "bound",
+                        openapi::ObjectBuilder::new().enum_values(Some(["unbounded"])),
+                    )
+                    .required("bound"),
+            )
+            .item(
+                openapi::ObjectBuilder::new()
+                    .property(
+                        "bound",
+                        openapi::ObjectBuilder::new().enum_values(Some(["included", "excluded"])),
+                    )
+                    .required("bound")
+                    .property("timestamp", Timestamp::<A>::schema())
+                    .required("timestamp"),
+            )
+            .build()
+            .into()
+    }
+}
+
+#[derive(Derivative, Serialize, Deserialize, ToSchema)]
+#[derivative(
+    Debug(bound = ""),
+    Clone(bound = ""),
+    PartialEq(bound = ""),
+    Eq(bound = ""),
+    Hash(bound = "")
+)]
+#[serde(rename_all = "camelCase", bound = "", deny_unknown_fields)]
+pub struct UnresolvedTimespan<A> {
+    pub start: Option<TimespanBound<A>>,
+    pub end: Option<TimespanBound<A>>,
+}
+
+#[derive(Derivative, Serialize, Deserialize, ToSchema)]
+#[derivative(
+    Debug(bound = ""),
+    Clone(bound = ""),
+    PartialEq(bound = ""),
+    Eq(bound = ""),
+    Hash(bound = "")
+)]
+#[serde(rename_all = "camelCase", bound = "", deny_unknown_fields)]
+pub struct Timespan<A> {
+    pub start: TimespanBound<A>,
+    pub end: TimespanBound<A>,
+}

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph/mod.rs
@@ -11,6 +11,7 @@ use edges::Edges;
 use error_stack::Result;
 
 use crate::{
+    identifier::time::{TimeProjection, UnresolvedTimeProjection},
     shared::identifier::GraphElementVertexId,
     store::{crud::Read, QueryError, Record},
     subgraph::{edges::GraphResolveDepths, vertices::Vertices},
@@ -26,16 +27,24 @@ pub struct Subgraph {
     pub vertices: Vertices,
     pub edges: Edges,
     pub depths: GraphResolveDepths,
+    pub time_projection: UnresolvedTimeProjection,
+    pub resolved_time_projection: TimeProjection,
 }
 
 impl Subgraph {
     #[must_use]
-    pub fn new(depths: GraphResolveDepths) -> Self {
+    pub fn new(
+        depths: GraphResolveDepths,
+        time_projection: UnresolvedTimeProjection,
+        resolved_time_projection: TimeProjection,
+    ) -> Self {
         Self {
             roots: HashSet::new(),
             vertices: Vertices::default(),
             edges: Edges::default(),
             depths,
+            time_projection,
+            resolved_time_projection,
         }
     }
 

--- a/packages/graph/hash_graph/lib/graph/src/shared/subgraph/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/subgraph/query.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 use utoipa::ToSchema;
 
 use crate::{
+    identifier::time::UnresolvedTimeProjection,
     knowledge::Entity,
     ontology::{DataTypeWithMetadata, EntityTypeWithMetadata, PropertyTypeWithMetadata},
     store::{query::Filter, Record},
@@ -164,4 +165,6 @@ pub struct StructuralQuery<'p, R: Record> {
     #[serde(bound = "'de: 'p, R::QueryPath<'p>: Deserialize<'de>")]
     pub filter: Filter<'p, R>,
     pub graph_resolve_depths: GraphResolveDepths,
+    #[serde(default)]
+    pub time_projection: UnresolvedTimeProjection,
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/knowledge.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/knowledge.rs
@@ -3,7 +3,10 @@ use error_stack::Result;
 use type_system::uri::VersionedUri;
 
 use crate::{
-    identifier::{knowledge::EntityId, time::DecisionTimestamp},
+    identifier::{
+        knowledge::EntityId,
+        time::{DecisionTime, Timestamp},
+    },
     knowledge::{Entity, EntityLinkOrder, EntityMetadata, EntityProperties, EntityUuid, LinkData},
     provenance::{OwnedById, UpdatedById},
     store::{crud, InsertionError, QueryError, UpdateError},
@@ -30,7 +33,7 @@ pub trait EntityStore: crud::Read<Entity> {
         &mut self,
         owned_by_id: OwnedById,
         entity_uuid: Option<EntityUuid>,
-        decision_time: Option<DecisionTimestamp>,
+        decision_time: Option<Timestamp<DecisionTime>>,
         updated_by_id: UpdatedById,
         archived: bool,
         entity_type_id: VersionedUri,
@@ -65,7 +68,7 @@ pub trait EntityStore: crud::Read<Entity> {
                 Option<EntityUuid>,
                 EntityProperties,
                 Option<LinkData>,
-                Option<DecisionTimestamp>,
+                Option<Timestamp<DecisionTime>>,
             ),
             IntoIter: Send,
         > + Send,
@@ -94,7 +97,7 @@ pub trait EntityStore: crud::Read<Entity> {
     async fn update_entity(
         &mut self,
         entity_id: EntityId,
-        decision_time: Option<DecisionTimestamp>,
+        decision_time: Option<Timestamp<DecisionTime>>,
         updated_by_id: UpdatedById,
         archived: bool,
         entity_type_id: VersionedUri,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -431,9 +431,14 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         let StructuralQuery {
             ref filter,
             graph_resolve_depths,
+            ref time_projection,
         } = *query;
 
-        let mut subgraph = Subgraph::new(graph_resolve_depths);
+        let mut subgraph = Subgraph::new(
+            graph_resolve_depths,
+            time_projection.clone(),
+            time_projection.clone().resolve(),
+        );
         let mut dependency_context = DependencyContext::default();
 
         for entity in Read::<Entity>::read(self, filter).await? {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     identifier::{
         knowledge::{EntityEditionId, EntityId, EntityRecordId, EntityVersion},
         ontology::OntologyTypeEditionId,
-        time::{DecisionTimeVersionTimespan, DecisionTimestamp, TransactionTimeVersionTimespan},
+        time::{DecisionTime, Timestamp, VersionTimespan},
         EntityVertexId,
     },
     knowledge::{Entity, EntityLinkOrder, EntityMetadata, EntityProperties, EntityUuid, LinkData},
@@ -251,7 +251,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         &mut self,
         owned_by_id: OwnedById,
         entity_uuid: Option<EntityUuid>,
-        decision_time: Option<DecisionTimestamp>,
+        decision_time: Option<Timestamp<DecisionTime>>,
         updated_by_id: UpdatedById,
         archived: bool,
         entity_type_id: VersionedUri,
@@ -328,8 +328,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         Ok(EntityMetadata::new(
             EntityEditionId::new(entity_id, EntityRecordId::new(row.get(0))),
             EntityVersion::new(
-                DecisionTimeVersionTimespan::from_anonymous(row.get(1)),
-                TransactionTimeVersionTimespan::from_anonymous(row.get(2)),
+                VersionTimespan::from_anonymous(row.get(1)),
+                VersionTimespan::from_anonymous(row.get(2)),
             ),
             entity_type_id,
             ProvenanceMetadata::new(updated_by_id),
@@ -347,7 +347,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 Option<EntityUuid>,
                 EntityProperties,
                 Option<LinkData>,
-                Option<DecisionTimestamp>,
+                Option<Timestamp<DecisionTime>>,
             ),
             IntoIter: Send,
         > + Send,
@@ -459,7 +459,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
     async fn update_entity(
         &mut self,
         entity_id: EntityId,
-        decision_time: Option<DecisionTimestamp>,
+        decision_time: Option<Timestamp<DecisionTime>>,
         updated_by_id: UpdatedById,
         archived: bool,
         entity_type_id: VersionedUri,
@@ -547,8 +547,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         Ok(EntityMetadata::new(
             EntityEditionId::new(entity_id, EntityRecordId::new(row.get(0))),
             EntityVersion::new(
-                DecisionTimeVersionTimespan::from_anonymous(row.get(1)),
-                TransactionTimeVersionTimespan::from_anonymous(row.get(2)),
+                VersionTimespan::from_anonymous(row.get(1)),
+                VersionTimespan::from_anonymous(row.get(2)),
             ),
             entity_type_id,
             ProvenanceMetadata::new(updated_by_id),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -11,7 +11,7 @@ use crate::{
     identifier::{
         account::AccountId,
         knowledge::{EntityEditionId, EntityId, EntityRecordId, EntityVersion},
-        time::{DecisionTimeVersionTimespan, TransactionTimeVersionTimespan},
+        time::VersionTimespan,
     },
     knowledge::{Entity, EntityProperties, EntityQueryPath, EntityUuid, LinkData},
     ontology::EntityTypeQueryPath,
@@ -136,10 +136,8 @@ impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
                         EntityRecordId::new(row.get(record_id_index)),
                     ),
                     EntityVersion::new(
-                        DecisionTimeVersionTimespan::from_anonymous(row.get(decision_time_index)),
-                        TransactionTimeVersionTimespan::from_anonymous(
-                            row.get(transaction_time_index),
-                        ),
+                        VersionTimespan::from_anonymous(row.get(decision_time_index)),
+                        VersionTimespan::from_anonymous(row.get(transaction_time_index)),
                     ),
                     entity_type_uri,
                     ProvenanceMetadata::new(updated_by_id),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -23,18 +23,8 @@ use type_system::{
 use uuid::Uuid;
 
 pub use self::pool::{AsClient, PostgresStorePool};
-#[cfg(feature = "__internal_bench")]
 use crate::{
-    identifier::knowledge::{EntityId, EntityRecordId, EntityVersion},
-    knowledge::{EntityProperties, LinkOrder},
-};
-use crate::{
-    identifier::{
-        account::AccountId,
-        ontology::OntologyTypeEditionId,
-        time::{DecisionTime, Timestamp, VersionTimespan},
-        EntityVertexId,
-    },
+    identifier::{account::AccountId, ontology::OntologyTypeEditionId, EntityVertexId},
     ontology::{OntologyElementMetadata, OntologyTypeWithMetadata},
     provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
@@ -46,6 +36,14 @@ use crate::{
         Record, Store, StoreError, Transaction, UpdateError,
     },
     subgraph::edges::GraphResolveDepths,
+};
+#[cfg(feature = "__internal_bench")]
+use crate::{
+    identifier::{
+        knowledge::{EntityId, EntityRecordId, EntityVersion},
+        time::{DecisionTime, Timestamp, VersionTimespan},
+    },
+    knowledge::{EntityProperties, LinkOrder},
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -26,13 +26,15 @@ pub use self::pool::{AsClient, PostgresStorePool};
 #[cfg(feature = "__internal_bench")]
 use crate::{
     identifier::knowledge::{EntityId, EntityRecordId, EntityVersion},
-    identifier::time::{
-        DecisionTimeVersionTimespan, DecisionTimestamp, TransactionTimeVersionTimespan,
-    },
     knowledge::{EntityProperties, LinkOrder},
 };
 use crate::{
-    identifier::{account::AccountId, ontology::OntologyTypeEditionId, EntityVertexId},
+    identifier::{
+        account::AccountId,
+        ontology::OntologyTypeEditionId,
+        time::{DecisionTime, Timestamp, VersionTimespan},
+        EntityVertexId,
+    },
     ontology::{OntologyElementMetadata, OntologyTypeWithMetadata},
     provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
@@ -845,7 +847,7 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
     async fn insert_entity_versions(
         &self,
         entities: impl IntoIterator<
-            Item = (EntityId, EntityRecordId, Option<DecisionTimestamp>),
+            Item = (EntityId, EntityRecordId, Option<Timestamp<DecisionTime>>),
             IntoIter: Send,
         > + Send,
     ) -> Result<Vec<EntityVersion>, InsertionError> {
@@ -931,8 +933,8 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
             .into_iter()
             .map(|row| {
                 EntityVersion::new(
-                    DecisionTimeVersionTimespan::from_anonymous(row.get(0)),
-                    TransactionTimeVersionTimespan::from_anonymous(row.get(1)),
+                    VersionTimespan::from_anonymous(row.get(0)),
+                    VersionTimespan::from_anonymous(row.get(1)),
                 )
             })
             .collect();

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -76,9 +76,14 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
         let StructuralQuery {
             ref filter,
             graph_resolve_depths,
+            ref time_projection,
         } = *query;
 
-        let mut subgraph = Subgraph::new(graph_resolve_depths);
+        let mut subgraph = Subgraph::new(
+            graph_resolve_depths,
+            time_projection.clone(),
+            time_projection.clone().resolve(),
+        );
         let mut dependency_context = DependencyContext::default();
 
         for data_type in Read::<DataTypeWithMetadata>::read(self, filter).await? {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -271,9 +271,14 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         let StructuralQuery {
             ref filter,
             graph_resolve_depths,
+            ref time_projection,
         } = *query;
 
-        let mut subgraph = Subgraph::new(graph_resolve_depths);
+        let mut subgraph = Subgraph::new(
+            graph_resolve_depths,
+            time_projection.clone(),
+            time_projection.clone().resolve(),
+        );
         let mut dependency_context = DependencyContext::default();
 
         for entity_type in Read::<EntityTypeWithMetadata>::read(self, filter).await? {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -179,9 +179,14 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         let StructuralQuery {
             ref filter,
             graph_resolve_depths,
+            ref time_projection,
         } = *query;
 
-        let mut subgraph = Subgraph::new(graph_resolve_depths);
+        let mut subgraph = Subgraph::new(
+            graph_resolve_depths,
+            time_projection.clone(),
+            time_projection.clone().resolve(),
+        );
         let mut dependency_context = DependencyContext::default();
 
         for property_type in Read::<PropertyTypeWithMetadata>::read(self, filter).await? {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -694,7 +694,7 @@ mod tests {
                 account::AccountId,
                 knowledge::EntityId,
                 ontology::{OntologyTypeEditionId, OntologyTypeVersion},
-                time::TransactionTimestamp,
+                time::Timestamp,
                 EntityVertexId,
             },
             knowledge::EntityUuid,
@@ -792,7 +792,7 @@ mod tests {
                     OwnedById::new(AccountId::new(Uuid::new_v4())),
                     EntityUuid::new(Uuid::new_v4()),
                 ),
-                TransactionTimestamp::now(),
+                Timestamp::now(),
             );
 
             let mut compiler = SelectCompiler::<Entity>::with_asterisk();
@@ -825,7 +825,7 @@ mod tests {
                     OwnedById::new(AccountId::new(Uuid::new_v4())),
                     EntityUuid::new(Uuid::new_v4()),
                 ),
-                TransactionTimestamp::now(),
+                Timestamp::now(),
             );
 
             let mut compiler = SelectCompiler::<Entity>::with_asterisk();
@@ -861,7 +861,7 @@ mod tests {
                     OwnedById::new(AccountId::new(Uuid::new_v4())),
                     EntityUuid::new(Uuid::new_v4()),
                 ),
-                TransactionTimestamp::now(),
+                Timestamp::now(),
             );
 
             let mut compiler = SelectCompiler::<Entity>::with_asterisk();
@@ -897,7 +897,7 @@ mod tests {
                     OwnedById::new(AccountId::new(Uuid::new_v4())),
                     EntityUuid::new(Uuid::new_v4()),
                 ),
-                TransactionTimestamp::now(),
+                Timestamp::now(),
             );
 
             let mut compiler = SelectCompiler::<Entity>::with_asterisk();

--- a/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
@@ -8,7 +8,9 @@ use uuid::Uuid;
 
 use crate::{
     identifier::{
-        knowledge::EntityId, ontology::OntologyTypeEditionId, time::TransactionTimestamp,
+        knowledge::EntityId,
+        ontology::OntologyTypeEditionId,
+        time::{Timestamp, TransactionTime},
         EntityVertexId,
     },
     knowledge::{Entity, EntityQueryPath},
@@ -348,7 +350,7 @@ pub enum Parameter<'p> {
     #[serde(skip)]
     SignedInteger(i64),
     #[serde(skip)]
-    Timestamp(TransactionTimestamp),
+    Timestamp(Timestamp<TransactionTime>),
 }
 
 impl Parameter<'_> {
@@ -413,7 +415,7 @@ impl Parameter<'_> {
             (Parameter::Text(text), ParameterType::Timestamp) => {
                 if text != "latest" {
                     *self = Parameter::Timestamp(
-                        TransactionTimestamp::from_str(&*text)
+                        Timestamp::from_str(&*text)
                             .into_report()
                             .change_context_lazy(|| ParameterConversionError {
                                 actual: self.to_owned(),
@@ -462,9 +464,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        identifier::{
-            account::AccountId, ontology::OntologyTypeVersion, time::TransactionTimestamp,
-        },
+        identifier::{account::AccountId, ontology::OntologyTypeVersion},
         knowledge::EntityUuid,
         ontology::{DataTypeQueryPath, DataTypeWithMetadata},
         provenance::OwnedById,
@@ -569,7 +569,7 @@ mod tests {
                 OwnedById::new(AccountId::new(Uuid::new_v4())),
                 EntityUuid::new(Uuid::new_v4()),
             ),
-            TransactionTimestamp::now(),
+            Timestamp::now(),
         );
 
         let expected = json! {{
@@ -603,7 +603,7 @@ mod tests {
                 OwnedById::new(AccountId::new(Uuid::new_v4())),
                 EntityUuid::new(Uuid::new_v4()),
             ),
-            TransactionTimestamp::now(),
+            Timestamp::now(),
         );
 
         let expected = json! {{
@@ -637,7 +637,7 @@ mod tests {
                 OwnedById::new(AccountId::new(Uuid::new_v4())),
                 EntityUuid::new(Uuid::new_v4()),
             ),
-            TransactionTimestamp::now(),
+            Timestamp::now(),
         );
 
         let expected = json! {{
@@ -671,7 +671,7 @@ mod tests {
                 OwnedById::new(AccountId::new(Uuid::new_v4())),
                 EntityUuid::new(Uuid::new_v4()),
             ),
-            TransactionTimestamp::now(),
+            Timestamp::now(),
         );
 
         let expected = json! {{

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -9,8 +9,14 @@ use std::borrow::Cow;
 use error_stack::Result;
 use graph::{
     identifier::{
-        account::AccountId, knowledge::EntityId, ontology::OntologyTypeEditionId,
-        time::TransactionTimestamp, EntityVertexId, GraphElementVertexId,
+        account::AccountId,
+        knowledge::EntityId,
+        ontology::OntologyTypeEditionId,
+        time::{
+            TimespanBound, Timestamp, TransactionTime, UnresolvedImage, UnresolvedKernel,
+            UnresolvedProjection, UnresolvedTimeProjection,
+        },
+        EntityVertexId, GraphElementVertexId,
     },
     knowledge::{
         Entity, EntityLinkOrder, EntityMetadata, EntityProperties, EntityQueryPath, EntityUuid,
@@ -163,6 +169,13 @@ impl DatabaseApi<'_> {
             .get_data_type(&StructuralQuery {
                 filter: Filter::for_versioned_uri(uri),
                 graph_resolve_depths: GraphResolveDepths::default(),
+                time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
+                    kernel: UnresolvedKernel::new(None),
+                    image: UnresolvedImage::new(
+                        Some(TimespanBound::Unbounded),
+                        Some(TimespanBound::Unbounded),
+                    ),
+                }),
             })
             .await?
             .vertices
@@ -202,6 +215,13 @@ impl DatabaseApi<'_> {
             .get_property_type(&StructuralQuery {
                 filter: Filter::for_versioned_uri(uri),
                 graph_resolve_depths: GraphResolveDepths::default(),
+                time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
+                    kernel: UnresolvedKernel::new(None),
+                    image: UnresolvedImage::new(
+                        Some(TimespanBound::Unbounded),
+                        Some(TimespanBound::Unbounded),
+                    ),
+                }),
             })
             .await?
             .vertices
@@ -241,6 +261,13 @@ impl DatabaseApi<'_> {
             .get_entity_type(&StructuralQuery {
                 filter: Filter::for_versioned_uri(uri),
                 graph_resolve_depths: GraphResolveDepths::default(),
+                time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
+                    kernel: UnresolvedKernel::new(None),
+                    image: UnresolvedImage::new(
+                        Some(TimespanBound::Unbounded),
+                        Some(TimespanBound::Unbounded),
+                    ),
+                }),
             })
             .await?
             .vertices
@@ -281,7 +308,7 @@ impl DatabaseApi<'_> {
     pub async fn get_entity(
         &self,
         entity_id: EntityId,
-        timestamp: TransactionTimestamp,
+        timestamp: Timestamp<TransactionTime>,
     ) -> Result<Entity, QueryError> {
         let entity_vertex_id = EntityVertexId::new(entity_id, timestamp);
         Ok(self
@@ -289,6 +316,13 @@ impl DatabaseApi<'_> {
             .get_entity(&StructuralQuery {
                 filter: Entity::create_filter_for_vertex_id(&entity_vertex_id),
                 graph_resolve_depths: GraphResolveDepths::default(),
+                time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
+                    kernel: UnresolvedKernel::new(None),
+                    image: UnresolvedImage::new(
+                        Some(TimespanBound::Unbounded),
+                        Some(TimespanBound::Unbounded),
+                    ),
+                }),
             })
             .await?
             .vertices
@@ -384,6 +418,13 @@ impl DatabaseApi<'_> {
             .get_entity(&StructuralQuery {
                 filter,
                 graph_resolve_depths: GraphResolveDepths::default(),
+                time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
+                    kernel: UnresolvedKernel::new(None),
+                    image: UnresolvedImage::new(
+                        Some(TimespanBound::Unbounded),
+                        Some(TimespanBound::Unbounded),
+                    ),
+                }),
             })
             .await?;
 
@@ -444,6 +485,13 @@ impl DatabaseApi<'_> {
             .get_entity(&StructuralQuery {
                 filter,
                 graph_resolve_depths: GraphResolveDepths::default(),
+                time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
+                    kernel: UnresolvedKernel::new(None),
+                    image: UnresolvedImage::new(
+                        Some(TimespanBound::Unbounded),
+                        Some(TimespanBound::Unbounded),
+                    ),
+                }),
             })
             .await?;
 

--- a/packages/hash/api/src/graphql/type-defs/subgraph.typedef.ts
+++ b/packages/hash/api/src/graphql/type-defs/subgraph.typedef.ts
@@ -7,6 +7,8 @@ export const subgraphTypedef = gql`
   scalar VersionedUri
   scalar Vertices
   scalar Edges
+  scalar TimeProjection
+  scalar ResolvedTimeProjection
 
   # TODO: Replace with \`EdgeResolveDepths\`
   #   see https://app.asana.com/0/1201095311341924/1203399511264512/f
@@ -43,5 +45,7 @@ export const subgraphTypedef = gql`
     vertices: Vertices!
     edges: Edges!
     depths: ResolveDepths!
+    timeProjection: TimeProjection!
+    resolvedTimeProjection: ResolvedTimeProjection!
   }
 `;

--- a/packages/hash/frontend/src/graphql/queries/subgraph.ts
+++ b/packages/hash/frontend/src/graphql/queries/subgraph.ts
@@ -33,5 +33,7 @@ export const subgraphFieldsFragment = gql`
         outgoing
       }
     }
+    timeProjection
+    resolvedTimeProjection
   }
 `;

--- a/packages/hash/shared/src/graphql/scalar-mapping.ts
+++ b/packages/hash/shared/src/graphql/scalar-mapping.ts
@@ -27,6 +27,8 @@ export const scalars = {
   Edges: "@hashintel/hash-subgraph#Edges",
   Vertices: "@hashintel/hash-subgraph#Vertices",
   LinkData: "@hashintel/hash-subgraph#LinkData",
+  TimeProjection: "@hashintel/hash-subgraph#TimeProjection",
+  ResolvedTimeProjection: "@hashintel/hash-subgraph#ResolvedTimeProjection",
 
   OwnedById: "@hashintel/hash-shared/types#OwnedById",
   UpdatedById: "@hashintel/hash-shared/types#UpdatedById",

--- a/packages/hash/subgraph/src/index.ts
+++ b/packages/hash/subgraph/src/index.ts
@@ -4,4 +4,5 @@ export * from "./types/edge";
 export * from "./types/element";
 export * from "./types/identifier";
 export * from "./types/subgraph";
+export * from "./types/time";
 export * from "./types/vertex";

--- a/packages/hash/subgraph/src/types/subgraph.ts
+++ b/packages/hash/subgraph/src/types/subgraph.ts
@@ -11,6 +11,7 @@ import {
   PropertyTypeWithMetadata,
 } from "./element";
 import { EntityVertexId } from "./identifier";
+import { ResolvedTimeProjection, TimeProjection } from "./time";
 import { Vertices } from "./vertex";
 
 export type SubgraphRootTypes = {
@@ -39,4 +40,6 @@ export type Subgraph<RootType extends SubgraphRootType = SubgraphRootType> = {
   vertices: Vertices;
   edges: Edges;
   depths: GraphResolveDepths;
+  timeProjection: TimeProjection;
+  resolvedTimeProjection: ResolvedTimeProjection;
 };

--- a/packages/hash/subgraph/src/types/time.ts
+++ b/packages/hash/subgraph/src/types/time.ts
@@ -1,0 +1,64 @@
+import { Timestamp } from "./identifier";
+
+export type TimespanBound =
+  | {
+      bound: "unbounded";
+    }
+  | {
+      bound: "included" | "excluded";
+      timestamp: Timestamp;
+    };
+
+export type DecisionTimeProjection = {
+  kernel: {
+    axis: "transaction";
+    timestamp?: Timestamp;
+  };
+  image: {
+    axis: "decision";
+    start?: TimespanBound;
+    end?: TimespanBound;
+  };
+};
+
+export type TransactionTimeProjection = {
+  kernel: {
+    axis: "decision";
+    timestamp?: Timestamp;
+  };
+  image: {
+    axis: "transaction";
+    start?: TimespanBound;
+    end?: TimespanBound;
+  };
+};
+
+export type TimeProjection = DecisionTimeProjection | TransactionTimeProjection;
+
+export type ResolvedDecisionTimeProjection = {
+  kernel: {
+    axis: "transaction";
+    timestamp: Timestamp;
+  };
+  image: {
+    axis: "decision";
+    start: TimespanBound;
+    end: TimespanBound;
+  };
+};
+
+export type ResolvedTransactionTimeProjection = {
+  kernel: {
+    axis: "decision";
+    timestamp: Timestamp;
+  };
+  image: {
+    axis: "transaction";
+    start: TimespanBound;
+    end: TimespanBound;
+  };
+};
+
+export type ResolvedTimeProjection =
+  | ResolvedDecisionTimeProjection
+  | ResolvedTransactionTimeProjection;

--- a/packages/hash/subgraph/tests/compatibility.test.ts
+++ b/packages/hash/subgraph/tests/compatibility.test.ts
@@ -49,6 +49,36 @@ test("Graph API subgraph type is compatible with library type", () => {
         outgoing: 0,
       },
     },
+    timeProjection: {
+      kernel: {
+        axis: "transaction",
+        timestamp: undefined,
+      },
+      image: {
+        axis: "decision",
+        start: {
+          bound: "unbounded",
+        },
+        end: {
+          bound: "unbounded",
+        },
+      },
+    },
+    resolvedTimeProjection: {
+      kernel: {
+        axis: "transaction",
+        timestamp: "2022-01-01T0:0:0",
+      },
+      image: {
+        axis: "decision",
+        start: {
+          bound: "unbounded",
+        },
+        end: {
+          bound: "unbounded",
+        },
+      },
+    },
   };
 
   // We just want to check for errors in the type when building the object, no need to use the return value
@@ -57,5 +87,7 @@ test("Graph API subgraph type is compatible with library type", () => {
     vertices: mapVertices(subgraphGraphApi.vertices),
     edges: mapEdges(subgraphGraphApi.edges),
     depths: subgraphGraphApi.depths,
+    timeProjection: subgraphGraphApi.timeProjection,
+    resolvedTimeProjection: subgraphGraphApi.resolvedTimeProjection,
   };
 });


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This is the first part of adjusting structural queries to utilize temporal versioning. This adds an interface to structural queries to specify a time [projection](https://en.wikipedia.org/wiki/Projection_(linear_algebra)) by pinning one axis ("kernel"). To allow a smoother transition, the parameter is made optional and defaults by pinning the transaction time to "now" and maps the decision time to a full, unbound range `(∞, ∞)`. The subgraph will return the same time projection parameter back and a resolved variant where "now" (represented as `null`) is a concrete timestamp. 

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203363157432087/1203491211535116/f) _(internal)_
- [Slack message reference](https://hashintel.slack.com/archives/C03F7V6DU9M/p1670945863261539) _(internal)_

## 🚫 Blocked by

- #1703 
- #1717 
- #1715 
- #1718 
- #1735



## 🔍 What does this change?

- Adds `Timespan`, a wrapper around `{ start?: TimespanBound, end?: TimespanBound }`
- Adds `Kernel` and `Image` structs
- Adds `Projection`, a struct containing `Kernal` and `Image`
- Adds `TimeProjection` enumeration to abstract over the two possible projections

## 🐾 Next steps

Implement the logic for structural queries
