### PR TITLE
Simplify reference table definitions

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/compile.rs
@@ -8,7 +8,8 @@ use crate::{
         postgres::query::{
             expression::Constant,
             table::{
-                DataTypes, Entities, EntityTypes, JsonField, OntologyIds, PropertyTypes, Relation,
+                DataTypes, Entities, EntityTypes, JsonField, OntologyIds, PropertyTypes,
+                ReferenceTable, Relation,
             },
             Alias, AliasedColumn, AliasedTable, Column, Condition, Distinctness, EqualityOperator,
             Expression, Function, JoinExpression, OrderByExpression, Ordering, PostgresQueryPath,
@@ -387,7 +388,7 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
         joined_table: AliasedTable,
     ) {
         match relation {
-            Relation::EntityTypeLinks => {
+            Relation::Reference(ReferenceTable::EntityTypeLinks) => {
                 self.artifacts.required_tables.insert(joined_table);
                 self.statement
                     .where_expression
@@ -407,7 +408,7 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
                         None,
                     ));
             }
-            Relation::EntityTypeInheritance => {
+            Relation::Reference(ReferenceTable::EntityTypeInheritance) => {
                 self.artifacts.required_tables.insert(joined_table);
                 self.statement
                     .where_expression
@@ -455,7 +456,7 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
             let current_alias = current_table.alias;
             for foreign_key_reference in relation.joins() {
                 let mut join_expression = JoinExpression::from_foreign_key(
-                    *foreign_key_reference,
+                    foreign_key_reference,
                     current_table.alias,
                     Alias {
                         condition_index: self.artifacts.condition_index,

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
@@ -3,7 +3,7 @@ use std::iter::once;
 use crate::{
     ontology::{EntityTypeQueryPath, EntityTypeWithMetadata},
     store::postgres::query::{
-        table::{Column, EntityTypes, JsonField, OntologyIds, Relation},
+        table::{Column, EntityTypes, JsonField, OntologyIds, ReferenceTable, Relation},
         PostgresQueryPath, PostgresRecord, Table,
     },
 };
@@ -25,15 +25,19 @@ impl PostgresQueryPath for EntityTypeQueryPath<'_> {
             | Self::AdditionalMetadata(_) => {
                 vec![Relation::EntityTypeIds]
             }
-            Self::Properties(path) => once(Relation::EntityTypePropertyTypeReferences)
+            Self::Properties(path) => once(Relation::Reference(
+                ReferenceTable::EntityTypePropertyTypeReferences,
+            ))
+            .chain(path.relations())
+            .collect(),
+            Self::Links(path) => once(Relation::Reference(ReferenceTable::EntityTypeLinks))
                 .chain(path.relations())
                 .collect(),
-            Self::Links(path) => once(Relation::EntityTypeLinks)
-                .chain(path.relations())
-                .collect(),
-            Self::InheritsFrom(path) => once(Relation::EntityTypeInheritance)
-                .chain(path.relations())
-                .collect(),
+            Self::InheritsFrom(path) => {
+                once(Relation::Reference(ReferenceTable::EntityTypeInheritance))
+                    .chain(path.relations())
+                    .collect()
+            }
             _ => vec![],
         }
     }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/property_type.rs
@@ -3,7 +3,7 @@ use std::iter::once;
 use crate::{
     ontology::{PropertyTypeQueryPath, PropertyTypeWithMetadata},
     store::postgres::query::{
-        table::{Column, JsonField, OntologyIds, PropertyTypes, Relation},
+        table::{Column, JsonField, OntologyIds, PropertyTypes, ReferenceTable, Relation},
         PostgresQueryPath, PostgresRecord, Table,
     },
 };
@@ -24,12 +24,16 @@ impl PostgresQueryPath for PropertyTypeQueryPath<'_> {
             | Self::AdditionalMetadata(_) => {
                 vec![Relation::PropertyTypeIds]
             }
-            Self::DataTypes(path) => once(Relation::PropertyTypeDataTypeReferences)
-                .chain(path.relations())
-                .collect(),
-            Self::PropertyTypes(path) => once(Relation::PropertyTypePropertyTypeReferences)
-                .chain(path.relations())
-                .collect(),
+            Self::DataTypes(path) => once(Relation::Reference(
+                ReferenceTable::PropertyTypeDataTypeReferences,
+            ))
+            .chain(path.relations())
+            .collect(),
+            Self::PropertyTypes(path) => once(Relation::Reference(
+                ReferenceTable::PropertyTypePropertyTypeReferences,
+            ))
+            .chain(path.relations())
+            .collect(),
             _ => vec![],
         }
     }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
@@ -2,6 +2,7 @@ use std::{
     borrow::Cow,
     fmt::{self, Debug},
     hash::Hash,
+    iter::{once, Chain, Once},
 };
 
 use crate::{
@@ -17,10 +18,89 @@ pub enum Table {
     PropertyTypes,
     EntityTypes,
     Entities,
+    ReferenceTable(ReferenceTable),
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum ReferenceTable {
     PropertyTypeDataTypeReferences,
     PropertyTypePropertyTypeReferences,
     EntityTypePropertyTypeReferences,
-    EntityTypeEntityTypeReferences,
+    EntityTypeLinks,
+    EntityTypeInheritance,
+}
+
+impl ReferenceTable {
+    pub const fn source_relation(self) -> ForeignKeyReference {
+        match self {
+            Self::PropertyTypeDataTypeReferences => ForeignKeyReference::Single {
+                on: Column::PropertyTypes(PropertyTypes::OntologyId),
+                join: Column::PropertyTypeDataTypeReferences(
+                    PropertyTypeDataTypeReferences::SourcePropertyTypeOntologyId,
+                ),
+            },
+            Self::PropertyTypePropertyTypeReferences => ForeignKeyReference::Single {
+                on: Column::PropertyTypes(PropertyTypes::OntologyId),
+                join: Column::PropertyTypePropertyTypeReferences(
+                    PropertyTypePropertyTypeReferences::SourcePropertyTypeOntologyId,
+                ),
+            },
+            Self::EntityTypePropertyTypeReferences => ForeignKeyReference::Single {
+                on: Column::EntityTypes(EntityTypes::OntologyId),
+                join: Column::EntityTypePropertyTypeReferences(
+                    EntityTypePropertyTypeReferences::SourceEntityTypeOntologyId,
+                ),
+            },
+            Self::EntityTypeLinks | Self::EntityTypeInheritance => ForeignKeyReference::Single {
+                on: Column::EntityTypes(EntityTypes::OntologyId),
+                join: Column::EntityTypeEntityTypeReferences(
+                    EntityTypeEntityTypeReferences::SourceEntityTypeOntologyId,
+                ),
+            },
+        }
+    }
+
+    pub const fn target_relation(self) -> ForeignKeyReference {
+        match self {
+            Self::PropertyTypeDataTypeReferences => ForeignKeyReference::Single {
+                on: Column::PropertyTypeDataTypeReferences(
+                    PropertyTypeDataTypeReferences::TargetDataTypeOntologyId,
+                ),
+                join: Column::DataTypes(DataTypes::OntologyId),
+            },
+            Self::PropertyTypePropertyTypeReferences => ForeignKeyReference::Single {
+                on: Column::PropertyTypePropertyTypeReferences(
+                    PropertyTypePropertyTypeReferences::TargetPropertyTypeOntologyId,
+                ),
+                join: Column::PropertyTypes(PropertyTypes::OntologyId),
+            },
+            Self::EntityTypePropertyTypeReferences => ForeignKeyReference::Single {
+                on: Column::EntityTypePropertyTypeReferences(
+                    EntityTypePropertyTypeReferences::TargetPropertyTypeOntologyId,
+                ),
+                join: Column::PropertyTypes(PropertyTypes::OntologyId),
+            },
+            Self::EntityTypeLinks | Self::EntityTypeInheritance => ForeignKeyReference::Single {
+                on: Column::EntityTypeEntityTypeReferences(
+                    EntityTypeEntityTypeReferences::TargetEntityTypeOntologyId,
+                ),
+                join: Column::EntityTypes(EntityTypes::OntologyId),
+            },
+        }
+    }
+}
+
+impl ReferenceTable {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::PropertyTypeDataTypeReferences => "property_type_data_type_references",
+            Self::PropertyTypePropertyTypeReferences => "property_type_property_type_references",
+            Self::EntityTypePropertyTypeReferences => "entity_type_property_type_references",
+            Self::EntityTypeLinks | Self::EntityTypeInheritance => {
+                "entity_type_entity_type_references"
+            }
+        }
+    }
 }
 
 impl Table {
@@ -35,10 +115,7 @@ impl Table {
             Self::PropertyTypes => "property_types",
             Self::EntityTypes => "entity_types",
             Self::Entities => "entities",
-            Self::PropertyTypeDataTypeReferences => "property_type_data_type_references",
-            Self::PropertyTypePropertyTypeReferences => "property_type_property_type_references",
-            Self::EntityTypePropertyTypeReferences => "entity_type_property_type_references",
-            Self::EntityTypeEntityTypeReferences => "entity_type_entity_type_references",
+            Self::ReferenceTable(table) => table.as_str(),
         }
     }
 }
@@ -336,12 +413,18 @@ impl<'p> Column<'p> {
             Self::PropertyTypes(_) => Table::PropertyTypes,
             Self::EntityTypes(_) => Table::EntityTypes,
             Self::Entities(_) => Table::Entities,
-            Self::PropertyTypeDataTypeReferences(_) => Table::PropertyTypeDataTypeReferences,
-            Self::PropertyTypePropertyTypeReferences(_) => {
-                Table::PropertyTypePropertyTypeReferences
+            Self::PropertyTypeDataTypeReferences(_) => {
+                Table::ReferenceTable(ReferenceTable::PropertyTypeDataTypeReferences)
             }
-            Self::EntityTypePropertyTypeReferences(_) => Table::EntityTypePropertyTypeReferences,
-            Self::EntityTypeEntityTypeReferences(_) => Table::EntityTypeEntityTypeReferences,
+            Self::PropertyTypePropertyTypeReferences(_) => {
+                Table::ReferenceTable(ReferenceTable::PropertyTypePropertyTypeReferences)
+            }
+            Self::EntityTypePropertyTypeReferences(_) => {
+                Table::ReferenceTable(ReferenceTable::EntityTypePropertyTypeReferences)
+            }
+            Self::EntityTypeEntityTypeReferences(_) => {
+                Table::ReferenceTable(ReferenceTable::EntityTypeInheritance)
+            }
         }
     }
 
@@ -462,16 +545,12 @@ pub enum Relation {
     DataTypeIds,
     PropertyTypeIds,
     EntityTypeIds,
-    PropertyTypeDataTypeReferences,
-    PropertyTypePropertyTypeReferences,
-    EntityTypePropertyTypeReferences,
-    EntityTypeLinks,
-    EntityTypeInheritance,
     EntityType,
     LeftEndpoint,
     RightEndpoint,
     OutgoingLink,
     IncomingLink,
+    Reference(ReferenceTable),
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -486,83 +565,54 @@ pub enum ForeignKeyReference {
     },
 }
 
-impl Relation {
-    #[expect(clippy::too_many_lines)]
-    pub const fn joins(self) -> &'static [ForeignKeyReference] {
+enum ForeignKeyJoin {
+    Plain(Once<ForeignKeyReference>),
+    Reference(Chain<Once<ForeignKeyReference>, Once<ForeignKeyReference>>),
+}
+
+impl From<ForeignKeyReference> for ForeignKeyJoin {
+    fn from(reference: ForeignKeyReference) -> Self {
+        Self::Plain(once(reference))
+    }
+}
+
+impl From<ReferenceTable> for ForeignKeyJoin {
+    fn from(table: ReferenceTable) -> Self {
+        Self::Reference(once(table.source_relation()).chain(once(table.target_relation())))
+    }
+}
+
+impl Iterator for ForeignKeyJoin {
+    type Item = ForeignKeyReference;
+
+    fn next(&mut self) -> Option<Self::Item> {
         match self {
-            Self::DataTypeIds => &[ForeignKeyReference::Single {
+            Self::Plain(value) => value.next(),
+            Self::Reference(values) => values.next(),
+        }
+    }
+}
+
+impl Relation {
+    pub fn joins(self) -> impl Iterator<Item = ForeignKeyReference> {
+        match self {
+            Self::DataTypeIds => ForeignKeyJoin::from(ForeignKeyReference::Single {
                 on: Column::DataTypes(DataTypes::OntologyId),
                 join: Column::OntologyIds(OntologyIds::OntologyId),
-            }],
-            Self::PropertyTypeIds => &[ForeignKeyReference::Single {
+            }),
+            Self::PropertyTypeIds => ForeignKeyJoin::from(ForeignKeyReference::Single {
                 on: Column::PropertyTypes(PropertyTypes::OntologyId),
                 join: Column::OntologyIds(OntologyIds::OntologyId),
-            }],
-            Self::EntityTypeIds => &[ForeignKeyReference::Single {
+            }),
+            Self::EntityTypeIds => ForeignKeyJoin::from(ForeignKeyReference::Single {
                 on: Column::EntityTypes(EntityTypes::OntologyId),
                 join: Column::OntologyIds(OntologyIds::OntologyId),
-            }],
-            Self::PropertyTypeDataTypeReferences => &[
-                ForeignKeyReference::Single {
-                    on: Column::PropertyTypes(PropertyTypes::OntologyId),
-                    join: Column::PropertyTypeDataTypeReferences(
-                        PropertyTypeDataTypeReferences::SourcePropertyTypeOntologyId,
-                    ),
-                },
-                ForeignKeyReference::Single {
-                    on: Column::PropertyTypeDataTypeReferences(
-                        PropertyTypeDataTypeReferences::TargetDataTypeOntologyId,
-                    ),
-                    join: Column::DataTypes(DataTypes::OntologyId),
-                },
-            ],
-            Self::PropertyTypePropertyTypeReferences => &[
-                ForeignKeyReference::Single {
-                    on: Column::PropertyTypes(PropertyTypes::OntologyId),
-                    join: Column::PropertyTypePropertyTypeReferences(
-                        PropertyTypePropertyTypeReferences::SourcePropertyTypeOntologyId,
-                    ),
-                },
-                ForeignKeyReference::Single {
-                    on: Column::PropertyTypePropertyTypeReferences(
-                        PropertyTypePropertyTypeReferences::TargetPropertyTypeOntologyId,
-                    ),
-                    join: Column::PropertyTypes(PropertyTypes::OntologyId),
-                },
-            ],
-            Self::EntityTypePropertyTypeReferences => &[
-                ForeignKeyReference::Single {
-                    on: Column::EntityTypes(EntityTypes::OntologyId),
-                    join: Column::EntityTypePropertyTypeReferences(
-                        EntityTypePropertyTypeReferences::SourceEntityTypeOntologyId,
-                    ),
-                },
-                ForeignKeyReference::Single {
-                    on: Column::EntityTypePropertyTypeReferences(
-                        EntityTypePropertyTypeReferences::TargetPropertyTypeOntologyId,
-                    ),
-                    join: Column::PropertyTypes(PropertyTypes::OntologyId),
-                },
-            ],
-            Self::EntityTypeLinks | Self::EntityTypeInheritance => &[
-                ForeignKeyReference::Single {
-                    on: Column::EntityTypes(EntityTypes::OntologyId),
-                    join: Column::EntityTypeEntityTypeReferences(
-                        EntityTypeEntityTypeReferences::SourceEntityTypeOntologyId,
-                    ),
-                },
-                ForeignKeyReference::Single {
-                    on: Column::EntityTypeEntityTypeReferences(
-                        EntityTypeEntityTypeReferences::TargetEntityTypeOntologyId,
-                    ),
-                    join: Column::EntityTypes(EntityTypes::OntologyId),
-                },
-            ],
-            Self::EntityType => &[ForeignKeyReference::Single {
+            }),
+            Self::EntityType => ForeignKeyJoin::from(ForeignKeyReference::Single {
                 on: Column::Entities(Entities::EntityTypeOntologyId),
                 join: Column::EntityTypes(EntityTypes::OntologyId),
-            }],
-            Self::LeftEndpoint => &[ForeignKeyReference::Double {
+            }),
+            Self::LeftEndpoint => ForeignKeyJoin::from(ForeignKeyReference::Double {
                 on: [
                     Column::Entities(Entities::LeftEntityOwnedById),
                     Column::Entities(Entities::LeftEntityUuid),
@@ -571,8 +621,8 @@ impl Relation {
                     Column::Entities(Entities::OwnedById),
                     Column::Entities(Entities::EntityUuid),
                 ],
-            }],
-            Self::RightEndpoint => &[ForeignKeyReference::Double {
+            }),
+            Self::RightEndpoint => ForeignKeyJoin::from(ForeignKeyReference::Double {
                 on: [
                     Column::Entities(Entities::RightEntityOwnedById),
                     Column::Entities(Entities::RightEntityUuid),
@@ -581,8 +631,8 @@ impl Relation {
                     Column::Entities(Entities::OwnedById),
                     Column::Entities(Entities::EntityUuid),
                 ],
-            }],
-            Self::OutgoingLink => &[ForeignKeyReference::Double {
+            }),
+            Self::OutgoingLink => ForeignKeyJoin::from(ForeignKeyReference::Double {
                 on: [
                     Column::Entities(Entities::OwnedById),
                     Column::Entities(Entities::EntityUuid),
@@ -591,8 +641,8 @@ impl Relation {
                     Column::Entities(Entities::LeftEntityOwnedById),
                     Column::Entities(Entities::LeftEntityUuid),
                 ],
-            }],
-            Self::IncomingLink => &[ForeignKeyReference::Double {
+            }),
+            Self::IncomingLink => ForeignKeyJoin::from(ForeignKeyReference::Double {
                 on: [
                     Column::Entities(Entities::OwnedById),
                     Column::Entities(Entities::EntityUuid),
@@ -601,7 +651,8 @@ impl Relation {
                     Column::Entities(Entities::RightEntityOwnedById),
                     Column::Entities(Entities::RightEntityUuid),
                 ],
-            }],
+            }),
+            Self::Reference(table) => ForeignKeyJoin::from(table),
         }
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

As noted in #2200, the `Relation::joins` function got very long and is expected to get even longer with more reference tables added, which is the next step.

## 🔗 Related links

- #2200

## 🚫 Blocked by

- #2200 

## 🔍 What does this change?

- Introduce `ReferenceTable` enumeration, which defines the layout of a reference table
- Use `ReferenceTable` inside of `Table::Reference(ReferenceTable)` to provide the same API
- Return `impl Iterator` instead of a dynamically sized list when requesting the required joins for a relation