### PR TITLE
Run actions on `push` to `trunk-merge/` branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - 'trunk-merge/**'
+      - "trunk-merge/**"
 
 env:
   TURBO_FORCE: true ## Turbo caching is disabled to avoid issues false cache hits (https://app.asana.com/0/1203193968491715/1203429129383865/f)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - 'trunk-merge/**'
 
 env:
   TURBO_FORCE: true ## Turbo caching is disabled to avoid issues false cache hits (https://app.asana.com/0/1203193968491715/1203429129383865/f)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,7 +4,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'trunk-merge/**'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main]

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - main
-      - 'trunk-merge/**'
+      - "trunk-merge/**"
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main]

--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -2,7 +2,9 @@ on:
   # We could allow configuring environment here.
   workflow_dispatch: {}
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'trunk-merge/**'
     paths:
       - "apps/hash-api/**"
       - "libs/@local/hash-backend-utils-utils/**"

--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - 'trunk-merge/**'
+      - "trunk-merge/**"
     paths:
       - "apps/hash-api/**"
       - "libs/@local/hash-backend-utils-utils/**"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
       - dev/**
-      - 'trunk-merge/**'
+      - "trunk-merge/**"
 
 defaults:
   run:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - dev/**
+      - 'trunk-merge/**'
 
 defaults:
   run:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -10,6 +10,7 @@ on:
       - main
       - canary
       - dev/*
+      - 'trunk-merge/**'
 
   schedule:
     - cron: "30 0 1,15 * *" # scheduled for 00:30 UTC on both the 1st and 15th of the month

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -10,7 +10,7 @@ on:
       - main
       - canary
       - dev/*
-      - 'trunk-merge/**'
+      - "trunk-merge/**"
 
   schedule:
     - cron: "30 0 1,15 * *" # scheduled for 00:30 UTC on both the 1st and 15th of the month


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In order to allow `trunk.io` to test the CI in their branches, the CI has to run

## 🔗 Related links

Step 7 at [their documentation](https://docs.trunk.io/docs/getting-started) says:
> Set up the required checks by configuring your CI provider to run the required jobs whenever a branch is pushed to your GitHub repository with the special prefix `trunk-merge/`.