### PR TITLE
Remove `push` branch from Backend CD

### DIFF
--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - "trunk-merge/**"
     paths:
       - "apps/hash-api/**"
       - "libs/@local/hash-backend-utils-utils/**"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#1904 accidentally also added the branch for trunk.io to the backend CD, which was not intended.