### PR TITLE
Fix `owned_by_id` not used when joining entity tables

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/compile.rs
@@ -283,31 +283,6 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
         }
     }
 
-    fn compile_latest_entity_version_filter(
-        &mut self,
-        path: &R::QueryPath<'_>,
-        operator: EqualityOperator,
-    ) -> Condition<'c> {
-        let alias = self.add_join_statements(path);
-        self.pin_entity_table(alias);
-        // Adds the variable interval condition, so we use the same time axis as specified in the
-        // temporal axes.
-        let condition = Condition::TimeIntervalContainsTimestamp(
-            Expression::Column(
-                Column::Entities(Entities::from_time_axis(
-                    self.temporal_axes.variable_time_axis(),
-                ))
-                .aliased(alias),
-            ),
-            Expression::Function(Function::Now),
-        );
-
-        match operator {
-            EqualityOperator::Equal => condition,
-            EqualityOperator::NotEqual => Condition::Not(Box::new(condition)),
-        }
-    }
-
     /// Searches for [`Filter`]s, which requires special treatment and returns the corresponding
     /// condition if any.
     ///
@@ -337,22 +312,6 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
                             path,
                             EqualityOperator::NotEqual,
                         ))
-                    }
-                    (Column::Entities(Entities::ProjectedTime), Filter::Equal(..), "latest") => {
-                        Some(
-                            self.compile_latest_entity_version_filter(
-                                path,
-                                EqualityOperator::Equal,
-                            ),
-                        )
-                    }
-                    (Column::Entities(Entities::ProjectedTime), Filter::NotEqual(..), "latest") => {
-                        Some(
-                            self.compile_latest_entity_version_filter(
-                                path,
-                                EqualityOperator::NotEqual,
-                            ),
-                        )
                     }
                     _ => None,
                 },
