### PR TITLE
Allow conversion from `Report` to `Error`

### DIFF
--- a/packages/libs/error-stack/CHANGELOG.md
+++ b/packages/libs/error-stack/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to `error-stack` will be documented in this file.
 
 - Add serializing support using [`serde`](https://serde.rs) ([#1290](https://github.com/hashintel/hash/pull/1290))
 - Support `Debug` hooks on `no-std` platforms via the `hooks` feature ([#1556](https://github.com/hashintel/hash/pull/1556))
+- Support converting `Report` into [`Error`](https://doc.rust-lang.org/core/error/trait.Error.html) via `Report::as_error` and `Report::into_error` ([#1749](https://github.com/hashintel/hash/pull/1749))
+- Support converting `Report` into `Box<dyn Error>` via the `From` trait ([#1749](https://github.com/hashintel/hash/pull/1749))
 
 ## [0.2.4](https://github.com/hashintel/hash/tree/error-stack%400.2.4/packages/libs/error-stack) - 2022-11-04
 

--- a/packages/libs/error-stack/src/error.rs
+++ b/packages/libs/error-stack/src/error.rs
@@ -1,0 +1,43 @@
+use core::fmt;
+#[cfg(nightly)]
+use core::{
+    any::{Demand, Provider},
+    error::Error,
+};
+#[cfg(not(nightly))]
+use std::error::Error;
+
+use crate::Report;
+
+#[repr(transparent)]
+pub(crate) struct ReportError<C>(Report<C>);
+
+impl<C> ReportError<C> {
+    pub(crate) const fn new(report: Report<C>) -> Self {
+        Self(report)
+    }
+
+    pub(crate) const fn from_ref(report: &Report<C>) -> &Self {
+        // SAFETY: `ReportError` is a `repr(transparent)` wrapper around `Report`.
+        unsafe { &*(report as *const Report<C>).cast() }
+    }
+}
+
+impl<C> fmt::Debug for ReportError<C> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, fmt)
+    }
+}
+
+impl<C> fmt::Display for ReportError<C> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, fmt)
+    }
+}
+
+impl<C> Error for ReportError<C> {
+    #[cfg(nightly)]
+    fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
+        self.0.frames().for_each(|frame| frame.provide(demand));
+    }
+}

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -464,7 +464,6 @@
 )]
 
 extern crate alloc;
-extern crate core;
 
 pub mod future;
 pub mod iter;
@@ -476,6 +475,8 @@ mod report;
 mod result;
 
 mod context;
+#[cfg(any(nightly, feature = "std"))]
+mod error;
 #[cfg(any(feature = "std", feature = "hooks"))]
 pub mod fmt;
 #[cfg(not(any(feature = "std", feature = "hooks")))]

--- a/packages/libs/error-stack/src/report.rs
+++ b/packages/libs/error-stack/src/report.rs
@@ -15,7 +15,6 @@ use tracing_error::{SpanTrace, SpanTraceStatus};
 #[cfg(nightly)]
 use crate::iter::{RequestRef, RequestValue};
 use crate::{
-    error::ReportError,
     iter::{Frames, FramesMut},
     Context, Frame,
 };
@@ -650,7 +649,7 @@ impl<C> Report<C> {
     where
         C: 'static,
     {
-        ReportError::new(self)
+        crate::error::ReportError::new(self)
     }
 
     /// Returns this `Report` as an [`Error`].
@@ -660,28 +659,32 @@ impl<C> Report<C> {
     where
         C: 'static,
     {
-        ReportError::from_ref(self)
+        crate::error::ReportError::from_ref(self)
     }
 }
 
+#[cfg(any(nightly, feature = "std"))]
 impl<C: 'static> From<Report<C>> for Box<dyn Error> {
     fn from(report: Report<C>) -> Self {
         Box::new(report.into_error())
     }
 }
 
+#[cfg(any(nightly, feature = "std"))]
 impl<C: 'static> From<Report<C>> for Box<dyn Error + Send> {
     fn from(report: Report<C>) -> Self {
         Box::new(report.into_error())
     }
 }
 
+#[cfg(any(nightly, feature = "std"))]
 impl<C: 'static> From<Report<C>> for Box<dyn Error + Sync> {
     fn from(report: Report<C>) -> Self {
         Box::new(report.into_error())
     }
 }
 
+#[cfg(any(nightly, feature = "std"))]
 impl<C: 'static> From<Report<C>> for Box<dyn Error + Send + Sync> {
     fn from(report: Report<C>) -> Self {
         Box::new(report.into_error())

--- a/packages/libs/error-stack/src/report.rs
+++ b/packages/libs/error-stack/src/report.rs
@@ -664,6 +664,30 @@ impl<C> Report<C> {
     }
 }
 
