### PR TITLE
Add `Interval::contains_interval` function

### DIFF
--- a/packages/graph/hash_graph/lib/interval-ops/src/interval.rs
+++ b/packages/graph/hash_graph/lib/interval-ops/src/interval.rs
@@ -406,7 +406,7 @@ mod tests {
         if lhs.merge(rhs) == lhs {
             assert!(
                 lhs.contains_interval(&rhs),
-                "{lhs:?} contains {rhs:?}, but does not report so"
+                "{lhs:?} contains {rhs:?}, but `contains_interval` reported otherwise"
             );
         } else {
             assert!(

--- a/packages/graph/hash_graph/lib/interval-ops/src/interval.rs
+++ b/packages/graph/hash_graph/lib/interval-ops/src/interval.rs
@@ -157,7 +157,7 @@ pub trait Interval<T>: Sized {
     ///
     /// Returns `true` if this interval's lower bound is less than or equal to the other interval's
     /// lower bound and this interval's upper bound is greater than or equal to the other
-    /// interval's.
+    /// interval's upper bound.
     #[must_use]
     fn contains_interval(&self, other: &impl Interval<T>) -> bool
     where

--- a/packages/graph/hash_graph/lib/interval-ops/src/interval.rs
+++ b/packages/graph/hash_graph/lib/interval-ops/src/interval.rs
@@ -411,7 +411,7 @@ mod tests {
         } else {
             assert!(
                 !lhs.contains_interval(&rhs),
-                "{lhs:?} does not contain {rhs:?}, but reports so"
+                "{lhs:?} does not contain {rhs:?}, but `contains_interval` reports so"
             );
         }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds a function to the `Interval` trait to check if another interval is contained in this interval

## 🚫 Blocked by

- #1834 


## 🛡 What tests cover this?

An additional test was added to the test suite based on `lhs.merge(rhs) == lhs`, which is only true, if `lhs` contains `rhs`