### PR TITLE
Simplify ontology table definitions

### DIFF
--- a/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
+++ b/packages/graph/hash_graph/lib/graph/src/store/postgres/mod.rs
@@ -190,7 +190,7 @@ where
             .into_report()
             .map(|row| row.get(0))
             .map_err(|report| match report.current_context().code() {
-                Some(&SqlState::UNIQUE_VIOLATION) => report
+                Some(&SqlState::EXCLUSION_VIOLATION | &SqlState::UNIQUE_VIOLATION) => report
                     .change_context(BaseUriAlreadyExists)
                     .attach_printable(uri.base_uri().clone())
                     .change_context(InsertionError),

--- a/packages/graph/hash_graph/postgres_migrations/V2__ontology_tables.sql
+++ b/packages/graph/hash_graph/postgres_migrations/V2__ontology_tables.sql
@@ -1,19 +1,12 @@
 CREATE TABLE IF NOT EXISTS
-  "base_uris" ("base_uri" TEXT PRIMARY KEY);
-
-CREATE TABLE IF NOT EXISTS
-  "version_ids" ("version_id" UUID PRIMARY KEY);
-
-CREATE TABLE IF NOT EXISTS
   "type_ids" (
-    "base_uri" TEXT NOT NULL REFERENCES "base_uris",
+    "version_id" UUID PRIMARY KEY,
+    "base_uri" TEXT NOT NULL,
     "version" BIGINT NOT NULL,
-    "version_id" UUID REFERENCES "version_ids",
     "owned_by_id" UUID NOT NULL REFERENCES "accounts",
     "updated_by_id" UUID NOT NULL REFERENCES "accounts",
     "transaction_time" tstzrange NOT NULL,
-    CONSTRAINT type_ids_pkey PRIMARY KEY ("base_uri", "version") DEFERRABLE INITIALLY IMMEDIATE,
-    CONSTRAINT type_id_unique UNIQUE ("version_id") DEFERRABLE INITIALLY IMMEDIATE,
+    UNIQUE ("base_uri", "version"),
     CONSTRAINT type_ids_overlapping EXCLUDE USING gist (
       base_uri
       WITH
@@ -29,19 +22,19 @@ COMMENT
 
 CREATE TABLE IF NOT EXISTS
   "data_types" (
-    "version_id" UUID PRIMARY KEY REFERENCES "version_ids",
+    "version_id" UUID PRIMARY KEY REFERENCES "type_ids",
     "schema" JSONB NOT NULL
   );
 
 CREATE TABLE IF NOT EXISTS
   "property_types" (
-    "version_id" UUID PRIMARY KEY REFERENCES "version_ids",
+    "version_id" UUID PRIMARY KEY REFERENCES "type_ids",
     "schema" JSONB NOT NULL
   );
 
 CREATE TABLE IF NOT EXISTS
   "entity_types" (
-    "version_id" UUID PRIMARY KEY REFERENCES "version_ids",
+    "version_id" UUID PRIMARY KEY REFERENCES "type_ids",
     "schema" JSONB NOT NULL
   );
 

--- a/packages/graph/hash_graph/postgres_migrations/V4__ontology_functions.sql
+++ b/packages/graph/hash_graph/postgres_migrations/V4__ontology_functions.sql
@@ -5,33 +5,19 @@ OR REPLACE FUNCTION create_ontology_id (
   "owned_by_id" UUID,
   "updated_by_id" UUID
 ) RETURNS TABLE (version_id UUID) AS $create_ontology_id$
-DECLARE
-  _version_id UUID;
 BEGIN
-  INSERT INTO "base_uris" (
-    base_uri
-  ) VALUES (
-    create_ontology_id.base_uri
-  );
-
-  INSERT INTO version_ids (
-    version_id
-  ) VALUES (
-    gen_random_uuid()
-  ) RETURNING version_ids.version_id INTO _version_id;
-
   RETURN QUERY
   INSERT INTO type_ids (
+    "version_id",
     "base_uri",
     "version",
-    "version_id",
     "owned_by_id",
     "updated_by_id",
     "transaction_time"
   ) VALUES (
+    gen_random_uuid(),
     create_ontology_id.base_uri,
     create_ontology_id.version,
-    _version_id,
     create_ontology_id.owned_by_id,
     create_ontology_id.updated_by_id,
     tstzrange(now(), NULL, '[)')
@@ -45,60 +31,54 @@ OR REPLACE FUNCTION update_ontology_id (
   "updated_by_id" UUID
 ) RETURNS TABLE (version_id UUID, owned_by_id UUID) AS $update_ontology_id$
 DECLARE
-  _version_id UUID;
+  "_version_id" UUID;
 BEGIN
-  INSERT INTO version_ids (
-    version_id
-  ) VALUES (
-    gen_random_uuid()
-  ) RETURNING version_ids.version_id INTO _version_id;
-
-  SET CONSTRAINTS type_ids_pkey DEFERRED;
-  SET CONSTRAINTS type_id_unique DEFERRED;
   SET CONSTRAINTS type_ids_overlapping DEFERRED;
+
+  _version_id := gen_random_uuid();
 
   RETURN QUERY
   UPDATE type_ids
   SET
-    "transaction_time" = tstzrange(now(), NULL, '[)'),
-    "version" = update_ontology_id.version,
     "version_id" = _version_id,
-    "updated_by_id" = update_ontology_id.updated_by_id
+    "version" = update_ontology_id.version,
+    "updated_by_id" = update_ontology_id.updated_by_id,
+    "transaction_time" = tstzrange(now(), NULL, '[)')
   WHERE type_ids.base_uri = update_ontology_id.base_uri
     AND type_ids.transaction_time @> now()
-  RETURNING type_ids.version_id, type_ids.owned_by_id;
+  RETURNING _version_id, type_ids.owned_by_id;
 
-  SET CONSTRAINTS type_ids_pkey IMMEDIATE;
-  SET CONSTRAINTS type_id_unique IMMEDIATE;
   SET CONSTRAINTS type_ids_overlapping IMMEDIATE;
 END $update_ontology_id$ VOLATILE LANGUAGE plpgsql;
 
 CREATE
-OR REPLACE FUNCTION "update_type_ids_trigger" () RETURNS TRIGGER AS $pga$
-    BEGIN
-      IF (OLD.version != NEW.version - 1) THEN
-        RAISE EXCEPTION 'Not updating the latest id: % -> %', OLD.version, NEW.version
-        USING ERRCODE = 'invalid_parameter_value';
-      END IF;
+OR REPLACE FUNCTION "update_type_ids_trigger" () RETURNS TRIGGER AS $update_type_ids_trigger$
+BEGIN
+  IF (OLD.version != NEW.version - 1) THEN
+    RAISE EXCEPTION 'Not updating the latest id: % -> %', OLD.version, NEW.version
+    USING ERRCODE = 'invalid_parameter_value';
+  END IF;
 
-      INSERT INTO type_ids (
-        "base_uri",
-        "version",
-        "version_id",
-        "owned_by_id",
-        "updated_by_id",
-        "transaction_time"
-      ) VALUES (
-        OLD.base_uri,
-        OLD.version,
-        OLD.version_id,
-        OLD.owned_by_id,
-        OLD.updated_by_id,
-        tstzrange(lower(OLD.transaction_time), lower(NEW.transaction_time), '[)')
-      );
+  INSERT INTO type_ids (
+    "version_id",
+    "base_uri",
+    "version",
+    "owned_by_id",
+    "updated_by_id",
+    "transaction_time"
+  ) VALUES (
+    NEW.version_id,
+    NEW.base_uri,
+    NEW.version,
+    NEW.owned_by_id,
+    NEW.updated_by_id,
+    NEW.transaction_time
+  );
 
-      RETURN NEW;
-    END$pga$ VOLATILE LANGUAGE plpgsql;
+  OLD.transaction_time = tstzrange(lower(OLD.transaction_time), lower(NEW.transaction_time), '[)');
+
+  RETURN OLD;
+END $update_type_ids_trigger$ VOLATILE LANGUAGE plpgsql;
 
 CREATE
 OR REPLACE TRIGGER "update_type_ids_trigger" BEFORE


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

With #1886, it's possible to greatly simplify the definition of the ontology tables. This is possible as inserting a new ontology type with a base URI will fail as there will be overlapping transaction times.

## 🔗 Related links

- #1886

## 🚫 Blocked by

- #1886
## 🔍 What does this change?

- Make `version_id` the primary key of `type_ids` (we still require `(base_uri, version)` to be unique)
- Remove `base_uris` table
- Remove `version_ids` table
- Change the insertion order on the update trigger to avoid unneeded deferring of constraints
- Adjust the Graph to also catch the overlapping-constraint on creating