### PR TITLE
Reverse logic to detect feature powerset on `cargo make`

### DIFF
--- a/.github/scripts/rust/Makefile.toml
+++ b/.github/scripts/rust/Makefile.toml
@@ -15,8 +15,8 @@ CARGO_RUN_FLAGS = ""
 CARGO_FORMAT_FLAGS = ""
 CARGO_FORMAT_HACK_FLAGS = "--workspace"
 
-CARGO_CLIPPY_FLAGS = { source = "${GITHUB_EVENT_NAME}", default_value = "--no-deps --all-targets --all-features", mapping = {"push" = "--no-deps --all-targets" } }
-CARGO_CLIPPY_HACK_FLAGS = { source = "${GITHUB_EVENT_NAME}", default_value = "--workspace", mapping = {"push" = "--workspace --optional-deps --feature-powerset" } }
+CARGO_CLIPPY_FLAGS = { source = "${GITHUB_EVENT_NAME}", default_value = "--no-deps --all-targets", mapping = {"pull_request" = "--no-deps --all-targets --all-features" } }
+CARGO_CLIPPY_HACK_FLAGS = { source = "${GITHUB_EVENT_NAME}", default_value = "--workspace --optional-deps --feature-powerset", mapping = {"pull_request" = "--workspace" } }
 
 CARGO_DOC_FLAGS = "--no-deps --all-features -Zunstable-options -Zrustdoc-scrape-examples"
 CARGO_DOC_HACK_FLAGS = "--workspace"
@@ -24,8 +24,8 @@ CARGO_DOC_HACK_FLAGS = "--workspace"
 CARGO_RUSTDOC_FLAGS = "--all-features -Zunstable-options -Zrustdoc-scrape-examples -- -Zunstable-options"
 CARGO_RUSTDOC_HACK_FLAGS = "--workspace"
 
-CARGO_TEST_FLAGS = { source = "${GITHUB_EVENT_NAME}", default_value = "--all-features", mapping = {"push" = "" } }
-CARGO_TEST_HACK_FLAGS = { source = "${GITHUB_EVENT_NAME}", default_value = "--workspace", mapping = {"push" = "--workspace --optional-deps --feature-powerset" } }
+CARGO_TEST_FLAGS = { source = "${GITHUB_EVENT_NAME}", default_value = "", mapping = {"pull_request" = "--all-features" } }
+CARGO_TEST_HACK_FLAGS = { source = "${GITHUB_EVENT_NAME}", default_value = "--workspace --optional-deps --feature-powerset", mapping = {"pull_request" = "--workspace" } }
 
 CARGO_DOC_TEST_FLAGS = "--workspace --all-features"
 

--- a/.github/scripts/rust/setup.py
+++ b/.github/scripts/rust/setup.py
@@ -40,7 +40,7 @@ DOCKER_PATTERNS = ["apps/hash-graph"]
 COVERAGE_EXCLUDE_PATTERNS = ["apps/engine**"]
 
 # We only run a subset of configurations for PRs, the rest will only be tested prior merging
-IS_PUSH_EVENT = "GITHUB_EVENT_NAME" in os.environ and os.environ["GITHUB_EVENT_NAME"] == "push"
+IS_PULL_REQUEST_EVENT = "GITHUB_EVENT_NAME" in os.environ and os.environ["GITHUB_EVENT_NAME"] == "pull_request"
 
 
 def generate_diffs():
@@ -218,7 +218,7 @@ def output_matrix(name, github_output_file, crates, **kwargs):
     available_toolchains = set()
     for crate in crates:
         available_toolchains.add(find_toolchain(crate))
-        if IS_PUSH_EVENT:
+        if not IS_PULL_REQUEST_EVENT:
             for pattern, additional_toolchains in TOOLCHAINS.items():
                 for additional_toolchain in additional_toolchains:
                     available_toolchains.add(additional_toolchain)
@@ -273,15 +273,15 @@ def main():
     github_output_file = open(os.environ["GITHUB_OUTPUT_FILE_PATH"], "w")
     
     output_matrix("lint", github_output_file, changed_parent_crates)
-    if IS_PUSH_EVENT:
-        output_matrix("test", github_output_file, changed_parent_crates, profile=["development", "production"])
-    else:
+    if IS_PULL_REQUEST_EVENT:
         output_matrix("test", github_output_file, changed_parent_crates, profile=["development"])
-    output_matrix("coverage", github_output_file, coverage_crates)
-    if IS_PUSH_EVENT:
-        output_matrix("docker", github_output_file, changed_docker_crates, profile=["production"])
     else:
+        output_matrix("test", github_output_file, changed_parent_crates, profile=["development", "production"])
+    output_matrix("coverage", github_output_file, coverage_crates)
+    if IS_PULL_REQUEST_EVENT:
         output_matrix("docker", github_output_file, changed_docker_crates, profile=["development"])
+    else:
+        output_matrix("docker", github_output_file, changed_docker_crates, profile=["production"])
     output_matrix(
         "publish",
         github_output_file,

--- a/packages/libs/error-stack/Makefile.toml
+++ b/packages/libs/error-stack/Makefile.toml
@@ -2,8 +2,8 @@ extend = { path = "../../../.github/scripts/rust/Makefile.toml" }
 
 [env]
 COMMON_HACK_FLAGS = "--optional-deps --feature-powerset --group-features eyre,hooks --group-features anyhow,serde"
-CARGO_CLIPPY_HACK_FLAGS = { source = "${GITHUB_EVENT_NAME}", default_value = "", mapping = { "push" = "${COMMON_HACK_FLAGS}" } }
-CARGO_TEST_HACK_FLAGS = { source = "${GITHUB_EVENT_NAME}", default_value = "", mapping = { "push" = "${COMMON_HACK_FLAGS}" } }
+CARGO_CLIPPY_HACK_FLAGS = { source = "${GITHUB_EVENT_NAME}", default_value = "${COMMON_HACK_FLAGS}", mapping = { "pull_request" = "" } }
+CARGO_TEST_HACK_FLAGS = { source = "${GITHUB_EVENT_NAME}", default_value = "${COMMON_HACK_FLAGS}", mapping = { "pull_request" = "" } }
 CARGO_INSTA_TEST_FLAGS = "--no-fail-fast"
 CARGO_RUSTDOC_HACK_FLAGS = ""
 CARGO_DOC_HACK_FLAGS = ""


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We have a logic in place to only run a subset in PRs and only run the full set of tests before merge. However, in order to test locally, this logic should be reversed and instead of testing for a `push` event, this should test for `pull_request` events.

## 🔗 Related links

- #1800