### PR TITLE
Update path to kratos to fix CD

### DIFF
--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -93,8 +93,8 @@ jobs:
           IMAGE_NAME: ${{ env.HASH_KRATOS_RESOURCE_NAME }}
         with:
           SHORTNAME: "kratos"
-          CONTEXT_PATH: ${{ github.workspace }}/packages/hash/external-services/kratos
-          DOCKERFILE_LOCATION: ${{ github.workspace }}/packages/hash/external-services/kratos/Dockerfile
+          CONTEXT_PATH: ${{ github.workspace }}/apps/hash-external-services/kratos
+          DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/kratos/Dockerfile
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ env.AWS_REGION }}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR fixes [a new error in CD](https://github.com/hashintel/hash/actions/runs/3958626453/jobs/6780421158):

```
ERROR: unable to prepare context: path "/home/runner/work/hash/hash/packages/hash/external-services/kratos" not found
Error: buildx failed with: ERROR: unable to prepare context: path "/home/runner/work/hash/hash/packages/hash/external-services/kratos" not found
```

It is a result of a clash between two PRs. https://github.com/hashintel/hash/pull/1864 was merged quite recently, after I checked paths in #1870. I did not check for the re-introduction of `packages/hash/external-services` this morning, so missed the clash. This should be fixed now.

## ❓ How to test this?

Merge and see if `hash-backend-cd.yml` passes