### PR TITLE
Remove `required_statuses` from `trunk.yaml`

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -10,14 +10,6 @@ plugins:
     - id: trunk
       ref: v0.0.8
       uri: https://github.com/trunk-io/plugins
-merge:
-  required_statuses:
-    - CI / Linting
-    - CI / Unit Tests
-    - CI / Backend integration tests
-    - CI / Playwright tests
-    - Rust / merging enabled
-    - Vercel – hash
 actions:
   enabled:
     - trunk-announce


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The CI is running fine for the `trunk_merge` branches, but it does not detect a passed CI. This PR attempts to solve this by removing the `required_statuses` section from the trunk configuration 