### PR TITLE
Rename `type_ids` table and `version_id` column

### DIFF
--- a/apps/hash-graph/bench/benches/representative_read/seed.rs
+++ b/apps/hash-graph/bench/benches/representative_read/seed.rs
@@ -260,9 +260,9 @@ async fn get_samples(account_id: AccountId, store_wrapper: &mut StoreWrapper) ->
                 r#"
                 -- Very naive and slow sampling, we can replace when this becomes a bottleneck
                 SELECT entity_uuid FROM entities
-                INNER JOIN type_ids
-                ON type_ids.version_id = entities.entity_type_version_id
-                WHERE type_ids.base_uri = $1 AND type_ids.version = $2
+                INNER JOIN ontology_ids
+                ON ontology_ids.ontology_id = entities.entity_type_ontology_id
+                WHERE ontology_ids.base_uri = $1 AND ontology_ids.version = $2
                 ORDER BY RANDOM()
                 LIMIT 50
                 "#,

--- a/apps/hash-graph/lib/graph/src/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/data_type.rs
@@ -149,7 +149,7 @@ pub enum DataTypeQueryPath {
     /// [`DataType::json_type()`]: type_system::DataType::json_type
     Type,
     /// Only used internally and not available for deserialization.
-    VersionId,
+    OntologyId,
     /// Only used internally and not available for deserialization.
     Schema,
 }
