### PR TITLE
Fix forwardref error in console in entity type editor

### DIFF
--- a/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[entity-type-id].page/definition-tab/property-list-card/property-type-form/expected-value-selector.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[entity-type-id].page/definition-tab/property-list-card/property-type-form/expected-value-selector.tsx
@@ -84,10 +84,11 @@ const ExpectedValueSelectorDropdown = ({ children, ...props }: PaperProps) => {
   );
 };
 
-const ExpectedValueSelector: ForwardRefRenderFunction<
-  HTMLInputElement,
-  { propertyTypeBaseUri?: BaseUri }
-> = ({ propertyTypeBaseUri }) => {
+export const ExpectedValueSelector = ({
+  propertyTypeBaseUri,
+}: {
+  propertyTypeBaseUri?: BaseUri;
+}) => {
   const propertyTypeFormMethods = useFormContext<PropertyTypeFormValues>();
 
   const expectedValueSelectorFormMethods =
@@ -357,7 +358,3 @@ const ExpectedValueSelector: ForwardRefRenderFunction<
     </CustomExpectedValueBuilderContext.Provider>
   );
 };
-
-const ExpectedValueSelectorForwardedRef = forwardRef(ExpectedValueSelector);
-
-export { ExpectedValueSelectorForwardedRef as ExpectedValueSelector };

--- a/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[entity-type-id].page/definition-tab/property-list-card/property-type-form/expected-value-selector.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[entity-type-id].page/definition-tab/property-list-card/property-type-form/expected-value-selector.tsx
@@ -6,13 +6,7 @@ import {
   TextField,
 } from "@hashintel/design-system";
 import { Autocomplete, Box, PaperProps, Typography } from "@mui/material";
-import {
-  forwardRef,
-  ForwardRefRenderFunction,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useMemo, useRef, useState } from "react";
 import {
   FormProvider,
   useController,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Removes unnecessary use of `forwardRef` which was causing React to warn in the console

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203543026679380/1203835239889656/f) _(internal)_
