### PR TITLE
Add the `merge_group` trigger to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - "trunk-merge/**"
+  merge_group:
 
 env:
   TURBO_FORCE: true ## Turbo caching is disabled to avoid issues false cache hits (https://app.asana.com/0/1203193968491715/1203429129383865/f)
@@ -16,8 +17,8 @@ env:
 jobs:
   linting:
     name: Linting
-    # Run only on push to `main` or `trunk_merge/**` or on pull requests
-    if: ${{ (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/trunk-merge/'))) || github.event_name == 'pull_request' }}
+    # Run only on push to `main` or `trunk_merge/**`, in a merge group, or on pull requests
+    if: ${{ (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/trunk-merge/'))) || github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -221,8 +222,8 @@ jobs:
 
   playwright-tests:
     name: Playwright tests
-    # Run only on push to `main` or `trunk_merge/**` or on pull requests
-    if: ${{ (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/trunk-merge/'))) || github.event_name == 'pull_request' }}
+    # Run only on push to `main` or `trunk_merge/**`, in a merge group, or on pull requests
+    if: ${{ (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/trunk-merge/'))) || github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main]
+  merge_group:
   schedule:
     - cron: "42 10 * * 1"
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,7 @@ on:
       - main
       - dev/**
       - "trunk-merge/**"
+  merge_group:
 
 defaults:
   run:
@@ -297,7 +298,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
 
       - name: Install tools
-        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
+        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
         shell: bash
         run: |
           cargo install cargo-quickinstall
@@ -307,12 +308,12 @@ jobs:
           cargo quickinstall cargo-semver-checks --version 0.17.0 || cargo install --version 0.17.0 cargo-semver-checks
 
       - name: Run lints
-        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
+        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
         working-directory: ${{ matrix.directory }}
         run: cargo +${{ matrix.toolchain }} make --profile ${{ matrix.profile }} lint
 
       - name: Run tests
-        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
+        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
         working-directory: ${{ matrix.directory }}
         run: cargo +${{ matrix.toolchain }} make --profile ${{ matrix.profile }} test --no-fail-fast
 
@@ -322,12 +323,12 @@ jobs:
           cargo login "${{ secrets.CARGO_REGISTRY_TOKEN }}"
 
       - name: SemVer check
-        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
+        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
         working-directory: ${{ matrix.directory }}
         run: cargo +${{ matrix.toolchain }} semver-checks check-release
 
       - name: Publish (dry run)
-        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' }}
+        if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/trunk-merge/')) || github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
         working-directory: ${{ matrix.directory }}
         run: cargo +${{ matrix.toolchain }} publish --all-features --dry-run
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -11,6 +11,7 @@ on:
       - canary
       - dev/*
       - "trunk-merge/**"
+  merge_group:
 
   schedule:
     - cron: "30 0 1,15 * *" # scheduled for 00:30 UTC on both the 1st and 15th of the month


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In the BP repository we enabled GH Merge Queue and this went pretty well. This is going to allow the GH Merge Queue in this repository as well.

## 🔗 Related links

- https://github.com/blockprotocol/blockprotocol/pull/1100
- [Slack thread](https://hashintel.slack.com/archives/C02TWBTT3ED/p1677788837126439) _(internal)_