### PR TITLE
Automatically upgrade rust toolchain (2nd attempt)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -48,26 +48,26 @@
     {
       "matchManagers": ["regex"],
       "matchDepNames": ["rust"],
-      "matchPaths": ["error-stack/**"],
-      "groupName": "error-stack",
       "separateMajorMinor": false,
       "fetchReleaseNotes": false
+    },
+    {
+      "matchManagers": ["regex"],
+      "matchDepNames": ["rust"],
+      "matchPaths": ["error-stack/**"],
+      "groupName": "error-stack"
     },
     {
       "matchManagers": ["regex"],
       "matchDepNames": ["rust"],
       "matchPaths": ["deer/**"],
-      "groupName": "deer",
-      "separateMajorMinor": false,
-      "fetchReleaseNotes": false
+      "groupName": "deer"
     },
     {
       "matchManagers": ["regex"],
       "matchDepNames": ["rust"],
       "matchPaths": ["graph/**"],
-      "groupName": "graph",
-      "separateMajorMinor": false,
-      "fetchReleaseNotes": false
+      "groupName": "graph"
     }
   ],
   "regexManagers": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -46,9 +46,8 @@
       "matchPackagePatterns": ["^@sentry/"]
     },
     {
-      "groupName": "Rust",
       "matchManagers": ["regex"],
-      "matchPackageNames": ["rust-lang/rust-analyzer"]
+      "matchPackageNames": ["rust"]
     }
   ],
   "regexManagers": [
@@ -57,7 +56,8 @@
       "matchStrings": [
         "channel\\s*=\\s*\"nightly-(?<currentValue>\\d+-\\d+-\\d+)\""
       ],
-      "depNameTemplate": "rust-lang/rust-analyzer",
+      "depNameTemplate": "rust",
+      "lookupNameTemplate": "rust-lang/rust-analyzer",
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "regex:(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)"
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -48,26 +48,26 @@
     {
       "matchManagers": ["regex"],
       "matchDepNames": ["rust"],
+      "matchPaths": ["error-stack/**"],
+      "groupName": "error-stack",
       "separateMajorMinor": false,
       "fetchReleaseNotes": false
     },
     {
       "matchManagers": ["regex"],
       "matchDepNames": ["rust"],
-      "matchPaths": ["error-stack/**"],
-      "groupName": "error-stack"
-    },
-    {
-      "matchManagers": ["regex"],
-      "matchDepNames": ["rust"],
       "matchPaths": ["deer/**"],
-      "groupName": "deer"
+      "groupName": "deer",
+      "separateMajorMinor": false,
+      "fetchReleaseNotes": false
     },
     {
       "matchManagers": ["regex"],
       "matchDepNames": ["rust"],
       "matchPaths": ["graph/**"],
-      "groupName": "graph"
+      "groupName": "graph",
+      "separateMajorMinor": false,
+      "fetchReleaseNotes": false
     }
   ],
   "regexManagers": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -57,7 +57,7 @@
         "channel\\s*=\\s*\"nightly-(?<currentValue>\\d+-\\d+-\\d+)\""
       ],
       "depNameTemplate": "rust",
