### PR TITLE
Fix updating the same ontology type resulting in an error

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -391,10 +391,12 @@ where
 
         // TODO - address potential race condition
         //  https://app.asana.com/0/1202805690238892/1203201674100967/f
-        let previous_ontology_type =
-            <Self as Read<T::WithMetadata>>::read_one(self, &Filter::for_base_uri(uri.base_uri()))
-                .await
-                .change_context(UpdateError)?;
+        let previous_ontology_type = <Self as Read<T::WithMetadata>>::read_one(
+            self,
+            &Filter::for_latest_base_uri(uri.base_uri()),
+        )
+        .await
+        .change_context(UpdateError)?;
 
         let owned_by_id = previous_ontology_type.metadata().owned_by_id();
 

--- a/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/filter.rs
@@ -59,6 +59,21 @@ where
         )
     }
 
+    /// Creates a `Filter` to search for the latest specific ontology type of kind `R`, identified
+    /// by its [`BaseUri`].
+    #[must_use]
+    pub fn for_latest_base_uri(base_uri: &'p BaseUri) -> Self {
+        Self::All(vec![
+            Self::for_base_uri(base_uri),
+            Self::Equal(
+                Some(FilterExpression::Path(<R::QueryPath<'p>>::version())),
+                Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
+                    "latest",
+                )))),
+            ),
+        ])
+    }
+
     /// Creates a `Filter` to filter by a given version.
     #[must_use]
     fn for_version(version: u32) -> Self {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We encountered an issue when updating the same ontology type more than once. This is because accidentally, we're trying to read all ontology types of a specific type base URI instead of only the latest.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Slack thread](https://hashintel.slack.com/archives/C022217GAHF/p1672854529471029)  by @nathggns _(internal)_
- [Slack thread](https://hashintel.slack.com/archives/C022217GAHF/p1672673003673429) by @Alfred-Mountfield _(internal)_

## 🔍 What does this change?

- Add pre-defined filter to return the latest an ontology type by Base URI
- Use the newly added filter in the update method

## ⚠️ Known issues

While this is a straightforward fix, tracking it down was challenging as the error was not reported back from the Graph API. @thehabbos007 tracked down that issue, but we don't have a proper solution yet. This PR fixes the issue on the Rust code, but we still have to figure out why specifying the OTLP endpoint hides the error.