### PR TITLE
Add prettier plugin for `*.sql` files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -18,6 +18,7 @@
 !*.ts
 !*.tsx
 !*.yml
+!*.sql
 
 # Keep license files as is
 LICENSE.md

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -8,5 +8,15 @@ module.exports = {
   plugins: [
     require("prettier-plugin-packagejson"),
     require("prettier-plugin-sh"),
+    require("prettier-plugin-sql"),
+  ],
+
+  overrides: [
+    {
+      files: "*.sql",
+      options: {
+        language: "postgresql",
+      },
+    },
   ],
 };

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "prettier": "2.8.2",
     "prettier-plugin-packagejson": "2.3.0",
     "prettier-plugin-sh": "0.12.8",
+    "prettier-plugin-sql": "0.12.1",
     "suppress-exit-code": "3.1.0",
     "turbo": "1.6.3",
     "wait-on": "6.0.1",

--- a/packages/graph/hash_graph/postgres_migrations/V1__initial.sql
+++ b/packages/graph/hash_graph/postgres_migrations/V1__initial.sql
@@ -1,130 +1,176 @@
-CREATE EXTENSION IF NOT EXISTS "btree_gist";
+CREATE EXTENSION
+  IF NOT EXISTS "btree_gist";
 
-CREATE TABLE IF NOT EXISTS "accounts" (
-  "account_id" UUID PRIMARY KEY
-);
+CREATE TABLE IF NOT EXISTS
+  "accounts" ("account_id" UUID PRIMARY KEY);
 
-CREATE TABLE IF NOT EXISTS "base_uris" (
-  "base_uri" TEXT PRIMARY KEY
-);
+CREATE TABLE IF NOT EXISTS
+  "base_uris" ("base_uri" TEXT PRIMARY KEY);
 
-CREATE TABLE IF NOT EXISTS "version_ids" (
-  "version_id" UUID PRIMARY KEY
-);
+CREATE TABLE IF NOT EXISTS
+  "version_ids" ("version_id" UUID PRIMARY KEY);
 
-CREATE TABLE IF NOT EXISTS "type_ids" (
-  "base_uri" TEXT NOT NULL REFERENCES "base_uris",
-  "version" BIGINT NOT NULL,
-  "version_id" UUID REFERENCES "version_ids"
-);
+CREATE TABLE IF NOT EXISTS
+  "type_ids" (
+    "base_uri" TEXT NOT NULL REFERENCES "base_uris",
+    "version" BIGINT NOT NULL,
+    "version_id" UUID REFERENCES "version_ids"
+  );
 
-COMMENT ON TABLE "type_ids" IS $pga$ This table is a boundary to define the actual identification scheme for our kinds of types. Assume that we use the UUIDs on the types to look up more specific ID details. $pga$;
+COMMENT
+  ON TABLE "type_ids" IS $pga$ This table is a boundary to define the actual identification scheme for our kinds of types. Assume that we use the UUIDs on the types to look up more specific ID details. $pga$;
 
-ALTER TABLE "type_ids"
-  ADD CONSTRAINT "type_ids_primary_key" PRIMARY KEY ("base_uri", "version");
+ALTER TABLE
+  "type_ids"
+ADD
+  CONSTRAINT "type_ids_primary_key" PRIMARY KEY ("base_uri", "version");
 
-CREATE TABLE IF NOT EXISTS "data_types" (
-  "version_id" UUID PRIMARY KEY REFERENCES "version_ids",
-  "schema" JSONB NOT NULL,
-  "owned_by_id" UUID NOT NULL REFERENCES "accounts",
-  "updated_by_id" UUID NOT NULL REFERENCES "accounts"
-);
+CREATE TABLE IF NOT EXISTS
+  "data_types" (
+    "version_id" UUID PRIMARY KEY REFERENCES "version_ids",
+    "schema" JSONB NOT NULL,
+    "owned_by_id" UUID NOT NULL REFERENCES "accounts",
+    "updated_by_id" UUID NOT NULL REFERENCES "accounts"
+  );
 
-CREATE TABLE IF NOT EXISTS "property_types" (
-  "version_id" UUID PRIMARY KEY REFERENCES "version_ids",
-  "schema" JSONB NOT NULL,
-  "owned_by_id" UUID NOT NULL REFERENCES "accounts",
-  "updated_by_id" UUID NOT NULL REFERENCES "accounts"
-);
+CREATE TABLE IF NOT EXISTS
+  "property_types" (
+    "version_id" UUID PRIMARY KEY REFERENCES "version_ids",
+    "schema" JSONB NOT NULL,
+    "owned_by_id" UUID NOT NULL REFERENCES "accounts",
+    "updated_by_id" UUID NOT NULL REFERENCES "accounts"
+  );
 
