### PR TITLE
Add `test_graph` module containing required and optional record fields

### DIFF
--- a/apps/hash-graph/Cargo.lock
+++ b/apps/hash-graph/Cargo.lock
@@ -822,6 +822,7 @@ dependencies = [
  "postgres-types",
  "refinery",
  "regex",
+ "semver",
  "serde",
  "serde_json",
  "tarpc",
@@ -2065,6 +2066,9 @@ name = "semver"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"

--- a/apps/hash-graph/lib/graph/Cargo.toml
+++ b/apps/hash-graph/lib/graph/Cargo.toml
@@ -23,6 +23,7 @@ mime = "0.3.17"
 postgres-types = { version = "0.2.4", default-features = false, features = ["derive", "with-uuid-1", "with-serde_json-1", "with-time-0_3"] }
 postgres-protocol = "0.6.4"
 regex = "1.7.3"
+semver = { version = "1.0.4", default-features = false, features = ["serde"] }
 serde = { version = "1.0.158", features = ["derive"] }
 serde_json = "1.0.94"
 tokio = { version = "1.27.0", default-features = false }

--- a/apps/hash-graph/lib/graph/src/shared/identifier/knowledge.rs
+++ b/apps/hash-graph/lib/graph/src/shared/identifier/knowledge.rs
@@ -91,7 +91,19 @@ impl EntityTemporalMetadata {
 }
 
 #[derive(
-    Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, FromSql, ToSql, ToSchema,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    FromSql,
+    ToSql,
+    ToSchema,
 )]
 #[postgres(transparent)]
 #[repr(transparent)]
