### PR TITLE
Store adjacency list for each (planned) reference table

### DIFF
--- a/apps/hash-graph/lib/graph/src/api/rest.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest.rs
@@ -37,8 +37,8 @@ use crate::{
         middleware::log_request_and_response,
         utoipa_typedef::subgraph::{
             Edges, KnowledgeGraphOutwardEdge, KnowledgeGraphRootedEdges, KnowledgeGraphVertex,
-            KnowledgeGraphVertices, OntologyOutwardEdge, OntologyRootedEdges, OntologyVertex,
-            OntologyVertices, Subgraph, Vertex, Vertices,
+            KnowledgeGraphVertices, OntologyOutwardEdge, OntologyRootedEdges, OntologyTypeVertexId,
+            OntologyVertex, OntologyVertices, Subgraph, Vertex, Vertices,
         },
     },
     identifier::{
@@ -62,7 +62,7 @@ use crate::{
         },
         identifier::{
             DataTypeVertexId, EntityIdWithInterval, EntityTypeVertexId, EntityVertexId,
-            GraphElementVertexId, OntologyTypeVertexId, PropertyTypeVertexId,
+            GraphElementVertexId, PropertyTypeVertexId,
         },
         temporal_axes::{QueryTemporalAxes, QueryTemporalAxesUnresolved, SubgraphTemporalAxes},
     },