@@ -183,7 +183,7 @@ impl OntologyQueryPath for DataTypeQueryPath {
 impl QueryPath for DataTypeQueryPath {
     fn expected_type(&self) -> ParameterType {
         match self {
-            Self::VersionId | Self::OwnedById | Self::UpdatedById => ParameterType::Uuid,
+            Self::OntologyId | Self::OwnedById | Self::UpdatedById => ParameterType::Uuid,
             Self::Schema => ParameterType::Any,
             Self::BaseUri => ParameterType::BaseUri,
             Self::VersionedUri => ParameterType::VersionedUri,
@@ -196,7 +196,7 @@ impl QueryPath for DataTypeQueryPath {
 impl fmt::Display for DataTypeQueryPath {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::VersionId => fmt.write_str("versionId"),
+            Self::OntologyId => fmt.write_str("ontologyId"),
             Self::BaseUri => fmt.write_str("baseUri"),
             Self::Version => fmt.write_str("version"),
             Self::VersionedUri => fmt.write_str("versionedUri"),
@@ -307,7 +307,7 @@ mod tests {
 
         assert_eq!(
             DataTypeQueryPath::deserialize(de::value::SeqDeserializer::<_, de::value::Error>::new(
-                once("version_id")
+                once("ontology_id")
             ))
             .expect_err(
                 "managed to convert data type query path with hidden token when it should have \
@@ -315,7 +315,7 @@ mod tests {
             )
             .to_string(),
             format!(
-                "unknown variant `version_id`, expected {}",
+                "unknown variant `ontology_id`, expected {}",
                 DataTypeQueryPathVisitor::EXPECTING
             )
         );

--- a/apps/hash-graph/lib/graph/src/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/entity_type.rs
@@ -257,7 +257,7 @@ pub enum EntityTypeQueryPath {
     /// [`EntityType::inherits_from()`]: type_system::EntityType::inherits_from
     InheritsFrom(Box<Self>),
     /// Only used internally and not available for deserialization.
-    VersionId,
+    OntologyId,
     /// Only used internally and not available for deserialization.
     Schema,
 }
@@ -291,7 +291,7 @@ impl OntologyQueryPath for EntityTypeQueryPath {
 impl QueryPath for EntityTypeQueryPath {
     fn expected_type(&self) -> ParameterType {
         match self {
-            Self::VersionId | Self::OwnedById | Self::UpdatedById => ParameterType::Uuid,
+            Self::OntologyId | Self::OwnedById | Self::UpdatedById => ParameterType::Uuid,
             Self::Schema => ParameterType::Any,
             Self::BaseUri => ParameterType::BaseUri,
             Self::VersionedUri => ParameterType::VersionedUri,
@@ -309,7 +309,7 @@ impl QueryPath for EntityTypeQueryPath {
 impl fmt::Display for EntityTypeQueryPath {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::VersionId => fmt.write_str("versionId"),
+            Self::OntologyId => fmt.write_str("ontologyId"),
             Self::BaseUri => fmt.write_str("baseUri"),
             Self::Version => fmt.write_str("version"),
             Self::VersionedUri => fmt.write_str("versionedUri"),
@@ -478,7 +478,7 @@ mod tests {
 
         assert_eq!(
             EntityTypeQueryPath::deserialize(
-                de::value::SeqDeserializer::<_, de::value::Error>::new(once("version_id"))
+                de::value::SeqDeserializer::<_, de::value::Error>::new(once("ontology_id"))
             )
             .expect_err(
                 "managed to convert entity type query path with hidden token when it should have \
@@ -486,7 +486,7 @@ mod tests {
             )
             .to_string(),
             format!(
-                "unknown variant `version_id`, expected {}",
+                "unknown variant `ontology_id`, expected {}",
                 EntityTypeQueryPathVisitor::EXPECTING
             )
         );

--- a/apps/hash-graph/lib/graph/src/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/property_type.rs
@@ -165,7 +165,7 @@ pub enum PropertyTypeQueryPath {
     /// [`PropertyType::property_type_references()`]: type_system::PropertyType::property_type_references
     PropertyTypes(Box<Self>),
     /// Only used internally and not available for deserialization.
-    VersionId,
+    OntologyId,
     /// Only used internally and not available for deserialization.
     Schema,
 }
@@ -199,7 +199,7 @@ impl OntologyQueryPath for PropertyTypeQueryPath {
 impl QueryPath for PropertyTypeQueryPath {
     fn expected_type(&self) -> ParameterType {
         match self {
-            Self::VersionId | Self::OwnedById | Self::UpdatedById => ParameterType::Uuid,
+            Self::OntologyId | Self::OwnedById | Self::UpdatedById => ParameterType::Uuid,
             Self::Schema => ParameterType::Any,
             Self::BaseUri => ParameterType::BaseUri,
             Self::VersionedUri => ParameterType::VersionedUri,
@@ -214,7 +214,7 @@ impl QueryPath for PropertyTypeQueryPath {
 impl fmt::Display for PropertyTypeQueryPath {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::VersionId => fmt.write_str("versionId"),
+            Self::OntologyId => fmt.write_str("ontologyId"),
             Self::BaseUri => fmt.write_str("baseUri"),
             Self::Version => fmt.write_str("version"),
             Self::VersionedUri => fmt.write_str("versionedUri"),
@@ -355,7 +355,7 @@ mod tests {
 
         assert_eq!(
             PropertyTypeQueryPath::deserialize(
-                de::value::SeqDeserializer::<_, de::value::Error>::new(once("version_id"))
+                de::value::SeqDeserializer::<_, de::value::Error>::new(once("ontology_id"))
             )
             .expect_err(
                 "managed to convert property type query path with hidden token when it should \
@@ -363,7 +363,7 @@ mod tests {
             )
             .to_string(),
             format!(
-                "unknown variant `version_id`, expected {}",
+                "unknown variant `ontology_id`, expected {}",
                 PropertyTypeQueryPathVisitor::EXPECTING
             )
         );

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -310,8 +310,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             entity_uuid.unwrap_or_else(|| EntityUuid::new(Uuid::new_v4())),
         );
 
-        let entity_type_version_id = self
-            .version_id_by_uri(&entity_type_id)
+        let entity_type_ontology_id = self
+            .ontology_id_by_uri(&entity_type_id)
             .await
             .change_context(InsertionError)?;
 
@@ -334,7 +334,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                         _decision_time := $3,
                         _updated_by_id := $4,
                         _archived := $5,
-                        _entity_type_version_id := $6,
+                        _entity_type_ontology_id := $6,
                         _properties := $7,
                         _left_owned_by_id := $8,
                         _left_entity_uuid := $9,
@@ -350,7 +350,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                     &decision_time,
                     &updated_by_id,
                     &archived,
-                    &entity_type_version_id,
+                    &entity_type_ontology_id,
                     &properties,
                     &link_data
                         .as_ref()
@@ -433,13 +433,13 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         // Using one entity type per entity would result in more lookups, which results in a more
         // complex logic and/or be inefficient.
         // Please see the documentation for this function on the trait for more information.
-        let entity_type_version_id = transaction
-            .version_id_by_uri(entity_type_id)
+        let entity_type_ontology_id = transaction
+            .ontology_id_by_uri(entity_type_id)
             .await
             .change_context(InsertionError)?;
 
         let entity_record_ids = transaction
-            .insert_entity_records(entity_editions, entity_type_version_id, actor_id)
+            .insert_entity_records(entity_editions, entity_type_ontology_id, actor_id)
             .await?;
 
         let entity_versions = transaction
@@ -522,8 +522,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         properties: EntityProperties,
         link_order: EntityLinkOrder,
     ) -> Result<EntityMetadata, UpdateError> {
-        let entity_type_version_id = self
-            .version_id_by_uri(&entity_type_id)
+        let entity_type_ontology_id = self
+            .ontology_id_by_uri(&entity_type_id)
             .await
             .change_context(UpdateError)?;
 
@@ -570,7 +570,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                         _decision_time := $3,
                         _updated_by_id := $4,
                         _archived := $5,
-                        _entity_type_version_id := $6,
+                        _entity_type_ontology_id := $6,
                         _properties := $7,
                         _left_to_right_order := $8,
                         _right_to_left_order := $9
@@ -582,7 +582,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                     &decision_time,
                     &updated_by_id,
                     &archived,
-                    &entity_type_version_id,
+                    &entity_type_ontology_id,
                     &properties,
                     &link_order.left_to_right(),
                     &link_order.right_to_left(),

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -257,12 +257,12 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         // This clone is currently necessary because we extract the references as we insert them.
         // We can only insert them after the type has been created, and so we currently extract them
         // after as well. See `insert_entity_type_references` taking `&entity_type`
-        let (version_id, metadata) = transaction
+        let (ontology_id, metadata) = transaction
             .create(entity_type.clone(), owned_by_id, updated_by_id)
             .await?;
 
         transaction
-            .insert_entity_type_references(&entity_type, version_id)
+            .insert_entity_type_references(&entity_type, ontology_id)
             .await
             .change_context(InsertionError)
             .attach_printable_lazy(|| {
@@ -332,12 +332,12 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         // This clone is currently necessary because we extract the references as we insert them.
         // We can only insert them after the type has been created, and so we currently extract them
         // after as well. See `insert_entity_type_references` taking `&entity_type`
-        let (version_id, metadata) = transaction
+        let (ontology_id, metadata) = transaction
             .update::<EntityType>(entity_type.clone(), updated_by)
             .await?;
 
         transaction
-            .insert_entity_type_references(&entity_type, version_id)
+            .insert_entity_type_references(&entity_type, ontology_id)
             .await
             .change_context(UpdateError)
             .attach_printable_lazy(|| {

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/mod.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/mod.rs
@@ -1,10 +1,12 @@
 mod data_type;
 mod entity_type;
+mod ontology_id;
 mod property_type;
 mod read;
 
 use type_system::{DataType, EntityType, PropertyType};
 
+pub use self::ontology_id::OntologyId;
 use crate::{ontology::OntologyType, store::postgres::query::PostgresRecord};
 
 /// Provides an abstraction over elements of the Type System stored in the Database.

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/ontology_id.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/ontology_id.rs
@@ -5,15 +5,12 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-// TODO: rename this to TypeInternalVersionId or something to distinguish it from versioned
-//  URIs and from entity ids
-//  https://app.asana.com/0/1202805690238892/1203214689883089/f
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema, FromSql, ToSql)]
 #[repr(transparent)]
 #[postgres(transparent)]
-pub struct VersionId(Uuid);
+pub struct OntologyId(Uuid);
 
-impl fmt::Display for VersionId {
+impl fmt::Display for OntologyId {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "{}", &self.0)
     }

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -163,12 +163,12 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         // This clone is currently necessary because we extract the references as we insert them.
         // We can only insert them after the type has been created, and so we currently extract them
         // after as well. See `insert_property_type_references` taking `&property_type`
-        let (version_id, metadata) = transaction
+        let (ontology_id, metadata) = transaction
             .create(property_type.clone(), owned_by_id, updated_by_id)
             .await?;
 
         transaction
-            .insert_property_type_references(&property_type, version_id)
+            .insert_property_type_references(&property_type, ontology_id)
             .await
             .change_context(InsertionError)
             .attach_printable_lazy(|| {
@@ -238,12 +238,12 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         // This clone is currently necessary because we extract the references as we insert them.
         // We can only insert them after the type has been created, and so we currently extract them
         // after as well. See `insert_property_type_references` taking `&property_type`
-        let (version_id, metadata) = transaction
+        let (ontology_id, metadata) = transaction
             .update::<PropertyType>(property_type.clone(), updated_by)
             .await?;
 
         transaction
-            .insert_property_type_references(&property_type, version_id)
+            .insert_property_type_references(&property_type, ontology_id)
             .await
             .change_context(UpdateError)
             .attach_printable_lazy(|| {

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/condition.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/condition.rs
@@ -208,7 +208,7 @@ mod tests {
                     Some(FilterExpression::Parameter(Parameter::Number(1.0))),
                 ),
             ]),
-            r#"("type_ids_0_1_0"."base_uri" = $1) AND ("type_ids_0_1_0"."version" = $2)"#,
+            r#"("ontology_ids_0_1_0"."base_uri" = $1) AND ("ontology_ids_0_1_0"."version" = $2)"#,
             &[
                 &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
                 &1.0,
@@ -242,7 +242,7 @@ mod tests {
                     Some(FilterExpression::Parameter(Parameter::Number(1.0))),
                 ),
             ]),
-            r#"(("type_ids_0_1_0"."base_uri" = $1) OR ("type_ids_0_1_0"."version" = $2))"#,
+            r#"(("ontology_ids_0_1_0"."base_uri" = $1) OR ("ontology_ids_0_1_0"."version" = $2))"#,
             &[
                 &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
                 &1.0,

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/data_type.rs
@@ -2,7 +2,7 @@ use super::table::OwnedOntologyMetadata;
 use crate::{
     ontology::{DataTypeQueryPath, DataTypeWithMetadata},
     store::postgres::query::{
-        table::{Column, DataTypes, JsonField, Relation, TypeIds},
+        table::{Column, DataTypes, JsonField, OntologyIds, Relation},
         PostgresQueryPath, PostgresRecord, Table,
     },
 };
@@ -28,11 +28,11 @@ impl PostgresQueryPath for DataTypeQueryPath {
 
     fn terminating_column(&self) -> Column<'static> {
         match self {
-            Self::BaseUri => Column::TypeIds(TypeIds::BaseUri),
-            Self::Version => Column::TypeIds(TypeIds::Version),
+            Self::BaseUri => Column::OntologyIds(OntologyIds::BaseUri),
+            Self::Version => Column::OntologyIds(OntologyIds::Version),
             Self::OwnedById => Column::OwnedOntologyMetadata(OwnedOntologyMetadata::OwnedById),
             Self::UpdatedById => Column::OwnedOntologyMetadata(OwnedOntologyMetadata::UpdatedById),
-            Self::VersionId => Column::DataTypes(DataTypes::VersionId),
+            Self::OntologyId => Column::DataTypes(DataTypes::OntologyId),
             Self::Schema => Column::DataTypes(DataTypes::Schema(None)),
             Self::VersionedUri => {
                 Column::DataTypes(DataTypes::Schema(Some(JsonField::StaticText("$id"))))

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
@@ -4,7 +4,7 @@ use super::table::OwnedOntologyMetadata;
 use crate::{
     ontology::{EntityTypeQueryPath, EntityTypeWithMetadata},
     store::postgres::query::{
-        table::{Column, EntityTypes, JsonField, Relation, TypeIds},
+        table::{Column, EntityTypes, JsonField, OntologyIds, Relation},
         PostgresQueryPath, PostgresRecord, Table,
     },
 };
@@ -40,11 +40,11 @@ impl PostgresQueryPath for EntityTypeQueryPath {
 
     fn terminating_column(&self) -> Column {
         match self {
-            Self::BaseUri => Column::TypeIds(TypeIds::BaseUri),
-            Self::Version => Column::TypeIds(TypeIds::Version),
+            Self::BaseUri => Column::OntologyIds(OntologyIds::BaseUri),
+            Self::Version => Column::OntologyIds(OntologyIds::Version),
             Self::OwnedById => Column::OwnedOntologyMetadata(OwnedOntologyMetadata::OwnedById),
             Self::UpdatedById => Column::OwnedOntologyMetadata(OwnedOntologyMetadata::UpdatedById),
-            Self::VersionId => Column::EntityTypes(EntityTypes::VersionId),
+            Self::OntologyId => Column::EntityTypes(EntityTypes::OntologyId),
             Self::Schema => Column::EntityTypes(EntityTypes::Schema(None)),
             Self::VersionedUri => {
                 Column::EntityTypes(EntityTypes::Schema(Some(JsonField::StaticText("$id"))))

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/conditional.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/conditional.rs
@@ -150,7 +150,7 @@ mod tests {
     fn transpile_window_expression() {
         assert_eq!(
             max_version_expression().transpile_to_string(),
-            r#"MAX("type_ids_0_0_0"."version") OVER (PARTITION BY "type_ids_0_0_0"."base_uri")"#
+            r#"MAX("ontology_ids_0_0_0"."version") OVER (PARTITION BY "ontology_ids_0_0_0"."base_uri")"#
         );
     }
 
@@ -167,7 +167,7 @@ mod tests {
                     })
             ))))
             .transpile_to_string(),
-            r#"MIN("type_ids_1_2_3"."version")"#
+            r#"MIN("ontology_ids_1_2_3"."version")"#
         );
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
@@ -39,7 +39,7 @@ impl Transpile for JoinExpression<'_> {
 mod tests {
     use super::*;
     use crate::store::postgres::query::{
-        table::{Column, DataTypes, TypeIds},
+        table::{Column, DataTypes, OntologyIds},
         Alias,
     };
 
@@ -47,19 +47,19 @@ mod tests {
     fn transpile_join_expression() {
         assert_eq!(
             JoinExpression::new(
-                Column::TypeIds(TypeIds::VersionId).aliased(Alias {
+                Column::OntologyIds(OntologyIds::OntologyId).aliased(Alias {
                     condition_index: 0,
                     chain_depth: 1,
                     number: 2,
                 }),
-                Column::DataTypes(DataTypes::VersionId).aliased(Alias {
+                Column::DataTypes(DataTypes::OntologyId).aliased(Alias {
                     condition_index: 1,
                     chain_depth: 2,
                     number: 3,
                 }),
             )
             .transpile_to_string(),
-            r#"INNER JOIN "type_ids" AS "type_ids_0_1_2" ON "type_ids_0_1_2"."version_id" = "data_types_1_2_3"."version_id""#
+            r#"INNER JOIN "ontology_ids" AS "ontology_ids_0_1_2" ON "ontology_ids_0_1_2"."ontology_id" = "data_types_1_2_3"."ontology_id""#
         );
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/order_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/order_clause.rs
@@ -68,7 +68,7 @@ mod tests {
         );
         assert_eq!(
             order_by_expression.transpile_to_string(),
-            r#"ORDER BY "type_ids_1_2_3"."version" ASC"#
+            r#"ORDER BY "ontology_ids_1_2_3"."version" ASC"#
         );
     }
 
@@ -97,7 +97,7 @@ mod tests {
         assert_eq!(
             trim_whitespace(order_by_expression.transpile_to_string()),
             trim_whitespace(
-                r#"ORDER BY "type_ids_1_2_3"."base_uri" ASC,
+                r#"ORDER BY "ontology_ids_1_2_3"."base_uri" ASC,
                 "data_types_4_5_6"."schema"->>'type' DESC"#
             )
         );

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/select_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/select_clause.rs
@@ -53,7 +53,7 @@ mod tests {
                 None
             )
             .transpile_to_string(),
-            r#""type_ids_1_2_3"."base_uri""#
+            r#""ontology_ids_1_2_3"."base_uri""#
         );
 
         assert_eq!(
@@ -98,7 +98,7 @@ mod tests {
                 Some(Cow::Borrowed("latest_version"))
             )
             .transpile_to_string(),
-            r#"MAX("type_ids_1_2_3"."version") OVER (PARTITION BY "type_ids_1_2_3"."base_uri") AS "latest_version""#
+            r#"MAX("ontology_ids_1_2_3"."version") OVER (PARTITION BY "ontology_ids_1_2_3"."base_uri") AS "latest_version""#
         );
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
@@ -70,7 +70,7 @@ mod tests {
 
         assert_eq!(
             where_clause.transpile_to_string(),
-            r#"WHERE "type_ids_0_1_0"."version" = "type_ids_0_1_0"."latest_version""#
+            r#"WHERE "ontology_ids_0_1_0"."version" = "ontology_ids_0_1_0"."latest_version""#
         );
 
         let filter_b = Filter::All(vec![
@@ -91,8 +91,8 @@ mod tests {
             trim_whitespace(where_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WHERE "type_ids_0_1_0"."version" = "type_ids_0_1_0"."latest_version"
-                  AND ("type_ids_0_1_0"."base_uri" = $1) AND ("type_ids_0_1_0"."version" = $2)"#
+                WHERE "ontology_ids_0_1_0"."version" = "ontology_ids_0_1_0"."latest_version"
+                  AND ("ontology_ids_0_1_0"."base_uri" = $1) AND ("ontology_ids_0_1_0"."version" = $2)"#
             )
         );
 
@@ -106,8 +106,8 @@ mod tests {
             trim_whitespace(where_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WHERE "type_ids_0_1_0"."version" = "type_ids_0_1_0"."latest_version"
-                  AND ("type_ids_0_1_0"."base_uri" = $1) AND ("type_ids_0_1_0"."version" = $2)
+                WHERE "ontology_ids_0_1_0"."version" = "ontology_ids_0_1_0"."latest_version"
+                  AND ("ontology_ids_0_1_0"."base_uri" = $1) AND ("ontology_ids_0_1_0"."version" = $2)
                   AND "data_types_0_0_0"."schema"->>'description' IS NOT NULL"#
             )
         );
@@ -132,8 +132,8 @@ mod tests {
             trim_whitespace(where_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WHERE "type_ids_0_1_0"."version" = "type_ids_0_1_0"."latest_version"
-                  AND ("type_ids_0_1_0"."base_uri" = $1) AND ("type_ids_0_1_0"."version" = $2)
+                WHERE "ontology_ids_0_1_0"."version" = "ontology_ids_0_1_0"."latest_version"
+                  AND ("ontology_ids_0_1_0"."base_uri" = $1) AND ("ontology_ids_0_1_0"."version" = $2)
                   AND "data_types_0_0_0"."schema"->>'description' IS NOT NULL
                   AND (("data_types_0_0_0"."schema"->>'title' = $3) OR ("data_types_0_0_0"."schema"->>'description' = $4))"#
             )

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/with_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/with_clause.rs
@@ -67,7 +67,7 @@ mod tests {
         let mut with_clause = WithExpression::default();
         assert_eq!(with_clause.transpile_to_string(), "");
 
-        with_clause.add_statement(Table::TypeIds, SelectStatement {
+        with_clause.add_statement(Table::OntologyIds, SelectStatement {
             with: WithExpression::default(),
             distinct: Vec::new(),
             selects: vec![
@@ -77,7 +77,7 @@ mod tests {
                     Some(Cow::Borrowed("latest_version")),
                 ),
             ],
-            from: Table::TypeIds.aliased(Alias {
+            from: Table::OntologyIds.aliased(Alias {
                 condition_index: 0,
                 chain_depth: 0,
                 number: 0,
@@ -91,7 +91,7 @@ mod tests {
             trim_whitespace(with_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WITH "type_ids" AS (SELECT *, MAX("type_ids_0_0_0"."version") OVER (PARTITION BY "type_ids_0_0_0"."base_uri") AS "latest_version" FROM "type_ids" AS "type_ids_0_0_0")"#
+                WITH "ontology_ids" AS (SELECT *, MAX("ontology_ids_0_0_0"."version") OVER (PARTITION BY "ontology_ids_0_0_0"."base_uri") AS "latest_version" FROM "ontology_ids" AS "ontology_ids_0_0_0")"#
             )
         );
 
@@ -113,7 +113,7 @@ mod tests {
             trim_whitespace(with_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WITH "type_ids" AS (SELECT *, MAX("type_ids_0_0_0"."version") OVER (PARTITION BY "type_ids_0_0_0"."base_uri") AS "latest_version" FROM "type_ids" AS "type_ids_0_0_0"),
+                WITH "ontology_ids" AS (SELECT *, MAX("ontology_ids_0_0_0"."version") OVER (PARTITION BY "ontology_ids_0_0_0"."base_uri") AS "latest_version" FROM "ontology_ids" AS "ontology_ids_0_0_0"),
                      "data_types" AS (SELECT * FROM "data_types" AS "data_types_3_4_5")"#
             )
         );

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/property_type.rs
@@ -4,7 +4,7 @@ use super::table::OwnedOntologyMetadata;
 use crate::{
     ontology::{PropertyTypeQueryPath, PropertyTypeWithMetadata},
     store::postgres::query::{
-        table::{Column, JsonField, PropertyTypes, Relation, TypeIds},
+        table::{Column, JsonField, OntologyIds, PropertyTypes, Relation},
         PostgresQueryPath, PostgresRecord, Table,
     },
 };
@@ -36,11 +36,11 @@ impl PostgresQueryPath for PropertyTypeQueryPath {
 
     fn terminating_column(&self) -> Column {
         match self {
-            Self::BaseUri => Column::TypeIds(TypeIds::BaseUri),
-            Self::Version => Column::TypeIds(TypeIds::Version),
+            Self::BaseUri => Column::OntologyIds(OntologyIds::BaseUri),
+            Self::Version => Column::OntologyIds(OntologyIds::Version),
             Self::OwnedById => Column::OwnedOntologyMetadata(OwnedOntologyMetadata::OwnedById),
             Self::UpdatedById => Column::OwnedOntologyMetadata(OwnedOntologyMetadata::UpdatedById),
-            Self::VersionId => Column::PropertyTypes(PropertyTypes::VersionId),
+            Self::OntologyId => Column::PropertyTypes(PropertyTypes::OntologyId),
             Self::Schema => Column::PropertyTypes(PropertyTypes::Schema(None)),
             Self::VersionedUri => {
                 Column::PropertyTypes(PropertyTypes::Schema(Some(JsonField::StaticText("$id"))))

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -175,9 +175,9 @@ mod tests {
             r#"
             SELECT *
             FROM "data_types" AS "data_types_0_0_0"
-            INNER JOIN "type_ids" AS "type_ids_0_1_0"
-              ON "type_ids_0_1_0"."version_id" = "data_types_0_0_0"."version_id"
-            WHERE ("type_ids_0_1_0"."base_uri" = $1) AND ("type_ids_0_1_0"."version" = $2)
+            INNER JOIN "ontology_ids" AS "ontology_ids_0_1_0"
+              ON "ontology_ids_0_1_0"."ontology_id" = "data_types_0_0_0"."ontology_id"
+            WHERE ("ontology_ids_0_1_0"."base_uri" = $1) AND ("ontology_ids_0_1_0"."version" = $2)
             "#,
             &[
                 &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
@@ -201,12 +201,12 @@ mod tests {
         test_compilation(
             &compiler,
             r#"
-            WITH "type_ids" AS (SELECT *, MAX("type_ids_0_0_0"."version") OVER (PARTITION BY "type_ids_0_0_0"."base_uri") AS "latest_version" FROM "type_ids" AS "type_ids_0_0_0")
+            WITH "ontology_ids" AS (SELECT *, MAX("ontology_ids_0_0_0"."version") OVER (PARTITION BY "ontology_ids_0_0_0"."base_uri") AS "latest_version" FROM "ontology_ids" AS "ontology_ids_0_0_0")
             SELECT *
             FROM "data_types" AS "data_types_0_0_0"
-            INNER JOIN "type_ids" AS "type_ids_0_1_0"
-              ON "type_ids_0_1_0"."version_id" = "data_types_0_0_0"."version_id"
-            WHERE "type_ids_0_1_0"."version" = "type_ids_0_1_0"."latest_version"
+            INNER JOIN "ontology_ids" AS "ontology_ids_0_1_0"
+              ON "ontology_ids_0_1_0"."ontology_id" = "data_types_0_0_0"."ontology_id"
+            WHERE "ontology_ids_0_1_0"."version" = "ontology_ids_0_1_0"."latest_version"
             "#,
             &[],
         );
@@ -227,12 +227,12 @@ mod tests {
         test_compilation(
             &compiler,
             r#"
-            WITH "type_ids" AS (SELECT *, MAX("type_ids_0_0_0"."version") OVER (PARTITION BY "type_ids_0_0_0"."base_uri") AS "latest_version" FROM "type_ids" AS "type_ids_0_0_0")
+            WITH "ontology_ids" AS (SELECT *, MAX("ontology_ids_0_0_0"."version") OVER (PARTITION BY "ontology_ids_0_0_0"."base_uri") AS "latest_version" FROM "ontology_ids" AS "ontology_ids_0_0_0")
             SELECT *
             FROM "data_types" AS "data_types_0_0_0"
-            INNER JOIN "type_ids" AS "type_ids_0_1_0"
-              ON "type_ids_0_1_0"."version_id" = "data_types_0_0_0"."version_id"
-            WHERE "type_ids_0_1_0"."version" != "type_ids_0_1_0"."latest_version"
+            INNER JOIN "ontology_ids" AS "ontology_ids_0_1_0"
+              ON "ontology_ids_0_1_0"."ontology_id" = "data_types_0_0_0"."ontology_id"
+            WHERE "ontology_ids_0_1_0"."version" != "ontology_ids_0_1_0"."latest_version"
             "#,
             &[],
         );
@@ -259,9 +259,9 @@ mod tests {
             SELECT *
             FROM "property_types" AS "property_types_0_0_0"
             INNER JOIN "property_type_data_type_references" AS "property_type_data_type_references_0_1_0"
-              ON "property_type_data_type_references_0_1_0"."source_property_type_version_id" = "property_types_0_0_0"."version_id"
+              ON "property_type_data_type_references_0_1_0"."source_property_type_ontology_id" = "property_types_0_0_0"."ontology_id"
             INNER JOIN "data_types" AS "data_types_0_2_0"
-              ON "data_types_0_2_0"."version_id" = "property_type_data_type_references_0_1_0"."target_data_type_version_id"
+              ON "data_types_0_2_0"."ontology_id" = "property_type_data_type_references_0_1_0"."target_data_type_ontology_id"
             WHERE "data_types_0_2_0"."schema"->>'title' = $1
             "#,
             &[&"Text"],
@@ -291,15 +291,15 @@ mod tests {
             SELECT *
             FROM "property_types" AS "property_types_0_0_0"
             INNER JOIN "property_type_data_type_references" AS "property_type_data_type_references_0_1_0"
-              ON "property_type_data_type_references_0_1_0"."source_property_type_version_id" = "property_types_0_0_0"."version_id"
+              ON "property_type_data_type_references_0_1_0"."source_property_type_ontology_id" = "property_types_0_0_0"."ontology_id"
             INNER JOIN "data_types" AS "data_types_0_2_0"
-              ON "data_types_0_2_0"."version_id" = "property_type_data_type_references_0_1_0"."target_data_type_version_id"
+              ON "data_types_0_2_0"."ontology_id" = "property_type_data_type_references_0_1_0"."target_data_type_ontology_id"
             INNER JOIN "property_type_data_type_references" AS "property_type_data_type_references_1_1_0"
-              ON "property_type_data_type_references_1_1_0"."source_property_type_version_id" = "property_types_0_0_0"."version_id"
-            INNER JOIN "type_ids" AS "type_ids_1_2_0"
-              ON "type_ids_1_2_0"."version_id" = "property_type_data_type_references_1_1_0"."target_data_type_version_id"
+              ON "property_type_data_type_references_1_1_0"."source_property_type_ontology_id" = "property_types_0_0_0"."ontology_id"
+            INNER JOIN "ontology_ids" AS "ontology_ids_1_2_0"
+              ON "ontology_ids_1_2_0"."ontology_id" = "property_type_data_type_references_1_1_0"."target_data_type_ontology_id"
             WHERE "data_types_0_2_0"."schema"->>'title' = $1
-              AND ("type_ids_1_2_0"."base_uri" = $2) AND ("type_ids_1_2_0"."version" = $3)
+              AND ("ontology_ids_1_2_0"."base_uri" = $2) AND ("ontology_ids_1_2_0"."version" = $3)
             "#,
             &[
                 &"Text",
@@ -331,9 +331,9 @@ mod tests {
             SELECT *
             FROM "property_types" AS "property_types_0_0_0"
             INNER JOIN "property_type_property_type_references" AS "property_type_property_type_references_0_1_0"
-              ON "property_type_property_type_references_0_1_0"."source_property_type_version_id" = "property_types_0_0_0"."version_id"
+              ON "property_type_property_type_references_0_1_0"."source_property_type_ontology_id" = "property_types_0_0_0"."ontology_id"
             INNER JOIN "property_types" AS "property_types_0_2_0"
-              ON "property_types_0_2_0"."version_id" = "property_type_property_type_references_0_1_0"."target_property_type_version_id"
+              ON "property_types_0_2_0"."ontology_id" = "property_type_property_type_references_0_1_0"."target_property_type_ontology_id"
             WHERE "property_types_0_2_0"."schema"->>'title' = $1
             "#,
             &[&"Text"],
@@ -362,9 +362,9 @@ mod tests {
             SELECT *
             FROM "entity_types" AS "entity_types_0_0_0"
             INNER JOIN "entity_type_property_type_references" AS "entity_type_property_type_references_0_1_0"
-              ON "entity_type_property_type_references_0_1_0"."source_entity_type_version_id" = "entity_types_0_0_0"."version_id"
+              ON "entity_type_property_type_references_0_1_0"."source_entity_type_ontology_id" = "entity_types_0_0_0"."ontology_id"
             INNER JOIN "property_types" AS "property_types_0_2_0"
-              ON "property_types_0_2_0"."version_id" = "entity_type_property_type_references_0_1_0"."target_property_type_version_id"
+              ON "property_types_0_2_0"."ontology_id" = "entity_type_property_type_references_0_1_0"."target_property_type_ontology_id"
             WHERE "property_types_0_2_0"."schema"->>'title' = $1
             "#,
             &[&"Name"],
@@ -395,13 +395,13 @@ mod tests {
             SELECT *
             FROM "entity_types" AS "entity_types_0_0_0"
             INNER JOIN "entity_type_entity_type_references" AS "entity_type_entity_type_references_0_1_0"
-              ON "entity_type_entity_type_references_0_1_0"."source_entity_type_version_id" = "entity_types_0_0_0"."version_id"
+              ON "entity_type_entity_type_references_0_1_0"."source_entity_type_ontology_id" = "entity_types_0_0_0"."ontology_id"
             INNER JOIN "entity_types" AS "entity_types_0_2_0"
-              ON "entity_types_0_2_0"."version_id" = "entity_type_entity_type_references_0_1_0"."target_entity_type_version_id"
+              ON "entity_types_0_2_0"."ontology_id" = "entity_type_entity_type_references_0_1_0"."target_entity_type_ontology_id"
             INNER JOIN "entity_type_entity_type_references" AS "entity_type_entity_type_references_0_3_0"
-              ON "entity_type_entity_type_references_0_3_0"."source_entity_type_version_id" = "entity_types_0_2_0"."version_id"
+              ON "entity_type_entity_type_references_0_3_0"."source_entity_type_ontology_id" = "entity_types_0_2_0"."ontology_id"
             INNER JOIN "entity_types" AS "entity_types_0_4_0"
-              ON "entity_types_0_4_0"."version_id" = "entity_type_entity_type_references_0_3_0"."target_entity_type_version_id"
+              ON "entity_types_0_4_0"."ontology_id" = "entity_type_entity_type_references_0_3_0"."target_entity_type_ontology_id"
             WHERE jsonb_extract_path("entity_types_0_0_0"."schema", 'links', "entity_types_0_2_0"."schema"->>'$id') IS NOT NULL
               AND jsonb_extract_path("entity_types_0_2_0"."schema", 'links', "entity_types_0_4_0"."schema"->>'$id') IS NOT NULL
               AND "entity_types_0_4_0"."schema"->>'title' = $1
@@ -432,13 +432,13 @@ mod tests {
             SELECT *
             FROM "entity_types" AS "entity_types_0_0_0"
             INNER JOIN "entity_type_entity_type_references" AS "entity_type_entity_type_references_0_1_0"
-              ON "entity_type_entity_type_references_0_1_0"."source_entity_type_version_id" = "entity_types_0_0_0"."version_id"
+              ON "entity_type_entity_type_references_0_1_0"."source_entity_type_ontology_id" = "entity_types_0_0_0"."ontology_id"
             INNER JOIN "entity_types" AS "entity_types_0_2_0"
-              ON "entity_types_0_2_0"."version_id" = "entity_type_entity_type_references_0_1_0"."target_entity_type_version_id"
-            INNER JOIN "type_ids" AS "type_ids_0_3_0"
-              ON "type_ids_0_3_0"."version_id" = "entity_types_0_2_0"."version_id"
+              ON "entity_types_0_2_0"."ontology_id" = "entity_type_entity_type_references_0_1_0"."target_entity_type_ontology_id"
+            INNER JOIN "ontology_ids" AS "ontology_ids_0_3_0"
+              ON "ontology_ids_0_3_0"."ontology_id" = "entity_types_0_2_0"."ontology_id"
             WHERE jsonb_contains("entity_types_0_0_0"."schema"->'allOf', jsonb_build_array(jsonb_build_object('$ref', "entity_types_0_2_0"."schema"->>'$id'))) IS NOT NULL
-              AND "type_ids_0_3_0"."base_uri" = $1
+              AND "ontology_ids_0_3_0"."base_uri" = $1
             "#,
             &[&"https://blockprotocol.org/@blockprotocol/types/entity-type/link/"],
         );
@@ -749,9 +749,9 @@ mod tests {
                 r#"
                 SELECT *
                 FROM "data_types" AS "data_types_0_0_0"
-                INNER JOIN "type_ids" AS "type_ids_0_1_0"
-                  ON "type_ids_0_1_0"."version_id" = "data_types_0_0_0"."version_id"
-                WHERE ("type_ids_0_1_0"."base_uri" = $1) AND ("type_ids_0_1_0"."version" = $2)
+                INNER JOIN "ontology_ids" AS "ontology_ids_0_1_0"
+                  ON "ontology_ids_0_1_0"."ontology_id" = "data_types_0_0_0"."ontology_id"
+                WHERE ("ontology_ids_0_1_0"."base_uri" = $1) AND ("ontology_ids_0_1_0"."version" = $2)
                 "#,
                 &[&uri.base_uri().as_str(), &i64::from(uri.version())],
             );
@@ -779,9 +779,9 @@ mod tests {
                 r#"
                 SELECT *
                 FROM "data_types" AS "data_types_0_0_0"
-                INNER JOIN "type_ids" AS "type_ids_0_1_0"
-                  ON "type_ids_0_1_0"."version_id" = "data_types_0_0_0"."version_id"
-                WHERE ("type_ids_0_1_0"."base_uri" = $1) AND ("type_ids_0_1_0"."version" = $2)
+                INNER JOIN "ontology_ids" AS "ontology_ids_0_1_0"
+                  ON "ontology_ids_0_1_0"."ontology_id" = "data_types_0_0_0"."ontology_id"
+                WHERE ("ontology_ids_0_1_0"."base_uri" = $1) AND ("ontology_ids_0_1_0"."version" = $2)
                 "#,
                 &[&uri.base_id().as_str(), &i64::from(uri.version().inner())],
             );

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
@@ -9,7 +9,7 @@ use crate::{identifier::time::TimeAxis, store::postgres::query::Transpile};
 /// The name of a [`Table`] in the Postgres database.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Table {
-    TypeIds,
+    OntologyIds,
     OwnedOntologyMetadata,
     DataTypes,
     PropertyTypes,
@@ -28,7 +28,7 @@ impl Table {
 
     const fn as_str(self) -> &'static str {
         match self {
-            Self::TypeIds => "type_ids",
+            Self::OntologyIds => "ontology_ids",
             Self::OwnedOntologyMetadata => "owned_ontology_metadata",
             Self::DataTypes => "data_types",
             Self::PropertyTypes => "property_types",
@@ -57,17 +57,17 @@ pub enum JsonField<'p> {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum TypeIds {
-    VersionId,
+pub enum OntologyIds {
+    OntologyId,
     BaseUri,
     Version,
     LatestVersion,
 }
 
-impl Transpile for TypeIds {
+impl Transpile for OntologyIds {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let column = match self {
-            Self::VersionId => "version_id",
+            Self::OntologyId => "ontology_id",
             Self::BaseUri => "base_uri",
             Self::Version => "version",
             Self::LatestVersion => "latest_version",
@@ -79,7 +79,7 @@ impl Transpile for TypeIds {
 #[expect(clippy::enum_variant_names)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum OwnedOntologyMetadata {
-    VersionId,
+    OntologyId,
     OwnedById,
     UpdatedById,
 }
@@ -87,7 +87,7 @@ pub enum OwnedOntologyMetadata {
 impl Transpile for OwnedOntologyMetadata {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let column = match self {
-            Self::VersionId => "version_id",
+            Self::OntologyId => "ontology_id",
             Self::OwnedById => "owned_by_id",
             Self::UpdatedById => "updated_by_id",
         };
@@ -100,14 +100,14 @@ macro_rules! impl_ontology_column {
         $(
             #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
             pub enum $name {
-                VersionId,
+                OntologyId,
                 Schema(Option<JsonField<'static>>),
             }
 
             impl $name {
                 pub const fn nullable(self) -> bool {
                     match self {
-                        Self::VersionId => false,
+                        Self::OntologyId => false,
                         Self::Schema(_) => true,
                     }
                 }
@@ -116,7 +116,7 @@ macro_rules! impl_ontology_column {
             impl Transpile for $name {
                 fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
                     let column = match self {
-                        Self::VersionId => "version_id",
+                        Self::OntologyId => "ontology_id",
                         Self::Schema(None) => "schema",
                         Self::Schema(Some(path)) => {
                             return match path {
@@ -159,7 +159,7 @@ pub enum Entities<'p> {
     Archived,
     OwnedById,
     UpdatedById,
-    EntityTypeVersionId,
+    EntityTypeOntologyId,
     Properties(Option<JsonField<'p>>),
     LeftToRightOrder,
     RightToLeftOrder,
@@ -180,7 +180,7 @@ impl Entities<'_> {
             | Self::Archived
             | Self::OwnedById
             | Self::UpdatedById
-            | Self::EntityTypeVersionId => false,
+            | Self::EntityTypeOntologyId => false,
             Self::Properties(_)
             | Self::LeftEntityUuid
             | Self::RightEntityUuid
@@ -210,7 +210,7 @@ impl Transpile for Entities<'_> {
             Self::Archived => "archived",
             Self::OwnedById => "owned_by_id",
             Self::UpdatedById => "updated_by_id",
-            Self::EntityTypeVersionId => "entity_type_version_id",
+            Self::EntityTypeOntologyId => "entity_type_ontology_id",
             Self::Properties(None) => "properties",
             Self::Properties(Some(path)) => {
                 return match path {
@@ -242,67 +242,67 @@ impl Transpile for Entities<'_> {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum PropertyTypeDataTypeReferences {
-    SourcePropertyTypeVersionId,
-    TargetDataTypeVersionId,
+    SourcePropertyTypeOntologyId,
+    TargetDataTypeOntologyId,
 }
 
 impl Transpile for PropertyTypeDataTypeReferences {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, r#"."{}""#, match self {
-            Self::SourcePropertyTypeVersionId => "source_property_type_version_id",
-            Self::TargetDataTypeVersionId => "target_data_type_version_id",
+            Self::SourcePropertyTypeOntologyId => "source_property_type_ontology_id",
+            Self::TargetDataTypeOntologyId => "target_data_type_ontology_id",
         })
     }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum PropertyTypePropertyTypeReferences {
-    SourcePropertyTypeVersionId,
-    TargetPropertyTypeVersionId,
+    SourcePropertyTypeOntologyId,
+    TargetPropertyTypeOntologyId,
 }
 
 impl Transpile for PropertyTypePropertyTypeReferences {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, r#"."{}""#, match self {
-            Self::SourcePropertyTypeVersionId => "source_property_type_version_id",
-            Self::TargetPropertyTypeVersionId => "target_property_type_version_id",
+            Self::SourcePropertyTypeOntologyId => "source_property_type_ontology_id",
+            Self::TargetPropertyTypeOntologyId => "target_property_type_ontology_id",
         })
     }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum EntityTypePropertyTypeReferences {
-    SourceEntityTypeVersionId,
-    TargetPropertyTypeVersionId,
+    SourceEntityTypeOntologyId,
+    TargetPropertyTypeOntologyId,
 }
 
 impl Transpile for EntityTypePropertyTypeReferences {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, r#"."{}""#, match self {
-            Self::SourceEntityTypeVersionId => "source_entity_type_version_id",
-            Self::TargetPropertyTypeVersionId => "target_property_type_version_id",
+            Self::SourceEntityTypeOntologyId => "source_entity_type_ontology_id",
+            Self::TargetPropertyTypeOntologyId => "target_property_type_ontology_id",
         })
     }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum EntityTypeEntityTypeReferences {
-    SourceEntityTypeVersionId,
-    TargetEntityTypeVersionId,
+    SourceEntityTypeOntologyId,
+    TargetEntityTypeOntologyId,
 }
 
 impl Transpile for EntityTypeEntityTypeReferences {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, r#"."{}""#, match self {
-            Self::SourceEntityTypeVersionId => "source_entity_type_version_id",
-            Self::TargetEntityTypeVersionId => "target_entity_type_version_id",
+            Self::SourceEntityTypeOntologyId => "source_entity_type_ontology_id",
+            Self::TargetEntityTypeOntologyId => "target_entity_type_ontology_id",
         })
     }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Column<'p> {
-    TypeIds(TypeIds),
+    OntologyIds(OntologyIds),
     OwnedOntologyMetadata(OwnedOntologyMetadata),
     DataTypes(DataTypes),
     PropertyTypes(PropertyTypes),
@@ -317,7 +317,7 @@ pub enum Column<'p> {
 impl<'p> Column<'p> {
     pub const fn table(self) -> Table {
         match self {
-            Self::TypeIds(_) => Table::TypeIds,
+            Self::OntologyIds(_) => Table::OntologyIds,
             Self::OwnedOntologyMetadata(_) => Table::OwnedOntologyMetadata,
             Self::DataTypes(_) => Table::DataTypes,
             Self::PropertyTypes(_) => Table::PropertyTypes,
@@ -354,7 +354,7 @@ impl Transpile for Column<'_> {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         self.table().transpile(fmt)?;
         match self {
-            Self::TypeIds(column) => column.transpile(fmt),
+            Self::OntologyIds(column) => column.transpile(fmt),
             Self::OwnedOntologyMetadata(column) => column.transpile(fmt),
             Self::DataTypes(column) => column.transpile(fmt),
             Self::PropertyTypes(column) => column.transpile(fmt),
@@ -440,7 +440,7 @@ impl Transpile for AliasedColumn<'_> {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         self.table().transpile(fmt)?;
         match self.column {
-            Column::TypeIds(column) => column.transpile(fmt),
+            Column::OntologyIds(column) => column.transpile(fmt),
             Column::OwnedOntologyMetadata(column) => column.transpile(fmt),
             Column::DataTypes(column) => column.transpile(fmt),
             Column::PropertyTypes(column) => column.transpile(fmt),
@@ -478,88 +478,88 @@ impl Relation {
     pub const fn joins(self) -> &'static [(Column<'static>, Column<'static>)] {
         match self {
             Self::DataTypeIds => &[(
-                Column::DataTypes(DataTypes::VersionId),
-                Column::TypeIds(TypeIds::VersionId),
+                Column::DataTypes(DataTypes::OntologyId),
+                Column::OntologyIds(OntologyIds::OntologyId),
             )],
             Self::PropertyTypeIds => &[(
-                Column::PropertyTypes(PropertyTypes::VersionId),
-                Column::TypeIds(TypeIds::VersionId),
+                Column::PropertyTypes(PropertyTypes::OntologyId),
+                Column::OntologyIds(OntologyIds::OntologyId),
             )],
             Self::EntityTypeIds => &[(
-                Column::EntityTypes(EntityTypes::VersionId),
-                Column::TypeIds(TypeIds::VersionId),
+                Column::EntityTypes(EntityTypes::OntologyId),
+                Column::OntologyIds(OntologyIds::OntologyId),
             )],
             Self::DataTypeOwnedMetadata => &[(
-                Column::DataTypes(DataTypes::VersionId),
-                Column::OwnedOntologyMetadata(OwnedOntologyMetadata::VersionId),
+                Column::DataTypes(DataTypes::OntologyId),
+                Column::OwnedOntologyMetadata(OwnedOntologyMetadata::OntologyId),
             )],
             Self::PropertyTypeOwnedMetadata => &[(
-                Column::PropertyTypes(PropertyTypes::VersionId),
-                Column::OwnedOntologyMetadata(OwnedOntologyMetadata::VersionId),
+                Column::PropertyTypes(PropertyTypes::OntologyId),
+                Column::OwnedOntologyMetadata(OwnedOntologyMetadata::OntologyId),
             )],
             Self::EntityTypeOwnedMetadata => &[(
-                Column::EntityTypes(EntityTypes::VersionId),
-                Column::OwnedOntologyMetadata(OwnedOntologyMetadata::VersionId),
+                Column::EntityTypes(EntityTypes::OntologyId),
+                Column::OwnedOntologyMetadata(OwnedOntologyMetadata::OntologyId),
             )],
             Self::PropertyTypeDataTypeReferences => &[
                 (
-                    Column::PropertyTypes(PropertyTypes::VersionId),
+                    Column::PropertyTypes(PropertyTypes::OntologyId),
                     Column::PropertyTypeDataTypeReferences(
-                        PropertyTypeDataTypeReferences::SourcePropertyTypeVersionId,
+                        PropertyTypeDataTypeReferences::SourcePropertyTypeOntologyId,
                     ),
                 ),
                 (
                     Column::PropertyTypeDataTypeReferences(
-                        PropertyTypeDataTypeReferences::TargetDataTypeVersionId,
+                        PropertyTypeDataTypeReferences::TargetDataTypeOntologyId,
                     ),
-                    Column::DataTypes(DataTypes::VersionId),
+                    Column::DataTypes(DataTypes::OntologyId),
                 ),
             ],
             Self::PropertyTypePropertyTypeReferences => &[
                 (
-                    Column::PropertyTypes(PropertyTypes::VersionId),
+                    Column::PropertyTypes(PropertyTypes::OntologyId),
                     Column::PropertyTypePropertyTypeReferences(
-                        PropertyTypePropertyTypeReferences::SourcePropertyTypeVersionId,
+                        PropertyTypePropertyTypeReferences::SourcePropertyTypeOntologyId,
                     ),
                 ),
                 (
                     Column::PropertyTypePropertyTypeReferences(
-                        PropertyTypePropertyTypeReferences::TargetPropertyTypeVersionId,
+                        PropertyTypePropertyTypeReferences::TargetPropertyTypeOntologyId,
                     ),
-                    Column::PropertyTypes(PropertyTypes::VersionId),
+                    Column::PropertyTypes(PropertyTypes::OntologyId),
                 ),
             ],
             Self::EntityTypePropertyTypeReferences => &[
                 (
-                    Column::EntityTypes(EntityTypes::VersionId),
+                    Column::EntityTypes(EntityTypes::OntologyId),
                     Column::EntityTypePropertyTypeReferences(
-                        EntityTypePropertyTypeReferences::SourceEntityTypeVersionId,
+                        EntityTypePropertyTypeReferences::SourceEntityTypeOntologyId,
                     ),
                 ),
                 (
                     Column::EntityTypePropertyTypeReferences(
-                        EntityTypePropertyTypeReferences::TargetPropertyTypeVersionId,
+                        EntityTypePropertyTypeReferences::TargetPropertyTypeOntologyId,
                     ),
-                    Column::PropertyTypes(PropertyTypes::VersionId),
+                    Column::PropertyTypes(PropertyTypes::OntologyId),
                 ),
             ],
             Self::EntityTypeLinks | Self::EntityTypeInheritance => &[
                 (
-                    Column::EntityTypes(EntityTypes::VersionId),
+                    Column::EntityTypes(EntityTypes::OntologyId),
                     Column::EntityTypeEntityTypeReferences(
-                        EntityTypeEntityTypeReferences::SourceEntityTypeVersionId,
+                        EntityTypeEntityTypeReferences::SourceEntityTypeOntologyId,
                     ),
                 ),
                 (
                     Column::EntityTypeEntityTypeReferences(
-                        EntityTypeEntityTypeReferences::TargetEntityTypeVersionId,
+                        EntityTypeEntityTypeReferences::TargetEntityTypeOntologyId,
                     ),
-                    Column::EntityTypes(EntityTypes::VersionId),
+                    Column::EntityTypes(EntityTypes::OntologyId),
                 ),
             ],
             Self::EntityType => &[(
-                Column::Entities(Entities::EntityTypeVersionId),
-                Column::EntityTypes(EntityTypes::VersionId),
+                Column::Entities(Entities::EntityTypeOntologyId),
+                Column::EntityTypes(EntityTypes::OntologyId),
             )],
             Self::LeftEndpoint => &[(
                 Column::Entities(Entities::LeftEntityUuid),
@@ -588,31 +588,34 @@ mod tests {
 
     #[test]
     fn transpile_table() {
-        assert_eq!(Table::TypeIds.transpile_to_string(), r#""type_ids""#);
+        assert_eq!(
+            Table::OntologyIds.transpile_to_string(),
+            r#""ontology_ids""#
+        );
         assert_eq!(Table::DataTypes.transpile_to_string(), r#""data_types""#);
     }
 
     #[test]
     fn transpile_aliased_table() {
         assert_eq!(
-            Table::TypeIds
+            Table::OntologyIds
                 .aliased(Alias {
                     condition_index: 1,
                     chain_depth: 2,
                     number: 3,
                 })
                 .transpile_to_string(),
-            r#""type_ids_1_2_3""#
+            r#""ontology_ids_1_2_3""#
         );
     }
 
     #[test]
     fn transpile_column() {
         assert_eq!(
-            DataTypeQueryPath::VersionId
+            DataTypeQueryPath::OntologyId
                 .terminating_column()
                 .transpile_to_string(),
-            r#""data_types"."version_id""#
+            r#""data_types"."ontology_id""#
         );
         assert_eq!(
             DataTypeQueryPath::Title
@@ -631,11 +634,11 @@ mod tests {
         };
 
         assert_eq!(
-            DataTypeQueryPath::VersionId
+            DataTypeQueryPath::OntologyId
                 .terminating_column()
                 .aliased(alias)
                 .transpile_to_string(),
-            r#""data_types_1_2_3"."version_id""#
+            r#""data_types_1_2_3"."ontology_id""#
         );
         assert_eq!(
             DataTypeQueryPath::Title

--- a/apps/hash-graph/postgres_migrations/V2__ontology_tables.sql
+++ b/apps/hash-graph/postgres_migrations/V2__ontology_tables.sql
@@ -1,11 +1,11 @@
 CREATE TABLE IF NOT EXISTS
-  "type_ids" (
-    "version_id" UUID PRIMARY KEY,
+  ontology_ids (
+    ontology_id UUID PRIMARY KEY,
     "base_uri" TEXT NOT NULL,
     "version" BIGINT NOT NULL,
     "transaction_time" tstzrange NOT NULL,
     UNIQUE ("base_uri", "version"),
-    CONSTRAINT type_ids_overlapping EXCLUDE USING gist (
+    CONSTRAINT ontology_ids_overlapping EXCLUDE USING gist (
       base_uri
       WITH
         =,
@@ -16,55 +16,55 @@ CREATE TABLE IF NOT EXISTS
   );
 
 COMMENT
-  ON TABLE "type_ids" IS $pga$ This table is a boundary to define the actual identification scheme for our kinds of types. Assume that we use the UUIDs on the types to look up more specific ID details. $pga$;
+  ON TABLE ontology_ids IS $pga$ This table is a boundary to define the actual identification scheme for our kinds of types. Assume that we use the UUIDs on the types to look up more specific ID details. $pga$;
 
 CREATE TABLE IF NOT EXISTS
   "owned_ontology_metadata" (
-    "version_id" UUID NOT NULL,
+    "ontology_id" UUID NOT NULL,
     "owned_by_id" UUID NOT NULL REFERENCES "accounts",
     "updated_by_id" UUID NOT NULL REFERENCES "accounts",
-    CONSTRAINT owned_ontology_metadata_pk PRIMARY KEY ("version_id") DEFERRABLE INITIALLY IMMEDIATE,
-    CONSTRAINT owned_ontology_metadata_fk FOREIGN KEY ("version_id") REFERENCES "type_ids" DEFERRABLE INITIALLY IMMEDIATE
+    CONSTRAINT owned_ontology_metadata_pk PRIMARY KEY ("ontology_id") DEFERRABLE INITIALLY IMMEDIATE,
+    CONSTRAINT owned_ontology_metadata_fk FOREIGN KEY ("ontology_id") REFERENCES ontology_ids DEFERRABLE INITIALLY IMMEDIATE
   );
 
 CREATE TABLE IF NOT EXISTS
   "data_types" (
-    "version_id" UUID PRIMARY KEY REFERENCES "type_ids",
+    "ontology_id" UUID PRIMARY KEY REFERENCES ontology_ids,
     "schema" JSONB NOT NULL
   );
 
 CREATE TABLE IF NOT EXISTS
   "property_types" (
-    "version_id" UUID PRIMARY KEY REFERENCES "type_ids",
+    "ontology_id" UUID PRIMARY KEY REFERENCES ontology_ids,
     "schema" JSONB NOT NULL
   );
 
 CREATE TABLE IF NOT EXISTS
   "entity_types" (
-    "version_id" UUID PRIMARY KEY REFERENCES "type_ids",
+    "ontology_id" UUID PRIMARY KEY REFERENCES ontology_ids,
     "schema" JSONB NOT NULL
   );
 
 CREATE TABLE IF NOT EXISTS
   "property_type_property_type_references" (
-    "source_property_type_version_id" UUID NOT NULL REFERENCES "property_types",
-    "target_property_type_version_id" UUID NOT NULL REFERENCES "property_types"
+    "source_property_type_ontology_id" UUID NOT NULL REFERENCES "property_types",
+    "target_property_type_ontology_id" UUID NOT NULL REFERENCES "property_types"
   );
 
 CREATE TABLE IF NOT EXISTS
   "property_type_data_type_references" (
-    "source_property_type_version_id" UUID NOT NULL REFERENCES "property_types",
-    "target_data_type_version_id" UUID NOT NULL REFERENCES "data_types"
+    "source_property_type_ontology_id" UUID NOT NULL REFERENCES "property_types",
+    "target_data_type_ontology_id" UUID NOT NULL REFERENCES "data_types"
   );
 
 CREATE TABLE IF NOT EXISTS
   "entity_type_property_type_references" (
-    "source_entity_type_version_id" UUID NOT NULL REFERENCES "entity_types",
-    "target_property_type_version_id" UUID NOT NULL REFERENCES "property_types"
+    "source_entity_type_ontology_id" UUID NOT NULL REFERENCES "entity_types",
+    "target_property_type_ontology_id" UUID NOT NULL REFERENCES "property_types"
   );
 
 CREATE TABLE IF NOT EXISTS
   "entity_type_entity_type_references" (
-    "source_entity_type_version_id" UUID NOT NULL REFERENCES "entity_types",
-    "target_entity_type_version_id" UUID NOT NULL REFERENCES "entity_types"
+    "source_entity_type_ontology_id" UUID NOT NULL REFERENCES "entity_types",
+    "target_entity_type_ontology_id" UUID NOT NULL REFERENCES "entity_types"
   );

--- a/apps/hash-graph/postgres_migrations/V3__knowledge_tables.sql
+++ b/apps/hash-graph/postgres_migrations/V3__knowledge_tables.sql
@@ -24,7 +24,7 @@ CREATE TABLE IF NOT EXISTS
 CREATE TABLE IF NOT EXISTS
   "entity_editions" (
     "entity_record_id" BIGINT PRIMARY KEY NOT NULL GENERATED ALWAYS AS IDENTITY,
-    "entity_type_version_id" UUID NOT NULL REFERENCES "entity_types",
+    "entity_type_ontology_id" UUID NOT NULL REFERENCES "entity_types",
     "properties" JSONB NOT NULL,
     "left_to_right_order" INTEGER,
     "right_to_left_order" INTEGER,
@@ -65,7 +65,7 @@ SELECT
   entity_versions.entity_uuid,
   entity_versions.decision_time,
   entity_versions.transaction_time,
-  entity_editions.entity_type_version_id,
+  entity_editions.entity_type_ontology_id,
   entity_editions.updated_by_id,
   entity_editions.properties,
   entity_editions.archived,

--- a/apps/hash-graph/postgres_migrations/V5__owned_ontology_functions.sql
+++ b/apps/hash-graph/postgres_migrations/V5__owned_ontology_functions.sql
@@ -4,28 +4,28 @@ OR REPLACE FUNCTION create_owned_ontology_id (
   "version" BIGINT,
   "owned_by_id" UUID,
   "updated_by_id" UUID
-) RETURNS TABLE (version_id UUID) AS $create_owned_ontology_id$
+) RETURNS TABLE (ontology_id UUID) AS $create_owned_ontology_id$
 DECLARE
-  "_version_id" UUID;
+  "_ontology_id" UUID;
 BEGIN
-  _version_id := gen_random_uuid();
+  _ontology_id := gen_random_uuid();
 
-  PERFORM create_type_id(
-    "version_id" := _version_id,
+  PERFORM create_ontology_id(
+    "ontology_id" := _ontology_id,
     "base_uri" := create_owned_ontology_id.base_uri,
     "version" := create_owned_ontology_id.version
   );
   
   RETURN QUERY
   INSERT INTO owned_ontology_metadata (
-    "version_id",
+    "ontology_id",
     "owned_by_id",
     "updated_by_id"    
   ) VALUES (
-    _version_id,
+    _ontology_id,
     create_owned_ontology_id.owned_by_id,
     create_owned_ontology_id.updated_by_id
-  ) RETURNING _version_id;
+  ) RETURNING _ontology_id;
 END $create_owned_ontology_id$ LANGUAGE plpgsql VOLATILE;
 
 CREATE
@@ -33,47 +33,47 @@ OR REPLACE FUNCTION update_owned_ontology_id (
   "base_uri" TEXT,
   "version" BIGINT,
   "updated_by_id" UUID
-) RETURNS TABLE (version_id UUID, owned_by_id UUID) AS $update_owned_ontology_id$
+) RETURNS TABLE (ontology_id UUID, owned_by_id UUID) AS $update_owned_ontology_id$
 DECLARE
-  "_version_id" UUID;
+  "_ontology_id" UUID;
 BEGIN
   SET CONSTRAINTS owned_ontology_metadata_pk DEFERRED;
   SET CONSTRAINTS owned_ontology_metadata_fk DEFERRED;
-  SET CONSTRAINTS type_ids_overlapping DEFERRED;
+  SET CONSTRAINTS ontology_ids_overlapping DEFERRED;
 
-  _version_id := gen_random_uuid();
+  _ontology_id := gen_random_uuid();
 
   RETURN QUERY
   UPDATE owned_ontology_metadata as metadata
   SET
-    "version_id" = _version_id,
+    "ontology_id" = _ontology_id,
     "updated_by_id" = update_owned_ontology_id.updated_by_id
-  FROM type_ids
-  WHERE type_ids.version_id = metadata.version_id
-    AND type_ids.base_uri = update_owned_ontology_id.base_uri
-    AND type_ids.transaction_time @> now()
-  RETURNING _version_id, metadata.owned_by_id;
+  FROM ontology_ids
+  WHERE ontology_ids.ontology_id = metadata.ontology_id
+    AND ontology_ids.base_uri = update_owned_ontology_id.base_uri
+    AND ontology_ids.transaction_time @> now()
+  RETURNING _ontology_id, metadata.owned_by_id;
 
-  PERFORM update_type_id(
-    _version_id,
+  PERFORM update_ontology_id(
+    _ontology_id,
     update_owned_ontology_id.base_uri,
     update_owned_ontology_id.version
   );
 
   SET CONSTRAINTS owned_ontology_metadata_pk IMMEDIATE;
   SET CONSTRAINTS owned_ontology_metadata_fk IMMEDIATE;
-  SET CONSTRAINTS type_ids_overlapping IMMEDIATE;
+  SET CONSTRAINTS ontology_ids_overlapping IMMEDIATE;
 END $update_owned_ontology_id$ LANGUAGE plpgsql VOLATILE;
 
 CREATE
 OR REPLACE FUNCTION "update_owned_ontology_metadata_trigger" () RETURNS TRIGGER AS $update_owned_ontology_metadata_trigger$
 BEGIN
   INSERT INTO owned_ontology_metadata (
-    "version_id", 
+    "ontology_id", 
     "owned_by_id", 
     "updated_by_id"
   ) VALUES (
-    NEW.version_id,
+    NEW.ontology_id,
     NEW.owned_by_id,
     NEW.updated_by_id
   );

--- a/apps/hash-graph/postgres_migrations/V6__knowledge_functions.sql
+++ b/apps/hash-graph/postgres_migrations/V6__knowledge_functions.sql
@@ -5,7 +5,7 @@ OR REPLACE FUNCTION "create_entity" (
   "_decision_time" TIMESTAMP WITH TIME ZONE,
   "_updated_by_id" UUID,
   "_archived" BOOLEAN,
-  "_entity_type_version_id" UUID,
+  "_entity_type_ontology_id" UUID,
   "_properties" JSONB,
   "_left_owned_by_id" UUID,
   "_left_entity_uuid" UUID,
@@ -43,14 +43,14 @@ OR REPLACE FUNCTION "create_entity" (
       INSERT INTO entity_editions (
         updated_by_id,
         archived,
-        entity_type_version_id,
+        entity_type_ontology_id,
         properties,
         left_to_right_order,
         right_to_left_order
       ) VALUES (
         _updated_by_id,
         _archived,
-        _entity_type_version_id,
+        _entity_type_ontology_id,
         _properties,
         _left_to_right_order,
         _right_to_left_order
@@ -80,7 +80,7 @@ OR REPLACE FUNCTION "update_entity" (
   "_decision_time" TIMESTAMP WITH TIME ZONE,
   "_updated_by_id" UUID,
   "_archived" BOOLEAN,
-  "_entity_type_version_id" UUID,
+  "_entity_type_ontology_id" UUID,
   "_properties" JSONB,
   "_left_to_right_order" INTEGER,
   "_right_to_left_order" INTEGER
@@ -97,14 +97,14 @@ OR REPLACE FUNCTION "update_entity" (
       INSERT INTO entity_editions (
         updated_by_id,
         archived,
-        entity_type_version_id,
+        entity_type_ontology_id,
         properties,
         left_to_right_order,
         right_to_left_order
       ) VALUES (
         _updated_by_id,
         _archived,
-        _entity_type_version_id,
+        _entity_type_ontology_id,
         _properties,
         _left_to_right_order,
         _right_to_left_order


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We use the term `type_id` when referring to a versioned URI. Similarly, the term `version_id` is confusing. This PR renames the `type_ids` table to `ontology_ids` and the `version_id` column to `ontology_id`.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1202805690238892/1203214689883089/f) _(internal)_

## 🔍 What does this change?

- Rename `type_ids` to `ontology_ids`
- Rename `ontology_ids::version_id` to `ontology_ids::ontology_id`

## 📜 Does this require a change to the docs?

This is an internal change only