### PR TITLE
Use edge definitions in query paths

### DIFF
--- a/apps/hash-graph/bench/representative_read/knowledge/entity.rs
+++ b/apps/hash-graph/bench/representative_read/knowledge/entity.rs
@@ -9,7 +9,7 @@ use graph::{
         EntityStore,
     },
     subgraph::{
-        edges::GraphResolveDepths,
+        edges::{GraphResolveDepths, KnowledgeGraphEdgeKind},
         query::StructuralQuery,
         temporal_axes::{
             PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
@@ -105,13 +105,15 @@ pub fn bench_get_link_by_target_by_property(
 ) {
     b.to_async(runtime).iter(|| async move {
         let mut filter = Filter::Equal(
-            Some(FilterExpression::Path(EntityQueryPath::RightEntity(
-                Box::new(EntityQueryPath::Properties(Some(
+            Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
+                path: Box::new(EntityQueryPath::Properties(Some(
                     JsonPath::from_path_tokens(vec![PathToken::Field(Cow::Borrowed(
                         "https://blockprotocol.org/@alice/types/property-type/name/",
                     ))]),
                 ))),
-            ))),
+                reversed: false,
+            })),
             Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
                 "Alice",
             )))),

--- a/apps/hash-graph/lib/graph/src/knowledge/entity/query.rs
+++ b/apps/hash-graph/lib/graph/src/knowledge/entity/query.rs
@@ -9,6 +9,7 @@ use utoipa::ToSchema;
 use crate::{
     ontology::{EntityTypeQueryPath, EntityTypeQueryPathVisitor},
     store::query::{JsonPath, ParameterType, PathToken, QueryPath},
+    subgraph::edges::{KnowledgeGraphEdgeKind, SharedEdgeKind},
 };
 
 #[derive(Debug, PartialEq, Eq)]
@@ -108,7 +109,9 @@ pub enum EntityQueryPath<'p> {
     /// [`ProvenanceMetadata`]: crate::provenance::ProvenanceMetadata
     /// [`Entity`]: crate::knowledge::Entity
     UpdatedById,
-    /// The [`EntityType`] of the [`EntityMetadata`] belonging to the [`Entity`].
+    /// An edge from this [`Entity`] to it's [`EntityType`] using a [`SharedEdgeKind`].
+    ///
+    /// The corresponding reversed edge is [`EntityTypeQueryPath::EntityEdge`].
     ///
     /// Deserializes from `["type", ...]` where `...` is a path to a field of an [`EntityType`].
     ///
@@ -116,35 +119,97 @@ pub enum EntityQueryPath<'p> {
     /// # use serde::Deserialize;
     /// # use serde_json::json;
     /// # use graph::{knowledge::EntityQueryPath, ontology::EntityTypeQueryPath};
+    /// # use graph::subgraph::edges::SharedEdgeKind;
     /// let path = EntityQueryPath::deserialize(json!(["type", "baseUrl"]))?;
-    /// assert_eq!(path, EntityQueryPath::Type(EntityTypeQueryPath::BaseUrl));
+    /// assert_eq!(path, EntityQueryPath::EntityTypeEdge {
+    ///     edge_kind: SharedEdgeKind::IsOfType,
+    ///     path: EntityTypeQueryPath::BaseUrl,
+    /// });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     ///
+    /// [`EntityType`]: type_system::PropertyType
     /// [`Entity`]: crate::knowledge::Entity
-    /// [`EntityMetadata`]: crate::knowledge::EntityMetadata
-    /// [`EntityType`]: type_system::EntityType
-    Type(EntityTypeQueryPath<'p>),
-    /// Represents an [`Entity`] linking to the [`Entity`].
+    EntityTypeEdge {
+        edge_kind: SharedEdgeKind,
+        path: EntityTypeQueryPath<'p>,
+    },
+    /// An edge between two [`Entities`][`Entity`] using a [`KnowledgeGraphEdgeKind`].
     ///
-    /// Deserializes from `["incomingLinks", ...]` where `...` is the path of the source
+    /// [`Entity`]: crate::knowledge::Entity
+    ///
+    ///
+    /// # Left entity
+    ///
+    /// Corresponds to the [`Entity`] specified by [`LinkData::left_entity_id()`].
+    ///
+    /// Deserializes from `["leftEntity", ...]` where `...` is the path of the left [`Entity`].
+    ///
+    /// ```rust
+    /// # use serde::Deserialize;
+    /// # use serde_json::json;
+    /// # use graph::knowledge::EntityQueryPath;
+    /// # use graph::subgraph::edges::KnowledgeGraphEdgeKind;
+    /// let path = EntityQueryPath::deserialize(json!(["leftEntity", "uuid"]))?;
+    /// assert_eq!(path, EntityQueryPath::EntityEdge {
+    ///     edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+    ///     path: Box::new(EntityQueryPath::Uuid),
+    ///     reversed: false
+    /// });
+    /// # Ok::<(), serde_json::Error>(())
+    /// ```
+    ///
+    /// [`LinkData::left_entity_id()`]: crate::knowledge::LinkData::left_entity_id
+    ///
+    ///
+    /// # Right entity
+    ///
+    /// Corresponds to the [`Entity`] specified by [`LinkData::right_entity_id()`].
+    ///
+    /// Deserializes from `["rightEntity", ...]` where `...` is the path of the left [`Entity`].
+    ///
+    /// ```rust
+    /// # use serde::Deserialize;
+    /// # use serde_json::json;
+    /// # use graph::knowledge::EntityQueryPath;
+    /// # use graph::subgraph::edges::KnowledgeGraphEdgeKind;
+    /// let path = EntityQueryPath::deserialize(json!(["rightEntity", "uuid"]))?;
+    /// assert_eq!(path, EntityQueryPath::EntityEdge {
+    ///     edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
+    ///     path: Box::new(EntityQueryPath::Uuid),
+    ///     reversed: false
+    /// });
+    /// # Ok::<(), serde_json::Error>(())
+    /// ```
+    ///
+    /// [`LinkData::right_entity_id()`]: crate::knowledge::LinkData::right_entity_id
+    ///
+    ///
+    /// # Incoming links
+    ///
+    /// Represents an [`Entity`] linked from this [`Entity`].
+    ///
+    /// Deserializes from `["incomingLinks", ...]` where `...` is the path of the target
     /// [`Entity`].
     ///
     /// ```rust
     /// # use serde::Deserialize;
     /// # use serde_json::json;
     /// # use graph::knowledge::EntityQueryPath;
+    /// # use graph::subgraph::edges::KnowledgeGraphEdgeKind;
     /// let path = EntityQueryPath::deserialize(json!(["incomingLinks", "uuid"]))?;
-    /// assert_eq!(
-    ///     path,
-    ///     EntityQueryPath::IncomingLinks(Box::new(EntityQueryPath::Uuid))
-    /// );
+    /// assert_eq!(path, EntityQueryPath::EntityEdge {
+    ///     edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
+    ///     path: Box::new(EntityQueryPath::Uuid),
+    ///     reversed: true
+    /// });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     ///
-    /// [`Entity`]: crate::knowledge::Entity
-    IncomingLinks(Box<Self>),
-    /// Represents an [`Entity`] linked from the [`Entity`].
+    ///
+    /// # Outgoing links
+    ///
+    /// Represents an [`Entity`] linked from this [`Entity`].
     ///
     /// Deserializes from `["outgoingLinks", ...]` where `...` is the path of the target
     /// [`Entity`].
@@ -153,54 +218,20 @@ pub enum EntityQueryPath<'p> {
     /// # use serde::Deserialize;
     /// # use serde_json::json;
     /// # use graph::knowledge::EntityQueryPath;
+    /// # use graph::subgraph::edges::KnowledgeGraphEdgeKind;
     /// let path = EntityQueryPath::deserialize(json!(["outgoingLinks", "uuid"]))?;
-    /// assert_eq!(
-    ///     path,
-    ///     EntityQueryPath::OutgoingLinks(Box::new(EntityQueryPath::Uuid))
-    /// );
+    /// assert_eq!(path, EntityQueryPath::EntityEdge {
+    ///     edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+    ///     path: Box::new(EntityQueryPath::Uuid),
+    ///     reversed: true
+    /// });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    ///
-    /// [`Entity`]: crate::knowledge::Entity
-    OutgoingLinks(Box<Self>),
-    /// Corresponds to the entity specified by [`LinkData::left_entity_id()`].
-    ///
-    /// Deserializes from `["leftEntity", ...]` where `...` is the path of the left [`Entity`].
-    ///
-    /// ```rust
-    /// # use serde::Deserialize;
-    /// # use serde_json::json;
-    /// # use graph::knowledge::EntityQueryPath;
-    /// let path = EntityQueryPath::deserialize(json!(["leftEntity", "uuid"]))?;
-    /// assert_eq!(
-    ///     path,
-    ///     EntityQueryPath::LeftEntity(Box::new(EntityQueryPath::Uuid))
-    /// );
-    /// # Ok::<(), serde_json::Error>(())
-    /// ```
-    ///
-    /// [`Entity`]: crate::knowledge::Entity
-    /// [`LinkData::left_entity_id()`]: crate::knowledge::LinkData::left_entity_id
-    LeftEntity(Box<Self>),
-    /// Corresponds to the entity specified by [`LinkData::right_entity_id()`].
-    ///
-    /// Deserializes from `["leftEntity", ...]` where `...` is the path of the right [`Entity`].
-    ///
-    /// ```rust
-    /// # use serde::Deserialize;
-    /// # use serde_json::json;
-    /// # use graph::knowledge::EntityQueryPath;
-    /// let path = EntityQueryPath::deserialize(json!(["rightEntity", "uuid"]))?;
-    /// assert_eq!(
-    ///     path,
-    ///     EntityQueryPath::RightEntity(Box::new(EntityQueryPath::Uuid))
-    /// );
-    /// # Ok::<(), serde_json::Error>(())
-    /// ```
-    ///
-    /// [`Entity`]: crate::knowledge::Entity
-    /// [`LinkData::right_entity_id()`]: crate::knowledge::LinkData::right_entity_id
-    RightEntity(Box<Self>),
+    EntityEdge {
+        edge_kind: KnowledgeGraphEdgeKind,
+        path: Box<Self>,
+        reversed: bool,
+    },
     /// Corresponds to [`EntityLinkOrder::left_to_right`].
     ///
     /// ```rust
@@ -264,13 +295,32 @@ impl fmt::Display for EntityQueryPath<'_> {
             Self::DecisionTime => fmt.write_str("decisionTime"),
             Self::TransactionTime => fmt.write_str("transactionTime"),
             Self::Archived => fmt.write_str("archived"),
-            Self::Type(path) => write!(fmt, "type.{path}"),
             Self::Properties(Some(property)) => write!(fmt, "properties.{property}"),
             Self::Properties(None) => fmt.write_str("properties"),
-            Self::IncomingLinks(link) => write!(fmt, "incomingLinks.{link}"),
-            Self::OutgoingLinks(link) => write!(fmt, "outgoingLinks.{link}"),
-            Self::LeftEntity(path) => write!(fmt, "leftEntityUuid.{path}"),
-            Self::RightEntity(path) => write!(fmt, "rightEntityUuid.{path}"),
+            Self::EntityTypeEdge {
+                edge_kind: SharedEdgeKind::IsOfType,
+                path,
+            } => write!(fmt, "type.{path}"),
+            Self::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                path,
+                reversed: false,
+            } => write!(fmt, "leftEntity.{path}"),
+            Self::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
+                path,
+                reversed: false,
+            } => write!(fmt, "rightEntity.{path}"),
+            Self::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                path,
+                reversed: true,
+            } => write!(fmt, "outgoingLinks.{path}"),
+            Self::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
+                path,
+                reversed: true,
+            } => write!(fmt, "incomingLinks.{path}"),
             Self::LeftToRightOrder => fmt.write_str("leftToRightOrder"),
             Self::RightToLeftOrder => fmt.write_str("rightToLeftOrder"),
         }
