### PR TITLE
Pin `thread_local` crate to version `1.1.4`

### DIFF
--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -39,7 +39,7 @@ once_cell = "1.17.0"
 supports-color = "2.0.0"
 supports-unicode = "1.0.2"
 owo-colors = "3.5.0"
-thread_local = "=1.1.5"
+thread_local = "=1.1.4"
 
 [build-dependencies]
 rustc_version = "0.4"

--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -39,6 +39,7 @@ once_cell = "1.17.0"
 supports-color = "2.0.0"
 supports-unicode = "1.0.2"
 owo-colors = "3.5.0"
+thread_local = "=1.1.5"
 
 [build-dependencies]
 rustc_version = "0.4"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

With `thread_local` v1.1.5 `miri` reports a memory leak. This pins the version of `thread_local` until the issue is fixed.

## 🔗 Related links

- https://github.com/Amanieu/thread_local-rs/issues/45
