### PR TITLE
Move `OwnedById` and `UpdatedById` to `type_ids` table

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/data_type.rs
@@ -17,7 +17,7 @@ impl PostgresRecord for DataTypeWithMetadata {
 impl PostgresQueryPath for DataTypeQueryPath {
     fn relations(&self) -> Vec<Relation> {
         match self {
-            Self::BaseUri | Self::Version => {
+            Self::BaseUri | Self::Version | Self::OwnedById | Self::UpdatedById => {
                 vec![Relation::DataTypeIds]
             }
             _ => vec![],
@@ -28,9 +28,9 @@ impl PostgresQueryPath for DataTypeQueryPath {
         match self {
             Self::BaseUri => Column::TypeIds(TypeIds::BaseUri),
             Self::Version => Column::TypeIds(TypeIds::Version),
+            Self::OwnedById => Column::TypeIds(TypeIds::OwnedById),
+            Self::UpdatedById => Column::TypeIds(TypeIds::UpdatedById),
             Self::VersionId => Column::DataTypes(DataTypes::VersionId),
-            Self::OwnedById => Column::DataTypes(DataTypes::OwnedById),
-            Self::UpdatedById => Column::DataTypes(DataTypes::UpdatedById),
             Self::Schema => Column::DataTypes(DataTypes::Schema(None)),
             Self::VersionedUri => Column::DataTypes(DataTypes::Schema(Some(JsonField::Text(
                 &Cow::Borrowed("$id"),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/entity_type.rs
@@ -18,7 +18,9 @@ impl PostgresQueryPath for EntityTypeQueryPath {
     /// Returns the relations that are required to access the path.
     fn relations(&self) -> Vec<Relation> {
         match self {
-            Self::BaseUri | Self::Version => vec![Relation::EntityTypeIds],
+            Self::BaseUri | Self::Version | Self::OwnedById | Self::UpdatedById => {
+                vec![Relation::EntityTypeIds]
+            }
             Self::Properties(path) => once(Relation::EntityTypePropertyTypeReferences)
                 .chain(path.relations())
                 .collect(),
@@ -36,9 +38,9 @@ impl PostgresQueryPath for EntityTypeQueryPath {
         match self {
             Self::BaseUri => Column::TypeIds(TypeIds::BaseUri),
             Self::Version => Column::TypeIds(TypeIds::Version),
+            Self::OwnedById => Column::TypeIds(TypeIds::OwnedById),
+            Self::UpdatedById => Column::TypeIds(TypeIds::UpdatedById),
             Self::VersionId => Column::EntityTypes(EntityTypes::VersionId),
-            Self::OwnedById => Column::EntityTypes(EntityTypes::OwnedById),
-            Self::UpdatedById => Column::EntityTypes(EntityTypes::UpdatedById),
             Self::Schema => Column::EntityTypes(EntityTypes::Schema(None)),
             Self::VersionedUri => Column::EntityTypes(EntityTypes::Schema(Some(JsonField::Text(
                 &Cow::Borrowed("$id"),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/property_type.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/property_type.rs
@@ -17,7 +17,9 @@ impl PostgresRecord for PropertyTypeWithMetadata {
 impl PostgresQueryPath for PropertyTypeQueryPath {
     fn relations(&self) -> Vec<Relation> {
         match self {
-            Self::BaseUri | Self::Version => vec![Relation::PropertyTypeIds],
+            Self::BaseUri | Self::Version | Self::OwnedById | Self::UpdatedById => {
+                vec![Relation::PropertyTypeIds]
+            }
             Self::DataTypes(path) => once(Relation::PropertyTypeDataTypeReferences)
                 .chain(path.relations())
                 .collect(),
@@ -32,9 +34,9 @@ impl PostgresQueryPath for PropertyTypeQueryPath {
         match self {
             Self::BaseUri => Column::TypeIds(TypeIds::BaseUri),
             Self::Version => Column::TypeIds(TypeIds::Version),
+            Self::OwnedById => Column::TypeIds(TypeIds::OwnedById),
+            Self::UpdatedById => Column::TypeIds(TypeIds::UpdatedById),
             Self::VersionId => Column::PropertyTypes(PropertyTypes::VersionId),
-            Self::OwnedById => Column::PropertyTypes(PropertyTypes::OwnedById),
-            Self::UpdatedById => Column::PropertyTypes(PropertyTypes::UpdatedById),
             Self::Schema => Column::PropertyTypes(PropertyTypes::Schema(None)),
             Self::VersionedUri => Column::PropertyTypes(PropertyTypes::Schema(Some(
                 JsonField::Text(&Cow::Borrowed("$id")),

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/query/table.rs
@@ -59,6 +59,8 @@ pub enum TypeIds {
     BaseUri,
     Version,
     LatestVersion,
+    OwnedById,
+    UpdatedById,
 }
 
 impl Transpile for TypeIds {
@@ -68,6 +70,8 @@ impl Transpile for TypeIds {
             Self::BaseUri => "base_uri",
             Self::Version => "version",
             Self::LatestVersion => "latest_version",
+            Self::OwnedById => "owned_by_id",
+            Self::UpdatedById => "updated_by_id",
         };
         write!(fmt, r#"."{column}""#)
     }
@@ -79,17 +83,13 @@ macro_rules! impl_ontology_column {
             #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
             pub enum $name {
                 VersionId,
-                OwnedById,
-                UpdatedById,
                 Schema(Option<JsonField<'static>>),
             }
 
             impl $name {
                 pub const fn nullable(self) -> bool {
                     match self {
-                        Self::VersionId
-                        | Self::OwnedById
-                        | Self::UpdatedById => false,
+                        Self::VersionId => false,
                         Self::Schema(_) => true,
                     }
                 }
@@ -99,8 +99,6 @@ macro_rules! impl_ontology_column {
                 fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
                     let column = match self {
                         Self::VersionId => "version_id",
-                        Self::OwnedById => "owned_by_id",
-                        Self::UpdatedById => "updated_by_id",
                         Self::Schema(None) => "schema",
                         Self::Schema(Some(path)) => match path {
                             JsonField::Json(field) => {

--- a/packages/graph/hash_graph/postgres_migrations/V2__ontology_tables.sql
+++ b/packages/graph/hash_graph/postgres_migrations/V2__ontology_tables.sql
@@ -9,6 +9,8 @@ CREATE TABLE IF NOT EXISTS
     "base_uri" TEXT NOT NULL REFERENCES "base_uris",
     "version" BIGINT NOT NULL,
     "version_id" UUID REFERENCES "version_ids",
+    "owned_by_id" UUID NOT NULL REFERENCES "accounts",
+    "updated_by_id" UUID NOT NULL REFERENCES "accounts",
     PRIMARY KEY ("base_uri", "version"),
     UNIQUE ("version_id")
   );
@@ -19,25 +21,19 @@ COMMENT
 CREATE TABLE IF NOT EXISTS
   "data_types" (
     "version_id" UUID PRIMARY KEY REFERENCES "version_ids",
-    "schema" JSONB NOT NULL,
-    "owned_by_id" UUID NOT NULL REFERENCES "accounts",
-    "updated_by_id" UUID NOT NULL REFERENCES "accounts"
+    "schema" JSONB NOT NULL
   );
 
 CREATE TABLE IF NOT EXISTS
   "property_types" (
     "version_id" UUID PRIMARY KEY REFERENCES "version_ids",
-    "schema" JSONB NOT NULL,
-    "owned_by_id" UUID NOT NULL REFERENCES "accounts",
-    "updated_by_id" UUID NOT NULL REFERENCES "accounts"
+    "schema" JSONB NOT NULL
   );
 
 CREATE TABLE IF NOT EXISTS
   "entity_types" (
     "version_id" UUID PRIMARY KEY REFERENCES "version_ids",
-    "schema" JSONB NOT NULL,
-    "owned_by_id" UUID NOT NULL REFERENCES "accounts",
-    "updated_by_id" UUID NOT NULL REFERENCES "accounts"
+    "schema" JSONB NOT NULL
   );
 
 CREATE TABLE IF NOT EXISTS


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

For future work and to avoid duplication we can move these types to the shared `type_ids` table

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- This is required for [this Asana task](https://app.asana.com/0/0/1203774687353268/f) _(internal)_

## 🔍 What does this change?

- Change the database layout
- Adjust inserting logic
- Adjust querying logic
- Drive-by: Query base URI and the version from the `type_ids` table as well
