### PR TITLE
Publish `error-stack` v0.3.1

### DIFF
--- a/libs/error-stack/CHANGELOG.md
+++ b/libs/error-stack/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to `error-stack` will be documented in this file.
 
 - Support for [`defmt`](https://defmt.ferrous-systems.com)
 
+## [0.3.1](https://github.com/hashintel/hash/tree/error-stack%400.3.1/libs/error-stack) - 2023-02-08
+
+- Fix multiline attachments not being aligned ([#2022](https://github.com/hashintel/hash/pull/2022))
+
 ## [0.3.0](https://github.com/hashintel/hash/tree/error-stack%400.3.0/libs/error-stack) - 2023-02-01
 
 ### Breaking Changes

--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["package.json"]
 
 [package]
 name = "error-stack"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["HASH"]
 edition = "2021"
 rust-version = "1.63.0"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A small bug was highlighted in #2019 and fixed in #2022, so we want to publish the fix.

## 🔗 Related links

- Closes #2019
- #2022

## ⚠️ Known issues

Currently, the `SemVer Check` job is disabled, so we have to run it manually. Output:
```
❯ cargo semver-checks check-release       
    Updating index
     Parsing error-stack v0.3.1 (current)
     Parsing error-stack v0.3.0 (baseline)
    Checking error-stack v0.3.0 -> v0.3.1 (minor change)
   Completed [   0.127s] 35 checks; 35 passed, 5 unnecessary
cargo semver-checks check-release  11.95s user 2.40s system 87% cpu 16.334 total
❯ echo $?
0
```
