### PR TITLE
Fix path to `hash-subgraph` in `Dockerfile`s

### DIFF
--- a/infra/docker/api/prod/Dockerfile
+++ b/infra/docker/api/prod/Dockerfile
@@ -8,19 +8,19 @@ COPY yarn.lock .
 RUN yarn install --frozen-lockfile --production --ignore-scripts --prefer-offline
 
 # Also ensure that api node modules can be cached
+COPY apps/hash-api/package.json apps/hash-api/
+COPY apps/hash-graph/clients/typescript/package.json apps/hash-graph/clients/typescript/
 COPY libs/@local/eslint-config/package.json libs/@local/eslint-config/
 COPY libs/@local/hash-backend-utils/package.json libs/@local/hash-backend-utils/
 COPY libs/@local/hash-isomorphic-utils/package.json libs/@local/hash-isomorphic-utils/
+COPY libs/@local/hash-subgraph/package.json libs/@local/hash-subgraph/
 COPY libs/@local/tsconfig/package.json libs/@local/tsconfig/
-COPY apps/hash-api/package.json apps/hash-api/
-COPY packages/hash/subgraph/package.json packages/hash/subgraph/
-COPY apps/hash-graph/clients/typescript/package.json apps/hash-graph/clients/typescript/
 RUN yarn workspace @apps/hash-api install --frozen-lockfile --ignore-scripts --prefer-offline
 
-COPY libs/@local/hash-isomorphic-utils/src/graphql libs/@local/hash-isomorphic-utils/src/graphql
-COPY libs/@local/hash-isomorphic-utils/src/queries libs/@local/hash-isomorphic-utils/src/queries
 COPY apps/hash-api/codegen.config.ts apps/hash-api/codegen.config.ts
 COPY apps/hash-api/src/graphql/type-defs apps/hash-api/src/graphql/type-defs
+COPY libs/@local/hash-isomorphic-utils/src/graphql libs/@local/hash-isomorphic-utils/src/graphql
+COPY libs/@local/hash-isomorphic-utils/src/queries libs/@local/hash-isomorphic-utils/src/queries
 
 RUN yarn workspace @apps/hash-api codegen
 
@@ -28,13 +28,13 @@ COPY libs/@local/hash-isomorphic-utils/codegen.config.ts libs/@local/hash-isomor
 
 RUN yarn workspace @local/hash-isomorphic-utils codegen
 
+COPY apps/hash-api apps/hash-api
+COPY apps/hash-graph/clients/typescript apps/hash-graph/clients/typescript
 COPY libs/@local/eslint-config libs/@local/eslint-config
 COPY libs/@local/hash-backend-utils libs/@local/hash-backend-utils
 COPY libs/@local/hash-isomorphic-utils libs/@local/hash-isomorphic-utils
+COPY libs/@local/hash-subgraph libs/@local/hash-subgraph
 COPY libs/@local/tsconfig libs/@local/tsconfig
-COPY apps/hash-graph/clients/typescript apps/hash-graph/clients/typescript
-COPY apps/hash-api apps/hash-api
-COPY packages/hash/subgraph packages/hash/subgraph
 RUN mkdir -p /app/var/uploads
 
 

--- a/infra/docker/frontend/prod/Dockerfile
+++ b/infra/docker/frontend/prod/Dockerfile
@@ -13,21 +13,21 @@ RUN yarn install --frozen-lockfile --prefer-offline --force --build-from-source
 
 
 # Also ensure that frontend node modules can be cached
+COPY apps/hash-frontend/package.json apps/hash-frontend/
+COPY apps/hash-graph/clients/typescript/package.json apps/hash-graph/clients/typescript/
 COPY libs/@local/design-system/package.json libs/@local/design-system/
 COPY libs/@local/eslint-config/package.json libs/@local/eslint-config/
 COPY libs/@local/hash-isomorphic-utils/package.json libs/@local/hash-isomorphic-utils/
+COPY libs/@local/hash-subgraph/package.json libs/@local/hash-subgraph/
 COPY libs/@local/tsconfig/package.json libs/@local/tsconfig/
-COPY apps/hash-graph/clients/typescript/package.json apps/hash-graph/clients/typescript/
-COPY apps/hash-frontend/package.json apps/hash-frontend/
-COPY packages/hash/subgraph/package.json packages/hash/subgraph/
 RUN yarn workspace @apps/hash-frontend install --frozen-lockfile --prefer-offline
 
-COPY libs/@local/hash-isomorphic-utils/src/graphql libs/@local/hash-isomorphic-utils/src/graphql
-COPY libs/@local/hash-isomorphic-utils/src/queries libs/@local/hash-isomorphic-utils/src/queries
 COPY apps/hash-api/codegen.config.ts apps/hash-api/codegen.config.ts
 COPY apps/hash-api/src/graphql/type-defs apps/hash-api/src/graphql/type-defs
 COPY apps/hash-frontend/codegen.config.ts apps/hash-frontend/codegen.config.ts
 COPY apps/hash-frontend/src/graphql/queries apps/hash-frontend/src/graphql/queries
