### PR TITLE
Fix Release action

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@apps/*", "@blocks/", "@local/*"],
+  "ignore": ["@apps/*", "@blocks/*", "@local/*"],
   "snapshot": {
     "useCalculatedVersion": true
   },

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@apps/*", "@local/*"],
+  "ignore": ["@apps/*", "@blocks/", "@local/*"],
   "snapshot": {
     "useCalculatedVersion": true
   },

--- a/libs/@local/hash-subgraph/package.json
+++ b/libs/@local/hash-subgraph/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@local/hash-subgraph",
   "version": "0.0.0-private",
+  "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

@TimDiekmann has noticed GitHub action failures, which are caused by Changesets trying to publish workspaces we don’t want: https://github.com/hashintel/hash/actions/runs/4015045206/jobs/6896304775

```
@blocks/calculation@0.2.0
@blocks/chart@0.1.0
@blocks/countdown@0.2.0
@blocks/drawing@0.2.1
@blocks/github-pr-overview@0.1.0
@blocks/html-para@0.1.0
@blocks/shuffle@0.1.0
@blocks/stopwatch@0.1.0
@blocks/timer@0.2.0
@blocks/toggle-item@0.1.0
@local/hash-subgraph@0.0.0
```

I have added `private: true` to `package.json` in `@local/hash-subgraph` and have also tweaked Changesets config for the fix.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->
- [Slack thread](https://hashintel.slack.com/archives/C02TWBTT3ED/p1674742091308839) _(internal)_
- [Asana task](https://app.asana.com/0/1203543026679373/1203835586239188/f) _(internal)_

## ❓ How to test this?

See if https://github.com/hashintel/hash/actions/workflows/release.yml is green once the PR is merged