### PR TITLE
Add description field to entity type editor form data

### DIFF
--- a/libs/@hashintel/type-editor/src/get-form-data-from-schema.ts
+++ b/libs/@hashintel/type-editor/src/get-form-data-from-schema.ts
@@ -9,6 +9,7 @@ type Entries<T> = {
 export const getFormDataFromSchema = (
   schema: EntityType,
 ): EntityTypeEditorFormData => ({
+  description: schema.description ?? "",
   properties: Object.entries(schema.properties).map(([propertyId, ref]) => {
     const isArray = "type" in ref;
 

--- a/libs/@hashintel/type-editor/src/get-schema-from-form-data.ts
+++ b/libs/@hashintel/type-editor/src/get-schema-from-form-data.ts
@@ -10,7 +10,9 @@ import { EntityTypeEditorFormData } from "./shared/form-types";
 
 export const getSchemaFromFormData = (
   data: EntityTypeEditorFormData,
-): Required<Pick<EntityType, "links" | "properties" | "required">> => {
+): Required<
+  Pick<EntityType, "description" | "links" | "properties" | "required">
+> => {
   const properties = data.properties;
 
   const schemaProperties: Record<
@@ -72,6 +74,7 @@ export const getSchemaFromFormData = (
   }
 
   return {
+    description: data.description,
     properties: schemaProperties,
     links,
     required,

--- a/libs/@hashintel/type-editor/src/shared/form-types.ts
+++ b/libs/@hashintel/type-editor/src/shared/form-types.ts
@@ -17,6 +17,7 @@ export type EntityTypeEditorLinkData = EntityTypeEditorTypeData & {
 };
 
 export type EntityTypeEditorFormData = {
+  description: string;
   properties: EntityTypeEditorPropertyData[];
   links: EntityTypeEditorLinkData[];
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
This PR adds description as a field to the entity type form data context, allowing react-hook-form to control it.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](link) _(internal)_
