### PR TITLE
Add a `snapshot` subcommand to the CLI

### DIFF
--- a/apps/hash-graph/Cargo.lock
+++ b/apps/hash-graph/Cargo.lock
@@ -921,6 +921,7 @@ dependencies = [
  "graph",
  "regex",
  "reqwest",
+ "semver",
  "serde_json",
  "tarpc",
  "time",

--- a/apps/hash-graph/bin/cli/Cargo.toml
+++ b/apps/hash-graph/bin/cli/Cargo.toml
@@ -18,6 +18,7 @@ futures = { version = "0.3.27", optional = true }
 graph = { path = "../../lib/graph", features = ["clap"] }
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 regex = "1.7.3"
+semver = { version = "1.0.4", default-features = false }
 serde_json = "1.0.94"
 tarpc = { version = "0.32", features = ["serde1", "tokio1", "serde-transport", "tcp"], optional = true }
 tokio = { version = "1.27.0", features = ["rt-multi-thread", "macros"] }

--- a/apps/hash-graph/bin/cli/src/main.rs
+++ b/apps/hash-graph/bin/cli/src/main.rs
@@ -22,5 +22,6 @@ async fn main() -> Result<(), GraphError> {
             subcommand::completions(args);
             Ok(())
         }
+        Subcommand::Snapshot(args) => subcommand::snapshot(args).await,
     }
 }

--- a/apps/hash-graph/bin/cli/src/subcommand.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand.rs
@@ -1,6 +1,7 @@
 mod completions;
 mod migrate;
 mod server;
+mod snapshot;
 #[cfg(feature = "type-fetcher")]
 mod type_fetcher;
 
@@ -10,6 +11,7 @@ pub use self::{
     completions::{completions, CompletionsArgs},
     migrate::{migrate, MigrateArgs},
     server::{server, ServerArgs},
+    snapshot::{snapshot, SnapshotArgs},
 };
 
 /// Subcommand for the program.
@@ -24,4 +26,6 @@ pub enum Subcommand {
     TypeFetcher(TypeFetcherArgs),
     /// Generate a completion script for the given shell and outputs it to stdout.
     Completions(CompletionsArgs),
+    /// Snapshot API for the database.
+    Snapshot(SnapshotArgs),
 }

