### PR TITLE
Remove get entity logged in gate

### DIFF
--- a/apps/hash-api/src/graphql/resolvers/index.ts
+++ b/apps/hash-api/src/graphql/resolvers/index.ts
@@ -97,7 +97,7 @@ export const resolvers = {
     pages: loggedInAndSignedUpMiddleware(pagesResolver),
     pageComments: loggedInAndSignedUpMiddleware(pageCommentsResolver),
     blocks: loggedInAndSignedUpMiddleware(blocksResolver),
-    getEntity: loggedInAndSignedUpMiddleware(getEntityResolver),
+    getEntity: getEntityResolver,
     getAllLatestEntities: getAllLatestEntitiesResolver,
     hashInstanceEntity: hashInstanceEntityResolver,
   },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#1340 introduced a temporary way of having 'anonymous readonly' pages which allowed any anonymous user to see any page.

#1823 broke this by introducing a new dependency on `getEntity` for resolving a page's data (in order to fetch the subgraph rooted at a block).

This PR fixes that by removing the logged in gate on `getEntity`. As mentioned in #1340 and elsewhere, these gates are superficial and do not provide proper security for any entity – which will be solved by introducing proper authorization – and this therefore does not represent removal of an effective security control.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Log in, find a page URL
2. View the page in incognito, check it loads without crashing
