### PR TITLE
Only run semver check if it's not an initial version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -336,7 +336,10 @@ jobs:
       - name: SemVer check
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
         working-directory: ${{ matrix.directory }}
-        run: cargo +${{ matrix.toolchain }} semver-checks check-release
+        run: |
+          # Only run semver checks if this is not the initial release
+          cargo +${{ matrix.toolchain }} metadata --format-version 1 | jq -e '.packages[].version != "0.0.0-reserved"' > /dev/null || echo exit 0
+          cargo +${{ matrix.toolchain }} semver-checks check-release
 
       - name: Publish (dry run)
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -338,7 +338,8 @@ jobs:
         working-directory: ${{ matrix.directory }}
         run: |
           # Only run semver checks if this is not the initial release
-          cargo +${{ matrix.toolchain }} metadata --format-version 1 | jq -e '.packages[].version != "0.0.0-reserved"' > /dev/null || echo exit 0
+          grep '^version' Cargo.toml | grep -q 0.0.0-reserved && exit 0
+
           cargo +${{ matrix.toolchain }} semver-checks check-release
 
       - name: Publish (dry run)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -338,7 +338,7 @@ jobs:
         working-directory: ${{ matrix.directory }}
         run: |
           # Only run semver checks if this is not the initial release
-          grep '^version' Cargo.toml | grep -q 0.0.0-reserved && exit 0
+          grep '^version' Cargo.toml | grep -q -v 0.0.0-reserved || exit 0
 
           cargo +${{ matrix.toolchain }} semver-checks check-release
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The publish job fails if an initial version of a crate is published. This PR changes the behavior to only run the check, if the version is not `0.0.0-reserved`, which cover all current and planned cases

## 🔗 Related links

- #2237 