@@ -283,15 +333,12 @@ impl QueryPath for EntityQueryPath<'_> {
             Self::EditionId | Self::Uuid | Self::OwnedById | Self::UpdatedById => {
                 ParameterType::Uuid
             }
-            Self::LeftEntity(path)
-            | Self::RightEntity(path)
-            | Self::IncomingLinks(path)
-            | Self::OutgoingLinks(path) => path.expected_type(),
             Self::DecisionTime | Self::TransactionTime => ParameterType::TimeInterval,
-            Self::Type(path) => path.expected_type(),
             Self::Properties(_) => ParameterType::Any,
             Self::LeftToRightOrder | Self::RightToLeftOrder => ParameterType::Number,
             Self::Archived => ParameterType::Boolean,
+            Self::EntityTypeEdge { path, .. } => path.expected_type(),
+            Self::EntityEdge { path, .. } => path.expected_type(),
         }
     }
 }
@@ -356,9 +403,10 @@ impl<'de> Visitor<'de> for EntityQueryPathVisitor {
             EntityQueryToken::OwnedById => EntityQueryPath::OwnedById,
             EntityQueryToken::UpdatedById => EntityQueryPath::UpdatedById,
             EntityQueryToken::Archived => EntityQueryPath::Archived,
-            EntityQueryToken::Type => EntityQueryPath::Type(
-                EntityTypeQueryPathVisitor::new(self.position).visit_seq(seq)?,
-            ),
+            EntityQueryToken::Type => EntityQueryPath::EntityTypeEdge {
+                edge_kind: SharedEdgeKind::IsOfType,
+                path: EntityTypeQueryPathVisitor::new(self.position).visit_seq(seq)?,
+            },
             EntityQueryToken::Properties => {
                 let mut path_tokens = Vec::new();
                 while let Some(property) = seq.next_element::<PathToken<'de>>()? {
@@ -372,18 +420,26 @@ impl<'de> Visitor<'de> for EntityQueryPathVisitor {
                     EntityQueryPath::Properties(Some(JsonPath::from_path_tokens(path_tokens)))
                 }
             }
-            EntityQueryToken::OutgoingLinks => {
-                EntityQueryPath::OutgoingLinks(Box::new(Self::new(self.position).visit_seq(seq)?))
-            }
-            EntityQueryToken::IncomingLinks => {
-                EntityQueryPath::IncomingLinks(Box::new(Self::new(self.position).visit_seq(seq)?))
-            }
-            EntityQueryToken::LeftEntity => {
-                EntityQueryPath::LeftEntity(Box::new(Self::new(self.position).visit_seq(seq)?))
-            }
-            EntityQueryToken::RightEntity => {
-                EntityQueryPath::RightEntity(Box::new(Self::new(self.position).visit_seq(seq)?))
-            }
+            EntityQueryToken::LeftEntity => EntityQueryPath::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                path: Box::new(Self::new(self.position).visit_seq(seq)?),
+                reversed: false,
+            },
+            EntityQueryToken::RightEntity => EntityQueryPath::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
+                path: Box::new(Self::new(self.position).visit_seq(seq)?),
+                reversed: false,
+            },
+            EntityQueryToken::OutgoingLinks => EntityQueryPath::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                path: Box::new(Self::new(self.position).visit_seq(seq)?),
+                reversed: true,
+            },
+            EntityQueryToken::IncomingLinks => EntityQueryPath::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
+                path: Box::new(Self::new(self.position).visit_seq(seq)?),
+                reversed: true,
+            },
             EntityQueryToken::LeftToRightOrder => EntityQueryPath::LeftToRightOrder,
             EntityQueryToken::RightToLeftOrder => EntityQueryPath::RightToLeftOrder,
         })
