### PR TITLE
`error-stack`: improve formatting docs

### DIFF
--- a/libs/error-stack/src/fmt.rs
+++ b/libs/error-stack/src/fmt.rs
@@ -204,10 +204,10 @@
 //! parent, we travel up the tree until we encounter our first [`Context`] node. Groups always
 //! contain lists, for the sake of clarity this explanation only shows the first element.
 //!
-//! Additional rules that apply:
+//! The rules stated above also derive some additional rules:
 //! * lists are never empty
 //! * lists are nested in groups
-//! * groups are always preceded by lists
+//! * groups are always preceded by a single list
 //! * groups are ordered left to right
 //!
 //! Using the aforementioned delimiters for lists and groups the end result would be:

--- a/libs/error-stack/src/fmt.rs
+++ b/libs/error-stack/src/fmt.rs
@@ -198,7 +198,7 @@
 //! more than `1` child, this means that `(2, 6)` is a group (they share `1` as an immediate context
 //! parent), while `(3, 4, 6)` is not. `(3, 4, 6)` share the same parent with more than 1 child
 //! (`1`), but `1` is not the immediate context parent of `3` and `4` (`2`) is. In the more detailed
-//! example `(Dᶜ, Hᶜ, Cᶜ)` is considered a group because they share the same *immediate* context
+//! example `(Dᶜ, Hᶜ, Iᶜ)` is considered a group because they share the same *immediate* context
 //! parent `Aᶜ`, important to note is that we only refer to immediate context parents, `Fᵃ` is the
 //! immediate parent of `Iᶜ`, but is not a [`Context`], therefore to find the immediate context
 //! parent, we travel up the tree until we encounter our first [`Context`] node. Groups always

--- a/libs/error-stack/src/fmt.rs
+++ b/libs/error-stack/src/fmt.rs
@@ -215,7 +215,9 @@
 //! Overview Tree: `[0, 1] ([2] ([3], [4, 5]), [6, 7, 8])`
 //! Detailed Tree: `[Aᶜ] ([Dᶜ], [Hᶜ], [Iᶜ])`
 //!
-//! Attachments are not ordered by insertion order but by depth in the tree. Each context uses the
+//! Attachments are not ordered by insertion order but by depth in the tree. The depth in the tree
+//! is the inverse of the insertion order, this means that the [`Debug`] output of all
+//! attachments is reversed from the calling order of [`Report::attach`]. Each context uses the
 //! attachments that are it's parents until the next context node. If attachments are shared between
 //! multiple contexts, they are duplicated and output twice.
 //!
@@ -269,11 +271,13 @@
 //!     ╰─▶ 8
 //! ```
 //!
-//! Attachments have been added to various places to simulate a real usecase with attachment and
-//! visualise their placement.
+//! Attachments have been added to various places to simulate a real use-case with attachments and
+//! to visualise their placement.
 //!
-//! The spacing and characters used are chosen carefully, as even when you have a context vs. group
-//! of contexts (as seen above) alignment is still ensured.
+//! The spacing and characters used are chosen carefully, to reduce indentation and increase visual
+//! legibility in large trees. The indentation of the group following the last entry in the
+//! preceding list is the same. To indicate that the last entry in the preceding list is the parent
+//! a new indentation of the connecting line is used.
 //!
 //! [`Display`]: core::fmt::Display
 //! [`Debug`]: core::fmt::Debug

--- a/libs/error-stack/src/fmt.rs
+++ b/libs/error-stack/src/fmt.rs
@@ -204,7 +204,7 @@
 //! parent, we travel up the tree until we encounter our first [`Context`] node. Groups always
 //! contain lists, for the sake of clarity this explanation only shows the first element.
 //!
-//! The rules stated above also derive some additional rules:
+//! The rules stated above also implies some additional rules:
 //! * lists are never empty
 //! * lists are nested in groups
 //! * groups are always preceded by a single list

--- a/libs/error-stack/src/fmt.rs
+++ b/libs/error-stack/src/fmt.rs
@@ -221,6 +221,9 @@
 //! attachments that are it's parents until the next context node. If attachments are shared between
 //! multiple contexts, they are duplicated and output twice.
 //!
+//! Groups are always preceded by a single list, the only case where this is not true is at the top
+//! level, in that case we opt to output separate trees for each member in the group.
+//!
 //! ### Output Formatting
 //!
 //! Lists are guaranteed to be non-empty and have at least a single context. The context is the

--- a/libs/error-stack/src/fmt.rs
+++ b/libs/error-stack/src/fmt.rs
@@ -189,10 +189,10 @@
 //! explanation will use terminology associated with trees, every [`Frame`] is a node and can have
 //! `0..n` children, a node that has no children (a leaf) is guaranteed to be a [`Context`].
 //!
-//! A list is a list of nodes where each node in the list if the parent of the following element and
-//! has only a single child, the last element of a list, can have `0..n` children. In the examples
-//! above, `[6, 7, 8]` is considered a list, while `[1, 6]` is not, because while `1` is a parent of
-//! `6`, `1` has more than 1 child.
+//! A list is a list of nodes where each node in the list is the parent of the next node in the list
+//! and only has a single child. The last node in the list is exempt of that rule of that rule and
+//! can have `0..n` children. In the examples above, `[6, 7, 8]` is considered a list, while `[1,
+//! 6]` is not, because while `1` is a parent of `6`, `1` has more than 1 child.
 //!
 //! A group is a list of nodes where each node shares a common immediate context parent that has
 //! more than `1` child, this means that `(2, 6)` is a group (they share `1` as an immediate context

--- a/libs/error-stack/src/fmt.rs
+++ b/libs/error-stack/src/fmt.rs
@@ -208,10 +208,12 @@
 //! * lists are never empty
 //! * lists are nested in groups
 //! * groups are always preceded by lists
+//! * groups are ordered left to right
 //!
 //! Using the aforementioned delimiters for lists and groups the end result would be:
 //!
 //! Overview Tree: `[0, 1] ([2] ([3], [4, 5]), [6, 7, 8])`
+//! Detailed Tree: `[Aᶜ] ([Dᶜ], [Hᶜ], [Iᶜ])`
 //!
 //! Attachments are not ordered by insertion order but by depth in the tree. Each context uses the
 //! attachments that are it's parents until the next context node. If attachments are shared between


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This adds additional documentation on formatting in `error-stack` through a new section: `Implementation Details`. This is part of a larger effort to reduce the accumulated tech debt in the `fmt` module by:

1) reduce allocations
    1.1) use of eager evaluation and use of `core::fmt` instead of requiring `Into<String>`
2) improve (internal) documentation
3) remove redundant code

This chain of PRs should have *no* user-facing changes, except documentation. Formatting will stay the same.
