### PR TITLE
Fix `variants` for the Heading Block

### DIFF
--- a/blocks/heading/package.json
+++ b/blocks/heading/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blocks/heading",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "description": "Write titles, sub-titles, and section headings in four different sizes",
   "keywords": [
@@ -50,7 +50,7 @@
     "blockType": {
       "entryPoint": "react"
     },
-    "name": "@hash/heading",
+    "name": "heading",
     "displayName": "Heading",
     "icon": "public/h1.svg",
     "image": "public/preview.svg",

--- a/blocks/heading/variants.json
+++ b/blocks/heading/variants.json
@@ -4,31 +4,50 @@
     "description": "For the largest (top-level) section headings",
     "icon": "public/h1.svg",
     "properties": {
-      "level": 1
-    }
+      "https://blockprotocol.org/@blockprotocol/types/property-type/html-heading-level/": 1
+    },
+    "examples": [
+      {
+        "https://blockprotocol.org/@blockprotocol/types/property-type/html-heading-level/": 1,
+        "https://blockprotocol.org/@blockprotocol/types/property-type/textual-content/": "I'm a top-level heading!"
+      }
+    ]
   },
   {
     "name": "Heading 2",
     "description": "For large section headings",
     "icon": "public/h2.svg",
     "properties": {
-      "level": 2
-    }
+      "https://blockprotocol.org/@blockprotocol/types/property-type/html-heading-level/": 2
+    },
+    "examples": [
+      {
+        "https://blockprotocol.org/@blockprotocol/types/property-type/html-heading-level/": 2,
+        "https://blockprotocol.org/@blockprotocol/types/property-type/textual-content/": "I'm a large heading!"
+      }
+    ]
   },
   {
     "name": "Heading 3",
     "description": "For medium section headings",
     "icon": "public/h3.svg",
     "properties": {
-      "level": 3
-    }
+      "https://blockprotocol.org/@blockprotocol/types/property-type/html-heading-level/": 3
+    },
+    "examples": [
+      {
+        "https://blockprotocol.org/@blockprotocol/types/property-type/html-heading-level/": 3,
+        "https://blockprotocol.org/@blockprotocol/types/property-type/textual-content/": "I'm a medium heading!"
+      }
+    ]
   },
   {
     "name": "Heading 4",
     "description": "For small section headings",
     "icon": "public/h4.svg",
     "properties": {
-      "level": 4
+      "https://blockprotocol.org/@blockprotocol/types/property-type/html-heading-level/": 4,
+      "https://blockprotocol.org/@blockprotocol/types/property-type/textual-content/": "I'm a small heading!"
     }
   }
 ]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `variants` of the Heading Block weren't updated to reflect the type system. This means that the demo on the hub is broken:

https://user-images.githubusercontent.com/25749103/228216172-33c3fbe7-4043-4c7f-b44e-a88d2ae2f66e.mov

This PR fixes this, when used in conjunction with https://github.com/blockprotocol/blockprotocol/pull/1223

## 📹 Demo

(After, with https://github.com/blockprotocol/blockprotocol/pull/1223)



https://user-images.githubusercontent.com/25749103/228216388-b4c54913-b697-4cda-a49d-accb00e3915a.mov



