### PR TITLE
Use reference tables for all edge kinds

### DIFF
--- a/apps/hash-graph/bench/representative_read/seed.rs
+++ b/apps/hash-graph/bench/representative_read/seed.rs
@@ -261,9 +261,9 @@ async fn get_samples(account_id: AccountId, store_wrapper: &mut StoreWrapper) ->
             .query(
                 r#"
                 -- Very naive and slow sampling, we can replace when this becomes a bottleneck
-                SELECT entity_uuid FROM entities
-                INNER JOIN ontology_ids
-                ON ontology_ids.ontology_id = entities.entity_type_ontology_id
+                SELECT entity_uuid FROM entity_temporal_metadata
+                INNER JOIN entity_is_of_type ON entity_is_of_type.entity_edition_id = entity_temporal_metadata.entity_edition_id
+                INNER JOIN ontology_ids ON ontology_ids.ontology_id = entity_is_of_type.entity_type_ontology_id
                 WHERE ontology_ids.base_url = $1 AND ontology_ids.version = $2
                 ORDER BY RANDOM()
                 LIMIT 50

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
@@ -26,15 +26,17 @@ impl PostgresQueryPath for EntityTypeQueryPath<'_> {
                 vec![Relation::EntityTypeIds]
             }
             Self::Properties(path) => once(Relation::Reference(
-                ReferenceTable::EntityTypePropertyTypeReferences,
+                ReferenceTable::EntityTypeConstrainsPropertiesOn,
             ))
             .chain(path.relations())
             .collect(),
-            Self::Links(path) => once(Relation::Reference(ReferenceTable::EntityTypeLinks))
-                .chain(path.relations())
-                .collect(),
+            Self::Links(path) => once(Relation::Reference(
+                ReferenceTable::EntityTypeConstrainsLinksOn,
+            ))
+            .chain(path.relations())
+            .collect(),
             Self::InheritsFrom(path) => {
-                once(Relation::Reference(ReferenceTable::EntityTypeInheritance))
+                once(Relation::Reference(ReferenceTable::EntityTypeInheritsFrom))
                     .chain(path.relations())
                     .collect()
             }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/property_type.rs
