### PR TITLE
Fix Renovate not picking up toolchain for `hash-graph`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -73,7 +73,7 @@
       "matchManagers": ["regex"],
       "matchDepNames": ["rust"],
       "matchDepPatterns": ["(R|r)ust(-.+)?"],
-      "matchPaths": ["**/graph/**"],
+      "matchPaths": ["**/hash-graph/**"],
       "groupName": "graph",
       "commitMessageTopic": "Rust toolchain for `graph`"
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When moving `packages/graph` to `apps/hash-graph` we forgot to update the renovate config