-CREATE TABLE IF NOT EXISTS "entity_types" (
-  "version_id" UUID PRIMARY KEY REFERENCES "version_ids",
-  "schema" JSONB NOT NULL,
-  "owned_by_id" UUID NOT NULL REFERENCES "accounts",
-  "updated_by_id" UUID NOT NULL REFERENCES "accounts"
-);
+CREATE TABLE IF NOT EXISTS
+  "entity_types" (
+    "version_id" UUID PRIMARY KEY REFERENCES "version_ids",
+    "schema" JSONB NOT NULL,
+    "owned_by_id" UUID NOT NULL REFERENCES "accounts",
+    "updated_by_id" UUID NOT NULL REFERENCES "accounts"
+  );
 
-CREATE TABLE IF NOT EXISTS "property_type_property_type_references" (
-  "source_property_type_version_id" UUID NOT NULL REFERENCES "property_types",
-  "target_property_type_version_id" UUID NOT NULL REFERENCES "property_types"
-);
+CREATE TABLE IF NOT EXISTS
+  "property_type_property_type_references" (
+    "source_property_type_version_id" UUID NOT NULL REFERENCES "property_types",
+    "target_property_type_version_id" UUID NOT NULL REFERENCES "property_types"
+  );
 
-CREATE TABLE IF NOT EXISTS "property_type_data_type_references" (
-  "source_property_type_version_id" UUID NOT NULL REFERENCES "property_types",
-  "target_data_type_version_id" UUID NOT NULL REFERENCES "data_types"
-);
+CREATE TABLE IF NOT EXISTS
+  "property_type_data_type_references" (
+    "source_property_type_version_id" UUID NOT NULL REFERENCES "property_types",
+    "target_data_type_version_id" UUID NOT NULL REFERENCES "data_types"
+  );
 
-CREATE TABLE IF NOT EXISTS "entity_type_property_type_references" (
-  "source_entity_type_version_id" UUID NOT NULL REFERENCES "entity_types",
-  "target_property_type_version_id" UUID NOT NULL REFERENCES "property_types"
-);
+CREATE TABLE IF NOT EXISTS
+  "entity_type_property_type_references" (
+    "source_entity_type_version_id" UUID NOT NULL REFERENCES "entity_types",
+    "target_property_type_version_id" UUID NOT NULL REFERENCES "property_types"
+  );
 
-CREATE TABLE IF NOT EXISTS "entity_type_entity_type_references" (
-  "source_entity_type_version_id" UUID NOT NULL REFERENCES "entity_types",
-  "target_entity_type_version_id" UUID NOT NULL REFERENCES "entity_types"
-);
+CREATE TABLE IF NOT EXISTS
+  "entity_type_entity_type_references" (
+    "source_entity_type_version_id" UUID NOT NULL REFERENCES "entity_types",
+    "target_entity_type_version_id" UUID NOT NULL REFERENCES "entity_types"
+  );
 
-CREATE TABLE IF NOT EXISTS "entity_ids" (
-  "owned_by_id" UUID NOT NULL REFERENCES "accounts",
-  "entity_uuid" UUID NOT NULL,
-  "left_owned_by_id" UUID,
-  "left_entity_uuid" UUID,
-  "right_owned_by_id" UUID,
-  "right_entity_uuid" UUID
-);
+CREATE TABLE IF NOT EXISTS
+  "entity_ids" (
+    "owned_by_id" UUID NOT NULL REFERENCES "accounts",
+    "entity_uuid" UUID NOT NULL,
+    "left_owned_by_id" UUID,
+    "left_entity_uuid" UUID,
+    "right_owned_by_id" UUID,
+    "right_entity_uuid" UUID
+  );
 