-      "lookupName": "rust-lang/rust-analyzer",
+      "packageNameTemplate": "rust-lang/rust-analyzer",
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "regex:(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)"
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -47,7 +47,27 @@
     },
     {
       "matchManagers": ["regex"],
-      "matchPackageNames": ["rust"]
+      "matchDepNames": ["rust"],
+      "separateMajorMinor": false,
+      "fetchReleaseNotes": false
+    },
+    {
+      "matchManagers": ["regex"],
+      "matchDepNames": ["rust"],
+      "matchPaths": ["error-stack/**"],
+      "groupName": "error-stack"
+    },
+    {
+      "matchManagers": ["regex"],
+      "matchDepNames": ["rust"],
+      "matchPaths": ["deer/**"],
+      "groupName": "deer"
+    },
+    {
+      "matchManagers": ["regex"],
+      "matchDepNames": ["rust"],
+      "matchPaths": ["graph/**"],
+      "groupName": "graph"
     }
   ],
   "regexManagers": [
@@ -60,6 +80,17 @@
       "packageNameTemplate": "rust-lang/rust-analyzer",
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "regex:(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)"
+    },
+    {
+      "fileMatch": ["(^|/)README\\.md?$", "(^|/)lib\\.rs?$"],
+      "matchStrings": [
+        "\\[!\\[rust-version]\\(https://img\\.shields\\.io/badge/Rust-(?<stable>\\d+\\.\\d+\\.\\d+)/nightly--(?<currentValue>\\d+--\\d+--\\d+)-blue\\)]\\[rust-version]"
+      ],
+      "depNameTemplate": "rust",
+      "packageNameTemplate": "rust-lan/rust-analyzer",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "regex:(?<major>\\d+)-?-(?<minor>\\d+)-?-(?<patch>\\d+)",
+      "autoReplaceStringTemplate": "[![rust-version](https://img.shields.io/badge/Rust-{{stable}}/nightly--{{replace '-' '--' newValue}}-blue)][rust-version]"
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -57,7 +57,7 @@
         "channel\\s*=\\s*\"nightly-(?<currentValue>\\d+-\\d+-\\d+)\""
       ],
       "depNameTemplate": "rust",
-      "lookupNameTemplate": "rust-lang/rust-analyzer",
+      "lookupName": "rust-lang/rust-analyzer",
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "regex:(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)"
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -87,7 +87,7 @@
         "\\[!\\[rust-version]\\(https://img\\.shields\\.io/badge/Rust-(?<stable>\\d+\\.\\d+\\.\\d+)/nightly--(?<currentValue>\\d+--\\d+--\\d+)-blue\\)]\\[rust-version]"
       ],
       "depNameTemplate": "rust",
-      "packageNameTemplate": "rust-lan/rust-analyzer",
+      "packageNameTemplate": "rust-lang/rust-analyzer",
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "regex:(?<major>\\d+)-?-(?<minor>\\d+)-?-(?<patch>\\d+)",
       "autoReplaceStringTemplate": "[![rust-version](https://img.shields.io/badge/Rust-{{stable}}/nightly--{{replace '-' '--' newValue}}-blue)][rust-version]"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This is an improvement of the previous PR, implementing suggestions from #1865. This includes:

* `separateMajorMinor: false`, we should™ now no longer get a "major" version bump every year for rust
* `fetchReleaseNotes: false`, we do not need rust-analyzer release notes if we just ~~ab~~use rust-analyzer to get the version number
* grouping into three buckets: <- this does **not** need to be updated for the move into `libs/`
	* `error-stack`
	* `deer`
	* `graph`
* update badge in README and `lib.rs` of projects automatically
	* there's no way to do this as a side-effect without a self-hosted bot, so we pretend it's a dependency we upgrade. This means that we cannot ensure that it is the same version, but assuming that the versions are always in sync and updated at the same time (through grouping), it should stay the same

## 📷 Demo