@@ -417,7 +473,10 @@ mod tests {
         assert_eq!(deserialize(["ownedById"]), EntityQueryPath::OwnedById);
         assert_eq!(
             deserialize(["type", "version"]),
-            EntityQueryPath::Type(EntityTypeQueryPath::Version)
+            EntityQueryPath::EntityTypeEdge {
+                edge_kind: SharedEdgeKind::IsOfType,
+                path: EntityTypeQueryPath::Version
+            }
         );
         assert_eq!(
             deserialize([
@@ -430,7 +489,11 @@ mod tests {
         );
         assert_eq!(
             deserialize(["leftEntity", "uuid"]),
-            EntityQueryPath::LeftEntity(Box::new(EntityQueryPath::Uuid))
+            EntityQueryPath::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                path: Box::new(EntityQueryPath::Uuid),
+                reversed: false
+            }
         );
 
         assert_eq!(

--- a/apps/hash-graph/lib/graph/src/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/data_type.rs
@@ -6,7 +6,11 @@ use serde::{
 };
 use utoipa::ToSchema;
 
-use crate::store::query::{JsonPath, OntologyQueryPath, ParameterType, PathToken, QueryPath};
+use crate::{
+    ontology::PropertyTypeQueryPath,
+    store::query::{JsonPath, OntologyQueryPath, ParameterType, PathToken, QueryPath},
+    subgraph::edges::OntologyEdgeKind,
+};
 
 /// A path to a [`DataType`] field.
 ///
@@ -154,6 +158,22 @@ pub enum DataTypeQueryPath<'p> {
     Schema(Option<JsonPath<'p>>),
     /// Only used internally and not available for deserialization.
     AdditionalMetadata(Option<JsonPath<'p>>),
+    /// A reversed edge from a [`PropertyType`] to this [`DataType`] using an [`OntologyEdgeKind`].
+    ///
+    /// The corresponding edge is [`PropertyTypeQueryPath::DataTypeEdge`].
+    ///
+    /// Allowed edge kinds are:
+    /// - [`ConstrainsValuesOn`]
+    ///
+    /// Only used internally and not available for deserialization.
+    ///
+    /// [`ConstrainsValuesOn`]: OntologyEdgeKind::ConstrainsValuesOn
+    /// [`DataType`]: type_system::DataType
+    /// [`PropertyType`]: type_system::PropertyType
+    PropertyTypeEdge {
+        edge_kind: OntologyEdgeKind,
+        path: Box<PropertyTypeQueryPath<'p>>,
+    },
 }
 
 impl OntologyQueryPath for DataTypeQueryPath<'_> {
@@ -191,6 +211,7 @@ impl QueryPath for DataTypeQueryPath<'_> {
             Self::VersionedUrl => ParameterType::VersionedUrl,
             Self::Version => ParameterType::OntologyTypeVersion,
             Self::Description | Self::Title | Self::Type => ParameterType::Text,
+            Self::PropertyTypeEdge { path, .. } => path.expected_type(),
         }
     }
 }
@@ -211,6 +232,15 @@ impl fmt::Display for DataTypeQueryPath<'_> {
             Self::Type => fmt.write_str("type"),
             Self::AdditionalMetadata(Some(path)) => write!(fmt, "additionalMetadata.{path}"),
             Self::AdditionalMetadata(None) => fmt.write_str("additionalMetadata"),
+            #[expect(
+                clippy::use_debug,
+                reason = "We don't have a `Display` impl for `OntologyEdgeKind` and this should \
+                          (a) never happen and (b) be easy to debug if it does happen. In the \
+                          future, this will become a compile-time check"
+            )]
+            Self::PropertyTypeEdge {
+                edge_kind, path, ..
+            } => write!(fmt, "<{edge_kind:?}>.{path}"),
         }
     }
 }

