### PR TITLE
Use lifetimes for strings

### DIFF
--- a/libs/sarif/src/schema.rs
+++ b/libs/sarif/src/schema.rs
@@ -37,7 +37,7 @@ impl SchemaVersion {
 #[cfg(test)]
 #[cfg(feature = "serde")]
 pub(crate) mod tests {
-    use std::{eprintln, fs::File, io::BufReader};
+    use std::{eprintln, fs};
 
     use coverage_helper::test;
 
@@ -73,43 +73,37 @@ pub(crate) mod tests {
 
     #[test]
     fn example_k1() {
-        let log = serde_json::from_reader(BufReader::new(
-            File::open("tests/example_reports/k1_minimal.sarif.json").expect("could not open file"),
-        ))
-        .expect("could not parse SARIF log");
+        let file_content =
+            fs::read("tests/example_reports/k1_minimal.sarif.json").expect("could not read file");
+        let log = serde_json::from_slice(&file_content).expect("could not parse SARIF log");
 
         validate_schema(&log);
     }
 
     #[test]
     fn example_k2() {
-        let log = serde_json::from_reader(BufReader::new(
-            File::open("tests/example_reports/k2_recommended_with_source.sarif.json")
-                .expect("could not open file"),
-        ))
-        .expect("could not parse SARIF log");
+        let file_content = fs::read("tests/example_reports/k2_recommended_with_source.sarif.json")
+            .expect("could not read file");
+        let log = serde_json::from_slice(&file_content).expect("could not parse SARIF log");
 
         validate_schema(&log);
     }
 
     #[test]
     fn example_k3() {
-        let log = serde_json::from_reader(BufReader::new(
-            File::open("tests/example_reports/k3_recommended_without_source.sarif.json")
-                .expect("could not open file"),
-        ))
-        .expect("could not parse SARIF log");
+        let file_content =
+            fs::read("tests/example_reports/k3_recommended_without_source.sarif.json")
+                .expect("could not read file");
+        let log = serde_json::from_slice(&file_content).expect("could not parse SARIF log");
 
         validate_schema(&log);
     }
 
     #[test]
     fn example_k4() {
-        let log = serde_json::from_reader(BufReader::new(
-            File::open("tests/example_reports/k4_comprehensive.sarif.json")
-                .expect("could not open file"),
-        ))
-        .expect("could not parse SARIF log");
+        let file_content = fs::read("tests/example_reports/k4_comprehensive.sarif.json")
+            .expect("could not read file");
+        let log = serde_json::from_slice(&file_content).expect("could not parse SARIF log");
 
         validate_schema(&log);
     }

--- a/libs/sarif/src/schema/log.rs
+++ b/libs/sarif/src/schema/log.rs
@@ -89,7 +89,7 @@ pub struct SarifLog<'s> {
     ///    management system, and the query was malformed.
     ///
     /// See [SARIF specification §3.13.4](https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html#_Toc10540920)
-    #[serde(default, borrow)]
+    #[cfg_attr(feature = "serde", serde(default, borrow))]
     pub runs: Option<Vec<Run<'s>>>,
 }
 

--- a/libs/sarif/src/schema/log.rs
+++ b/libs/sarif/src/schema/log.rs
@@ -369,5 +369,19 @@ pub(crate) mod tests {
         let log = SarifLog::deserialize(json).expect("failed to deserialize");
         validate_schema(&log);
         assert_eq!(log.schema, Cow::Borrowed(SchemaVersion::V2_1_0.schema_id()));
+        assert_eq!(
+            log.runs.as_ref().expect("no runs in log found")[0]
+                .tool
+                .driver
+                .name,
+            Cow::Borrowed("clippy")
+        );
+        assert_eq!(
+            log.runs.as_ref().expect("no runs in log found")[0]
+                .tool
+                .driver
+                .version,
+            Some(Cow::Borrowed("0.1.0"))
+        );
     }
 }

--- a/libs/sarif/src/schema/log.rs
+++ b/libs/sarif/src/schema/log.rs
@@ -89,6 +89,7 @@ pub struct SarifLog<'s> {
     ///    management system, and the query was malformed.
     ///
     /// See [SARIF specification §3.13.4](https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html#_Toc10540920)
+    #[serde(default, borrow)]
     pub runs: Option<Vec<Run<'s>>>,
 }
 

