### PR TITLE
Second attempt to enable `required_statuses` for trunk

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -10,6 +10,14 @@ plugins:
     - id: trunk
       ref: v0.0.8
       uri: https://github.com/trunk-io/plugins
+merge:
+  required_statuses:
+    - Linting
+    - Unit Tests
+    - Backend integration tests
+    - Playwright tests
+    - merging enabled
+    - Vercel – hash
 actions:
   enabled:
     - trunk-announce

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -13,7 +13,7 @@ plugins:
 merge:
   required_statuses:
     - Linting
-    - Unit Tests
+    - Unit tests
     - Backend integration tests
     - Playwright tests
     - merging enabled


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The CI now correctly runs on the pushed branch of `trunk`, however, it still does not merge the PRs. This is another attempt to add `required_statuses` to the configuration file