### PR TITLE
Fix wrongly inserted vertex id for nested properties

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -103,7 +103,7 @@ impl<C: AsClient> PostgresStore<C> {
                         );
 
                         subgraph
-                            .insert_vertex(&property_type_vertex_id, referenced_property_type);
+                            .insert_vertex(&referenced_property_type_vertex_id, referenced_property_type);
 
                         property_type_queue.push((
                             referenced_property_type_vertex_id,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When traversing nested properties, they are not correctly inserted into the subgraph, this fixes that.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204086167143889/1204284866390930/f) _(internal)_