### PR TITLE
Expose ontology transaction time to the graph

### DIFF
--- a/apps/hash-graph/lib/graph/src/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/data_type.rs
@@ -83,6 +83,16 @@ pub enum DataTypeQueryPath<'p> {
     /// [`VersionedUrl`]: type_system::url::VersionedUrl
     /// [`DataType`]: type_system::DataType
     VersionedUrl,
+    /// The transaction time of the [`DataType`].
+    ///
+    /// It's not possible to query for the temporal axis directly, this has to be done via the
+    /// `temporalAxes` parameter on [`StructuralQuery`]. The transaction time is currently not part
+    /// of the [`OntologyElementMetadata`].
+    ///
+    /// [`EntityType`]: type_system::EntityType
+    /// [`OntologyElementMetadata`]: crate::ontology::OntologyElementMetadata
+    /// [`StructuralQuery`]: crate::subgraph::query::StructuralQuery
+    TransactionTime,
     /// The [`OwnedById`] of the [`OntologyElementMetadata`] belonging to the [`DataType`].
     ///
     /// ```rust
@@ -189,6 +199,10 @@ impl OntologyQueryPath for DataTypeQueryPath<'_> {
         Self::Version
     }
 
+    fn transaction_time() -> Self {
+        Self::TransactionTime
+    }
+
     fn updated_by_id() -> Self {
         Self::UpdatedById
     }
@@ -209,6 +223,7 @@ impl QueryPath for DataTypeQueryPath<'_> {
             Self::Schema(_) | Self::AdditionalMetadata(_) => ParameterType::Any,
             Self::BaseUrl => ParameterType::BaseUrl,
             Self::VersionedUrl => ParameterType::VersionedUrl,
+            Self::TransactionTime => ParameterType::TimeInterval,
             Self::Version => ParameterType::OntologyTypeVersion,
             Self::Description | Self::Title | Self::Type => ParameterType::Text,
             Self::PropertyTypeEdge { path, .. } => path.expected_type(),
@@ -223,6 +238,7 @@ impl fmt::Display for DataTypeQueryPath<'_> {
             Self::BaseUrl => fmt.write_str("baseUrl"),
             Self::Version => fmt.write_str("version"),
             Self::VersionedUrl => fmt.write_str("versionedUrl"),
+            Self::TransactionTime => fmt.write_str("transactionTime"),
             Self::OwnedById => fmt.write_str("ownedById"),
             Self::UpdatedById => fmt.write_str("updatedById"),
             Self::Schema(Some(path)) => write!(fmt, "schema.{path}"),

--- a/apps/hash-graph/lib/graph/src/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/data_type.rs
@@ -89,7 +89,7 @@ pub enum DataTypeQueryPath<'p> {
     /// `temporalAxes` parameter on [`StructuralQuery`]. The transaction time is currently not part
     /// of the [`OntologyElementMetadata`].
     ///
-    /// [`EntityType`]: type_system::EntityType
+    /// [`DataType`]: type_system::DataType
     /// [`OntologyElementMetadata`]: crate::ontology::OntologyElementMetadata
     /// [`StructuralQuery`]: crate::subgraph::query::StructuralQuery
     TransactionTime,

--- a/apps/hash-graph/lib/graph/src/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/entity_type.rs
@@ -78,6 +78,16 @@ pub enum EntityTypeQueryPath<'p> {
     /// [`EntityType`]: type_system::EntityType
     /// [`VersionedUrl`]: type_system::url::VersionedUrl
     VersionedUrl,
+    /// The transaction time of the [`EntityType`].
+    ///
+    /// It's not possible to query for the temporal axis directly, this has to be done via the
+    /// `temporalAxes` parameter on [`StructuralQuery`]. The transaction time is currently not part
+    /// of the [`OntologyElementMetadata`].
+    ///
+    /// [`EntityType`]: type_system::EntityType
+    /// [`OntologyElementMetadata`]: crate::ontology::OntologyElementMetadata
+    /// [`StructuralQuery`]: crate::subgraph::query::StructuralQuery
+    TransactionTime,
     /// The [`OwnedById`] of the [`OntologyElementMetadata`] belonging to the [`EntityType`].
     ///
     /// ```rust
@@ -306,6 +316,10 @@ impl OntologyQueryPath for EntityTypeQueryPath<'_> {
         Self::Version
     }
 
