### PR TITLE
Make time projections available to the query compiler

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
@@ -36,7 +36,7 @@ use self::{api_resource::RoutedResource, middleware::span_maker};
 use crate::{
     api::rest::middleware::log_request_and_response,
     identifier::time::{
-        DecisionTime, DecisionTimeProjection, ResolvedDecisionTimeProjection,
+        DecisionTime, DecisionTimeProjection, ProjectedTimestamp, ResolvedDecisionTimeProjection,
         ResolvedTimeProjection, ResolvedTransactionTimeProjection, TimeProjection, TimespanBound,
         Timestamp, TransactionTime, TransactionTimeProjection,
     },
@@ -147,6 +147,7 @@ async fn serve_static_schema(Path(path): Path<String>) -> Result<Response, Statu
             ResolvedDecisionTimeProjection,
             TransactionTime,
             TransactionTimeProjection,
+            ProjectedTimestamp,
             ResolvedTransactionTimeProjection,
         )
     ),

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/utoipa_typedef/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/utoipa_typedef/mod.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::identifier::{knowledge::EntityId, time::TransactionTimestamp};
+use crate::identifier::{knowledge::EntityId, time::ProjectedTimestamp};
 
 pub mod subgraph;
 
@@ -9,5 +9,5 @@ pub mod subgraph;
 #[serde(rename_all = "camelCase")]
 pub struct EntityIdAndTimestamp {
     pub base_id: EntityId,
-    pub timestamp: TransactionTimestamp,
+    pub timestamp: ProjectedTimestamp,
 }

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/edges.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/edges.rs
@@ -12,7 +12,7 @@ use crate::{
     identifier::{
         knowledge::EntityId,
         ontology::{OntologyTypeEditionId, OntologyTypeVersion},
-        time::TransactionTimestamp,
+        time::{ProjectedTimestamp, TimeAxis},
     },
     store::Record,
     subgraph::edges::{KnowledgeGraphEdgeKind, OntologyOutwardEdges, OutwardEdge, SharedEdgeKind},
@@ -40,7 +40,7 @@ impl ToSchema for KnowledgeGraphOutwardEdges {
 #[derive(Default, Debug, Serialize, ToSchema)]
 #[serde(transparent)]
 pub struct KnowledgeGraphRootedEdges(
-    pub HashMap<EntityId, BTreeMap<TransactionTimestamp, Vec<KnowledgeGraphOutwardEdges>>>,
+    pub HashMap<EntityId, BTreeMap<ProjectedTimestamp, Vec<KnowledgeGraphOutwardEdges>>>,
 );
 
 #[derive(Default, Debug, Serialize, ToSchema)]
@@ -61,6 +61,7 @@ impl Edges {
     pub fn from_vertices_and_store_edges(
         edges: crate::subgraph::edges::Edges,
         vertices: &Vertices,
+        time_axis: TimeAxis,
     ) -> Self {
         Self {
             ontology: OntologyRootedEdges(edges.ontology.into_iter().fold(
@@ -115,7 +116,7 @@ impl Edges {
                                     vertices.earliest_entity_by_id(&id.base_id())
                                 }
                                     .expect("entity must exist in subgraph")
-                                    .vertex_id()
+                                    .vertex_id(time_axis)
                                     .version();
 
                                 KnowledgeGraphOutwardEdges::ToKnowledgeGraph(OutwardEdge {

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/mod.rs
@@ -33,7 +33,11 @@ pub struct Subgraph {
 impl From<crate::subgraph::Subgraph> for Subgraph {
     fn from(subgraph: crate::subgraph::Subgraph) -> Self {
         let vertices = subgraph.vertices.into();
-        let edges = Edges::from_vertices_and_store_edges(subgraph.edges, &vertices);
+        let edges = Edges::from_vertices_and_store_edges(
+            subgraph.edges,
+            &vertices,
+            subgraph.resolved_time_projection.time_axis(),
+        );
         Self {
             roots: subgraph.roots.into_iter().collect(),
             vertices,

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/vertices/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/vertices/mod.rs
@@ -9,7 +9,7 @@ use utoipa::{
 
 pub use self::vertex::*;
 use crate::{
-    identifier::{knowledge::EntityId, ontology::OntologyTypeVersion, time::TransactionTimestamp},
+    identifier::{knowledge::EntityId, ontology::OntologyTypeVersion, time::ProjectedTimestamp},
     knowledge::Entity,
 };
 
@@ -22,7 +22,7 @@ pub struct OntologyVertices(pub HashMap<BaseUri, BTreeMap<OntologyTypeVersion, O
 #[derive(Serialize, ToSchema)]
 #[serde(transparent)]
 pub struct KnowledgeGraphVertices(
-    HashMap<EntityId, BTreeMap<TransactionTimestamp, KnowledgeGraphVertex>>,
+    HashMap<EntityId, BTreeMap<ProjectedTimestamp, KnowledgeGraphVertex>>,
 );
 
 #[derive(Serialize)]

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/mod.rs
@@ -18,6 +18,7 @@ pub use self::query::{EntityQueryPath, EntityQueryPathVisitor, EntityQueryToken}
 use crate::{
     identifier::{
         knowledge::{EntityEditionId, EntityId, EntityVersion},
+        time::TimeAxis,
         EntityVertexId,
     },
     provenance::ProvenanceMetadata,
@@ -292,11 +293,11 @@ impl Record for Entity {
         &self.metadata.edition_id
     }
 
-    fn vertex_id(&self) -> Self::VertexId {
-        EntityVertexId::new(
-            self.edition_id().base_id(),
-            self.metadata().version().transaction_time().start,
-        )
+    fn vertex_id(&self, time_axis: TimeAxis) -> Self::VertexId {
+        EntityVertexId::new(self.edition_id().base_id(), match time_axis {
+            TimeAxis::DecisionTime => self.metadata().version().decision_time().start.cast(),
+            TimeAxis::TransactionTime => self.metadata().version().transaction_time().start.cast(),
+        })
     }
 
     fn create_filter_for_vertex_id(vertex_id: &Self::VertexId) -> Filter<Self> {

--- a/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/ontology/mod.rs
@@ -23,7 +23,7 @@ pub use self::{
     property_type::{PropertyTypeQueryPath, PropertyTypeQueryPathVisitor, PropertyTypeQueryToken},
 };
 use crate::{
-    identifier::ontology::OntologyTypeEditionId,
+    identifier::{ontology::OntologyTypeEditionId, time::TimeAxis},
     provenance::{OwnedById, ProvenanceMetadata},
     store::{query::Filter, Record},
     subgraph::Subgraph,
@@ -207,7 +207,7 @@ impl Record for DataTypeWithMetadata {
         self.metadata().edition_id()
     }
 
-    fn vertex_id(&self) -> Self::VertexId {
+    fn vertex_id(&self, _time_axis: TimeAxis) -> Self::VertexId {
         self.edition_id().clone()
     }
 
@@ -263,7 +263,7 @@ impl Record for PropertyTypeWithMetadata {
         self.metadata().edition_id()
     }
 
-    fn vertex_id(&self) -> Self::VertexId {
+    fn vertex_id(&self, _time_axis: TimeAxis) -> Self::VertexId {
         self.edition_id().clone()
     }
 
@@ -319,7 +319,7 @@ impl Record for EntityTypeWithMetadata {
         self.metadata().edition_id()
     }
 
-    fn vertex_id(&self) -> Self::VertexId {
+    fn vertex_id(&self, _time_axis: TimeAxis) -> Self::VertexId {
         self.edition_id().clone()
     }
 

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/mod.rs
@@ -9,7 +9,7 @@ use type_system::uri::BaseUri;
 use utoipa::{openapi, ToSchema};
 
 use crate::identifier::{
-    knowledge::EntityId, ontology::OntologyTypeEditionId, time::TransactionTimestamp,
+    knowledge::EntityId, ontology::OntologyTypeEditionId, time::ProjectedTimestamp,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -37,12 +37,12 @@ impl ToSchema for GraphElementId {
 #[serde(rename_all = "camelCase")]
 pub struct EntityVertexId {
     base_id: EntityId,
-    version: TransactionTimestamp,
+    version: ProjectedTimestamp,
 }
 
 impl EntityVertexId {
     #[must_use]
-    pub const fn new(base_id: EntityId, version: TransactionTimestamp) -> Self {
+    pub const fn new(base_id: EntityId, version: ProjectedTimestamp) -> Self {
         Self { base_id, version }
     }
 
@@ -52,7 +52,7 @@ impl EntityVertexId {
     }
 
     #[must_use]
-    pub const fn version(&self) -> TransactionTimestamp {
+    pub const fn version(&self) -> ProjectedTimestamp {
         self.version
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/mod.rs
@@ -11,9 +11,9 @@ use postgres_types::{FromSql, Type};
 pub use self::{
     axis::{
         DecisionTime, DecisionTimeProjection, DecisionTimeVersionTimespan, DecisionTimestamp,
-        ResolvedDecisionTimeProjection, ResolvedTimeProjection, ResolvedTransactionTimeProjection,
-        TimeProjection, TransactionTime, TransactionTimeProjection, TransactionTimeVersionTimespan,
-        TransactionTimestamp,
+        ProjectedTimestamp, ResolvedDecisionTimeProjection, ResolvedTimeProjection,TimeAxis,
+        ResolvedTransactionTimeProjection, TimeProjection, TransactionTime,
+        TransactionTimeProjection, TransactionTimeVersionTimespan, TransactionTimestamp,
     },
     projection::{Image, Kernel, Projection, ResolvedImage, ResolvedKernel, ResolvedProjection},
     timespan::{ResolvedTimespan, Timespan, TimespanBound},

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/timespan.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/timespan.rs
@@ -24,6 +24,17 @@ pub enum TimespanBound<A> {
     Excluded(Timestamp<A>),
 }
 
+impl<A> TimespanBound<A> {
+    #[must_use]
+    pub const fn cast<B>(&self) -> TimespanBound<B> {
+        match self {
+            Self::Unbounded => TimespanBound::Unbounded,
+            Self::Included(timestamp) => TimespanBound::Included(timestamp.cast()),
+            Self::Excluded(timestamp) => TimespanBound::Excluded(timestamp.cast()),
+        }
+    }
+}
+
 impl<A> ToSchema for TimespanBound<A> {
     fn schema() -> openapi::Schema {
         openapi::OneOfBuilder::new()
@@ -76,4 +87,14 @@ pub struct Timespan<A> {
 pub struct ResolvedTimespan<A> {
     pub start: TimespanBound<A>,
     pub end: TimespanBound<A>,
+}
+
+impl<A> ResolvedTimespan<A> {
+    #[must_use]
+    pub const fn cast<B>(&self) -> ResolvedTimespan<B> {
+        ResolvedTimespan {
+            start: self.start.cast(),
+            end: self.end.cast(),
+        }
+    }
 }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -11,7 +11,9 @@ use crate::{
     identifier::{
         account::AccountId,
         knowledge::{EntityEditionId, EntityId, EntityRecordId, EntityVersion},
-        time::{DecisionTimeVersionTimespan, TransactionTimeVersionTimespan},
+        time::{
+            DecisionTimeVersionTimespan, ResolvedTimeProjection, TransactionTimeVersionTimespan,
+        },
     },
     knowledge::{Entity, EntityProperties, EntityQueryPath, EntityUuid, LinkData},
     ontology::EntityTypeQueryPath,
@@ -27,7 +29,11 @@ use crate::{
 #[async_trait]
 impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
     #[tracing::instrument(level = "info", skip(self))]
-    async fn read(&self, filter: &Filter<Entity>) -> Result<Vec<Entity>, QueryError> {
+    async fn read(
+        &self,
+        filter: &Filter<Entity>,
+        time_projection: &ResolvedTimeProjection,
+    ) -> Result<Vec<Entity>, QueryError> {
         // We can't define these inline otherwise we'll drop while borrowed
         let left_entity_uuid_path = EntityQueryPath::LeftEntity(Box::new(EntityQueryPath::Uuid));
         let left_owned_by_id_query_path =
@@ -36,7 +42,7 @@ impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
         let right_owned_by_id_query_path =
             EntityQueryPath::RightEntity(Box::new(EntityQueryPath::OwnedById));
 
-        let mut compiler = SelectCompiler::new();
+        let mut compiler = SelectCompiler::new(time_projection);
 
         let owned_by_id_index = compiler.add_selection_path(&EntityQueryPath::OwnedById);
         let entity_uuid_index = compiler.add_selection_path(&EntityQueryPath::Uuid);

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -32,7 +32,9 @@ use crate::{
     knowledge::{EntityProperties, LinkOrder},
 };
 use crate::{
-    identifier::{account::AccountId, ontology::OntologyTypeEditionId, EntityVertexId},
+    identifier::{
+        account::AccountId, ontology::OntologyTypeEditionId, time::TimeProjection, EntityVertexId,
+    },
     ontology::{OntologyElementMetadata, OntologyTypeWithMetadata},
     provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
@@ -354,10 +356,13 @@ where
 
         // TODO - address potential race condition
         //  https://app.asana.com/0/1202805690238892/1203201674100967/f
-        let previous_ontology_type =
-            <Self as Read<T::WithMetadata>>::read_one(self, &Filter::for_base_uri(uri.base_uri()))
-                .await
-                .change_context(UpdateError)?;
+        let previous_ontology_type = <Self as Read<T::WithMetadata>>::read_one(
+            self,
+            &Filter::for_base_uri(uri.base_uri()),
+            &TimeProjection::default().resolve(),
+        )
+        .await
+        .change_context(UpdateError)?;
 
         let owned_by_id = previous_ontology_type.metadata().owned_by_id();
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -7,7 +7,7 @@ use tokio_postgres::GenericClient;
 use type_system::uri::VersionedUri;
 
 use crate::{
-    identifier::ontology::OntologyTypeEditionId,
+    identifier::{ontology::OntologyTypeEditionId, time::ResolvedTimeProjection},
     ontology::{OntologyElementMetadata, OntologyType, OntologyTypeWithMetadata},
     provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
@@ -25,13 +25,17 @@ where
     for<'p> T::QueryPath<'p>: OntologyQueryPath,
 {
     #[tracing::instrument(level = "info", skip(self, filter))]
-    async fn read(&self, filter: &Filter<T>) -> Result<Vec<T>, QueryError> {
+    async fn read(
+        &self,
+        filter: &Filter<T>,
+        time_projection: &ResolvedTimeProjection,
+    ) -> Result<Vec<T>, QueryError> {
         let versioned_uri_path = <T::QueryPath<'static> as OntologyQueryPath>::versioned_uri();
         let schema_path = <T::QueryPath<'static> as OntologyQueryPath>::schema();
         let owned_by_id_path = <T::QueryPath<'static> as OntologyQueryPath>::owned_by_id();
         let updated_by_id_path = <T::QueryPath<'static> as OntologyQueryPath>::updated_by_id();
 
-        let mut compiler = SelectCompiler::new();
+        let mut compiler = SelectCompiler::new(time_projection);
 
         let versioned_uri_index = compiler.add_distinct_selection_with_ordering(
             &versioned_uri_path,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
@@ -3,16 +3,19 @@ use std::{borrow::Cow, collections::HashSet, fmt::Display, marker::PhantomData};
 use postgres_types::ToSql;
 use tokio_postgres::row::RowIndex;
 
-use crate::store::{
-    postgres::query::{
-        expression::Constant,
-        table::{Entities, EntityTypes, JsonField, Relation, TypeIds},
-        Alias, AliasedColumn, AliasedTable, Column, Condition, Distinctness, EqualityOperator,
-        Expression, Function, JoinExpression, OrderByExpression, Ordering, PostgresQueryPath,
-        PostgresRecord, SelectExpression, SelectStatement, Table, Transpile, WhereExpression,
-        WindowStatement, WithExpression,
+use crate::{
+    identifier::time::ResolvedTimeProjection,
+    store::{
+        postgres::query::{
+            expression::Constant,
+            table::{Entities, EntityTypes, JsonField, Relation, TypeIds},
+            Alias, AliasedColumn, AliasedTable, Column, Condition, Distinctness, EqualityOperator,
+            Expression, Function, JoinExpression, OrderByExpression, Ordering, PostgresQueryPath,
+            PostgresRecord, SelectExpression, SelectStatement, Table, Transpile, WhereExpression,
+            WindowStatement, WithExpression,
+        },
+        query::{Filter, FilterExpression, Parameter},
     },
-    query::{Filter, FilterExpression, Parameter},
 };
 
 // # Lifetime guidance
@@ -29,12 +32,13 @@ pub struct CompilerArtifacts<'p> {
 pub struct SelectCompiler<'c, 'p, T> {
     statement: SelectStatement<'c>,
     artifacts: CompilerArtifacts<'p>,
+    time_projection: &'c ResolvedTimeProjection,
     _marker: PhantomData<fn(*const T)>,
 }
 
 impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
     /// Creates a new, empty compiler.
-    pub fn new() -> Self {
+    pub fn new(time_projection: &'c ResolvedTimeProjection) -> Self {
         Self {
             statement: SelectStatement {
                 with: WithExpression::default(),
@@ -54,13 +58,14 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
                 condition_index: 0,
                 required_tables: HashSet::new(),
             },
+            time_projection,
             _marker: PhantomData,
         }
     }
 
     /// Creates a new compiler, which will select everything using the asterisk (`*`).
-    pub fn with_asterisk() -> Self {
-        let mut default = Self::new();
+    pub fn with_asterisk(time_projection: &'c ResolvedTimeProjection) -> Self {
+        let mut default = Self::new(time_projection);
         default
             .statement
             .selects

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
@@ -93,6 +93,7 @@ mod tests {
     use postgres_types::ToSql;
 
     use crate::{
+        identifier::time::TimeProjection,
         ontology::{DataTypeQueryPath, DataTypeWithMetadata},
         store::{
             postgres::query::{SelectCompiler, Transpile},
@@ -105,7 +106,8 @@ mod tests {
         rendered: &'static str,
         parameters: &[&'p dyn ToSql],
     ) {
-        let mut compiler = SelectCompiler::new();
+        let time_projection = TimeProjection::default().resolve();
+        let mut compiler = SelectCompiler::new(&time_projection);
         let condition = compiler.compile_filter(filter);
 
         assert_eq!(condition.transpile_to_string(), rendered);

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
@@ -49,6 +49,7 @@ mod tests {
 
     use super::*;
     use crate::{
+        identifier::time::TimeProjection,
         ontology::{DataTypeQueryPath, DataTypeWithMetadata},
         store::{
             postgres::query::{test_helper::trim_whitespace, SelectCompiler},
@@ -58,7 +59,8 @@ mod tests {
 
     #[test]
     fn transpile_where_expression() {
-        let mut compiler = SelectCompiler::<DataTypeWithMetadata>::new();
+        let time_projection = TimeProjection::default().resolve();
+        let mut compiler = SelectCompiler::<DataTypeWithMetadata>::new(&time_projection);
         let mut where_clause = WhereExpression::default();
         assert_eq!(where_clause.transpile_to_string(), "");
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -81,6 +81,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::{
+        identifier::time::TimeProjection,
         knowledge::{Entity, EntityQueryPath},
         ontology::{
             DataTypeQueryPath, DataTypeWithMetadata, EntityTypeQueryPath, EntityTypeWithMetadata,
@@ -121,8 +122,9 @@ mod tests {
 
     #[test]
     fn asterisk() {
+        let time_projection = TimeProjection::default().resolve();
         test_compilation(
-            &SelectCompiler::<DataTypeWithMetadata>::with_asterisk(),
+            &SelectCompiler::<DataTypeWithMetadata>::with_asterisk(&time_projection),
             r#"SELECT * FROM "data_types" AS "data_types_0_0_0""#,
             &[],
         );
@@ -130,7 +132,8 @@ mod tests {
 
     #[test]
     fn simple_expression() {
-        let mut compiler = SelectCompiler::<DataTypeWithMetadata>::with_asterisk();
+        let time_projection = TimeProjection::default().resolve();
+        let mut compiler = SelectCompiler::<DataTypeWithMetadata>::with_asterisk(&time_projection);
         compiler.add_filter(&Filter::Equal(
             Some(FilterExpression::Path(DataTypeQueryPath::VersionedUri)),
             Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
@@ -150,7 +153,8 @@ mod tests {
 
     #[test]
     fn specific_version() {
-        let mut compiler = SelectCompiler::<DataTypeWithMetadata>::with_asterisk();
+        let time_projection = TimeProjection::default().resolve();
+        let mut compiler = SelectCompiler::<DataTypeWithMetadata>::with_asterisk(&time_projection);
 
         let filter = Filter::All(vec![
             Filter::Equal(
@@ -184,7 +188,8 @@ mod tests {
 
     #[test]
     fn latest_version() {
-        let mut compiler = SelectCompiler::<DataTypeWithMetadata>::with_asterisk();
+        let time_projection = TimeProjection::default().resolve();
+        let mut compiler = SelectCompiler::<DataTypeWithMetadata>::with_asterisk(&time_projection);
 
         compiler.add_filter(&Filter::Equal(
             Some(FilterExpression::Path(DataTypeQueryPath::Version)),
@@ -209,7 +214,8 @@ mod tests {
 
     #[test]
     fn not_latest_version() {
-        let mut compiler = SelectCompiler::<DataTypeWithMetadata>::with_asterisk();
+        let time_projection = TimeProjection::default().resolve();
+        let mut compiler = SelectCompiler::<DataTypeWithMetadata>::with_asterisk(&time_projection);
 
         compiler.add_filter(&Filter::NotEqual(
             Some(FilterExpression::Path(DataTypeQueryPath::Version)),
@@ -234,7 +240,9 @@ mod tests {
 
     #[test]
     fn property_type_by_referenced_data_types() {
-        let mut compiler = SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk();
+        let time_projection = TimeProjection::default().resolve();
+        let mut compiler =
+            SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk(&time_projection);
 
         compiler.add_filter(&Filter::Equal(
             Some(FilterExpression::Path(PropertyTypeQueryPath::DataTypes(
@@ -303,7 +311,9 @@ mod tests {
 
     #[test]
     fn property_type_by_referenced_property_types() {
-        let mut compiler = SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk();
+        let time_projection = TimeProjection::default().resolve();
+        let mut compiler =
+            SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk(&time_projection);
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(
@@ -332,7 +342,9 @@ mod tests {
 
     #[test]
     fn entity_type_by_referenced_property_types() {
-        let mut compiler = SelectCompiler::<EntityTypeWithMetadata>::with_asterisk();
+        let time_projection = TimeProjection::default().resolve();
+        let mut compiler =
+            SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(&time_projection);
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityTypeQueryPath::Properties(
@@ -361,7 +373,9 @@ mod tests {
 
     #[test]
     fn entity_type_by_referenced_link_types() {
-        let mut compiler = SelectCompiler::<EntityTypeWithMetadata>::with_asterisk();
+        let time_projection = TimeProjection::default().resolve();
+        let mut compiler =
+            SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(&time_projection);
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityTypeQueryPath::Links(
@@ -398,7 +412,9 @@ mod tests {
 
     #[test]
     fn entity_type_by_inheritance() {
-        let mut compiler = SelectCompiler::<EntityTypeWithMetadata>::with_asterisk();
+        let time_projection = TimeProjection::default().resolve();
+        let mut compiler =
+            SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(&time_projection);
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityTypeQueryPath::InheritsFrom(
@@ -430,7 +446,8 @@ mod tests {
 
     #[test]
     fn entity_simple_query() {
-        let mut compiler = SelectCompiler::<Entity>::with_asterisk();
+        let time_projection = TimeProjection::default().resolve();
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(&time_projection);
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityQueryPath::Uuid)),
@@ -454,7 +471,8 @@ mod tests {
 
     #[test]
     fn entity_latest_version_query() {
-        let mut compiler = SelectCompiler::<Entity>::with_asterisk();
+        let time_projection = TimeProjection::default().resolve();
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(&time_projection);
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(
@@ -480,7 +498,8 @@ mod tests {
 
     #[test]
     fn entity_with_manual_selection() {
-        let mut compiler = SelectCompiler::<Entity>::new();
+        let time_projection = TimeProjection::default().resolve();
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(&time_projection);
         compiler.add_distinct_selection_with_ordering(
             &EntityQueryPath::Uuid,
             Distinctness::Distinct,
@@ -519,7 +538,8 @@ mod tests {
 
     #[test]
     fn entity_property_query() {
-        let mut compiler = SelectCompiler::<Entity>::with_asterisk();
+        let time_projection = TimeProjection::default().resolve();
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(&time_projection);
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityQueryPath::Properties(Some(
@@ -548,7 +568,8 @@ mod tests {
 
     #[test]
     fn entity_property_null_query() {
-        let mut compiler = SelectCompiler::<Entity>::with_asterisk();
+        let time_projection = TimeProjection::default().resolve();
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(&time_projection);
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityQueryPath::Properties(Some(
@@ -572,7 +593,8 @@ mod tests {
 
     #[test]
     fn entity_outgoing_link_query() {
-        let mut compiler = SelectCompiler::<Entity>::with_asterisk();
+        let time_projection = TimeProjection::default().resolve();
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(&time_projection);
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityQueryPath::OutgoingLinks(
@@ -606,7 +628,8 @@ mod tests {
 
     #[test]
     fn entity_incoming_link_query() {
-        let mut compiler = SelectCompiler::<Entity>::with_asterisk();
+        let time_projection = TimeProjection::default().resolve();
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(&time_projection);
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityQueryPath::IncomingLinks(
@@ -640,7 +663,8 @@ mod tests {
 
     #[test]
     fn link_entity_left_right_id() {
-        let mut compiler = SelectCompiler::<Entity>::with_asterisk();
+        let time_projection = TimeProjection::default().resolve();
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(&time_projection);
 
         let filter = Filter::All(vec![
             Filter::Equal(
@@ -694,7 +718,7 @@ mod tests {
                 account::AccountId,
                 knowledge::EntityId,
                 ontology::{OntologyTypeEditionId, OntologyTypeVersion},
-                time::TransactionTimestamp,
+                time::ProjectedTimestamp,
                 EntityVertexId,
             },
             knowledge::EntityUuid,
@@ -711,7 +735,9 @@ mod tests {
                 1,
             );
 
-            let mut compiler = SelectCompiler::<DataTypeWithMetadata>::with_asterisk();
+            let time_projection = TimeProjection::default().resolve();
+            let mut compiler =
+                SelectCompiler::<DataTypeWithMetadata>::with_asterisk(&time_projection);
 
             let filter = Filter::for_versioned_uri(&uri);
             compiler.add_filter(&filter);
@@ -739,7 +765,9 @@ mod tests {
                 OntologyTypeVersion::new(1),
             );
 
-            let mut compiler = SelectCompiler::<DataTypeWithMetadata>::with_asterisk();
+            let time_projection = TimeProjection::default().resolve();
+            let mut compiler =
+                SelectCompiler::<DataTypeWithMetadata>::with_asterisk(&time_projection);
 
             let filter = Filter::for_ontology_type_edition_id(&uri);
             compiler.add_filter(&filter);
@@ -764,7 +792,8 @@ mod tests {
                 EntityUuid::new(Uuid::new_v4()),
             );
 
-            let mut compiler = SelectCompiler::<Entity>::with_asterisk();
+            let time_projection = TimeProjection::default().resolve();
+            let mut compiler = SelectCompiler::<Entity>::with_asterisk(&time_projection);
 
             let filter = Filter::for_entity_by_entity_id(entity_id);
             compiler.add_filter(&filter);
@@ -792,10 +821,11 @@ mod tests {
                     OwnedById::new(AccountId::new(Uuid::new_v4())),
                     EntityUuid::new(Uuid::new_v4()),
                 ),
-                TransactionTimestamp::now(),
+                ProjectedTimestamp::now(),
             );
 
-            let mut compiler = SelectCompiler::<Entity>::with_asterisk();
+            let time_projection = TimeProjection::default().resolve();
+            let mut compiler = SelectCompiler::<Entity>::with_asterisk(&time_projection);
 
             let filter = Filter::for_entity_by_vertex_id(entity_vertex_id);
             compiler.add_filter(&filter);
@@ -825,10 +855,11 @@ mod tests {
                     OwnedById::new(AccountId::new(Uuid::new_v4())),
                     EntityUuid::new(Uuid::new_v4()),
                 ),
-                TransactionTimestamp::now(),
+                ProjectedTimestamp::now(),
             );
 
-            let mut compiler = SelectCompiler::<Entity>::with_asterisk();
+            let time_projection = TimeProjection::default().resolve();
+            let mut compiler = SelectCompiler::<Entity>::with_asterisk(&time_projection);
 
             let filter = Filter::for_outgoing_link_by_source_entity_vertex_id(entity_vertex_id);
             compiler.add_filter(&filter);
@@ -861,10 +892,11 @@ mod tests {
                     OwnedById::new(AccountId::new(Uuid::new_v4())),
                     EntityUuid::new(Uuid::new_v4()),
                 ),
-                TransactionTimestamp::now(),
+                ProjectedTimestamp::now(),
             );
 
-            let mut compiler = SelectCompiler::<Entity>::with_asterisk();
+            let time_projection = TimeProjection::default().resolve();
+            let mut compiler = SelectCompiler::<Entity>::with_asterisk(&time_projection);
 
             let filter = Filter::for_left_entity_by_entity_vertex_id(entity_vertex_id);
             compiler.add_filter(&filter);
@@ -897,10 +929,11 @@ mod tests {
                     OwnedById::new(AccountId::new(Uuid::new_v4())),
                     EntityUuid::new(Uuid::new_v4()),
                 ),
-                TransactionTimestamp::now(),
+                ProjectedTimestamp::now(),
             );
 
-            let mut compiler = SelectCompiler::<Entity>::with_asterisk();
+            let time_projection = TimeProjection::default().resolve();
+            let mut compiler = SelectCompiler::<Entity>::with_asterisk(&time_projection);
 
             let filter = Filter::for_right_entity_by_entity_vertex_id(entity_vertex_id);
             compiler.add_filter(&filter);

--- a/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 
 use crate::{
     identifier::{
-        knowledge::EntityId, ontology::OntologyTypeEditionId, time::TransactionTimestamp,
+        knowledge::EntityId, ontology::OntologyTypeEditionId, time::ProjectedTimestamp,
         EntityVertexId,
     },
     knowledge::{Entity, EntityQueryPath},
@@ -333,7 +333,7 @@ pub enum Parameter<'p> {
     #[serde(skip)]
     SignedInteger(i64),
     #[serde(skip)]
-    Timestamp(TransactionTimestamp),
+    Timestamp(ProjectedTimestamp),
 }
 
 impl Parameter<'_> {
@@ -398,7 +398,7 @@ impl Parameter<'_> {
             (Parameter::Text(text), ParameterType::Timestamp) => {
                 if text != "latest" {
                     *self = Parameter::Timestamp(
-                        TransactionTimestamp::from_str(&*text)
+                        ProjectedTimestamp::from_str(&*text)
                             .into_report()
                             .change_context_lazy(|| ParameterConversionError {
                                 actual: self.to_owned(),
@@ -447,9 +447,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        identifier::{
-            account::AccountId, ontology::OntologyTypeVersion, time::TransactionTimestamp,
-        },
+        identifier::{account::AccountId, ontology::OntologyTypeVersion},
         knowledge::EntityUuid,
         ontology::{DataTypeQueryPath, DataTypeWithMetadata},
         provenance::OwnedById,
@@ -554,7 +552,7 @@ mod tests {
                 OwnedById::new(AccountId::new(Uuid::new_v4())),
                 EntityUuid::new(Uuid::new_v4()),
             ),
-            TransactionTimestamp::now(),
+            ProjectedTimestamp::now(),
         );
 
         let expected = json! {{
@@ -588,7 +586,7 @@ mod tests {
                 OwnedById::new(AccountId::new(Uuid::new_v4())),
                 EntityUuid::new(Uuid::new_v4()),
             ),
-            TransactionTimestamp::now(),
+            ProjectedTimestamp::now(),
         );
 
         let expected = json! {{
@@ -622,7 +620,7 @@ mod tests {
                 OwnedById::new(AccountId::new(Uuid::new_v4())),
                 EntityUuid::new(Uuid::new_v4()),
             ),
-            TransactionTimestamp::now(),
+            ProjectedTimestamp::now(),
         );
 
         let expected = json! {{
@@ -656,7 +654,7 @@ mod tests {
                 OwnedById::new(AccountId::new(Uuid::new_v4())),
                 EntityUuid::new(Uuid::new_v4()),
             ),
-            TransactionTimestamp::now(),
+            ProjectedTimestamp::now(),
         );
 
         let expected = json! {{

--- a/packages/graph/hash_graph/lib/graph/src/store/record.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/record.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{
-    identifier::GraphElementVertexId,
+    identifier::{time::TimeAxis, GraphElementVertexId},
     store::query::{Filter, QueryPath},
     subgraph::Subgraph,
 };
@@ -19,7 +19,7 @@ pub trait Record: Sized + Send {
 
     fn edition_id(&self) -> &Self::EditionId;
 
-    fn vertex_id(&self) -> Self::VertexId;
+    fn vertex_id(&self, time_axis: TimeAxis) -> Self::VertexId;
 
     fn create_filter_for_vertex_id(vertex_id: &Self::VertexId) -> Filter<Self>;
 
@@ -29,14 +29,14 @@ pub trait Record: Sized + Send {
     ) -> RawEntryMut<'s, Self::VertexId, Self, RandomState>;
 
     fn insert_into_subgraph(self, subgraph: &mut Subgraph) -> &Self {
-        let vertex_id = self.vertex_id();
+        let vertex_id = self.vertex_id(subgraph.resolved_time_projection.time_axis());
         Self::subgraph_entry(subgraph, &vertex_id)
             .or_insert(vertex_id, self)
             .1
     }
 
     fn insert_into_subgraph_as_root(self, subgraph: &mut Subgraph) -> &Self {
-        let vertex_id = self.vertex_id();
+        let vertex_id = self.vertex_id(subgraph.resolved_time_projection.time_axis());
         subgraph.roots.insert(vertex_id.clone().into());
         Self::subgraph_entry(subgraph, &vertex_id)
             .or_insert(vertex_id, self)

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -309,13 +309,13 @@ impl DatabaseApi<'_> {
         entity_id: EntityId,
         timestamp: TransactionTimestamp,
     ) -> Result<Entity, QueryError> {
-        let entity_vertex_id = EntityVertexId::new(entity_id, timestamp);
+        let entity_vertex_id = EntityVertexId::new(entity_id, timestamp.cast());
         Ok(self
             .store
             .get_entity(&StructuralQuery {
                 filter: Entity::create_filter_for_vertex_id(&entity_vertex_id),
                 graph_resolve_depths: GraphResolveDepths::default(),
-                time_projection: TimeProjection::DecisionTime(Projection {
+                time_projection: TimeProjection::TransactionTime(Projection {
                     kernel: Kernel::new(None),
                     image: Image::new(
                         Some(TimespanBound::Unbounded),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To allow the structural query compiler to use the provided time projection, the compiler needs to know about it. This PR makes the time projection required to create the compiler. The compiler does not anything with the information yet!
As the time projection is required to be available everywhere, the subgraph can also now be adjusted to return the correct time axis as vertex.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- Part of [this Asana task](https://app.asana.com/0/1203363157432087/1203491211535116/f) _(internal)_

## 🚫 Blocked by

- #1703 
- #1717 
- #1715 
- #1718 
- #1735
- #1738 

## 🔍 What does this change?

- Introduce the `ProjectedTime` axis, which is either the `DecisionTime` or the `TransactionTime`. The `ProjectedTime` is used in the subgraph and is identified by the `TimeProjection` passed to the queries. A few helper methods were added to convert between those types
- Make the `TimeProjection` available to the compiler

This is a fairly small change but the diff is pretty sizy as those structs were used in many places.

## 🐾 Next steps

- Adjust the dependency resolving logic to also store the resolved time and take that into account
- Adjust the query compiler to use the time projection to filter records