### PR TITLE
Add check to CI to compare Semantic Version prior releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   linting:
     name: Linting
     # Run only on push to `main` or `trunk_merge/**` or on pull requests
-    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
+    if: ${{ (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/trunk-merge/'))) || github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -220,7 +220,7 @@ jobs:
   playwright-tests:
     name: Playwright tests
     # Run only on push to `main` or `trunk_merge/**` or on pull requests
-    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
+    if: ${{ (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/trunk-merge/'))) || github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -316,6 +316,7 @@ jobs:
           cargo quickinstall cargo-make --version 0.36.3
           cargo quickinstall cargo-hack --version 0.5.26
           cargo quickinstall cargo-nextest --version 0.9.37
+          cargo quickinstall cargo-semver-checks --version 0.17.0
 
       - name: Run lints
         if: github.event_name == 'pull_request'
@@ -331,6 +332,11 @@ jobs:
         run: |
           [[ -n "${{ secrets.CARGO_REGISTRY_TOKEN }}" ]]
           cargo login "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+
+      - name: SemVer check
+        if: github.event_name == 'pull_request'
+        working-directory: ${{ matrix.directory }}
+        run: cargo +${{ matrix.toolchain }} semver-checks check-release
 
       - name: Publish (dry run)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -309,7 +309,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
 
       - name: Install tools
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/') || github.event_name == 'pull_request' }}
+        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
         shell: bash
         run: |
           cargo install cargo-quickinstall
@@ -319,12 +319,12 @@ jobs:
           cargo quickinstall cargo-semver-checks --version 0.17.0
 
       - name: Run lints
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/') || github.event_name == 'pull_request' }}
+        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
         working-directory: ${{ matrix.directory }}
         run: cargo +${{ matrix.toolchain }} make --profile ${{ matrix.profile }} lint
 
       - name: Run tests
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/') || github.event_name == 'pull_request' }}
+        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
         working-directory: ${{ matrix.directory }}
         run: cargo +${{ matrix.toolchain }} make --profile ${{ matrix.profile }} test --no-fail-fast
 
@@ -334,12 +334,12 @@ jobs:
           cargo login "${{ secrets.CARGO_REGISTRY_TOKEN }}"
 
       - name: SemVer check
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/') || github.event_name == 'pull_request' }}
+        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
         working-directory: ${{ matrix.directory }}
         run: cargo +${{ matrix.toolchain }} semver-checks check-release
 
       - name: Publish (dry run)
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/') || github.event_name == 'pull_request' }}
+        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
         working-directory: ${{ matrix.directory }}
         run: cargo +${{ matrix.toolchain }} publish --all-features --dry-run
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -309,7 +309,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
 
       - name: Install tools
-        if: github.event_name == 'pull_request'
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/') || github.event_name == 'pull_request' }}
         shell: bash
         run: |
           cargo install cargo-quickinstall
@@ -319,12 +319,12 @@ jobs:
           cargo quickinstall cargo-semver-checks --version 0.17.0
 
       - name: Run lints
-        if: github.event_name == 'pull_request'
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/') || github.event_name == 'pull_request' }}
         working-directory: ${{ matrix.directory }}
         run: cargo +${{ matrix.toolchain }} make --profile ${{ matrix.profile }} lint
 
       - name: Run tests
-        if: github.event_name == 'pull_request'
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/') || github.event_name == 'pull_request' }}
         working-directory: ${{ matrix.directory }}
         run: cargo +${{ matrix.toolchain }} make --profile ${{ matrix.profile }} test --no-fail-fast
 
@@ -334,12 +334,12 @@ jobs:
           cargo login "${{ secrets.CARGO_REGISTRY_TOKEN }}"
 
       - name: SemVer check
-        if: github.event_name == 'pull_request'
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/') || github.event_name == 'pull_request' }}
         working-directory: ${{ matrix.directory }}
         run: cargo +${{ matrix.toolchain }} semver-checks check-release
 
       - name: Publish (dry run)
-        if: github.event_name == 'pull_request'
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/') || github.event_name == 'pull_request' }}
         working-directory: ${{ matrix.directory }}
         run: cargo +${{ matrix.toolchain }} publish --all-features --dry-run
 

--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["package.json"]
 
 [package]
 name = "error-stack"
-version = "0.2.5"
+version = "0.2.4"
 authors = ["HASH"]
 edition = "2021"
 rust-version = "1.63.0"

--- a/packages/libs/error-stack/Cargo.toml
+++ b/packages/libs/error-stack/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["package.json"]
 
 [package]
 name = "error-stack"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["HASH"]
 edition = "2021"
 rust-version = "1.63.0"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

[`cargo-semver-checks`](https://crates.io/crates/cargo-semver-checks) is a small tool, which checks if the version to be released is SemVer conform.

## 🔍 What does this change?

- Installs `cargo-semver-checks` in the `publish` CI job
- Checks for SemVer conform version bump
- Attempt to publish a breaking release with a minor version bump: 5992696d8dc31db6835e2bdb6c9732fa348011b0 (reverted in 2f18ccc340bb99209857558d23e4d3818cf587c1)
- Drive-by: Run the `publish` job in trunk CI as well

## 📹 Demo

```
   Updating index
     Parsing error-stack v0.2.5 (current)
     Parsing error-stack v0.2.4 (baseline)
    Checking error-stack v0.2.4 -> v0.2.5 (minor change)
   Completed [   0.161s] 35 checks; 33 passed, 2 failed, 5 unnecessary

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.17.0/src/queries/inherent_method_missing.ron

Failed in:
  Frame::location, previously in file /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/error-stack-0.2.4/src/frame/mod.rs:39
  Frame::source, previously in file /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/error-stack-0.2.4/src/frame/mod.rs:46
  Frame::source_mut, previously in file /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/error-stack-0.2.4/src/frame/mod.rs:63
  Report::backtrace, previously in file /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/error-stack-0.2.4/src/report.rs:288
  Report::span_trace, previously in file /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/error-stack-0.2.4/src/report.rs:311
  Report::set_debug_hook, previously in file /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/error-stack-0.2.4/src/hook.rs:231
  Report::set_display_hook, previously in file /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/error-stack-0.2.4/src/hook.rs:290

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.17.0/src/queries/struct_missing.ron

Failed in:
  struct error_stack::HookAlreadySet, previously in file /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/error-stack-0.2.4/src/hook.rs:24
  struct error_stack::fmt::HookContext, previously in file /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/error-stack-0.2.4/src/fmt/hook.rs:267
       Final [   0.186s] semver requires new major version: 2 major and 0 minor checks failed
```