--- a/apps/hash-graph/lib/graph/src/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/property_type.rs
@@ -7,8 +7,11 @@ use serde::{
 use utoipa::ToSchema;
 
 use crate::{
-    ontology::{data_type::DataTypeQueryPathVisitor, DataTypeQueryPath, Selector},
+    ontology::{
+        data_type::DataTypeQueryPathVisitor, DataTypeQueryPath, EntityTypeQueryPath, Selector,
+    },
     store::query::{JsonPath, OntologyQueryPath, ParameterType, PathToken, QueryPath},
+    subgraph::edges::OntologyEdgeKind,
 };
 
 /// A path to a [`PropertyType`] field.
@@ -118,31 +121,49 @@ pub enum PropertyTypeQueryPath<'p> {
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     Description,
-    /// Corresponds to [`PropertyType::data_type_references()`].
+    /// An edge to a [`DataType`] using an [`OntologyEdgeKind`].
+    ///
+    /// The corresponding reversed edge is [`DataTypeQueryPath::PropertyTypeEdge`].
+    ///
+    /// Allowed edge kinds are:
+    /// - [`ConstrainsValuesOn`]
+    ///
+    /// [`DataType`]: type_system::DataType
+    /// [`ConstrainsValuesOn`]: OntologyEdgeKind::ConstrainsValuesOn
+    /// [`PropertyType`]: type_system::PropertyType
+    ///
+    /// ## Constraining data types
     ///
     /// As a [`PropertyType`] can have multiple [`DataType`]s, the deserialized path requires an
     /// additional selector to identify the [`DataType`] to query. Currently, only the `*` selector
     /// is available, so the path will be deserialized as `["dataTypes", "*", ...]` where `...` is
     /// the path to the desired field of the [`DataType`].
     ///
-    /// [`PropertyType::data_type_references()`]: type_system::PropertyType::data_type_references
-    /// [`PropertyType`]: type_system::PropertyType
-    ///
     /// ```rust
     /// # use serde::Deserialize;
     /// # use serde_json::json;
     /// # use graph::ontology::{DataTypeQueryPath, PropertyTypeQueryPath};
+    /// # use graph::subgraph::edges::OntologyEdgeKind;
     /// let path = PropertyTypeQueryPath::deserialize(json!(["dataTypes", "*", "title"]))?;
-    /// assert_eq!(
-    ///     path,
-    ///     PropertyTypeQueryPath::DataTypes(DataTypeQueryPath::Title)
-    /// );
+    /// assert_eq!(path, PropertyTypeQueryPath::DataTypeEdge {
+    ///     edge_kind: OntologyEdgeKind::ConstrainsValuesOn,
+    ///     path: DataTypeQueryPath::Title,
+    /// });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    DataTypeEdge {
+        edge_kind: OntologyEdgeKind,
+        path: DataTypeQueryPath<'p>,
+    },
+    /// An edge between two [`PropertyType`]s using an [`OntologyEdgeKind`].
     ///
-    /// [`DataType`]: type_system::DataType
-    DataTypes(DataTypeQueryPath<'p>),
-    /// Corresponds to [`PropertyType::property_type_references()`].
+    /// Allowed edge kinds are:
+    /// - [`ConstrainsPropertiesOn`]
+    ///
+    /// [`ConstrainsPropertiesOn`]: OntologyEdgeKind::ConstrainsPropertiesOn
+    /// [`PropertyType`]: type_system::PropertyType
+    ///
+    /// ## Constraining other property types
     ///
     /// As a [`PropertyType`] can have multiple nested [`PropertyType`]s, the deserialized path
     /// requires an additional selector to identify the [`PropertyType`] to query. Currently, only
@@ -151,19 +172,41 @@ pub enum PropertyTypeQueryPath<'p> {
     ///
     /// ```rust
     /// # use serde::Deserialize;
-    /// use serde_json::json;
+    /// # use serde_json::json;
     /// # use graph::ontology::PropertyTypeQueryPath;
+    /// # use graph::subgraph::edges::OntologyEdgeKind;
     /// let path = PropertyTypeQueryPath::deserialize(json!(["propertyTypes", "*", "title"]))?;
-    /// assert_eq!(
-    ///     path,
-    ///     PropertyTypeQueryPath::PropertyTypes(Box::new(PropertyTypeQueryPath::Title))
-    /// );
+    /// assert_eq!(path, PropertyTypeQueryPath::PropertyTypeEdge {
+    ///     edge_kind: OntologyEdgeKind::ConstrainsPropertiesOn,
+    ///     path: Box::new(PropertyTypeQueryPath::Title),
+    ///     reversed: false
+    /// });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    PropertyTypeEdge {
+        edge_kind: OntologyEdgeKind,
+        path: Box<Self>,
+        reversed: bool,
+    },
+    /// A reversed edge from an [`EntityType`] to this [`PropertyType`] using an
+    /// [`OntologyEdgeKind`].
     ///
+    /// The corresponding edge is [`EntityTypeQueryPath::PropertyTypeEdge`].
+    ///
+    /// Allowed edge kinds are:
+    /// - [`ConstrainsPropertiesOn`]
+    ///
+    /// [`ConstrainsPropertiesOn`]: OntologyEdgeKind::ConstrainsPropertiesOn
     /// [`PropertyType`]: type_system::PropertyType
-    /// [`PropertyType::property_type_references()`]: type_system::PropertyType::property_type_references
-    PropertyTypes(Box<Self>),
+    /// [`EntityType`]: type_system::PropertyType
+    ///
+    /// ## Constraining other property types
+    ///
+    /// Only used internally and not available for deserialization.
+    EntityTypeEdge {
+        edge_kind: OntologyEdgeKind,
+        path: Box<EntityTypeQueryPath<'p>>,
+    },
     /// Only used internally and not available for deserialization.
     OntologyId,
     /// Only used internally and not available for deserialization.
@@ -207,8 +250,9 @@ impl QueryPath for PropertyTypeQueryPath<'_> {
             Self::VersionedUrl => ParameterType::VersionedUrl,
             Self::Version => ParameterType::OntologyTypeVersion,
             Self::Title | Self::Description => ParameterType::Text,
-            Self::DataTypes(path) => path.expected_type(),
-            Self::PropertyTypes(path) => path.expected_type(),
+            Self::DataTypeEdge { path, .. } => path.expected_type(),
+            Self::PropertyTypeEdge { path, .. } => path.expected_type(),
+            Self::EntityTypeEdge { path, .. } => path.expected_type(),
         }
     }
 }
@@ -226,8 +270,40 @@ impl fmt::Display for PropertyTypeQueryPath<'_> {
             Self::Schema(None) => fmt.write_str("schema"),
             Self::Title => fmt.write_str("title"),
             Self::Description => fmt.write_str("description"),
