### PR TITLE
Use version object on draft entity subgraph to prevent crash 

### DIFF
--- a/packages/hash/frontend/src/pages/[shortname]/entities/[entity-uuid].page/create-entity-page.tsx
+++ b/packages/hash/frontend/src/pages/[shortname]/entities/[entity-uuid].page/create-entity-page.tsx
@@ -80,6 +80,10 @@ export const CreateEntityPage = ({ entityTypeId }: CreateEntityPageProps) => {
                     entityTypeId,
                     provenance: { updatedById: "" },
                     archived: false,
+                    version: {
+                      decisionTime: { start: draftEntityVertexId.version },
+                      transactionTime: { start: draftEntityVertexId.version },
+                    },
                   },
                 },
               },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR fixes a bug caused app crashing when users try to update any value cell on new entity page (draft / not-published).

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch / view the deployment
1.  Create an entity draft
1.  Change a value cell
2. Confirm that app is not crashing
