### PR TITLE
Fix task-executor deployments

### DIFF
--- a/packages/hash/api/package.json
+++ b/packages/hash/api/package.json
@@ -10,7 +10,7 @@
     "fix:eslint": "eslint --fix .",
     "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
-    "start": "cross-env NODE_ENV=production node --max-old-space-size=2048 ./node_modules/.bin/ts-node --transpile-only ./src/index.ts",
+    "start": "cross-env NODE_ENV=production node --max-old-space-size=8192 ./node_modules/.bin/ts-node --transpile-only ./src/index.ts",
     "test": "jest"
   },
   "dependencies": {

--- a/packages/hash/api/src/graph/index.ts
+++ b/packages/hash/api/src/graph/index.ts
@@ -69,6 +69,11 @@ export class GraphApiError extends Error {
   payload: JSONValue;
 
   constructor(axiosError: AxiosError) {
+    console.error(
+      `Axios error: ${axiosError}, ${
+        axiosError.status
+      }, ${axiosError.toJSON()}`,
+    );
     const responseData = axiosError.response?.data;
 
     const message = `GraphApi error: ${

--- a/packages/hash/docker/task-executor/Dockerfile
+++ b/packages/hash/docker/task-executor/Dockerfile
@@ -2,16 +2,16 @@ FROM node:16.18.1-alpine AS builder
 
 WORKDIR /app
 
-COPY libs/javascript/@local/tsconfig libs/javascript/@local/tsconfig
-COPY packages/hash/task-executor packages/hash/task-executor
+# Ensure that the node module layer can be cached
 COPY package.json .
 COPY yarn.lock .
+RUN yarn install --frozen-lockfile --production --ignore-scripts --prefer-offline
 
-RUN --mount=type=cache,mode=0755,target=/yarn-cache \
-  --mount=type=cache,mode=0755,target=/var/cache/apt \
-  --mount=type=cache,mode=0755,target=/var/lib/apt \
-  yarn workspace @hashintel/hash-task-executor install --cache-folder /yarn-cache \
-  && yarn install --production --ignore-scripts --prefer-offline --cache-folder /yarn-cache # Remove devDependencies
+COPY libs/javascript/@local/tsconfig/* libs/javascript/@local/tsconfig/
+COPY libs/javascript/@local/eslint-config/package.json libs/javascript/@local/eslint-config/
+COPY packages/hash/task-executor packages/hash/task-executor
+
+RUN yarn workspace @hashintel/hash-task-executor install --ignore-scripts --prefer-offline
 
   #########################################################################################
 
@@ -24,6 +24,10 @@ ENV PYTHONUNBUFFERED=1
 RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
 RUN python3 -m ensurepip
 RUN pip3 install --no-cache --upgrade pip setuptools
+
+# Install docker
+RUN apk add --update docker openrc
+RUN rc-update add docker boot
 
 WORKDIR /app
 

--- a/packages/hash/external-services/docker-compose.prod.yml
+++ b/packages/hash/external-services/docker-compose.prod.yml
@@ -30,8 +30,8 @@ services:
     # `listen_addresses` and other postgres config to lock down access.
     # The database port isn't forwarded outside the docker network.
     # Uncomment the next lines to debug/introspect the instance.
-    # ports:
-    #   - "5432:5432"
+    ports:
+      - "5432:5432"
     volumes:
       - hash-postgres-data:/var/lib/postgresql/data
       - ./postgres/postgresql.conf:/etc/postgresql/postgresql.conf:ro

--- a/packages/hash/external-services/docker-compose.prod.yml
+++ b/packages/hash/external-services/docker-compose.prod.yml
@@ -2,6 +2,10 @@ version: "3.9"
 
 volumes:
   hash-postgres-data:
+  task-executor-secrets:
+    # We need this volume name to be static or else it's prefixed by the docker compose project name
+    # which means we can't mount it inside the task-executor
+    name: task-executor-secrets
 
 services:
   postgres:
@@ -190,14 +194,33 @@ services:
 
       HASH_OPENSEARCH_ENABLED: "false"
 
-      HASH_TASK_EXECUTOR_HOST: "${HASH_TASK_EXECUTOR_HOST}"
-      HASH_TASK_EXECUTOR_PORT: "${HASH_TASK_EXECUTOR_PORT}"
+      HASH_TASK_EXECUTOR_HOST: "task-executor"
+      HASH_TASK_EXECUTOR_PORT: "5010"
 
       ORY_KRATOS_PUBLIC_URL: "http://kratos:4433"
       ORY_KRATOS_ADMIN_URL: "http://kratos:4434"
       KRATOS_API_KEY: "${KRATOS_API_KEY}"
     ports:
       - "5001:5001"
+
+  task-executor:
+    build:
+      context: ../../../
+      dockerfile: packages/hash/docker/task-executor/Dockerfile
+    deploy:
+      restart_policy:
+        condition: on-failure
+    environment:
+      FRONTEND_URL: "${FRONTEND_URL}"
+      HASH_TASK_EXECUTOR_HOST: "${HASH_TASK_EXECUTOR_HOST}"
+      HASH_TASK_EXECUTOR_PORT: "${HASH_TASK_EXECUTOR_PORT}"
+    volumes:
+      # Give the container access to the docker socket, so that it's able to create *sibling*
+      # containers (needed to be able to run Airbyte connector images)
+      - /var/run/docker.sock:/var/run/docker.sock:rw
+      - task-executor-secrets:/var/run/task-executor-secrets
+    ports:
+      - "5010:5010"
 
   hash-frontend:
     build:

--- a/packages/hash/task-executor/src/airbyte/executor.ts
+++ b/packages/hash/task-executor/src/airbyte/executor.ts
@@ -67,11 +67,11 @@ export class BaseExecutor implements AirbyteExecutor {
       "run",
       "--rm",
       "-v",
-      `${configPath}:/secrets/config.json`,
+      `task-executor-secrets:/var/run/task-executor-secrets`,
       this.imageName,
       "check",
       "--config",
-      "/secrets/config.json",
+      configPath,
     ]);
 
     const messages = parseMessageStream(response);
@@ -97,11 +97,11 @@ export class BaseExecutor implements AirbyteExecutor {
       "run",
       "--rm",
       "-v",
-      `${configPath}:/secrets/config.json`,
+      `task-executor-secrets:/var/run/task-executor-secrets`,
       this.imageName,
       "discover",
       "--config",
-      "/secrets/config.json",
+      configPath,
     ]);
 
     const messages = parseMessageStream(response);
@@ -134,15 +134,13 @@ export class BaseExecutor implements AirbyteExecutor {
       "run",
       "--rm",
       "-v",
-      `${configPath}:/secrets/config.json`,
-      "-v",
-      `${catalogPath}:/secrets/catalog.json`,
+      `task-executor-secrets:/var/run/task-executor-secrets`,
       this.imageName,
       "read",
       "--config",
-      "/secrets/config.json",
+      configPath,
       "--catalog",
-      "/secrets/catalog.json",
+      catalogPath,
     ];
 
     if (statePath) {

--- a/packages/hash/task-executor/src/airbyte/executor.ts
+++ b/packages/hash/task-executor/src/airbyte/executor.ts
@@ -40,7 +40,7 @@ export class BaseExecutor implements AirbyteExecutor {
   async runSpec(): Promise<ConnectorSpecification> {
     const response = await executeTask("docker", [
       "run",
-      "--rm",
+      // "--rm",
       this.imageName,
       "spec",
     ]);
@@ -65,7 +65,7 @@ export class BaseExecutor implements AirbyteExecutor {
 
     const response = await executeTask("docker", [
       "run",
-      "--rm",
+      // "--rm",
       "-v",
       `task-executor-secrets:/var/run/task-executor-secrets`,
       this.imageName,
@@ -95,7 +95,7 @@ export class BaseExecutor implements AirbyteExecutor {
 
     const response = await executeTask("docker", [
       "run",
-      "--rm",
+      // "--rm",
       "-v",
       `task-executor-secrets:/var/run/task-executor-secrets`,
       this.imageName,
@@ -132,7 +132,7 @@ export class BaseExecutor implements AirbyteExecutor {
 
     const args = [
       "run",
-      "--rm",
+      // "--rm",
       "-v",
       `task-executor-secrets:/var/run/task-executor-secrets`,
       this.imageName,

--- a/packages/hash/task-executor/src/airbyte/temp-io.ts
+++ b/packages/hash/task-executor/src/airbyte/temp-io.ts
@@ -1,12 +1,13 @@
 import { promises as fs } from "node:fs";
-import * as os from "node:os";
 import path from "node:path";
+
+const SECRETS_DIR = "/var/run/task-executor-secrets";
 
 export const writeToTempFile = async (
   fileName: string,
   fileContents: string,
 ): Promise<string> => {
-  const tmpDir = await fs.mkdtemp(`${os.tmpdir()}${path.sep}`);
+  const tmpDir = await fs.mkdtemp(`${SECRETS_DIR}${path.sep}`);
   const filePath = `${tmpDir}${path.sep}${fileName}`;
   await fs.writeFile(filePath, fileContents);
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The task-executor requires access to docker to run (it spawns Airbyte connector docker images). This meant it wouldn't work in our deployments because it would require docker within docker.

This PR updates the Dockerfile to work, and updates the prod deployment to contain the task-executor image, utilising the "Docker outside of Docker" approach ("[the socket solution](https://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/)").

## 🔗 Related links

- [Asana task](https://app.asana.com/0/0/1203663849889699/f) _(internal)_

## 🚫 Blocked by

N/A

## 🔍 What does this change?

See diff, should be small enough

## 📜 Does this require a change to the docs?

Not yet, the task-executor isn't stable enough for usage

## ⚠️ Known issues

- Docker compose prefixes volume names, so we have to use a static name for the volume which is considered bad practice. I have added a comment explaining this, perhaps there is a way around it but I do not know of one.
- The catalog is copied into the docker image, rather than being provided at runtime through GraphQL or something. This means you need to generate the right `catalog.json` _before_ running the production deployment, which is fairly annoying. Even in the short term, ideally the catalog will be something that's provided as part of the request, where users can select the streams they want, rather than a physical file.

## 🐾 Next steps

- Add Asana integration

## 🛡 What tests cover this?

None

## ❓ How to test this?

1.  Checkout the branch / view the deployment
1. Make a `task-executor/src/tasks/source-github/secrets` folder if you haven't already
1.  Follow the instructions for running the prod docker compose
  1. You can copy your `.env` file to your `.env.local` and run the following:
  3.  docker compose --file packages/hash/external-services/docker-compose.prod.yml --env-file .env.local up --build
1. Follow the instructions for running mutations outlined in the previous PR: #1771 

## 📹 Demo
<img width="701" alt="image" src="https://user-images.githubusercontent.com/25749103/211046826-2039bb55-fb74-4018-8102-f5bf780f3dae.png">