@@ -25,12 +25,12 @@ impl PostgresQueryPath for PropertyTypeQueryPath<'_> {
                 vec![Relation::PropertyTypeIds]
             }
             Self::DataTypes(path) => once(Relation::Reference(
-                ReferenceTable::PropertyTypeDataTypeReferences,
+                ReferenceTable::PropertyTypeConstrainsValuesOn,
             ))
             .chain(path.relations())
             .collect(),
             Self::PropertyTypes(path) => once(Relation::Reference(
-                ReferenceTable::PropertyTypePropertyTypeReferences,
+                ReferenceTable::PropertyTypeConstrainsPropertiesOn,
             ))
             .chain(path.relations())
             .collect(),

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -258,10 +258,10 @@ mod tests {
             r#"
             SELECT *
             FROM "property_types" AS "property_types_0_0_0"
-            INNER JOIN "property_type_data_type_references" AS "property_type_data_type_references_0_1_0"
-              ON "property_type_data_type_references_0_1_0"."source_property_type_ontology_id" = "property_types_0_0_0"."ontology_id"
+            INNER JOIN "property_type_constrains_values_on" AS "property_type_constrains_values_on_0_1_0"
+              ON "property_type_constrains_values_on_0_1_0"."source_property_type_ontology_id" = "property_types_0_0_0"."ontology_id"
             INNER JOIN "data_types" AS "data_types_0_2_0"
-              ON "data_types_0_2_0"."ontology_id" = "property_type_data_type_references_0_1_0"."target_data_type_ontology_id"
+              ON "data_types_0_2_0"."ontology_id" = "property_type_constrains_values_on_0_1_0"."target_data_type_ontology_id"
             WHERE "data_types_0_2_0"."schema"->>'title' = $1
             "#,
             &[&"Text"],
@@ -288,20 +288,20 @@ mod tests {
         test_compilation(
             &compiler,
             r#"
-            SELECT *
-            FROM "property_types" AS "property_types_0_0_0"
-            INNER JOIN "property_type_data_type_references" AS "property_type_data_type_references_0_1_0"
-              ON "property_type_data_type_references_0_1_0"."source_property_type_ontology_id" = "property_types_0_0_0"."ontology_id"
+            SELECT * FROM "property_types" AS "property_types_0_0_0"
+            INNER JOIN "property_type_constrains_values_on" AS "property_type_constrains_values_on_0_1_0"
+              ON "property_type_constrains_values_on_0_1_0"."source_property_type_ontology_id" = "property_types_0_0_0"."ontology_id"
             INNER JOIN "data_types" AS "data_types_0_2_0"
-              ON "data_types_0_2_0"."ontology_id" = "property_type_data_type_references_0_1_0"."target_data_type_ontology_id"
-            INNER JOIN "property_type_data_type_references" AS "property_type_data_type_references_1_1_0"
-              ON "property_type_data_type_references_1_1_0"."source_property_type_ontology_id" = "property_types_0_0_0"."ontology_id"
+              ON "data_types_0_2_0"."ontology_id" = "property_type_constrains_values_on_0_1_0"."target_data_type_ontology_id"
+            INNER JOIN "property_type_constrains_values_on" AS "property_type_constrains_values_on_1_1_0"
+              ON "property_type_constrains_values_on_1_1_0"."source_property_type_ontology_id" = "property_types_0_0_0"."ontology_id"
             INNER JOIN "data_types" AS "data_types_1_2_0"
-              ON "data_types_1_2_0"."ontology_id" = "property_type_data_type_references_1_1_0"."target_data_type_ontology_id"
+              ON "data_types_1_2_0"."ontology_id" = "property_type_constrains_values_on_1_1_0"."target_data_type_ontology_id"
             INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_1_3_0"
               ON "ontology_id_with_metadata_1_3_0"."ontology_id" = "data_types_1_2_0"."ontology_id"
             WHERE "data_types_0_2_0"."schema"->>'title' = $1
-              AND ("ontology_id_with_metadata_1_3_0"."base_url" = $2) AND ("ontology_id_with_metadata_1_3_0"."version" = $3)
+              AND ("ontology_id_with_metadata_1_3_0"."base_url" = $2)
+              AND ("ontology_id_with_metadata_1_3_0"."version" = $3)
             "#,
             &[
                 &"Text",
@@ -332,10 +332,10 @@ mod tests {
             r#"
             SELECT *
             FROM "property_types" AS "property_types_0_0_0"
-            INNER JOIN "property_type_property_type_references" AS "property_type_property_type_references_0_1_0"
-              ON "property_type_property_type_references_0_1_0"."source_property_type_ontology_id" = "property_types_0_0_0"."ontology_id"
+            INNER JOIN "property_type_constrains_properties_on" AS "property_type_constrains_properties_on_0_1_0"
+              ON "property_type_constrains_properties_on_0_1_0"."source_property_type_ontology_id" = "property_types_0_0_0"."ontology_id"
             INNER JOIN "property_types" AS "property_types_0_2_0"
-              ON "property_types_0_2_0"."ontology_id" = "property_type_property_type_references_0_1_0"."target_property_type_ontology_id"
+              ON "property_types_0_2_0"."ontology_id" = "property_type_constrains_properties_on_0_1_0"."target_property_type_ontology_id"
             WHERE "property_types_0_2_0"."schema"->>'title' = $1
             "#,
             &[&"Text"],
@@ -362,10 +362,10 @@ mod tests {
             r#"
             SELECT *
             FROM "entity_types" AS "entity_types_0_0_0"
-            INNER JOIN "entity_type_property_type_references" AS "entity_type_property_type_references_0_1_0"
-              ON "entity_type_property_type_references_0_1_0"."source_entity_type_ontology_id" = "entity_types_0_0_0"."ontology_id"
+            INNER JOIN "entity_type_constrains_properties_on" AS "entity_type_constrains_properties_on_0_1_0"
+              ON "entity_type_constrains_properties_on_0_1_0"."source_entity_type_ontology_id" = "entity_types_0_0_0"."ontology_id"
             INNER JOIN "property_types" AS "property_types_0_2_0"
-              ON "property_types_0_2_0"."ontology_id" = "entity_type_property_type_references_0_1_0"."target_property_type_ontology_id"
+              ON "property_types_0_2_0"."ontology_id" = "entity_type_constrains_properties_on_0_1_0"."target_property_type_ontology_id"
             WHERE "property_types_0_2_0"."schema"->>'title' = $1
             "#,
             &[&"Name"],
@@ -394,17 +394,15 @@ mod tests {
             r#"
             SELECT *
             FROM "entity_types" AS "entity_types_0_0_0"
-            INNER JOIN "entity_type_entity_type_references" AS "entity_type_entity_type_references_0_1_0"
-              ON "entity_type_entity_type_references_0_1_0"."source_entity_type_ontology_id" = "entity_types_0_0_0"."ontology_id"
+            INNER JOIN "entity_type_constrains_links_on" AS "entity_type_constrains_links_on_0_1_0"
+              ON "entity_type_constrains_links_on_0_1_0"."source_entity_type_ontology_id" = "entity_types_0_0_0"."ontology_id"
             INNER JOIN "entity_types" AS "entity_types_0_2_0"
-              ON "entity_types_0_2_0"."ontology_id" = "entity_type_entity_type_references_0_1_0"."target_entity_type_ontology_id"
-            INNER JOIN "entity_type_entity_type_references" AS "entity_type_entity_type_references_0_3_0"
-              ON "entity_type_entity_type_references_0_3_0"."source_entity_type_ontology_id" = "entity_types_0_2_0"."ontology_id"
+              ON "entity_types_0_2_0"."ontology_id" = "entity_type_constrains_links_on_0_1_0"."target_entity_type_ontology_id"
+            INNER JOIN "entity_type_constrains_links_on" AS "entity_type_constrains_links_on_0_3_0"
+              ON "entity_type_constrains_links_on_0_3_0"."source_entity_type_ontology_id" = "entity_types_0_2_0"."ontology_id"
             INNER JOIN "entity_types" AS "entity_types_0_4_0"
-              ON "entity_types_0_4_0"."ontology_id" = "entity_type_entity_type_references_0_3_0"."target_entity_type_ontology_id"
-            WHERE jsonb_extract_path("entity_types_0_0_0"."schema", 'links', "entity_types_0_2_0"."schema"->>'$id') IS NOT NULL
-              AND jsonb_extract_path("entity_types_0_2_0"."schema", 'links', "entity_types_0_4_0"."schema"->>'$id') IS NOT NULL
-              AND "entity_types_0_4_0"."schema"->>'title' = $1
+              ON "entity_types_0_4_0"."ontology_id" = "entity_type_constrains_links_on_0_3_0"."target_entity_type_ontology_id"
+            WHERE "entity_types_0_4_0"."schema"->>'title' = $1
             "#,
             &[&"Friend Of"],
         );
@@ -430,14 +428,13 @@ mod tests {
             r#"
             SELECT *
             FROM "entity_types" AS "entity_types_0_0_0"
-            INNER JOIN "entity_type_entity_type_references" AS "entity_type_entity_type_references_0_1_0"
-              ON "entity_type_entity_type_references_0_1_0"."source_entity_type_ontology_id" = "entity_types_0_0_0"."ontology_id"
+            INNER JOIN "entity_type_inherits_from" AS "entity_type_inherits_from_0_1_0"
+              ON "entity_type_inherits_from_0_1_0"."source_entity_type_ontology_id" = "entity_types_0_0_0"."ontology_id"
             INNER JOIN "entity_types" AS "entity_types_0_2_0"
-              ON "entity_types_0_2_0"."ontology_id" = "entity_type_entity_type_references_0_1_0"."target_entity_type_ontology_id"
+              ON "entity_types_0_2_0"."ontology_id" = "entity_type_inherits_from_0_1_0"."target_entity_type_ontology_id"
             INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_3_0"
               ON "ontology_id_with_metadata_0_3_0"."ontology_id" = "entity_types_0_2_0"."ontology_id"
-            WHERE jsonb_contains("entity_types_0_0_0"."schema"->'allOf', jsonb_build_array(jsonb_build_object('$ref', "entity_types_0_2_0"."schema"->>'$id'))) IS NOT NULL
-              AND "ontology_id_with_metadata_0_3_0"."base_url" = $1
+            WHERE "ontology_id_with_metadata_0_3_0"."base_url" = $1
             "#,
             &[&"https://blockprotocol.org/@blockprotocol/types/entity-type/link/"],
         );
@@ -461,10 +458,10 @@ mod tests {
             &compiler,
             r#"
             SELECT *
-            FROM "entities" AS "entities_0_0_0"
-            WHERE "entities_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
-              AND "entities_0_0_0"."decision_time" && $2
-              AND "entities_0_0_0"."entity_uuid" = $3
+            FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+            WHERE "entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "entity_temporal_metadata_0_0_0"."decision_time" && $2
+              AND "entity_temporal_metadata_0_0_0"."entity_uuid" = $3
             "#,
             &[
                 &pinned_timestamp,
@@ -501,16 +498,18 @@ mod tests {
             &compiler,
             r#"
             SELECT
-                DISTINCT ON("entities_0_0_0"."entity_uuid", "entities_0_0_0"."decision_time")
-                "entities_0_0_0"."entity_uuid",
-                "entities_0_0_0"."decision_time",
-                "entities_0_0_0"."properties"
-            FROM "entities" AS "entities_0_0_0"
-            WHERE "entities_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
-              AND "entities_0_0_0"."decision_time" && $2
-              AND "entities_0_0_0"."record_created_by_id" = $3
-            ORDER BY "entities_0_0_0"."entity_uuid" ASC,
-                     "entities_0_0_0"."decision_time" DESC
+                DISTINCT ON("entity_temporal_metadata_0_0_0"."entity_uuid", "entity_temporal_metadata_0_0_0"."decision_time")
+                "entity_temporal_metadata_0_0_0"."entity_uuid",
+                "entity_temporal_metadata_0_0_0"."decision_time",
+                "entity_editions_0_1_0"."properties"
+            FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+            INNER JOIN "entity_editions" AS "entity_editions_0_1_0"
+              ON "entity_editions_0_1_0"."entity_edition_id" = "entity_temporal_metadata_0_0_0"."entity_edition_id"
+            WHERE "entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "entity_temporal_metadata_0_0_0"."decision_time" && $2
+              AND "entity_editions_0_1_0"."record_created_by_id" = $3
+            ORDER BY "entity_temporal_metadata_0_0_0"."entity_uuid" ASC,
+                     "entity_temporal_metadata_0_0_0"."decision_time" DESC
             "#,
             &[
                 &pinned_timestamp,
@@ -543,10 +542,12 @@ mod tests {
             &compiler,
             r#"
             SELECT *
-            FROM "entities" AS "entities_0_0_0"
-            WHERE "entities_0_0_0"."transaction_time" @> $2::TIMESTAMPTZ
-              AND "entities_0_0_0"."decision_time" && $3
-              AND jsonb_path_query_first("entities_0_0_0"."properties", $1::text::jsonpath) = $4
+            FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+            INNER JOIN "entity_editions" AS "entity_editions_0_1_0"
+              ON "entity_editions_0_1_0"."entity_edition_id" = "entity_temporal_metadata_0_0_0"."entity_edition_id"
+            WHERE "entity_temporal_metadata_0_0_0"."transaction_time" @> $2::TIMESTAMPTZ
+              AND "entity_temporal_metadata_0_0_0"."decision_time" && $3
+              AND jsonb_path_query_first("entity_editions_0_1_0"."properties", $1::text::jsonpath) = $4
             "#,
             &[
                 &json_path,
@@ -578,10 +579,12 @@ mod tests {
             &compiler,
             r#"
             SELECT *
-            FROM "entities" AS "entities_0_0_0"
-            WHERE "entities_0_0_0"."transaction_time" @> $2::TIMESTAMPTZ
-              AND "entities_0_0_0"."decision_time" && $3
-              AND jsonb_path_query_first("entities_0_0_0"."properties", $1::text::jsonpath) IS NULL
+            FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+            INNER JOIN "entity_editions" AS "entity_editions_0_1_0"
+              ON "entity_editions_0_1_0"."entity_edition_id" = "entity_temporal_metadata_0_0_0"."entity_edition_id"
+            WHERE "entity_temporal_metadata_0_0_0"."transaction_time" @> $2::TIMESTAMPTZ
+              AND "entity_temporal_metadata_0_0_0"."decision_time" && $3
+              AND jsonb_path_query_first("entity_editions_0_1_0"."properties", $1::text::jsonpath) IS NULL
             "#,
             &[
                 &json_path,
@@ -611,20 +614,26 @@ mod tests {
             &compiler,
             r#"
             SELECT *
-            FROM "entities" AS "entities_0_0_0"
-            LEFT OUTER JOIN "entities" AS "entities_0_1_0"
-              ON "entities_0_1_0"."left_owned_by_id" = "entities_0_0_0"."owned_by_id"
-             AND "entities_0_1_0"."left_entity_uuid" = "entities_0_0_0"."entity_uuid"
-            RIGHT OUTER JOIN "entities" AS "entities_0_2_0"
-              ON "entities_0_2_0"."owned_by_id" = "entities_0_1_0"."right_owned_by_id"
-             AND "entities_0_2_0"."entity_uuid" = "entities_0_1_0"."right_entity_uuid"
-            WHERE "entities_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
-              AND "entities_0_0_0"."decision_time" && $2
-              AND "entities_0_1_0"."transaction_time" @> $1::TIMESTAMPTZ
-              AND "entities_0_1_0"."decision_time" && $2
-              AND "entities_0_2_0"."transaction_time" @> $1::TIMESTAMPTZ
-              AND "entities_0_2_0"."decision_time" && $2
-              AND "entities_0_2_0"."entity_edition_id" = $3
+            FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+            LEFT OUTER JOIN "entity_has_left_entity" AS "entity_has_left_entity_0_1_0"
+              ON "entity_has_left_entity_0_1_0"."left_owned_by_id" = "entity_temporal_metadata_0_0_0"."owned_by_id"
+             AND "entity_has_left_entity_0_1_0"."left_entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
+            RIGHT OUTER JOIN "entity_temporal_metadata" AS "entity_temporal_metadata_0_2_0"
+              ON "entity_temporal_metadata_0_2_0"."owned_by_id" = "entity_has_left_entity_0_1_0"."owned_by_id"
+             AND "entity_temporal_metadata_0_2_0"."entity_uuid" = "entity_has_left_entity_0_1_0"."entity_uuid"
+            LEFT OUTER JOIN "entity_has_right_entity" AS "entity_has_right_entity_0_3_0"
+              ON "entity_has_right_entity_0_3_0"."owned_by_id" = "entity_temporal_metadata_0_2_0"."owned_by_id"
+             AND "entity_has_right_entity_0_3_0"."entity_uuid" = "entity_temporal_metadata_0_2_0"."entity_uuid"
+            RIGHT OUTER JOIN "entity_temporal_metadata" AS "entity_temporal_metadata_0_4_0"
+              ON "entity_temporal_metadata_0_4_0"."owned_by_id" = "entity_has_right_entity_0_3_0"."right_owned_by_id"
+             AND "entity_temporal_metadata_0_4_0"."entity_uuid" = "entity_has_right_entity_0_3_0"."right_entity_uuid"
+            WHERE "entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "entity_temporal_metadata_0_0_0"."decision_time" && $2
+              AND "entity_temporal_metadata_0_2_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "entity_temporal_metadata_0_2_0"."decision_time" && $2
+              AND "entity_temporal_metadata_0_4_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "entity_temporal_metadata_0_4_0"."decision_time" && $2
+              AND "entity_temporal_metadata_0_4_0"."entity_edition_id" = $3
             "#,
             &[&pinned_timestamp, &temporal_axes.variable_interval(), &10],
         );
@@ -650,20 +659,26 @@ mod tests {
             &compiler,
             r#"
             SELECT *
-            FROM "entities" AS "entities_0_0_0"
-            LEFT OUTER JOIN "entities" AS "entities_0_1_0"
-              ON "entities_0_1_0"."right_owned_by_id" = "entities_0_0_0"."owned_by_id"
-             AND "entities_0_1_0"."right_entity_uuid" = "entities_0_0_0"."entity_uuid"
-            RIGHT OUTER JOIN "entities" AS "entities_0_2_0"
-              ON "entities_0_2_0"."owned_by_id" = "entities_0_1_0"."left_owned_by_id"
-             AND "entities_0_2_0"."entity_uuid" = "entities_0_1_0"."left_entity_uuid"
-            WHERE "entities_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
-              AND "entities_0_0_0"."decision_time" && $2
-              AND "entities_0_1_0"."transaction_time" @> $1::TIMESTAMPTZ
-              AND "entities_0_1_0"."decision_time" && $2
-              AND "entities_0_2_0"."transaction_time" @> $1::TIMESTAMPTZ
-              AND "entities_0_2_0"."decision_time" && $2
-              AND "entities_0_2_0"."entity_edition_id" = $3
+            FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+            LEFT OUTER JOIN "entity_has_right_entity" AS "entity_has_right_entity_0_1_0"
+              ON "entity_has_right_entity_0_1_0"."right_owned_by_id" = "entity_temporal_metadata_0_0_0"."owned_by_id"
+             AND "entity_has_right_entity_0_1_0"."right_entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
+            RIGHT OUTER JOIN "entity_temporal_metadata" AS "entity_temporal_metadata_0_2_0"
+              ON "entity_temporal_metadata_0_2_0"."owned_by_id" = "entity_has_right_entity_0_1_0"."owned_by_id"
+             AND "entity_temporal_metadata_0_2_0"."entity_uuid" = "entity_has_right_entity_0_1_0"."entity_uuid"
+            LEFT OUTER JOIN "entity_has_left_entity" AS "entity_has_left_entity_0_3_0"
+              ON "entity_has_left_entity_0_3_0"."owned_by_id" = "entity_temporal_metadata_0_2_0"."owned_by_id"
+             AND "entity_has_left_entity_0_3_0"."entity_uuid" = "entity_temporal_metadata_0_2_0"."entity_uuid"
+            RIGHT OUTER JOIN "entity_temporal_metadata" AS "entity_temporal_metadata_0_4_0"
+              ON "entity_temporal_metadata_0_4_0"."owned_by_id" = "entity_has_left_entity_0_3_0"."left_owned_by_id"
+             AND "entity_temporal_metadata_0_4_0"."entity_uuid" = "entity_has_left_entity_0_3_0"."left_entity_uuid"
+            WHERE "entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "entity_temporal_metadata_0_0_0"."decision_time" && $2
+              AND "entity_temporal_metadata_0_2_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "entity_temporal_metadata_0_2_0"."decision_time" && $2
+              AND "entity_temporal_metadata_0_4_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "entity_temporal_metadata_0_4_0"."decision_time" && $2
+              AND "entity_temporal_metadata_0_4_0"."entity_edition_id" = $3
             "#,
             &[&pinned_timestamp, &temporal_axes.variable_interval(), &10],
         );
@@ -707,13 +722,19 @@ mod tests {
             &compiler,
             r#"
             SELECT *
-            FROM "entities" AS "entities_0_0_0"
-            WHERE "entities_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
-              AND "entities_0_0_0"."decision_time" && $2
-              AND ("entities_0_0_0"."left_entity_uuid" = $3)
-              AND ("entities_0_0_0"."left_owned_by_id" = $4)
-              AND ("entities_0_0_0"."right_entity_uuid" = $5)
-              AND ("entities_0_0_0"."right_owned_by_id" = $6)
+            FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+            LEFT OUTER JOIN "entity_has_left_entity" AS "entity_has_left_entity_0_1_0"
+              ON "entity_has_left_entity_0_1_0"."owned_by_id" = "entity_temporal_metadata_0_0_0"."owned_by_id"
+             AND "entity_has_left_entity_0_1_0"."entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
+            LEFT OUTER JOIN "entity_has_right_entity" AS "entity_has_right_entity_0_1_0"
+              ON "entity_has_right_entity_0_1_0"."owned_by_id" = "entity_temporal_metadata_0_0_0"."owned_by_id"
+             AND "entity_has_right_entity_0_1_0"."entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
+            WHERE "entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "entity_temporal_metadata_0_0_0"."decision_time" && $2
+              AND ("entity_has_left_entity_0_1_0"."left_entity_uuid" = $3)
+              AND ("entity_has_left_entity_0_1_0"."left_owned_by_id" = $4)
+              AND ("entity_has_right_entity_0_1_0"."right_entity_uuid" = $5)
+              AND ("entity_has_right_entity_0_1_0"."right_owned_by_id" = $6)
             "#,
             &[
                 &pinned_timestamp,
@@ -755,27 +776,40 @@ mod tests {
         test_compilation(
             &compiler,
             r#"
-             SELECT *
-             FROM "entities" AS "entities_0_0_0"
-             RIGHT OUTER JOIN "entities" AS "entities_0_1_0"
-               ON "entities_0_1_0"."owned_by_id" = "entities_0_0_0"."left_owned_by_id"
-              AND "entities_0_1_0"."entity_uuid" = "entities_0_0_0"."left_entity_uuid"
-             INNER JOIN "entity_types" AS "entity_types_0_2_0"
-               ON "entity_types_0_2_0"."ontology_id" = "entities_0_1_0"."entity_type_ontology_id"
-             INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_3_0"
-               ON "ontology_id_with_metadata_0_3_0"."ontology_id" = "entity_types_0_2_0"."ontology_id"
-             RIGHT OUTER JOIN "entities" AS "entities_0_1_1"
-               ON "entities_0_1_1"."owned_by_id" = "entities_0_0_0"."right_owned_by_id"
-              AND "entities_0_1_1"."entity_uuid" = "entities_0_0_0"."right_entity_uuid"
-             INNER JOIN "entity_types" AS "entity_types_0_2_1"
-               ON "entity_types_0_2_1"."ontology_id" = "entities_0_1_1"."entity_type_ontology_id"
-             INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_3_1"
-               ON "ontology_id_with_metadata_0_3_1"."ontology_id" = "entity_types_0_2_1"."ontology_id"
-             WHERE "entities_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ AND "entities_0_0_0"."decision_time" && $2
-               AND "entities_0_1_0"."transaction_time" @> $1::TIMESTAMPTZ AND "entities_0_1_0"."decision_time" && $2
-               AND "entities_0_1_1"."transaction_time" @> $1::TIMESTAMPTZ AND "entities_0_1_1"."decision_time" && $2
-               AND ("ontology_id_with_metadata_0_3_0"."base_url" = $3)
-               AND ("ontology_id_with_metadata_0_3_1"."base_url" = $4)
+            SELECT *
+            FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+            LEFT OUTER JOIN "entity_has_left_entity" AS "entity_has_left_entity_0_1_0"
+              ON "entity_has_left_entity_0_1_0"."owned_by_id" = "entity_temporal_metadata_0_0_0"."owned_by_id"
+             AND "entity_has_left_entity_0_1_0"."entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
+            RIGHT OUTER JOIN "entity_temporal_metadata" AS "entity_temporal_metadata_0_2_0"
+              ON "entity_temporal_metadata_0_2_0"."owned_by_id" = "entity_has_left_entity_0_1_0"."left_owned_by_id"
+             AND "entity_temporal_metadata_0_2_0"."entity_uuid" = "entity_has_left_entity_0_1_0"."left_entity_uuid"
+            INNER JOIN "entity_is_of_type" AS "entity_is_of_type_0_3_0"
+              ON "entity_is_of_type_0_3_0"."entity_edition_id" = "entity_temporal_metadata_0_2_0"."entity_edition_id"
+            INNER JOIN "entity_types" AS "entity_types_0_4_0"
+              ON "entity_types_0_4_0"."ontology_id" = "entity_is_of_type_0_3_0"."entity_type_ontology_id"
+            INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_5_0"
+              ON "ontology_id_with_metadata_0_5_0"."ontology_id" = "entity_types_0_4_0"."ontology_id"
+            LEFT OUTER JOIN "entity_has_right_entity" AS "entity_has_right_entity_0_1_0"
+              ON "entity_has_right_entity_0_1_0"."owned_by_id" = "entity_temporal_metadata_0_0_0"."owned_by_id"
+             AND "entity_has_right_entity_0_1_0"."entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
+            RIGHT OUTER JOIN "entity_temporal_metadata" AS "entity_temporal_metadata_0_2_1"
+              ON "entity_temporal_metadata_0_2_1"."owned_by_id" = "entity_has_right_entity_0_1_0"."right_owned_by_id"
+             AND "entity_temporal_metadata_0_2_1"."entity_uuid" = "entity_has_right_entity_0_1_0"."right_entity_uuid"
+            INNER JOIN "entity_is_of_type" AS "entity_is_of_type_0_3_1"
+              ON "entity_is_of_type_0_3_1"."entity_edition_id" = "entity_temporal_metadata_0_2_1"."entity_edition_id"
+            INNER JOIN "entity_types" AS "entity_types_0_4_1"
+              ON "entity_types_0_4_1"."ontology_id" = "entity_is_of_type_0_3_1"."entity_type_ontology_id"
+            INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_5_1"
+              ON "ontology_id_with_metadata_0_5_1"."ontology_id" = "entity_types_0_4_1"."ontology_id"
+            WHERE "entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "entity_temporal_metadata_0_0_0"."decision_time" && $2
+              AND "entity_temporal_metadata_0_2_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "entity_temporal_metadata_0_2_0"."decision_time" && $2
+              AND "entity_temporal_metadata_0_2_1"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "entity_temporal_metadata_0_2_1"."decision_time" && $2
+              AND ("ontology_id_with_metadata_0_5_0"."base_url" = $3)
+              AND ("ontology_id_with_metadata_0_5_1"."base_url" = $4)
             "#,
             &[
                 &pinned_timestamp,
@@ -878,11 +912,11 @@ mod tests {
                 &compiler,
                 r#"
                 SELECT *
-                FROM "entities" AS "entities_0_0_0"
-                WHERE "entities_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
-                  AND "entities_0_0_0"."decision_time" && $2
-                  AND ("entities_0_0_0"."owned_by_id" = $3)
-                  AND ("entities_0_0_0"."entity_uuid" = $4)
+                FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+                WHERE "entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+                  AND "entity_temporal_metadata_0_0_0"."decision_time" && $2
+                  AND ("entity_temporal_metadata_0_0_0"."owned_by_id" = $3)
+                  AND ("entity_temporal_metadata_0_0_0"."entity_uuid" = $4)
                 "#,
                 &[
                     &pinned_timestamp,
@@ -911,11 +945,14 @@ mod tests {
                 &compiler,
                 r#"
                 SELECT *
-                FROM "entities" AS "entities_0_0_0"
-                WHERE "entities_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
-                  AND "entities_0_0_0"."decision_time" && $2
-                  AND ("entities_0_0_0"."right_owned_by_id" = $3)
-                  AND ("entities_0_0_0"."right_entity_uuid" = $4)
+                FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+                LEFT OUTER JOIN "entity_has_right_entity" AS "entity_has_right_entity_0_1_0"
+                  ON "entity_has_right_entity_0_1_0"."owned_by_id" = "entity_temporal_metadata_0_0_0"."owned_by_id"
+                 AND "entity_has_right_entity_0_1_0"."entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
+                WHERE "entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+                  AND "entity_temporal_metadata_0_0_0"."decision_time" && $2
+                  AND ("entity_has_right_entity_0_1_0"."right_owned_by_id" = $3)
+                  AND ("entity_has_right_entity_0_1_0"."right_entity_uuid" = $4)
                 "#,
                 &[
                     &pinned_timestamp,
@@ -944,11 +981,14 @@ mod tests {
                 &compiler,
                 r#"
                 SELECT *
-                FROM "entities" AS "entities_0_0_0"
-                WHERE "entities_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
-                  AND "entities_0_0_0"."decision_time" && $2
-                  AND ("entities_0_0_0"."left_owned_by_id" = $3)
-                  AND ("entities_0_0_0"."left_entity_uuid" = $4)
+                FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+                LEFT OUTER JOIN "entity_has_left_entity" AS "entity_has_left_entity_0_1_0"
+                  ON "entity_has_left_entity_0_1_0"."owned_by_id" = "entity_temporal_metadata_0_0_0"."owned_by_id"
+                 AND "entity_has_left_entity_0_1_0"."entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
+                WHERE "entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+                  AND "entity_temporal_metadata_0_0_0"."decision_time" && $2
+                  AND ("entity_has_left_entity_0_1_0"."left_owned_by_id" = $3)
+                  AND ("entity_has_left_entity_0_1_0"."left_entity_uuid" = $4)
                 "#,
                 &[
                     &pinned_timestamp,
@@ -977,16 +1017,19 @@ mod tests {
                 &compiler,
                 r#"
                 SELECT *
-                FROM "entities" AS "entities_0_0_0"
-                LEFT OUTER JOIN "entities" AS "entities_0_1_0"
-                  ON "entities_0_1_0"."left_owned_by_id" = "entities_0_0_0"."owned_by_id"
-                 AND "entities_0_1_0"."left_entity_uuid" = "entities_0_0_0"."entity_uuid"
-                WHERE "entities_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
-                  AND "entities_0_0_0"."decision_time" && $2
-                  AND "entities_0_1_0"."transaction_time" @> $1::TIMESTAMPTZ
-                  AND "entities_0_1_0"."decision_time" && $2
-                  AND ("entities_0_1_0"."owned_by_id" = $3)
-                  AND ("entities_0_1_0"."entity_uuid" = $4)
+                FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+                LEFT OUTER JOIN "entity_has_left_entity" AS "entity_has_left_entity_0_1_0"
+                  ON "entity_has_left_entity_0_1_0"."left_owned_by_id" = "entity_temporal_metadata_0_0_0"."owned_by_id"
+                 AND "entity_has_left_entity_0_1_0"."left_entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
+                RIGHT OUTER JOIN "entity_temporal_metadata" AS "entity_temporal_metadata_0_2_0"
+                  ON "entity_temporal_metadata_0_2_0"."owned_by_id" = "entity_has_left_entity_0_1_0"."owned_by_id"
+                 AND "entity_temporal_metadata_0_2_0"."entity_uuid" = "entity_has_left_entity_0_1_0"."entity_uuid"
+                WHERE "entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+                  AND "entity_temporal_metadata_0_0_0"."decision_time" && $2
+                  AND "entity_temporal_metadata_0_2_0"."transaction_time" @> $1::TIMESTAMPTZ
+                  AND "entity_temporal_metadata_0_2_0"."decision_time" && $2
+                  AND ("entity_temporal_metadata_0_2_0"."owned_by_id" = $3)
+                  AND ("entity_temporal_metadata_0_2_0"."entity_uuid" = $4)
                 "#,
                 &[
                     &pinned_timestamp,
@@ -1015,16 +1058,19 @@ mod tests {
                 &compiler,
                 r#"
                 SELECT *
-                FROM "entities" AS "entities_0_0_0"
-                LEFT OUTER JOIN "entities" AS "entities_0_1_0"
-                  ON "entities_0_1_0"."right_owned_by_id" = "entities_0_0_0"."owned_by_id"
-                 AND "entities_0_1_0"."right_entity_uuid" = "entities_0_0_0"."entity_uuid"
-                WHERE "entities_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
-                  AND "entities_0_0_0"."decision_time" && $2
-                  AND "entities_0_1_0"."transaction_time" @> $1::TIMESTAMPTZ
-                  AND "entities_0_1_0"."decision_time" && $2
-                  AND ("entities_0_1_0"."owned_by_id" = $3)
-                  AND ("entities_0_1_0"."entity_uuid" = $4)
+                FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+                LEFT OUTER JOIN "entity_has_right_entity" AS "entity_has_right_entity_0_1_0"
+                  ON "entity_has_right_entity_0_1_0"."right_owned_by_id" = "entity_temporal_metadata_0_0_0"."owned_by_id"
+                 AND "entity_has_right_entity_0_1_0"."right_entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
+                RIGHT OUTER JOIN "entity_temporal_metadata" AS "entity_temporal_metadata_0_2_0"
+                  ON "entity_temporal_metadata_0_2_0"."owned_by_id" = "entity_has_right_entity_0_1_0"."owned_by_id"
+                 AND "entity_temporal_metadata_0_2_0"."entity_uuid" = "entity_has_right_entity_0_1_0"."entity_uuid"
+                WHERE "entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+                  AND "entity_temporal_metadata_0_0_0"."decision_time" && $2
+                  AND "entity_temporal_metadata_0_2_0"."transaction_time" @> $1::TIMESTAMPTZ
+                  AND "entity_temporal_metadata_0_2_0"."decision_time" && $2
+                  AND ("entity_temporal_metadata_0_2_0"."owned_by_id" = $3)
+                  AND ("entity_temporal_metadata_0_2_0"."entity_uuid" = $4)
                 "#,
                 &[
                     &pinned_timestamp,

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
@@ -79,24 +79,24 @@ impl ReferenceTable {
                 join: Column::EntityIsOfType(EntityIsOfType::EntityEditionId),
             },
             Self::EntityHasLeftEntity => ForeignKeyReference::Double {
-                on: (
+                on: [
                     Column::Entities(Entities::OwnedById),
                     Column::Entities(Entities::EntityUuid),
-                ),
-                join: (
+                ],
+                join: [
                     Column::EntityHasLeftEntity(EntityHasLeftEntity::OwnedById),
                     Column::EntityHasLeftEntity(EntityHasLeftEntity::EntityUuid),
-                ),
+                ],
             },
             Self::EntityHasRightEntity => ForeignKeyReference::Double {
-                on: (
+                on: [
                     Column::Entities(Entities::OwnedById),
                     Column::Entities(Entities::EntityUuid),
-                ),
-                join: (
+                ],
+                join: [
                     Column::EntityHasRightEntity(EntityHasRightEntity::OwnedById),
                     Column::EntityHasRightEntity(EntityHasRightEntity::EntityUuid),
-                ),
+                ],
             },
         }
     }
@@ -144,24 +144,24 @@ impl ReferenceTable {
                 join: Column::EntityTypes(EntityTypes::OntologyId),
             },
             Self::EntityHasLeftEntity => ForeignKeyReference::Double {
-                on: (
+                on: [
                     Column::EntityHasLeftEntity(EntityHasLeftEntity::LeftEntityOwnedById),
                     Column::EntityHasLeftEntity(EntityHasLeftEntity::LeftEntityUuid),
-                ),
-                join: (
+                ],
+                join: [
                     Column::Entities(Entities::OwnedById),
                     Column::Entities(Entities::EntityUuid),
-                ),
+                ],
             },
             Self::EntityHasRightEntity => ForeignKeyReference::Double {
-                on: (
+                on: [
                     Column::EntityHasRightEntity(EntityHasRightEntity::RightEntityOwnedById),
                     Column::EntityHasRightEntity(EntityHasRightEntity::RightEntityUuid),
-                ),
-                join: (
+                ],
+                join: [
                     Column::Entities(Entities::OwnedById),
                     Column::Entities(Entities::EntityUuid),
-                ),
+                ],
             },
         }
     }
@@ -765,10 +765,7 @@ impl ForeignKeyReference {
     pub const fn reverse(self) -> Self {
         match self {
             Self::Single { on, join } => Self::Single { on: join, join: on },
-            Self::Double { on, join } => Self::Double {
-                on: (join.0, join.1),
-                join: (on.0, on.1),
-            },
+            Self::Double { on, join } => Self::Double { on: join, join: on },
         }
     }
 }
@@ -826,7 +823,7 @@ impl Relation {
                 join: Column::EntityEditions(EntityEditions::EditionId),
             }),
             Self::LeftEntity => ForeignKeyJoin::from_reference(ForeignKeyReference::Double {
-                on: (
+                on: [
                     Column::Entities(Entities::OwnedById),
                     Column::Entities(Entities::EntityUuid),
                 ],

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
@@ -18,43 +18,84 @@ pub enum Table {
     PropertyTypes,
     EntityTypes,
     Entities,
+    EntityEditions,
     ReferenceTable(ReferenceTable),
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum ReferenceTable {
-    PropertyTypeDataTypeReferences,
-    PropertyTypePropertyTypeReferences,
-    EntityTypePropertyTypeReferences,
-    EntityTypeLinks,
-    EntityTypeInheritance,
+    PropertyTypeConstrainsValuesOn,
+    PropertyTypeConstrainsPropertiesOn,
+    EntityTypeConstrainsPropertiesOn,
+    EntityTypeInheritsFrom,
+    EntityTypeConstrainsLinksOn,
+    EntityTypeConstrainsLinkDestinationsOn,
+    EntityIsOfType,
+    EntityHasLeftEntity,
+    EntityHasRightEntity,
 }
 
 impl ReferenceTable {
     pub const fn source_relation(self) -> ForeignKeyReference {
         match self {
-            Self::PropertyTypeDataTypeReferences => ForeignKeyReference::Single {
+            Self::PropertyTypeConstrainsValuesOn => ForeignKeyReference::Single {
                 on: Column::PropertyTypes(PropertyTypes::OntologyId),
-                join: Column::PropertyTypeDataTypeReferences(
-                    PropertyTypeDataTypeReferences::SourcePropertyTypeOntologyId,
+                join: Column::PropertyTypeConstrainsValuesOn(
+                    PropertyTypeConstrainsValuesOn::SourcePropertyTypeOntologyId,
                 ),
             },
-            Self::PropertyTypePropertyTypeReferences => ForeignKeyReference::Single {
+            Self::PropertyTypeConstrainsPropertiesOn => ForeignKeyReference::Single {
                 on: Column::PropertyTypes(PropertyTypes::OntologyId),
-                join: Column::PropertyTypePropertyTypeReferences(
-                    PropertyTypePropertyTypeReferences::SourcePropertyTypeOntologyId,
+                join: Column::PropertyTypeConstrainsPropertiesOn(
+                    PropertyTypeConstrainsPropertiesOn::SourcePropertyTypeOntologyId,
                 ),
             },
-            Self::EntityTypePropertyTypeReferences => ForeignKeyReference::Single {
+            Self::EntityTypeConstrainsPropertiesOn => ForeignKeyReference::Single {
                 on: Column::EntityTypes(EntityTypes::OntologyId),
-                join: Column::EntityTypePropertyTypeReferences(
-                    EntityTypePropertyTypeReferences::SourceEntityTypeOntologyId,
+                join: Column::EntityTypeConstrainsPropertiesOn(
+                    EntityTypeConstrainsPropertiesOn::SourceEntityTypeOntologyId,
                 ),
             },
-            Self::EntityTypeLinks | Self::EntityTypeInheritance => ForeignKeyReference::Single {
+            Self::EntityTypeInheritsFrom => ForeignKeyReference::Single {
                 on: Column::EntityTypes(EntityTypes::OntologyId),
-                join: Column::EntityTypeEntityTypeReferences(
-                    EntityTypeEntityTypeReferences::SourceEntityTypeOntologyId,
+                join: Column::EntityTypeInheritsFrom(
+                    EntityTypeInheritsFrom::SourceEntityTypeOntologyId,
+                ),
+            },
+            Self::EntityTypeConstrainsLinksOn => ForeignKeyReference::Single {
+                on: Column::EntityTypes(EntityTypes::OntologyId),
+                join: Column::EntityTypeConstrainsLinksOn(
+                    EntityTypeConstrainsLinksOn::SourceEntityTypeOntologyId,
+                ),
+            },
+            Self::EntityTypeConstrainsLinkDestinationsOn => ForeignKeyReference::Single {
+                on: Column::EntityTypes(EntityTypes::OntologyId),
+                join: Column::EntityTypeConstrainsLinkDestinationsOn(
+                    EntityTypeConstrainsLinkDestinationsOn::SourceEntityTypeOntologyId,
+                ),
+            },
+            Self::EntityIsOfType => ForeignKeyReference::Single {
+                on: Column::Entities(Entities::EditionId),
+                join: Column::EntityIsOfType(EntityIsOfType::EntityEditionId),
+            },
+            Self::EntityHasLeftEntity => ForeignKeyReference::Double {
+                on: (
+                    Column::Entities(Entities::OwnedById),
+                    Column::Entities(Entities::EntityUuid),
+                ),
+                join: (
+                    Column::EntityHasLeftEntity(EntityHasLeftEntity::OwnedById),
+                    Column::EntityHasLeftEntity(EntityHasLeftEntity::EntityUuid),
+                ),
+            },
+            Self::EntityHasRightEntity => ForeignKeyReference::Double {
+                on: (
+                    Column::Entities(Entities::OwnedById),
+                    Column::Entities(Entities::EntityUuid),
+                ),
+                join: (
+                    Column::EntityHasRightEntity(EntityHasRightEntity::OwnedById),
+                    Column::EntityHasRightEntity(EntityHasRightEntity::EntityUuid),
                 ),
             },
         }
@@ -62,29 +103,65 @@ impl ReferenceTable {
 
     pub const fn target_relation(self) -> ForeignKeyReference {
         match self {
-            Self::PropertyTypeDataTypeReferences => ForeignKeyReference::Single {
-                on: Column::PropertyTypeDataTypeReferences(
-                    PropertyTypeDataTypeReferences::TargetDataTypeOntologyId,
+            Self::PropertyTypeConstrainsValuesOn => ForeignKeyReference::Single {
+                on: Column::PropertyTypeConstrainsValuesOn(
+                    PropertyTypeConstrainsValuesOn::TargetDataTypeOntologyId,
                 ),
                 join: Column::DataTypes(DataTypes::OntologyId),
             },
-            Self::PropertyTypePropertyTypeReferences => ForeignKeyReference::Single {
-                on: Column::PropertyTypePropertyTypeReferences(
-                    PropertyTypePropertyTypeReferences::TargetPropertyTypeOntologyId,
+            Self::PropertyTypeConstrainsPropertiesOn => ForeignKeyReference::Single {
+                on: Column::PropertyTypeConstrainsPropertiesOn(
+                    PropertyTypeConstrainsPropertiesOn::TargetPropertyTypeOntologyId,
                 ),
                 join: Column::PropertyTypes(PropertyTypes::OntologyId),
             },
-            Self::EntityTypePropertyTypeReferences => ForeignKeyReference::Single {
-                on: Column::EntityTypePropertyTypeReferences(
-                    EntityTypePropertyTypeReferences::TargetPropertyTypeOntologyId,
+            Self::EntityTypeConstrainsPropertiesOn => ForeignKeyReference::Single {
+                on: Column::EntityTypeConstrainsPropertiesOn(
+                    EntityTypeConstrainsPropertiesOn::TargetPropertyTypeOntologyId,
                 ),
                 join: Column::PropertyTypes(PropertyTypes::OntologyId),
             },
-            Self::EntityTypeLinks | Self::EntityTypeInheritance => ForeignKeyReference::Single {
-                on: Column::EntityTypeEntityTypeReferences(
-                    EntityTypeEntityTypeReferences::TargetEntityTypeOntologyId,
+            Self::EntityTypeInheritsFrom => ForeignKeyReference::Single {
+                on: Column::EntityTypeInheritsFrom(
+                    EntityTypeInheritsFrom::TargetEntityTypeOntologyId,
                 ),
                 join: Column::EntityTypes(EntityTypes::OntologyId),
+            },
+            Self::EntityTypeConstrainsLinksOn => ForeignKeyReference::Single {
+                on: Column::EntityTypeConstrainsLinksOn(
+                    EntityTypeConstrainsLinksOn::TargetEntityTypeOntologyId,
+                ),
+                join: Column::EntityTypes(EntityTypes::OntologyId),
+            },
+            Self::EntityTypeConstrainsLinkDestinationsOn => ForeignKeyReference::Single {
+                on: Column::EntityTypeConstrainsLinkDestinationsOn(
+                    EntityTypeConstrainsLinkDestinationsOn::TargetEntityTypeOntologyId,
+                ),
+                join: Column::EntityTypes(EntityTypes::OntologyId),
+            },
+            Self::EntityIsOfType => ForeignKeyReference::Single {
+                on: Column::EntityIsOfType(EntityIsOfType::EntityTypeOntologyId),
+                join: Column::EntityTypes(EntityTypes::OntologyId),
+            },
+            Self::EntityHasLeftEntity => ForeignKeyReference::Double {
+                on: (
+                    Column::EntityHasLeftEntity(EntityHasLeftEntity::LeftEntityOwnedById),
+                    Column::EntityHasLeftEntity(EntityHasLeftEntity::LeftEntityUuid),
+                ),
+                join: (
+                    Column::Entities(Entities::OwnedById),
+                    Column::Entities(Entities::EntityUuid),
+                ),
+            },
+            Self::EntityHasRightEntity => ForeignKeyReference::Double {
+                on: (
+                    Column::EntityHasRightEntity(EntityHasRightEntity::RightEntityOwnedById),
+                    Column::EntityHasRightEntity(EntityHasRightEntity::RightEntityUuid),
+                ),
+                join: (
+                    Column::Entities(Entities::OwnedById),
+                    Column::Entities(Entities::EntityUuid),
+                ),
             },
         }
     }
@@ -93,12 +170,17 @@ impl ReferenceTable {
 impl ReferenceTable {
     const fn as_str(self) -> &'static str {
         match self {
-            Self::PropertyTypeDataTypeReferences => "property_type_data_type_references",
-            Self::PropertyTypePropertyTypeReferences => "property_type_property_type_references",
-            Self::EntityTypePropertyTypeReferences => "entity_type_property_type_references",
-            Self::EntityTypeLinks | Self::EntityTypeInheritance => {
-                "entity_type_entity_type_references"
+            Self::PropertyTypeConstrainsValuesOn => "property_type_constrains_values_on",
+            Self::PropertyTypeConstrainsPropertiesOn => "property_type_constrains_properties_on",
+            Self::EntityTypeConstrainsPropertiesOn => "entity_type_constrains_properties_on",
+            Self::EntityTypeInheritsFrom => "entity_type_inherits_from",
+            Self::EntityTypeConstrainsLinksOn => "entity_type_constrains_links_on",
+            Self::EntityTypeConstrainsLinkDestinationsOn => {
+                "entity_type_constrains_link_destinations_on"
             }
+            Self::EntityIsOfType => "entity_is_of_type",
+            Self::EntityHasLeftEntity => "entity_has_left_entity",
+            Self::EntityHasRightEntity => "entity_has_right_entity",
         }
     }
 }
@@ -114,7 +196,8 @@ impl Table {
             Self::DataTypes => "data_types",
             Self::PropertyTypes => "property_types",
             Self::EntityTypes => "entity_types",
-            Self::Entities => "entities",
+            Self::Entities => "entity_temporal_metadata",
+            Self::EntityEditions => "entity_editions",
             Self::ReferenceTable(table) => table.as_str(),
         }
     }
@@ -254,45 +337,15 @@ impl_ontology_column!(PropertyTypes);
 impl_ontology_column!(EntityTypes);
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum Entities<'p> {
+pub enum Entities {
+    OwnedById,
     EntityUuid,
     EditionId,
     DecisionTime,
     TransactionTime,
-    Archived,
-    OwnedById,
-    UpdatedById,
-    EntityTypeOntologyId,
-    Properties(Option<JsonField<'p>>),
-    LeftToRightOrder,
-    RightToLeftOrder,
-    LeftEntityUuid,
-    RightEntityUuid,
-    LeftEntityOwnedById,
-    RightEntityOwnedById,
 }
 
-impl Entities<'_> {
-    pub const fn nullable(self) -> bool {
-        match self {
-            Self::EntityUuid
-            | Self::EditionId
-            | Self::DecisionTime
-            | Self::TransactionTime
-            | Self::Archived
-            | Self::OwnedById
-            | Self::UpdatedById
-            | Self::EntityTypeOntologyId => false,
-            Self::Properties(_)
-            | Self::LeftEntityUuid
-            | Self::RightEntityUuid
-            | Self::LeftEntityOwnedById
-            | Self::RightEntityOwnedById
-            | Self::LeftToRightOrder
-            | Self::RightToLeftOrder => true,
-        }
-    }
-
+impl Entities {
     pub const fn from_time_axis(time_axis: TimeAxis) -> Self {
         match time_axis {
             TimeAxis::DecisionTime => Self::DecisionTime,
@@ -301,27 +354,14 @@ impl Entities<'_> {
     }
 }
 
-impl Entities<'_> {
-    fn transpile_column(&self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
+impl Entities {
+    fn transpile_column(self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
         let column = match self {
+            Self::OwnedById => "owned_by_id",
             Self::EntityUuid => "entity_uuid",
             Self::EditionId => "entity_edition_id",
             Self::DecisionTime => "decision_time",
             Self::TransactionTime => "transaction_time",
-            Self::Archived => "archived",
-            Self::OwnedById => "owned_by_id",
-            Self::UpdatedById => "record_created_by_id",
-            Self::EntityTypeOntologyId => "entity_type_ontology_id",
-            Self::Properties(None) => "properties",
-            Self::Properties(Some(path)) => {
-                return transpile_json_field(path, "properties", table, fmt);
-            }
-            Self::LeftToRightOrder => "left_to_right_order",
-            Self::RightToLeftOrder => "right_to_left_order",
-            Self::LeftEntityUuid => "left_entity_uuid",
-            Self::RightEntityUuid => "right_entity_uuid",
-            Self::LeftEntityOwnedById => "left_owned_by_id",
-            Self::RightEntityOwnedById => "right_owned_by_id",
         };
         table.transpile(fmt)?;
         write!(fmt, r#"."{column}""#)
@@ -329,12 +369,108 @@ impl Entities<'_> {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum PropertyTypeDataTypeReferences {
+pub enum EntityEditions<'p> {
+    EditionId,
+    Properties(Option<JsonField<'p>>),
+    LeftToRightOrder,
+    RightToLeftOrder,
+    UpdatedById,
+    Archived,
+}
+
+impl EntityEditions<'_> {
+    pub const fn nullable(self) -> bool {
+        match self {
+            Self::EditionId | Self::Archived | Self::UpdatedById => false,
+            Self::Properties(_) | Self::LeftToRightOrder | Self::RightToLeftOrder => true,
+        }
+    }
+}
+
+impl EntityEditions<'_> {
+    fn transpile_column(&self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let column = match self {
+            Self::EditionId => "entity_edition_id",
+            Self::Properties(None) => "properties",
+            Self::Properties(Some(path)) => {
+                return transpile_json_field(path, "properties", table, fmt);
+            }
+            Self::LeftToRightOrder => "left_to_right_order",
+            Self::RightToLeftOrder => "right_to_left_order",
+            Self::UpdatedById => "record_created_by_id",
+            Self::Archived => "archived",
+        };
+        table.transpile(fmt)?;
+        write!(fmt, r#"."{column}""#)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum EntityIsOfType {
+    EntityEditionId,
+    EntityTypeOntologyId,
+}
+
+impl EntityIsOfType {
+    fn transpile_column(self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let column = match self {
+            Self::EntityEditionId => "entity_edition_id",
+            Self::EntityTypeOntologyId => "entity_type_ontology_id",
+        };
+        table.transpile(fmt)?;
+        write!(fmt, r#"."{column}""#)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum EntityHasLeftEntity {
+    OwnedById,
+    EntityUuid,
+    LeftEntityOwnedById,
+    LeftEntityUuid,
+}
+
+impl EntityHasLeftEntity {
+    fn transpile_column(self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let column = match self {
+            Self::OwnedById => "owned_by_id",
+            Self::EntityUuid => "entity_uuid",
+            Self::LeftEntityOwnedById => "left_owned_by_id",
+            Self::LeftEntityUuid => "left_entity_uuid",
+        };
+        table.transpile(fmt)?;
+        write!(fmt, r#"."{column}""#)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum EntityHasRightEntity {
+    OwnedById,
+    EntityUuid,
+    RightEntityOwnedById,
+    RightEntityUuid,
+}
+
+impl EntityHasRightEntity {
+    fn transpile_column(self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let column = match self {
+            Self::OwnedById => "owned_by_id",
+            Self::EntityUuid => "entity_uuid",
+            Self::RightEntityOwnedById => "right_owned_by_id",
+            Self::RightEntityUuid => "right_entity_uuid",
+        };
+        table.transpile(fmt)?;
+        write!(fmt, r#"."{column}""#)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum PropertyTypeConstrainsValuesOn {
     SourcePropertyTypeOntologyId,
     TargetDataTypeOntologyId,
 }
 
-impl PropertyTypeDataTypeReferences {
+impl PropertyTypeConstrainsValuesOn {
     fn transpile_column(self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
         table.transpile(fmt)?;
         write!(fmt, r#"."{}""#, match self {
@@ -345,12 +481,12 @@ impl PropertyTypeDataTypeReferences {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum PropertyTypePropertyTypeReferences {
+pub enum PropertyTypeConstrainsPropertiesOn {
     SourcePropertyTypeOntologyId,
     TargetPropertyTypeOntologyId,
 }
 
-impl PropertyTypePropertyTypeReferences {
+impl PropertyTypeConstrainsPropertiesOn {
     fn transpile_column(self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
         table.transpile(fmt)?;
         write!(fmt, r#"."{}""#, match self {
@@ -361,12 +497,12 @@ impl PropertyTypePropertyTypeReferences {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum EntityTypePropertyTypeReferences {
+pub enum EntityTypeConstrainsPropertiesOn {
     SourceEntityTypeOntologyId,
     TargetPropertyTypeOntologyId,
 }
 
-impl EntityTypePropertyTypeReferences {
+impl EntityTypeConstrainsPropertiesOn {
     fn transpile_column(self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
         table.transpile(fmt)?;
         write!(fmt, r#"."{}""#, match self {
@@ -377,12 +513,44 @@ impl EntityTypePropertyTypeReferences {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum EntityTypeEntityTypeReferences {
+pub enum EntityTypeInheritsFrom {
     SourceEntityTypeOntologyId,
     TargetEntityTypeOntologyId,
 }
 
-impl EntityTypeEntityTypeReferences {
+impl EntityTypeInheritsFrom {
+    fn transpile_column(self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
+        table.transpile(fmt)?;
+        write!(fmt, r#"."{}""#, match self {
+            Self::SourceEntityTypeOntologyId => "source_entity_type_ontology_id",
+            Self::TargetEntityTypeOntologyId => "target_entity_type_ontology_id",
+        })
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum EntityTypeConstrainsLinksOn {
+    SourceEntityTypeOntologyId,
+    TargetEntityTypeOntologyId,
+}
+
+impl EntityTypeConstrainsLinksOn {
+    fn transpile_column(self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
+        table.transpile(fmt)?;
+        write!(fmt, r#"."{}""#, match self {
+            Self::SourceEntityTypeOntologyId => "source_entity_type_ontology_id",
+            Self::TargetEntityTypeOntologyId => "target_entity_type_ontology_id",
+        })
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum EntityTypeConstrainsLinkDestinationsOn {
+    SourceEntityTypeOntologyId,
+    TargetEntityTypeOntologyId,
+}
+
+impl EntityTypeConstrainsLinkDestinationsOn {
     fn transpile_column(self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
         table.transpile(fmt)?;
         write!(fmt, r#"."{}""#, match self {
@@ -398,11 +566,17 @@ pub enum Column<'p> {
     DataTypes(DataTypes<'p>),
     PropertyTypes(PropertyTypes<'p>),
     EntityTypes(EntityTypes<'p>),
-    Entities(Entities<'p>),
-    PropertyTypeDataTypeReferences(PropertyTypeDataTypeReferences),
-    PropertyTypePropertyTypeReferences(PropertyTypePropertyTypeReferences),
-    EntityTypePropertyTypeReferences(EntityTypePropertyTypeReferences),
-    EntityTypeEntityTypeReferences(EntityTypeEntityTypeReferences),
+    Entities(Entities),
+    EntityEditions(EntityEditions<'p>),
+    PropertyTypeConstrainsValuesOn(PropertyTypeConstrainsValuesOn),
+    PropertyTypeConstrainsPropertiesOn(PropertyTypeConstrainsPropertiesOn),
+    EntityTypeConstrainsPropertiesOn(EntityTypeConstrainsPropertiesOn),
+    EntityTypeInheritsFrom(EntityTypeInheritsFrom),
+    EntityTypeConstrainsLinksOn(EntityTypeConstrainsLinksOn),
+    EntityTypeConstrainsLinkDestinationsOn(EntityTypeConstrainsLinkDestinationsOn),
+    EntityIsOfType(EntityIsOfType),
+    EntityHasLeftEntity(EntityHasLeftEntity),
+    EntityHasRightEntity(EntityHasRightEntity),
 }
 
 impl<'p> Column<'p> {
@@ -413,17 +587,31 @@ impl<'p> Column<'p> {
             Self::PropertyTypes(_) => Table::PropertyTypes,
             Self::EntityTypes(_) => Table::EntityTypes,
             Self::Entities(_) => Table::Entities,
-            Self::PropertyTypeDataTypeReferences(_) => {
-                Table::ReferenceTable(ReferenceTable::PropertyTypeDataTypeReferences)
+            Self::EntityEditions(_) => Table::EntityEditions,
+            Self::PropertyTypeConstrainsValuesOn(_) => {
+                Table::ReferenceTable(ReferenceTable::PropertyTypeConstrainsValuesOn)
             }
-            Self::PropertyTypePropertyTypeReferences(_) => {
-                Table::ReferenceTable(ReferenceTable::PropertyTypePropertyTypeReferences)
+            Self::PropertyTypeConstrainsPropertiesOn(_) => {
+                Table::ReferenceTable(ReferenceTable::PropertyTypeConstrainsPropertiesOn)
             }
-            Self::EntityTypePropertyTypeReferences(_) => {
-                Table::ReferenceTable(ReferenceTable::EntityTypePropertyTypeReferences)
+            Self::EntityTypeConstrainsPropertiesOn(_) => {
+                Table::ReferenceTable(ReferenceTable::EntityTypeConstrainsPropertiesOn)
             }
-            Self::EntityTypeEntityTypeReferences(_) => {
-                Table::ReferenceTable(ReferenceTable::EntityTypeInheritance)
+            Self::EntityTypeInheritsFrom(_) => {
+                Table::ReferenceTable(ReferenceTable::EntityTypeInheritsFrom)
+            }
+            Self::EntityTypeConstrainsLinksOn(_) => {
+                Table::ReferenceTable(ReferenceTable::EntityTypeConstrainsLinksOn)
+            }
+            Self::EntityTypeConstrainsLinkDestinationsOn(_) => {
+                Table::ReferenceTable(ReferenceTable::EntityTypeConstrainsLinkDestinationsOn)
+            }
+            Self::EntityIsOfType(_) => Table::ReferenceTable(ReferenceTable::EntityIsOfType),
+            Self::EntityHasLeftEntity(_) => {
+                Table::ReferenceTable(ReferenceTable::EntityHasLeftEntity)
+            }
+            Self::EntityHasRightEntity(_) => {
+                Table::ReferenceTable(ReferenceTable::EntityHasRightEntity)
             }
         }
     }
@@ -433,7 +621,8 @@ impl<'p> Column<'p> {
             Self::DataTypes(column) => column.nullable(),
             Self::PropertyTypes(column) => column.nullable(),
             Self::EntityTypes(column) => column.nullable(),
-            Self::Entities(column) => column.nullable(),
+            Self::EntityEditions(column) => column.nullable(),
+            Self::EntityHasLeftEntity(_) | Self::EntityHasRightEntity(_) => true,
             _ => false,
         }
     }
@@ -452,10 +641,18 @@ impl<'p> Column<'p> {
             Self::PropertyTypes(column) => column.transpile_column(table, fmt),
             Self::EntityTypes(column) => column.transpile_column(table, fmt),
             Self::Entities(column) => column.transpile_column(table, fmt),
-            Self::PropertyTypeDataTypeReferences(column) => column.transpile_column(table, fmt),
-            Self::PropertyTypePropertyTypeReferences(column) => column.transpile_column(table, fmt),
-            Self::EntityTypePropertyTypeReferences(column) => column.transpile_column(table, fmt),
-            Self::EntityTypeEntityTypeReferences(column) => column.transpile_column(table, fmt),
+            Self::EntityEditions(column) => column.transpile_column(table, fmt),
+            Self::PropertyTypeConstrainsValuesOn(column) => column.transpile_column(table, fmt),
+            Self::PropertyTypeConstrainsPropertiesOn(column) => column.transpile_column(table, fmt),
+            Self::EntityTypeConstrainsPropertiesOn(column) => column.transpile_column(table, fmt),
+            Self::EntityTypeInheritsFrom(column) => column.transpile_column(table, fmt),
+            Self::EntityTypeConstrainsLinksOn(column) => column.transpile_column(table, fmt),
+            Self::EntityTypeConstrainsLinkDestinationsOn(column) => {
+                column.transpile_column(table, fmt)
+            }
+            Self::EntityIsOfType(column) => column.transpile_column(table, fmt),
+            Self::EntityHasLeftEntity(column) => column.transpile_column(table, fmt),
+            Self::EntityHasRightEntity(column) => column.transpile_column(table, fmt),
         }
     }
 }
@@ -545,12 +742,11 @@ pub enum Relation {
     DataTypeIds,
     PropertyTypeIds,
     EntityTypeIds,
-    EntityType,
-    LeftEndpoint,
-    RightEndpoint,
-    OutgoingLink,
-    IncomingLink,
+    EntityEditions,
+    LeftEntity,
+    RightEntity,
     Reference(ReferenceTable),
+    ReversedReference(ReferenceTable),
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -565,20 +761,38 @@ pub enum ForeignKeyReference {
     },
 }
 
-enum ForeignKeyJoin {
-    Plain(Once<ForeignKeyReference>),
-    Reference(Chain<Once<ForeignKeyReference>, Once<ForeignKeyReference>>),
-}
-
-impl From<ForeignKeyReference> for ForeignKeyJoin {
-    fn from(reference: ForeignKeyReference) -> Self {
-        Self::Plain(once(reference))
+impl ForeignKeyReference {
+    pub const fn reverse(self) -> Self {
+        match self {
+            Self::Single { on, join } => Self::Single { on: join, join: on },
+            Self::Double { on, join } => Self::Double {
+                on: (join.0, join.1),
+                join: (on.0, on.1),
+            },
+        }
     }
 }
 
-impl From<ReferenceTable> for ForeignKeyJoin {
-    fn from(table: ReferenceTable) -> Self {
-        Self::Reference(once(table.source_relation()).chain(once(table.target_relation())))
+enum ForeignKeyJoin {
+    Plain(Once<ForeignKeyReference>),
+    Reference(Chain<Once<ForeignKeyReference>, Once<ForeignKeyReference>>),
+    ReversedReference(Chain<Once<ForeignKeyReference>, Once<ForeignKeyReference>>),
+}
+
+impl ForeignKeyJoin {
+    fn from_reference(reference: ForeignKeyReference) -> Self {
+        Self::Plain(once(reference))
+    }
+
+    fn from_reference_table(table: ReferenceTable, reversed: bool) -> Self {
+        if reversed {
+            Self::ReversedReference(
+                once(table.target_relation().reverse())
+                    .chain(once(table.source_relation().reverse())),
+            )
+        } else {
+            Self::Reference(once(table.source_relation()).chain(once(table.target_relation())))
+        }
     }
 }
 
@@ -588,7 +802,7 @@ impl Iterator for ForeignKeyJoin {
     fn next(&mut self) -> Option<Self::Item> {
         match self {
             Self::Plain(value) => value.next(),
-            Self::Reference(values) => values.next(),
+            Self::Reference(values) | Self::ReversedReference(values) => values.next(),
         }
     }
 }
@@ -596,63 +810,44 @@ impl Iterator for ForeignKeyJoin {
 impl Relation {
     pub fn joins(self) -> impl Iterator<Item = ForeignKeyReference> {
         match self {
-            Self::DataTypeIds => ForeignKeyJoin::from(ForeignKeyReference::Single {
+            Self::DataTypeIds => ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
                 on: Column::DataTypes(DataTypes::OntologyId),
                 join: Column::OntologyIds(OntologyIds::OntologyId),
             }),
-            Self::PropertyTypeIds => ForeignKeyJoin::from(ForeignKeyReference::Single {
+            Self::PropertyTypeIds => ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
                 on: Column::PropertyTypes(PropertyTypes::OntologyId),
                 join: Column::OntologyIds(OntologyIds::OntologyId),
             }),
-            Self::EntityTypeIds => ForeignKeyJoin::from(ForeignKeyReference::Single {
+            Self::EntityTypeIds => ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
                 on: Column::EntityTypes(EntityTypes::OntologyId),
                 join: Column::OntologyIds(OntologyIds::OntologyId),
             }),
-            Self::EntityType => ForeignKeyJoin::from(ForeignKeyReference::Single {
-                on: Column::Entities(Entities::EntityTypeOntologyId),
-                join: Column::EntityTypes(EntityTypes::OntologyId),
+            Self::EntityEditions => ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
+                on: Column::Entities(Entities::EditionId),
+                join: Column::EntityEditions(EntityEditions::EditionId),
             }),
-            Self::LeftEndpoint => ForeignKeyJoin::from(ForeignKeyReference::Double {
-                on: [
-                    Column::Entities(Entities::LeftEntityOwnedById),
-                    Column::Entities(Entities::LeftEntityUuid),
-                ],
-                join: [
+            Self::LeftEntity => ForeignKeyJoin::from_reference(ForeignKeyReference::Double {
+                on: (
                     Column::Entities(Entities::OwnedById),
                     Column::Entities(Entities::EntityUuid),
                 ],
-            }),
-            Self::RightEndpoint => ForeignKeyJoin::from(ForeignKeyReference::Double {
-                on: [
-                    Column::Entities(Entities::RightEntityOwnedById),
-                    Column::Entities(Entities::RightEntityUuid),
-                ],
                 join: [
-                    Column::Entities(Entities::OwnedById),
-                    Column::Entities(Entities::EntityUuid),
+                    Column::EntityHasLeftEntity(EntityHasLeftEntity::OwnedById),
+                    Column::EntityHasLeftEntity(EntityHasLeftEntity::EntityUuid),
                 ],
             }),
-            Self::OutgoingLink => ForeignKeyJoin::from(ForeignKeyReference::Double {
+            Self::RightEntity => ForeignKeyJoin::from_reference(ForeignKeyReference::Double {
                 on: [
                     Column::Entities(Entities::OwnedById),
                     Column::Entities(Entities::EntityUuid),
                 ],
                 join: [
-                    Column::Entities(Entities::LeftEntityOwnedById),
-                    Column::Entities(Entities::LeftEntityUuid),
+                    Column::EntityHasRightEntity(EntityHasRightEntity::OwnedById),
+                    Column::EntityHasRightEntity(EntityHasRightEntity::EntityUuid),
                 ],
             }),
-            Self::IncomingLink => ForeignKeyJoin::from(ForeignKeyReference::Double {
-                on: [
-                    Column::Entities(Entities::OwnedById),
-                    Column::Entities(Entities::EntityUuid),
-                ],
-                join: [
-                    Column::Entities(Entities::RightEntityOwnedById),
-                    Column::Entities(Entities::RightEntityUuid),
-                ],
-            }),
-            Self::Reference(table) => ForeignKeyJoin::from(table),
+            Self::Reference(table) => ForeignKeyJoin::from_reference_table(table, false),
+            Self::ReversedReference(table) => ForeignKeyJoin::from_reference_table(table, true),
         }
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
@@ -776,7 +776,6 @@ impl ForeignKeyReference {
 enum ForeignKeyJoin {
     Plain(Once<ForeignKeyReference>),
     Reference(Chain<Once<ForeignKeyReference>, Once<ForeignKeyReference>>),
-    ReversedReference(Chain<Once<ForeignKeyReference>, Once<ForeignKeyReference>>),
 }
 
 impl ForeignKeyJoin {
@@ -786,7 +785,7 @@ impl ForeignKeyJoin {
 
     fn from_reference_table(table: ReferenceTable, reversed: bool) -> Self {
         if reversed {
-            Self::ReversedReference(
+            Self::Reference(
                 once(table.target_relation().reverse())
                     .chain(once(table.source_relation().reverse())),
             )
@@ -802,7 +801,7 @@ impl Iterator for ForeignKeyJoin {
     fn next(&mut self) -> Option<Self::Item> {
         match self {
             Self::Plain(value) => value.next(),
-            Self::Reference(values) | Self::ReversedReference(values) => values.next(),
+            Self::Reference(values) => values.next(),
         }
     }
 }

--- a/apps/hash-graph/postgres_migrations/V2__ontology_tables.sql
+++ b/apps/hash-graph/postgres_migrations/V2__ontology_tables.sql
@@ -86,25 +86,37 @@ CREATE TABLE IF NOT EXISTS
   );
 
 CREATE TABLE IF NOT EXISTS
-  "property_type_property_type_references" (
+  "property_type_constrains_properties_on" (
     "source_property_type_ontology_id" UUID NOT NULL REFERENCES "property_types",
     "target_property_type_ontology_id" UUID NOT NULL REFERENCES "property_types"
   );
 
 CREATE TABLE IF NOT EXISTS
-  "property_type_data_type_references" (
+  "property_type_constrains_values_on" (
     "source_property_type_ontology_id" UUID NOT NULL REFERENCES "property_types",
     "target_data_type_ontology_id" UUID NOT NULL REFERENCES "data_types"
   );
 
 CREATE TABLE IF NOT EXISTS
-  "entity_type_property_type_references" (
+  "entity_type_constrains_properties_on" (
     "source_entity_type_ontology_id" UUID NOT NULL REFERENCES "entity_types",
     "target_property_type_ontology_id" UUID NOT NULL REFERENCES "property_types"
   );
 
 CREATE TABLE IF NOT EXISTS
-  "entity_type_entity_type_references" (
+  "entity_type_inherits_from" (
+    "source_entity_type_ontology_id" UUID NOT NULL REFERENCES "entity_types",
+    "target_entity_type_ontology_id" UUID NOT NULL REFERENCES "entity_types"
+  );
+
+CREATE TABLE IF NOT EXISTS
+  "entity_type_constrains_links_on" (
+    "source_entity_type_ontology_id" UUID NOT NULL REFERENCES "entity_types",
+    "target_entity_type_ontology_id" UUID NOT NULL REFERENCES "entity_types"
+  );
+
+CREATE TABLE IF NOT EXISTS
+  "entity_type_constrains_link_destinations_on" (
     "source_entity_type_ontology_id" UUID NOT NULL REFERENCES "entity_types",
     "target_entity_type_ontology_id" UUID NOT NULL REFERENCES "entity_types"
   );

--- a/apps/hash-graph/postgres_migrations/V3__knowledge_tables.sql
+++ b/apps/hash-graph/postgres_migrations/V3__knowledge_tables.sql
@@ -2,34 +2,43 @@ CREATE TABLE IF NOT EXISTS
   "entity_ids" (
     "owned_by_id" UUID NOT NULL REFERENCES "accounts",
     "entity_uuid" UUID NOT NULL,
-    "left_owned_by_id" UUID,
-    "left_entity_uuid" UUID,
-    "right_owned_by_id" UUID,
-    "right_entity_uuid" UUID,
-    PRIMARY KEY ("owned_by_id", "entity_uuid"),
-    FOREIGN KEY ("left_owned_by_id", "left_entity_uuid") REFERENCES "entity_ids",
-    FOREIGN KEY ("right_owned_by_id", "right_entity_uuid") REFERENCES "entity_ids",
-    CHECK (
-      left_entity_uuid IS NULL
-      AND right_entity_uuid IS NULL
-      AND left_owned_by_id IS NULL
-      AND right_owned_by_id IS NULL
-      OR left_entity_uuid IS NOT NULL
-      AND right_entity_uuid IS NOT NULL
-      AND left_owned_by_id IS NOT NULL
-      AND right_owned_by_id IS NOT NULL
-    )
+    PRIMARY KEY ("owned_by_id", "entity_uuid")
+  );
+
+CREATE TABLE IF NOT EXISTS
+  "entity_has_left_entity" (
+    "owned_by_id" UUID NOT NULL,
+    "entity_uuid" UUID NOT NULL,
+    "left_owned_by_id" UUID NOT NULL,
+    "left_entity_uuid" UUID NOT NULL,
+    FOREIGN KEY ("owned_by_id", "entity_uuid") REFERENCES "entity_ids",
+    FOREIGN KEY ("left_owned_by_id", "left_entity_uuid") REFERENCES "entity_ids"
+  );
+
+CREATE TABLE IF NOT EXISTS
+  "entity_has_right_entity" (
+    "owned_by_id" UUID NOT NULL,
+    "entity_uuid" UUID NOT NULL,
+    "right_owned_by_id" UUID NOT NULL,
+    "right_entity_uuid" UUID NOT NULL,
+    FOREIGN KEY ("owned_by_id", "entity_uuid") REFERENCES "entity_ids",
+    FOREIGN KEY ("right_owned_by_id", "right_entity_uuid") REFERENCES "entity_ids"
   );
 
 CREATE TABLE IF NOT EXISTS
   "entity_editions" (
     "entity_edition_id" UUID NOT NULL PRIMARY KEY,
-    "entity_type_ontology_id" UUID NOT NULL REFERENCES "entity_types",
     "properties" JSONB NOT NULL,
     "left_to_right_order" INTEGER,
     "right_to_left_order" INTEGER,
     "record_created_by_id" UUID NOT NULL REFERENCES "accounts",
     "archived" BOOLEAN NOT NULL
+  );
+
+CREATE TABLE IF NOT EXISTS
+  "entity_is_of_type" (
+    "entity_edition_id" UUID NOT NULL REFERENCES "entity_editions",
+    "entity_type_ontology_id" UUID NOT NULL REFERENCES "entity_types"
   );
 
 CREATE TABLE IF NOT EXISTS
@@ -56,27 +65,3 @@ CREATE TABLE IF NOT EXISTS
     ) DEFERRABLE INITIALLY IMMEDIATE,
     CHECK (LOWER(decision_time) <= LOWER(transaction_time))
   );
-
-CREATE VIEW
-  "entities" AS
-SELECT
-  entity_ids.owned_by_id,
-  entity_ids.entity_uuid,
-  entity_editions.entity_edition_id,
-  entity_temporal_metadata.decision_time,
-  entity_temporal_metadata.transaction_time,
-  entity_editions.entity_type_ontology_id,
-  entity_editions.record_created_by_id,
-  entity_editions.properties,
-  entity_editions.archived,
-  entity_ids.left_owned_by_id,
-  entity_ids.left_entity_uuid,
-  entity_editions.left_to_right_order,
-  entity_ids.right_owned_by_id,
-  entity_ids.right_entity_uuid,
-  entity_editions.right_to_left_order
-FROM
-  entity_temporal_metadata
-  JOIN entity_editions ON entity_temporal_metadata.entity_edition_id = entity_editions.entity_edition_id
-  JOIN entity_ids ON entity_temporal_metadata.owned_by_id = entity_ids.owned_by_id
-  AND entity_temporal_metadata.entity_uuid = entity_ids.entity_uuid;

--- a/apps/hash-graph/postgres_migrations/V6__knowledge_functions.sql
+++ b/apps/hash-graph/postgres_migrations/V6__knowledge_functions.sql
@@ -25,26 +25,45 @@ OR REPLACE FUNCTION "create_entity" (
 
       INSERT INTO entity_ids (
         owned_by_id,
-        entity_uuid,
-        left_owned_by_id,
-        left_entity_uuid,
-        right_owned_by_id,
-        right_entity_uuid
+        entity_uuid
       ) VALUES (
         _owned_by_id,
-        _entity_uuid,
-        _left_owned_by_id,
-        _left_entity_uuid,
-        _right_owned_by_id,
-        _right_entity_uuid
+        _entity_uuid
       );
+
+      IF _left_entity_uuid IS NOT NULL THEN
+        INSERT INTO entity_has_left_entity (
+          owned_by_id,
+          entity_uuid,
+          left_owned_by_id,
+          left_entity_uuid
+        ) VALUES (
+          _owned_by_id,
+          _entity_uuid,
+          _left_owned_by_id,
+          _left_entity_uuid
+        );
+      END IF;
+
+      IF _right_entity_uuid IS NOT NULL THEN
+        INSERT INTO entity_has_right_entity (
+          owned_by_id,
+          entity_uuid,
+          right_owned_by_id,
+          right_entity_uuid
+        ) VALUES (
+          _owned_by_id,
+          _entity_uuid,
+          _right_owned_by_id,
+          _right_entity_uuid
+        );
+      END IF;
 
       -- insert the data of the entity
       INSERT INTO entity_editions (
         entity_edition_id,
         record_created_by_id,
         archived,
-        entity_type_ontology_id,
         properties,
         left_to_right_order,
         right_to_left_order
@@ -52,11 +71,18 @@ OR REPLACE FUNCTION "create_entity" (
         gen_random_uuid(),
         _record_created_by_id,
         _archived,
-        _entity_type_ontology_id,
         _properties,
         _left_to_right_order,
         _right_to_left_order
       ) RETURNING entity_editions.entity_edition_id INTO _entity_edition_id;
+
+      INSERT INTO entity_is_of_type (
+        entity_edition_id,
+        entity_type_ontology_id
+      ) VALUES (
+        _entity_edition_id,
+        _entity_type_ontology_id
+      );
 
       RETURN QUERY
       INSERT INTO entity_temporal_metadata (
@@ -100,7 +126,6 @@ OR REPLACE FUNCTION "update_entity" (
         entity_edition_id,
         record_created_by_id,
         archived,
-        entity_type_ontology_id,
         properties,
         left_to_right_order,
         right_to_left_order
@@ -108,12 +133,19 @@ OR REPLACE FUNCTION "update_entity" (
         gen_random_uuid(),
         _record_created_by_id,
         _archived,
-        _entity_type_ontology_id,
         _properties,
         _left_to_right_order,
         _right_to_left_order
       )
       RETURNING entity_editions.entity_edition_id INTO _new_entity_edition_id;
+
+      INSERT INTO entity_is_of_type (
+        entity_edition_id,
+        entity_type_ontology_id
+      ) VALUES (
+        _new_entity_edition_id,
+        _entity_type_ontology_id
+      );
 
       RETURN QUERY
       UPDATE entity_temporal_metadata


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We're migrating the database to use reference tables for all edge kinds.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204000740778935/1204165137291098/f) _(internal)_

## 🚫 Blocked by

- #2200 
- #2201 

## 🔍 What does this change?

- Adds the reference tables to the migration files
- Adjust the table and relation definitions
- Allow a "reversed" edge relation to avoid duplication (possible due to prior work in #2200 and #2201)
- Adjust a bunch of test cases and seeding scripts

## 📜 Does this require a change to the docs?

This is an internal change

## 🛡 What tests cover this?

Pretty much every test will directly or indirectly test this part of the code

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204117847656665