### PR TITLE
Support nested fields and array index in structural queries

### DIFF
--- a/apps/hash-graph/bench/benches/representative_read/knowledge/entity.rs
+++ b/apps/hash-graph/bench/benches/representative_read/knowledge/entity.rs
@@ -65,7 +65,7 @@ pub fn bench_get_entities_by_property(
         let mut filter = Filter::Equal(
             Some(FilterExpression::Path(EntityQueryPath::Properties(Some(
                 JsonPath::from_path_tokens(vec![PathToken::Field(Cow::Borrowed(
-                    r#"$."https://blockprotocol.org/@alice/types/property-type/name/""#,
+                    "https://blockprotocol.org/@alice/types/property-type/name/",
                 ))]),
             )))),
             Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(

--- a/apps/hash-graph/bench/benches/representative_read/knowledge/entity.rs
+++ b/apps/hash-graph/bench/benches/representative_read/knowledge/entity.rs
@@ -8,7 +8,7 @@ use graph::{
     },
     knowledge::{EntityQueryPath, EntityUuid},
     store::{
-        query::{Filter, FilterExpression, Parameter},
+        query::{Filter, FilterExpression, JsonPath, Parameter, PathToken},
         EntityStore,
     },
     subgraph::{edges::GraphResolveDepths, query::StructuralQuery},
@@ -64,7 +64,9 @@ pub fn bench_get_entities_by_property(
     b.to_async(runtime).iter(|| async move {
         let mut filter = Filter::Equal(
             Some(FilterExpression::Path(EntityQueryPath::Properties(Some(
-                Cow::Borrowed("https://blockprotocol.org/@alice/types/property-type/name/"),
+                JsonPath::from_path_tokens(vec![PathToken::Field(Cow::Borrowed(
+                    r#"$."https://blockprotocol.org/@alice/types/property-type/name/""#,
+                ))]),
             )))),
             Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
                 "Alice",
@@ -100,9 +102,11 @@ pub fn bench_get_link_by_target_by_property(
     b.to_async(runtime).iter(|| async move {
         let mut filter = Filter::Equal(
             Some(FilterExpression::Path(EntityQueryPath::RightEntity(
-                Box::new(EntityQueryPath::Properties(Some(Cow::Borrowed(
-                    "https://blockprotocol.org/@alice/types/property-type/name/",
-                )))),
+                Box::new(EntityQueryPath::Properties(Some(
+                    JsonPath::from_path_tokens(vec![PathToken::Field(Cow::Borrowed(
+                        "https://blockprotocol.org/@alice/types/property-type/name/",
+                    ))]),
+                ))),
             ))),
             Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
                 "Alice",

--- a/apps/hash-graph/lib/graph/src/knowledge/entity/query.rs
+++ b/apps/hash-graph/lib/graph/src/knowledge/entity/query.rs
@@ -240,7 +240,7 @@ pub enum EntityQueryPath<'p> {
     /// ]))?;
     /// assert_eq!(
     ///     path.to_string(),
-    ///     r#"properties."https://blockprotocol.org/@blockprotocol/types/property-type/address/"[0]."street""#
+    ///     r#"properties.$."https://blockprotocol.org/@blockprotocol/types/property-type/address/"[0]."street""#
     /// );
     /// # Ok::<(), serde_json::Error>(())
     /// ```
@@ -261,7 +261,7 @@ impl fmt::Display for EntityQueryPath<'_> {
             Self::TransactionTime => fmt.write_str("transactionTime"),
             Self::Archived => fmt.write_str("archived"),
             Self::Type(path) => write!(fmt, "type.{path}"),
-            Self::Properties(Some(property)) => write!(fmt, "properties{property}"),
+            Self::Properties(Some(property)) => write!(fmt, "properties.{property}"),
             Self::Properties(None) => fmt.write_str("properties"),
             Self::IncomingLinks(link) => write!(fmt, "incomingLinks.{link}"),
             Self::OutgoingLinks(link) => write!(fmt, "outgoingLinks.{link}"),

--- a/apps/hash-graph/lib/graph/src/knowledge/entity/query.rs
+++ b/apps/hash-graph/lib/graph/src/knowledge/entity/query.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, fmt};
+use std::fmt;
 
 use serde::{
     de::{self, SeqAccess, Visitor},
@@ -8,7 +8,7 @@ use utoipa::ToSchema;
 
 use crate::{
     ontology::{EntityTypeQueryPath, EntityTypeQueryPathVisitor},
-    store::query::{ParameterType, QueryPath},
+    store::query::{JsonPath, ParameterType, PathToken, QueryPath},
 };
 
 #[derive(Debug, PartialEq, Eq)]
@@ -229,26 +229,25 @@ pub enum EntityQueryPath<'p> {
     /// [`Entity`].
     ///
     /// ```rust
-    /// # use std::borrow::Cow;
     /// # use serde::Deserialize;
     /// # use serde_json::json;
     /// # use graph::knowledge::EntityQueryPath;
     /// let path = EntityQueryPath::deserialize(json!([
     ///     "properties",
-    ///     "https://blockprotocol.org/@blockprotocol/types/property-type/name/"
+    ///     "https://blockprotocol.org/@blockprotocol/types/property-type/address/",
+    ///     0,
+    ///     "street"
     /// ]))?;
     /// assert_eq!(
-    ///     path,
-    ///     EntityQueryPath::Properties(Some(Cow::Borrowed(
-    ///         "https://blockprotocol.org/@blockprotocol/types/property-type/name/"
-    ///     )))
+    ///     path.to_string(),
+    ///     r#"properties."https://blockprotocol.org/@blockprotocol/types/property-type/address/"[0]."street""#
     /// );
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     ///
     /// [`Entity`]: crate::knowledge::Entity
     /// [`Entity::properties()`]: crate::knowledge::Entity::properties
-    Properties(Option<Cow<'p, str>>),
+    Properties(Option<JsonPath<'p>>),
 }
 
 impl fmt::Display for EntityQueryPath<'_> {
@@ -262,7 +261,7 @@ impl fmt::Display for EntityQueryPath<'_> {
             Self::TransactionTime => fmt.write_str("transactionTime"),
             Self::Archived => fmt.write_str("archived"),
             Self::Type(path) => write!(fmt, "type.{path}"),
-            Self::Properties(Some(property)) => write!(fmt, "properties.{property}"),
+            Self::Properties(Some(property)) => write!(fmt, "properties{property}"),
             Self::Properties(None) => fmt.write_str("properties"),
             Self::IncomingLinks(link) => write!(fmt, "incomingLinks.{link}"),
             Self::OutgoingLinks(link) => write!(fmt, "outgoingLinks.{link}"),
@@ -355,7 +354,19 @@ impl<'de> Visitor<'de> for EntityQueryPathVisitor {
             EntityQueryToken::Type => EntityQueryPath::Type(
                 EntityTypeQueryPathVisitor::new(self.position).visit_seq(seq)?,
             ),
-            EntityQueryToken::Properties => EntityQueryPath::Properties(seq.next_element()?),
+            EntityQueryToken::Properties => {
+                let mut path_tokens = Vec::new();
+                while let Some(property) = seq.next_element::<PathToken<'de>>()? {
+                    path_tokens.push(property);
+                    self.position += 1;
+                }
+
+                if path_tokens.is_empty() {
+                    EntityQueryPath::Properties(None)
+                } else {
+                    EntityQueryPath::Properties(Some(JsonPath::from_path_tokens(path_tokens)))
+                }
+            }
             EntityQueryToken::OutgoingLinks => {
                 EntityQueryPath::OutgoingLinks(Box::new(Self::new(self.position).visit_seq(seq)?))
             }
@@ -385,7 +396,7 @@ impl<'de: 'p, 'p> Deserialize<'de> for EntityQueryPath<'p> {
 
 #[cfg(test)]
 mod tests {
-    use std::iter::once;
+    use std::{borrow::Cow, iter::once};
 
     use super::*;
 
@@ -408,9 +419,9 @@ mod tests {
                 "properties",
                 "https://blockprotocol.org/@alice/types/property-type/name/"
             ]),
-            EntityQueryPath::Properties(Some(Cow::Borrowed(
-                "https://blockprotocol.org/@alice/types/property-type/name/"
-            )))
+            EntityQueryPath::Properties(Some(JsonPath::from_path_tokens(vec![PathToken::Field(
+                Cow::Borrowed("https://blockprotocol.org/@alice/types/property-type/name/")
+            )])))
         );
         assert_eq!(
             deserialize(["leftEntity", "uuid"]),

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/compile.rs
@@ -356,15 +356,17 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
 
     pub fn compile_path_column(&mut self, path: &'p R::QueryPath<'_>) -> AliasedColumn<'c> {
         let column = path.terminating_column();
-        let column =
-            if let Column::Entities(Entities::Properties(Some(JsonField::Json(field)))) = column {
-                self.artifacts.parameters.push(field);
-                Column::Entities(Entities::Properties(Some(JsonField::JsonParameter(
-                    self.artifacts.parameters.len(),
-                ))))
-            } else {
-                column
-            };
+        let column = if let Column::Entities(Entities::Properties(Some(JsonField::JsonPath(
+            field,
+        )))) = column
+        {
+            self.artifacts.parameters.push(field);
+            Column::Entities(Entities::Properties(Some(JsonField::JsonParameter(
+                self.artifacts.parameters.len(),
+            ))))
+        } else {
+            column
+        };
 
         let alias = self.add_join_statements(path);
 

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/entity.rs
@@ -70,7 +70,7 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
             Self::Properties(path) => path
                 .as_ref()
                 .map_or(Column::Entities(Entities::Properties(None)), |path| {
-                    Column::Entities(Entities::Properties(Some(JsonField::Json(path))))
+                    Column::Entities(Entities::Properties(Some(JsonField::JsonPath(path))))
                 }),
         }
     }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -543,7 +543,7 @@ mod tests {
             FROM "entities" AS "entities_0_0_0"
             WHERE "entities_0_0_0"."transaction_time" @> $2::TIMESTAMPTZ
               AND "entities_0_0_0"."decision_time" && $3
-              AND jsonb_path_query_first("entities_0_0_0"."properties", $1) = $4
+              AND jsonb_path_query_first("entities_0_0_0"."properties", $1::text::jsonpath) = $4
             "#,
             &[&json_path, &kernel, &time_projection.image(), &"Bob"],
         );
@@ -573,7 +573,7 @@ mod tests {
             FROM "entities" AS "entities_0_0_0"
             WHERE "entities_0_0_0"."transaction_time" @> $2::TIMESTAMPTZ
               AND "entities_0_0_0"."decision_time" && $3
-              AND jsonb_path_query_first("entities_0_0_0"."properties", $1) IS NULL
+              AND jsonb_path_query_first("entities_0_0_0"."properties", $1::text::jsonpath) IS NULL
             "#,
             &[&json_path, &kernel, &time_projection.image()],
         );

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
@@ -4,7 +4,10 @@ use std::{
     hash::Hash,
 };
 
-use crate::{identifier::time::TimeAxis, store::postgres::query::Transpile};
+use crate::{
+    identifier::time::TimeAxis,
+    store::{postgres::query::Transpile, query::JsonPath},
+};
 
 /// The name of a [`Table`] in the Postgres database.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -46,9 +49,12 @@ impl Transpile for Table {
     }
 }
 
+// TODO: We should add another enum to only contain variants, which may be passed as parameters,
+//       so the lifetime of that struct will be `'static`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum JsonField<'p> {
     Json(&'p Cow<'p, str>),
+    JsonPath(&'p JsonPath<'p>),
     JsonParameter(usize),
     StaticText(&'static str),
     StaticJson(&'static str),
@@ -62,14 +68,15 @@ pub enum TypeIds {
     LatestVersion,
 }
 
-impl Transpile for TypeIds {
-    fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+impl TypeIds {
+    fn transpile_column(&self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
         let column = match self {
             Self::VersionId => "version_id",
             Self::BaseUri => "base_uri",
             Self::Version => "version",
             Self::LatestVersion => "latest_version",
         };
+        table.transpile(fmt)?;
         write!(fmt, r#"."{column}""#)
     }
 }
@@ -96,17 +103,22 @@ macro_rules! impl_ontology_column {
                 }
             }
 
-            impl Transpile for $name {
-                fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+            impl $name {
+                fn transpile_column(&self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
                     let column = match self {
                         Self::VersionId => "version_id",
                         Self::OwnedById => "owned_by_id",
                         Self::UpdatedById => "updated_by_id",
                         Self::Schema(None) => "schema",
                         Self::Schema(Some(path)) => {
+                            table.transpile(fmt)?;
                             return match path {
                                 JsonField::Json(field) => panic!(
                                     "attempting to access JSON field `{field}` on schema column \
+                                     without preparing the value"
+                                ),
+                                JsonField::JsonPath(path) => panic!(
+                                    "attempting to access JSON path `{path}` on schema column \
                                      without preparing the value"
                                 ),
                                 JsonField::JsonParameter(index) => {
@@ -121,6 +133,7 @@ macro_rules! impl_ontology_column {
                             };
                         }
                     };
+                    table.transpile(fmt)?;
                     write!(fmt, r#"."{}""#, column)
                 }
             }
@@ -184,8 +197,8 @@ impl Entities<'_> {
     }
 }
 
-impl Transpile for Entities<'_> {
-    fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+impl Entities<'_> {
+    fn transpile_column(&self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
         let column = match self {
             Self::EntityUuid => "entity_uuid",
             Self::RecordId => "entity_record_id",
@@ -198,19 +211,26 @@ impl Transpile for Entities<'_> {
             Self::EntityTypeVersionId => "entity_type_version_id",
             Self::Properties(None) => "properties",
             Self::Properties(Some(path)) => {
+                write!(fmt, "jsonb_path_query_first(")?;
+                table.transpile(fmt)?;
+                write!(fmt, r#"."properties", "#)?;
                 return match path {
                     JsonField::Json(field) => panic!(
                         "attempting to access JSON field `{field}` on properties column without \
                          preparing the value"
                     ),
-                    JsonField::JsonParameter(index) => {
-                        write!(fmt, r#"."properties"->${index}"#)
-                    }
+                    JsonField::JsonPath(path) => panic!(
+                        "attempting to access JSON path `{path}` on properties column without \
+                         preparing the value"
+                    ),
                     JsonField::StaticText(field) => {
-                        write!(fmt, r#"."properties"->>'{field}'"#)
+                        panic!("attempting to access JSON field `{field}` on properties as text")
+                    }
+                    JsonField::JsonParameter(index) => {
+                        write!(fmt, "${index})")
                     }
                     JsonField::StaticJson(field) => {
-                        write!(fmt, r#"."properties"->'{field}'"#)
+                        write!(fmt, r#"'{field}::text::jsonpath')"#)
                     }
                 };
             }
@@ -221,6 +241,7 @@ impl Transpile for Entities<'_> {
             Self::LeftEntityOwnedById => "left_owned_by_id",
             Self::RightEntityOwnedById => "right_owned_by_id",
         };
+        table.transpile(fmt)?;
         write!(fmt, r#"."{column}""#)
     }
 }
@@ -231,8 +252,9 @@ pub enum PropertyTypeDataTypeReferences {
     TargetDataTypeVersionId,
 }
 
-impl Transpile for PropertyTypeDataTypeReferences {
-    fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+impl PropertyTypeDataTypeReferences {
+    fn transpile_column(&self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
+        table.transpile(fmt)?;
         write!(fmt, r#"."{}""#, match self {
             Self::SourcePropertyTypeVersionId => "source_property_type_version_id",
             Self::TargetDataTypeVersionId => "target_data_type_version_id",
@@ -246,8 +268,9 @@ pub enum PropertyTypePropertyTypeReferences {
     TargetPropertyTypeVersionId,
 }
 
-impl Transpile for PropertyTypePropertyTypeReferences {
-    fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+impl PropertyTypePropertyTypeReferences {
+    fn transpile_column(&self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
+        table.transpile(fmt)?;
         write!(fmt, r#"."{}""#, match self {
             Self::SourcePropertyTypeVersionId => "source_property_type_version_id",
             Self::TargetPropertyTypeVersionId => "target_property_type_version_id",
@@ -261,8 +284,9 @@ pub enum EntityTypePropertyTypeReferences {
     TargetPropertyTypeVersionId,
 }
 
-impl Transpile for EntityTypePropertyTypeReferences {
-    fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+impl EntityTypePropertyTypeReferences {
+    fn transpile_column(&self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
+        table.transpile(fmt)?;
         write!(fmt, r#"."{}""#, match self {
             Self::SourceEntityTypeVersionId => "source_entity_type_version_id",
             Self::TargetPropertyTypeVersionId => "target_property_type_version_id",
@@ -276,8 +300,9 @@ pub enum EntityTypeEntityTypeReferences {
     TargetEntityTypeVersionId,
 }
 
-impl Transpile for EntityTypeEntityTypeReferences {
-    fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+impl EntityTypeEntityTypeReferences {
+    fn transpile_column(&self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
+        table.transpile(fmt)?;
         write!(fmt, r#"."{}""#, match self {
             Self::SourceEntityTypeVersionId => "source_entity_type_version_id",
             Self::TargetEntityTypeVersionId => "target_entity_type_version_id",
@@ -331,22 +356,25 @@ impl<'p> Column<'p> {
             alias,
         }
     }
+
+    fn transpile_column(&self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::TypeIds(column) => column.transpile_column(table, fmt),
+            Self::DataTypes(column) => column.transpile_column(table, fmt),
+            Self::PropertyTypes(column) => column.transpile_column(table, fmt),
+            Self::EntityTypes(column) => column.transpile_column(table, fmt),
+            Self::Entities(column) => column.transpile_column(table, fmt),
+            Self::PropertyTypeDataTypeReferences(column) => column.transpile_column(table, fmt),
+            Self::PropertyTypePropertyTypeReferences(column) => column.transpile_column(table, fmt),
+            Self::EntityTypePropertyTypeReferences(column) => column.transpile_column(table, fmt),
+            Self::EntityTypeEntityTypeReferences(column) => column.transpile_column(table, fmt),
+        }
+    }
 }
 
 impl Transpile for Column<'_> {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        self.table().transpile(fmt)?;
-        match self {
-            Self::TypeIds(column) => column.transpile(fmt),
-            Self::DataTypes(column) => column.transpile(fmt),
-            Self::PropertyTypes(column) => column.transpile(fmt),
-            Self::EntityTypes(column) => column.transpile(fmt),
-            Self::Entities(column) => column.transpile(fmt),
-            Self::PropertyTypeDataTypeReferences(column) => column.transpile(fmt),
-            Self::PropertyTypePropertyTypeReferences(column) => column.transpile(fmt),
-            Self::EntityTypePropertyTypeReferences(column) => column.transpile(fmt),
-            Self::EntityTypeEntityTypeReferences(column) => column.transpile(fmt),
-        }
+        self.transpile_column(&self.table(), fmt)
     }
 }
 
@@ -420,18 +448,7 @@ impl AliasedColumn<'_> {
 
 impl Transpile for AliasedColumn<'_> {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        self.table().transpile(fmt)?;
-        match self.column {
-            Column::TypeIds(column) => column.transpile(fmt),
-            Column::DataTypes(column) => column.transpile(fmt),
-            Column::PropertyTypes(column) => column.transpile(fmt),
-            Column::EntityTypes(column) => column.transpile(fmt),
-            Column::Entities(column) => column.transpile(fmt),
-            Column::PropertyTypeDataTypeReferences(column) => column.transpile(fmt),
-            Column::PropertyTypePropertyTypeReferences(column) => column.transpile(fmt),
-            Column::EntityTypePropertyTypeReferences(column) => column.transpile(fmt),
-            Column::EntityTypeEntityTypeReferences(column) => column.transpile(fmt),
-        }
+        self.column.transpile_column(&self.table(), fmt)
     }
 }
 

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
@@ -227,7 +227,7 @@ impl Entities<'_> {
                         panic!("attempting to access JSON field `{field}` on properties as text")
                     }
                     JsonField::JsonParameter(index) => {
-                        write!(fmt, "${index})")
+                        write!(fmt, "${index}::text::jsonpath)")
                     }
                     JsonField::StaticJson(field) => {
                         write!(fmt, r#"'{field}::text::jsonpath')"#)

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
@@ -51,6 +51,7 @@ impl Transpile for Table {
 
 // TODO: We should add another enum to only contain variants, which may be passed as parameters,
 //       so the lifetime of that struct will be `'static`.
+//   see https://app.asana.com/0/0/1203821263193164/f
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum JsonField<'p> {
     Json(&'p Cow<'p, str>),

--- a/apps/hash-graph/lib/graph/src/store/query/mod.rs
+++ b/apps/hash-graph/lib/graph/src/store/query/mod.rs
@@ -1,8 +1,12 @@
 mod filter;
+mod path;
 
 use std::fmt;
 
-pub use self::filter::{Filter, FilterExpression, Parameter, ParameterConversionError};
+pub use self::{
+    filter::{Filter, FilterExpression, Parameter, ParameterConversionError},
+    path::{JsonPath, PathToken},
+};
 
 pub trait QueryPath {
     /// Returns what type this resolved `Path` has.

--- a/apps/hash-graph/lib/graph/src/store/query/path.rs
+++ b/apps/hash-graph/lib/graph/src/store/query/path.rs
@@ -1,0 +1,76 @@
+use std::{borrow::Cow, error::Error, fmt, fmt::Write};
+
+use postgres_types::{private::BytesMut, IsNull, ToSql, Type};
+use serde::{Deserialize, Serialize, Serializer};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
+#[serde(untagged)]
+pub enum PathToken<'p> {
+    Field(Cow<'p, str>),
+    Index(usize),
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct JsonPath<'p> {
+    path: Vec<PathToken<'p>>,
+}
+
+impl<'p> JsonPath<'p> {
+    pub fn from_path_tokens(path: Vec<PathToken<'p>>) -> Self {
+        Self { path }
+    }
+
+    fn write(&self, writer: &mut impl Write) -> Result<(), fmt::Error> {
+        for token in &self.path {
+            match token {
+                PathToken::Field(field) => {
+                    write!(writer, ".{field:?}")?;
+                }
+                PathToken::Index(index) => {
+                    write!(writer, "[{index}]")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for JsonPath<'_> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.write_char('\'')?;
+        self.write(fmt)?;
+        fmt.write_char('\'')
+    }
+}
+
+impl fmt::Display for JsonPath<'_> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.write(fmt)
+    }
+}
+
+impl Serialize for JsonPath<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl ToSql for JsonPath<'_> {
+    // Ideally, we want to accept `JSONPATH`, but that requires a special format, which we don't
+    // know, so we accept `TEXT` instead and have to cast it to `JSONPATH` in postgres.
+    postgres_types::accepts!(TEXT);
+
+    postgres_types::to_sql_checked!();
+
+    fn to_sql(&self, _: &Type, out: &mut BytesMut) -> Result<IsNull, Box<dyn Error + Sync + Send>>
+    where
+        Self: Sized,
+    {
+        out.write_char('$')?;
+        self.write(out)?;
+        Ok(IsNull::No)
+    }
+}

--- a/apps/hash-graph/lib/graph/src/store/query/path.rs
+++ b/apps/hash-graph/lib/graph/src/store/query/path.rs
@@ -21,6 +21,7 @@ impl<'p> JsonPath<'p> {
     }
 
     fn write(&self, writer: &mut impl Write) -> Result<(), fmt::Error> {
+        writer.write_char('$')?;
         for token in &self.path {
             match token {
                 PathToken::Field(field) => {
@@ -69,7 +70,6 @@ impl ToSql for JsonPath<'_> {
     where
         Self: Sized,
     {
-        out.write_char('$')?;
         self.write(out)?;
         Ok(IsNull::No)
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This adds the support to index by nested fields and index arrays inside of `properties` of an entity query

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203543021352041/1202884883200943/f) _(internal)_

## 🔍 What does this change?

- Changes the `EntityTypeQuery::Properties` variant to hold a `JsonPath`
- `JsonPath` can be constructed from a list of tokens, which consists of strings or arrays

## 📜 Does this require a change to the docs?

The documentation for `EntityTypeQuery::Properties` were adjusted

## ⚠️ Known issues

I was not able to construct `Type::JSONPATH` from Rust as it's most likely has a special format. Instead, we push it as `TEXT` and convert it to `JSONPATH` in postgres.

## 🐾 Next steps

Support the same operations on `*TypeQuery::Schema` as well