### PR TITLE
Disable Apollo cache on SSR requests

### DIFF
--- a/apps/hash-frontend/src/lib/apollo-client.ts
+++ b/apps/hash-frontend/src/lib/apollo-client.ts
@@ -1,3 +1,5 @@
 import { createApolloClient } from "@local/hash-isomorphic-utils/graphql/create-apollo-client";
 
-export const apolloClient = createApolloClient();
+import { isBrowser } from "./config";
+
+export const apolloClient = createApolloClient({ isBrowser });

--- a/libs/@local/hash-isomorphic-utils/src/graphql/create-apollo-client.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graphql/create-apollo-client.ts
@@ -1,6 +1,7 @@
 import {
   ApolloClient,
   ApolloLink,
+  DefaultOptions,
   HttpLink,
   InMemoryCache,
   NormalizedCacheObject,
@@ -38,6 +39,7 @@ const errorLink = onError(({ graphQLErrors, operation }) => {
 // @todo update references
 export const createApolloClient = (params?: {
   name?: string;
+  isBrowser: boolean;
   additionalHeaders?: { [key: string]: string | undefined };
 }): ApolloClient<NormalizedCacheObject> => {
   const ponyfilledFetch =
@@ -84,6 +86,21 @@ export const createApolloClient = (params?: {
 
   const entityKeyFields = { keyFields: ["entityId"] };
 
+  // When the client is running in the browser, we want to use the cache
+  // otherwise we want to disable the cache on the server to prevent sharing user data.
+  const defaultOptions: DefaultOptions | undefined = params?.isBrowser
+    ? undefined
+    : {
+        watchQuery: {
+          fetchPolicy: "no-cache",
+          errorPolicy: "ignore",
+        },
+        query: {
+          fetchPolicy: "no-cache",
+          errorPolicy: "all",
+        },
+      };
+
   return new ApolloClient({
     cache: new InMemoryCache({
       possibleTypes: possibleTypes.possibleTypes,
@@ -103,5 +120,6 @@ export const createApolloClient = (params?: {
     credentials: "include",
     link,
     name: params?.name,
+    defaultOptions,
   });
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
This PR disables apollo cache for any request by default on the NextJS server-side.
This reason why we do this is to prevent requests that take no params to be shared responses to users (i.e. the `me` query)

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202805690238892/1203788788550913/f) _(internal)_

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- The Apollo client shared by client/server now conditionally disable caching

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

nope

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch / view the deployment
1.  Start local development setup as usual
1. Follow steps by @yusufkinatas to trigger response sharing:
```
1. Open two different browsers on incognito mode, side by side
2. Register `charlie`  on left
3. Register `dean`  on right
4. Refresh `charlie`’s page
    a. `charlie`  becomes `dean`
5. After step 4 , if we log out from everything, then try logging in to another account, that one gets replaced on refresh as well 
```
1. Observe if step `4.a.` does not happen anymore
