### PR TITLE
`ci`: use `yq` to install all necessary components

### DIFF
--- a/.github/actions/install-rust-toolchain/action.yml
+++ b/.github/actions/install-rust-toolchain/action.yml
@@ -18,7 +18,7 @@ runs:
       shell: bash
       run: |
         # regex for components that are only available on nightly and should not be installed on stable
-        NIGHTLY_ONLY="miri|llmv-cov-minimal"
+        NIGHTLY_ONLY="miri|llvm-tools"
 
         # extract components from the rust-toolchain.toml 
         COMPONENTS=$(cat rust-toolchain.toml | yq -p toml '.toolchain.components[]')

--- a/.github/actions/install-rust-toolchain/action.yml
+++ b/.github/actions/install-rust-toolchain/action.yml
@@ -18,6 +18,7 @@ runs:
       shell: bash
       run: |
         # regex for components that are only available on nightly and should not be installed on stable
+        # these are in variables due to: https://stackoverflow.com/a/56449915/9077988
         NIGHTLY_ONLY="miri|llvm-tools|llvm-tools-preview"
         NIGHTLY_TOOLCHAIN="nightly-.*"
 

--- a/.github/actions/install-rust-toolchain/action.yml
+++ b/.github/actions/install-rust-toolchain/action.yml
@@ -20,21 +20,20 @@ runs:
         # regex for components that are only available on nightly and should not be installed on stable
         NIGHTLY_ONLY="miri|llmv-cov-minimal"
 
-        # extract the toolchain version and components from the rust-toolchain.toml 
-        TOOLCHAIN=$(cat rust-toolchain.toml | yq -p toml '.toolchain.channel')
+        # extract components from the rust-toolchain.toml 
         COMPONENTS=$(cat rust-toolchain.toml | yq -p toml '.toolchain.components[]')
 
-        rustup toolchain install $TOOLCHAIN
+        rustup toolchain install "${{ inputs.toolchain }}"
 
         for component in $COMPONENTS; do
           # depending on the toolchain we need to conditionally skip specific components
           if [[ ! "${{ inputs.toolchain }}" == nightly* ]]; then
             # ensure that we only install components that are meant for stable
             if [[ ! $component =~ "$NIGHTLY_ONLY" ]]; then
-              rustup component add "$component"
+              rustup component add --toolchain "${{ inputs.toolchain }}" "$component"
             fi
           else
-            rustup component add "$component"  
+            rustup component add --toolchain "${{ inputs.toolchain }}" "$component"  
           fi
         done
 

--- a/.github/actions/install-rust-toolchain/action.yml
+++ b/.github/actions/install-rust-toolchain/action.yml
@@ -17,15 +17,25 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
-        # If the toolchain does match `rust-toolchain.toml` we can rely on `rustup show` to install the toolchain. If it
-        # does not match, we need to install the toolchain manually.
-        if grep -q "${{ inputs.toolchain }}" rust-toolchain.toml; then
-          rustup set profile minimal
-        else
-          export RUSTUP_TOOLCHAIN=${{ inputs.toolchain }}
-          rustup set profile default
-        fi
+        # regex for components that are only available on nightly and should not be installed on stable
+        NIGHTLY_ONLY="miri|llmv-cov-minimal"
 
-        # Installs the specified toolchains and prints it
-        rustup show
+        # extract the toolchain version and components from the rust-toolchain.toml 
+        TOOLCHAIN=$(cat rust-toolchain.toml | yq -p toml '.toolchain.channel')
+        COMPONENTS=$(cat rust-toolchain.toml | yq -p toml '.toolchain.components[]')
+
+        rustup toolchain install $TOOLCHAIN
+
+        for component in $COMPONENTS; do
+          # depending on the toolchain we need to conditionally skip specific components
+          if [[ ! "${{ inputs.toolchain }}" == nightly* ]]; then
+            # ensure that we only install components that are meant for stable
+            if [[ ! $component =~ "$NIGHTLY_ONLY" ]]; then
+              rustup component add "$component"
+            fi
+          else
+            rustup component add "$component"  
+          fi
+        done
+
         echo "RUSTUP_TOOLCHAIN=${{ inputs.toolchain }}" >> $GITHUB_ENV