+COPY libs/@local/hash-isomorphic-utils/src/graphql libs/@local/hash-isomorphic-utils/src/graphql
+COPY libs/@local/hash-isomorphic-utils/src/queries libs/@local/hash-isomorphic-utils/src/queries
 
 RUN yarn workspace @apps/hash-frontend codegen
 
@@ -35,13 +35,13 @@ COPY libs/@local/hash-isomorphic-utils/codegen.config.ts libs/@local/hash-isomor
 
 RUN yarn workspace @local/hash-isomorphic-utils codegen
 
+COPY apps/hash-frontend apps/hash-frontend
+COPY apps/hash-graph/clients/typescript apps/hash-graph/clients/typescript
 COPY libs/@local/design-system libs/@local/design-system
 COPY libs/@local/eslint-config libs/@local/eslint-config
 COPY libs/@local/hash-isomorphic-utils libs/@local/hash-isomorphic-utils
+COPY libs/@local/hash-subgraph libs/@local/hash-subgraph
 COPY libs/@local/tsconfig libs/@local/tsconfig
-COPY apps/hash-graph/clients/typescript apps/hash-graph/clients/typescript
-COPY apps/hash-frontend apps/hash-frontend
-COPY packages/hash/subgraph packages/hash/subgraph
 
 WORKDIR /app/apps/hash-frontend
 ENV NODE_ENV production

--- a/infra/docker/search-loader/prod/Dockerfile
+++ b/infra/docker/search-loader/prod/Dockerfile
@@ -8,26 +8,26 @@ COPY yarn.lock .
 RUN yarn install --frozen-lockfile --production --ignore-scripts --prefer-offline
 
 # Also ensure that api node modules can be cached
+COPY apps/hash-api/package.json apps/hash-api/
 COPY apps/hash-search-realtime/package.json apps/hash-search-realtime/
 COPY libs/@local/hash-backend-utils/package.json libs/@local/hash-backend-utils/
 COPY libs/@local/hash-isomorphic-utils/package.json libs/@local/hash-isomorphic-utils/
 COPY libs/@local/tsconfig/package.json libs/@local/tsconfig/
-COPY apps/hash-api/package.json apps/hash-api/
 RUN yarn workspace @apps/hash-search-loader install --frozen-lockfile --ignore-scripts --prefer-offline
 
-COPY libs/@local/hash-isomorphic-utils/src/graphql libs/@local/hash-isomorphic-utils/src/graphql
-COPY libs/@local/hash-isomorphic-utils/src/queries libs/@local/hash-isomorphic-utils/src/queries
 COPY apps/hash-api/codegen.config.ts apps/hash-api/codegen.config.ts
 COPY apps/hash-api/src/collab/graphql/queries apps/hash-api/src/collab/graphql/queries
 COPY apps/hash-api/src/graphql/type-defs apps/hash-api/src/graphql/type-defs
+COPY libs/@local/hash-isomorphic-utils/src/graphql libs/@local/hash-isomorphic-utils/src/graphql
+COPY libs/@local/hash-isomorphic-utils/src/queries libs/@local/hash-isomorphic-utils/src/queries
 
 RUN yarn workspace @apps/hash-api codegen
 
+COPY apps/hash-api apps/hash-api
 COPY apps/hash-search-realtime apps/hash-search-realtime
 COPY libs/@local/hash-backend-utils libs/@local/hash-backend-utils
 COPY libs/@local/hash-isomorphic-utils libs/@local/hash-isomorphic-utils
 COPY libs/@local/tsconfig libs/@local/tsconfig
-COPY apps/hash-api apps/hash-api
 
 
 #########################################################################################

--- a/infra/docker/task-executor/Dockerfile
+++ b/infra/docker/task-executor/Dockerfile
@@ -2,8 +2,8 @@ FROM node:16.18.1-alpine AS builder
 
 WORKDIR /app
 
-COPY libs/@local/tsconfig libs/@local/tsconfig
 COPY apps/hash-task-executor apps/hash-task-executor
+COPY libs/@local/tsconfig libs/@local/tsconfig
 COPY package.json .
 COPY yarn.lock .
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
       "blocks/*",
       "libs/*",
       "libs/@local/*",
-      "packages/hash/subgraph",
       "packages/libs/error-stack",
       "tests/*"
     ]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR fixes [HASH backend deployment](https://github.com/hashintel/hash/actions/workflows/hash-backend-cd.yml) action which I broke in #1896. I must have forgotten to re-check paths after resolving conflicts, or there was something else. In addition to replacing `packages/hash/subgraph` with `libs/@local/hash-subgraph` I ordered paths in `COPY` directives to simplify code scanning with a human eye.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203543021352032/1203324923411371/f) _(internal)_
- [Slack thread](https://hashintel.slack.com/archives/C022217GAHF/p1674572887579809) _(internal)_

## ❓ How to test this?

- Check CI
- Check CD in `main` after merge