### PR TITLE
Fix Publish job to correctly pick up subcrates

### DIFF
--- a/.github/scripts/rust/setup.py
+++ b/.github/scripts/rust/setup.py
@@ -64,12 +64,7 @@ def find_local_crates():
     `cargo-make` will run the sub-crate automatically.
     :return: a list of crate paths
     """
-    all_crates = [path.relative_to(CWD).parent for path in CWD.rglob("Cargo.toml")]
-    checked_crates = []
-    for crate in all_crates:
-        if not any(path in crate.parents for path in all_crates):
-            checked_crates.append(crate)
-    return checked_crates
+    return [path.relative_to(CWD).parent for path in CWD.rglob("Cargo.toml")]
 
 
 def find_toolchain(crate):


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When rebasing `dev/links` onto `main`, we re-added the logic to filter for sub-crates to `find_local_crates`, but this logic was moved to `filter_parent_crates`. This reverts this change