@@ -404,21 +363,7 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
         expression: &'p FilterExpression<'f, R>,
     ) -> Expression<'c> {
         match expression {
-            FilterExpression::Path(path) => {
-                let column = self.compile_path_column(path);
-                // TODO: Remove special casing when correctly resolving time intervals in subgraphs.
-                //   see https://app.asana.com/0/0/1203701389454316/f
-                if column.column == Column::Entities(Entities::ProjectedTime) {
-                    Expression::Function(Function::Lower(Box::new(Expression::Column(
-                        Column::Entities(Entities::from_time_axis(
-                            self.temporal_axes.variable_time_axis(),
-                        ))
-                        .aliased(column.alias),
-                    ))))
-                } else {
-                    Expression::Column(column)
-                }
-            }
+            FilterExpression::Path(path) => Expression::Column(self.compile_path_column(path)),
             FilterExpression::Parameter(parameter) => {
                 match parameter {
                     Parameter::Number(number) => self.artifacts.parameters.push(number),

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression.rs
@@ -7,7 +7,7 @@ mod with_clause;
 
 pub use self::{
     conditional::{Constant, Expression, Function},
-    join_clause::JoinExpression,
+    join_clause::{JoinCondition, JoinExpression},
     order_clause::{OrderByExpression, Ordering},
     select_clause::SelectExpression,
     where_clause::WhereExpression,

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
@@ -1,37 +1,119 @@
-use std::fmt;
+use std::{fmt, fmt::Write};
 
-use crate::store::postgres::query::{AliasedColumn, Transpile};
+use crate::store::postgres::query::{
+    table::{Column, ForeignKeyReference},
+    Alias, AliasedTable, Transpile,
+};
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct JoinCondition<'p> {
+    pub join: Column<'p>,
+    pub on: Column<'p>,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub enum JoinType {
+    Inner,
+    LeftOuter,
+    RightOuter,
+    FullOuter,
+}
+
+impl Transpile for JoinType {
+    fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Inner => fmt.write_str("INNER JOIN"),
+            Self::LeftOuter => fmt.write_str("LEFT OUTER JOIN"),
+            Self::RightOuter => fmt.write_str("RIGHT OUTER JOIN"),
+            Self::FullOuter => fmt.write_str("FULL OUTER JOIN"),
+        }
+    }
+}
+
+impl JoinType {
+    #[must_use]
+    const fn from_nullability(left: bool, right: bool) -> Self {
+        match (left, right) {
+            (false, false) => Self::Inner,
+            (true, false) => Self::LeftOuter,
+            (false, true) => Self::RightOuter,
+            (true, true) => Self::FullOuter,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct JoinOn<'p> {
+    pub left: Column<'p>,
+    pub right: Column<'p>,
+}
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct JoinExpression<'p> {
-    pub join: AliasedColumn<'p>,
-    pub on: AliasedColumn<'p>,
+    pub join: JoinType,
+    pub table: AliasedTable,
+    pub on_alias: Alias,
+    pub on: Vec<JoinOn<'p>>,
 }
 
 impl<'p> JoinExpression<'p> {
-    #[must_use]
-    pub const fn new(join: AliasedColumn<'p>, on: AliasedColumn<'p>) -> Self {
-        Self { join, on }
+    pub fn from_foreign_key(
+        foreign_key_reference: ForeignKeyReference,
+        on_alias: Alias,
+        join_alias: Alias,
+    ) -> Self {
+        match foreign_key_reference {
+            ForeignKeyReference::Single { join, on } => Self {
+                join: JoinType::from_nullability(join.nullable(), on.nullable()),
+                table: join.table().aliased(join_alias),
+                on_alias,
+                on: vec![JoinOn {
+                    left: join,
+                    right: on,
+                }],
+            },
+            ForeignKeyReference::Double {
+                join: (join1, join2),
+                on: (on1, on2),
+            } => Self {
+                join: JoinType::from_nullability(
+                    join1.nullable() || join2.nullable(),
+                    on1.nullable() || on2.nullable(),
+                ),
+                table: join1.table().aliased(join_alias),
+                on_alias,
+                on: vec![
+                    JoinOn {
+                        left: join1,
+                        right: on1,
+                    },
+                    JoinOn {
+                        left: join2,
+                        right: on2,
+                    },
+                ],
+            },
+        }
     }
 }
 
 impl Transpile for JoinExpression<'_> {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match (self.join.column.nullable(), self.on.column.nullable()) {
-            (false, false) => write!(fmt, "INNER JOIN ")?,
-            (true, false) => write!(fmt, "LEFT OUTER JOIN ")?,
-            (false, true) => write!(fmt, "RIGHT OUTER JOIN ")?,
-            (true, true) => write!(fmt, "FULL OUTER JOIN ")?,
-        };
-        let table = self.join.table();
-        table.table.transpile(fmt)?;
-        fmt.write_str(" AS ")?;
-        table.transpile(fmt)?;
-
-        fmt.write_str(" ON ")?;
         self.join.transpile(fmt)?;
-        fmt.write_str(" = ")?;
-        self.on.transpile(fmt)
+        fmt.write_char(' ')?;
+        self.table.table.transpile(fmt)?;
+        fmt.write_str(" AS ")?;
+        self.table.transpile(fmt)?;
+        fmt.write_str(" ON ")?;
+        for (i, condition) in self.on.iter().enumerate() {
+            if i > 0 {
+                fmt.write_str(" AND ")?;
+            }
+            condition.left.aliased(self.table.alias).transpile(fmt)?;
+            fmt.write_str(" = ")?;
+            condition.right.aliased(self.on_alias).transpile(fmt)?;
+        }
+        Ok(())
     }
 }
 
