### PR TITLE
Attempt to fix linting job in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,17 +72,17 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ${{ matrix.directory }}
-
       - name: Install tools
         shell: bash
         run: |
           cargo install cargo-quickinstall
           cargo quickinstall cargo-make --version 0.36.3
           cargo quickinstall cargo-hack --version 0.5.26
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ${{ matrix.directory }}
 
       # To be removed once https://github.com/open-telemetry/opentelemetry-rust/issues/934 is sorted
       - name: Install Protoc
@@ -137,12 +137,6 @@ jobs:
             **/node_modules
           key: ${{ hashFiles('**/yarn.lock') }}
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ${{ matrix.directory }}
-          key: ${{ matrix.profile }}
-
       - name: Install tools
         shell: bash
         run: |
@@ -150,6 +144,12 @@ jobs:
           cargo quickinstall cargo-make --version 0.36.3
           cargo quickinstall cargo-hack --version 0.5.26
           cargo quickinstall cargo-nextest --version 0.9.37
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ${{ matrix.directory }}
+          key: ${{ matrix.profile }}
 
       # To be removed once https://github.com/open-telemetry/opentelemetry-rust/issues/934 is sorted
       - name: Install Protoc
@@ -221,12 +221,6 @@ jobs:
             **/node_modules
           key: ${{ hashFiles('**/yarn.lock') }}
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ${{ matrix.directory }}
-          key: ${{ matrix.profile }}
-
       - name: Install tools
         shell: bash
         run: |
@@ -234,6 +228,12 @@ jobs:
           cargo quickinstall cargo-make --version 0.36.3
           cargo quickinstall cargo-nextest --version 0.9.37
           cargo quickinstall cargo-llvm-cov --version 0.5.9
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ${{ matrix.directory }}
+          key: ${{ matrix.profile }}
 
       # To be removed once https://github.com/open-telemetry/opentelemetry-rust/issues/934 is sorted
       - name: Install Protoc


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In various PR the Rust CI linting job is failing as `cargo make` is supposed to be installed, but it's not. This PR tries to solve this by not caching the tools (which is probably a good idea anyway). If this PR is able to be merged, this issue should be solved, otherwise, it's very likely hitting the same bug.

## 🔗  Related links

This error happened in
- #1800
- #1973 
- #1976