### PR TITLE
Add `IntelliJ Plugin` app and team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,6 @@ LICENSE.md @hashintel/legal
 
 # Database/migrations
 /apps/hash-graph/postgres_migrations/ @hashintel/hash-database
+
+# Apps
+/apps/intellij-plugin/ @hashintel/intellij-plugin


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds the _IntelliJ Plugin_ app and team to the CODEOWNERS file.