### PR TITLE
Change vercel disabled branches to match `trunk-merge/*`

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   },
   "git": {
     "deploymentEnabled": {
-      "trunk-merge-*": false
+      "trunk-merge/*": false
     }
   }
 }


### PR DESCRIPTION
Seems that the pattern is `trunk-merge/2048/1qeq9ATg-UYT2` and not with a slash before the PR number. Maybe this would work?