### PR TITLE
Provide a `snapshot restore` command

### DIFF
--- a/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
@@ -75,8 +75,6 @@ pub async fn snapshot(args: SnapshotArgs) -> Result<(), GraphError> {
                 .into_report()
                 .change_context(GraphError)?;
 
-            println!("{:#?}", test_data);
-
             store
                 .write_test_graph(test_data)
                 .await

--- a/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
@@ -71,12 +71,12 @@ pub async fn snapshot(args: SnapshotArgs) -> Result<(), GraphError> {
                 .change_context(GraphError)?;
         }
         SnapshotCommand::Restore(_) => {
-            let test_data: test_graph::TestData = serde_json::from_reader(std::io::stdin())
+            let snapshot: test_graph::TestData = serde_json::from_reader(std::io::stdin())
                 .into_report()
                 .change_context(GraphError)?;
 
             store
-                .write_test_graph(test_data)
+                .write_test_graph(snapshot)
                 .await
                 .change_context(GraphError)?;
         }

--- a/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
@@ -3,15 +3,13 @@ use std::io::Write;
 use clap::Parser;
 use error_stack::{IntoReport, Result, ResultExt};
 use graph::{
-    knowledge::Entity,
     logging::{init_logger, LoggingArgs},
     store::{
-        crud::Read, query::Filter, test_graph, test_graph::BlockProtocolModuleVersions,
+        test_graph::{self, TestStore},
         DatabaseConnectionInfo, PostgresStorePool, StorePool,
     },
 };
 use tokio_postgres::NoTls;
-use type_system::{DataType, EntityType, PropertyType};
 
 use crate::error::GraphError;
 
@@ -19,8 +17,12 @@ use crate::error::GraphError;
 pub struct SnapshotDumpArgs;
 
 #[derive(Debug, Parser)]
+pub struct SnapshotRestoreArgs;
+
+#[derive(Debug, Parser)]
 pub enum SnapshotCommand {
     Dump(SnapshotDumpArgs),
+    Restore(SnapshotRestoreArgs),
 }
 
 #[derive(Debug, Parser)]
@@ -47,7 +49,7 @@ pub async fn snapshot(args: SnapshotArgs) -> Result<(), GraphError> {
             report
         })?;
 
-    let store = pool
+    let mut store = pool
         .acquire()
         .await
         .change_context(GraphError)
@@ -58,53 +60,26 @@ pub async fn snapshot(args: SnapshotArgs) -> Result<(), GraphError> {
 
     match args.command {
         SnapshotCommand::Dump(_) => {
-            let data_types = Read::<test_graph::OntologyTypeRecord<DataType>>::read(
-                &store,
-                &Filter::All(vec![]),
-                None,
+            serde_json::to_writer(
+                &mut std::io::stdout(),
+                &store.read_test_graph().await.change_context(GraphError)?,
             )
-            .await
+            .into_report()
             .change_context(GraphError)?;
-
-            let property_types = Read::<test_graph::OntologyTypeRecord<PropertyType>>::read(
-                &store,
-                &Filter::All(vec![]),
-                None,
-            )
-            .await
-            .change_context(GraphError)?;
-
-            let entity_types = Read::<test_graph::OntologyTypeRecord<EntityType>>::read(
-                &store,
-                &Filter::All(vec![]),
-                None,
-            )
-            .await
-            .change_context(GraphError)?;
-
-            let entities = Read::<Entity>::read(&store, &Filter::All(vec![]), None)
-                .await
-                .change_context(GraphError)?
-                .into_iter()
-                .map(test_graph::EntityRecord::from)
-                .collect();
-
-            let test_graph = test_graph::TestData {
-                block_protocol_module_versions: BlockProtocolModuleVersions {
-                    graph: semver::Version::new(0, 3, 0),
-                },
-                data_types,
-                property_types,
-                entity_types,
-                entities,
-                custom: test_graph::CustomGlobalMetadata::default(),
-            };
-
-            serde_json::to_writer(&mut std::io::stdout(), &test_graph)
-                .into_report()
-                .change_context(GraphError)?;
             writeln!(std::io::stdout())
                 .into_report()
+                .change_context(GraphError)?;
+        }
+        SnapshotCommand::Restore(_) => {
+            let test_data: test_graph::TestData = serde_json::from_reader(std::io::stdin())
+                .into_report()
+                .change_context(GraphError)?;
+
+            println!("{:#?}", test_data);
+
+            store
+                .write_test_graph(test_data)
+                .await
                 .change_context(GraphError)?;
         }
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

After reading all data from the store we want to write it back. This adds the interface to write back the data to the graph.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- Part of [this Asana task](https://app.asana.com/0/1204086167143889/1204216809501006/f) _(internal)_

## 🚫 Blocked by

- #2316

## 🔍 What does this change?

- Moves reading logic to the library
- Wrap reading logic in a function
- Add writing entry point to CLI
- Temporarily fail with error when attempting to write

## 🔍 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [ ] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [x] does not modify any publishable libraries
- [ ] I am unsure / need advice

## 🐾 Next steps

Implement the logic to insert the data

## 🛡 What tests cover this?

This is supposed to be used in tests

## ❓ How to test this?

The first commit does contain a `println!` wich helps debugging. In order to extract a snapshot, run
```sh
hash-graph snapshot dump --database dev_graph > snapshot.json
```

To read it back, run
```
cat snapshot.json | hash-graph snapshot restore --database dev_graph
# or
hash-graph snapshot dump --database dev_graph | hash-graph snapshot restore --database dev_graph
```