### PR TITLE
Disable doc tests for release build in the Graph

### DIFF
--- a/packages/graph/hash_graph/Makefile.toml
+++ b/packages/graph/hash_graph/Makefile.toml
@@ -18,6 +18,9 @@ run_task = [
     { name = ["test-task"] }
 ]
 
+[tasks.test-task-doc]
+condition = { profiles = ["development"] }
+
 [tasks.miri]
 clear = true
 command = "echo"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The doc-string tests are pretty slow in release builds because a new binary has to be compiled per test. This disables the doc-tests in release build to speed up the CI