+impl<C: 'static> From<Report<C>> for Box<dyn Error> {
+    fn from(report: Report<C>) -> Self {
+        Box::new(report.into_error())
+    }
+}
+
+impl<C: 'static> From<Report<C>> for Box<dyn Error + Send> {
+    fn from(report: Report<C>) -> Self {
+        Box::new(report.into_error())
+    }
+}
+
+impl<C: 'static> From<Report<C>> for Box<dyn Error + Sync> {
+    fn from(report: Report<C>) -> Self {
+        Box::new(report.into_error())
+    }
+}
+
+impl<C: 'static> From<Report<C>> for Box<dyn Error + Send + Sync> {
+    fn from(report: Report<C>) -> Self {
+        Box::new(report.into_error())
+    }
+}
+
 #[cfg(feature = "std")]
 impl<Context> std::process::Termination for Report<Context> {
     fn report(self) -> ExitCode {

--- a/packages/libs/error-stack/tests/test_compatibility.rs
+++ b/packages/libs/error-stack/tests/test_compatibility.rs
@@ -13,6 +13,27 @@ use error_stack::IntoReportCompat;
 use error_stack::Report;
 
 #[test]
+#[cfg(any(nightly, feature = "std"))]
+fn error() {
+    let report = create_report().change_context(ContextA(10));
+    let error_ref = report.as_error();
+    assert_eq!(error_ref.to_string(), "context A");
+    #[cfg(nightly)]
+    assert_eq!(
+        *core::any::request_ref::<u32>(error_ref).expect("requested value not found"),
+        10
+    );
+
+    let error = report.into_error();
+    assert_eq!(error.to_string(), "context A");
+    #[cfg(nightly)]
+    assert_eq!(
+        *core::any::request_ref::<u32>(&error).expect("requested value not found"),
+        10
+    );
+}
+
+#[test]
 #[cfg(all(feature = "std", feature = "anyhow"))]
 fn anyhow() {
     let anyhow: Result<(), _> = Err(anyhow::anyhow!(RootError)

--- a/packages/libs/error-stack/tests/test_conversion.rs
+++ b/packages/libs/error-stack/tests/test_conversion.rs
@@ -3,7 +3,7 @@
 
 use std::io;
 
-use error_stack::IntoReport;
+use error_stack::{IntoReport, ResultExt};
 
 fn io_error() -> Result<(), io::Error> {
     Err(io::Error::from(io::ErrorKind::Other))
@@ -11,14 +11,34 @@ fn io_error() -> Result<(), io::Error> {
 
 #[test]
 fn report() {
-    let report = io_error().into_report().expect_err("Not an error");
+    let report = io_error().into_report().expect_err("not an error");
     assert!(report.contains::<io::Error>());
     assert_eq!(report.current_context().kind(), io::ErrorKind::Other);
 }
 
 #[test]
 fn into_report() {
-    let report = io_error().into_report().expect_err("Not an error");
+    let report = io_error().into_report().expect_err("not an error");
     assert!(report.contains::<io::Error>());
     assert_eq!(report.current_context().kind(), io::ErrorKind::Other);
+}
+
+fn returning_boxed_error() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    io_error().into_report().attach(10_u32)?;
+    Ok(())
+}
+
+#[test]
+fn boxed_error() {
+    let report = returning_boxed_error().expect_err("not an error");
+    assert_eq!(
+        report.to_string(),
+        io_error().expect_err("not an error").to_string()
+    );
+
+    #[cfg(nightly)]
+    assert_eq!(
+        *core::any::request_ref::<u32>(report.as_ref()).expect("requested value not found"),
+        10
+    );
 }

--- a/packages/libs/error-stack/tests/ui/into_report.rs
+++ b/packages/libs/error-stack/tests/ui/into_report.rs
@@ -1,0 +1,23 @@
+use core::fmt;
+
+use error_stack::{Context, IntoReport, Report};
+
+#[derive(Debug)]
+pub struct RootError;
+
+impl fmt::Display for RootError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.write_str("root error")
+    }
+}
+
+impl Context for RootError {}
+
+fn main() {
+    let result = Err::<(), _>(RootError);
+    let _: Result<(), Report<RootError>> = result.into_report();
+
+    let result = Err::<(), _>(Report::new(RootError));
+    // Not allowed
+    let _ = result.into_report();
+}

--- a/packages/libs/error-stack/tests/ui/into_report.stderr
+++ b/packages/libs/error-stack/tests/ui/into_report.stderr
@@ -1,0 +1,19 @@
+error[E0599]: the method `into_report` exists for enum `Result<(), error_stack::Report<RootError>>`, but its trait bounds were not satisfied
+    |
+   ::: src/report.rs
+    |
+    | pub struct Report<C> {
+    | -------------------- doesn't satisfy `_: From<error_stack::Report<RootError>>`
+    |
+   ::: $RUST/core/src/result.rs
+    |
+    | pub enum Result<T, E> {
+    | --------------------- doesn't satisfy `_: IntoReport`
+   --> tests/ui/into_report.rs:22:20
+    |
+22  |     let _ = result.into_report();
+    |                    ^^^^^^^^^^^
+    |
+    = note: the following trait bounds were not satisfied:
+            `error_stack::Report<error_stack::Report<RootError>>: From<error_stack::Report<RootError>>`
+            which is required by `Result<(), error_stack::Report<RootError>>: IntoReport`


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

It's currently hard to deal with `Report` when an `Error` is required. This PR adds conversions from `Report` to `Error`.

## 🔗 Related links

- resolves https://github.com/hashintel/hash/issues/1746

## 🔍 What does this change?

- Add `Report::into_error` to convert `impl Error`
- Add `Report::as_error` to return `&impl Error`
- Add `From` implementation of `Report` for `Box<dyn Error>` (+ `Send` and/or `Sync`)

## 📜 Does this require a change to the docs?

The changelog was changed to reflect these changes

## 🛡 What tests cover this?

Three new tests were added:
- A UI test to make sure, that `into_report` cannot be called on `Result<T, Report<C>>`
- Two tests to check the new methods/trait implementation by converting a `Report` to `Error` and ensure, that the provided values are still accessible