### PR TITLE
Rename `Span` to `Interval`

### DIFF
--- a/packages/graph/clients/typescript/api.ts
+++ b/packages/graph/clients/typescript/api.ts
@@ -351,16 +351,16 @@ export interface DecisionTimeImage {
   axis: DecisionTime;
   /**
    *
-   * @type {TimespanBound}
+   * @type {TimeIntervalBound}
    * @memberof DecisionTimeImage
    */
-  end: TimespanBound;
+  end: TimeIntervalBound;
   /**
    *
-   * @type {TimespanBound}
+   * @type {TimeIntervalBound}
    * @memberof DecisionTimeImage
    */
-  start: TimespanBound;
+  start: TimeIntervalBound;
 }
 /**
  *
@@ -383,16 +383,16 @@ export interface DecisionTimeImageAllOf {
 export interface DecisionTimeImageAllOf1 {
   /**
    *
-   * @type {TimespanBound}
+   * @type {TimeIntervalBound}
    * @memberof DecisionTimeImageAllOf1
    */
-  end: TimespanBound;
+  end: TimeIntervalBound;
   /**
    *
-   * @type {TimespanBound}
+   * @type {TimeIntervalBound}
    * @memberof DecisionTimeImageAllOf1
    */
-  start: TimespanBound;
+  start: TimeIntervalBound;
 }
 /**
  *
@@ -802,16 +802,16 @@ export interface EntityTypeWithMetadata {
 export interface EntityVersion {
   /**
    *
-   * @type {VersionTimespan}
+   * @type {VersionInterval}
    * @memberof EntityVersion
    */
-  decisionTime: VersionTimespan;
+  decisionTime: VersionInterval;
   /**
    *
-   * @type {VersionTimespan}
+   * @type {VersionInterval}
    * @memberof EntityVersion
    */
-  transactionTime: VersionTimespan;
+  transactionTime: VersionInterval;
 }
 /**
  *
@@ -1914,65 +1914,67 @@ export interface Subgraph {
   vertices: Vertices;
 }
 /**
- * @type TimeProjection
+ * @type TimeIntervalBound
  * @export
  */
-export type TimeProjection = DecisionTimeProjection | TransactionTimeProjection;
-
-/**
- * @type TimespanBound
- * @export
- */
-export type TimespanBound = TimespanBoundOneOf | TimespanBoundOneOf1;
+export type TimeIntervalBound =
+  | TimeIntervalBoundOneOf
+  | TimeIntervalBoundOneOf1;
 
 /**
  *
  * @export
- * @interface TimespanBoundOneOf
+ * @interface TimeIntervalBoundOneOf
  */
-export interface TimespanBoundOneOf {
+export interface TimeIntervalBoundOneOf {
   /**
    *
    * @type {object}
-   * @memberof TimespanBoundOneOf
+   * @memberof TimeIntervalBoundOneOf
    */
-  bound: TimespanBoundOneOfBoundEnum;
+  bound: TimeIntervalBoundOneOfBoundEnum;
 }
 
-export const TimespanBoundOneOfBoundEnum = {
+export const TimeIntervalBoundOneOfBoundEnum = {
   Unbounded: "unbounded",
 } as const;
 
-export type TimespanBoundOneOfBoundEnum =
-  (typeof TimespanBoundOneOfBoundEnum)[keyof typeof TimespanBoundOneOfBoundEnum];
+export type TimeIntervalBoundOneOfBoundEnum =
+  (typeof TimeIntervalBoundOneOfBoundEnum)[keyof typeof TimeIntervalBoundOneOfBoundEnum];
 
 /**
  *
  * @export
- * @interface TimespanBoundOneOf1
+ * @interface TimeIntervalBoundOneOf1
  */
-export interface TimespanBoundOneOf1 {
+export interface TimeIntervalBoundOneOf1 {
   /**
    *
    * @type {object}
-   * @memberof TimespanBoundOneOf1
+   * @memberof TimeIntervalBoundOneOf1
    */
-  bound: TimespanBoundOneOf1BoundEnum;
+  bound: TimeIntervalBoundOneOf1BoundEnum;
   /**
    *
    * @type {string}
-   * @memberof TimespanBoundOneOf1
+   * @memberof TimeIntervalBoundOneOf1
    */
   timestamp: string;
 }
 
-export const TimespanBoundOneOf1BoundEnum = {
+export const TimeIntervalBoundOneOf1BoundEnum = {
   Included: "included",
   Excluded: "excluded",
 } as const;
 
-export type TimespanBoundOneOf1BoundEnum =
-  (typeof TimespanBoundOneOf1BoundEnum)[keyof typeof TimespanBoundOneOf1BoundEnum];
+export type TimeIntervalBoundOneOf1BoundEnum =
+  (typeof TimeIntervalBoundOneOf1BoundEnum)[keyof typeof TimeIntervalBoundOneOf1BoundEnum];
+
+/**
+ * @type TimeProjection
+ * @export
+ */
+export type TimeProjection = DecisionTimeProjection | TransactionTimeProjection;
 
 /**
  * Time axis for the transaction time.  This is used as the generic argument to time-related structs and can be used as tag value.
@@ -2001,16 +2003,16 @@ export interface TransactionTimeImage {
   axis: TransactionTime;
   /**
    *
-   * @type {TimespanBound}
+   * @type {TimeIntervalBound}
    * @memberof TransactionTimeImage
    */
-  end: TimespanBound;
+  end: TimeIntervalBound;
   /**
    *
-   * @type {TimespanBound}
+   * @type {TimeIntervalBound}
    * @memberof TransactionTimeImage
    */
-  start: TimespanBound;
+  start: TimeIntervalBound;
 }
 /**
  *
@@ -2077,16 +2079,16 @@ export interface UnresolvedDecisionTimeImage {
   axis: DecisionTime;
   /**
    *
-   * @type {TimespanBound}
+   * @type {TimeIntervalBound}
    * @memberof UnresolvedDecisionTimeImage
    */
-  end?: TimespanBound;
+  end?: TimeIntervalBound;
   /**
    *
-   * @type {TimespanBound}
+   * @type {TimeIntervalBound}
    * @memberof UnresolvedDecisionTimeImage
    */
-  start?: TimespanBound;
+  start?: TimeIntervalBound;
 }
 /**
  *
@@ -2096,16 +2098,16 @@ export interface UnresolvedDecisionTimeImage {
 export interface UnresolvedDecisionTimeImageAllOf {
   /**
    *
-   * @type {TimespanBound}
+   * @type {TimeIntervalBound}
    * @memberof UnresolvedDecisionTimeImageAllOf
    */
-  end?: TimespanBound;
+  end?: TimeIntervalBound;
   /**
    *
-   * @type {TimespanBound}
+   * @type {TimeIntervalBound}
    * @memberof UnresolvedDecisionTimeImageAllOf
    */
-  start?: TimespanBound;
+  start?: TimeIntervalBound;
 }
 /**
  *
@@ -2167,16 +2169,16 @@ export interface UnresolvedTransactionTimeImage {
   axis: TransactionTime;
   /**
    *
-   * @type {TimespanBound}
+   * @type {TimeIntervalBound}
    * @memberof UnresolvedTransactionTimeImage
    */
-  end?: TimespanBound;
+  end?: TimeIntervalBound;
   /**
    *
-   * @type {TimespanBound}
+   * @type {TimeIntervalBound}
    * @memberof UnresolvedTransactionTimeImage
    */
-  start?: TimespanBound;
+  start?: TimeIntervalBound;
 }
 /**
  *
@@ -2541,19 +2543,19 @@ export interface UpdatePropertyTypeRequest {
 /**
  *
  * @export
- * @interface VersionTimespan
+ * @interface VersionInterval
  */
