### PR TITLE
Globally allow `clippy::significant_drop_tightening`

### DIFF
--- a/.config/lints.toml
+++ b/.config/lints.toml
@@ -1,6 +1,9 @@
 allow = [
-    # "This encourages importing `as` which breaks IDEs"
-    "clippy::module_name_repetitions"
+    # This encourages importing `as` which breaks IDEs
+    "clippy::module_name_repetitions",
+
+    # The lint is great, but sadly it has too many false positives
+    "clippy::significant_drop_tightening",
 ]
 
 warn = [

--- a/apps/hash-graph/.cargo/config.toml
+++ b/apps/hash-graph/.cargo/config.toml
@@ -95,5 +95,6 @@ rustflags = [
     "-Wfuture_incompatible",
     "-Wnonstandard_style",
     "-Aclippy::module_name_repetitions",
+    "-Aclippy::significant_drop_tightening",
     ## END CLIPPY LINTS ##
 ]

--- a/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
@@ -179,10 +179,6 @@ pub fn bench_get_entity_by_id(
 }
 
 #[criterion]
-#[expect(
-    clippy::significant_drop_tightening,
-    reason = "false positive, see https://github.com/rust-lang/rust-clippy/issues/10413"
-)]
 fn bench_scaling_read_entity_zero_depths(c: &mut Criterion) {
     let mut group = c.benchmark_group("scaling_read_entity_complete_zero_depth");
 
@@ -234,10 +230,6 @@ fn bench_scaling_read_entity_zero_depths(c: &mut Criterion) {
 }
 
 #[criterion]
-#[expect(
-    clippy::significant_drop_tightening,
-    reason = "false positive, see https://github.com/rust-lang/rust-clippy/issues/10413"
-)]
 fn bench_scaling_read_entity_one_depth(c: &mut Criterion) {
     let mut group = c.benchmark_group("scaling_read_entity_complete_one_depth");
 

--- a/apps/hash-graph/bench/representative_read/lib.rs
+++ b/apps/hash-graph/bench/representative_read/lib.rs
@@ -68,10 +68,6 @@ fn bench_representative_read_entity(c: &mut Criterion) {
 
 #[criterion]
 #[expect(clippy::too_many_lines)]
-#[expect(
-    clippy::significant_drop_tightening,
-    reason = "false positive, see https://github.com/rust-lang/rust-clippy/issues/10413"
-)]
 fn bench_representative_read_multiple_entities(c: &mut Criterion) {
     let mut group = c.benchmark_group("representative_read_multiple_entities");
     let (runtime, store_wrapper) = setup(DB_NAME, false, false);

--- a/apps/hash-graph/lib/graph/src/logging/init.rs
+++ b/apps/hash-graph/lib/graph/src/logging/init.rs
@@ -60,7 +60,6 @@ where
     }
 }
 
-#[expect(clippy::significant_drop_tightening, reason = "false positive")]
 fn configure_opentelemetry_layer(
     otlp_endpoint: &str,
 ) -> OpenTelemetryLayer<Layered<EnvFilter, Registry>, Tracer> {

--- a/libs/deer/.cargo/config.toml
+++ b/libs/deer/.cargo/config.toml
@@ -102,6 +102,7 @@ rustflags = [
     "-Aclippy::missing_errors_doc",
     "-Aclippy::module_name_repetitions",
     "-Aclippy::redundant_pub_crate",
+    "-Aclippy::significant_drop_tightening",
     "-Amissing_docs",
     ## END CLIPPY LINTS ##
 ]

--- a/libs/error-stack/.cargo/config.toml
+++ b/libs/error-stack/.cargo/config.toml
@@ -101,5 +101,6 @@ rustflags = [
     "-Aclippy::missing_errors_doc",
     "-Aclippy::module_name_repetitions",
     "-Aclippy::redundant_pub_crate",
+    "-Aclippy::significant_drop_tightening",
     ## END CLIPPY LINTS ##
 ]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The lint is a great idea, but sadly it currently only has false positives. This PR disables the lint globally for now.

## 🔗 Related links

- [Lint description](https://rust-lang.github.io/rust-clippy/master/#significant_drop_tightening)