### PR TITLE
Expose batch insertion of ontology types

### DIFF
--- a/apps/hash-api/src/graphql/resolvers/task-executor/generation.ts
+++ b/apps/hash-api/src/graphql/resolvers/task-executor/generation.ts
@@ -231,7 +231,7 @@ export const createPropertyTypeTree = async (
             actorId: user.accountId,
             schema: record.schema,
           })
-        ).data,
+        ).data as OntologyElementMetadata,
       );
     } catch (err) {
       throw new Error(
@@ -330,7 +330,7 @@ export const createEntityTypeTree = async (
             actorId: user.accountId,
             schema: record.schema,
           })
-        ).data,
+        ).data as OntologyElementMetadata,
       );
     } catch (err) {
       throw new Error(

--- a/apps/hash-graph/lib/graph/src/api/rest.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest.rs
@@ -11,6 +11,7 @@ mod entity;
 mod entity_type;
 mod property_type;
 mod utoipa_typedef;
+
 use std::{collections::HashMap, sync::Arc};
 
 use axum::{
@@ -35,10 +36,13 @@ use self::{api_resource::RoutedResource, middleware::span_trace_layer};
 use crate::{
     api::rest::{
         middleware::log_request_and_response,
-        utoipa_typedef::subgraph::{
-            Edges, KnowledgeGraphOutwardEdge, KnowledgeGraphRootedEdges, KnowledgeGraphVertex,
-            KnowledgeGraphVertices, OntologyOutwardEdge, OntologyRootedEdges, OntologyTypeVertexId,
-            OntologyVertex, OntologyVertices, Subgraph, Vertex, Vertices,
+        utoipa_typedef::{
+            subgraph::{
+                Edges, KnowledgeGraphOutwardEdge, KnowledgeGraphRootedEdges, KnowledgeGraphVertex,
+                KnowledgeGraphVertices, OntologyOutwardEdge, OntologyRootedEdges,
+                OntologyTypeVertexId, OntologyVertex, OntologyVertices, Subgraph, Vertex, Vertices,
+            },
+            MaybeListOfOntologyElementMetadata,
         },
     },
     identifier::{
@@ -179,6 +183,7 @@ async fn serve_static_schema(Path(path): Path<String>) -> Result<Response, Statu
             ProvenanceMetadata,
             OntologyTypeRecordId,
             OntologyElementMetadata,
+            MaybeListOfOntologyElementMetadata,
             OwnedOntologyElementMetadata,
             ExternalOntologyElementMetadata,
             EntityVertexId,

--- a/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
@@ -6,12 +6,14 @@ use axum::{http::StatusCode, routing::post, Extension, Json, Router};
 use error_stack::IntoReport;
 use futures::TryFutureExt;
 use serde::{Deserialize, Serialize};
-use type_system::{repr, url::VersionedUrl, EntityType};
+use type_system::{url::VersionedUrl, EntityType};
 use utoipa::{OpenApi, ToSchema};
 
 use crate::{
     api::rest::{
-        api_resource::RoutedResource, report_to_status_code, utoipa_typedef::subgraph::Subgraph,
+        api_resource::RoutedResource,
+        report_to_status_code,
+        utoipa_typedef::{subgraph::Subgraph, ListOrValue, MaybeListOfEntityType},
     },
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
@@ -68,8 +70,8 @@ impl RoutedResource for EntityTypeResource {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 struct CreateEntityTypeRequest {
-    #[schema(value_type = VAR_ENTITY_TYPE)]
-    schema: repr::EntityType,
+    #[schema(inline)]
+    schema: MaybeListOfEntityType,
     owned_by_id: OwnedById,
     actor_id: UpdatedById,
 }
@@ -80,7 +82,7 @@ struct CreateEntityTypeRequest {
     request_body = CreateEntityTypeRequest,
     tag = "EntityType",
     responses(
-        (status = 201, content_type = "application/json", description = "The metadata of the created entity type", body = OntologyElementMetadata),
+        (status = 201, content_type = "application/json", description = "The metadata of the created entity type", body = MaybeListOfOntologyElementMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 409, description = "Unable to create entity type in the datastore as the base entity type ID already exists"),
@@ -93,42 +95,54 @@ async fn create_entity_type<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
     domain_validator: Extension<DomainValidator>,
     body: Json<CreateEntityTypeRequest>,
-) -> Result<Json<OntologyElementMetadata>, StatusCode> {
+) -> Result<Json<ListOrValue<OntologyElementMetadata>>, StatusCode> {
     let Json(CreateEntityTypeRequest {
         schema,
         owned_by_id,
         actor_id,
     }) = body;
 
-    let entity_type: EntityType = schema.try_into().into_report().map_err(|report| {
-        tracing::error!(error=?report, "Couldn't convert schema to Entity Type");
-        // Shame there isn't an UNPROCESSABLE_ENTITY_TYPE code :D
-        StatusCode::UNPROCESSABLE_ENTITY
-        // TODO - We should probably return more information to the client
-        //  https://app.asana.com/0/1201095311341924/1202574350052904/f
-    })?;
+    let is_list = matches!(&schema, ListOrValue::List(_));
 
-    domain_validator.validate(&entity_type).map_err(|report| {
-        tracing::error!(error=?report, id=entity_type.id().to_string(), "Entity Type ID failed to validate");
-        StatusCode::UNPROCESSABLE_ENTITY
-    })?;
+    let schema_iter = schema.into_iter();
+    let mut entity_types = Vec::with_capacity(schema_iter.size_hint().0);
+    let mut metadata = Vec::with_capacity(schema_iter.size_hint().0);
+
+    for schema in schema_iter {
+        let entity_type: EntityType = schema.try_into().into_report().map_err(|report| {
+            tracing::error!(error=?report, "Couldn't convert schema to Entity Type");
+            // Shame there isn't an UNPROCESSABLE_ENTITY_TYPE code :D
+            StatusCode::UNPROCESSABLE_ENTITY
+            // TODO - We should probably return more information to the client
+            //  https://app.asana.com/0/1201095311341924/1202574350052904/f
+        })?;
+
+        domain_validator.validate(&entity_type).map_err(|report| {
+            tracing::error!(error=?report, id=entity_type.id().to_string(), "Entity Type ID failed to validate");
+            StatusCode::UNPROCESSABLE_ENTITY
+        })?;
+
+        metadata.push(OntologyElementMetadata::Owned(
+            OwnedOntologyElementMetadata::new(
+                entity_type.id().clone().into(),
+                ProvenanceMetadata::new(actor_id),
+                owned_by_id,
+            ),
+        ));
+
+        entity_types.push(entity_type);
+    }
 
     let mut store = pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let metadata = OntologyElementMetadata::Owned(OwnedOntologyElementMetadata::new(
-        entity_type.id().clone().into(),
-        ProvenanceMetadata::new(actor_id),
-        owned_by_id,
-    ));
-
     store
-        .create_entity_type(entity_type, &metadata)
+        .create_entity_types(entity_types.into_iter().zip(metadata.iter()))
         .await
         .map_err(|report| {
-            tracing::error!(error=?report, "Could not create entity type");
+            tracing::error!(error=?report, "Could not create entity types");
 
             if report.contains::<BaseUrlAlreadyExists>() {
                 return StatusCode::CONFLICT;
@@ -138,7 +152,13 @@ async fn create_entity_type<P: StorePool + Send>(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    Ok(Json(metadata))
+    if is_list {
+        Ok(Json(ListOrValue::List(metadata)))
+    } else {
+        Ok(Json(ListOrValue::Value(
+            metadata.pop().expect("metadata does not contain a value"),
+        )))
+    }
 }
 
 #[utoipa::path(

--- a/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
@@ -6,12 +6,15 @@ use axum::{http::StatusCode, routing::post, Extension, Json, Router};
 use error_stack::IntoReport;
 use futures::TryFutureExt;
 use serde::{Deserialize, Serialize};
-use type_system::{repr, url::VersionedUrl, PropertyType};
+use type_system::{url::VersionedUrl, PropertyType};
 use utoipa::{OpenApi, ToSchema};
 
 use super::api_resource::RoutedResource;
 use crate::{
-    api::rest::{report_to_status_code, utoipa_typedef::subgraph::Subgraph},
+    api::rest::{
+        report_to_status_code,
+        utoipa_typedef::{subgraph::Subgraph, ListOrValue, MaybeListOfPropertyType},
+    },
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
         patch_id_and_parse, OntologyElementMetadata, OwnedOntologyElementMetadata,
@@ -64,8 +67,8 @@ impl RoutedResource for PropertyTypeResource {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 struct CreatePropertyTypeRequest {
-    #[schema(value_type = VAR_PROPERTY_TYPE)]
-    schema: repr::PropertyType,
+    #[schema(inline)]
+    schema: MaybeListOfPropertyType,
     owned_by_id: OwnedById,
     actor_id: UpdatedById,
 }
@@ -76,7 +79,7 @@ struct CreatePropertyTypeRequest {
     request_body = CreatePropertyTypeRequest,
     tag = "PropertyType",
     responses(
-        (status = 201, content_type = "application/json", description = "The metadata of the created property type", body = OntologyElementMetadata),
+        (status = 201, content_type = "application/json", description = "The metadata of the created property type", body = MaybeListOfOntologyElementMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 409, description = "Unable to create property type in the store as the base property type ID already exists"),
@@ -89,43 +92,55 @@ async fn create_property_type<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
     domain_validator: Extension<DomainValidator>,
     body: Json<CreatePropertyTypeRequest>,
-) -> Result<Json<OntologyElementMetadata>, StatusCode> {
+) -> Result<Json<ListOrValue<OntologyElementMetadata>>, StatusCode> {
     let Json(CreatePropertyTypeRequest {
         schema,
         owned_by_id,
         actor_id,
     }) = body;
 
-    let property_type: PropertyType = schema.try_into().into_report().map_err(|report| {
-        tracing::error!(error=?report, "Couldn't convert schema to Property Type");
-        StatusCode::UNPROCESSABLE_ENTITY
-        // TODO - We should probably return more information to the client
-        //  https://app.asana.com/0/1201095311341924/1202574350052904/f
-    })?;
+    let is_list = matches!(&schema, ListOrValue::List(_));
 
-    domain_validator
-        .validate(&property_type)
-        .map_err(|report| {
-            tracing::error!(error=?report, id=property_type.id().to_string(), "Property Type ID failed to validate");
+    let schema_iter = schema.into_iter();
+    let mut property_types = Vec::with_capacity(schema_iter.size_hint().0);
+    let mut metadata = Vec::with_capacity(schema_iter.size_hint().0);
+
+    for schema in schema_iter {
+        let property_type: PropertyType = schema.try_into().into_report().map_err(|report| {
+            tracing::error!(error=?report, "Couldn't convert schema to Property Type");
             StatusCode::UNPROCESSABLE_ENTITY
+            // TODO - We should probably return more information to the client
+            //  https://app.asana.com/0/1201095311341924/1202574350052904/f
         })?;
+
+        domain_validator
+            .validate(&property_type)
+            .map_err(|report| {
+                tracing::error!(error=?report, id=property_type.id().to_string(), "Property Type ID failed to validate");
+                StatusCode::UNPROCESSABLE_ENTITY
+            })?;
+
+        metadata.push(OntologyElementMetadata::Owned(
+            OwnedOntologyElementMetadata::new(
+                property_type.id().clone().into(),
+                ProvenanceMetadata::new(actor_id),
+                owned_by_id,
+            ),
+        ));
+
+        property_types.push(property_type);
+    }
 
     let mut store = pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let metadata = OntologyElementMetadata::Owned(OwnedOntologyElementMetadata::new(
-        property_type.id().clone().into(),
-        ProvenanceMetadata::new(actor_id),
-        owned_by_id,
-    ));
-
     store
-        .create_property_type(property_type, &metadata)
+        .create_property_types(property_types.into_iter().zip(metadata.iter()))
         .await
         .map_err(|report| {
-            tracing::error!(error=?report, "Could not create property type");
+            tracing::error!(error=?report, "Could not create property types");
 
             if report.contains::<BaseUrlAlreadyExists>() {
                 return StatusCode::CONFLICT;
@@ -135,7 +150,13 @@ async fn create_property_type<P: StorePool + Send>(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    Ok(Json(metadata))
+    if is_list {
+        Ok(Json(ListOrValue::List(metadata)))
+    } else {
+        Ok(Json(ListOrValue::Value(
+            metadata.pop().expect("metadata does not contain a value"),
+        )))
+    }
 }
 
 #[utoipa::path(

--- a/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef.rs
@@ -1,1 +1,74 @@
+use serde::{Deserialize, Serialize};
+use type_system::repr;
+use utoipa::{
+    openapi::{OneOfBuilder, Ref, RefOr, Schema},
+    ToSchema,
+};
+
+use crate::ontology::OntologyElementMetadata;
+
 pub mod subgraph;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ListOrValue<T> {
+    List(Vec<T>),
+    Value(T),
+}
+
+// Utoipa doesn't seem to be able to generate sensible interfaces for this, it gets confused by
+// the generic
+impl<T> ListOrValue<T> {
+    pub(crate) fn generate_schema(schema_name: &'static str) -> RefOr<Schema> {
+        OneOfBuilder::new()
+            .item(Ref::from_schema_name(schema_name))
+            .item(Ref::from_schema_name(schema_name).to_array_builder())
+            .into()
+    }
+}
+
+pub type MaybeListOfOntologyElementMetadata = ListOrValue<OntologyElementMetadata>;
+impl ToSchema<'_> for MaybeListOfOntologyElementMetadata {
+    fn schema() -> (&'static str, RefOr<Schema>) {
+        (
+            "MaybeListOfOntologyElementMetadata",
+            Self::generate_schema(OntologyElementMetadata::schema().0),
+        )
+    }
+}
+
+pub type MaybeListOfDataType = ListOrValue<repr::DataType>;
+impl ToSchema<'_> for MaybeListOfDataType {
+    fn schema() -> (&'static str, RefOr<Schema>) {
+        ("MaybeListOf", Self::generate_schema("DataType"))
+    }
+}
+
+pub type MaybeListOfPropertyType = ListOrValue<repr::PropertyType>;
+impl ToSchema<'_> for MaybeListOfPropertyType {
+    fn schema() -> (&'static str, RefOr<Schema>) {
+        (
+            "MaybeListOfPropertyType",
+            Self::generate_schema("PropertyType"),
+        )
+    }
+}
+
+pub type MaybeListOfEntityType = ListOrValue<repr::EntityType>;
+impl ToSchema<'_> for MaybeListOfEntityType {
+    fn schema() -> (&'static str, RefOr<Schema>) {
+        ("MaybeListOfEntityType", Self::generate_schema("EntityType"))
+    }
+}
+
+impl<T> IntoIterator for ListOrValue<T> {
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+    type Item = T;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            Self::List(list) => list.into_iter(),
+            Self::Value(value) => vec![value].into_iter(),
+        }
+    }
+}

--- a/apps/hash-graph/tests/rest-test.http
+++ b/apps/hash-graph/tests/rest-test.http
@@ -78,20 +78,30 @@ Accept: application/json
 {
   "ownedById": "{{account_id}}",
   "actorId": "{{account_id}}",
-  "schema": {
-    "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
-    "kind": "dataType",
-    "$id": "http://localhost:3000/@alice/types/data-type/text/v/1",
-    "title": "Text",
-    "type": "string"
-  }
+  "schema": [
+    {
+      "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
+      "kind": "dataType",
+      "$id": "http://localhost:3000/@alice/types/data-type/text/v/1",
+      "title": "Text",
+      "type": "string"
+    },
+    {
+      "$schema": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type",
+      "kind": "dataType",
+      "$id": "http://localhost:3000/@alice/types/data-type/number/v/1",
+      "title": "Text",
+      "type": "string"
+    }
+  ]
 }
 
 > {%
     client.test("status", function() {
         client.assert(response.status === 200, "Response status is not 200");
     });
-    client.global.set("text_data_type_id", `${response.body.recordId.baseUrl}v/${response.body.recordId.version}`);
+    client.global.set("text_data_type_id", `${response.body[0].recordId.baseUrl}v/${response.body[0].recordId.version}`);
+    client.assert(response.body.length === 2, "Unexpected number of data types");
 %}
 
 ### Get Text data type

--- a/libs/@local/hash-graph-client/api.ts
+++ b/libs/@local/hash-graph-client/api.ts
@@ -96,11 +96,17 @@ export interface CreateDataTypeRequest {
   ownedById: string;
   /**
    *
-   * @type {DataType}
+   * @type {CreateDataTypeRequestSchema}
    * @memberof CreateDataTypeRequest
    */
-  schema: DataType;
+  schema: CreateDataTypeRequestSchema;
 }
+/**
+ * @type CreateDataTypeRequestSchema
+ * @export
+ */
+export type CreateDataTypeRequestSchema = Array<DataType> | DataType;
+
 /**
  *
  * @export
@@ -164,11 +170,17 @@ export interface CreateEntityTypeRequest {
   ownedById: string;
   /**
    *
-   * @type {EntityType}
+   * @type {CreateEntityTypeRequestSchema}
    * @memberof CreateEntityTypeRequest
    */
-  schema: EntityType;
+  schema: CreateEntityTypeRequestSchema;
 }
+/**
+ * @type CreateEntityTypeRequestSchema
+ * @export
+ */
+export type CreateEntityTypeRequestSchema = Array<EntityType> | EntityType;
+
 /**
  *
  * @export
@@ -189,11 +201,19 @@ export interface CreatePropertyTypeRequest {
   ownedById: string;
   /**
    *
-   * @type {PropertyType}
+   * @type {CreatePropertyTypeRequestSchema}
    * @memberof CreatePropertyTypeRequest
    */
-  schema: PropertyType;
+  schema: CreatePropertyTypeRequestSchema;
 }
+/**
+ * @type CreatePropertyTypeRequestSchema
+ * @export
+ */
+export type CreatePropertyTypeRequestSchema =
+  | Array<PropertyType>
+  | PropertyType;
+
 /**
  * Specifies the structure of a Data Type
  * @export
@@ -1216,6 +1236,14 @@ export interface LinkDataAllOf {
    */
   rightEntityId: string;
 }
+/**
+ * @type MaybeListOfOntologyElementMetadata
+ * @export
+ */
+export type MaybeListOfOntologyElementMetadata =
+  | Array<OntologyElementMetadata>
+  | OntologyElementMetadata;
+
 /**
  *
  * @export
@@ -2921,7 +2949,7 @@ export const DataTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<OntologyElementMetadata>
+      ) => AxiosPromise<MaybeListOfOntologyElementMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.createDataType(
         createDataTypeRequest,
@@ -3007,7 +3035,7 @@ export const DataTypeApiFactory = function (
     createDataType(
       createDataTypeRequest: CreateDataTypeRequest,
       options?: any,
-    ): AxiosPromise<OntologyElementMetadata> {
+    ): AxiosPromise<MaybeListOfOntologyElementMetadata> {
       return localVarFp
         .createDataType(createDataTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -3059,7 +3087,7 @@ export interface DataTypeApiInterface {
   createDataType(
     createDataTypeRequest: CreateDataTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<OntologyElementMetadata>;
+  ): AxiosPromise<MaybeListOfOntologyElementMetadata>;
 
   /**
    *
@@ -3738,7 +3766,7 @@ export const EntityTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<OntologyElementMetadata>
+      ) => AxiosPromise<MaybeListOfOntologyElementMetadata>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.createEntityType(
@@ -3826,7 +3854,7 @@ export const EntityTypeApiFactory = function (
     createEntityType(
       createEntityTypeRequest: CreateEntityTypeRequest,
       options?: any,
-    ): AxiosPromise<OntologyElementMetadata> {
+    ): AxiosPromise<MaybeListOfOntologyElementMetadata> {
       return localVarFp
         .createEntityType(createEntityTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -3878,7 +3906,7 @@ export interface EntityTypeApiInterface {
   createEntityType(
     createEntityTypeRequest: CreateEntityTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<OntologyElementMetadata>;
+  ): AxiosPromise<MaybeListOfOntologyElementMetadata>;
 
   /**
    *
@@ -4686,7 +4714,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<OntologyElementMetadata>
+      ) => AxiosPromise<MaybeListOfOntologyElementMetadata>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.createDataType(
         createDataTypeRequest,
@@ -4735,7 +4763,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<OntologyElementMetadata>
+      ) => AxiosPromise<MaybeListOfOntologyElementMetadata>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.createEntityType(
@@ -4762,7 +4790,7 @@ export const GraphApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<OntologyElementMetadata>
+      ) => AxiosPromise<MaybeListOfOntologyElementMetadata>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.createPropertyType(
@@ -5008,7 +5036,7 @@ export const GraphApiFactory = function (
     createDataType(
       createDataTypeRequest: CreateDataTypeRequest,
       options?: any,
-    ): AxiosPromise<OntologyElementMetadata> {
+    ): AxiosPromise<MaybeListOfOntologyElementMetadata> {
       return localVarFp
         .createDataType(createDataTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -5036,7 +5064,7 @@ export const GraphApiFactory = function (
     createEntityType(
       createEntityTypeRequest: CreateEntityTypeRequest,
       options?: any,
-    ): AxiosPromise<OntologyElementMetadata> {
+    ): AxiosPromise<MaybeListOfOntologyElementMetadata> {
       return localVarFp
         .createEntityType(createEntityTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -5050,7 +5078,7 @@ export const GraphApiFactory = function (
     createPropertyType(
       createPropertyTypeRequest: CreatePropertyTypeRequest,
       options?: any,
-    ): AxiosPromise<OntologyElementMetadata> {
+    ): AxiosPromise<MaybeListOfOntologyElementMetadata> {
       return localVarFp
         .createPropertyType(createPropertyTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -5194,7 +5222,7 @@ export interface GraphApiInterface {
   createDataType(
     createDataTypeRequest: CreateDataTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<OntologyElementMetadata>;
+  ): AxiosPromise<MaybeListOfOntologyElementMetadata>;
 
   /**
    *
@@ -5218,7 +5246,7 @@ export interface GraphApiInterface {
   createEntityType(
     createEntityTypeRequest: CreateEntityTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<OntologyElementMetadata>;
+  ): AxiosPromise<MaybeListOfOntologyElementMetadata>;
 
   /**
    *
@@ -5230,7 +5258,7 @@ export interface GraphApiInterface {
   createPropertyType(
     createPropertyTypeRequest: CreatePropertyTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<OntologyElementMetadata>;
+  ): AxiosPromise<MaybeListOfOntologyElementMetadata>;
 
   /**
    *
@@ -5732,7 +5760,7 @@ export const PropertyTypeApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<OntologyElementMetadata>
+      ) => AxiosPromise<MaybeListOfOntologyElementMetadata>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.createPropertyType(
@@ -5820,7 +5848,7 @@ export const PropertyTypeApiFactory = function (
     createPropertyType(
       createPropertyTypeRequest: CreatePropertyTypeRequest,
       options?: any,
-    ): AxiosPromise<OntologyElementMetadata> {
+    ): AxiosPromise<MaybeListOfOntologyElementMetadata> {
       return localVarFp
         .createPropertyType(createPropertyTypeRequest, options)
         .then((request) => request(axios, basePath));
@@ -5872,7 +5900,7 @@ export interface PropertyTypeApiInterface {
   createPropertyType(
     createPropertyTypeRequest: CreatePropertyTypeRequest,
     options?: AxiosRequestConfig,
-  ): AxiosPromise<OntologyElementMetadata>;
+  ): AxiosPromise<MaybeListOfOntologyElementMetadata>;
 
   /**
    *


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, it's not possible to insert circular dependencies in ontology types. This PR adjusts the Rest API to allow either a schema or a list of schemas to be passed

## 🔗 Related links

- [Slack thread](https://hashintel.slack.com/archives/C03TWBSRT8B/p1679330213212829) _(internal)_

## 🔍 What does this change?

- Define a utoipa-type to allow either (de-)serialize a thing or a list of things
- Implement logic on the REST Api

## ⚠️ Known issues

This _does not_ expose the same functionality for updating (this is not implemented in the Graph, yet).