### PR TITLE
Allow specifying CLI arguments globally to the Graph

### DIFF
--- a/apps/hash-graph/lib/graph/src/logging/args.rs
+++ b/apps/hash-graph/lib/graph/src/logging/args.rs
@@ -86,29 +86,38 @@ pub struct LoggingArgs {
             default_value = "pretty",
             value_enum,
             env = "HASH_GRAPH_LOG_FORMAT",
+            global = true,
         )
     )]
     pub log_format: LogFormat,
 
     /// Logging verbosity to use. If not set `RUST_LOG` will be used.
-    #[cfg_attr(feature = "clap", clap(long, value_enum))]
+    #[cfg_attr(feature = "clap", clap(long, value_enum, global = true))]
     pub log_level: Option<LogLevel>,
 
     /// Logging output folder. The folder is created if it doesn't exist.
     #[cfg_attr(
         feature = "clap",
-        clap(long, default_value = "./log", env = "HASH_GRAPH_LOG_FOLDER")
+        clap(
+            long,
+            default_value = "./log",
+            env = "HASH_GRAPH_LOG_FOLDER",
+            global = true
+        )
     )]
     pub log_folder: PathBuf,
 
     /// Logging output file prefix.
-    #[cfg_attr(feature = "clap", clap(short, long, default_value = "out"))]
+    #[cfg_attr(
+        feature = "clap",
+        clap(short, long, default_value = "out", global = true)
+    )]
     pub log_file_prefix: String,
 
     /// The OpenTelemetry protocol endpoint for sending traces.
     #[cfg_attr(
         feature = "clap",
-        clap(long, default_value = None, env = "HASH_GRAPH_OTLP_ENDPOINT")
+    clap(long, default_value = None, env = "HASH_GRAPH_OTLP_ENDPOINT", global = true)
     )]
     pub otlp_endpoint: Option<String>,
 }

--- a/apps/hash-graph/lib/graph/src/store/config.rs
+++ b/apps/hash-graph/lib/graph/src/store/config.rs
@@ -11,41 +11,69 @@ pub enum DatabaseType {
 #[cfg_attr(feature = "clap", derive(clap::Args))]
 pub struct DatabaseConnectionInfo {
     /// The database type to connect to.
-    #[cfg_attr(feature = "clap", clap(long, default_value = "postgres", value_enum))]
+    #[cfg_attr(
+        feature = "clap",
+        clap(long, default_value = "postgres", value_enum, global = true)
+    )]
     database_type: DatabaseType,
 
     /// Database username.
     #[cfg_attr(
         feature = "clap",
-        clap(long, default_value = "postgres", env = "HASH_GRAPH_PG_USER")
+        clap(
+            long,
+            default_value = "postgres",
+            env = "HASH_GRAPH_PG_USER",
+            global = true
+        )
     )]
     user: String,
 
     /// Database password for authentication.
     #[cfg_attr(
         feature = "clap",
-        clap(long, default_value = "postgres", env = "HASH_GRAPH_PG_PASSWORD")
+        clap(
+            long,
+            default_value = "postgres",
+            env = "HASH_GRAPH_PG_PASSWORD",
+            global = true
+        )
     )]
     password: String,
 
     /// The host to connect to.
     #[cfg_attr(
         feature = "clap",
-        clap(long, default_value = "localhost", env = "HASH_GRAPH_PG_HOST")
+        clap(
+            long,
+            default_value = "localhost",
+            env = "HASH_GRAPH_PG_HOST",
+            global = true
+        )
     )]
     host: String,
 
     /// The port to connect to.
     #[cfg_attr(
         feature = "clap",
-        clap(long, default_value = "5432", env = "HASH_GRAPH_PG_PORT")
+        clap(
+            long,
+            default_value = "5432",
+            env = "HASH_GRAPH_PG_PORT",
+            global = true
+        )
     )]
     port: u16,
 
     /// The database name to use.
     #[cfg_attr(
         feature = "clap",
-        clap(long, default_value = "graph", env = "HASH_GRAPH_PG_DATABASE")
+        clap(
+            long,
+            default_value = "graph",
+            env = "HASH_GRAPH_PG_DATABASE",
+            global = true
+        )
     )]
     database: String,
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, the parameters has to be passed at the exact location. This might sounds intuitive but it's actually pretty annoying as soon as you have nested subcommand.

Example: Let's assume we have a `hash-graph snapshot dump` command. The database parameters are shared across all `snapshot` commands. However, it's required to pass it as
```
hash-graph snapshot --database dev_graph --port 1234 dump
```
while it would be more readable to append the information, e.g.
```
hash-graph snapshot dump --database dev_graph --port 1234
```

## 🔍 What does this change?

Set `global = true` for `clap` attributes