+    fn transaction_time() -> Self {
+        Self::TransactionTime
+    }
+
     fn updated_by_id() -> Self {
         Self::UpdatedById
     }
@@ -329,6 +343,7 @@ impl QueryPath for EntityTypeQueryPath<'_> {
             Self::BaseUrl => ParameterType::BaseUrl,
             Self::VersionedUrl => ParameterType::VersionedUrl,
             Self::Version => ParameterType::OntologyTypeVersion,
+            Self::TransactionTime => ParameterType::TimeInterval,
             Self::Title | Self::Description => ParameterType::Text,
             Self::PropertyTypeEdge { path, .. } => path.expected_type(),
             Self::EntityTypeEdge { path, .. } => path.expected_type(),
@@ -344,6 +359,7 @@ impl fmt::Display for EntityTypeQueryPath<'_> {
             Self::BaseUrl => fmt.write_str("baseUrl"),
             Self::Version => fmt.write_str("version"),
             Self::VersionedUrl => fmt.write_str("versionedUrl"),
+            Self::TransactionTime => fmt.write_str("transactionTime"),
             Self::OwnedById => fmt.write_str("ownedById"),
             Self::UpdatedById => fmt.write_str("updatedById"),
             Self::Schema(Some(path)) => write!(fmt, "schema.{path}"),

--- a/apps/hash-graph/lib/graph/src/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/property_type.rs
@@ -70,7 +70,7 @@ pub enum PropertyTypeQueryPath<'p> {
     /// `temporalAxes` parameter on [`StructuralQuery`]. The transaction time is currently not part
     /// of the [`OntologyElementMetadata`].
     ///
-    /// [`EntityType`]: type_system::EntityType
+    /// [`PropertyType`]: type_system::PropertyType
     /// [`OntologyElementMetadata`]: crate::ontology::OntologyElementMetadata
     /// [`StructuralQuery`]: crate::subgraph::query::StructuralQuery
     TransactionTime,

--- a/apps/hash-graph/lib/graph/src/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/property_type.rs
@@ -64,6 +64,16 @@ pub enum PropertyTypeQueryPath<'p> {
     /// [`PropertyType`]: type_system::PropertyType
     /// [`VersionedUrl`]: type_system::url::VersionedUrl
     VersionedUrl,
+    /// The transaction time of the [`PropertyType`].
+    ///
+    /// It's not possible to query for the temporal axis directly, this has to be done via the
+    /// `temporalAxes` parameter on [`StructuralQuery`]. The transaction time is currently not part
+    /// of the [`OntologyElementMetadata`].
+    ///
+    /// [`EntityType`]: type_system::EntityType
+    /// [`OntologyElementMetadata`]: crate::ontology::OntologyElementMetadata
+    /// [`StructuralQuery`]: crate::subgraph::query::StructuralQuery
+    TransactionTime,
     /// The [`OwnedById`] of the [`OntologyElementMetadata`] belonging to the [`PropertyType`].
     ///
     /// ```rust
@@ -228,6 +238,10 @@ impl OntologyQueryPath for PropertyTypeQueryPath<'_> {
         Self::Version
     }
 
+    fn transaction_time() -> Self {
+        Self::TransactionTime
+    }
+
     fn updated_by_id() -> Self {
         Self::UpdatedById
     }
@@ -249,6 +263,7 @@ impl QueryPath for PropertyTypeQueryPath<'_> {
             Self::BaseUrl => ParameterType::BaseUrl,
             Self::VersionedUrl => ParameterType::VersionedUrl,
             Self::Version => ParameterType::OntologyTypeVersion,
+            Self::TransactionTime => ParameterType::TimeInterval,
             Self::Title | Self::Description => ParameterType::Text,
             Self::DataTypeEdge { path, .. } => path.expected_type(),
             Self::PropertyTypeEdge { path, .. } => path.expected_type(),
@@ -264,6 +279,7 @@ impl fmt::Display for PropertyTypeQueryPath<'_> {
             Self::BaseUrl => fmt.write_str("baseUrl"),
             Self::Version => fmt.write_str("version"),
             Self::VersionedUrl => fmt.write_str("versionedUrl"),
+            Self::TransactionTime => fmt.write_str("transactionTime"),
             Self::OwnedById => fmt.write_str("ownedById"),
             Self::UpdatedById => fmt.write_str("updatedById"),
             Self::Schema(Some(path)) => write!(fmt, "schema.{path}"),

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/data_type.rs
@@ -26,6 +26,7 @@ impl PostgresQueryPath for DataTypeQueryPath<'_> {
             | Self::Schema(_) => vec![],
             Self::BaseUrl
             | Self::Version
