### PR TITLE
Install `cargo-make` manually

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,7 +83,10 @@ jobs:
       - name: Install tools
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-make@0.36.3,cargo-hack@0.5.26,cargo-script@0.2.8,clippy-sarif@0.3.7,sarif-fmt@0.3.7
+          tool: cargo-hack@0.5.26,cargo-script@0.2.8,clippy-sarif@0.3.7,sarif-fmt@0.3.7
+
+      - name: Install cargo-make
+        run: cargo install --version 0.36.3 cargo-make
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -174,7 +177,10 @@ jobs:
       - name: Install tools
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-make@0.36.3,cargo-hack@0.5.26,cargo-nextest@0.9.37
+          tool: cargo-hack@0.5.26,cargo-nextest@0.9.37
+
+      - name: Install cargo-make
+        run: cargo install --version 0.36.3 cargo-make
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -252,7 +258,10 @@ jobs:
       - name: Install tools
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-make@0.36.3,cargo-nextest@0.9.37,cargo-llvm-cov@0.5.9
+          tool: cargo-nextest@0.9.37,cargo-llvm-cov@0.5.9
+
+      - name: Install cargo-make
+        run: cargo install --version 0.36.3 cargo-make
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -297,10 +306,8 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v3
 
-      - name: Install tools
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-make@0.36.3
+      - name: Install cargo-make
+        run: cargo install --version 0.36.3 cargo-make
 
       - name: Build Docker container
         run: cargo make --profile ${{ matrix.profile }} build-docker
@@ -332,7 +339,10 @@ jobs:
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-make@0.36.3,cargo-hack@0.5.26,cargo-nextest@0.9.37,cargo-script@0.2.8,cargo-semver-checks@0.17.0
+          tool: cargo-hack@0.5.26,cargo-nextest@0.9.37,cargo-script@0.2.8,cargo-semver-checks@0.17.0
+
+      - name: Install cargo-make
+        run: cargo install --version 0.36.3 cargo-make
 
       - name: Run lints
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We're currently not able to install `cargo-make` in CI in 90% of the cases. This uses `cargo install` to have a slow but working CI