-            Self::DataTypes(path) => write!(fmt, "dataTypes.{path}"),
-            Self::PropertyTypes(path) => write!(fmt, "propertyTypes.{path}"),
+            Self::DataTypeEdge {
+                edge_kind: OntologyEdgeKind::ConstrainsValuesOn,
+                path,
+            } => write!(fmt, "dataTypes.{path}"),
+            #[expect(
+                clippy::use_debug,
+                reason = "We don't have a `Display` impl for `OntologyEdgeKind` and this should \
+                          (a) never happen and (b) be easy to debug if it does happen. In the \
+                          future, this will become a compile-time check"
+            )]
+            Self::DataTypeEdge { edge_kind, path } => write!(fmt, "<{edge_kind:?}>.{path}"),
+            Self::PropertyTypeEdge {
+                edge_kind: OntologyEdgeKind::ConstrainsPropertiesOn,
+                path,
+                ..
+            } => write!(fmt, "propertyTypes.{path}"),
+            #[expect(
+                clippy::use_debug,
+                reason = "We don't have a `Display` impl for `OntologyEdgeKind` and this should \
+                          (a) never happen and (b) be easy to debug if it does happen. In the \
+                          future, this will become a compile-time check"
+            )]
+            Self::PropertyTypeEdge {
+                edge_kind, path, ..
+            } => write!(fmt, "<{edge_kind:?}>.{path}"),
+            #[expect(
+                clippy::use_debug,
+                reason = "We don't have a `Display` impl for `OntologyEdgeKind` and this should \
+                          (a) never happen and (b) be easy to debug if it does happen. In the \
+                          future, this will become a compile-time check"
+            )]
+            Self::EntityTypeEdge {
+                edge_kind, path, ..
+            } => write!(fmt, "<{edge_kind:?}>.{path}"),
             Self::AdditionalMetadata(Some(path)) => write!(fmt, "additionalMetadata.{path}"),
             Self::AdditionalMetadata(None) => fmt.write_str("additionalMetadata"),
         }
@@ -297,19 +373,21 @@ impl<'de> Visitor<'de> for PropertyTypeQueryPathVisitor {
                     .ok_or_else(|| de::Error::invalid_length(self.position, &self))?;
                 self.position += 1;
 
-                let data_type_query_path =
-                    DataTypeQueryPathVisitor::new(self.position).visit_seq(seq)?;
-
-                PropertyTypeQueryPath::DataTypes(data_type_query_path)
+                PropertyTypeQueryPath::DataTypeEdge {
+                    edge_kind: OntologyEdgeKind::ConstrainsValuesOn,
+                    path: DataTypeQueryPathVisitor::new(self.position).visit_seq(seq)?,
+                }
             }
             PropertyTypeQueryToken::PropertyTypes => {
                 seq.next_element::<Selector>()?
                     .ok_or_else(|| de::Error::invalid_length(self.position, &self))?;
                 self.position += 1;
 
-                let property_type_query_path = Self::new(self.position).visit_seq(seq)?;
-
-                PropertyTypeQueryPath::PropertyTypes(Box::new(property_type_query_path))
+                PropertyTypeQueryPath::PropertyTypeEdge {
+                    edge_kind: OntologyEdgeKind::ConstrainsPropertiesOn,
+                    path: Box::new(Self::new(self.position).visit_seq(seq)?),
+                    reversed: false,
+                }
             }
             PropertyTypeQueryToken::Schema => {
                 let mut path_tokens = Vec::new();
@@ -366,11 +444,18 @@ mod tests {
         );
         assert_eq!(
             deserialize(["dataTypes", "*", "version"]),
-            PropertyTypeQueryPath::DataTypes(DataTypeQueryPath::Version)
+            PropertyTypeQueryPath::DataTypeEdge {
+                edge_kind: OntologyEdgeKind::ConstrainsValuesOn,
+                path: DataTypeQueryPath::Version
+            }
         );
         assert_eq!(
             deserialize(["propertyTypes", "*", "baseUrl"]),
-            PropertyTypeQueryPath::PropertyTypes(Box::new(PropertyTypeQueryPath::BaseUrl))
+            PropertyTypeQueryPath::PropertyTypeEdge {
+                edge_kind: OntologyEdgeKind::ConstrainsPropertiesOn,
+                path: Box::new(PropertyTypeQueryPath::BaseUrl),
+                reversed: false
+            }
         );
 
         assert_eq!(

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -24,7 +24,10 @@ use crate::{
         query::Filter,
         AsClient, PostgresStore, QueryError,
     },
-    subgraph::temporal_axes::QueryTemporalAxes,
+    subgraph::{
+        edges::{KnowledgeGraphEdgeKind, SharedEdgeKind},
+        temporal_axes::QueryTemporalAxes,
+    },
 };
 
 #[async_trait]
@@ -36,12 +39,26 @@ impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
         temporal_axes: &QueryTemporalAxes,
     ) -> Result<Vec<Entity>, QueryError> {
         // We can't define these inline otherwise we'll drop while borrowed
-        let left_entity_uuid_path = EntityQueryPath::LeftEntity(Box::new(EntityQueryPath::Uuid));
-        let left_owned_by_id_query_path =
-            EntityQueryPath::LeftEntity(Box::new(EntityQueryPath::OwnedById));
-        let right_entity_uuid_path = EntityQueryPath::RightEntity(Box::new(EntityQueryPath::Uuid));
-        let right_owned_by_id_query_path =
-            EntityQueryPath::RightEntity(Box::new(EntityQueryPath::OwnedById));
+        let left_entity_uuid_path = EntityQueryPath::EntityEdge {
+            edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+            path: Box::new(EntityQueryPath::Uuid),
+            reversed: false,
+        };
+        let left_owned_by_id_query_path = EntityQueryPath::EntityEdge {
+            edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+            path: Box::new(EntityQueryPath::OwnedById),
+            reversed: false,
+        };
+        let right_entity_uuid_path = EntityQueryPath::EntityEdge {
+            edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
+            path: Box::new(EntityQueryPath::Uuid),
+            reversed: false,
+        };
+        let right_owned_by_id_query_path = EntityQueryPath::EntityEdge {
+            edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
+            path: Box::new(EntityQueryPath::OwnedById),
+            reversed: false,
+        };
 
         let mut compiler = SelectCompiler::new(temporal_axes);
 
@@ -55,8 +72,10 @@ impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
         let decision_time_index = compiler.add_selection_path(&EntityQueryPath::DecisionTime);
         let transaction_time_index = compiler.add_selection_path(&EntityQueryPath::TransactionTime);
 
-        let type_id_index =
-            compiler.add_selection_path(&EntityQueryPath::Type(EntityTypeQueryPath::VersionedUrl));
+        let type_id_index = compiler.add_selection_path(&EntityQueryPath::EntityTypeEdge {
+            edge_kind: SharedEdgeKind::IsOfType,
+            path: EntityTypeQueryPath::VersionedUrl,
+        });
 
         let properties_index = compiler.add_selection_path(&EntityQueryPath::Properties(None));
 

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/data_type.rs
@@ -1,9 +1,12 @@
+use std::iter::once;
+
 use crate::{
     ontology::{DataTypeQueryPath, DataTypeWithMetadata},
     store::postgres::query::{
-        table::{Column, DataTypes, JsonField, OntologyIds, Relation},
+        table::{Column, DataTypes, JsonField, OntologyIds, ReferenceTable, Relation},
         PostgresQueryPath, PostgresRecord, Table,
     },
+    subgraph::edges::OntologyEdgeKind,
 };
 
 impl PostgresRecord for DataTypeWithMetadata {
@@ -15,6 +18,12 @@ impl PostgresRecord for DataTypeWithMetadata {
 impl PostgresQueryPath for DataTypeQueryPath<'_> {
     fn relations(&self) -> Vec<Relation> {
         match self {
+            Self::VersionedUrl
+            | Self::Title
+            | Self::Description
+            | Self::Type
+            | Self::OntologyId
+            | Self::Schema(_) => vec![],
             Self::BaseUrl
             | Self::Version
             | Self::UpdatedById
@@ -22,7 +31,16 @@ impl PostgresQueryPath for DataTypeQueryPath<'_> {
             | Self::AdditionalMetadata(_) => {
                 vec![Relation::DataTypeIds]
             }
-            _ => vec![],
+            Self::PropertyTypeEdge {
+                edge_kind: OntologyEdgeKind::ConstrainsValuesOn,
+                path,
+            } => once(Relation::Reference {
+                table: ReferenceTable::PropertyTypeConstrainsValuesOn,
+                reversed: true,
+            })
+            .chain(path.relations())
+            .collect(),
+            Self::PropertyTypeEdge { .. } => unreachable!("Invalid path: {self}"),
         }
     }
 
@@ -50,6 +68,7 @@ impl PostgresQueryPath for DataTypeQueryPath<'_> {
             Self::Description => Column::DataTypes(DataTypes::Schema(Some(JsonField::StaticText(
                 "description",
             )))),
+            Self::PropertyTypeEdge { path, .. } => path.terminating_column(),
             Self::AdditionalMetadata(path) => path.as_ref().map_or(
                 Column::OntologyIds(OntologyIds::AdditionalMetadata(None)),
                 |path| {

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/entity.rs
@@ -9,6 +9,7 @@ use crate::{
         },
         PostgresQueryPath, PostgresRecord, Table,
     },
+    subgraph::edges::{KnowledgeGraphEdgeKind, SharedEdgeKind},
 };
 
 impl PostgresRecord for Entity {
@@ -30,37 +31,47 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
             | Self::RightToLeftOrder
             | Self::UpdatedById
             | Self::Archived => vec![Relation::EntityEditions],
-            Self::Type(path) => once(Relation::Reference(ReferenceTable::EntityIsOfType))
-                .chain(path.relations())
-                .collect(),
-            Self::LeftEntity(path)
-                if **path == EntityQueryPath::Uuid || **path == EntityQueryPath::OwnedById =>
-            {
-                vec![Relation::LeftEntity]
-            }
-            Self::RightEntity(path)
-                if **path == EntityQueryPath::Uuid || **path == EntityQueryPath::OwnedById =>
-            {
-                vec![Relation::RightEntity]
-            }
-            Self::LeftEntity(path) => {
-                once(Relation::Reference(ReferenceTable::EntityHasLeftEntity))
-                    .chain(path.relations())
-                    .collect()
-            }
-            Self::RightEntity(path) => {
-                once(Relation::Reference(ReferenceTable::EntityHasRightEntity))
-                    .chain(path.relations())
-                    .collect()
-            }
-            Self::IncomingLinks(path) => once(Relation::ReversedReference(
-                ReferenceTable::EntityHasRightEntity,
-            ))
+            Self::EntityTypeEdge {
+                edge_kind: SharedEdgeKind::IsOfType,
+                path,
+            } => once(Relation::Reference {
+                table: ReferenceTable::EntityIsOfType,
+                reversed: false,
+            })
             .chain(path.relations())
             .collect(),
-            Self::OutgoingLinks(path) => once(Relation::ReversedReference(
-                ReferenceTable::EntityHasLeftEntity,
-            ))
+            Self::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                path,
+                reversed: false,
+            } if **path == EntityQueryPath::Uuid || **path == EntityQueryPath::OwnedById => {
+                vec![Relation::LeftEntity]
+            }
+            Self::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                path,
+                reversed,
+            } => once(Relation::Reference {
+                table: ReferenceTable::EntityHasLeftEntity,
+                reversed: *reversed,
+            })
+            .chain(path.relations())
+            .collect(),
+            Self::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
+                path,
+                reversed: false,
+            } if **path == EntityQueryPath::Uuid || **path == EntityQueryPath::OwnedById => {
+                vec![Relation::RightEntity]
+            }
+            Self::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
+                path,
+                reversed,
+            } => once(Relation::Reference {
+                table: ReferenceTable::EntityHasRightEntity,
+                reversed: *reversed,
+            })
             .chain(path.relations())
             .collect(),
         }