+            | Self::TransactionTime
             | Self::UpdatedById
             | Self::OwnedById
             | Self::AdditionalMetadata(_) => {
@@ -48,6 +49,7 @@ impl PostgresQueryPath for DataTypeQueryPath<'_> {
         match self {
             Self::BaseUrl => Column::OntologyIds(OntologyIds::BaseUrl),
             Self::Version => Column::OntologyIds(OntologyIds::Version),
+            Self::TransactionTime => Column::OntologyIds(OntologyIds::TransactionTime),
             Self::OwnedById => Column::OntologyIds(OntologyIds::AdditionalMetadata(Some(
                 JsonField::StaticText("owned_by_id"),
             ))),

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
@@ -89,6 +89,7 @@ impl PostgresQueryPath for EntityTypeQueryPath<'_> {
         match self {
             Self::BaseUrl => Column::OntologyIds(OntologyIds::BaseUrl),
             Self::Version => Column::OntologyIds(OntologyIds::Version),
+            Self::TransactionTime => Column::OntologyIds(OntologyIds::TransactionTime),
             Self::OwnedById => Column::OntologyIds(OntologyIds::AdditionalMetadata(Some(
                 JsonField::StaticText("owned_by_id"),
             ))),

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/property_type.rs
@@ -66,6 +66,7 @@ impl PostgresQueryPath for PropertyTypeQueryPath<'_> {
         match self {
             Self::BaseUrl => Column::OntologyIds(OntologyIds::BaseUrl),
             Self::Version => Column::OntologyIds(OntologyIds::Version),
+            Self::TransactionTime => Column::OntologyIds(OntologyIds::TransactionTime),
             Self::OwnedById => Column::OntologyIds(OntologyIds::AdditionalMetadata(Some(
                 JsonField::StaticText("owned_by_id"),
             ))),

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
@@ -228,6 +228,7 @@ pub enum OntologyIds<'p> {
     Version,
     UpdatedById,
     LatestVersion,
+    TransactionTime,
     AdditionalMetadata(Option<JsonField<'p>>),
 }
 
@@ -267,6 +268,7 @@ impl OntologyIds<'_> {
         let column = match self {
             Self::OntologyId => "ontology_id",
             Self::BaseUrl => "base_url",
+            Self::TransactionTime => "transaction_time",
             Self::Version => "version",
             Self::LatestVersion => "latest_version",
             Self::UpdatedById => "record_created_by_id",

--- a/apps/hash-graph/lib/graph/src/store/query.rs
+++ b/apps/hash-graph/lib/graph/src/store/query.rs
@@ -58,6 +58,9 @@ pub trait OntologyQueryPath {
     /// [`OntologyTypeVersion`]: crate::identifier::ontology::OntologyTypeVersion
     fn version() -> Self;
 
+    /// Returns the path identifying the transaction time.
+    fn transaction_time() -> Self;
+
     /// Returns the path identifying the [`UpdatedById`].
     ///
     /// [`UpdatedById`]: crate::provenance::UpdatedById


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The goal is to have proper testing of the returned subgraph. This implies, that a set of data is present in the database. To insert a set of data into the data the easiest way to achieve this is to import a previously exported set of data. As we, however, do want the data to be exactly the same after exporting, wiping, and importing the data, it implies, that the graph requires information about the time, when an ontology type was inserted into the database, which is recorded in `transactionTime`, a variable, which is not exposed yet at all.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204000740778938/1204216809501000/f) _(internal)_

## 🔍 What does this change?

- Add `TransactionTime` to the ontology query paths
- Make the query compiler aware of `TransactionTime`

## 📜 Does this require a change to the docs?

A doc-string has been added to the newly added query path parameters, but the field is still not exposed anywhere.

## ⚠️ Known issues

- Currently, this is only tested manually but not automatically.

## 🐾 Next steps

Please see the sibling tasks of the task, which is linked above

## 🛡 What tests cover this?

- none (yet)

## ❓ How to test this?

Add a transaction time query to the read implementation of the ontology types, print it, and make sure, it's the correct value (Should be `[now(), +∞)`)

## 📹 Demo

With the steps described above, this prints this to the terminal:
```
transaction_time: [2023-03-22 13:41:39.102656 +00:00:00, +∞)
```
