### PR TITLE
`antsi`: rework getter

### DIFF
--- a/libs/antsi/src/decorations.rs
+++ b/libs/antsi/src/decorations.rs
@@ -45,7 +45,7 @@ pub enum Frame {
 /// [ISO 6429]: https://www.iso.org/standard/12782.html
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
 pub struct Decorations {
-    frame: Option<Frame>,
+    pub frame: Option<Frame>,
 }
 
 impl Decorations {

--- a/libs/antsi/src/font.rs
+++ b/libs/antsi/src/font.rs
@@ -208,6 +208,7 @@ impl Font {
         self
     }
 
+    #[cfg(feature = "script")]
     #[must_use]
     pub const fn with_script(mut self, script: FontScript) -> Self {
         self.script = Some(script);

--- a/libs/antsi/src/font.rs
+++ b/libs/antsi/src/font.rs
@@ -131,13 +131,13 @@ impl FontStyle {
     #[must_use]
     const fn mask(self) -> u8 {
         match self {
-            Self::Strikethrough => 0b0000_0001,
-            Self::Hidden => 0b0000_0010,
-            Self::Inverse => 0b0000_0100,
-            Self::Italic => 0b0000_1000,
+            Self::Strikethrough => 1 << 0,
+            Self::Hidden => 1 << 1,
+            Self::Inverse => 1 << 2,
+            Self::Italic => 1 << 3,
             #[cfg(feature = "overstrike")]
-            Self::Overstrike => 0b0001_0000,
-            Self::Overline => 0b0010_0000,
+            Self::Overstrike => 1 << 4,
+            Self::Overline => 1 << 5,
         }
     }
 }

--- a/libs/antsi/src/font.rs
+++ b/libs/antsi/src/font.rs
@@ -116,13 +116,40 @@ pub enum FontScript {
     Super,
 }
 
+#[derive(Copy, Clone)]
+enum FontStyle {
+    Strikethrough,
+    Hidden,
+    Inverse,
+    Italic,
+    #[cfg(feature = "overstrike")]
+    Overstrike,
+    Overline,
+}
+
+impl FontStyle {
+    #[must_use]
+    const fn mask(self) -> u8 {
+        match self {
+            Self::Strikethrough => 0b0000_0001,
+            Self::Hidden => 0b0000_0010,
+            Self::Inverse => 0b0000_0100,
+            Self::Italic => 0b0000_1000,
+            #[cfg(feature = "overstrike")]
+            Self::Overstrike => 0b0001_0000,
+            Self::Overline => 0b0010_0000,
+        }
+    }
+}
+
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
+#[non_exhaustive]
 pub struct Font {
-    weight: Option<FontWeight>,
-    family: Option<FontFamily>,
+    pub weight: Option<FontWeight>,
+    pub family: Option<FontFamily>,
     // mintty extension
     #[cfg(feature = "script")]
-    script: Option<FontScript>,
+    pub script: Option<FontScript>,
 
     // Value layout: `XXÖO_IRHS`
     //
@@ -135,8 +162,8 @@ pub struct Font {
     // * `X`: unused
     style: u8,
 
-    underline: Option<Underline>,
-    blinking: Option<Blinking>,
+    pub underline: Option<Underline>,
+    pub blinking: Option<Blinking>,
 }
 
 impl Font {
@@ -153,21 +180,9 @@ impl Font {
         }
     }
 
-    pub fn set_weight(&mut self, weight: FontWeight) -> &mut Self {
-        self.weight = Some(weight);
-
-        self
-    }
-
     #[must_use]
     pub const fn with_weight(mut self, weight: FontWeight) -> Self {
         self.weight = Some(weight);
-
-        self
-    }
-
-    pub fn set_family(&mut self, family: FontFamily) -> &mut Self {
-        self.family = Some(family);
 
         self
     }
@@ -179,21 +194,9 @@ impl Font {
         self
     }
 
-    pub fn set_underline(&mut self, underline: Underline) -> &mut Self {
-        self.underline = Some(underline);
-
-        self
-    }
-
     #[must_use]
     pub const fn with_underline(mut self, underline: Underline) -> Self {
         self.underline = Some(underline);
-
-        self
-    }
-
-    pub fn set_blinking(&mut self, blinking: Blinking) -> &mut Self {
-        self.blinking = Some(blinking);
 
         self
     }
@@ -205,94 +208,118 @@ impl Font {
         self
     }
 
-    // TODO: set, get font-script
-
-    pub fn set_strikethrough(&mut self) -> &mut Self {
-        self.style |= 1 << 0;
+    #[must_use]
+    pub const fn with_script(mut self, script: FontScript) -> Self {
+        self.script = Some(script);
 
         self
     }
 
-    #[must_use]
-    pub const fn with_strikethrough(mut self) -> Self {
-        self.style |= 1 << 0;
+    const fn with_style(mut self, style: FontStyle, enable: bool) -> Self {
+        let mask = style.mask();
 
+        self.style = if enable {
+            self.style | mask
+        } else {
+            self.style & !mask
+        };
         self
     }
 
-    // TODO: is_strikethrough
-
-    pub fn set_inverse(&mut self) -> &mut Self {
-        self.style |= 1 << 1;
-
-        self
+    const fn is_style(self, style: FontStyle) -> bool {
+        (self.style & style.mask()) > 0
     }
 
-    #[must_use]
-    pub const fn with_inverse(mut self) -> Self {
-        self.style |= 1 << 1;
-
-        self
-    }
-
-    // TODO: is_inverse
-
-    pub fn set_hidden(&mut self) -> &mut Self {
-        self.style |= 1 << 2;
-
+    pub fn set_strikethrough(&mut self, enable: bool) -> &mut Self {
+        *self = self.with_style(FontStyle::Strikethrough, enable);
         self
     }
 
     #[must_use]
-    pub const fn with_hidden(mut self) -> Self {
-        self.style |= 1 << 2;
+    pub const fn with_strikethrough(self) -> Self {
+        self.with_style(FontStyle::Strikethrough, true)
+    }
 
+    #[must_use]
+    pub const fn is_strikethrough(&self) -> bool {
+        self.is_style(FontStyle::Strikethrough)
+    }
+
+    pub fn set_inverse(&mut self, enable: bool) -> &mut Self {
+        *self = self.with_style(FontStyle::Inverse, enable);
         self
     }
 
-    // TODO: is_hidden
+    #[must_use]
+    pub const fn with_inverse(self) -> Self {
+        self.with_style(FontStyle::Inverse, true)
+    }
 
-    pub fn set_italic(&mut self) -> &mut Self {
-        self.style |= 1 << 3;
+    #[must_use]
+    pub const fn is_inverse(&self) -> bool {
+        self.is_style(FontStyle::Inverse)
+    }
 
+    pub fn set_hidden(&mut self, enable: bool) -> &mut Self {
+        *self = self.with_style(FontStyle::Hidden, enable);
         self
     }
 
     #[must_use]
-    pub const fn with_italic(mut self) -> Self {
-        self.style |= 1 << 3;
+    pub const fn with_hidden(self) -> Self {
+        self.with_style(FontStyle::Hidden, true)
+    }
 
+    #[must_use]
+    pub const fn is_hidden(&self) -> bool {
+        self.is_style(FontStyle::Hidden)
+    }
+
+    pub fn set_italic(&mut self, enable: bool) -> &mut Self {
+        *self = self.with_style(FontStyle::Italic, enable);
         self
     }
 
-    // TODO: is_italic
-
-    // -> These need cfg guard
-    // TODO: set_overstrike
-    // TODO: with_overstrike
-    // TODO: is_overstrike
-
-    // TODO: set_overline
-    // TODO: with_overline
-    // TODO: is_overline
-
     #[must_use]
-    pub const fn weight(&self) -> Option<FontWeight> {
-        self.weight
+    pub const fn with_italic(self) -> Self {
+        self.with_style(FontStyle::Italic, true)
     }
 
     #[must_use]
-    pub const fn family(&self) -> Option<FontFamily> {
-        self.family
+    pub const fn is_italic(&self) -> bool {
+        self.is_style(FontStyle::Italic)
+    }
+
+    #[cfg(feature = "overstrike")]
+    pub fn set_overstrike(&mut self, enable: bool) -> &mut Self {
+        *self = self.with_style(FontStyle::Overstrike, enable);
+        self
+    }
+
+    #[cfg(feature = "overstrike")]
+    #[must_use]
+    pub const fn with_overstrike(self) -> Self {
+        self.with_style(FontStyle::Overstrike, true)
+    }
+
+    #[cfg(feature = "overstrike")]
+    #[must_use]
+    pub const fn is_overstrike(&self) -> bool {
+        self.is_style(FontStyle::Overstrike)
+    }
+
+    pub fn set_overline(&mut self, enable: bool) -> &mut Self {
+        *self = self.with_style(FontStyle::Overline, enable);
+        self
     }
 
     #[must_use]
-    pub const fn underline(&self) -> Option<Underline> {
-        self.underline
+    pub const fn with_overline(self) -> Self {
+        self.with_style(FontStyle::Overline, true)
     }
 
     #[must_use]
-    pub const fn blinking(&self) -> Option<Blinking> {
-        self.blinking
+    pub const fn is_overline(&self) -> bool {
+        self.is_style(FontStyle::Overline)
     }
 }

--- a/libs/antsi/src/lib.rs
+++ b/libs/antsi/src/lib.rs
@@ -49,6 +49,11 @@ impl Foreground {
     pub const fn new(color: Color) -> Self {
         Self(color)
     }
+
+    #[must_use]
+    pub const fn color(self) -> Color {
+        self.0
+    }
 }
 
 impl_const! {
@@ -69,6 +74,11 @@ impl Background {
     #[must_use]
     pub const fn new(color: Color) -> Self {
         Self(color)
+    }
+
+    #[must_use]
+    pub const fn color(self) -> Color {
+        self.0
     }
 }
 
@@ -93,6 +103,11 @@ impl UnderlineColor {
     #[must_use]
     pub const fn new(color: Color) -> Self {
         Self(color)
+    }
+
+    #[must_use]
+    pub const fn color(self) -> Color {
+        self.0
     }
 }
 
@@ -130,16 +145,17 @@ impl_const! {
 /// [kitty + vte extension]: https://sw.kovidgoyal.net/kitty/underlines/
 /// [mintty extension]: https://github.com/mintty/mintty/wiki/CtrlSeqs
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
+#[non_exhaustive]
 pub struct Style {
-    font: Font,
+    pub font: Font,
 
-    decorations: Decorations,
+    pub decorations: Decorations,
 
-    foreground: Option<Foreground>,
-    background: Option<Background>,
+    pub foreground: Option<Foreground>,
+    pub background: Option<Background>,
 
     #[cfg(feature = "underline-color")]
-    underline_color: Option<UnderlineColor>,
+    pub underline_color: Option<UnderlineColor>,
 }
 
 impl Style {
@@ -222,67 +238,5 @@ impl Style {
         self.font = font;
 
         self
-    }
-
-    pub fn set_font(&mut self, font: Font) -> &mut Self {
-        self.font = font;
-
-        self
-    }
-
-    pub fn set_foreground(&mut self, color: impl Into<Foreground>) -> &mut Self {
-        self.foreground = Some(color.into());
-
-        self
-    }
-
-    pub fn set_background(&mut self, color: impl Into<Background>) -> &mut Self {
-        self.background = Some(color.into());
-
-        self
-    }
-
-    #[cfg(feature = "underline-color")]
-    pub fn set_underline_color(&mut self, color: impl Into<UnderlineColor>) -> &mut Self {
-        self.underline_color = Some(color.into());
-
-        self
-    }
-
-    #[must_use]
-    pub const fn font(&self) -> Font {
-        self.font
-    }
-
-    pub fn font_mut(&mut self) -> &mut Font {
-        &mut self.font
-    }
-
-    #[must_use]
-    pub const fn foreground(&self) -> Option<Color> {
-        if let Some(Foreground(color)) = self.foreground {
-            Some(color)
-        } else {
-            None
-        }
-    }
-
-    #[must_use]
-    pub const fn background(&self) -> Option<Color> {
-        if let Some(Background(color)) = self.background {
-            Some(color)
-        } else {
-            None
-        }
-    }
-
-    #[cfg(feature = "underline-color")]
-    #[must_use]
-    pub const fn underline_color(&self) -> Option<Color> {
-        if let Some(UnderlineColor(color)) = self.underline_color {
-            Some(color)
-        } else {
-            None
-        }
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Remove all getter and setter (prefixed with `set_`), adhering to the builder-lite principle. Since we do not need to uphold any invariants on the struct, all fields have been marked pub, the only exception is `Font::style`, which is a bitfield and therefore needs special methods for access. These have been unified and made more readable.

