### PR TITLE
Add `Interval::contains_point` method

### DIFF
--- a/packages/graph/hash_graph/lib/interval-ops/src/bounds.rs
+++ b/packages/graph/hash_graph/lib/interval-ops/src/bounds.rs
@@ -173,12 +173,12 @@ where
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-enum BoundType {
+pub enum BoundType {
     Lower,
     Upper,
 }
 
-fn compare_bounds<T: PartialOrd>(
+pub fn compare_bounds<T: PartialOrd>(
     lhs: Bound<&T>,
     rhs: Bound<&T>,
     lhs_type: BoundType,

--- a/packages/graph/hash_graph/lib/interval-ops/src/interval.rs
+++ b/packages/graph/hash_graph/lib/interval-ops/src/interval.rs
@@ -450,7 +450,7 @@ mod tests {
     }
 
     #[test]
-    fn test_partially_overlapping() {
+    fn partially_overlapping() {
         // Range A:      [-----]   |   [-----]
         // Range B:        [-----] | [-----]
         // intersection:   [---]   |   [---]
@@ -867,7 +867,7 @@ mod tests {
     }
 
     #[test]
-    fn test_disjoint() {
+    fn disjoint() {
         // Range A:      [---]       |       [---]
         // Range B:            [---] | [---]
         // intersection:    empty    |    empty
@@ -1238,7 +1238,7 @@ mod tests {
     }
 
     #[test]
-    fn test_adjacent() {
+    fn adjacent() {
         // Range A:      [---]     |     [---]
         // Range B:          [---] | [---]
         // intersection:     |     |     |
@@ -1333,7 +1333,7 @@ mod tests {
     }
 
     #[test]
-    fn test_contained() {
+    fn contained() {
         // Range A:      [-------] |   [---]
         // Range B:        [---]   | [-------]
         // intersection:   [---]   |   [---]
@@ -1428,7 +1428,7 @@ mod tests {
     }
 
     #[test]
-    fn test_equal() {
+    fn equal() {
         for interval in [
             included_included(0, 5),
             excluded_included(0, 5),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently not required but for the sake of completeness, this adds `contains_point` similar to #1835 

## 🔗 Related links

- #1835

## 🔍 What does this change?

- Adds `Interval::contains_point`
- Drive-by: Remove `test_` from the name of tests, they are already residing in a `tests` module

## 🛡 What tests cover this?

Tests were added to test various values with different intervals