### PR TITLE
Merge overlapping intervals when iterating through edge endpoints

### DIFF
--- a/apps/hash-graph/lib/graph/src/shared/identifier.rs
+++ b/apps/hash-graph/lib/graph/src/shared/identifier.rs
@@ -206,9 +206,9 @@ impl IntoIterator for EntityIdWithIntervalSet {
                         // then those would have been merged into one in the previous iteration
                         // (again because they are sorted).
                         if let Some(last) = acc.pop() {
-                            // `union` ensures that the resulting intervals are sorted, either
-                            // one or two intervals are returned, depending on whether they
-                            // overlap or not.
+                            // `union` either returns one or two intervals, depending on whether
+                            // they overlap or not. If two intervals are returned, the ordering is
+                            // stable, so we can just push them in order.
                             acc.extend(last.union(interval));
                         } else {
                             acc.push(interval);

--- a/apps/hash-graph/lib/graph/src/shared/identifier.rs
+++ b/apps/hash-graph/lib/graph/src/shared/identifier.rs
@@ -4,7 +4,7 @@ pub mod ontology;
 pub mod time;
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     hash::BuildHasher,
 };
 
@@ -153,20 +153,20 @@ impl EdgeEndpoint for EntityIdWithInterval {
 pub trait EdgeEndpointSet: IntoIterator<Item = Self::EdgeEndpoint> {
     type EdgeEndpoint: EdgeEndpoint;
 
-    fn insert(&mut self, target_id: Self::EdgeEndpoint) -> bool;
+    fn insert(&mut self, target_id: Self::EdgeEndpoint);
 }
 
 impl<S: BuildHasher> EdgeEndpointSet for HashSet<OntologyTypeVertexId, S> {
     type EdgeEndpoint = OntologyTypeVertexId;
 
-    fn insert(&mut self, edge_target_id: Self::EdgeEndpoint) -> bool {
-        self.insert(edge_target_id)
+    fn insert(&mut self, edge_target_id: Self::EdgeEndpoint) {
+        self.insert(edge_target_id);
     }
 }
 
 #[derive(Debug, Default)]
 pub struct EntityIdWithIntervalSet {
-    inner: HashMap<EntityId, HashSet<LeftClosedTemporalInterval<VariableAxis>>>,
+    inner: HashMap<EntityId, BTreeSet<LeftClosedTemporalInterval<VariableAxis>>>,
 }
 
 impl IntoIterator for EntityIdWithIntervalSet {
@@ -176,7 +176,46 @@ impl IntoIterator for EntityIdWithIntervalSet {
 
     fn into_iter(self) -> Self::IntoIter {
         self.inner.into_iter().flat_map(|(entity_id, intervals)| {
+            // This merges overlapping intervals
+            //  Examples   |       1       |       2       |       3
+            //  ===========|===============|===============|===============
+            //  Interval A | [--]          | (--]          | [--]
+            //  Interval B |      [-]      |      [-)      |      [-)
+            //  Interval C |  [--]         |  [--]         |  [---]
+            //  Interval D |           [-] |           [-] |        [----]
+            //  -----------|---------------|---------------|---------------
+            //  Union      | [------]  [-] | (------)  [-] | [-----------]
+
+            // TODO: This is a very primitive implementation. Instead of iterating over all elements
+            //       and merging them, we should use a data structure that allows for efficient
+            //       merging of intervals. This is probably a tree structure that allows for
+            //       efficient merging of overlapping intervals.
+            //   See https://en.wikipedia.org/wiki/Interval_tree
+            //    or https://en.wikipedia.org/wiki/Segment_tree
+            //       For simplicity, we stick with this fairly robust implementation for now, but
+            //       as a short-term optimization, we could utilize `#![feature(generators)]` to
+            //       avoid the allocation of the intermediate vector.
             intervals
+                .into_iter()
+                .fold(
+                    Vec::<LeftClosedTemporalInterval<VariableAxis>>::new(),
+                    |mut acc, interval| {
+                        // The intervals are sorted, it's only necessary to check the union of this
+                        // with the last interval, if it overlaps two of the previous ones (which
+                        // would make it necessary to check the union with more than just the last)
+                        // then those would have been merged into one in the previous iteration
+                        // (again because they are sorted).
+                        if let Some(last) = acc.pop() {
+                            // `union` ensures that the resulting intervals are sorted, either
+                            // one or two intervals are returned, depending on whether they
+                            // overlap or not.
+                            acc.extend(last.union(interval));
+                        } else {
+                            acc.push(interval);
+                        }
+                        acc
+                    },
+                )
                 .into_iter()
                 .map(move |interval| EntityIdWithInterval {
                     entity_id,
@@ -189,12 +228,10 @@ impl IntoIterator for EntityIdWithIntervalSet {
 impl EdgeEndpointSet for EntityIdWithIntervalSet {
     type EdgeEndpoint = EntityIdWithInterval;
 
-    fn insert(&mut self, edge_target_id: Self::EdgeEndpoint) -> bool {
-        // TODO: Merge overlapping intervals
-        //   see https://app.asana.com/0/0/1203399924452451/f
+    fn insert(&mut self, edge_target_id: Self::EdgeEndpoint) {
         self.inner
             .entry(edge_target_id.entity_id)
             .or_default()
-            .insert(edge_target_id.interval)
+            .insert(edge_target_id.interval);
     }
 }

--- a/apps/hash-graph/lib/graph/src/shared/interval.rs
+++ b/apps/hash-graph/lib/graph/src/shared/interval.rs
@@ -1136,7 +1136,7 @@ mod tests {
             lhs: included_included(10, 15),
             rhs: included_included(0, 5),
             intersection: [],
-            union: [included_included(0, 5), included_included(10, 15)],
+            union: [included_included(10, 15), included_included(0, 5)],
             merge: included_included(0, 15),
             difference: [included_included(10, 15)],
         });
@@ -1159,7 +1159,7 @@ mod tests {
             lhs: included_included(10, 15),
             rhs: included_excluded(0, 5),
             intersection: [],
-            union: [included_excluded(0, 5), included_included(10, 15)],
+            union: [included_included(10, 15), included_excluded(0, 5)],
             merge: included_included(0, 15),
             difference: [included_included(10, 15)],
         });
@@ -1182,7 +1182,7 @@ mod tests {
             lhs: included_excluded(10, 15),
             rhs: included_included(0, 5),
             intersection: [],
-            union: [included_included(0, 5), included_excluded(10, 15)],
+            union: [included_excluded(10, 15), included_included(0, 5)],
             merge: included_excluded(0, 15),
             difference: [included_excluded(10, 15)],
         });
@@ -1205,7 +1205,7 @@ mod tests {
             lhs: included_excluded(10, 15),
             rhs: included_excluded(0, 5),
             intersection: [],
-            union: [included_excluded(0, 5), included_excluded(10, 15)],
+            union: [included_excluded(10, 15), included_excluded(0, 5)],
             merge: included_excluded(0, 15),
             difference: [included_excluded(10, 15)],
         });
@@ -1228,7 +1228,7 @@ mod tests {
             lhs: included_included(10, 15),
             rhs: excluded_included(0, 5),
             intersection: [],
-            union: [excluded_included(0, 5), included_included(10, 15)],
+            union: [included_included(10, 15), excluded_included(0, 5)],
             merge: excluded_included(0, 15),
             difference: [included_included(10, 15)],
         });
@@ -1251,7 +1251,7 @@ mod tests {
             lhs: included_included(10, 15),
             rhs: excluded_excluded(0, 5),
             intersection: [],
-            union: [excluded_excluded(0, 5), included_included(10, 15)],
+            union: [included_included(10, 15), excluded_excluded(0, 5)],
             merge: excluded_included(0, 15),
             difference: [included_included(10, 15)],
         });
@@ -1274,7 +1274,7 @@ mod tests {
             lhs: included_excluded(10, 15),
             rhs: excluded_included(0, 5),
             intersection: [],
-            union: [excluded_included(0, 5), included_excluded(10, 15)],
+            union: [included_excluded(10, 15), excluded_included(0, 5)],
             merge: excluded_excluded(0, 15),
             difference: [included_excluded(10, 15)],
         });
@@ -1297,7 +1297,7 @@ mod tests {
             lhs: included_excluded(10, 15),
             rhs: excluded_excluded(0, 5),
             intersection: [],
-            union: [excluded_excluded(0, 5), included_excluded(10, 15)],
+            union: [included_excluded(10, 15), excluded_excluded(0, 5)],
             merge: excluded_excluded(0, 15),
             difference: [included_excluded(10, 15)],
         });
@@ -1320,7 +1320,7 @@ mod tests {
             lhs: excluded_included(10, 15),
             rhs: included_included(0, 5),
             intersection: [],
-            union: [included_included(0, 5), excluded_included(10, 15)],
+            union: [excluded_included(10, 15), included_included(0, 5)],
             merge: included_included(0, 15),
             difference: [excluded_included(10, 15)],
         });
@@ -1343,7 +1343,7 @@ mod tests {
             lhs: excluded_included(10, 15),
             rhs: included_excluded(0, 5),
             intersection: [],
-            union: [included_excluded(0, 5), excluded_included(10, 15)],
+            union: [excluded_included(10, 15), included_excluded(0, 5)],
             merge: included_included(0, 15),
             difference: [excluded_included(10, 15)],
         });
@@ -1366,7 +1366,7 @@ mod tests {
             lhs: excluded_excluded(10, 15),
             rhs: included_included(0, 5),
             intersection: [],
-            union: [included_included(0, 5), excluded_excluded(10, 15)],
+            union: [excluded_excluded(10, 15), included_included(0, 5)],
             merge: included_excluded(0, 15),
             difference: [excluded_excluded(10, 15)],
         });
@@ -1389,7 +1389,7 @@ mod tests {
             lhs: excluded_excluded(10, 15),
             rhs: included_excluded(0, 5),
             intersection: [],
-            union: [included_excluded(0, 5), excluded_excluded(10, 15)],
+            union: [excluded_excluded(10, 15), included_excluded(0, 5)],
             merge: included_excluded(0, 15),
             difference: [excluded_excluded(10, 15)],
         });
