### PR TITLE
Deduplicate graph traversal for entities

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -78,7 +78,6 @@ impl<C: AsClient> PostgresStore<C> {
                         unreachable!("The edge interval and the entity interval do not overlap")
                     });
 
-                // reversed `HasLeftEntity` is equivalent to an outgoing link `Entity`
                 subgraph.insert_edge(
                     &entity_vertex_id,
                     edge_kind,

--- a/apps/hash-graph/lib/graph/src/subgraph/edges/edge.rs
+++ b/apps/hash-graph/lib/graph/src/subgraph/edges/edge.rs
@@ -33,6 +33,16 @@ pub enum EdgeDirection {
     Incoming,
 }
 
+impl EdgeDirection {
+    #[must_use]
+    pub const fn reversed(self) -> Self {
+        match self {
+            Self::Outgoing => Self::Incoming,
+            Self::Incoming => Self::Outgoing,
+        }
+    }
+}
+
 // Utoipa doesn't seem to be able to generate sensible interfaces for this, it gets confused by
 // the generic
 impl<'s, K, E> OutwardEdge<K, E>

--- a/apps/hash-graph/lib/graph/src/subgraph/edges/edge.rs
+++ b/apps/hash-graph/lib/graph/src/subgraph/edges/edge.rs
@@ -4,8 +4,6 @@ use utoipa::{openapi, ToSchema};
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct OutwardEdge<K, E> {
     pub kind: K,
-    /// If true, interpret this as a reversed mapping and the endpoint as the source, that is,
-    /// instead of Source-Edge-Target, interpret it as Target-Edge-Source
     pub direction: EdgeDirection,
     pub right_endpoint: E,
 }

--- a/apps/hash-graph/lib/graph/src/subgraph/edges/edge.rs
+++ b/apps/hash-graph/lib/graph/src/subgraph/edges/edge.rs
@@ -25,9 +25,12 @@ where
     }
 }
 
+/// The direction of an edge in a graph.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum EdgeDirection {
+    /// Represents an edge that points from the left endpoint to the right endpoint.
     Outgoing,
+    /// Represents a reversed edge that points from the right endpoint to the left endpoint.
     Incoming,
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The logic for traversing entities is only different in its parameters, so it can be deduplicated

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203363157432084/1203444301722127/f) _(internal)_

## 🚫 Blocked by

- #2207 
- #2208 
- #2223 
- #2226 
- #2229 

## 🔍 What does this change?

- Move traversal logic for entities to function
- Fix a bug to correctly resolve the edge interval. This is not necessarily the link's interval but the intersection of both endpoints. We did never encounter issues so far as without deletion it's not possible to construct this case.