### PR TITLE
Implement `Interval` ordering

### DIFF
--- a/apps/hash-graph/lib/graph/src/shared/interval.rs
+++ b/apps/hash-graph/lib/graph/src/shared/interval.rs
@@ -115,7 +115,7 @@ impl<T, S: IntervalBound<T>, E: IntervalBound<T>> Interval<T, S, E> {
     /// Panics if the start bound is greater than the end bound.
     pub fn new(start: S, end: E) -> Self
     where
-        T: PartialOrd,
+        T: Ord,
     {
         assert_ne!(
             compare_bounds(
@@ -123,6 +123,7 @@ impl<T, S: IntervalBound<T>, E: IntervalBound<T>> Interval<T, S, E> {
                 end.as_bound(),
                 BoundType::Start,
                 BoundType::End,
+                Ord::cmp,
             ),
             Ordering::Greater,
             "Start bound must be less than or equal to end bound"
@@ -149,7 +150,7 @@ impl<T, S: IntervalBound<T>, E: IntervalBound<T>> Interval<T, S, E> {
         other: &Interval<T, impl IntervalBound<T>, impl IntervalBound<T>>,
     ) -> bool
     where
-        T: PartialOrd,
+        T: Ord,
     {
         // Examples |      1     |     2
         // =========|============|============
@@ -177,11 +178,11 @@ impl<T, S: IntervalBound<T>, E: IntervalBound<T>> Interval<T, S, E> {
         other: &Interval<T, impl IntervalBound<T>, impl IntervalBound<T>>,
     ) -> bool
     where
-        T: PartialEq,
+        T: Eq,
     {
         fn bounds_are_adjacent<T>(lhs: &impl IntervalBound<T>, rhs: &impl IntervalBound<T>) -> bool
         where
-            T: PartialEq,
+            T: Eq,
         {
             match (lhs.as_bound(), rhs.as_bound()) {
                 (Bound::Included(lhs), Bound::Excluded(rhs))
@@ -201,7 +202,7 @@ impl<T, S: IntervalBound<T>, E: IntervalBound<T>> Interval<T, S, E> {
     #[must_use]
     pub fn contains_point(&self, other: &T) -> bool
     where
-        T: PartialOrd,
+        T: Ord,
     {
         matches!(
             compare_bounds(
@@ -209,6 +210,7 @@ impl<T, S: IntervalBound<T>, E: IntervalBound<T>> Interval<T, S, E> {
                 Bound::Included(other),
                 BoundType::Start,
                 BoundType::Start,
+                Ord::cmp,
             ),
             Ordering::Less | Ordering::Equal
         ) && matches!(
@@ -217,6 +219,7 @@ impl<T, S: IntervalBound<T>, E: IntervalBound<T>> Interval<T, S, E> {
                 Bound::Included(other),
                 BoundType::End,
                 BoundType::End,
+                Ord::cmp,
             ),
             Ordering::Greater | Ordering::Equal
         )
@@ -233,7 +236,7 @@ impl<T, S: IntervalBound<T>, E: IntervalBound<T>> Interval<T, S, E> {
         other: &Interval<T, impl IntervalBound<T>, impl IntervalBound<T>>,
     ) -> bool
     where
-        T: PartialOrd,
+        T: Ord,
     {
         matches!(
             self.cmp_start_to_start(other),
@@ -251,7 +254,7 @@ impl<T, S: IntervalBound<T>, E: IntervalBound<T>> Interval<T, S, E> {
     #[must_use]
     pub fn complement(self) -> impl ExactSizeIterator<Item = Self>
     where
-        T: PartialOrd,
+        T: Ord,
     {
         // Examples   |      1      |    2    |    3    |    4    |    5
         // =========================|=========|=========|=========|=========
@@ -270,7 +273,7 @@ impl<T, S: IntervalBound<T>, E: IntervalBound<T>> Interval<T, S, E> {
     #[must_use]
     pub fn merge(self, other: Self) -> Self
     where
-        T: PartialOrd,
+        T: Ord,
     {
         let start_ordering = self.cmp_start_to_start(&other);
         let end_ordering = self.cmp_end_to_end(&other);
@@ -297,7 +300,7 @@ impl<T, S: IntervalBound<T>, E: IntervalBound<T>> Interval<T, S, E> {
     /// In comparison to [`Self::merge`], this method returns two intervals if they don't overlap.
     pub fn union(self, other: Self) -> impl ExactSizeIterator<Item = Self>
     where
-        T: PartialOrd,
+        T: Ord,
     {
         if self.overlaps(&other) || self.is_adjacent_to(&other) {
             Return::one(self.merge(other))
@@ -312,7 +315,7 @@ impl<T, S: IntervalBound<T>, E: IntervalBound<T>> Interval<T, S, E> {
     #[must_use]
     pub fn intersect(self, other: Self) -> Option<Self>
     where
-        T: PartialOrd,
+        T: Ord,
     {
         self.overlaps(&other).then(|| {
             let start_ordering = self.cmp_start_to_start(&other);
@@ -343,7 +346,7 @@ impl<T, S: IntervalBound<T>, E: IntervalBound<T>> Interval<T, S, E> {
     /// disjoint intervals, `None` is returned.
     pub fn difference(self, other: Self) -> impl ExactSizeIterator<Item = Self>
     where
-        T: PartialOrd,
+        T: Ord,
     {
         match (
             self.cmp_start_to_start(&other),
@@ -501,11 +504,6 @@ where
             .into(),
         )
     }
-}
-
-#[inline(never)]
-fn invalid_bounds() -> ! {
-    panic!("interval lower bound must be less than or equal to its upper bound")
 }
 
 #[cfg(test)]

--- a/apps/hash-graph/lib/graph/src/shared/interval.rs
+++ b/apps/hash-graph/lib/graph/src/shared/interval.rs
@@ -451,6 +451,45 @@ where
 {
 }
 
+impl<T, S, E> PartialOrd for Interval<T, S, E>
+where
+    T: PartialOrd,
+    S: IntervalBound<T>,
+    E: IntervalBound<T>,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        let start_ordering = compare_bounds(
+            self.start_bound(),
+            other.start_bound(),
+            BoundType::Start,
+            BoundType::Start,
+            PartialOrd::partial_cmp,
+        )?;
+        match start_ordering {
+            Ordering::Equal => compare_bounds(
+                self.end_bound(),
+                other.end_bound(),
+                BoundType::End,
+                BoundType::End,
+                PartialOrd::partial_cmp,
+            ),
+            ordering => Some(ordering),
+        }
+    }
+}
+
+impl<T, S, E> Ord for Interval<T, S, E>
+where
+    T: Ord,
+    S: IntervalBound<T>,
+    E: IntervalBound<T>,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.cmp_start_to_start(other)
+            .then_with(|| self.cmp_end_to_end(other))
+    }
+}
+
 impl<T, S, E> Hash for Interval<T, S, E>
 where
     S: Hash,

--- a/apps/hash-graph/lib/graph/src/shared/interval/bounds.rs
+++ b/apps/hash-graph/lib/graph/src/shared/interval/bounds.rs
@@ -1,6 +1,6 @@
 use core::{cmp::Ordering, ops::Bound};
 
-use super::{invalid_bounds, Interval};
+use super::Interval;
 
 pub trait IntervalBound<T> {
     fn as_bound(&self) -> Bound<&T>;
@@ -47,13 +47,14 @@ where
         other: &Interval<T, impl IntervalBound<T>, impl IntervalBound<T>>,
     ) -> Ordering
     where
-        T: PartialOrd,
+        T: Ord,
     {
         compare_bounds(
             self.start().as_bound(),
             other.start().as_bound(),
             BoundType::Start,
             BoundType::Start,
+            Ord::cmp,
         )
     }
 
@@ -62,13 +63,14 @@ where
         other: &Interval<T, impl IntervalBound<T>, impl IntervalBound<T>>,
     ) -> Ordering
     where
-        T: PartialOrd,
+        T: Ord,
     {
         compare_bounds(
             self.start().as_bound(),
             other.end().as_bound(),
             BoundType::Start,
             BoundType::End,
+            Ord::cmp,
         )
     }
 
@@ -77,13 +79,14 @@ where
         other: &Interval<T, impl IntervalBound<T>, impl IntervalBound<T>>,
     ) -> Ordering
     where
-        T: PartialOrd,
+        T: Ord,
     {
         compare_bounds(
             self.end().as_bound(),
             other.start().as_bound(),
             BoundType::End,
             BoundType::Start,
+            Ord::cmp,
         )
     }
 
@@ -92,13 +95,14 @@ where
         other: &Interval<T, impl IntervalBound<T>, impl IntervalBound<T>>,
     ) -> Ordering
     where
-        T: PartialOrd,
+        T: Ord,
     {
         compare_bounds(
             self.end().as_bound(),
             other.end().as_bound(),
             BoundType::End,
             BoundType::End,
+            Ord::cmp,
         )
     }
 }
@@ -109,12 +113,13 @@ pub enum BoundType {
     End,
 }
 
-pub fn compare_bounds<T: PartialOrd>(
+pub fn compare_bounds<T: PartialEq, O: From<Ordering>>(
     lhs: Bound<&T>,
     rhs: Bound<&T>,
     lhs_type: BoundType,
     rhs_type: BoundType,
-) -> Ordering {
+    cmp: impl FnOnce(&T, &T) -> O,
+) -> O {
     match (lhs, rhs, lhs_type, rhs_type) {
         // If the bound values are not equal, then the bound with the start value is less than the
         // bound with the higher value.
@@ -122,25 +127,25 @@ pub fn compare_bounds<T: PartialOrd>(
             Bound::Included(lhs) | Bound::Excluded(lhs),
             Bound::Included(rhs) | Bound::Excluded(rhs),
             ..,
-        ) if lhs != rhs => lhs.partial_cmp(rhs).unwrap_or_else(|| invalid_bounds()),
+        ) if lhs != rhs => cmp(lhs, rhs),
 
         // From here onwards, the bound values are equal
         (Bound::Unbounded, Bound::Unbounded, BoundType::Start, BoundType::Start)
         | (Bound::Unbounded, Bound::Unbounded, BoundType::End, BoundType::End)
         | (Bound::Excluded(_), Bound::Excluded(_), BoundType::Start, BoundType::Start)
         | (Bound::Excluded(_), Bound::Excluded(_), BoundType::End, BoundType::End)
-        | (Bound::Included(_), Bound::Included(_), ..) => Ordering::Equal,
+        | (Bound::Included(_), Bound::Included(_), ..) => Ordering::Equal.into(),
 
         (Bound::Unbounded, _, BoundType::Start, _)
         | (_, Bound::Unbounded, _, BoundType::End)
         | (Bound::Excluded(_), Bound::Excluded(_), BoundType::End, BoundType::Start)
         | (Bound::Excluded(_), Bound::Included(_), BoundType::End, _)
-        | (Bound::Included(_), Bound::Excluded(_), _, BoundType::Start) => Ordering::Less,
+        | (Bound::Included(_), Bound::Excluded(_), _, BoundType::Start) => Ordering::Less.into(),
 
         (Bound::Unbounded, _, BoundType::End, _)
         | (_, Bound::Unbounded, _, BoundType::Start)
         | (Bound::Excluded(_), Bound::Excluded(_), BoundType::Start, BoundType::End)
         | (Bound::Excluded(_), Bound::Included(_), BoundType::Start, _)
-        | (Bound::Included(_), Bound::Excluded(_), _, BoundType::End) => Ordering::Greater,
+        | (Bound::Included(_), Bound::Excluded(_), _, BoundType::End) => Ordering::Greater.into(),
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, we cannot sort intervals. Sorting is required to have a more or less efficient and easy way to merge overlapping intervals in a list.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1202805690238892/1203835712237857/f) _(internal)_

## 🚫 Blocked by

- #2110 

## 🔍 What does this change?

- Use the correct bounds for `Interval` operations: The bounds needs to be `Ord` and `Eq` over `PartialOrd` and `PartialEq`, otherwise weird panic messages will happen when for example comparing `[NaN, +∞)` and `[NaN, +∞)`. The intervals can be constructed (as `NaN` is not greater than `+∞`), but comparing `NaN` to `NaN` will panic)
- Implement `PartialOrd` and `Ord` for `Interval`