### PR TITLE
`deer`: introduce `FieldAccess`

### DIFF
--- a/libs/deer/src/error.rs
+++ b/libs/deer/src/error.rs
@@ -453,6 +453,14 @@ error!(
 );
 
 error!(
+    /// Every [`FieldAccess`] implementation must return this error, this is just a wrapper context,
+    /// which is used to aid in error recovery. The underlying error should implement [`Error`] instead.
+    ///
+    /// [`FieldAccess`]: crate::FieldAccess
+    FieldAccessError: "field access encountered one or more errors during access"
+);
+
+error!(
     /// Every [`ArrayAccess`] implementation must return this error, this is just a wrapper context,
     /// which is used to aid error recovery. The actual error should implement [`Error`] instead.
     ///

--- a/libs/deer/src/lib.rs
+++ b/libs/deer/src/lib.rs
@@ -16,7 +16,7 @@
 use alloc::{string::String, vec::Vec};
 use core::marker::PhantomData;
 
-use error_stack::{FutureExt, Report, Result, ResultExt};
+use error_stack::{Report, Result, ResultExt};
 use num_traits::{FromPrimitive, ToPrimitive};
 pub use schema::{Document, Reflection, Schema};
 
@@ -55,6 +55,9 @@ impl<'de, T: Deserialize<'de>, U: Deserialize<'de>> FieldAccess<'de> for Generic
     }
 }
 
+type FieldKeyValue<'de, F> = (<F as FieldAccess<'de>>::Key, <F as FieldAccess<'de>>::Value);
+type FieldResult<'de, F> = Option<Result<FieldKeyValue<'de, F>, ObjectAccessError>>;
+
 pub trait ObjectAccess<'de> {
     /// This enables bound-checking for [`ObjectAccess`].
     ///
@@ -88,7 +91,7 @@ pub trait ObjectAccess<'de> {
         self.field(GenericFieldAccess(PhantomData))
     }
 
-    fn field<F>(&mut self, access: F) -> Option<Result<(F::Key, F::Value), ObjectAccessError>>
+    fn field<F>(&mut self, access: F) -> FieldResult<'de, F>
     where
         F: FieldAccess<'de>;
 

--- a/libs/deer/src/lib.rs
+++ b/libs/deer/src/lib.rs
@@ -102,7 +102,7 @@ pub trait ObjectAccess<'de> {
 
 pub trait FieldAccess<'de> {
     type Key: Deserialize<'de>;
-    type Value: Deserialize<'de>;
+    type Value;
 
     fn key<D>(&self, deserializer: D) -> Result<Self::Key, FieldAccessError>
     where


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This introduces a new API, `FieldAccess`, which is conjunction with `ObjectAccess` and can be used to conditionally get the value depending on the underlying type. This enables `Enum` style access, e.g. for `Result`.

### Differences between `serde` and `deer`

Because we decided to have a minimal API surface and unify the access through `Object` vs. `Array` we have a fundamental problem: conditional values based on the key, this is best shown with `Result`, `Result<T, E>` has two variants: `Ok` and `Err` and depending on the key. This is now possible, by implementing something similar to:

```rust
enum Key {
	Ok,
	Err
}

/* impl Deserialize for Key */

pub trait FieldAccess<'de> {
	type Key: Key;
    type Value: Result<T, E>;

    fn value(&self, key: &Key, deserializer: D) -> Result<Self::Value, FieldAccessError> {
       match key {
          Key::Ok => T::deserialize(deserializer).map(Ok).change_context(FieldAccessError),
          Key::Err => ...
       }
    }
}
```

in `serde` this is implemented through the `EnumAccess` in the `visit_enum` variant, which is a lot more complicated, otherwise one can use `next_key` and `next_value`. The problem with those is that they are prone to abuse, there is no type-system contract that `next_value` must always follow `next_key`, hand that they are only used in combination. With `FieldAccess` this is not possible, because `value()` required `&Key` and therefore can only be called after `Key`

### Downsides

Because `next()` now defaults to `field()` and the `field()` value depends on the key we cannot probe the value for an error if the key errored out. Previously we got the error from both.

### 👂 Open Questions

Does `FieldAccess::Value` and `FieldAccess::Key` need to be `Deserialize<'de>`? Because `FieldAccess::Value` is not used in a default implementation we could relax the bound, but I do not know if we want to keep the bound, just to ensure that a user does not misuse the API, for `FieldAccess::Key` the bound is needed for the default implementation, which I think is fine. @TimDiekmann , @thehabbos007 , what do you think?
