### PR TITLE
Fix collecting of edges by merging them

### DIFF
--- a/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/edges.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/edges.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::{hash_map::Entry, BTreeMap, HashMap},
-    fmt::Debug,
     hash::Hash,
 };
 

--- a/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/edges.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/edges.rs
@@ -27,6 +27,7 @@ use crate::{
 #[serde(untagged)]
 pub enum OntologyOutwardEdge {
     ToOntology(OutwardEdge<OntologyEdgeKind, OntologyTypeVertexId>),
+    ToKnowledgeGraph(OutwardEdge<SharedEdgeKind, EntityIdWithInterval>),
 }
 
 impl From<OutwardEdge<OntologyEdgeKind, EntityTypeVertexId>> for OntologyOutwardEdge {
@@ -59,6 +60,12 @@ impl From<OutwardEdge<OntologyEdgeKind, DataTypeVertexId>> for OntologyOutwardEd
     }
 }
 
+impl From<OutwardEdge<SharedEdgeKind, EntityIdWithInterval>> for OntologyOutwardEdge {
+    fn from(edge: OutwardEdge<SharedEdgeKind, EntityIdWithInterval>) -> Self {
+        Self::ToKnowledgeGraph(edge)
+    }
+}
+
 // WARNING: This MUST be kept up to date with the enum variants.
 //   We have to do this because utoipa doesn't understand serde untagged:
 //   https://github.com/juhaku/utoipa/issues/320
@@ -70,6 +77,11 @@ impl ToSchema<'_> for OntologyOutwardEdge {
                 .item(
                     <OutwardEdge<OntologyEdgeKind, OntologyTypeVertexId>>::generate_schema(
                         "OntologyToOntologyOutwardEdge",
+                    ),
+                )
+                .item(
+                    <OutwardEdge<SharedEdgeKind, EntityIdWithInterval>>::generate_schema(
+                        "OntologyToKnowledgeGraphOutwardEdge",
                     ),
                 )
                 .into(),

--- a/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/edges.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/edges.rs
@@ -278,17 +278,26 @@ mod tests {
             SharedEdgeKind::IsOfType,
             false,
             EntityTypeVertexId {
-                base_id: BaseUrl::new("https://example.com/".to_owned()).unwrap(),
+                base_id: BaseUrl::new("https://example.com/".to_owned())
+                    .expect("should be valid URL"),
                 revision_id: OntologyTypeVersion::new(0),
             },
         );
 
         let edges = Edges::from(edges);
         assert_eq!(edges.knowledge_graph.0.len(), 1);
-        let (_, values) = edges.knowledge_graph.0.iter().next().unwrap();
+
+        let (_, values) = edges
+            .knowledge_graph
+            .0
+            .iter()
+            .next()
+            .expect("should have at least a single entry");
         assert_eq!(values.len(), 1);
 
-        let (_, edges) = values.first_key_value().unwrap();
+        let (_, edges) = values
+            .first_key_value()
+            .expect("should have at least a single entry");
         assert_eq!(edges.len(), 2);
     }
 }

--- a/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/edges.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/edges.rs
@@ -143,7 +143,7 @@ pub struct Edges {
     pub knowledge_graph: KnowledgeGraphRootedEdges,
 }
 
-fn collect_merge<T: Hash + Eq + Debug, U: Ord + Debug, V: Debug>(
+fn collect_merge<T: Hash + Eq, U: Ord, V>(
     mut accumulator: HashMap<T, BTreeMap<U, Vec<V>>>,
     (key, value): (T, BTreeMap<U, Vec<V>>),
 ) -> HashMap<T, BTreeMap<U, Vec<V>>> {

--- a/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/edges.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef/subgraph/edges.rs
@@ -26,7 +26,6 @@ use crate::{
 #[serde(untagged)]
 pub enum OntologyOutwardEdge {
     ToOntology(OutwardEdge<OntologyEdgeKind, OntologyTypeVertexId>),
-    ToKnowledgeGraph(OutwardEdge<SharedEdgeKind, EntityIdWithInterval>),
 }
 
 impl From<OutwardEdge<OntologyEdgeKind, EntityTypeVertexId>> for OntologyOutwardEdge {
@@ -59,12 +58,6 @@ impl From<OutwardEdge<OntologyEdgeKind, DataTypeVertexId>> for OntologyOutwardEd
     }
 }
 
-impl From<OutwardEdge<SharedEdgeKind, EntityIdWithInterval>> for OntologyOutwardEdge {
-    fn from(edge: OutwardEdge<SharedEdgeKind, EntityIdWithInterval>) -> Self {
-        Self::ToKnowledgeGraph(edge)
-    }
-}
-
 // WARNING: This MUST be kept up to date with the enum variants.
 //   We have to do this because utoipa doesn't understand serde untagged:
 //   https://github.com/juhaku/utoipa/issues/320
@@ -76,11 +69,6 @@ impl ToSchema<'_> for OntologyOutwardEdge {
                 .item(
                     <OutwardEdge<OntologyEdgeKind, OntologyTypeVertexId>>::generate_schema(
                         "OntologyToOntologyOutwardEdge",
-                    ),
-                )
-                .item(
-                    <OutwardEdge<SharedEdgeKind, EntityIdWithInterval>>::generate_schema(
-                        "OntologyToKnowledgeGraphOutwardEdge",
                     ),
                 )
                 .into(),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, there's a bug that only the entity types will be returned if entity edges and entity types are requested in the same query. This is because instead of merging the flattened adjacency lists, only the last list is collected (due to the use of `collect()`). This PR instead uses fold and properly merges duplicate entity ids.

> This is also possible if entity types and property types are requested.

