### PR TITLE
Run CI on pushes to `main` and `trunk-merge/` branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ env:
 jobs:
   linting:
     name: Linting
-    if: ${{ github.event_name == 'pull_request' }}
+    # Run only on push to `main` or `trunk_merge/**` or on pull requests
+    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -197,7 +198,8 @@ jobs:
 
   playwright-tests:
     name: Playwright tests
-    if: ${{ github.event_name == 'pull_request' }}
+    # Run only on push to `main` or `trunk_merge/**` or on pull requests
+    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To allow `trunk` to check the CI on their `trunk_merges/**` branches, it's required the CI runs on `push` events