### PR TITLE
`error-stack`: remove leading space for multiline attachments

### DIFF
--- a/libs/error-stack/src/fmt.rs
+++ b/libs/error-stack/src/fmt.rs
@@ -366,7 +366,7 @@ impl Indent {
                 group: false,
                 visible: true,
                 spacing: Some(Spacing::Minimal),
-            } => sym!('│', ' ', ' '),
+            } => sym!('│', ' '),
             Self {
                 group: false,
                 visible: true,
@@ -381,7 +381,7 @@ impl Indent {
                 visible: false,
                 spacing: Some(Spacing::Minimal),
                 ..
-            } => sym!(' ', ' ', ' '),
+            } => sym!(' ', ' '),
             Self {
                 visible: false,
                 spacing: None,

--- a/libs/error-stack/tests/snapshots/doc/fmt__emit_alt.snap
+++ b/libs/error-stack/tests/snapshots/doc/fmt__emit_alt.snap
@@ -3,17 +3,17 @@
 ├╴backtrace (1)
 ├╴error code: 404
 ├╴suggestion 0:
-│    do you have a connection to the internet?
+│   do you have a connection to the internet?
 ├╴suggestion (0)
 ├╴error code: 405
 ├╴abnormal program execution detected
 ├╴warning: unable to determine environment
 ├╴suggestion 1:
-│    execute the program from the fish shell
+│   execute the program from the fish shell
 ├╴suggestion (1)
 ├╴error code: 501
 ├╴suggestion 2:
-│    try better next time!
+│   try better next time!
 ╰╴suggestion (2)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/libs/error-stack/tests/snapshots/test_debug__full__multiline.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__full__multiline.snap
@@ -7,13 +7,13 @@ root error
 ├╴backtrace (1)
 ├╴span trace with 2 frames (1)
 ├╴A multiline
-│  attachment
-│  that might have some
-│  additional info
+│ attachment
+│ that might have some
+│ additional info
 ╰╴A multiline
-   attachment
-   that might have some
-   additional info
+  attachment
+  that might have some
+  additional info
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This was an oversight in #1980, where we removed the leading space from attachments but forgot multiline attachments.

## 🔗 Related links

- #2019

