### PR TITLE
`error-stack`: remove `owo-colors` as dependency

### DIFF
--- a/packages/libs/error-stack/CHANGELOG.md
+++ b/packages/libs/error-stack/CHANGELOG.md
@@ -20,7 +20,6 @@ All notable changes to `error-stack` will be documented in this file.
 - Support converting `Report` into [`Error`](https://doc.rust-lang.org/core/error/trait.Error.html) via `Report::as_error` and `Report::into_error` ([#1749](https://github.com/hashintel/hash/pull/1749))
 - Support converting `Report` into `Box<dyn Error>` via the `From` trait ([#1749](https://github.com/hashintel/hash/pull/1749))
 - Programmatic selection of color mode and charset used for `Debug` output ([#1800](https://github.com/hashintel/hash/pull/1800))
-- New feature `color`, supersedes `pretty-print` feature ([#1800](https://github.com/hashintel/hash/pull/1800))
 
 ## [0.2.4](https://github.com/hashintel/hash/tree/error-stack%400.2.4/packages/libs/error-stack) - 2022-11-04
 

--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -21,7 +21,6 @@ categories = ["rust-patterns", "no-std"]
 tracing-error = { version = "0.2", optional = true, default_features = false }
 anyhow = { version = "1.0.65", default-features = false, optional = true }
 eyre = { version = "0.6", default-features = false, optional = true }
-owo-colors = { version = "3", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true }
 spin = { version = "0.9", default-features = false, optional = true, features = ['rwlock', 'once'] }
 
@@ -39,6 +38,7 @@ ansi-to-html = "0.1.2"
 once_cell = "1.17.0"
 supports-color = "2.0.0"
 supports-unicode = "1.0.2"
+owo-colors = "3"
 
 [build-dependencies]
 rustc_version = "0.4"
@@ -46,7 +46,6 @@ rustc_version = "0.4"
 [features]
 default = ["std"]
 
-color = ["dep:owo-colors"]
 spantrace = ["dep:tracing-error", "std"]
 std = ["anyhow?/std"]
 eyre = ["dep:eyre", "std"]

--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -38,7 +38,7 @@ ansi-to-html = "0.1.2"
 once_cell = "1.17.0"
 supports-color = "2.0.0"
 supports-unicode = "1.0.2"
-owo-colors = "3"
+owo-colors = "3.5.0"
 
 [build-dependencies]
 rustc_version = "0.4"

--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -71,7 +71,7 @@ required-features = ["std"]
 
 [[example]]
 name = "detect"
-required-features = ['std', 'color']
+required-features = ['std']
 
 
 [[test]]

--- a/packages/libs/error-stack/Makefile.toml
+++ b/packages/libs/error-stack/Makefile.toml
@@ -7,9 +7,9 @@ CARGO_TEST_HACK_FLAGS = { source = "${GITHUB_EVENT_NAME}", default_value = "${CO
 CARGO_INSTA_TEST_FLAGS = "--no-fail-fast"
 CARGO_RUSTDOC_HACK_FLAGS = ""
 CARGO_DOC_HACK_FLAGS = ""
-# The only features that are of relevance are: spantrace, color, std, hooks
+# The only features that are of relevance are: spantrace, std, hooks
 # all others do not change the output
-CARGO_INSTA_TEST_HACK_FLAGS = "--keep-going --feature-powerset --include-features spantrace,color,std,hooks"
+CARGO_INSTA_TEST_HACK_FLAGS = "--keep-going --feature-powerset --include-features spantrace,std,hooks"
 
 # Workaround for https://github.com/taiki-e/cargo-hack/issues/161
 # instead, we should pass `--ignore-unknown-features` to `cargo hack`

--- a/packages/libs/error-stack/src/fmt/charset.rs
+++ b/packages/libs/error-stack/src/fmt/charset.rs
@@ -54,9 +54,6 @@ static CHARSET_OVERRIDE: AtomicOverride<Charset> = AtomicOverride::new();
 impl Report<()> {
     /// Set the charset preference
     ///
-    /// If the value is [`None`], a previously set preference will be unset, while with [`Some`] a
-    /// specific charset will be set.
-    ///
     /// The value defaults to [`Charset::Utf8`].
     ///
     /// # Example

--- a/packages/libs/error-stack/src/fmt/color.rs
+++ b/packages/libs/error-stack/src/fmt/color.rs
@@ -66,7 +66,7 @@ static COLOR_OVERRIDE: AtomicOverride<ColorMode> = AtomicOverride::new();
 impl Report<()> {
     /// Set the color mode preference
     ///
-    /// The value defaults to [`ColorMode::Emphasis`], otherwise [`ColorMode::None`].
+    /// The value defaults to [`ColorMode::Emphasis`].
     ///
     /// # Example
     ///

--- a/packages/libs/error-stack/src/fmt/color.rs
+++ b/packages/libs/error-stack/src/fmt/color.rs
@@ -63,7 +63,7 @@ static COLOR_OVERRIDE: AtomicOverride<ColorMode> = AtomicOverride::new();
 impl Report<()> {
     /// Set the color mode preference
     ///
-    /// If no [`ColorMode`] is set, it defaults to [`Emphasis`].
+    /// If no [`ColorMode`] is set, it defaults to [`ColorMode::Emphasis`].
     ///
     /// # Example
     ///

--- a/packages/libs/error-stack/src/fmt/color.rs
+++ b/packages/libs/error-stack/src/fmt/color.rs
@@ -363,11 +363,7 @@ impl DisplayStyle {
     }
 
     fn end_ansi(self, sequence: &mut ControlSequence) -> fmt::Result {
-        if self.bold {
-            sequence.push_control("21")?;
-        }
-
-        if self.faint {
+        if self.faint || self.bold {
             sequence.push_control("22")?;
         }
 

--- a/packages/libs/error-stack/src/fmt/config.rs
+++ b/packages/libs/error-stack/src/fmt/config.rs
@@ -26,8 +26,6 @@ impl Config {
         self.context.cast()
     }
 
-    // Not used in all configurations, only some (w/ `color`)
-    #[allow(unused)]
     pub(crate) const fn color_mode(&self) -> ColorMode {
         self.context.color_mode()
     }
@@ -61,8 +59,6 @@ impl Config {
         Self::new(color_mode, charset, alternate)
     }
 
-    // Not used in all configurations, only some (w/ `color`)
-    #[allow(unused)]
     pub(crate) const fn color_mode(&self) -> ColorMode {
         self.color_mode
     }

--- a/packages/libs/error-stack/src/fmt/hook.rs
+++ b/packages/libs/error-stack/src/fmt/hook.rs
@@ -470,8 +470,6 @@ mod default {
     #[cfg(feature = "std")]
     use std::sync::Once;
 
-    #[cfg(feature = "color")]
-    use owo_colors::OwoColorize;
     #[cfg(all(not(feature = "std"), feature = "hooks"))]
     use spin::once::Once;
     #[cfg(feature = "spantrace")]

--- a/packages/libs/error-stack/src/fmt/location.rs
+++ b/packages/libs/error-stack/src/fmt/location.rs
@@ -4,28 +4,20 @@ use core::{
     panic::Location,
 };
 
-#[cfg(feature = "color")]
-use owo_colors::OwoColorize;
-
-use crate::fmt::ColorMode;
+use crate::fmt::{
+    color::{Color, DisplayStyle, Style},
+    ColorMode,
+};
 
 pub(super) struct LocationDisplay<'a> {
     location: &'a Location<'static>,
-    #[cfg(feature = "color")]
     mode: ColorMode,
 }
 
 impl<'a> LocationDisplay<'a> {
-    // rust is likely to just remove this anyway, but as this is an internal only API having the
-    // color mode always present makes it easier to work with.
-    #[allow(unused)]
     #[must_use]
     pub(super) const fn new(location: &'a Location<'static>, mode: ColorMode) -> Self {
-        Self {
-            location,
-            #[cfg(feature = "color")]
-            mode,
-        }
+        Self { location, mode }
     }
 }
 
@@ -33,15 +25,15 @@ impl<'a> Display for LocationDisplay<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let location = self.location;
 
-        #[cfg(feature = "color")]
-        match self.mode {
-            ColorMode::None => f.write_fmt(format_args!("at {location}")),
-            ColorMode::Color => Display::fmt(&(*location).bright_black(), f),
-            ColorMode::Emphasis => Display::fmt(&(*location).italic(), f),
-        }?;
+        let mut style = Style::new();
 
-        #[cfg(not(feature = "color"))]
-        f.write_fmt(format_args!("at {location}"))?;
+        match self.mode {
+            ColorMode::None => {}
+            ColorMode::Color => style.set_foreground(Color::Black, true),
+            ColorMode::Emphasis => style.set_display(DisplayStyle::new().with_italic(true)),
+        };
+
+        f.write_fmt(format_args!("at {}", style.apply(&location)))?;
 
         Ok(())
     }

--- a/packages/libs/error-stack/src/fmt/mod.rs
+++ b/packages/libs/error-stack/src/fmt/mod.rs
@@ -877,10 +877,13 @@ fn debug_frame(root: &Frame, prefix: &[&Frame], config: &mut Config) -> Vec<Line
             // each "paket" on the stack is made up of a head (guaranteed to be a `Context`) and
             // `n` attachments.
             // The attachments are rendered as direct descendants of the parent context
-            let head_context = debug_context(match head.kind() {
-                FrameKind::Context(c) => c,
-                FrameKind::Attachment(_) => unreachable!(),
-            });
+            let head_context = debug_context(
+                match head.kind() {
+                    FrameKind::Context(c) => c,
+                    FrameKind::Attachment(_) => unreachable!(),
+                },
+                config.color_mode(),
+            );
 
             // reverse all attachments, to make it more logical relative to the attachment order
             body.reverse();

--- a/packages/libs/error-stack/src/fmt/mod.rs
+++ b/packages/libs/error-stack/src/fmt/mod.rs
@@ -209,10 +209,6 @@ enum Symbol {
 /// ])
 /// ```
 macro_rules! sym {
-    (#char '@') => {
-        Symbol::Location
-    };
-
     (#char '│') => {
         Symbol::Vertical
     };
@@ -458,9 +454,9 @@ impl Instruction {
             },
 
             Self::Attachment { position } => match position {
-                Position::First => PreparedInstruction::Symbols(sym!('├', '╴', ' ')),
-                Position::Inner => PreparedInstruction::Symbols(sym!('├', '╴', ' ')),
-                Position::Final => PreparedInstruction::Symbols(sym!('╰', '╴', ' ')),
+                Position::First => PreparedInstruction::Symbols(sym!('├', '╴')),
+                Position::Inner => PreparedInstruction::Symbols(sym!('├', '╴')),
+                Position::Final => PreparedInstruction::Symbols(sym!('╰', '╴')),
             },
 
             // Indentation (like `|   ` or ` |  `)

--- a/packages/libs/error-stack/src/fmt/mod.rs
+++ b/packages/libs/error-stack/src/fmt/mod.rs
@@ -630,7 +630,7 @@ fn partition<'a>(stack: &'a [&'a Frame]) -> (Vec<(&'a Frame, Vec<&'a Frame>)>, V
     (result, queue)
 }
 
-fn debug_context(context: &dyn Context) -> Lines {
+fn debug_context(context: &dyn Context, mode: ColorMode) -> Lines {
     context
         .to_string()
         .lines()
@@ -638,10 +638,13 @@ fn debug_context(context: &dyn Context) -> Lines {
         .enumerate()
         .map(|(idx, value)| {
             if idx == 0 {
-                Line::new().push(Instruction::Value {
-                    value,
-                    style: Style::new().with_display(DisplayStyle::new().with_bold(true)),
-                })
+                let mut style = Style::new();
+
+                if mode == ColorMode::Color || mode == ColorMode::Emphasis {
+                    style.set_display(DisplayStyle::new().with_bold(true));
+                }
+
+                Line::new().push(Instruction::Value { value, style })
             } else {
                 Line::new().push(Instruction::Value {
                     value,

--- a/packages/libs/error-stack/src/fmt/mod.rs
+++ b/packages/libs/error-stack/src/fmt/mod.rs
@@ -487,11 +487,9 @@ impl Display for InstructionDisplay<'_> {
 
                 let mut style = Style::new();
 
-                match self.color {
-                    ColorMode::Color => style.set_foreground(Color::Red, false),
-                    ColorMode::Emphasis => style.set_display(DisplayStyle::new().with_bold(true)),
-                    ColorMode::None => {}
-                };
+                if self.color == ColorMode::Color {
+                    style.set_foreground(Color::Red, false);
+                }
 
                 Display::fmt(&style.apply(&display), fmt)?;
             }

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -414,8 +414,8 @@
 //! ### Colored output and charset selection
 //!
 //! You can override the color support by using the [`Report::set_color_mode`]. To override the
-//! charset used, you can use [`Report::set_charset`]. The default color mode is emphasis (if the
-//! `color` feature is enabled). The default charset is `UTF-8`.
+//! charset used, you can use [`Report::set_charset`]. The default color mode is emphasis.
+//! The default charset is `UTF-8`.
 //!
 //! To automatically detect support if your target output supports unicode and colors you can check
 //! out the `detect.rs` example.
@@ -425,7 +425,6 @@
 //!  Feature       | Description                                                        | default
 //! ---------------|--------------------------------------------------------------------|----------
 //! `std`          | Enables support for [`Error`], and, on Rust 1.65+, [`Backtrace`]   | enabled
-//! `color`        | Provide support for color in [`Debug`] output                      | disabled
 //! `spantrace`    | Enables automatic capturing of [`SpanTrace`]s                      | disabled
 //! `hooks`        | Enables hooks on `no-std` platforms using spin locks               | disabled
 //! `anyhow`       | Provides `into_report` to convert [`anyhow::Error`] to [`Report`]  | disabled

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__charset_ascii.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__charset_ascii.snap
@@ -1,7 +1,7 @@
 <b>invalid input parameter</b>
-<b>|- </b>at <i>src/fmt/charset.rs:21:5</i>
-<b>|- </b>backtrace (1)
-<b>|- </b>suggestion: oh no, try again
+|- at <i>src/fmt/charset.rs:21:5</i>
+|- backtrace (1)
+|- suggestion: oh no, try again
 
 ========================================
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__charset_ascii.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__charset_ascii.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<b>|- </b><i>src/fmt/charset.rs:21:5</i>
+<b>|- </b>at <i>src/fmt/charset.rs:21:5</i>
 <b>|- </b>backtrace (1)
 <b>|- </b>suggestion: oh no, try again
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__charset_ascii.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__charset_ascii.snap
@@ -1,7 +1,7 @@
 <b>invalid input parameter</b>
-|- at <i>src/fmt/charset.rs:21:5</i>
-|- backtrace (1)
-|- suggestion: oh no, try again
+|-at <i>src/fmt/charset.rs:21:5</i>
+|-backtrace (1)
+|-suggestion: oh no, try again
 
 ========================================
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__charset_utf8.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__charset_utf8.snap
@@ -1,7 +1,7 @@
 <b>invalid input parameter</b>
-<b>├╴ </b>at <i>src/fmt/charset.rs:21:5</i>
-<b>├╴ </b>backtrace (1)
-<b>╰╴ </b>📝 oh no, try again
+├╴ at <i>src/fmt/charset.rs:21:5</i>
+├╴ backtrace (1)
+╰╴ 📝 oh no, try again
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__charset_utf8.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__charset_utf8.snap
@@ -1,7 +1,7 @@
 <b>invalid input parameter</b>
-├╴ at <i>src/fmt/charset.rs:21:5</i>
-├╴ backtrace (1)
-╰╴ 📝 oh no, try again
+├╴at <i>src/fmt/charset.rs:21:5</i>
+├╴backtrace (1)
+╰╴📝 oh no, try again
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__charset_utf8.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__charset_utf8.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<b>├╴ </b><i>src/fmt/charset.rs:21:5</i>
+<b>├╴ </b>at <i>src/fmt/charset.rs:21:5</i>
 <b>├╴ </b>backtrace (1)
 <b>╰╴ </b>📝 oh no, try again
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__diagnostics_add.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__diagnostics_add.snap
@@ -1,8 +1,8 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/fmt/hook.rs:19:14</span>
-<span style='color:#a00'>├╴ </span>backtrace (1)
-<span style='color:#a00'>├╴ </span>suggestion: try better next time
-<span style='color:#a00'>╰╴ </span>sorry for the inconvenience!
+<span style='color:#a00'>├╴</span>at <span style='color:#555'>src/fmt/hook.rs:19:14</span>
+<span style='color:#a00'>├╴</span>backtrace (1)
+<span style='color:#a00'>├╴</span>suggestion: try better next time
+<span style='color:#a00'>╰╴</span>sorry for the inconvenience!
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__diagnostics_add.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__diagnostics_add.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span><span style='color:#555'>src/fmt/hook.rs:19:14</span>
+<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/fmt/hook.rs:19:14</span>
 <span style='color:#a00'>├╴ </span>backtrace (1)
 <span style='color:#a00'>├╴ </span>suggestion: try better next time
 <span style='color:#a00'>╰╴ </span>sorry for the inconvenience!

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__doc.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__doc.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span><span style='color:#555'>src/fmt/mod.rs:57:14</span>
+<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/fmt/mod.rs:57:14</span>
 <span style='color:#a00'>├╴ </span>backtrace (1)
 <span style='color:#a00'>├╴ </span>error (404)
 <span style='color:#a00'>├╴ </span>suggestion 1: try to be connected to the internet.

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__doc.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__doc.snap
@@ -1,10 +1,10 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/fmt/mod.rs:57:14</span>
-<span style='color:#a00'>├╴ </span>backtrace (1)
-<span style='color:#a00'>├╴ </span>error (404)
-<span style='color:#a00'>├╴ </span>suggestion 1: try to be connected to the internet.
-<span style='color:#a00'>├╴ </span>suggestion 2: try better next time!
-<span style='color:#a00'>╰╴ </span>warning (1) occurred
+<span style='color:#a00'>├╴</span>at <span style='color:#555'>src/fmt/mod.rs:57:14</span>
+<span style='color:#a00'>├╴</span>backtrace (1)
+<span style='color:#a00'>├╴</span>error (404)
+<span style='color:#a00'>├╴</span>suggestion 1: try to be connected to the internet.
+<span style='color:#a00'>├╴</span>suggestion 2: try better next time!
+<span style='color:#a00'>╰╴</span>warning (1) occurred
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__emit.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__emit.snap
@@ -1,14 +1,14 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/fmt/hook.rs:49:14</span>
-<span style='color:#a00'>├╴ </span>backtrace (1)
-<span style='color:#a00'>├╴ </span>error code: 404
-<span style='color:#a00'>├╴ </span>suggestion (0)
-<span style='color:#a00'>├╴ </span>error code: 405
-<span style='color:#a00'>├╴ </span>abnormal program execution detected
-<span style='color:#a00'>├╴ </span>warning: unable to determine environment
-<span style='color:#a00'>├╴ </span>suggestion (1)
-<span style='color:#a00'>├╴ </span>error code: 501
-<span style='color:#a00'>╰╴ </span>suggestion (2)
+<span style='color:#a00'>├╴</span>at <span style='color:#555'>src/fmt/hook.rs:49:14</span>
+<span style='color:#a00'>├╴</span>backtrace (1)
+<span style='color:#a00'>├╴</span>error code: 404
+<span style='color:#a00'>├╴</span>suggestion (0)
+<span style='color:#a00'>├╴</span>error code: 405
+<span style='color:#a00'>├╴</span>abnormal program execution detected
+<span style='color:#a00'>├╴</span>warning: unable to determine environment
+<span style='color:#a00'>├╴</span>suggestion (1)
+<span style='color:#a00'>├╴</span>error code: 501
+<span style='color:#a00'>╰╴</span>suggestion (2)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__emit.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__emit.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span><span style='color:#555'>src/fmt/hook.rs:49:14</span>
+<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/fmt/hook.rs:49:14</span>
 <span style='color:#a00'>├╴ </span>backtrace (1)
 <span style='color:#a00'>├╴ </span>error code: 404
 <span style='color:#a00'>├╴ </span>suggestion (0)

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__emit_alt.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__emit_alt.snap
@@ -1,20 +1,20 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/fmt/hook.rs:49:14</span>
-<span style='color:#a00'>├╴ </span>backtrace (1)
-<span style='color:#a00'>├╴ </span>error code: 404
-<span style='color:#a00'>├╴ </span>suggestion 0:
+<span style='color:#a00'>├╴</span>at <span style='color:#555'>src/fmt/hook.rs:49:14</span>
+<span style='color:#a00'>├╴</span>backtrace (1)
+<span style='color:#a00'>├╴</span>error code: 404
+<span style='color:#a00'>├╴</span>suggestion 0:
 <span style='color:#a00'>│  </span>  do you have a connection to the internet?
-<span style='color:#a00'>├╴ </span>suggestion (0)
-<span style='color:#a00'>├╴ </span>error code: 405
-<span style='color:#a00'>├╴ </span>abnormal program execution detected
-<span style='color:#a00'>├╴ </span>warning: unable to determine environment
-<span style='color:#a00'>├╴ </span>suggestion 1:
+<span style='color:#a00'>├╴</span>suggestion (0)
+<span style='color:#a00'>├╴</span>error code: 405
+<span style='color:#a00'>├╴</span>abnormal program execution detected
+<span style='color:#a00'>├╴</span>warning: unable to determine environment
+<span style='color:#a00'>├╴</span>suggestion 1:
 <span style='color:#a00'>│  </span>  execute the program from the fish shell
-<span style='color:#a00'>├╴ </span>suggestion (1)
-<span style='color:#a00'>├╴ </span>error code: 501
-<span style='color:#a00'>├╴ </span>suggestion 2:
+<span style='color:#a00'>├╴</span>suggestion (1)
+<span style='color:#a00'>├╴</span>error code: 501
+<span style='color:#a00'>├╴</span>suggestion 2:
 <span style='color:#a00'>│  </span>  try better next time!
-<span style='color:#a00'>╰╴ </span>suggestion (2)
+<span style='color:#a00'>╰╴</span>suggestion (2)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__emit_alt.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__emit_alt.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span><span style='color:#555'>src/fmt/hook.rs:49:14</span>
+<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/fmt/hook.rs:49:14</span>
 <span style='color:#a00'>├╴ </span>backtrace (1)
 <span style='color:#a00'>├╴ </span>error code: 404
 <span style='color:#a00'>├╴ </span>suggestion 0:

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_cast.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_cast.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span><span style='color:#555'>src/hook/context.rs:27:14</span>
+<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/hook/context.rs:27:14</span>
 <span style='color:#a00'>├╴ </span>backtrace (1)
 <span style='color:#a00'>├╴ </span>[1] [ERROR] unable to reach remote host
 <span style='color:#a00'>├╴ </span>[2] [WARN] disk nearly full

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_cast.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_cast.snap
@@ -1,9 +1,9 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/hook/context.rs:27:14</span>
-<span style='color:#a00'>├╴ </span>backtrace (1)
-<span style='color:#a00'>├╴ </span>[1] [ERROR] unable to reach remote host
-<span style='color:#a00'>├╴ </span>[2] [WARN] disk nearly full
-<span style='color:#a00'>╰╴ </span>[3] [ERROR] cannot resolve example.com: unknown host
+<span style='color:#a00'>├╴</span>at <span style='color:#555'>src/hook/context.rs:27:14</span>
+<span style='color:#a00'>├╴</span>backtrace (1)
+<span style='color:#a00'>├╴</span>[1] [ERROR] unable to reach remote host
+<span style='color:#a00'>├╴</span>[2] [WARN] disk nearly full
+<span style='color:#a00'>╰╴</span>[3] [ERROR] cannot resolve example.com: unknown host
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_decrement.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_decrement.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span><span style='color:#555'>src/hook/context.rs:17:14</span>
+<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/hook/context.rs:17:14</span>
 <span style='color:#a00'>├╴ </span>backtrace (1)
 <span style='color:#a00'>├╴ </span>suggestion -1: use a file you can read next time!
 <span style='color:#a00'>╰╴ </span>suggestion -2: don&#39;t press any random keys!

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_decrement.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_decrement.snap
@@ -1,8 +1,8 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/hook/context.rs:17:14</span>
-<span style='color:#a00'>├╴ </span>backtrace (1)
-<span style='color:#a00'>├╴ </span>suggestion -1: use a file you can read next time!
-<span style='color:#a00'>╰╴ </span>suggestion -2: don&#39;t press any random keys!
+<span style='color:#a00'>├╴</span>at <span style='color:#555'>src/hook/context.rs:17:14</span>
+<span style='color:#a00'>├╴</span>backtrace (1)
+<span style='color:#a00'>├╴</span>suggestion -1: use a file you can read next time!
+<span style='color:#a00'>╰╴</span>suggestion -2: don&#39;t press any random keys!
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_emit.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_emit.snap
@@ -1,8 +1,8 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/fmt/hook.rs:24:14</span>
-<span style='color:#a00'>├╴ </span>backtrace (1)
-<span style='color:#a00'>├╴ </span>error 404
-<span style='color:#a00'>╰╴ </span>error 405
+<span style='color:#a00'>├╴</span>at <span style='color:#555'>src/fmt/hook.rs:24:14</span>
+<span style='color:#a00'>├╴</span>backtrace (1)
+<span style='color:#a00'>├╴</span>error 404
+<span style='color:#a00'>╰╴</span>error 405
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_emit.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_emit.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span><span style='color:#555'>src/fmt/hook.rs:24:14</span>
+<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/fmt/hook.rs:24:14</span>
 <span style='color:#a00'>├╴ </span>backtrace (1)
 <span style='color:#a00'>├╴ </span>error 404
 <span style='color:#a00'>╰╴ </span>error 405

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_increment.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_increment.snap
@@ -1,8 +1,8 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/hook/context.rs:17:14</span>
-<span style='color:#a00'>├╴ </span>backtrace (1)
-<span style='color:#a00'>├╴ </span>suggestion 0: use a file you can read next time!
-<span style='color:#a00'>╰╴ </span>suggestion 1: don&#39;t press any random keys!
+<span style='color:#a00'>├╴</span>at <span style='color:#555'>src/hook/context.rs:17:14</span>
+<span style='color:#a00'>├╴</span>backtrace (1)
+<span style='color:#a00'>├╴</span>suggestion 0: use a file you can read next time!
+<span style='color:#a00'>╰╴</span>suggestion 1: don&#39;t press any random keys!
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_increment.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_increment.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span><span style='color:#555'>src/hook/context.rs:17:14</span>
+<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/hook/context.rs:17:14</span>
 <span style='color:#a00'>├╴ </span>backtrace (1)
 <span style='color:#a00'>├╴ </span>suggestion 0: use a file you can read next time!
 <span style='color:#a00'>╰╴ </span>suggestion 1: don&#39;t press any random keys!

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_storage.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_storage.snap
@@ -1,8 +1,8 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/fmt/hook.rs:31:14</span>
-<span style='color:#a00'>├╴ </span>backtrace (1)
-<span style='color:#a00'>├╴ </span>computation for 2 (acc = 2, div = 0.5)
-<span style='color:#a00'>╰╴ </span>computation for 3 (acc = 5, div = 0.16666667)
+<span style='color:#a00'>├╴</span>at <span style='color:#555'>src/fmt/hook.rs:31:14</span>
+<span style='color:#a00'>├╴</span>backtrace (1)
+<span style='color:#a00'>├╴</span>computation for 2 (acc = 2, div = 0.5)
+<span style='color:#a00'>╰╴</span>computation for 3 (acc = 5, div = 0.16666667)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_storage.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_storage.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span><span style='color:#555'>src/fmt/hook.rs:31:14</span>
+<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/fmt/hook.rs:31:14</span>
 <span style='color:#a00'>├╴ </span>backtrace (1)
 <span style='color:#a00'>├╴ </span>computation for 2 (acc = 2, div = 0.5)
 <span style='color:#a00'>╰╴ </span>computation for 3 (acc = 5, div = 0.16666667)

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__preference_color.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__preference_color.snap
@@ -1,7 +1,7 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/fmt/color.rs:24:5</span>
-<span style='color:#a00'>├╴ </span>backtrace (1)
-<span style='color:#a00'>╰╴ </span><span style='color:#0a0'>suggestion: oh no, try again</span>
+<span style='color:#a00'>├╴</span>at <span style='color:#555'>src/fmt/color.rs:24:5</span>
+<span style='color:#a00'>├╴</span>backtrace (1)
+<span style='color:#a00'>╰╴</span><span style='color:#0a0'>suggestion: oh no, try again</span>
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__preference_color.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__preference_color.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span><span style='color:#555'>src/fmt/color.rs:24:5</span>
+<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/fmt/color.rs:24:5</span>
 <span style='color:#a00'>├╴ </span>backtrace (1)
 <span style='color:#a00'>╰╴ </span><span style='color:#0a0'>suggestion: oh no, try again</span>
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__preference_emphasis.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__preference_emphasis.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<b>├╴ </b><i>src/fmt/color.rs:24:5</i>
+<b>├╴ </b>at <i>src/fmt/color.rs:24:5</i>
 <b>├╴ </b>backtrace (1)
 <b>╰╴ </b><i>suggestion: oh no, try again</i>
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__preference_emphasis.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__preference_emphasis.snap
@@ -1,7 +1,7 @@
 <b>invalid input parameter</b>
-├╴ at <i>src/fmt/color.rs:24:5</i>
-├╴ backtrace (1)
-╰╴ <i>suggestion: oh no, try again</i>
+├╴at <i>src/fmt/color.rs:24:5</i>
+├╴backtrace (1)
+╰╴<i>suggestion: oh no, try again</i>
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__preference_emphasis.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__preference_emphasis.snap
@@ -1,7 +1,7 @@
 <b>invalid input parameter</b>
-<b>├╴ </b>at <i>src/fmt/color.rs:24:5</i>
-<b>├╴ </b>backtrace (1)
-<b>╰╴ </b><i>suggestion: oh no, try again</i>
+├╴ at <i>src/fmt/color.rs:24:5</i>
+├╴ backtrace (1)
+╰╴ <i>suggestion: oh no, try again</i>
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__preference_none.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__preference_none.snap
@@ -1,4 +1,4 @@
-<b>invalid input parameter</b>
+invalid input parameter
 ├╴ at src/fmt/color.rs:24:5
 ├╴ backtrace (1)
 ╰╴ suggestion: oh no, try again

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__preference_none.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__preference_none.snap
@@ -1,7 +1,7 @@
 invalid input parameter
-├╴ at src/fmt/color.rs:24:5
-├╴ backtrace (1)
-╰╴ suggestion: oh no, try again
+├╴at src/fmt/color.rs:24:5
+├╴backtrace (1)
+╰╴suggestion: oh no, try again
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__preference_none.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__preference_none.snap
@@ -1,4 +1,4 @@
-invalid input parameter
+<b>invalid input parameter</b>
 ├╴ at src/fmt/color.rs:24:5
 ├╴ backtrace (1)
 ╰╴ suggestion: oh no, try again

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt_doc_alt.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt_doc_alt.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span><span style='color:#555'>src/fmt/mod.rs:57:14</span>
+<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/fmt/mod.rs:57:14</span>
 <span style='color:#a00'>├╴ </span>backtrace (1)
 <span style='color:#a00'>├╴ </span>error (404)
 <span style='color:#a00'>├╴ </span>suggestion 1: try to be connected to the internet.

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt_doc_alt.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt_doc_alt.snap
@@ -1,10 +1,10 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/fmt/mod.rs:57:14</span>
-<span style='color:#a00'>├╴ </span>backtrace (1)
-<span style='color:#a00'>├╴ </span>error (404)
-<span style='color:#a00'>├╴ </span>suggestion 1: try to be connected to the internet.
-<span style='color:#a00'>├╴ </span>suggestion 2: try better next time!
-<span style='color:#a00'>╰╴ </span>warning (1) occurred
+<span style='color:#a00'>├╴</span>at <span style='color:#555'>src/fmt/mod.rs:57:14</span>
+<span style='color:#a00'>├╴</span>backtrace (1)
+<span style='color:#a00'>├╴</span>error (404)
+<span style='color:#a00'>├╴</span>suggestion 1: try to be connected to the internet.
+<span style='color:#a00'>├╴</span>suggestion 2: try better next time!
+<span style='color:#a00'>╰╴</span>warning (1) occurred
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/doc/hook__debug_hook.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/hook__debug_hook.snap
@@ -1,7 +1,7 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/hook/mod.rs:19:5</span>
-<span style='color:#a00'>├╴ </span>backtrace (1)
-<span style='color:#a00'>╰╴ </span>suggestion: oh no, try again
+<span style='color:#a00'>├╴</span>at <span style='color:#555'>src/hook/mod.rs:19:5</span>
+<span style='color:#a00'>├╴</span>backtrace (1)
+<span style='color:#a00'>╰╴</span>suggestion: oh no, try again
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/doc/hook__debug_hook.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/hook__debug_hook.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span><span style='color:#555'>src/hook/mod.rs:19:5</span>
+<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/hook/mod.rs:19:5</span>
 <span style='color:#a00'>├╴ </span>backtrace (1)
 <span style='color:#a00'>╰╴ </span>suggestion: oh no, try again
 

--- a/packages/libs/error-stack/tests/snapshots/doc/hook__debug_hook_provide.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/hook__debug_hook_provide.snap
@@ -1,8 +1,8 @@
 <b>invalid user input</b>
-<span style='color:#a00'>├╴ </span>suggestion: try better next time!
-<span style='color:#a00'>├╴ </span>error code: 420
-<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/hook/mod.rs:49:14</span>
-<span style='color:#a00'>╰╴ </span>backtrace (1)
+<span style='color:#a00'>├╴</span>suggestion: try better next time!
+<span style='color:#a00'>├╴</span>error code: 420
+<span style='color:#a00'>├╴</span>at <span style='color:#555'>src/hook/mod.rs:49:14</span>
+<span style='color:#a00'>╰╴</span>backtrace (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/doc/hook__debug_hook_provide.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/hook__debug_hook_provide.snap
@@ -1,7 +1,7 @@
 <b>invalid user input</b>
 <span style='color:#a00'>├╴ </span>suggestion: try better next time!
 <span style='color:#a00'>├╴ </span>error code: 420
-<span style='color:#a00'>├╴ </span><span style='color:#555'>src/hook/mod.rs:49:14</span>
+<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/hook/mod.rs:49:14</span>
 <span style='color:#a00'>╰╴ </span>backtrace (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/packages/libs/error-stack/tests/snapshots/doc/lib__suggestion.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/lib__suggestion.snap
@@ -1,10 +1,10 @@
 <b>could not parse configuration file</b>
-<span style='color:#a00'>├╴ </span><span style='color:#555'>src/lib.rs:25:10</span>
+<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/lib.rs:25:10</span>
 <span style='color:#a00'>├╴ </span>could not read file &quot;test.txt&quot;
 <span style='color:#a00'>├╴ </span>1 additional opaque attachment
 <span style='color:#a00'>│</span>
 <span style='color:#a00'>╰─▶ </span><b>No such file or directory (os error 2)</b>
-<span style='color:#a00'>    </span><span style='color:#a00'>├╴ </span><span style='color:#555'>src/lib.rs:24:10</span>
+<span style='color:#a00'>    </span><span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/lib.rs:24:10</span>
 <span style='color:#a00'>    </span><span style='color:#a00'>╰╴ </span>backtrace (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/packages/libs/error-stack/tests/snapshots/doc/lib__suggestion.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/lib__suggestion.snap
@@ -1,11 +1,11 @@
 <b>could not parse configuration file</b>
-<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/lib.rs:25:10</span>
-<span style='color:#a00'>├╴ </span>could not read file &quot;test.txt&quot;
-<span style='color:#a00'>├╴ </span>1 additional opaque attachment
+<span style='color:#a00'>├╴</span>at <span style='color:#555'>src/lib.rs:25:10</span>
+<span style='color:#a00'>├╴</span>could not read file &quot;test.txt&quot;
+<span style='color:#a00'>├╴</span>1 additional opaque attachment
 <span style='color:#a00'>│</span>
 <span style='color:#a00'>╰─▶ </span><b>No such file or directory (os error 2)</b>
-<span style='color:#a00'>    </span><span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/lib.rs:24:10</span>
-<span style='color:#a00'>    </span><span style='color:#a00'>╰╴ </span>backtrace (1)
+<span style='color:#a00'>    </span><span style='color:#a00'>├╴</span>at <span style='color:#555'>src/lib.rs:24:10</span>
+<span style='color:#a00'>    </span><span style='color:#a00'>╰╴</span>backtrace (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/doc/report_debug__doc.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/report_debug__doc.snap
@@ -1,12 +1,12 @@
 <b>could not parse &quot;./path/to/config.file&quot;</b>
-<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/report.rs:61:14</span>
+<span style='color:#a00'>├╴</span>at <span style='color:#555'>src/report.rs:61:14</span>
 <span style='color:#a00'>│</span>
 <span style='color:#a00'>├─▶ </span><b>config file is invalid</b>
-<span style='color:#a00'>│   </span><span style='color:#a00'>╰╴ </span>at <span style='color:#555'>src/report.rs:53:58</span>
+<span style='color:#a00'>│   </span><span style='color:#a00'>╰╴</span>at <span style='color:#555'>src/report.rs:53:58</span>
 <span style='color:#a00'>│</span>
 <span style='color:#a00'>╰─▶ </span><b>No such file or directory (os error 2)</b>
-<span style='color:#a00'>    </span><span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/report.rs:53:44</span>
-<span style='color:#a00'>    </span><span style='color:#a00'>╰╴ </span>backtrace (1)
+<span style='color:#a00'>    </span><span style='color:#a00'>├╴</span>at <span style='color:#555'>src/report.rs:53:44</span>
+<span style='color:#a00'>    </span><span style='color:#a00'>╰╴</span>backtrace (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/doc/report_debug__doc.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/report_debug__doc.snap
@@ -1,11 +1,11 @@
 <b>could not parse &quot;./path/to/config.file&quot;</b>
-<span style='color:#a00'>├╴ </span><span style='color:#555'>src/report.rs:61:14</span>
+<span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/report.rs:61:14</span>
 <span style='color:#a00'>│</span>
 <span style='color:#a00'>├─▶ </span><b>config file is invalid</b>
-<span style='color:#a00'>│   </span><span style='color:#a00'>╰╴ </span><span style='color:#555'>src/report.rs:53:58</span>
+<span style='color:#a00'>│   </span><span style='color:#a00'>╰╴ </span>at <span style='color:#555'>src/report.rs:53:58</span>
 <span style='color:#a00'>│</span>
 <span style='color:#a00'>╰─▶ </span><b>No such file or directory (os error 2)</b>
-<span style='color:#a00'>    </span><span style='color:#a00'>├╴ </span><span style='color:#555'>src/report.rs:53:44</span>
+<span style='color:#a00'>    </span><span style='color:#a00'>├╴ </span>at <span style='color:#555'>src/report.rs:53:44</span>
 <span style='color:#a00'>    </span><span style='color:#a00'>╰╴ </span>backtrace (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__alt.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__alt.snap
@@ -3,10 +3,10 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 root error
-├╴ at tests/common.rs:4:5
-├╴ backtrace (1)
-├╴ span trace with 2 frames (1)
-╰╴ Empty
+├╴at tests/common.rs:4:5
+├╴backtrace (1)
+├╴span trace with 2 frames (1)
+╰╴Empty
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__charset_ascii.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__charset_ascii.snap
@@ -3,9 +3,9 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 root error
-|- at tests/common.rs:4:5
-|- backtrace (1)
-|- span trace with 2 frames (1)
+|-at tests/common.rs:4:5
+|-backtrace (1)
+|-span trace with 2 frames (1)
 
 ========================================
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__color_mode_color.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__color_mode_color.snap
@@ -3,9 +3,9 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 [1mroot error[22m
-[31m├╴ [39mat [90mtests/common.rs:4:5[39m
-[31m├╴ [39mbacktrace (1)
-[31m╰╴ [39mspan trace with 2 frames (1)
+[31m├╴[39mat [90mtests/common.rs:4:5[39m
+[31m├╴[39mbacktrace (1)
+[31m╰╴[39mspan trace with 2 frames (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__color_mode_color.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__color_mode_color.snap
@@ -2,8 +2,8 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-[1mroot error[0m
-[31m├╴ [39m[90mtests/common.rs:4:5[39m
+[1mroot error[22m
+[31m├╴ [39mat [90mtests/common.rs:4:5[39m
 [31m├╴ [39mbacktrace (1)
 [31m╰╴ [39mspan trace with 2 frames (1)
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__color_mode_emphasis.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__color_mode_emphasis.snap
@@ -3,9 +3,9 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 [1mroot error[22m
-[1m├╴ [22mat [3mtests/common.rs:4:5[23m
-[1m├╴ [22mbacktrace (1)
-[1m╰╴ [22mspan trace with 2 frames (1)
+├╴ at [3mtests/common.rs:4:5[23m
+├╴ backtrace (1)
+╰╴ span trace with 2 frames (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__color_mode_emphasis.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__color_mode_emphasis.snap
@@ -3,9 +3,9 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 [1mroot error[22m
-├╴ at [3mtests/common.rs:4:5[23m
-├╴ backtrace (1)
-╰╴ span trace with 2 frames (1)
+├╴at [3mtests/common.rs:4:5[23m
+├╴backtrace (1)
+╰╴span trace with 2 frames (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__color_mode_emphasis.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__color_mode_emphasis.snap
@@ -2,10 +2,10 @@
 source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
-[1mroot error[0m
-[1m├╴ [0m[3mtests/common.rs:4:5[0m
-[1m├╴ [0mbacktrace (1)
-[1m╰╴ [0mspan trace with 2 frames (1)
+[1mroot error[22m
+[1m├╴ [22mat [3mtests/common.rs:4:5[23m
+[1m├╴ [22mbacktrace (1)
+[1m╰╴ [22mspan trace with 2 frames (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__complex.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__complex.snap
@@ -3,7 +3,7 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴ at tests/test_debug.rs:439:14
+├╴ at tests/test_debug.rs:434:14
 ├╴ printable A
 │
 ╰┬▶ root error

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__complex.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__complex.snap
@@ -3,30 +3,30 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴ at tests/test_debug.rs:434:14
-├╴ printable A
+├╴at tests/test_debug.rs:434:14
+├╴printable A
 │
 ╰┬▶ root error
- │  ├╴ at tests/common.rs:4:5
- │  ├╴ backtrace (1)
- │  ├╴ span trace with 2 frames (1)
- │  ╰╴ printable A
+ │  ├╴at tests/common.rs:4:5
+ │  ├╴backtrace (1)
+ │  ├╴span trace with 2 frames (1)
+ │  ╰╴printable A
  │
  ├▶ root error
- │  ├╴ at tests/common.rs:4:5
- │  ├╴ backtrace (2)
- │  ├╴ span trace with 2 frames (2)
- │  ├╴ printable B
- │  ├╴ Test
- │  ╰╴ 1 additional opaque attachment
+ │  ├╴at tests/common.rs:4:5
+ │  ├╴backtrace (2)
+ │  ├╴span trace with 2 frames (2)
+ │  ├╴printable B
+ │  ├╴Test
+ │  ╰╴1 additional opaque attachment
  │
  ╰▶ root error
-    ├╴ at tests/common.rs:4:5
-    ├╴ backtrace (3)
-    ├╴ span trace with 2 frames (3)
-    ├╴ printable B
-    ├╴ Test
-    ╰╴ 3 additional opaque attachments
+    ├╴at tests/common.rs:4:5
+    ├╴backtrace (3)
+    ├╴span trace with 2 frames (3)
+    ├╴printable B
+    ├╴Test
+    ╰╴3 additional opaque attachments
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook.snap
@@ -3,10 +3,10 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 root error
-├╴ at tests/common.rs:4:5
-├╴ backtrace (1)
-├╴ span trace with 2 frames (1)
-╰╴ unsigned 32bit integer
+├╴at tests/common.rs:4:5
+├╴backtrace (1)
+├╴span trace with 2 frames (1)
+╰╴unsigned 32bit integer
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_context.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_context.snap
@@ -3,10 +3,10 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 root error
-├╴ at tests/common.rs:4:5
-├╴ backtrace (1)
-├╴ span trace with 2 frames (1)
-╰╴ unsigned 32bit integer (No. 0)
+├╴at tests/common.rs:4:5
+├╴backtrace (1)
+├╴span trace with 2 frames (1)
+╰╴unsigned 32bit integer (No. 0)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_decr.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_decr.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 root error
-├╴ at tests/common.rs:4:5
-├╴ backtrace (1)
-├╴ span trace with 2 frames (1)
-├╴ -1
-├╴ -2
-╰╴ -3
+├╴at tests/common.rs:4:5
+├╴backtrace (1)
+├╴span trace with 2 frames (1)
+├╴-1
+├╴-2
+╰╴-3
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_for_context.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_for_context.snap
@@ -3,10 +3,10 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 root error
-├╴ at tests/common.rs:4:5
-├╴ backtrace (1)
-├╴ span trace with 2 frames (1)
-╰╴ 1 additional opaque attachment
+├╴at tests/common.rs:4:5
+├╴backtrace (1)
+├╴span trace with 2 frames (1)
+╰╴1 additional opaque attachment
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_incr.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_incr.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 root error
-├╴ at tests/common.rs:4:5
-├╴ backtrace (1)
-├╴ span trace with 2 frames (1)
-├╴ 0
-├╴ 1
-╰╴ 2
+├╴at tests/common.rs:4:5
+├╴backtrace (1)
+├╴span trace with 2 frames (1)
+├╴0
+├╴1
+╰╴2
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_location.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_location.snap
@@ -3,8 +3,8 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 root error
-├╴ backtrace (1)
-╰╴ span trace with 2 frames (1)
+├╴backtrace (1)
+╰╴span trace with 2 frames (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_multiple.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_multiple.snap
@@ -3,11 +3,11 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 root error
-├╴ at tests/common.rs:4:5
-├╴ backtrace (1)
-├╴ span trace with 2 frames (1)
-├╴ unsigned 32bit integer
-╰╴ unsigned 64bit integer
+├╴at tests/common.rs:4:5
+├╴backtrace (1)
+├╴span trace with 2 frames (1)
+├╴unsigned 32bit integer
+╰╴unsigned 64bit integer
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_provider.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_provider.snap
@@ -5,7 +5,7 @@ expression: "format!(\"{report:?}\")"
 context D
 ├╴ usize: 420
 ├╴ &'static str: Invalid User Input
-├╴ at tests/test_debug.rs:594:38
+├╴ at tests/test_debug.rs:589:38
 │
 ╰─▶ root error
     ├╴ at tests/common.rs:4:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_provider.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__hook_provider.snap
@@ -3,14 +3,14 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context D
-├╴ usize: 420
-├╴ &'static str: Invalid User Input
-├╴ at tests/test_debug.rs:589:38
+├╴usize: 420
+├╴&'static str: Invalid User Input
+├╴at tests/test_debug.rs:589:38
 │
 ╰─▶ root error
-    ├╴ at tests/common.rs:4:5
-    ├╴ backtrace (1)
-    ╰╴ span trace with 2 frames (1)
+    ├╴at tests/common.rs:4:5
+    ├╴backtrace (1)
+    ╰╴span trace with 2 frames (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__linear.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__linear.snap
@@ -3,20 +3,20 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context B
-├╴ at tests/test_debug.rs:279:14
-├╴ printable C
+├╴at tests/test_debug.rs:279:14
+├╴printable C
 │
 ├─▶ context A
-│   ├╴ at tests/test_debug.rs:276:14
-│   ├╴ printable B
-│   ╰╴ 1 additional opaque attachment
+│   ├╴at tests/test_debug.rs:276:14
+│   ├╴printable B
+│   ╰╴1 additional opaque attachment
 │
 ╰─▶ root error
-    ├╴ at tests/common.rs:4:5
-    ├╴ backtrace (1)
-    ├╴ span trace with 2 frames (1)
-    ├╴ printable A
-    ╰╴ 2 additional opaque attachments
+    ├╴at tests/common.rs:4:5
+    ├╴backtrace (1)
+    ├╴span trace with 2 frames (1)
+    ├╴printable A
+    ╰╴2 additional opaque attachments
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__linear.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__linear.snap
@@ -3,11 +3,11 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context B
-├╴ at tests/test_debug.rs:284:14
+├╴ at tests/test_debug.rs:279:14
 ├╴ printable C
 │
 ├─▶ context A
-│   ├╴ at tests/test_debug.rs:281:14
+│   ├╴ at tests/test_debug.rs:276:14
 │   ├╴ printable B
 │   ╰╴ 1 additional opaque attachment
 │

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__linear_ext.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__linear_ext.snap
@@ -3,20 +3,20 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 context B
-├╴ at tests/test_debug.rs:296:14
-├╴ printable C
+├╴at tests/test_debug.rs:296:14
+├╴printable C
 │
 ├─▶ context A
-│   ├╴ at tests/test_debug.rs:293:14
-│   ├╴ printable B
-│   ╰╴ 1 additional opaque attachment
+│   ├╴at tests/test_debug.rs:293:14
+│   ├╴printable B
+│   ╰╴1 additional opaque attachment
 │
 ╰─▶ root error
-    ├╴ at tests/common.rs:4:5
-    ├╴ backtrace (1)
-    ├╴ span trace with 2 frames (1)
-    ├╴ printable A
-    ╰╴ 2 additional opaque attachments
+    ├╴at tests/common.rs:4:5
+    ├╴backtrace (1)
+    ├╴span trace with 2 frames (1)
+    ├╴printable A
+    ╰╴2 additional opaque attachments
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__linear_ext.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__linear_ext.snap
@@ -3,11 +3,11 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 context B
-├╴ at tests/test_debug.rs:301:14
+├╴ at tests/test_debug.rs:296:14
 ├╴ printable C
 │
 ├─▶ context A
-│   ├╴ at tests/test_debug.rs:298:14
+│   ├╴ at tests/test_debug.rs:293:14
 │   ├╴ printable B
 │   ╰╴ 1 additional opaque attachment
 │

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__multiline.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__multiline.snap
@@ -3,14 +3,14 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 root error
-├╴ at tests/common.rs:4:5
-├╴ backtrace (1)
-├╴ span trace with 2 frames (1)
-├╴ A multiline
+├╴at tests/common.rs:4:5
+├╴backtrace (1)
+├╴span trace with 2 frames (1)
+├╴A multiline
 │  attachment
 │  that might have some
 │  additional info
-╰╴ A multiline
+╰╴A multiline
    attachment
    that might have some
    additional info

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__multiline_context.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__multiline_context.snap
@@ -3,20 +3,20 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 context B
-├╴ at tests/test_debug.rs:326:14
+├╴ at tests/test_debug.rs:321:14
 ├╴ printable C
 │
 ├─▶ A multiline
 │   context that might have
 │   a bit more info
-│   ├╴ at tests/test_debug.rs:323:14
+│   ├╴ at tests/test_debug.rs:318:14
 │   ├╴ printable B
 │   ╰╴ 1 additional opaque attachment
 │
 ╰─▶ A multiline
     context that might have
     a bit more info
-    ├╴ at tests/test_debug.rs:322:22
+    ├╴ at tests/test_debug.rs:317:22
     ╰╴ backtrace (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__multiline_context.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__multiline_context.snap
@@ -3,21 +3,21 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 context B
-├╴ at tests/test_debug.rs:321:14
-├╴ printable C
+├╴at tests/test_debug.rs:321:14
+├╴printable C
 │
 ├─▶ A multiline
 │   context that might have
 │   a bit more info
-│   ├╴ at tests/test_debug.rs:318:14
-│   ├╴ printable B
-│   ╰╴ 1 additional opaque attachment
+│   ├╴at tests/test_debug.rs:318:14
+│   ├╴printable B
+│   ╰╴1 additional opaque attachment
 │
 ╰─▶ A multiline
     context that might have
     a bit more info
-    ├╴ at tests/test_debug.rs:317:22
-    ╰╴ backtrace (1)
+    ├╴at tests/test_debug.rs:317:22
+    ╰╴backtrace (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__norm.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__norm.snap
@@ -3,10 +3,10 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 root error
-├╴ at tests/common.rs:4:5
-├╴ backtrace (1)
-├╴ span trace with 2 frames (1)
-╰╴ Empty
+├╴at tests/common.rs:4:5
+├╴backtrace (1)
+├╴span trace with 2 frames (1)
+╰╴Empty
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__sources.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__sources.snap
@@ -3,29 +3,29 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴ at tests/test_debug.rs:366:14
-├╴ 1 additional opaque attachment
+├╴at tests/test_debug.rs:366:14
+├╴1 additional opaque attachment
 │
 ╰┬▶ root error
- │  ├╴ at tests/common.rs:4:5
- │  ├╴ backtrace (1)
- │  ├╴ span trace with 2 frames (1)
- │  ├╴ printable A
- │  ╰╴ 1 additional opaque attachment
+ │  ├╴at tests/common.rs:4:5
+ │  ├╴backtrace (1)
+ │  ├╴span trace with 2 frames (1)
+ │  ├╴printable A
+ │  ╰╴1 additional opaque attachment
  │
  ├▶ root error
- │  ├╴ at tests/common.rs:4:5
- │  ├╴ backtrace (2)
- │  ├╴ span trace with 2 frames (2)
- │  ├╴ printable B
- │  ╰╴ 1 additional opaque attachment
+ │  ├╴at tests/common.rs:4:5
+ │  ├╴backtrace (2)
+ │  ├╴span trace with 2 frames (2)
+ │  ├╴printable B
+ │  ╰╴1 additional opaque attachment
  │
  ╰▶ root error
-    ├╴ at tests/common.rs:4:5
-    ├╴ backtrace (3)
-    ├╴ span trace with 2 frames (3)
-    ├╴ printable B
-    ╰╴ 1 additional opaque attachment
+    ├╴at tests/common.rs:4:5
+    ├╴backtrace (3)
+    ├╴span trace with 2 frames (3)
+    ├╴printable B
+    ╰╴1 additional opaque attachment
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__sources.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__sources.snap
@@ -3,7 +3,7 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴ at tests/test_debug.rs:371:14
+├╴ at tests/test_debug.rs:366:14
 ├╴ 1 additional opaque attachment
 │
 ╰┬▶ root error

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__sources_transparent.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__sources_transparent.snap
@@ -3,7 +3,7 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴ at tests/test_debug.rs:412:18
+├╴ at tests/test_debug.rs:407:18
 ├╴ 1 additional opaque attachment
 │
 ╰┬▶ root error

--- a/packages/libs/error-stack/tests/snapshots/test_debug__full__sources_transparent.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__full__sources_transparent.snap
@@ -3,31 +3,31 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴ at tests/test_debug.rs:407:18
-├╴ 1 additional opaque attachment
+├╴at tests/test_debug.rs:407:18
+├╴1 additional opaque attachment
 │
 ╰┬▶ root error
- │  ├╴ at tests/common.rs:4:5
- │  ├╴ backtrace (1)
- │  ├╴ span trace with 2 frames (1)
- │  ├╴ printable A
- │  ╰╴ 1 additional opaque attachment
+ │  ├╴at tests/common.rs:4:5
+ │  ├╴backtrace (1)
+ │  ├╴span trace with 2 frames (1)
+ │  ├╴printable A
+ │  ╰╴1 additional opaque attachment
  │
  ├▶ root error
- │  ├╴ at tests/common.rs:4:5
- │  ├╴ backtrace (2)
- │  ├╴ span trace with 2 frames (2)
- │  ├╴ printable B
- │  ├╴ printable A
- │  ╰╴ 1 additional opaque attachment
+ │  ├╴at tests/common.rs:4:5
+ │  ├╴backtrace (2)
+ │  ├╴span trace with 2 frames (2)
+ │  ├╴printable B
+ │  ├╴printable A
+ │  ╰╴1 additional opaque attachment
  │
  ╰▶ root error
-    ├╴ at tests/common.rs:4:5
-    ├╴ backtrace (3)
-    ├╴ span trace with 2 frames (3)
-    ├╴ printable B
-    ├╴ printable A
-    ╰╴ 1 additional opaque attachment
+    ├╴at tests/common.rs:4:5
+    ├╴backtrace (3)
+    ├╴span trace with 2 frames (3)
+    ├╴printable B
+    ├╴printable A
+    ╰╴1 additional opaque attachment
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴ at tests/test_debug.rs:211:10
+├╴ at tests/test_debug.rs:207:10
 ├╴ 2
 ├╴ 1
 │
 ╰┬▶ context A
- │  ├╴ at tests/test_debug.rs:205:10
+ │  ├╴ at tests/test_debug.rs:201:10
  │  ├╴ 4
  │  ├╴ 3
  │  │
@@ -17,16 +17,16 @@ context A
  │      ╰╴ 6
  │
  ╰▶ context A
-    ├╴ at tests/test_debug.rs:200:10
+    ├╴ at tests/test_debug.rs:196:10
     ├╴ 5
     ├╴ 3
     │
     ├─▶ context A
-    │   ├╴ at tests/test_debug.rs:198:10
+    │   ├╴ at tests/test_debug.rs:194:10
     │   ╰╴ 7
     │
     ╰┬▶ context A
-     │  ├╴ at tests/test_debug.rs:189:34
+     │  ├╴ at tests/test_debug.rs:185:34
      │  ├╴ 9
      │  ├╴ 8
      │  │
@@ -34,7 +34,7 @@ context A
      │      ╰╴ at tests/common.rs:4:5
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:183:10
+     │  ├╴ at tests/test_debug.rs:179:10
      │  ├╴ 13
      │  ├╴ 10
      │  ├╴ 16
@@ -45,7 +45,7 @@ context A
      │      ╰╴ at tests/common.rs:4:5
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:169:10
+     │  ├╴ at tests/test_debug.rs:165:10
      │  ├╴ 15
      │  ├╴ 14
      │  ├╴ 10
@@ -57,7 +57,7 @@ context A
      │      ╰╴ at tests/common.rs:4:5
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:179:10
+     │  ├╴ at tests/test_debug.rs:175:10
      │  ├╴ 11
      │  ├╴ 9
      │  ├╴ 8
@@ -66,13 +66,13 @@ context A
      │      ╰╴ at tests/common.rs:4:5
      │
      ╰▶ context A
-        ├╴ at tests/test_debug.rs:175:10
+        ├╴ at tests/test_debug.rs:171:10
         ├╴ 12
         ├╴ 9
         ├╴ 8
         │
         ├─▶ context A
-        │   ╰╴ at tests/test_debug.rs:174:10
+        │   ╰╴ at tests/test_debug.rs:170:10
         │
         ╰─▶ root error
             ╰╴ at tests/common.rs:4:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested.snap
@@ -3,76 +3,76 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴ at tests/test_debug.rs:207:10
-├╴ 2
-├╴ 1
+├╴at tests/test_debug.rs:207:10
+├╴2
+├╴1
 │
 ╰┬▶ context A
- │  ├╴ at tests/test_debug.rs:201:10
- │  ├╴ 4
- │  ├╴ 3
+ │  ├╴at tests/test_debug.rs:201:10
+ │  ├╴4
+ │  ├╴3
  │  │
  │  ╰─▶ root error
- │      ├╴ at tests/common.rs:4:5
- │      ╰╴ 6
+ │      ├╴at tests/common.rs:4:5
+ │      ╰╴6
  │
  ╰▶ context A
-    ├╴ at tests/test_debug.rs:196:10
-    ├╴ 5
-    ├╴ 3
+    ├╴at tests/test_debug.rs:196:10
+    ├╴5
+    ├╴3
     │
     ├─▶ context A
-    │   ├╴ at tests/test_debug.rs:194:10
-    │   ╰╴ 7
+    │   ├╴at tests/test_debug.rs:194:10
+    │   ╰╴7
     │
     ╰┬▶ context A
-     │  ├╴ at tests/test_debug.rs:185:34
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:185:34
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ╰╴ at tests/common.rs:4:5
+     │      ╰╴at tests/common.rs:4:5
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:179:10
-     │  ├╴ 13
-     │  ├╴ 10
-     │  ├╴ 16
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:179:10
+     │  ├╴13
+     │  ├╴10
+     │  ├╴16
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ╰╴ at tests/common.rs:4:5
+     │      ╰╴at tests/common.rs:4:5
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:165:10
-     │  ├╴ 15
-     │  ├╴ 14
-     │  ├╴ 10
-     │  ├╴ 16
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:165:10
+     │  ├╴15
+     │  ├╴14
+     │  ├╴10
+     │  ├╴16
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ╰╴ at tests/common.rs:4:5
+     │      ╰╴at tests/common.rs:4:5
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:175:10
-     │  ├╴ 11
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:175:10
+     │  ├╴11
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ╰╴ at tests/common.rs:4:5
+     │      ╰╴at tests/common.rs:4:5
      │
      ╰▶ context A
-        ├╴ at tests/test_debug.rs:171:10
-        ├╴ 12
-        ├╴ 9
-        ├╴ 8
+        ├╴at tests/test_debug.rs:171:10
+        ├╴12
+        ├╴9
+        ├╴8
         │
         ├─▶ context A
-        │   ╰╴ at tests/test_debug.rs:170:10
+        │   ╰╴at tests/test_debug.rs:170:10
         │
         ╰─▶ root error
-            ╰╴ at tests/common.rs:4:5
+            ╰╴at tests/common.rs:4:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@backtrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@backtrace.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴ at tests/test_debug.rs:211:10
+├╴ at tests/test_debug.rs:207:10
 ├╴ 2
 ├╴ 1
 │
 ╰┬▶ context A
- │  ├╴ at tests/test_debug.rs:205:10
+ │  ├╴ at tests/test_debug.rs:201:10
  │  ├╴ 4
  │  ├╴ 3
  │  │
@@ -18,16 +18,16 @@ context A
  │      ╰╴ 6
  │
  ╰▶ context A
-    ├╴ at tests/test_debug.rs:200:10
+    ├╴ at tests/test_debug.rs:196:10
     ├╴ 5
     ├╴ 3
     │
     ├─▶ context A
-    │   ├╴ at tests/test_debug.rs:198:10
+    │   ├╴ at tests/test_debug.rs:194:10
     │   ╰╴ 7
     │
     ╰┬▶ context A
-     │  ├╴ at tests/test_debug.rs:189:34
+     │  ├╴ at tests/test_debug.rs:185:34
      │  ├╴ 9
      │  ├╴ 8
      │  │
@@ -36,7 +36,7 @@ context A
      │      ╰╴ backtrace (2)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:183:10
+     │  ├╴ at tests/test_debug.rs:179:10
      │  ├╴ 13
      │  ├╴ 10
      │  ├╴ 16
@@ -48,7 +48,7 @@ context A
      │      ╰╴ backtrace (3)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:169:10
+     │  ├╴ at tests/test_debug.rs:165:10
      │  ├╴ 15
      │  ├╴ 14
      │  ├╴ 10
@@ -61,7 +61,7 @@ context A
      │      ╰╴ backtrace (4)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:179:10
+     │  ├╴ at tests/test_debug.rs:175:10
      │  ├╴ 11
      │  ├╴ 9
      │  ├╴ 8
@@ -71,13 +71,13 @@ context A
      │      ╰╴ backtrace (5)
      │
      ╰▶ context A
-        ├╴ at tests/test_debug.rs:175:10
+        ├╴ at tests/test_debug.rs:171:10
         ├╴ 12
         ├╴ 9
         ├╴ 8
         │
         ├─▶ context A
-        │   ╰╴ at tests/test_debug.rs:174:10
+        │   ╰╴ at tests/test_debug.rs:170:10
         │
         ╰─▶ root error
             ├╴ at tests/common.rs:4:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@backtrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@backtrace.snap
@@ -3,85 +3,85 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴ at tests/test_debug.rs:207:10
-├╴ 2
-├╴ 1
+├╴at tests/test_debug.rs:207:10
+├╴2
+├╴1
 │
 ╰┬▶ context A
- │  ├╴ at tests/test_debug.rs:201:10
- │  ├╴ 4
- │  ├╴ 3
+ │  ├╴at tests/test_debug.rs:201:10
+ │  ├╴4
+ │  ├╴3
  │  │
  │  ╰─▶ root error
- │      ├╴ at tests/common.rs:4:5
- │      ├╴ backtrace (1)
- │      ╰╴ 6
+ │      ├╴at tests/common.rs:4:5
+ │      ├╴backtrace (1)
+ │      ╰╴6
  │
  ╰▶ context A
-    ├╴ at tests/test_debug.rs:196:10
-    ├╴ 5
-    ├╴ 3
+    ├╴at tests/test_debug.rs:196:10
+    ├╴5
+    ├╴3
     │
     ├─▶ context A
-    │   ├╴ at tests/test_debug.rs:194:10
-    │   ╰╴ 7
+    │   ├╴at tests/test_debug.rs:194:10
+    │   ╰╴7
     │
     ╰┬▶ context A
-     │  ├╴ at tests/test_debug.rs:185:34
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:185:34
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ╰╴ backtrace (2)
+     │      ├╴at tests/common.rs:4:5
+     │      ╰╴backtrace (2)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:179:10
-     │  ├╴ 13
-     │  ├╴ 10
-     │  ├╴ 16
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:179:10
+     │  ├╴13
+     │  ├╴10
+     │  ├╴16
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ╰╴ backtrace (3)
+     │      ├╴at tests/common.rs:4:5
+     │      ╰╴backtrace (3)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:165:10
-     │  ├╴ 15
-     │  ├╴ 14
-     │  ├╴ 10
-     │  ├╴ 16
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:165:10
+     │  ├╴15
+     │  ├╴14
+     │  ├╴10
+     │  ├╴16
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ╰╴ backtrace (4)
+     │      ├╴at tests/common.rs:4:5
+     │      ╰╴backtrace (4)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:175:10
-     │  ├╴ 11
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:175:10
+     │  ├╴11
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ╰╴ backtrace (5)
+     │      ├╴at tests/common.rs:4:5
+     │      ╰╴backtrace (5)
      │
      ╰▶ context A
-        ├╴ at tests/test_debug.rs:171:10
-        ├╴ 12
-        ├╴ 9
-        ├╴ 8
+        ├╴at tests/test_debug.rs:171:10
+        ├╴12
+        ├╴9
+        ├╴8
         │
         ├─▶ context A
-        │   ╰╴ at tests/test_debug.rs:170:10
+        │   ╰╴at tests/test_debug.rs:170:10
         │
         ╰─▶ root error
-            ├╴ at tests/common.rs:4:5
-            ╰╴ backtrace (6)
+            ├╴at tests/common.rs:4:5
+            ╰╴backtrace (6)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace-backtrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace-backtrace.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴ at tests/test_debug.rs:211:10
+├╴ at tests/test_debug.rs:207:10
 ├╴ 2
 ├╴ 1
 │
 ╰┬▶ context A
- │  ├╴ at tests/test_debug.rs:205:10
+ │  ├╴ at tests/test_debug.rs:201:10
  │  ├╴ 4
  │  ├╴ 3
  │  │
@@ -19,16 +19,16 @@ context A
  │      ╰╴ 6
  │
  ╰▶ context A
-    ├╴ at tests/test_debug.rs:200:10
+    ├╴ at tests/test_debug.rs:196:10
     ├╴ 5
     ├╴ 3
     │
     ├─▶ context A
-    │   ├╴ at tests/test_debug.rs:198:10
+    │   ├╴ at tests/test_debug.rs:194:10
     │   ╰╴ 7
     │
     ╰┬▶ context A
-     │  ├╴ at tests/test_debug.rs:189:34
+     │  ├╴ at tests/test_debug.rs:185:34
      │  ├╴ 9
      │  ├╴ 8
      │  │
@@ -38,7 +38,7 @@ context A
      │      ╰╴ span trace with 2 frames (2)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:183:10
+     │  ├╴ at tests/test_debug.rs:179:10
      │  ├╴ 13
      │  ├╴ 10
      │  ├╴ 16
@@ -51,7 +51,7 @@ context A
      │      ╰╴ span trace with 2 frames (3)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:169:10
+     │  ├╴ at tests/test_debug.rs:165:10
      │  ├╴ 15
      │  ├╴ 14
      │  ├╴ 10
@@ -65,7 +65,7 @@ context A
      │      ╰╴ span trace with 2 frames (4)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:179:10
+     │  ├╴ at tests/test_debug.rs:175:10
      │  ├╴ 11
      │  ├╴ 9
      │  ├╴ 8
@@ -76,13 +76,13 @@ context A
      │      ╰╴ span trace with 2 frames (5)
      │
      ╰▶ context A
-        ├╴ at tests/test_debug.rs:175:10
+        ├╴ at tests/test_debug.rs:171:10
         ├╴ 12
         ├╴ 9
         ├╴ 8
         │
         ├─▶ context A
-        │   ╰╴ at tests/test_debug.rs:174:10
+        │   ╰╴ at tests/test_debug.rs:170:10
         │
         ╰─▶ root error
             ├╴ at tests/common.rs:4:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace-backtrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace-backtrace.snap
@@ -3,91 +3,91 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴ at tests/test_debug.rs:207:10
-├╴ 2
-├╴ 1
+├╴at tests/test_debug.rs:207:10
+├╴2
+├╴1
 │
 ╰┬▶ context A
- │  ├╴ at tests/test_debug.rs:201:10
- │  ├╴ 4
- │  ├╴ 3
+ │  ├╴at tests/test_debug.rs:201:10
+ │  ├╴4
+ │  ├╴3
  │  │
  │  ╰─▶ root error
- │      ├╴ at tests/common.rs:4:5
- │      ├╴ backtrace (1)
- │      ├╴ span trace with 2 frames (1)
- │      ╰╴ 6
+ │      ├╴at tests/common.rs:4:5
+ │      ├╴backtrace (1)
+ │      ├╴span trace with 2 frames (1)
+ │      ╰╴6
  │
  ╰▶ context A
-    ├╴ at tests/test_debug.rs:196:10
-    ├╴ 5
-    ├╴ 3
+    ├╴at tests/test_debug.rs:196:10
+    ├╴5
+    ├╴3
     │
     ├─▶ context A
-    │   ├╴ at tests/test_debug.rs:194:10
-    │   ╰╴ 7
+    │   ├╴at tests/test_debug.rs:194:10
+    │   ╰╴7
     │
     ╰┬▶ context A
-     │  ├╴ at tests/test_debug.rs:185:34
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:185:34
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ├╴ backtrace (2)
-     │      ╰╴ span trace with 2 frames (2)
+     │      ├╴at tests/common.rs:4:5
+     │      ├╴backtrace (2)
+     │      ╰╴span trace with 2 frames (2)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:179:10
-     │  ├╴ 13
-     │  ├╴ 10
-     │  ├╴ 16
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:179:10
+     │  ├╴13
+     │  ├╴10
+     │  ├╴16
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ├╴ backtrace (3)
-     │      ╰╴ span trace with 2 frames (3)
+     │      ├╴at tests/common.rs:4:5
+     │      ├╴backtrace (3)
+     │      ╰╴span trace with 2 frames (3)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:165:10
-     │  ├╴ 15
-     │  ├╴ 14
-     │  ├╴ 10
-     │  ├╴ 16
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:165:10
+     │  ├╴15
+     │  ├╴14
+     │  ├╴10
+     │  ├╴16
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ├╴ backtrace (4)
-     │      ╰╴ span trace with 2 frames (4)
+     │      ├╴at tests/common.rs:4:5
+     │      ├╴backtrace (4)
+     │      ╰╴span trace with 2 frames (4)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:175:10
-     │  ├╴ 11
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:175:10
+     │  ├╴11
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ├╴ backtrace (5)
-     │      ╰╴ span trace with 2 frames (5)
+     │      ├╴at tests/common.rs:4:5
+     │      ├╴backtrace (5)
+     │      ╰╴span trace with 2 frames (5)
      │
      ╰▶ context A
-        ├╴ at tests/test_debug.rs:171:10
-        ├╴ 12
-        ├╴ 9
-        ├╴ 8
+        ├╴at tests/test_debug.rs:171:10
+        ├╴12
+        ├╴9
+        ├╴8
         │
         ├─▶ context A
-        │   ╰╴ at tests/test_debug.rs:170:10
+        │   ╰╴at tests/test_debug.rs:170:10
         │
         ╰─▶ root error
-            ├╴ at tests/common.rs:4:5
-            ├╴ backtrace (6)
-            ╰╴ span trace with 2 frames (6)
+            ├╴at tests/common.rs:4:5
+            ├╴backtrace (6)
+            ╰╴span trace with 2 frames (6)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace.snap
@@ -3,85 +3,85 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴ at tests/test_debug.rs:207:10
-├╴ 2
-├╴ 1
+├╴at tests/test_debug.rs:207:10
+├╴2
+├╴1
 │
 ╰┬▶ context A
- │  ├╴ at tests/test_debug.rs:201:10
- │  ├╴ 4
- │  ├╴ 3
+ │  ├╴at tests/test_debug.rs:201:10
+ │  ├╴4
+ │  ├╴3
  │  │
  │  ╰─▶ root error
- │      ├╴ at tests/common.rs:4:5
- │      ├╴ span trace with 2 frames (1)
- │      ╰╴ 6
+ │      ├╴at tests/common.rs:4:5
+ │      ├╴span trace with 2 frames (1)
+ │      ╰╴6
  │
  ╰▶ context A
-    ├╴ at tests/test_debug.rs:196:10
-    ├╴ 5
-    ├╴ 3
+    ├╴at tests/test_debug.rs:196:10
+    ├╴5
+    ├╴3
     │
     ├─▶ context A
-    │   ├╴ at tests/test_debug.rs:194:10
-    │   ╰╴ 7
+    │   ├╴at tests/test_debug.rs:194:10
+    │   ╰╴7
     │
     ╰┬▶ context A
-     │  ├╴ at tests/test_debug.rs:185:34
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:185:34
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ╰╴ span trace with 2 frames (2)
+     │      ├╴at tests/common.rs:4:5
+     │      ╰╴span trace with 2 frames (2)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:179:10
-     │  ├╴ 13
-     │  ├╴ 10
-     │  ├╴ 16
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:179:10
+     │  ├╴13
+     │  ├╴10
+     │  ├╴16
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ╰╴ span trace with 2 frames (3)
+     │      ├╴at tests/common.rs:4:5
+     │      ╰╴span trace with 2 frames (3)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:165:10
-     │  ├╴ 15
-     │  ├╴ 14
-     │  ├╴ 10
-     │  ├╴ 16
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:165:10
+     │  ├╴15
+     │  ├╴14
+     │  ├╴10
+     │  ├╴16
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ╰╴ span trace with 2 frames (4)
+     │      ├╴at tests/common.rs:4:5
+     │      ╰╴span trace with 2 frames (4)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:175:10
-     │  ├╴ 11
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:175:10
+     │  ├╴11
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ╰╴ span trace with 2 frames (5)
+     │      ├╴at tests/common.rs:4:5
+     │      ╰╴span trace with 2 frames (5)
      │
      ╰▶ context A
-        ├╴ at tests/test_debug.rs:171:10
-        ├╴ 12
-        ├╴ 9
-        ├╴ 8
+        ├╴at tests/test_debug.rs:171:10
+        ├╴12
+        ├╴9
+        ├╴8
         │
         ├─▶ context A
-        │   ╰╴ at tests/test_debug.rs:170:10
+        │   ╰╴at tests/test_debug.rs:170:10
         │
         ╰─▶ root error
-            ├╴ at tests/common.rs:4:5
-            ╰╴ span trace with 2 frames (6)
+            ├╴at tests/common.rs:4:5
+            ╰╴span trace with 2 frames (6)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴ at tests/test_debug.rs:211:10
+├╴ at tests/test_debug.rs:207:10
 ├╴ 2
 ├╴ 1
 │
 ╰┬▶ context A
- │  ├╴ at tests/test_debug.rs:205:10
+ │  ├╴ at tests/test_debug.rs:201:10
  │  ├╴ 4
  │  ├╴ 3
  │  │
@@ -18,16 +18,16 @@ context A
  │      ╰╴ 6
  │
  ╰▶ context A
-    ├╴ at tests/test_debug.rs:200:10
+    ├╴ at tests/test_debug.rs:196:10
     ├╴ 5
     ├╴ 3
     │
     ├─▶ context A
-    │   ├╴ at tests/test_debug.rs:198:10
+    │   ├╴ at tests/test_debug.rs:194:10
     │   ╰╴ 7
     │
     ╰┬▶ context A
-     │  ├╴ at tests/test_debug.rs:189:34
+     │  ├╴ at tests/test_debug.rs:185:34
      │  ├╴ 9
      │  ├╴ 8
      │  │
@@ -36,7 +36,7 @@ context A
      │      ╰╴ span trace with 2 frames (2)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:183:10
+     │  ├╴ at tests/test_debug.rs:179:10
      │  ├╴ 13
      │  ├╴ 10
      │  ├╴ 16
@@ -48,7 +48,7 @@ context A
      │      ╰╴ span trace with 2 frames (3)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:169:10
+     │  ├╴ at tests/test_debug.rs:165:10
      │  ├╴ 15
      │  ├╴ 14
      │  ├╴ 10
@@ -61,7 +61,7 @@ context A
      │      ╰╴ span trace with 2 frames (4)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:179:10
+     │  ├╴ at tests/test_debug.rs:175:10
      │  ├╴ 11
      │  ├╴ 9
      │  ├╴ 8
@@ -71,13 +71,13 @@ context A
      │      ╰╴ span trace with 2 frames (5)
      │
      ╰▶ context A
-        ├╴ at tests/test_debug.rs:175:10
+        ├╴ at tests/test_debug.rs:171:10
         ├╴ 12
         ├╴ 9
         ├╴ 8
         │
         ├─▶ context A
-        │   ╰╴ at tests/test_debug.rs:174:10
+        │   ╰╴ at tests/test_debug.rs:170:10
         │
         ╰─▶ root error
             ├╴ at tests/common.rs:4:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 context A
-├╴ at tests/test_debug.rs:211:10
+├╴ at tests/test_debug.rs:207:10
 ├╴ 2
 ├╴ 1
 │
 ╰┬▶ context A
- │  ├╴ at tests/test_debug.rs:205:10
+ │  ├╴ at tests/test_debug.rs:201:10
  │  ├╴ 4
  │  ├╴ 3
  │  │
@@ -17,16 +17,16 @@ context A
  │      ╰╴ 6
  │
  ╰▶ context A
-    ├╴ at tests/test_debug.rs:200:10
+    ├╴ at tests/test_debug.rs:196:10
     ├╴ 5
     ├╴ 3
     │
     ├─▶ context A
-    │   ├╴ at tests/test_debug.rs:198:10
+    │   ├╴ at tests/test_debug.rs:194:10
     │   ╰╴ 7
     │
     ╰┬▶ context A
-     │  ├╴ at tests/test_debug.rs:189:34
+     │  ├╴ at tests/test_debug.rs:185:34
      │  ├╴ 9
      │  ├╴ 8
      │  │
@@ -34,7 +34,7 @@ context A
      │      ╰╴ at tests/common.rs:4:5
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:183:10
+     │  ├╴ at tests/test_debug.rs:179:10
      │  ├╴ 13
      │  ├╴ 10
      │  ├╴ 16
@@ -45,7 +45,7 @@ context A
      │      ╰╴ at tests/common.rs:4:5
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:169:10
+     │  ├╴ at tests/test_debug.rs:165:10
      │  ├╴ 15
      │  ├╴ 14
      │  ├╴ 10
@@ -57,7 +57,7 @@ context A
      │      ╰╴ at tests/common.rs:4:5
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:179:10
+     │  ├╴ at tests/test_debug.rs:175:10
      │  ├╴ 11
      │  ├╴ 9
      │  ├╴ 8
@@ -66,13 +66,13 @@ context A
      │      ╰╴ at tests/common.rs:4:5
      │
      ╰▶ context A
-        ├╴ at tests/test_debug.rs:175:10
+        ├╴ at tests/test_debug.rs:171:10
         ├╴ 12
         ├╴ 9
         ├╴ 8
         │
         ├─▶ context A
-        │   ╰╴ at tests/test_debug.rs:174:10
+        │   ╰╴ at tests/test_debug.rs:170:10
         │
         ╰─▶ root error
             ╰╴ at tests/common.rs:4:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate.snap
@@ -3,76 +3,76 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 context A
-├╴ at tests/test_debug.rs:207:10
-├╴ 2
-├╴ 1
+├╴at tests/test_debug.rs:207:10
+├╴2
+├╴1
 │
 ╰┬▶ context A
- │  ├╴ at tests/test_debug.rs:201:10
- │  ├╴ 4
- │  ├╴ 3
+ │  ├╴at tests/test_debug.rs:201:10
+ │  ├╴4
+ │  ├╴3
  │  │
  │  ╰─▶ root error
- │      ├╴ at tests/common.rs:4:5
- │      ╰╴ 6
+ │      ├╴at tests/common.rs:4:5
+ │      ╰╴6
  │
  ╰▶ context A
-    ├╴ at tests/test_debug.rs:196:10
-    ├╴ 5
-    ├╴ 3
+    ├╴at tests/test_debug.rs:196:10
+    ├╴5
+    ├╴3
     │
     ├─▶ context A
-    │   ├╴ at tests/test_debug.rs:194:10
-    │   ╰╴ 7
+    │   ├╴at tests/test_debug.rs:194:10
+    │   ╰╴7
     │
     ╰┬▶ context A
-     │  ├╴ at tests/test_debug.rs:185:34
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:185:34
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ╰╴ at tests/common.rs:4:5
+     │      ╰╴at tests/common.rs:4:5
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:179:10
-     │  ├╴ 13
-     │  ├╴ 10
-     │  ├╴ 16
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:179:10
+     │  ├╴13
+     │  ├╴10
+     │  ├╴16
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ╰╴ at tests/common.rs:4:5
+     │      ╰╴at tests/common.rs:4:5
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:165:10
-     │  ├╴ 15
-     │  ├╴ 14
-     │  ├╴ 10
-     │  ├╴ 16
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:165:10
+     │  ├╴15
+     │  ├╴14
+     │  ├╴10
+     │  ├╴16
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ╰╴ at tests/common.rs:4:5
+     │      ╰╴at tests/common.rs:4:5
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:175:10
-     │  ├╴ 11
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:175:10
+     │  ├╴11
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ╰╴ at tests/common.rs:4:5
+     │      ╰╴at tests/common.rs:4:5
      │
      ╰▶ context A
-        ├╴ at tests/test_debug.rs:171:10
-        ├╴ 12
-        ├╴ 9
-        ├╴ 8
+        ├╴at tests/test_debug.rs:171:10
+        ├╴12
+        ├╴9
+        ├╴8
         │
         ├─▶ context A
-        │   ╰╴ at tests/test_debug.rs:170:10
+        │   ╰╴at tests/test_debug.rs:170:10
         │
         ╰─▶ root error
-            ╰╴ at tests/common.rs:4:5
+            ╰╴at tests/common.rs:4:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@backtrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@backtrace.snap
@@ -3,85 +3,85 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 context A
-├╴ at tests/test_debug.rs:207:10
-├╴ 2
-├╴ 1
+├╴at tests/test_debug.rs:207:10
+├╴2
+├╴1
 │
 ╰┬▶ context A
- │  ├╴ at tests/test_debug.rs:201:10
- │  ├╴ 4
- │  ├╴ 3
+ │  ├╴at tests/test_debug.rs:201:10
+ │  ├╴4
+ │  ├╴3
  │  │
  │  ╰─▶ root error
- │      ├╴ at tests/common.rs:4:5
- │      ├╴ backtrace (1)
- │      ╰╴ 6
+ │      ├╴at tests/common.rs:4:5
+ │      ├╴backtrace (1)
+ │      ╰╴6
  │
  ╰▶ context A
-    ├╴ at tests/test_debug.rs:196:10
-    ├╴ 5
-    ├╴ 3
+    ├╴at tests/test_debug.rs:196:10
+    ├╴5
+    ├╴3
     │
     ├─▶ context A
-    │   ├╴ at tests/test_debug.rs:194:10
-    │   ╰╴ 7
+    │   ├╴at tests/test_debug.rs:194:10
+    │   ╰╴7
     │
     ╰┬▶ context A
-     │  ├╴ at tests/test_debug.rs:185:34
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:185:34
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ╰╴ backtrace (2)
+     │      ├╴at tests/common.rs:4:5
+     │      ╰╴backtrace (2)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:179:10
-     │  ├╴ 13
-     │  ├╴ 10
-     │  ├╴ 16
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:179:10
+     │  ├╴13
+     │  ├╴10
+     │  ├╴16
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ╰╴ backtrace (3)
+     │      ├╴at tests/common.rs:4:5
+     │      ╰╴backtrace (3)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:165:10
-     │  ├╴ 15
-     │  ├╴ 14
-     │  ├╴ 10
-     │  ├╴ 16
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:165:10
+     │  ├╴15
+     │  ├╴14
+     │  ├╴10
+     │  ├╴16
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ╰╴ backtrace (4)
+     │      ├╴at tests/common.rs:4:5
+     │      ╰╴backtrace (4)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:175:10
-     │  ├╴ 11
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:175:10
+     │  ├╴11
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ╰╴ backtrace (5)
+     │      ├╴at tests/common.rs:4:5
+     │      ╰╴backtrace (5)
      │
      ╰▶ context A
-        ├╴ at tests/test_debug.rs:171:10
-        ├╴ 12
-        ├╴ 9
-        ├╴ 8
+        ├╴at tests/test_debug.rs:171:10
+        ├╴12
+        ├╴9
+        ├╴8
         │
         ├─▶ context A
-        │   ╰╴ at tests/test_debug.rs:170:10
+        │   ╰╴at tests/test_debug.rs:170:10
         │
         ╰─▶ root error
-            ├╴ at tests/common.rs:4:5
-            ╰╴ backtrace (6)
+            ├╴at tests/common.rs:4:5
+            ╰╴backtrace (6)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@backtrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@backtrace.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 context A
-├╴ at tests/test_debug.rs:211:10
+├╴ at tests/test_debug.rs:207:10
 ├╴ 2
 ├╴ 1
 │
 ╰┬▶ context A
- │  ├╴ at tests/test_debug.rs:205:10
+ │  ├╴ at tests/test_debug.rs:201:10
  │  ├╴ 4
  │  ├╴ 3
  │  │
@@ -18,16 +18,16 @@ context A
  │      ╰╴ 6
  │
  ╰▶ context A
-    ├╴ at tests/test_debug.rs:200:10
+    ├╴ at tests/test_debug.rs:196:10
     ├╴ 5
     ├╴ 3
     │
     ├─▶ context A
-    │   ├╴ at tests/test_debug.rs:198:10
+    │   ├╴ at tests/test_debug.rs:194:10
     │   ╰╴ 7
     │
     ╰┬▶ context A
-     │  ├╴ at tests/test_debug.rs:189:34
+     │  ├╴ at tests/test_debug.rs:185:34
      │  ├╴ 9
      │  ├╴ 8
      │  │
@@ -36,7 +36,7 @@ context A
      │      ╰╴ backtrace (2)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:183:10
+     │  ├╴ at tests/test_debug.rs:179:10
      │  ├╴ 13
      │  ├╴ 10
      │  ├╴ 16
@@ -48,7 +48,7 @@ context A
      │      ╰╴ backtrace (3)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:169:10
+     │  ├╴ at tests/test_debug.rs:165:10
      │  ├╴ 15
      │  ├╴ 14
      │  ├╴ 10
@@ -61,7 +61,7 @@ context A
      │      ╰╴ backtrace (4)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:179:10
+     │  ├╴ at tests/test_debug.rs:175:10
      │  ├╴ 11
      │  ├╴ 9
      │  ├╴ 8
@@ -71,13 +71,13 @@ context A
      │      ╰╴ backtrace (5)
      │
      ╰▶ context A
-        ├╴ at tests/test_debug.rs:175:10
+        ├╴ at tests/test_debug.rs:171:10
         ├╴ 12
         ├╴ 9
         ├╴ 8
         │
         ├─▶ context A
-        │   ╰╴ at tests/test_debug.rs:174:10
+        │   ╰╴ at tests/test_debug.rs:170:10
         │
         ╰─▶ root error
             ├╴ at tests/common.rs:4:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace-backtrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace-backtrace.snap
@@ -3,91 +3,91 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 context A
-├╴ at tests/test_debug.rs:207:10
-├╴ 2
-├╴ 1
+├╴at tests/test_debug.rs:207:10
+├╴2
+├╴1
 │
 ╰┬▶ context A
- │  ├╴ at tests/test_debug.rs:201:10
- │  ├╴ 4
- │  ├╴ 3
+ │  ├╴at tests/test_debug.rs:201:10
+ │  ├╴4
+ │  ├╴3
  │  │
  │  ╰─▶ root error
- │      ├╴ at tests/common.rs:4:5
- │      ├╴ backtrace (1)
- │      ├╴ span trace with 2 frames (1)
- │      ╰╴ 6
+ │      ├╴at tests/common.rs:4:5
+ │      ├╴backtrace (1)
+ │      ├╴span trace with 2 frames (1)
+ │      ╰╴6
  │
  ╰▶ context A
-    ├╴ at tests/test_debug.rs:196:10
-    ├╴ 5
-    ├╴ 3
+    ├╴at tests/test_debug.rs:196:10
+    ├╴5
+    ├╴3
     │
     ├─▶ context A
-    │   ├╴ at tests/test_debug.rs:194:10
-    │   ╰╴ 7
+    │   ├╴at tests/test_debug.rs:194:10
+    │   ╰╴7
     │
     ╰┬▶ context A
-     │  ├╴ at tests/test_debug.rs:185:34
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:185:34
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ├╴ backtrace (2)
-     │      ╰╴ span trace with 2 frames (2)
+     │      ├╴at tests/common.rs:4:5
+     │      ├╴backtrace (2)
+     │      ╰╴span trace with 2 frames (2)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:179:10
-     │  ├╴ 13
-     │  ├╴ 10
-     │  ├╴ 16
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:179:10
+     │  ├╴13
+     │  ├╴10
+     │  ├╴16
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ├╴ backtrace (3)
-     │      ╰╴ span trace with 2 frames (3)
+     │      ├╴at tests/common.rs:4:5
+     │      ├╴backtrace (3)
+     │      ╰╴span trace with 2 frames (3)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:165:10
-     │  ├╴ 15
-     │  ├╴ 14
-     │  ├╴ 10
-     │  ├╴ 16
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:165:10
+     │  ├╴15
+     │  ├╴14
+     │  ├╴10
+     │  ├╴16
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ├╴ backtrace (4)
-     │      ╰╴ span trace with 2 frames (4)
+     │      ├╴at tests/common.rs:4:5
+     │      ├╴backtrace (4)
+     │      ╰╴span trace with 2 frames (4)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:175:10
-     │  ├╴ 11
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:175:10
+     │  ├╴11
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ├╴ backtrace (5)
-     │      ╰╴ span trace with 2 frames (5)
+     │      ├╴at tests/common.rs:4:5
+     │      ├╴backtrace (5)
+     │      ╰╴span trace with 2 frames (5)
      │
      ╰▶ context A
-        ├╴ at tests/test_debug.rs:171:10
-        ├╴ 12
-        ├╴ 9
-        ├╴ 8
+        ├╴at tests/test_debug.rs:171:10
+        ├╴12
+        ├╴9
+        ├╴8
         │
         ├─▶ context A
-        │   ╰╴ at tests/test_debug.rs:170:10
+        │   ╰╴at tests/test_debug.rs:170:10
         │
         ╰─▶ root error
-            ├╴ at tests/common.rs:4:5
-            ├╴ backtrace (6)
-            ╰╴ span trace with 2 frames (6)
+            ├╴at tests/common.rs:4:5
+            ├╴backtrace (6)
+            ╰╴span trace with 2 frames (6)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace-backtrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace-backtrace.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 context A
-├╴ at tests/test_debug.rs:211:10
+├╴ at tests/test_debug.rs:207:10
 ├╴ 2
 ├╴ 1
 │
 ╰┬▶ context A
- │  ├╴ at tests/test_debug.rs:205:10
+ │  ├╴ at tests/test_debug.rs:201:10
  │  ├╴ 4
  │  ├╴ 3
  │  │
@@ -19,16 +19,16 @@ context A
  │      ╰╴ 6
  │
  ╰▶ context A
-    ├╴ at tests/test_debug.rs:200:10
+    ├╴ at tests/test_debug.rs:196:10
     ├╴ 5
     ├╴ 3
     │
     ├─▶ context A
-    │   ├╴ at tests/test_debug.rs:198:10
+    │   ├╴ at tests/test_debug.rs:194:10
     │   ╰╴ 7
     │
     ╰┬▶ context A
-     │  ├╴ at tests/test_debug.rs:189:34
+     │  ├╴ at tests/test_debug.rs:185:34
      │  ├╴ 9
      │  ├╴ 8
      │  │
@@ -38,7 +38,7 @@ context A
      │      ╰╴ span trace with 2 frames (2)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:183:10
+     │  ├╴ at tests/test_debug.rs:179:10
      │  ├╴ 13
      │  ├╴ 10
      │  ├╴ 16
@@ -51,7 +51,7 @@ context A
      │      ╰╴ span trace with 2 frames (3)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:169:10
+     │  ├╴ at tests/test_debug.rs:165:10
      │  ├╴ 15
      │  ├╴ 14
      │  ├╴ 10
@@ -65,7 +65,7 @@ context A
      │      ╰╴ span trace with 2 frames (4)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:179:10
+     │  ├╴ at tests/test_debug.rs:175:10
      │  ├╴ 11
      │  ├╴ 9
      │  ├╴ 8
@@ -76,13 +76,13 @@ context A
      │      ╰╴ span trace with 2 frames (5)
      │
      ╰▶ context A
-        ├╴ at tests/test_debug.rs:175:10
+        ├╴ at tests/test_debug.rs:171:10
         ├╴ 12
         ├╴ 9
         ├╴ 8
         │
         ├─▶ context A
-        │   ╰╴ at tests/test_debug.rs:174:10
+        │   ╰╴ at tests/test_debug.rs:170:10
         │
         ╰─▶ root error
             ├╴ at tests/common.rs:4:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 context A
-├╴ at tests/test_debug.rs:211:10
+├╴ at tests/test_debug.rs:207:10
 ├╴ 2
 ├╴ 1
 │
 ╰┬▶ context A
- │  ├╴ at tests/test_debug.rs:205:10
+ │  ├╴ at tests/test_debug.rs:201:10
  │  ├╴ 4
  │  ├╴ 3
  │  │
@@ -18,16 +18,16 @@ context A
  │      ╰╴ 6
  │
  ╰▶ context A
-    ├╴ at tests/test_debug.rs:200:10
+    ├╴ at tests/test_debug.rs:196:10
     ├╴ 5
     ├╴ 3
     │
     ├─▶ context A
-    │   ├╴ at tests/test_debug.rs:198:10
+    │   ├╴ at tests/test_debug.rs:194:10
     │   ╰╴ 7
     │
     ╰┬▶ context A
-     │  ├╴ at tests/test_debug.rs:189:34
+     │  ├╴ at tests/test_debug.rs:185:34
      │  ├╴ 9
      │  ├╴ 8
      │  │
@@ -36,7 +36,7 @@ context A
      │      ╰╴ span trace with 2 frames (2)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:183:10
+     │  ├╴ at tests/test_debug.rs:179:10
      │  ├╴ 13
      │  ├╴ 10
      │  ├╴ 16
@@ -48,7 +48,7 @@ context A
      │      ╰╴ span trace with 2 frames (3)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:169:10
+     │  ├╴ at tests/test_debug.rs:165:10
      │  ├╴ 15
      │  ├╴ 14
      │  ├╴ 10
@@ -61,7 +61,7 @@ context A
      │      ╰╴ span trace with 2 frames (4)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:179:10
+     │  ├╴ at tests/test_debug.rs:175:10
      │  ├╴ 11
      │  ├╴ 9
      │  ├╴ 8
@@ -71,13 +71,13 @@ context A
      │      ╰╴ span trace with 2 frames (5)
      │
      ╰▶ context A
-        ├╴ at tests/test_debug.rs:175:10
+        ├╴ at tests/test_debug.rs:171:10
         ├╴ 12
         ├╴ 9
         ├╴ 8
         │
         ├─▶ context A
-        │   ╰╴ at tests/test_debug.rs:174:10
+        │   ╰╴ at tests/test_debug.rs:170:10
         │
         ╰─▶ root error
             ├╴ at tests/common.rs:4:5

--- a/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace.snap
+++ b/packages/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace.snap
@@ -3,85 +3,85 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 context A
-├╴ at tests/test_debug.rs:207:10
-├╴ 2
-├╴ 1
+├╴at tests/test_debug.rs:207:10
+├╴2
+├╴1
 │
 ╰┬▶ context A
- │  ├╴ at tests/test_debug.rs:201:10
- │  ├╴ 4
- │  ├╴ 3
+ │  ├╴at tests/test_debug.rs:201:10
+ │  ├╴4
+ │  ├╴3
  │  │
  │  ╰─▶ root error
- │      ├╴ at tests/common.rs:4:5
- │      ├╴ span trace with 2 frames (1)
- │      ╰╴ 6
+ │      ├╴at tests/common.rs:4:5
+ │      ├╴span trace with 2 frames (1)
+ │      ╰╴6
  │
  ╰▶ context A
-    ├╴ at tests/test_debug.rs:196:10
-    ├╴ 5
-    ├╴ 3
+    ├╴at tests/test_debug.rs:196:10
+    ├╴5
+    ├╴3
     │
     ├─▶ context A
-    │   ├╴ at tests/test_debug.rs:194:10
-    │   ╰╴ 7
+    │   ├╴at tests/test_debug.rs:194:10
+    │   ╰╴7
     │
     ╰┬▶ context A
-     │  ├╴ at tests/test_debug.rs:185:34
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:185:34
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ╰╴ span trace with 2 frames (2)
+     │      ├╴at tests/common.rs:4:5
+     │      ╰╴span trace with 2 frames (2)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:179:10
-     │  ├╴ 13
-     │  ├╴ 10
-     │  ├╴ 16
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:179:10
+     │  ├╴13
+     │  ├╴10
+     │  ├╴16
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ╰╴ span trace with 2 frames (3)
+     │      ├╴at tests/common.rs:4:5
+     │      ╰╴span trace with 2 frames (3)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:165:10
-     │  ├╴ 15
-     │  ├╴ 14
-     │  ├╴ 10
-     │  ├╴ 16
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:165:10
+     │  ├╴15
+     │  ├╴14
+     │  ├╴10
+     │  ├╴16
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ╰╴ span trace with 2 frames (4)
+     │      ├╴at tests/common.rs:4:5
+     │      ╰╴span trace with 2 frames (4)
      │
      ├▶ context A
-     │  ├╴ at tests/test_debug.rs:175:10
-     │  ├╴ 11
-     │  ├╴ 9
-     │  ├╴ 8
+     │  ├╴at tests/test_debug.rs:175:10
+     │  ├╴11
+     │  ├╴9
+     │  ├╴8
      │  │
      │  ╰─▶ root error
-     │      ├╴ at tests/common.rs:4:5
-     │      ╰╴ span trace with 2 frames (5)
+     │      ├╴at tests/common.rs:4:5
+     │      ╰╴span trace with 2 frames (5)
      │
      ╰▶ context A
-        ├╴ at tests/test_debug.rs:171:10
-        ├╴ 12
-        ├╴ 9
-        ├╴ 8
+        ├╴at tests/test_debug.rs:171:10
+        ├╴12
+        ├╴9
+        ├╴8
         │
         ├─▶ context A
-        │   ╰╴ at tests/test_debug.rs:170:10
+        │   ╰╴at tests/test_debug.rs:170:10
         │
         ╰─▶ root error
-            ├╴ at tests/common.rs:4:5
-            ╰╴ span trace with 2 frames (6)
+            ├╴at tests/common.rs:4:5
+            ╰╴span trace with 2 frames (6)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/libs/error-stack/tests/test_debug.rs
+++ b/packages/libs/error-stack/tests/test_debug.rs
@@ -6,9 +6,7 @@
 mod common;
 
 use common::*;
-use error_stack::fmt::Charset;
-#[cfg(feature = "color")]
-use error_stack::fmt::ColorMode;
+use error_stack::fmt::{Charset, ColorMode};
 #[allow(unused_imports)]
 use error_stack::Report;
 use insta::assert_snapshot;
@@ -41,7 +39,6 @@ fn setup_backtrace() {
     std::env::set_var("RUST_LIB_BACKTRACE", "1");
 }
 
-#[cfg(feature = "color")]
 fn setup_color() {
     Report::set_color_mode(ColorMode::None);
 }
@@ -49,7 +46,6 @@ fn setup_color() {
 fn setup() {
     setup_tracing();
     setup_backtrace();
-    #[cfg(feature = "color")]
     setup_color();
     Report::set_charset(Charset::Utf8);
 }
@@ -236,8 +232,7 @@ fn sources_nested_alternate() {
 #[cfg(all(
     rust_1_65,
     any(feature = "std", feature = "hooks"),
-    feature = "spantrace",
-    feature = "color"
+    feature = "spantrace"
 ))]
 mod full {
     //! Why so many cfg guards?


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Remove `owo-colors` as a dependency. This means we can push the enable `colors` support without an extra feature! `owo-colors` is being replaced with a vendored solution that does the same thing, only more correct.

This also implements the suggestion from https://github.com/hashintel/hash/pull/1800#discussion_r1089753480

### Why remove `owo-colors`?

Don't get me wrong, `owo-colors` is a great crate, but for our purposes is a bit too heavy. 

Initially, we chose `owo-colors` because of the convenience, and we thought that it might provide Windows support (my bad 😅) and automatic detection of color support.

In 0.3, we have removed automatic detection support and discovered that `owo-colors` does not - in fact - provide Windows support. In that case, it is pretty easy to create an alternative with a similar level of convenience, and after going on an adventure 🥾  with @TimDiekmann through the lands of Windows 11 terminals and discovered that pretty much every built-in terminal either supports ANSI escape sequences natively out-of-the-box, or it can be enabled (on older installations).

### Correctness of `owo-colors`

What about correctness? After looking through snapshots I have discovered that for style attributes like `bold` or `italic` `owo-colors` actually does the wrong thing when resetting the styles. I will be posting a follow-up PR for `owo-colors`, but due to it being passively maintained I think there's a low chance it will be in time for 0.3 anyway.

![image](https://user-images.githubusercontent.com/7252775/215569683-2bf9bd12-7076-4fcc-a7c1-f2c2b3545767.png)

The problem: when using style attributes like `bold` (`\e[1m`) or `italic` (`\e[3m`) when you want to end the portion of text there are two options:
1) nuclear: `\e[0m`, this removes all formatting (`owo-colors` uses this)
2) 🎩 gentleman: `\e[22m` (not `bold`), `\e[23m` (not `italic`), instead of removing and resetting everything it just disables bold or italic respectively, allowing for nested styles and even colored text in italic text (not possible with the nuclear option)

We also compress as much as possible, meaning that `bold italic` is not `\e[1m\e[3m` but instead `\e[1;3m`. Small optimization, but a nice one c:

## 👂 Open Questions

I went ahead and just implemented all ANSI escape sequences, they are currently lacking tests (coming soon), but most are currently unused. Should we remove the ones that are not needed or future-proof the solution?

Do we want to expose the coloring methods through `error-stack`?

> IMO, no, if we want to go ahead with something like that, it should go in a separate crate

## 🔗 Related links

## 📹 Demo

