### PR TITLE
Define full block names in package.json files

### DIFF
--- a/blocks/calculation/package.json
+++ b/blocks/calculation/package.json
@@ -43,10 +43,10 @@
     "port": 63210
   },
   "blockprotocol": {
-    "name": "@thehabbos007/calculation",
     "blockType": {
       "entryPoint": "react"
     },
+    "name": "@thehabbos007/calculation",
     "displayName": "Calculation",
     "examples": [
       {

--- a/blocks/calculation/package.json
+++ b/blocks/calculation/package.json
@@ -43,6 +43,7 @@
     "port": 63210
   },
   "blockprotocol": {
+    "name": "@thehabbos007/calculation",
     "blockType": {
       "entryPoint": "react"
     },

--- a/blocks/callout/package.json
+++ b/blocks/callout/package.json
@@ -41,6 +41,7 @@
     "servePort": 63212
   },
   "blockprotocol": {
+    "name": "@hash/callout",
     "blockType": {
       "entryPoint": "react"
     },

--- a/blocks/callout/package.json
+++ b/blocks/callout/package.json
@@ -41,10 +41,10 @@
     "servePort": 63212
   },
   "blockprotocol": {
-    "name": "@hash/callout",
     "blockType": {
       "entryPoint": "react"
     },
+    "name": "@hash/callout",
     "displayName": "Callout",
     "icon": "public/bullhorn-variant-outline.svg",
     "image": "public/preview.svg",

--- a/blocks/chart/package.json
+++ b/blocks/chart/package.json
@@ -43,6 +43,7 @@
     "servePort": 63217
   },
   "blockprotocol": {
+    "name": "@ben/chart",
     "displayName": "Chart",
     "examples": [
       {}

--- a/blocks/countdown/package.json
+++ b/blocks/countdown/package.json
@@ -47,6 +47,7 @@
     "servePort": 63215
   },
   "blockprotocol": {
+    "name": "@timdiekmann/countdown",
     "blockType": {
       "entryPoint": "react"
     },

--- a/blocks/countdown/package.json
+++ b/blocks/countdown/package.json
@@ -47,10 +47,10 @@
     "servePort": 63215
   },
   "blockprotocol": {
-    "name": "@timdiekmann/countdown",
     "blockType": {
       "entryPoint": "react"
     },
+    "name": "@timdiekmann/countdown",
     "displayName": "Countdown",
     "examples": [
       {

--- a/blocks/divider/package.json
+++ b/blocks/divider/package.json
@@ -40,6 +40,7 @@
     "servePort": 62679
   },
   "blockprotocol": {
+    "name": "@hash/divider",
     "displayName": "Divider",
     "icon": "public/divider.svg",
     "image": "public/preview.svg",

--- a/blocks/drawing/package.json
+++ b/blocks/drawing/package.json
@@ -48,10 +48,10 @@
     "servePort": 62722
   },
   "blockprotocol": {
-    "name": "@tldraw/drawing",
     "blockType": {
       "entryPoint": "react"
     },
+    "name": "@tldraw/drawing",
     "displayName": "Drawing",
     "examples": [
       {

--- a/blocks/drawing/package.json
+++ b/blocks/drawing/package.json
@@ -48,6 +48,7 @@
     "servePort": 62722
   },
   "blockprotocol": {
+    "name": "@tldraw/drawing",
     "blockType": {
       "entryPoint": "react"
     },

--- a/blocks/embed/package.json
+++ b/blocks/embed/package.json
@@ -43,6 +43,7 @@
     "servePort": 62680
   },
   "blockprotocol": {
+    "name": "@hash/embed",
     "displayName": "Embed",
     "icon": "public/embed.svg",
     "image": "public/preview.svg",

--- a/blocks/github-pr-overview/package.json
+++ b/blocks/github-pr-overview/package.json
@@ -53,10 +53,10 @@
     "servePort": 63222
   },
   "blockprotocol": {
-    "name": "@alfie/github-pr-overview",
     "blockType": {
       "entryPoint": "react"
     },
+    "name": "@alfie/github-pr-overview",
     "displayName": "GitHub Pull-Request Overview",
     "examples": [
       {

--- a/blocks/github-pr-overview/package.json
+++ b/blocks/github-pr-overview/package.json
@@ -53,6 +53,7 @@
     "servePort": 63222
   },
   "blockprotocol": {
+    "name": "@alfie/github-pr-overview",
     "blockType": {
       "entryPoint": "react"
     },

--- a/blocks/header/package.json
+++ b/blocks/header/package.json
@@ -41,6 +41,7 @@
     "servePort": 63282
   },
   "blockprotocol": {
+    "name": "@hash/heading",
     "blockType": {
       "entryPoint": "react"
     },

--- a/blocks/header/package.json
+++ b/blocks/header/package.json
@@ -41,10 +41,10 @@
     "servePort": 63282
   },
   "blockprotocol": {
-    "name": "@hash/heading",
     "blockType": {
       "entryPoint": "react"
     },
+    "name": "@hash/heading",
     "displayName": "Heading",
     "icon": "public/h1.svg",
     "image": "public/preview.svg",

--- a/blocks/html-para/package.json
+++ b/blocks/html-para/package.json
@@ -18,6 +18,7 @@
     "serve": "14.1.0"
   },
   "blockprotocol": {
+    "name": "@hash/html-para",
     "displayName": "Inline HTML",
     "icon": "public/html.svg",
     "image": "public/preview.svg",

--- a/blocks/image/package.json
+++ b/blocks/image/package.json
@@ -42,6 +42,7 @@
     "servePort": 62677
   },
   "blockprotocol": {
+    "name": "@hash/image",
     "blockType": {
       "entryPoint": "react"
     },

--- a/blocks/image/package.json
+++ b/blocks/image/package.json
@@ -42,10 +42,10 @@
     "servePort": 62677
   },
   "blockprotocol": {
-    "name": "@hash/image",
     "blockType": {
       "entryPoint": "react"
     },
+    "name": "@hash/image",
     "displayName": "Image",
     "icon": "public/image.svg",
     "image": "public/preview.svg",

--- a/blocks/paragraph/package.json
+++ b/blocks/paragraph/package.json
@@ -41,6 +41,7 @@
     "servePort": 62682
   },
   "blockprotocol": {
+    "name": "@hash/paragraph",
     "blockType": {
       "entryPoint": "react"
     },

--- a/blocks/paragraph/package.json
+++ b/blocks/paragraph/package.json
@@ -41,10 +41,10 @@
     "servePort": 62682
   },
   "blockprotocol": {
-    "name": "@hash/paragraph",
     "blockType": {
       "entryPoint": "react"
     },
+    "name": "@hash/paragraph",
     "displayName": "Paragraph",
     "icon": "public/paragraph.svg",
     "image": "public/preview.svg",

--- a/blocks/person/package.json
+++ b/blocks/person/package.json
@@ -42,6 +42,7 @@
     "servePort": 62692
   },
   "blockprotocol": {
+    "name": "@hash/person",
     "blockType": {
       "entryPoint": "react"
     },

--- a/blocks/person/package.json
+++ b/blocks/person/package.json
@@ -42,10 +42,10 @@
     "servePort": 62692
   },
   "blockprotocol": {
-    "name": "@hash/person",
     "blockType": {
       "entryPoint": "react"
     },
+    "name": "@hash/person",
     "displayName": "Person",
     "icon": "public/account-circle.svg",
     "image": "public/preview.svg",

--- a/blocks/shuffle/package.json
+++ b/blocks/shuffle/package.json
@@ -53,6 +53,7 @@
     "port": 63212
   },
   "blockprotocol": {
+    "name": "@hash/shuffle",
     "blockType": {
       "entryPoint": "react"
     },

--- a/blocks/shuffle/package.json
+++ b/blocks/shuffle/package.json
@@ -53,10 +53,10 @@
     "port": 63212
   },
   "blockprotocol": {
-    "name": "@hash/shuffle",
     "blockType": {
       "entryPoint": "react"
     },
+    "name": "@hash/shuffle",
     "displayName": "shuffle",
     "examples": [
       {

--- a/blocks/stopwatch/package.json
+++ b/blocks/stopwatch/package.json
@@ -39,7 +39,8 @@
     "servePort": 63214
   },
   "blockprotocol": {
-    "displayName": "timer",
+    "name": "@hash/stopwatch",
+    "displayName": "Stopwatch",
     "examples": [
       {}
     ],

--- a/blocks/table/package.json
+++ b/blocks/table/package.json
@@ -48,10 +48,10 @@
     "servePort": 62678
   },
   "blockprotocol": {
-    "name": "@hash/table",
     "blockType": {
       "entryPoint": "react"
     },
+    "name": "@hash/table",
     "displayName": "Table",
     "icon": "public/table.svg",
     "image": "public/preview.svg",

--- a/blocks/table/package.json
+++ b/blocks/table/package.json
@@ -48,6 +48,7 @@
     "servePort": 62678
   },
   "blockprotocol": {
+    "name": "@hash/table",
     "blockType": {
       "entryPoint": "react"
     },

--- a/blocks/timer/package.json
+++ b/blocks/timer/package.json
@@ -41,6 +41,7 @@
     "servePort": 63213
   },
   "blockprotocol": {
+    "name": "@timdiekmann/timer",
     "blockType": {
       "entryPoint": "react"
     },

--- a/blocks/timer/package.json
+++ b/blocks/timer/package.json
@@ -41,10 +41,10 @@
     "servePort": 63213
   },
   "blockprotocol": {
-    "name": "@timdiekmann/timer",
     "blockType": {
       "entryPoint": "react"
     },
+    "name": "@timdiekmann/timer",
     "displayName": "Timer",
     "examples": [
       {

--- a/blocks/toggle-item/package.json
+++ b/blocks/toggle-item/package.json
@@ -39,6 +39,7 @@
     "servePort": 63216
   },
   "blockprotocol": {
+    "name": "@hash/toggle-item",
     "displayName": "Toggle List Item",
     "examples": [
       {

--- a/blocks/video/package.json
+++ b/blocks/video/package.json
@@ -41,10 +41,10 @@
     "servePort": 62683
   },
   "blockprotocol": {
-    "name": "@hash/video",
     "blockType": {
       "entryPoint": "react"
     },
+    "name": "@hash/video",
     "displayName": "Video",
     "icon": "public/play-box-outline.svg",
     "image": "public/preview.svg",

--- a/blocks/video/package.json
+++ b/blocks/video/package.json
@@ -41,6 +41,7 @@
     "servePort": 62683
   },
   "blockprotocol": {
+    "name": "@hash/video",
     "blockType": {
       "entryPoint": "react"
     },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR enables upcoming updates to the block publishing process. It defines block names in `package.json` → `"blockprotocol"`.

The new values of `"name"` include author and are different to the Yarn workspace names (`@blocks/*`). The only block in which I don’t update `"name"` is _Code_, in which it is equal to `"@hash/code"` already:

https://github.com/hashintel/hash/blob/4a18af145a4e20cda5b7026576256cda8c85d104/blocks/code/package.json#L45-L52

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->
- [Asana task](https://app.asana.com/0/1203358502199087/1203388867587773/f) _(internal)_


## 🧪 How to test this?

- See tests and preview deployment in https://github.com/blockprotocol/blockprotocol/pull/947

There is a chance that HASH app may have some issues because of the new metadata. We will see this after merging https://github.com/blockprotocol/blockprotocol/pull/947. The chance of this is small though because the Code block had `"@hash/code"` as `"name"` already.