### PR TITLE
Allow batch insertion of (owned and external) ontology types

### DIFF
--- a/apps/hash-graph/bench/benches/util.rs
+++ b/apps/hash-graph/bench/benches/util.rs
@@ -2,7 +2,8 @@ use std::mem::ManuallyDrop;
 
 use graph::{
     identifier::account::AccountId,
-    provenance::{OwnedById, UpdatedById},
+    ontology::{OntologyElementMetadata, OwnedOntologyElementMetadata},
+    provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
         AsClient, BaseUriAlreadyExists, DataTypeStore, DatabaseConnectionInfo, DatabaseType,
         EntityTypeStore, PostgresStore, PostgresStorePool, PropertyTypeStore, StorePool,
@@ -196,8 +197,11 @@ pub async fn seed<D, P, E, C>(
         match store
             .create_data_type(
                 data_type.clone(),
-                OwnedById::new(account_id),
-                UpdatedById::new(account_id),
+                &OntologyElementMetadata::Owned(OwnedOntologyElementMetadata::new(
+                    data_type.id().into(),
+                    ProvenanceMetadata::new(UpdatedById::new(account_id)),
+                    OwnedById::new(account_id),
+                )),
             )
             .await
         {
@@ -224,8 +228,11 @@ pub async fn seed<D, P, E, C>(
         match store
             .create_property_type(
                 property_type.clone(),
-                OwnedById::new(account_id),
-                UpdatedById::new(account_id),
+                &OntologyElementMetadata::Owned(OwnedOntologyElementMetadata::new(
+                    property_type.id().into(),
+                    ProvenanceMetadata::new(UpdatedById::new(account_id)),
+                    OwnedById::new(account_id),
+                )),
             )
             .await
         {
@@ -252,8 +259,11 @@ pub async fn seed<D, P, E, C>(
         match store
             .create_entity_type(
                 entity_type.clone(),
-                OwnedById::new(account_id),
-                UpdatedById::new(account_id),
+                &OntologyElementMetadata::Owned(OwnedOntologyElementMetadata::new(
+                    entity_type.id().into(),
+                    ProvenanceMetadata::new(UpdatedById::new(account_id)),
+                    OwnedById::new(account_id),
+                )),
             )
             .await
         {

--- a/apps/hash-graph/bin/cli/src/subcommands/server.rs
+++ b/apps/hash-graph/bin/cli/src/subcommands/server.rs
@@ -6,8 +6,10 @@ use graph::{
     api::rest::{rest_api_router, RestRouterDependencies},
     identifier::account::AccountId,
     logging::{init_logger, LoggingArgs},
-    ontology::domain_validator::DomainValidator,
-    provenance::{OwnedById, UpdatedById},
+    ontology::{
+        domain_validator::DomainValidator, OntologyElementMetadata, OwnedOntologyElementMetadata,
+    },
+    provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
         AccountStore, BaseUriAlreadyExists, DataTypeStore, DatabaseConnectionInfo, EntityTypeStore,
         PostgresStorePool, StorePool,
@@ -215,33 +217,40 @@ async fn stop_gap_setup(pool: &PostgresStorePool<NoTls>) -> Result<(), GraphErro
     // Seed the primitive data types if they don't already exist
     for data_type in [text, number, boolean, empty_list, object, null] {
         let title = data_type.title().to_owned();
+
+        let data_type_metadata = OntologyElementMetadata::Owned(OwnedOntologyElementMetadata::new(
+            data_type.id().into(),
+            ProvenanceMetadata::new(UpdatedById::new(root_account_id)),
+            OwnedById::new(root_account_id),
+        ));
+
         if let Err(error) = connection
-            .create_data_type(
-                data_type,
-                OwnedById::new(root_account_id),
-                UpdatedById::new(root_account_id),
-            )
+            .create_data_type(data_type, &data_type_metadata)
             .await
             .change_context(GraphError)
         {
             if error.contains::<BaseUriAlreadyExists>() {
-                tracing::info!(%root_account_id, "tried to insert primitive {} data type, but it already exists", title);
+                tracing::info!(%root_account_id, "tried to insert primitive {title} data type, but it already exists");
             } else {
                 return Err(error.change_context(GraphError));
             }
         } else {
-            tracing::info!(%root_account_id, "inserted the primitive {} data type", title);
+            tracing::info!(%root_account_id, "inserted the primitive {title} data type");
         }
     }
 
     // Seed the entity types if they don't already exist
     let title = link_entity_type.title().to_owned();
-    if let Err(error) = connection
-        .create_entity_type(
-            link_entity_type,
+
+    let link_entity_type_metadata =
+        OntologyElementMetadata::Owned(OwnedOntologyElementMetadata::new(
+            link_entity_type.id().into(),
+            ProvenanceMetadata::new(UpdatedById::new(root_account_id)),
             OwnedById::new(root_account_id),
-            UpdatedById::new(root_account_id),
-        )
+        ));
+
+    if let Err(error) = connection
+        .create_entity_type(link_entity_type, &link_entity_type_metadata)
         .await
     {
         if error.contains::<BaseUriAlreadyExists>() {

--- a/apps/hash-graph/lib/graph/src/store/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/store/ontology.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use async_trait::async_trait;
 use error_stack::Result;
 use type_system::{DataType, EntityType, PropertyType};
@@ -19,14 +21,30 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     ///
     /// # Errors:
     ///
-    /// - if the account referred to by `owned_by_id` does not exist.
-    /// - if the [`BaseUri`] of the `data_type` already exist.
+    /// - if any account referred to by `metadata` does not exist.
+    /// - if the [`BaseUri`] of the `data_type` already exists.
     ///
     /// [`BaseUri`]: type_system::uri::BaseUri
     async fn create_data_type(
         &mut self,
         schema: DataType,
         metadata: &OntologyElementMetadata,
+    ) -> Result<(), InsertionError> {
+        self.create_data_types(iter::once((schema, metadata))).await
+    }
+
+    /// Creates the provided [`DataType`]s.
+    ///
+    /// # Errors:
+    ///
+    /// - if any account referred to by the metadata does not exist.
+    /// - if any [`BaseUri`] of the data type already exists.
+    ///
+    /// [`BaseUri`]: type_system::uri::BaseUri
+    async fn create_data_types(
+        &mut self,
+        property_types: impl IntoIterator<Item = (DataType, &OntologyElementMetadata), IntoIter: Send>
+        + Send,
     ) -> Result<(), InsertionError>;
 
     /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
@@ -58,7 +76,7 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     ///
     /// # Errors:
     ///
-    /// - if the account referred to by `owned_by_id` does not exist.
+    /// - if any account referred to by `metadata` does not exist.
     /// - if the [`BaseUri`] of the `property_type` already exists.
     ///
     /// [`BaseUri`]: type_system::uri::BaseUri
@@ -66,6 +84,25 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
         &mut self,
         schema: PropertyType,
         metadata: &OntologyElementMetadata,
+    ) -> Result<(), InsertionError> {
+        self.create_property_types(iter::once((schema, metadata)))
+            .await
+    }
+
+    /// Creates the provided [`PropertyType`]s.
+    ///
+    /// # Errors:
+    ///
+    /// - if any account referred to by the metadata does not exist.
+    /// - if any [`BaseUri`] of the property type already exists.
+    ///
+    /// [`BaseUri`]: type_system::uri::BaseUri
+    async fn create_property_types(
+        &mut self,
+        property_types: impl IntoIterator<
+            Item = (PropertyType, &OntologyElementMetadata),
+            IntoIter: Send,
+        > + Send,
     ) -> Result<(), InsertionError>;
 
     /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
@@ -97,14 +134,31 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     ///
     /// # Errors:
     ///
-    /// - if the account referred to by `owned_by_id` does not exist.
-    /// - if the [`BaseUri`] of the `entity_type` already exist.
+    /// - if any account referred to by `metadata` does not exist.
+    /// - if the [`BaseUri`] of the `entity_type` already exists.
     ///
     /// [`BaseUri`]: type_system::uri::BaseUri
     async fn create_entity_type(
         &mut self,
         schema: EntityType,
         metadata: &OntologyElementMetadata,
+    ) -> Result<(), InsertionError> {
+        self.create_entity_types(iter::once((schema, metadata)))
+            .await
+    }
+
+    /// Creates the provided [`EntityType`]s.
+    ///
+    /// # Errors:
+    ///
+    /// - if any account referred to by the metadata does not exist.
+    /// - if any [`BaseUri`] of the entity type already exists.
+    ///
+    /// [`BaseUri`]: type_system::uri::BaseUri
+    async fn create_entity_types(
+        &mut self,
+        property_types: impl IntoIterator<Item = (EntityType, &OntologyElementMetadata), IntoIter: Send>
+        + Send,
     ) -> Result<(), InsertionError>;
 
     /// Get the [`Subgraph`]s specified by the [`StructuralQuery`].

--- a/apps/hash-graph/lib/graph/src/store/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/store/ontology.rs
@@ -7,7 +7,7 @@ use crate::{
         DataTypeWithMetadata, EntityTypeWithMetadata, OntologyElementMetadata,
         PropertyTypeWithMetadata,
     },
-    provenance::{OwnedById, UpdatedById},
+    provenance::UpdatedById,
     store::{crud, InsertionError, QueryError, UpdateError},
     subgraph::{query::StructuralQuery, Subgraph},
 };
@@ -25,10 +25,9 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     /// [`BaseUri`]: type_system::uri::BaseUri
     async fn create_data_type(
         &mut self,
-        data_type: DataType,
-        owned_by_id: OwnedById,
-        actor_id: UpdatedById,
-    ) -> Result<OntologyElementMetadata, InsertionError>;
+        schema: DataType,
+        metadata: &OntologyElementMetadata,
+    ) -> Result<(), InsertionError>;
 
     /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
     ///
@@ -65,10 +64,9 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     /// [`BaseUri`]: type_system::uri::BaseUri
     async fn create_property_type(
         &mut self,
-        property_type: PropertyType,
-        owned_by_id: OwnedById,
-        actor_id: UpdatedById,
-    ) -> Result<OntologyElementMetadata, InsertionError>;
+        schema: PropertyType,
+        metadata: &OntologyElementMetadata,
+    ) -> Result<(), InsertionError>;
 
     /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
     ///
@@ -105,10 +103,9 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     /// [`BaseUri`]: type_system::uri::BaseUri
     async fn create_entity_type(
         &mut self,
-        entity_type: EntityType,
-        owned_by_id: OwnedById,
-        actor_id: UpdatedById,
-    ) -> Result<OntologyElementMetadata, InsertionError>;
+        schema: EntityType,
+        metadata: &OntologyElementMetadata,
+    ) -> Result<(), InsertionError>;
 
     /// Get the [`Subgraph`]s specified by the [`StructuralQuery`].
     ///

--- a/apps/hash-graph/lib/graph/src/store/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/store/ontology.rs
@@ -1,4 +1,4 @@
-use std::iter;
+use std::{borrow::Borrow, iter};
 
 use async_trait::async_trait;
 use error_stack::Result;
@@ -43,8 +43,10 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     /// [`BaseUri`]: type_system::uri::BaseUri
     async fn create_data_types(
         &mut self,
-        property_types: impl IntoIterator<Item = (DataType, &OntologyElementMetadata), IntoIter: Send>
-        + Send,
+        property_types: impl IntoIterator<
+            Item = (DataType, impl Borrow<OntologyElementMetadata> + Send + Sync),
+            IntoIter: Send,
+        > + Send,
     ) -> Result<(), InsertionError>;
 
     /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
@@ -100,7 +102,10 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     async fn create_property_types(
         &mut self,
         property_types: impl IntoIterator<
-            Item = (PropertyType, &OntologyElementMetadata),
+            Item = (
+                PropertyType,
+                impl Borrow<OntologyElementMetadata> + Send + Sync,
+            ),
             IntoIter: Send,
         > + Send,
     ) -> Result<(), InsertionError>;
@@ -157,8 +162,13 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     /// [`BaseUri`]: type_system::uri::BaseUri
     async fn create_entity_types(
         &mut self,
-        property_types: impl IntoIterator<Item = (EntityType, &OntologyElementMetadata), IntoIter: Send>
-        + Send,
+        property_types: impl IntoIterator<
+            Item = (
+                EntityType,
+                impl Borrow<OntologyElementMetadata> + Send + Sync,
+            ),
+            IntoIter: Send,
+        > + Send,
     ) -> Result<(), InsertionError>;
 
     /// Get the [`Subgraph`]s specified by the [`StructuralQuery`].

--- a/apps/hash-graph/tests/integration/lib.rs
+++ b/apps/hash-graph/tests/integration/lib.rs
@@ -1,1 +1,3 @@
+#![feature(associated_type_bounds)]
+
 mod postgres;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR introduces two changes: It changes the `Store` methods to take the ontology metadata to either insert an owned or an external ontology type. Also, it introduces a batch insertion for ontology types (currently internal to the graph), which defers the insertion of references to the end of the insertion.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203543026679380/1203843814258954/f) _(internal)_

## 🔍 What does this change?

- Make the `Store::create_*_type` to take `OntologyElementMetadata` instead of `UpdatedById` and `OwnedById`
- Add `Store::create_*_types`, which defers insertion of references to the end
- Default implement `Store::crate_*_type` to use the `Store::crate_*_types` method
- Correctly implement `ToSql` and `FromSql` for `OntologyTypeVersion`
- Use the batch insertion in integration tests

## 🐾 Next steps

The Graph needs to be made aware of the type fetcher and on demand ask for external types to be inserted

## 🛡 What tests cover this?

- The integration tests use the batch insertion directly
- All other tests using the database will implicitly test the new insertion method