### PR TITLE
Refetch block subgraph when block entity is updated

### DIFF
--- a/apps/hash-frontend/src/components/block-loader/block-loader.tsx
+++ b/apps/hash-frontend/src/components/block-loader/block-loader.tsx
@@ -16,9 +16,11 @@ import {
 import { useBlockLoadedContext } from "../../blocks/on-block-loaded";
 import { useBlockContext } from "../../blocks/page/block-context";
 import { useFetchBlockSubgraph } from "../../blocks/use-fetch-block-subgraph";
+import { useBlockProtocolAggregateEntities } from "../hooks/block-protocol-functions/knowledge/use-block-protocol-aggregate-entities";
 import { useBlockProtocolFileUpload } from "../hooks/block-protocol-functions/knowledge/use-block-protocol-file-upload";
 import { useBlockProtocolUpdateEntity } from "../hooks/block-protocol-functions/knowledge/use-block-protocol-update-entity";
 import { RemoteBlock } from "../remote-block/remote-block";
+import { fetchEmbedCode } from "./fetch-embed-code";
 
 type BlockLoaderProps = {
   blockEntityId?: EntityId; // @todo make this always defined
@@ -47,6 +49,7 @@ export const BlockLoader: FunctionComponent<BlockLoaderProps> = ({
   wrappingEntityId,
   readonly,
 }) => {
+  const { aggregateEntities } = useBlockProtocolAggregateEntities();
   const { updateEntity } = useBlockProtocolUpdateEntity();
   const { uploadFile } = useBlockProtocolFileUpload(readonly);
 
@@ -58,6 +61,16 @@ export const BlockLoader: FunctionComponent<BlockLoaderProps> = ({
       (newBlockSubgraph) => setBlockSubgraph(newBlockSubgraph),
     );
   }, [fetchBlockSubgraph, blockEntityId, blockEntityTypeId, setBlockSubgraph]);
+
+  const functions = {
+    aggregateEntities,
+    /**
+     * @todo remove this when embed block no longer relies on server-side oEmbed calls
+     * @see https://app.asana.com/0/1200211978612931/1202509819279267/f
+     */
+    getEmbedBlock: fetchEmbedCode,
+    uploadFile,
+  };
 
   const onBlockLoadedFromContext = useBlockLoadedContext().onBlockLoaded;
   const onBlockLoadedRef = useRef(onBlockLoaded);
@@ -128,7 +141,7 @@ export const BlockLoader: FunctionComponent<BlockLoaderProps> = ({
       blockMetadata={blockMetadata}
       editableRef={editableRef}
       graphCallbacks={{
-        uploadFile,
+        ...functions,
         updateEntity: async (...args) => {
           const res = await updateEntity(...args);
 

--- a/apps/hash-frontend/src/components/block-loader/block-loader.tsx
+++ b/apps/hash-frontend/src/components/block-loader/block-loader.tsx
@@ -16,11 +16,9 @@ import {
 import { useBlockLoadedContext } from "../../blocks/on-block-loaded";
 import { useBlockContext } from "../../blocks/page/block-context";
 import { useFetchBlockSubgraph } from "../../blocks/use-fetch-block-subgraph";
-import { useBlockProtocolAggregateEntities } from "../hooks/block-protocol-functions/knowledge/use-block-protocol-aggregate-entities";
 import { useBlockProtocolFileUpload } from "../hooks/block-protocol-functions/knowledge/use-block-protocol-file-upload";
 import { useBlockProtocolUpdateEntity } from "../hooks/block-protocol-functions/knowledge/use-block-protocol-update-entity";
 import { RemoteBlock } from "../remote-block/remote-block";
-import { fetchEmbedCode } from "./fetch-embed-code";
 
 type BlockLoaderProps = {
   blockEntityId?: EntityId; // @todo make this always defined
@@ -49,7 +47,6 @@ export const BlockLoader: FunctionComponent<BlockLoaderProps> = ({
   wrappingEntityId,
   readonly,
 }) => {
-  const { aggregateEntities } = useBlockProtocolAggregateEntities();
   const { updateEntity } = useBlockProtocolUpdateEntity();
   const { uploadFile } = useBlockProtocolFileUpload(readonly);
 
@@ -61,17 +58,6 @@ export const BlockLoader: FunctionComponent<BlockLoaderProps> = ({
       (newBlockSubgraph) => setBlockSubgraph(newBlockSubgraph),
     );
   }, [fetchBlockSubgraph, blockEntityId, blockEntityTypeId, setBlockSubgraph]);
-
-  const functions = {
-    aggregateEntities,
-    /**
-     * @todo remove this when embed block no longer relies on server-side oEmbed calls
-     * @see https://app.asana.com/0/1200211978612931/1202509819279267/f
-     */
-    getEmbedBlock: fetchEmbedCode,
-    updateEntity,
-    uploadFile,
-  };
 
   const onBlockLoadedFromContext = useBlockLoadedContext().onBlockLoaded;
   const onBlockLoadedRef = useRef(onBlockLoaded);
@@ -141,7 +127,20 @@ export const BlockLoader: FunctionComponent<BlockLoaderProps> = ({
     <RemoteBlock
       blockMetadata={blockMetadata}
       editableRef={editableRef}
-      graphCallbacks={functions}
+      graphCallbacks={{
+        uploadFile,
+        updateEntity: async (...args) => {
+          const res = await updateEntity(...args);
+
+          const newBlockSubgraph = await fetchBlockSubgraph(
+            blockEntityTypeId,
+            blockEntityId,
+          );
+          setBlockSubgraph(newBlockSubgraph);
+
+          return res;
+        },
+      }}
       graphProperties={temporaryBackwardsCompatibleProperties}
       onBlockLoaded={onRemoteBlockLoaded}
     />

--- a/apps/hash-frontend/src/components/block-loader/block-loader.tsx
+++ b/apps/hash-frontend/src/components/block-loader/block-loader.tsx
@@ -1,4 +1,7 @@
-import { BlockGraphProperties } from "@blockprotocol/graph";
+import {
+  BlockGraphProperties,
+  EmbedderGraphMessageCallbacks,
+} from "@blockprotocol/graph";
 import { VersionedUri } from "@blockprotocol/type-system/slim";
 import { HashBlockMeta } from "@local/hash-isomorphic-utils/blocks";
 import { EntityId } from "@local/hash-isomorphic-utils/types";
@@ -62,15 +65,39 @@ export const BlockLoader: FunctionComponent<BlockLoaderProps> = ({
     );
   }, [fetchBlockSubgraph, blockEntityId, blockEntityTypeId, setBlockSubgraph]);
 
-  const functions = {
-    aggregateEntities,
-    /**
-     * @todo remove this when embed block no longer relies on server-side oEmbed calls
-     * @see https://app.asana.com/0/1200211978612931/1202509819279267/f
-     */
-    getEmbedBlock: fetchEmbedCode,
-    uploadFile,
-  };
+  const functions = useMemo(
+    () => ({
+      aggregateEntities,
+      /**
+       * @todo remove this when embed block no longer relies on server-side oEmbed calls
+       * @see https://app.asana.com/0/1200211978612931/1202509819279267/f
+       */
+      getEmbedBlock: fetchEmbedCode,
+      uploadFile,
+      updateEntity: async (
+        ...args: Parameters<EmbedderGraphMessageCallbacks["updateEntity"]>
+      ) => {
+        const res = await updateEntity(...args);
+
+        const newBlockSubgraph = await fetchBlockSubgraph(
+          blockEntityTypeId,
+          blockEntityId,
+        );
+        setBlockSubgraph(newBlockSubgraph);
+
+        return res;
+      },
+    }),
+    [
+      aggregateEntities,
+      setBlockSubgraph,
+      fetchBlockSubgraph,
+      updateEntity,
+      blockEntityId,
+      blockEntityTypeId,
+      uploadFile,
+    ],
+  );
 
   const onBlockLoadedFromContext = useBlockLoadedContext().onBlockLoaded;
   const onBlockLoadedRef = useRef(onBlockLoaded);
@@ -140,20 +167,7 @@ export const BlockLoader: FunctionComponent<BlockLoaderProps> = ({
     <RemoteBlock
       blockMetadata={blockMetadata}
       editableRef={editableRef}
-      graphCallbacks={{
-        ...functions,
-        updateEntity: async (...args) => {
-          const res = await updateEntity(...args);
-
-          const newBlockSubgraph = await fetchBlockSubgraph(
-            blockEntityTypeId,
-            blockEntityId,
-          );
-          setBlockSubgraph(newBlockSubgraph);
-
-          return res;
-        },
-      }}
+      graphCallbacks={functions}
       graphProperties={temporaryBackwardsCompatibleProperties}
       onBlockLoaded={onRemoteBlockLoaded}
     />

--- a/apps/hash-frontend/src/components/remote-block/remote-block.tsx
+++ b/apps/hash-frontend/src/components/remote-block/remote-block.tsx
@@ -80,6 +80,12 @@ export const RemoteBlock: FunctionComponent<RemoteBlockProps> = ({
     ...graphProperties,
   });
 
+  useEffect(() => {
+    if (graphService) {
+      graphService.registerCallbacks(graphCallbacks);
+    }
+  }, [graphCallbacks, graphService]);
+
   useHookEmbedderService(wrapperRef, {
     callbacks: {
       // eslint-disable-next-line @typescript-eslint/require-await -- async is required upstream


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To keep the block subgraphs provided to blocks up-to-date when they get updated, we need to refetch the block subgraph. Ideally, this should be handled by Collab service in future.

For more context, check this [Slack thread](https://hashintel.slack.com/archives/C022217GAHF/p1674725747666169) _(internal)_
