### PR TITLE
Group unrelated error-stack features

### DIFF
--- a/packages/libs/error-stack/Makefile.toml
+++ b/packages/libs/error-stack/Makefile.toml
@@ -1,8 +1,8 @@
 extend = { path = "../../../.github/scripts/rust/Makefile.toml" }
 
 [env]
-CARGO_CLIPPY_HACK_FLAGS = "--workspace --optional-deps --feature-powerset --exclude-features default"
-CARGO_TEST_HACK_FLAGS = "--workspace --optional-deps --feature-powerset --exclude-features default"
+CARGO_CLIPPY_HACK_FLAGS = "--optional-deps --feature-powerset --exclude-features default --group-features eyre,hooks --group-features anyhow,serde"
+CARGO_TEST_HACK_FLAGS = "--optional-deps --feature-powerset --exclude-features default --group-features eyre,hooks --group-features anyhow,serde"
 CARGO_INSTA_TEST_FLAGS = "--no-fail-fast"
 CARGO_RUSTDOC_HACK_FLAGS = ""
 CARGO_DOC_HACK_FLAGS = ""
@@ -10,10 +10,32 @@ CARGO_DOC_HACK_FLAGS = ""
 # all others do not change the output
 CARGO_INSTA_TEST_HACK_FLAGS = "--keep-going --feature-powerset --include-features spantrace,pretty-print,std,hooks"
 
+# Workaround for https://github.com/taiki-e/cargo-hack/issues/161
+# instead, we should pass `--ignore-unknown-features` to `cargo hack`
+[tasks.clippy]
+workspace = true
+run_task = [
+    { name = ["clippy-task"], condition = { env_true = ["CARGO_MAKE_CRATE_IS_WORKSPACE"] } },
+    { name = ["clippy-task-subcrate"] },
+]
+
+[tasks.clippy-task-subcrate]
+env = { CARGO_CLIPPY_HACK_FLAGS = "--feature-powerset" }
+run_task = { name = ["clippy-task"] }
+
 
 [tasks.test]
+workspace = true
 dependencies = ["install-rust-src"]
 env = { TRYBUILD = "overwrite" }
+run_task = [
+    { name = ["test-task"], condition = { env_true = ["CARGO_MAKE_CRATE_IS_WORKSPACE"] } },
+    { name = ["test-task-subcrate"] },
+]
+
+[tasks.test-task-subcrate]
+env = { CARGO_TEST_HACK_FLAGS = "--feature-powerset" }
+run_task = { name = ["test-task"] }
 
 [tasks.coverage]
 dependencies = ["install-rust-src"]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The error-stack PR is currently pretty slow, by grouping some features together, it's possible to eliminate 75% of the tests

## ⚠️ Known issues

Due to https://github.com/taiki-e/cargo-hack/issues/161 it's not possible to pass `--ignore-unknown-features` alongside with `--group-features`, so this PR works around that limitation