-ALTER TABLE "entity_ids"
-  ADD CONSTRAINT "entity_ids_primary_key" PRIMARY KEY ("owned_by_id", "entity_uuid"),
-  ADD CONSTRAINT "entity_ids_left_reference" FOREIGN KEY ("left_owned_by_id", "left_entity_uuid") REFERENCES "entity_ids",
-  ADD CONSTRAINT "entity_ids_right_reference" FOREIGN KEY ("right_owned_by_id", "right_entity_uuid") REFERENCES "entity_ids",
-  ADD CONSTRAINT "entity_ids_relation_constraint" CHECK (left_entity_uuid IS NULL AND right_entity_uuid IS NULL AND left_owned_by_id IS NULL AND right_owned_by_id IS NULL OR
-                                                         left_entity_uuid IS NOT NULL AND right_entity_uuid IS NOT NULL AND left_owned_by_id IS NOT NULL AND right_owned_by_id IS NOT NULL);
+ALTER TABLE
+  "entity_ids"
+ADD
+  CONSTRAINT "entity_ids_primary_key" PRIMARY KEY ("owned_by_id", "entity_uuid"),
+ADD
+  CONSTRAINT "entity_ids_left_reference" FOREIGN KEY ("left_owned_by_id", "left_entity_uuid") REFERENCES "entity_ids",
+ADD
+  CONSTRAINT "entity_ids_right_reference" FOREIGN KEY ("right_owned_by_id", "right_entity_uuid") REFERENCES "entity_ids",
+ADD
+  CONSTRAINT "entity_ids_relation_constraint" CHECK (
+    left_entity_uuid IS NULL
+    AND right_entity_uuid IS NULL
+    AND left_owned_by_id IS NULL
+    AND right_owned_by_id IS NULL
+    OR left_entity_uuid IS NOT NULL
+    AND right_entity_uuid IS NOT NULL
+    AND left_owned_by_id IS NOT NULL
+    AND right_owned_by_id IS NOT NULL
+  );
 
-CREATE TABLE IF NOT EXISTS "entity_editions" (
-  "entity_record_id" BIGINT PRIMARY KEY NOT NULL GENERATED ALWAYS AS IDENTITY,
-  "entity_type_version_id" UUID NOT NULL REFERENCES "entity_types",
-  "properties" JSONB NOT NULL,
-  "left_to_right_order" integer,
-  "right_to_left_order" integer,
-  "updated_by_id" UUID NOT NULL REFERENCES "accounts",
-  "archived" BOOLEAN NOT NULL
-);
+CREATE TABLE IF NOT EXISTS
+  "entity_editions" (
+    "entity_record_id" BIGINT PRIMARY KEY NOT NULL GENERATED ALWAYS AS IDENTITY,
+    "entity_type_version_id" UUID NOT NULL REFERENCES "entity_types",
+    "properties" JSONB NOT NULL,
+    "left_to_right_order" integer,
+    "right_to_left_order" integer,
+    "updated_by_id" UUID NOT NULL REFERENCES "accounts",
+    "archived" BOOLEAN NOT NULL
+  );
 
-CREATE TABLE IF NOT EXISTS "entity_versions" (
-  "owned_by_id" UUID NOT NULL,
-  "entity_uuid" UUID NOT NULL,
-  "entity_record_id" BIGINT NOT NULL REFERENCES "entity_editions",
-  "decision_time" tstzrange NOT NULL,
-  "transaction_time" tstzrange NOT NULL
-);
+CREATE TABLE IF NOT EXISTS
+  "entity_versions" (
+    "owned_by_id" UUID NOT NULL,
+    "entity_uuid" UUID NOT NULL,
+    "entity_record_id" BIGINT NOT NULL REFERENCES "entity_editions",
+    "decision_time" tstzrange NOT NULL,
+    "transaction_time" tstzrange NOT NULL
+  );
 
-ALTER TABLE "entity_versions"
-  ADD CONSTRAINT "entity_versions_reference" FOREIGN KEY ("owned_by_id", "entity_uuid") REFERENCES "entity_ids",
-  ADD CONSTRAINT "entity_versions_overlapping" EXCLUDE USING gist (owned_by_id WITH =, entity_uuid WITH =, decision_time WITH &&, transaction_time WITH &&) DEFERRABLE INITIALLY IMMEDIATE,
-  ADD CONSTRAINT "entity_versions_decision_time_validation" CHECK (lower(decision_time) <= lower(transaction_time));
+ALTER TABLE
+  "entity_versions"
+ADD
+  CONSTRAINT "entity_versions_reference" FOREIGN KEY ("owned_by_id", "entity_uuid") REFERENCES "entity_ids",
+ADD
+  CONSTRAINT "entity_versions_overlapping" EXCLUDE USING gist (
+    owned_by_id
+    WITH
+      =,
+      entity_uuid
+    WITH
+      =,
+      decision_time
+    WITH
+      &&,
+      transaction_time
+    WITH
+      &&
+  ) DEFERRABLE INITIALLY IMMEDIATE,
+ADD
+  CONSTRAINT "entity_versions_decision_time_validation" CHECK (lower(decision_time) <= lower(transaction_time));
 