-export interface VersionTimespan {
+export interface VersionInterval {
   /**
    *
    * @type {string}
-   * @memberof VersionTimespan
+   * @memberof VersionInterval
    */
   end?: string;
   /**
    *
    * @type {string}
-   * @memberof VersionTimespan
+   * @memberof VersionInterval
    */
   start: string;
 }

--- a/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/complete/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/complete/entity.rs
@@ -6,7 +6,7 @@ use graph::{
     identifier::{
         account::AccountId,
         time::{
-            TimespanBound, UnresolvedImage, UnresolvedKernel, UnresolvedProjection,
+            TimeIntervalBound, UnresolvedImage, UnresolvedKernel, UnresolvedProjection,
             UnresolvedTimeProjection,
         },
     },
@@ -166,8 +166,8 @@ pub fn bench_get_entity_by_id(
                     time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
                         kernel: UnresolvedKernel::new(None),
                         image: UnresolvedImage::new(
-                            Some(TimespanBound::Unbounded),
-                            Some(TimespanBound::Unbounded),
+                            Some(TimeIntervalBound::Unbounded),
+                            Some(TimeIntervalBound::Unbounded),
                         ),
                     }),
                 })

--- a/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/linkless/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/read_scaling/knowledge/linkless/entity.rs
@@ -6,7 +6,7 @@ use graph::{
     identifier::{
         account::AccountId,
         time::{
-            TimespanBound, UnresolvedImage, UnresolvedKernel, UnresolvedProjection,
+            TimeIntervalBound, UnresolvedImage, UnresolvedKernel, UnresolvedProjection,
             UnresolvedTimeProjection,
         },
     },
@@ -120,8 +120,8 @@ pub fn bench_get_entity_by_id(
                     time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
                         kernel: UnresolvedKernel::new(None),
                         image: UnresolvedImage::new(
-                            Some(TimespanBound::Unbounded),
-                            Some(TimespanBound::Unbounded),
+                            Some(TimeIntervalBound::Unbounded),
+                            Some(TimeIntervalBound::Unbounded),
                         ),
                     }),
                 })

--- a/packages/graph/hash_graph/bench/benches/representative_read/knowledge/entity.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/knowledge/entity.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use criterion::{BatchSize::SmallInput, Bencher};
 use graph::{
     identifier::time::{
-        TimespanBound, UnresolvedImage, UnresolvedKernel, UnresolvedProjection,
+        TimeIntervalBound, UnresolvedImage, UnresolvedKernel, UnresolvedProjection,
         UnresolvedTimeProjection,
     },
     knowledge::{EntityQueryPath, EntityUuid},
@@ -53,8 +53,8 @@ pub fn bench_get_entity_by_id(
                     time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
                         kernel: UnresolvedKernel::new(None),
                         image: UnresolvedImage::new(
-                            Some(TimespanBound::Unbounded),
-                            Some(TimespanBound::Unbounded),
+                            Some(TimeIntervalBound::Unbounded),
+                            Some(TimeIntervalBound::Unbounded),
                         ),
                     }),
                 })
@@ -87,8 +87,8 @@ pub fn bench_get_entities_by_property(
                 time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
                     kernel: UnresolvedKernel::new(None),
                     image: UnresolvedImage::new(
-                        Some(TimespanBound::Unbounded),
-                        Some(TimespanBound::Unbounded),
+                        Some(TimeIntervalBound::Unbounded),
+                        Some(TimeIntervalBound::Unbounded),
                     ),
                 }),
             })
@@ -121,8 +121,8 @@ pub fn bench_get_link_by_target_by_property(
                 time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
                     kernel: UnresolvedKernel::new(None),
                     image: UnresolvedImage::new(
-                        Some(TimespanBound::Unbounded),
-                        Some(TimespanBound::Unbounded),
+                        Some(TimeIntervalBound::Unbounded),
+                        Some(TimeIntervalBound::Unbounded),
                     ),
                 }),
             })