@@ -1412,7 +1412,7 @@ mod tests {
             lhs: excluded_included(10, 15),
             rhs: excluded_included(0, 5),
             intersection: [],
-            union: [excluded_included(0, 5), excluded_included(10, 15)],
+            union: [excluded_included(10, 15), excluded_included(0, 5)],
             merge: excluded_included(0, 15),
             difference: [excluded_included(10, 15)],
         });
@@ -1435,7 +1435,7 @@ mod tests {
             lhs: excluded_included(10, 15),
             rhs: excluded_excluded(0, 5),
             intersection: [],
-            union: [excluded_excluded(0, 5), excluded_included(10, 15)],
+            union: [excluded_included(10, 15), excluded_excluded(0, 5)],
             merge: excluded_included(0, 15),
             difference: [excluded_included(10, 15)],
         });
@@ -1458,7 +1458,7 @@ mod tests {
             lhs: excluded_excluded(10, 15),
             rhs: excluded_included(0, 5),
             intersection: [],
-            union: [excluded_included(0, 5), excluded_excluded(10, 15)],
+            union: [excluded_excluded(10, 15), excluded_included(0, 5)],
             merge: excluded_excluded(0, 15),
             difference: [excluded_excluded(10, 15)],
         });
@@ -1481,7 +1481,7 @@ mod tests {
             lhs: excluded_excluded(5, 15),
             rhs: excluded_excluded(0, 5),
             intersection: [],
-            union: [excluded_excluded(0, 5), excluded_excluded(5, 15)],
+            union: [excluded_excluded(5, 15), excluded_excluded(0, 5)],
             merge: excluded_excluded(0, 15),
             difference: [excluded_excluded(5, 15)],
         });