```json
{
  "regex": [
    {
      "packageFile": "libs/deer/rust-toolchain.toml",
      "deps": [
        {
          "depName": "rust-lang/rust-analyzer",
          "currentValue": "2022-11-14",
          "datasource": "github-releases",
          "versioning": "regex:(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)",
          "replaceString": "channel = \"nightly-2022-11-14\"",
          "depIndex": 0,
          "updates": [
            {
              "bucket": "non-major",
              "newVersion": "2022-12-26",
              "newValue": "2022-12-26",
              "releaseTimestamp": "2022-12-26T08:03:47.000Z",
              "newMajor": 2022,
              "newMinor": 12,
              "updateType": "minor",
              "branchName": "renovate/rust"
            },
            {
              "bucket": "major",
              "newVersion": "2023-01-16",
              "newValue": "2023-01-16",
              "releaseTimestamp": "2023-01-16T07:55:54.000Z",
              "newMajor": 2023,
              "newMinor": 1,
              "updateType": "major",
              "branchName": "renovate/major-rust"
            }
          ],
          "warnings": [],
          "sourceUrl": "https://github.com/rust-lang/rust-analyzer",
          "registryUrl": "https://github.com",
          "currentVersion": "2022-11-14",
          "isSingleVersion": true,
          "fixedVersion": "2022-11-14"
        }
      ],
      "matchStrings": [
        "channel\\s*=\\s*\"nightly-(?<currentValue>\\d+-\\d+-\\d+)\""
      ],
      "depNameTemplate": "rust-lang/rust-analyzer",
      "datasourceTemplate": "github-releases",
      "versioningTemplate": "regex:(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)"
    },
    {
      "packageFile": "packages/graph/rust-toolchain.toml",
      "deps": [
        {
          "depName": "rust-lang/rust-analyzer",
          "currentValue": "2023-01-03",
          "datasource": "github-releases",
          "versioning": "regex:(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)",
          "replaceString": "channel = \"nightly-2023-01-03\"",
          "depIndex": 0,
          "updates": [
            {
              "bucket": "non-major",
              "newVersion": "2023-01-16",
              "newValue": "2023-01-16",
              "releaseTimestamp": "2023-01-16T07:55:54.000Z",
              "newMajor": 2023,
              "newMinor": 1,
              "updateType": "patch",
              "branchName": "renovate/rust"
            }
          ],
          "warnings": [],
          "sourceUrl": "https://github.com/rust-lang/rust-analyzer",
          "registryUrl": "https://github.com",
          "currentVersion": "2023-01-03",
          "isSingleVersion": true,
          "fixedVersion": "2023-01-03"
        }
      ],
      "matchStrings": [
        "channel\\s*=\\s*\"nightly-(?<currentValue>\\d+-\\d+-\\d+)\""
      ],
      "depNameTemplate": "rust-lang/rust-analyzer",
      "datasourceTemplate": "github-releases",
      "versioningTemplate": "regex:(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)"
    },
    {
      "packageFile": "packages/libs/error-stack/rust-toolchain.toml",
      "deps": [
        {
          "depName": "rust-lang/rust-analyzer",
          "currentValue": "2022-12-09",
          "datasource": "github-releases",
          "versioning": "regex:(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)",
          "replaceString": "channel = \"nightly-2022-12-09\"",
          "depIndex": 0,
          "updates": [
            {
              "bucket": "non-major",
              "newVersion": "2022-12-26",
              "newValue": "2022-12-26",
              "releaseTimestamp": "2022-12-26T08:03:47.000Z",
              "newMajor": 2022,
              "newMinor": 12,
              "updateType": "patch",
              "branchName": "renovate/rust"
            },
            {
              "bucket": "major",
              "newVersion": "2023-01-16",
              "newValue": "2023-01-16",
              "releaseTimestamp": "2023-01-16T07:55:54.000Z",
              "newMajor": 2023,
              "newMinor": 1,
              "updateType": "major",
              "branchName": "renovate/major-rust"
            }
          ],
          "warnings": [],
          "sourceUrl": "https://github.com/rust-lang/rust-analyzer",
          "registryUrl": "https://github.com",
          "currentVersion": "2022-12-09",
          "isSingleVersion": true,
          "fixedVersion": "2022-12-09"
        }
      ],
      "matchStrings": [
        "channel\\s*=\\s*\"nightly-(?<currentValue>\\d+-\\d+-\\d+)\""
      ],
      "depNameTemplate": "rust-lang/rust-analyzer",
      "datasourceTemplate": "github-releases",
      "versioningTemplate": "regex:(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)"
    },
    {
      "packageFile": "libs/deer/rust-toolchain.toml",
      "deps": [
        {
          "depName": "rust",
          "packageName": "rust-lang/rust-analyzer",
          "currentValue": "2022-11-14",
          "datasource": "github-releases",
          "versioning": "regex:(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)",
          "replaceString": "channel = \"nightly-2022-11-14\"",
          "depIndex": 0,
          "updates": [
            {
              "bucket": "non-major",
              "newVersion": "2022-12-26",
              "newValue": "2022-12-26",
              "releaseTimestamp": "2022-12-26T08:03:47.000Z",
              "newMajor": 2022,
              "newMinor": 12,
              "updateType": "minor",
              "branchName": "renovate/rust-2022.x"
            },
            {
              "bucket": "major",
              "newVersion": "2023-01-16",
              "newValue": "2023-01-16",
              "releaseTimestamp": "2023-01-16T07:55:54.000Z",
              "newMajor": 2023,
              "newMinor": 1,
              "updateType": "major",
              "branchName": "renovate/rust-2023.x"
            }
          ],
          "warnings": [],
          "sourceUrl": "https://github.com/rust-lang/rust-analyzer",
          "registryUrl": "https://github.com",
          "currentVersion": "2022-11-14",
          "isSingleVersion": true,
          "fixedVersion": "2022-11-14"
        }
      ],
      "matchStrings": [
        "channel\\s*=\\s*\"nightly-(?<currentValue>\\d+-\\d+-\\d+)\""
      ],
      "depNameTemplate": "rust",
      "packageNameTemplate": "rust-lang/rust-analyzer",
      "datasourceTemplate": "github-releases",
      "versioningTemplate": "regex:(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)"
    },
    {
      "packageFile": "packages/graph/rust-toolchain.toml",
      "deps": [
        {
          "depName": "rust",
          "packageName": "rust-lang/rust-analyzer",
          "currentValue": "2023-01-03",
          "datasource": "github-releases",
          "versioning": "regex:(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)",
          "replaceString": "channel = \"nightly-2023-01-03\"",
          "depIndex": 0,
          "updates": [
            {
              "bucket": "non-major",
              "newVersion": "2023-01-16",
              "newValue": "2023-01-16",
              "releaseTimestamp": "2023-01-16T07:55:54.000Z",
              "newMajor": 2023,
              "newMinor": 1,
              "updateType": "patch",
              "branchName": "renovate/rust-2023.x"
            }
          ],
          "warnings": [],
          "sourceUrl": "https://github.com/rust-lang/rust-analyzer",
          "registryUrl": "https://github.com",
          "currentVersion": "2023-01-03",
          "isSingleVersion": true,
          "fixedVersion": "2023-01-03"
        }
      ],
      "matchStrings": [
        "channel\\s*=\\s*\"nightly-(?<currentValue>\\d+-\\d+-\\d+)\""
      ],
      "depNameTemplate": "rust",
      "packageNameTemplate": "rust-lang/rust-analyzer",
      "datasourceTemplate": "github-releases",
      "versioningTemplate": "regex:(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)"
    },
    {
      "packageFile": "packages/libs/error-stack/rust-toolchain.toml",
      "deps": [
        {
          "depName": "rust",
          "packageName": "rust-lang/rust-analyzer",
          "currentValue": "2022-12-09",
          "datasource": "github-releases",
          "versioning": "regex:(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)",
          "replaceString": "channel = \"nightly-2022-12-09\"",
          "depIndex": 0,
          "updates": [
            {
              "bucket": "non-major",
              "newVersion": "2022-12-26",
              "newValue": "2022-12-26",
              "releaseTimestamp": "2022-12-26T08:03:47.000Z",
              "newMajor": 2022,
              "newMinor": 12,
              "updateType": "patch",
              "branchName": "renovate/rust-2022.x"
            },
            {
              "bucket": "major",
              "newVersion": "2023-01-16",
              "newValue": "2023-01-16",
              "releaseTimestamp": "2023-01-16T07:55:54.000Z",
              "newMajor": 2023,
              "newMinor": 1,
              "updateType": "major",
              "branchName": "renovate/rust-2023.x"
            }
          ],
          "warnings": [],
          "sourceUrl": "https://github.com/rust-lang/rust-analyzer",
          "registryUrl": "https://github.com",
          "currentVersion": "2022-12-09",
          "isSingleVersion": true,
          "fixedVersion": "2022-12-09"
        }
      ],
      "matchStrings": [
        "channel\\s*=\\s*\"nightly-(?<currentValue>\\d+-\\d+-\\d+)\""
      ],
      "depNameTemplate": "rust",
      "packageNameTemplate": "rust-lang/rust-analyzer",
      "datasourceTemplate": "github-releases",
      "versioningTemplate": "regex:(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)"
    },
    {
      "packageFile": "packages/libs/error-stack/README.md",
      "deps": [
        {
          "depName": "rust",
          "packageName": "rust-lang/rust-analyzer",
          "currentValue": "2022--12--09",
          "datasource": "github-releases",
          "versioning": "regex:(?<major>\\d+)-?-(?<minor>\\d+)-?-(?<patch>\\d+)",
          "replaceString": "[![rust-version](https://img.shields.io/badge/Rust-1.63.0/nightly--2022--12--09-blue)][rust-version]",
          "depIndex": 0,
          "updates": [
            {
              "bucket": "non-major",
              "newVersion": "2022-12-26",
              "newValue": "2022-12-26",
              "releaseTimestamp": "2022-12-26T08:03:47.000Z",
              "newMajor": 2022,
              "newMinor": 12,
              "updateType": "patch",
              "branchName": "renovate/rust-2022.x"
            },
            {
              "bucket": "major",
              "newVersion": "2023-01-16",
              "newValue": "2023-01-16",
              "releaseTimestamp": "2023-01-16T07:55:54.000Z",
              "newMajor": 2023,
              "newMinor": 1,
              "updateType": "major",
              "branchName": "renovate/rust-2023.x"
            }
          ],
          "warnings": [],
          "sourceUrl": "https://github.com/rust-lang/rust-analyzer",
          "registryUrl": "https://github.com",
          "currentVersion": "2022--12--09",
          "isSingleVersion": true,
          "fixedVersion": "2022--12--09"
        }
      ],
      "matchStrings": [
        "\\[!\\[rust-version]\\(https://img\\.shields\\.io/badge/Rust-(?<stable>\\d+\\.\\d+\\.\\d+)/nightly--(?<currentValue>\\d+--\\d+--\\d+)-blue\\)]\\[rust-version]"
      ],
      "depNameTemplate": "rust",
      "packageNameTemplate": "rust-lang/rust-analyzer",
      "datasourceTemplate": "github-releases",
      "versioningTemplate": "regex:(?<major>\\d+)-?-(?<minor>\\d+)-?-(?<patch>\\d+)",
      "autoReplaceStringTemplate": "[![rust-version](https://img.shields.io/badge/Rust-{{stable}}/nightly--{{replace '-' '--' newValue}}-blue)][rust-version]"
    },
    {
      "packageFile": "packages/libs/error-stack/macros/README.md",
      "deps": [
        {
          "depName": "rust",
          "packageName": "rust-lang/rust-analyzer",
          "currentValue": "2022--11--14",
          "datasource": "github-releases",
          "versioning": "regex:(?<major>\\d+)-?-(?<minor>\\d+)-?-(?<patch>\\d+)",
          "replaceString": "[![rust-version](https://img.shields.io/badge/Rust-1.63.0/nightly--2022--11--14-blue)][rust-version]",
          "depIndex": 0,
          "updates": [
            {
              "bucket": "non-major",
              "newVersion": "2022-12-26",
              "newValue": "2022-12-26",
              "releaseTimestamp": "2022-12-26T08:03:47.000Z",
              "newMajor": 2022,
              "newMinor": 12,
              "updateType": "minor",
              "branchName": "renovate/rust-2022.x"
            },
            {
              "bucket": "major",
              "newVersion": "2023-01-16",
              "newValue": "2023-01-16",
              "releaseTimestamp": "2023-01-16T07:55:54.000Z",
              "newMajor": 2023,
              "newMinor": 1,
              "updateType": "major",
              "branchName": "renovate/rust-2023.x"
            }
          ],
          "warnings": [],
          "sourceUrl": "https://github.com/rust-lang/rust-analyzer",
          "registryUrl": "https://github.com",
          "currentVersion": "2022--11--14",
          "isSingleVersion": true,
          "fixedVersion": "2022--11--14"
        }
      ],
      "matchStrings": [
        "\\[!\\[rust-version]\\(https://img\\.shields\\.io/badge/Rust-(?<stable>\\d+\\.\\d+\\.\\d+)/nightly--(?<currentValue>\\d+--\\d+--\\d+)-blue\\)]\\[rust-version]"
      ],
      "depNameTemplate": "rust",
      "packageNameTemplate": "rust-lang/rust-analyzer",
      "datasourceTemplate": "github-releases",
      "versioningTemplate": "regex:(?<major>\\d+)-?-(?<minor>\\d+)-?-(?<patch>\\d+)",
      "autoReplaceStringTemplate": "[![rust-version](https://img.shields.io/badge/Rust-{{stable}}/nightly--{{replace '-' '--' newValue}}-blue)][rust-version]"
    },
    {
      "packageFile": "packages/libs/error-stack/src/lib.rs",
      "deps": [
        {
          "depName": "rust",
          "packageName": "rust-lang/rust-analyzer",
          "currentValue": "2022--12--09",
          "datasource": "github-releases",
          "versioning": "regex:(?<major>\\d+)-?-(?<minor>\\d+)-?-(?<patch>\\d+)",
          "replaceString": "[![rust-version](https://img.shields.io/badge/Rust-1.63.0/nightly--2022--12--09-blue)][rust-version]",
          "depIndex": 0,
          "updates": [
            {
              "bucket": "non-major",
              "newVersion": "2022-12-26",
              "newValue": "2022-12-26",
              "releaseTimestamp": "2022-12-26T08:03:47.000Z",
              "newMajor": 2022,
              "newMinor": 12,
              "updateType": "patch",
              "branchName": "renovate/rust-2022.x"
            },
            {
              "bucket": "major",
              "newVersion": "2023-01-16",
              "newValue": "2023-01-16",
              "releaseTimestamp": "2023-01-16T07:55:54.000Z",
              "newMajor": 2023,
              "newMinor": 1,
              "updateType": "major",
              "branchName": "renovate/rust-2023.x"
            }
          ],
          "warnings": [],
          "sourceUrl": "https://github.com/rust-lang/rust-analyzer",
          "registryUrl": "https://github.com",
          "currentVersion": "2022--12--09",
          "isSingleVersion": true,
          "fixedVersion": "2022--12--09"
        }
      ],
      "matchStrings": [
        "\\[!\\[rust-version]\\(https://img\\.shields\\.io/badge/Rust-(?<stable>\\d+\\.\\d+\\.\\d+)/nightly--(?<currentValue>\\d+--\\d+--\\d+)-blue\\)]\\[rust-version]"
      ],
      "depNameTemplate": "rust",
      "packageNameTemplate": "rust-lang/rust-analyzer",
      "datasourceTemplate": "github-releases",
      "versioningTemplate": "regex:(?<major>\\d+)-?-(?<minor>\\d+)-?-(?<patch>\\d+)",
      "autoReplaceStringTemplate": "[![rust-version](https://img.shields.io/badge/Rust-{{stable}}/nightly--{{replace '-' '--' newValue}}-blue)][rust-version]"
    }
  ]
}
```