-CREATE VIEW "entities" AS
-    SELECT
-      entity_versions.entity_record_id,
-      entity_versions.owned_by_id,
-      entity_versions.entity_uuid,
-      entity_versions.decision_time,
-      entity_versions.transaction_time,
-      entity_editions.entity_type_version_id,
-      entity_editions.updated_by_id,
-      entity_editions.properties,
-      entity_editions.archived,
-      entity_ids.left_owned_by_id,
-      entity_ids.left_entity_uuid,
-      entity_editions.left_to_right_order,
-      entity_ids.right_owned_by_id,
-      entity_ids.right_entity_uuid,
-      entity_editions.right_to_left_order
-    FROM entity_versions
-    JOIN entity_editions ON entity_versions.entity_record_id = entity_editions.entity_record_id
-    JOIN entity_ids ON entity_versions.owned_by_id = entity_ids.owned_by_id AND entity_versions.entity_uuid = entity_ids.entity_uuid;
+CREATE VIEW
+  "entities" AS
+SELECT
+  entity_versions.entity_record_id,
+  entity_versions.owned_by_id,
+  entity_versions.entity_uuid,
+  entity_versions.decision_time,
+  entity_versions.transaction_time,
+  entity_editions.entity_type_version_id,
+  entity_editions.updated_by_id,
+  entity_editions.properties,
+  entity_editions.archived,
+  entity_ids.left_owned_by_id,
+  entity_ids.left_entity_uuid,
+  entity_editions.left_to_right_order,
+  entity_ids.right_owned_by_id,
+  entity_ids.right_entity_uuid,
+  entity_editions.right_to_left_order
+FROM
+  entity_versions
+  JOIN entity_editions ON entity_versions.entity_record_id = entity_editions.entity_record_id
+  JOIN entity_ids ON entity_versions.owned_by_id = entity_ids.owned_by_id
+  AND entity_versions.entity_uuid = entity_ids.entity_uuid;
 
