### PR TITLE
Consistently set private: true in blocks

### DIFF
--- a/blocks/address/package.json
+++ b/blocks/address/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocks/address",
   "version": "0.1.2",
+  "private": true,
   "description": "Search for an address using the Mapbox Address Autofill and Mapbox Static Images APIs",
   "keywords": [
     "blockprotocol",

--- a/blocks/how-to/package.json
+++ b/blocks/how-to/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@blocks/how-to",
   "version": "0.1.3",
-  "description": "Describe a task or process via a list of steps ",
+  "private": true,
+  "description": "Describe a task or process via a list of steps",
   "keywords": [
     "blockprotocol",
     "blocks",

--- a/blocks/minesweeper/package.json
+++ b/blocks/minesweeper/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocks/minesweeper",
   "version": "0.0.1",
+  "private": true,
   "description": "Play Minesweeper in your browser!",
   "keywords": [
     "blockprotocol",

--- a/blocks/table/package.json
+++ b/blocks/table/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocks/table",
   "version": "0.3.0",
+  "private": true,
   "description": "Display and manipulate tabular data with filter, sort, and search features",
   "keywords": [
     "blockprotocol",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We set `private: true` in the `package.json` for blocks, so that Changesets does not attempt to publish updates to them when their dependencies (e.g. `@hashintel/design-system`) are updated.

Although we have an `ignore` setting in `.changeset/config.json`, this only prevents Changesets from offering the packages as an option when generating changesets. It doesn't stop it attempting to update them when a dependency is updated. We have a [patch](https://github.com/hashintel/hash/blob/main/patches/%40changesets%2Bget-dependents-graph%2B1.3.5.patch) which prevents Changesets from trying to publish dependents who are set as `private: true`, but this requires we set `private: true` in packages we don't want published.

This PR fixes a few missing ocurrences of that. 
