### PR TITLE
Account for horizontal scrollbar in code block sizing

### DIFF
--- a/blocks/code/package.json
+++ b/blocks/code/package.json
@@ -52,7 +52,7 @@
     "image": "public/preview.svg",
     "examples": [
       {
-        "https://blockprotocol-pktjfgq1m.stage.hash.ai/@blockprotocol/types/property-type/content/": "\"function debounce(func, timeout = 300){\\n  let timer;\\n  return (...args) => {\\n    clearTimeout(timer);\\n    timer = setTimeout(() => { func.apply(this, args); }, timeout);\\n  };\\n}\"",
+        "https://blockprotocol-pktjfgq1m.stage.hash.ai/@blockprotocol/types/property-type/content/": "function debounce(func, timeout = 300){\n  let timer;\n  return (...args) => {\n    clearTimeout(timer);\n    timer = setTimeout(() => { func.apply(this, args); }, timeout);\n  };\n}",
         "https://blockprotocol-pktjfgq1m.stage.hash.ai/@blockprotocol/types/property-type/language/": "javascript",
         "https://blockprotocol-pktjfgq1m.stage.hash.ai/@blockprotocol/types/property-type/caption/": "A JavaScript code example."
       }

--- a/blocks/code/src/dev.tsx
+++ b/blocks/code/src/dev.tsx
@@ -25,7 +25,7 @@ const initialEntity: RootEntity = {
   },
   properties: {
     "https://blockprotocol-pktjfgq1m.stage.hash.ai/@blockprotocol/types/property-type/content/":
-      'var foo = "bar";',
+      "function debounce(func, timeout = 300){\n  let timer;\n  return (...args) => {\n    clearTimeout(timer);\n    timer = setTimeout(() => { func.apply(this, args); }, timeout);\n  };\n}",
     "https://blockprotocol-pktjfgq1m.stage.hash.ai/@blockprotocol/types/property-type/language/":
       "javascript",
   },

--- a/blocks/code/src/editor.module.css
+++ b/blocks/code/src/editor.module.css
@@ -10,6 +10,11 @@
   background-color: transparent;
 }
 
+.editor pre[class*="language-"]::-webkit-scrollbar,
+.editor :not(pre) > code[class*="language-"]::-webkit-scrollbar {
+  display: none;
+}
+
 .editor code[class*="language-"],
 .editor pre[class*="language-"],
 .editor textarea {

--- a/blocks/code/src/editor.tsx
+++ b/blocks/code/src/editor.tsx
@@ -56,10 +56,24 @@ export const Editor = ({
     const preEl = highlightedElementRef.current; // <pre> element
     if (!textAreaEl || !preEl) return;
 
+    const hasHorizontalScrollbar =
+      textAreaEl.scrollWidth > textAreaEl.clientWidth;
+    const additionalHeight = hasHorizontalScrollbar ? 30 : 0;
+
     textAreaEl.style.height = "auto";
-    textAreaEl.style.height = `${textAreaEl.scrollHeight}px`;
-    preEl.style.height = `${textAreaEl.scrollHeight}px`;
+    textAreaEl.style.height = `${textAreaEl.scrollHeight + additionalHeight}px`;
+    preEl.style.height = `${textAreaEl.scrollHeight + additionalHeight}px`;
   }, [textAreaRef, highlightedElementRef]);
+
+  useEffect(() => {
+    const resizeListener = () => {
+      syncHeight();
+    };
+
+    window.addEventListener("resize", resizeListener);
+
+    return () => window.removeEventListener("resize", resizeListener);
+  });
 
   useEffect(() => {
     syncHeight();


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes an issue with the code block whereby a horizontal scrollbar was not accounted for in the textarea and pre height (textarea is present for editing, pre for formatted display), which introduced a vertical scrollbar and made it impossible to view the lowest lines.

This also fixes an issue I just introduced in #2107 where line breaks in the example content were escaped.

## ❓ How to test this?

1.  `cd blocks/code && yarn dev`

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

### Previously

You can see the existing behavior in the [Hub](https://blockprotocol.org/@hash/blocks/code) or in the following video:


https://user-images.githubusercontent.com/37743469/220299060-6f7dc877-ca84-4b62-bd4b-b377930f801e.mp4

---

### Now


https://user-images.githubusercontent.com/37743469/220299187-6f134947-e9ed-479c-8b57-5c47fce55d2e.mp4


