### PR TITLE
Add new `OntologyMetadata` enum that contains variants for Owned and External

### DIFF
--- a/apps/hash-graph/lib/graph/src/api/rest.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest.rs
@@ -54,7 +54,10 @@ use crate::{
         },
         EntityVertexId, GraphElementId, GraphElementVertexId,
     },
-    ontology::{domain_validator::DomainValidator, OntologyElementMetadata, Selector},
+    ontology::{
+        domain_validator::DomainValidator, ExternalOntologyElementMetadata,
+        OntologyElementMetadata, OwnedOntologyElementMetadata, Selector,
+    },
     provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
     store::{QueryError, StorePool},
     subgraph::edges::{
@@ -182,6 +185,8 @@ async fn serve_static_schema(Path(path): Path<String>) -> Result<Response, Statu
             ProvenanceMetadata,
             OntologyTypeEditionId,
             OntologyElementMetadata,
+            OwnedOntologyElementMetadata,
+            ExternalOntologyElementMetadata,
             EntityVertexId,
             Selector,
 

--- a/apps/hash-graph/lib/graph/src/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/ontology.rs
@@ -213,6 +213,7 @@ pub struct ExternalOntologyElementMetadata {
     edition_id: OntologyTypeEditionId,
     #[serde(rename = "provenance")]
     provenance_metadata: ProvenanceMetadata,
+    #[schema(value_type = String)]
     fetched_at: OffsetDateTime,
 }
 

--- a/apps/hash-graph/lib/graph/src/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/ontology.rs
@@ -10,6 +10,7 @@ use core::fmt;
 use error_stack::{Context, IntoReport, Result, ResultExt};
 use serde::{Deserialize, Serialize, Serializer};
 use serde_json;
+use time::OffsetDateTime;
 use type_system::{
     repr, uri::VersionedUri, DataType, EntityType, ParseDataTypeError, ParseEntityTypeError,
     ParsePropertyTypeError, PropertyType,
@@ -149,16 +150,34 @@ pub trait OntologyTypeWithMetadata: Record {
     fn metadata(&self) -> &OntologyElementMetadata;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(untagged)]
+pub enum OntologyElementMetadata {
+    Owned(OwnedOntologyElementMetadata),
+    #[serde(skip_serializing)]
+    External(ExternalOntologyElementMetadata),
+}
+
+impl OntologyElementMetadata {
+    #[must_use]
+    pub const fn edition_id(&self) -> &OntologyTypeEditionId {
+        match self {
+            Self::Owned(owned) => owned.edition_id(),
+            Self::External(external) => external.edition_id(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct OntologyElementMetadata {
+pub struct OwnedOntologyElementMetadata {
     edition_id: OntologyTypeEditionId,
     #[serde(rename = "provenance")]
     provenance_metadata: ProvenanceMetadata,
     owned_by_id: OwnedById,
 }
 
-impl OntologyElementMetadata {
+impl OwnedOntologyElementMetadata {
     #[must_use]
     pub const fn new(
         edition_id: OntologyTypeEditionId,
@@ -173,8 +192,42 @@ impl OntologyElementMetadata {
     }
 
     #[must_use]
+    pub const fn edition_id(&self) -> &OntologyTypeEditionId {
+        &self.edition_id
+    }
+
+    #[must_use]
+    pub const fn provenance_metadata(&self) -> ProvenanceMetadata {
+        self.provenance_metadata
+    }
+
+    #[must_use]
     pub const fn owned_by_id(&self) -> OwnedById {
         self.owned_by_id
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalOntologyElementMetadata {
+    edition_id: OntologyTypeEditionId,
+    #[serde(rename = "provenance")]
+    provenance_metadata: ProvenanceMetadata,
+    fetched_at: OffsetDateTime,
+}
+
+impl ExternalOntologyElementMetadata {
+    #[must_use]
+    pub const fn new(
+        edition_id: OntologyTypeEditionId,
+        provenance_metadata: ProvenanceMetadata,
+        fetched_at: OffsetDateTime,
+    ) -> Self {
+        Self {
+            edition_id,
+            provenance_metadata,
+            fetched_at,
+        }
     }
 
     #[must_use]
@@ -185,6 +238,11 @@ impl OntologyElementMetadata {
     #[must_use]
     pub const fn provenance_metadata(&self) -> ProvenanceMetadata {
         self.provenance_metadata
+    }
+
+    #[must_use]
+    pub const fn fetched_at(&self) -> OffsetDateTime {
+        self.fetched_at
     }
 }
 

--- a/apps/hash-graph/lib/graph/src/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/data_type.rs
@@ -152,6 +152,8 @@ pub enum DataTypeQueryPath<'p> {
     OntologyId,
     /// Only used internally and not available for deserialization.
     Schema(Option<JsonPath<'p>>),
+    /// Only used internally and not available for deserialization.
+    AdditionalMetadata(Option<JsonPath<'p>>),
 }
 
 impl OntologyQueryPath for DataTypeQueryPath<'_> {
@@ -167,10 +169,6 @@ impl OntologyQueryPath for DataTypeQueryPath<'_> {
         Self::Version
     }
 
-    fn owned_by_id() -> Self {
-        Self::OwnedById
-    }
-
     fn updated_by_id() -> Self {
         Self::UpdatedById
     }
@@ -178,13 +176,17 @@ impl OntologyQueryPath for DataTypeQueryPath<'_> {
     fn schema() -> Self {
         Self::Schema(None)
     }
+
+    fn additional_metadata() -> Self {
+        Self::AdditionalMetadata(None)
+    }
 }
 
 impl QueryPath for DataTypeQueryPath<'_> {
     fn expected_type(&self) -> ParameterType {
         match self {
             Self::OntologyId | Self::OwnedById | Self::UpdatedById => ParameterType::Uuid,
-            Self::Schema(_) => ParameterType::Any,
+            Self::Schema(_) | Self::AdditionalMetadata(_) => ParameterType::Any,
             Self::BaseUri => ParameterType::BaseUri,
             Self::VersionedUri => ParameterType::VersionedUri,
             Self::Version => ParameterType::UnsignedInteger,
@@ -207,6 +209,8 @@ impl fmt::Display for DataTypeQueryPath<'_> {
             Self::Title => fmt.write_str("title"),
             Self::Description => fmt.write_str("description"),
             Self::Type => fmt.write_str("type"),
+            Self::AdditionalMetadata(Some(path)) => write!(fmt, "additionalMetadata.{path}"),
+            Self::AdditionalMetadata(None) => fmt.write_str("additionalMetadata"),
         }
     }
 }

--- a/apps/hash-graph/lib/graph/src/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/entity_type.rs
@@ -260,6 +260,8 @@ pub enum EntityTypeQueryPath<'p> {
     OntologyId,
     /// Only used internally and not available for deserialization.
     Schema(Option<JsonPath<'p>>),
+    /// Only used internally and not available for deserialization.
+    AdditionalMetadata(Option<JsonPath<'p>>),
 }
 
 impl OntologyQueryPath for EntityTypeQueryPath<'_> {
@@ -275,10 +277,6 @@ impl OntologyQueryPath for EntityTypeQueryPath<'_> {
         Self::Version
     }
 
-    fn owned_by_id() -> Self {
-        Self::OwnedById
-    }
-
     fn updated_by_id() -> Self {
         Self::UpdatedById
     }
@@ -286,13 +284,17 @@ impl OntologyQueryPath for EntityTypeQueryPath<'_> {
     fn schema() -> Self {
         Self::Schema(None)
     }
+
+    fn additional_metadata() -> Self {
+        Self::AdditionalMetadata(None)
+    }
 }
 
 impl QueryPath for EntityTypeQueryPath<'_> {
     fn expected_type(&self) -> ParameterType {
         match self {
             Self::OntologyId | Self::OwnedById | Self::UpdatedById => ParameterType::Uuid,
-            Self::Schema(_) => ParameterType::Any,
+            Self::Schema(_) | Self::AdditionalMetadata(_) => ParameterType::Any,
             Self::BaseUri => ParameterType::BaseUri,
             Self::VersionedUri => ParameterType::VersionedUri,
             Self::Version => ParameterType::UnsignedInteger,
@@ -326,6 +328,8 @@ impl fmt::Display for EntityTypeQueryPath<'_> {
             Self::Links(path) => write!(fmt, "links.{path}"),
             Self::RequiredLinks => fmt.write_str("requiredLinks"),
             Self::InheritsFrom(path) => write!(fmt, "inheritsFrom.{path}"),
+            Self::AdditionalMetadata(Some(path)) => write!(fmt, "additionalMetadata.{path}"),
+            Self::AdditionalMetadata(None) => fmt.write_str("additionalMetadata"),
         }
     }
 }

--- a/apps/hash-graph/lib/graph/src/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/property_type.rs
@@ -168,6 +168,8 @@ pub enum PropertyTypeQueryPath<'p> {
     OntologyId,
     /// Only used internally and not available for deserialization.
     Schema(Option<JsonPath<'p>>),
+    /// Only used internally and not available for deserialization.
+    AdditionalMetadata(Option<JsonPath<'p>>),
 }
 
 impl OntologyQueryPath for PropertyTypeQueryPath<'_> {
@@ -183,10 +185,6 @@ impl OntologyQueryPath for PropertyTypeQueryPath<'_> {
         Self::Version
     }
 
-    fn owned_by_id() -> Self {
-        Self::OwnedById
-    }
-
     fn updated_by_id() -> Self {
         Self::UpdatedById
     }
@@ -194,13 +192,17 @@ impl OntologyQueryPath for PropertyTypeQueryPath<'_> {
     fn schema() -> Self {
         Self::Schema(None)
     }
+
+    fn additional_metadata() -> Self {
+        Self::AdditionalMetadata(None)
+    }
 }
 
 impl QueryPath for PropertyTypeQueryPath<'_> {
     fn expected_type(&self) -> ParameterType {
         match self {
             Self::OntologyId | Self::OwnedById | Self::UpdatedById => ParameterType::Uuid,
-            Self::Schema(_) => ParameterType::Any,
+            Self::Schema(_) | Self::AdditionalMetadata(_) => ParameterType::Any,
             Self::BaseUri => ParameterType::BaseUri,
             Self::VersionedUri => ParameterType::VersionedUri,
             Self::Version => ParameterType::UnsignedInteger,
@@ -226,6 +228,8 @@ impl fmt::Display for PropertyTypeQueryPath<'_> {
             Self::Description => fmt.write_str("description"),
             Self::DataTypes(path) => write!(fmt, "dataTypes.{path}"),
             Self::PropertyTypes(path) => write!(fmt, "propertyTypes.{path}"),
+            Self::AdditionalMetadata(Some(path)) => write!(fmt, "additionalMetadata.{path}"),
+            Self::AdditionalMetadata(None) => fmt.write_str("additionalMetadata"),
         }
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres.rs
@@ -30,7 +30,7 @@ use crate::{
         time::{ProjectedTime, TimeInterval},
         EntityVertexId,
     },
-    ontology::OntologyElementMetadata,
+    ontology::{OntologyElementMetadata, OwnedOntologyElementMetadata},
     provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
         error::{VersionedUriAlreadyExists, WrongOntologyVersion},
@@ -393,11 +393,11 @@ where
 
         Ok((
             ontology_id,
-            OntologyElementMetadata::new(
+            OntologyElementMetadata::Owned(OwnedOntologyElementMetadata::new(
                 OntologyTypeEditionId::from(&uri),
                 ProvenanceMetadata::new(updated_by_id),
                 owned_by_id,
-            ),
+            )),
         ))
     }
 
@@ -433,11 +433,11 @@ where
 
         Ok((
             ontology_id,
-            OntologyElementMetadata::new(
+            OntologyElementMetadata::Owned(OwnedOntologyElementMetadata::new(
                 edition_id,
                 ProvenanceMetadata::new(updated_by_id),
                 owned_by_id,
-            ),
+            )),
         ))
     }
 

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -1,6 +1,11 @@
+use std::error::Error;
+
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
 use futures::{StreamExt, TryStreamExt};
+use postgres_types::{FromSql, Type};
+use serde::Deserialize;
+use time::OffsetDateTime;
 use tokio_postgres::GenericClient;
 use type_system::uri::BaseUri;
 
@@ -9,7 +14,10 @@ use crate::{
         ontology::{OntologyTypeEditionId, OntologyTypeVersion},
         time::TimeProjection,
     },
-    ontology::{OntologyElementMetadata, OntologyType, OntologyTypeWithMetadata},
+    ontology::{
+        ExternalOntologyElementMetadata, OntologyElementMetadata, OntologyType,
+        OntologyTypeWithMetadata, OwnedOntologyElementMetadata,
+    },
     provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
         crud::Read,
@@ -18,6 +26,27 @@ use crate::{
         AsClient, PostgresStore, QueryError,
     },
 };
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum AdditionalOntologyMetadata {
+    Owned { owned_by_id: OwnedById },
+    External { fetched_at: OffsetDateTime },
+}
+
+impl<'a> FromSql<'a> for AdditionalOntologyMetadata {
+    fn from_sql(
+        ty: &Type,
+        raw: &'a [u8],
+    ) -> std::result::Result<Self, Box<dyn Error + Sync + Send>> {
+        let value = serde_json::Value::from_sql(ty, raw)?;
+        Ok(serde_json::from_value(value)?)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        serde_json::Value::accepts(ty)
+    }
+}
 
 #[async_trait]
 impl<C: AsClient, T> Read<T> for PostgresStore<C>
@@ -34,8 +63,9 @@ where
         let base_uri_path = <T::QueryPath<'static> as OntologyQueryPath>::base_uri();
         let version_path = <T::QueryPath<'static> as OntologyQueryPath>::version();
         let schema_path = <T::QueryPath<'static> as OntologyQueryPath>::schema();
-        let owned_by_id_path = <T::QueryPath<'static> as OntologyQueryPath>::owned_by_id();
         let updated_by_id_path = <T::QueryPath<'static> as OntologyQueryPath>::updated_by_id();
+        let additional_metadata_path =
+            <T::QueryPath<'static> as OntologyQueryPath>::additional_metadata();
 
         let mut compiler = SelectCompiler::new(time_projection);
 
@@ -50,8 +80,8 @@ where
             None,
         );
         let schema_index = compiler.add_selection_path(&schema_path);
-        let owned_by_id_index = compiler.add_selection_path(&owned_by_id_path);
         let updated_by_id_path_index = compiler.add_selection_path(&updated_by_id_path);
+        let additional_metadata_index = compiler.add_selection_path(&additional_metadata_path);
 
         compiler.add_filter(filter);
         let (statement, parameters) = compiler.compile();
@@ -68,8 +98,8 @@ where
                     .change_context(QueryError)?;
                 let version: i64 = row.get(version_index);
                 let version = OntologyTypeVersion::new(version as u32);
-                let owned_by_id = OwnedById::new(row.get(owned_by_id_index));
                 let updated_by_id = UpdatedById::new(row.get(updated_by_id_path_index));
+                let metadata: AdditionalOntologyMetadata = row.get(additional_metadata_index);
 
                 let record_repr: <T::OntologyType as OntologyType>::Representation =
                     serde_json::from_value(row.get(schema_index))
@@ -79,14 +109,23 @@ where
                     .into_report()
                     .change_context(QueryError)?;
 
-                Ok(T::new(
-                    record,
-                    OntologyElementMetadata::new(
-                        OntologyTypeEditionId::new(base_uri, version),
-                        ProvenanceMetadata::new(updated_by_id),
-                        owned_by_id,
-                    ),
-                ))
+                let edition_id = OntologyTypeEditionId::new(base_uri, version);
+                let provenance = ProvenanceMetadata::new(updated_by_id);
+
+                Ok(T::new(record, match metadata {
+                    AdditionalOntologyMetadata::Owned { owned_by_id } => {
+                        OntologyElementMetadata::Owned(OwnedOntologyElementMetadata::new(
+                            edition_id,
+                            provenance,
+                            owned_by_id,
+                        ))
+                    }
+                    AdditionalOntologyMetadata::External { fetched_at } => {
+                        OntologyElementMetadata::External(ExternalOntologyElementMetadata::new(
+                            edition_id, provenance, fetched_at,
+                        ))
+                    }
+                }))
             })
             .try_collect()
             .await

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/condition.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/condition.rs
@@ -208,7 +208,7 @@ mod tests {
                     Some(FilterExpression::Parameter(Parameter::Number(1.0))),
                 ),
             ]),
