### PR TITLE
Use type fetcher when creating or updating types

### DIFF
--- a/apps/hash-graph/bin/cli/src/subcommand/server.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/server.rs
@@ -13,22 +13,18 @@ use graph::{
     },
     provenance::{ProvenanceMetadata, UpdatedById},
     store::{
-        AccountStore, BaseUriAlreadyExists, DataTypeStore, DatabaseConnectionInfo, EntityTypeStore,
+        AccountStore, BaseUriAlreadyExists, DatabaseConnectionInfo, EntityTypeStore,
         PostgresStorePool, StorePool,
     },
 };
 use regex::Regex;
 use reqwest::Client;
-#[cfg(feature = "type-fetcher")]
-use tarpc::context;
 use time::OffsetDateTime;
 use tokio::time::timeout;
 use tokio_postgres::NoTls;
-#[cfg(feature = "type-fetcher")]
-use type_fetcher::fetcher::OntologyType;
 use type_system::{
     uri::{BaseUri, VersionedUri},
-    AllOf, DataType, EntityType, Links, Object,
+    AllOf, EntityType, Links, Object,
 };
 use uuid::Uuid;
 
@@ -143,7 +139,9 @@ async fn insert_link_entity_type(
 #[expect(clippy::too_many_lines, reason = "temporary solution")]
 #[cfg(not(feature = "type-fetcher"))]
 async fn stop_gap_setup(pool: &PostgresStorePool<NoTls>) -> Result<(), GraphError> {
+    use graph::store::DataTypeStore;
     use serde_json::json;
+    use type_system::DataType;
 
     // TODO: how do we make these URIs compliant
     let text = DataType::new(
@@ -287,24 +285,8 @@ async fn stop_gap_setup(pool: &PostgresStorePool<NoTls>) -> Result<(), GraphErro
 }
 
 #[cfg(feature = "type-fetcher")]
-async fn stop_gap_setup_type_fetcher<A: tokio::net::ToSocketAddrs + Send + Sync + Clone>(
-    pool: &FetchingPool<PostgresStorePool<NoTls>, A>,
-) -> Result<(), GraphError> {
-    let mut fetching_store = pool.acquire().await.change_context(GraphError)?;
-    let type_fetcher = fetching_store
-        .fetcher_client()
-        .await
-        .change_context(GraphError)?;
-    let store = fetching_store.store().await;
-
-    let ontology_types = [
-        "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
-        "https://blockprotocol.org/@blockprotocol/types/data-type/number/",
-        "https://blockprotocol.org/@blockprotocol/types/data-type/boolean/",
-        "https://blockprotocol.org/@blockprotocol/types/data-type/empty-list/",
-        "https://blockprotocol.org/@blockprotocol/types/data-type/object/",
-        "https://blockprotocol.org/@blockprotocol/types/data-type/null/",
-    ];
+async fn stop_gap_setup_type_fetcher(pool: &impl StorePool) -> Result<(), GraphError> {
+    let mut store = pool.acquire().await.change_context(GraphError)?;
 
     // TODO: Revisit once an authentication and authorization setup is in place
     let root_account_id = AccountId::new(Uuid::nil());
@@ -322,55 +304,7 @@ async fn stop_gap_setup_type_fetcher<A: tokio::net::ToSocketAddrs + Send + Sync 
         tracing::info!(%root_account_id, "created root account id");
     }
 
-    for ontology_type in ontology_types {
-        let fetched_ontology_types = type_fetcher
-            .fetch_ontology_type_exhaustive(
-                context::current(),
-                VersionedUri::new(BaseUri::new(ontology_type.to_owned()).unwrap(), 1),
-            )
-            .await
-            .into_report()
-            .change_context(GraphError)?
-            .into_report()
-            .change_context(GraphError)?;
-
-        for fetched_ontology_type in fetched_ontology_types.results {
-            match fetched_ontology_type.ontology_type {
-                OntologyType::DataType(data_type) => {
-                    let data_type = DataType::try_from(data_type)
-                        .into_report()
-                        .change_context(GraphError)?;
-                    let metadata =
-                        OntologyElementMetadata::External(ExternalOntologyElementMetadata::new(
-                            data_type.id().into(),
-                            ProvenanceMetadata::new(UpdatedById::new(root_account_id)),
-                            fetched_ontology_type.fetched_at,
-                        ));
-                    let title = data_type.title().to_owned();
-
-                    if let Err(error) = store
-                        .create_data_type(data_type, &metadata)
-                        .await
-                        .change_context(GraphError)
-                    {
-                        if error.contains::<BaseUriAlreadyExists>() {
-                            tracing::info!(%root_account_id, "tried to insert primitive {title} data type, but it already exists");
-                        } else {
-                            return Err(error.change_context(GraphError));
-                        }
-                    } else {
-                        tracing::info!(%root_account_id, "inserted the primitive {title} data type");
-                    }
-                }
-
-                OntologyType::PropertyType(_) | OntologyType::EntityType(_) => {
-                    unimplemented!("Only data types are covered in the stop gap solution")
-                }
-            }
-        }
-    }
-
-    insert_link_entity_type(store, root_account_id).await?;
+    insert_link_entity_type(&mut store, root_account_id).await?;
 
     Ok(())
 }
@@ -392,6 +326,12 @@ pub async fn server(args: ServerArgs) -> Result<(), GraphError> {
             err
         })?;
 
+    #[cfg(not(feature = "type-fetcher"))]
+    stop_gap_setup(&pool).await?;
+
+    #[cfg(feature = "type-fetcher")]
+    stop_gap_setup_type_fetcher(&pool).await?;
+
     #[cfg(feature = "type-fetcher")]
     let pool = FetchingPool::new(
         pool,
@@ -402,12 +342,6 @@ pub async fn server(args: ServerArgs) -> Result<(), GraphError> {
         DomainValidator::new(args.allowed_url_domain.clone()),
     )
     .change_context(GraphError)?;
-
-    #[cfg(not(feature = "type-fetcher"))]
-    stop_gap_setup(&pool).await?;
-
-    #[cfg(feature = "type-fetcher")]
-    stop_gap_setup_type_fetcher(&pool).await?;
 
     let rest_router = rest_api_router(RestRouterDependencies {
         store: Arc::new(pool),

--- a/apps/hash-graph/lib/graph/src/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/ontology.rs
@@ -188,6 +188,14 @@ impl OntologyElementMetadata {
             Self::External(external) => external.record_id(),
         }
     }
+
+    #[must_use]
+    pub const fn provenance_metadata(&self) -> ProvenanceMetadata {
+        match self {
+            Self::Owned(owned) => owned.provenance_metadata,
+            Self::External(external) => external.provenance_metadata,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]

--- a/apps/hash-graph/lib/graph/src/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/ontology.rs
@@ -11,6 +11,11 @@ use error_stack::{Context, IntoReport, Result, ResultExt};
 use serde::{Deserialize, Serialize, Serializer};
 use serde_json;
 use time::OffsetDateTime;
+#[cfg(feature = "type-fetcher")]
+use type_fetcher::fetcher_server::{
+    traverse_data_type_references, traverse_entity_type_references,
+    traverse_property_type_references, OntologyTypeReference,
+};
 use type_system::{
     repr, uri::VersionedUri, DataType, EntityType, ParseDataTypeError, ParseEntityTypeError,
     ParsePropertyTypeError, PropertyType,
@@ -108,6 +113,9 @@ pub trait OntologyType:
     type WithMetadata: OntologyTypeWithMetadata<OntologyType = Self>;
 
     fn id(&self) -> &VersionedUri;
+
+    #[cfg(feature = "type-fetcher")]
+    fn traverse_references(&self) -> Vec<OntologyTypeReference>;
 }
 
 impl OntologyType for DataType {
@@ -117,6 +125,11 @@ impl OntologyType for DataType {
 
     fn id(&self) -> &VersionedUri {
         self.id()
+    }
+
+    #[cfg(feature = "type-fetcher")]
+    fn traverse_references(&self) -> Vec<OntologyTypeReference> {
+        traverse_data_type_references(self).collect()
     }
 }
 
@@ -128,6 +141,11 @@ impl OntologyType for PropertyType {
     fn id(&self) -> &VersionedUri {
         self.id()
     }
+
+    #[cfg(feature = "type-fetcher")]
+    fn traverse_references(&self) -> Vec<OntologyTypeReference> {
+        traverse_property_type_references(self).collect()
+    }
 }
 
 impl OntologyType for EntityType {
@@ -137,6 +155,11 @@ impl OntologyType for EntityType {
 
     fn id(&self) -> &VersionedUri {
         self.id()
+    }
+
+    #[cfg(feature = "type-fetcher")]
+    fn traverse_references(&self) -> Vec<OntologyTypeReference> {
+        traverse_entity_type_references(self).collect()
     }
 }
 

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -1,31 +1,41 @@
-use std::borrow::Borrow;
+use std::{borrow::Borrow, iter::once};
 
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
+use tarpc::context;
 use tokio::net::ToSocketAddrs;
 #[cfg(feature = "type-fetcher")]
 use tokio_serde::formats::MessagePack;
 #[cfg(feature = "type-fetcher")]
 use type_fetcher::fetcher::FetcherClient;
-use type_system::{uri::VersionedUri, DataType, EntityType, PropertyType};
+use type_fetcher::{fetcher::OntologyType, fetcher_server::OntologyTypeReference};
+use type_system::{
+    uri::VersionedUri, DataType, DataTypeReference, EntityType, EntityTypeReference, PropertyType,
+    PropertyTypeReference,
+};
 
 use crate::{
     identifier::{
         account::AccountId,
         knowledge::EntityId,
-        time::{DecisionTime, TimeProjection, Timestamp},
+        time::{
+            DecisionTime, TimeProjection, Timestamp, UnresolvedImage, UnresolvedKernel,
+            UnresolvedProjection, UnresolvedTimeProjection,
+        },
     },
     knowledge::{Entity, EntityLinkOrder, EntityMetadata, EntityProperties, EntityUuid, LinkData},
     ontology::{
         domain_validator::DomainValidator, DataTypeWithMetadata, EntityTypeWithMetadata,
-        OntologyElementMetadata, PropertyTypeWithMetadata,
+        ExternalOntologyElementMetadata, OntologyElementMetadata, PropertyTypeWithMetadata,
     },
-    provenance::{OwnedById, UpdatedById},
+    provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
-        crud::Read, query::Filter, AccountStore, DataTypeStore, EntityStore, EntityTypeStore,
-        InsertionError, PropertyTypeStore, QueryError, Record, StoreError, StorePool, UpdateError,
+        crud::Read,
+        query::{Filter, OntologyQueryPath},
+        AccountStore, DataTypeStore, EntityStore, EntityTypeStore, InsertionError,
+        PropertyTypeStore, QueryError, Record, StoreError, StorePool, UpdateError,
     },
-    subgraph::{query::StructuralQuery, Subgraph},
+    subgraph::{edges::GraphResolveDepths, query::StructuralQuery, Subgraph},
 };
 
 pub struct FetchingPool<P, A> {
@@ -81,11 +91,6 @@ pub struct FetchingStore<S, A> {
     store: S,
     address: A,
     config: tarpc::client::Config,
-    #[expect(
-        dead_code,
-        reason = "This will be used when dynamically using the type fetcher on creation or \
-                  updating of a type"
-    )]
     domain_validator: DomainValidator,
 }
 
@@ -105,8 +110,246 @@ where
         Ok(FetcherClient::new(self.config.clone(), transport).spawn())
     }
 
-    pub async fn store(&mut self) -> &mut S {
+    pub fn store(&mut self) -> &mut S {
         &mut self.store
+    }
+}
+
+impl<'t, S, A> FetchingStore<S, A>
+where
+    A: ToSocketAddrs + Send + Sync,
+    S: DataTypeStore + PropertyTypeStore + EntityTypeStore + Send,
+{
+    async fn contains_ontology_type(
+        &self,
+        ontology_type_reference: OntologyTypeReference<'_>,
+    ) -> Result<bool, StoreError>
+    where
+        S: DataTypeStore + PropertyTypeStore + EntityTypeStore + Send,
+        A: Send + Sync,
+    {
+        fn create_query<'u, T>(versioned_uri: &'u VersionedUri) -> StructuralQuery<'u, T>
+        where
+            T: Record<QueryPath<'u>: OntologyQueryPath>,
+        {
+            StructuralQuery {
+                filter: Filter::for_versioned_uri(versioned_uri),
+                graph_resolve_depths: GraphResolveDepths::default(),
+                time_projection: UnresolvedTimeProjection::DecisionTime(UnresolvedProjection {
+                    kernel: UnresolvedKernel::new(None),
+                    image: UnresolvedImage::new(None, None),
+                }),
+            }
+        }
+
+        let uri = match ontology_type_reference {
+            OntologyTypeReference::DataTypeReference(reference) => reference.uri(),
+            OntologyTypeReference::PropertyTypeReference(reference) => reference.uri(),
+            OntologyTypeReference::EntityTypeReference(reference) => reference.uri(),
+        };
+
+        if self.domain_validator.validate_url(uri.base_uri().as_str()) {
+            // If the domain is valid, we own the data type and it either exists or we cannot
+            // reference it.
+            return Ok(true);
+        }
+
+        match ontology_type_reference {
+            OntologyTypeReference::DataTypeReference(_) => {
+                self.store.get_data_type(&create_query(uri)).await
+            }
+            OntologyTypeReference::PropertyTypeReference(_) => {
+                self.store.get_property_type(&create_query(uri)).await
+            }
+            OntologyTypeReference::EntityTypeReference(_) => {
+                self.store.get_entity_type(&create_query(uri)).await
+            }
+        }
+        .change_context(StoreError)
+        .attach_printable("Could not check if ontology type exists")
+        .map(|subgraph| !subgraph.roots.is_empty())
+    }
+
+    async fn collect_external_ontology_types<'o, T: crate::ontology::OntologyType>(
+        &self,
+        ontology_type: &'o T,
+    ) -> Result<Vec<OntologyTypeReference<'o>>, QueryError> {
+        let mut references = Vec::new();
+        for reference in ontology_type.traverse_references() {
+            if !self
+                .contains_ontology_type(reference)
+                .await
+                .change_context(QueryError)?
+            {
+                references.push(reference);
+            }
+        }
+
+        Ok(references)
+    }
+
+    async fn fetch_external_ontology_types(
+        &self,
+        ontology_type_references: impl IntoIterator<Item = (OntologyTypeReference<'_>, UpdatedById)>,
+    ) -> Result<
+        (
+            Vec<(DataType, OntologyElementMetadata)>,
+            Vec<(PropertyType, OntologyElementMetadata)>,
+            Vec<(EntityType, OntologyElementMetadata)>,
+        ),
+        StoreError,
+    > {
+        let fetcher_client = self.fetcher_client().await?;
+
+        let mut data_types = Vec::new();
+        let mut property_types = Vec::new();
+        let mut entity_types = Vec::new();
+
+        for (reference, fetched_by) in ontology_type_references {
+            let provenance_metadata = ProvenanceMetadata::new(fetched_by);
+            let fetched_ontology_types = fetcher_client
+                .fetch_ontology_type_exhaustive(context::current(), reference.uri().clone())
+                .await
+                .into_report()
+                .change_context(StoreError)?
+                .into_report()
+                .change_context(StoreError)?;
+
+            for fetched_ontology_type in fetched_ontology_types.results {
+                match fetched_ontology_type.ontology_type {
+                    OntologyType::DataType(data_type) => {
+                        let data_type = DataType::try_from(data_type)
+                            .into_report()
+                            .change_context(StoreError)?;
+                        let data_type_reference = DataTypeReference::new(data_type.id().clone());
+                        if !self
+                            .contains_ontology_type(OntologyTypeReference::DataTypeReference(
+                                &data_type_reference,
+                            ))
+                            .await?
+                        {
+                            let metadata = ExternalOntologyElementMetadata::new(
+                                data_type.id().into(),
+                                provenance_metadata,
+                                fetched_ontology_type.fetched_at,
+                            );
+
+                            data_types
+                                .push((data_type, OntologyElementMetadata::External(metadata)));
+                        }
+                    }
+                    OntologyType::PropertyType(property_type) => {
+                        let property_type = PropertyType::try_from(property_type)
+                            .into_report()
+                            .change_context(StoreError)?;
+                        let property_type_reference =
+                            PropertyTypeReference::new(property_type.id().clone());
+                        if !self
+                            .contains_ontology_type(OntologyTypeReference::PropertyTypeReference(
+                                &property_type_reference,
+                            ))
+                            .await?
+                        {
+                            let metadata = ExternalOntologyElementMetadata::new(
+                                property_type.id().into(),
+                                provenance_metadata,
+                                fetched_ontology_type.fetched_at,
+                            );
+
+                            property_types
+                                .push((property_type, OntologyElementMetadata::External(metadata)));
+                        }
+                    }
+                    OntologyType::EntityType(entity_type) => {
+                        let entity_type = EntityType::try_from(entity_type)
+                            .into_report()
+                            .change_context(StoreError)?;
+                        let entity_type_reference =
+                            EntityTypeReference::new(entity_type.id().clone());
+                        if !self
+                            .contains_ontology_type(OntologyTypeReference::EntityTypeReference(
+                                &entity_type_reference,
+                            ))
+                            .await?
+                        {
+                            let metadata = ExternalOntologyElementMetadata::new(
+                                entity_type.id().into(),
+                                provenance_metadata,
+                                fetched_ontology_type.fetched_at,
+                            );
+
+                            entity_types
+                                .push((entity_type, OntologyElementMetadata::External(metadata)));
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok((data_types, property_types, entity_types))
+    }
+
+    async fn insert_external_types<'o, T: crate::ontology::OntologyType + 'o>(
+        &mut self,
+        ontology_types: impl IntoIterator<Item = (&'o T, UpdatedById), IntoIter: Send> + Send,
+    ) -> Result<(), InsertionError> {
+        // Without collecting it first, we get a "Higher-ranked lifetime error" because of the
+        // limitations of Rust being able to look into a `Pin<Box<dyn Future>>`, which is returned
+        // by `#[async_trait]` methods.
+        let ontology_types = ontology_types.into_iter().collect::<Vec<_>>();
+
+        let mut ontology_types_to_fetch = Vec::new();
+        for (ontology_type, fetched_by) in ontology_types {
+            ontology_types_to_fetch.extend(
+                self.collect_external_ontology_types(ontology_type)
+                    .await
+                    .change_context(InsertionError)?
+                    .into_iter()
+                    .map(|ontology_type| (ontology_type, fetched_by)),
+            );
+        }
+
+        if ontology_types_to_fetch.is_empty() {
+            return Ok(());
+        }
+
+        let (fetched_data_types, fetched_property_types, fetched_entity_types) = self
+            .fetch_external_ontology_types(ontology_types_to_fetch)
+            .await
+            .change_context(InsertionError)?;
+
+        self.store.create_data_types(fetched_data_types).await?;
+        self.store
+            .create_property_types(fetched_property_types)
+            .await?;
+        self.store.create_entity_types(fetched_entity_types).await?;
+
+        Ok(())
+    }
+
+    async fn insert_external_types_by_reference(
+        &mut self,
+        reference: OntologyTypeReference<'_>,
+        fetched_by: UpdatedById,
+    ) -> Result<(), InsertionError> {
+        if !self
+            .contains_ontology_type(reference)
+            .await
+            .change_context(InsertionError)?
+        {
+            let (fetched_data_types, fetched_property_types, fetched_entity_types) = self
+                .fetch_external_ontology_types(once((reference, fetched_by)))
+                .await
+                .change_context(InsertionError)?;
+
+            self.store.create_data_types(fetched_data_types).await?;
+            self.store
+                .create_property_types(fetched_property_types)
+                .await?;
+            self.store.create_entity_types(fetched_entity_types).await?;
+        }
+
+        Ok(())
     }
 }
 
@@ -139,8 +382,8 @@ where
 #[async_trait]
 impl<S, A> DataTypeStore for FetchingStore<S, A>
 where
-    S: DataTypeStore + Send,
-    A: Send + Sync,
+    S: DataTypeStore + PropertyTypeStore + EntityTypeStore + Send,
+    A: ToSocketAddrs + Send + Sync,
 {
     async fn create_data_types(
         &mut self,
@@ -149,6 +392,16 @@ where
             IntoIter: Send,
         > + Send,
     ) -> Result<(), InsertionError> {
+        let data_types = data_types.into_iter().collect::<Vec<_>>();
+
+        self.insert_external_types(data_types.iter().map(|(data_type, metadata)| {
+            (
+                data_type,
+                metadata.borrow().provenance_metadata().updated_by_id(),
+            )
+        }))
+        .await?;
+
         self.store.create_data_types(data_types).await
     }
 
@@ -164,6 +417,10 @@ where
         data_type: DataType,
         actor_id: UpdatedById,
     ) -> Result<OntologyElementMetadata, UpdateError> {
+        self.insert_external_types(once((&data_type, actor_id)))
+            .await
+            .change_context(UpdateError)?;
+
         self.store.update_data_type(data_type, actor_id).await
     }
 }
@@ -171,8 +428,8 @@ where
 #[async_trait]
 impl<S, A> PropertyTypeStore for FetchingStore<S, A>
 where
-    S: PropertyTypeStore + Send,
-    A: Send + Sync,
+    S: DataTypeStore + PropertyTypeStore + EntityTypeStore + Send,
+    A: ToSocketAddrs + Send + Sync,
 {
     async fn create_property_types(
         &mut self,
@@ -184,6 +441,16 @@ where
             IntoIter: Send,
         > + Send,
     ) -> Result<(), InsertionError> {
+        let property_types = property_types.into_iter().collect::<Vec<_>>();
+
+        self.insert_external_types(property_types.iter().map(|(property_type, metadata)| {
+            (
+                property_type,
+                metadata.borrow().provenance_metadata().updated_by_id(),
+            )
+        }))
+        .await?;
+
         self.store.create_property_types(property_types).await
     }
 
@@ -199,6 +466,10 @@ where
         property_type: PropertyType,
         actor_id: UpdatedById,
     ) -> Result<OntologyElementMetadata, UpdateError> {
+        self.insert_external_types(once((&property_type, actor_id)))
+            .await
+            .change_context(UpdateError)?;
+
         self.store
             .update_property_type(property_type, actor_id)
             .await
@@ -208,8 +479,8 @@ where
 #[async_trait]
 impl<S, A> EntityTypeStore for FetchingStore<S, A>
 where
-    S: EntityTypeStore + Send,
-    A: Send + Sync,
+    S: DataTypeStore + PropertyTypeStore + EntityTypeStore + Send,
+    A: ToSocketAddrs + Send + Sync,
 {
     async fn create_entity_types(
         &mut self,
@@ -221,6 +492,16 @@ where
             IntoIter: Send,
         > + Send,
     ) -> Result<(), InsertionError> {
+        let entity_types = entity_types.into_iter().collect::<Vec<_>>();
+
+        self.insert_external_types(entity_types.iter().map(|(entity_type, metadata)| {
+            (
+                entity_type,
+                metadata.borrow().provenance_metadata().updated_by_id(),
+            )
+        }))
+        .await?;
+
         self.store.create_entity_types(entity_types).await
     }
 
@@ -236,6 +517,10 @@ where
         entity_type: EntityType,
         actor_id: UpdatedById,
     ) -> Result<OntologyElementMetadata, UpdateError> {
+        self.insert_external_types(once((&entity_type, actor_id)))
+            .await
+            .change_context(UpdateError)?;
+
         self.store.update_entity_type(entity_type, actor_id).await
     }
 }
@@ -243,8 +528,8 @@ where
 #[async_trait]
 impl<S, A> EntityStore for FetchingStore<S, A>
 where
-    S: EntityStore + Send,
-    A: Send + Sync,
+    S: DataTypeStore + PropertyTypeStore + EntityTypeStore + EntityStore + Send,
+    A: ToSocketAddrs + Send + Sync,
 {
     async fn create_entity(
         &mut self,
@@ -257,6 +542,13 @@ where
         properties: EntityProperties,
         link_data: Option<LinkData>,
     ) -> Result<EntityMetadata, InsertionError> {
+        let entity_type_reference = EntityTypeReference::new(entity_type_id.clone());
+        self.insert_external_types_by_reference(
+            OntologyTypeReference::EntityTypeReference(&entity_type_reference),
+            updated_by_id,
+        )
+        .await?;
+
         self.store
             .create_entity(
                 owned_by_id,
@@ -287,6 +579,13 @@ where
         actor_id: UpdatedById,
         entity_type_id: &VersionedUri,
     ) -> Result<Vec<EntityMetadata>, InsertionError> {
+        let entity_type_reference = EntityTypeReference::new(entity_type_id.clone());
+        self.insert_external_types_by_reference(
+            OntologyTypeReference::EntityTypeReference(&entity_type_reference),
+            actor_id,
+        )
+        .await?;
+
         self.store
             .insert_entities_batched_by_type(entities, actor_id, entity_type_id)
             .await
@@ -306,6 +605,14 @@ where
         properties: EntityProperties,
         link_order: EntityLinkOrder,
     ) -> Result<EntityMetadata, UpdateError> {
+        let entity_type_reference = EntityTypeReference::new(entity_type_id.clone());
+        self.insert_external_types_by_reference(
+            OntologyTypeReference::EntityTypeReference(&entity_type_reference),
+            updated_by_id,
+        )
+        .await
+        .change_context(UpdateError)?;
+
         self.store
             .update_entity(
                 entity_id,

--- a/apps/hash-graph/lib/graph/src/store/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/store/ontology.rs
@@ -43,7 +43,7 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     /// [`BaseUri`]: type_system::uri::BaseUri
     async fn create_data_types(
         &mut self,
-        property_types: impl IntoIterator<
+        data_types: impl IntoIterator<
             Item = (DataType, impl Borrow<OntologyElementMetadata> + Send + Sync),
             IntoIter: Send,
         > + Send,

--- a/apps/hash-graph/tests/rest-test.http
+++ b/apps/hash-graph/tests/rest-test.http
@@ -66,7 +66,7 @@ Content-Type: application/json
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
-        client.assert(response.body.roots.length === 6, "Unexpected number of data types"); // The number of primitive data types
+        client.assert(response.body.roots.length === 0, "Unexpected number of data types"); // The number of primitive data types
     });
 %}
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This adds the usage of the type fetcher in the `FetchingStore` and avoids the requirement of having pre-seeded data types. 

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203543026679380/1203843814258959/f) _(internal)_

## 🚫 Blocked by

- #2067 
- #2068 

## 🔍 What does this change?

- [Implement `traverse_references` on `OntologyType`](https://github.com/hashintel/hash/commit/091b526eb06b1d9039cfbc503dc91fd7600b0b43)
- [Provide `provenance_metadata` from `OntologyElementMetadata`](https://github.com/hashintel/hash/commit/e987ec1455c8453dc5caa5eadc6d6224f2bf0b21)
- [Implement fetching logic on the `FetchingStore`](https://github.com/hashintel/hash/commit/256040b2de6c6a8a244220fd8fd161c1a55f17e3)
- [Don't seed datatypes in the stop-gap solution](https://github.com/hashintel/hash/commit/55e92234167d733c02b91632a69ca97282fdbc04)