--- a/.github/actions/install-rust-toolchain/action.yml
+++ b/.github/actions/install-rust-toolchain/action.yml
@@ -18,7 +18,7 @@ runs:
       shell: bash
       run: |
         # regex for components that are only available on nightly and should not be installed on stable
-        NIGHTLY_ONLY="miri|llvm-tools"
+        NIGHTLY_ONLY="miri|llvm-tools|llvm-tools-preview"
 
         # extract components from the rust-toolchain.toml 
         COMPONENTS=$(cat rust-toolchain.toml | yq -p toml '.toolchain.components[]')
@@ -27,7 +27,7 @@ runs:
 
         for component in $COMPONENTS; do
           # depending on the toolchain we need to conditionally skip specific components
-          if [[ ! "${{ inputs.toolchain }}" == nightly* ]]; then
+          if [[ ! "${{ inputs.toolchain }}" =~ "nightly-.*" ]]; then
             # ensure that we only install components that are meant for stable
             if [[ ! $component =~ "$NIGHTLY_ONLY" ]]; then
               rustup component add --toolchain "${{ inputs.toolchain }}" "$component"

--- a/.github/actions/install-rust-toolchain/action.yml
+++ b/.github/actions/install-rust-toolchain/action.yml
@@ -19,6 +19,7 @@ runs:
       run: |
         # regex for components that are only available on nightly and should not be installed on stable
         NIGHTLY_ONLY="miri|llvm-tools|llvm-tools-preview"
+        NIGHTLY_TOOLCHAIN="nightly-.*"
 
         # extract components from the rust-toolchain.toml 
         COMPONENTS=$(cat rust-toolchain.toml | yq -p toml '.toolchain.components[]')
@@ -27,9 +28,9 @@ runs:
 
         for component in $COMPONENTS; do
           # depending on the toolchain we need to conditionally skip specific components
-          if [[ ! "${{ inputs.toolchain }}" =~ "nightly-.*" ]]; then
+          if [[ ! "${{ inputs.toolchain }}" =~ $NIGHTLY_TOOLCHAIN ]]; then
             # ensure that we only install components that are meant for stable
-            if [[ ! $component =~ "$NIGHTLY_ONLY" ]]; then
+            if [[ ! $component =~ $NIGHTLY_ONLY ]]; then
               rustup component add --toolchain "${{ inputs.toolchain }}" "$component"
             fi
           else

--- a/.github/scripts/rust/setup.py
+++ b/.github/scripts/rust/setup.py
@@ -41,7 +41,7 @@ PUBLISH_PATTERNS = [
 COVERAGE_EXCLUDE_PATTERNS = ["apps/engine**"]
 
 # We only run a subset of configurations for PRs, the rest will only be tested prior merging
-IS_PULL_REQUEST_EVENT = False
+IS_PULL_REQUEST_EVENT = "GITHUB_EVENT_NAME" in os.environ and os.environ["GITHUB_EVENT_NAME"] == "pull_request"
 
 
 def generate_diffs():

--- a/.github/scripts/rust/setup.py
+++ b/.github/scripts/rust/setup.py
@@ -41,7 +41,7 @@ PUBLISH_PATTERNS = [
 COVERAGE_EXCLUDE_PATTERNS = ["apps/engine**"]
 
 # We only run a subset of configurations for PRs, the rest will only be tested prior merging
-IS_PULL_REQUEST_EVENT = "GITHUB_EVENT_NAME" in os.environ and os.environ["GITHUB_EVENT_NAME"] == "pull_request"
+IS_PULL_REQUEST_EVENT = False
 
 
 def generate_diffs():


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This changes the rust ci action to install components, not via the profile but individually from the `rust-toolchain.toml`.

We can only do this now because last week, the runner image shipped with version 1.33 of `yq`, landing read toml support, without needing to install additional tools.

The runner-image is available on 99.99% of all runners (only five are left, but those have no image version tag and are always "left behind").


