### PR TITLE
Stop running all benchmarks in a `test` environment

### DIFF
--- a/apps/engine/rust-toolchain.toml
+++ b/apps/engine/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2022-08-08"
-components = ['rustfmt', 'clippy', 'miri']
+components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'miri']

--- a/apps/hash-graph/.justfile
+++ b/apps/hash-graph/.justfile
@@ -38,6 +38,7 @@ generate-openapi-client:
 test *arguments:
   @just deployment-up
   @just --justfile {{repo}}/.justfile test {{arguments}}
+  cargo test --workspace --benches --profile {{profile}} {{arguments}}
   @just deployment-up graph --wait
   just yarn httpyac send --all {{repo}}/apps/hash-graph/tests/rest-test.http
   just generate-openapi-client

--- a/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
+++ b/apps/hash-graph/bench/read_scaling/knowledge/complete/entity.rs
@@ -191,7 +191,16 @@ fn bench_scaling_read_entity_zero_depths(c: &mut Criterion) {
         Uuid::from_str("bf5a9ef5-dc3b-43cf-a291-6210c0321eba").expect("invalid uuid"),
     );
 
-    for size in [1, 5, 10, 25, 50] {
+    for size in [
+        1,
+        5,
+        #[cfg(not(test))]
+        10,
+        #[cfg(not(test))]
+        25,
+        #[cfg(not(test))]
+        50,
+    ] {
         // TODO: reuse the database if it already exists like we do for representative_read
         let (runtime, mut store_wrapper) = setup(DB_NAME, true, true);
 
@@ -242,7 +251,16 @@ fn bench_scaling_read_entity_one_depth(c: &mut Criterion) {
         Uuid::from_str("bf5a9ef5-dc3b-43cf-a291-6210c0321eba").expect("invalid uuid"),
     );
 
-    for size in [1, 5, 10, 25, 50] {
+    for size in [
+        1,
+        5,
+        #[cfg(not(test))]
+        10,
+        #[cfg(not(test))]
+        25,
+        #[cfg(not(test))]
+        50,
+    ] {
         // TODO: reuse the database if it already exists like we do for representative_read
         let (runtime, mut store_wrapper) = setup(DB_NAME, true, true);
 

--- a/apps/hash-graph/bench/representative_read/lib.rs
+++ b/apps/hash-graph/bench/representative_read/lib.rs
@@ -212,6 +212,7 @@ fn bench_representative_read_multiple_entities(c: &mut Criterion) {
                 outgoing: 0,
             },
         },
+        #[cfg(not(test))]
         GraphResolveDepths {
             inherits_from: OutgoingEdgeResolveDepth {
                 outgoing: 1,

--- a/apps/hash-graph/rust-toolchain.toml
+++ b/apps/hash-graph/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-03-20"
-components = ['rustfmt', 'clippy']
+channel = "nightly-2023-03-19"
+components = ['rustfmt', 'clippy', 'llvm-tools-preview']

--- a/libs/@local/status/crate/rust-toolchain.toml
+++ b/libs/@local/status/crate/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2023-03-21"
-components = ['rustfmt', 'clippy']
+components = ['rustfmt', 'clippy', 'llvm-tools-preview']

--- a/libs/antsi/rust-toolchain.toml
+++ b/libs/antsi/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2023-03-20"
-components = ['rustfmt', 'clippy']
+components = ['rustfmt', 'clippy', 'llvm-tools-preview']

--- a/libs/deer/rust-toolchain.toml
+++ b/libs/deer/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2023-03-20"
-components = ['rustfmt', 'clippy', 'miri']
+components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'miri']

--- a/libs/error-stack/rust-toolchain.toml
+++ b/libs/error-stack/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # Please also update the badges in `README.md`s (`error-stack` and `error-stack-macros`), and `src/lib.rs`
 channel = "nightly-2023-03-20"
-components = ['rustfmt', 'clippy', 'miri', 'rust-src']
+components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'miri', 'rust-src']

--- a/libs/sarif/rust-toolchain.toml
+++ b/libs/sarif/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2023-03-20"
-components = ['rustfmt', 'clippy']
+components = ['rustfmt', 'clippy', 'llvm-tools-preview']


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We're running the benchmarks (as test, not with all iterations) from `just coverage` to check, if the benchmarks are working (we don't run `just bench` in CI). As we have a few fairly long-running setups, this PR disable those in a `cargo test` environment.

## 🔍 What does this change?

- Add `#[cfg(not(test))]` to long-running configurations
- Drive-by: Add `llvm-tools` to `rust-toolchain.toml`. This is required by `llvm-cov`, but is installed automatically when in a terminal without `stdin` (such as CI). Locally, this however ends up in a prompt to install the component. We require the component to be present, so it should exist in `rust-toolchain.toml`.
- Run the benchmarks from `just test` as well, so it's easy to locally test the full setup by just running `just test`. Previously, `just coverage` or `just bench` would need to be run in addition.