--- a/packages/graph/hash_graph/bench/benches/representative_read/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/bench/benches/representative_read/ontology/entity_type.rs
@@ -1,7 +1,7 @@
 use criterion::{BatchSize::SmallInput, Bencher};
 use graph::{
     identifier::time::{
-        TimespanBound, UnresolvedImage, UnresolvedKernel, UnresolvedProjection,
+        TimeIntervalBound, UnresolvedImage, UnresolvedKernel, UnresolvedProjection,
         UnresolvedTimeProjection,
     },
     store::{query::Filter, EntityTypeStore},
@@ -35,8 +35,8 @@ pub fn bench_get_entity_type_by_id(
                     time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
                         kernel: UnresolvedKernel::new(None),
                         image: UnresolvedImage::new(
-                            Some(TimespanBound::Unbounded),
-                            Some(TimespanBound::Unbounded),
+                            Some(TimeIntervalBound::Unbounded),
+                            Some(TimeIntervalBound::Unbounded),
                         ),
                     }),
                 })

--- a/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/api/rest/mod.rs
@@ -45,11 +45,11 @@ use crate::{
         ontology::OntologyTypeEditionId,
         time::{
             DecisionTime, DecisionTimeImage, DecisionTimeKernel, DecisionTimeProjection,
-            TimeProjection, TimespanBound, Timestamp, TransactionTime, TransactionTimeImage,
+            TimeIntervalBound, TimeProjection, Timestamp, TransactionTime, TransactionTimeImage,
             TransactionTimeKernel, TransactionTimeProjection, UnresolvedDecisionTimeImage,
             UnresolvedDecisionTimeKernel, UnresolvedDecisionTimeProjection,
             UnresolvedTimeProjection, UnresolvedTransactionTimeImage,
-            UnresolvedTransactionTimeKernel, UnresolvedTransactionTimeProjection, VersionTimespan,
+            UnresolvedTransactionTimeKernel, UnresolvedTransactionTimeProjection, VersionInterval,
         },
         EntityVertexId, GraphElementId, GraphElementVertexId,
     },
@@ -463,12 +463,12 @@ impl Modify for TimeSchemaAddon {
                 .schemas
                 .insert("Timestamp".to_owned(), Timestamp::<()>::schema().into());
             components.schemas.insert(
-                "VersionTimespan".to_owned(),
-                VersionTimespan::<()>::schema().into(),
+                "VersionInterval".to_owned(),
+                VersionInterval::<()>::schema().into(),
             );
             components.schemas.insert(
-                "TimespanBound".to_owned(),
-                TimespanBound::<()>::schema().into(),
+                "TimeIntervalBound".to_owned(),
+                TimeIntervalBound::<()>::schema().into(),
             );
         }
     }

--- a/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
+++ b/packages/graph/hash_graph/lib/graph/src/knowledge/entity/query.rs
@@ -287,7 +287,7 @@ impl QueryPath for EntityQueryPath<'_> {
             | Self::RightEntity(path)
             | Self::IncomingLinks(path)
             | Self::OutgoingLinks(path) => path.expected_type(),
