### PR TITLE
Allow returning different type from `Read`

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/crud.rs
+++ b/apps/hash-graph/lib/graph/src/store/crud.rs
@@ -20,7 +20,9 @@ use crate::{
 // TODO: Use queries, which are passed to the query-endpoint
 //   see https://app.asana.com/0/1202805690238892/1202979057056097/f
 #[async_trait]
-pub trait Read<R: Record + Send>: Sync {
+pub trait Read<R>: Sync {
+    type Record: Record;
+
     // TODO: Return a stream of `R` instead
     //   see https://app.asana.com/0/1202805690238892/1202923536131158/f
     /// Returns a value from the [`Store`] specified by the passed `query`.
@@ -28,14 +30,14 @@ pub trait Read<R: Record + Send>: Sync {
     /// [`Store`]: crate::store::Store
     async fn read(
         &self,
-        query: &Filter<R>,
+        query: &Filter<Self::Record>,
         temporal_axes: &QueryTemporalAxes,
     ) -> Result<Vec<R>, QueryError>;
 
     #[tracing::instrument(level = "info", skip(self, query))]
     async fn read_one(
         &self,
-        query: &Filter<R>,
+        query: &Filter<Self::Record>,
         temporal_axes: &QueryTemporalAxes,
     ) -> Result<R, QueryError> {
         let mut records = self.read(query, temporal_axes).await?;

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -403,9 +403,11 @@ where
     A: Send + Sync,
     S: Read<R> + Send,
 {
+    type Record = S::Record;
+
     async fn read(
         &self,
-        query: &Filter<R>,
+        query: &Filter<Self::Record>,
         temporal_axes: &QueryTemporalAxes,
     ) -> Result<Vec<R>, QueryError> {
         self.store.read(query, temporal_axes).await

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -32,6 +32,8 @@ use crate::{
 
 #[async_trait]
 impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
+    type Record = Entity;
+
     #[tracing::instrument(level = "info", skip(self))]
     async fn read(
         &self,

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -57,6 +57,8 @@ where
     T: OntologyTypeWithMetadata + PostgresRecord,
     for<'p> T::QueryPath<'p>: OntologyQueryPath,
 {
+    type Record = T;
+
     #[tracing::instrument(level = "info", skip(self, filter))]
     async fn read(
         &self,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We currently have only a very limited API to read from the database. Only changing the `Read` trait to have an associated type, greatly extends the possibilities.

This is required for two things: 
- Allow reading all data from the database, required for snapshots
- Allow reading a subset of data, e.g. edges only, required for a faster traversal logic

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1204000740778938/1204241372922558/f) _(internal)_

## 🔍 What does this change?

- Use an associative type in the `Read` trait
- Remove unused function in `Subgraph` (I'm happy to finally being able to remove it, this was the main blocker to this task)