### PR TITLE
Satisfy clippy for new Rust toolchain

### DIFF
--- a/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
@@ -179,6 +179,10 @@ pub fn bench_get_entity_by_id(
 }
 
 #[criterion]
+#[expect(
+    clippy::significant_drop_tightening,
+    reason = "false positive, see https://github.com/rust-lang/rust-clippy/issues/10413"
+)]
 fn bench_scaling_read_entity_zero_depths(c: &mut Criterion) {
     let mut group = c.benchmark_group("scaling_read_entity_complete_zero_depth");
 
@@ -230,6 +234,10 @@ fn bench_scaling_read_entity_zero_depths(c: &mut Criterion) {
 }
 
 #[criterion]
+#[expect(
+    clippy::significant_drop_tightening,
+    reason = "false positive, see https://github.com/rust-lang/rust-clippy/issues/10413"
+)]
 fn bench_scaling_read_entity_one_depth(c: &mut Criterion) {
     let mut group = c.benchmark_group("scaling_read_entity_complete_one_depth");
 

--- a/apps/hash-graph/bench/representative_read/lib.rs
+++ b/apps/hash-graph/bench/representative_read/lib.rs
@@ -68,6 +68,10 @@ fn bench_representative_read_entity(c: &mut Criterion) {
 
 #[criterion]
 #[expect(clippy::too_many_lines)]
+#[expect(
+    clippy::significant_drop_tightening,
+    reason = "false positive, see https://github.com/rust-lang/rust-clippy/issues/10413"
+)]
 fn bench_representative_read_multiple_entities(c: &mut Criterion) {
     let mut group = c.benchmark_group("representative_read_multiple_entities");
     let (runtime, store_wrapper) = setup(DB_NAME, false, false);

--- a/apps/hash-graph/lib/graph/src/shared/identifier/time/bound.rs
+++ b/apps/hash-graph/lib/graph/src/shared/identifier/time/bound.rs
@@ -1,3 +1,8 @@
+#![expect(
+    clippy::let_underscore_untyped,
+    reason = "Upstream issue of `derivative`"
+)]
+
 use std::ops::Bound;
 
 use derivative::Derivative;

--- a/apps/hash-graph/lib/graph/src/shared/identifier/time/interval.rs
+++ b/apps/hash-graph/lib/graph/src/shared/identifier/time/interval.rs
@@ -1,3 +1,8 @@
+#![expect(
+    clippy::let_underscore_untyped,
+    reason = "Upstream issue of `derivative`"
+)]
+
 use std::{error::Error, fmt, ops::Bound};
 
 use derivative::Derivative;

--- a/apps/hash-graph/lib/graph/src/shared/subgraph/query.rs
+++ b/apps/hash-graph/lib/graph/src/shared/subgraph/query.rs
@@ -1,3 +1,8 @@
+#![expect(
+    clippy::let_underscore_untyped,
+    reason = "Upstream issue of `derivative`"
+)]
+
 use std::fmt::Debug;
 
 use derivative::Derivative;

--- a/apps/hash-graph/lib/graph/src/store/query/filter.rs
+++ b/apps/hash-graph/lib/graph/src/store/query/filter.rs
@@ -1,3 +1,8 @@
+#![expect(
+    clippy::let_underscore_untyped,
+    reason = "Upstream issue of `derivative`"
+)]
+
 use std::{borrow::Cow, fmt, str::FromStr};
 
 use derivative::Derivative;

--- a/libs/deer/desert/src/error.rs
+++ b/libs/deer/desert/src/error.rs
@@ -65,7 +65,7 @@ impl<'a> BareError<'a> {
 
         let properties = object.get("properties")?;
 
-        let _ = object.get("message")?;
+        _ = object.get("message")?;
 
         // ensure that there are exactly 4 properties
         if object.len() != 4 {

--- a/libs/deer/tests/test_value.rs
+++ b/libs/deer/tests/test_value.rs
@@ -272,7 +272,7 @@ fn null_ok() {
     let context = Context::new();
 
     let de = NullDeserializer::new(&context);
-    let _ = Null::deserialize(de).expect("able to deserializer");
+    _ = Null::deserialize(de).expect("able to deserializer");
 }
 
 #[test]

--- a/libs/error-stack/examples/detect.rs
+++ b/libs/error-stack/examples/detect.rs
@@ -38,7 +38,7 @@ impl Display for ParseConfigError {
 impl std::error::Error for ParseConfigError {}
 
 fn parse_config(path: impl AsRef<Path>) -> Result<Config, ParseConfigError> {
-    let _ = path.as_ref();
+    _ = path.as_ref();
 
     /*
        usually you would actually do something here, we just error out, for a more complete example


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

With the next Rust toolchain (`2023-02-27`), clippy will have a few more lints, which are enabled. This prepares the codebase to take those into account or ignore the false positives.

## 🔗 Related links

- #2143