-            Self::DecisionTime | Self::TransactionTime => ParameterType::Timespan,
+            Self::DecisionTime | Self::TransactionTime => ParameterType::TimeInterval,
             Self::ProjectedTime => ParameterType::Timestamp,
             Self::Type(path) => path.expected_type(),
             Self::Properties(_) => ParameterType::Any,

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/knowledge.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/knowledge.rs
@@ -10,7 +10,7 @@ use utoipa::{openapi, ToSchema};
 use crate::{
     identifier::{
         account::AccountId,
-        time::{DecisionTime, TransactionTime, VersionTimespan},
+        time::{DecisionTime, TransactionTime, VersionInterval},
         EntityVertexId,
     },
     knowledge::{Entity, EntityUuid},
@@ -90,8 +90,8 @@ impl ToSchema for EntityId {
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EntityVersion {
-    decision_time: VersionTimespan<DecisionTime>,
-    transaction_time: VersionTimespan<TransactionTime>,
+    decision_time: VersionInterval<DecisionTime>,
+    transaction_time: VersionInterval<TransactionTime>,
 }
 
 impl ToSchema for EntityVersion {
@@ -99,12 +99,12 @@ impl ToSchema for EntityVersion {
         openapi::ObjectBuilder::new()
             .property(
                 "decisionTime",
-                openapi::Ref::from_schema_name("VersionTimespan"),
+                openapi::Ref::from_schema_name("VersionInterval"),
             )
             .required("decisionTime")
             .property(
                 "transactionTime",
-                openapi::Ref::from_schema_name("VersionTimespan"),
+                openapi::Ref::from_schema_name("VersionInterval"),
             )
             .required("transactionTime")
             .build()
@@ -115,8 +115,8 @@ impl ToSchema for EntityVersion {
 impl EntityVersion {
     #[must_use]
     pub const fn new(
-        decision_time: VersionTimespan<DecisionTime>,
-        transaction_time: VersionTimespan<TransactionTime>,
+        decision_time: VersionInterval<DecisionTime>,
+        transaction_time: VersionInterval<TransactionTime>,
     ) -> Self {
         Self {
             decision_time,
@@ -125,12 +125,12 @@ impl EntityVersion {
     }
 
     #[must_use]
-    pub const fn decision_time(&self) -> VersionTimespan<DecisionTime> {
+    pub const fn decision_time(&self) -> VersionInterval<DecisionTime> {
         self.decision_time
     }
 
     #[must_use]
-    pub const fn transaction_time(&self) -> VersionTimespan<TransactionTime> {
+    pub const fn transaction_time(&self) -> VersionInterval<TransactionTime> {
         self.transaction_time
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/interval.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/interval.rs
@@ -23,24 +23,24 @@ use crate::identifier::time::Timestamp;
     tag = "bound",
     content = "timestamp"
 )]
-pub enum TimespanBound<A> {
+pub enum TimeIntervalBound<A> {
     Unbounded,
     Included(Timestamp<A>),
     Excluded(Timestamp<A>),
 }
 
-impl<A> TimespanBound<A> {
+impl<A> TimeIntervalBound<A> {
     #[must_use]
-    pub const fn cast<B>(&self) -> TimespanBound<B> {
+    pub const fn cast<B>(&self) -> TimeIntervalBound<B> {
         match self {
-            Self::Unbounded => TimespanBound::Unbounded,
-            Self::Included(timestamp) => TimespanBound::Included(timestamp.cast()),
-            Self::Excluded(timestamp) => TimespanBound::Excluded(timestamp.cast()),
+            Self::Unbounded => TimeIntervalBound::Unbounded,
+            Self::Included(timestamp) => TimeIntervalBound::Included(timestamp.cast()),
+            Self::Excluded(timestamp) => TimeIntervalBound::Excluded(timestamp.cast()),
         }
     }
 }
 
-impl<A> From<Bound<Timestamp<A>>> for TimespanBound<A> {
+impl<A> From<Bound<Timestamp<A>>> for TimeIntervalBound<A> {
     fn from(bound: Bound<Timestamp<A>>) -> Self {
         match bound {
             Bound::Included(timestamp) => Self::Included(timestamp),
@@ -50,17 +50,17 @@ impl<A> From<Bound<Timestamp<A>>> for TimespanBound<A> {
     }
 }
 
-impl<A> From<TimespanBound<A>> for Bound<Timestamp<A>> {
-    fn from(bound: TimespanBound<A>) -> Self {
+impl<A> From<TimeIntervalBound<A>> for Bound<Timestamp<A>> {
+    fn from(bound: TimeIntervalBound<A>) -> Self {
         match bound {
-            TimespanBound::Included(timestamp) => Self::Included(timestamp),
-            TimespanBound::Excluded(timestamp) => Self::Excluded(timestamp),
-            TimespanBound::Unbounded => Self::Unbounded,
+            TimeIntervalBound::Included(timestamp) => Self::Included(timestamp),
+            TimeIntervalBound::Excluded(timestamp) => Self::Excluded(timestamp),
+            TimeIntervalBound::Unbounded => Self::Unbounded,
         }
     }
 }
 
-impl<A> LowerBound<Timestamp<A>> for TimespanBound<A> {
+impl<A> LowerBound<Timestamp<A>> for TimeIntervalBound<A> {
     fn as_bound(&self) -> Bound<&Timestamp<A>> {
         match self {
             Self::Unbounded => Bound::Unbounded,
@@ -78,7 +78,7 @@ impl<A> LowerBound<Timestamp<A>> for TimespanBound<A> {
     }
 }
 
-impl<A> UpperBound<Timestamp<A>> for TimespanBound<A> {
+impl<A> UpperBound<Timestamp<A>> for TimeIntervalBound<A> {
     fn as_bound(&self) -> Bound<&Timestamp<A>> {
         match self {
             Self::Unbounded => Bound::Unbounded,
@@ -96,7 +96,7 @@ impl<A> UpperBound<Timestamp<A>> for TimespanBound<A> {
     }
 }
 
-impl<A> ToSchema for TimespanBound<A> {
+impl<A> ToSchema for TimeIntervalBound<A> {
     fn schema() -> openapi::Schema {
         openapi::OneOfBuilder::new()
             .item(
@@ -131,9 +131,9 @@ impl<A> ToSchema for TimespanBound<A> {
     Hash(bound = "")
 )]
 #[serde(rename_all = "camelCase", bound = "", deny_unknown_fields)]
-pub struct UnresolvedTimespan<A> {
-    pub start: Option<TimespanBound<A>>,
-    pub end: Option<TimespanBound<A>>,
+pub struct UnresolvedTimeInterval<A> {
+    pub start: Option<TimeIntervalBound<A>>,
+    pub end: Option<TimeIntervalBound<A>>,
 }
 
 #[derive(Derivative, Serialize, Deserialize, ToSchema)]
@@ -145,15 +145,15 @@ pub struct UnresolvedTimespan<A> {
     Hash(bound = "")
 )]
 #[serde(rename_all = "camelCase", bound = "", deny_unknown_fields)]
-pub struct Timespan<A> {
-    pub start: TimespanBound<A>,
-    pub end: TimespanBound<A>,
+pub struct TimeInterval<A> {
+    pub start: TimeIntervalBound<A>,
+    pub end: TimeIntervalBound<A>,
 }
 
-impl<A> Timespan<A> {
+impl<A> TimeInterval<A> {
     #[must_use]
-    pub const fn cast<B>(&self) -> Timespan<B> {
-        Timespan {
+    pub const fn cast<B>(&self) -> TimeInterval<B> {
+        TimeInterval {
             start: self.start.cast(),
             end: self.end.cast(),
         }
@@ -165,9 +165,9 @@ impl<A> Timespan<A> {
     }
 }
 
-impl<A> Interval<Timestamp<A>> for Timespan<A> {
-    type LowerBound = TimespanBound<A>;
-    type UpperBound = TimespanBound<A>;
+impl<A> Interval<Timestamp<A>> for TimeInterval<A> {
+    type LowerBound = TimeIntervalBound<A>;
+    type UpperBound = TimeIntervalBound<A>;
 
     fn from_bounds(lower: Self::LowerBound, upper: Self::UpperBound) -> Self
     where
@@ -192,7 +192,7 @@ impl<A> Interval<Timestamp<A>> for Timespan<A> {
     }
 }
 
-impl<A> ToSql for Timespan<A> {
+impl<A> ToSql for TimeInterval<A> {
     postgres_types::accepts!(TSTZ_RANGE);
 
     postgres_types::to_sql_checked!();
@@ -203,16 +203,16 @@ impl<A> ToSql for Timespan<A> {
         buf: &mut BytesMut,
     ) -> Result<postgres_types::IsNull, Box<dyn Error + Sync + Send>> {
         fn bound_to_sql<A>(
-            bound: TimespanBound<A>,
+            bound: TimeIntervalBound<A>,
             buf: &mut BytesMut,
         ) -> Result<RangeBound<postgres_protocol::IsNull>, Box<dyn Error + Sync + Send>> {
             Ok(match bound {
-                TimespanBound::Unbounded => RangeBound::Unbounded,
-                TimespanBound::Included(timestamp) => {
+                TimeIntervalBound::Unbounded => RangeBound::Unbounded,
+                TimeIntervalBound::Included(timestamp) => {
                     timestamp.to_sql(&postgres_types::Type::TIMESTAMPTZ, buf)?;
                     RangeBound::Inclusive(postgres_protocol::IsNull::No)
                 }
-                TimespanBound::Excluded(timestamp) => {
+                TimeIntervalBound::Excluded(timestamp) => {
                     timestamp.to_sql(&postgres_types::Type::TIMESTAMPTZ, buf)?;
                     RangeBound::Exclusive(postgres_protocol::IsNull::No)
                 }

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/mod.rs
@@ -1,11 +1,12 @@
 mod axis;
+mod interval;
 mod projection;
-mod timespan;
 mod timestamp;
 mod version;
 
 pub use self::{
     axis::{DecisionTime, ProjectedTime, TimeAxis, TransactionTime},
+    interval::{TimeInterval, TimeIntervalBound, UnresolvedTimeInterval},
     projection::{
         DecisionTimeImage, DecisionTimeKernel, DecisionTimeProjection, Image, Kernel,
         TimeProjection, TransactionTimeImage, TransactionTimeKernel, TransactionTimeProjection,
@@ -14,7 +15,6 @@ pub use self::{
         UnresolvedTimeProjection, UnresolvedTransactionTimeImage, UnresolvedTransactionTimeKernel,
         UnresolvedTransactionTimeProjection,
     },
-    timespan::{Timespan, TimespanBound, UnresolvedTimespan},
     timestamp::Timestamp,
-    version::VersionTimespan,
+    version::VersionInterval,
 };

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/projection.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/projection.rs
@@ -2,8 +2,8 @@ use serde::{Deserialize, Serialize};
 use utoipa::{openapi, ToSchema};
 
 use crate::identifier::time::{
-    DecisionTime, ProjectedTime, TimeAxis, Timespan, TimespanBound, Timestamp, TransactionTime,
-    UnresolvedTimespan,
+    DecisionTime, ProjectedTime, TimeAxis, TimeInterval, TimeIntervalBound, Timestamp,
+    TransactionTime, UnresolvedTimeInterval,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -54,15 +54,15 @@ impl ToSchema for UnresolvedTransactionTimeKernel {
 pub struct UnresolvedImage<A> {
     pub axis: A,
     #[serde(flatten)]
-    pub span: UnresolvedTimespan<A>,
+    pub interval: UnresolvedTimeInterval<A>,
 }
 
 impl<A: Default> UnresolvedImage<A> {
     #[must_use]
-    pub fn new(start: Option<TimespanBound<A>>, end: Option<TimespanBound<A>>) -> Self {
+    pub fn new(start: Option<TimeIntervalBound<A>>, end: Option<TimeIntervalBound<A>>) -> Self {
         Self {
             axis: A::default(),
-            span: UnresolvedTimespan { start, end },
+            interval: UnresolvedTimeInterval { start, end },
         }
     }
 }
@@ -77,7 +77,7 @@ impl ToSchema for UnresolvedDecisionTimeImage {
                     .property("axis", openapi::Ref::from_schema_name("DecisionTime"))
                     .required("axis"),
             )
-            .item(UnresolvedTimespan::<DecisionTime>::schema())
+            .item(UnresolvedTimeInterval::<DecisionTime>::schema())
             .build()
             .into()
     }
@@ -93,7 +93,7 @@ impl ToSchema for UnresolvedTransactionTimeImage {
                     .property("axis", openapi::Ref::from_schema_name("TransactionTime"))
                     .required("axis"),
             )
-            .item(UnresolvedTimespan::<DecisionTime>::schema())
+            .item(UnresolvedTimeInterval::<DecisionTime>::schema())
             .build()
             .into()
     }
@@ -119,17 +119,13 @@ impl<K, I> UnresolvedProjection<K, I> {
             },
             image: Image {
                 axis: self.image.axis,
-                span: Timespan {
-                    start: self
-                        .image
-                        .span
-                        .start
-                        .unwrap_or_else(|| TimespanBound::Included(Timestamp::from_anonymous(now))),
-                    end: self
-                        .image
-                        .span
-                        .end
-                        .unwrap_or_else(|| TimespanBound::Included(Timestamp::from_anonymous(now))),
+                interval: TimeInterval {
+                    start: self.image.interval.start.unwrap_or_else(|| {
+                        TimeIntervalBound::Included(Timestamp::from_anonymous(now))
+                    }),
+                    end: self.image.interval.end.unwrap_or_else(|| {
+                        TimeIntervalBound::Included(Timestamp::from_anonymous(now))
+                    }),
                 },
             },
         }
@@ -186,8 +182,8 @@ impl Default for UnresolvedTimeProjection {
         Self::DecisionTime(UnresolvedProjection {
             kernel: UnresolvedKernel::new(None),
             image: UnresolvedImage::new(
-                Some(TimespanBound::Unbounded),
-                Some(TimespanBound::Unbounded),
+                Some(TimeIntervalBound::Unbounded),
+                Some(TimeIntervalBound::Unbounded),
             ),
         })
     }
@@ -264,7 +260,7 @@ impl ToSchema for TransactionTimeKernel {
 pub struct Image<A> {
     pub axis: A,
     #[serde(flatten)]
-    pub span: Timespan<A>,
+    pub interval: TimeInterval<A>,
 }
 
 pub type DecisionTimeImage = Image<DecisionTime>;
@@ -277,7 +273,7 @@ impl ToSchema for DecisionTimeImage {
                     .property("axis", openapi::Ref::from_schema_name("DecisionTime"))
                     .required("axis"),
             )
-            .item(Timespan::<DecisionTime>::schema())
+            .item(TimeInterval::<DecisionTime>::schema())
             .build()
             .into()
     }
@@ -293,7 +289,7 @@ impl ToSchema for TransactionTimeImage {
                     .property("axis", openapi::Ref::from_schema_name("TransactionTime"))
                     .required("axis"),
             )
-            .item(Timespan::<DecisionTime>::schema())
+            .item(TimeInterval::<DecisionTime>::schema())
             .build()
             .into()
     }
@@ -387,10 +383,10 @@ impl TimeProjection {
     }
 
     #[must_use]
-    pub const fn image(&self) -> Timespan<ProjectedTime> {
+    pub const fn image(&self) -> TimeInterval<ProjectedTime> {
         match self {
-            Self::DecisionTime(projection) => projection.image.span.cast(),
-            Self::TransactionTime(projection) => projection.image.span.cast(),
+            Self::DecisionTime(projection) => projection.image.interval.cast(),
+            Self::TransactionTime(projection) => projection.image.interval.cast(),
         }
     }
 }

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/projection.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/projection.rs
@@ -346,9 +346,9 @@ impl ToSchema for TransactionTimeProjection {
 ///
 /// In order to query data from the Graph, only one of the two time axes can be used. This is
 /// achieved by using a `TimeProjection`. The `TimeProjection` pins one axis to a specified
-/// [`Timestamp`], while the other axis can be a [`Timespan`]. The pinned axis is called the
+/// [`Timestamp`], while the other axis can be a [`TimeInterval`]. The pinned axis is called the
 /// [`Kernel`] and the other axis is called the [`Image`] of a projection. The returned data will
-/// then only contain temporal data that is contained in the [`Timespan`] of the [`Image`], the
+/// then only contain temporal data that is contained in the [`TimeInterval`] of the [`Image`], the
 /// [`ProjectedTime`], for the given [`Timestamp`] of the [`Kernel`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/version.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/version.rs
@@ -9,12 +9,12 @@ use utoipa::ToSchema;
 use crate::identifier::time::timestamp::Timestamp;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
-pub struct VersionTimespan<A> {
+pub struct VersionInterval<A> {
     pub start: Timestamp<A>,
     pub end: Option<Timestamp<A>>,
 }
 
-impl<A> Interval<Timestamp<A>> for VersionTimespan<A> {
+impl<A> Interval<Timestamp<A>> for VersionInterval<A> {
     type LowerBound = Timestamp<A>;
     type UpperBound = Option<Timestamp<A>>;
 
@@ -45,9 +45,9 @@ impl<A> Interval<Timestamp<A>> for VersionTimespan<A> {
     }
 }
 
-impl<A> VersionTimespan<A> {
+impl<A> VersionInterval<A> {
     #[must_use]
-    pub fn from_anonymous(interval: VersionTimespan<()>) -> Self {
+    pub fn from_anonymous(interval: VersionInterval<()>) -> Self {
         Self {
             start: Timestamp::from_anonymous(interval.start),
             end: interval.end.map(Timestamp::from_anonymous),
@@ -60,7 +60,7 @@ impl<A> VersionTimespan<A> {
     }
 }
 
-impl<A> RangeBounds<Timestamp<A>> for VersionTimespan<A> {
+impl<A> RangeBounds<Timestamp<A>> for VersionInterval<A> {
     fn start_bound(&self) -> Bound<&Timestamp<A>> {
         LowerBound::as_bound(&self.start)
     }
@@ -103,7 +103,7 @@ fn parse_bound(
     }
 }
 
-impl FromSql<'_> for VersionTimespan<()> {
+impl FromSql<'_> for VersionInterval<()> {
     fn from_sql(_: &Type, buf: &[u8]) -> Result<Self, Box<dyn Error + Send + Sync>> {
         match postgres_protocol::types::range_from_sql(buf)? {
             postgres_protocol::types::Range::Empty => {

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     identifier::{
         knowledge::{EntityEditionId, EntityId, EntityRecordId, EntityVersion},
         ontology::OntologyTypeEditionId,
-        time::{DecisionTime, Timestamp, VersionTimespan},
+        time::{DecisionTime, Timestamp, VersionInterval},
         EntityVertexId,
     },
     knowledge::{Entity, EntityLinkOrder, EntityMetadata, EntityProperties, EntityUuid, LinkData},
@@ -339,8 +339,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         Ok(EntityMetadata::new(
             EntityEditionId::new(entity_id, EntityRecordId::new(row.get(0))),
             EntityVersion::new(
-                VersionTimespan::from_anonymous(row.get(1)),
-                VersionTimespan::from_anonymous(row.get(2)),
+                VersionInterval::from_anonymous(row.get(1)),
+                VersionInterval::from_anonymous(row.get(2)),
             ),
             entity_type_id,
             ProvenanceMetadata::new(updated_by_id),
@@ -565,8 +565,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         Ok(EntityMetadata::new(
             EntityEditionId::new(entity_id, EntityRecordId::new(row.get(0))),
             EntityVersion::new(
-                VersionTimespan::from_anonymous(row.get(1)),
-                VersionTimespan::from_anonymous(row.get(2)),
+                VersionInterval::from_anonymous(row.get(1)),
+                VersionInterval::from_anonymous(row.get(2)),
             ),
             entity_type_id,
             ProvenanceMetadata::new(updated_by_id),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -11,7 +11,7 @@ use crate::{
     identifier::{
         account::AccountId,
         knowledge::{EntityEditionId, EntityId, EntityRecordId, EntityVersion},
-        time::{TimeProjection, VersionTimespan},
+        time::{TimeProjection, VersionInterval},
     },
     knowledge::{Entity, EntityProperties, EntityQueryPath, EntityUuid, LinkData},
     ontology::EntityTypeQueryPath,
@@ -140,8 +140,8 @@ impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
                         EntityRecordId::new(row.get(record_id_index)),
                     ),
                     EntityVersion::new(
-                        VersionTimespan::from_anonymous(row.get(decision_time_index)),
-                        VersionTimespan::from_anonymous(row.get(transaction_time_index)),
+                        VersionInterval::from_anonymous(row.get(decision_time_index)),
+                        VersionInterval::from_anonymous(row.get(transaction_time_index)),
                     ),
                     entity_type_uri,
                     ProvenanceMetadata::new(updated_by_id),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -44,7 +44,7 @@ use crate::{
 use crate::{
     identifier::{
         knowledge::{EntityId, EntityRecordId, EntityVersion},
-        time::{DecisionTime, Timestamp, VersionTimespan},
+        time::{DecisionTime, Timestamp, VersionInterval},
     },
     knowledge::{EntityProperties, LinkOrder},
 };
@@ -935,8 +935,8 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
             .into_iter()
             .map(|row| {
                 EntityVersion::new(
-                    VersionTimespan::from_anonymous(row.get(0)),
-                    VersionTimespan::from_anonymous(row.get(1)),
+                    VersionInterval::from_anonymous(row.get(0)),
+                    VersionInterval::from_anonymous(row.get(1)),
                 )
             })
             .collect();

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
@@ -87,11 +87,11 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
             match self.time_projection {
                 TimeProjection::DecisionTime(projection) => {
                     self.artifacts.parameters.push(&projection.kernel.timestamp);
-                    self.artifacts.parameters.push(&projection.image.span);
+                    self.artifacts.parameters.push(&projection.image.interval);
                 }
                 TimeProjection::TransactionTime(projection) => {
                     self.artifacts.parameters.push(&projection.kernel.timestamp);
-                    self.artifacts.parameters.push(&projection.image.span);
+                    self.artifacts.parameters.push(&projection.image.interval);
                 }
             };
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/compile.rs
@@ -105,9 +105,8 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
         if !temporal_table_info.tables.contains(&table) {
             // Adds the kernel timestamp condition, so for the projected decision time, we use the
             // transaction time and vice versa.
-            self.statement
-                .where_expression
-                .add_condition(Condition::TimerangeContainsTimestamp(
+            self.statement.where_expression.add_condition(
+                Condition::TimeIntervalContainsTimestamp(
                     Expression::Column(
                         Column::Entities(Entities::from_time_axis(
                             self.time_projection.kernel_time_axis(),
@@ -115,8 +114,8 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
                         .aliased(alias),
                     ),
                     Expression::Parameter(temporal_table_info.kernel_index),
-                ));
-
+                ),
+            );
             self.statement
                 .where_expression
                 .add_condition(Condition::Overlap(
@@ -290,7 +289,7 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
         self.pin_entity_table(alias);
         // Adds the image timestamp condition, so we use the same time axis as specified in the
         // projection.
-        let condition = Condition::TimerangeContainsTimestamp(
+        let condition = Condition::TimeIntervalContainsTimestamp(
             Expression::Column(
                 Column::Entities(Entities::from_time_axis(
                     self.time_projection.image_time_axis(),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/condition.rs
@@ -12,7 +12,7 @@ pub enum Condition<'p> {
     Not(Box<Self>),
     Equal(Option<Expression<'p>>, Option<Expression<'p>>),
     NotEqual(Option<Expression<'p>>, Option<Expression<'p>>),
-    TimerangeContainsTimestamp(Expression<'p>, Expression<'p>),
+    TimeIntervalContainsTimestamp(Expression<'p>, Expression<'p>),
     Overlap(Expression<'p>, Expression<'p>),
 }
 
@@ -78,7 +78,7 @@ impl Transpile for Condition<'_> {
                 fmt.write_str(" != ")?;
                 rhs.transpile(fmt)
             }
-            Condition::TimerangeContainsTimestamp(lhs, rhs) => {
+            Condition::TimeIntervalContainsTimestamp(lhs, rhs) => {
                 lhs.transpile(fmt)?;
                 fmt.write_str(" @> ")?;
                 rhs.transpile(fmt)?;

--- a/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/query/mod.rs
@@ -21,7 +21,7 @@ pub enum ParameterType {
     // TODO: Reevaluate if we need this after https://app.asana.com/0/0/1203491211535116/f
     Timestamp,
     // TODO: Reevaluate if we need this after https://app.asana.com/0/0/1203491211535116/f
-    Timespan,
+    TimeInterval,
     Any,
 }
 
@@ -36,7 +36,7 @@ impl fmt::Display for ParameterType {
             Self::BaseUri => fmt.write_str("base URI"),
             Self::VersionedUri => fmt.write_str("versioned URI"),
             Self::Timestamp => fmt.write_str("timestamp"),
-            Self::Timespan => fmt.write_str("timespan"),
+            Self::TimeInterval => fmt.write_str("time interval"),
             Self::Any => fmt.write_str("any"),
         }
     }

--- a/packages/graph/hash_graph/tests/integration/postgres/mod.rs
+++ b/packages/graph/hash_graph/tests/integration/postgres/mod.rs
@@ -13,7 +13,7 @@ use graph::{
         knowledge::EntityId,
         ontology::OntologyTypeEditionId,
         time::{
-            TimespanBound, Timestamp, TransactionTime, UnresolvedImage, UnresolvedKernel,
+            TimeIntervalBound, Timestamp, TransactionTime, UnresolvedImage, UnresolvedKernel,
             UnresolvedProjection, UnresolvedTimeProjection,
         },
         EntityVertexId, GraphElementVertexId,
@@ -172,8 +172,8 @@ impl DatabaseApi<'_> {
                 time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
                     kernel: UnresolvedKernel::new(None),
                     image: UnresolvedImage::new(
-                        Some(TimespanBound::Unbounded),
-                        Some(TimespanBound::Unbounded),
+                        Some(TimeIntervalBound::Unbounded),
+                        Some(TimeIntervalBound::Unbounded),
                     ),
                 }),
             })
@@ -218,8 +218,8 @@ impl DatabaseApi<'_> {
                 time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
                     kernel: UnresolvedKernel::new(None),
                     image: UnresolvedImage::new(
-                        Some(TimespanBound::Unbounded),
-                        Some(TimespanBound::Unbounded),
+                        Some(TimeIntervalBound::Unbounded),
+                        Some(TimeIntervalBound::Unbounded),
                     ),
                 }),
             })
@@ -264,8 +264,8 @@ impl DatabaseApi<'_> {
                 time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
                     kernel: UnresolvedKernel::new(None),
                     image: UnresolvedImage::new(
-                        Some(TimespanBound::Unbounded),
-                        Some(TimespanBound::Unbounded),
+                        Some(TimeIntervalBound::Unbounded),
+                        Some(TimeIntervalBound::Unbounded),
                     ),
                 }),
             })
@@ -319,8 +319,8 @@ impl DatabaseApi<'_> {
                 time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
                     kernel: UnresolvedKernel::new(None),
                     image: UnresolvedImage::new(
-                        Some(TimespanBound::Unbounded),
-                        Some(TimespanBound::Unbounded),
+                        Some(TimeIntervalBound::Unbounded),
+                        Some(TimeIntervalBound::Unbounded),
                     ),
                 }),
             })
@@ -421,8 +421,8 @@ impl DatabaseApi<'_> {
                 time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
                     kernel: UnresolvedKernel::new(None),
                     image: UnresolvedImage::new(
-                        Some(TimespanBound::Unbounded),
-                        Some(TimespanBound::Unbounded),
+                        Some(TimeIntervalBound::Unbounded),
+                        Some(TimeIntervalBound::Unbounded),
                     ),
                 }),
             })
@@ -486,8 +486,8 @@ impl DatabaseApi<'_> {
                 time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
                     kernel: UnresolvedKernel::new(None),
                     image: UnresolvedImage::new(
-                        Some(TimespanBound::Unbounded),
-                        Some(TimespanBound::Unbounded),
+                        Some(TimeIntervalBound::Unbounded),
+                        Some(TimeIntervalBound::Unbounded),
                     ),
                 }),
             })

--- a/packages/hash/subgraph/src/types/identifier.ts
+++ b/packages/hash/subgraph/src/types/identifier.ts
@@ -35,14 +35,14 @@ export const extractEntityUuidFromEntityId = (entityId: EntityId): string => {
 /** @todo - consider Type Branding this */
 export type Timestamp = string;
 
-export type VersionTimespan = {
+export type VersionInterval = {
   start: Timestamp;
   end?: Timestamp;
 };
 
 export type EntityVersion = {
-  decisionTime: VersionTimespan;
-  transactionTime: VersionTimespan;
+  decisionTime: VersionInterval;
+  transactionTime: VersionInterval;
 };
 
 export type EntityRecordId = number;

--- a/packages/hash/subgraph/src/types/time.ts
+++ b/packages/hash/subgraph/src/types/time.ts
@@ -1,6 +1,6 @@
 import { Timestamp } from "./identifier";
 
-export type TimespanBound =
+export type TimeIntervalBound =
   | {
       bound: "unbounded";
     }
@@ -16,8 +16,8 @@ export type DecisionTimeProjection = {
   };
   image: {
     axis: "decision";
-    start?: TimespanBound;
-    end?: TimespanBound;
+    start?: TimeIntervalBound;
+    end?: TimeIntervalBound;
   };
 };
 
@@ -28,8 +28,8 @@ export type TransactionTimeProjection = {
   };
   image: {
     axis: "transaction";
-    start?: TimespanBound;
-    end?: TimespanBound;
+    start?: TimeIntervalBound;
+    end?: TimeIntervalBound;
   };
 };
 
@@ -42,8 +42,8 @@ export type ResolvedDecisionTimeProjection = {
   };
   image: {
     axis: "decision";
-    start: TimespanBound;
-    end: TimespanBound;
+    start: TimeIntervalBound;
+    end: TimeIntervalBound;
   };
 };
 
@@ -54,8 +54,8 @@ export type ResolvedTransactionTimeProjection = {
   };
   image: {
     axis: "transaction";
-    start: TimespanBound;
-    end: TimespanBound;
+    start: TimeIntervalBound;
+    end: TimeIntervalBound;
   };
 };
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To be consistent in the terms, we decided to rename `Span` to `Interval` and `VersionTimespan` to `VersionInterval`

## 🚫 Blocked by

- #1801 
- #1802 