### PR TITLE
Temporarily disable `Rust / publish` job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -350,7 +350,7 @@ jobs:
 
   merging-enabled:
     name: Merging enabled
-    needs: [setup, lint, test, coverage, docker, publish]
+    needs: [setup, lint, test, coverage, docker]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -291,62 +291,62 @@ jobs:
       - name: Ensure empty git diff
         run: git --no-pager diff --exit-code --color
 
-  publish:
-    name: publish
-    needs: setup
-    if: needs.setup.outputs.publish != '{}'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.setup.outputs.publish) }}
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v3
-
-      - name: Install Rust toolchain
-        uses: ./.github/actions/install-rust-toolchain
-        with:
-          toolchain: ${{ matrix.toolchain }}
-
-      - name: Install tools
-        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
-        shell: bash
-        run: |
-          cargo install cargo-quickinstall
-          cargo quickinstall cargo-make --version 0.36.3
-          cargo quickinstall cargo-hack --version 0.5.26
-          cargo quickinstall cargo-nextest --version 0.9.37
-          cargo quickinstall cargo-semver-checks --version 0.17.0
-
-      - name: Run lints
-        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
-        working-directory: ${{ matrix.directory }}
-        run: cargo +${{ matrix.toolchain }} make --profile ${{ matrix.profile }} lint
-
-      - name: Run tests
-        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
-        working-directory: ${{ matrix.directory }}
-        run: cargo +${{ matrix.toolchain }} make --profile ${{ matrix.profile }} test --no-fail-fast
-
-      - name: Login
-        run: |
-          [[ -n "${{ secrets.CARGO_REGISTRY_TOKEN }}" ]]
-          cargo login "${{ secrets.CARGO_REGISTRY_TOKEN }}"
-
-      - name: SemVer check
-        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
-        working-directory: ${{ matrix.directory }}
-        run: cargo +${{ matrix.toolchain }} semver-checks check-release
-
-      - name: Publish (dry run)
-        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
-        working-directory: ${{ matrix.directory }}
-        run: cargo +${{ matrix.toolchain }} publish --all-features --dry-run
-
-      - name: Publish
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        working-directory: ${{ matrix.directory }}
-        run: cargo +${{ matrix.toolchain }} publish --all-features
+  #  publish:
+  #    name: publish
+  #    needs: setup
+  #    if: needs.setup.outputs.publish != '{}'
+  #    runs-on: ubuntu-latest
+  #    strategy:
+  #      fail-fast: false
+  #      matrix: ${{ fromJSON(needs.setup.outputs.publish) }}
+  #    steps:
+  #      - name: Checkout source code
+  #        uses: actions/checkout@v3
+  #
+  #      - name: Install Rust toolchain
+  #        uses: ./.github/actions/install-rust-toolchain
+  #        with:
+  #          toolchain: ${{ matrix.toolchain }}
+  #
+  #      - name: Install tools
+  #        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
+  #        shell: bash
+  #        run: |
+  #          cargo install cargo-quickinstall
+  #          cargo quickinstall cargo-make --version 0.36.3
+  #          cargo quickinstall cargo-hack --version 0.5.26
+  #          cargo quickinstall cargo-nextest --version 0.9.37
+  #          cargo quickinstall cargo-semver-checks --version 0.17.0
+  #
+  #      - name: Run lints
+  #        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
+  #        working-directory: ${{ matrix.directory }}
+  #        run: cargo +${{ matrix.toolchain }} make --profile ${{ matrix.profile }} lint
+  #
+  #      - name: Run tests
+  #        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
+  #        working-directory: ${{ matrix.directory }}
+  #        run: cargo +${{ matrix.toolchain }} make --profile ${{ matrix.profile }} test --no-fail-fast
+  #
+  #      - name: Login
+  #        run: |
+  #          [[ -n "${{ secrets.CARGO_REGISTRY_TOKEN }}" ]]
+  #          cargo login "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+  #
+  #      - name: SemVer check
+  #        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
+  #        working-directory: ${{ matrix.directory }}
+  #        run: cargo +${{ matrix.toolchain }} semver-checks check-release
+  #
+  #      - name: Publish (dry run)
+  #        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
+  #        working-directory: ${{ matrix.directory }}
+  #        run: cargo +${{ matrix.toolchain }} publish --all-features --dry-run
+  #
+  #      - name: Publish
+  #        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  #        working-directory: ${{ matrix.directory }}
+  #        run: cargo +${{ matrix.toolchain }} publish --all-features
 
   merging-enabled:
     name: Merging enabled
@@ -369,6 +369,7 @@ jobs:
       - name: check docker
         run: |
           [[ ${{ needs.docker.result }} =~ success|skipped ]]
-      - name: check publish
-        run: |
-          [[ ${{ needs.publish.result }} =~ success|skipped ]]
+
+#      - name: check publish
+#        run: |
+#          [[ ${{ needs.publish.result }} =~ success|skipped ]]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In order to move `error-stack` to `libs/` (#1985), which is touching the `version` line in the `Cargo.toml`, we need to disable the `publish` job, otherwise, it will try to publish the crate with an unchanged version. There is probably a better way to detect a version change, but this is currently out of scope, and moving a whole crate is unlikely to happen again in the future.

## 🔗 Related links

- #1985