### PR TITLE
Change `EntityEditionId` to be a `UUID`

### DIFF
--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/link-table/cells/linked-with-cell/linked-entity-list-editor.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/link-table/cells/linked-with-cell/linked-entity-list-editor.tsx
@@ -32,7 +32,7 @@ export const createDraftLinkEntity = ({
     linkData: { rightEntityId, leftEntityId },
     metadata: {
       archived: false,
-      editionId: { recordId: 1, baseId: `draft%${Date.now()}` },
+      editionId: { recordId: "", baseId: `draft%${Date.now()}` },
       entityTypeId: linkEntityTypeId,
       provenance: { updatedById: "" },
       version: {

--- a/apps/hash-graph/lib/graph/src/shared/identifier/knowledge.rs
+++ b/apps/hash-graph/lib/graph/src/shared/identifier/knowledge.rs
@@ -6,6 +6,7 @@ use std::{
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use tokio_postgres::types::ToSql;
 use utoipa::{openapi, ToSchema};
+use uuid::Uuid;
 
 use crate::{
     identifier::{
@@ -147,16 +148,16 @@ impl EntityRevision {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, ToSql, ToSchema)]
 #[postgres(transparent)]
 #[repr(transparent)]
-pub struct EntityEditionId(i64);
+pub struct EntityEditionId(Uuid);
 
 impl EntityEditionId {
     #[must_use]
-    pub const fn new(id: i64) -> Self {
+    pub const fn new(id: Uuid) -> Self {
         Self(id)
     }
 
     #[must_use]
-    pub const fn as_i64(&self) -> i64 {
+    pub const fn as_uuid(&self) -> Uuid {
         self.0
     }
 }

--- a/apps/hash-graph/postgres_migrations/V3__knowledge_tables.sql
+++ b/apps/hash-graph/postgres_migrations/V3__knowledge_tables.sql
@@ -23,7 +23,7 @@ CREATE TABLE IF NOT EXISTS
 
 CREATE TABLE IF NOT EXISTS
   "entity_records" (
-    "entity_edition_id" BIGINT PRIMARY KEY NOT NULL GENERATED ALWAYS AS IDENTITY,
+    "entity_edition_id" UUID NOT NULL PRIMARY KEY,
     "entity_type_ontology_id" UUID NOT NULL REFERENCES "entity_types",
     "properties" JSONB NOT NULL,
     "left_to_right_order" INTEGER,
@@ -36,7 +36,7 @@ CREATE TABLE IF NOT EXISTS
   "entity_revisions" (
     "owned_by_id" UUID NOT NULL,
     "entity_uuid" UUID NOT NULL,
-    "entity_edition_id" BIGINT NOT NULL REFERENCES "entity_records",
+    "entity_edition_id" UUID NOT NULL REFERENCES "entity_records",
     "decision_time" tstzrange NOT NULL,
     "transaction_time" tstzrange NOT NULL,
     FOREIGN KEY ("owned_by_id", "entity_uuid") REFERENCES "entity_ids",

--- a/apps/hash-graph/postgres_migrations/V6__knowledge_functions.sql
+++ b/apps/hash-graph/postgres_migrations/V6__knowledge_functions.sql
@@ -14,12 +14,12 @@ OR REPLACE FUNCTION "create_entity" (
   "_left_to_right_order" INTEGER,
   "_right_to_left_order" INTEGER
 ) RETURNS TABLE (
-  entity_edition_id BIGINT,
+  entity_edition_id UUID,
   decision_time tstzrange,
   transaction_time tstzrange
 ) AS $pga$
     DECLARE
-      _entity_edition_id BIGINT;
+      _entity_edition_id UUID;
     BEGIN
       IF _decision_time IS NULL THEN _decision_time := now(); END IF;
 
@@ -41,6 +41,7 @@ OR REPLACE FUNCTION "create_entity" (
 
       -- insert the data of the entity
       INSERT INTO entity_records (
+        entity_edition_id,
         updated_by_id,
         archived,
         entity_type_ontology_id,
@@ -48,6 +49,7 @@ OR REPLACE FUNCTION "create_entity" (
         left_to_right_order,
         right_to_left_order
       ) VALUES (
+        gen_random_uuid(),
         _updated_by_id,
         _archived,
         _entity_type_ontology_id,
@@ -85,16 +87,17 @@ OR REPLACE FUNCTION "update_entity" (
   "_left_to_right_order" INTEGER,
   "_right_to_left_order" INTEGER
 ) RETURNS TABLE (
-  entity_edition_id BIGINT,
+  entity_edition_id UUID,
   decision_time tstzrange,
   transaction_time tstzrange
 ) AS $pga$
     DECLARE
-      _new_entity_edition_id BIGINT;
+      _new_entity_edition_id UUID;
     BEGIN
       IF _decision_time IS NULL THEN _decision_time := now(); END IF;
 
       INSERT INTO entity_records (
+        entity_edition_id,
         updated_by_id,
         archived,
         entity_type_ontology_id,
@@ -102,6 +105,7 @@ OR REPLACE FUNCTION "update_entity" (
         left_to_right_order,
         right_to_left_order
       ) VALUES (
+        gen_random_uuid(),
         _updated_by_id,
         _archived,
         _entity_type_ontology_id,

--- a/libs/@local/hash-graph-client/api.ts
+++ b/libs/@local/hash-graph-client/api.ts
@@ -606,10 +606,10 @@ export interface EntityRecordId {
   baseId: string;
   /**
    *
-   * @type {number}
+   * @type {string}
    * @memberof EntityRecordId
    */
-  recordId: number;
+  recordId: string;
 }
 /**
  *

--- a/libs/@local/hash-subgraph/src/types/identifier.ts
+++ b/libs/@local/hash-subgraph/src/types/identifier.ts
@@ -45,7 +45,7 @@ export type EntityVersion = {
   transactionTime: VersionInterval;
 };
 
-export type EntityRecordId = number;
+export type EntityRecordId = string;
 
 /**
  * An identifier of a specific edition of an `Entity` at a given `EntityRecordId`


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To be more future proof, we want the (opaque!) edition id of an entity to be a UUID as this is easier when sharding.

## 🚫 Blocked by

- #1975 

## 🔍 What does this change?

Change the inner type of `EntityEditionId` to be a `UUID`