### PR TITLE
Unpin `thread_local` crate version

### DIFF
--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -39,7 +39,6 @@ once_cell = "1.17.0"
 supports-color = "2.0.0"
 supports-unicode = "1.0.2"
 owo-colors = "3.5.0"
-thread_local = "=1.1.4"
 
 [build-dependencies]
 rustc_version = "0.4"


### PR DESCRIPTION
This reverts commit 9e13ea2f

## 🌟 What is the purpose of this PR?

With https://github.com/hashintel/hash/pull/2033 we pinned `thread_local` to `1.1.4` as a. bug was discovered in `1.1.5`. The release was yanked, so it's safe to stop pinning the version.

## 🔗 Related links

- #2033 
- https://github.com/Amanieu/thread_local-rs/issues/45