### PR TITLE
Set `"private": true` in `@blocks/*/package.json`, where missing

### DIFF
--- a/blocks/calculation/package.json
+++ b/blocks/calculation/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocks/calculation",
   "version": "0.2.0",
+  "private": true,
   "description": "Spreadsheet-like table for doing computation on entities",
   "keywords": [
     "blockprotocol",

--- a/blocks/chart/package.json
+++ b/blocks/chart/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocks/chart",
   "version": "0.1.0",
+  "private": true,
   "description": "A block for plotting entities in a 2D chart",
   "keywords": [
     "blockprotocol",

--- a/blocks/countdown/package.json
+++ b/blocks/countdown/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocks/countdown",
   "version": "0.2.0",
+  "private": true,
   "description": "Countdown to a time and date",
   "keywords": [
     "blockprotocol",

--- a/blocks/drawing/package.json
+++ b/blocks/drawing/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocks/drawing",
   "version": "0.2.1",
+  "private": true,
   "description": "Create a diagram, sketch an idea, or map a process",
   "keywords": [
     "blockprotocol",

--- a/blocks/github-pr-overview/package.json
+++ b/blocks/github-pr-overview/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocks/github-pr-overview",
   "version": "0.1.0",
+  "private": true,
   "description": "Display an overview of a GitHub Pull Request, including a timeline of key events",
   "keywords": [
     "blockprotocol",

--- a/blocks/html-para/package.json
+++ b/blocks/html-para/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocks/html-para",
   "version": "0.1.0",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/hashintel/hash.git#main",

--- a/blocks/shuffle/package.json
+++ b/blocks/shuffle/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocks/shuffle",
   "version": "0.1.0",
+  "private": true,
   "description": "Create a list and set it into a random order",
   "keywords": [
     "blockprotocol",

--- a/blocks/stopwatch/package.json
+++ b/blocks/stopwatch/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocks/stopwatch",
   "version": "0.1.0",
+  "private": true,
   "description": "stopwatch block",
   "keywords": [
     "blockprotocol",

--- a/blocks/timer/package.json
+++ b/blocks/timer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocks/timer",
   "version": "0.2.0",
+  "private": true,
   "description": "Set a countdown timer to remind you when a certain amount of time has elapsed",
   "keywords": [
     "blockprotocol",

--- a/blocks/toggle-item/package.json
+++ b/blocks/toggle-item/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocks/toggle-item",
   "version": "0.1.0",
+  "private": true,
   "description": "Toggle list item block",
   "keywords": [
     "blockprotocol",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR complements #1950, where we prevent Changesets from publishing blocks via  its `ignore` option. In addition to that, this PR adds `private: true` to 10 out of 20 blocks we host in this repo. Other blocks have already had this property. 

Ensuring `private: true` in all blocks makes our setup more consistent and prevents accidental publish attempts from package folders directly. I have also checked the property in other workspace by searching for `"name": "@apps/`, `"name": "@local/` and `"name": "@tests/`.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Slack thread](https://hashintel.slack.com/archives/C02TWBTT3ED/p1674742091308839) _(internal)_
- [Asana task](https://hashintel.slack.com/archives/C02TWBTT3ED/p1674742091308839) _(internal)_


## ❓ How to test this?

1.  Check Release GitHub action result after merge