@@ -46,17 +128,21 @@ mod tests {
     #[test]
     fn transpile_join_expression() {
         assert_eq!(
-            JoinExpression::new(
-                Column::OntologyIds(OntologyIds::OntologyId).aliased(Alias {
-                    condition_index: 0,
-                    chain_depth: 1,
-                    number: 2,
-                }),
-                Column::DataTypes(DataTypes::OntologyId).aliased(Alias {
+            JoinExpression::from_foreign_key(
+                ForeignKeyReference::Single {
+                    on: Column::DataTypes(DataTypes::OntologyId),
+                    join: Column::OntologyIds(OntologyIds::OntologyId),
+                },
+                Alias {
                     condition_index: 1,
                     chain_depth: 2,
                     number: 3,
-                }),
+                },
+                Alias {
+                    condition_index: 0,
+                    chain_depth: 1,
+                    number: 2,
+                }
             )
             .transpile_to_string(),
             r#"INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_1_2" ON "ontology_id_with_metadata_0_1_2"."ontology_id" = "data_types_1_2_3"."ontology_id""#

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
@@ -44,8 +44,8 @@ impl JoinType {
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct JoinOn<'p> {
-    pub left: Column<'p>,
-    pub right: Column<'p>,
+    pub join: Column<'p>,
+    pub on: Column<'p>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -67,14 +67,11 @@ impl<'p> JoinExpression<'p> {
                 join: JoinType::from_nullability(join.nullable(), on.nullable()),
                 table: join.table().aliased(join_alias),
                 on_alias,
-                on: vec![JoinOn {
-                    left: join,
-                    right: on,
-                }],
+                on: vec![JoinOn { join, on }],
             },
             ForeignKeyReference::Double {
-                join: (join1, join2),
-                on: (on1, on2),
+                join: [join1, join2],
+                on: [on1, on2],
             } => Self {
                 join: JoinType::from_nullability(
                     join1.nullable() || join2.nullable(),
@@ -84,12 +81,12 @@ impl<'p> JoinExpression<'p> {
                 on_alias,
                 on: vec![
                     JoinOn {
-                        left: join1,
-                        right: on1,
+                        join: join1,
+                        on: on1,
                     },
                     JoinOn {
-                        left: join2,
-                        right: on2,
+                        join: join2,
+                        on: on2,
                     },
                 ],
             },
@@ -109,9 +106,9 @@ impl Transpile for JoinExpression<'_> {
             if i > 0 {
                 fmt.write_str(" AND ")?;
             }
-            condition.left.aliased(self.table.alias).transpile(fmt)?;
+            condition.join.aliased(self.table.alias).transpile(fmt)?;
             fmt.write_str(" = ")?;
-            condition.right.aliased(self.on_alias).transpile(fmt)?;
+            condition.on.aliased(self.on_alias).transpile(fmt)?;
         }
         Ok(())
     }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -613,9 +613,11 @@ mod tests {
             SELECT *
             FROM "entities" AS "entities_0_0_0"
             LEFT OUTER JOIN "entities" AS "entities_0_1_0"
-              ON "entities_0_1_0"."left_entity_uuid" = "entities_0_0_0"."entity_uuid"
+              ON "entities_0_1_0"."left_owned_by_id" = "entities_0_0_0"."owned_by_id"
+             AND "entities_0_1_0"."left_entity_uuid" = "entities_0_0_0"."entity_uuid"
             RIGHT OUTER JOIN "entities" AS "entities_0_2_0"
-              ON "entities_0_2_0"."entity_uuid" = "entities_0_1_0"."right_entity_uuid"
+              ON "entities_0_2_0"."owned_by_id" = "entities_0_1_0"."right_owned_by_id"
+             AND "entities_0_2_0"."entity_uuid" = "entities_0_1_0"."right_entity_uuid"
             WHERE "entities_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
               AND "entities_0_0_0"."decision_time" && $2
               AND "entities_0_1_0"."transaction_time" @> $1::TIMESTAMPTZ
@@ -650,9 +652,11 @@ mod tests {
             SELECT *
             FROM "entities" AS "entities_0_0_0"
             LEFT OUTER JOIN "entities" AS "entities_0_1_0"
-              ON "entities_0_1_0"."right_entity_uuid" = "entities_0_0_0"."entity_uuid"
+              ON "entities_0_1_0"."right_owned_by_id" = "entities_0_0_0"."owned_by_id"
+             AND "entities_0_1_0"."right_entity_uuid" = "entities_0_0_0"."entity_uuid"
             RIGHT OUTER JOIN "entities" AS "entities_0_2_0"
-              ON "entities_0_2_0"."entity_uuid" = "entities_0_1_0"."left_entity_uuid"
+              ON "entities_0_2_0"."owned_by_id" = "entities_0_1_0"."left_owned_by_id"
+             AND "entities_0_2_0"."entity_uuid" = "entities_0_1_0"."left_entity_uuid"
             WHERE "entities_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
               AND "entities_0_0_0"."decision_time" && $2
               AND "entities_0_1_0"."transaction_time" @> $1::TIMESTAMPTZ
@@ -753,12 +757,20 @@ mod tests {
             r#"
              SELECT *
              FROM "entities" AS "entities_0_0_0"
-             RIGHT OUTER JOIN "entities" AS "entities_0_1_0" ON "entities_0_1_0"."entity_uuid" = "entities_0_0_0"."left_entity_uuid"
-             INNER JOIN "entity_types" AS "entity_types_0_2_0" ON "entity_types_0_2_0"."ontology_id" = "entities_0_1_0"."entity_type_ontology_id"
-             INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_3_0" ON "ontology_id_with_metadata_0_3_0"."ontology_id" = "entity_types_0_2_0"."ontology_id"
-             RIGHT OUTER JOIN "entities" AS "entities_0_1_1" ON "entities_0_1_1"."entity_uuid" = "entities_0_0_0"."right_entity_uuid"
-             INNER JOIN "entity_types" AS "entity_types_0_2_1" ON "entity_types_0_2_1"."ontology_id" = "entities_0_1_1"."entity_type_ontology_id"
-             INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_3_1" ON "ontology_id_with_metadata_0_3_1"."ontology_id" = "entity_types_0_2_1"."ontology_id"
+             RIGHT OUTER JOIN "entities" AS "entities_0_1_0"
+               ON "entities_0_1_0"."owned_by_id" = "entities_0_0_0"."left_owned_by_id"
+              AND "entities_0_1_0"."entity_uuid" = "entities_0_0_0"."left_entity_uuid"
+             INNER JOIN "entity_types" AS "entity_types_0_2_0"
+               ON "entity_types_0_2_0"."ontology_id" = "entities_0_1_0"."entity_type_ontology_id"
+             INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_3_0"
+               ON "ontology_id_with_metadata_0_3_0"."ontology_id" = "entity_types_0_2_0"."ontology_id"
+             RIGHT OUTER JOIN "entities" AS "entities_0_1_1"
+               ON "entities_0_1_1"."owned_by_id" = "entities_0_0_0"."right_owned_by_id"
+              AND "entities_0_1_1"."entity_uuid" = "entities_0_0_0"."right_entity_uuid"
+             INNER JOIN "entity_types" AS "entity_types_0_2_1"
+               ON "entity_types_0_2_1"."ontology_id" = "entities_0_1_1"."entity_type_ontology_id"
+             INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_3_1"
+               ON "ontology_id_with_metadata_0_3_1"."ontology_id" = "entity_types_0_2_1"."ontology_id"
              WHERE "entities_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ AND "entities_0_0_0"."decision_time" && $2
                AND "entities_0_1_0"."transaction_time" @> $1::TIMESTAMPTZ AND "entities_0_1_0"."decision_time" && $2
                AND "entities_0_1_1"."transaction_time" @> $1::TIMESTAMPTZ AND "entities_0_1_1"."decision_time" && $2
@@ -967,7 +979,8 @@ mod tests {
                 SELECT *
                 FROM "entities" AS "entities_0_0_0"
                 LEFT OUTER JOIN "entities" AS "entities_0_1_0"
-                  ON "entities_0_1_0"."left_entity_uuid" = "entities_0_0_0"."entity_uuid"
+                  ON "entities_0_1_0"."left_owned_by_id" = "entities_0_0_0"."owned_by_id"
+                 AND "entities_0_1_0"."left_entity_uuid" = "entities_0_0_0"."entity_uuid"
                 WHERE "entities_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
                   AND "entities_0_0_0"."decision_time" && $2
                   AND "entities_0_1_0"."transaction_time" @> $1::TIMESTAMPTZ
@@ -1004,7 +1017,8 @@ mod tests {
                 SELECT *
                 FROM "entities" AS "entities_0_0_0"
                 LEFT OUTER JOIN "entities" AS "entities_0_1_0"
-                  ON "entities_0_1_0"."right_entity_uuid" = "entities_0_0_0"."entity_uuid"
+                  ON "entities_0_1_0"."right_owned_by_id" = "entities_0_0_0"."owned_by_id"
+                 AND "entities_0_1_0"."right_entity_uuid" = "entities_0_0_0"."entity_uuid"
                 WHERE "entities_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
                   AND "entities_0_0_0"."decision_time" && $2
                   AND "entities_0_1_0"."transaction_time" @> $1::TIMESTAMPTZ

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
@@ -479,97 +479,134 @@ pub enum Relation {
     IncomingLink,
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum ForeignKeyReference {
+    Single {
+        on: Column<'static>,
+        join: Column<'static>,
+    },
+    Double {
+        on: (Column<'static>, Column<'static>),
+        join: (Column<'static>, Column<'static>),
+    },
+}
+
 impl Relation {
-    pub const fn joins(self) -> &'static [(Column<'static>, Column<'static>)] {
+    #[expect(clippy::too_many_lines)]
+    pub const fn joins(self) -> &'static [ForeignKeyReference] {
         match self {
-            Self::DataTypeIds => &[(
-                Column::DataTypes(DataTypes::OntologyId),
-                Column::OntologyIds(OntologyIds::OntologyId),
-            )],
-            Self::PropertyTypeIds => &[(
-                Column::PropertyTypes(PropertyTypes::OntologyId),
-                Column::OntologyIds(OntologyIds::OntologyId),
-            )],
-            Self::EntityTypeIds => &[(
-                Column::EntityTypes(EntityTypes::OntologyId),
-                Column::OntologyIds(OntologyIds::OntologyId),
-            )],
+            Self::DataTypeIds => &[ForeignKeyReference::Single {
+                on: Column::DataTypes(DataTypes::OntologyId),
+                join: Column::OntologyIds(OntologyIds::OntologyId),
+            }],
+            Self::PropertyTypeIds => &[ForeignKeyReference::Single {
+                on: Column::PropertyTypes(PropertyTypes::OntologyId),
+                join: Column::OntologyIds(OntologyIds::OntologyId),
+            }],
+            Self::EntityTypeIds => &[ForeignKeyReference::Single {
+                on: Column::EntityTypes(EntityTypes::OntologyId),
+                join: Column::OntologyIds(OntologyIds::OntologyId),
+            }],
             Self::PropertyTypeDataTypeReferences => &[
-                (
-                    Column::PropertyTypes(PropertyTypes::OntologyId),
-                    Column::PropertyTypeDataTypeReferences(
+                ForeignKeyReference::Single {
+                    on: Column::PropertyTypes(PropertyTypes::OntologyId),
+                    join: Column::PropertyTypeDataTypeReferences(
                         PropertyTypeDataTypeReferences::SourcePropertyTypeOntologyId,
                     ),
-                ),
-                (
-                    Column::PropertyTypeDataTypeReferences(
+                },
+                ForeignKeyReference::Single {
+                    on: Column::PropertyTypeDataTypeReferences(
                         PropertyTypeDataTypeReferences::TargetDataTypeOntologyId,
                     ),
-                    Column::DataTypes(DataTypes::OntologyId),
-                ),
+                    join: Column::DataTypes(DataTypes::OntologyId),
+                },
             ],
             Self::PropertyTypePropertyTypeReferences => &[
-                (
-                    Column::PropertyTypes(PropertyTypes::OntologyId),
-                    Column::PropertyTypePropertyTypeReferences(
+                ForeignKeyReference::Single {
+                    on: Column::PropertyTypes(PropertyTypes::OntologyId),
+                    join: Column::PropertyTypePropertyTypeReferences(
                         PropertyTypePropertyTypeReferences::SourcePropertyTypeOntologyId,
                     ),
-                ),
-                (
-                    Column::PropertyTypePropertyTypeReferences(
+                },
+                ForeignKeyReference::Single {
+                    on: Column::PropertyTypePropertyTypeReferences(
                         PropertyTypePropertyTypeReferences::TargetPropertyTypeOntologyId,
                     ),
-                    Column::PropertyTypes(PropertyTypes::OntologyId),
-                ),
+                    join: Column::PropertyTypes(PropertyTypes::OntologyId),
+                },
             ],
             Self::EntityTypePropertyTypeReferences => &[
-                (
-                    Column::EntityTypes(EntityTypes::OntologyId),
-                    Column::EntityTypePropertyTypeReferences(
+                ForeignKeyReference::Single {
+                    on: Column::EntityTypes(EntityTypes::OntologyId),
+                    join: Column::EntityTypePropertyTypeReferences(
                         EntityTypePropertyTypeReferences::SourceEntityTypeOntologyId,
                     ),
-                ),
-                (
-                    Column::EntityTypePropertyTypeReferences(
+                },
+                ForeignKeyReference::Single {
+                    on: Column::EntityTypePropertyTypeReferences(
                         EntityTypePropertyTypeReferences::TargetPropertyTypeOntologyId,
                     ),
-                    Column::PropertyTypes(PropertyTypes::OntologyId),
-                ),
+                    join: Column::PropertyTypes(PropertyTypes::OntologyId),
+                },
             ],
             Self::EntityTypeLinks | Self::EntityTypeInheritance => &[
-                (
-                    Column::EntityTypes(EntityTypes::OntologyId),
-                    Column::EntityTypeEntityTypeReferences(
+                ForeignKeyReference::Single {
+                    on: Column::EntityTypes(EntityTypes::OntologyId),
+                    join: Column::EntityTypeEntityTypeReferences(
                         EntityTypeEntityTypeReferences::SourceEntityTypeOntologyId,
                     ),
-                ),
-                (
-                    Column::EntityTypeEntityTypeReferences(
+                },
+                ForeignKeyReference::Single {
+                    on: Column::EntityTypeEntityTypeReferences(
                         EntityTypeEntityTypeReferences::TargetEntityTypeOntologyId,
                     ),
-                    Column::EntityTypes(EntityTypes::OntologyId),
-                ),
+                    join: Column::EntityTypes(EntityTypes::OntologyId),
+                },
             ],
-            Self::EntityType => &[(
-                Column::Entities(Entities::EntityTypeOntologyId),
-                Column::EntityTypes(EntityTypes::OntologyId),
-            )],
-            Self::LeftEndpoint => &[(
-                Column::Entities(Entities::LeftEntityUuid),
-                Column::Entities(Entities::EntityUuid),
-            )],
-            Self::RightEndpoint => &[(
-                Column::Entities(Entities::RightEntityUuid),
-                Column::Entities(Entities::EntityUuid),
-            )],
-            Self::OutgoingLink => &[(
-                Column::Entities(Entities::EntityUuid),
-                Column::Entities(Entities::LeftEntityUuid),
-            )],
-            Self::IncomingLink => &[(
-                Column::Entities(Entities::EntityUuid),
-                Column::Entities(Entities::RightEntityUuid),
-            )],
+            Self::EntityType => &[ForeignKeyReference::Single {
+                on: Column::Entities(Entities::EntityTypeOntologyId),
+                join: Column::EntityTypes(EntityTypes::OntologyId),
+            }],
+            Self::LeftEndpoint => &[ForeignKeyReference::Double {
+                on: (
+                    Column::Entities(Entities::LeftEntityOwnedById),
+                    Column::Entities(Entities::LeftEntityUuid),
+                ),
+                join: (
+                    Column::Entities(Entities::OwnedById),
+                    Column::Entities(Entities::EntityUuid),
+                ),
+            }],
+            Self::RightEndpoint => &[ForeignKeyReference::Double {
+                on: (
+                    Column::Entities(Entities::RightEntityOwnedById),
+                    Column::Entities(Entities::RightEntityUuid),
+                ),
+                join: (
+                    Column::Entities(Entities::OwnedById),
+                    Column::Entities(Entities::EntityUuid),
+                ),
+            }],
+            Self::OutgoingLink => &[ForeignKeyReference::Double {
+                on: (
+                    Column::Entities(Entities::OwnedById),
+                    Column::Entities(Entities::EntityUuid),
+                ),
+                join: (
+                    Column::Entities(Entities::LeftEntityOwnedById),
+                    Column::Entities(Entities::LeftEntityUuid),
+                ),
+            }],
+            Self::IncomingLink => &[ForeignKeyReference::Double {
+                on: (
+                    Column::Entities(Entities::OwnedById),
+                    Column::Entities(Entities::EntityUuid),
+                ),
+                join: (
+                    Column::Entities(Entities::RightEntityOwnedById),
+                    Column::Entities(Entities::RightEntityUuid),
+                ),
+            }],
         }
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
@@ -182,9 +182,6 @@ pub enum Entities<'p> {
     EditionId,
     DecisionTime,
     TransactionTime,
-    // TODO: Remove when correctly resolving time intervals in subgraphs.
-    //   see https://app.asana.com/0/0/1203701389454316/f
-    ProjectedTime,
     Archived,
     OwnedById,
     UpdatedById,
@@ -205,7 +202,6 @@ impl Entities<'_> {
             | Self::EditionId
             | Self::DecisionTime
             | Self::TransactionTime
-            | Self::ProjectedTime
             | Self::Archived
             | Self::OwnedById
             | Self::UpdatedById
@@ -235,7 +231,6 @@ impl Entities<'_> {
             Self::EditionId => "entity_edition_id",
             Self::DecisionTime => "decision_time",
             Self::TransactionTime => "transaction_time",
-            Self::ProjectedTime => unreachable!("projected time is not a column"),
             Self::Archived => "archived",
             Self::OwnedById => "owned_by_id",
             Self::UpdatedById => "record_created_by_id",

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
@@ -481,8 +481,8 @@ pub enum ForeignKeyReference {
         join: Column<'static>,
     },
     Double {
-        on: (Column<'static>, Column<'static>),
-        join: (Column<'static>, Column<'static>),
+        on: [Column<'static>; 2],
+        join: [Column<'static>; 2],
     },
 }
 
@@ -563,44 +563,44 @@ impl Relation {
                 join: Column::EntityTypes(EntityTypes::OntologyId),
             }],
             Self::LeftEndpoint => &[ForeignKeyReference::Double {
-                on: (
+                on: [
                     Column::Entities(Entities::LeftEntityOwnedById),
                     Column::Entities(Entities::LeftEntityUuid),
-                ),
-                join: (
+                ],
+                join: [
                     Column::Entities(Entities::OwnedById),
                     Column::Entities(Entities::EntityUuid),
-                ),
+                ],
             }],
             Self::RightEndpoint => &[ForeignKeyReference::Double {
-                on: (
+                on: [
                     Column::Entities(Entities::RightEntityOwnedById),
                     Column::Entities(Entities::RightEntityUuid),
-                ),
-                join: (
+                ],
+                join: [
                     Column::Entities(Entities::OwnedById),
                     Column::Entities(Entities::EntityUuid),
-                ),
+                ],
             }],
             Self::OutgoingLink => &[ForeignKeyReference::Double {
-                on: (
+                on: [
                     Column::Entities(Entities::OwnedById),
                     Column::Entities(Entities::EntityUuid),
-                ),
-                join: (
+                ],
+                join: [
                     Column::Entities(Entities::LeftEntityOwnedById),
                     Column::Entities(Entities::LeftEntityUuid),
-                ),
+                ],
             }],
             Self::IncomingLink => &[ForeignKeyReference::Double {
-                on: (
+                on: [
                     Column::Entities(Entities::OwnedById),
                     Column::Entities(Entities::EntityUuid),
-                ),
-                join: (
+                ],
+                join: [
                     Column::Entities(Entities::RightEntityOwnedById),
                     Column::Entities(Entities::RightEntityUuid),
-                ),
+                ],
             }],
         }
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We currently do not support joining entities by `entity_uuid` *and* `owned_by_id`. This is likely to be one cause why our experiments with Citus results in slower performance than expected.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204000740778935/1204165137291102/f) _(internal)_

## 🔍 What does this change?

- Enhance the `Relation::joins` function to allow returning multiple columns
- Adjust compiler and test outputs to take these changes into account
- Drive-by: Remove obsolete `ProjectedTime`

## ⚠️ Known issues

The `Relation` enumeration is quite large. Also, the `ForeignKeyReference` does not check, if the columns belong to the same table. I have a few ideas how to improve this, but this is out of scope in this PR.

## 🐾 Next steps

Initially, this was done as a drive-by when migrating to reference tables, but the issue was actually harder so solve than expected. Based on these changes it's easier to implement reference tables (correctly)