### PR TITLE
Use functions to create ontology types

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -198,7 +198,8 @@ where
             })
     }
 
-    /// Creates a new [`VersionId`] from the provided [`VersionedUri`].
+    /// Updates the latest version of [`VersionedUri::base_uri`] and creates a new [`VersionId`] for
+    /// it..
     ///
     /// # Errors
     ///

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -201,7 +201,7 @@ where
     }
 
     /// Updates the latest version of [`VersionedUri::base_uri`] and creates a new [`VersionId`] for
-    /// it..
+    /// it.
     ///
     /// # Errors
     ///

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -14,30 +14,24 @@ use std::{
 
 use async_trait::async_trait;
 use error_stack::{IntoReport, Report, Result, ResultExt};
-use tokio_postgres::GenericClient;
 #[cfg(feature = "__internal_bench")]
 use tokio_postgres::{binary_copy::BinaryCopyInWriter, types::Type};
+use tokio_postgres::{error::SqlState, GenericClient};
 use type_system::{
-    uri::{BaseUri, VersionedUri},
-    DataTypeReference, EntityType, EntityTypeReference, PropertyType, PropertyTypeReference,
+    uri::VersionedUri, DataTypeReference, EntityType, EntityTypeReference, PropertyType,
+    PropertyTypeReference,
 };
-use uuid::Uuid;
 
 pub use self::pool::{AsClient, PostgresStorePool};
 use crate::{
-    identifier::{
-        account::AccountId, ontology::OntologyTypeEditionId, time::UnresolvedTimeProjection,
-        EntityVertexId,
-    },
-    ontology::{OntologyElementMetadata, OntologyTypeWithMetadata},
+    identifier::{account::AccountId, ontology::OntologyTypeEditionId, EntityVertexId},
+    ontology::OntologyElementMetadata,
     provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
-        crud::Read,
         error::VersionedUriAlreadyExists,
-        postgres::{ontology::OntologyDatabaseType, query::PostgresRecord, version_id::VersionId},
-        query::{Filter, OntologyQueryPath},
-        AccountStore, BaseUriAlreadyExists, BaseUriDoesNotExist, InsertionError, QueryError,
-        Record, Store, StoreError, Transaction, UpdateError,
+        postgres::{ontology::OntologyDatabaseType, version_id::VersionId},
+        AccountStore, BaseUriAlreadyExists, BaseUriDoesNotExist, InsertionError, QueryError, Store,
+        StoreError, Transaction, UpdateError,
     },
     subgraph::edges::GraphResolveDepths,
 };
@@ -162,148 +156,94 @@ where
         Self { client }
     }
 
-    /// Checks if the specified [`BaseUri`] exists in the database.
+    /// Creates a new [`VersionId`] from the provided [`VersionedUri`].
     ///
     /// # Errors
     ///
