### PR TITLE
Permit cross-origin requests for types as json

### DIFF
--- a/apps/hash-frontend/next.config.js
+++ b/apps/hash-frontend/next.config.js
@@ -55,6 +55,30 @@ module.exports = withSentryConfig(
     withTM(
       /** @type {import('next').NextConfig} */
       {
+        async headers() {
+          return [
+            {
+              /**
+               * allow fetching types as JSON from anywhere
+               * @see ./src/middleware.page.ts for middleware which serves the JSON
+               */
+              source: "/:shortname/types/:path*",
+              has: [
+                {
+                  type: "header",
+                  key: "accept",
+                  value: "(application/json)",
+                },
+              ],
+              headers: [
+                {
+                  key: "access-control-allow-origin",
+                  value: "*",
+                },
+              ],
+            },
+          ];
+        },
         pageExtensions: [
           "page.tsx",
           "page.ts",

--- a/apps/hash-frontend/next.config.js
+++ b/apps/hash-frontend/next.config.js
@@ -67,7 +67,7 @@ module.exports = withSentryConfig(
                 {
                   type: "header",
                   key: "accept",
-                  value: "(application/json)",
+                  value: "application/json",
                 },
               ],
               headers: [

--- a/apps/hash-frontend/next.config.js
+++ b/apps/hash-frontend/next.config.js
@@ -67,7 +67,7 @@ module.exports = withSentryConfig(
                 {
                   type: "header",
                   key: "accept",
-                  value: "application/json",
+                  value: "(.*application/json.*)",
                 },
               ],
               headers: [

--- a/apps/hash-frontend/src/middleware.page.ts
+++ b/apps/hash-frontend/src/middleware.page.ts
@@ -10,6 +10,9 @@ export const middleware = async (request: NextRequest) => {
   }
 };
 
+/**
+ * Allow any cross-origin request for type JSON is set via headers in next.config.js
+ */
 export const config = {
   matcher: "/:shortname/types/:path*",
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#1612 introduced the ability to retrieve a JSON version of any ontology type, so that machine-readable versions of types are available at their `$id`.

This PR allows fetching of these from any origin, since they are intended to be retrievable from anywhere and not just within the HASH app.

## 🐾 Next steps

I am going to use this in type fetching code for the WordPress plugin.

## ❓ How to test this?

- Open a tab from some random domain, e.g. https://www.google.com
- In the console, try a fetch request:
```js
fetch(
  "https://hash-fwe0goic1.stage.hash.ai/@ciaran/types/entity-type/code-snippet/v/1", 
  { headers: { accept: "application/json" } } // also accepts any value that contains "application/json"
);
```
It will `404` because the type id uses the production domain, but it won't be rejected by CORS.

You can try removing the "accept" header or changing it to not contain "application/json" to see the CORS rejection.
