### PR TITLE
Use `VersionedUri` instead of `String` in type fetcher

### DIFF
--- a/apps/hash-graph/bin/cli/src/subcommand/server.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/server.rs
@@ -302,12 +302,12 @@ async fn stop_gap_setup_type_fetcher<A: tokio::net::ToSocketAddrs + Send + Sync 
     let store = fetching_store.store().await;
 
     let ontology_types = [
-        "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
-        "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1",
-        "https://blockprotocol.org/@blockprotocol/types/data-type/boolean/v/1",
-        "https://blockprotocol.org/@blockprotocol/types/data-type/empty-list/v/1",
-        "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1",
-        "https://blockprotocol.org/@blockprotocol/types/data-type/null/v/1",
+        "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
+        "https://blockprotocol.org/@blockprotocol/types/data-type/number/",
+        "https://blockprotocol.org/@blockprotocol/types/data-type/boolean/",
+        "https://blockprotocol.org/@blockprotocol/types/data-type/empty-list/",
+        "https://blockprotocol.org/@blockprotocol/types/data-type/object/",
+        "https://blockprotocol.org/@blockprotocol/types/data-type/null/",
     ];
 
     // TODO: Revisit once an authentication and authorization setup is in place
@@ -328,7 +328,10 @@ async fn stop_gap_setup_type_fetcher<A: tokio::net::ToSocketAddrs + Send + Sync 
 
     for ontology_type in ontology_types {
         let fetched_ontology_types = type_fetcher
-            .fetch_ontology_type_exhaustive(context::current(), ontology_type.to_owned())
+            .fetch_ontology_type_exhaustive(
+                context::current(),
+                VersionedUri::new(BaseUri::new(ontology_type.to_owned()).unwrap(), 1),
+            )
             .await
             .into_report()
             .change_context(GraphError)?

--- a/apps/hash-graph/lib/type-fetcher/src/fetcher.rs
+++ b/apps/hash-graph/lib/type-fetcher/src/fetcher.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use error_stack::Context;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
-use type_system::repr;
+use type_system::{repr, uri::VersionedUri};
 
 // We would really like to use error-stack for this. It's not possible because
 // we need Serialize and Deserialize for `Report`
@@ -56,6 +56,6 @@ impl TypeFetchResponse {
 pub trait Fetcher {
     /// Fetch an entity type by its URL and return all types that are reachable from it.
     async fn fetch_ontology_type_exhaustive(
-        entity_type_url: String,
+        ontology_type_url: VersionedUri,
     ) -> Result<TypeFetchResponse, FetcherError>;
 }

--- a/apps/hash-graph/lib/type-fetcher/src/fetcher.rs
+++ b/apps/hash-graph/lib/type-fetcher/src/fetcher.rs
@@ -54,7 +54,7 @@ impl TypeFetchResponse {
 
 #[tarpc::service]
 pub trait Fetcher {
-    /// Fetch an entity type by its URL and return all types that are reachable from it.
+    /// Fetch an ontology type by its URL and return all types that are reachable from it.
     async fn fetch_ontology_type_exhaustive(
         ontology_type_url: VersionedUri,
     ) -> Result<TypeFetchResponse, FetcherError>;

--- a/apps/hash-graph/lib/type-fetcher/src/fetcher_server.rs
+++ b/apps/hash-graph/lib/type-fetcher/src/fetcher_server.rs
@@ -8,7 +8,7 @@ use reqwest::{
 use tarpc::context::Context;
 use time::OffsetDateTime;
 use type_system::{
-    DataType, DataTypeReference, EntityType, EntityTypeReference, PropertyType,
+    uri::VersionedUri, DataType, DataTypeReference, EntityType, EntityTypeReference, PropertyType,
     PropertyTypeReference,
 };
 
@@ -22,24 +22,24 @@ impl Fetcher for FetchServer {
     async fn fetch_ontology_type_exhaustive(
         self,
         _context: Context,
-        entity_type_url: String,
+        ontology_type_url: VersionedUri,
     ) -> Result<TypeFetchResponse, FetcherError> {
-        fetch_ontology_type_exhaustive(entity_type_url).await
+        fetch_ontology_type_exhaustive(ontology_type_url).await
     }
 }
 
 #[derive(Debug)]
 struct StreamState {
-    seen: HashSet<String>,
-    queue: VecDeque<String>,
+    seen: HashSet<VersionedUri>,
+    queue: VecDeque<VersionedUri>,
 }
 
 impl StreamState {
-    fn new(seen: HashSet<String>, queue: VecDeque<String>) -> Self {
+    fn new(seen: HashSet<VersionedUri>, queue: VecDeque<VersionedUri>) -> Self {
         Self { seen, queue }
     }
 
-    fn with_intitial_state(start: String) -> Self {
+    fn with_intitial_state(start: VersionedUri) -> Self {
         let mut seen = HashSet::new();
         seen.insert(start.clone());
         let mut queue = VecDeque::new();
@@ -50,13 +50,11 @@ impl StreamState {
 }
 
 async fn fetch_ontology_type_exhaustive(
-    entity_type_url: String,
+    ontology_type_url: VersionedUri,
 ) -> Result<TypeFetchResponse, FetcherError> {
-    // let seen: DashSet<String> = DashSet::new();
-
     let http_client = Client::new();
     let res = stream::try_unfold(
-        StreamState::with_intitial_state(entity_type_url),
+        StreamState::with_intitial_state(ontology_type_url),
         |mut state| async {
             let client = http_client.clone();
             let next_url = state.queue.pop_front();
@@ -64,7 +62,7 @@ async fn fetch_ontology_type_exhaustive(
             let Some(url) = next_url else { return Ok(None) };
             let response = fetch_ontology_type(client, url).await?;
 
-            let uris: Vec<String> = match response.ontology_type.clone() {
+            let uris: Vec<VersionedUri> = match response.ontology_type.clone() {
                 OntologyType::EntityType(schema) => {
                     let entity_type: EntityType = schema.try_into().map_err(|error| {
                         tracing::error!(error=?error, "Couldn't convert schema to Entity Type");
@@ -72,7 +70,9 @@ async fn fetch_ontology_type_exhaustive(
                             "Error parsing ontology type: {error:?}"
                         ))
                     })?;
-                    traverse_entity_type_references(&entity_type).collect()
+                    traverse_entity_type_references(&entity_type)
+                        .map(|reference| reference.uri().clone())
+                        .collect()
                 }
                 OntologyType::PropertyType(schema) => {
                     let property_type: PropertyType = schema.try_into().map_err(|error| {
@@ -82,7 +82,9 @@ async fn fetch_ontology_type_exhaustive(
                         ))
                     })?;
 
-                    traverse_property_type_references(&property_type).collect()
+                    traverse_property_type_references(&property_type)
+                        .map(|reference| reference.uri().clone())
+                        .collect()
                 }
                 OntologyType::DataType(schema) => {
                     let data_type: DataType = schema.try_into().map_err(|error| {
@@ -92,16 +94,13 @@ async fn fetch_ontology_type_exhaustive(
                         ))
                     })?;
 
-                    traverse_data_type_references(&data_type).collect()
+                    traverse_data_type_references(&data_type)
+                        .map(|reference| reference.uri().clone())
+                        .collect()
                 }
             };
 
             for uri in uris {
-                // TODO: reconsider how we should handle these "builtin" external types.
-                if uri.starts_with("https://blockprotocol.org/@blockprotocol/types/") {
-                    continue;
-                }
-
                 if !state.seen.contains(&uri) {
                     state.seen.insert(uri.clone());
                     state.queue.push_back(uri);
@@ -119,22 +118,22 @@ async fn fetch_ontology_type_exhaustive(
 
 pub async fn fetch_ontology_type(
     client: Client,
-    url: String,
+    url: VersionedUri,
 ) -> Result<FetchedOntologyType, FetcherError> {
     let ontology_type = client
-        .get(&url)
+        .get(url.to_url())
         .header(ACCEPT, "application/json")
         .header(USER_AGENT, "HASH Graph")
         .send()
         .await
         .map_err(|err| {
-            tracing::error!(error=?err, url=&url, "Could not fetch ontology type");
+            tracing::error!(error=?err, %url, "Could not fetch ontology type");
             FetcherError::NetworkError(format!("Error fetching {url}: {err:?}"))
         })?
         .json::<OntologyType>()
         .await
         .map_err(|err| {
-            tracing::error!(error=?err, url=&url, "Could not deserialize response");
+            tracing::error!(error=?err, %url, "Could not deserialize response");
             FetcherError::SerializationError(format!("Error deserializing {url}: {err:?}"))
         })?;
 
@@ -144,11 +143,22 @@ pub async fn fetch_ontology_type(
     })
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[allow(clippy::enum_variant_names)]
-enum OntologyTypeReference<'a> {
+pub enum OntologyTypeReference<'a> {
     EntityTypeReference(&'a EntityTypeReference),
     PropertyTypeReference(&'a PropertyTypeReference),
     DataTypeReference(&'a DataTypeReference),
+}
+
+impl OntologyTypeReference<'_> {
+    pub fn uri(&self) -> &VersionedUri {
+        match self {
+            OntologyTypeReference::EntityTypeReference(r) => r.uri(),
+            OntologyTypeReference::PropertyTypeReference(r) => r.uri(),
+            OntologyTypeReference::DataTypeReference(r) => r.uri(),
+        }
+    }
 }
 
 impl<'a> From<OntologyTypeReference<'a>> for String {
@@ -162,7 +172,9 @@ impl<'a> From<OntologyTypeReference<'a>> for String {
     }
 }
 
-fn traverse_entity_type_references(entity_type: &EntityType) -> impl Iterator<Item = String> + '_ {
+pub fn traverse_entity_type_references(
+    entity_type: &EntityType,
+) -> impl Iterator<Item = OntologyTypeReference> + '_ {
     entity_type
         .property_type_references()
         .into_iter()
@@ -180,20 +192,21 @@ fn traverse_entity_type_references(entity_type: &EntityType) -> impl Iterator<It
                 references.push(OntologyTypeReference::EntityTypeReference(link_entity_type));
 
                 if let Some(entity_type_constraint) = destination_entity_type_constraint {
-                    references.extend(entity_type_constraint.iter().map(|entity_type| {
-                        OntologyTypeReference::EntityTypeReference(entity_type)
-                    }));
+                    references.extend(
+                        entity_type_constraint
+                            .iter()
+                            .map(OntologyTypeReference::EntityTypeReference),
+                    );
                 }
 
                 references
             },
         ))
-        .map(Into::<String>::into)
 }
 
-fn traverse_property_type_references(
+pub fn traverse_property_type_references(
     property_type: &PropertyType,
-) -> impl Iterator<Item = String> + '_ {
+) -> impl Iterator<Item = OntologyTypeReference> + '_ {
     property_type
         .property_type_references()
         .into_iter()
@@ -204,10 +217,11 @@ fn traverse_property_type_references(
                 .into_iter()
                 .map(OntologyTypeReference::DataTypeReference),
         )
-        .map(Into::<String>::into)
 }
 
-fn traverse_data_type_references(_data_type: &DataType) -> impl Iterator<Item = String> + '_ {
+pub fn traverse_data_type_references(
+    _data_type: &DataType,
+) -> impl Iterator<Item = OntologyTypeReference> + '_ {
     // Doesn't currently have other references.
     std::iter::empty()
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, the type fetcher takes in a string, but we have a more descriptive way for ontology types. This also makes the traversal operations public, so they can be used in the fetching client.

This is a required change to have a working type fetcher at HASH to unblock further work on the `FetchingStore`

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203623179643281/1203958456055089/f) _(internal)_

## 🔍 What does this change?

- Use `VersionedUri` in the type fetcher
- Expose traversal functions