### PR TITLE
Add all fields for `Tool` struct

### DIFF
--- a/libs/sarif/Cargo.toml
+++ b/libs/sarif/Cargo.toml
@@ -13,11 +13,11 @@ categories = ["no-std", "data-structures", "development-tools", "parsing"]
 
 [dependencies]
 serde = { version = "1", default-features = false, features = ["derive"], optional = true }
+serde_json = { version = "1", default-features = false, features = ["alloc"], optional = true }
 
 [features]
-serde = ["dep:serde"]
+serde = ["dep:serde", "dep:serde_json"]
 
 [dev-dependencies]
-serde_json = "1"
 jsonschema = { version = "0.17.0", default-features = false }
 coverage-helper = "0.1.0"

--- a/libs/sarif/Makefile.toml
+++ b/libs/sarif/Makefile.toml
@@ -3,3 +3,7 @@ extend = { path = "../../.github/scripts/rust/Makefile.toml" }
 # This crate has no unsafe code
 [tasks.miri]
 disabled = true
+
+[tasks.coverage-task]
+extend = "cargo"
+args = ["llvm-cov", "test", "--workspace", "--all-features", "--doctests", "${@}"]

--- a/libs/sarif/Makefile.toml
+++ b/libs/sarif/Makefile.toml
@@ -5,5 +5,5 @@ extend = { path = "../../.github/scripts/rust/Makefile.toml" }
 disabled = true
 
 [tasks.coverage-task]
-extend = "cargo"
 args = ["llvm-cov", "test", "--workspace", "--all-features", "--doctests", "${@}"]
+dependencies = ["install-llvm-tools"]

--- a/libs/sarif/src/lib.rs
+++ b/libs/sarif/src/lib.rs
@@ -1,7 +1,11 @@
 #![doc = include_str!("../README.md")]
 #![no_std]
 #![feature(lint_reasons)]
-#![feature(doc_auto_cfg)]
+#![cfg_attr(
+    doc,
+    feature(doc_auto_cfg),
+    doc(test(attr(deny(warnings, clippy::pedantic, clippy::nursery))))
+)]
 #![cfg_attr(coverage_nightly, feature(no_coverage))]
 
 extern crate alloc;

--- a/libs/sarif/src/schema.rs
+++ b/libs/sarif/src/schema.rs
@@ -1,6 +1,7 @@
 //! The JSON schema of the SARIF log file format as a Rust module.
 
 mod log;
+mod properties;
 mod run;
 mod tool;
 
@@ -9,6 +10,7 @@ use serde::{Deserialize, Serialize};
 
 pub use self::{
     log::SarifLog,
+    properties::PropertyBag,
     run::Run,
     tool::{Tool, ToolComponent},
 };

