### PR TITLE
`error-stack`: clarify documentation of `HookContext`

### DIFF
--- a/packages/libs/error-stack/src/fmt/hook.rs
+++ b/packages/libs/error-stack/src/fmt/hook.rs
@@ -13,9 +13,9 @@ use core::mem;
 pub(crate) use default::install_builtin_hooks;
 
 #[cfg(any(feature = "std", feature = "hooks"))]
-use crate::fmt::Frame;
-use crate::fmt::{charset::Charset, ColorMode};
+use crate::fmt::{charset::Charset, ColorMode, Frame};
 
+#[cfg(any(feature = "std", feature = "hooks"))]
 pub(crate) struct Format {
     alternate: bool,
 
@@ -26,6 +26,7 @@ pub(crate) struct Format {
     appendix: Vec<String>,
 }
 
+#[cfg(any(feature = "std", feature = "hooks"))]
 impl Format {
     pub(crate) const fn new(alternate: bool, color: ColorMode, charset: Charset) -> Self {
         Self {
@@ -461,12 +462,10 @@ impl Hooks {
 }
 
 mod default {
-    #![allow(unused_imports)]
-
-    use alloc::{format, string::ToString, vec, vec::Vec};
+    #[cfg(any(all(feature = "std", rust_1_65), feature = "spantrace"))]
+    use alloc::format;
+    use alloc::string::ToString;
     use core::{
-        any::TypeId,
-        fmt::Write,
         panic::Location,
         sync::atomic::{AtomicBool, Ordering},
     };
@@ -475,20 +474,14 @@ mod default {
     #[cfg(feature = "std")]
     use std::sync::Once;
 
-    #[cfg(feature = "color")]
-    use owo_colors::OwoColorize;
     #[cfg(all(not(feature = "std"), feature = "hooks"))]
     use spin::once::Once;
     #[cfg(feature = "spantrace")]
     use tracing_error::SpanTrace;
 
     use crate::{
-        fmt::{
-            hook::{into_boxed_hook, BoxedHook, HookContext},
-            location::LocationDisplay,
-            ColorMode,
-        },
-        Frame, Report,
+        fmt::{hook::HookContext, location::LocationDisplay},
+        Report,
     };
 
     pub(crate) fn install_builtin_hooks() {

--- a/packages/libs/error-stack/src/fmt/hook.rs
+++ b/packages/libs/error-stack/src/fmt/hook.rs
@@ -50,185 +50,187 @@ impl Format {
     }
 }
 
-/// Carrier for contextual information used across hook invocations.
-///
-/// `HookContext` has two fundamental use-cases:
-/// 1) Adding body entries and appendix entries
-/// 2) Storage
-///
-/// ## Adding body entries and appendix entries
-///
-/// A [`Debug`] backtrace consists of two different sections, a rendered tree of objects (the
-/// **body**) and additional text/information that is too large to fit into the tree (the
-/// **appendix**).
-///
-/// Entries for the body can be attached to the rendered tree of objects via
-/// [`HookContext::push_body`]. An appendix entry can be attached via
-/// [`HookContext::push_appendix`].
-///
-/// [`Debug`]: core::fmt::Debug
-///
-/// ### Example
-///
-/// ```rust
-/// # // we only test with Rust 1.65, which means that `render()` is unused on earlier version
-/// # #![cfg_attr(not(rust_1_65), allow(dead_code, unused_variables, unused_imports))]
-/// use std::io::{Error, ErrorKind};
-///
-/// use error_stack::Report;
-///
-/// struct Warning(&'static str);
-/// struct HttpResponseStatusCode(u64);
-/// struct Suggestion(&'static str);
-/// struct Secret(&'static str);
-///
-/// Report::install_debug_hook::<HttpResponseStatusCode>(|HttpResponseStatusCode(value), context| {
-///     // Create a new appendix, which is going to be displayed when someone requests the alternate
-///     // version (`:#?`) of the report.
-///     if context.alternate() {
-///         context.push_appendix(format!("error {value}: {} error", if *value < 500 {"client"} else {"server"}))
-///     }
-///
-///     // This will push a new entry onto the body with the specified value
-///     context.push_body(format!("error code: {value}"));
-/// });
-///
-/// Report::install_debug_hook::<Suggestion>(|Suggestion(value), context| {
-///     let idx = context.increment_counter();
-///
-///     // Create a new appendix, which is going to be displayed when someone requests the alternate
-///     // version (`:#?`) of the report.
-///     if context.alternate() {
-///         context.push_body(format!("suggestion {idx}:\n  {value}"));
-///     }
-///
-///     // This will push a new entry onto the body with the specified value
-///     context.push_body(format!("suggestion ({idx})"));
-/// });
-///
-/// Report::install_debug_hook::<Warning>(|Warning(value), context| {
-///     // You can add multiples entries to the body (and appendix) in the same hook.
-///     context.push_body("abnormal program execution detected");
-///     context.push_body(format!("warning: {value}"));
-/// });
-///
-/// // By not adding anything you are able to hide an attachment
-/// // (it will still be counted towards opaque attachments)
-/// Report::install_debug_hook::<Secret>(|_, _| {});
-///
-/// let report = Report::new(Error::from(ErrorKind::InvalidInput))
-///     .attach(HttpResponseStatusCode(404))
-///     .attach(Suggestion("do you have a connection to the internet?"))
-///     .attach(HttpResponseStatusCode(405))
-///     .attach(Warning("unable to determine environment"))
-///     .attach(Secret("pssst, don't tell anyone else c;"))
-///     .attach(Suggestion("execute the program from the fish shell"))
-///     .attach(HttpResponseStatusCode(501))
-///     .attach(Suggestion("try better next time!"));
-///
-/// # Report::set_color_mode(error_stack::fmt::ColorMode::Color);
-/// # fn render(value: String) -> String {
-/// #     let backtrace = regex::Regex::new(r"backtrace no\. (\d+)\n(?:  .*\n)*  .*").unwrap();
-/// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
-/// #
-/// #     let value = backtrace.replace_all(&value, "backtrace no. $1\n  [redacted]");
-/// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
-/// #
-/// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
-/// # }
-/// #
-/// # #[cfg(rust_1_65)]
-/// # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__emit.snap")].assert_eq(&render(format!("{report:?}")));
-/// #
-/// println!("{report:?}");
-///
-/// # #[cfg(rust_1_65)]
-/// # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__emit_alt.snap")].assert_eq(&render(format!("{report:#?}")));
-/// #
-/// println!("{report:#?}");
-/// ```
-///
-/// The output of `println!("{report:?}")`:
-///
-/// <pre>
-#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__emit.snap"))]
-/// </pre>
-///
-/// The output of `println!("{report:#?}")`:
-///
-/// <pre>
-#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__emit_alt.snap"))]
-/// </pre>
-///
-/// ## Storage
-///
-/// `HookContext` can be used to store and retrieve values that are going to be used on multiple
-/// hook invocations in a single [`Debug`] call.
-///
-/// Every hook can request their corresponding `HookContext`.
-/// This is especially useful for incrementing/decrementing values, but can also be used to store
-/// any arbitrary value for the duration of the [`Debug`] invocation.
-///
-/// All data stored in `HookContext` is completely separated from all other hooks and can store
-/// any arbitrary data of any type, and even data of multiple types at the same time.
-///
-/// ### Example
-///
-/// ```rust
-/// # // we only test with Rust 1.65, which means that `render()` is unused on earlier version
-/// # #![cfg_attr(not(rust_1_65), allow(dead_code, unused_variables, unused_imports))]
-/// use std::io::ErrorKind;
-///
-/// use error_stack::Report;
-///
-/// struct Computation(u64);
-///
-/// Report::install_debug_hook::<Computation>(|Computation(value), context| {
-///     // Get a value of type `u64`, if we didn't insert one yet, default to 0
-///     let mut acc = context.get::<u64>().copied().unwrap_or(0);
-///     acc += *value;
-///
-///     // Get a value of type `f64`, if we didn't insert one yet, default to 1.0
-///     let mut div = context.get::<f32>().copied().unwrap_or(1.0);
-///     div /= *value as f32;
-///
-///     // Insert the calculated `u64` and `f32` back into storage, so that we can use them
-///     // in the invocations following this one (for the same `Debug` call)
-///     context.insert(acc);
-///     context.insert(div);
-///
-///     context.push_body(format!(
-///         "computation for {value} (acc = {acc}, div = {div})"
-///     ));
-/// });
-///
-/// let report = Report::new(std::io::Error::from(ErrorKind::InvalidInput))
-///     .attach(Computation(2))
-///     .attach(Computation(3));
-///
-/// # Report::set_color_mode(error_stack::fmt::ColorMode::Color);
-/// # fn render(value: String) -> String {
-/// #     let backtrace = regex::Regex::new(r"backtrace no\. (\d+)\n(?:  .*\n)*  .*").unwrap();
-/// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
-/// #
-/// #     let value = backtrace.replace_all(&value, "backtrace no. $1\n  [redacted]");
-/// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
-/// #
-/// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
-/// # }
-/// #
-/// # #[cfg(rust_1_65)]
-/// # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_storage.snap")].assert_eq(&render(format!("{report:?}")));
-/// #
-/// println!("{report:?}");
-/// ```
-///
-/// <pre>
-#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_storage.snap"))]
-/// </pre>
-///
-/// [`Debug`]: core::fmt::Debug
-pub type HookContext<T> = crate::hook::context::HookContext<Format, T>;
+crate::hook::context::impl_hook_context! {
+    /// Carrier for contextual information used across hook invocations.
+    ///
+    /// `HookContext` has two fundamental use-cases:
+    /// 1) Adding body entries and appendix entries
+    /// 2) Storage
+    ///
+    /// ## Adding body entries and appendix entries
+    ///
+    /// A [`Debug`] backtrace consists of two different sections, a rendered tree of objects (the
+    /// **body**) and additional text/information that is too large to fit into the tree (the
+    /// **appendix**).
+    ///
+    /// Entries for the body can be attached to the rendered tree of objects via
+    /// [`HookContext::push_body`]. An appendix entry can be attached via
+    /// [`HookContext::push_appendix`].
+    ///
+    /// [`Debug`]: core::fmt::Debug
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// # // we only test with Rust 1.65, which means that `render()` is unused on earlier version
+    /// # #![cfg_attr(not(rust_1_65), allow(dead_code, unused_variables, unused_imports))]
+    /// use std::io::{Error, ErrorKind};
+    ///
+    /// use error_stack::Report;
+    ///
+    /// struct Warning(&'static str);
+    /// struct HttpResponseStatusCode(u64);
+    /// struct Suggestion(&'static str);
+    /// struct Secret(&'static str);
+    ///
+    /// Report::install_debug_hook::<HttpResponseStatusCode>(|HttpResponseStatusCode(value), context| {
+    ///     // Create a new appendix, which is going to be displayed when someone requests the alternate
+    ///     // version (`:#?`) of the report.
+    ///     if context.alternate() {
+    ///         context.push_appendix(format!("error {value}: {} error", if *value < 500 {"client"} else {"server"}))
+    ///     }
+    ///
+    ///     // This will push a new entry onto the body with the specified value
+    ///     context.push_body(format!("error code: {value}"));
+    /// });
+    ///
+    /// Report::install_debug_hook::<Suggestion>(|Suggestion(value), context| {
+    ///     let idx = context.increment_counter();
+    ///
+    ///     // Create a new appendix, which is going to be displayed when someone requests the alternate
+    ///     // version (`:#?`) of the report.
+    ///     if context.alternate() {
+    ///         context.push_body(format!("suggestion {idx}:\n  {value}"));
+    ///     }
+    ///
+    ///     // This will push a new entry onto the body with the specified value
+    ///     context.push_body(format!("suggestion ({idx})"));
+    /// });
+    ///
+    /// Report::install_debug_hook::<Warning>(|Warning(value), context| {
+    ///     // You can add multiples entries to the body (and appendix) in the same hook.
+    ///     context.push_body("abnormal program execution detected");
+    ///     context.push_body(format!("warning: {value}"));
+    /// });
+    ///
+    /// // By not adding anything you are able to hide an attachment
+    /// // (it will still be counted towards opaque attachments)
+    /// Report::install_debug_hook::<Secret>(|_, _| {});
+    ///
+    /// let report = Report::new(Error::from(ErrorKind::InvalidInput))
+    ///     .attach(HttpResponseStatusCode(404))
+    ///     .attach(Suggestion("do you have a connection to the internet?"))
+    ///     .attach(HttpResponseStatusCode(405))
+    ///     .attach(Warning("unable to determine environment"))
+    ///     .attach(Secret("pssst, don't tell anyone else c;"))
+    ///     .attach(Suggestion("execute the program from the fish shell"))
+    ///     .attach(HttpResponseStatusCode(501))
+    ///     .attach(Suggestion("try better next time!"));
+    ///
+    /// # Report::set_color_mode(error_stack::fmt::ColorMode::Color);
+    /// # fn render(value: String) -> String {
+    /// #     let backtrace = regex::Regex::new(r"backtrace no\. (\d+)\n(?:  .*\n)*  .*").unwrap();
+    /// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
+    /// #
+    /// #     let value = backtrace.replace_all(&value, "backtrace no. $1\n  [redacted]");
+    /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
+    /// #
+    /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
+    /// # }
+    /// #
+    /// # #[cfg(rust_1_65)]
+    /// # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__emit.snap")].assert_eq(&render(format!("{report:?}")));
+    /// #
+    /// println!("{report:?}");
+    ///
+    /// # #[cfg(rust_1_65)]
+    /// # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__emit_alt.snap")].assert_eq(&render(format!("{report:#?}")));
+    /// #
+    /// println!("{report:#?}");
+    /// ```
+    ///
+    /// The output of `println!("{report:?}")`:
+    ///
+    /// <pre>
+    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__emit.snap"))]
+    /// </pre>
+    ///
+    /// The output of `println!("{report:#?}")`:
+    ///
+    /// <pre>
+    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__emit_alt.snap"))]
+    /// </pre>
+    ///
+    /// ## Storage
+    ///
+    /// `HookContext` can be used to store and retrieve values that are going to be used on multiple
+    /// hook invocations in a single [`Debug`] call.
+    ///
+    /// Every hook can request their corresponding `HookContext`.
+    /// This is especially useful for incrementing/decrementing values, but can also be used to store
+    /// any arbitrary value for the duration of the [`Debug`] invocation.
+    ///
+    /// All data stored in `HookContext` is completely separated from all other hooks and can store
+    /// any arbitrary data of any type, and even data of multiple types at the same time.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// # // we only test with Rust 1.65, which means that `render()` is unused on earlier version
+    /// # #![cfg_attr(not(rust_1_65), allow(dead_code, unused_variables, unused_imports))]
+    /// use std::io::ErrorKind;
+    ///
+    /// use error_stack::Report;
+    ///
+    /// struct Computation(u64);
+    ///
+    /// Report::install_debug_hook::<Computation>(|Computation(value), context| {
+    ///     // Get a value of type `u64`, if we didn't insert one yet, default to 0
+    ///     let mut acc = context.get::<u64>().copied().unwrap_or(0);
+    ///     acc += *value;
+    ///
+    ///     // Get a value of type `f64`, if we didn't insert one yet, default to 1.0
+    ///     let mut div = context.get::<f32>().copied().unwrap_or(1.0);
+    ///     div /= *value as f32;
+    ///
+    ///     // Insert the calculated `u64` and `f32` back into storage, so that we can use them
+    ///     // in the invocations following this one (for the same `Debug` call)
+    ///     context.insert(acc);
+    ///     context.insert(div);
+    ///
+    ///     context.push_body(format!(
+    ///         "computation for {value} (acc = {acc}, div = {div})"
+    ///     ));
+    /// });
+    ///
+    /// let report = Report::new(std::io::Error::from(ErrorKind::InvalidInput))
+    ///     .attach(Computation(2))
+    ///     .attach(Computation(3));
+    ///
+    /// # Report::set_color_mode(error_stack::fmt::ColorMode::Color);
+    /// # fn render(value: String) -> String {
+    /// #     let backtrace = regex::Regex::new(r"backtrace no\. (\d+)\n(?:  .*\n)*  .*").unwrap();
+    /// #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
+    /// #
+    /// #     let value = backtrace.replace_all(&value, "backtrace no. $1\n  [redacted]");
+    /// #     let value = backtrace_info.replace_all(value.as_ref(), "backtrace ($3)");
+    /// #
+    /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
+    /// # }
+    /// #
+    /// # #[cfg(rust_1_65)]
+    /// # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_storage.snap")].assert_eq(&render(format!("{report:?}")));
+    /// #
+    /// println!("{report:?}");
+    /// ```
+    ///
+    /// <pre>
+    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_storage.snap"))]
+    /// </pre>
+    ///
+    /// [`Debug`]: core::fmt::Debug
+    pub struct HookContext<Format> { .. }
+}
 
 impl<T> HookContext<T> {
     pub(crate) fn appendix(&self) -> &[String] {

--- a/packages/libs/error-stack/src/fmt/hook.rs
+++ b/packages/libs/error-stack/src/fmt/hook.rs
@@ -3,19 +3,13 @@
 // implementation: `pub(crate)` and `pub`.
 #![cfg_attr(not(feature = "std"), allow(unreachable_pub))]
 
-#[cfg(any(feature = "std", feature = "hooks"))]
-use alloc::boxed::Box;
-use alloc::{string::String, vec::Vec};
-#[cfg(any(feature = "std", feature = "hooks"))]
-use core::any::TypeId;
-use core::mem;
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::{any::TypeId, mem};
 
 pub(crate) use default::install_builtin_hooks;
 
-#[cfg(any(feature = "std", feature = "hooks"))]
 use crate::fmt::{charset::Charset, ColorMode, Frame};
 
-#[cfg(any(feature = "std", feature = "hooks"))]
 pub(crate) struct Format {
     alternate: bool,
 
@@ -26,7 +20,6 @@ pub(crate) struct Format {
     appendix: Vec<String>,
 }
 
-#[cfg(any(feature = "std", feature = "hooks"))]
 impl Format {
     pub(crate) const fn new(alternate: bool, color: ColorMode, charset: Charset) -> Self {
         Self {
@@ -231,7 +224,6 @@ crate::hook::context::impl_hook_context! {
     pub struct HookContext<Format> { .. }
 }
 
-#[cfg(any(feature = "std", feature = "hooks"))]
 impl<T> HookContext<T> {
     pub(crate) fn appendix(&self) -> &[String] {
         self.inner().extra().appendix()
@@ -377,10 +369,8 @@ impl<T> HookContext<T> {
     }
 }
 
-#[cfg(any(feature = "std", feature = "hooks"))]
 type BoxedHook = Box<dyn Fn(&Frame, &mut HookContext<Frame>) -> bool + Send + Sync>;
 
-#[cfg(any(feature = "std", feature = "hooks"))]
 fn into_boxed_hook<T: Send + Sync + 'static>(
     hook: impl Fn(&T, &mut HookContext<T>) + Send + Sync + 'static,
 ) -> BoxedHook {
@@ -429,14 +419,12 @@ fn into_boxed_hook<T: Send + Sync + 'static>(
 /// [`Display`]: core::fmt::Display
 /// [`Debug`]: core::fmt::Debug
 /// [`.insert()`]: Hooks::insert
-#[cfg(any(feature = "std", feature = "hooks"))]
 pub(crate) struct Hooks {
     // We use `Vec`, instead of `HashMap` or `BTreeMap`, so that ordering is consistent with the
     // insertion order of types.
     pub(crate) inner: Vec<(TypeId, BoxedHook)>,
 }
 
-#[cfg(any(feature = "std", feature = "hooks"))]
 impl Hooks {
     pub(crate) fn insert<T: Send + Sync + 'static>(
         &mut self,

--- a/packages/libs/error-stack/src/hook/context.rs
+++ b/packages/libs/error-stack/src/hook/context.rs
@@ -67,13 +67,11 @@ macro_rules! impl_hook_context {
 //  is currently not implemented for repr(transparent).
 $(#[$meta])*
 #[cfg_attr(not(doc), repr(transparent))]
-#[cfg(any(feature = "std", feature = "hooks"))]
 $vis struct HookContext<T> {
     inner: $crate::hook::context::Inner<$extra>,
     _marker: core::marker::PhantomData<fn(&T)>,
 }
 
-#[cfg(any(feature = "std", feature = "hooks"))]
 impl HookContext<()> {
     pub(crate) fn new(extra: $extra) -> Self {
         Self {
@@ -83,7 +81,6 @@ impl HookContext<()> {
     }
 }
 
-#[cfg(any(feature = "std", feature = "hooks"))]
 impl<T> HookContext<T> {
     pub(crate) const fn inner(&self) -> &$crate::hook::context::Inner<$extra> {
         &self.inner

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -489,8 +489,16 @@ mod hook;
 #[cfg(feature = "serde")]
 mod serde;
 
-#[cfg(all(doc, any(feature = "std", feature = "hooks")))]
-pub use hook::context::HookContext;
+#[cfg(doc)]
+pub mod docs {
+    //! Documentation of unreachable public types
+    //!
+    //! These types are considered to be an implementation detail, but due to limitations of
+    //! rustdoc, `error-stack` is unable to render them inline.
+
+    #[cfg(any(feature = "std", feature = "hooks"))]
+    pub use crate::hook::context::HookContext;
+}
 
 pub use self::{
     compat::IntoReportCompat,

--- a/packages/libs/error-stack/src/lib.rs
+++ b/packages/libs/error-stack/src/lib.rs
@@ -489,17 +489,6 @@ mod hook;
 #[cfg(feature = "serde")]
 mod serde;
 
-#[cfg(doc)]
-pub mod docs {
-    //! Documentation of unreachable public types
-    //!
-    //! These types are considered to be an implementation detail, but due to limitations of
-    //! rustdoc, `error-stack` is unable to render them inline.
-
-    #[cfg(any(feature = "std", feature = "hooks"))]
-    pub use crate::hook::context::HookContext;
-}
-
 pub use self::{
     compat::IntoReportCompat,
     context::Context,

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_cast.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_cast.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span><span style='color:#555'>src/hook/context.rs:27:14</span>
+<span style='color:#a00'>├╴ </span><span style='color:#555'>src/fmt/hook.rs:27:14</span>
 <span style='color:#a00'>├╴ </span>backtrace (1)
 <span style='color:#a00'>├╴ </span>[1] [ERROR] unable to reach remote host
 <span style='color:#a00'>├╴ </span>[2] [WARN] disk nearly full

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_cast.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_cast.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴</span>at <span style='color:#555'>src/hook/context.rs:27:14</span>
+<span style='color:#a00'>├╴</span>at <span style='color:#555'>src/fmt/hook.rs:27:14</span>
 <span style='color:#a00'>├╴</span>backtrace (1)
 <span style='color:#a00'>├╴</span>[1] [ERROR] unable to reach remote host
 <span style='color:#a00'>├╴</span>[2] [WARN] disk nearly full

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_decrement.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_decrement.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴</span>at <span style='color:#555'>src/hook/context.rs:17:14</span>
+<span style='color:#a00'>├╴</span>at <span style='color:#555'>src/fmt/hook.rs:17:14</span>
 <span style='color:#a00'>├╴</span>backtrace (1)
 <span style='color:#a00'>├╴</span>suggestion -1: use a file you can read next time!
 <span style='color:#a00'>╰╴</span>suggestion -2: don&#39;t press any random keys!

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_decrement.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_decrement.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span><span style='color:#555'>src/hook/context.rs:17:14</span>
+<span style='color:#a00'>├╴ </span><span style='color:#555'>src/fmt/hook.rs:17:14</span>
 <span style='color:#a00'>├╴ </span>backtrace (1)
 <span style='color:#a00'>├╴ </span>suggestion -1: use a file you can read next time!
 <span style='color:#a00'>╰╴ </span>suggestion -2: don&#39;t press any random keys!

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_increment.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_increment.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴</span>at <span style='color:#555'>src/hook/context.rs:17:14</span>
+<span style='color:#a00'>├╴</span>at <span style='color:#555'>src/fmt/hook.rs:17:14</span>
 <span style='color:#a00'>├╴</span>backtrace (1)
 <span style='color:#a00'>├╴</span>suggestion 0: use a file you can read next time!
 <span style='color:#a00'>╰╴</span>suggestion 1: don&#39;t press any random keys!

--- a/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_increment.snap
+++ b/packages/libs/error-stack/tests/snapshots/doc/fmt__hookcontext_increment.snap
@@ -1,5 +1,5 @@
 <b>invalid input parameter</b>
-<span style='color:#a00'>├╴ </span><span style='color:#555'>src/hook/context.rs:17:14</span>
+<span style='color:#a00'>├╴ </span><span style='color:#555'>src/fmt/hook.rs:17:14</span>
 <span style='color:#a00'>├╴ </span>backtrace (1)
 <span style='color:#a00'>├╴ </span>suggestion 0: use a file you can read next time!
 <span style='color:#a00'>╰╴ </span>suggestion 1: don&#39;t press any random keys!


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#1693 separated `fmt::HookContext` into `hook::HookContext` and `fmt::HookContext`, so that it can be used in #1558. While working, the problem is that documentation doesn't render correctly because `hook::HookContext` is private in public. Therefore unreachable rustdoc is unable to navigate to the type, and the documentation is incomplete.

This PR moves to a macro-based approach to enable better documentation. Instead of using an unreachable public type, we have a macro that implements the necessary common functions. This is by far not ideal, but I found this to be the best way without compromising #1558 or future hooks.

