### PR TITLE
Raise a better error if entity update failed

### DIFF
--- a/apps/hash-graph/postgres_migrations/V6__knowledge_functions.sql
+++ b/apps/hash-graph/postgres_migrations/V6__knowledge_functions.sql
@@ -125,6 +125,11 @@ OR REPLACE FUNCTION "update_entity" (
         AND entity_temporal_metadata.decision_time @> _decision_time
         AND entity_temporal_metadata.transaction_time @> now()
       RETURNING entity_temporal_metadata.entity_edition_id, entity_temporal_metadata.decision_time, entity_temporal_metadata.transaction_time;
+
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'No entity found for the owner ID `%` and entity ID `%`', _owned_by_id, _entity_uuid
+        USING ERRCODE = 'restrict_violation';
+      END IF;
     END
     $pga$ VOLATILE LANGUAGE plpgsql;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Similar to #2004, this also adds a better error message when an entity update failed

## 🔍 What does this change?

raises an exception, if the updated did not happen

## ⚠️ Known issues

When I initially implemented that logic, I had a pretty complicated (manual) test setup, which I haven't reproduced it. Mainly, I was testing two concurrent updates with different parameters. The logic here didi not change, only how we report the error, but we should investigate further when exactly an update can fail. Currently, we're checking from Rust, if the entity exist.