### PR TITLE
Use `rust-script` instead of `cargo-script`

### DIFF
--- a/.github/scripts/rust/lint.rs
+++ b/.github/scripts/rust/lint.rs
@@ -13,7 +13,7 @@ use std::{
     collections::{BTreeSet, HashMap},
     env, fs,
     iter::once,
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use serde::Deserialize;
@@ -309,16 +309,25 @@ fn check(cwd: &Path) {
 }
 
 fn main() {
-    let cwd = env::current_dir().expect("should be able to get current directory");
-
-    let mode = env::args()
+    let mut args = env::args();
+    let mode = args
+        .by_ref()
         .skip(1)
         .next()
         .expect("at least one position argument specifying mode required");
 
+    let cwd = args
+        .next()
+        .map(PathBuf::from)
+        .ok_or_else(env::current_dir)
+        .expect("unable to read working directory");
+
     match mode.as_str() {
         "generate" => generate(&cwd),
         "check" => check(&cwd),
-        arg => panic!("unrecognized mode `{}`, available: `generate`, `check`", arg),
+        arg => panic!(
+            "unrecognized mode `{}`, available: `generate`, `check`",
+            arg
+        ),
     };
 }

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Install tools
         uses: taiki-e/install-action@v2
         with:
-          tool: just@1.13.0,cargo-hack@0.5.26,cargo-script@0.2.8,clippy-sarif@0.3.7,sarif-fmt@0.3.7
+          tool: just@1.13.0,cargo-hack@0.5.26,rust-script@0.23.0,clippy-sarif@0.3.7,sarif-fmt@0.3.7
 
       # To be removed once https://github.com/open-telemetry/opentelemetry-rust/issues/934 is sorted
       - name: Install Protoc
@@ -311,7 +311,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
         uses: taiki-e/install-action@v2
         with:
-          tool: just@1.13.0,cargo-hack@0.5.26,cargo-nextest@0.9.37,cargo-script@0.2.8,cargo-semver-checks@0.17.0
+          tool: just@1.13.0,cargo-hack@0.5.26,cargo-nextest@0.9.37,rust-script@0.23.0,cargo-semver-checks@0.17.0
 
       - name: Run lints
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}

--- a/.justfile
+++ b/.justfile
@@ -122,7 +122,7 @@ install-cargo-insta:
 [private]
 [no-cd]
 lint-toml mode:
-  @rust-script "{{repo}}/.github/scripts/rust/lint.rs" {{mode}}
+  @rust-script "{{repo}}/.github/scripts/rust/lint.rs" {{mode}} `cargo metadata --no-deps --format-version 1 | jq '.workspace_root' -r`
 
 # Runs all linting commands and fails if the CI would fail
 [no-cd]

--- a/.justfile
+++ b/.justfile
@@ -102,8 +102,8 @@ install-cargo-nextest:
   @just install-cargo-tool 'cargo nextest' cargo-nextest 0.9.37
 
 [private]
-install-cargo-script:
-  @just install-cargo-tool 'cargo script' cargo-script 0.2.8
+install-rust-script:
+  @just install-cargo-tool 'rust-script' rust-script 0.23.0
 
 [private]
 install-llvm-cov:
@@ -122,7 +122,7 @@ install-cargo-insta:
 [private]
 [no-cd]
 lint-toml mode:
-  @cargo script "{{repo}}/.github/scripts/rust/lint.rs" {{mode}}
+  @rust-script "{{repo}}/.github/scripts/rust/lint.rs" {{mode}}
 
 # Runs all linting commands and fails if the CI would fail
 [no-cd]
@@ -139,7 +139,7 @@ format *arguments:
 
 # Lint the code using `clippy`
 [no-cd]
-clippy *arguments: install-cargo-hack install-cargo-script
+clippy *arguments: install-cargo-hack install-rust-script
   @just lint-toml "generate"
   @just in-pr cargo clippy --profile {{profile}} --workspace --all-features --all-targets --no-deps {{arguments}}
   @just not-in-pr cargo hack --workspace --optional-deps --feature-powerset clippy --profile {{profile}} --all-targets --no-deps {{arguments}}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

As mentioned in #2292, `cargo-script` is unmaintained, and `rust-script` is a maintained fork, which solves the issue we currently have.

## 🔍 What does this change?

- Replace `cargo-script` with `rust-script@0.23.0`
- Drive-by: allow running `just` in all directories within a workspace