### PR TITLE
Manually invoke `cargo-script` instead of using `cargo-make`

### DIFF
--- a/.github/scripts/rust/Makefile.lint.toml
+++ b/.github/scripts/rust/Makefile.lint.toml
@@ -1,9 +1,9 @@
-[tasks.update-clippy]
-env = { "CARGO_MAKE_RUST_SCRIPT_PROVIDER" = "cargo-script", RUST_LOG = "cargo-script=warn" }
-script_runner = "@rust"
-script = { file = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/lint.rs", absolute_path = true }
+[tasks.install-cargo-script]
+private = true
+install_crate = { crate_name = "cargo-script", version = "0.2.8", binary = "cargo", test_arg = ["script", "--version"] }
 
 [tasks.update-clippy-check]
-private = true
-env = { CARGO_MAKE_CLIPPY_LINT_MODE = "generate" }
-run_task = "update-clippy"
+env = { RUST_LOG = "cargo-script=warn", CARGO_MAKE_CLIPPY_LINT_MODE = "generate" }
+command = 'cargo'
+args = ['script', "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/lint.rs"]
+dependencies = ['install-cargo-script']

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Install tools
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-make@0.36.3,cargo-hack@0.5.26
+          tool: cargo-make@0.36.3,cargo-hack@0.5.26,cargo-script@0.2.8
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, it's not possible to invoke `cargo make clippy` when passing additional arguments (e.g. `cargo make clippy --message-format=json`). This fixes the issue by manually invoking it

Special thanks to @indietyp for providing this snippet!