### PR TITLE
Downgrade `status` from an ES-Module

### DIFF
--- a/apps/hash-graph/package.json
+++ b/apps/hash-graph/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "cargo make build",
-    "exe": "node --unhandled-rejections=strict --experimental-loader ts-node/esm/transpile-only --es-module-specifier-resolution=node"
+    "exe": "ts-node"
   },
   "dependencies": {
     "@local/status": "0.0.0-private"

--- a/libs/@local/status/package.json
+++ b/libs/@local/status/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0-private",
   "private": true,
   "license": "(MIT OR Apache-2.0)",
-  "type": "module",
   "exports": {
     ".": {
       "types": "./pkg/src/main.ts",

--- a/libs/@local/status/scripts/codegen.ts
+++ b/libs/@local/status/scripts/codegen.ts
@@ -5,9 +5,7 @@ import { mkdir, readdir, writeFile } from "node:fs/promises";
 import * as path from "node:path";
 import { argv } from "node:process";
 
-// We don't want/need sync but we can't seem to import the normal async execa function in ESM with
-// execa 5.1.1. If we upgrade to 6.x it might work.
-import { sync as execaSync } from "execa";
+import execa from "execa";
 import snakeCase from "lodash/snakeCase";
 import yargs from "yargs";
 
@@ -103,7 +101,7 @@ const codegen = async ({
           `${snakeCase(fileName)}.rs`,
         );
 
-        execaSync("quicktype", [
+        await execa("quicktype", [
           filePath,
           "-o",
           rustOutputPath,
@@ -127,7 +125,7 @@ const codegen = async ({
           `${snakeCase(fileName)}.json`,
         );
 
-        execaSync("quicktype", [
+        await execa("quicktype", [
           filePath,
           "--lang",
           "schema",

--- a/libs/@local/status/tsconfig.json
+++ b/libs/@local/status/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@local/tsconfig/legacy-base-tsconfig-to-refactor.json",
   "compilerOptions": {
-    "module": "ESNext",
     "esModuleInterop": true
   },
   "include": ["./pkg/src/", "./scripts", "./type-defs"]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `@local/status` package was an ES-Module. 

That caused us problems within the backend (`hash-api` package) as our `ts-node` package failed to handle it when importing it. I've played around with trying to fix this, and I think there are three options:
1. Move away from `ts-node` for the HASH App (it's not recommended for production anyway)
2. Upgrade the `hash-api` to ESM
3. Downgrade `status` from ESM

I've opted to go with `3.` for now, as `2.` has a higher risk profile, and `1.` involves a lot more development than I currently have capacity for.

This has highlighted a general issue with our setup though, wherein we can't create or easily use all kinds of ES Modules, this is a problem and will force us to introduce bundlers and build steps within the monorepo if we don't address this but want to be able to start using ESM.

## 🔍 What does this change?

- Downgrades `@local/status` from being an ES Module

## 📜 Does this require a change to the docs?

- No

## ⚠️ Known issues

- CI didn't pick up that the backend completely failed to run
- We don't seem to be able to create ESM packages which are imported in the backend

## 🐾 Next steps

- Address the issue of the backend not being tested in CI
- Ideally look at moving away from `ts-node`

## 🛡 What tests cover this?

- CI
- Manual tests **(clearly important under the current state)**

## ❓ How to test this?

1.  Checkout the branch / view the deployment
1.  Run the app as usual
1.  Ensure it works (this shouldn't affect features, more just compilation)
