### PR TITLE
Temporarily disable `SemVer check` job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -333,10 +333,10 @@ jobs:
           [[ -n "${{ secrets.CARGO_REGISTRY_TOKEN }}" ]]
           cargo login "${{ secrets.CARGO_REGISTRY_TOKEN }}"
 
-      - name: SemVer check
-        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
-        working-directory: ${{ matrix.directory }}
-        run: cargo +${{ matrix.toolchain }} semver-checks check-release
+      #      - name: SemVer check
+      #        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
+      #        working-directory: ${{ matrix.directory }}
+      #        run: cargo +${{ matrix.toolchain }} semver-checks check-release
 
       - name: Publish (dry run)
         if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `SemVer check` job does not allow publishing a crate, which did not exist in the index. To publish #2018, we have to temporarily disable this job.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1202805690238892/1203893818926461/f) _(internal)_