-    /// - if checking for the [`BaseUri`] failed.
-    ///
-    /// [`BaseUri`]: type_system::uri::BaseUri
+    /// - if [`VersionedUri::base_uri`] did already exist in the database
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn contains_base_uri(&self, base_uri: &BaseUri) -> Result<bool, QueryError> {
-        Ok(self
-            .client
-            .as_client()
-            .query_one(
-                r#"
-                    SELECT EXISTS(
-                        SELECT 1
-                        FROM base_uris
-                        WHERE base_uri = $1
-                    );
-                "#,
-                &[&base_uri.as_str()],
-            )
-            .await
-            .into_report()
-            .change_context(QueryError)
-            .attach_printable_lazy(|| base_uri.clone())?
-            .get(0))
-    }
-
-    /// Checks if the specified [`VersionedUri`] exists in the database.
-    ///
-    /// # Errors
-    ///
-    /// - if checking for the [`VersionedUri`] failed.
-    #[tracing::instrument(level = "debug", skip(self))]
-    async fn contains_uri(&self, uri: &VersionedUri) -> Result<bool, QueryError> {
-        let version = i64::from(uri.version());
-        Ok(self
-            .client
-            .as_client()
-            .query_one(
-                r#"
-                    SELECT EXISTS(
-                        SELECT 1
-                        FROM type_ids
-                        WHERE base_uri = $1 AND version = $2
-                    );
-                "#,
-                &[&uri.base_uri().as_str(), &version],
-            )
-            .await
-            .into_report()
-            .change_context(QueryError)
-            .attach_printable_lazy(|| uri.clone())?
-            .get(0))
-    }
-
-    /// Inserts the specified [`VersionedUri`] into the database.
-    ///
-    /// # Errors
-    ///
-    /// - if inserting the [`VersionedUri`] failed.
-    #[tracing::instrument(level = "debug", skip(self))]
-    async fn insert_uri(
+    async fn create_ontology_id(
         &self,
         uri: &VersionedUri,
-        version_id: VersionId,
         owned_by_id: OwnedById,
         updated_by_id: UpdatedById,
-    ) -> Result<(), InsertionError> {
-        let version = i64::from(uri.version());
+    ) -> Result<VersionId, InsertionError> {
         self.as_client()
             .query_one(
                 r#"
-                    INSERT INTO type_ids (base_uri, version, version_id, owned_by_id, updated_by_id)
-                    VALUES ($1, $2, $3, $4, $5)
-                    RETURNING version_id;
-                "#,
+                SELECT create_ontology_id(
+                    base_uri := $1,
+                    version := $2,
+                    owned_by_id := $3,
+                    updated_by_id := $4
+                );"#,
                 &[
                     &uri.base_uri().as_str(),
-                    &version,
-                    &version_id,
+                    &i64::from(uri.version()),
                     &owned_by_id,
                     &updated_by_id,
                 ],
             )
             .await
             .into_report()
-            .change_context(InsertionError)
-            .attach_printable_lazy(|| uri.clone())?;
-
-        Ok(())
+            .map(|row| row.get(0))
+            .map_err(|report| match report.current_context().code() {
+                Some(&SqlState::UNIQUE_VIOLATION) => report
+                    .change_context(BaseUriAlreadyExists)
+                    .attach_printable(uri.base_uri().clone())
+                    .change_context(InsertionError),
+                _ => report
+                    .change_context(InsertionError)
+                    .attach_printable(uri.clone()),
+            })
     }
 
-    /// Inserts the specified [`BaseUri`] into the database.
+    /// Creates a new [`VersionId`] from the provided [`VersionedUri`].
     ///
     /// # Errors
     ///
-    /// - if inserting the [`BaseUri`] failed.
-    ///
-    /// [`BaseUri`]: type_system::uri::BaseUri
+    /// - if [`VersionedUri::base_uri`] did not already exist in the database
+    /// - if [`VersionedUri`] did already exist in the database
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn insert_base_uri(&self, base_uri: &BaseUri) -> Result<(), InsertionError> {
+    async fn update_ontology_id(
+        &self,
+        uri: &VersionedUri,
+        updated_by_id: UpdatedById,
+    ) -> Result<(VersionId, OwnedById), UpdateError> {
         self.as_client()
-            .query_one(
+            .query_opt(
                 r#"
-                    INSERT INTO base_uris (base_uri)
-                    VALUES ($1)
-                    RETURNING base_uri;
-                "#,
-                &[&base_uri.as_str()],
+                SELECT
+                    version_id,
+                    owned_by_id
+                FROM update_ontology_id(
+                    base_uri := $1,
+                    version := $2,
+                    updated_by_id := $3
+                );"#,
+                &[
+                    &uri.base_uri().as_str(),
+                    &i64::from(uri.version()),
+                    &updated_by_id,
+                ],
             )
             .await
             .into_report()
-            .change_context(InsertionError)
-            .attach_printable_lazy(|| base_uri.clone())?;
-
-        Ok(())
-    }
-
-    /// Inserts the specified [`VersionId`] into the database.
-    ///
-    /// # Errors
-    ///
-    /// - if inserting the [`VersionId`] failed.
-    #[tracing::instrument(level = "debug", skip(self))]
-    async fn insert_version_id(&self, version_id: VersionId) -> Result<(), InsertionError> {
-        self.as_client()
-            .query_one(
-                r#"
-                    INSERT INTO version_ids (version_id)
-                    VALUES ($1)
-                    RETURNING version_id;
-                "#,
-                &[&version_id],
-            )
-            .await
-            .into_report()
-            .change_context(InsertionError)
-            .attach_printable(version_id)?;
-
-        Ok(())
+            .map_err(|report| match report.current_context().code() {
+                Some(&SqlState::UNIQUE_VIOLATION) => report
+                    .change_context(VersionedUriAlreadyExists)
+                    .attach_printable(uri.clone())
+                    .change_context(UpdateError),
+                _ => report
+                    .change_context(UpdateError)
+                    .attach_printable(uri.clone()),
+            })?
+            .map(|row| (row.get(0), OwnedById::new(row.get(1))))
+            .ok_or_else(|| {
+                Report::new(BaseUriDoesNotExist)
+                    .attach_printable(uri.base_uri().clone())
+                    .change_context(UpdateError)
+            })
     }
 
     /// Inserts the specified [`OntologyDatabaseType`].
@@ -325,35 +265,12 @@ where
         updated_by_id: UpdatedById,
     ) -> Result<(VersionId, OntologyElementMetadata), InsertionError>
     where
-        T: OntologyDatabaseType<Representation: Send> + Send + Sync,
+        T: OntologyDatabaseType,
     {
         let uri = database_type.id().clone();
 
-        if self
-            .contains_base_uri(uri.base_uri())
-            .await
-            .change_context(InsertionError)?
-        {
-            return Err(Report::new(BaseUriAlreadyExists)
-                .attach_printable(uri.base_uri().clone())
-                .change_context(InsertionError));
-        }
-
-        self.insert_base_uri(uri.base_uri()).await?;
-
-        if self
-            .contains_uri(&uri)
-            .await
-            .change_context(InsertionError)?
-        {
-            return Err(Report::new(InsertionError)
-                .attach_printable(VersionedUriAlreadyExists)
-                .attach(uri.clone()));
-        }
-
-        let version_id = VersionId::new(Uuid::new_v4());
-        self.insert_version_id(version_id).await?;
-        self.insert_uri(&uri, version_id, owned_by_id, updated_by_id)
+        let version_id = self
+            .create_ontology_id(&uri, owned_by_id, updated_by_id)
             .await?;
 
         self.insert_with_id(version_id, database_type).await?;
@@ -385,39 +302,13 @@ where
         updated_by_id: UpdatedById,
     ) -> Result<(VersionId, OntologyElementMetadata), UpdateError>
     where
-        T: OntologyDatabaseType<Representation: Send> + Send + Sync,
-        T::WithMetadata: PostgresRecord + Send,
-        for<'p> <T::WithMetadata as Record>::QueryPath<'p>: OntologyQueryPath + Send + Sync,
+        T: OntologyDatabaseType,
     {
-        let uri = database_type.id().clone();
+        let uri = database_type.id();
+        let edition_id = OntologyTypeEditionId::from(uri);
 
-        if !self
-            .contains_base_uri(uri.base_uri())
-            .await
-            .change_context(UpdateError)?
-        {
-            return Err(Report::new(BaseUriDoesNotExist)
-                .attach_printable(uri.base_uri().clone())
-                .change_context(UpdateError));
-        }
-
-        // TODO - address potential race condition
-        //  https://app.asana.com/0/1202805690238892/1203201674100967/f
-        let previous_ontology_type = <Self as Read<T::WithMetadata>>::read_one(
-            self,
-            &Filter::for_latest_base_uri(uri.base_uri()),
-            &UnresolvedTimeProjection::default().resolve(),
-        )
-        .await
-        .change_context(UpdateError)?;
-
-        let owned_by_id = previous_ontology_type.metadata().owned_by_id();
-
-        let version_id = VersionId::new(Uuid::new_v4());
-        self.insert_version_id(version_id)
-            .await
-            .change_context(UpdateError)?;
-        self.insert_uri(&uri, version_id, owned_by_id, updated_by_id)
+        let (version_id, owned_by_id) = self
+            .update_ontology_id(uri, updated_by_id)
             .await
             .change_context(UpdateError)?;
         self.insert_with_id(version_id, database_type)
@@ -427,7 +318,7 @@ where
         Ok((
             version_id,
             OntologyElementMetadata::new(
-                OntologyTypeEditionId::from(&uri),
+                edition_id,
                 ProvenanceMetadata::new(updated_by_id),
                 owned_by_id,
             ),
@@ -447,7 +338,7 @@ where
         database_type: T,
     ) -> Result<(), InsertionError>
     where
-        T: OntologyDatabaseType<Representation: Send> + Send + Sync,
+        T: OntologyDatabaseType,
     {
         let value_repr = T::Representation::from(database_type);
         let value = serde_json::to_value(value_repr)

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -171,7 +171,9 @@ where
         self.as_client()
             .query_one(
                 r#"
-                SELECT create_ontology_id(
+                SELECT
+                    version_id
+                FROM create_ontology_id(
                     base_uri := $1,
                     version := $2,
                     owned_by_id := $3,

--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/version_id.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/version_id.rs
@@ -13,13 +13,6 @@ use uuid::Uuid;
 #[postgres(transparent)]
 pub struct VersionId(Uuid);
 
-impl VersionId {
-    #[must_use]
-    pub const fn new(uuid: Uuid) -> Self {
-        Self(uuid)
-    }
-}
-
 impl fmt::Display for VersionId {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "{}", &self.0)

--- a/packages/graph/hash_graph/postgres_migrations/V2__ontology_tables.sql
+++ b/packages/graph/hash_graph/postgres_migrations/V2__ontology_tables.sql
@@ -11,8 +11,8 @@ CREATE TABLE IF NOT EXISTS
     "version_id" UUID REFERENCES "version_ids",
     "owned_by_id" UUID NOT NULL REFERENCES "accounts",
     "updated_by_id" UUID NOT NULL REFERENCES "accounts",
-    PRIMARY KEY ("base_uri", "version"),
-    UNIQUE ("version_id")
+    CONSTRAINT type_ids_pkey PRIMARY KEY ("base_uri", "version") DEFERRABLE INITIALLY IMMEDIATE,
+    CONSTRAINT type_id_unique UNIQUE ("version_id") DEFERRABLE INITIALLY IMMEDIATE
   );
 
 COMMENT

--- a/packages/graph/hash_graph/postgres_migrations/V4__ontology_functions.sql
+++ b/packages/graph/hash_graph/postgres_migrations/V4__ontology_functions.sql
@@ -1,0 +1,97 @@
+CREATE
+OR REPLACE FUNCTION create_ontology_id (
+  "base_uri" TEXT,
+  "version" BIGINT,
+  "owned_by_id" UUID,
+  "updated_by_id" UUID
+) RETURNS UUID AS $create_ontology_id$
+DECLARE
+  _version_id UUID;
+BEGIN
+  INSERT INTO "base_uris" (
+    base_uri
+  ) VALUES (
+    create_ontology_id.base_uri
+  );
+
+  INSERT INTO version_ids (
+    version_id
+  ) VALUES (
+    gen_random_uuid()
+  ) RETURNING version_ids.version_id INTO _version_id;
+
+  INSERT INTO type_ids (
+    "base_uri",
+    "version",
+    "version_id",
+    "owned_by_id",
+    "updated_by_id"
+  ) VALUES (
+    create_ontology_id.base_uri,
+    create_ontology_id.version,
+    _version_id,
+    create_ontology_id.owned_by_id,
+    create_ontology_id.updated_by_id
+  );
+
+  RETURN _version_id;
+END $create_ontology_id$ VOLATILE LANGUAGE plpgsql;
+
+CREATE
+OR REPLACE FUNCTION update_ontology_id (
+  "base_uri" TEXT,
+  "version" BIGINT,
+  "updated_by_id" UUID
+) RETURNS TABLE (version_id UUID, owned_by_id UUID) AS $update_ontology_id$
+DECLARE
+  _version_id UUID;
+BEGIN
+  INSERT INTO version_ids (
+    version_id
+  ) VALUES (
+    gen_random_uuid()
+  ) RETURNING version_ids.version_id INTO _version_id;
+
+  SET CONSTRAINTS type_ids_pkey DEFERRED;
+  SET CONSTRAINTS type_id_unique DEFERRED;
+
+  RETURN QUERY
+  UPDATE type_ids
+  SET
+    "version" = update_ontology_id.version,
+    "version_id" = _version_id,
+    "updated_by_id" = update_ontology_id.updated_by_id
+  WHERE type_ids.base_uri = update_ontology_id.base_uri
+    AND type_ids.version = update_ontology_id.version - 1
+  RETURNING type_ids.version_id, type_ids.owned_by_id;
+
+  SET CONSTRAINTS type_ids_pkey IMMEDIATE;
+  SET CONSTRAINTS type_id_unique IMMEDIATE;
+END $update_ontology_id$ VOLATILE LANGUAGE plpgsql;
+
+CREATE
+OR REPLACE FUNCTION "update_type_ids_trigger" () RETURNS TRIGGER AS $pga$
+    BEGIN
+      INSERT INTO type_ids (
+        "base_uri",
+        "version",
+        "version_id",
+        "owned_by_id",
+        "updated_by_id"
+      ) VALUES (
+        OLD.base_uri,
+        OLD.version,
+        OLD.version_id,
+        OLD.owned_by_id,
+        OLD.updated_by_id
+      );
+
+      RETURN NEW;
+    END$pga$ VOLATILE LANGUAGE plpgsql;
+
+CREATE
+OR REPLACE TRIGGER "update_type_ids_trigger" BEFORE
+UPDATE
+  ON "type_ids" FOR EACH ROW
+EXECUTE
+  PROCEDURE "update_type_ids_trigger" ();

--- a/packages/graph/hash_graph/postgres_migrations/V4__ontology_functions.sql
+++ b/packages/graph/hash_graph/postgres_migrations/V4__ontology_functions.sql
@@ -4,7 +4,7 @@ OR REPLACE FUNCTION create_ontology_id (
   "version" BIGINT,
   "owned_by_id" UUID,
   "updated_by_id" UUID
-) RETURNS UUID AS $create_ontology_id$
+) RETURNS TABLE (version_id UUID) AS $create_ontology_id$
 DECLARE
   _version_id UUID;
 BEGIN
@@ -20,6 +20,7 @@ BEGIN
     gen_random_uuid()
   ) RETURNING version_ids.version_id INTO _version_id;
 
+  RETURN QUERY
   INSERT INTO type_ids (
     "base_uri",
     "version",
@@ -32,9 +33,7 @@ BEGIN
     _version_id,
     create_ontology_id.owned_by_id,
     create_ontology_id.updated_by_id
-  );
-
-  RETURN _version_id;
+  ) RETURNING type_ids.version_id;
 END $create_ontology_id$ VOLATILE LANGUAGE plpgsql;
 
 CREATE


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To more robustly create ontology types and allow changes to the database without touching the Rust code, we are going to move to function based creation and updating of ontology types (the same logic as we do for entities). This also resolved the potential data race

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202805690238892/1203201674100967/f) _(internal)_

## 🔍 What does this change?

- Use functions similar to the create/update functions of `entities`
- Clean up Rust code and properly handle errors