### PR TITLE
Support streaming data from the datastore

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/crud.rs
+++ b/apps/hash-graph/lib/graph/src/store/crud.rs
@@ -8,6 +8,7 @@
 
 use async_trait::async_trait;
 use error_stack::{ensure, Report, Result};
+use futures::TryStreamExt;
 
 use crate::{
     store::{query::Filter, QueryError, Record},
@@ -22,6 +23,7 @@ use crate::{
 #[async_trait]
 pub trait Read<R>: Sync {
     type Record: Record;
+    type ReadStream: futures::Stream<Item = Result<R, QueryError>> + Send + Sync;
 
     // TODO: Return a stream of `R` instead
     //   see https://app.asana.com/0/1202805690238892/1202923536131158/f
@@ -32,15 +34,29 @@ pub trait Read<R>: Sync {
         &self,
         query: &Filter<Self::Record>,
         temporal_axes: Option<&QueryTemporalAxes>,
-    ) -> Result<Vec<R>, QueryError>;
+    ) -> Result<Self::ReadStream, QueryError>;
+
+    async fn read_vec(
+        &self,
+        query: &Filter<Self::Record>,
+        temporal_axes: Option<&QueryTemporalAxes>,
+    ) -> Result<Vec<R>, QueryError>
+    where
+        R: Send,
+    {
+        self.read(query, temporal_axes).await?.try_collect().await
+    }
 
     #[tracing::instrument(level = "info", skip(self, query))]
     async fn read_one(
         &self,
         query: &Filter<Self::Record>,
         temporal_axes: Option<&QueryTemporalAxes>,
-    ) -> Result<R, QueryError> {
-        let mut records = self.read(query, temporal_axes).await?;
+    ) -> Result<R, QueryError>
+    where
+        R: Send,
+    {
+        let mut records = self.read_vec(query, temporal_axes).await?;
         ensure!(
             records.len() <= 1,
             Report::new(QueryError).attach_printable(format!(

--- a/apps/hash-graph/lib/graph/src/store/crud.rs
+++ b/apps/hash-graph/lib/graph/src/store/crud.rs
@@ -25,8 +25,6 @@ pub trait Read<R>: Sync {
     type Record: Record;
     type ReadStream: futures::Stream<Item = Result<R, QueryError>> + Send + Sync;
 
-    // TODO: Return a stream of `R` instead
-    //   see https://app.asana.com/0/1202805690238892/1202923536131158/f
     /// Returns a value from the [`Store`] specified by the passed `query`.
     ///
     /// [`Store`]: crate::store::Store

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -409,13 +409,14 @@ where
     A: Send + Sync,
     S: Read<R> + Send,
 {
+    type ReadStream = S::ReadStream;
     type Record = S::Record;
 
     async fn read(
         &self,
         query: &Filter<Self::Record>,
         temporal_axes: Option<&QueryTemporalAxes>,
-    ) -> Result<Vec<R>, QueryError> {
+    ) -> Result<Self::ReadStream, QueryError> {
         self.store.read(query, temporal_axes).await
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -58,7 +58,7 @@ impl<C: AsClient> PostgresStore<C> {
         {
             let time_axis = subgraph.temporal_axes.resolved.variable_time_axis();
 
-            for edge_entity in <Self as Read<Entity>>::read(
+            for edge_entity in <Self as Read<Entity>>::read_vec(
                 self,
                 &Filter::for_knowledge_graph_edge_by_entity_id(
                     entity_vertex_id.base_id,
@@ -152,7 +152,7 @@ impl<C: AsClient> PostgresStore<C> {
                 if let Some(new_graph_resolve_depths) = graph_resolve_depths
                     .decrement_depth_for_edge(SharedEdgeKind::IsOfType, EdgeDirection::Outgoing)
                 {
-                    for entity_type in <Self as Read<EntityTypeWithMetadata>>::read(
+                    for entity_type in <Self as Read<EntityTypeWithMetadata>>::read_vec(
                         self,
                         &Filter::for_shared_edge_by_entity_id(
                             entity_vertex_id.base_id,
@@ -455,7 +455,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         let temporal_axes = unresolved_temporal_axes.clone().resolve();
         let time_axis = temporal_axes.variable_time_axis();
 
-        let entities = Read::<Entity>::read(self, filter, Some(&temporal_axes))
+        let entities = Read::<Entity>::read_vec(self, filter, Some(&temporal_axes))
             .await?
             .into_iter()
             .map(|entity| (entity.vertex_id(time_axis), entity))

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -74,7 +74,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
         let temporal_axes = unresolved_temporal_axes.clone().resolve();
         let time_axis = temporal_axes.variable_time_axis();
 
-        let data_types = Read::<DataTypeWithMetadata>::read(self, filter, Some(&temporal_axes))
+        let data_types = Read::<DataTypeWithMetadata>::read_vec(self, filter, Some(&temporal_axes))
             .await?
             .into_iter()
             .map(|entity| (entity.vertex_id(time_axis), entity))

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -47,7 +47,7 @@ impl<C: AsClient> PostgresStore<C> {
                         EdgeDirection::Outgoing,
                     )
                 {
-                    for property_type in <Self as Read<PropertyTypeWithMetadata>>::read(
+                    for property_type in <Self as Read<PropertyTypeWithMetadata>>::read_vec(
                         self,
                         &Filter::<PropertyTypeWithMetadata>::for_ontology_edge_by_entity_type_vertex_id(
                             &entity_type_vertex_id,
@@ -82,7 +82,7 @@ impl<C: AsClient> PostgresStore<C> {
                         EdgeDirection::Outgoing,
                     )
                 {
-                    for referenced_entity_type in <Self as Read<EntityTypeWithMetadata>>::read(
+                    for referenced_entity_type in <Self as Read<EntityTypeWithMetadata>>::read_vec(
                         self,
                         &Filter::<EntityTypeWithMetadata>::for_ontology_edge_by_entity_type_vertex_id(
                             &entity_type_vertex_id,
@@ -118,7 +118,7 @@ impl<C: AsClient> PostgresStore<C> {
                         EdgeDirection::Outgoing,
                     )
                 {
-                    for referenced_entity_type in <Self as Read<EntityTypeWithMetadata>>::read(
+                    for referenced_entity_type in <Self as Read<EntityTypeWithMetadata>>::read_vec(
                         self,
                         &Filter::<EntityTypeWithMetadata>::for_ontology_edge_by_entity_type_vertex_id(
                             &entity_type_vertex_id,
@@ -154,7 +154,7 @@ impl<C: AsClient> PostgresStore<C> {
                         EdgeDirection::Outgoing,
                     )
                 {
-                    for referenced_entity_type in <Self as Read<EntityTypeWithMetadata>>::read(
+                    for referenced_entity_type in <Self as Read<EntityTypeWithMetadata>>::read_vec(
                         self,
                         &Filter::<EntityTypeWithMetadata>::for_ontology_edge_by_entity_type_vertex_id(
                             &entity_type_vertex_id,
@@ -253,11 +253,12 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         let temporal_axes = unresolved_temporal_axes.clone().resolve();
         let time_axis = temporal_axes.variable_time_axis();
 
-        let entity_types = Read::<EntityTypeWithMetadata>::read(self, filter, Some(&temporal_axes))
-            .await?
-            .into_iter()
-            .map(|entity| (entity.vertex_id(time_axis), entity))
-            .collect();
+        let entity_types =
+            Read::<EntityTypeWithMetadata>::read_vec(self, filter, Some(&temporal_axes))
+                .await?
+                .into_iter()
+                .map(|entity| (entity.vertex_id(time_axis), entity))
+                .collect();
 
         let mut subgraph = Subgraph::new(
             graph_resolve_depths,

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -47,7 +47,7 @@ impl<C: AsClient> PostgresStore<C> {
                         EdgeDirection::Outgoing,
                     )
                 {
-                    for data_type in <Self as Read<DataTypeWithMetadata>>::read(
+                    for data_type in <Self as Read<DataTypeWithMetadata>>::read_vec(
                         self,
                         &Filter::<DataTypeWithMetadata>::for_ontology_edge_by_property_type_vertex_id(
                             &property_type_vertex_id,
@@ -82,7 +82,7 @@ impl<C: AsClient> PostgresStore<C> {
                         EdgeDirection::Outgoing,
                     )
                 {
-                    for referenced_property_type in <Self as Read<PropertyTypeWithMetadata>>::read(
+                    for referenced_property_type in <Self as Read<PropertyTypeWithMetadata>>::read_vec(
                         self,
                         &Filter::<PropertyTypeWithMetadata>::for_ontology_edge_by_property_type_vertex_id(
                             &property_type_vertex_id,
@@ -183,7 +183,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         let time_axis = temporal_axes.variable_time_axis();
 
         let property_types =
-            Read::<PropertyTypeWithMetadata>::read(self, filter, Some(&temporal_axes))
+            Read::<PropertyTypeWithMetadata>::read_vec(self, filter, Some(&temporal_axes))
                 .await?
                 .into_iter()
                 .map(|entity| (entity.vertex_id(time_axis), entity))


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To avoid keeping the database in memory when writing it to stdout, this changes the `Read` trait to allow streaming of the data.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1204086167143892/1204320436419772/f) _(internal)_
- [Asana task](https://app.asana.com/0/1202805690238892/1202923536131158/f) _(internal)_


## 🔍 What does this change?

- Add `ReadStream` associated type to `Read`
- Move the `try_collect()` to `read_vec`, which can be seen as a convenient function to deal with the streams. I'm going to remove this functionality again in a later PR but to avoid touching the traversing logic, now, I leave this behavior unchanged
- Replace almost all calls to `read` to `read_vec`
- Use the stream returned from `read` when writing the test data. This PR still stores the data in memory, but enables streaming from the datastore to the graph at all.

## 🔍 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [ ] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [x] does not modify any publishable libraries
- [ ] I am unsure / need advice