### PR TITLE
Make temporal axes optional in `Read` trait

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/crud.rs
+++ b/apps/hash-graph/lib/graph/src/store/crud.rs
@@ -31,14 +31,14 @@ pub trait Read<R>: Sync {
     async fn read(
         &self,
         query: &Filter<Self::Record>,
-        temporal_axes: &QueryTemporalAxes,
+        temporal_axes: Option<&QueryTemporalAxes>,
     ) -> Result<Vec<R>, QueryError>;
 
     #[tracing::instrument(level = "info", skip(self, query))]
     async fn read_one(
         &self,
         query: &Filter<Self::Record>,
-        temporal_axes: &QueryTemporalAxes,
+        temporal_axes: Option<&QueryTemporalAxes>,
     ) -> Result<R, QueryError> {
         let mut records = self.read(query, temporal_axes).await?;
         ensure!(

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -414,7 +414,7 @@ where
     async fn read(
         &self,
         query: &Filter<Self::Record>,
-        temporal_axes: &QueryTemporalAxes,
+        temporal_axes: Option<&QueryTemporalAxes>,
     ) -> Result<Vec<R>, QueryError> {
         self.store.read(query, temporal_axes).await
     }

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -65,7 +65,7 @@ impl<C: AsClient> PostgresStore<C> {
                     edge_kind,
                     edge_direction.reversed(),
                 ),
-                temporal_axes,
+                Some(temporal_axes),
             )
             .await?
             {
@@ -158,7 +158,7 @@ impl<C: AsClient> PostgresStore<C> {
                             entity_vertex_id.base_id,
                             SharedEdgeKind::IsOfType,
                         ),
-                        &temporal_axes,
+                        Some(&temporal_axes),
                     )
                     .await?
                     {
@@ -455,7 +455,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         let temporal_axes = unresolved_temporal_axes.clone().resolve();
         let time_axis = temporal_axes.variable_time_axis();
 
-        let entities = Read::<Entity>::read(self, filter, &temporal_axes)
+        let entities = Read::<Entity>::read(self, filter, Some(&temporal_axes))
             .await?
             .into_iter()
             .map(|entity| (entity.vertex_id(time_axis), entity))

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -38,7 +38,7 @@ impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
     async fn read(
         &self,
         filter: &Filter<Entity>,
-        temporal_axes: &QueryTemporalAxes,
+        temporal_axes: Option<&QueryTemporalAxes>,
     ) -> Result<Vec<Entity>, QueryError> {
         // We can't define these inline otherwise we'll drop while borrowed
         let left_entity_uuid_path = EntityQueryPath::EntityEdge {
@@ -62,7 +62,7 @@ impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
             direction: EdgeDirection::Outgoing,
         };
 
-        let mut compiler = SelectCompiler::new(Some(temporal_axes));
+        let mut compiler = SelectCompiler::new(temporal_axes);
 
         let owned_by_id_index = compiler.add_selection_path(&EntityQueryPath::OwnedById);
         let entity_uuid_index = compiler.add_selection_path(&EntityQueryPath::Uuid);

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -74,7 +74,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
         let temporal_axes = unresolved_temporal_axes.clone().resolve();
         let time_axis = temporal_axes.variable_time_axis();
 
-        let data_types = Read::<DataTypeWithMetadata>::read(self, filter, &temporal_axes)
+        let data_types = Read::<DataTypeWithMetadata>::read(self, filter, Some(&temporal_axes))
             .await?
             .into_iter()
             .map(|entity| (entity.vertex_id(time_axis), entity))

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -53,7 +53,7 @@ impl<C: AsClient> PostgresStore<C> {
                             &entity_type_vertex_id,
                             OntologyEdgeKind::ConstrainsPropertiesOn,
                         ),
-                        &temporal_axes,
+                        Some(&temporal_axes),
                     )
                         .await?
                     {
@@ -89,7 +89,7 @@ impl<C: AsClient> PostgresStore<C> {
                             OntologyEdgeKind::InheritsFrom,
                             EdgeDirection::Incoming,
                         ),
-                        &temporal_axes,
+                        Some(&temporal_axes),
                     )
                         .await?
                     {
@@ -125,7 +125,7 @@ impl<C: AsClient> PostgresStore<C> {
                             OntologyEdgeKind::ConstrainsLinksOn,
                             EdgeDirection::Incoming,
                         ),
-                        &temporal_axes,
+                        Some(&temporal_axes),
                     )
                         .await?
                     {
@@ -161,7 +161,7 @@ impl<C: AsClient> PostgresStore<C> {
                             OntologyEdgeKind::ConstrainsLinkDestinationsOn,
                             EdgeDirection::Incoming,
                         ),
-                        &temporal_axes,
+                        Some(&temporal_axes),
                     )
                         .await?
                     {
@@ -253,7 +253,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         let temporal_axes = unresolved_temporal_axes.clone().resolve();
         let time_axis = temporal_axes.variable_time_axis();
 
-        let entity_types = Read::<EntityTypeWithMetadata>::read(self, filter, &temporal_axes)
+        let entity_types = Read::<EntityTypeWithMetadata>::read(self, filter, Some(&temporal_axes))
             .await?
             .into_iter()
             .map(|entity| (entity.vertex_id(time_axis), entity))

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -53,7 +53,7 @@ impl<C: AsClient> PostgresStore<C> {
                             &property_type_vertex_id,
                             OntologyEdgeKind::ConstrainsValuesOn,
                         ),
-                        &temporal_axes,
+                        Some(&temporal_axes),
                     )
                     .await?
                     {
@@ -89,7 +89,7 @@ impl<C: AsClient> PostgresStore<C> {
                             OntologyEdgeKind::ConstrainsPropertiesOn,
                             EdgeDirection::Incoming,
                         ),
-                        &temporal_axes,
+                        Some(&temporal_axes),
                     )
                     .await?
                     {
@@ -182,11 +182,12 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         let temporal_axes = unresolved_temporal_axes.clone().resolve();
         let time_axis = temporal_axes.variable_time_axis();
 
-        let property_types = Read::<PropertyTypeWithMetadata>::read(self, filter, &temporal_axes)
-            .await?
-            .into_iter()
-            .map(|entity| (entity.vertex_id(time_axis), entity))
-            .collect();
+        let property_types =
+            Read::<PropertyTypeWithMetadata>::read(self, filter, Some(&temporal_axes))
+                .await?
+                .into_iter()
+                .map(|entity| (entity.vertex_id(time_axis), entity))
+                .collect();
 
         let mut subgraph = Subgraph::new(
             graph_resolve_depths,

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -63,7 +63,7 @@ where
     async fn read(
         &self,
         filter: &Filter<T>,
-        temporal_axes: &QueryTemporalAxes,
+        temporal_axes: Option<&QueryTemporalAxes>,
     ) -> Result<Vec<T>, QueryError> {
         let base_url_path = <T::QueryPath<'static> as OntologyQueryPath>::base_url();
         let version_path = <T::QueryPath<'static> as OntologyQueryPath>::version();
@@ -73,7 +73,7 @@ where
         let additional_metadata_path =
             <T::QueryPath<'static> as OntologyQueryPath>::additional_metadata();
 
-        let mut compiler = SelectCompiler::new(Some(temporal_axes));
+        let mut compiler = SelectCompiler::new(temporal_axes);
 
         let base_url_index = compiler.add_distinct_selection_with_ordering(
             &base_url_path,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To make a snapshot of the data in the database, we want to re-use the `Read` trait to avoid duplicated implementation of the same concept and eventually utilize the structural query compiler. To allow reading all temporal data, we must not restrict it by temporal axes.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- Part of [this Asana task](https://app.asana.com/0/1204000740778938/1204216809501005/f) _(internal)_

## 🚫 Blocked by

- #2285 

## 🔍 What does this change?

- Make temporal axes optional in `Read` trait