### PR TITLE
Fix bug that tables may be joined multiple times

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/compile.rs
@@ -498,19 +498,17 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
                 // entity_type_version_id = type_ids.version_id`. We, however, need to
                 // make sure, that we only alter a join statement with a table we don't require
                 // anymore.
-                if true {
-                    if let Some(last_join) = self.statement.joins.pop() {
-                        // Check if we are joining on the same column as the previous join
-                        if last_join.join == current_column
-                            && !self
-                                .artifacts
-                                .required_tables
-                                .contains(&last_join.join.table())
-                        {
-                            current_column = last_join.on;
-                        } else {
-                            self.statement.joins.push(last_join);
-                        }
+                if let Some(last_join) = self.statement.joins.pop() {
+                    // Check if we are joining on the same column as the previous join
+                    if last_join.join == current_column
+                        && !self
+                            .artifacts
+                            .required_tables
+                            .contains(&last_join.join.table())
+                    {
+                        current_column = last_join.on;
+                    } else {
+                        self.statement.joins.push(last_join);
                     }
                 }
 

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -296,10 +296,10 @@ mod tests {
               ON "data_types_0_2_0"."version_id" = "property_type_data_type_references_0_1_0"."target_data_type_version_id"
             INNER JOIN "property_type_data_type_references" AS "property_type_data_type_references_1_1_0"
               ON "property_type_data_type_references_1_1_0"."source_property_type_version_id" = "property_types_0_0_0"."version_id"
-            INNER JOIN "type_ids" AS "type_ids_1_2_0"
-              ON "type_ids_1_2_0"."version_id" = "property_type_data_type_references_1_1_0"."target_data_type_version_id"
+            INNER JOIN "type_ids" AS "type_ids_1_3_0"
+              ON "type_ids_1_3_0"."version_id" = "property_type_data_type_references_1_1_0"."target_data_type_version_id"
             WHERE "data_types_0_2_0"."schema"->>'title' = $1
-              AND ("type_ids_1_2_0"."base_uri" = $2) AND ("type_ids_1_2_0"."version" = $3)
+              AND ("type_ids_1_3_0"."base_uri" = $2) AND ("type_ids_1_3_0"."version" = $3)
             "#,
             &[
                 &"Text",
@@ -706,6 +706,56 @@ mod tests {
                 &Uuid::nil(),
                 &Uuid::nil(),
                 &Uuid::nil(),
+            ],
+        );
+    }
+
+    #[test]
+    fn filter_left_and_right() {
+        let time_projection = UnresolvedTimeProjection::default().resolve();
+        let kernel = time_projection.kernel().cast::<TransactionTime>();
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(&time_projection);
+
+        let filter = Filter::All(vec![
+            Filter::Equal(
+                Some(FilterExpression::Path(EntityQueryPath::LeftEntity(
+                    Box::new(EntityQueryPath::Type(EntityTypeQueryPath::BaseUri)),
+                ))),
+                Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
+                    "https://example.com/@example-org/types/entity-type/address",
+                )))),
+            ),
+            Filter::Equal(
+                Some(FilterExpression::Path(EntityQueryPath::RightEntity(
+                    Box::new(EntityQueryPath::Type(EntityTypeQueryPath::BaseUri)),
+                ))),
+                Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
+                    "https://example.com/@example-org/types/entity-type/name",
+                )))),
+            ),
+        ]);
+        compiler.add_filter(&filter);
+
+        test_compilation(
+            &compiler,
+            r#"
+             SELECT *
+             FROM "entities" AS "entities_0_0_0"
+             RIGHT OUTER JOIN "entities" AS "entities_0_1_0" ON "entities_0_1_0"."entity_uuid" = "entities_0_0_0"."left_entity_uuid"
+             INNER JOIN "type_ids" AS "type_ids_0_3_0" ON "type_ids_0_3_0"."version_id" = "entities_0_1_0"."entity_type_version_id"
+             RIGHT OUTER JOIN "entities" AS "entities_0_1_1" ON "entities_0_1_1"."entity_uuid" = "entities_0_0_0"."right_entity_uuid"
+             INNER JOIN "type_ids" AS "type_ids_0_3_1" ON "type_ids_0_3_1"."version_id" = "entities_0_1_1"."entity_type_version_id"
+             WHERE "entities_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ AND "entities_0_0_0"."decision_time" && $2
+               AND "entities_0_1_0"."transaction_time" @> $1::TIMESTAMPTZ AND "entities_0_1_0"."decision_time" && $2
+               AND "entities_0_1_1"."transaction_time" @> $1::TIMESTAMPTZ AND "entities_0_1_1"."decision_time" && $2
+               AND ("type_ids_0_3_0"."base_uri" = $3)
+               AND ("type_ids_0_3_1"."base_uri" = $4)
+            "#,
+            &[
+                &kernel,
+                &time_projection.image(),
+                &"https://example.com/@example-org/types/entity-type/address",
+                &"https://example.com/@example-org/types/entity-type/name",
             ],
         );
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

@indietyp encountered an issue, where the same table was joined multiple times with the same name. The bug occurred, if from the same base table the same table was joined multiple times, where another table was joined on the joined tables, e.g. `entity_types` were joined on `entities` twice and on each `entity_types` an `type_ids` table was joined. The `entity_types` tables are intermediate and not required in the final query, so they are optimized out. However, then `type_ids` was joined with the same name. This PR fixes this issue.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1202805690238892/1203811012038440/f) _(internal)_
- [Slack discussion](https://hashintel.slack.com/archives/C03TWBSRT8B/p1674570505708979) _(internal)_

## 🔍 What does this change?

- Instead of modifying the last table on the stack, we pop it and treat it as the current table unless we need it, then we push it back to the stack
- Reverse the logic, when an entity table is pinned as the `current_table` is not necessarily an entity table

## 🛡 What tests cover this?

A test case was added to match the expected result. Without this fix, the test would fail.

## ❓ How to test this?

Run this query with and without a fix. Without the fix, there should be an error. Wiih the fix the query will succeed (but may not return any roots)
```json

{
  "filter": {
    "all": [
      {
        "equal": [
          { "path": ["leftEntity", "type", "baseUri"] },
          { "parameter": "http://localhost:3000/@example-org/types/entity-type/category/" }
        ]
      },
      {
        "equal": [
          { "path": ["rightEntity", "type", "baseUri"] },
          { "parameter": "http://localhost:3000/@example-org/types/entity-type/category/" }
        ]
      }
    ]
  }
}
```
