### PR TITLE
Remove deprecated link in GitHub Issues config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,6 +9,3 @@ contact_links:
   - name: Discord
     url: https://hash.ai/discord
     about: Join our discord server for quick help and support
-  - name: Community Forum
-    url: https://hash.ai/discord
-    about: Post on our community forum


### PR DESCRIPTION
Removes a deprecated link to the old community forum, in favor of only the Discord going forward. This was found in the GitHub issues template configuration file.