### PR TITLE
Fix Timestamps on ontology types not being updated on `update`

### DIFF
--- a/apps/hash-graph/postgres_migrations/V4__ontology_functions.sql
+++ b/apps/hash-graph/postgres_migrations/V4__ontology_functions.sql
@@ -37,7 +37,8 @@ BEGIN
   SET
     "ontology_id" = update_ontology_id.ontology_id,
     "version" = update_ontology_id.version,
-    "record_created_by_id" = update_ontology_id.record_created_by_id
+    "record_created_by_id" = update_ontology_id.record_created_by_id,
+    "transaction_time" = tstzrange(now(), NULL, '[)')
   WHERE ontology_ids.base_url = update_ontology_id.base_url
     AND ontology_ids.version = update_ontology_id.version_to_update
   RETURNING update_ontology_id.ontology_id;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When calling update on an ontology type the timestamp is not updated.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203623179643290/1204091652018645/f) _(internal)_

## 🚫 Blocked by

- This PR is not blocked on anything

## 🔍 What does this change?

Fix that the timestamp is being set on the update method

## 📜 Does this require a change to the docs?

This is a feature, which is currently not exposed at all, thus, it does not need a change for documentation

## ⚠️ Known issues

We should investigate how we can fix these kind of bugs later when we cannot simply change old migration files

## 🐾 Next steps

After this PR has been merged we need to redeploy the Backend

## 🛡 What tests cover this?

This is a feature, which is currently not exposed, so there is no way to automatically test it

## ❓ How to test this?

1.  Run the REST API tests
1.  open the Database
1.  make sure, that the timestamps on the same type differ between their versions

## 📹 Demo

<img width="929" alt="image" src="https://user-images.githubusercontent.com/21277928/222448270-4ba3da7f-6990-4430-b485-a538dbc4468f.png">