### PR TITLE
Add `external-services/kratos` path to CD push trigger

### DIFF
--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -6,8 +6,10 @@ on:
       - main
     paths:
       - "apps/hash-api/**"
+      - "apps/hash-external-services/kratos/**"
       - "libs/@local/hash-backend-utils-utils/**"
       - "libs/@local/hash-isomorphic-utils/**"
+      # TODO: remove/rewrite these as we remove the package directory.
       - "packages/graph/**"
       - "packages/hash/**"
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
This PR adds a path check for kratos configuration in the backend CD workflow

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203543021352041/1203767287750379/f) _(internal)_