### PR TITLE
Add documentation to newly added query path variants

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
@@ -43,11 +43,38 @@ pub enum EntityQueryPath<'p> {
     /// [`EntityId`]: crate::identifier::knowledge::EntityId
     /// [`Entity`]: crate::knowledge::Entity
     OwnedById,
-    // TODO: DOC: https://app.asana.com/0/0/1203505325130325/f
+    /// The [`EntityRecordId`] of the [`EntityRecordId`] belonging to the [`Entity`].
+    ///
+    /// ```rust
+    /// # use serde::Deserialize;
+    /// # use serde_json::json;
+    /// # use graph::knowledge::EntityQueryPath;
+    /// let path = EntityQueryPath::deserialize(json!(["recordId"]))?;
+    /// assert_eq!(path, EntityQueryPath::RecordId);
+    /// # Ok::<(), serde_json::Error>(())
+    /// ```
+    ///
+    /// [`EntityEditionId`]: crate::identifier::knowledge::EntityEditionId
+    /// [`EntityRecordId`]: crate::identifier::knowledge::EntityRecordId
+    /// [`Entity`]: crate::knowledge::Entity
     RecordId,
-    // TODO: DOC: https://app.asana.com/0/0/1203505325130325/f
+    /// The decision time axis of the [`EntityVersion`] belonging to the [`Entity`].
+    ///
+    /// To query for an [`EntityVersion`] the time projection is specified on the
+    /// [`StructuralQuery`].
+    ///
+    /// [`StructuralQuery`]: crate::shared::subgraph::query::StructuralQuery
+    /// [`EntityVersion`]: crate::identifier::knowledge::EntityVersion
+    /// [`Entity`]: crate::knowledge::Entity
     DecisionTime,
-    // TODO: DOC: https://app.asana.com/0/0/1203505325130325/f
+    /// The transaction time axis of the [`EntityVersion`] belonging to the [`Entity`].
+    ///
+    /// To query for an [`EntityVersion`] the time projection is specified on the
+    /// [`StructuralQuery`].
+    ///
+    /// [`StructuralQuery`]: crate::shared::subgraph::query::StructuralQuery
+    /// [`EntityVersion`]: crate::identifier::knowledge::EntityVersion
+    /// [`Entity`]: crate::knowledge::Entity
     TransactionTime,
     // TODO: Remove when adjusting structural queries
     //   see https://app.asana.com/0/0/1203491211535116/f


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We added a few new `EntityQueryPath` variants recently, which had to be documented

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203363157432087/1203505325130325/f) _(internal)_

## 🔍 What does this change?

Adds doc-strings to newly added query path parameters