### PR TITLE
Support querying for all entities without pinning a temporal axis

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -62,7 +62,7 @@ impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
             direction: EdgeDirection::Outgoing,
         };
 
-        let mut compiler = SelectCompiler::new(temporal_axes);
+        let mut compiler = SelectCompiler::new(Some(temporal_axes));
 
         let owned_by_id_index = compiler.add_selection_path(&EntityQueryPath::OwnedById);
         let entity_uuid_index = compiler.add_selection_path(&EntityQueryPath::Uuid);

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -73,7 +73,7 @@ where
         let additional_metadata_path =
             <T::QueryPath<'static> as OntologyQueryPath>::additional_metadata();
 
-        let mut compiler = SelectCompiler::new(temporal_axes);
+        let mut compiler = SelectCompiler::new(Some(temporal_axes));
 
         let base_url_index = compiler.add_distinct_selection_with_ordering(
             &base_url_path,

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/compile.rs
@@ -41,13 +41,13 @@ pub struct CompilerArtifacts<'p> {
 pub struct SelectCompiler<'c, 'p, T> {
     statement: SelectStatement<'c>,
     artifacts: CompilerArtifacts<'p>,
-    temporal_axes: &'p QueryTemporalAxes,
+    temporal_axes: Option<&'p QueryTemporalAxes>,
     _marker: PhantomData<fn(*const T)>,
 }
 
 impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
     /// Creates a new, empty compiler.
-    pub fn new(temporal_axes: &'p QueryTemporalAxes) -> Self {
+    pub fn new(temporal_axes: Option<&'p QueryTemporalAxes>) -> Self {
         Self {
             statement: SelectStatement {
                 with: WithExpression::default(),
@@ -74,7 +74,7 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
     }
 
     /// Creates a new compiler, which will select everything using the asterisk (`*`).
-    pub fn with_asterisk(temporal_axes: &'p QueryTemporalAxes) -> Self {
+    pub fn with_asterisk(temporal_axes: Option<&'p QueryTemporalAxes>) -> Self {
         let mut default = Self::new(temporal_axes);
         default
             .statement
@@ -84,52 +84,54 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
     }
 
     fn pin_entity_table(&mut self, alias: Alias) {
-        let table = Table::EntityTemporalMetadata.aliased(alias);
-        let temporal_table_info = self.artifacts.temporal_tables.get_or_insert_with(|| {
-            match self.temporal_axes {
-                QueryTemporalAxes::DecisionTime { pinned, variable } => {
-                    self.artifacts.parameters.push(&pinned.timestamp);
-                    self.artifacts.parameters.push(&variable.interval);
-                }
-                QueryTemporalAxes::TransactionTime { pinned, variable } => {
-                    self.artifacts.parameters.push(&pinned.timestamp);
-                    self.artifacts.parameters.push(&variable.interval);
-                }
-            };
+        if let Some(temporal_axes) = self.temporal_axes {
+            let table = Table::EntityTemporalMetadata.aliased(alias);
+            let temporal_table_info = self.artifacts.temporal_tables.get_or_insert_with(|| {
+                match temporal_axes {
+                    QueryTemporalAxes::DecisionTime { pinned, variable } => {
+                        self.artifacts.parameters.push(&pinned.timestamp);
+                        self.artifacts.parameters.push(&variable.interval);
+                    }
+                    QueryTemporalAxes::TransactionTime { pinned, variable } => {
+                        self.artifacts.parameters.push(&pinned.timestamp);
+                        self.artifacts.parameters.push(&variable.interval);
+                    }
+                };
 
-            TemporalTableInfo {
-                tables: HashSet::new(),
-                pinned_timestamp_index: self.artifacts.parameters.len() - 1,
-                variable_interval_index: self.artifacts.parameters.len(),
+                TemporalTableInfo {
+                    tables: HashSet::new(),
+                    pinned_timestamp_index: self.artifacts.parameters.len() - 1,
+                    variable_interval_index: self.artifacts.parameters.len(),
+                }
+            });
+
+            if !temporal_table_info.tables.contains(&table) {
+                // Adds the pinned timestamp condition, so for the projected decision time, we use
+                // the transaction time and vice versa.
+                self.statement.where_expression.add_condition(
+                    Condition::TimeIntervalContainsTimestamp(
+                        Expression::Column(
+                            Column::EntityTemporalMetadata(EntityTemporalMetadata::from_time_axis(
+                                temporal_axes.pinned_time_axis(),
+                            ))
+                            .aliased(alias),
+                        ),
+                        Expression::Parameter(temporal_table_info.pinned_timestamp_index),
+                    ),
+                );
+                self.statement
+                    .where_expression
+                    .add_condition(Condition::Overlap(
+                        Expression::Column(
+                            Column::EntityTemporalMetadata(EntityTemporalMetadata::from_time_axis(
+                                temporal_axes.variable_time_axis(),
+                            ))
+                            .aliased(alias),
+                        ),
+                        Expression::Parameter(temporal_table_info.variable_interval_index),
+                    ));
+                temporal_table_info.tables.insert(table);
             }
-        });
-
-        if !temporal_table_info.tables.contains(&table) {
-            // Adds the pinned timestamp condition, so for the projected decision time, we use the
-            // transaction time and vice versa.
-            self.statement.where_expression.add_condition(
-                Condition::TimeIntervalContainsTimestamp(
-                    Expression::Column(
-                        Column::EntityTemporalMetadata(EntityTemporalMetadata::from_time_axis(
-                            self.temporal_axes.pinned_time_axis(),
-                        ))
-                        .aliased(alias),
-                    ),
-                    Expression::Parameter(temporal_table_info.pinned_timestamp_index),
-                ),
-            );
-            self.statement
-                .where_expression
-                .add_condition(Condition::Overlap(
-                    Expression::Column(
-                        Column::EntityTemporalMetadata(EntityTemporalMetadata::from_time_axis(
-                            self.temporal_axes.variable_time_axis(),
-                        ))
-                        .aliased(alias),
-                    ),
-                    Expression::Parameter(temporal_table_info.variable_interval_index),
-                ));
-            temporal_table_info.tables.insert(table);
         }
     }
 

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/condition.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/condition.rs
@@ -114,7 +114,7 @@ mod tests {
         parameters: &[&'p dyn ToSql],
     ) {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
-        let mut compiler = SelectCompiler::new(&temporal_axes);
+        let mut compiler = SelectCompiler::new(Some(&temporal_axes));
         let condition = compiler.compile_filter(filter);
 
         assert_eq!(condition.transpile_to_string(), rendered);

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
@@ -56,7 +56,7 @@ mod tests {
     #[test]
     fn transpile_where_expression() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
-        let mut compiler = SelectCompiler::<DataTypeWithMetadata>::new(&temporal_axes);
+        let mut compiler = SelectCompiler::<DataTypeWithMetadata>::new(Some(&temporal_axes));
         let mut where_clause = WhereExpression::default();
         assert_eq!(where_clause.transpile_to_string(), "");
 

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -127,7 +127,7 @@ mod tests {
     fn asterisk() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
         test_compilation(
-            &SelectCompiler::<DataTypeWithMetadata>::with_asterisk(&temporal_axes),
+            &SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes)),
             r#"SELECT * FROM "data_types" AS "data_types_0_0_0""#,
             &[],
         );
@@ -136,7 +136,8 @@ mod tests {
     #[test]
     fn simple_expression() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
-        let mut compiler = SelectCompiler::<DataTypeWithMetadata>::with_asterisk(&temporal_axes);
+        let mut compiler =
+            SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
         compiler.add_filter(&Filter::Equal(
             Some(FilterExpression::Path(DataTypeQueryPath::VersionedUrl)),
             Some(FilterExpression::Parameter(Parameter::Text(Cow::Borrowed(
@@ -157,7 +158,8 @@ mod tests {
     #[test]
     fn specific_version() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
-        let mut compiler = SelectCompiler::<DataTypeWithMetadata>::with_asterisk(&temporal_axes);
+        let mut compiler =
+            SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
         let filter = Filter::All(vec![
             Filter::Equal(
@@ -192,7 +194,8 @@ mod tests {
     #[test]
     fn latest_version() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
-        let mut compiler = SelectCompiler::<DataTypeWithMetadata>::with_asterisk(&temporal_axes);
+        let mut compiler =
+            SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
         compiler.add_filter(&Filter::Equal(
             Some(FilterExpression::Path(DataTypeQueryPath::Version)),
@@ -218,7 +221,8 @@ mod tests {
     #[test]
     fn not_latest_version() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
-        let mut compiler = SelectCompiler::<DataTypeWithMetadata>::with_asterisk(&temporal_axes);
+        let mut compiler =
+            SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
         compiler.add_filter(&Filter::NotEqual(
             Some(FilterExpression::Path(DataTypeQueryPath::Version)),
@@ -245,7 +249,7 @@ mod tests {
     fn property_type_by_referenced_data_types() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
         let mut compiler =
-            SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk(&temporal_axes);
+            SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
         compiler.add_filter(&Filter::Equal(
             Some(FilterExpression::Path(
@@ -327,7 +331,7 @@ mod tests {
     fn property_type_by_referenced_property_types() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
         let mut compiler =
-            SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk(&temporal_axes);
+            SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(
@@ -361,7 +365,8 @@ mod tests {
     #[test]
     fn entity_type_by_referenced_property_types() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
-        let mut compiler = SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(&temporal_axes);
+        let mut compiler =
+            SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(
@@ -394,7 +399,8 @@ mod tests {
     #[test]
     fn entity_type_by_referenced_link_types() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
-        let mut compiler = SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(&temporal_axes);
+        let mut compiler =
+            SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(
@@ -436,7 +442,8 @@ mod tests {
     #[test]
     fn entity_type_by_inheritance() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
-        let mut compiler = SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(&temporal_axes);
+        let mut compiler =
+            SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(
@@ -473,7 +480,7 @@ mod tests {
     fn entity_simple_query() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
-        let mut compiler = SelectCompiler::<Entity>::with_asterisk(&temporal_axes);
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes));
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityQueryPath::Uuid)),
@@ -504,7 +511,7 @@ mod tests {
     fn entity_with_manual_selection() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
-        let mut compiler = SelectCompiler::<Entity>::new(&temporal_axes);
+        let mut compiler = SelectCompiler::<Entity>::new(Some(&temporal_axes));
         compiler.add_distinct_selection_with_ordering(
             &EntityQueryPath::Uuid,
             Distinctness::Distinct,
@@ -552,7 +559,7 @@ mod tests {
     fn entity_property_query() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
-        let mut compiler = SelectCompiler::<Entity>::with_asterisk(&temporal_axes);
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes));
         let json_path = JsonPath::from_path_tokens(vec![PathToken::Field(Cow::Borrowed(
             r#"$."https://blockprotocol.org/@alice/types/property-type/name/""#,
         ))]);
@@ -591,7 +598,7 @@ mod tests {
     fn entity_property_null_query() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
-        let mut compiler = SelectCompiler::<Entity>::with_asterisk(&temporal_axes);
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes));
         let json_path = JsonPath::from_path_tokens(vec![PathToken::Field(Cow::Borrowed(
             r#"$."https://blockprotocol.org/@alice/types/property-type/name/""#,
         ))]);
@@ -627,7 +634,7 @@ mod tests {
     fn entity_outgoing_link_query() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
-        let mut compiler = SelectCompiler::<Entity>::with_asterisk(&temporal_axes);
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes));
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
@@ -676,7 +683,7 @@ mod tests {
     fn entity_incoming_link_query() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
-        let mut compiler = SelectCompiler::<Entity>::with_asterisk(&temporal_axes);
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes));
 
         let filter = Filter::Equal(
             Some(FilterExpression::Path(EntityQueryPath::EntityEdge {
@@ -725,7 +732,7 @@ mod tests {
     fn link_entity_left_right_id() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
-        let mut compiler = SelectCompiler::<Entity>::with_asterisk(&temporal_axes);
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes));
 
         let filter = Filter::All(vec![
             Filter::Equal(
@@ -796,7 +803,7 @@ mod tests {
     fn filter_left_and_right() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
-        let mut compiler = SelectCompiler::<Entity>::with_asterisk(&temporal_axes);
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes));
 
         let filter = Filter::All(vec![
             Filter::Equal(
@@ -898,7 +905,7 @@ mod tests {
 
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
             let mut compiler =
-                SelectCompiler::<DataTypeWithMetadata>::with_asterisk(&temporal_axes);
+                SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
             let filter = Filter::for_versioned_url(&url);
             compiler.add_filter(&filter);
@@ -931,7 +938,7 @@ mod tests {
 
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
             let mut compiler =
-                SelectCompiler::<DataTypeWithMetadata>::with_asterisk(&temporal_axes);
+                SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
             let filter = Filter::for_ontology_type_vertex_id(&url);
             compiler.add_filter(&filter);
@@ -961,7 +968,7 @@ mod tests {
 
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
             let mut compiler =
-                SelectCompiler::<DataTypeWithMetadata>::with_asterisk(&temporal_axes);
+                SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
             let filter =
                 Filter::<DataTypeWithMetadata>::for_ontology_edge_by_property_type_vertex_id(
@@ -1000,7 +1007,7 @@ mod tests {
 
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
             let mut compiler =
-                SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk(&temporal_axes);
+                SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
             let filter =
                 Filter::<PropertyTypeWithMetadata>::for_ontology_edge_by_data_type_vertex_id(
@@ -1039,7 +1046,7 @@ mod tests {
 
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
             let mut compiler =
-                SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk(&temporal_axes);
+                SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
             let filter =
                 Filter::<PropertyTypeWithMetadata>::for_ontology_edge_by_property_type_vertex_id(
@@ -1079,7 +1086,7 @@ mod tests {
 
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
             let mut compiler =
-                SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk(&temporal_axes);
+                SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
             let filter =
                 Filter::<PropertyTypeWithMetadata>::for_ontology_edge_by_property_type_vertex_id(
@@ -1119,7 +1126,7 @@ mod tests {
 
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
             let mut compiler =
-                SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(&temporal_axes);
+                SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
             let filter =
                 Filter::<EntityTypeWithMetadata>::for_ontology_edge_by_property_type_vertex_id(
@@ -1158,7 +1165,7 @@ mod tests {
 
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
             let mut compiler =
-                SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk(&temporal_axes);
+                SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
             let filter =
                 Filter::<PropertyTypeWithMetadata>::for_ontology_edge_by_entity_type_vertex_id(
@@ -1197,7 +1204,7 @@ mod tests {
 
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
             let mut compiler =
-                SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(&temporal_axes);
+                SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
             let filter =
                 Filter::<EntityTypeWithMetadata>::for_ontology_edge_by_entity_type_vertex_id(
@@ -1237,7 +1244,7 @@ mod tests {
 
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
             let mut compiler =
-                SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(&temporal_axes);
+                SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
             let filter =
                 Filter::<EntityTypeWithMetadata>::for_ontology_edge_by_entity_type_vertex_id(
@@ -1277,7 +1284,7 @@ mod tests {
 
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
             let mut compiler =
-                SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(&temporal_axes);
+                SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
             let filter =
                 Filter::<EntityTypeWithMetadata>::for_ontology_edge_by_entity_type_vertex_id(
@@ -1317,7 +1324,7 @@ mod tests {
 
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
             let mut compiler =
-                SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(&temporal_axes);
+                SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
             let filter =
                 Filter::<EntityTypeWithMetadata>::for_ontology_edge_by_entity_type_vertex_id(
@@ -1357,7 +1364,7 @@ mod tests {
 
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
             let mut compiler =
-                SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(&temporal_axes);
+                SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
             let filter =
                 Filter::<EntityTypeWithMetadata>::for_ontology_edge_by_entity_type_vertex_id(
@@ -1397,7 +1404,7 @@ mod tests {
 
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
             let mut compiler =
-                SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(&temporal_axes);
+                SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
             let filter =
                 Filter::<EntityTypeWithMetadata>::for_ontology_edge_by_entity_type_vertex_id(
@@ -1435,7 +1442,7 @@ mod tests {
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
             let pinned_timestamp = temporal_axes.pinned_timestamp();
             let mut compiler =
-                SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(&temporal_axes);
+                SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
             let filter = Filter::<EntityTypeWithMetadata>::for_shared_edge_by_entity_id(
                 entity_id,
@@ -1478,7 +1485,7 @@ mod tests {
 
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
             let pinned_timestamp = temporal_axes.pinned_timestamp();
-            let mut compiler = SelectCompiler::<Entity>::with_asterisk(&temporal_axes);
+            let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes));
 
             let filter = Filter::<Entity>::for_shared_edge_by_entity_type_vertex_id(
                 &url,
@@ -1520,7 +1527,7 @@ mod tests {
 
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
             let pinned_timestamp = temporal_axes.pinned_timestamp();
-            let mut compiler = SelectCompiler::<Entity>::with_asterisk(&temporal_axes);
+            let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes));
 
             let filter = Filter::for_entity_by_entity_id(entity_id);
             compiler.add_filter(&filter);
@@ -1553,7 +1560,7 @@ mod tests {
 
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
             let pinned_timestamp = temporal_axes.pinned_timestamp();
-            let mut compiler = SelectCompiler::<Entity>::with_asterisk(&temporal_axes);
+            let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes));
 
             let filter = Filter::for_knowledge_graph_edge_by_entity_id(
                 entity_id,
@@ -1593,7 +1600,7 @@ mod tests {
 
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
             let pinned_timestamp = temporal_axes.pinned_timestamp();
-            let mut compiler = SelectCompiler::<Entity>::with_asterisk(&temporal_axes);
+            let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes));
 
             let filter = Filter::for_knowledge_graph_edge_by_entity_id(
                 entity_id,
@@ -1633,7 +1640,7 @@ mod tests {
 
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
             let pinned_timestamp = temporal_axes.pinned_timestamp();
-            let mut compiler = SelectCompiler::<Entity>::with_asterisk(&temporal_axes);
+            let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes));
 
             let filter = Filter::for_knowledge_graph_edge_by_entity_id(
                 entity_id,
@@ -1678,7 +1685,7 @@ mod tests {
 
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
             let pinned_timestamp = temporal_axes.pinned_timestamp();
-            let mut compiler = SelectCompiler::<Entity>::with_asterisk(&temporal_axes);
+            let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes));
 
             let filter = Filter::for_knowledge_graph_edge_by_entity_id(
                 entity_id,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To store all entities, it's required that temporal data is extracted from the database.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- Part of [this Asana task](https://app.asana.com/0/1204000740778938/1204216809501005/f) _(internal)_

## 🔍 What does this change?

- Make the temporal axes parameter to the compiler optional

## 🛡 What tests cover this?

Two almost identical tests has been added, one with and one without temporal axes passed to the compiler