--- a/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph.rs
@@ -10,8 +10,8 @@ pub use self::{
         OntologyRootedEdges,
     },
     vertices::{
-        KnowledgeGraphVertex, KnowledgeGraphVertices, OntologyVertex, OntologyVertices, Vertex,
-        Vertices,
+        KnowledgeGraphVertex, KnowledgeGraphVertices, OntologyTypeVertexId, OntologyVertex,
+        OntologyVertices, Vertex, Vertices,
     },
 };
 use crate::subgraph::{

--- a/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/edges.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/edges.rs
@@ -11,7 +11,10 @@ use crate::{
     identifier::{knowledge::EntityId, ontology::OntologyTypeVersion, time::Timestamp},
     subgraph::{
         edges::{KnowledgeGraphEdgeKind, OntologyEdgeKind, OutwardEdge, SharedEdgeKind},
-        identifier::{EntityIdWithInterval, OntologyTypeVertexId},
+        identifier::{
+            DataTypeVertexId, EntityIdWithInterval, EntityTypeVertexId, OntologyTypeVertexId,
+            PropertyTypeVertexId,
+        },
         temporal_axes::VariableAxis,
     },
 };
@@ -23,9 +26,33 @@ pub enum OntologyOutwardEdge {
     ToKnowledgeGraph(OutwardEdge<SharedEdgeKind, EntityIdWithInterval>),
 }
 
-impl From<OutwardEdge<OntologyEdgeKind, OntologyTypeVertexId>> for OntologyOutwardEdge {
-    fn from(edge: OutwardEdge<OntologyEdgeKind, OntologyTypeVertexId>) -> Self {
-        Self::ToOntology(edge)
+impl From<OutwardEdge<OntologyEdgeKind, EntityTypeVertexId>> for OntologyOutwardEdge {
+    fn from(edge: OutwardEdge<OntologyEdgeKind, EntityTypeVertexId>) -> Self {
+        Self::ToOntology(OutwardEdge {
+            kind: edge.kind,
+            reversed: edge.reversed,
+            right_endpoint: OntologyTypeVertexId::EntityType(edge.right_endpoint),
+        })
+    }
+}
+
+impl From<OutwardEdge<OntologyEdgeKind, PropertyTypeVertexId>> for OntologyOutwardEdge {
+    fn from(edge: OutwardEdge<OntologyEdgeKind, PropertyTypeVertexId>) -> Self {
+        Self::ToOntology(OutwardEdge {
+            kind: edge.kind,
+            reversed: edge.reversed,
+            right_endpoint: OntologyTypeVertexId::PropertyType(edge.right_endpoint),
+        })
+    }
+}
+
+impl From<OutwardEdge<OntologyEdgeKind, DataTypeVertexId>> for OntologyOutwardEdge {
+    fn from(edge: OutwardEdge<OntologyEdgeKind, DataTypeVertexId>) -> Self {
+        Self::ToOntology(OutwardEdge {
+            kind: edge.kind,
+            reversed: edge.reversed,
+            right_endpoint: OntologyTypeVertexId::DataType(edge.right_endpoint),
+        })
     }
 }
 
@@ -71,9 +98,13 @@ impl From<OutwardEdge<KnowledgeGraphEdgeKind, EntityIdWithInterval>> for Knowled
     }
 }
 
-impl From<OutwardEdge<SharedEdgeKind, OntologyTypeVertexId>> for KnowledgeGraphOutwardEdge {
-    fn from(edge: OutwardEdge<SharedEdgeKind, OntologyTypeVertexId>) -> Self {
-        Self::ToOntology(edge)
+impl From<OutwardEdge<SharedEdgeKind, EntityTypeVertexId>> for KnowledgeGraphOutwardEdge {
+    fn from(edge: OutwardEdge<SharedEdgeKind, EntityTypeVertexId>) -> Self {
+        Self::ToOntology(OutwardEdge {
+            kind: edge.kind,
+            reversed: edge.reversed,
+            right_endpoint: OntologyTypeVertexId::EntityType(edge.right_endpoint),
+        })
     }
 }
 
@@ -125,22 +156,32 @@ impl From<crate::subgraph::edges::Edges> for Edges {
         Self {
             ontology: OntologyRootedEdges(
                 edges
-                    .ontology_to_ontology
+                    .entity_type_to_entity_type
                     .into_flattened::<OntologyOutwardEdge>()
                     .chain(
                         edges
-                            .ontology_to_knowledge
+                            .entity_type_to_property_type
+                            .into_flattened::<OntologyOutwardEdge>(),
+                    )
+                    .chain(
+                        edges
+                            .property_type_to_property_type
+                            .into_flattened::<OntologyOutwardEdge>(),
+                    )
+                    .chain(
+                        edges
+                            .property_type_to_data_type
                             .into_flattened::<OntologyOutwardEdge>(),
                     )
                     .collect(),
             ),
             knowledge_graph: KnowledgeGraphRootedEdges(
                 edges
-                    .knowledge_to_ontology
+                    .entity_to_entity
                     .into_flattened::<KnowledgeGraphOutwardEdge>()
                     .chain(
                         edges
-                            .knowledge_to_knowledge
+                            .entity_to_entity_type
                             .into_flattened::<KnowledgeGraphOutwardEdge>(),
                     )
                     .collect(),

--- a/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/edges.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/edges.rs
@@ -8,12 +8,12 @@ use utoipa::{
 };
 
 use crate::{
+    api::rest::utoipa_typedef::subgraph::vertices::OntologyTypeVertexId,
     identifier::{knowledge::EntityId, ontology::OntologyTypeVersion, time::Timestamp},
     subgraph::{
         edges::{KnowledgeGraphEdgeKind, OntologyEdgeKind, OutwardEdge, SharedEdgeKind},
         identifier::{
-            DataTypeVertexId, EntityIdWithInterval, EntityTypeVertexId, OntologyTypeVertexId,
-            PropertyTypeVertexId,
+            DataTypeVertexId, EntityIdWithInterval, EntityTypeVertexId, PropertyTypeVertexId,
         },
         temporal_axes::VariableAxis,
     },

--- a/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/vertices.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/vertices.rs
@@ -10,10 +10,7 @@ use utoipa::{
 pub use self::vertex::*;
 use crate::{
     identifier::{knowledge::EntityId, ontology::OntologyTypeVersion, time::Timestamp},
-    subgraph::{
-        identifier::{OntologyTypeVertexId, VertexId},
-        temporal_axes::VariableAxis,
-    },
+    subgraph::temporal_axes::VariableAxis,
 };
 
 pub mod vertex;

--- a/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/vertices.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/vertices.rs
@@ -11,7 +11,7 @@ pub use self::vertex::*;
 use crate::{
     identifier::{knowledge::EntityId, ontology::OntologyTypeVersion, time::Timestamp},
     subgraph::{
-        identifier::{EdgeEndpoint, OntologyTypeVertexId},
+        identifier::{OntologyTypeVertexId, VertexId},
         temporal_axes::VariableAxis,
     },
 };

--- a/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/vertices/vertex.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/vertices/vertex.rs
@@ -1,10 +1,42 @@
 use serde::Serialize;
+use type_system::url::BaseUrl;
 use utoipa::ToSchema;
 
 use crate::{
+    identifier::ontology::OntologyTypeVersion,
     knowledge::Entity,
     ontology::{DataTypeWithMetadata, EntityTypeWithMetadata, PropertyTypeWithMetadata},
+    subgraph::identifier::{DataTypeVertexId, EntityTypeVertexId, PropertyTypeVertexId},
 };
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, ToSchema)]
+#[serde(untagged)]
+#[expect(clippy::enum_variant_names)]
+pub enum OntologyTypeVertexId {
+    DataType(DataTypeVertexId),
+    PropertyType(PropertyTypeVertexId),
+    EntityType(EntityTypeVertexId),
+}
+
+impl OntologyTypeVertexId {
+    #[must_use]
+    pub const fn base_id(&self) -> &BaseUrl {
+        match self {
+            Self::DataType(id) => &id.base_id,
+            Self::PropertyType(id) => &id.base_id,
+            Self::EntityType(id) => &id.base_id,
+        }
+    }
+
+    #[must_use]
+    pub const fn revision_id(&self) -> OntologyTypeVersion {
+        match self {
+            Self::DataType(id) => id.revision_id,
+            Self::PropertyType(id) => id.revision_id,
+            Self::EntityType(id) => id.revision_id,
+        }
+    }
+}
 
 #[derive(Debug, PartialEq, Eq, Serialize, ToSchema)]
 #[serde(tag = "kind", content = "inner")]

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -27,9 +27,7 @@ use crate::{
             EdgeResolveDepths, GraphResolveDepths, KnowledgeGraphEdgeKind,
             OutgoingEdgeResolveDepth, SharedEdgeKind,
         },
-        identifier::{
-            EntityIdWithInterval, EntityTypeVertexId, EntityVertexId, OntologyTypeVertexId,
-        },
+        identifier::{EntityIdWithInterval, EntityTypeVertexId, EntityVertexId},
         query::StructuralQuery,
         temporal_axes::QueryTemporalAxes,
         Subgraph,
@@ -94,7 +92,7 @@ impl<C: AsClient> PostgresStore<C> {
                     subgraph.insert_edge(
                         &entity_vertex_id,
                         SharedEdgeKind::IsOfType,
-                        OntologyTypeVertexId::EntityType(entity_type_id.clone()),
+                        entity_type_id.clone(),
                     );
 
                     self.traverse_entity_type(

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     subgraph::{
         edges::{GraphResolveDepths, OntologyEdgeKind, OutgoingEdgeResolveDepth},
-        identifier::{EntityTypeVertexId, OntologyTypeVertexId, PropertyTypeVertexId},
+        identifier::{EntityTypeVertexId, PropertyTypeVertexId},
         query::StructuralQuery,
         temporal_axes::QueryTemporalAxes,
         Subgraph,
@@ -101,9 +101,9 @@ impl<C: AsClient> PostgresStore<C> {
                             PropertyTypeVertexId::from(property_type_ref_url);
 
                         subgraph.insert_edge(
-                            &OntologyTypeVertexId::EntityType(entity_type_id.clone()),
+                            &entity_type_id,
                             OntologyEdgeKind::ConstrainsPropertiesOn,
-                            OntologyTypeVertexId::PropertyType(property_type_vertex_id.clone()),
+                            property_type_vertex_id.clone(),
                         );
 
                         self.traverse_property_type(
@@ -132,9 +132,9 @@ impl<C: AsClient> PostgresStore<C> {
                             EntityTypeVertexId::from(inherits_from_type_ref_url);
 
                         subgraph.insert_edge(
-                            &OntologyTypeVertexId::EntityType(entity_type_id.clone()),
+                            &entity_type_id,
                             OntologyEdgeKind::InheritsFrom,
-                            OntologyTypeVertexId::EntityType(inherits_from_type_vertex_id.clone()),
+                            inherits_from_type_vertex_id.clone(),
                         );
 
                         queue.push((
@@ -157,9 +157,9 @@ impl<C: AsClient> PostgresStore<C> {
                             let link_type_vertex_id = EntityTypeVertexId::from(link_type_url);
 
                             subgraph.insert_edge(
-                                &OntologyTypeVertexId::EntityType(entity_type_id.clone()),
+                                &entity_type_id,
                                 OntologyEdgeKind::ConstrainsLinksOn,
-                                OntologyTypeVertexId::EntityType(link_type_vertex_id.clone()),
+                                link_type_vertex_id.clone(),
                             );
 
                             queue.push((
@@ -187,11 +187,9 @@ impl<C: AsClient> PostgresStore<C> {
                                         EntityTypeVertexId::from(destination_type_url);
 
                                     subgraph.insert_edge(
-                                        &OntologyTypeVertexId::EntityType(entity_type_id.clone()),
+                                        &entity_type_id,
                                         OntologyEdgeKind::ConstrainsLinkDestinationsOn,
-                                        OntologyTypeVertexId::EntityType(
-                                            destination_type_vertex_id.clone(),
-                                        ),
+                                        destination_type_vertex_id.clone(),
                                     );
 
                                     queue.push((

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     subgraph::{
         edges::{GraphResolveDepths, OntologyEdgeKind, OutgoingEdgeResolveDepth},
-        identifier::{DataTypeVertexId, OntologyTypeVertexId, PropertyTypeVertexId},
+        identifier::{DataTypeVertexId, PropertyTypeVertexId},
         query::StructuralQuery,
         temporal_axes::QueryTemporalAxes,
         Subgraph,
@@ -79,9 +79,9 @@ impl<C: AsClient> PostgresStore<C> {
                         let data_type_vertex_id = DataTypeVertexId::from(data_type_ref);
 
                         subgraph.insert_edge(
-                            &OntologyTypeVertexId::PropertyType(property_type_id.clone()),
+                            &property_type_id,
                             OntologyEdgeKind::ConstrainsValuesOn,
-                            OntologyTypeVertexId::DataType(data_type_vertex_id.clone()),
+                            data_type_vertex_id.clone(),
                         );
 
                         self.traverse_data_type(
@@ -108,9 +108,9 @@ impl<C: AsClient> PostgresStore<C> {
                             PropertyTypeVertexId::from(property_type_ref_url);
 
                         subgraph.insert_edge(
-                            &OntologyTypeVertexId::PropertyType(property_type_id.clone()),
+                            &property_type_id,
                             OntologyEdgeKind::ConstrainsPropertiesOn,
-                            OntologyTypeVertexId::PropertyType(property_type_vertex_id.clone()),
+                            property_type_vertex_id.clone(),
                         );
 
                         queue.push((

--- a/apps/hash-graph/lib/graph/src/store/record.rs
+++ b/apps/hash-graph/lib/graph/src/store/record.rs
@@ -1,14 +1,14 @@
 use crate::{
     identifier::time::TimeAxis,
     store::query::{Filter, QueryPath},
-    subgraph::vertices::VertexIndex,
+    subgraph::identifier::VertexId,
 };
 
 /// A record stored in the [`store`].
 ///
 /// [`store`]: crate::store
 pub trait Record: Sized + Send {
-    type VertexId: VertexIndex<Self> + Send + Sync;
+    type VertexId: VertexId<Record = Self> + Send + Sync;
     type QueryPath<'p>: QueryPath + Send + Sync;
 
     fn vertex_id(&self, time_axis: TimeAxis) -> Self::VertexId;

--- a/apps/hash-graph/lib/graph/src/subgraph.rs
+++ b/apps/hash-graph/lib/graph/src/subgraph.rs
@@ -18,7 +18,7 @@ use self::{
     edges::{Edges, GraphResolveDepths},
     identifier::GraphElementVertexId,
     temporal_axes::{QueryTemporalAxes, QueryTemporalAxesUnresolved, SubgraphTemporalAxes},
-    vertices::{VertexIndex, Vertices},
+    vertices::Vertices,
 };
 use crate::{
     store::{crud::Read, QueryError, Record},
@@ -67,7 +67,10 @@ impl Subgraph {
         vertex_id.vertices_entry(&self.vertices)
     }
 
-    pub fn insert_vertex<R: Record>(&mut self, vertex_id: &R::VertexId, record: R) -> Option<R> {
+    pub fn insert_vertex<R: Record>(&mut self, vertex_id: &R::VertexId, record: R) -> Option<R>
+    where
+        R::VertexId: Eq + Clone + Hash,
+    {
         match self.vertex_entry_mut(vertex_id) {
             RawEntryMut::Occupied(mut entry) => Some(entry.insert(record)),
             RawEntryMut::Vacant(entry) => {
@@ -117,12 +120,16 @@ impl Subgraph {
     /// - Returns an error if the [`Record`] could not be read from the [`Store`].
     ///
     /// [`Store`]: crate::store::Store
-    pub async fn get_or_read<'r, R: Record + Sync + 'r>(
+    pub async fn get_or_read<'r, R>(
         &'r mut self,
         store: &impl Read<R>,
         vertex_id: &R::VertexId,
         temporal_axes: &QueryTemporalAxes,
-    ) -> Result<&'r R, QueryError> {
+    ) -> Result<&'r R, QueryError>
+    where
+        R: Record + 'r,
+        R::VertexId: Eq + Clone + Hash,
+    {
         Ok(match self.vertex_entry_mut(vertex_id) {
             RawEntryMut::Occupied(entry) => entry.into_mut(),
             RawEntryMut::Vacant(entry) => {

--- a/apps/hash-graph/lib/graph/src/subgraph.rs
+++ b/apps/hash-graph/lib/graph/src/subgraph.rs
@@ -60,11 +60,11 @@ impl Subgraph {
         &mut self,
         vertex_id: &R::VertexId,
     ) -> RawEntryMut<R::VertexId, R, RandomState> {
-        vertex_id.vertices_entry_mut(&mut self.vertices)
+        vertex_id.subgraph_entry_mut(&mut self.vertices)
     }
 
     pub fn get_vertex<R: Record>(&self, vertex_id: &R::VertexId) -> Option<&R> {
-        vertex_id.vertices_entry(&self.vertices)
+        vertex_id.subgraph_entry(&self.vertices)
     }
 
     pub fn insert_vertex<R: Record>(&mut self, vertex_id: &R::VertexId, record: R) -> Option<R>
@@ -86,7 +86,7 @@ impl Subgraph {
         R: EdgeEndpoint,
         E: EdgeKind<L, R, false, EdgeSet: Default> + Eq + Hash,
     {
-        edge_kind.edge_entry_mut(&mut self.edges).insert(
+        edge_kind.subgraph_entry_mut(&mut self.edges).insert(
             left_endpoint,
             edge_kind,
             false,
@@ -104,7 +104,7 @@ impl Subgraph {
         R: EdgeEndpoint,
         E: EdgeKind<L, R, true, EdgeSet: Default> + Eq + Hash,
     {
-        edge_kind.edge_entry_mut(&mut self.edges).insert(
+        edge_kind.subgraph_entry_mut(&mut self.edges).insert(
             left_endpoint,
             edge_kind,
             true,

--- a/apps/hash-graph/lib/graph/src/subgraph/edges.rs
+++ b/apps/hash-graph/lib/graph/src/subgraph/edges.rs
@@ -17,7 +17,9 @@ pub use self::{
 };
 use crate::subgraph::{
     edges::endpoint::{EdgeEndpointSet, EntityIdWithIntervalSet},
-    identifier::{EntityVertexId, OntologyTypeVertexId, VertexId},
+    identifier::{
+        DataTypeVertexId, EntityTypeVertexId, EntityVertexId, PropertyTypeVertexId, VertexId,
+    },
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -135,12 +137,16 @@ where
 
 #[derive(Default, Debug)]
 pub struct Edges {
-    pub ontology_to_ontology:
-        AdjacencyList<OntologyTypeVertexId, OntologyEdgeKind, HashSet<OntologyTypeVertexId>>,
-    pub ontology_to_knowledge:
-        AdjacencyList<OntologyTypeVertexId, SharedEdgeKind, EntityIdWithIntervalSet>,
-    pub knowledge_to_ontology:
-        AdjacencyList<EntityVertexId, SharedEdgeKind, HashSet<OntologyTypeVertexId>>,
-    pub knowledge_to_knowledge:
+    pub entity_to_entity:
         AdjacencyList<EntityVertexId, KnowledgeGraphEdgeKind, EntityIdWithIntervalSet>,
+    pub entity_to_entity_type:
+        AdjacencyList<EntityVertexId, SharedEdgeKind, HashSet<EntityTypeVertexId>>,
+    pub entity_type_to_entity_type:
+        AdjacencyList<EntityTypeVertexId, OntologyEdgeKind, HashSet<EntityTypeVertexId>>,
+    pub entity_type_to_property_type:
+        AdjacencyList<EntityTypeVertexId, OntologyEdgeKind, HashSet<PropertyTypeVertexId>>,
+    pub property_type_to_property_type:
+        AdjacencyList<PropertyTypeVertexId, OntologyEdgeKind, HashSet<PropertyTypeVertexId>>,
+    pub property_type_to_data_type:
+        AdjacencyList<PropertyTypeVertexId, OntologyEdgeKind, HashSet<DataTypeVertexId>>,
 }

--- a/apps/hash-graph/lib/graph/src/subgraph/edges/kind.rs
+++ b/apps/hash-graph/lib/graph/src/subgraph/edges/kind.rs
@@ -17,7 +17,7 @@ use crate::subgraph::{
 pub trait EdgeKind<L: VertexId, R: EdgeEndpoint, const REVERSED: bool>: Sized {
     type EdgeSet: EdgeEndpointSet<EdgeEndpoint = R>;
 
-    fn edge_entry_mut<'a>(
+    fn subgraph_entry_mut<'a>(
         &self,
         edges: &'a mut Edges,
     ) -> &'a mut AdjacencyList<L, Self, Self::EdgeSet>;
@@ -56,7 +56,7 @@ impl<const REVERSED: bool> EdgeKind<EntityTypeVertexId, EntityTypeVertexId, REVE
 {
     type EdgeSet = HashSet<EntityTypeVertexId>;
 
-    fn edge_entry_mut<'a>(
+    fn subgraph_entry_mut<'a>(
         &self,
         edges: &'a mut Edges,
     ) -> &'a mut AdjacencyList<EntityTypeVertexId, Self, Self::EdgeSet> {
@@ -69,7 +69,7 @@ impl<const REVERSED: bool> EdgeKind<EntityTypeVertexId, PropertyTypeVertexId, RE
 {
     type EdgeSet = HashSet<PropertyTypeVertexId>;
 
-    fn edge_entry_mut<'a>(
+    fn subgraph_entry_mut<'a>(
         &self,
         edges: &'a mut Edges,
     ) -> &'a mut AdjacencyList<EntityTypeVertexId, Self, Self::EdgeSet> {
@@ -82,7 +82,7 @@ impl<const REVERSED: bool> EdgeKind<PropertyTypeVertexId, PropertyTypeVertexId, 
 {
     type EdgeSet = HashSet<PropertyTypeVertexId>;
 
-    fn edge_entry_mut<'a>(
+    fn subgraph_entry_mut<'a>(
         &self,
         edges: &'a mut Edges,
     ) -> &'a mut AdjacencyList<PropertyTypeVertexId, Self, Self::EdgeSet> {
@@ -95,7 +95,7 @@ impl<const REVERSED: bool> EdgeKind<PropertyTypeVertexId, DataTypeVertexId, REVE
 {
     type EdgeSet = HashSet<DataTypeVertexId>;
 
-    fn edge_entry_mut<'a>(
+    fn subgraph_entry_mut<'a>(
         &self,
         edges: &'a mut Edges,
     ) -> &'a mut AdjacencyList<PropertyTypeVertexId, Self, Self::EdgeSet> {
@@ -124,7 +124,7 @@ impl<const REVERSED: bool> EdgeKind<EntityVertexId, EntityIdWithInterval, REVERS
 {
     type EdgeSet = EntityIdWithIntervalSet;
 
-    fn edge_entry_mut<'a>(
+    fn subgraph_entry_mut<'a>(
         &self,
         edges: &'a mut Edges,
     ) -> &'a mut AdjacencyList<EntityVertexId, Self, Self::EdgeSet> {
@@ -145,7 +145,7 @@ pub enum SharedEdgeKind {
 impl EdgeKind<EntityVertexId, EntityTypeVertexId, false> for SharedEdgeKind {
     type EdgeSet = HashSet<EntityTypeVertexId>;
 
-    fn edge_entry_mut<'a>(
+    fn subgraph_entry_mut<'a>(
         &self,
         edges: &'a mut Edges,
     ) -> &'a mut AdjacencyList<EntityVertexId, Self, Self::EdgeSet> {

--- a/apps/hash-graph/lib/graph/src/subgraph/edges/kind.rs
+++ b/apps/hash-graph/lib/graph/src/subgraph/edges/kind.rs
@@ -9,7 +9,8 @@ use crate::subgraph::{
         AdjacencyList, Edges,
     },
     identifier::{
-        EdgeEndpoint, EntityIdWithInterval, EntityVertexId, OntologyTypeVertexId, VertexId,
+        DataTypeVertexId, EdgeEndpoint, EntityIdWithInterval, EntityTypeVertexId, EntityVertexId,
+        PropertyTypeVertexId, VertexId,
     },
 };
 
@@ -50,16 +51,55 @@ pub enum OntologyEdgeKind {
     ConstrainsLinkDestinationsOn,
 }
 
-impl<const REVERSED: bool> EdgeKind<OntologyTypeVertexId, OntologyTypeVertexId, REVERSED>
+impl<const REVERSED: bool> EdgeKind<EntityTypeVertexId, EntityTypeVertexId, REVERSED>
     for OntologyEdgeKind
 {
-    type EdgeSet = HashSet<OntologyTypeVertexId>;
+    type EdgeSet = HashSet<EntityTypeVertexId>;
 
     fn edge_entry_mut<'a>(
         &self,
         edges: &'a mut Edges,
-    ) -> &'a mut AdjacencyList<OntologyTypeVertexId, Self, Self::EdgeSet> {
-        &mut edges.ontology_to_ontology
+    ) -> &'a mut AdjacencyList<EntityTypeVertexId, Self, Self::EdgeSet> {
+        &mut edges.entity_type_to_entity_type
+    }
+}
+
+impl<const REVERSED: bool> EdgeKind<EntityTypeVertexId, PropertyTypeVertexId, REVERSED>
+    for OntologyEdgeKind
+{
+    type EdgeSet = HashSet<PropertyTypeVertexId>;
+
+    fn edge_entry_mut<'a>(
+        &self,
+        edges: &'a mut Edges,
+    ) -> &'a mut AdjacencyList<EntityTypeVertexId, Self, Self::EdgeSet> {
+        &mut edges.entity_type_to_property_type
+    }
+}
+
+impl<const REVERSED: bool> EdgeKind<PropertyTypeVertexId, PropertyTypeVertexId, REVERSED>
+    for OntologyEdgeKind
+{
+    type EdgeSet = HashSet<PropertyTypeVertexId>;
+
+    fn edge_entry_mut<'a>(
+        &self,
+        edges: &'a mut Edges,
+    ) -> &'a mut AdjacencyList<PropertyTypeVertexId, Self, Self::EdgeSet> {
+        &mut edges.property_type_to_property_type
+    }
+}
+
+impl<const REVERSED: bool> EdgeKind<PropertyTypeVertexId, DataTypeVertexId, REVERSED>
+    for OntologyEdgeKind
+{
+    type EdgeSet = HashSet<DataTypeVertexId>;
+
+    fn edge_entry_mut<'a>(
+        &self,
+        edges: &'a mut Edges,
+    ) -> &'a mut AdjacencyList<PropertyTypeVertexId, Self, Self::EdgeSet> {
+        &mut edges.property_type_to_data_type
     }
 }
 
@@ -88,7 +128,7 @@ impl<const REVERSED: bool> EdgeKind<EntityVertexId, EntityIdWithInterval, REVERS
         &self,
         edges: &'a mut Edges,
     ) -> &'a mut AdjacencyList<EntityVertexId, Self, Self::EdgeSet> {
-        &mut edges.knowledge_to_knowledge
+        &mut edges.entity_to_entity
     }
 }
 
@@ -102,25 +142,14 @@ pub enum SharedEdgeKind {
     IsOfType,
 }
 
-impl EdgeKind<EntityVertexId, OntologyTypeVertexId, false> for SharedEdgeKind {
-    type EdgeSet = HashSet<OntologyTypeVertexId>;
+impl EdgeKind<EntityVertexId, EntityTypeVertexId, false> for SharedEdgeKind {
+    type EdgeSet = HashSet<EntityTypeVertexId>;
 
     fn edge_entry_mut<'a>(
         &self,
         edges: &'a mut Edges,
     ) -> &'a mut AdjacencyList<EntityVertexId, Self, Self::EdgeSet> {
-        &mut edges.knowledge_to_ontology
-    }
-}
-
-impl EdgeKind<OntologyTypeVertexId, EntityIdWithInterval, true> for SharedEdgeKind {
-    type EdgeSet = EntityIdWithIntervalSet;
-
-    fn edge_entry_mut<'a>(
-        &self,
-        edges: &'a mut Edges,
-    ) -> &'a mut AdjacencyList<OntologyTypeVertexId, Self, Self::EdgeSet> {
-        &mut edges.ontology_to_knowledge
+        &mut edges.entity_to_entity_type
     }
 }
 

--- a/apps/hash-graph/lib/graph/src/subgraph/identifier.rs
+++ b/apps/hash-graph/lib/graph/src/subgraph/identifier.rs
@@ -5,6 +5,6 @@ pub use self::{
     edge::{EdgeEndpoint, EntityIdWithInterval},
     vertex::{
         DataTypeVertexId, EntityTypeVertexId, EntityVertexId, GraphElementVertexId,
-        OntologyTypeVertexId, PropertyTypeVertexId, VertexId,
+        PropertyTypeVertexId, VertexId,
     },
 };

--- a/apps/hash-graph/lib/graph/src/subgraph/identifier/edge.rs
+++ b/apps/hash-graph/lib/graph/src/subgraph/identifier/edge.rs
@@ -8,10 +8,10 @@ use crate::{
 
 pub trait EdgeEndpoint {
     type BaseId;
-    type RightEndpoint;
+    type RevisionId;
 
     fn base_id(&self) -> &Self::BaseId;
-    fn revision_id(&self) -> Self::RightEndpoint;
+    fn revision_id(&self) -> Self::RevisionId;
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
@@ -23,13 +23,13 @@ pub struct EntityIdWithInterval {
 
 impl EdgeEndpoint for EntityIdWithInterval {
     type BaseId = EntityId;
-    type RightEndpoint = LeftClosedTemporalInterval<VariableAxis>;
+    type RevisionId = LeftClosedTemporalInterval<VariableAxis>;
 
     fn base_id(&self) -> &Self::BaseId {
         &self.entity_id
     }
 
-    fn revision_id(&self) -> Self::RightEndpoint {
+    fn revision_id(&self) -> Self::RevisionId {
         self.interval
     }
 }

--- a/apps/hash-graph/lib/graph/src/subgraph/identifier/edge.rs
+++ b/apps/hash-graph/lib/graph/src/subgraph/identifier/edge.rs
@@ -3,7 +3,7 @@ use utoipa::ToSchema;
 
 use crate::{
     identifier::{knowledge::EntityId, time::LeftClosedTemporalInterval},
-    subgraph::{identifier::VertexId, temporal_axes::VariableAxis},
+    subgraph::temporal_axes::VariableAxis,
 };
 
 pub trait EdgeEndpoint {

--- a/apps/hash-graph/lib/graph/src/subgraph/identifier/edge.rs
+++ b/apps/hash-graph/lib/graph/src/subgraph/identifier/edge.rs
@@ -1,15 +1,9 @@
 use serde::{Deserialize, Serialize};
-use type_system::url::BaseUrl;
 use utoipa::ToSchema;
 
 use crate::{
-    identifier::{
-        knowledge::EntityId, ontology::OntologyTypeVersion, time::LeftClosedTemporalInterval,
-    },
-    subgraph::{
-        identifier::{OntologyTypeVertexId, VertexId},
-        temporal_axes::VariableAxis,
-    },
+    identifier::{knowledge::EntityId, time::LeftClosedTemporalInterval},
+    subgraph::{identifier::VertexId, temporal_axes::VariableAxis},
 };
 
 pub trait EdgeEndpoint {
@@ -18,19 +12,6 @@ pub trait EdgeEndpoint {
 
     fn base_id(&self) -> &Self::BaseId;
     fn revision_id(&self) -> Self::RightEndpoint;
-}
-
-impl EdgeEndpoint for OntologyTypeVertexId {
-    type BaseId = BaseUrl;
-    type RightEndpoint = OntologyTypeVersion;
-
-    fn base_id(&self) -> &Self::BaseId {
-        VertexId::base_id(self)
-    }
-
-    fn revision_id(&self) -> Self::RightEndpoint {
-        VertexId::revision_id(self)
-    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]

--- a/apps/hash-graph/lib/graph/src/subgraph/identifier/vertex.rs
+++ b/apps/hash-graph/lib/graph/src/subgraph/identifier/vertex.rs
@@ -20,9 +20,13 @@ pub trait VertexId: Sized {
     fn revision_id(&self) -> Self::RevisionId;
 
     /// Returns a shared reference to the [`Record`] vertex in the subgraph.
+    ///
+    /// [`Record`]: Self::Record
     fn subgraph_entry<'a>(&self, vertices: &'a Vertices) -> Option<&'a Self::Record>;
 
     /// Returns a mutable reference to the [`Record`] vertex in the subgraph.
+    ///
+    /// [`Record`]: Self::Record
     fn subgraph_entry_mut<'a>(
         &self,
         vertices: &'a mut Vertices,

--- a/apps/hash-graph/lib/graph/src/subgraph/identifier/vertex.rs
+++ b/apps/hash-graph/lib/graph/src/subgraph/identifier/vertex.rs
@@ -20,10 +20,10 @@ pub trait VertexId: Sized {
     fn revision_id(&self) -> Self::RevisionId;
 
     /// Returns a shared reference to the [`Record`] vertex in the subgraph.
-    fn vertices_entry<'a>(&self, vertices: &'a Vertices) -> Option<&'a Self::Record>;
+    fn subgraph_entry<'a>(&self, vertices: &'a Vertices) -> Option<&'a Self::Record>;
 
     /// Returns a mutable reference to the [`Record`] vertex in the subgraph.
-    fn vertices_entry_mut<'a>(
+    fn subgraph_entry_mut<'a>(
         &self,
         vertices: &'a mut Vertices,
     ) -> RawEntryMut<'a, Self, Self::Record, RandomState>;
@@ -51,11 +51,11 @@ macro_rules! define_ontology_type_vertex_id {
                 self.revision_id
             }
 
-            fn vertices_entry<'a>(&self, vertices: &'a Vertices) -> Option<&'a $ontology_type> {
+            fn subgraph_entry<'a>(&self, vertices: &'a Vertices) -> Option<&'a $ontology_type> {
                 vertices.$vertex_set.get(self)
             }
 
-            fn vertices_entry_mut<'a>(
+            fn subgraph_entry_mut<'a>(
                 &self,
                 vertices: &'a mut Vertices,
             ) -> RawEntryMut<'a, Self, $ontology_type, RandomState> {
@@ -65,13 +65,13 @@ macro_rules! define_ontology_type_vertex_id {
 
         impl EdgeEndpoint for $name {
             type BaseId = BaseUrl;
-            type RightEndpoint = OntologyTypeVersion;
+            type RevisionId = OntologyTypeVersion;
 
             fn base_id(&self) -> &Self::BaseId {
                 &self.base_id
             }
 
-            fn revision_id(&self) -> Self::RightEndpoint {
+            fn revision_id(&self) -> Self::RevisionId {
                 self.revision_id
             }
         }
@@ -115,11 +115,11 @@ impl VertexId for EntityVertexId {
         self.revision_id
     }
 
-    fn vertices_entry<'a>(&self, vertices: &'a Vertices) -> Option<&'a Entity> {
+    fn subgraph_entry<'a>(&self, vertices: &'a Vertices) -> Option<&'a Entity> {
         vertices.entities.get(self)
     }
 
-    fn vertices_entry_mut<'a>(
+    fn subgraph_entry_mut<'a>(
         &self,
         vertices: &'a mut Vertices,
     ) -> RawEntryMut<'a, Self, Entity, RandomState> {

--- a/apps/hash-graph/lib/graph/src/subgraph/identifier/vertex.rs
+++ b/apps/hash-graph/lib/graph/src/subgraph/identifier/vertex.rs
@@ -90,35 +90,6 @@ define_ontology_type_vertex_id!(
 );
 define_ontology_type_vertex_id!(EntityTypeVertexId, EntityTypeWithMetadata, entity_types);
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, ToSchema)]
-#[serde(untagged)]
-pub enum OntologyTypeVertexId {
-    DataType(DataTypeVertexId),
-    PropertyType(PropertyTypeVertexId),
-    EntityType(EntityTypeVertexId),
-}
-
-impl VertexId for OntologyTypeVertexId {
-    type BaseId = BaseUrl;
-    type RevisionId = OntologyTypeVersion;
-
-    fn base_id(&self) -> &Self::BaseId {
-        match self {
-            Self::DataType(id) => &id.base_id,
-            Self::PropertyType(id) => &id.base_id,
-            Self::EntityType(id) => &id.base_id,
-        }
-    }
-
-    fn revision_id(&self) -> Self::RevisionId {
-        match self {
-            Self::DataType(id) => id.revision_id,
-            Self::PropertyType(id) => id.revision_id,
-            Self::EntityType(id) => id.revision_id,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct EntityVertexId {

--- a/apps/hash-graph/lib/graph/src/subgraph/identifier/vertex.rs
+++ b/apps/hash-graph/lib/graph/src/subgraph/identifier/vertex.rs
@@ -11,6 +11,7 @@ use crate::{
     subgraph::{
         temporal_axes::VariableAxis,
         vertices::{VertexIndex, Vertices},
+        EdgeEndpoint,
     },
 };
 
@@ -57,6 +58,19 @@ macro_rules! define_ontology_type_vertex_id {
             }
         }
 
+        impl EdgeEndpoint for $name {
+            type BaseId = BaseUrl;
+            type RightEndpoint = OntologyTypeVersion;
+
+            fn base_id(&self) -> &Self::BaseId {
+                &self.base_id
+            }
+
+            fn revision_id(&self) -> Self::RightEndpoint {
+                self.revision_id
+            }
+        }
+
         impl From<VersionedUrl> for $name {
             fn from(url: VersionedUrl) -> Self {
                 Self {
@@ -90,17 +104,17 @@ impl VertexId for OntologyTypeVertexId {
 
     fn base_id(&self) -> &Self::BaseId {
         match self {
-            Self::DataType(id) => id.base_id(),
-            Self::PropertyType(id) => id.base_id(),
-            Self::EntityType(id) => id.base_id(),
+            Self::DataType(id) => &id.base_id,
+            Self::PropertyType(id) => &id.base_id,
+            Self::EntityType(id) => &id.base_id,
         }
     }
 
     fn revision_id(&self) -> Self::RevisionId {
         match self {
-            Self::DataType(id) => id.revision_id(),
-            Self::PropertyType(id) => id.revision_id(),
-            Self::EntityType(id) => id.revision_id(),
+            Self::DataType(id) => id.revision_id,
+            Self::PropertyType(id) => id.revision_id,
+            Self::EntityType(id) => id.revision_id,
         }
     }
 }

--- a/apps/hash-graph/lib/graph/src/subgraph/vertices.rs
+++ b/apps/hash-graph/lib/graph/src/subgraph/vertices.rs
@@ -1,18 +1,10 @@
-use std::{
-    collections::{
-        hash_map::{RandomState, RawEntryMut},
-        HashMap,
-    },
-    hash::Hash,
-};
+use std::collections::HashMap;
 
 use crate::{
     knowledge::Entity,
     ontology::{DataTypeWithMetadata, EntityTypeWithMetadata, PropertyTypeWithMetadata},
-    store::Record,
     subgraph::identifier::{
-        DataTypeVertexId, EntityTypeVertexId, EntityVertexId, GraphElementVertexId,
-        PropertyTypeVertexId, VertexId,
+        DataTypeVertexId, EntityTypeVertexId, EntityVertexId, PropertyTypeVertexId,
     },
 };
 
@@ -22,23 +14,4 @@ pub struct Vertices {
     pub property_types: HashMap<PropertyTypeVertexId, PropertyTypeWithMetadata>,
     pub entity_types: HashMap<EntityTypeVertexId, EntityTypeWithMetadata>,
     pub entities: HashMap<EntityVertexId, Entity>,
-}
-
-/// Used for index operations on the [`Vertices`] on a [`Subgraph`].
-///
-/// Depending on `R`, the index operation will be performed on the respective collection of the
-/// subgraph.
-///
-/// [`Subgraph`]: crate::subgraph::Subgraph
-pub trait VertexIndex<R: Record>:
-    VertexId + Clone + Eq + Hash + Into<GraphElementVertexId>
-{
-    /// Returns a shared reference to the [`Record`] vertex in the subgraph.
-    fn vertices_entry<'a>(&self, vertices: &'a Vertices) -> Option<&'a R>;
-
-    /// Returns a mutable reference to the [`Record`] vertex in the subgraph.
-    fn vertices_entry_mut<'a>(
-        &self,
-        vertices: &'a mut Vertices,
-    ) -> RawEntryMut<'a, R::VertexId, R, RandomState>;
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We are going to have reference tables between entities and entities, and between entities and entity types. To simplify batched reading of the data from the database, we store a set of edges per reference table

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](link) _(internal)_

## 🚫 Blocked by

- #2178 
- #2181 

## 🔍 What does this change?

- Use adjacency lists for each kind of edge (determined by the endpoints, not by the edge kind itself)
    - If we chose to have reference tables for each edge kind, this can easily be added later on
- Merge `VertexIndex` and `VertexId` traits. They are now implemented on exactly the same types in the same context
- Move `OntologyTypeVertexId` to `utoipa_typedef`. As mentioned previously, this could be removed entirely, but to avoid touching the `utoipa_typedef` too many times moving it is sufficient for now. The subgraph typedefs have a very close representation to the current representation of the internal subgraph already. I'm confident that we can remove the `utoipa_typedef` module entirely soon.
- Rename the methods on `VertexId` and `EdgeKind` to align

## 📜 Does this require a change to the docs?

No
