### PR TITLE
Don't require `Vercel` to pass on merge

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -17,7 +17,6 @@ merge:
     - Backend integration tests
     - Playwright tests
     - Merging enabled
-    - Vercel – hash
 actions:
   enabled:
     - trunk-announce


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We having some issues with Vercel queuing jobs properly. If we don't consider this as a blocker for merge PRs, we don't need to require it.

## 🔗 Related links

- [slack thread](https://hashintel.slack.com/archives/C02TWBTT3ED/p1676034546212509) _(internal)_