### PR TITLE
Disable automerge for renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
 
-  "automerge": true,
+  "automerge": false,
   "dependencyDashboard": true,
   "dependencyDashboardApproval": true,
   "ignorePaths": ["apps/engine/**"],


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Renovate bot attempts to merge automatically, which is unwanted behavior.