### PR TITLE
Disable caching for `CI` job

### DIFF
--- a/.github/actions/warm-up-repo/action.yml
+++ b/.github/actions/warm-up-repo/action.yml
@@ -14,7 +14,7 @@ runs:
     - uses: actions/setup-node@v3
       with:
         node-version: 16 ## aligned with Node version on Vercel
-        cache: yarn
+        # cache: yarn ## Currently disabled because of frequent timeouts
 
     - run: yarn install
       shell: bash

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -130,13 +130,6 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
 
-      - name: Cache Node dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            **/node_modules
-          key: ${{ hashFiles('**/yarn.lock') }}
-
       - name: Install tools
         shell: bash
         run: |
@@ -214,13 +207,6 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           override: true
 
-      - name: Cache Node dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            **/node_modules
-          key: ${{ hashFiles('**/yarn.lock') }}
-
       - name: Install tools
         shell: bash
         run: |
@@ -269,13 +255,6 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
-
-      - name: Cache Node dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            **/node_modules
-          key: ${{ hashFiles('**/yarn.lock') }}
 
       - name: Install tools
         run: |


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We encountered a lot of issues recently due to caching not working. This disables the caching on `warm-up repo`.

## 🔗 Related links

- [Slack discussion](https://hashintel.slack.com/archives/C02TWBTT3ED/p1676466201924619) _(internal)_

## ⚠️ Known issues

Caching usually speeds up the CI. In our case, however, running `yarn install` does not take very long. See the slack discussion linked above for more information.