### PR TITLE
Remove `just-install` from `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "cross-env": "7.0.3",
     "dotenv-flow": "3.2.0",
     "husky": "8.0.3",
-    "just-install": "1.0.11",
     "lint-staged": "13.0.4",
     "lockfile-lint": "4.9.6",
     "markdownlint-cli": "0.32.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15251,11 +15251,6 @@ jsprim@^1.2.2:
     array-includes "^3.1.5"
     object.assign "^4.1.3"
 
-just-install@1.0.11:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/just-install/-/just-install-1.0.11.tgz#157a7f98a3dc8045bcce7669485c9a1c640b1e2f"
-  integrity sha512-3nW53hWK9muHUTXthiTcUqFkd5FXDad7YLoDWJonVhPUZxX8PgCVGvaI8AQ5gqJZ45MBd/hdqg5XPIWPh9Bk/g==
-
 jwa@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We switched from `cargo-make` to `just`. Previously, we asked people to install `cargo-make` manually if they want to use it, however, there is a package called `just-install` for npm, which installs `just` in `./node_modules/bin/just` on `yarn install`, so we added this package as a dev-dependency. However, this binary installs `just` at its latest version and to get the information it requires a GitHub API endpoint. As we have quite a few jobs running in parallel in GitHub this results in rate limiting and thus failing the install action (typically in the warm-up repo job).

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1204086167143889/1204291503420526/f) _(internal)_
- https://github.com/casey/just/issues/1573