### PR TITLE
Support inserting the same external type with different versions

### DIFF
--- a/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
@@ -18,7 +18,7 @@ use crate::{
         OwnedOntologyElementMetadata,
     },
     provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
-    store::{BaseUriAlreadyExists, BaseUriDoesNotExist, DataTypeStore, StorePool},
+    store::{BaseUriAlreadyExists, DataTypeStore, OntologyVersionDoesNotExist, StorePool},
     subgraph::query::{DataTypeStructuralQuery, StructuralQuery},
 };
 
@@ -228,7 +228,7 @@ async fn update_data_type<P: StorePool + Send>(
         .map_err(|report| {
             tracing::error!(error=?report, "Could not update data type");
 
-            if report.contains::<BaseUriDoesNotExist>() {
+            if report.contains::<OntologyVersionDoesNotExist>() {
                 return StatusCode::NOT_FOUND;
             }
 

--- a/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
-        error::{BaseUriAlreadyExists, BaseUriDoesNotExist},
+        error::{BaseUriAlreadyExists, OntologyVersionDoesNotExist},
         EntityTypeStore, StorePool,
     },
     subgraph::query::{EntityTypeStructuralQuery, StructuralQuery},
@@ -238,7 +238,7 @@ async fn update_entity_type<P: StorePool + Send>(
         .map_err(|report| {
             tracing::error!(error=?report, "Could not update entity type");
 
-            if report.contains::<BaseUriDoesNotExist>() {
+            if report.contains::<OntologyVersionDoesNotExist>() {
                 return StatusCode::NOT_FOUND;
             }
 

--- a/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
@@ -18,7 +18,7 @@ use crate::{
         PropertyTypeQueryToken, PropertyTypeWithMetadata,
     },
     provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
-    store::{BaseUriAlreadyExists, BaseUriDoesNotExist, PropertyTypeStore, StorePool},
+    store::{BaseUriAlreadyExists, OntologyVersionDoesNotExist, PropertyTypeStore, StorePool},
     subgraph::query::{PropertyTypeStructuralQuery, StructuralQuery},
 };
 
@@ -235,7 +235,7 @@ async fn update_property_type<P: StorePool + Send>(
         .map_err(|report| {
             tracing::error!(error=?report, "Could not update property type");
 
-            if report.contains::<BaseUriDoesNotExist>() {
+            if report.contains::<OntologyVersionDoesNotExist>() {
                 return StatusCode::NOT_FOUND;
             }
 

--- a/apps/hash-graph/lib/graph/src/store.rs
+++ b/apps/hash-graph/lib/graph/src/store.rs
@@ -22,7 +22,7 @@ pub use self::{
     account::AccountStore,
     config::{DatabaseConnectionInfo, DatabaseType},
     error::{
-        BaseUriAlreadyExists, BaseUriDoesNotExist, InsertionError, QueryError, StoreError,
+        BaseUriAlreadyExists, InsertionError, OntologyVersionDoesNotExist, QueryError, StoreError,
         UpdateError,
     },
     knowledge::EntityStore,

--- a/apps/hash-graph/lib/graph/src/store/error.rs
+++ b/apps/hash-graph/lib/graph/src/store/error.rs
@@ -63,18 +63,6 @@ impl Context for BaseUriAlreadyExists {}
 
 #[derive(Debug)]
 #[must_use]
-pub struct BaseUriDoesNotExist;
-
-impl fmt::Display for BaseUriDoesNotExist {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.write_str("base URI does not exist")
-    }
-}
-
-impl Context for BaseUriDoesNotExist {}
-
-#[derive(Debug)]
-#[must_use]
 pub struct EntityDoesNotExist;
 
 impl fmt::Display for EntityDoesNotExist {
@@ -111,15 +99,27 @@ impl Context for VersionedUriAlreadyExists {}
 
 #[derive(Debug)]
 #[must_use]
-pub struct WrongOntologyVersion;
+pub struct OntologyVersionDoesNotExist;
 
-impl fmt::Display for WrongOntologyVersion {
+impl fmt::Display for OntologyVersionDoesNotExist {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.write_str("tried to update an ontology type with a different version")
+        fmt.write_str("tried to update an ontology type which does not exist")
     }
 }
 
-impl Context for WrongOntologyVersion {}
+impl Context for OntologyVersionDoesNotExist {}
+
+#[derive(Debug)]
+#[must_use]
+pub struct OntologyTypeIsNotOwned;
+
+impl fmt::Display for OntologyTypeIsNotOwned {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.write_str("tried to update a non-owned ontology type")
+    }
+}
+
+impl Context for OntologyTypeIsNotOwned {}
 
 #[derive(Debug)]
 pub struct MigrationError;

--- a/apps/hash-graph/lib/graph/src/store/postgres.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres.rs
@@ -262,8 +262,8 @@ where
                 FROM create_owned_ontology_id(
                     base_uri := $1,
                     version := $2,
-                    record_created_by_id := $4,
-                    owned_by_id := $3
+                    record_created_by_id := $3,
+                    owned_by_id := $4
                 );"#,
                 &[
                     &metadata.record_id().base_uri.as_str(),
@@ -306,14 +306,14 @@ where
                 FROM create_external_ontology_id(
                     base_uri := $1,
                     version := $2,
-                    record_created_by_id := $4,
-                    fetched_at := $3
+                    record_created_by_id := $3,
+                    fetched_at := $4
                 );"#,
                 &[
                     &metadata.record_id().base_uri.as_str(),
                     &metadata.record_id().version,
-                    &metadata.fetched_at(),
                     &metadata.provenance_metadata().updated_by_id(),
+                    &metadata.fetched_at(),
                 ],
             )
             .await

--- a/apps/hash-graph/lib/graph/src/store/postgres.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres.rs
@@ -35,10 +35,9 @@ use crate::{
     },
     provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
-        error::{VersionedUriAlreadyExists, WrongOntologyVersion},
+        error::{OntologyTypeIsNotOwned, OntologyVersionDoesNotExist, VersionedUriAlreadyExists},
         postgres::ontology::{OntologyDatabaseType, OntologyId},
-        AccountStore, BaseUriAlreadyExists, BaseUriDoesNotExist, InsertionError, QueryError,
-        StoreError, UpdateError,
+        AccountStore, BaseUriAlreadyExists, InsertionError, QueryError, StoreError, UpdateError,
     },
     subgraph::edges::GraphResolveDepths,
 };
@@ -263,21 +262,21 @@ where
                 FROM create_owned_ontology_id(
                     base_uri := $1,
                     version := $2,
-                    owned_by_id := $3,
-                    record_created_by_id := $4
+                    record_created_by_id := $4,
+                    owned_by_id := $3
                 );"#,
                 &[
                     &metadata.record_id().base_uri.as_str(),
                     &metadata.record_id().version,
-                    &metadata.owned_by_id(),
                     &metadata.provenance_metadata().updated_by_id(),
+                    &metadata.owned_by_id(),
                 ],
             )
             .await
             .into_report()
             .map(|row| row.get(0))
             .map_err(|report| match report.current_context().code() {
-                Some(&SqlState::EXCLUSION_VIOLATION | &SqlState::UNIQUE_VIOLATION) => report
+                Some(&SqlState::UNIQUE_VIOLATION) => report
                     .change_context(BaseUriAlreadyExists)
                     .attach_printable(metadata.record_id().base_uri.clone())
                     .change_context(InsertionError),
@@ -291,7 +290,9 @@ where
     ///
     /// # Errors
     ///
-    /// - if [`VersionedUri::base_uri`] did already exist in the database
+    /// - [`BaseUriAlreadyExists`] if [`VersionedUri::base_uri`] is an owned base uri
+    /// - [`VersionedUriAlreadyExists`] if [`VersionedUri::version`] is already used for the base
+    ///   uri
     #[tracing::instrument(level = "debug", skip(self))]
     async fn create_external_ontology_id(
         &self,
@@ -305,8 +306,8 @@ where
                 FROM create_external_ontology_id(
                     base_uri := $1,
                     version := $2,
-                    fetched_at := $3,
-                    record_created_by_id := $4
+                    record_created_by_id := $4,
+                    fetched_at := $3
                 );"#,
                 &[
                     &metadata.record_id().base_uri.as_str(),
@@ -319,8 +320,12 @@ where
             .into_report()
             .map(|row| row.get(0))
             .map_err(|report| match report.current_context().code() {
-                Some(&SqlState::EXCLUSION_VIOLATION | &SqlState::UNIQUE_VIOLATION) => report
+                Some(&SqlState::INVALID_PARAMETER_VALUE) => report
                     .change_context(BaseUriAlreadyExists)
+                    .attach_printable(metadata.record_id().base_uri.clone())
+                    .change_context(InsertionError),
+                Some(&SqlState::UNIQUE_VIOLATION) => report
+                    .change_context(VersionedUriAlreadyExists)
                     .attach_printable(metadata.record_id().base_uri.clone())
                     .change_context(InsertionError),
                 _ => report
@@ -334,8 +339,9 @@ where
     ///
     /// # Errors
     ///
-    /// - if [`VersionedUri::base_uri`] did not already exist in the database
-    /// - if [`VersionedUri`] did already exist in the database
+    /// - [`VersionedUriAlreadyExists`] if [`VersionedUri`] does already exist in the database
+    /// - [`OntologyVersionDoesNotExist`] if the previous version does not exist
+    /// - [`OntologyTypeIsNotOwned`] if ontology type is an external ontology type
     #[tracing::instrument(level = "debug", skip(self))]
     async fn update_owned_ontology_id(
         &self,
@@ -352,11 +358,13 @@ where
                 FROM update_owned_ontology_id(
                     base_uri := $1,
                     version := $2,
-                    record_created_by_id := $3
+                    version_to_update := $3,
+                    record_created_by_id := $4
                 );"#,
                 &[
                     &uri.base_uri.as_str(),
                     &i64::from(uri.version),
+                    &i64::from(uri.version - 1),
                     &updated_by_id,
                 ],
             )
@@ -368,11 +376,11 @@ where
                     .attach_printable(uri.clone())
                     .change_context(UpdateError),
                 Some(&SqlState::INVALID_PARAMETER_VALUE) => report
-                    .change_context(WrongOntologyVersion)
-                    .attach_printable(uri.clone())
+                    .change_context(OntologyVersionDoesNotExist)
+                    .attach_printable(uri.base_uri.clone())
                     .change_context(UpdateError),
                 Some(&SqlState::RESTRICT_VIOLATION) => report
-                    .change_context(BaseUriDoesNotExist)
+                    .change_context(OntologyTypeIsNotOwned)
                     .attach_printable(uri.base_uri.clone())
                     .change_context(UpdateError),
                 _ => report
@@ -441,10 +449,7 @@ where
         let uri = database_type.id();
         let record_id = OntologyTypeRecordId::from(uri.clone());
 
-        let (ontology_id, owned_by_id) = self
-            .update_owned_ontology_id(uri, updated_by_id)
-            .await
-            .change_context(UpdateError)?;
+        let (ontology_id, owned_by_id) = self.update_owned_ontology_id(uri, updated_by_id).await?;
         self.insert_with_id(ontology_id, database_type)
             .await
             .change_context(UpdateError)?;

--- a/apps/hash-graph/postgres_migrations/V2__ontology_tables.sql
+++ b/apps/hash-graph/postgres_migrations/V2__ontology_tables.sql
@@ -1,19 +1,25 @@
 CREATE TABLE IF NOT EXISTS
+  base_uris ("base_uri" TEXT PRIMARY KEY);
+
+CREATE TABLE IF NOT EXISTS
   ontology_ids (
     "ontology_id" UUID PRIMARY KEY,
-    "base_uri" TEXT NOT NULL,
+    "base_uri" TEXT NOT NULL REFERENCES "base_uris",
     "version" BIGINT NOT NULL,
     "transaction_time" tstzrange NOT NULL,
     "record_created_by_id" UUID NOT NULL REFERENCES "accounts",
     UNIQUE ("base_uri", "version"),
-    CONSTRAINT ontology_ids_overlapping EXCLUDE USING gist (
-      base_uri
+    EXCLUDE USING gist (
+      "base_uri"
       WITH
         =,
-        transaction_time
+        "version"
+      WITH
+        =,
+        "transaction_time"
       WITH
         &&
-    ) DEFERRABLE INITIALLY IMMEDIATE
+    )
   );
 
 COMMENT
@@ -21,18 +27,14 @@ COMMENT
 
 CREATE TABLE IF NOT EXISTS
   "ontology_owned_metadata" (
-    "ontology_id" UUID NOT NULL,
-    "owned_by_id" UUID NOT NULL REFERENCES "accounts",
-    CONSTRAINT ontology_owned_metadata_pk PRIMARY KEY ("ontology_id") DEFERRABLE INITIALLY IMMEDIATE,
-    CONSTRAINT ontology_owned_metadata_fk FOREIGN KEY ("ontology_id") REFERENCES ontology_ids DEFERRABLE INITIALLY IMMEDIATE
+    "ontology_id" UUID PRIMARY KEY REFERENCES "ontology_ids",
+    "owned_by_id" UUID NOT NULL REFERENCES "accounts"
   );
 
 CREATE TABLE IF NOT EXISTS
   "ontology_external_metadata" (
-    "ontology_id" UUID NOT NULL,
-    "fetched_at" TIMESTAMP WITH TIME ZONE NOT NULL,
-    CONSTRAINT ontology_external_metadata_pk PRIMARY KEY ("ontology_id") DEFERRABLE INITIALLY IMMEDIATE,
-    CONSTRAINT ontology_external_metadata_fk FOREIGN KEY ("ontology_id") REFERENCES "ontology_ids" DEFERRABLE INITIALLY IMMEDIATE
+    "ontology_id" UUID PRIMARY KEY REFERENCES "ontology_ids",
+    "fetched_at" TIMESTAMP WITH TIME ZONE NOT NULL
   );
 
 CREATE VIEW

--- a/apps/hash-graph/postgres_migrations/V4__ontology_functions.sql
+++ b/apps/hash-graph/postgres_migrations/V4__ontology_functions.sql
@@ -28,6 +28,7 @@ OR REPLACE FUNCTION update_ontology_id (
   "ontology_id" UUID,
   "base_uri" TEXT,
   "version" BIGINT,
+  "version_to_update" BIGINT,
   "record_created_by_id" UUID
 ) RETURNS TABLE (_ontology_id UUID) AS $update_ontology_id$
 BEGIN
@@ -36,15 +37,17 @@ BEGIN
   SET
     "ontology_id" = update_ontology_id.ontology_id,
     "version" = update_ontology_id.version,
-    "record_created_by_id" = update_ontology_id.record_created_by_id,
-    "transaction_time" = tstzrange(now(), NULL, '[)')
+    "record_created_by_id" = update_ontology_id.record_created_by_id
   WHERE ontology_ids.base_uri = update_ontology_id.base_uri
-    AND ontology_ids.transaction_time @> now()
+    AND ontology_ids.version = update_ontology_id.version_to_update
   RETURNING update_ontology_id.ontology_id;
 
   IF NOT FOUND THEN
-    RAISE EXCEPTION 'Trying to update an ontology type without specifying metadata'
-    USING ERRCODE = 'restrict_violation';
+    RAISE EXCEPTION 'Tried to update ontology type with base_uri `%` from version `%` to version `%` but it does not exist',
+      update_ontology_id.base_uri,
+      update_ontology_id.version_to_update,
+      update_ontology_id.version
+    USING ERRCODE = 'invalid_parameter_value';
   END IF;
   
 END $update_ontology_id$ LANGUAGE plpgsql VOLATILE;
@@ -52,11 +55,6 @@ END $update_ontology_id$ LANGUAGE plpgsql VOLATILE;
 CREATE
 OR REPLACE FUNCTION "update_ontology_ids_trigger" () RETURNS TRIGGER AS $update_ontology_ids_trigger$
 BEGIN
-  IF (OLD.version != NEW.version - 1) THEN
-    RAISE EXCEPTION 'Not updating the latest id: % -> %', OLD.version, NEW.version
-    USING ERRCODE = 'invalid_parameter_value';
-  END IF;
-
   INSERT INTO ontology_ids (
     "ontology_id",
     "base_uri",
@@ -70,8 +68,6 @@ BEGIN
     NEW.record_created_by_id,
     NEW.transaction_time
   );
-
-  OLD.transaction_time = tstzrange(lower(OLD.transaction_time), lower(NEW.transaction_time), '[)');
 
   RETURN OLD;
 END $update_ontology_ids_trigger$ LANGUAGE plpgsql VOLATILE;

--- a/apps/hash-graph/postgres_migrations/V5__ontology_metadata_functions.sql
+++ b/apps/hash-graph/postgres_migrations/V5__ontology_metadata_functions.sql
@@ -2,13 +2,19 @@ CREATE
 OR REPLACE FUNCTION create_owned_ontology_id (
   "base_uri" TEXT,
   "version" BIGINT,
-  "owned_by_id" UUID,
-  "record_created_by_id" UUID
+  "record_created_by_id" UUID,
+  "owned_by_id" UUID
 ) RETURNS TABLE (ontology_id UUID) AS $create_owned_ontology_id$
 DECLARE
   "_ontology_id" UUID;
 BEGIN
   _ontology_id := gen_random_uuid();
+
+  INSERT INTO base_uris (
+    "base_uri"
+  ) VALUES (
+    create_owned_ontology_id.base_uri
+  );
 
   PERFORM create_ontology_id(
     "ontology_id" := _ontology_id,
@@ -39,6 +45,20 @@ DECLARE
 BEGIN
   _ontology_id := gen_random_uuid();
 
+  BEGIN
+    INSERT INTO base_uris (
+      "base_uri"
+    ) VALUES (
+      create_external_ontology_id.base_uri
+    );
+  EXCEPTION WHEN unique_violation THEN
+    IF EXISTS (SELECT FROM ontology_ids NATURAL JOIN ontology_owned_metadata WHERE ontology_ids.base_uri = create_external_ontology_id.base_uri) THEN
+      RAISE EXCEPTION 'Owned ontology with base_uri `%` already exists',
+        create_external_ontology_id.base_uri
+      USING ERRCODE = 'invalid_parameter_value';
+    END IF;
+  END;
+
   PERFORM create_ontology_id(
     "ontology_id" := _ontology_id,
     "base_uri" := create_external_ontology_id.base_uri,
@@ -60,16 +80,21 @@ CREATE
 OR REPLACE FUNCTION update_owned_ontology_id (
   "base_uri" TEXT,
   "version" BIGINT,
+  "version_to_update" BIGINT,
   "record_created_by_id" UUID
 ) RETURNS TABLE (ontology_id UUID, owned_by_id UUID) AS $update_owned_ontology_id$
 DECLARE
   "_ontology_id" UUID;
 BEGIN
-  SET CONSTRAINTS ontology_owned_metadata_pk DEFERRED;
-  SET CONSTRAINTS ontology_owned_metadata_fk DEFERRED;
-  SET CONSTRAINTS ontology_ids_overlapping DEFERRED;
-
   _ontology_id := gen_random_uuid();
+
+  PERFORM update_ontology_id(
+    _ontology_id,
+    update_owned_ontology_id.base_uri,
+    update_owned_ontology_id.version,
+    update_owned_ontology_id.version_to_update,
+    update_owned_ontology_id.record_created_by_id
+  );
 
   RETURN QUERY
   UPDATE ontology_owned_metadata as metadata
@@ -78,79 +103,27 @@ BEGIN
   FROM ontology_ids
   WHERE ontology_ids.ontology_id = metadata.ontology_id
     AND ontology_ids.base_uri = update_owned_ontology_id.base_uri
-    AND ontology_ids.transaction_time @> now()
+    AND ontology_ids.version = update_owned_ontology_id.version_to_update
   RETURNING _ontology_id, metadata.owned_by_id;
   IF NOT FOUND THEN
-    RAISE EXCEPTION 'No owned ontology type with base_uri % does not exist', update_owned_ontology_id.base_uri
+    RAISE EXCEPTION 'No owned ontology type with base_uri `%` and version `%` does exist',
+      update_owned_ontology_id.base_uri,
+      update_owned_ontology_id.version_to_update
     USING ERRCODE = 'restrict_violation';
   END IF;
-
-  PERFORM update_ontology_id(
-    _ontology_id,
-    update_owned_ontology_id.base_uri,
-    update_owned_ontology_id.version,
-    update_owned_ontology_id.record_created_by_id
-  );
-
-  SET CONSTRAINTS ontology_owned_metadata_pk IMMEDIATE;
-  SET CONSTRAINTS ontology_owned_metadata_fk IMMEDIATE;
-  SET CONSTRAINTS ontology_ids_overlapping IMMEDIATE;
 END $update_owned_ontology_id$ LANGUAGE plpgsql VOLATILE;
-
-CREATE
-OR REPLACE FUNCTION update_external_ontology_id (
-  "base_uri" TEXT,
-  "version" BIGINT,
-  "record_created_by_id" UUID,
-  "fetched_at" TIMESTAMP WITH TIME ZONE
-) RETURNS TABLE (ontology_id UUID) AS $update_external_ontology_id$
-DECLARE
-  "_ontology_id" UUID;
-BEGIN
-  SET CONSTRAINTS ontology_external_metadata_pk DEFERRED;
-  SET CONSTRAINTS ontology_external_metadata_fk DEFERRED;
-  SET CONSTRAINTS ontology_ids_overlapping DEFERRED;
-
-  _ontology_id := gen_random_uuid();
-
-  RETURN QUERY
-  UPDATE ontology_external_metadata as metadata
-  SET
-    "ontology_id" = _ontology_id,
-    "fetched_at" = update_external_ontology_id.fetched_at
-  FROM ontology_ids
-  WHERE ontology_ids.ontology_id = metadata.ontology_id
-    AND ontology_ids.base_uri = update_external_ontology_id.base_uri
-    AND ontology_ids.transaction_time @> now()
-  RETURNING metadata.ontology_id;
-  IF NOT FOUND THEN
-    RAISE EXCEPTION 'No external ontology type with base_uri % does not exist', update_external_ontology_id.base_uri
-    USING ERRCODE = 'restrict_violation';
-  END IF;
-
-  PERFORM update_ontology_id(
-    _ontology_id,
-    update_external_ontology_id.base_uri,
-    update_external_ontology_id.version,
-    update_external_ontology_id.record_created_by_id
-  );
-
-  SET CONSTRAINTS ontology_external_metadata_pk IMMEDIATE;
-  SET CONSTRAINTS ontology_external_metadata_fk IMMEDIATE;
-  SET CONSTRAINTS ontology_ids_overlapping IMMEDIATE;
-END $update_external_ontology_id$ LANGUAGE plpgsql VOLATILE;
 
 CREATE
 OR REPLACE FUNCTION "update_owned_ontology_metadata_trigger" () RETURNS TRIGGER AS $update_owned_ontology_metadata_trigger$
 BEGIN
   INSERT INTO ontology_owned_metadata (
-    "ontology_id", 
+    "ontology_id",
     "owned_by_id"
   ) VALUES (
     NEW.ontology_id,
     NEW.owned_by_id
   );
-  
+
   RETURN OLD;
 END $update_owned_ontology_metadata_trigger$ LANGUAGE plpgsql VOLATILE;
 
@@ -160,24 +133,3 @@ UPDATE
   ON "ontology_owned_metadata" FOR EACH ROW
 EXECUTE
   PROCEDURE "update_owned_ontology_metadata_trigger" ();
-
-CREATE
-OR REPLACE FUNCTION "update_external_ontology_metadata_trigger" () RETURNS TRIGGER AS $update_external_ontology_metadata_trigger$
-BEGIN
-  INSERT INTO ontology_external_metadata (
-    "ontology_id",
-    "fetched_at"
-  ) VALUES (
-    NEW.ontology_id,
-    NEW.fetched_at
-  );
-
-  RETURN OLD;
-END $update_external_ontology_metadata_trigger$ LANGUAGE plpgsql VOLATILE;
-
-CREATE
-OR REPLACE TRIGGER "update_external_ontology_metadata_trigger" BEFORE
-UPDATE
-  ON "ontology_external_metadata" FOR EACH ROW
-EXECUTE
-  PROCEDURE "update_external_ontology_metadata_trigger" ();

--- a/apps/hash-graph/postgres_migrations/V5__ontology_metadata_functions.sql
+++ b/apps/hash-graph/postgres_migrations/V5__ontology_metadata_functions.sql
@@ -106,7 +106,7 @@ BEGIN
     AND ontology_ids.version = update_owned_ontology_id.version_to_update
   RETURNING _ontology_id, metadata.owned_by_id;
   IF NOT FOUND THEN
-    RAISE EXCEPTION 'No owned ontology type with base_uri `%` and version `%` does exist',
+    RAISE EXCEPTION 'No owned ontology type with base_uri `%` and version `%` exists',
       update_owned_ontology_id.base_uri,
       update_owned_ontology_id.version_to_update
     USING ERRCODE = 'restrict_violation';

--- a/apps/hash-graph/tests/integration/postgres/data_type.rs
+++ b/apps/hash-graph/tests/integration/postgres/data_type.rs
@@ -1,4 +1,10 @@
-use graph::ontology::OntologyTypeWithMetadata;
+use graph::{
+    ontology::OntologyTypeWithMetadata,
+    store::{
+        error::{OntologyTypeIsNotOwned, OntologyVersionDoesNotExist, VersionedUriAlreadyExists},
+        BaseUriAlreadyExists,
+    },
+};
 use type_system::{repr, DataType};
 
 use crate::DatabaseTestWrapper;
@@ -16,7 +22,7 @@ async fn insert() {
         .await
         .expect("could not seed database");
 
-    api.create_data_type(boolean_dt)
+    api.create_owned_data_type(boolean_dt)
         .await
         .expect("could not create data type");
 }
@@ -34,7 +40,7 @@ async fn query() {
         .await
         .expect("could not seed database");
 
-    api.create_data_type(empty_list_dt.clone())
+    api.create_owned_data_type(empty_list_dt.clone())
         .await
         .expect("could not create data type");
 
@@ -64,7 +70,7 @@ async fn update() {
         .await
         .expect("could not seed database");
 
-    api.create_data_type(object_dt_v1.clone())
+    api.create_owned_data_type(object_dt_v1.clone())
         .await
         .expect("could not create data type");
 
@@ -87,4 +93,162 @@ async fn update() {
 
     assert_eq!(&object_dt_v1, returned_object_dt_v1.inner());
     assert_eq!(&object_dt_v2, returned_object_dt_v2.inner());
+}
+
+#[tokio::test]
+async fn insert_same_base_uri() {
+    let object_dt_v1_repr: repr::DataType =
+        serde_json::from_str(graph_test_data::data_type::OBJECT_V1)
+            .expect("could not parse data type representation");
+    let object_dt_v1 = DataType::try_from(object_dt_v1_repr).expect("could not parse data type");
+
+    let object_dt_v2_repr: repr::DataType =
+        serde_json::from_str(graph_test_data::data_type::OBJECT_V2)
+            .expect("could not parse data type representation");
+    let object_dt_v2 = DataType::try_from(object_dt_v2_repr).expect("could not parse data type");
+
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = database
+        .seed([], [], [])
+        .await
+        .expect("could not seed database");
+
+    api.create_owned_data_type(object_dt_v1.clone())
+        .await
+        .expect("could not create data type");
+
+    let report = api
+        .create_owned_data_type(object_dt_v1.clone())
+        .await
+        .expect_err("could create data type");
+    assert!(
+        report.contains::<BaseUriAlreadyExists>(),
+        "wrong error, expected `BaseUriDoesNotExist`, got {report:?}"
+    );
+
+    let report = api
+        .create_owned_data_type(object_dt_v2.clone())
+        .await
+        .expect_err("could create data type");
+    assert!(
+        report.contains::<BaseUriAlreadyExists>(),
+        "wrong error, expected `BaseUriDoesNotExist`, got {report:?}"
+    );
+
+    let report = api
+        .create_external_data_type(object_dt_v1.clone())
+        .await
+        .expect_err("could create data type");
+    assert!(
+        report.contains::<BaseUriAlreadyExists>(),
+        "wrong error, expected `BaseUriDoesNotExist`, got {report:?}"
+    );
+
+    let report = api
+        .create_external_data_type(object_dt_v2.clone())
+        .await
+        .expect_err("could create data type");
+    assert!(
+        report.contains::<BaseUriAlreadyExists>(),
+        "wrong error, expected `BaseUriDoesNotExist`, got {report:?}"
+    );
+}
+
+#[tokio::test]
+async fn wrong_update_order() {
+    let object_dt_v1_repr: repr::DataType =
+        serde_json::from_str(graph_test_data::data_type::OBJECT_V1)
+            .expect("could not parse data type representation");
+    let object_dt_v1 = DataType::try_from(object_dt_v1_repr).expect("could not parse data type");
+
+    let object_dt_v2_repr: repr::DataType =
+        serde_json::from_str(graph_test_data::data_type::OBJECT_V2)
+            .expect("could not parse data type representation");
+    let object_dt_v2 = DataType::try_from(object_dt_v2_repr).expect("could not parse data type");
+
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = database
+        .seed([], [], [])
+        .await
+        .expect("could not seed database");
+
+    let report = api
+        .update_data_type(object_dt_v1.clone())
+        .await
+        .expect_err("could create data type");
+    assert!(
+        report.contains::<OntologyVersionDoesNotExist>(),
+        "wrong error, expected `BaseUriDoesNotExist`, got {report:?}"
+    );
+
+    api.create_owned_data_type(object_dt_v1.clone())
+        .await
+        .expect("could not create data type");
+
+    let report = api
+        .update_data_type(object_dt_v1.clone())
+        .await
+        .expect_err("could update data type");
+    assert!(
+        report.contains::<OntologyVersionDoesNotExist>(),
+        "wrong error, expected `OntologyVersionDoesNotExist`, got {report:?}"
+    );
+
+    api.update_data_type(object_dt_v2.clone())
+        .await
+        .expect("could not update data type");
+
+    let report = api
+        .update_data_type(object_dt_v2.clone())
+        .await
+        .expect_err("could update data type");
+    assert!(
+        report.contains::<VersionedUriAlreadyExists>(),
+        "wrong error, expected `OntologyVersionDoesNotExist`, got {report:?}"
+    );
+}
+
+#[tokio::test]
+async fn update_external_with_owned() {
+    let object_dt_v1_repr: repr::DataType =
+        serde_json::from_str(graph_test_data::data_type::OBJECT_V1)
+            .expect("could not parse data type representation");
+    let object_dt_v1 = DataType::try_from(object_dt_v1_repr).expect("could not parse data type");
+
+    let object_dt_v2_repr: repr::DataType =
+        serde_json::from_str(graph_test_data::data_type::OBJECT_V2)
+            .expect("could not parse data type representation");
+    let object_dt_v2 = DataType::try_from(object_dt_v2_repr).expect("could not parse data type");
+
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = database
+        .seed([], [], [])
+        .await
+        .expect("could not seed database");
+
+    api.create_external_data_type(object_dt_v1.clone())
+        .await
+        .expect("could not create data type");
+
+    let report = api
+        .update_data_type(object_dt_v2.clone())
+        .await
+        .expect_err("could update data type");
+    assert!(
+        report.contains::<OntologyTypeIsNotOwned>(),
+        "wrong error, expected `OntologyTypeIsNotOwned`, got {report:?}"
+    );
+
+    api.create_external_data_type(object_dt_v2.clone())
+        .await
+        .expect("could not create data type");
+
+    let report = api
+        .update_data_type(object_dt_v2.clone())
+        .await
+        .expect_err("could update data type");
+    assert!(
+        report.contains::<VersionedUriAlreadyExists>(),
+        "wrong error, expected `VersionedUriAlreadyExists`, got {report:?}"
+    );
 }

--- a/apps/hash-graph/tests/integration/postgres/lib.rs
+++ b/apps/hash-graph/tests/integration/postgres/lib.rs
@@ -31,8 +31,9 @@ use graph::{
         LinkData,
     },
     ontology::{
-        DataTypeWithMetadata, EntityTypeQueryPath, EntityTypeWithMetadata, OntologyElementMetadata,
-        OwnedOntologyElementMetadata, PropertyTypeWithMetadata,
+        DataTypeWithMetadata, EntityTypeQueryPath, EntityTypeWithMetadata,
+        ExternalOntologyElementMetadata, OntologyElementMetadata, OwnedOntologyElementMetadata,
+        PropertyTypeWithMetadata,
     },
     provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
@@ -183,7 +184,7 @@ fn generate_decision_time() -> Timestamp<DecisionTime> {
 
 // TODO: Add get_all_* methods
 impl DatabaseApi<'_> {
-    pub async fn create_data_type(
+    pub async fn create_owned_data_type(
         &mut self,
         data_type: DataType,
     ) -> Result<OntologyElementMetadata, InsertionError> {
@@ -191,6 +192,21 @@ impl DatabaseApi<'_> {
             data_type.id().clone().into(),
             ProvenanceMetadata::new(UpdatedById::new(self.account_id)),
             OwnedById::new(self.account_id),
+        ));
+
+        self.store.create_data_type(data_type, &metadata).await?;
+
+        Ok(metadata)
+    }
+
+    pub async fn create_external_data_type(
+        &mut self,
+        data_type: DataType,
+    ) -> Result<OntologyElementMetadata, InsertionError> {
+        let metadata = OntologyElementMetadata::External(ExternalOntologyElementMetadata::new(
+            data_type.id().clone().into(),
+            ProvenanceMetadata::new(UpdatedById::new(self.account_id)),
+            OffsetDateTime::now_utc(),
         ));
 
         self.store.create_data_type(data_type, &metadata).await?;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The current database layout asserts, that we only call "create" once per Base URI.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203623179643284/1203958456055099/f) _(internal)_

## 🔍 What does this change?

- Adjust database to allow multiple versions of external ontology data to be **created** (we can't _update_ them as they may be inserted in arbitrary order)
- Greatly improve the error handling code in Postgres

## 🛡 What tests cover this?

- A bunch of new integration tests was added to catch different possibilities of inserting various data. This also asserts the correct errors.

## ❓ How to test this?

- Modify the Rest API tests and try out different configurations
- keep in mind that you cannot insert external types from the Rest API, so may you also want to play around with the newly added tests
