### PR TITLE
`deer`: `deserialize_optional`

### DIFF
--- a/libs/deer/json/src/lib.rs
+++ b/libs/deer/json/src/lib.rs
@@ -370,6 +370,18 @@ impl<'a, 'de> deer::Deserializer<'de> for Deserializer<'a> {
             else => Error
         })
     }
+
+    fn deserialize_optional<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    where
+        V: Visitor<'de>,
+    {
+        match &self.value {
+            None => visitor.visit_none(),
+            Some(Value::Null) => visitor.visit_null(),
+            _ => visitor.visit_some(self),
+        }
+        .change_context(DeserializerError)
+    }
 }
 
 #[must_use]

--- a/libs/deer/src/impls/core/integral.rs
+++ b/libs/deer/src/impls/core/integral.rs
@@ -45,6 +45,7 @@ macro_rules! impl_integral {
     };
 }
 
+// TODO: fit smaller values (visit) into them / try to fit them
 impl_integral![
     u8::deserialize_u8() <- U8Visitor.visit_u8(),
     u16::deserialize_u16() <- U16Visitor.visit_u16(),

--- a/libs/deer/src/macros.rs
+++ b/libs/deer/src/macros.rs
@@ -100,4 +100,7 @@ macro_rules! forward_to_deserialize_any_helper {
     (array < $l:tt, $v:ident >) => {
         forward_to_deserialize_any_method! {deserialize_array<$l, $v>()}
     };
+    (optional < $l:tt, $v:ident >) => {
+        forward_to_deserialize_any_method! {deserialize_optional<$l, $v>()}
+    };
 }

--- a/libs/deer/src/value.rs
+++ b/libs/deer/src/value.rs
@@ -59,6 +59,13 @@ macro_rules! impl_owned {
             {
                 visitor.$method(self.value).change_context(DeserializerError)
             }
+
+            fn deserialize_optional<V>(self, visitor: V) -> error_stack::Result<V::Value, DeserializerError>
+            where
+                V: Visitor<'de>
+            {
+                visitor.visit_some(self).change_context(DeserializerError)
+            }
         }
 
         impl<'de> IntoDeserializer<'de> for $ty {
@@ -134,6 +141,13 @@ impl<'de> Deserializer<'de> for NoneDeserializer<'_> {
     {
         visitor.visit_none().change_context(DeserializerError)
     }
+
+    fn deserialize_optional<V>(self, visitor: V) -> error_stack::Result<V::Value, DeserializerError>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_none().change_context(DeserializerError)
+    }
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -171,6 +185,13 @@ impl<'de> Deserializer<'de> for NullDeserializer<'_> {
     {
         visitor.visit_null().change_context(DeserializerError)
     }
+
+    fn deserialize_optional<V>(self, visitor: V) -> error_stack::Result<V::Value, DeserializerError>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_null().change_context(DeserializerError)
+    }
 }
 
 impl_owned!(bool, BoolDeserializer, visit_bool);
@@ -191,5 +212,3 @@ impl_owned!(f32, F32Deserializer, visit_f32);
 impl_owned!(f64, F64Deserializer, visit_f64);
 
 impl_owned!(!copy: Number, NumberDeserializer, visit_number);
-
-// TODO: test

--- a/libs/deer/src/value/array.rs
+++ b/libs/deer/src/value/array.rs
@@ -45,4 +45,11 @@ where
             .visit_array(self.value)
             .change_context(DeserializerError)
     }
+
+    fn deserialize_optional<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_some(self).change_context(DeserializerError)
+    }
 }

--- a/libs/deer/src/value/bytes.rs
+++ b/libs/deer/src/value/bytes.rs
@@ -46,6 +46,13 @@ impl<'de> Deserializer<'de> for BytesDeserializer<'_, '_> {
             .visit_bytes(self.value)
             .change_context(DeserializerError)
     }
+
+    fn deserialize_optional<V>(self, visitor: V) -> error_stack::Result<V::Value, DeserializerError>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_some(self).change_context(DeserializerError)
+    }
 }
 
 impl<'de, 'b> IntoDeserializer<'de> for &'b [u8] {
@@ -96,6 +103,13 @@ impl<'de> Deserializer<'de> for BorrowedBytesDeserializer<'_, 'de> {
         visitor
             .visit_borrowed_bytes(self.value)
             .change_context(DeserializerError)
+    }
+
+    fn deserialize_optional<V>(self, visitor: V) -> error_stack::Result<V::Value, DeserializerError>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_some(self).change_context(DeserializerError)
     }
 }
 

--- a/libs/deer/src/value/object.rs
+++ b/libs/deer/src/value/object.rs
@@ -45,4 +45,11 @@ where
             .visit_object(self.value)
             .change_context(DeserializerError)
     }
+
+    fn deserialize_optional<V>(self, visitor: V) -> Result<V::Value, DeserializerError>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_some(self).change_context(DeserializerError)
+    }
 }

--- a/libs/deer/src/value/string.rs
+++ b/libs/deer/src/value/string.rs
@@ -46,6 +46,13 @@ impl<'de> Deserializer<'de> for StrDeserializer<'_, '_> {
             .visit_str(self.value)
             .change_context(DeserializerError)
     }
+
+    fn deserialize_optional<V>(self, visitor: V) -> error_stack::Result<V::Value, DeserializerError>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_some(self).change_context(DeserializerError)
+    }
 }
 
 impl<'de, 'b> IntoDeserializer<'de> for &'b str {
@@ -96,6 +103,13 @@ impl<'de> Deserializer<'de> for BorrowedStrDeserializer<'_, 'de> {
         visitor
             .visit_borrowed_str(self.value)
             .change_context(DeserializerError)
+    }
+
+    fn deserialize_optional<V>(self, visitor: V) -> error_stack::Result<V::Value, DeserializerError>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_some(self).change_context(DeserializerError)
     }
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

I did not want to include this initially, being afraid to be too be too Rust centric and keeping things as generic as possible.

The implementation of the remaining core types has shown that at least a special deserialize method (`deserialize_optional`), similar to [`deserialize_option`](https://docs.rs/serde/latest/serde/trait.Deserializer.html#tymethod.deserialize_option) is needed.

`deserialize_optional` can be considered unique, as it will only every call three different visitor functions:
* `visit_none`
* `visit_null`
* `visit_some`

`visit_some` takes the `Deserializer` as an argument and enables the possibility of deserializing inner types.

Why is this needed?

The initial implementation of `Option<T>` uses `deserialize_any`, but this isn't sufficient, as only self-describing formats like `JSON`, but not formats like `bincode` can make use of the method, meaning that `Option<T>` (and other types that rely on the fact that a value is either present or not) cannot be used in such circumstances. This is bad. Therefore, a unique deserialize method and visit function have been added.