### PR TITLE
Allow `Read`ing (almost) all data from the database

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -10,7 +10,7 @@ use tokio_postgres::GenericClient;
 use type_system::url::BaseUrl;
 
 use crate::{
-    identifier::ontology::{OntologyTypeRecordId, OntologyTypeVersion},
+    identifier::ontology::OntologyTypeRecordId,
     ontology::{
         ExternalOntologyElementMetadata, OntologyElementMetadata, OntologyType,
         OntologyTypeWithMetadata, OwnedOntologyElementMetadata,
@@ -20,7 +20,11 @@ use crate::{
         crud::Read,
         postgres::query::{Distinctness, PostgresRecord, SelectCompiler},
         query::{Filter, OntologyQueryPath},
-        AsClient, PostgresStore, QueryError,
+        test_graph::{
+            CustomOntologyMetadata, OntologyTemporalMetadata, OntologyTypeMetadata,
+            OntologyTypeRecord,
+        },
+        AsClient, PostgresStore, QueryError, Record,
     },
     subgraph::temporal_axes::QueryTemporalAxes,
 };
@@ -52,26 +56,31 @@ impl<'a> FromSql<'a> for AdditionalOntologyMetadata {
 }
 
 #[async_trait]
-impl<C: AsClient, T> Read<T> for PostgresStore<C>
+impl<C: AsClient, T> Read<OntologyTypeRecord<T>> for PostgresStore<C>
 where
-    T: OntologyTypeWithMetadata + PostgresRecord,
-    for<'p> T::QueryPath<'p>: OntologyQueryPath,
+    T: OntologyType<WithMetadata: PostgresRecord, Representation: Send>,
+    for<'p> <T::WithMetadata as Record>::QueryPath<'p>: OntologyQueryPath,
 {
-    type Record = T;
+    type Record = T::WithMetadata;
 
     #[tracing::instrument(level = "info", skip(self, filter))]
     async fn read(
         &self,
-        filter: &Filter<T>,
+        filter: &Filter<Self::Record>,
         temporal_axes: Option<&QueryTemporalAxes>,
-    ) -> Result<Vec<T>, QueryError> {
-        let base_url_path = <T::QueryPath<'static> as OntologyQueryPath>::base_url();
-        let version_path = <T::QueryPath<'static> as OntologyQueryPath>::version();
-        let schema_path = <T::QueryPath<'static> as OntologyQueryPath>::schema();
+    ) -> Result<Vec<OntologyTypeRecord<T>>, QueryError> {
+        let base_url_path =
+            <<Self::Record as Record>::QueryPath<'static> as OntologyQueryPath>::base_url();
+        let version_path =
+            <<Self::Record as Record>::QueryPath<'static> as OntologyQueryPath>::version();
+        let schema_path =
+            <<Self::Record as Record>::QueryPath<'static> as OntologyQueryPath>::schema();
         let record_created_by_id_path =
-            <T::QueryPath<'static> as OntologyQueryPath>::record_created_by_id();
+            <<Self::Record as Record>::QueryPath<'static> as OntologyQueryPath>::record_created_by_id();
         let additional_metadata_path =
-            <T::QueryPath<'static> as OntologyQueryPath>::additional_metadata();
+            <<Self::Record as Record>::QueryPath<'static> as OntologyQueryPath>::additional_metadata();
+        let transaction_time_path =
+            <<Self::Record as Record>::QueryPath<'static> as OntologyQueryPath>::transaction_time();
 
         let mut compiler = SelectCompiler::new(temporal_axes);
 
@@ -89,6 +98,7 @@ where
         let record_created_by_id_path_index =
             compiler.add_selection_path(&record_created_by_id_path);
         let additional_metadata_index = compiler.add_selection_path(&additional_metadata_path);
+        let transaction_time_index = compiler.add_selection_path(&transaction_time_path);
 
         compiler.add_filter(filter);
         let (statement, parameters) = compiler.compile();
@@ -100,41 +110,105 @@ where
             .change_context(QueryError)?
             .map(|row| row.into_report().change_context(QueryError))
             .and_then(|row| async move {
-                let base_url = BaseUrl::new(row.get(base_url_index))
-                    .into_report()
-                    .change_context(QueryError)?;
-                let version: OntologyTypeVersion = row.get(version_index);
-                let record_created_by_id =
-                    RecordCreatedById::new(row.get(record_created_by_id_path_index));
-                let metadata: AdditionalOntologyMetadata = row.get(additional_metadata_index);
+                let additional_metadata: AdditionalOntologyMetadata =
+                    row.get(additional_metadata_index);
 
-                let record_repr: <T::OntologyType as OntologyType>::Representation =
-                    serde_json::from_value(row.get(schema_index))
+                let provenance = ProvenanceMetadata::new(RecordCreatedById::new(
+                    row.get(record_created_by_id_path_index),
+                ));
+                let temporal_versioning = OntologyTemporalMetadata {
+                    transaction_time: row.get(transaction_time_index),
+                };
+                let (owned_by_id, fetched_at) = match additional_metadata {
+                    AdditionalOntologyMetadata::Owned { owned_by_id } => (Some(owned_by_id), None),
+                    AdditionalOntologyMetadata::External { fetched_at } => (None, Some(fetched_at)),
+                };
+
+                Ok(OntologyTypeRecord {
+                    schema: serde_json::from_value(row.get(schema_index))
                         .into_report()
-                        .change_context(QueryError)?;
-                let record = T::OntologyType::try_from(record_repr)
-                    .into_report()
-                    .change_context(QueryError)?;
+                        .change_context(QueryError)?,
+                    metadata: OntologyTypeMetadata {
+                        record_id: OntologyTypeRecordId {
+                            base_url: BaseUrl::new(row.get(base_url_index))
+                                .into_report()
+                                .change_context(QueryError)?,
+                            version: row.get(version_index),
+                        },
+                        custom: CustomOntologyMetadata {
+                            provenance: Some(provenance),
+                            temporal_versioning: Some(temporal_versioning),
+                            owned_by_id,
+                            fetched_at,
+                        },
+                    },
+                })
+            })
+            .try_collect()
+            .await
+    }
+}
 
-                let record_id = OntologyTypeRecordId { base_url, version };
-                let provenance = ProvenanceMetadata::new(record_created_by_id);
+#[async_trait]
+impl<C: AsClient, T> Read<T> for PostgresStore<C>
+where
+    Self: Read<OntologyTypeRecord<T::OntologyType>, Record = T>,
+    T: OntologyTypeWithMetadata,
+{
+    type Record = T;
 
-                Ok(T::new(record, match metadata {
-                    AdditionalOntologyMetadata::Owned { owned_by_id } => {
+    #[tracing::instrument(level = "info", skip(self, filter))]
+    async fn read(
+        &self,
+        filter: &Filter<T>,
+        temporal_axes: Option<&QueryTemporalAxes>,
+    ) -> Result<Vec<T>, QueryError> {
+        Read::<OntologyTypeRecord<T::OntologyType>>::read(self, filter, temporal_axes)
+            .await?
+            .into_iter()
+            .map(|record| {
+                let provenance = record.metadata.custom.provenance.unwrap_or_else(|| {
+                    unreachable!(
+                        "`OntologyTypeRecord` should always have provenance metadata if it is \
+                         read from the store"
+                    )
+                });
+
+                let metadata = match (
+                    record.metadata.custom.owned_by_id,
+                    record.metadata.custom.fetched_at,
+                ) {
+                    (Some(owned_by_id), None) => {
                         OntologyElementMetadata::Owned(OwnedOntologyElementMetadata::new(
-                            record_id,
+                            record.metadata.record_id,
                             provenance,
                             owned_by_id,
                         ))
                     }
-                    AdditionalOntologyMetadata::External { fetched_at } => {
+                    (None, Some(fetched_at)) => {
                         OntologyElementMetadata::External(ExternalOntologyElementMetadata::new(
-                            record_id, provenance, fetched_at,
+                            record.metadata.record_id,
+                            provenance,
+                            fetched_at,
                         ))
                     }
-                }))
+                    (Some(_), Some(_)) => unreachable!(
+                        "Ontology type record has both `owned_by_id` and `fetched_at` metadata"
+                    ),
+                    (None, None) => unreachable!(
+                        "Ontology type record has neither `owned_by_id` nor `fetched_at` metadata"
+                    ),
+                };
+
+                Ok(T::new(
+                    record
+                        .schema
+                        .try_into()
+                        .into_report()
+                        .change_context(QueryError)?,
+                    metadata,
+                ))
             })
-            .try_collect()
-            .await
+            .collect()
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In #2313 a set of structs were added to contain ontology types, which contains more information than exposed to HASH. Reading those types is slightly different, so this PR adds support for reading those.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204000740778938/1204216809501005/f) _(internal)_

## 🚫 Blocked by

- #2313
- #2310 (Will fail at runtime until merged)

## 🔍 What does this change?

- Use `OntologyTypeRecord<T>` from `test_graph` to read from the data store
- Re-use the implementation from above to return the "old" type to the `Store` trait

- The docs for x need updating to explain that y

## ⚠️ Known issues

We have to call `expect()` in the wrapping logic. While we can expect that the Rust compiler will optimize out this branch, the data for the transaction time is still queried from the database. This can be avoided by duplicating a large portion of the code, but this is the more maintainable solution for now. Especially, as this is in the ontology-type reading methods, I don't expect this to be a bottleneck at all.