### PR TITLE
Ensure properties/links tables reliably update when data loads in entity type editor

### DIFF
--- a/patches/react-hook-form+7.37.0.patch
+++ b/patches/react-hook-form+7.37.0.patch
@@ -1,3 +1,21 @@
+diff --git a/node_modules/react-hook-form/dist/index.esm.mjs b/node_modules/react-hook-form/dist/index.esm.mjs
+index f27670f..34dd8d9 100644
+--- a/node_modules/react-hook-form/dist/index.esm.mjs
++++ b/node_modules/react-hook-form/dist/index.esm.mjs
+@@ -991,6 +991,13 @@ function useFieldArray(props) {
+         callback,
+         subject: control._subjects.array,
+     });
++    const _callback = React.useRef(callback);
++    _callback.current = callback;
++    const _control = React.useRef(control);
++    _control.current = control;
++    React.useEffect(() => {
++        _callback.current({ values: _control.current._formValues })
++    }, []);
+     const updateValues = React.useCallback((updatedFieldArrayValues) => {
+         _actioned.current = true;
+         control._updateFieldArray(name, updatedFieldArrayValues);
 diff --git a/node_modules/react-hook-form/dist/types/path/common.d.ts b/node_modules/react-hook-form/dist/types/path/common.d.ts
 index 874f54e..0844b93 100644
 --- a/node_modules/react-hook-form/dist/types/path/common.d.ts

--- a/patches/react-hook-form+7.37.0.patch
+++ b/patches/react-hook-form+7.37.0.patch
@@ -1,7 +1,16 @@
 diff --git a/node_modules/react-hook-form/dist/index.esm.mjs b/node_modules/react-hook-form/dist/index.esm.mjs
-index f27670f..34dd8d9 100644
+index f27670f..74a9686 100644
 --- a/node_modules/react-hook-form/dist/index.esm.mjs
 +++ b/node_modules/react-hook-form/dist/index.esm.mjs
+@@ -170,7 +170,7 @@ var shouldSubscribeByName = (name, signalName, exact) => exact && signalName
+ function useSubscribe(props) {
+     const _props = React.useRef(props);
+     _props.current = props;
+-    React.useEffect(() => {
++    React.useLayoutEffect(() => {
+         const subscription = !props.disabled &&
+             _props.current.subject.subscribe({
+                 next: _props.current.callback,
 @@ -991,6 +991,13 @@ function useFieldArray(props) {
          callback,
          subject: control._subjects.array,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

A bug in react-hook-form meant that the internal state of `useFieldArray` (used for properties/links tables) wasn't updating when the entity type loaded if the entity type hadn't loaded by the time the entity type editor page loaded.

This PR uses `patch-package` to patch this bug, but it's also been reported to react-hook-form to see if they're willing to address it. 

Replaces https://github.com/hashintel/hash/pull/2013 

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203543021352032/1203771430939706/f) _(internal)_
- [Github issue in react-hook-form](https://github.com/react-hook-form/react-hook-form/issues/9878)

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

N/A

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- A new effect is added to `useFieldArray` in react-hook-form to update its internal state on mount, to ensure it takes into account any changes made prior to subscribing. This ensures properties/links tables update as expected on load. `useSubscribe` is also updated to attach the subscription earlier for extra safety. 

I considered fixing this on our end, by using `useEffect` to update the form instead of `useLayoutEffect`, but this led to some consequences where data rendered using react hook form vs using react state were temporarily out of sync, so this was preferable. This is what was attempted in https://github.com/hashintel/hash/pull/2013 

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

N/A

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

N/A

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

Ideally, react-hook-form will fix this bug by adopting our patch, or some other way. 

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Load the entity type editor on a slow network
2. Ensure properties/links load as expected