### PR TITLE
Make `error-stack` a Yarn workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
       "packages/graph/clients/typescript",
       "packages/hash/api",
       "packages/hash/frontend",
-      "packages/hash/task-executor",
       "packages/hash/subgraph",
+      "packages/hash/task-executor",
+      "packages/libs/error-stack",
       "tests/*"
     ]
   },

--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [".", "macros"]
 default-members = ["."]
+exclude = ["package.json"]
 
 [package]
 name = "error-stack"

--- a/packages/libs/error-stack/package.json
+++ b/packages/libs/error-stack/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "error-stack",
+  "version": "0.0.0-private",
+  "private": true,
+  "description": "This is a Rust crate – look at Cargo.toml for details"
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR facilitates the completion of #1851. It partially repeats #1858, but does not move `packages/libs/error-stack` to `libs`. This will be done separately.

Adding `package.json` to `error-stack` improves the output of `yarn lint:license-in-workspaces`:

### Before

```
[EXTRA]   packages/libs/error-stack/LICENSE.md
[EXTRA]   packages/libs/error-stack/LICENSE-APACHE.md
[EXTRA]   packages/libs/error-stack/LICENSE-MIT.md
```

### After

```
[FOUND]   packages/libs/error-stack/LICENSE.md
          packages/libs/error-stack/LICENSE-APACHE.md
          packages/libs/error-stack/LICENSE-MIT.md
```
