### PR TITLE
Add CODEOWNERS for libs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,8 @@
+# Libs teams
+/libs/deer/ @hashintel/deer
+/packages/libs/error-stack/ @hashintel/error-stack
+
+# Legal team
 LICENSE @hashintel/legal
 LICENSE.txt @hashintel/legal
 LICENSE.md @hashintel/legal


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Specifies team CODEOWNERS for `deer` and `error-stack` libraries.