### PR TITLE
Disable Vercel deployment for `trunk-merge-*` branches

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,10 @@
 {
   "github": {
     "silent": true
+  },
+  "git": {
+    "deploymentEnabled": {
+      "trunk-merge-*": false
+    }
   }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

No idea if `vercel.json` supports glob patterns in branch name definitions here. Let's try it, and hope.

Corresponding Vercel docs: https://vercel.com/docs/concepts/projects/project-configuration/git-configuration#git.deploymentenabled