### PR TITLE
Fix ontology transaction-time query paths results in panic

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
@@ -28,6 +28,7 @@ impl PostgresQueryPath for EntityTypeQueryPath<'_> {
             | Self::Schema(_) => vec![],
             Self::BaseUrl
             | Self::Version
+            | Self::TransactionTime
             | Self::RecordCreatedById
             | Self::OwnedById
             | Self::AdditionalMetadata(_) => {

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/property_type.rs
@@ -25,6 +25,7 @@ impl PostgresQueryPath for PropertyTypeQueryPath<'_> {
             | Self::Schema(_) => vec![],
             Self::BaseUrl
             | Self::Version
+            | Self::TransactionTime
             | Self::RecordCreatedById
             | Self::OwnedById
             | Self::AdditionalMetadata(_) => {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Recently, we added the possibility to query for the transaction time of an ontology type. When querying for the transaction time for property types or entity types, this currently results in a `panic!`.

## 🔍 What does this change?

- Add `TransactionTime` to the correct match arm

## ⚠️ Known issues

We currently have a catch-all arm in the logic as we only have a single `EdgeKind` enumeration for ontology edges. This will be changed in the future, but until then we need to deal with this.