### PR TITLE
Fix CI

### DIFF
--- a/apps/hash-external-services/kratos/Dockerfile
+++ b/apps/hash-external-services/kratos/Dockerfile
@@ -4,7 +4,7 @@ USER root
 
 RUN sed -i 's|v3\.\d*|edge|' /etc/apk/repositories
 RUN apk update
-RUN apk add yq~=4.30
+RUN apk add yq=~4
 
 # This can be either `dev` or `prod`
 ARG ENV=dev


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
Fix failing CI due to a `yq` version

Test locally by running
```console
DOCKER_BUILDKIT=1 docker build ./apps/hash-external-services/kratos --build-arg ENV=prod -t kratos:latest
```
from the root before/after this change (with a cleared docker builder cache)