### PR TITLE
Support searching for `rust-toolchain.toml` files in parent directories in CI

### DIFF
--- a/packages/libs/deer/macros/rust-toolchain.toml
+++ b/packages/libs/deer/macros/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly-2022-09-27"

--- a/packages/libs/error-stack/macros/rust-toolchain.toml
+++ b/packages/libs/error-stack/macros/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly-2022-12-09"

--- a/packages/libs/error-stack/rust-toolchain.toml
+++ b/packages/libs/error-stack/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-# Please also update the badges in `README.md`s (`error-stack` and `error-stack-macros`), `src/lib.rs`, and `macros/`
+# Please also update the badges in `README.md`s (`error-stack` and `error-stack-macros`), and `src/lib.rs`
 channel = "nightly-2022-12-09"
 components = ['rust-src', 'miri', 'clippy', 'rustfmt']


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

rustup is able to search for the `rust-toolchain.toml` in the crate's or parent directory. Our CI currently requires the file to be present in the crate's directory (next to `Cargo.toml`). This is restricting, if we want to run `cargo` from another directory than the crate root.

Currently, #1827 fails because of this. Also, the toolchain files of `error-stack` and `deer` are currently duplicated because of this issue.

## 🔗 Related links

- #1827

## 🔍 What does this change?

- Add a function to the `setup.py` script to find the correct toolchain file (or error otherwise)
- Remove the obsolete toolchain files in `error-stack//macro` and `deer/macros`