### PR TITLE
initialize drawing block with draw tool selected

### DIFF
--- a/blocks/drawing/package.json
+++ b/blocks/drawing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blocks/drawing",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Create a diagram, sketch an idea, or map a process",
   "keywords": [
     "blockprotocol",

--- a/blocks/drawing/src/app.tsx
+++ b/blocks/drawing/src/app.tsx
@@ -4,7 +4,7 @@ import {
   BlockComponent,
   useGraphBlockService,
 } from "@blockprotocol/graph/react";
-import { TDDocument, Tldraw, TldrawApp } from "@tldraw/tldraw";
+import { TDDocument, TDShapeType, Tldraw, TldrawApp } from "@tldraw/tldraw";
 import {
   SyntheticEvent,
   useCallback,
@@ -166,6 +166,7 @@ export const App: BlockComponent<BlockEntityProperties> = ({
   const handleMount = useCallback(
     (app: TldrawApp) => {
       rTldrawApp.current = app;
+      app.selectTool(TDShapeType.Draw);
 
       if (localState.darkMode !== rTldrawApp.current.settings.isDarkMode) {
         rTldrawApp.current.toggleDarkMode();


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](link) _(internal)_

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch
1.  Start drawing block on local
1.  Confirm that it starts with "draw" tool selected

## 📹 Demo

https://user-images.githubusercontent.com/39553853/210763652-d4610dee-aef6-4b54-81a0-9a7234c02b3d.mov