-            r#"("ontology_ids_0_1_0"."base_uri" = $1) AND ("ontology_ids_0_1_0"."version" = $2)"#,
+            r#"("ontology_id_with_metadata_0_1_0"."base_uri" = $1) AND ("ontology_id_with_metadata_0_1_0"."version" = $2)"#,
             &[
                 &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
                 &1.0,
@@ -242,7 +242,7 @@ mod tests {
                     Some(FilterExpression::Parameter(Parameter::Number(1.0))),
                 ),
             ]),
-            r#"(("ontology_ids_0_1_0"."base_uri" = $1) OR ("ontology_ids_0_1_0"."version" = $2))"#,
+            r#"(("ontology_id_with_metadata_0_1_0"."base_uri" = $1) OR ("ontology_id_with_metadata_0_1_0"."version" = $2))"#,
             &[
                 &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
                 &1.0,

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/data_type.rs
@@ -1,4 +1,3 @@
-use super::table::OwnedOntologyMetadata;
 use crate::{
     ontology::{DataTypeQueryPath, DataTypeWithMetadata},
     store::postgres::query::{
@@ -16,11 +15,12 @@ impl PostgresRecord for DataTypeWithMetadata {
 impl PostgresQueryPath for DataTypeQueryPath<'_> {
     fn relations(&self) -> Vec<Relation> {
         match self {
-            Self::BaseUri | Self::Version => {
+            Self::BaseUri
+            | Self::Version
+            | Self::UpdatedById
+            | Self::OwnedById
+            | Self::AdditionalMetadata(_) => {
                 vec![Relation::DataTypeIds]
-            }
-            Self::OwnedById | Self::UpdatedById => {
-                vec![Relation::DataTypeOwnedMetadata]
             }
             _ => vec![],
         }
@@ -30,7 +30,9 @@ impl PostgresQueryPath for DataTypeQueryPath<'_> {
         match self {
             Self::BaseUri => Column::OntologyIds(OntologyIds::BaseUri),
             Self::Version => Column::OntologyIds(OntologyIds::Version),
-            Self::OwnedById => Column::OwnedOntologyMetadata(OwnedOntologyMetadata::OwnedById),
+            Self::OwnedById => Column::OntologyIds(OntologyIds::AdditionalMetadata(Some(
+                JsonField::StaticText("owned_by_id"),
+            ))),
             Self::UpdatedById => Column::OntologyIds(OntologyIds::UpdatedById),
             Self::OntologyId => Column::DataTypes(DataTypes::OntologyId),
             Self::Schema(path) => path
@@ -48,6 +50,14 @@ impl PostgresQueryPath for DataTypeQueryPath<'_> {
             Self::Description => Column::DataTypes(DataTypes::Schema(Some(JsonField::StaticText(
                 "description",
             )))),
+            Self::AdditionalMetadata(path) => path.as_ref().map_or(
+                Column::OntologyIds(OntologyIds::AdditionalMetadata(None)),
+                |path| {
+                    Column::OntologyIds(OntologyIds::AdditionalMetadata(Some(JsonField::JsonPath(
+                        path,
+                    ))))
+                },
+            ),
         }
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
@@ -23,7 +23,7 @@ impl PostgresQueryPath for EntityTypeQueryPath<'_> {
             | Self::UpdatedById
             | Self::OwnedById
             | Self::AdditionalMetadata(_) => {
-                vec![Relation::DataTypeIds]
+                vec![Relation::EntityTypeIds]
             }
             Self::Properties(path) => once(Relation::EntityTypePropertyTypeReferences)
                 .chain(path.relations())

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
@@ -1,6 +1,5 @@
 use std::iter::once;
 
-use super::table::OwnedOntologyMetadata;
 use crate::{
     ontology::{EntityTypeQueryPath, EntityTypeWithMetadata},
     store::postgres::query::{
@@ -19,11 +18,12 @@ impl PostgresQueryPath for EntityTypeQueryPath<'_> {
     /// Returns the relations that are required to access the path.
     fn relations(&self) -> Vec<Relation> {
         match self {
-            Self::BaseUri | Self::Version => {
-                vec![Relation::EntityTypeIds]
-            }
-            Self::OwnedById | Self::UpdatedById => {
-                vec![Relation::EntityTypeOwnedMetadata]
+            Self::BaseUri
+            | Self::Version
+            | Self::UpdatedById
+            | Self::OwnedById
+            | Self::AdditionalMetadata(_) => {
+                vec![Relation::DataTypeIds]
             }
             Self::Properties(path) => once(Relation::EntityTypePropertyTypeReferences)
                 .chain(path.relations())
@@ -42,7 +42,9 @@ impl PostgresQueryPath for EntityTypeQueryPath<'_> {
         match self {
             Self::BaseUri => Column::OntologyIds(OntologyIds::BaseUri),
             Self::Version => Column::OntologyIds(OntologyIds::Version),
-            Self::OwnedById => Column::OwnedOntologyMetadata(OwnedOntologyMetadata::OwnedById),
+            Self::OwnedById => Column::OntologyIds(OntologyIds::AdditionalMetadata(Some(
+                JsonField::StaticText("owned_by_id"),
+            ))),
             Self::UpdatedById => Column::OntologyIds(OntologyIds::UpdatedById),
             Self::OntologyId => Column::EntityTypes(EntityTypes::OntologyId),
             Self::Schema(path) => path
@@ -73,6 +75,14 @@ impl PostgresQueryPath for EntityTypeQueryPath<'_> {
             ))),
             Self::Links(path) | Self::InheritsFrom(path) => path.terminating_column(),
             Self::Properties(path) => path.terminating_column(),
+            Self::AdditionalMetadata(path) => path.as_ref().map_or(
+                Column::OntologyIds(OntologyIds::AdditionalMetadata(None)),
+                |path| {
+                    Column::OntologyIds(OntologyIds::AdditionalMetadata(Some(JsonField::JsonPath(
+                        path,
+                    ))))
+                },
+            ),
         }
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/conditional.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/conditional.rs
@@ -150,7 +150,7 @@ mod tests {
     fn transpile_window_expression() {
         assert_eq!(
             max_version_expression().transpile_to_string(),
-            r#"MAX("ontology_ids_0_0_0"."version") OVER (PARTITION BY "ontology_ids_0_0_0"."base_uri")"#
+            r#"MAX("ontology_id_with_metadata_0_0_0"."version") OVER (PARTITION BY "ontology_id_with_metadata_0_0_0"."base_uri")"#
         );
     }
 
@@ -167,7 +167,7 @@ mod tests {
                     })
             ))))
             .transpile_to_string(),
-            r#"MIN("ontology_ids_1_2_3"."version")"#
+            r#"MIN("ontology_id_with_metadata_1_2_3"."version")"#
         );
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
@@ -59,7 +59,7 @@ mod tests {
                 }),
             )
             .transpile_to_string(),
-            r#"INNER JOIN "ontology_ids" AS "ontology_ids_0_1_2" ON "ontology_ids_0_1_2"."ontology_id" = "data_types_1_2_3"."ontology_id""#
+            r#"INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_1_2" ON "ontology_id_with_metadata_0_1_2"."ontology_id" = "data_types_1_2_3"."ontology_id""#
         );
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/order_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/order_clause.rs
@@ -68,7 +68,7 @@ mod tests {
         );
         assert_eq!(
             order_by_expression.transpile_to_string(),
-            r#"ORDER BY "ontology_ids_1_2_3"."version" ASC"#
+            r#"ORDER BY "ontology_id_with_metadata_1_2_3"."version" ASC"#
         );
     }
 
