### PR TITLE
Use reference tables when looking up ontology references

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -14,6 +14,7 @@ use crate::{
         time::{DecisionTime, Timestamp},
     },
     knowledge::{Entity, EntityLinkOrder, EntityMetadata, EntityProperties, EntityUuid, LinkData},
+    ontology::EntityTypeWithMetadata,
     provenance::{OwnedById, ProvenanceMetadata, UpdatedById},
     store::{
         crud::Read,
@@ -27,7 +28,7 @@ use crate::{
             EdgeResolveDepths, GraphResolveDepths, KnowledgeGraphEdgeKind,
             OutgoingEdgeResolveDepth, SharedEdgeKind,
         },
-        identifier::{EntityIdWithInterval, EntityTypeVertexId, EntityVertexId},
+        identifier::{EntityIdWithInterval, EntityVertexId},
         query::StructuralQuery,
         temporal_axes::QueryTemporalAxes,
         Subgraph,
@@ -41,30 +42,27 @@ impl<C: AsClient> PostgresStore<C> {
     #[tracing::instrument(level = "trace", skip(self, traversal_context, subgraph))]
     pub(crate) async fn traverse_entities(
         &self,
-        entity_vertex_ids: Vec<EntityVertexId>,
-        temporal_axes: QueryTemporalAxes,
-        graph_resolve_depths: GraphResolveDepths,
+        mut entity_queue: Vec<(EntityVertexId, GraphResolveDepths, QueryTemporalAxes)>,
         traversal_context: &mut TraversalContext,
         subgraph: &mut Subgraph,
     ) -> Result<(), QueryError> {
-        let time_axis = temporal_axes.variable_time_axis();
+        let time_axis = subgraph.temporal_axes.resolved.variable_time_axis();
 
-        let mut queue = entity_vertex_ids
-            .into_iter()
-            .map(|id| (id, graph_resolve_depths, temporal_axes.clone()))
-            .collect::<Vec<_>>();
+        let mut entity_type_queue = Vec::new();
 
-        while !queue.is_empty() {
+        while !entity_queue.is_empty() {
             // TODO: We could re-use the memory here but we expect to batch the processing of this
             //       for-loop. See https://app.asana.com/0/0/1204117847656663/f
-            for (entity_vertex_id, graph_resolve_depths, temporal_axes) in mem::take(&mut queue) {
-                let entity: &Entity = subgraph.get_vertex(&entity_vertex_id).unwrap_or_else(|| {
-                    // Entities are always inserted into the subgraph before they are resolved,
-                    // so this should never happen. If it does, it is a bug.
-                    unreachable!("entity should already be in the subgraph");
-                });
-
-                let entity_interval = entity
+            for (entity_vertex_id, graph_resolve_depths, temporal_axes) in
+                mem::take(&mut entity_queue)
+            {
+                let entity_interval = subgraph
+                    .get_vertex::<Entity>(&entity_vertex_id)
+                    .unwrap_or_else(|| {
+                        // Entities are always inserted into the subgraph before they are resolved,
+                        // so this should never happen. If it does, it is a bug.
+                        unreachable!("entity should already be in the subgraph");
+                    })
                     .metadata
                     .temporal_versioning()
                     .variable_time_interval(time_axis);
@@ -87,28 +85,38 @@ impl<C: AsClient> PostgresStore<C> {
                     });
 
                 if graph_resolve_depths.is_of_type.outgoing > 0 {
-                    let entity_type_id =
-                        EntityTypeVertexId::from(entity.metadata.entity_type_id().clone());
-                    subgraph.insert_edge(
-                        &entity_vertex_id,
-                        SharedEdgeKind::IsOfType,
-                        entity_type_id.clone(),
-                    );
-
-                    self.traverse_entity_type(
-                        vec![entity_type_id],
-                        temporal_axes.clone(),
-                        GraphResolveDepths {
-                            is_of_type: OutgoingEdgeResolveDepth {
-                                outgoing: graph_resolve_depths.is_of_type.outgoing - 1,
-                                ..graph_resolve_depths.is_of_type
-                            },
-                            ..graph_resolve_depths
-                        },
-                        traversal_context,
-                        subgraph,
+                    for entity_type in <Self as Read<EntityTypeWithMetadata>>::read(
+                        self,
+                        &Filter::for_shared_edge_by_entity_id(
+                            entity_vertex_id.base_id,
+                            SharedEdgeKind::IsOfType,
+                        ),
+                        &temporal_axes,
                     )
-                    .await?;
+                    .await?
+                    {
+                        let entity_type_vertex_id = entity_type.vertex_id(time_axis);
+
+                        subgraph.insert_edge(
+                            &entity_vertex_id,
+                            SharedEdgeKind::IsOfType,
+                            entity_type_vertex_id.clone(),
+                        );
+
+                        subgraph.insert_vertex(&entity_type_vertex_id, entity_type);
+
+                        entity_type_queue.push((
+                            entity_type_vertex_id,
+                            GraphResolveDepths {
+                                is_of_type: OutgoingEdgeResolveDepth {
+                                    outgoing: graph_resolve_depths.is_of_type.outgoing - 1,
+                                    ..graph_resolve_depths.is_of_type
+                                },
+                                ..graph_resolve_depths
+                            },
+                            temporal_axes.clone(),
+                        ));
+                    }
                 }
 
                 if graph_resolve_depths.has_left_entity.incoming > 0 {
@@ -143,7 +151,7 @@ impl<C: AsClient> PostgresStore<C> {
                         subgraph
                             .insert_vertex(&outgoing_link_entity_vertex_id, outgoing_link_entity);
 
-                        queue.push((
+                        entity_queue.push((
                             outgoing_link_entity_vertex_id,
                             GraphResolveDepths {
                                 has_left_entity: EdgeResolveDepths {
@@ -189,7 +197,7 @@ impl<C: AsClient> PostgresStore<C> {
                         subgraph
                             .insert_vertex(&incoming_link_entity_vertex_id, incoming_link_entity);
 
-                        queue.push((
+                        entity_queue.push((
                             incoming_link_entity_vertex_id,
                             GraphResolveDepths {
                                 has_right_entity: EdgeResolveDepths {
@@ -227,7 +235,7 @@ impl<C: AsClient> PostgresStore<C> {
                         let left_entity_vertex_id = left_entity.vertex_id(time_axis);
                         subgraph.insert_vertex(&left_entity_vertex_id, left_entity);
 
-                        queue.push((
+                        entity_queue.push((
                             left_entity_vertex_id,
                             GraphResolveDepths {
                                 has_left_entity: EdgeResolveDepths {
@@ -265,7 +273,7 @@ impl<C: AsClient> PostgresStore<C> {
                         let right_entity_vertex_id = right_entity.vertex_id(time_axis);
                         subgraph.insert_vertex(&right_entity_vertex_id, right_entity);
 
-                        queue.push((
+                        entity_queue.push((
                             right_entity_vertex_id,
                             GraphResolveDepths {
                                 has_right_entity: EdgeResolveDepths {
@@ -280,6 +288,9 @@ impl<C: AsClient> PostgresStore<C> {
                 }
             }
         }
+
+        self.traverse_entity_types(entity_type_queue, traversal_context, subgraph)
+            .await?;
 
         Ok(())
     }
@@ -537,9 +548,18 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         // TODO: We currently pass in the subgraph as mutable reference, thus we cannot borrow the
         //       vertices and have to `.collect()` the keys.
         self.traverse_entities(
-            subgraph.vertices.entities.keys().copied().collect(),
-            subgraph.temporal_axes.resolved.clone(),
-            subgraph.depths,
+            subgraph
+                .vertices
+                .entities
+                .keys()
+                .map(|id| {
+                    (
+                        *id,
+                        subgraph.depths,
+                        subgraph.temporal_axes.resolved.clone(),
+                    )
+                })
+                .collect(),
             &mut TraversalContext,
             &mut subgraph,
         )

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -125,7 +125,7 @@ impl<C: AsClient> PostgresStore<C> {
                         &Filter::for_knowledge_graph_edge_by_entity_id(
                             entity_vertex_id.base_id,
                             KnowledgeGraphEdgeKind::HasLeftEntity,
-                            true,
+                            false,
                         ),
                         &temporal_axes,
                     )
@@ -171,7 +171,7 @@ impl<C: AsClient> PostgresStore<C> {
                         &Filter::for_knowledge_graph_edge_by_entity_id(
                             entity_vertex_id.base_id,
                             KnowledgeGraphEdgeKind::HasRightEntity,
-                            true,
+                            false,
                         ),
                         &temporal_axes,
                     )
@@ -217,7 +217,7 @@ impl<C: AsClient> PostgresStore<C> {
                         &Filter::for_knowledge_graph_edge_by_entity_id(
                             entity_vertex_id.base_id,
                             KnowledgeGraphEdgeKind::HasLeftEntity,
-                            false,
+                            true,
                         ),
                         &temporal_axes,
                     )
@@ -255,7 +255,7 @@ impl<C: AsClient> PostgresStore<C> {
                         &Filter::for_knowledge_graph_edge_by_entity_id(
                             entity_vertex_id.base_id,
                             KnowledgeGraphEdgeKind::HasRightEntity,
-                            false,
+                            true,
                         ),
                         &temporal_axes,
                     )

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -2,18 +2,18 @@ use std::{borrow::Borrow, mem};
 
 use async_trait::async_trait;
 use error_stack::{Result, ResultExt};
-use type_system::{EntityType, EntityTypeReference, PropertyTypeReference};
+use type_system::EntityType;
 
 use crate::{
-    ontology::{EntityTypeWithMetadata, OntologyElementMetadata, OntologyTypeWithMetadata},
+    ontology::{EntityTypeWithMetadata, OntologyElementMetadata, PropertyTypeWithMetadata},
     provenance::UpdatedById,
     store::{
-        crud::Read, postgres::TraversalContext, AsClient, EntityTypeStore, InsertionError,
-        PostgresStore, QueryError, Record, UpdateError,
+        crud::Read, postgres::TraversalContext, query::Filter, AsClient, EntityTypeStore,
+        InsertionError, PostgresStore, QueryError, Record, UpdateError,
     },
     subgraph::{
         edges::{GraphResolveDepths, OntologyEdgeKind, OutgoingEdgeResolveDepth},
-        identifier::{EntityTypeVertexId, PropertyTypeVertexId},
+        identifier::EntityTypeVertexId,
         query::StructuralQuery,
         temporal_axes::QueryTemporalAxes,
         Subgraph,
@@ -25,196 +25,182 @@ impl<C: AsClient> PostgresStore<C> {
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
     #[tracing::instrument(level = "trace", skip(self, traversal_context, subgraph))]
-    pub(crate) async fn traverse_entity_type(
+    pub(crate) async fn traverse_entity_types(
         &self,
-        entity_type_ids: Vec<EntityTypeVertexId>,
-        temporal_axes: QueryTemporalAxes,
-        graph_resolve_depths: GraphResolveDepths,
+        mut entity_type_queue: Vec<(EntityTypeVertexId, GraphResolveDepths, QueryTemporalAxes)>,
         traversal_context: &mut TraversalContext,
         subgraph: &mut Subgraph,
     ) -> Result<(), QueryError> {
-        let mut queue = entity_type_ids
-            .into_iter()
-            .map(|id| (id, graph_resolve_depths, temporal_axes.clone()))
-            .collect::<Vec<_>>();
+        let time_axis = subgraph.temporal_axes.resolved.variable_time_axis();
 
-        while !queue.is_empty() {
+        let mut property_type_queue = Vec::new();
+
+        while !entity_type_queue.is_empty() {
             // TODO: We could re-use the memory here but we expect to batch the processing of this
             //       for-loop. See https://app.asana.com/0/0/1204117847656663/f
-            for (entity_type_id, current_resolve_depths, temporal_axes) in mem::take(&mut queue) {
-                let entity_type = subgraph
-                    .get_or_read::<EntityTypeWithMetadata>(self, &entity_type_id, &temporal_axes)
-                    .await?;
-
-                // Collecting references before traversing further to avoid having a shared
-                // reference to the subgraph when borrowing it mutably
-                let property_type_ref_urls =
-                    (current_resolve_depths.constrains_properties_on.outgoing > 0).then(|| {
-                        entity_type
-                            .inner()
-                            .property_type_references()
-                            .into_iter()
-                            .map(PropertyTypeReference::url)
-                            .cloned()
-                            .collect::<Vec<_>>()
-                    });
-
-                let inherits_from_type_ref_urls =
-                    (current_resolve_depths.inherits_from.outgoing > 0).then(|| {
-                        entity_type
-                            .inner()
-                            .inherits_from()
-                            .all_of()
-                            .iter()
-                            .map(EntityTypeReference::url)
-                            .cloned()
-                            .collect::<Vec<_>>()
-                    });
-
-                let link_mappings = (current_resolve_depths.constrains_links_on.outgoing > 0
-                    || current_resolve_depths
-                        .constrains_link_destinations_on
-                        .outgoing
-                        > 0)
-                .then(|| {
-                    entity_type
-                        .inner()
-                        .link_mappings()
-                        .into_iter()
-                        .map(|(entity_type_ref, destinations)| {
-                            (
-                                entity_type_ref.url().clone(),
-                                destinations
-                                    .into_iter()
-                                    .flatten()
-                                    .map(EntityTypeReference::url)
-                                    .cloned()
-                                    .collect::<Vec<_>>(),
-                            )
-                        })
-                        .collect::<Vec<_>>()
-                });
-
-                if let Some(property_type_ref_urls) = property_type_ref_urls {
-                    for property_type_ref_url in property_type_ref_urls {
-                        let property_type_vertex_id =
-                            PropertyTypeVertexId::from(property_type_ref_url);
+            for (entity_type_vertex_id, graph_resolve_depths, temporal_axes) in
+                mem::take(&mut entity_type_queue)
+            {
+                if graph_resolve_depths.constrains_properties_on.outgoing > 0 {
+                    tracing::trace!(
+                        "reading property types for `{}v/{}`",
+                        entity_type_vertex_id.base_id.as_str(),
+                        entity_type_vertex_id.revision_id.inner()
+                    );
+                    for property_type in <Self as Read<PropertyTypeWithMetadata>>::read(
+                        self,
+                        &Filter::<PropertyTypeWithMetadata>::for_ontology_edge_by_entity_type_vertex_id(
+                            &entity_type_vertex_id,
+                            OntologyEdgeKind::ConstrainsPropertiesOn,
+                        ),
+                        &temporal_axes,
+                    )
+                        .await?
+                    {
+                        let property_type_vertex_id = property_type.vertex_id(time_axis);
 
                         subgraph.insert_edge(
-                            &entity_type_id,
+                            &entity_type_vertex_id,
                             OntologyEdgeKind::ConstrainsPropertiesOn,
                             property_type_vertex_id.clone(),
                         );
 
-                        self.traverse_property_type(
-                            vec![property_type_vertex_id],
-                            temporal_axes.clone(),
+                        subgraph.insert_vertex(&property_type_vertex_id, property_type);
+
+                        property_type_queue.push((
+                            property_type_vertex_id,
                             GraphResolveDepths {
                                 constrains_properties_on: OutgoingEdgeResolveDepth {
-                                    outgoing: current_resolve_depths
-                                        .constrains_properties_on
-                                        .outgoing
+                                    outgoing: graph_resolve_depths.constrains_properties_on.outgoing
                                         - 1,
-                                    ..current_resolve_depths.constrains_properties_on
+                                    ..graph_resolve_depths.constrains_properties_on
                                 },
-                                ..current_resolve_depths
+                                ..graph_resolve_depths
                             },
-                            traversal_context,
-                            subgraph,
-                        )
-                        .await?;
-                    }
-                }
-
-                if let Some(inherits_from_type_ref_urls) = inherits_from_type_ref_urls {
-                    for inherits_from_type_ref_url in inherits_from_type_ref_urls {
-                        let inherits_from_type_vertex_id =
-                            EntityTypeVertexId::from(inherits_from_type_ref_url);
-
-                        subgraph.insert_edge(
-                            &entity_type_id,
-                            OntologyEdgeKind::InheritsFrom,
-                            inherits_from_type_vertex_id.clone(),
-                        );
-
-                        queue.push((
-                            inherits_from_type_vertex_id,
-                            GraphResolveDepths {
-                                inherits_from: OutgoingEdgeResolveDepth {
-                                    outgoing: current_resolve_depths.inherits_from.outgoing - 1,
-                                    ..current_resolve_depths.inherits_from
-                                },
-                                ..current_resolve_depths
-                            },
-                            temporal_axes.clone(),
+                            temporal_axes.clone()
                         ));
                     }
                 }
 
-                if let Some(link_mappings) = link_mappings {
-                    for (link_type_url, destination_type_urls) in link_mappings {
-                        if current_resolve_depths.constrains_links_on.outgoing > 0 {
-                            let link_type_vertex_id = EntityTypeVertexId::from(link_type_url);
+                if graph_resolve_depths.inherits_from.outgoing > 0 {
+                    for referenced_entity_type in <Self as Read<EntityTypeWithMetadata>>::read(
+                        self,
+                        &Filter::<EntityTypeWithMetadata>::for_ontology_edge_by_entity_type_vertex_id(
+                            &entity_type_vertex_id,
+                            OntologyEdgeKind::InheritsFrom,
+                            true,
+                        ),
+                        &temporal_axes,
+                    )
+                        .await?
+                    {
+                        let referenced_entity_type_vertex_id = referenced_entity_type.vertex_id(time_axis);
 
-                            subgraph.insert_edge(
-                                &entity_type_id,
-                                OntologyEdgeKind::ConstrainsLinksOn,
-                                link_type_vertex_id.clone(),
-                            );
+                        subgraph.insert_edge(
+                            &entity_type_vertex_id,
+                            OntologyEdgeKind::InheritsFrom,
+                            referenced_entity_type_vertex_id.clone(),
+                        );
 
-                            queue.push((
-                                link_type_vertex_id,
-                                GraphResolveDepths {
-                                    constrains_links_on: OutgoingEdgeResolveDepth {
-                                        outgoing: current_resolve_depths
-                                            .constrains_links_on
-                                            .outgoing
-                                            - 1,
-                                        ..current_resolve_depths.constrains_links_on
-                                    },
-                                    ..current_resolve_depths
+                        subgraph.insert_vertex(&referenced_entity_type_vertex_id, referenced_entity_type);
+
+                        entity_type_queue.push((
+                            referenced_entity_type_vertex_id,
+                            GraphResolveDepths {
+                                inherits_from: OutgoingEdgeResolveDepth {
+                                    outgoing: graph_resolve_depths.inherits_from.outgoing
+                                        - 1,
+                                    ..graph_resolve_depths.inherits_from
                                 },
-                                temporal_axes.clone(),
-                            ));
+                                ..graph_resolve_depths
+                            },
+                            temporal_axes.clone()
+                        ));
+                    }
+                }
 
-                            if current_resolve_depths
-                                .constrains_link_destinations_on
-                                .outgoing
-                                > 0
-                            {
-                                for destination_type_url in destination_type_urls {
-                                    let destination_type_vertex_id =
-                                        EntityTypeVertexId::from(destination_type_url);
+                if graph_resolve_depths.constrains_links_on.outgoing > 0 {
+                    for referenced_entity_type in <Self as Read<EntityTypeWithMetadata>>::read(
+                        self,
+                        &Filter::<EntityTypeWithMetadata>::for_ontology_edge_by_entity_type_vertex_id(
+                            &entity_type_vertex_id,
+                            OntologyEdgeKind::ConstrainsLinksOn,
+                            true,
+                        ),
+                        &temporal_axes,
+                    )
+                        .await?
+                    {
+                        let referenced_entity_type_vertex_id = referenced_entity_type.vertex_id(time_axis);
 
-                                    subgraph.insert_edge(
-                                        &entity_type_id,
-                                        OntologyEdgeKind::ConstrainsLinkDestinationsOn,
-                                        destination_type_vertex_id.clone(),
-                                    );
+                        subgraph.insert_edge(
+                            &entity_type_vertex_id,
+                            OntologyEdgeKind::ConstrainsLinksOn,
+                            referenced_entity_type_vertex_id.clone(),
+                        );
 
-                                    queue.push((
-                                        destination_type_vertex_id,
-                                        GraphResolveDepths {
-                                            constrains_link_destinations_on:
-                                                OutgoingEdgeResolveDepth {
-                                                    outgoing: current_resolve_depths
-                                                        .constrains_link_destinations_on
-                                                        .outgoing
-                                                        - 1,
-                                                    ..current_resolve_depths
-                                                        .constrains_link_destinations_on
-                                                },
-                                            ..current_resolve_depths
-                                        },
-                                        temporal_axes.clone(),
-                                    ));
-                                }
-                            }
-                        }
+                        subgraph.insert_vertex(&referenced_entity_type_vertex_id, referenced_entity_type);
+
+                        entity_type_queue.push((
+                            referenced_entity_type_vertex_id,
+                            GraphResolveDepths {
+                                constrains_links_on: OutgoingEdgeResolveDepth {
+                                    outgoing: graph_resolve_depths.constrains_links_on.outgoing
+                                        - 1,
+                                    ..graph_resolve_depths.constrains_links_on
+                                },
+                                ..graph_resolve_depths
+                            },
+                            temporal_axes.clone()
+                        ));
+                    }
+                }
+
+                if graph_resolve_depths
+                    .constrains_link_destinations_on
+                    .outgoing
+                    > 0
+                {
+                    for referenced_entity_type in <Self as Read<EntityTypeWithMetadata>>::read(
+                        self,
+                        &Filter::<EntityTypeWithMetadata>::for_ontology_edge_by_entity_type_vertex_id(
+                            &entity_type_vertex_id,
+                            OntologyEdgeKind::ConstrainsLinkDestinationsOn,
+                            true,
+                        ),
+                        &temporal_axes,
+                    )
+                        .await?
+                    {
+                        let referenced_entity_type_vertex_id = referenced_entity_type.vertex_id(time_axis);
+
+                        subgraph.insert_edge(
+                            &entity_type_vertex_id,
+                            OntologyEdgeKind::ConstrainsLinkDestinationsOn,
+                            referenced_entity_type_vertex_id.clone(),
+                        );
+
+                        subgraph.insert_vertex(&referenced_entity_type_vertex_id, referenced_entity_type);
+
+                        entity_type_queue.push((
+                            referenced_entity_type_vertex_id,
+                            GraphResolveDepths {
+                                constrains_link_destinations_on: OutgoingEdgeResolveDepth {
+                                    outgoing: graph_resolve_depths.constrains_link_destinations_on.outgoing
+                                        - 1,
+                                    ..graph_resolve_depths.constrains_link_destinations_on
+                                },
+                                ..graph_resolve_depths
+                            },
+                            temporal_axes.clone()
+                        ));
                     }
                 }
             }
         }
+
+        self.traverse_property_types(property_type_queue, traversal_context, subgraph)
+            .await?;
 
         Ok(())
     }
@@ -296,10 +282,19 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
 
         // TODO: We currently pass in the subgraph as mutable reference, thus we cannot borrow the
         //       vertices and have to `.collect()` the keys.
-        self.traverse_entity_type(
-            subgraph.vertices.entity_types.keys().cloned().collect(),
-            subgraph.temporal_axes.resolved.clone(),
-            subgraph.depths,
+        self.traverse_entity_types(
+            subgraph
+                .vertices
+                .entity_types
+                .keys()
+                .map(|id| {
+                    (
+                        id.clone(),
+                        subgraph.depths,
+                        subgraph.temporal_axes.resolved.clone(),
+                    )
+                })
+                .collect(),
             &mut TraversalContext,
             &mut subgraph,
         )

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -2,18 +2,18 @@ use std::{borrow::Borrow, mem};
 
 use async_trait::async_trait;
 use error_stack::{Result, ResultExt};
-use type_system::{DataTypeReference, PropertyType, PropertyTypeReference};
+use type_system::PropertyType;
 
 use crate::{
-    ontology::{OntologyElementMetadata, OntologyTypeWithMetadata, PropertyTypeWithMetadata},
+    ontology::{DataTypeWithMetadata, OntologyElementMetadata, PropertyTypeWithMetadata},
     provenance::UpdatedById,
     store::{
-        crud::Read, postgres::TraversalContext, AsClient, InsertionError, PostgresStore,
-        PropertyTypeStore, QueryError, Record, UpdateError,
+        crud::Read, postgres::TraversalContext, query::Filter, AsClient, InsertionError,
+        PostgresStore, PropertyTypeStore, QueryError, Record, UpdateError,
     },
     subgraph::{
         edges::{GraphResolveDepths, OntologyEdgeKind, OutgoingEdgeResolveDepth},
-        identifier::{DataTypeVertexId, PropertyTypeVertexId},
+        identifier::PropertyTypeVertexId,
         query::StructuralQuery,
         temporal_axes::QueryTemporalAxes,
         Subgraph,
@@ -25,105 +25,92 @@ impl<C: AsClient> PostgresStore<C> {
     ///
     /// This is used to recursively resolve a type, so the result can be reused.
     #[tracing::instrument(level = "trace", skip(self, traversal_context, subgraph))]
-    pub(crate) async fn traverse_property_type(
+    pub(crate) async fn traverse_property_types(
         &self,
-        property_type_ids: Vec<PropertyTypeVertexId>,
-        temporal_axes: QueryTemporalAxes,
-        graph_resolve_depths: GraphResolveDepths,
+        mut property_type_queue: Vec<(PropertyTypeVertexId, GraphResolveDepths, QueryTemporalAxes)>,
         traversal_context: &mut TraversalContext,
         subgraph: &mut Subgraph,
     ) -> Result<(), QueryError> {
-        let mut queue = property_type_ids
-            .into_iter()
-            .map(|id| (id, graph_resolve_depths, temporal_axes.clone()))
-            .collect::<Vec<_>>();
+        let time_axis = subgraph.temporal_axes.resolved.variable_time_axis();
 
-        while !queue.is_empty() {
+        let mut data_type_queue = Vec::new();
+
+        while !property_type_queue.is_empty() {
             // TODO: We could re-use the memory here but we expect to batch the processing of this
             //       for-loop. See https://app.asana.com/0/0/1204117847656663/f
-            for (property_type_id, current_resolve_depths, temporal_axes) in mem::take(&mut queue) {
-                let property_type = subgraph
-                    .get_or_read::<PropertyTypeWithMetadata>(
+            for (property_type_vertex_id, graph_resolve_depths, temporal_axes) in
+                mem::take(&mut property_type_queue)
+            {
+                if graph_resolve_depths.constrains_values_on.outgoing > 0 {
+                    for data_type in <Self as Read<DataTypeWithMetadata>>::read(
                         self,
-                        &property_type_id,
+                        &Filter::<DataTypeWithMetadata>::for_ontology_edge_by_property_type_vertex_id(
+                            &property_type_vertex_id,
+                            OntologyEdgeKind::ConstrainsValuesOn,
+                        ),
                         &temporal_axes,
                     )
-                    .await?;
-
-                // Collecting references before traversing further to avoid having a shared
-                // reference to the subgraph when borrowing it mutably
-                let data_type_ref_urls = (current_resolve_depths.constrains_values_on.outgoing > 0)
-                    .then(|| {
-                        property_type
-                            .inner()
-                            .data_type_references()
-                            .into_iter()
-                            .map(DataTypeReference::url)
-                            .cloned()
-                            .collect::<Vec<_>>()
-                    });
-
-                let property_type_ref_urls =
-                    (current_resolve_depths.constrains_properties_on.outgoing > 0).then(|| {
-                        property_type
-                            .inner()
-                            .property_type_references()
-                            .into_iter()
-                            .map(PropertyTypeReference::url)
-                            .cloned()
-                            .collect::<Vec<_>>()
-                    });
-
-                if let Some(data_type_ref_urls) = data_type_ref_urls {
-                    for data_type_ref in data_type_ref_urls {
-                        let data_type_vertex_id = DataTypeVertexId::from(data_type_ref);
+                    .await?
+                    {
+                        let data_type_vertex_id = data_type.vertex_id(time_axis);
 
                         subgraph.insert_edge(
-                            &property_type_id,
+                            &property_type_vertex_id,
                             OntologyEdgeKind::ConstrainsValuesOn,
                             data_type_vertex_id.clone(),
                         );
 
-                        self.traverse_data_type(
-                            vec![data_type_vertex_id],
-                            temporal_axes.clone(),
+                        subgraph.insert_vertex(&data_type_vertex_id, data_type);
+
+                        data_type_queue.push((
+                            data_type_vertex_id,
                             GraphResolveDepths {
                                 constrains_values_on: OutgoingEdgeResolveDepth {
-                                    outgoing: current_resolve_depths.constrains_values_on.outgoing
+                                    outgoing: graph_resolve_depths.constrains_values_on.outgoing
                                         - 1,
-                                    ..current_resolve_depths.constrains_values_on
+                                    ..graph_resolve_depths.constrains_values_on
                                 },
-                                ..current_resolve_depths
+                                ..graph_resolve_depths
                             },
-                            traversal_context,
-                            subgraph,
-                        )
-                        .await?;
+                            temporal_axes.clone()
+                        ));
                     }
                 }
 
-                if let Some(property_type_ref_urls) = property_type_ref_urls {
-                    for property_type_ref_url in property_type_ref_urls {
-                        let property_type_vertex_id =
-                            PropertyTypeVertexId::from(property_type_ref_url);
+                if graph_resolve_depths.constrains_properties_on.outgoing > 0 {
+                    for referenced_property_type in <Self as Read<PropertyTypeWithMetadata>>::read(
+                        self,
+                        &Filter::<PropertyTypeWithMetadata>::for_ontology_edge_by_property_type_vertex_id(
+                            &property_type_vertex_id,
+                            OntologyEdgeKind::ConstrainsPropertiesOn,
+                            true,
+                        ),
+                        &temporal_axes,
+                    )
+                    .await?
+                    {
+                        let referenced_property_type_vertex_id = referenced_property_type.vertex_id(time_axis);
 
                         subgraph.insert_edge(
-                            &property_type_id,
+                            &property_type_vertex_id,
                             OntologyEdgeKind::ConstrainsPropertiesOn,
-                            property_type_vertex_id.clone(),
+                            referenced_property_type_vertex_id.clone(),
                         );
 
-                        queue.push((
-                            property_type_vertex_id,
+                        subgraph
+                            .insert_vertex(&property_type_vertex_id, referenced_property_type);
+
+                        property_type_queue.push((
+                            referenced_property_type_vertex_id,
                             GraphResolveDepths {
                                 constrains_properties_on: OutgoingEdgeResolveDepth {
-                                    outgoing: current_resolve_depths
+                                    outgoing: graph_resolve_depths
                                         .constrains_properties_on
                                         .outgoing
                                         - 1,
-                                    ..current_resolve_depths.constrains_properties_on
+                                    ..graph_resolve_depths.constrains_properties_on
                                 },
-                                ..current_resolve_depths
+                                ..graph_resolve_depths
                             },
                             temporal_axes.clone(),
                         ));
@@ -131,6 +118,9 @@ impl<C: AsClient> PostgresStore<C> {
                 }
             }
         }
+
+        self.traverse_data_types(data_type_queue, traversal_context, subgraph)
+            .await?;
 
         Ok(())
     }
@@ -212,10 +202,19 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
 
         // TODO: We currently pass in the subgraph as mutable reference, thus we cannot borrow the
         //       vertices and have to `.collect()` the keys.
-        self.traverse_property_type(
-            subgraph.vertices.property_types.keys().cloned().collect(),
-            subgraph.temporal_axes.resolved.clone(),
-            subgraph.depths,
+        self.traverse_property_types(
+            subgraph
+                .vertices
+                .property_types
+                .keys()
+                .map(|id| {
+                    (
+                        id.clone(),
+                        subgraph.depths,
+                        subgraph.temporal_axes.resolved.clone(),
+                    )
+                })
+                .collect(),
             &mut TraversalContext,
             &mut subgraph,
         )


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We're going to look up the references before looking up the actual records. This implies, that ontology references also needs to be looked up through the database. This also implies, that ontology types do not need to be looked up one-by-one.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204000740778935/1204117847656666/f) _(internal)_

## 🚫 Blocked by

- #2202 
- #2207
- #2208

## 🔍 What does this change?

Replace lazy lookups based on the returned ontology reference iterators with direct lookups through reference tables

## 🐾 Next steps

The structure of looking up edges is now almost identical, which enables further work to [deduplicate the subgraph traversal logic](https://app.asana.com/0/1203363157432084/1203444301722127/f)