--- a/libs/sarif/src/schema/log.rs
+++ b/libs/sarif/src/schema/log.rs
@@ -98,7 +98,7 @@ impl<'s, 'de: 's> Deserialize<'de> for SarifLog<'s> {
         #[derive(Deserialize)]
         #[serde(rename_all = "camelCase")]
         struct OptionalSarifLog<'s> {
-            #[serde(default, rename = "$schema")]
+            #[serde(default, borrow, rename = "$schema")]
             schema: Option<Cow<'s, str>>,
             #[serde(default)]
             version: Option<SchemaVersion>,

--- a/libs/sarif/src/schema/log.rs
+++ b/libs/sarif/src/schema/log.rs
@@ -28,7 +28,7 @@ use crate::schema::{Run, SchemaVersion};
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize), serde(rename_all = "camelCase"))]
-pub struct SarifLog {
+pub struct SarifLog<'s> {
     /// The format version of the SARIF specification to which this log file conforms.
     ///
     /// See [SARIF specification §3.13.2](https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html#_Toc10540918)
@@ -64,8 +64,8 @@ pub struct SarifLog {
     /// The SARIF schema is available at <https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json>.
     ///
     /// [`version`]: [Self::version]
-    #[cfg_attr(feature = "serde", serde(rename = "$schema"))]
-    pub schema: Cow<'static, str>,
+    #[cfg_attr(feature = "serde", serde(rename = "$schema", borrow))]
+    pub schema: Cow<'s, str>,
 
     /// The set of runs contained in this log file.
     ///
@@ -89,20 +89,21 @@ pub struct SarifLog {
     ///    management system, and the query was malformed.
     ///
     /// See [SARIF specification §3.13.4](https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html#_Toc10540920)
-    pub runs: Option<Vec<Run>>,
+    pub runs: Option<Vec<Run<'s>>>,
 }
 
 #[cfg(feature = "serde")]
-impl<'de> Deserialize<'de> for SarifLog {
+impl<'s, 'de: 's> Deserialize<'de> for SarifLog<'s> {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         #[derive(Deserialize)]
         #[serde(rename_all = "camelCase")]
-        struct OptionalSarifLog {
+        struct OptionalSarifLog<'s> {
             #[serde(default, rename = "$schema")]
-            schema: Option<Cow<'static, str>>,
+            schema: Option<Cow<'s, str>>,
             #[serde(default)]
             version: Option<SchemaVersion>,
-            runs: Option<Vec<Run>>,
+            #[serde(default, borrow)]
+            runs: Option<Vec<Run<'s>>>,
         }
 
         let log = OptionalSarifLog::deserialize(deserializer)?;
@@ -115,7 +116,7 @@ impl<'de> Deserialize<'de> for SarifLog {
     }
 }
 
-impl SarifLog {
+impl<'s> SarifLog<'s> {
     /// Creates a new SARIF log with the given schema version.
     ///
     /// Depending on the schema version, the `schema` field will be set to the corresponding schema
@@ -136,7 +137,7 @@ impl SarifLog {
         Self {
             schema: version.schema_id().into(),
             version,
-            runs: Some(Vec::new()),
+            runs: Some(vec![]),
         }
     }
 
@@ -154,7 +155,7 @@ impl SarifLog {
     /// assert_eq!(log.schema, "https://example.com/sarif-2.1.0.json");
     /// ```
     #[must_use]
-    pub fn with_schema_id(mut self, schema_id: impl Into<Cow<'static, str>>) -> Self {
+    pub fn with_schema_id(mut self, schema_id: impl Into<Cow<'s, str>>) -> Self {
         self.schema = schema_id.into();
         self
     }
@@ -172,7 +173,7 @@ impl SarifLog {
     /// assert_eq!(log.runs.unwrap().len(), 1);
     /// ```
     #[must_use]
-    pub fn with_run(mut self, run: Run) -> Self {
+    pub fn with_run(mut self, run: Run<'s>) -> Self {
         match self.runs {
             Some(ref mut runs) => runs.push(run),
             None => self.runs = Some(vec![run]),
@@ -195,7 +196,7 @@ impl SarifLog {
     /// assert_eq!(log.runs.unwrap().len(), 2);
     /// ```
     #[must_use]
-    pub fn with_runs(mut self, runs: impl IntoIterator<Item = Run>) -> Self {
+    pub fn with_runs(mut self, runs: impl IntoIterator<Item = Run<'s>>) -> Self {
         match self.runs {
             Some(ref mut existing_runs) => existing_runs.extend(runs),
             None => self.runs = Some(runs.into_iter().collect()),
@@ -204,8 +205,8 @@ impl SarifLog {
     }
 }
 
-impl Extend<Run> for SarifLog {
-    fn extend<T: IntoIterator<Item = Run>>(&mut self, iter: T) {
+impl<'s> Extend<Run<'s>> for SarifLog<'s> {
+    fn extend<T: IntoIterator<Item = Run<'s>>>(&mut self, iter: T) {
         match self.runs {
             Some(ref mut runs) => runs.extend(iter),
             None => self.runs = Some(iter.into_iter().collect()),
@@ -216,7 +217,11 @@ impl Extend<Run> for SarifLog {
 #[cfg(test)]
 #[cfg(feature = "serde")]
 pub(crate) mod tests {
+    use alloc::{borrow::Cow, vec};
+
     use coverage_helper::test;
+    use serde::Deserialize;
+    use serde_json::json;
 
     use crate::schema::{
         tests::validate_schema, Run, SarifLog, SchemaVersion, Tool, ToolComponent,
@@ -337,5 +342,31 @@ pub(crate) mod tests {
                 ),
             ]),
         );
+    }
+
+    #[test]
+    fn borrowed() {
+        let json = json!({
+            "version": "2.1.0",
+            "$schema": SchemaVersion::V2_1_0.schema_id(),
+            "runs": [{
+                "tool": {
+                    "driver": {
+                        "name": "clippy",
+                        "version": "0.1.0"
+                    }
+                }
+            }, {
+                "tool": {
+                    "driver": {
+                        "name": "rustfmt",
+                        "version": "0.1.0"
+                    }
+                }
+            }]
+        });
+        let log = SarifLog::deserialize(json).expect("failed to deserialize");
+        validate_schema(&log);
+        assert_eq!(log.schema, Cow::Borrowed(SchemaVersion::V2_1_0.schema_id()));
     }
 }

--- a/libs/sarif/src/schema/properties.rs
+++ b/libs/sarif/src/schema/properties.rs
@@ -12,19 +12,19 @@ use serde::{Deserialize, Serialize};
     derive(Serialize, Deserialize),
     serde(rename_all = "camelCase")
 )]
-pub struct PropertyBag {
+pub struct PropertyBag<'s> {
     /// A set of distinct strings that provide additional information.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "BTreeSet::is_empty"))]
-    pub tags: BTreeSet<Cow<'static, str>>,
+    pub tags: BTreeSet<Cow<'s, str>>,
 
     /// A dictionary, each of whose keys specifies a distinct additional information element and
     /// each of whose values provides the information.
     #[cfg(feature = "serde")]
-    #[serde(flatten)]
-    pub additional: BTreeMap<Cow<'static, str>, serde_json::Value>,
+    #[serde(flatten, borrow)]
+    pub additional: BTreeMap<Cow<'s, str>, serde_json::Value>,
 }
 
-impl PropertyBag {
+impl<'s> PropertyBag<'s> {
     /// Create a new, empty `PropertyBag`.
     ///
     /// # Example
@@ -65,7 +65,7 @@ impl PropertyBag {
     /// );
     /// ```
     #[must_use]
-    pub fn with_tag(mut self, tag: impl Into<Cow<'static, str>>) -> Self {
+    pub fn with_tag(mut self, tag: impl Into<Cow<'s, str>>) -> Self {
         self.tags.insert(tag.into());
         self
     }
@@ -87,10 +87,7 @@ impl PropertyBag {
     /// );
     /// ```
     #[must_use]
-    pub fn with_tags(
-        mut self,
-        tags: impl IntoIterator<Item = impl Into<Cow<'static, str>>>,
-    ) -> Self {
+    pub fn with_tags(mut self, tags: impl IntoIterator<Item = impl Into<Cow<'s, str>>>) -> Self {
         self.tags.extend(tags.into_iter().map(Into::into));
         self
     }
@@ -119,7 +116,7 @@ impl PropertyBag {
     #[cfg(feature = "serde")]
     pub fn with_property(
         mut self,
-        key: impl Into<Cow<'static, str>>,
+        key: impl Into<Cow<'s, str>>,
         value: impl Into<serde_json::Value>,
     ) -> Self {
         self.additional.insert(key.into(), value.into());
@@ -152,9 +149,7 @@ impl PropertyBag {
     #[cfg(feature = "serde")]
     pub fn with_properties(
         mut self,
-        properties: impl IntoIterator<
-            Item = (impl Into<Cow<'static, str>>, impl Into<serde_json::Value>),
-        >,
+        properties: impl IntoIterator<Item = (impl Into<Cow<'s, str>>, impl Into<serde_json::Value>)>,
     ) -> Self {
         self.additional
             .extend(properties.into_iter().map(|(k, v)| (k.into(), v.into())));

--- a/libs/sarif/src/schema/properties.rs
+++ b/libs/sarif/src/schema/properties.rs
@@ -16,8 +16,7 @@ pub struct PropertyBag<'s> {
     /// A set of distinct strings that provide additional information.
     #[cfg_attr(
         feature = "serde",
-        serde(skip_serializing_if = "BTreeSet::is_empty"),
-        borrow
+        serde(skip_serializing_if = "BTreeSet::is_empty", borrow)
     )]
     pub tags: BTreeSet<Cow<'s, str>>,
 

--- a/libs/sarif/src/schema/properties.rs
+++ b/libs/sarif/src/schema/properties.rs
@@ -14,7 +14,11 @@ use serde::{Deserialize, Serialize};
 )]
 pub struct PropertyBag<'s> {
     /// A set of distinct strings that provide additional information.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "BTreeSet::is_empty"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(skip_serializing_if = "BTreeSet::is_empty"),
+        borrow
+    )]
     pub tags: BTreeSet<Cow<'s, str>>,
 
     /// A dictionary, each of whose keys specifies a distinct additional information element and

--- a/libs/sarif/src/schema/run.rs
+++ b/libs/sarif/src/schema/run.rs
@@ -11,16 +11,17 @@ use crate::schema::Tool;
     serde(rename_all = "camelCase")
 )]
 #[non_exhaustive]
-pub struct Run {
+pub struct Run<'s> {
     /// Information about the tool or tool pipeline that generated the results in this run
     ///
     /// A run can only contain results produced by a single tool or tool pipeline. A run can
     /// aggregate results from multiple log files, as long as context around the tool run (tool
     /// command-line arguments and the like) is identical for all aggregated files.
-    pub tool: Tool,
+    #[cfg_attr(feature = "serde", serde(borrow))]
+    pub tool: Tool<'s>,
 }
 
-impl Run {
+impl<'s> Run<'s> {
     /// Create a new `Run` with the given tool.
     ///
     /// # Example
@@ -33,7 +34,7 @@ impl Run {
     /// assert_eq!(run.tool.driver.name, "clippy");
     /// ```
     #[must_use]
-    pub const fn new(tool: Tool) -> Self {
+    pub const fn new(tool: Tool<'s>) -> Self {
         Self { tool }
     }
 }

--- a/libs/sarif/src/schema/tool.rs
+++ b/libs/sarif/src/schema/tool.rs
@@ -14,12 +14,13 @@ use crate::schema::PropertyBag;
 )]
 pub struct Tool<'s> {
     /// The analysis tool that was run.
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub driver: ToolComponent<'s>,
 
     /// Tool extensions that contributed to or reconfigured the analysis tool that was run.
     #[cfg_attr(
         feature = "serde",
-        serde(default, skip_serializing_if = "Vec::is_empty")
+        serde(default, skip_serializing_if = "Vec::is_empty", borrow)
     )]
     pub extensions: Vec<ToolComponent<'s>>,
 
@@ -151,10 +152,14 @@ impl<'s> Tool<'s> {
 #[non_exhaustive]
 pub struct ToolComponent<'s> {
     /// The name of the tool component.
+    #[cfg_attr(feature = "serde", serde(borrow))]
     pub name: Cow<'s, str>,
 
     /// The tool component version, in whatever format the component natively provides.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(skip_serializing_if = "Option::is_none", borrow)
+    )]
     pub version: Option<Cow<'s, str>>,
 
     /// The tool component version in the format specified by Semantic Versioning 2.0.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

There is no real reason to propagate the lifetimes of the strings, so this exposes the lifetime `'s` for all string-fields