@@ -97,7 +97,7 @@ mod tests {
         assert_eq!(
             trim_whitespace(order_by_expression.transpile_to_string()),
             trim_whitespace(
-                r#"ORDER BY "ontology_ids_1_2_3"."base_uri" ASC,
+                r#"ORDER BY "ontology_id_with_metadata_1_2_3"."base_uri" ASC,
                 "data_types_4_5_6"."schema"->>'type' DESC"#
             )
         );

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/select_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/select_clause.rs
@@ -53,7 +53,7 @@ mod tests {
                 None
             )
             .transpile_to_string(),
-            r#""ontology_ids_1_2_3"."base_uri""#
+            r#""ontology_id_with_metadata_1_2_3"."base_uri""#
         );
 
         assert_eq!(
@@ -98,7 +98,7 @@ mod tests {
                 Some(Cow::Borrowed("latest_version"))
             )
             .transpile_to_string(),
-            r#"MAX("ontology_ids_1_2_3"."version") OVER (PARTITION BY "ontology_ids_1_2_3"."base_uri") AS "latest_version""#
+            r#"MAX("ontology_id_with_metadata_1_2_3"."version") OVER (PARTITION BY "ontology_id_with_metadata_1_2_3"."base_uri") AS "latest_version""#
         );
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
@@ -70,7 +70,7 @@ mod tests {
 
         assert_eq!(
             where_clause.transpile_to_string(),
-            r#"WHERE "ontology_ids_0_1_0"."version" = "ontology_ids_0_1_0"."latest_version""#
+            r#"WHERE "ontology_id_with_metadata_0_1_0"."version" = "ontology_id_with_metadata_0_1_0"."latest_version""#
         );
 
         let filter_b = Filter::All(vec![
@@ -91,8 +91,8 @@ mod tests {
             trim_whitespace(where_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WHERE "ontology_ids_0_1_0"."version" = "ontology_ids_0_1_0"."latest_version"
-                  AND ("ontology_ids_0_1_0"."base_uri" = $1) AND ("ontology_ids_0_1_0"."version" = $2)"#
+                WHERE "ontology_id_with_metadata_0_1_0"."version" = "ontology_id_with_metadata_0_1_0"."latest_version"
+                  AND ("ontology_id_with_metadata_0_1_0"."base_uri" = $1) AND ("ontology_id_with_metadata_0_1_0"."version" = $2)"#
             )
         );
 
@@ -106,8 +106,8 @@ mod tests {
             trim_whitespace(where_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WHERE "ontology_ids_0_1_0"."version" = "ontology_ids_0_1_0"."latest_version"
-                  AND ("ontology_ids_0_1_0"."base_uri" = $1) AND ("ontology_ids_0_1_0"."version" = $2)
+                WHERE "ontology_id_with_metadata_0_1_0"."version" = "ontology_id_with_metadata_0_1_0"."latest_version"
+                  AND ("ontology_id_with_metadata_0_1_0"."base_uri" = $1) AND ("ontology_id_with_metadata_0_1_0"."version" = $2)
                   AND "data_types_0_0_0"."schema"->>'description' IS NOT NULL"#
             )
         );
@@ -132,8 +132,8 @@ mod tests {
             trim_whitespace(where_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WHERE "ontology_ids_0_1_0"."version" = "ontology_ids_0_1_0"."latest_version"
-                  AND ("ontology_ids_0_1_0"."base_uri" = $1) AND ("ontology_ids_0_1_0"."version" = $2)
+                WHERE "ontology_id_with_metadata_0_1_0"."version" = "ontology_id_with_metadata_0_1_0"."latest_version"
+                  AND ("ontology_id_with_metadata_0_1_0"."base_uri" = $1) AND ("ontology_id_with_metadata_0_1_0"."version" = $2)
                   AND "data_types_0_0_0"."schema"->>'description' IS NOT NULL
                   AND (("data_types_0_0_0"."schema"->>'title' = $3) OR ("data_types_0_0_0"."schema"->>'description' = $4))"#
             )

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/with_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/with_clause.rs
@@ -91,7 +91,7 @@ mod tests {
             trim_whitespace(with_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WITH "ontology_ids" AS (SELECT *, MAX("ontology_ids_0_0_0"."version") OVER (PARTITION BY "ontology_ids_0_0_0"."base_uri") AS "latest_version" FROM "ontology_ids" AS "ontology_ids_0_0_0")"#
+                WITH "ontology_id_with_metadata" AS (SELECT *, MAX("ontology_id_with_metadata_0_0_0"."version") OVER (PARTITION BY "ontology_id_with_metadata_0_0_0"."base_uri") AS "latest_version" FROM "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_0_0")"#
             )
         );
 
@@ -113,7 +113,7 @@ mod tests {
             trim_whitespace(with_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WITH "ontology_ids" AS (SELECT *, MAX("ontology_ids_0_0_0"."version") OVER (PARTITION BY "ontology_ids_0_0_0"."base_uri") AS "latest_version" FROM "ontology_ids" AS "ontology_ids_0_0_0"),
+                WITH "ontology_id_with_metadata" AS (SELECT *, MAX("ontology_id_with_metadata_0_0_0"."version") OVER (PARTITION BY "ontology_id_with_metadata_0_0_0"."base_uri") AS "latest_version" FROM "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_0_0"),
                      "data_types" AS (SELECT * FROM "data_types" AS "data_types_3_4_5")"#
             )
         );

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/property_type.rs
@@ -22,7 +22,7 @@ impl PostgresQueryPath for PropertyTypeQueryPath<'_> {
             | Self::UpdatedById
             | Self::OwnedById
             | Self::AdditionalMetadata(_) => {
-                vec![Relation::DataTypeIds]
+                vec![Relation::PropertyTypeIds]
             }
             Self::DataTypes(path) => once(Relation::PropertyTypeDataTypeReferences)
                 .chain(path.relations())

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -175,9 +175,9 @@ mod tests {
             r#"
             SELECT *
             FROM "data_types" AS "data_types_0_0_0"
-            INNER JOIN "ontology_ids" AS "ontology_ids_0_1_0"
-              ON "ontology_ids_0_1_0"."ontology_id" = "data_types_0_0_0"."ontology_id"
-            WHERE ("ontology_ids_0_1_0"."base_uri" = $1) AND ("ontology_ids_0_1_0"."version" = $2)
+            INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_1_0"
+              ON "ontology_id_with_metadata_0_1_0"."ontology_id" = "data_types_0_0_0"."ontology_id"
+            WHERE ("ontology_id_with_metadata_0_1_0"."base_uri" = $1) AND ("ontology_id_with_metadata_0_1_0"."version" = $2)
             "#,
             &[
                 &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
@@ -201,12 +201,12 @@ mod tests {
         test_compilation(
             &compiler,
             r#"
-            WITH "ontology_ids" AS (SELECT *, MAX("ontology_ids_0_0_0"."version") OVER (PARTITION BY "ontology_ids_0_0_0"."base_uri") AS "latest_version" FROM "ontology_ids" AS "ontology_ids_0_0_0")
+            WITH "ontology_id_with_metadata" AS (SELECT *, MAX("ontology_id_with_metadata_0_0_0"."version") OVER (PARTITION BY "ontology_id_with_metadata_0_0_0"."base_uri") AS "latest_version" FROM "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_0_0")
             SELECT *
             FROM "data_types" AS "data_types_0_0_0"
-            INNER JOIN "ontology_ids" AS "ontology_ids_0_1_0"
-              ON "ontology_ids_0_1_0"."ontology_id" = "data_types_0_0_0"."ontology_id"
-            WHERE "ontology_ids_0_1_0"."version" = "ontology_ids_0_1_0"."latest_version"
+            INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_1_0"
+              ON "ontology_id_with_metadata_0_1_0"."ontology_id" = "data_types_0_0_0"."ontology_id"
+            WHERE "ontology_id_with_metadata_0_1_0"."version" = "ontology_id_with_metadata_0_1_0"."latest_version"
             "#,
             &[],
         );
@@ -227,12 +227,12 @@ mod tests {
         test_compilation(
             &compiler,
             r#"
-            WITH "ontology_ids" AS (SELECT *, MAX("ontology_ids_0_0_0"."version") OVER (PARTITION BY "ontology_ids_0_0_0"."base_uri") AS "latest_version" FROM "ontology_ids" AS "ontology_ids_0_0_0")
+            WITH "ontology_id_with_metadata" AS (SELECT *, MAX("ontology_id_with_metadata_0_0_0"."version") OVER (PARTITION BY "ontology_id_with_metadata_0_0_0"."base_uri") AS "latest_version" FROM "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_0_0")
             SELECT *
             FROM "data_types" AS "data_types_0_0_0"
-            INNER JOIN "ontology_ids" AS "ontology_ids_0_1_0"
-              ON "ontology_ids_0_1_0"."ontology_id" = "data_types_0_0_0"."ontology_id"
-            WHERE "ontology_ids_0_1_0"."version" != "ontology_ids_0_1_0"."latest_version"
+            INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_1_0"
+              ON "ontology_id_with_metadata_0_1_0"."ontology_id" = "data_types_0_0_0"."ontology_id"
+            WHERE "ontology_id_with_metadata_0_1_0"."version" != "ontology_id_with_metadata_0_1_0"."latest_version"
             "#,
             &[],
         );
@@ -296,10 +296,10 @@ mod tests {
               ON "data_types_0_2_0"."ontology_id" = "property_type_data_type_references_0_1_0"."target_data_type_ontology_id"
             INNER JOIN "property_type_data_type_references" AS "property_type_data_type_references_1_1_0"
               ON "property_type_data_type_references_1_1_0"."source_property_type_ontology_id" = "property_types_0_0_0"."ontology_id"
-            INNER JOIN "ontology_ids" AS "ontology_ids_1_3_0"
-              ON "ontology_ids_1_3_0"."ontology_id" = "property_type_data_type_references_1_1_0"."target_data_type_ontology_id"
+            INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_1_3_0"
+              ON "ontology_id_with_metadata_1_3_0"."ontology_id" = "property_type_data_type_references_1_1_0"."target_data_type_ontology_id"
             WHERE "data_types_0_2_0"."schema"->>'title' = $1
-              AND ("ontology_ids_1_3_0"."base_uri" = $2) AND ("ontology_ids_1_3_0"."version" = $3)
+              AND ("ontology_id_with_metadata_1_3_0"."base_uri" = $2) AND ("ontology_id_with_metadata_1_3_0"."version" = $3)
             "#,
             &[
                 &"Text",
@@ -435,10 +435,10 @@ mod tests {
               ON "entity_type_entity_type_references_0_1_0"."source_entity_type_ontology_id" = "entity_types_0_0_0"."ontology_id"
             INNER JOIN "entity_types" AS "entity_types_0_2_0"
               ON "entity_types_0_2_0"."ontology_id" = "entity_type_entity_type_references_0_1_0"."target_entity_type_ontology_id"
-            INNER JOIN "ontology_ids" AS "ontology_ids_0_3_0"
-              ON "ontology_ids_0_3_0"."ontology_id" = "entity_types_0_2_0"."ontology_id"
+            INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_3_0"
+              ON "ontology_id_with_metadata_0_3_0"."ontology_id" = "entity_types_0_2_0"."ontology_id"
             WHERE jsonb_contains("entity_types_0_0_0"."schema"->'allOf', jsonb_build_array(jsonb_build_object('$ref', "entity_types_0_2_0"."schema"->>'$id'))) IS NOT NULL
-              AND "ontology_ids_0_3_0"."base_uri" = $1
+              AND "ontology_id_with_metadata_0_3_0"."base_uri" = $1
             "#,
             &[&"https://blockprotocol.org/@blockprotocol/types/entity-type/link/"],
         );
@@ -742,14 +742,14 @@ mod tests {
              SELECT *
              FROM "entities" AS "entities_0_0_0"
              RIGHT OUTER JOIN "entities" AS "entities_0_1_0" ON "entities_0_1_0"."entity_uuid" = "entities_0_0_0"."left_entity_uuid"
-             INNER JOIN "ontology_ids" AS "ontology_ids_0_3_0" ON "ontology_ids_0_3_0"."ontology_id" = "entities_0_1_0"."entity_type_ontology_id"
+             INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_3_0" ON "ontology_id_with_metadata_0_3_0"."ontology_id" = "entities_0_1_0"."entity_type_ontology_id"
              RIGHT OUTER JOIN "entities" AS "entities_0_1_1" ON "entities_0_1_1"."entity_uuid" = "entities_0_0_0"."right_entity_uuid"
-             INNER JOIN "ontology_ids" AS "ontology_ids_0_3_1" ON "ontology_ids_0_3_1"."ontology_id" = "entities_0_1_1"."entity_type_ontology_id"
+             INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_3_1" ON "ontology_id_with_metadata_0_3_1"."ontology_id" = "entities_0_1_1"."entity_type_ontology_id"
              WHERE "entities_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ AND "entities_0_0_0"."decision_time" && $2
                AND "entities_0_1_0"."transaction_time" @> $1::TIMESTAMPTZ AND "entities_0_1_0"."decision_time" && $2
                AND "entities_0_1_1"."transaction_time" @> $1::TIMESTAMPTZ AND "entities_0_1_1"."decision_time" && $2
-               AND ("ontology_ids_0_3_0"."base_uri" = $3)
-               AND ("ontology_ids_0_3_1"."base_uri" = $4)
+               AND ("ontology_id_with_metadata_0_3_0"."base_uri" = $3)
+               AND ("ontology_id_with_metadata_0_3_1"."base_uri" = $4)
             "#,
             &[
                 &kernel,
@@ -796,9 +796,9 @@ mod tests {
                 r#"
                 SELECT *
                 FROM "data_types" AS "data_types_0_0_0"
-                INNER JOIN "ontology_ids" AS "ontology_ids_0_1_0"
-                  ON "ontology_ids_0_1_0"."ontology_id" = "data_types_0_0_0"."ontology_id"
-                WHERE ("ontology_ids_0_1_0"."base_uri" = $1) AND ("ontology_ids_0_1_0"."version" = $2)
+                INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_1_0"
+                  ON "ontology_id_with_metadata_0_1_0"."ontology_id" = "data_types_0_0_0"."ontology_id"
+                WHERE ("ontology_id_with_metadata_0_1_0"."base_uri" = $1) AND ("ontology_id_with_metadata_0_1_0"."version" = $2)
                 "#,
                 &[&uri.base_uri().as_str(), &i64::from(uri.version())],
             );
@@ -826,9 +826,9 @@ mod tests {
                 r#"
                 SELECT *
                 FROM "data_types" AS "data_types_0_0_0"
-                INNER JOIN "ontology_ids" AS "ontology_ids_0_1_0"
-                  ON "ontology_ids_0_1_0"."ontology_id" = "data_types_0_0_0"."ontology_id"
-                WHERE ("ontology_ids_0_1_0"."base_uri" = $1) AND ("ontology_ids_0_1_0"."version" = $2)
+                INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_1_0"
+                  ON "ontology_id_with_metadata_0_1_0"."ontology_id" = "data_types_0_0_0"."ontology_id"
+                WHERE ("ontology_id_with_metadata_0_1_0"."base_uri" = $1) AND ("ontology_id_with_metadata_0_1_0"."version" = $2)
                 "#,
                 &[&uri.base_id().as_str(), &i64::from(uri.version().inner())],
             );

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
@@ -583,7 +583,7 @@ mod tests {
     fn transpile_table() {
         assert_eq!(
             Table::OntologyIds.transpile_to_string(),
-            r#""ontology_ids""#
+            r#""ontology_id_with_metadata""#
         );
         assert_eq!(Table::DataTypes.transpile_to_string(), r#""data_types""#);
     }
@@ -598,7 +598,7 @@ mod tests {
                     number: 3,
                 })
                 .transpile_to_string(),
-            r#""ontology_ids_1_2_3""#
+            r#""ontology_id_with_metadata_1_2_3""#
         );
     }
 

--- a/apps/hash-graph/lib/graph/src/store/query.rs
+++ b/apps/hash-graph/lib/graph/src/store/query.rs
@@ -58,11 +58,6 @@ pub trait OntologyQueryPath {
     /// [`OntologyTypeVersion`]: crate::identifier::ontology::OntologyTypeVersion
     fn version() -> Self;
 
-    /// Returns the path identifying the [`OwnedById`].
-    ///
-    /// [`OwnedById`]: crate::provenance::OwnedById
-    fn owned_by_id() -> Self;
-
     /// Returns the path identifying the [`UpdatedById`].
     ///
     /// [`UpdatedById`]: crate::provenance::UpdatedById
@@ -70,4 +65,7 @@ pub trait OntologyQueryPath {
 
     /// Returns the path identifying the schema.
     fn schema() -> Self;
+
+    /// Returns the path identifying the metadata
+    fn additional_metadata() -> Self;
 }

--- a/libs/@local/hash-graph-client/api.ts
+++ b/libs/@local/hash-graph-client/api.ts
@@ -845,6 +845,31 @@ export interface EqualFilter {
   equal: Array<FilterExpression>;
 }
 /**
+ *
+ * @export
+ * @interface ExternalOntologyElementMetadata
+ */
+export interface ExternalOntologyElementMetadata {
+  /**
+   *
+   * @type {OntologyTypeEditionId}
+   * @memberof ExternalOntologyElementMetadata
+   */
+  editionId: OntologyTypeEditionId;
+  /**
+   *
+   * @type {OffsetDateTime}
+   * @memberof ExternalOntologyElementMetadata
+   */
+  fetchedAt: OffsetDateTime;
+  /**
+   *
+   * @type {ProvenanceMetadata}
+   * @memberof ExternalOntologyElementMetadata
+   */
+  provenance: ProvenanceMetadata;
+}
+/**
  * @type Filter
  * @export
  */
@@ -1198,30 +1223,11 @@ export type OntologyEdgeKind =
   (typeof OntologyEdgeKind)[keyof typeof OntologyEdgeKind];
 
 /**
- *
+ * @type OntologyElementMetadata
  * @export
- * @interface OntologyElementMetadata
  */
-export interface OntologyElementMetadata {
-  /**
-   *
-   * @type {OntologyTypeEditionId}
-   * @memberof OntologyElementMetadata
-   */
-  editionId: OntologyTypeEditionId;
-  /**
-   *
-   * @type {string}
-   * @memberof OntologyElementMetadata
-   */
-  ownedById: string;
-  /**
-   *
-   * @type {ProvenanceMetadata}
-   * @memberof OntologyElementMetadata
-   */
-  provenance: ProvenanceMetadata;
-}
+export type OntologyElementMetadata = OwnedOntologyElementMetadata;
+
 /**
  * @type OntologyOutwardEdges
  * @export
@@ -1456,6 +1462,31 @@ export interface OutgoingEdgeResolveDepth {
    * @memberof OutgoingEdgeResolveDepth
    */
   outgoing: number;
+}
+/**
+ *
+ * @export
+ * @interface OwnedOntologyElementMetadata
+ */
+export interface OwnedOntologyElementMetadata {
+  /**
+   *
+   * @type {OntologyTypeEditionId}
+   * @memberof OwnedOntologyElementMetadata
+   */
+  editionId: OntologyTypeEditionId;
+  /**
+   *
+   * @type {string}
+   * @memberof OwnedOntologyElementMetadata
+   */
+  ownedById: string;
+  /**
+   *
+   * @type {ProvenanceMetadata}
+   * @memberof OwnedOntologyElementMetadata
+   */
+  provenance: ProvenanceMetadata;
 }
 /**
  *

--- a/libs/@local/hash-graph-client/api.ts
+++ b/libs/@local/hash-graph-client/api.ts
@@ -858,10 +858,10 @@ export interface ExternalOntologyElementMetadata {
   editionId: OntologyTypeEditionId;
   /**
    *
-   * @type {OffsetDateTime}
+   * @type {string}
    * @memberof ExternalOntologyElementMetadata
    */
-  fetchedAt: OffsetDateTime;
+  fetchedAt: string;
   /**
    *
    * @type {ProvenanceMetadata}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

With #2004 we added support for external metadata to the database. This requires new handling on the Graph API to properly query for that metadata.

For now, only the logic to query the database is implemented, external metadata is not exposed yet to the TS backend. For this, only the `skip_serialize` has to be removed from the added enumeration.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203543026679380/1203843814258952/f) _(internal)_

## 🔍 What does this change?

- Split `OntologyElementMetadata` into `OwnedOntologyElementMetadata` and `ExternalOntologyElementMetadata`
- Adjust structural queries to query for the `additional_metadata` column
- Remove old references to the `owned_ontology_ids` table