### PR TITLE
Use `rust-toolchain.toml` file to install toolchains

### DIFF
--- a/.github/actions/install-rust-toolchain/action.yml
+++ b/.github/actions/install-rust-toolchain/action.yml
@@ -23,7 +23,7 @@ runs:
         if grep -q "${{ inputs.toolchain }}" rust-toolchain.toml; then
           rustup show
         else
-          rustup toolchain install "${{ inputs.toolchain }}"
+          rustup default "${{ inputs.toolchain }}"
           rustup component add rustfmt
           rustup component add clippy
           rustup show

--- a/.github/actions/install-rust-toolchain/action.yml
+++ b/.github/actions/install-rust-toolchain/action.yml
@@ -15,8 +15,8 @@ runs:
   steps:
     - name: "Install Rust"
       working-directory: ${{ inputs.working-directory }}
+      shell: bash
       run: |
-
         # If the toolchain does match `rust-toolchain.toml` we can rely on `rustup show` to install the toolchain. If it
         # does not match, we need to install the toolchain manually.
         if grep -q "${{ inputs.toolchain }}" rust-toolchain.toml; then
@@ -28,4 +28,3 @@ runs:
 
         rustup show
         echo "RUSTUP_TOOLCHAIN=${{ inputs.toolchain }}" >> $GITHUB_ENV
-      shell: bash

--- a/.github/actions/install-rust-toolchain/action.yml
+++ b/.github/actions/install-rust-toolchain/action.yml
@@ -23,7 +23,8 @@ runs:
         if grep -q "${{ inputs.toolchain }}" rust-toolchain.toml; then
           rustup show
         else
-          rustup default "${{ inputs.toolchain }}"
+          export RUSTUP_TOOLCHAIN=${{ inputs.toolchain }}
+          rustup default "$RUSTUP_TOOLCHAIN"
           rustup component add rustfmt
           rustup component add clippy
           rustup show

--- a/.github/actions/install-rust-toolchain/action.yml
+++ b/.github/actions/install-rust-toolchain/action.yml
@@ -16,19 +16,16 @@ runs:
     - name: "Install Rust"
       working-directory: ${{ inputs.working-directory }}
       run: |
-        rustup set profile minimal
 
         # If the toolchain does match `rust-toolchain.toml` we can rely on `rustup show` to install the toolchain. If it
         # does not match, we need to install the toolchain manually.
         if grep -q "${{ inputs.toolchain }}" rust-toolchain.toml; then
-          rustup show
+          rustup set profile minimal
         else
           export RUSTUP_TOOLCHAIN=${{ inputs.toolchain }}
-          rustup default "$RUSTUP_TOOLCHAIN"
-          rustup component add rustfmt
-          rustup component add clippy
-          rustup show
+          rustup set profile default
         fi
 
+        rustup show
         echo "RUSTUP_TOOLCHAIN=${{ inputs.toolchain }}" >> $GITHUB_ENV
       shell: bash

--- a/.github/actions/install-rust-toolchain/action.yml
+++ b/.github/actions/install-rust-toolchain/action.yml
@@ -26,5 +26,6 @@ runs:
           rustup set profile default
         fi
 
+        # Installs the specified toolchains and prints it
         rustup show
         echo "RUSTUP_TOOLCHAIN=${{ inputs.toolchain }}" >> $GITHUB_ENV

--- a/.github/actions/install-rust-toolchain/action.yml
+++ b/.github/actions/install-rust-toolchain/action.yml
@@ -9,27 +9,25 @@ inputs:
     description: "Working directory to run the action in"
     required: false
     default: "."
-  components:
-    description: "Rust components to install"
-    required: false
-    default: ""
 
 runs:
   using: "composite"
   steps:
     - name: "Install Rust"
-      env:
-        RUSTUP_TOOLCHAIN: ${{ inputs.toolchain }}
       working-directory: ${{ inputs.working-directory }}
       run: |
         rustup set profile minimal
-        rustup show
 
-        # Split the list of components by a comma and call `rustup component add` for each component
-        IFS=',' read -ra components <<< "${{ inputs.components }}"
-        for component in "${components[@]}"; do
-          rustup component add "$component"
-        done
+        # If the toolchain does match `rust-toolchain.toml` we can rely on `rustup show` to install the toolchain. If it
+        # does not match, we need to install the toolchain manually.
+        if grep -q "${{ inputs.toolchain }}" rust-toolchain.toml; then
+          rustup show
+        else
+          rustup toolchain install "${{ inputs.toolchain }}"
+          rustup component add rustfmt
+          rustup component add clippy
+          rustup show
+        fi
 
-        echo "RUSTUP_TOOLCHAIN=$RUSTUP_TOOLCHAIN" >> $GITHUB_ENV
+        echo "RUSTUP_TOOLCHAIN=${{ inputs.toolchain }}" >> $GITHUB_ENV
       shell: bash

--- a/.github/scripts/rust/setup.py
+++ b/.github/scripts/rust/setup.py
@@ -41,7 +41,8 @@ PUBLISH_PATTERNS = [
 COVERAGE_EXCLUDE_PATTERNS = ["apps/engine**"]
 
 # We only run a subset of configurations for PRs, the rest will only be tested prior merging
-IS_PULL_REQUEST_EVENT = "GITHUB_EVENT_NAME" in os.environ and os.environ["GITHUB_EVENT_NAME"] == "pull_request"
+# IS_PULL_REQUEST_EVENT = "GITHUB_EVENT_NAME" in os.environ and os.environ["GITHUB_EVENT_NAME"] == "pull_request"
+IS_PULL_REQUEST_EVENT = False
 
 
 def generate_diffs():

--- a/.github/scripts/rust/setup.py
+++ b/.github/scripts/rust/setup.py
@@ -41,8 +41,7 @@ PUBLISH_PATTERNS = [
 COVERAGE_EXCLUDE_PATTERNS = ["apps/engine**"]
 
 # We only run a subset of configurations for PRs, the rest will only be tested prior merging
-# IS_PULL_REQUEST_EVENT = "GITHUB_EVENT_NAME" in os.environ and os.environ["GITHUB_EVENT_NAME"] == "pull_request"
-IS_PULL_REQUEST_EVENT = False
+IS_PULL_REQUEST_EVENT = "GITHUB_EVENT_NAME" in os.environ and os.environ["GITHUB_EVENT_NAME"] == "pull_request"
 
 
 def generate_diffs():

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -204,9 +204,7 @@ jobs:
       - name: Run miri
         if: ${{ startsWith(matrix.toolchain, 'nightly') }}
         working-directory: ${{ matrix.directory }}
-        run: |
-          rustup component add miri
-          just miri --no-fail-fast
+        run: just miri --no-fail-fast
 
       - name: Ensure empty git diff
         run: git --no-pager diff --exit-code --color

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,7 +79,6 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           working-directory: ${{ matrix.directory }}
-          components: rustfmt,clippy
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -173,7 +172,6 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           working-directory: ${{ matrix.directory }}
-          components: rust-src
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -253,7 +251,6 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           working-directory: ${{ matrix.directory }}
-          components: rust-src
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -305,7 +302,6 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           working-directory: ${{ matrix.directory }}
-          components: rustfmt,clippy
 
       - name: Install tools
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

As noticed in #2292, the `rust-toolchain.toml` should be the location, where the components are specified. In #2292 I ran into limitations as `RUSTUP_TOOLCHAIN` would override the `rust-toolchain.toml`. This PR works around this by not setting `RUSTUP_TOOLCHAIN` if the toolchain does match with the one inside of `rust-toolchain.toml`