### PR TITLE
`deer`: remove `ObjectAccess::value`

### DIFF
--- a/libs/deer/desert/src/deserializer.rs
+++ b/libs/deer/desert/src/deserializer.rs
@@ -1,5 +1,4 @@
 use alloc::borrow::ToOwned;
-use core::ops::Range;
 
 use deer::{error::DeserializerError, Context, OptionalVisitor, Visitor};
 use error_stack::{Result, ResultExt};
@@ -22,13 +21,7 @@ macro_rules! forward {
 #[derive(Debug)]
 pub struct Deserializer<'a, 'de> {
     context: &'a Context,
-    tape: Tape<'a, 'de>,
-}
-
-impl<'a, 'de> Deserializer<'a, 'de> {
-    pub(crate) fn erase(&mut self, range: Range<usize>) {
-        self.tape.set_trivia(range);
-    }
+    tape: Tape<'de>,
 }
 
 impl<'a, 'de> deer::Deserializer<'de> for &mut Deserializer<'a, 'de> {
@@ -102,7 +95,7 @@ impl<'a, 'de> deer::Deserializer<'de> for &mut Deserializer<'a, 'de> {
 }
 
 impl<'a, 'de> Deserializer<'a, 'de> {
-    pub(crate) const fn new_bare(tape: Tape<'a, 'de>, context: &'a Context) -> Self {
+    pub(crate) const fn new_bare(tape: Tape<'de>, context: &'a Context) -> Self {
         Self { context, tape }
     }
 
@@ -122,11 +115,11 @@ impl<'a, 'de> Deserializer<'a, 'de> {
         self.tape.next().expect("should have token to deserialize")
     }
 
-    pub(crate) const fn tape(&self) -> &Tape<'a, 'de> {
+    pub(crate) const fn tape(&self) -> &Tape<'de> {
         &self.tape
     }
 
-    pub(crate) fn tape_mut(&mut self) -> &mut Tape<'a, 'de> {
+    pub(crate) fn tape_mut(&mut self) -> &mut Tape<'de> {
         &mut self.tape
     }
 

--- a/libs/deer/json/src/lib.rs
+++ b/libs/deer/json/src/lib.rs
@@ -19,9 +19,8 @@ use std::any::Demand;
 use deer::{
     error::{
         ArrayAccessError, ArrayLengthError, BoundedContractViolationError, DeserializeError,
-        DeserializerError, ExpectedLength, ExpectedType, MissingError, ObjectAccessError,
-        ObjectItemsExtraError, ReceivedKey, ReceivedLength, ReceivedType, ReceivedValue, TypeError,
-        ValueError, Variant,
+        DeserializerError, ExpectedLength, ExpectedType, ObjectAccessError, ObjectItemsExtraError,
+        ReceivedKey, ReceivedLength, ReceivedType, ReceivedValue, TypeError, ValueError, Variant,
     },
     Context, Deserialize, DeserializeOwned, Document, FieldAccess, OptionalVisitor, Reflection,
     Schema, Visitor,

--- a/libs/deer/json/src/lib.rs
+++ b/libs/deer/json/src/lib.rs
@@ -1,21 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(nightly, feature(provide_any, error_in_core))]
-#![warn(
-    unreachable_pub,
-    clippy::pedantic,
-    clippy::nursery,
-    clippy::alloc_instead_of_core,
-    clippy::std_instead_of_alloc,
-    clippy::std_instead_of_core,
-    clippy::if_then_some_else_none,
-    clippy::print_stdout,
-    clippy::print_stderr,
-    clippy::mod_module_files
-)]
 // TODO: once more stable introduce: warning missing_docs, clippy::missing_errors_doc
-#![allow(clippy::module_name_repetitions)]
-#![allow(clippy::redundant_pub_crate)]
-#![allow(clippy::missing_errors_doc)]
 #![deny(unsafe_code)]
 mod error;
 

--- a/libs/deer/src/lib.rs
+++ b/libs/deer/src/lib.rs
@@ -79,10 +79,6 @@ pub trait ObjectAccess<'de> {
     /// calling this function or this function has been called repeatably.
     fn set_bounded(&mut self, length: usize) -> Result<(), ObjectAccessError>;
 
-    fn value<T>(&mut self, key: &str) -> Result<T, ObjectAccessError>
-    where
-        T: Deserialize<'de>;
-
     fn next<K, V>(&mut self) -> Option<Result<(K, V), ObjectAccessError>>
     where
         K: Deserialize<'de>,

--- a/libs/deer/src/lib.rs
+++ b/libs/deer/src/lib.rs
@@ -63,20 +63,15 @@ pub trait ObjectAccess<'de> {
     ///
     /// After calling this [`ObjectAccess`] will
     /// ensure that there are never more than `length` values returned by [`Self::next`], if there
-    /// are not enough items present [`ArrayAccess`] will call [`Visitor::visit_none`], for
-    /// [`Self::value`] calls [`Visitor::visit_none`] will be called on the tuple of `(K, V)`, while
-    /// [`Self::value`] will call [`Visitor::visit_none`] of `V`.
-    ///
-    /// [`Self::value`] also counts toward the length, behaviour of multiple calls to
-    /// [`Self::value`] will always decrement the counter.
+    /// are not enough items present [`ArrayAccess`] will call [`Visitor::visit_none`].
     ///
     /// This is best suited for types where the length/amount of keys is already predetermined, like
     /// structs or enum variants.
     ///
     /// # Errors
     ///
-    /// This will error if a call to [`Self::next`] or [`Self::value`] has been made before
-    /// calling this function or this function has been called repeatably.
+    /// This will error if a call to [`Self::next`] has been made before calling this function or
+    /// this function has been called repeatably.
     fn set_bounded(&mut self, length: usize) -> Result<(), ObjectAccessError>;
 
     fn next<K, V>(&mut self) -> Option<Result<(K, V), ObjectAccessError>>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#2263 has shown that `FieldAccess` introduced in #2157 is enough to model structs and arbitrarily named fields.

To reduce the complexity required for implementation (no look ahead etc.) this removes the `ObjectAccess::value` method.

