### PR TITLE
Make step ordering deterministic in How To block

### DIFF
--- a/blocks/how-to/src/app.tsx
+++ b/blocks/how-to/src/app.tsx
@@ -94,10 +94,16 @@ export const App: BlockComponent<RootEntity> = ({
 
   const stepLinkedEntities: LinkEntityAndRightEntity[] = useMemo(
     () =>
-      linkedEntities.filter(
-        ({ linkEntity }) =>
-          linkEntity?.metadata.entityTypeId === hasHowToBlockStep,
-      ),
+      linkedEntities
+        .filter(
+          ({ linkEntity }) =>
+            linkEntity?.metadata.entityTypeId === hasHowToBlockStep,
+        )
+        .sort(
+          (a, b) =>
+            (a.linkEntity.linkData?.leftToRightOrder ?? 0) -
+            (b.linkEntity.linkData?.leftToRightOrder ?? 0),
+        ),
     [linkedEntities],
   );
 
@@ -149,12 +155,15 @@ export const App: BlockComponent<RootEntity> = ({
             linkData: {
               leftEntityId: entityId,
               rightEntityId: createdEntityId,
+              leftToRightOrder:
+                (stepLinkedEntities?.[stepLinkedEntities.length - 1]?.linkEntity
+                  .linkData?.leftToRightOrder ?? 0) + 1,
             },
           },
         });
       }
     },
-    [graphModule],
+    [graphModule, stepLinkedEntities],
   );
 
   const createIntroduction = async () => {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The How To block intends the steps linked to it to be in a certain order, but was not specifying one – it happened to work in some environments where the order the application returned the links was deterministic in the right way, but the block cannot rely on this (applications might send the latest createst links first, for example).

This PR fixes that by specifying a position for the link when creating it.