### PR TITLE
Countdown Block improvements

### DIFF
--- a/blocks/countdown/src/countdown-title.tsx
+++ b/blocks/countdown/src/countdown-title.tsx
@@ -16,13 +16,33 @@ export const CountdownTitle: FunctionComponent<CountdownTitleProps> = ({
   const textareaEl = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!textareaEl.current) return;
-    textareaEl.current.textContent = value ?? "";
-  }, [value]);
+    const textarea = textareaEl.current;
+    if (!textarea) return;
+    textarea.textContent = value ?? "";
+
+    // Calling this whenever value changes makes it so the cursor position is lost in some browsers
+    // (firefox and safari for example), so we leave it out of the dependency array
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const textarea = textareaEl.current;
+    if (!textarea) return;
+
+    const onKeyDown = ({ code }: KeyboardEvent) => {
+      if (code === "Enter") {
+        textarea.blur();
+        onBlur();
+      }
+    };
+
+    textarea.addEventListener("keydown", onKeyDown);
+    return () => textarea.removeEventListener("keydown", onKeyDown);
+  }, [onBlur]);
 
   const handleChange = (evt: ChangeEvent<HTMLDivElement>) => {
     if (!textareaEl.current) return;
-    textareaEl.current.textContent = evt.target.textContent;
+
     onChangeText(evt.currentTarget.textContent ?? "");
   };
 

--- a/blocks/countdown/src/countdown-title.tsx
+++ b/blocks/countdown/src/countdown-title.tsx
@@ -26,20 +26,6 @@ export const CountdownTitle: FunctionComponent<CountdownTitleProps> = ({
     }
   }, [value]);
 
-  useEffect(() => {
-    const textarea = textareaEl.current;
-    if (!textarea) return;
-
-    const onKeyDown = ({ key }: KeyboardEvent) => {
-      if (key === "Enter") {
-        textarea.blur();
-      }
-    };
-
-    textarea.addEventListener("keydown", onKeyDown);
-    return () => textarea.removeEventListener("keydown", onKeyDown);
-  }, [onBlur]);
-
   const handleChange = (evt: ChangeEvent<HTMLDivElement>) => {
     if (!textareaEl.current) return;
 
@@ -51,10 +37,18 @@ export const CountdownTitle: FunctionComponent<CountdownTitleProps> = ({
       <div
         ref={textareaEl}
         className="title-input"
-        {...(!readonly && { contentEditable: "true" })}
         placeholder="Event name"
         onInput={handleChange}
         onBlur={onBlur}
+        {...(!readonly && {
+          role: "textbox",
+          contentEditable: "true",
+          onKeyDown: ({ key }) => {
+            if (key === "Enter" || key === "Escape") {
+              textareaEl.current?.blur();
+            }
+          },
+        })}
       />
       {!readonly && (
         <button onClick={onBlur} type="button">

--- a/blocks/countdown/src/countdown-title.tsx
+++ b/blocks/countdown/src/countdown-title.tsx
@@ -18,21 +18,21 @@ export const CountdownTitle: FunctionComponent<CountdownTitleProps> = ({
   useEffect(() => {
     const textarea = textareaEl.current;
     if (!textarea) return;
-    textarea.textContent = value ?? "";
 
-    // Calling this whenever value changes makes it so the cursor position is lost in some browsers
-    // (firefox and safari for example), so we leave it out of the dependency array
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    // We only want to set textContent when the value changes externally because
+    // by setting it we lose the cursor position in some browsers (firefox, safari)
+    if (value !== textarea.textContent) {
+      textarea.textContent = value ?? "";
+    }
+  }, [value]);
 
   useEffect(() => {
     const textarea = textareaEl.current;
     if (!textarea) return;
 
-    const onKeyDown = ({ code }: KeyboardEvent) => {
-      if (code === "Enter") {
+    const onKeyDown = ({ key }: KeyboardEvent) => {
+      if (key === "Enter") {
         textarea.blur();
-        onBlur();
       }
     };
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
This PR fixes an issue with the Countdown block where the cursor would lose its position when changing the title value.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204086167143889/1204270112397116/f) _(internal)_

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Made it so the value of the title's input isn't set every time it changes, which was causing the cursor to lose its position in some browsers (firefox and safari for example);
- Added a keydown event listener to submit the changes whenever Enter is pressed.

## 🔍 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [ ] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [ ] does not modify any publishable libraries
- [x] I am unsure / need advice

Are blocks libraries? They do need publishing