-CREATE OR REPLACE FUNCTION "create_entity" (
+CREATE
+OR REPLACE FUNCTION "create_entity" (
   "_owned_by_id" UUID,
   "_entity_uuid" UUID,
   "_decision_time" TIMESTAMP WITH TIME ZONE,
@@ -137,9 +183,12 @@ CREATE OR REPLACE FUNCTION "create_entity" (
   "_right_owned_by_id" UUID,
   "_right_entity_uuid" UUID,
   "_left_to_right_order" INTEGER,
-  "_right_to_left_order" INTEGER)
-  RETURNS TABLE (entity_record_id BIGINT, decision_time tstzrange, transaction_time tstzrange)
-  AS $pga$
+  "_right_to_left_order" INTEGER
+) RETURNS TABLE (
+  entity_record_id BIGINT,
+  decision_time tstzrange,
+  transaction_time tstzrange
+) AS $pga$
     DECLARE
       _entity_record_id BIGINT;
     BEGIN
@@ -193,22 +242,24 @@ CREATE OR REPLACE FUNCTION "create_entity" (
         tstzrange(now(), NULL, '[)')
       ) RETURNING entity_versions.entity_record_id, entity_versions.decision_time, entity_versions.transaction_time;
     END
-    $pga$
-  VOLATILE
-  LANGUAGE plpgsql;
+    $pga$ VOLATILE LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION "update_entity" (
-  "_owned_by_id" UUID, 
-  "_entity_uuid" UUID, 
-  "_decision_time" TIMESTAMP WITH TIME ZONE, 
-  "_updated_by_id" UUID, 
-  "_archived" BOOLEAN, 
-  "_entity_type_version_id" UUID, 
-  "_properties" JSONB, 
-  "_left_to_right_order" INTEGER, 
-  "_right_to_left_order" INTEGER)
-  RETURNS TABLE (entity_record_id BIGINT, decision_time tstzrange, transaction_time tstzrange)
-  AS $pga$
+CREATE
+OR REPLACE FUNCTION "update_entity" (
+  "_owned_by_id" UUID,
+  "_entity_uuid" UUID,
+  "_decision_time" TIMESTAMP WITH TIME ZONE,
+  "_updated_by_id" UUID,
+  "_archived" BOOLEAN,
+  "_entity_type_version_id" UUID,
+  "_properties" JSONB,
+  "_left_to_right_order" INTEGER,
+  "_right_to_left_order" INTEGER
+) RETURNS TABLE (
+  entity_record_id BIGINT,
+  decision_time tstzrange,
+  transaction_time tstzrange
+) AS $pga$
     DECLARE
       _new_entity_record_id BIGINT;
     BEGIN
@@ -242,13 +293,10 @@ CREATE OR REPLACE FUNCTION "update_entity" (
         AND entity_versions.transaction_time @> now()
       RETURNING entity_versions.entity_record_id, entity_versions.decision_time, entity_versions.transaction_time;
     END
-    $pga$
-  VOLATILE
-  LANGUAGE plpgsql;
+    $pga$ VOLATILE LANGUAGE plpgsql;
 
-CREATE FUNCTION "update_entity_version_trigger" ()
-  RETURNS TRIGGER
-  AS $pga$
+CREATE FUNCTION
+  "update_entity_version_trigger" () RETURNS TRIGGER AS $pga$
     BEGIN
       SET CONSTRAINTS entity_versions_overlapping DEFERRED;
 
@@ -283,11 +331,11 @@ CREATE FUNCTION "update_entity_version_trigger" ()
       );
 
       RETURN NEW;
-    END$pga$
-  VOLATILE
-  LANGUAGE plpgsql;
+    END$pga$ VOLATILE LANGUAGE plpgsql;
 
-CREATE TRIGGER "update_entity_version_trigger"
-  BEFORE UPDATE ON "entity_versions"
-  FOR EACH ROW
-  EXECUTE PROCEDURE "update_entity_version_trigger"();
+CREATE TRIGGER
+  "update_entity_version_trigger" BEFORE
+UPDATE
+  ON "entity_versions" FOR EACH ROW
+EXECUTE
+  PROCEDURE "update_entity_version_trigger" ();

--- a/packages/hash/docker/citus/prod/initdb/0000_init.sql
+++ b/packages/hash/docker/citus/prod/initdb/0000_init.sql
@@ -1,1 +1,2 @@
-create extension citus;
+create extension
+  citus;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8864,7 +8864,7 @@ better-opn@^2.1.1:
   dependencies:
     open "^7.0.3"
 
-big-integer@^1.6.44:
+big-integer@^1.6.44, big-integer@^1.6.48:
   version "1.6.51"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
   integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
@@ -16435,6 +16435,13 @@ node-releases@^2.0.6:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.6.tgz#8a7088c63a55e493845683ebf3c828d8c51c5503"
   integrity sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==
 
+node-sql-parser@^4.4.0:
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/node-sql-parser/-/node-sql-parser-4.6.4.tgz#35b00401ca23018798b69d3cec0917aa87e5a84d"
+  integrity sha512-OPzbsiN5VX37/HM5BgGxcoDt1ggvFUc6gdzyQzoPjk8orTOHBlgHuDUugP5oRU+CcOw8GniilvV3pt5FBxp47A==
+  dependencies:
+    big-integer "^1.6.48"
+
 nodemailer@6.6.3:
   version "6.6.3"
   resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.6.3.tgz#31fb53dd4d8ae16fc088a65cb9ffa8d928a69b48"
@@ -17454,6 +17461,15 @@ prettier-plugin-sh@0.12.8:
     mvdan-sh "^0.10.1"
     sh-syntax "^0.3.6"
     synckit "^0.8.1"
+
+prettier-plugin-sql@0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-sql/-/prettier-plugin-sql-0.12.1.tgz#ae1d87640a51cd2e3f82c51561a299c0d30003d7"
+  integrity sha512-2z0pMmQEC61Xywerw2FJFpEIaA9lJUjB5mj+9dfRU8HkU7iICFrIizpMjSSDMoGkhh5W+IRROVgLlgRdpphI7g==
+  dependencies:
+    node-sql-parser "^4.4.0"
+    sql-formatter "^10.0.0"
+    tslib "^2.4.0"
 
 prettier@2.8.2, prettier@^2.3.2, prettier@^2.6.2, prettier@^2.8.0:
   version "2.8.2"
@@ -19579,6 +19595,14 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+sql-formatter@^10.0.0:
+  version "10.7.2"
+  resolved "https://registry.yarnpkg.com/sql-formatter/-/sql-formatter-10.7.2.tgz#e482d73c44fa1243a6730f27dfab2ad734b95f30"
+  integrity sha512-YspJXMr2rKMGZY50zYRBs2nCtEO/AKDrmQOxmV2CrGEOFSXUhY3YbsOUe6lX0T/7xbBs4pAYv4UObmwf78vtKg==
+  dependencies:
+    argparse "^2.0.1"
+    nearley "^2.20.1"
 
 sshpk@^1.7.0:
   version "1.17.0"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The new migration scripts require, that the migration files did not change since the previous migration. Without consistent formatting, this will be very hard and, honestly, the generated format from Postgres is ugly.

## 🔍 What does this change?

- Adds the `prettier-plugin-sql` 
- Specifies `postgresql` as the language