### PR TITLE
Fix `Address` block error state when retrieving a suggestion

### DIFF
--- a/blocks/address/src/app.tsx
+++ b/blocks/address/src/app.tsx
@@ -685,7 +685,6 @@ export const App: BlockComponent<RootEntity> = ({
                 <Collapse
                   in={shouldDisplayCard && !animatingOut && !suggestionsError}
                   onEntered={() => setAnimatingIn(null)}
-                  onExited={() => resetBlock()}
                 >
                   {displayFullAddress ? (
                     <AddressCard
@@ -699,6 +698,9 @@ export const App: BlockComponent<RootEntity> = ({
                       readonly={readonly}
                       onClose={() => {
                         setAnimatingOut(true);
+                        setTimeout(() => {
+                          void resetBlock();
+                        }, 300);
                       }}
                       updateTitle={updateTitle}
                       updateDescription={updateDescription}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
This PR fixes an edge case introduced by #2262

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203801045329780/1204249591562078/f) _(internal)_

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

Changed the block to only reset the state in the `onClose` callback, instead of when the address card animates out. Because of the loading state introduced in #2262, the address card will always animate in when a suggestion is selected. If the block fails to retieve that suggestion's data it will display an error state and animate out. Because we were resetting the block after the card animated out, the error was being cleared as well.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
Before:
![before](https://user-images.githubusercontent.com/37453800/227223287-518246fe-fa1a-4f25-bf43-d6a953f38b53.gif)



After:
![after](https://user-images.githubusercontent.com/37453800/227223300-c48450e4-b8e0-4e78-932a-132acf134118.gif)