@@ -109,7 +121,7 @@ impl EntityEditionId {
     }
 }
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, ToSchema)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct EntityRecordId {
     pub entity_id: EntityId,

--- a/apps/hash-graph/lib/graph/src/store.rs
+++ b/apps/hash-graph/lib/graph/src/store.rs
@@ -1,6 +1,7 @@
 pub mod crud;
 pub mod error;
 pub mod query;
+pub mod test_graph;
 
 mod account;
 mod config;

--- a/apps/hash-graph/lib/graph/src/store/test_graph.rs
+++ b/apps/hash-graph/lib/graph/src/store/test_graph.rs
@@ -133,27 +133,16 @@ impl CustomGlobalMetadata {
     }
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BlockProtocolModuleVersions {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub graph: Option<semver::Version>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub authorization: Option<semver::Version>,
-}
-
-impl BlockProtocolModuleVersions {
-    #[must_use]
-    const fn is_empty(&self) -> bool {
-        self.graph.is_none() && self.authorization.is_none()
-    }
+    pub graph: semver::Version,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TestData {
-    #[serde(default, skip_serializing_if = "BlockProtocolModuleVersions::is_empty")]
-    pub block_protocol_spec: BlockProtocolModuleVersions,
+    pub block_protocol_module_versions: BlockProtocolModuleVersions,
     pub data_types: Vec<OntologyTypeRecord<DataType>>,
     pub property_types: Vec<OntologyTypeRecord<PropertyType>>,
     pub entity_types: Vec<OntologyTypeRecord<EntityType>>,

--- a/apps/hash-graph/lib/graph/src/store/test_graph.rs
+++ b/apps/hash-graph/lib/graph/src/store/test_graph.rs
@@ -133,10 +133,27 @@ impl CustomGlobalMetadata {
     }
 }
 
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockProtocolModuleVersions {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub graph: Option<semver::Version>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authorization: Option<semver::Version>,
+}
+
+impl BlockProtocolModuleVersions {
+    #[must_use]
+    const fn is_empty(&self) -> bool {
+        self.graph.is_none() && self.authorization.is_none()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TestData {
-    pub block_protocol_spec: semver::Version,
+    #[serde(default, skip_serializing_if = "BlockProtocolModuleVersions::is_empty")]
+    pub block_protocol_spec: BlockProtocolModuleVersions,
     pub data_types: Vec<OntologyTypeRecord<DataType>>,
     pub property_types: Vec<OntologyTypeRecord<PropertyType>>,
     pub entity_types: Vec<OntologyTypeRecord<EntityType>>,

--- a/apps/hash-graph/lib/graph/src/store/test_graph.rs
+++ b/apps/hash-graph/lib/graph/src/store/test_graph.rs
@@ -1,0 +1,146 @@
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+use type_system::{url::VersionedUrl, DataType, EntityType, PropertyType};
+
+use crate::{
+    identifier::{
+        knowledge::{EntityRecordId, EntityTemporalMetadata},
+        ontology::OntologyTypeRecordId,
+        time::{LeftClosedTemporalInterval, TransactionTime},
+    },
+    knowledge::{Entity, EntityProperties, LinkData},
+    ontology::OntologyType,
+    provenance::{OwnedById, ProvenanceMetadata},
+};
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomEntityMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<ProvenanceMetadata>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archived: Option<bool>,
+}
+
+impl CustomEntityMetadata {
+    #[must_use]
+    const fn is_empty(&self) -> bool {
+        self.provenance.is_none() && self.archived.is_none()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityMetadata {
+    pub record_id: EntityRecordId,
+    pub entity_type_id: VersionedUrl,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub temporal_versioning: Option<EntityTemporalMetadata>,
+    #[serde(default, skip_serializing_if = "CustomEntityMetadata::is_empty")]
+    pub custom: CustomEntityMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityRecord {
+    pub properties: EntityProperties,
+    pub metadata: EntityMetadata,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub link_data: Option<LinkData>,
+}
+
+impl From<Entity> for EntityRecord {
+    fn from(entity: Entity) -> Self {
+        Self {
+            properties: entity.properties,
+            metadata: EntityMetadata {
+                record_id: entity.metadata.record_id(),
+                entity_type_id: entity.metadata.entity_type_id().clone(),
+                temporal_versioning: Some(entity.metadata.temporal_versioning().clone()),
+                custom: CustomEntityMetadata {
+                    provenance: Some(entity.metadata.provenance()),
+                    archived: Some(entity.metadata.archived()),
+                },
+            },
+            link_data: entity.link_data,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomOntologyMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<ProvenanceMetadata>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub temporal_versioning: Option<OntologyTemporalMetadata>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owned_by_id: Option<OwnedById>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "time::serde::iso8601::option"
+    )]
+    pub fetched_at: Option<OffsetDateTime>,
+}
+
+impl CustomOntologyMetadata {
+    #[must_use]
+    const fn is_empty(&self) -> bool {
+        self.provenance.is_none()
+            && self.temporal_versioning.is_none()
+            && self.owned_by_id.is_none()
+            && self.fetched_at.is_none()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OntologyTypeMetadata {
+    pub record_id: OntologyTypeRecordId,
+    #[serde(default, skip_serializing_if = "CustomOntologyMetadata::is_empty")]
+    pub custom: CustomOntologyMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    rename_all = "camelCase",
+    bound(
+        serialize = "T::Representation: Serialize",
+        deserialize = "T::Representation: Deserialize<'de>"
+    )
+)]
+pub struct OntologyTypeRecord<T: OntologyType> {
+    pub schema: T::Representation,
+    pub metadata: OntologyTypeMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OntologyTemporalMetadata {
+    pub transaction_time: Option<LeftClosedTemporalInterval<TransactionTime>>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomGlobalMetadata;
+
+impl CustomGlobalMetadata {
+    #[must_use]
+    #[expect(clippy::unused_self)]
+    const fn is_empty(&self) -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TestData {
+    pub block_protocol_spec: semver::Version,
+    pub data_types: Vec<OntologyTypeRecord<DataType>>,
+    pub property_types: Vec<OntologyTypeRecord<PropertyType>>,
+    pub entity_types: Vec<OntologyTypeRecord<EntityType>>,
+    pub entities: Vec<EntityRecord>,
+    #[serde(default, skip_serializing_if = "CustomGlobalMetadata::is_empty")]
+    pub custom: CustomGlobalMetadata,
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

For creating a snapshot, we cannot re-use the representation for the ontology types as we store more information in the database than exposed, e.g. the `transaction-time`. Also, we want to distinguish between fields specified by blockprotocol.org and custom fields we use internally in HASH.

This PR adds a module, which contains the structs required to deserialize a graph.

## 🔗 Related links

- Part of [this Asana task](https://app.asana.com/0/1204000740778938/1204216809501005/f) _(internal)_

## 🔍 What does this change?

- Implement `Deserialize` for `EntityEditionId` and `EntityRecordId`
- Add structs to represent ontology types and entities with an optional field for metadata. Note, that I don't have added `AccountId`s (yet) as I don't expect it to be used in the short-term future. Querying those is complicated because that does not go through structural queries and when an account id is missing when inserting test data, the graph has to deal with that.