### PR TITLE
Support `version` and `semantic_version` in `ToolComponent`

### DIFF
--- a/libs/sarif/Cargo.toml
+++ b/libs/sarif/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["no-std", "data-structures", "development-tools", "parsing"]
 [dependencies]
 serde = { version = "1", default-features = false, features = ["derive"], optional = true }
 serde_json = { version = "1", default-features = false, features = ["alloc"], optional = true }
+semver = { version = "1", default-features = false, features = ["serde"] }
 
 [features]
 serde = ["dep:serde", "dep:serde_json"]

--- a/libs/sarif/src/schema/log.rs
+++ b/libs/sarif/src/schema/log.rs
@@ -312,8 +312,10 @@ pub(crate) mod tests {
         validate_schema(
             &SarifLog::new(SchemaVersion::V2_1_0).with_runs([
                 Run::new(
-                    Tool::new(ToolComponent::new("prettier"))
-                        .with_extension(ToolComponent::new("prettier-plugin-sql"))
+                    Tool::new(ToolComponent::new("prettier").with_version("2.8.2"))
+                        .with_extension(
+                            ToolComponent::new("prettier-plugin-sql").with_version("0.12.1"),
+                        )
                         .with_properties(|properties| {
                             properties
                                 .with_tag("format")
@@ -322,7 +324,11 @@ pub(crate) mod tests {
                         }),
                 ),
                 Run::new(
-                    Tool::new(ToolComponent::new("rustfmt")).with_properties(|properties| {
+                    Tool::new(
+                        ToolComponent::new("rustfmt")
+                            .with_semantic_version(semver::Version::new(1, 5, 2)),
+                    )
+                    .with_properties(|properties| {
                         properties
                             .with_tag("format")
                             .with_property("language", "rust")

--- a/libs/sarif/src/schema/tool.rs
+++ b/libs/sarif/src/schema/tool.rs
@@ -149,6 +149,14 @@ impl Tool {
 pub struct ToolComponent {
     /// The name of the tool component.
     pub name: Cow<'static, str>,
+
+    /// The tool component version, in whatever format the component natively provides.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub version: Option<Cow<'static, str>>,
+
+    /// The tool component version in the format specified by Semantic Versioning 2.0.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub semantic_version: Option<semver::Version>,
 }
 
 impl ToolComponent {
@@ -164,6 +172,52 @@ impl ToolComponent {
     /// assert_eq!(tool_component.name, "prettier");
     /// ```
     pub fn new(name: impl Into<Cow<'static, str>>) -> Self {
-        Self { name: name.into() }
+        Self {
+            name: name.into(),
+            version: None,
+            semantic_version: None,
+        }
+    }
+
+    /// Set the version of the tool component.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sarif::schema::ToolComponent;
+    ///
+    /// let tool_component = ToolComponent::new("rustc").with_version("1.70.0");
+    ///
+    /// assert_eq!(tool_component.version, Some("1.70.0".into()));
+    /// ```
+    #[must_use]
+    pub fn with_version(mut self, version: impl Into<Cow<'static, str>>) -> Self {
+        self.version = Some(version.into());
+        self
+    }
+
+    /// Set the semantic version of the tool component.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use sarif::schema::ToolComponent;
+    ///
+    /// let tool_component =
+    ///     ToolComponent::new("rustc").with_semantic_version(semver::Version::new(1, 70, 0));
+    ///
+    /// assert_eq!(
+    ///     tool_component.semantic_version,
+    ///     Some(semver::Version::new(1, 70, 0))
+    /// );
+    /// ```
+    #[must_use]
+    #[expect(
+        clippy::missing_const_for_fn,
+        reason = "destructor of `Option<Version>` cannot be evaluated at compile-time"
+    )]
+    pub fn with_semantic_version(mut self, version: semver::Version) -> Self {
+        self.semantic_version = Some(version);
+        self
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This further extends the `ToolComponent` struct

## 🚫 Blocked by

- #2243
- #2245

## 🔍 What does this change?

- Add `ToolComponent::version`
- Add `ToolComponent::semantic_version`
- Add builder methods and documentation
- Add to the `full` test

## 🛡 What tests cover this?

- This branch has 💯% test coverage