### PR TITLE
Fix `-u` flag outside of CI

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -89,7 +89,7 @@ not-in-pr +command:
 [no-cd]
 in-ci +command:
   #!/usr/bin/env bash
-  set -euo pipefail
+  set -eo pipefail
   if [ -n "$CI" ]; then
     echo "{{command}}" >&2
     {{command}}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `-u` flag checks if a variable is set, but `CI` is not set outside of CI and we don't check over variables.