### PR TITLE
Update `type-system` crate to latest version

### DIFF
--- a/apps/hash-graph/Cargo.lock
+++ b/apps/hash-graph/Cargo.lock
@@ -2333,22 +2333,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -2817,10 +2817,9 @@ dependencies = [
 [[package]]
 name = "type-system"
 version = "0.0.0"
-source = "git+https://github.com/blockprotocol/blockprotocol?rev=b8351b3#b8351b38f12c301bc881f8f6ddaa366770a9809e"
+source = "git+https://github.com/blockprotocol/blockprotocol?rev=bd6a197#bd6a1971fa39db69c02baa4f961f9062122f0fa8"
 dependencies = [
  "console_error_panic_hook",
- "regex",
  "serde",
  "serde_json",
  "thiserror",

--- a/apps/hash-graph/bench/Cargo.toml
+++ b/apps/hash-graph/bench/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"
 tokio = { version = "1.27.0", features = ["rt-multi-thread", "macros"] }
 tokio-postgres = { version = "0.7.8", default-features = false }
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "b8351b3" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "bd6a197" }
 uuid = { version = "1.3.0", features = ["v4", "serde"] }
 
 [[bench]]

--- a/apps/hash-graph/bin/cli/Cargo.toml
+++ b/apps/hash-graph/bin/cli/Cargo.toml
@@ -25,7 +25,7 @@ tokio = { version = "1.27.0", features = ["rt-multi-thread", "macros"] }
 tokio-postgres = { version = "0.7.8", default-features = false }
 tokio-serde = { version = "0.8", features = ["messagepack"], optional = true }
 tracing = "0.1.37"
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "b8351b3" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "bd6a197" }
 uuid = "1.3.0"
 
 # Remove again when the type fetcher is used in the graph

--- a/apps/hash-graph/lib/graph/Cargo.toml
+++ b/apps/hash-graph/lib/graph/Cargo.toml
@@ -38,7 +38,7 @@ tonic = "0.8.3"
 opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
 opentelemetry-otlp = "0.11.0"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "json"] }
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "b8351b3" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "bd6a197" }
 uuid = { version = "1.3.0", features = ["v4", "serde"] }
 utoipa = { version = "3.2.1", features = ["uuid"] }
 include_dir = "0.7.3"

--- a/apps/hash-graph/lib/type-fetcher/Cargo.toml
+++ b/apps/hash-graph/lib/type-fetcher/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 description = "RPC service definition to fetch external BP types"
 
 [dependencies]
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "b8351b3" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "bd6a197" }
 
 serde = { version = "1.0.159", features = ["derive"] }
 time = { version = "0.3.20", features = ['serde'] }

--- a/apps/hash-graph/tests/integration/Cargo.toml
+++ b/apps/hash-graph/tests/integration/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = "1.0.95"
 time = "0.3.20"
 tokio = { version = "1.27.0", features = ["rt-multi-thread", "macros"] }
 tokio-postgres = { version = "0.7.8", default-features = false }
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "b8351b3" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "bd6a197" }
 uuid = { version = "1.3.0", features = ["v4", "serde"] }
 
 [[test]]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The current `type-system` package does rely on a feature, which was changed. I already did actions on this to fix it in the upstream package, but the version was not updated in the graph.

This is blocking any further toolchain bumps