### PR TITLE
Disable caching on codegen scripts

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,7 @@
       "dependsOn": ["codegen"]
     },
     "codegen": {
+      "inputs": ["@hashintel/hash-shared/graphql/scalar-mapping"],
       "outputs": ["./src/**/*.gen.*"]
     },
     "fix:eslint": {

--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,7 @@
       "dependsOn": ["codegen"]
     },
     "codegen": {
-      "inputs": ["@hashintel/hash-shared/graphql/scalar-mapping"],
+      "cache": false,
       "outputs": ["./src/**/*.gen.*"]
     },
     "fix:eslint": {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Disables caching on `codegen` scripts – Turbo repo is not detecting that changes to `"@hashintel/hash-shared/graphql/scalar-mapping"`, a dependency of other packages used in their `codegen` scripts, is a reason to bust the cache (e.g. amend `scalar-mapping.ts` and see that cache is hit in other packages).

We need to figure out how to express it properly as a dependency.

I initially tried adding `"@hashintel/hash-shared/graphql/scalar-mapping"` as an explicit `inputs` to `codegen` commands in the repo, but this did not work (`inputs` appears to be for relative/local file paths only).

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Related task](https://app.asana.com/0/1201095311341924/1203756634855180/f) _(internal)_

## 🐾 Next steps

- Figure out how to express the dependency properly.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Change something in the `scalar-mapping` file
2. `yarn`
3. Make sure that there aren't cache hits for any codegen script