@@ -73,25 +84,38 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
             Self::DecisionTime => Column::Entities(Entities::DecisionTime),
             Self::TransactionTime => Column::Entities(Entities::TransactionTime),
             Self::Archived => Column::EntityEditions(EntityEditions::Archived),
-            Self::Type(path) => path.terminating_column(),
             Self::OwnedById => Column::Entities(Entities::OwnedById),
             Self::UpdatedById => Column::EntityEditions(EntityEditions::UpdatedById),
-            Self::LeftEntity(path) if **path == EntityQueryPath::Uuid => {
+            Self::EntityTypeEdge { path, .. } => path.terminating_column(),
+            Self::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                path,
+                reversed: false,
+            } if **path == EntityQueryPath::Uuid => {
                 Column::EntityHasLeftEntity(EntityHasLeftEntity::LeftEntityUuid)
             }
-            Self::LeftEntity(path) if **path == EntityQueryPath::OwnedById => {
+            Self::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                path,
+                reversed: false,
+            } if **path == EntityQueryPath::OwnedById => {
                 Column::EntityHasLeftEntity(EntityHasLeftEntity::LeftEntityOwnedById)
             }
-            Self::RightEntity(path) if **path == EntityQueryPath::Uuid => {
+            Self::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
+                path,
+                reversed: false,
+            } if **path == EntityQueryPath::Uuid => {
                 Column::EntityHasRightEntity(EntityHasRightEntity::RightEntityUuid)
             }
-            Self::RightEntity(path) if **path == EntityQueryPath::OwnedById => {
+            Self::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
+                path,
+                reversed: false,
+            } if **path == EntityQueryPath::OwnedById => {
                 Column::EntityHasRightEntity(EntityHasRightEntity::RightEntityOwnedById)
             }
