### PR TITLE
Always get latest entity type in the entity type editor

### DIFF
--- a/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[entity-type-id].page/use-entity-type-value.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[entity-type-id].page/use-entity-type-value.tsx
@@ -85,12 +85,22 @@ export const useEntityTypeValue = (
       entityTypeBaseUri,
     );
 
-    /** @todo - pick the latest version? */
-    // @todo handle adding any linked properties to known property types
-    const relevantEntityType =
-      relevantEntityTypes.length > 0 ? relevantEntityTypes[0]!.schema : null;
+    if (relevantEntityTypes.length > 0) {
+      const relevantVersions = relevantEntityTypes.map(
+        ({
+          metadata: {
+            editionId: { version },
+          },
+        }) => version,
+      );
+      const relevantVersionindex = relevantVersions.indexOf(
+        Math.max(...relevantVersions),
+      );
 
-    return relevantEntityType;
+      return relevantEntityTypes[relevantVersionindex]!.schema;
+    }
+
+    return null;
   }, [entityTypeBaseUri, entityTypesLoading, entityTypesSubgraph]);
 
   const [stateEntityType, setStateEntityType] = useState(contextEntityType);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The entity type editor is not always getting the latest version of the entity type.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203179076056209/1203945433650363/f) _(internal)_
- [Slack Thread](https://hashintel.slack.com/archives/C022217GAHF/p1676023551778349)

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Create an entity type;
2.  Create another entity type and create a link to the first entity type (it will link to v1);
3.  Update the first entity type to create a v2;
4.  Refresh the page;
5.  Ensure v2 is shown instead of v1.

