### PR TITLE
Emit warning when finding an `'infinity'` or `'-infinity'` value

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/mod.rs
@@ -3,6 +3,7 @@ mod timestamp;
 mod version;
 use std::{error::Error, ops::Bound};
 
+use postgres_protocol::types::timestamp_from_sql;
 use postgres_types::{FromSql, Type};
 
 pub use self::{
@@ -14,10 +15,25 @@ pub use self::{
     version::VersionTimespan,
 };
 
+fn is_infinity(bytes: &[u8]) -> Result<bool, Box<dyn Error + Send + Sync>> {
+    let sql_timestamp = timestamp_from_sql(bytes)?;
+    Ok(sql_timestamp == i64::MIN || sql_timestamp == i64::MAX)
+}
+
 fn parse_bound(
     bound: &postgres_protocol::types::RangeBound<Option<&[u8]>>,
 ) -> Result<Bound<Timestamp<()>>, Box<dyn Error + Send + Sync>> {
     match bound {
+        postgres_protocol::types::RangeBound::Inclusive(Some(bytes))
+        | postgres_protocol::types::RangeBound::Exclusive(Some(bytes))
+            if is_infinity(bytes)? =>
+        {
+            tracing::warn!(
+                "Found an `-infinity` or `infinity` timestamp in the database, falling back to \
+                 unbounded range instead"
+            );
+            Ok(Bound::Unbounded)
+        }
         postgres_protocol::types::RangeBound::Inclusive(Some(bytes)) => Ok(Bound::Included(
             Timestamp::from_sql(&Type::TIMESTAMPTZ, bytes)?,
         )),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We don't want to use `'infinity'` or `'-infinity'` in the database but unbounded bounds instead. In the case an infinity-value is in the database, this will fail to deserialize. This PR falls back to an unbounded bound and emits a warning instead of erroring.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Slack thread](https://hashintel.slack.com/archives/C03F7V6DU9M/p1672930907628839) _(internal)_