### PR TITLE
Add DB/migration owners to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,4 +9,4 @@ LICENSE.txt @hashintel/legal
 LICENSE.md @hashintel/legal
 
 # Database/migrations
-apps/hash-graph/postgres_migrations/ @hashintel/hash-database
+/apps/hash-graph/postgres_migrations/ @hashintel/hash-database

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,12 @@
-# Libs teams
+# Libraries
 /libs/deer/ @hashintel/deer
 /libs/antsi/ @hashintel/antsi
 /libs/error-stack/ @hashintel/error-stack
 
-# Legal team
+# Legal
 LICENSE @hashintel/legal
 LICENSE.txt @hashintel/legal
 LICENSE.md @hashintel/legal
+
+# Database/migrations
+apps/hash-graph/postgres_migrations/ @hashintel/hash-database


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds `@hashintel/hash-database` as CODEOWNER of `apps/hash-graph/postgres_migrations/`.

The team contains @hashdotai @TimDiekmann @thehabbos007.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204015588280819