-            Self::LeftEntity(path)
-            | Self::RightEntity(path)
-            | Self::IncomingLinks(path)
-            | Self::OutgoingLinks(path) => path.terminating_column(),
+            Self::EntityEdge { path, .. } => path.terminating_column(),
             Self::LeftToRightOrder => Column::EntityEditions(EntityEditions::LeftToRightOrder),
             Self::RightToLeftOrder => Column::EntityEditions(EntityEditions::RightToLeftOrder),
             Self::Properties(path) => path.as_ref().map_or(

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
@@ -6,6 +6,7 @@ use crate::{
         table::{Column, EntityTypes, JsonField, OntologyIds, ReferenceTable, Relation},
         PostgresQueryPath, PostgresRecord, Table,
     },
+    subgraph::edges::{OntologyEdgeKind, SharedEdgeKind},
 };
 
 impl PostgresRecord for EntityTypeWithMetadata {
@@ -18,6 +19,13 @@ impl PostgresQueryPath for EntityTypeQueryPath<'_> {
     /// Returns the relations that are required to access the path.
     fn relations(&self) -> Vec<Relation> {
         match self {
+            Self::VersionedUrl
+            | Self::Title
+            | Self::Description
+            | Self::Examples
+            | Self::Required
+            | Self::OntologyId
+            | Self::Schema(_) => vec![],
             Self::BaseUrl
             | Self::Version
             | Self::UpdatedById
@@ -25,22 +33,55 @@ impl PostgresQueryPath for EntityTypeQueryPath<'_> {
             | Self::AdditionalMetadata(_) => {
                 vec![Relation::EntityTypeIds]
             }
-            Self::Properties(path) => once(Relation::Reference(
-                ReferenceTable::EntityTypeConstrainsPropertiesOn,
-            ))
+            Self::PropertyTypeEdge {
+                edge_kind: OntologyEdgeKind::ConstrainsPropertiesOn,
+                path,
+            } => once(Relation::Reference {
+                table: ReferenceTable::EntityTypeConstrainsPropertiesOn,
+                reversed: false,
+            })
             .chain(path.relations())
             .collect(),
-            Self::Links(path) => once(Relation::Reference(
-                ReferenceTable::EntityTypeConstrainsLinksOn,
-            ))
+            Self::EntityTypeEdge {
+                edge_kind: OntologyEdgeKind::InheritsFrom,
+                path,
+                reversed,
+            } => once(Relation::Reference {
+                table: ReferenceTable::EntityTypeInheritsFrom,
+                reversed: *reversed,
+            })
             .chain(path.relations())
             .collect(),
-            Self::InheritsFrom(path) => {
-                once(Relation::Reference(ReferenceTable::EntityTypeInheritsFrom))
-                    .chain(path.relations())
-                    .collect()
-            }
-            _ => vec![],
+            Self::EntityTypeEdge {
+                edge_kind: OntologyEdgeKind::ConstrainsLinksOn,
+                path,
+                reversed,
+            } => once(Relation::Reference {
+                table: ReferenceTable::EntityTypeConstrainsLinksOn,
+                reversed: *reversed,
+            })
+            .chain(path.relations())
+            .collect(),
+            Self::EntityTypeEdge {
+                edge_kind: OntologyEdgeKind::ConstrainsLinkDestinationsOn,
+                path,
+                reversed,
+            } => once(Relation::Reference {
+                table: ReferenceTable::EntityTypeConstrainsLinkDestinationsOn,
+                reversed: *reversed,
+            })
+            .chain(path.relations())
+            .collect(),
+            Self::EntityEdge {
+                edge_kind: SharedEdgeKind::IsOfType,
+                path,
+            } => once(Relation::Reference {
+                table: ReferenceTable::EntityIsOfType,
+                reversed: true,
+            })
+            .chain(path.relations())
+            .collect(),
+            _ => unreachable!("Invalid path: {self}"),
         }
     }
 
@@ -73,8 +114,9 @@ impl PostgresQueryPath for EntityTypeQueryPath<'_> {
             Self::Required => {
                 Column::EntityTypes(EntityTypes::Schema(Some(JsonField::StaticText("required"))))
             }
-            Self::Links(path) | Self::InheritsFrom(path) => path.terminating_column(),
-            Self::Properties(path) => path.terminating_column(),
+            Self::PropertyTypeEdge { path, .. } => path.terminating_column(),
+            Self::EntityTypeEdge { path, .. } => path.terminating_column(),
+            Self::EntityEdge { path, .. } => path.terminating_column(),
             Self::AdditionalMetadata(path) => path.as_ref().map_or(
                 Column::OntologyIds(OntologyIds::AdditionalMetadata(None)),
                 |path| {

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/property_type.rs
@@ -6,6 +6,7 @@ use crate::{
         table::{Column, JsonField, OntologyIds, PropertyTypes, ReferenceTable, Relation},
         PostgresQueryPath, PostgresRecord, Table,
     },
+    subgraph::edges::OntologyEdgeKind,
 };
 
 impl PostgresRecord for PropertyTypeWithMetadata {
@@ -17,6 +18,11 @@ impl PostgresRecord for PropertyTypeWithMetadata {
 impl PostgresQueryPath for PropertyTypeQueryPath<'_> {
     fn relations(&self) -> Vec<Relation> {
         match self {
+            Self::VersionedUrl
+            | Self::Title
+            | Self::Description
+            | Self::OntologyId
+            | Self::Schema(_) => vec![],
             Self::BaseUrl
             | Self::Version
             | Self::UpdatedById
@@ -24,17 +30,35 @@ impl PostgresQueryPath for PropertyTypeQueryPath<'_> {
             | Self::AdditionalMetadata(_) => {
                 vec![Relation::PropertyTypeIds]
             }
-            Self::DataTypes(path) => once(Relation::Reference(
-                ReferenceTable::PropertyTypeConstrainsValuesOn,
-            ))
+            Self::DataTypeEdge {
+                edge_kind: OntologyEdgeKind::ConstrainsValuesOn,
+                path,
+            } => once(Relation::Reference {
+                table: ReferenceTable::PropertyTypeConstrainsValuesOn,
+                reversed: false,
+            })
             .chain(path.relations())
             .collect(),
-            Self::PropertyTypes(path) => once(Relation::Reference(
-                ReferenceTable::PropertyTypeConstrainsPropertiesOn,
-            ))
+            Self::PropertyTypeEdge {
+                edge_kind: OntologyEdgeKind::ConstrainsPropertiesOn,
+                path,
+                reversed,
+            } => once(Relation::Reference {
+                table: ReferenceTable::PropertyTypeConstrainsPropertiesOn,
+                reversed: *reversed,
+            })
             .chain(path.relations())
             .collect(),
-            _ => vec![],
+            Self::EntityTypeEdge {
+                edge_kind: OntologyEdgeKind::ConstrainsPropertiesOn,
+                path,
+            } => once(Relation::Reference {
+                table: ReferenceTable::EntityTypeConstrainsPropertiesOn,
+                reversed: true,
+            })
+            .chain(path.relations())
+            .collect(),
+            _ => unreachable!("Invalid path: {self}"),
         }
     }
 
@@ -64,8 +88,9 @@ impl PostgresQueryPath for PropertyTypeQueryPath<'_> {
             Self::Description => Column::PropertyTypes(PropertyTypes::Schema(Some(
                 JsonField::StaticText("description"),
             ))),
-            Self::DataTypes(path) => path.terminating_column(),
-            Self::PropertyTypes(path) => path.terminating_column(),
+            Self::DataTypeEdge { path, .. } => path.terminating_column(),
+            Self::PropertyTypeEdge { path, .. } => path.terminating_column(),
+            Self::EntityTypeEdge { path, .. } => path.terminating_column(),
             Self::AdditionalMetadata(path) => path.as_ref().map_or(
                 Column::OntologyIds(OntologyIds::AdditionalMetadata(None)),
                 |path| {

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
@@ -745,8 +745,10 @@ pub enum Relation {
     EntityEditions,
     LeftEntity,
     RightEntity,
-    Reference(ReferenceTable),
-    ReversedReference(ReferenceTable),
+    Reference {
+        table: ReferenceTable,
+        reversed: bool,
+    },
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -842,8 +844,9 @@ impl Relation {
                     Column::EntityHasRightEntity(EntityHasRightEntity::EntityUuid),
                 ],
             }),
-            Self::Reference(table) => ForeignKeyJoin::from_reference_table(table, false),
-            Self::ReversedReference(table) => ForeignKeyJoin::from_reference_table(table, true),
+            Self::Reference { table, reversed } => {
+                ForeignKeyJoin::from_reference_table(table, reversed)
+            }
         }
     }
 }

--- a/apps/hash-graph/tests/integration/postgres/lib.rs
+++ b/apps/hash-graph/tests/integration/postgres/lib.rs
@@ -39,7 +39,7 @@ use graph::{
         QueryError, StorePool, UpdateError,
     },
     subgraph::{
-        edges::GraphResolveDepths,
+        edges::{GraphResolveDepths, KnowledgeGraphEdgeKind, SharedEdgeKind},
         identifier::{
             DataTypeVertexId, EntityTypeVertexId, GraphElementVertexId, PropertyTypeVertexId,
         },
@@ -497,33 +497,39 @@ impl DatabaseApi<'_> {
     ) -> Result<Entity, QueryError> {
         let filter = Filter::All(vec![
             Filter::Equal(
-                Some(FilterExpression::Path(EntityQueryPath::LeftEntity(
-                    Box::new(EntityQueryPath::Uuid),
-                ))),
+                Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
+                    edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                    path: Box::new(EntityQueryPath::Uuid),
+                    reversed: false,
+                })),
                 Some(FilterExpression::Parameter(Parameter::Uuid(
                     source_entity_id.entity_uuid.as_uuid(),
                 ))),
             ),
             Filter::Equal(
-                Some(FilterExpression::Path(EntityQueryPath::LeftEntity(
-                    Box::new(EntityQueryPath::OwnedById),
-                ))),
+                Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
+                    edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                    path: Box::new(EntityQueryPath::OwnedById),
+                    reversed: false,
+                })),
                 Some(FilterExpression::Parameter(Parameter::Uuid(
                     source_entity_id.owned_by_id.as_uuid(),
                 ))),
             ),
             Filter::Equal(
-                Some(FilterExpression::Path(EntityQueryPath::Type(
-                    EntityTypeQueryPath::BaseUrl,
-                ))),
+                Some(FilterExpression::Path(EntityQueryPath::EntityTypeEdge {
+                    edge_kind: SharedEdgeKind::IsOfType,
+                    path: EntityTypeQueryPath::BaseUrl,
+                })),
                 Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
                     link_type_id.base_url.as_str(),
                 )))),
             ),
             Filter::Equal(
-                Some(FilterExpression::Path(EntityQueryPath::Type(
-                    EntityTypeQueryPath::Version,
-                ))),
+                Some(FilterExpression::Path(EntityQueryPath::EntityTypeEdge {
+                    edge_kind: SharedEdgeKind::IsOfType,
+                    path: EntityTypeQueryPath::Version,
+                })),
                 Some(FilterExpression::Parameter(Parameter::OntologyTypeVersion(
                     OntologyTypeVersion::new(link_type_id.version),
                 ))),
@@ -568,17 +574,21 @@ impl DatabaseApi<'_> {
     ) -> Result<Vec<Entity>, QueryError> {
         let filter = Filter::All(vec![
             Filter::Equal(
-                Some(FilterExpression::Path(EntityQueryPath::LeftEntity(
-                    Box::new(EntityQueryPath::Uuid),
-                ))),
+                Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
+                    edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                    path: Box::new(EntityQueryPath::Uuid),
+                    reversed: false,
+                })),
                 Some(FilterExpression::Parameter(Parameter::Uuid(
                     source_entity_id.entity_uuid.as_uuid(),
                 ))),
             ),
             Filter::Equal(
-                Some(FilterExpression::Path(EntityQueryPath::LeftEntity(
-                    Box::new(EntityQueryPath::OwnedById),
-                ))),
+                Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
+                    edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                    path: Box::new(EntityQueryPath::OwnedById),
+                    reversed: false,
+                })),
                 Some(FilterExpression::Parameter(Parameter::Uuid(
                     source_entity_id.owned_by_id.as_uuid(),
                 ))),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To store reversed edges it's easier to store the edge kind in the query path than both edges. For types with the same right endpoint of an edge (currently entity types and entities), this also avoids duplication of these definitions.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1204000740778935/1204165139634983/f) _(internal)_

## 🚫 Blocked by

- #2202

## 🔍 What does this change?

- Use the edge definitions to identify query paths

## ⚠️ Known issues

With the current implementation, there is not much advantage to change the definitions of the query paths, however, with the two follow-up PRs, this will be more clear.

## 🐾 Next steps

- [Support reversed edges in structural ontology queries](https://app.asana.com/0/1204000740778935/1204165139634979/f) _(internal)_
- [Migrate the current implementation of looking up ontology type references in memory to instead be from the linking tables in DB](https://app.asana.com/0/1204000740778935/1204117847656666/f) _(internal)_

## 🛡 What tests cover this?

Basically every test, which uses structural query. Also a new unit test for a missing filter was added.