### PR TITLE
Support nested fields and array index for ontology schemas

### DIFF
--- a/apps/hash-graph/lib/graph/src/knowledge/entity/query.rs
+++ b/apps/hash-graph/lib/graph/src/knowledge/entity/query.rs
@@ -120,7 +120,7 @@ pub enum EntityQueryPath<'p> {
     /// [`Entity`]: crate::knowledge::Entity
     /// [`EntityMetadata`]: crate::knowledge::EntityMetadata
     /// [`EntityType`]: type_system::EntityType
-    Type(EntityTypeQueryPath),
+    Type(EntityTypeQueryPath<'p>),
     /// Represents an [`Entity`] linking to the [`Entity`].
     ///
     /// Deserializes from `["incomingLinks", ...]` where `...` is the path of the source

--- a/apps/hash-graph/lib/graph/src/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/data_type.rs
@@ -202,7 +202,7 @@ impl fmt::Display for DataTypeQueryPath<'_> {
             Self::VersionedUri => fmt.write_str("versionedUri"),
             Self::OwnedById => fmt.write_str("ownedById"),
             Self::UpdatedById => fmt.write_str("updatedById"),
-            Self::Schema(Some(path)) => write!(fmt, "schema{path}"),
+            Self::Schema(Some(path)) => write!(fmt, "schema.{path}"),
             Self::Schema(None) => fmt.write_str("schema"),
             Self::Title => fmt.write_str("title"),
             Self::Description => fmt.write_str("description"),

--- a/apps/hash-graph/lib/graph/src/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/data_type.rs
@@ -6,7 +6,7 @@ use serde::{
 };
 use utoipa::ToSchema;
 
-use crate::store::query::{OntologyQueryPath, ParameterType, QueryPath};
+use crate::store::query::{JsonPath, OntologyQueryPath, ParameterType, PathToken, QueryPath};
 
 /// A path to a [`DataType`] field.
 ///
@@ -18,7 +18,7 @@ use crate::store::query::{OntologyQueryPath, ParameterType, QueryPath};
 // TODO: Adjust enum and docs when adding non-primitive data types
 //   see https://app.asana.com/0/1200211978612931/1202464168422955/f
 #[derive(Debug, PartialEq, Eq)]
-pub enum DataTypeQueryPath {
+pub enum DataTypeQueryPath<'p> {
     /// The [`BaseUri`] of the [`DataType`].
     ///
     /// ```rust
@@ -151,10 +151,10 @@ pub enum DataTypeQueryPath {
     /// Only used internally and not available for deserialization.
     VersionId,
     /// Only used internally and not available for deserialization.
-    Schema,
+    Schema(Option<JsonPath<'p>>),
 }
 
-impl OntologyQueryPath for DataTypeQueryPath {
+impl OntologyQueryPath for DataTypeQueryPath<'_> {
     fn base_uri() -> Self {
         Self::BaseUri
     }
@@ -176,15 +176,15 @@ impl OntologyQueryPath for DataTypeQueryPath {
     }
 
     fn schema() -> Self {
-        Self::Schema
+        Self::Schema(None)
     }
 }
 
-impl QueryPath for DataTypeQueryPath {
+impl QueryPath for DataTypeQueryPath<'_> {
     fn expected_type(&self) -> ParameterType {
         match self {
             Self::VersionId | Self::OwnedById | Self::UpdatedById => ParameterType::Uuid,
-            Self::Schema => ParameterType::Any,
+            Self::Schema(_) => ParameterType::Any,
             Self::BaseUri => ParameterType::BaseUri,
             Self::VersionedUri => ParameterType::VersionedUri,
             Self::Version => ParameterType::UnsignedInteger,
@@ -193,7 +193,7 @@ impl QueryPath for DataTypeQueryPath {
     }
 }
 
-impl fmt::Display for DataTypeQueryPath {
+impl fmt::Display for DataTypeQueryPath<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::VersionId => fmt.write_str("versionId"),
@@ -202,7 +202,8 @@ impl fmt::Display for DataTypeQueryPath {
             Self::VersionedUri => fmt.write_str("versionedUri"),
             Self::OwnedById => fmt.write_str("ownedById"),
             Self::UpdatedById => fmt.write_str("updatedById"),
-            Self::Schema => fmt.write_str("schema"),
+            Self::Schema(Some(path)) => write!(fmt, "schema{path}"),
+            Self::Schema(None) => fmt.write_str("schema"),
             Self::Title => fmt.write_str("title"),
             Self::Description => fmt.write_str("description"),
             Self::Type => fmt.write_str("type"),
@@ -222,6 +223,8 @@ pub enum DataTypeQueryToken {
     Title,
     Description,
     Type,
+    #[serde(skip)]
+    Schema,
 }
 
 /// Deserializes a [`DataTypeQueryPath`] from a string sequence.
@@ -242,7 +245,7 @@ impl DataTypeQueryPathVisitor {
 }
 
 impl<'de> Visitor<'de> for DataTypeQueryPathVisitor {
-    type Value = DataTypeQueryPath;
+    type Value = DataTypeQueryPath<'de>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str(Self::EXPECTING)
@@ -266,11 +269,24 @@ impl<'de> Visitor<'de> for DataTypeQueryPathVisitor {
             DataTypeQueryToken::Title => DataTypeQueryPath::Title,
             DataTypeQueryToken::Description => DataTypeQueryPath::Description,
             DataTypeQueryToken::Type => DataTypeQueryPath::Type,
+            DataTypeQueryToken::Schema => {
+                let mut path_tokens = Vec::new();
+                while let Some(field) = seq.next_element::<PathToken<'de>>()? {
+                    path_tokens.push(field);
+                    self.position += 1;
+                }
+
+                if path_tokens.is_empty() {
+                    DataTypeQueryPath::Schema(None)
+                } else {
+                    DataTypeQueryPath::Schema(Some(JsonPath::from_path_tokens(path_tokens)))
+                }
+            }
         })
     }
 }
 
-impl<'de> Deserialize<'de> for DataTypeQueryPath {
+impl<'de: 'p, 'p> Deserialize<'de> for DataTypeQueryPath<'p> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -285,7 +301,7 @@ mod tests {
 
     use super::*;
 
-    fn deserialize<'p>(segments: impl IntoIterator<Item = &'p str>) -> DataTypeQueryPath {
+    fn deserialize<'p>(segments: impl IntoIterator<Item = &'p str>) -> DataTypeQueryPath<'p> {
         DataTypeQueryPath::deserialize(de::value::SeqDeserializer::<_, de::value::Error>::new(
             segments.into_iter(),
         ))

--- a/apps/hash-graph/lib/graph/src/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/entity_type.rs
@@ -315,7 +315,7 @@ impl fmt::Display for EntityTypeQueryPath<'_> {
             Self::VersionedUri => fmt.write_str("versionedUri"),
             Self::OwnedById => fmt.write_str("ownedById"),
             Self::UpdatedById => fmt.write_str("updatedById"),
-            Self::Schema(Some(path)) => write!(fmt, "schema{path}"),
+            Self::Schema(Some(path)) => write!(fmt, "schema.{path}"),
             Self::Schema(None) => fmt.write_str("schema"),
             Self::Title => fmt.write_str("title"),
             Self::Description => fmt.write_str("description"),

--- a/apps/hash-graph/lib/graph/src/ontology/mod.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/mod.rs
@@ -198,7 +198,7 @@ pub struct DataTypeWithMetadata {
 
 impl Record for DataTypeWithMetadata {
     type EditionId = OntologyTypeEditionId;
-    type QueryPath<'p> = DataTypeQueryPath;
+    type QueryPath<'p> = DataTypeQueryPath<'p>;
     type VertexId = Self::EditionId;
 
     fn edition_id(&self) -> &Self::EditionId {
@@ -243,7 +243,7 @@ pub struct PropertyTypeWithMetadata {
 
 impl Record for PropertyTypeWithMetadata {
     type EditionId = OntologyTypeEditionId;
-    type QueryPath<'p> = PropertyTypeQueryPath;
+    type QueryPath<'p> = PropertyTypeQueryPath<'p>;
     type VertexId = Self::EditionId;
 
     fn edition_id(&self) -> &Self::EditionId {
@@ -288,7 +288,7 @@ pub struct EntityTypeWithMetadata {
 
 impl Record for EntityTypeWithMetadata {
     type EditionId = OntologyTypeEditionId;
-    type QueryPath<'p> = EntityTypeQueryPath;
+    type QueryPath<'p> = EntityTypeQueryPath<'p>;
     type VertexId = Self::EditionId;
 
     fn edition_id(&self) -> &Self::EditionId {

--- a/apps/hash-graph/lib/graph/src/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/property_type.rs
@@ -220,7 +220,7 @@ impl fmt::Display for PropertyTypeQueryPath<'_> {
             Self::VersionedUri => fmt.write_str("versionedUri"),
             Self::OwnedById => fmt.write_str("ownedById"),
             Self::UpdatedById => fmt.write_str("updatedById"),
-            Self::Schema(Some(path)) => write!(fmt, "schema{path}"),
+            Self::Schema(Some(path)) => write!(fmt, "schema.{path}"),
             Self::Schema(None) => fmt.write_str("schema"),
             Self::Title => fmt.write_str("title"),
             Self::Description => fmt.write_str("description"),

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/compile.rs
@@ -361,7 +361,7 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
         )))) = column
         {
             self.artifacts.parameters.push(field);
-            Column::Entities(Entities::Properties(Some(JsonField::JsonParameter(
+            Column::Entities(Entities::Properties(Some(JsonField::JsonPathParameter(
                 self.artifacts.parameters.len(),
             ))))
         } else {

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/compile.rs
@@ -357,8 +357,7 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
     }
 
     pub fn compile_path_column(&mut self, path: &'p R::QueryPath<'_>) -> AliasedColumn<'c> {
-        let column = path.terminating_column();
-        let column = match column {
+        let column = match path.terminating_column() {
             Column::DataTypes(DataTypes::Schema(Some(JsonField::JsonPath(field)))) => {
                 self.artifacts.parameters.push(field);
                 Column::DataTypes(DataTypes::Schema(Some(JsonField::JsonPathParameter(

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/compile.rs
@@ -8,7 +8,9 @@ use crate::{
     store::{
         postgres::query::{
             expression::Constant,
-            table::{Entities, EntityTypes, JsonField, Relation, TypeIds},
+            table::{
+                DataTypes, Entities, EntityTypes, JsonField, PropertyTypes, Relation, TypeIds,
+            },
             Alias, AliasedColumn, AliasedTable, Column, Condition, Distinctness, EqualityOperator,
             Expression, Function, JoinExpression, OrderByExpression, Ordering, PostgresQueryPath,
             PostgresRecord, SelectExpression, SelectStatement, Table, Transpile, WhereExpression,
@@ -356,16 +358,32 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
 
     pub fn compile_path_column(&mut self, path: &'p R::QueryPath<'_>) -> AliasedColumn<'c> {
         let column = path.terminating_column();
-        let column = if let Column::Entities(Entities::Properties(Some(JsonField::JsonPath(
-            field,
-        )))) = column
-        {
-            self.artifacts.parameters.push(field);
-            Column::Entities(Entities::Properties(Some(JsonField::JsonPathParameter(
-                self.artifacts.parameters.len(),
-            ))))
-        } else {
-            column
+        let column = match column {
+            Column::DataTypes(DataTypes::Schema(Some(JsonField::JsonPath(field)))) => {
+                self.artifacts.parameters.push(field);
+                Column::DataTypes(DataTypes::Schema(Some(JsonField::JsonPathParameter(
+                    self.artifacts.parameters.len(),
+                ))))
+            }
+            Column::PropertyTypes(PropertyTypes::Schema(Some(JsonField::JsonPath(field)))) => {
+                self.artifacts.parameters.push(field);
+                Column::PropertyTypes(PropertyTypes::Schema(Some(JsonField::JsonPathParameter(
+                    self.artifacts.parameters.len(),
+                ))))
+            }
+            Column::EntityTypes(EntityTypes::Schema(Some(JsonField::JsonPath(field)))) => {
+                self.artifacts.parameters.push(field);
+                Column::EntityTypes(EntityTypes::Schema(Some(JsonField::JsonPathParameter(
+                    self.artifacts.parameters.len(),
+                ))))
+            }
+            Column::Entities(Entities::Properties(Some(JsonField::JsonPath(field)))) => {
+                self.artifacts.parameters.push(field);
+                Column::Entities(Entities::Properties(Some(JsonField::JsonPathParameter(
+                    self.artifacts.parameters.len(),
+                ))))
+            }
+            column => column,
         };
 
         let alias = self.add_join_statements(path);

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
@@ -14,7 +14,7 @@ impl PostgresRecord for EntityTypeWithMetadata {
     }
 }
 
-impl PostgresQueryPath for EntityTypeQueryPath {
+impl PostgresQueryPath for EntityTypeQueryPath<'_> {
     /// Returns the relations that are required to access the path.
     fn relations(&self) -> Vec<Relation> {
         match self {
@@ -39,7 +39,11 @@ impl PostgresQueryPath for EntityTypeQueryPath {
             Self::VersionId => Column::EntityTypes(EntityTypes::VersionId),
             Self::OwnedById => Column::EntityTypes(EntityTypes::OwnedById),
             Self::UpdatedById => Column::EntityTypes(EntityTypes::UpdatedById),
-            Self::Schema => Column::EntityTypes(EntityTypes::Schema(None)),
+            Self::Schema(path) => path
+                .as_ref()
+                .map_or(Column::EntityTypes(EntityTypes::Schema(None)), |path| {
+                    Column::EntityTypes(EntityTypes::Schema(Some(JsonField::JsonPath(path))))
+                }),
             Self::VersionedUri => {
                 Column::EntityTypes(EntityTypes::Schema(Some(JsonField::StaticText("$id"))))
             }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/property_type.rs
@@ -14,7 +14,7 @@ impl PostgresRecord for PropertyTypeWithMetadata {
     }
 }
 
-impl PostgresQueryPath for PropertyTypeQueryPath {
+impl PostgresQueryPath for PropertyTypeQueryPath<'_> {
     fn relations(&self) -> Vec<Relation> {
         match self {
             Self::BaseUri | Self::Version => vec![Relation::PropertyTypeIds],
@@ -35,7 +35,14 @@ impl PostgresQueryPath for PropertyTypeQueryPath {
             Self::VersionId => Column::PropertyTypes(PropertyTypes::VersionId),
             Self::OwnedById => Column::PropertyTypes(PropertyTypes::OwnedById),
             Self::UpdatedById => Column::PropertyTypes(PropertyTypes::UpdatedById),
-            Self::Schema => Column::PropertyTypes(PropertyTypes::Schema(None)),
+            Self::Schema(path) => {
+                path.as_ref()
+                    .map_or(Column::PropertyTypes(PropertyTypes::Schema(None)), |path| {
+                        Column::PropertyTypes(PropertyTypes::Schema(Some(JsonField::JsonPath(
+                            path,
+                        ))))
+                    })
+            }
             Self::VersionedUri => {
                 Column::PropertyTypes(PropertyTypes::Schema(Some(JsonField::StaticText("$id"))))
             }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We have the functionality to query for nested fields and arrays in entity properties but not for ontology schema. The functionality can be transferred, so this PR adds the functionality to the `"schema"` field.
This, however, does not expose querying for the schema, yet.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203543026679373/1203821263193159/f) _(internal)_

## 🚫 Blocked by

- #1952 

## 🔍 What does this change?

- Renames `JsonField::JsonParameter` to `JsonField::JsonPathParameter` to make the intention more clear
- Adds `JsonPath` to the `Schema` variants for ontology types
- Adds `Schema` to ontology type tokens, but hides them via adding `#[serde(skip)]` for now