### PR TITLE
Correctly resolve time intervals when traversing the Graph

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/knowledge.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/knowledge.rs
@@ -10,7 +10,7 @@ use utoipa::{openapi, ToSchema};
 use crate::{
     identifier::{
         account::AccountId,
-        time::{DecisionTime, TransactionTime, VersionInterval},
+        time::{DecisionTime, ProjectedTime, TimeAxis, TransactionTime, VersionInterval},
         EntityVertexId,
     },
     knowledge::{Entity, EntityUuid},
@@ -132,6 +132,14 @@ impl EntityVersion {
     #[must_use]
     pub const fn transaction_time(&self) -> VersionInterval<TransactionTime> {
         self.transaction_time
+    }
+
+    #[must_use]
+    pub fn projected_time(&self, time_axis: TimeAxis) -> VersionInterval<ProjectedTime> {
+        match time_axis {
+            TimeAxis::DecisionTime => self.decision_time.cast(),
+            TimeAxis::TransactionTime => self.transaction_time.cast(),
+        }
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/version.rs
+++ b/packages/graph/hash_graph/lib/graph/src/shared/identifier/time/version.rs
@@ -1,12 +1,12 @@
 use std::{collections::Bound, error::Error, ops::RangeBounds};
 
-use interval_ops::{Interval, IntervalBounds, LowerBound, UpperBound};
+use interval_ops::{Interval, LowerBound, UpperBound};
 use postgres_protocol::types::timestamp_from_sql;
 use postgres_types::{FromSql, Type};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::identifier::time::timestamp::Timestamp;
+use crate::identifier::time::{timestamp::Timestamp, TimeInterval, TimeIntervalBound};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
 pub struct VersionInterval<A> {
@@ -55,8 +55,20 @@ impl<A> VersionInterval<A> {
     }
 
     #[must_use]
-    pub fn into_interval_bounds(self) -> IntervalBounds<Timestamp<A>> {
-        IntervalBounds::from_range(self)
+    pub fn into_time_interval(self) -> TimeInterval<A> {
+        TimeInterval::from_bounds(
+            TimeIntervalBound::Included(self.start),
+            self.end
+                .map_or(TimeIntervalBound::Unbounded, TimeIntervalBound::Excluded),
+        )
+    }
+
+    #[must_use]
+    pub fn cast<B>(self) -> VersionInterval<B> {
+        VersionInterval {
+            start: self.start.cast(),
+            end: self.end.map(Timestamp::cast),
+        }
     }
 }
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -13,6 +13,7 @@ use std::{
 
 use async_trait::async_trait;
 use error_stack::{IntoReport, Report, Result, ResultExt};
+use interval_ops::Interval;
 use tokio_postgres::GenericClient;
 #[cfg(feature = "__internal_bench")]
 use tokio_postgres::{binary_copy::BinaryCopyInWriter, types::Type};
@@ -25,7 +26,9 @@ use uuid::Uuid;
 pub use self::pool::{AsClient, PostgresStorePool};
 use crate::{
     identifier::{
-        account::AccountId, ontology::OntologyTypeEditionId, time::UnresolvedTimeProjection,
+        account::AccountId,
+        ontology::OntologyTypeEditionId,
+        time::{ProjectedTime, TimeInterval, UnresolvedTimeProjection},
         EntityVertexId,
     },
     ontology::{OntologyElementMetadata, OntologyTypeWithMetadata},
@@ -49,14 +52,21 @@ use crate::{
     knowledge::{EntityProperties, LinkOrder},
 };
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+/// Status of a traversal of the graph.
+///
+/// This is used to determine whether a traversal should continue or stop. If a traversal is
+/// resolved for a sufficient depths and a large enough interval, [`DependencyStatus::Resolved`]
+/// will be returned from [`DependencyMap::update`], otherwise [`DependencyStatus::Unresolved`] will
+/// be returned with the [`GraphResolveDepths`] and [`TimeInterval`] that the traversal should
+/// continue with.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DependencyStatus {
-    Unresolved,
+    Unresolved(GraphResolveDepths, TimeInterval<ProjectedTime>),
     Resolved,
 }
 
 pub struct DependencyMap<K> {
-    resolved: HashMap<K, GraphResolveDepths>,
+    resolved: HashMap<K, (GraphResolveDepths, TimeInterval<ProjectedTime>)>,
 }
 
 impl<K> Default for DependencyMap<K> {
@@ -69,34 +79,115 @@ impl<K> Default for DependencyMap<K> {
 
 impl<K> DependencyMap<K>
 where
-    K: Eq + Hash + Clone,
+    K: Eq + Hash + Clone + Debug,
 {
     /// Inserts a dependency into the map.
     ///
     /// If the dependency does not already exist in the dependency map, it will be inserted with the
-    /// provided `resolved_depth` and a reference to this dependency will be returned in order to
-    /// continue resolving it. In the case, that the dependency already exists, the
-    /// `resolved_depth` will be compared with depth used when inserting it before:
-    /// - If the previous `resolved_depth` was `None`, the dependency was not resolved yet and the
-    ///   value is returned
-    /// - If the new depth is higher, the depth will be updated and a reference to the dependency
-    ///   will be returned in order to keep resolving it
-    /// - Otherwise, `None` will be returned as no further resolution is needed
-    pub fn insert(
+    /// provided `new_resolve_depth` and `new_interval`. If the dependency was already resolved it
+    /// is checked whether the new resolve depth and interval are more general than the existing
+    /// resolve depth and interval. If they are, the existing resolve depth and interval are updated
+    /// to cover the new resolve depth and interval.
+    ///
+    /// If the traversed entry has to be resolved further, [`DependencyStatus::Unresolved`] is
+    /// returned with the new resolve depth and interval that the traversal should continue with.
+    pub fn update(
         &mut self,
         identifier: &K,
-        resolved_depth: GraphResolveDepths,
+        new_resolve_depth: GraphResolveDepths,
+        new_interval: TimeInterval<ProjectedTime>,
     ) -> DependencyStatus {
         match self.resolved.raw_entry_mut().from_key(identifier) {
             RawEntryMut::Vacant(entry) => {
-                entry.insert(identifier.clone(), resolved_depth);
-                DependencyStatus::Unresolved
+                entry.insert(
+                    identifier.clone(),
+                    (new_resolve_depth, new_interval.clone()),
+                );
+                DependencyStatus::Unresolved(new_resolve_depth, new_interval)
             }
             RawEntryMut::Occupied(entry) => {
-                if entry.into_mut().update(resolved_depth) {
-                    DependencyStatus::Unresolved
-                } else {
+                let (current_depths, current_interval) = entry.into_mut();
+                let old_interval = current_interval.clone();
+                *current_interval = current_interval.clone().merge(new_interval.clone());
+
+                if current_depths.update(new_resolve_depth) {
+                    // It does not matter if the interval is updated or not, as it has to be
+                    // resolved for the full interval anyway.
+                    DependencyStatus::Unresolved(*current_depths, current_interval.clone())
+                } else if old_interval.contains_interval(&new_interval) {
+                    tracing::info!("{old_interval:?} contains {new_interval:?}");
+                    // The dependency is already resolved for the required interval
+                    // old: [-----)
+                    // new:  [---)
                     DependencyStatus::Resolved
+                } else if new_interval.contains_interval(&old_interval)
+                    | new_interval.is_adjacent_to(&old_interval)
+                {
+                    // The dependency is already resolved, but not for the required interval or the
+                    // intervals are adjacent so we only have to resolve the new interval
+                    // old:  [---)   |  [---)
+                    // new: [-----)  |      [---)
+                    DependencyStatus::Unresolved(*current_depths, new_interval)
+                } else if old_interval.overlaps(&new_interval) {
+                    // The time intervals either overlap or are disjoint, so only have to resolve
+                    // the difference of the two intervals.
+                    // old:     [-----)
+                    // new:       [-------)
+                    // resolve:       [---)
+                    let difference = new_interval.difference(old_interval);
+                    // The intervals do overlap and the current interval is not a subset of
+                    // the required interval, so the difference must be a single interval
+                    debug_assert_eq!(difference.len(), 1, "difference must be a single interval");
+
+                    DependencyStatus::Unresolved(
+                        *current_depths,
+                        difference
+                            .into_iter()
+                            .next()
+                            .expect("difference must be a single interval"),
+                    )
+                } else {
+                    // The time intervals are disjoint. Ideally, we only would resolve the new
+                    // interval, but we did not came up with a good way to store the different
+                    // intervals in the dependency map. So we resolve the full interval for now.
+
+                    // This case is expected to happen very rarely, so falling back to this logic
+                    // is fine for now. If it turns out to be a performance bottleneck, we can
+                    // find and implement a better solution. To track this, we log a warning.
+                    tracing::warn!(
+                        vertex_id=?identifier,
+                        ?old_interval,
+                        ?new_interval,
+                        "dependency is resolved for disjoint intervals"
+                    );
+
+                    // We only require this logic when traversing edges of the graph, so the roots
+                    // of the graph are always precisely resolved correctly. By this implementation,
+                    // we may get a few more dependencies resolved than necessary, which will appear
+                    // as vertices/edges in the subgraph. As we do not guarantee that the subgraph's
+                    // vertices/edges are minimal, this is not a problem.
+
+                    // However, we only have to resolve the difference of the merge of the two, as
+                    // the old interval is already resolved. and the intervals are disjoint:
+                    // Examples |      1      |      B
+                    // =========|=============|=============
+                    // old      | [---)       |       [---)
+                    // new      |       [---) | [---)
+                    // ---------|-------------|-------------
+                    // resolve  |     [-----) | [-----)
+                    let difference = old_interval
+                        .clone()
+                        .merge(new_interval)
+                        .difference(old_interval);
+                    debug_assert_eq!(difference.len(), 1, "difference must be a single interval");
+
+                    DependencyStatus::Unresolved(
+                        *current_depths,
+                        difference
+                            .into_iter()
+                            .next()
+                            .expect("difference must be a single interval"),
+                    )
                 }
             }
         }

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -6,7 +6,7 @@ use futures::FutureExt;
 use type_system::{EntityType, EntityTypeReference, PropertyTypeReference};
 
 use crate::{
-    identifier::ontology::OntologyTypeEditionId,
+    identifier::{ontology::OntologyTypeEditionId, time::TimeProjection},
     ontology::{EntityTypeWithMetadata, OntologyElementMetadata, OntologyTypeWithMetadata},
     provenance::{OwnedById, UpdatedById},
     store::{
@@ -35,16 +35,22 @@ impl<C: AsClient> PostgresStore<C> {
         entity_type_id: &'a OntologyTypeEditionId,
         dependency_context: &'a mut DependencyContext,
         subgraph: &'a mut Subgraph,
-        current_resolve_depth: GraphResolveDepths,
+        mut resolve_depths: GraphResolveDepths,
+        mut time_projection: TimeProjection,
     ) -> Pin<Box<dyn Future<Output = Result<(), QueryError>> + Send + 'a>> {
         async move {
-            let dependency_status = dependency_context
-                .ontology_dependency_map
-                .insert(entity_type_id, current_resolve_depth);
+            let dependency_status = dependency_context.ontology_dependency_map.update(
+                entity_type_id,
+                resolve_depths,
+                time_projection.image(),
+            );
 
             let entity_type = match dependency_status {
-                DependencyStatus::Unresolved => {
-                    let time_projection = subgraph.resolved_time_projection.clone();
+                DependencyStatus::Unresolved(depths, interval) => {
+                    // The dependency may have to be resolved more than anticipated, so we update
+                    // the resolve depth and time projection.
+                    resolve_depths = depths;
+                    time_projection.set_image(interval);
                     subgraph
                         .get_or_read::<EntityTypeWithMetadata>(
                             self,
@@ -58,8 +64,8 @@ impl<C: AsClient> PostgresStore<C> {
 
             // Collecting references before traversing further to avoid having a shared
             // reference to the subgraph when borrowing it mutably
-            let property_type_ref_uris =
-                (current_resolve_depth.constrains_properties_on.outgoing > 0).then(|| {
+            let property_type_ref_uris = (resolve_depths.constrains_properties_on.outgoing > 0)
+                .then(|| {
                     entity_type
                         .inner()
                         .property_type_references()
@@ -69,8 +75,8 @@ impl<C: AsClient> PostgresStore<C> {
                         .collect::<Vec<_>>()
                 });
 
-            let inherits_from_type_ref_uris = (current_resolve_depth.inherits_from.outgoing > 0)
-                .then(|| {
+            let inherits_from_type_ref_uris =
+                (resolve_depths.inherits_from.outgoing > 0).then(|| {
                     entity_type
                         .inner()
                         .inherits_from()
@@ -81,29 +87,26 @@ impl<C: AsClient> PostgresStore<C> {
                         .collect::<Vec<_>>()
                 });
 
-            let link_mappings = (current_resolve_depth.constrains_links_on.outgoing > 0
-                || current_resolve_depth
-                    .constrains_link_destinations_on
-                    .outgoing
-                    > 0)
-            .then(|| {
-                entity_type
-                    .inner()
-                    .link_mappings()
-                    .into_iter()
-                    .map(|(entity_type_ref, destinations)| {
-                        (
-                            entity_type_ref.uri().clone(),
-                            destinations
-                                .into_iter()
-                                .flatten()
-                                .map(EntityTypeReference::uri)
-                                .cloned()
-                                .collect::<Vec<_>>(),
-                        )
-                    })
-                    .collect::<Vec<_>>()
-            });
+            let link_mappings = (resolve_depths.constrains_links_on.outgoing > 0
+                || resolve_depths.constrains_link_destinations_on.outgoing > 0)
+                .then(|| {
+                    entity_type
+                        .inner()
+                        .link_mappings()
+                        .into_iter()
+                        .map(|(entity_type_ref, destinations)| {
+                            (
+                                entity_type_ref.uri().clone(),
+                                destinations
+                                    .into_iter()
+                                    .flatten()
+                                    .map(EntityTypeReference::uri)
+                                    .cloned()
+                                    .collect::<Vec<_>>(),
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                });
 
             if let Some(property_type_ref_uris) = property_type_ref_uris {
                 for property_type_ref_uri in property_type_ref_uris {
@@ -122,12 +125,12 @@ impl<C: AsClient> PostgresStore<C> {
                         subgraph,
                         GraphResolveDepths {
                             constrains_properties_on: OutgoingEdgeResolveDepth {
-                                outgoing: current_resolve_depth.constrains_properties_on.outgoing
-                                    - 1,
-                                ..current_resolve_depth.constrains_properties_on
+                                outgoing: resolve_depths.constrains_properties_on.outgoing - 1,
+                                ..resolve_depths.constrains_properties_on
                             },
-                            ..current_resolve_depth
+                            ..resolve_depths
                         },
+                        time_projection.clone(),
                     )
                     .await?;
                 }
@@ -152,11 +155,12 @@ impl<C: AsClient> PostgresStore<C> {
                         subgraph,
                         GraphResolveDepths {
                             inherits_from: OutgoingEdgeResolveDepth {
-                                outgoing: current_resolve_depth.inherits_from.outgoing - 1,
-                                ..current_resolve_depth.inherits_from
+                                outgoing: resolve_depths.inherits_from.outgoing - 1,
+                                ..resolve_depths.inherits_from
                             },
-                            ..current_resolve_depth
+                            ..resolve_depths
                         },
+                        time_projection.clone(),
                     )
                     .await?;
                 }
@@ -164,7 +168,7 @@ impl<C: AsClient> PostgresStore<C> {
 
             if let Some(link_mappings) = link_mappings {
                 for (link_type_uri, destination_type_uris) in link_mappings {
-                    if current_resolve_depth.constrains_links_on.outgoing > 0 {
+                    if resolve_depths.constrains_links_on.outgoing > 0 {
                         subgraph.edges.insert(Edge::Ontology {
                             vertex_id: entity_type_id.clone(),
                             outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
@@ -180,20 +184,16 @@ impl<C: AsClient> PostgresStore<C> {
                             subgraph,
                             GraphResolveDepths {
                                 constrains_links_on: OutgoingEdgeResolveDepth {
-                                    outgoing: current_resolve_depth.constrains_links_on.outgoing
-                                        - 1,
-                                    ..current_resolve_depth.constrains_links_on
+                                    outgoing: resolve_depths.constrains_links_on.outgoing - 1,
+                                    ..resolve_depths.constrains_links_on
                                 },
-                                ..current_resolve_depth
+                                ..resolve_depths
                             },
+                            time_projection.clone(),
                         )
                         .await?;
 
-                        if current_resolve_depth
-                            .constrains_link_destinations_on
-                            .outgoing
-                            > 0
-                        {
+                        if resolve_depths.constrains_link_destinations_on.outgoing > 0 {
                             for destination_type_uri in destination_type_uris {
                                 subgraph.edges.insert(Edge::Ontology {
                                     vertex_id: entity_type_id.clone(),
@@ -212,14 +212,15 @@ impl<C: AsClient> PostgresStore<C> {
                                     subgraph,
                                     GraphResolveDepths {
                                         constrains_link_destinations_on: OutgoingEdgeResolveDepth {
-                                            outgoing: current_resolve_depth
+                                            outgoing: resolve_depths
                                                 .constrains_link_destinations_on
                                                 .outgoing
                                                 - 1,
-                                            ..current_resolve_depth.constrains_link_destinations_on
+                                            ..resolve_depths.constrains_link_destinations_on
                                         },
-                                        ..current_resolve_depth
+                                        ..resolve_depths
                                     },
+                                    time_projection.clone(),
                                 )
                                 .await?;
                             }
@@ -276,20 +277,21 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         let StructuralQuery {
             ref filter,
             graph_resolve_depths,
-            ref time_projection,
+            time_projection: ref unresolved_time_projection,
         } = *query;
+
+        let time_projection = unresolved_time_projection.clone().resolve();
+        let time_axis = time_projection.image_time_axis();
 
         let mut subgraph = Subgraph::new(
             graph_resolve_depths,
+            unresolved_time_projection.clone(),
             time_projection.clone(),
-            time_projection.clone().resolve(),
         );
         let mut dependency_context = DependencyContext::default();
-        let time_axis = subgraph.resolved_time_projection.image_time_axis();
 
         for entity_type in
-            Read::<EntityTypeWithMetadata>::read(self, filter, &subgraph.resolved_time_projection)
-                .await?
+            Read::<EntityTypeWithMetadata>::read(self, filter, &time_projection).await?
         {
             let vertex_id = entity_type.vertex_id(time_axis);
             // Insert the vertex into the subgraph to avoid another lookup when traversing it
@@ -300,6 +302,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
                 &mut dependency_context,
                 &mut subgraph,
                 graph_resolve_depths,
+                time_projection.clone(),
             )
             .await?;
 

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -6,7 +6,7 @@ use futures::FutureExt;
 use type_system::{DataTypeReference, PropertyType, PropertyTypeReference};
 
 use crate::{
-    identifier::ontology::OntologyTypeEditionId,
+    identifier::{ontology::OntologyTypeEditionId, time::TimeProjection},
     ontology::{OntologyElementMetadata, OntologyTypeWithMetadata, PropertyTypeWithMetadata},
     provenance::{OwnedById, UpdatedById},
     store::{
@@ -35,16 +35,22 @@ impl<C: AsClient> PostgresStore<C> {
         property_type_id: &'a OntologyTypeEditionId,
         dependency_context: &'a mut DependencyContext,
         subgraph: &'a mut Subgraph,
-        current_resolve_depth: GraphResolveDepths,
+        mut resolve_depths: GraphResolveDepths,
+        mut time_projection: TimeProjection,
     ) -> Pin<Box<dyn Future<Output = Result<(), QueryError>> + Send + 'a>> {
         async move {
-            let dependency_status = dependency_context
-                .ontology_dependency_map
-                .insert(property_type_id, current_resolve_depth);
+            let dependency_status = dependency_context.ontology_dependency_map.update(
+                property_type_id,
+                resolve_depths,
+                time_projection.image(),
+            );
 
             let property_type = match dependency_status {
-                DependencyStatus::Unresolved => {
-                    let time_projection = subgraph.resolved_time_projection.clone();
+                DependencyStatus::Unresolved(depths, interval) => {
+                    // The dependency may have to be resolved more than anticipated, so we update
+                    // the resolve depth and time projection.
+                    resolve_depths = depths;
+                    time_projection.set_image(interval);
                     subgraph
                         .get_or_read::<PropertyTypeWithMetadata>(
                             self,
@@ -58,8 +64,8 @@ impl<C: AsClient> PostgresStore<C> {
 
             // Collecting references before traversing further to avoid having a shared
             // reference to the subgraph when borrowing it mutably
-            let data_type_ref_uris = (current_resolve_depth.constrains_values_on.outgoing > 0)
-                .then(|| {
+            let data_type_ref_uris =
+                (resolve_depths.constrains_values_on.outgoing > 0).then(|| {
                     property_type
                         .inner()
                         .data_type_references()
@@ -69,8 +75,8 @@ impl<C: AsClient> PostgresStore<C> {
                         .collect::<Vec<_>>()
                 });
 
-            let property_type_ref_uris =
-                (current_resolve_depth.constrains_properties_on.outgoing > 0).then(|| {
+            let property_type_ref_uris = (resolve_depths.constrains_properties_on.outgoing > 0)
+                .then(|| {
                     property_type
                         .inner()
                         .property_type_references()
@@ -97,11 +103,12 @@ impl<C: AsClient> PostgresStore<C> {
                         subgraph,
                         GraphResolveDepths {
                             constrains_values_on: OutgoingEdgeResolveDepth {
-                                outgoing: current_resolve_depth.constrains_values_on.outgoing - 1,
-                                ..current_resolve_depth.constrains_values_on
+                                outgoing: resolve_depths.constrains_values_on.outgoing - 1,
+                                ..resolve_depths.constrains_values_on
                             },
-                            ..current_resolve_depth
+                            ..resolve_depths
                         },
+                        time_projection.clone(),
                     )
                     .await?;
                 }
@@ -124,12 +131,12 @@ impl<C: AsClient> PostgresStore<C> {
                         subgraph,
                         GraphResolveDepths {
                             constrains_properties_on: OutgoingEdgeResolveDepth {
-                                outgoing: current_resolve_depth.constrains_properties_on.outgoing
-                                    - 1,
-                                ..current_resolve_depth.constrains_properties_on
+                                outgoing: resolve_depths.constrains_properties_on.outgoing - 1,
+                                ..resolve_depths.constrains_properties_on
                             },
-                            ..current_resolve_depth
+                            ..resolve_depths
                         },
+                        time_projection.clone(),
                     )
                     .await?;
                 }
@@ -184,20 +191,21 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         let StructuralQuery {
             ref filter,
             graph_resolve_depths,
-            ref time_projection,
+            time_projection: ref unresolved_time_projection,
         } = *query;
+
+        let time_projection = unresolved_time_projection.clone().resolve();
+        let time_axis = time_projection.image_time_axis();
 
         let mut subgraph = Subgraph::new(
             graph_resolve_depths,
+            unresolved_time_projection.clone(),
             time_projection.clone(),
-            time_projection.clone().resolve(),
         );
         let mut dependency_context = DependencyContext::default();
-        let time_axis = subgraph.resolved_time_projection.image_time_axis();
 
         for property_type in
-            Read::<PropertyTypeWithMetadata>::read(self, filter, &subgraph.resolved_time_projection)
-                .await?
+            Read::<PropertyTypeWithMetadata>::read(self, filter, &time_projection).await?
         {
             let vertex_id = property_type.vertex_id(time_axis);
             // Insert the vertex into the subgraph to avoid another lookup when traversing it
@@ -208,6 +216,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                 &mut dependency_context,
                 &mut subgraph,
                 graph_resolve_depths,
+                time_projection.clone(),
             )
             .await?;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We correctly resolve the roots of the subgraph based on the `timeProjection` passed to the structural query. It's however not required to resolve all edges for the graph.

This changes the logic to only resolve edges where the edge exists for the vertex in both, the vertex time interval (i.e. the entity version) and the time interval provided by the time projection. Effectively, this is an intersection of these two intervals.

Applying this logic reduces the number of queries issued to the Graph when running the REST API tests by roughly 15% (with only very few versioned data).

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203543021352032/1203701389454316/f) _(internal)_

## 🔍 What does this change?

- Some operations were required to convert between the different temporal structs, c679ae5df55cbf822cf54c94030226bc15669b65 adds those
- The `DependencMap` was changed to identify already resolved intervals and report which intervals have to be resolved further. The logic is implemented in d0a0810110ee6c4ba6342e1d43c6d24b43862404
- faad89fd19b2d2f5c0e41a215ca958574e909dd1 uses the new interface defined in the two commits above. As mentioned above, the time projection's image will be intersected with the version of the entity, which then will be used in the dependency map. When the given resolve depths and intervals are not sufficiently resolved, information is returned on how to traverse the graph further.

## 📜 Does this require a change to the docs?

Some extensive documentation has been added to the `DependencyMap` update logic. A follow-up PR requires some renaming changes. With this in place, the documentation will be slightly enhanced as well.

## ⚠️ Known issues

In some rare edge cases, it's possible, that the subgraph is expected to resolve an entity, which was already resolved, but the resolved interval and the newly requested interval are disjoint. In this case, we couldn't come up with a proper representation (Postgres' multirange would probably be an option), so this PR handles this case by merging the two intervals into one big interval. This may result in a few more edges, which will be resolved. I don't consider this as a big issue as this is only inside of _a single entity_ based on its vertex id. I added a warning for this specific case so if we encounter this warning frequently, we may want to further take a look.

## 🐾 Next steps

- Rename `TimeProjection` to `TimeAxes`
- Rename `TimeProjection::kernel` to `TimeAxes::pinned`
- Rename `TimeProjection::image` to `TimeAxes::variable`

## 🛡 What tests cover this?

All tests, which are using the subgraph, including
- Graph Integration tests
- Rest API tests
- backend integration tests
- playwright tests
- manual testing 🙃 