### PR TITLE
Always warm up repository in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         run: git pull --force --no-tags origin main:main
 
       - uses: ./.github/actions/warm-up-repo
+        if: ${{ success() || failure() }}
 
       - name: Run yarn lint:changeset
         if: ${{ (success() || failure()) && github.event.pull_request.title != 'Version Packages' }}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The linting CI currently fails in CIs that do not target `main`. This hotfix does not solve the issue, but at least it does not skip the warm-up task, so other tasks can still be checked.

## 🔗 Related links

- https://github.com/hashintel/hash/pull/1972
- https://github.com/hashintel/hash/pull/1329
- [Slack thread](https://hashintel.slack.com/archives/C02TWBTT3ED/p1675079929051119) _(internal)_