### PR TITLE
Make `utoipa` definitions more readable

### DIFF
--- a/apps/hash-graph/lib/graph/src/api/rest.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest.rs
@@ -37,7 +37,7 @@ use crate::{
     api::rest::{
         middleware::log_request_and_response,
         utoipa_typedef::subgraph::{
-            Edges, KnowledgeGraphOutwardEdges, KnowledgeGraphRootedEdges, KnowledgeGraphVertex,
+            Edges, KnowledgeGraphOutwardEdge, KnowledgeGraphRootedEdges, KnowledgeGraphVertex,
             KnowledgeGraphVertices, OntologyRootedEdges, OntologyVertex, OntologyVertices,
             Subgraph, Vertex, Vertices,
         },
@@ -60,7 +60,7 @@ use crate::{
     subgraph::{
         edges::{
             EdgeResolveDepths, GraphResolveDepths, KnowledgeGraphEdgeKind, OntologyEdgeKind,
-            OntologyOutwardEdges, OutgoingEdgeResolveDepth, SharedEdgeKind,
+            OntologyOutwardEdge, OutgoingEdgeResolveDepth, SharedEdgeKind,
         },
         temporal_axes::{QueryTemporalAxes, QueryTemporalAxesUnresolved},
         SubgraphTemporalAxes,
@@ -195,8 +195,8 @@ async fn serve_static_schema(Path(path): Path<String>) -> Result<Response, Statu
             SharedEdgeKind,
             KnowledgeGraphEdgeKind,
             OntologyEdgeKind,
-            OntologyOutwardEdges,
-            KnowledgeGraphOutwardEdges,
+            OntologyOutwardEdge,
+            KnowledgeGraphOutwardEdge,
             OntologyRootedEdges,
             KnowledgeGraphRootedEdges,
             Edges,

--- a/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use utoipa::ToSchema;
 
 pub use self::{
-    edges::{Edges, KnowledgeGraphOutwardEdges, KnowledgeGraphRootedEdges, OntologyRootedEdges},
+    edges::{Edges, KnowledgeGraphOutwardEdge, KnowledgeGraphRootedEdges, OntologyRootedEdges},
     vertices::{
         KnowledgeGraphVertex, KnowledgeGraphVertices, OntologyVertex, OntologyVertices, Vertex,
         Vertices,

--- a/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/edges.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/edges.rs
@@ -94,12 +94,14 @@ impl Edges {
             knowledge_graph: KnowledgeGraphRootedEdges(edges.knowledge_graph.into_iter().fold(
                 HashMap::new(),
                 |mut map, (id, edges)| {
-                    let edges = edges.into_iter().map(|edge| {
-                        match edge {
-                            crate::subgraph::edges::KnowledgeGraphOutwardEdges::ToOntology(edge) => {
+                    let edges = edges
+                        .into_iter()
+                        .map(|edge| {
+                            match edge {
+                            crate::subgraph::edges::KnowledgeGraphOutwardEdge::ToOntology(edge) => {
                                 KnowledgeGraphOutwardEdge::ToOntology(edge)
                             }
-                            crate::subgraph::edges::KnowledgeGraphOutwardEdges::ToKnowledgeGraph(
+                            crate::subgraph::edges::KnowledgeGraphOutwardEdge::ToKnowledgeGraph(
                                 edge,
                             ) => {
                                 // We avoid storing redundant information when multiple editions of
@@ -141,19 +143,14 @@ impl Edges {
                                 })
                             }
                         }
-                    }).collect();
+                        })
+                        .collect();
                     match map.entry(id.base_id) {
                         Entry::Occupied(entry) => {
-                            entry.into_mut().insert(
-                                id.version,
-                                edges,
-                            );
+                            entry.into_mut().insert(id.version, edges);
                         }
                         Entry::Vacant(entry) => {
-                            entry.insert(BTreeMap::from([(
-                                id.version,
-                                edges,
-                            )]));
+                            entry.insert(BTreeMap::from([(id.version, edges)]));
                         }
                     }
                     map

--- a/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/vertices/vertex.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/vertices/vertex.rs
@@ -11,8 +11,11 @@ use crate::{
 #[serde(rename_all = "camelCase")]
 #[expect(clippy::enum_variant_names)]
 pub enum OntologyVertex {
+    #[schema(title = "DataTypeVertex")]
     DataType(Box<DataTypeWithMetadata>),
+    #[schema(title = "PropertyTypeVertex")]
     PropertyType(Box<PropertyTypeWithMetadata>),
+    #[schema(title = "EntityTypeVertex")]
     EntityType(Box<EntityTypeWithMetadata>),
 }
 
@@ -38,6 +41,7 @@ impl From<EntityTypeWithMetadata> for OntologyVertex {
 #[serde(tag = "kind", content = "inner")]
 #[serde(rename_all = "camelCase")]
 pub enum KnowledgeGraphVertex {
+    #[schema(title = "EntityVertex")]
     Entity(Entity),
 }
 
@@ -46,6 +50,8 @@ pub enum KnowledgeGraphVertex {
 #[serde(untagged)]
 #[expect(dead_code, reason = "This is used in the generated OpenAPI spec")]
 pub enum Vertex {
+    #[schema(title = "OntologyVertex")]
     Ontology(Box<OntologyVertex>),
+    #[schema(title = "KnowledgeGraphVertex")]
     KnowledgeGraph(Box<KnowledgeGraphVertex>),
 }

--- a/apps/hash-graph/lib/graph/src/shared/subgraph/edges.rs
+++ b/apps/hash-graph/lib/graph/src/shared/subgraph/edges.rs
@@ -6,7 +6,7 @@ mod edge;
 mod kind;
 
 pub use self::{
-    edge::{KnowledgeGraphOutwardEdges, OntologyOutwardEdges, OutwardEdge},
+    edge::{KnowledgeGraphOutwardEdges, OntologyOutwardEdge, OutwardEdge},
     kind::{
         EdgeResolveDepths, GraphResolveDepths, KnowledgeGraphEdgeKind, OntologyEdgeKind,
         OutgoingEdgeResolveDepth, SharedEdgeKind,
@@ -15,14 +15,14 @@ pub use self::{
 
 #[derive(Default, Debug)]
 pub struct Edges {
-    pub ontology: HashMap<OntologyTypeVertexId, HashSet<OntologyOutwardEdges>>,
+    pub ontology: HashMap<OntologyTypeVertexId, HashSet<OntologyOutwardEdge>>,
     pub knowledge_graph: HashMap<EntityVertexId, HashSet<KnowledgeGraphOutwardEdges>>,
 }
 
 pub enum Edge {
     Ontology {
         vertex_id: OntologyTypeVertexId,
-        outward_edge: OntologyOutwardEdges,
+        outward_edge: OntologyOutwardEdge,
     },
     KnowledgeGraph {
         vertex_id: EntityVertexId,

--- a/apps/hash-graph/lib/graph/src/shared/subgraph/edges.rs
+++ b/apps/hash-graph/lib/graph/src/shared/subgraph/edges.rs
@@ -6,7 +6,7 @@ mod edge;
 mod kind;
 
 pub use self::{
-    edge::{KnowledgeGraphOutwardEdges, OntologyOutwardEdge, OutwardEdge},
+    edge::{KnowledgeGraphOutwardEdge, OntologyOutwardEdge, OutwardEdge},
     kind::{
         EdgeResolveDepths, GraphResolveDepths, KnowledgeGraphEdgeKind, OntologyEdgeKind,
         OutgoingEdgeResolveDepth, SharedEdgeKind,
@@ -16,7 +16,7 @@ pub use self::{
 #[derive(Default, Debug)]
 pub struct Edges {
     pub ontology: HashMap<OntologyTypeVertexId, HashSet<OntologyOutwardEdge>>,
-    pub knowledge_graph: HashMap<EntityVertexId, HashSet<KnowledgeGraphOutwardEdges>>,
+    pub knowledge_graph: HashMap<EntityVertexId, HashSet<KnowledgeGraphOutwardEdge>>,
 }
 
 pub enum Edge {
@@ -26,7 +26,7 @@ pub enum Edge {
     },
     KnowledgeGraph {
         vertex_id: EntityVertexId,
-        outward_edge: KnowledgeGraphOutwardEdges,
+        outward_edge: KnowledgeGraphOutwardEdge,
     },
 }
 

--- a/apps/hash-graph/lib/graph/src/shared/subgraph/edges/edge.rs
+++ b/apps/hash-graph/lib/graph/src/shared/subgraph/edges/edge.rs
@@ -74,7 +74,7 @@ impl ToSchema<'_> for OntologyOutwardEdge {
 
 #[derive(Debug, Hash, PartialEq, Eq, Serialize)]
 #[serde(untagged)]
-pub enum KnowledgeGraphOutwardEdges {
+pub enum KnowledgeGraphOutwardEdge {
     ToKnowledgeGraph(OutwardEdge<KnowledgeGraphEdgeKind, EntityId>),
     ToOntology(OutwardEdge<SharedEdgeKind, OntologyTypeVertexId>),
 }

--- a/apps/hash-graph/lib/graph/src/shared/subgraph/edges/edge.rs
+++ b/apps/hash-graph/lib/graph/src/shared/subgraph/edges/edge.rs
@@ -18,32 +18,33 @@ pub struct OutwardEdge<K, E> {
 
 // Utoipa doesn't seem to be able to generate sensible interfaces for this, it gets confused by
 // the generic
-impl<'s, K, E> ToSchema<'s> for OutwardEdge<K, E>
+impl<'s, K, E> OutwardEdge<K, E>
 where
     K: ToSchema<'s>,
     E: ToSchema<'s>,
 {
-    fn schema() -> (&'static str, openapi::RefOr<openapi::Schema>) {
-        (
-            "OutwardEdge",
-            openapi::ObjectBuilder::new()
-                .property("kind", K::schema().1)
-                .required("kind")
-                .property(
-                    "reversed",
-                    openapi::Object::with_type(openapi::SchemaType::Boolean),
-                )
-                .required("reversed")
-                .property("rightEndpoint", E::schema().1)
-                .required("rightEndpoint")
-                .into(),
-        )
+    pub(crate) fn generate_schema(title: impl Into<String>) -> openapi::RefOr<openapi::Schema> {
+        openapi::ObjectBuilder::new()
+            .title(Some(title))
+            .property("kind", openapi::Ref::from_schema_name(K::schema().0))
+            .required("kind")
+            .property(
+                "reversed",
+                openapi::Object::with_type(openapi::SchemaType::Boolean),
+            )
+            .required("reversed")
+            .property(
+                "rightEndpoint",
+                openapi::Ref::from_schema_name(E::schema().0),
+            )
+            .required("rightEndpoint")
+            .into()
     }
 }
 
 #[derive(Debug, Hash, PartialEq, Eq, Serialize)]
 #[serde(untagged)]
-pub enum OntologyOutwardEdges {
+pub enum OntologyOutwardEdge {
     ToOntology(OutwardEdge<OntologyEdgeKind, OntologyTypeVertexId>),
     ToKnowledgeGraph(OutwardEdge<SharedEdgeKind, EntityVertexId>),
 }
@@ -51,13 +52,21 @@ pub enum OntologyOutwardEdges {
 // WARNING: This MUST be kept up to date with the enum variants.
 //   We have to do this because utoipa doesn't understand serde untagged:
 //   https://github.com/juhaku/utoipa/issues/320
-impl ToSchema<'_> for OntologyOutwardEdges {
+impl ToSchema<'_> for OntologyOutwardEdge {
     fn schema() -> (&'static str, openapi::RefOr<openapi::Schema>) {
         (
-            "OntologyOutwardEdges",
+            "OntologyOutwardEdge",
             openapi::OneOfBuilder::new()
-                .item(<OutwardEdge<OntologyEdgeKind, OntologyTypeVertexId>>::schema().1)
-                .item(<OutwardEdge<SharedEdgeKind, EntityVertexId>>::schema().1)
+                .item(
+                    <OutwardEdge<OntologyEdgeKind, OntologyTypeVertexId>>::generate_schema(
+                        "OntologyToOntologyOutwardEdge",
+                    ),
+                )
+                .item(
+                    <OutwardEdge<SharedEdgeKind, EntityVertexId>>::generate_schema(
+                        "OntologyToKnowledgeGraphOutwardEdge",
+                    ),
+                )
                 .into(),
         )
     }

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -27,7 +27,7 @@ use crate::{
     subgraph::{
         edges::{
             Edge, EdgeResolveDepths, GraphResolveDepths, KnowledgeGraphEdgeKind,
-            KnowledgeGraphOutwardEdges, OutgoingEdgeResolveDepth, OutwardEdge, SharedEdgeKind,
+            KnowledgeGraphOutwardEdge, OutgoingEdgeResolveDepth, OutwardEdge, SharedEdgeKind,
         },
         query::StructuralQuery,
         temporal_axes::QueryTemporalAxes,
@@ -104,7 +104,7 @@ impl<C: AsClient> PostgresStore<C> {
                     OntologyTypeVertexId::from(entity.metadata.entity_type_id().clone());
                 subgraph.edges.insert(Edge::KnowledgeGraph {
                     vertex_id: entity_vertex_id,
-                    outward_edge: KnowledgeGraphOutwardEdges::ToOntology(OutwardEdge {
+                    outward_edge: KnowledgeGraphOutwardEdge::ToOntology(OutwardEdge {
                         kind: SharedEdgeKind::IsOfType,
                         reversed: false,
                         right_endpoint: entity_type_id.clone(),
@@ -137,7 +137,7 @@ impl<C: AsClient> PostgresStore<C> {
                 {
                     subgraph.edges.insert(Edge::KnowledgeGraph {
                         vertex_id: entity_vertex_id,
-                        outward_edge: KnowledgeGraphOutwardEdges::ToKnowledgeGraph(OutwardEdge {
+                        outward_edge: KnowledgeGraphOutwardEdge::ToKnowledgeGraph(OutwardEdge {
                             // (HasLeftEntity, reversed=true) is equivalent to an
                             // outgoing link `Entity`
                             kind: KnowledgeGraphEdgeKind::HasLeftEntity,
@@ -176,7 +176,7 @@ impl<C: AsClient> PostgresStore<C> {
                 {
                     subgraph.edges.insert(Edge::KnowledgeGraph {
                         vertex_id: entity_vertex_id,
-                        outward_edge: KnowledgeGraphOutwardEdges::ToKnowledgeGraph(OutwardEdge {
+                        outward_edge: KnowledgeGraphOutwardEdge::ToKnowledgeGraph(OutwardEdge {
                             // (HasRightEntity, reversed=true) is equivalent to an
                             // incoming link `Entity`
                             kind: KnowledgeGraphEdgeKind::HasRightEntity,
@@ -215,7 +215,7 @@ impl<C: AsClient> PostgresStore<C> {
                 {
                     subgraph.edges.insert(Edge::KnowledgeGraph {
                         vertex_id: entity_vertex_id,
-                        outward_edge: KnowledgeGraphOutwardEdges::ToKnowledgeGraph(OutwardEdge {
+                        outward_edge: KnowledgeGraphOutwardEdge::ToKnowledgeGraph(OutwardEdge {
                             // (HasLeftEndpoint, reversed=true) is equivalent to an
                             // outgoing `Link` `Entity`
                             kind: KnowledgeGraphEdgeKind::HasLeftEntity,
@@ -254,7 +254,7 @@ impl<C: AsClient> PostgresStore<C> {
                 {
                     subgraph.edges.insert(Edge::KnowledgeGraph {
                         vertex_id: entity_vertex_id,
-                        outward_edge: KnowledgeGraphOutwardEdges::ToKnowledgeGraph(OutwardEdge {
+                        outward_edge: KnowledgeGraphOutwardEdge::ToKnowledgeGraph(OutwardEdge {
                             // (HasLeftEndpoint, reversed=true) is equivalent to an
                             // outgoing `Link` `Entity`
                             kind: KnowledgeGraphEdgeKind::HasRightEntity,

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     subgraph::{
         edges::{
-            Edge, GraphResolveDepths, OntologyEdgeKind, OntologyOutwardEdges,
+            Edge, GraphResolveDepths, OntologyEdgeKind, OntologyOutwardEdge,
             OutgoingEdgeResolveDepth, OutwardEdge,
         },
         query::StructuralQuery,
@@ -113,7 +113,7 @@ impl<C: AsClient> PostgresStore<C> {
 
                     subgraph.edges.insert(Edge::Ontology {
                         vertex_id: entity_type_id.clone(),
-                        outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
+                        outward_edge: OntologyOutwardEdge::ToOntology(OutwardEdge {
                             kind: OntologyEdgeKind::ConstrainsPropertiesOn,
                             reversed: false,
                             right_endpoint: property_type_vertex_id.clone(),
@@ -145,7 +145,7 @@ impl<C: AsClient> PostgresStore<C> {
 
                     subgraph.edges.insert(Edge::Ontology {
                         vertex_id: entity_type_id.clone(),
-                        outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
+                        outward_edge: OntologyOutwardEdge::ToOntology(OutwardEdge {
                             kind: OntologyEdgeKind::InheritsFrom,
                             reversed: false,
                             right_endpoint: inherits_from_type_vertex_id.clone(),
@@ -176,7 +176,7 @@ impl<C: AsClient> PostgresStore<C> {
 
                         subgraph.edges.insert(Edge::Ontology {
                             vertex_id: entity_type_id.clone(),
-                            outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
+                            outward_edge: OntologyOutwardEdge::ToOntology(OutwardEdge {
                                 kind: OntologyEdgeKind::ConstrainsLinksOn,
                                 reversed: false,
                                 right_endpoint: link_type_vertex_id.clone(),
@@ -210,7 +210,7 @@ impl<C: AsClient> PostgresStore<C> {
 
                                 subgraph.edges.insert(Edge::Ontology {
                                     vertex_id: entity_type_id.clone(),
-                                    outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
+                                    outward_edge: OntologyOutwardEdge::ToOntology(OutwardEdge {
                                         kind: OntologyEdgeKind::ConstrainsLinkDestinationsOn,
                                         reversed: false,
                                         right_endpoint: destination_type_vertex_id.clone(),

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     subgraph::{
         edges::{
-            Edge, GraphResolveDepths, OntologyEdgeKind, OntologyOutwardEdges,
+            Edge, GraphResolveDepths, OntologyEdgeKind, OntologyOutwardEdge,
             OutgoingEdgeResolveDepth, OutwardEdge,
         },
         query::StructuralQuery,
@@ -93,7 +93,7 @@ impl<C: AsClient> PostgresStore<C> {
 
                     subgraph.edges.insert(Edge::Ontology {
                         vertex_id: property_type_id.clone(),
-                        outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
+                        outward_edge: OntologyOutwardEdge::ToOntology(OutwardEdge {
                             kind: OntologyEdgeKind::ConstrainsValuesOn,
                             reversed: false,
                             right_endpoint: data_type_vertex_id.clone(),
@@ -123,7 +123,7 @@ impl<C: AsClient> PostgresStore<C> {
 
                     subgraph.edges.insert(Edge::Ontology {
                         vertex_id: property_type_id.clone(),
-                        outward_edge: OntologyOutwardEdges::ToOntology(OutwardEdge {
+                        outward_edge: OntologyOutwardEdge::ToOntology(OutwardEdge {
                             kind: OntologyEdgeKind::ConstrainsPropertiesOn,
                             reversed: false,
                             right_endpoint: property_type_vertex_id.clone(),

--- a/libs/@local/hash-graph-client/api.ts
+++ b/libs/@local/hash-graph-client/api.ts
@@ -402,8 +402,8 @@ export interface Edges {
  * @export
  */
 export type EdgesValueValueInner =
-  | KnowledgeGraphOutwardEdges
-  | OntologyOutwardEdges;
+  | KnowledgeGraphOutwardEdge
+  | OntologyOutwardEdge;
 
 /**
  * A record of an [`Entity`] that has been persisted in the datastore, with its associated metadata.
@@ -1008,125 +1008,70 @@ export type KnowledgeGraphEdgeKind =
   (typeof KnowledgeGraphEdgeKind)[keyof typeof KnowledgeGraphEdgeKind];
 
 /**
- * @type KnowledgeGraphOutwardEdges
+ * @type KnowledgeGraphOutwardEdge
  * @export
  */
-export type KnowledgeGraphOutwardEdges =
-  | KnowledgeGraphOutwardEdgesOneOf
-  | KnowledgeGraphOutwardEdgesOneOf1;
+export type KnowledgeGraphOutwardEdge =
+  | KnowledgeGraphToKnowledgeGraphOutwardEdge
+  | KnowledgeGraphToOntologyOutwardEdge;
 
-/**
- *
- * @export
- * @interface KnowledgeGraphOutwardEdgesOneOf
- */
-export interface KnowledgeGraphOutwardEdgesOneOf {
-  /**
-   *
-   * @type {string}
-   * @memberof KnowledgeGraphOutwardEdgesOneOf
-   */
-  kind: KnowledgeGraphOutwardEdgesOneOfKindEnum;
-  /**
-   *
-   * @type {boolean}
-   * @memberof KnowledgeGraphOutwardEdgesOneOf
-   */
-  reversed: boolean;
-  /**
-   *
-   * @type {KnowledgeGraphOutwardEdgesOneOfRightEndpoint}
-   * @memberof KnowledgeGraphOutwardEdgesOneOf
-   */
-  rightEndpoint: KnowledgeGraphOutwardEdgesOneOfRightEndpoint;
-}
-
-export const KnowledgeGraphOutwardEdgesOneOfKindEnum = {
-  LeftEntity: "HAS_LEFT_ENTITY",
-  RightEntity: "HAS_RIGHT_ENTITY",
-} as const;
-
-export type KnowledgeGraphOutwardEdgesOneOfKindEnum =
-  (typeof KnowledgeGraphOutwardEdgesOneOfKindEnum)[keyof typeof KnowledgeGraphOutwardEdgesOneOfKindEnum];
-
-/**
- *
- * @export
- * @interface KnowledgeGraphOutwardEdgesOneOf1
- */
-export interface KnowledgeGraphOutwardEdgesOneOf1 {
-  /**
-   *
-   * @type {string}
-   * @memberof KnowledgeGraphOutwardEdgesOneOf1
-   */
-  kind: KnowledgeGraphOutwardEdgesOneOf1KindEnum;
-  /**
-   *
-   * @type {boolean}
-   * @memberof KnowledgeGraphOutwardEdgesOneOf1
-   */
-  reversed: boolean;
-  /**
-   *
-   * @type {KnowledgeGraphOutwardEdgesOneOf1RightEndpoint}
-   * @memberof KnowledgeGraphOutwardEdgesOneOf1
-   */
-  rightEndpoint: KnowledgeGraphOutwardEdgesOneOf1RightEndpoint;
-}
-
-export const KnowledgeGraphOutwardEdgesOneOf1KindEnum = {
-  IsOfType: "IS_OF_TYPE",
-} as const;
-
-export type KnowledgeGraphOutwardEdgesOneOf1KindEnum =
-  (typeof KnowledgeGraphOutwardEdgesOneOf1KindEnum)[keyof typeof KnowledgeGraphOutwardEdgesOneOf1KindEnum];
-
-/**
- *
- * @export
- * @interface KnowledgeGraphOutwardEdgesOneOf1RightEndpoint
- */
-export interface KnowledgeGraphOutwardEdgesOneOf1RightEndpoint {
-  /**
-   *
-   * @type {string}
-   * @memberof KnowledgeGraphOutwardEdgesOneOf1RightEndpoint
-   */
-  baseId: string;
-  /**
-   *
-   * @type {number}
-   * @memberof KnowledgeGraphOutwardEdgesOneOf1RightEndpoint
-   */
-  version: number;
-}
-/**
- *
- * @export
- * @interface KnowledgeGraphOutwardEdgesOneOfRightEndpoint
- */
-export interface KnowledgeGraphOutwardEdgesOneOfRightEndpoint {
-  /**
-   *
-   * @type {string}
-   * @memberof KnowledgeGraphOutwardEdgesOneOfRightEndpoint
-   */
-  baseId: string;
-  /**
-   *
-   * @type {string}
-   * @memberof KnowledgeGraphOutwardEdgesOneOfRightEndpoint
-   */
-  timestamp: string;
-}
 /**
  *
  * @export
  * @interface KnowledgeGraphRootedEdges
  */
 export interface KnowledgeGraphRootedEdges {
-  [key: string]: { [key: string]: Array<KnowledgeGraphOutwardEdges> };
+  [key: string]: { [key: string]: Array<KnowledgeGraphOutwardEdge> };
+}
+/**
+ *
+ * @export
+ * @interface KnowledgeGraphToKnowledgeGraphOutwardEdge
+ */
+export interface KnowledgeGraphToKnowledgeGraphOutwardEdge {
+  /**
+   *
+   * @type {KnowledgeGraphEdgeKind}
+   * @memberof KnowledgeGraphToKnowledgeGraphOutwardEdge
+   */
+  kind: KnowledgeGraphEdgeKind;
+  /**
+   *
+   * @type {boolean}
+   * @memberof KnowledgeGraphToKnowledgeGraphOutwardEdge
+   */
+  reversed: boolean;
+  /**
+   *
+   * @type {EntityIdAndTimestamp}
+   * @memberof KnowledgeGraphToKnowledgeGraphOutwardEdge
+   */
+  rightEndpoint: EntityIdAndTimestamp;
+}
+/**
+ *
+ * @export
+ * @interface KnowledgeGraphToOntologyOutwardEdge
+ */
+export interface KnowledgeGraphToOntologyOutwardEdge {
+  /**
+   *
+   * @type {SharedEdgeKind}
+   * @memberof KnowledgeGraphToOntologyOutwardEdge
+   */
+  kind: SharedEdgeKind;
+  /**
+   *
+   * @type {boolean}
+   * @memberof KnowledgeGraphToOntologyOutwardEdge
+   */
+  reversed: boolean;
+  /**
+   *
+   * @type {OntologyTypeVertexId}
+   * @memberof KnowledgeGraphToOntologyOutwardEdge
+   */
+  rightEndpoint: OntologyTypeVertexId;
 }
 /**
  * @type KnowledgeGraphVertex
@@ -1269,109 +1214,70 @@ export type OntologyElementMetadata =
   | OwnedOntologyElementMetadata;
 
 /**
- * @type OntologyOutwardEdges
+ * @type OntologyOutwardEdge
  * @export
  */
-export type OntologyOutwardEdges =
-  | OntologyOutwardEdgesOneOf
-  | OntologyOutwardEdgesOneOf1;
+export type OntologyOutwardEdge =
+  | OntologyToKnowledgeGraphOutwardEdge
+  | OntologyToOntologyOutwardEdge;
 
-/**
- *
- * @export
- * @interface OntologyOutwardEdgesOneOf
- */
-export interface OntologyOutwardEdgesOneOf {
-  /**
-   *
-   * @type {string}
-   * @memberof OntologyOutwardEdgesOneOf
-   */
-  kind: OntologyOutwardEdgesOneOfKindEnum;
-  /**
-   *
-   * @type {boolean}
-   * @memberof OntologyOutwardEdgesOneOf
-   */
-  reversed: boolean;
-  /**
-   *
-   * @type {KnowledgeGraphOutwardEdgesOneOf1RightEndpoint}
-   * @memberof OntologyOutwardEdgesOneOf
-   */
-  rightEndpoint: KnowledgeGraphOutwardEdgesOneOf1RightEndpoint;
-}
-
-export const OntologyOutwardEdgesOneOfKindEnum = {
-  InheritsFrom: "INHERITS_FROM",
-  ConstrainsValuesOn: "CONSTRAINS_VALUES_ON",
-  ConstrainsPropertiesOn: "CONSTRAINS_PROPERTIES_ON",
-  ConstrainsLinksOn: "CONSTRAINS_LINKS_ON",
-  ConstrainsLinkDestinationsOn: "CONSTRAINS_LINK_DESTINATIONS_ON",
-} as const;
-
-export type OntologyOutwardEdgesOneOfKindEnum =
-  (typeof OntologyOutwardEdgesOneOfKindEnum)[keyof typeof OntologyOutwardEdgesOneOfKindEnum];
-
-/**
- *
- * @export
- * @interface OntologyOutwardEdgesOneOf1
- */
-export interface OntologyOutwardEdgesOneOf1 {
-  /**
-   *
-   * @type {string}
-   * @memberof OntologyOutwardEdgesOneOf1
-   */
-  kind: OntologyOutwardEdgesOneOf1KindEnum;
-  /**
-   *
-   * @type {boolean}
-   * @memberof OntologyOutwardEdgesOneOf1
-   */
-  reversed: boolean;
-  /**
-   *
-   * @type {OntologyOutwardEdgesOneOf1RightEndpoint}
-   * @memberof OntologyOutwardEdgesOneOf1
-   */
-  rightEndpoint: OntologyOutwardEdgesOneOf1RightEndpoint;
-}
-
-export const OntologyOutwardEdgesOneOf1KindEnum = {
-  IsOfType: "IS_OF_TYPE",
-} as const;
-
-export type OntologyOutwardEdgesOneOf1KindEnum =
-  (typeof OntologyOutwardEdgesOneOf1KindEnum)[keyof typeof OntologyOutwardEdgesOneOf1KindEnum];
-
-/**
- *
- * @export
- * @interface OntologyOutwardEdgesOneOf1RightEndpoint
- */
-export interface OntologyOutwardEdgesOneOf1RightEndpoint {
-  /**
-   *
-   * @type {string}
-   * @memberof OntologyOutwardEdgesOneOf1RightEndpoint
-   */
-  baseId: string;
-  /**
-   *
-   * @type {string}
-   * @memberof OntologyOutwardEdgesOneOf1RightEndpoint
-   */
-  version: string;
-}
 /**
  *
  * @export
  * @interface OntologyRootedEdges
  */
 export interface OntologyRootedEdges {
-  [key: string]: { [key: string]: Array<OntologyOutwardEdges> };
+  [key: string]: { [key: string]: Array<OntologyOutwardEdge> };
+}
+/**
+ *
+ * @export
+ * @interface OntologyToKnowledgeGraphOutwardEdge
+ */
+export interface OntologyToKnowledgeGraphOutwardEdge {
+  /**
+   *
+   * @type {SharedEdgeKind}
+   * @memberof OntologyToKnowledgeGraphOutwardEdge
+   */
+  kind: SharedEdgeKind;
+  /**
+   *
+   * @type {boolean}
+   * @memberof OntologyToKnowledgeGraphOutwardEdge
+   */
+  reversed: boolean;
+  /**
+   *
+   * @type {EntityVertexId}
+   * @memberof OntologyToKnowledgeGraphOutwardEdge
+   */
+  rightEndpoint: EntityVertexId;
+}
+/**
+ *
+ * @export
+ * @interface OntologyToOntologyOutwardEdge
+ */
+export interface OntologyToOntologyOutwardEdge {
+  /**
+   *
+   * @type {OntologyEdgeKind}
+   * @memberof OntologyToOntologyOutwardEdge
+   */
+  kind: OntologyEdgeKind;
+  /**
+   *
+   * @type {boolean}
+   * @memberof OntologyToOntologyOutwardEdge
+   */
+  reversed: boolean;
+  /**
+   *
+   * @type {OntologyTypeVertexId}
+   * @memberof OntologyToOntologyOutwardEdge
+   */
+  rightEndpoint: OntologyTypeVertexId;
 }
 /**
  *

--- a/libs/@local/hash-graph-client/api.ts
+++ b/libs/@local/hash-graph-client/api.ts
@@ -315,6 +315,33 @@ export interface DataTypeStructuralQuery {
 /**
  *
  * @export
+ * @interface DataTypeVertex
+ */
+export interface DataTypeVertex {
+  /**
+   *
+   * @type {DataTypeWithMetadata}
+   * @memberof DataTypeVertex
+   */
+  inner: DataTypeWithMetadata;
+  /**
+   *
+   * @type {string}
+   * @memberof DataTypeVertex
+   */
+  kind: DataTypeVertexKindEnum;
+}
+
+export const DataTypeVertexKindEnum = {
+  DataType: "dataType",
+} as const;
+
+export type DataTypeVertexKindEnum =
+  (typeof DataTypeVertexKindEnum)[keyof typeof DataTypeVertexKindEnum];
+
+/**
+ *
+ * @export
  * @interface DataTypeWithMetadata
  */
 export interface DataTypeWithMetadata {
@@ -707,6 +734,33 @@ export interface EntityTypeStructuralQuery {
 /**
  *
  * @export
+ * @interface EntityTypeVertex
+ */
+export interface EntityTypeVertex {
+  /**
+   *
+   * @type {EntityTypeWithMetadata}
+   * @memberof EntityTypeVertex
+   */
+  inner: EntityTypeWithMetadata;
+  /**
+   *
+   * @type {string}
+   * @memberof EntityTypeVertex
+   */
+  kind: EntityTypeVertexKindEnum;
+}
+
+export const EntityTypeVertexKindEnum = {
+  EntityType: "entityType",
+} as const;
+
+export type EntityTypeVertexKindEnum =
+  (typeof EntityTypeVertexKindEnum)[keyof typeof EntityTypeVertexKindEnum];
+
+/**
+ *
+ * @export
  * @interface EntityTypeWithMetadata
  */
 export interface EntityTypeWithMetadata {
@@ -723,6 +777,33 @@ export interface EntityTypeWithMetadata {
    */
   schema: EntityType;
 }
+/**
+ *
+ * @export
+ * @interface EntityVertex
+ */
+export interface EntityVertex {
+  /**
+   *
+   * @type {Entity}
+   * @memberof EntityVertex
+   */
+  inner: Entity;
+  /**
+   *
+   * @type {string}
+   * @memberof EntityVertex
+   */
+  kind: EntityVertexKindEnum;
+}
+
+export const EntityVertexKindEnum = {
+  Entity: "entity",
+} as const;
+
+export type EntityVertexKindEnum =
+  (typeof EntityVertexKindEnum)[keyof typeof EntityVertexKindEnum];
+
 /**
  *
  * @export
@@ -1051,34 +1132,7 @@ export interface KnowledgeGraphRootedEdges {
  * @type KnowledgeGraphVertex
  * @export
  */
-export type KnowledgeGraphVertex = KnowledgeGraphVertexOneOf;
-
-/**
- *
- * @export
- * @interface KnowledgeGraphVertexOneOf
- */
-export interface KnowledgeGraphVertexOneOf {
-  /**
-   *
-   * @type {Entity}
-   * @memberof KnowledgeGraphVertexOneOf
-   */
-  inner: Entity;
-  /**
-   *
-   * @type {string}
-   * @memberof KnowledgeGraphVertexOneOf
-   */
-  kind: KnowledgeGraphVertexOneOfKindEnum;
-}
-
-export const KnowledgeGraphVertexOneOfKindEnum = {
-  Entity: "entity",
-} as const;
-
-export type KnowledgeGraphVertexOneOfKindEnum =
-  (typeof KnowledgeGraphVertexOneOfKindEnum)[keyof typeof KnowledgeGraphVertexOneOfKindEnum];
+export type KnowledgeGraphVertex = EntityVertex;
 
 /**
  *
@@ -1362,90 +1416,9 @@ export interface OntologyTypeVertexId {
  * @export
  */
 export type OntologyVertex =
-  | OntologyVertexOneOf
-  | OntologyVertexOneOf1
-  | OntologyVertexOneOf2;
-
-/**
- *
- * @export
- * @interface OntologyVertexOneOf
- */
-export interface OntologyVertexOneOf {
-  /**
-   *
-   * @type {DataTypeWithMetadata}
-   * @memberof OntologyVertexOneOf
-   */
-  inner: DataTypeWithMetadata;
-  /**
-   *
-   * @type {string}
-   * @memberof OntologyVertexOneOf
-   */
-  kind: OntologyVertexOneOfKindEnum;
-}
-
-export const OntologyVertexOneOfKindEnum = {
-  DataType: "dataType",
-} as const;
-
-export type OntologyVertexOneOfKindEnum =
-  (typeof OntologyVertexOneOfKindEnum)[keyof typeof OntologyVertexOneOfKindEnum];
-
-/**
- *
- * @export
- * @interface OntologyVertexOneOf1
- */
-export interface OntologyVertexOneOf1 {
-  /**
-   *
-   * @type {PropertyTypeWithMetadata}
-   * @memberof OntologyVertexOneOf1
-   */
-  inner: PropertyTypeWithMetadata;
-  /**
-   *
-   * @type {string}
-   * @memberof OntologyVertexOneOf1
-   */
-  kind: OntologyVertexOneOf1KindEnum;
-}
-
-export const OntologyVertexOneOf1KindEnum = {
-  PropertyType: "propertyType",
-} as const;
-
-export type OntologyVertexOneOf1KindEnum =
-  (typeof OntologyVertexOneOf1KindEnum)[keyof typeof OntologyVertexOneOf1KindEnum];
-
-/**
- *
- * @export
- * @interface OntologyVertexOneOf2
- */
-export interface OntologyVertexOneOf2 {
-  /**
-   *
-   * @type {EntityTypeWithMetadata}
-   * @memberof OntologyVertexOneOf2
-   */
-  inner: EntityTypeWithMetadata;
-  /**
-   *
-   * @type {string}
-   * @memberof OntologyVertexOneOf2
-   */
-  kind: OntologyVertexOneOf2KindEnum;
-}
-
-export const OntologyVertexOneOf2KindEnum = {
-  EntityType: "entityType",
-} as const;
-
-export type OntologyVertexOneOf2KindEnum =
-  (typeof OntologyVertexOneOf2KindEnum)[keyof typeof OntologyVertexOneOf2KindEnum];
+  | DataTypeVertex
+  | EntityTypeVertex
+  | PropertyTypeVertex;
 
 /**
  *
@@ -1754,6 +1727,33 @@ export interface PropertyTypeStructuralQuery {
    */
   temporalAxes: QueryTemporalAxesUnresolved;
 }
+/**
+ *
+ * @export
+ * @interface PropertyTypeVertex
+ */
+export interface PropertyTypeVertex {
+  /**
+   *
+   * @type {PropertyTypeWithMetadata}
+   * @memberof PropertyTypeVertex
+   */
+  inner: PropertyTypeWithMetadata;
+  /**
+   *
+   * @type {string}
+   * @memberof PropertyTypeVertex
+   */
+  kind: PropertyTypeVertexKindEnum;
+}
+
+export const PropertyTypeVertexKindEnum = {
+  PropertyType: "propertyType",
+} as const;
+
+export type PropertyTypeVertexKindEnum =
+  (typeof PropertyTypeVertexKindEnum)[keyof typeof PropertyTypeVertexKindEnum];
+
 /**
  *
  * @export

--- a/libs/@local/hash-subgraph/src/temp/map-edges.ts
+++ b/libs/@local/hash-subgraph/src/temp/map-edges.ts
@@ -1,8 +1,8 @@
 import { validateBaseUri } from "@blockprotocol/type-system";
 import {
   Edges as EdgesGraphApi,
-  KnowledgeGraphOutwardEdges as KnowledgeGraphOutwardEdgesGraphApi,
-  OntologyOutwardEdges as OntologyOutwardEdgesGraphApi,
+  KnowledgeGraphOutwardEdge as KnowledgeGraphOutwardEdgeGraphApi,
+  OntologyOutwardEdge as OntologyOutwardEdgeGraphApi,
 } from "@local/hash-graph-client";
 
 import {
@@ -18,9 +18,7 @@ import {
 } from "../types";
 
 export const mapOutwardEdge = (
-  outwardEdge:
-    | OntologyOutwardEdgesGraphApi
-    | KnowledgeGraphOutwardEdgesGraphApi,
+  outwardEdge: OntologyOutwardEdgeGraphApi | KnowledgeGraphOutwardEdgeGraphApi,
 ): OutwardEdge => {
   switch (outwardEdge.kind) {
     // Ontology edge-kind cases

--- a/libs/@local/hash-subgraph/tests/compatibility.test/map-edges.ts
+++ b/libs/@local/hash-subgraph/tests/compatibility.test/map-edges.ts
@@ -1,8 +1,8 @@
 import { validateBaseUri } from "@blockprotocol/type-system";
 import {
   Edges as EdgesGraphApi,
-  KnowledgeGraphOutwardEdges as KnowledgeGraphOutwardEdgesGraphApi,
-  OntologyOutwardEdges as OntologyOutwardEdgesGraphApi,
+  KnowledgeGraphOutwardEdge as KnowledgeGraphOutwardEdgeGraphApi,
+  OntologyOutwardEdge as OntologyOutwardEdgeGraphApi,
 } from "@local/hash-graph-client";
 import {
   BaseUri,
@@ -17,9 +17,7 @@ import {
 } from "@local/hash-subgraph";
 
 export const mapOutwardEdge = (
-  outwardEdge:
-    | OntologyOutwardEdgesGraphApi
-    | KnowledgeGraphOutwardEdgesGraphApi,
+  outwardEdge: OntologyOutwardEdgeGraphApi | KnowledgeGraphOutwardEdgeGraphApi,
 ): OutwardEdge => {
   switch (outwardEdge.kind) {
     // Ontology edge-kind cases


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We currently have still a lot of `OneOf` and more unreadable things in our `api.ts` file. This makes it very unreadable. By only tweaking a few small bits on the Graph API we are able to greatly improve readability. One example is removing `OntologyOutwardEdgesOneOfKindEnum` and just using (the already defined) `OntologyEdgeKind` enumeration.

This also fixes a naming issue on the `*Edges` enumeration and removes the trailing `s`.

## 🚫 Blocked by

- #1854 