### PR TITLE
Add transaction time to ontology types

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/error.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/error.rs
@@ -110,6 +110,18 @@ impl fmt::Display for VersionedUriAlreadyExists {
 impl Context for VersionedUriAlreadyExists {}
 
 #[derive(Debug)]
+#[must_use]
+pub struct WrongOntologyVersion;
+
+impl fmt::Display for WrongOntologyVersion {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.write_str("tried to update an ontology type with a different version")
+    }
+}
+
+impl Context for WrongOntologyVersion {}
+
+#[derive(Debug)]
 pub struct MigrationError;
 
 impl Context for MigrationError {}

--- a/packages/graph/hash_graph/postgres_migrations/V2__ontology_tables.sql
+++ b/packages/graph/hash_graph/postgres_migrations/V2__ontology_tables.sql
@@ -11,8 +11,17 @@ CREATE TABLE IF NOT EXISTS
     "version_id" UUID REFERENCES "version_ids",
     "owned_by_id" UUID NOT NULL REFERENCES "accounts",
     "updated_by_id" UUID NOT NULL REFERENCES "accounts",
+    "transaction_time" tstzrange NOT NULL,
     CONSTRAINT type_ids_pkey PRIMARY KEY ("base_uri", "version") DEFERRABLE INITIALLY IMMEDIATE,
-    CONSTRAINT type_id_unique UNIQUE ("version_id") DEFERRABLE INITIALLY IMMEDIATE
+    CONSTRAINT type_id_unique UNIQUE ("version_id") DEFERRABLE INITIALLY IMMEDIATE,
+    CONSTRAINT type_ids_overlapping EXCLUDE USING gist (
+      base_uri
+      WITH
+        =,
+        transaction_time
+      WITH
+        &&
+    ) DEFERRABLE INITIALLY IMMEDIATE
   );
 
 COMMENT

--- a/packages/graph/hash_graph/postgres_migrations/V4__ontology_functions.sql
+++ b/packages/graph/hash_graph/postgres_migrations/V4__ontology_functions.sql
@@ -26,13 +26,15 @@ BEGIN
     "version",
     "version_id",
     "owned_by_id",
-    "updated_by_id"
+    "updated_by_id",
+    "transaction_time"
   ) VALUES (
     create_ontology_id.base_uri,
     create_ontology_id.version,
     _version_id,
     create_ontology_id.owned_by_id,
-    create_ontology_id.updated_by_id
+    create_ontology_id.updated_by_id,
+    tstzrange(now(), NULL, '[)')
   ) RETURNING type_ids.version_id;
 END $create_ontology_id$ VOLATILE LANGUAGE plpgsql;
 
@@ -53,36 +55,46 @@ BEGIN
 
   SET CONSTRAINTS type_ids_pkey DEFERRED;
   SET CONSTRAINTS type_id_unique DEFERRED;
+  SET CONSTRAINTS type_ids_overlapping DEFERRED;
 
   RETURN QUERY
   UPDATE type_ids
   SET
+    "transaction_time" = tstzrange(now(), NULL, '[)'),
     "version" = update_ontology_id.version,
     "version_id" = _version_id,
     "updated_by_id" = update_ontology_id.updated_by_id
   WHERE type_ids.base_uri = update_ontology_id.base_uri
-    AND type_ids.version = update_ontology_id.version - 1
+    AND type_ids.transaction_time @> now()
   RETURNING type_ids.version_id, type_ids.owned_by_id;
 
   SET CONSTRAINTS type_ids_pkey IMMEDIATE;
   SET CONSTRAINTS type_id_unique IMMEDIATE;
+  SET CONSTRAINTS type_ids_overlapping IMMEDIATE;
 END $update_ontology_id$ VOLATILE LANGUAGE plpgsql;
 
 CREATE
 OR REPLACE FUNCTION "update_type_ids_trigger" () RETURNS TRIGGER AS $pga$
     BEGIN
+      IF (OLD.version != NEW.version - 1) THEN
+        RAISE EXCEPTION 'Not updating the latest id: % -> %', OLD.version, NEW.version
+        USING ERRCODE = 'invalid_parameter_value';
+      END IF;
+
       INSERT INTO type_ids (
         "base_uri",
         "version",
         "version_id",
         "owned_by_id",
-        "updated_by_id"
+        "updated_by_id",
+        "transaction_time"
       ) VALUES (
         OLD.base_uri,
         OLD.version,
         OLD.version_id,
         OLD.owned_by_id,
-        OLD.updated_by_id
+        OLD.updated_by_id,
+        tstzrange(lower(OLD.transaction_time), lower(NEW.transaction_time), '[)')
       );
 
       RETURN NEW;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Storing the transaction time for ontology types gives us the ability to use it at some later point. This also enables validation, if we are actually updating to the version after the latest version.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202805690238892/1203596982776833/f) _(internal)_

## 🔍 What does this change?

- Add `transaction_time` to `type_ids` table and adjust functions
- raise an exception, if the version does not match