### PR TITLE
Update labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -35,22 +35,22 @@ C-dependencies:
   - "**/yarn.lock"
 
 frontend:
-  - apps/hash-frontend/**
+  - "apps/hash-frontend/**"
 
 api:
-  - apps/hash-api/**
+  - "apps/hash-api/**"
 
 integration:
-  - tests/hash-backend-integration/**
+  - "tests/hash-backend-integration/**"
 
 docker:
-  - infra/docker/**
+  - "infra/docker/**"
 
 playwright:
-  - tests/hash-playwright/**
+  - "tests/hash-playwright/**"
 
 realtime:
-  - apps/hash-realtime/**
+  - "apps/hash-realtime/**"
 
 search-loader:
-  - apps/hash-search-realtime/**
+  - "apps/hash-search-realtime/**"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,102 +1,56 @@
 A-infra:
-  - ".github/*"
-  - ".github/.*"
-  - ".github/**/*"
-  - ".github/**/.*"
+  - ".github/**"
+  - ".*ignore"
+  - ".markdownlint*"
+  - "*.json"
   - "*.md"
   - "*.yml"
-  - "*.json"
-  - ".markdownlint*"
-  - ".*ignore"
 
 A-blocks:
-  - "blocks/*"
-  - "blocks/.*"
-  - "blocks/**/*"
-  - "blocks/**/.*"
+  - "blocks/**"
 
 A-hash:
-  - "packages/hash/*"
-  - "packages/hash/.*"
-  - "packages/hash/**/*"
-  - "packages/hash/**/.*"
+  - "apps/hash-*/**"
+  - "libs/@local/hash-*/**"
+  - "libs/hash-*/**"
 
 A-engine:
-  - "apps/engine/*"
-  - "apps/engine/.*"
-  - "apps/engine/**/*"
-  - "apps/engine/**/.*"
+  - "apps/engine/**"
 
 A-learn:
-  - "apps/hashdotai/docs/*"
-  - "apps/hashdotai/docs/.*"
-  - "apps/hashdotai/docs/**/*"
-  - "apps/hashdotai/docs/**/.*"
-  - "apps/hashdotai/glossary/*"
-  - "apps/hashdotai/glossary/.*"
-  - "apps/hashdotai/glossary/**/*"
-  - "apps/hashdotai/glossary/**/.*"
+  - "apps/hashdotai/docs/**"
+  - "apps/hashdotai/glossary/**"
 
 A-error-stack:
-  - "packages/libs/error-stack/*"
-  - "packages/libs/error-stack/.*"
-  - "packages/libs/error-stack/**/*"
-  - "packages/libs/error-stack/**/.*"
+  - "packages/libs/error-stack/**"
 
 A-deer:
-  - "libs/deer/*"
-  - "libs/deer/.*"
-  - "libs/deer/**/*"
-  - "libs/deer/**/.*"
+  - "libs/deer/**"
 
 A-backend:
-  - "apps/hash-graph/*"
-  - "apps/hash-graph/.*"
-  - "apps/hash-graph/**/*"
-  - "apps/hash-graph/**/.*"
+  - "apps/hash-graph/**"
 
 C-dependencies:
   - "**/Cargo.lock"
   - "**/yarn.lock"
 
 frontend:
-  - apps/hash-frontend/*
-  - apps/hash-frontend/.*
-  - apps/hash-frontend/**/*
-  - apps/hash-frontend/**/.*
+  - apps/hash-frontend/**
 
 api:
-  - apps/hash-api/*
-  - apps/hash-api/.*
-  - apps/hash-api/**/*
-  - apps/hash-api/**/.*
+  - apps/hash-api/**
 
 integration:
-  - tests/hash-backend-integration/*
-  - tests/hash-backend-integration/.*
-  - tests/hash-backend-integration/**/*
-  - tests/hash-backend-integration/**/.*
+  - tests/hash-backend-integration/**
 
 docker:
-  - infra/docker/*
-  - infra/docker/.*
-  - infra/docker/**/*
-  - infra/docker/**/.*
+  - infra/docker/**
 
 playwright:
-  - tests/hash-playwright/*
-  - tests/hash-playwright/.*
-  - tests/hash-playwright/**/*
-  - tests/hash-playwright/**/.*
+  - tests/hash-playwright/**
 
 realtime:
-  - apps/hash-realtime/*
-  - apps/hash-realtime/.*
-  - apps/hash-realtime/**/*
-  - apps/hash-realtime/**/.*
+  - apps/hash-realtime/**
 
 search-loader:
-  - apps/hash-search-realtime/*
-  - apps/hash-search-realtime/.*
-  - apps/hash-search-realtime/**/*
-  - apps/hash-search-realtime/**/.*
+  - apps/hash-search-realtime/**

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,9 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v4
+      - uses: kachkaev/labeler@d89797c51d07680aec17049cc6790e9d323d9a93
+        ## @todo replace with actions/labeler@v3 (or newer) when this PR is merged
+        ## https://github.com/actions/labeler/pull/316
         with:
+          dot: true
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,8 +6,8 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: kachkaev/labeler@d89797c51d07680aec17049cc6790e9d323d9a93
-        ## @todo replace with actions/labeler@v3 (or newer) when this PR is merged
+      - uses: kachkaev/labeler@305cfeb74cfa5c4878bf6418b4815a4106f2e345
+        ## @todo replace with actions/labeler@v4 (or newer) when this PR is merged:
         ## https://github.com/actions/labeler/pull/316
         with:
           dot: true


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The aim of this PR is to re-enable Slack notification for changes related to HASH app. It replaces a few globs for `packages/hash/...` with `apps/hash-*/**`, `libs/hash-*/**` and `libs/@local/hash-*/**`. To avoid repetition, I replaced the official labeler versio with the latest commit from https://github.com/actions/labeler/pull/316.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203543026679373/1203800233887959/f) _(internal)_
- [Slack thread](https://hashintel.slack.com/archives/C02THT2LG8N/p1674566469357439) _(internal)_

## 🐾 Next steps

- Check if labeler works (we can only see this once the PR is merged because we use `pull_request_target` as a trigger) 
- Wait for `dot` option to reach GA and use the official labeler.
- We can also consider syncing the labels with BP repo and get rid of `A/B/C-`. This does not bring a lot of added value in short term, so I haven’t tasked that out.

## 🛡 What tests cover this?

- Linting
- CI in https://github.com/actions/labeler/pull/316