### PR TITLE
Rename database columns and tables

### DIFF
--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/link-table/cells/linked-with-cell/linked-entity-list-editor.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor/links-section/link-table/cells/linked-with-cell/linked-entity-list-editor.tsx
@@ -32,7 +32,7 @@ export const createDraftLinkEntity = ({
     linkData: { rightEntityId, leftEntityId },
     metadata: {
       archived: false,
-      editionId: { recordId: 1, baseId: `draft%${Date.now()}` },
+      editionId: { recordId: "", baseId: `draft%${Date.now()}` },
       entityTypeId: linkEntityTypeId,
       provenance: { updatedById: "" },
       version: {

--- a/apps/hash-graph/lib/graph/src/shared/identifier/knowledge.rs
+++ b/apps/hash-graph/lib/graph/src/shared/identifier/knowledge.rs
@@ -6,6 +6,7 @@ use std::{
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use tokio_postgres::types::ToSql;
 use utoipa::{openapi, ToSchema};
+use uuid::Uuid;
 
 use crate::{
     identifier::{
@@ -147,16 +148,16 @@ impl EntityVersion {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, ToSql, ToSchema)]
 #[postgres(transparent)]
 #[repr(transparent)]
-pub struct EntityRecordId(i64);
+pub struct EntityRecordId(Uuid);
 
 impl EntityRecordId {
     #[must_use]
-    pub const fn new(id: i64) -> Self {
+    pub const fn new(id: Uuid) -> Self {
         Self(id)
     }
 
     #[must_use]
-    pub const fn as_i64(&self) -> i64 {
+    pub const fn as_uuid(&self) -> Uuid {
         self.0
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity/mod.rs
@@ -324,7 +324,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             .query_one(
                 r#"
                 SELECT
-                    entity_record_id,
+                    entity_edition_id,
                     decision_time,
                     transaction_time
                 FROM
@@ -332,7 +332,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                         _owned_by_id := $1,
                         _entity_uuid := $2,
                         _decision_time := $3,
-                        _updated_by_id := $4,
+                        _record_created_by_id := $4,
                         _archived := $5,
                         _entity_type_ontology_id := $6,
                         _properties := $7,
@@ -560,7 +560,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             .query_opt(
                 r#"
                 SELECT
-                    entity_record_id,
+                    entity_edition_id,
                     decision_time,
                     transaction_time
                 FROM
@@ -568,7 +568,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                         _owned_by_id := $1,
                         _entity_uuid := $2,
                         _decision_time := $3,
-                        _updated_by_id := $4,
+                        _record_created_by_id := $4,
                         _archived := $5,
                         _entity_type_ontology_id := $6,
                         _properties := $7,

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -509,7 +509,7 @@ mod tests {
             FROM "entities" AS "entities_0_0_0"
             WHERE "entities_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
               AND "entities_0_0_0"."decision_time" && $2
-              AND "entities_0_0_0"."updated_by_id" = $3
+              AND "entities_0_0_0"."record_created_by_id" = $3
             ORDER BY "entities_0_0_0"."entity_uuid" ASC,
                      "entities_0_0_0"."decision_time" DESC
             "#,
@@ -610,7 +610,7 @@ mod tests {
               AND "entities_0_1_0"."decision_time" && $2
               AND "entities_0_2_0"."transaction_time" @> $1::TIMESTAMPTZ
               AND "entities_0_2_0"."decision_time" && $2
-              AND "entities_0_2_0"."entity_record_id" = $3
+              AND "entities_0_2_0"."entity_edition_id" = $3
             "#,
             &[&kernel, &time_projection.image(), &10.0],
         );
@@ -647,7 +647,7 @@ mod tests {
               AND "entities_0_1_0"."decision_time" && $2
               AND "entities_0_2_0"."transaction_time" @> $1::TIMESTAMPTZ
               AND "entities_0_2_0"."decision_time" && $2
-              AND "entities_0_2_0"."entity_record_id" = $3
+              AND "entities_0_2_0"."entity_edition_id" = $3
             "#,
             &[&kernel, &time_projection.image(), &10.0],
         );

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
@@ -32,7 +32,7 @@ impl Table {
     const fn as_str(self) -> &'static str {
         match self {
             Self::OntologyIds => "ontology_ids",
-            Self::OwnedOntologyMetadata => "owned_ontology_metadata",
+            Self::OwnedOntologyMetadata => "ontology_owned_metadata",
             Self::DataTypes => "data_types",
             Self::PropertyTypes => "property_types",
             Self::EntityTypes => "entity_types",
@@ -97,7 +97,7 @@ impl OwnedOntologyMetadata {
         let column = match self {
             Self::OntologyId => "ontology_id",
             Self::OwnedById => "owned_by_id",
-            Self::UpdatedById => "updated_by_id",
+            Self::UpdatedById => "record_created_by_id",
         };
         table.transpile(fmt)?;
         write!(fmt, r#"."{column}""#)
@@ -219,13 +219,13 @@ impl Entities<'_> {
     fn transpile_column(&self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
         let column = match self {
             Self::EntityUuid => "entity_uuid",
-            Self::RecordId => "entity_record_id",
+            Self::RecordId => "entity_edition_id",
             Self::DecisionTime => "decision_time",
             Self::TransactionTime => "transaction_time",
             Self::ProjectedTime => unreachable!("projected time is not a column"),
             Self::Archived => "archived",
             Self::OwnedById => "owned_by_id",
-            Self::UpdatedById => "updated_by_id",
+            Self::UpdatedById => "record_created_by_id",
             Self::EntityTypeOntologyId => "entity_type_ontology_id",
             Self::Properties(None) => "properties",
             Self::Properties(Some(path)) => {

--- a/apps/hash-graph/postgres_migrations/V2__ontology_tables.sql
+++ b/apps/hash-graph/postgres_migrations/V2__ontology_tables.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS
   ontology_ids (
-    ontology_id UUID PRIMARY KEY,
+    "ontology_id" UUID PRIMARY KEY,
     "base_uri" TEXT NOT NULL,
     "version" BIGINT NOT NULL,
     "transaction_time" tstzrange NOT NULL,
@@ -19,12 +19,12 @@ COMMENT
   ON TABLE ontology_ids IS $pga$ This table is a boundary to define the actual identification scheme for our kinds of types. Assume that we use the UUIDs on the types to look up more specific ID details. $pga$;
 
 CREATE TABLE IF NOT EXISTS
-  "owned_ontology_metadata" (
+  "ontology_owned_metadata" (
     "ontology_id" UUID NOT NULL,
     "owned_by_id" UUID NOT NULL REFERENCES "accounts",
-    "updated_by_id" UUID NOT NULL REFERENCES "accounts",
-    CONSTRAINT owned_ontology_metadata_pk PRIMARY KEY ("ontology_id") DEFERRABLE INITIALLY IMMEDIATE,
-    CONSTRAINT owned_ontology_metadata_fk FOREIGN KEY ("ontology_id") REFERENCES ontology_ids DEFERRABLE INITIALLY IMMEDIATE
+    "record_created_by_id" UUID NOT NULL REFERENCES "accounts",
+    CONSTRAINT ontology_owned_metadata_pk PRIMARY KEY ("ontology_id") DEFERRABLE INITIALLY IMMEDIATE,
+    CONSTRAINT ontology_owned_metadata_fk FOREIGN KEY ("ontology_id") REFERENCES ontology_ids DEFERRABLE INITIALLY IMMEDIATE
   );
 
 CREATE TABLE IF NOT EXISTS

--- a/apps/hash-graph/postgres_migrations/V3__knowledge_tables.sql
+++ b/apps/hash-graph/postgres_migrations/V3__knowledge_tables.sql
@@ -23,24 +23,24 @@ CREATE TABLE IF NOT EXISTS
 
 CREATE TABLE IF NOT EXISTS
   "entity_editions" (
-    "entity_record_id" BIGINT PRIMARY KEY NOT NULL GENERATED ALWAYS AS IDENTITY,
+    "entity_edition_id" UUID NOT NULL PRIMARY KEY,
     "entity_type_ontology_id" UUID NOT NULL REFERENCES "entity_types",
     "properties" JSONB NOT NULL,
     "left_to_right_order" INTEGER,
     "right_to_left_order" INTEGER,
-    "updated_by_id" UUID NOT NULL REFERENCES "accounts",
+    "record_created_by_id" UUID NOT NULL REFERENCES "accounts",
     "archived" BOOLEAN NOT NULL
   );
 
 CREATE TABLE IF NOT EXISTS
-  "entity_versions" (
+  "entity_temporal_metadata" (
     "owned_by_id" UUID NOT NULL,
     "entity_uuid" UUID NOT NULL,
-    "entity_record_id" BIGINT NOT NULL REFERENCES "entity_editions",
+    "entity_edition_id" UUID NOT NULL REFERENCES "entity_editions",
     "decision_time" tstzrange NOT NULL,
     "transaction_time" tstzrange NOT NULL,
     FOREIGN KEY ("owned_by_id", "entity_uuid") REFERENCES "entity_ids",
-    CONSTRAINT entity_versions_overlapping EXCLUDE USING gist (
+    CONSTRAINT entity_temporal_metadata_overlapping EXCLUDE USING gist (
       owned_by_id
       WITH
         =,
@@ -60,13 +60,13 @@ CREATE TABLE IF NOT EXISTS
 CREATE VIEW
   "entities" AS
 SELECT
-  entity_versions.entity_record_id,
-  entity_versions.owned_by_id,
-  entity_versions.entity_uuid,
-  entity_versions.decision_time,
-  entity_versions.transaction_time,
+  entity_ids.owned_by_id,
+  entity_ids.entity_uuid,
+  entity_editions.entity_edition_id,
+  entity_temporal_metadata.decision_time,
+  entity_temporal_metadata.transaction_time,
   entity_editions.entity_type_ontology_id,
-  entity_editions.updated_by_id,
+  entity_editions.record_created_by_id,
   entity_editions.properties,
   entity_editions.archived,
   entity_ids.left_owned_by_id,
@@ -76,7 +76,7 @@ SELECT
   entity_ids.right_entity_uuid,
   entity_editions.right_to_left_order
 FROM
-  entity_versions
-  JOIN entity_editions ON entity_versions.entity_record_id = entity_editions.entity_record_id
-  JOIN entity_ids ON entity_versions.owned_by_id = entity_ids.owned_by_id
-  AND entity_versions.entity_uuid = entity_ids.entity_uuid;
+  entity_temporal_metadata
+  JOIN entity_editions ON entity_temporal_metadata.entity_edition_id = entity_editions.entity_edition_id
+  JOIN entity_ids ON entity_temporal_metadata.owned_by_id = entity_ids.owned_by_id
+  AND entity_temporal_metadata.entity_uuid = entity_ids.entity_uuid;

--- a/apps/hash-graph/postgres_migrations/V5__owned_ontology_functions.sql
+++ b/apps/hash-graph/postgres_migrations/V5__owned_ontology_functions.sql
@@ -3,7 +3,7 @@ OR REPLACE FUNCTION create_owned_ontology_id (
   "base_uri" TEXT,
   "version" BIGINT,
   "owned_by_id" UUID,
-  "updated_by_id" UUID
+  "record_created_by_id" UUID
 ) RETURNS TABLE (ontology_id UUID) AS $create_owned_ontology_id$
 DECLARE
   "_ontology_id" UUID;
@@ -17,14 +17,14 @@ BEGIN
   );
   
   RETURN QUERY
-  INSERT INTO owned_ontology_metadata (
+  INSERT INTO ontology_owned_metadata (
     "ontology_id",
     "owned_by_id",
-    "updated_by_id"    
+    "record_created_by_id"    
   ) VALUES (
     _ontology_id,
     create_owned_ontology_id.owned_by_id,
-    create_owned_ontology_id.updated_by_id
+    create_owned_ontology_id.record_created_by_id
   ) RETURNING _ontology_id;
 END $create_owned_ontology_id$ LANGUAGE plpgsql VOLATILE;
 
@@ -32,22 +32,22 @@ CREATE
 OR REPLACE FUNCTION update_owned_ontology_id (
   "base_uri" TEXT,
   "version" BIGINT,
-  "updated_by_id" UUID
+  "record_created_by_id" UUID
 ) RETURNS TABLE (ontology_id UUID, owned_by_id UUID) AS $update_owned_ontology_id$
 DECLARE
   "_ontology_id" UUID;
 BEGIN
-  SET CONSTRAINTS owned_ontology_metadata_pk DEFERRED;
-  SET CONSTRAINTS owned_ontology_metadata_fk DEFERRED;
+  SET CONSTRAINTS ontology_owned_metadata_pk DEFERRED;
+  SET CONSTRAINTS ontology_owned_metadata_fk DEFERRED;
   SET CONSTRAINTS ontology_ids_overlapping DEFERRED;
 
   _ontology_id := gen_random_uuid();
 
   RETURN QUERY
-  UPDATE owned_ontology_metadata as metadata
+  UPDATE ontology_owned_metadata as metadata
   SET
     "ontology_id" = _ontology_id,
-    "updated_by_id" = update_owned_ontology_id.updated_by_id
+    "record_created_by_id" = update_owned_ontology_id.record_created_by_id
   FROM ontology_ids
   WHERE ontology_ids.ontology_id = metadata.ontology_id
     AND ontology_ids.base_uri = update_owned_ontology_id.base_uri
@@ -60,30 +60,30 @@ BEGIN
     update_owned_ontology_id.version
   );
 
-  SET CONSTRAINTS owned_ontology_metadata_pk IMMEDIATE;
-  SET CONSTRAINTS owned_ontology_metadata_fk IMMEDIATE;
+  SET CONSTRAINTS ontology_owned_metadata_pk IMMEDIATE;
+  SET CONSTRAINTS ontology_owned_metadata_fk IMMEDIATE;
   SET CONSTRAINTS ontology_ids_overlapping IMMEDIATE;
 END $update_owned_ontology_id$ LANGUAGE plpgsql VOLATILE;
 
 CREATE
-OR REPLACE FUNCTION "update_owned_ontology_metadata_trigger" () RETURNS TRIGGER AS $update_owned_ontology_metadata_trigger$
+OR REPLACE FUNCTION "update_ontology_owned_metadata_trigger" () RETURNS TRIGGER AS $update_ontology_owned_metadata_trigger$
 BEGIN
-  INSERT INTO owned_ontology_metadata (
+  INSERT INTO ontology_owned_metadata (
     "ontology_id", 
     "owned_by_id", 
-    "updated_by_id"
+    "record_created_by_id"
   ) VALUES (
     NEW.ontology_id,
     NEW.owned_by_id,
-    NEW.updated_by_id
+    NEW.record_created_by_id
   );
   
   RETURN OLD;
-END $update_owned_ontology_metadata_trigger$ LANGUAGE plpgsql VOLATILE;
+END $update_ontology_owned_metadata_trigger$ LANGUAGE plpgsql VOLATILE;
 
 CREATE
-OR REPLACE TRIGGER "update_owned_ontology_metadata_trigger" BEFORE
+OR REPLACE TRIGGER "update_ontology_owned_metadata_trigger" BEFORE
 UPDATE
-  ON "owned_ontology_metadata" FOR EACH ROW
+  ON "ontology_owned_metadata" FOR EACH ROW
 EXECUTE
-  PROCEDURE "update_owned_ontology_metadata_trigger" ();
+  PROCEDURE "update_ontology_owned_metadata_trigger" ();

--- a/apps/hash-graph/postgres_migrations/V6__knowledge_functions.sql
+++ b/apps/hash-graph/postgres_migrations/V6__knowledge_functions.sql
@@ -3,7 +3,7 @@ OR REPLACE FUNCTION "create_entity" (
   "_owned_by_id" UUID,
   "_entity_uuid" UUID,
   "_decision_time" TIMESTAMP WITH TIME ZONE,
-  "_updated_by_id" UUID,
+  "_record_created_by_id" UUID,
   "_archived" BOOLEAN,
   "_entity_type_ontology_id" UUID,
   "_properties" JSONB,
@@ -14,12 +14,12 @@ OR REPLACE FUNCTION "create_entity" (
   "_left_to_right_order" INTEGER,
   "_right_to_left_order" INTEGER
 ) RETURNS TABLE (
-  entity_record_id BIGINT,
+  entity_edition_id UUID,
   decision_time tstzrange,
   transaction_time tstzrange
 ) AS $pga$
     DECLARE
-      _entity_record_id BIGINT;
+      _entity_edition_id UUID;
     BEGIN
       IF _decision_time IS NULL THEN _decision_time := now(); END IF;
 
@@ -41,35 +41,37 @@ OR REPLACE FUNCTION "create_entity" (
 
       -- insert the data of the entity
       INSERT INTO entity_editions (
-        updated_by_id,
+        entity_edition_id,
+        record_created_by_id,
         archived,
         entity_type_ontology_id,
         properties,
         left_to_right_order,
         right_to_left_order
       ) VALUES (
-        _updated_by_id,
+        gen_random_uuid(),
+        _record_created_by_id,
         _archived,
         _entity_type_ontology_id,
         _properties,
         _left_to_right_order,
         _right_to_left_order
-      ) RETURNING entity_editions.entity_record_id INTO _entity_record_id;
+      ) RETURNING entity_editions.entity_edition_id INTO _entity_edition_id;
 
       RETURN QUERY
-      INSERT INTO entity_versions (
+      INSERT INTO entity_temporal_metadata (
         owned_by_id,
         entity_uuid,
-        entity_record_id,
+        entity_edition_id,
         decision_time,
         transaction_time
       ) VALUES (
         _owned_by_id,
         _entity_uuid,
-        _entity_record_id,
+        _entity_edition_id,
         tstzrange(_decision_time, NULL, '[)'),
         tstzrange(now(), NULL, '[)')
-      ) RETURNING entity_versions.entity_record_id, entity_versions.decision_time, entity_versions.transaction_time;
+      ) RETURNING entity_temporal_metadata.entity_edition_id, entity_temporal_metadata.decision_time, entity_temporal_metadata.transaction_time;
     END
     $pga$ VOLATILE LANGUAGE plpgsql;
 
@@ -78,83 +80,85 @@ OR REPLACE FUNCTION "update_entity" (
   "_owned_by_id" UUID,
   "_entity_uuid" UUID,
   "_decision_time" TIMESTAMP WITH TIME ZONE,
-  "_updated_by_id" UUID,
+  "_record_created_by_id" UUID,
   "_archived" BOOLEAN,
   "_entity_type_ontology_id" UUID,
   "_properties" JSONB,
   "_left_to_right_order" INTEGER,
   "_right_to_left_order" INTEGER
 ) RETURNS TABLE (
-  entity_record_id BIGINT,
+  entity_edition_id UUID,
   decision_time tstzrange,
   transaction_time tstzrange
 ) AS $pga$
     DECLARE
-      _new_entity_record_id BIGINT;
+      _new_entity_edition_id UUID;
     BEGIN
       IF _decision_time IS NULL THEN _decision_time := now(); END IF;
 
       INSERT INTO entity_editions (
-        updated_by_id,
+        entity_edition_id,
+        record_created_by_id,
         archived,
         entity_type_ontology_id,
         properties,
         left_to_right_order,
         right_to_left_order
       ) VALUES (
-        _updated_by_id,
+        gen_random_uuid(),
+        _record_created_by_id,
         _archived,
         _entity_type_ontology_id,
         _properties,
         _left_to_right_order,
         _right_to_left_order
       )
-      RETURNING entity_editions.entity_record_id INTO _new_entity_record_id;
+      RETURNING entity_editions.entity_edition_id INTO _new_entity_edition_id;
 
       RETURN QUERY
-      UPDATE entity_versions
-      SET decision_time = tstzrange(_decision_time, upper(entity_versions.decision_time), '[)'),
+      UPDATE entity_temporal_metadata
+      SET decision_time = tstzrange(_decision_time, upper(entity_temporal_metadata.decision_time), '[)'),
           transaction_time = tstzrange(now(), NULL, '[)'),
-          entity_record_id = _new_entity_record_id
-      WHERE entity_versions.owned_by_id = _owned_by_id
-        AND entity_versions.entity_uuid = _entity_uuid
-        AND entity_versions.decision_time @> _decision_time
-        AND entity_versions.transaction_time @> now()
-      RETURNING entity_versions.entity_record_id, entity_versions.decision_time, entity_versions.transaction_time;
+          entity_edition_id = _new_entity_edition_id
+      WHERE entity_temporal_metadata.owned_by_id = _owned_by_id
+        AND entity_temporal_metadata.entity_uuid = _entity_uuid
+        AND entity_temporal_metadata.decision_time @> _decision_time
+        AND entity_temporal_metadata.transaction_time @> now()
+      RETURNING entity_temporal_metadata.entity_edition_id, entity_temporal_metadata.decision_time, entity_temporal_metadata.transaction_time;
     END
     $pga$ VOLATILE LANGUAGE plpgsql;
 
 CREATE
 OR REPLACE FUNCTION "update_entity_version_trigger" () RETURNS TRIGGER AS $pga$
     BEGIN
-      SET CONSTRAINTS entity_versions_overlapping DEFERRED;
+      SET CONSTRAINTS entity_temporal_metadata_overlapping DEFERRED;
 
       -- Insert a new version with the old decision time and the system time up until now
-      INSERT INTO entity_versions (
+      INSERT INTO entity_temporal_metadata (
         owned_by_id,
         entity_uuid,
-        entity_record_id,
+        entity_edition_id,
         decision_time,
         transaction_time
       ) VALUES (
         OLD.owned_by_id,
         OLD.entity_uuid,
-        OLD.entity_record_id,
+        OLD.entity_edition_id,
         OLD.decision_time,
         tstzrange(lower(OLD.transaction_time),lower(NEW.transaction_time), '[)')
       );
 
       -- Insert a new version with the previous decision time until the new decision time
-      INSERT INTO entity_versions (
+      INSERT INTO entity_temporal_metadata (
         owned_by_id,
         entity_uuid,
-        entity_record_id,
+        entity_edition_id,
         decision_time,
         transaction_time
       ) VALUES (
         OLD.owned_by_id,
         OLD.entity_uuid,
-        OLD.entity_record_id,
+        OLD.entity_edition_id,
         tstzrange(lower(OLD.decision_time), lower(NEW.decision_time), '[)'),
         NEW.transaction_time
       );
@@ -165,6 +169,6 @@ OR REPLACE FUNCTION "update_entity_version_trigger" () RETURNS TRIGGER AS $pga$
 CREATE
 OR REPLACE TRIGGER "update_entity_version_trigger" BEFORE
 UPDATE
-  ON "entity_versions" FOR EACH ROW
+  ON "entity_temporal_metadata" FOR EACH ROW
 EXECUTE
   PROCEDURE "update_entity_version_trigger" ();

--- a/libs/@local/hash-graph-client/api.ts
+++ b/libs/@local/hash-graph-client/api.ts
@@ -506,10 +506,10 @@ export interface EntityEditionId {
   baseId: string;
   /**
    *
-   * @type {number}
+   * @type {string}
    * @memberof EntityEditionId
    */
-  recordId: number;
+  recordId: string;
 }
 /**
  *

--- a/libs/@local/hash-subgraph/src/types/identifier.ts
+++ b/libs/@local/hash-subgraph/src/types/identifier.ts
@@ -45,7 +45,7 @@ export type EntityVersion = {
   transactionTime: VersionInterval;
 };
 
-export type EntityRecordId = number;
+export type EntityRecordId = string;
 
 /**
  * An identifier of a specific edition of an `Entity` at a given `EntityRecordId`


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This is a subset of changes made with other PRs and some further renames with minimal effect on things outside of the database layout. We chose this route to allow merging #1978 into `main` sooner than later.

## 🔗 Related links

Supersedes
- https://github.com/hashintel/hash/pull/1975
- https://github.com/hashintel/hash/pull/1979
- https://github.com/hashintel/hash/pull/1988

## 🔍 What does this change?

- These are mainly the changes as in the linked three pull request, but only trying to touch database related functions.
- Also renames `updated_by_id` to `record_created_by_id` in ontology tables
- Make naming of tables more consistent