### PR TITLE
Always run Rust jobs when `.config` changed

### DIFF
--- a/.github/scripts/rust/setup.py
+++ b/.github/scripts/rust/setup.py
@@ -19,7 +19,7 @@ from pygit2 import Repository, Commit
 CWD = Path.cwd()
 
 # All jobs for all crates will run if any of these paths change
-ALWAYS_RUN_PATTERNS = [".github/**"]
+ALWAYS_RUN_PATTERNS = [".github/**", ".config/**"]
 
 # Toolchains used for the specified crates in addition to the toolchain which is defined in
 # rust-toolchain.toml

--- a/libs/antsi/.cargo/config.toml
+++ b/libs/antsi/.cargo/config.toml
@@ -102,6 +102,7 @@ rustflags = [
     "-Aclippy::missing_errors_doc",
     "-Aclippy::module_name_repetitions",
     "-Aclippy::redundant_pub_crate",
+    "-Aclippy::significant_drop_tightening",
     "-Amissing_docs",
     ## END CLIPPY LINTS ##
 ]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In a recent PR we changed the allowed lints in `.config`, but this did not run all expected test, thus, currently `cargo make clippy` will fail when running in the `antsi` crate

## 🔍 What does this change?

- Change `setup.py` to also cover `.config`
- fix config file for `antsi`