@@ -1576,7 +1576,7 @@ mod tests {
             lhs: excluded_included(5, 10),
             rhs: included_excluded(0, 5),
             intersection: [],
-            union: [included_excluded(0, 5), excluded_included(5, 10)],
+            union: [excluded_included(5, 10), included_excluded(0, 5)],
             merge: included_included(0, 10),
             difference: [excluded_included(5, 10)],
         });

--- a/apps/hash-graph/lib/graph/src/shared/interval.rs
+++ b/apps/hash-graph/lib/graph/src/shared/interval.rs
@@ -298,16 +298,16 @@ impl<T, S: IntervalBound<T>, E: IntervalBound<T>> Interval<T, S, E> {
     /// Returns a new interval that contains all points in both intervals.
     ///
     /// In comparison to [`Self::merge`], this method returns two intervals if they don't overlap.
+    /// If two intervals are returned, the ordering is stable, i.e. `self` is always the first
+    /// interval and `other` is always the second interval.
     pub fn union(self, other: Self) -> impl ExactSizeIterator<Item = Self>
     where
         T: Ord,
     {
         if self.overlaps(&other) || self.is_adjacent_to(&other) {
             Return::one(self.merge(other))
-        } else if self.cmp_start_to_start(&other) == Ordering::Less {
-            Return::two(self, other)
         } else {
-            Return::two(other, self)
+            Return::two(self, other)
         }
     }
 

--- a/apps/hash-graph/lib/graph/src/shared/subgraph/edges.rs
+++ b/apps/hash-graph/lib/graph/src/shared/subgraph/edges.rs
@@ -46,8 +46,7 @@ where
         edge_kind: K,
         reversed: bool,
         right_endpoint: E::EdgeEndpoint,
-    ) -> bool
-    where
+    ) where
         V::BaseId: Hash + Eq + Clone,
         V::RevisionId: Ord,
         K: Hash + Eq,
@@ -66,7 +65,7 @@ where
                 reversed,
             })
             .or_default()
-            .insert(right_endpoint)
+            .insert(right_endpoint);
     }
 
     pub fn into_flattened<O>(
@@ -168,7 +167,7 @@ impl Edges {
     ///
     /// - If the set did not previously contain this value, `true` is returned.
     /// - If the set already contained this value, `false` is returned.
-    pub fn insert(&mut self, edge: Edge) -> bool {
+    pub fn insert(&mut self, edge: Edge) {
         match edge {
             Edge::Ontology {
                 vertex_id,
@@ -206,7 +205,7 @@ impl Edges {
                     right_endpoint,
                 }) => {
                     self.knowledge_to_knowledge
-                        .insert(&vertex_id, kind, reversed, right_endpoint)
+                        .insert(&vertex_id, kind, reversed, right_endpoint);
                 }
             },
         }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This implements merging overlapping intervals on edge endpoints.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201095311341924/1203399924452451/f) _(internal)_

## 🚫 Blocked by

- #2110 
- #2115 

## 🔍 What does this change?

- Implements unification of intervals when iterating the `EntityIdWithIntervalSet`
- Simplify implementation of `Interval::union`

## ⚠️ Known issues

Please see the TODO comment in `EntityIdWithIntervalSet::into_iter`