--- a/apps/hash-graph/bin/cli/src/subcommand/migrate.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/migrate.rs
@@ -24,27 +24,27 @@ pub async fn migrate(args: MigrateArgs) -> Result<(), GraphError> {
     let pool = PostgresStorePool::new(&args.db_info, NoTls)
         .await
         .change_context(GraphError)
-        .map_err(|err| {
-            tracing::error!("{err:?}");
-            err
+        .map_err(|report| {
+            tracing::error!(error = ?report, "Failed to connect to database");
+            report
         })?;
 
     let mut connection = pool
         .acquire()
         .await
         .change_context(GraphError)
-        .map_err(|err| {
-            tracing::error!("{err:?}");
-            err
+        .map_err(|report| {
+            tracing::error!(error = ?report, "Failed to acquire database connection");
+            report
         })?;
 
     connection
         .run_migrations()
         .await
         .change_context(GraphError)
-        .map_err(|err| {
-            tracing::error!("{err:?}");
-            err
+        .map_err(|report| {
+            tracing::error!(error = ?report, "Failed to run migrations");
+            report
         })?;
 
     Ok(())

--- a/apps/hash-graph/bin/cli/src/subcommand/server.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/server.rs
@@ -192,7 +192,7 @@ async fn stop_gap_setup(pool: &PostgresStorePool<NoTls>) -> Result<(), GraphErro
         .await
         .change_context(GraphError)
         .map_err(|err| {
-            tracing::error!("{err:?}");
+            tracing::error!(?err, "Failed to acquire database connection");
             err
         })?;
 
@@ -287,9 +287,9 @@ pub async fn server(args: ServerArgs) -> Result<(), GraphError> {
     let pool = PostgresStorePool::new(&args.db_info, NoTls)
         .await
         .change_context(GraphError)
-        .map_err(|err| {
-            tracing::error!("{err:?}");
-            err
+        .map_err(|report| {
+            tracing::error!(error = ?report, "Failed to connect to database");
+            report
         })?;
 
     #[cfg(not(feature = "type-fetcher"))]

--- a/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
@@ -103,7 +103,7 @@ pub async fn snapshot(args: SnapshotArgs) -> Result<(), GraphError> {
             serde_json::to_writer(&mut std::io::stdout(), &test_graph)
                 .into_report()
                 .change_context(GraphError)?;
-            writeln!(std::io::stdout(), "")
+            writeln!(std::io::stdout())
                 .into_report()
                 .change_context(GraphError)?;
         }

--- a/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
@@ -42,18 +42,18 @@ pub async fn snapshot(args: SnapshotArgs) -> Result<(), GraphError> {
     let pool = PostgresStorePool::new(&args.db_info, NoTls)
         .await
         .change_context(GraphError)
-        .map_err(|err| {
-            tracing::error!("{err:?}");
-            err
+        .map_err(|report| {
+            tracing::error!(error = ?report, "Failed to connect to database");
+            report
         })?;
 
     let store = pool
         .acquire()
         .await
         .change_context(GraphError)
-        .map_err(|err| {
-            tracing::error!("{err:?}");
-            err
+        .map_err(|report| {
+            tracing::error!(error = ?report, "Failed to acquire database connection");
+            report
         })?;
 
     match args.command {

--- a/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
@@ -6,7 +6,8 @@ use graph::{
     knowledge::Entity,
     logging::{init_logger, LoggingArgs},
     store::{
-        crud::Read, query::Filter, test_graph, DatabaseConnectionInfo, PostgresStorePool, StorePool,
+        crud::Read, query::Filter, test_graph, test_graph::BlockProtocolModuleVersions,
+        DatabaseConnectionInfo, PostgresStorePool, StorePool,
     },
 };
 use tokio_postgres::NoTls;
@@ -89,7 +90,9 @@ pub async fn snapshot(args: SnapshotArgs) -> Result<(), GraphError> {
                 .collect();
 
             let test_graph = test_graph::TestData {
-                block_protocol_spec: semver::Version::new(0, 3, 0),
+                block_protocol_module_versions: BlockProtocolModuleVersions {
+                    graph: semver::Version::new(0, 3, 0),
+                },
                 data_types,
                 property_types,
                 entity_types,

--- a/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
@@ -1,0 +1,110 @@
+use std::io::Write;
+
+use clap::Parser;
+use error_stack::{IntoReport, Result, ResultExt};
+use graph::{
+    knowledge::Entity,
+    logging::{init_logger, LoggingArgs},
+    store::{
+        crud::Read, query::Filter, test_graph, DatabaseConnectionInfo, PostgresStorePool, StorePool,
+    },
+};
+use tokio_postgres::NoTls;
+use type_system::{DataType, EntityType, PropertyType};
+
+use crate::error::GraphError;
+
+#[derive(Debug, Parser)]
+pub struct SnapshotDumpArgs;
+
+#[derive(Debug, Parser)]
+pub enum SnapshotCommand {
+    Dump(SnapshotDumpArgs),
+}
+
+#[derive(Debug, Parser)]
+#[clap(version, author, about, long_about = None)]
+pub struct SnapshotArgs {
+    #[command(subcommand)]
+    pub command: SnapshotCommand,
+
+    #[clap(flatten)]
+    pub log_config: LoggingArgs,
+
+    #[clap(flatten)]
+    pub db_info: DatabaseConnectionInfo,
+}
+
+pub async fn snapshot(args: SnapshotArgs) -> Result<(), GraphError> {
+    let _log_guard = init_logger(&args.log_config);
+
+    let pool = PostgresStorePool::new(&args.db_info, NoTls)
+        .await
+        .change_context(GraphError)
+        .map_err(|err| {
+            tracing::error!("{err:?}");
+            err
+        })?;
+
+    let store = pool
+        .acquire()
+        .await
+        .change_context(GraphError)
+        .map_err(|err| {
+            tracing::error!("{err:?}");
+            err
+        })?;
+
+    match args.command {
+        SnapshotCommand::Dump(_) => {
+            let data_types = Read::<test_graph::OntologyTypeRecord<DataType>>::read(
+                &store,
+                &Filter::All(vec![]),
+                None,
+            )
+            .await
+            .change_context(GraphError)?;
+
+            let property_types = Read::<test_graph::OntologyTypeRecord<PropertyType>>::read(
+                &store,
+                &Filter::All(vec![]),
+                None,
+            )
+            .await
+            .change_context(GraphError)?;
+
+            let entity_types = Read::<test_graph::OntologyTypeRecord<EntityType>>::read(
+                &store,
+                &Filter::All(vec![]),
+                None,
+            )
+            .await
+            .change_context(GraphError)?;
+
+            let entities = Read::<Entity>::read(&store, &Filter::All(vec![]), None)
+                .await
+                .change_context(GraphError)?
+                .into_iter()
+                .map(test_graph::EntityRecord::from)
+                .collect();
+
+            let test_graph = test_graph::TestData {
+                block_protocol_spec: semver::Version::new(0, 3, 0),
+                data_types,
+                property_types,
+                entity_types,
+                entities,
+                custom: test_graph::CustomGlobalMetadata::default(),
+            };
+
+            serde_json::to_writer(&mut std::io::stdout(), &test_graph)
+                .into_report()
+                .change_context(GraphError)?;
+            writeln!(std::io::stdout(), "")
+                .into_report()
+                .change_context(GraphError)?;
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In #2314 support to read the data was added, this PR adds an interface to dump the data to the terminal.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204000740778938/1204216809501005/f) _(internal)_

## 🚫 Blocked by

- #2313 
- #2314 
- #2310 (Will fail at runtime until merged)
- #2285 
- #2304 (compilation will fail until merged)

## 🔍 What does this change?

This adds a simple subcommand to dump `test_graph::TestData` to the terminal as JSON.

## ❓ How to test this?

```sh
cargo run -- snapshot --database dev_graph dump | jq
```