--- a/libs/sarif/src/schema.rs
+++ b/libs/sarif/src/schema.rs
@@ -44,12 +44,12 @@ pub(crate) mod tests {
     #[expect(clippy::panic)]
     #[cfg_attr(coverage_nightly, no_coverage)]
     pub(crate) fn validate_schema(log: &SarifLog) {
-        let log_value = serde_json::to_value(log).expect("serializing `Log` into JSON failed");
+        let log_value = serde_json::to_value(log).expect("serializing `SarifLog` into JSON failed");
 
         assert_eq!(
-            SarifLog::deserialize(&log_value).expect("could not serialize into `Log`"),
+            SarifLog::deserialize(&log_value).expect("could not serialize into `SarifLog`"),
             *log,
-            "serialized `Log` is not equal to original"
+            "serialized `SarifLog` is not equal to original"
         );
 
         let json_schema_str = include_str!("../tests/schemas/sarif-2.1.0.json");

--- a/libs/sarif/src/schema/log.rs
+++ b/libs/sarif/src/schema/log.rs
@@ -309,27 +309,27 @@ pub(crate) mod tests {
 
     #[test]
     fn full() {
-        let runs = [
-            Run::new(
-                Tool::new(ToolComponent::new("prettier"))
-                    .with_extension(ToolComponent::new("prettier-plugin-sql"))
-                    .with_properties(|properties| {
+        validate_schema(
+            &SarifLog::new(SchemaVersion::V2_1_0).with_runs([
+                Run::new(
+                    Tool::new(ToolComponent::new("prettier"))
+                        .with_extension(ToolComponent::new("prettier-plugin-sql"))
+                        .with_properties(|properties| {
+                            properties
+                                .with_tag("format")
+                                .with_property("language", "sql")
+                                .with_property("precision", "low")
+                        }),
+                ),
+                Run::new(
+                    Tool::new(ToolComponent::new("rustfmt")).with_properties(|properties| {
                         properties
                             .with_tag("format")
-                            .with_property("language", "sql")
-                            .with_property("precision", "low")
+                            .with_property("language", "rust")
+                            .with_property("precision", "high")
                     }),
-            ),
-            Run::new(
-                Tool::new(ToolComponent::new("rustfmt")).with_properties(|properties| {
-                    properties
-                        .with_tag("format")
-                        .with_property("language", "rust")
-                        .with_property("precision", "high")
-                }),
-            ),
-        ];
-
-        validate_schema(&runs.into_iter().collect());
+                ),
+            ]),
+        );
     }
 }

--- a/libs/sarif/src/schema/log.rs
+++ b/libs/sarif/src/schema/log.rs
@@ -26,7 +26,7 @@ use crate::schema::{Run, SchemaVersion};
 ///   ]
 /// }
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(rename_all = "camelCase"))]
 pub struct SarifLog {
     /// The format version of the SARIF specification to which this log file conforms.
@@ -305,5 +305,31 @@ pub(crate) mod tests {
         validate_schema(&log_2);
 
         assert_eq!(log, log_2);
+    }
+
+    #[test]
+    fn full() {
+        let runs = [
+            Run::new(
+                Tool::new(ToolComponent::new("prettier"))
+                    .with_extension(ToolComponent::new("prettier-plugin-sql"))
+                    .with_properties(|properties| {
+                        properties
+                            .with_tag("format")
+                            .with_property("language", "sql")
+                            .with_property("precision", "low")
+                    }),
+            ),
+            Run::new(
+                Tool::new(ToolComponent::new("rustfmt")).with_properties(|properties| {
+                    properties
+                        .with_tag("format")
+                        .with_property("language", "rust")
+                        .with_property("precision", "high")
+                }),
+            ),
+        ];
+
+        validate_schema(&runs.into_iter().collect());
     }
 }

--- a/libs/sarif/src/schema/properties.rs
+++ b/libs/sarif/src/schema/properties.rs
@@ -21,7 +21,7 @@ pub struct PropertyBag {
     /// each of whose values provides the information.
     #[cfg(feature = "serde")]
     #[serde(flatten)]
-    pub extra: BTreeMap<Cow<'static, str>, serde_json::Value>,
+    pub additional: BTreeMap<Cow<'static, str>, serde_json::Value>,
 }
 
 impl PropertyBag {
@@ -35,14 +35,14 @@ impl PropertyBag {
     /// let properties = PropertyBag::new();
     ///
     /// assert!(properties.tags.is_empty());
-    /// assert!(properties.extra.is_empty());
+    /// assert!(properties.additional.is_empty());
     /// ```
     #[must_use]
     pub const fn new() -> Self {
         Self {
             tags: BTreeSet::new(),
             #[cfg(feature = "serde")]
-            extra: BTreeMap::new(),
+            additional: BTreeMap::new(),
         }
     }
 
@@ -106,8 +106,14 @@ impl PropertyBag {
     ///     .with_property("precision", "very-high")
     ///     .with_property("confidence", "high");
     ///
-    /// assert_eq!(properties.extra.get("precision"), Some(&"very-high".into()));
-    /// assert_eq!(properties.extra.get("confidence"), Some(&"high".into()));
+    /// assert_eq!(
+    ///     properties.additional.get("precision"),
+    ///     Some(&"very-high".into())
+    /// );
+    /// assert_eq!(
+    ///     properties.additional.get("confidence"),
+    ///     Some(&"high".into())
+    /// );
     /// ```
     #[must_use]
     #[cfg(feature = "serde")]
@@ -116,7 +122,7 @@ impl PropertyBag {
         key: impl Into<Cow<'static, str>>,
         value: impl Into<serde_json::Value>,
     ) -> Self {
-        self.extra.insert(key.into(), value.into());
+        self.additional.insert(key.into(), value.into());
         self
     }
 
@@ -133,8 +139,14 @@ impl PropertyBag {
     ///
     /// let properties = PropertyBag::default().with_properties(map);
     ///
-    /// assert_eq!(properties.extra.get("precision"), Some(&"very-high".into()));
-    /// assert_eq!(properties.extra.get("confidence"), Some(&"high".into()));
+    /// assert_eq!(
+    ///     properties.additional.get("precision"),
+    ///     Some(&"very-high".into())
+    /// );
+    /// assert_eq!(
+    ///     properties.additional.get("confidence"),
+    ///     Some(&"high".into())
+    /// );
     /// ```
     #[must_use]
     #[cfg(feature = "serde")]
@@ -144,7 +156,7 @@ impl PropertyBag {
             Item = (impl Into<Cow<'static, str>>, impl Into<serde_json::Value>),
         >,
     ) -> Self {
-        self.extra
+        self.additional
             .extend(properties.into_iter().map(|(k, v)| (k.into(), v.into())));
         self
     }
@@ -167,7 +179,7 @@ impl PropertyBag {
 
         #[cfg(feature = "serde")]
         {
-            is_empty &= self.extra.is_empty();
+            is_empty &= self.additional.is_empty();
         }
         is_empty
     }

--- a/libs/sarif/src/schema/properties.rs
+++ b/libs/sarif/src/schema/properties.rs
@@ -1,0 +1,174 @@
+#[cfg(feature = "serde")]
+use alloc::collections::BTreeMap;
+use alloc::{borrow::Cow, collections::BTreeSet};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// Key/value pairs that provide additional information about the object
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(rename_all = "camelCase")
+)]
+pub struct PropertyBag {
+    /// A set of distinct strings that provide additional information.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "BTreeSet::is_empty"))]
+    pub tags: BTreeSet<Cow<'static, str>>,
+
+    /// A dictionary, each of whose keys specifies a distinct additional information element and
+    /// each of whose values provides the information.
+    #[cfg(feature = "serde")]
+    #[serde(flatten)]
+    pub extra: BTreeMap<Cow<'static, str>, serde_json::Value>,
+}
+
+impl PropertyBag {
+    /// Create a new, empty `PropertyBag`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sarif::schema::PropertyBag;
+    ///
+    /// let properties = PropertyBag::new();
+    ///
+    /// assert!(properties.tags.is_empty());
+    /// assert!(properties.extra.is_empty());
+    /// ```
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            tags: BTreeSet::new(),
+            #[cfg(feature = "serde")]
+            extra: BTreeMap::new(),
+        }
+    }
+
+    /// Add a tag to the property bag.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sarif::schema::PropertyBag;
+    ///
+    /// let properties = PropertyBag::default()
+    ///     .with_tag("code-quality")
+    ///     .with_tag("static-analysis");
+    ///
+    /// assert!(
+    ///     properties
+    ///         .tags
+    ///         .iter()
+    ///         .eq(["code-quality", "static-analysis"])
+    /// );
+    /// ```
+    #[must_use]
+    pub fn with_tag(mut self, tag: impl Into<Cow<'static, str>>) -> Self {
+        self.tags.insert(tag.into());
+        self
+    }
+
+    /// Add tags to the property bag.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sarif::schema::PropertyBag;
+    ///
+    /// let properties = PropertyBag::default().with_tags(["code-quality", "static-analysis"]);
+    ///
+    /// assert!(
+    ///     properties
+    ///         .tags
+    ///         .iter()
+    ///         .eq(["code-quality", "static-analysis"])
+    /// );
+    /// ```
+    #[must_use]
+    pub fn with_tags(
+        mut self,
+        tags: impl IntoIterator<Item = impl Into<Cow<'static, str>>>,
+    ) -> Self {
+        self.tags.extend(tags.into_iter().map(Into::into));
+        self
+    }
+
+    /// Add a property to the property bag.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sarif::schema::PropertyBag;
+    ///
+    /// let properties = PropertyBag::default()
+    ///     .with_property("precision", "very-high")
+    ///     .with_property("confidence", "high");
+    ///
+    /// assert_eq!(properties.extra.get("precision"), Some(&"very-high".into()));
+    /// assert_eq!(properties.extra.get("confidence"), Some(&"high".into()));
+    /// ```
+    #[must_use]
+    #[cfg(feature = "serde")]
+    pub fn with_property(
+        mut self,
+        key: impl Into<Cow<'static, str>>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        self.extra.insert(key.into(), value.into());
+        self
+    }
+
+    /// Add properties to the property bag.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    ///
+    /// use sarif::schema::PropertyBag;
+    ///
+    /// let map = HashMap::from([("confidence", "high"), ("precision", "very-high")]);
+    ///
+    /// let properties = PropertyBag::default().with_properties(map);
+    ///
+    /// assert_eq!(properties.extra.get("precision"), Some(&"very-high".into()));
+    /// assert_eq!(properties.extra.get("confidence"), Some(&"high".into()));
+    /// ```
+    #[must_use]
+    #[cfg(feature = "serde")]
+    pub fn with_properties(
+        mut self,
+        properties: impl IntoIterator<
+            Item = (impl Into<Cow<'static, str>>, impl Into<serde_json::Value>),
+        >,
+    ) -> Self {
+        self.extra
+            .extend(properties.into_iter().map(|(k, v)| (k.into(), v.into())));
+        self
+    }
+
+    /// Returns `true` if the property bag is empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sarif::schema::PropertyBag;
+    ///
+    /// let properties = PropertyBag::default();
+    ///
+    /// assert!(properties.is_empty());
+    /// ```
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        #[cfg_attr(not(feature = "serde"), expect(unused_mut))]
+        let mut is_empty = self.tags.is_empty();
+
+        #[cfg(feature = "serde")]
+        {
+            is_empty &= self.extra.is_empty();
+        }
+        is_empty
+    }
+}

--- a/libs/sarif/src/schema/run.rs
+++ b/libs/sarif/src/schema/run.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::schema::Tool;
 
 /// Describes a single run of an analysis tool, and contains the reported output of that run.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
@@ -22,6 +22,16 @@ pub struct Run {
 
 impl Run {
     /// Create a new `Run` with the given tool.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sarif::schema::{Run, Tool, ToolComponent};
+    ///
+    /// let run = Run::new(Tool::new(ToolComponent::new("clippy")));
+    ///
+    /// assert_eq!(run.tool.driver.name, "clippy");
+    /// ```
     #[must_use]
     pub const fn new(tool: Tool) -> Self {
         Self { tool }

--- a/libs/sarif/src/schema/tool.rs
+++ b/libs/sarif/src/schema/tool.rs
@@ -117,7 +117,10 @@ impl Tool {
     ///         .with_tag("static-analysis")
     /// });
     ///
-    /// assert_eq!(tool.properties.extra.get("precision"), Some(&"high".into()));
+    /// assert_eq!(
+    ///     tool.properties.additional.get("precision"),
+    ///     Some(&"high".into())
+    /// );
     /// assert!(
     ///     tool.properties
     ///         .tags

--- a/libs/sarif/src/schema/tool.rs
+++ b/libs/sarif/src/schema/tool.rs
@@ -1,31 +1,142 @@
-use alloc::borrow::Cow;
+use alloc::{borrow::Cow, vec::Vec};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+use crate::schema::PropertyBag;
+
 /// The analysis tool that was run.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
-    serde(rename_all = "camelCase")
+    serde(rename_all = "camelCase", deny_unknown_fields)
 )]
-#[non_exhaustive]
 pub struct Tool {
     /// The analysis tool that was run.
     pub driver: ToolComponent,
+
+    /// Tool extensions that contributed to or reconfigured the analysis tool that was run.
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Vec::is_empty")
+    )]
+    pub extensions: Vec<ToolComponent>,
+
+    /// Key/value pairs that provide additional information about the tool.
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "PropertyBag::is_empty")
+    )]
+    pub properties: PropertyBag,
 }
 
 impl Tool {
     /// Create a new `Tool` with the given driver.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sarif::schema::{Tool, ToolComponent};
+    ///
+    /// let tool = Tool::new(ToolComponent::new("prettier"));
+    ///
+    /// assert_eq!(tool.driver.name, "prettier");
+    /// assert!(tool.extensions.is_empty());
+    /// assert!(tool.properties.is_empty());
+    /// ```
     #[must_use]
     pub const fn new(driver: ToolComponent) -> Self {
-        Self { driver }
+        Self {
+            driver,
+            extensions: Vec::new(),
+            properties: PropertyBag::new(),
+        }
+    }
+
+    /// Add an extension to the tool.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sarif::schema::{Tool, ToolComponent};
+    ///
+    /// let tool = Tool::new(ToolComponent::new("prettier"))
+    ///     .with_extension(ToolComponent::new("prettier-plugin-packagejson"))
+    ///     .with_extension(ToolComponent::new("prettier-plugin-sh"))
+    ///     .with_extension(ToolComponent::new("prettier-plugin-sql"));
+    ///
+    /// assert_eq!(tool.extensions, vec![
+    ///     ToolComponent::new("prettier-plugin-packagejson"),
+    ///     ToolComponent::new("prettier-plugin-sh"),
+    ///     ToolComponent::new("prettier-plugin-sql"),
+    /// ]);
+    /// ```
+    #[must_use]
+    pub fn with_extension(mut self, extension: ToolComponent) -> Self {
+        self.extensions.push(extension);
+        self
+    }
+
+    /// Add extensions to the tool.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sarif::schema::{Tool, ToolComponent};
+    ///
+    /// let tool = Tool::new(ToolComponent::new("prettier")).with_extensions([
+    ///     ToolComponent::new("prettier-plugin-packagejson"),
+    ///     ToolComponent::new("prettier-plugin-sh"),
+    ///     ToolComponent::new("prettier-plugin-sql"),
+    /// ]);
+    ///
+    /// assert_eq!(tool.extensions, vec![
+    ///     ToolComponent::new("prettier-plugin-packagejson"),
+    ///     ToolComponent::new("prettier-plugin-sh"),
+    ///     ToolComponent::new("prettier-plugin-sql"),
+    /// ]);
+    /// ```
+    #[must_use]
+    pub fn with_extensions(mut self, extension: impl IntoIterator<Item = ToolComponent>) -> Self {
+        self.extensions.extend(extension);
+        self
+    }
+
+    /// Add a property to the tool.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sarif::schema::{Tool, ToolComponent};
+    ///
+    /// let tool = Tool::new(ToolComponent::new("clippy")).with_properties(|properties| {
+    ///     properties
+    ///         .with_property("precision", "high")
+    ///         .with_tag("code-quality")
+    ///         .with_tag("static-analysis")
+    /// });
+    ///
+    /// assert_eq!(tool.properties.extra.get("precision"), Some(&"high".into()));
+    /// assert!(
+    ///     tool.properties
+    ///         .tags
+    ///         .iter()
+    ///         .eq(["code-quality", "static-analysis"])
+    /// );
+    /// ```
+    #[must_use]
+    pub fn with_properties(
+        mut self,
+        mut properties: impl FnMut(PropertyBag) -> PropertyBag,
+    ) -> Self {
+        self.properties = properties(self.properties);
+        self
     }
 }
 
 /// A component, such as a plug-in or the driver, of the analysis tool that was run.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
@@ -39,6 +150,16 @@ pub struct ToolComponent {
 
 impl ToolComponent {
     /// Create a new `ToolComponent` with the given name.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sarif::schema::ToolComponent;
+    ///
+    /// let tool_component = ToolComponent::new("prettier");
+    ///
+    /// assert_eq!(tool_component.name, "prettier");
+    /// ```
     pub fn new(name: impl Into<Cow<'static, str>>) -> Self {
         Self { name: name.into() }
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This exhaustively adds all fields to the `Tool` struct and the API around it

## 🚫 Blocked by

- #2243 

## 🔍 What does this change?

- Add `PropertyBag`
- Add fields to `Tools`
- Greatly extend documentation and tests

## 🛡 What tests cover this?

- This branch has 💯% test coverage