### PR TITLE
Commit code block types. Change codegen command

### DIFF
--- a/blocks/code/package.json
+++ b/blocks/code/package.json
@@ -12,9 +12,9 @@
   "author": "HASH",
   "scripts": {
     "build": "block-scripts build",
-    "generate-types": "block-scripts codegen",
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
+    "generate-types": "block-scripts codegen",
     "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "serve": "block-scripts serve"

--- a/blocks/code/package.json
+++ b/blocks/code/package.json
@@ -12,7 +12,7 @@
   "author": "HASH",
   "scripts": {
     "build": "block-scripts build",
-    "codegen": "block-scripts codegen",
+    "generate-types": "block-scripts codegen",
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
     "lint:eslint": "eslint --report-unused-disable-directives .",
@@ -58,6 +58,6 @@
       }
     ],
     "protocol": "0.3",
-    "schema": "https://alpha.hash.ai/@ciaran/types/entity-type/code-snippet/v/1"
+    "schema": "https://alpha.hash.ai/@ciaran/types/entity-type/code-snippet/v/2"
   }
 }

--- a/blocks/code/src/app.tsx
+++ b/blocks/code/src/app.tsx
@@ -8,7 +8,7 @@ import { useEffect, useRef, useState } from "react";
 import styles from "./app.module.css";
 import { Editor } from "./editor";
 import { CopyIcon } from "./icons";
-import { RootEntity } from "./types.gen";
+import { RootEntity } from "./types";
 import { languages, LanguageType } from "./utils";
 
 export const App: BlockComponent<RootEntity> = ({

--- a/blocks/code/src/dev.tsx
+++ b/blocks/code/src/dev.tsx
@@ -7,7 +7,7 @@ import { createRoot } from "react-dom/client";
 
 import packageJSON from "../package.json";
 import Component from "./index";
-import { RootEntity } from "./types.gen";
+import { RootEntity } from "./types";
 
 const node = document.getElementById("app");
 

--- a/blocks/code/src/types.ts
+++ b/blocks/code/src/types.ts
@@ -1,6 +1,5 @@
 import { Entity } from "@blockprotocol/graph";
 
-/* eslint-disable */
 /**
  * This file was automatically generated – do not edit it.
  * @see https://alpha.hash.ai/@ciaran/types/entity-type/code-snippet/v/2 for the root JSON Schema these types were generated from
@@ -31,12 +30,10 @@ export type CodeSnippetProperties = {
   "https://alpha.hash.ai/@ciaran/types/property-type/content/": Content;
   "https://alpha.hash.ai/@ciaran/types/property-type/language/": Language;
   "https://alpha.hash.ai/@ciaran/types/property-type/caption/"?: Caption;
-}
+};
 
 export type CodeSnippet = Entity<CodeSnippetProperties>;
-export type CodeSnippetLinksByLinkTypeId = {
-
-};
+export type CodeSnippetLinksByLinkTypeId = {};
 
 export type CodeSnippetLinkAndRightEntities = NonNullable<
   CodeSnippetLinksByLinkTypeId[keyof CodeSnippetLinksByLinkTypeId]

--- a/blocks/code/src/types.ts
+++ b/blocks/code/src/types.ts
@@ -1,0 +1,47 @@
+import { Entity } from "@blockprotocol/graph";
+
+/* eslint-disable */
+/**
+ * This file was automatically generated – do not edit it.
+ * @see https://alpha.hash.ai/@ciaran/types/entity-type/code-snippet/v/2 for the root JSON Schema these types were generated from
+ * Types for link entities and their destination were generated to a depth of 2 from the root
+ */
+
+/**
+ * Textual content
+ */
+export type Content = Text;
+/**
+ * An ordered sequence of characters
+ */
+export type Text = string;
+/**
+ * a language
+ */
+export type Language = Text;
+/**
+ * A caption
+ */
+export type Caption = Text;
+
+/**
+ * A snippet of code
+ */
+export type CodeSnippetProperties = {
+  "https://alpha.hash.ai/@ciaran/types/property-type/content/": Content;
+  "https://alpha.hash.ai/@ciaran/types/property-type/language/": Language;
+  "https://alpha.hash.ai/@ciaran/types/property-type/caption/"?: Caption;
+}
+
+export type CodeSnippet = Entity<CodeSnippetProperties>;
+export type CodeSnippetLinksByLinkTypeId = {
+
+};
+
+export type CodeSnippetLinkAndRightEntities = NonNullable<
+  CodeSnippetLinksByLinkTypeId[keyof CodeSnippetLinksByLinkTypeId]
+>;
+
+export type RootEntity = CodeSnippet;
+export type RootEntityLinkedEntities = CodeSnippetLinkAndRightEntities;
+export type RootLinkMap = CodeSnippetLinksByLinkTypeId;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The code block has types which are automatically generated from a remote URI, which (a) the block source relies on and (b) are run as part of the repo's `codegen` command across all workspaces.

Because alpha.hash.ai's data is not yet stable, this risks the CI pipeline breaking, either because the type is not available, or because it is different from the expectations in the code block (if it has been recreated).

This PR commits the code block's types and renames its `codegen` command so that it is not run as part of CI and is available in the format the block requires to build.