### PR TITLE
Fix numbers not being passed correctly to Postgres

### DIFF
--- a/apps/hash-graph/lib/graph/src/lib.rs
+++ b/apps/hash-graph/lib/graph/src/lib.rs
@@ -14,11 +14,6 @@
 #![feature(bound_map)]
 #![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
 #![cfg_attr(not(miri), doc(test(attr(deny(warnings, clippy::all)))))]
-#![expect(
-    clippy::cast_possible_truncation,
-    reason = "Postgres doesn't support unsigned values, so we cast from i64 to u32. We don't use \
-              the negative part, though"
-)]
 
 pub mod api;
 

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/condition.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/condition.rs
@@ -205,13 +205,13 @@ mod tests {
                 ),
                 Filter::Equal(
                     Some(FilterExpression::Path(DataTypeQueryPath::Version)),
-                    Some(FilterExpression::Parameter(Parameter::Number(1.0))),
+                    Some(FilterExpression::Parameter(Parameter::Number(1))),
                 ),
             ]),
             r#"("ontology_id_with_metadata_0_1_0"."base_uri" = $1) AND ("ontology_id_with_metadata_0_1_0"."version" = $2)"#,
             &[
                 &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
-                &1.0,
+                &1,
             ],
         );
     }
@@ -239,13 +239,13 @@ mod tests {
                 ),
                 Filter::Equal(
                     Some(FilterExpression::Path(DataTypeQueryPath::Version)),
-                    Some(FilterExpression::Parameter(Parameter::Number(1.0))),
+                    Some(FilterExpression::Parameter(Parameter::Number(1))),
                 ),
             ]),
             r#"(("ontology_id_with_metadata_0_1_0"."base_uri" = $1) OR ("ontology_id_with_metadata_0_1_0"."version" = $2))"#,
             &[
                 &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
-                &1.0,
+                &1,
             ],
         );
     }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
@@ -82,7 +82,7 @@ mod tests {
             ),
             Filter::Equal(
                 Some(FilterExpression::Path(DataTypeQueryPath::Version)),
-                Some(FilterExpression::Parameter(Parameter::Number(1.0))),
+                Some(FilterExpression::Parameter(Parameter::Number(1))),
             ),
         ]);
         where_clause.add_condition(compiler.compile_filter(&filter_b));
@@ -147,7 +147,7 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(parameters, &[
             "\"https://blockprotocol.org/@blockprotocol/types/data-type/text/\"",
-            "1.0",
+            "1",
             "\"some title\"",
             "\"some description\""
         ]);

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -165,7 +165,7 @@ mod tests {
             ),
             Filter::Equal(
                 Some(FilterExpression::Path(DataTypeQueryPath::Version)),
-                Some(FilterExpression::Parameter(Parameter::Number(1.0))),
+                Some(FilterExpression::Parameter(Parameter::Number(1))),
             ),
         ]);
         compiler.add_filter(&filter);
@@ -181,7 +181,7 @@ mod tests {
             "#,
             &[
                 &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
-                &1.0,
+                &1,
             ],
         );
     }
@@ -280,7 +280,7 @@ mod tests {
                 Some(FilterExpression::Path(PropertyTypeQueryPath::DataTypes(
                     DataTypeQueryPath::Version,
                 ))),
-                Some(FilterExpression::Parameter(Parameter::Number(1.0))),
+                Some(FilterExpression::Parameter(Parameter::Number(1))),
             ),
         ]);
         compiler.add_filter(&filter);
@@ -304,7 +304,7 @@ mod tests {
             &[
                 &"Text",
                 &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
-                &1.0,
+                &1,
             ],
         );
     }
@@ -591,7 +591,7 @@ mod tests {
                     EntityQueryPath::EditionId,
                 ))),
             ))),
-            Some(FilterExpression::Parameter(Parameter::Number(10.0))),
+            Some(FilterExpression::Parameter(Parameter::Number(10))),
         );
         compiler.add_filter(&filter);
 
@@ -612,7 +612,7 @@ mod tests {
               AND "entities_0_2_0"."decision_time" && $2
               AND "entities_0_2_0"."entity_edition_id" = $3
             "#,
-            &[&kernel, &time_projection.image(), &10.0],
+            &[&kernel, &time_projection.image(), &10],
         );
     }
 
@@ -628,7 +628,7 @@ mod tests {
                     EntityQueryPath::EditionId,
                 ))),
             ))),
-            Some(FilterExpression::Parameter(Parameter::Number(10.0))),
+            Some(FilterExpression::Parameter(Parameter::Number(10))),
         );
         compiler.add_filter(&filter);
 
@@ -649,7 +649,7 @@ mod tests {
               AND "entities_0_2_0"."decision_time" && $2
               AND "entities_0_2_0"."entity_edition_id" = $3
             "#,
-            &[&kernel, &time_projection.image(), &10.0],
+            &[&kernel, &time_projection.image(), &10],
         );
     }
 

--- a/apps/hash-graph/lib/graph/src/store/query/filter.rs
+++ b/apps/hash-graph/lib/graph/src/store/query/filter.rs
@@ -267,7 +267,7 @@ pub enum FilterExpression<'p, R: Record + ?Sized> {
     Parameter(Parameter<'p>),
 }
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
 #[serde(untagged)]
 pub enum Parameter<'p> {
     Boolean(bool),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We currently only require integers for predefined fields (fields inside of JSON like `"properties"."..."` are treated differently):
- unsigned 32-bit value for ontology versions
- signed 32-bit value for ordering (this may change in the future)

- It's possible to truncate the value for ontology versions if the number was too big (resulting in the wrong error, annoying but not a major issue)
- It's *not* possible to specify a parameter for `"leftToRightOrder"` or `"rightToLeftOrder"` *at all* as this will fail with the following error:
```
graph::api::rest::entity: Could not read entities from the store, error: Could not query from store
│
╰─▶ error serializing parameter 2: cannot convert between the Rust type `f64` and the Postgres type `int4`
```

## 🔗 Related links

- [Asana Task](https://app.asana.com/0/0/1203977361907410) (_internal_)
- [Another Asana Task](https://app.asana.com/0/0/1202884883200973) (_internal_)

## 🔍 What does this change?

Change the parameter to take an `i32` instead. This does not cover all values of an unsigned 32-bit integer, which is used for the ontology version, but changing this to an `i64` would require adding a new variant specifically for the ordering, the effort required for this is not worth it currently.

## ❓ How to test this?

- Make sure you can query for an entity by its link ordering
- Make sure you can still compare a property by numbers