### PR TITLE
Use a codec to read/write JSON Lines

### DIFF
--- a/apps/hash-graph/Cargo.lock
+++ b/apps/hash-graph/Cargo.lock
@@ -815,6 +815,7 @@ dependencies = [
  "hash-status",
  "hyper",
  "include_dir",
+ "memchr",
  "mime",
  "opentelemetry 0.18.0",
  "opentelemetry-otlp",

--- a/apps/hash-graph/Cargo.lock
+++ b/apps/hash-graph/Cargo.lock
@@ -830,6 +830,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-serde",
+ "tokio-util",
  "tonic",
  "tower",
  "tower-http",
@@ -928,6 +929,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-serde",
+ "tokio-util",
  "tracing",
  "type-fetcher",
  "type-system",
@@ -2517,9 +2519,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6a3b08b64e6dfad376fa2432c7b1f01522e37a623c3050bc95db2d3ff21583"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes",
  "futures-core",

--- a/apps/hash-graph/Cargo.lock
+++ b/apps/hash-graph/Cargo.lock
@@ -815,7 +815,6 @@ dependencies = [
  "hash-status",
  "hyper",
  "include_dir",
- "memchr",
  "mime",
  "opentelemetry 0.18.0",
  "opentelemetry-otlp",

--- a/apps/hash-graph/bin/cli/Cargo.toml
+++ b/apps/hash-graph/bin/cli/Cargo.toml
@@ -24,6 +24,7 @@ tarpc = { version = "0.32", features = ["serde1", "tokio1", "serde-transport", "
 tokio = { version = "1.27.0", features = ["rt-multi-thread", "macros"] }
 tokio-postgres = { version = "0.7.8", default-features = false }
 tokio-serde = { version = "0.8", features = ["messagepack"], optional = true }
+tokio-util = { version = "0.7.7", default-features = false, features = ["codec"] }
 tracing = "0.1.37"
 type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "bd6a197" }
 uuid = "1.3.0"

--- a/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
@@ -59,7 +59,7 @@ pub async fn snapshot(args: SnapshotArgs) -> Result<(), GraphError> {
             store
                 .dump_snapshot(FramedWrite::new(
                     io::BufWriter::new(io::stdout()),
-                    codec::JsonLines::default(),
+                    codec::JsonLinesEncoder::default(),
                 ))
                 .await
                 .change_context(GraphError)?;
@@ -70,7 +70,7 @@ pub async fn snapshot(args: SnapshotArgs) -> Result<(), GraphError> {
             store
                 .restore_snapshot(FramedRead::new(
                     io::BufReader::new(io::stdin()),
-                    codec::JsonLines::default(),
+                    codec::JsonLinesDecoder::default(),
                 ))
                 .await
                 .change_context(GraphError)?;

--- a/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
@@ -1,6 +1,5 @@
 use clap::Parser;
 use error_stack::{Result, ResultExt};
-use futures::{SinkExt, TryStreamExt};
 use graph::{
     logging::{init_logger, LoggingArgs},
     snapshot::{codec, SnapshotEntry, SnapshotStore},

--- a/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
@@ -69,21 +69,10 @@ pub async fn snapshot(args: SnapshotArgs) -> Result<(), GraphError> {
         }
         SnapshotCommand::Restore(_) => {
             store
-                .restore_snapshot(
-                    FramedRead::new(
-                        io::BufReader::new(io::stdin()),
-                        codec::JsonLines::default(),
-                    )
-                    .filter_map(|value| async move {
-                        match value {
-                            Ok(value) => Some(value),
-                            Err(report) => {
-                                tracing::error!(error = ?report, "Failed to read snapshot record");
-                                None
-                            }
-                        }
-                    }),
-                )
+                .restore_snapshot(FramedRead::new(
+                    io::BufReader::new(io::stdin()),
+                    codec::JsonLines::default(),
+                ))
                 .await
                 .change_context(GraphError)?;
 

--- a/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
@@ -59,35 +59,25 @@ pub async fn snapshot(args: SnapshotArgs) -> Result<(), GraphError> {
     match args.command {
         SnapshotCommand::Dump(_) => {
             store
-                .dump_snapshot(
-                    FramedWrite::new(
-                        io::BufWriter::new(io::stdout()),
-                        codec::JsonLinesEncoder::default(),
-                    )
-                    .sink_map_err(|report| {
-                        report.attach_printable("Failed to write snapshot to stdout")
-                    }),
-                )
+                .dump_snapshot(FramedWrite::new(
+                    io::BufWriter::new(io::stdout()),
+                    codec::JsonLinesEncoder::default(),
+                ))
                 .await
                 .change_context(GraphError)
-                .attach_printable("Failed to read snapshot from store")?;
+                .attach_printable("Failed to produce snapshot dump")?;
 
             tracing::info!("Snapshot dumped successfully");
         }
         SnapshotCommand::Restore(_) => {
             store
-                .restore_snapshot(
-                    FramedRead::new(
-                        io::BufReader::new(io::stdin()),
-                        codec::JsonLinesDecoder::default(),
-                    )
-                    .map_err(|report| {
-                        report.attach_printable("Failed to read snapshot from stdin")
-                    }),
-                )
+                .restore_snapshot(FramedRead::new(
+                    io::BufReader::new(io::stdin()),
+                    codec::JsonLinesDecoder::default(),
+                ))
                 .await
                 .change_context(GraphError)
-                .attach_printable("Failed to write snapshot to store")?;
+                .attach_printable("Failed to restore snapshot")?;
 
             tracing::info!("Snapshot restored successfully");
         }

--- a/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
@@ -1,6 +1,5 @@
 use clap::Parser;
 use error_stack::{Result, ResultExt};
-use futures::StreamExt;
 use graph::{
     logging::{init_logger, LoggingArgs},
     snapshot::{codec, SnapshotStore},

--- a/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
@@ -1,14 +1,14 @@
-use std::io::{self, BufRead, BufReader, BufWriter, Write};
-
 use clap::Parser;
-use error_stack::{IntoReport, Report, Result, ResultExt};
-use futures::{SinkExt, StreamExt};
+use error_stack::{Result, ResultExt};
+use futures::StreamExt;
 use graph::{
     logging::{init_logger, LoggingArgs},
-    snapshot::{SnapshotEntry, SnapshotStore},
+    snapshot::{codec, SnapshotStore},
     store::{DatabaseConnectionInfo, PostgresStorePool, StorePool},
 };
+use tokio::io;
 use tokio_postgres::NoTls;
+use tokio_util::codec::{FramedRead, FramedWrite};
 
 use crate::error::GraphError;
 
@@ -48,63 +48,43 @@ pub async fn snapshot(args: SnapshotArgs) -> Result<(), GraphError> {
             report
         })?;
 
-    let mut store = SnapshotStore::new(
-        pool.acquire_owned()
-            .await
-            .change_context(GraphError)
-            .map_err(|report| {
-                tracing::error!(error = ?report, "Failed to acquire database connection");
-                report
-            })?,
-    );
-
-    // TODO: Use a thin wrapper around serde-json which implements `Sink` and `Stream` to avoid the
-    //       need for a separate thread.
-    let (sender, mut receiver) = futures::channel::mpsc::channel::<SnapshotEntry>(8);
-    let mut sender = sender.sink_map_err(Report::new);
+    let mut store = SnapshotStore::new(pool.acquire().await.change_context(GraphError).map_err(
+        |report| {
+            tracing::error!(error = ?report, "Failed to acquire database connection");
+            report
+        },
+    )?);
 
     match args.command {
         SnapshotCommand::Dump(_) => {
-            let reader = tokio::spawn(async move { store.dump_snapshot(sender).await });
-
-            let mut stdout = BufWriter::new(io::stdout());
-            while let Some(entry) = receiver.next().await {
-                serde_json::to_writer(&mut stdout, &entry)
-                    .into_report()
-                    .change_context(GraphError)?;
-                stdout
-                    .write(&[b'\n'])
-                    .into_report()
-                    .change_context(GraphError)?;
-            }
-
-            reader
+            store
+                .dump_snapshot(FramedWrite::new(
+                    io::BufWriter::new(io::stdout()),
+                    codec::JsonLines::default(),
+                ))
                 .await
-                .into_report()
-                .change_context(GraphError)?
                 .change_context(GraphError)?;
 
             tracing::info!("Snapshot dumped successfully");
         }
         SnapshotCommand::Restore(_) => {
-            let writer = tokio::spawn(async move { store.restore_snapshot(receiver).await });
-
-            for line in BufReader::new(io::stdin()).lines() {
-                let entry: SnapshotEntry =
-                    serde_json::from_str(&line.into_report().change_context(GraphError)?)
-                        .into_report()
-                        .change_context(GraphError)?;
-
-                sender.send(entry).await.change_context(GraphError)?;
-            }
-
-            // Close the channel to signal the writer that we are done.
-            sender.close().await.change_context(GraphError)?;
-
-            writer
+            store
+                .restore_snapshot(
+                    FramedRead::new(
+                        io::BufReader::new(io::stdin()),
+                        codec::JsonLines::default(),
+                    )
+                    .filter_map(|value| async move {
+                        match value {
+                            Ok(value) => Some(value),
+                            Err(report) => {
+                                tracing::error!(error = ?report, "Failed to read snapshot record");
+                                None
+                            }
+                        }
+                    }),
+                )
                 .await
-                .into_report()
-                .change_context(GraphError)?
                 .change_context(GraphError)?;
 
             tracing::info!("Snapshot restored successfully");

--- a/apps/hash-graph/lib/graph/Cargo.toml
+++ b/apps/hash-graph/lib/graph/Cargo.toml
@@ -19,7 +19,6 @@ error-stack = { version = "0.3.1", features = ["spantrace"] }
 futures = "0.3.28"
 hash-status = { path = "../../../../libs/@local/status/crate" }
 hyper = "0.14.25"
-memchr = "2.5.0"
 mime = "0.3.17"
 postgres-types = { version = "0.2.5", default-features = false, features = ["derive", "with-uuid-1", "with-serde_json-1", "with-time-0_3"] }
 postgres-protocol = "0.6.5"

--- a/apps/hash-graph/lib/graph/Cargo.toml
+++ b/apps/hash-graph/lib/graph/Cargo.toml
@@ -19,6 +19,7 @@ error-stack = { version = "0.3.1", features = ["spantrace"] }
 futures = "0.3.28"
 hash-status = { path = "../../../../libs/@local/status/crate" }
 hyper = "0.14.25"
+memchr = "2.5.0"
 mime = "0.3.17"
 postgres-types = { version = "0.2.5", default-features = false, features = ["derive", "with-uuid-1", "with-serde_json-1", "with-time-0_3"] }
 postgres-protocol = "0.6.5"

--- a/apps/hash-graph/lib/graph/Cargo.toml
+++ b/apps/hash-graph/lib/graph/Cargo.toml
@@ -28,6 +28,7 @@ serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"
 tokio = { version = "1.27.0", default-features = false }
 tokio-postgres = { version = "0.7.8", default-features = false }
+tokio-util = { version = "0.7.7", default-features = false, features = ["codec"] }
 tower = "0.4.13"
 tower-http = { version = "0.4.0", features = ["trace"] }
 tracing = "0.1.37"

--- a/apps/hash-graph/lib/graph/src/shared/identifier/knowledge.rs
+++ b/apps/hash-graph/lib/graph/src/shared/identifier/knowledge.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{fmt, str::FromStr};
 
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use tokio_postgres::types::{FromSql, ToSql};
@@ -23,12 +23,18 @@ pub struct EntityId {
     pub entity_uuid: EntityUuid,
 }
 
+impl fmt::Display for EntityId {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "{}%{}", self.owned_by_id, self.entity_uuid)
+    }
+}
+
 impl Serialize for EntityId {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        serializer.serialize_str(&format!("{}%{}", self.owned_by_id, self.entity_uuid))
+        serializer.serialize_str(&self.to_string())
     }
 }
 

--- a/apps/hash-graph/lib/graph/src/snapshot.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot.rs
@@ -78,15 +78,13 @@ impl SnapshotEntry {
                 }
             }
             Self::Entity(entity) => {
-                let entity_id = format!(
-                    "{}%{}",
-                    entity.metadata.record_id.entity_id.owned_by_id,
-                    entity.metadata.record_id.entity_id.entity_uuid
-                );
-                context.push_body(format!("entity: {entity_id}"));
+                context.push_body(format!("entity: {}", entity.metadata.record_id.entity_id));
                 if context.alternate() {
                     if let Ok(json) = serde_json::to_string_pretty(entity) {
-                        context.push_appendix(format!("{entity_id}:\n{json}"));
+                        context.push_appendix(format!(
+                            "{}:\n{json}",
+                            entity.metadata.record_id.entity_id
+                        ));
                     }
                 }
             }

--- a/apps/hash-graph/lib/graph/src/snapshot.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot.rs
@@ -1,3 +1,5 @@
+pub mod codec;
+
 mod entity;
 mod error;
 mod metadata;

--- a/apps/hash-graph/lib/graph/src/snapshot.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot.rs
@@ -183,9 +183,7 @@ where
     ) -> Result<(), SnapshotRestoreError> {
         let mut snapshot = pin!(snapshot);
         while let Some(entry) = snapshot.next().await {
-            let entry = entry
-                .change_context(SnapshotRestoreError::Canceled)
-                .attach_printable("reading the records resulted in an error")?;
+            let entry = entry.change_context(SnapshotRestoreError::Canceled)?;
 
             match entry {
                 SnapshotEntry::Snapshot(global) => {

--- a/apps/hash-graph/lib/graph/src/snapshot/codec.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/codec.rs
@@ -1,0 +1,53 @@
+use std::{
+    io::{self, BufRead, Write},
+    marker::PhantomData,
+};
+
+use bytes::{Buf, BufMut, BytesMut};
+use derivative::Derivative;
+use error_stack::Report;
+use serde::{de::DeserializeOwned, Serialize};
+use tokio_util::codec::{Decoder, Encoder};
+
+#[derive(Derivative)]
+#[derivative(
+    Debug(bound = ""),
+    Default(bound = ""),
+    Copy(bound = ""),
+    Clone(bound = ""),
+    Eq(bound = ""),
+    PartialEq(bound = ""),
+    Hash(bound = "")
+)]
+pub struct JsonLines<T> {
+    _marker: PhantomData<fn() -> T>,
+}
+
+impl<T: Serialize> Encoder<T> for JsonLines<T> {
+    type Error = Report<io::Error>;
+
+    fn encode(&mut self, item: T, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        let mut writer = dst.writer();
+        serde_json::to_writer(&mut writer, &item).map_err(io::Error::from)?;
+        writeln!(writer)?;
+        Ok(())
+    }
+}
+
+impl<T: DeserializeOwned> Decoder for JsonLines<T> {
+    type Error = Report<io::Error>;
+    type Item = T;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<T>, Self::Error> {
+        let mut reader = src.reader();
+        let mut line = String::new();
+        reader.read_line(&mut line)?;
+        if line.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(
+                serde_json::from_str::<T>(&line).map_err(io::Error::from)?,
+            ))
+        }
+    }
+}

--- a/apps/hash-graph/lib/graph/src/snapshot/codec.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/codec.rs
@@ -37,6 +37,24 @@ pub struct JsonLinesDecoder<T> {
     _marker: PhantomData<fn() -> T>,
 }
 
+impl<T> JsonLinesDecoder<T> {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            lines: LinesCodec::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    #[must_use]
+    pub fn with_max_length(max_length: usize) -> Self {
+        Self {
+            lines: LinesCodec::new_with_max_length(max_length),
+            _marker: PhantomData,
+        }
+    }
+}
+
 impl<T: DeserializeOwned> Decoder for JsonLinesDecoder<T> {
     // `Decoder::Error` requires `From<io::Error>` so we need to use `Report<io::Error>` here.
     type Error = Report<io::Error>;

--- a/apps/hash-graph/lib/graph/src/snapshot/error.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/error.rs
@@ -22,12 +22,14 @@ impl Error for SnapshotDumpError {}
 #[derive(Debug)]
 pub enum SnapshotRestoreError {
     Unsupported,
+    Canceled,
 }
 
 impl fmt::Display for SnapshotRestoreError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Unsupported => write!(f, "The snapshot contains unsupported entries"),
+            Self::Canceled => write!(f, "The snapshot restore was canceled"),
         }
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, we rely on channels, which is suboptimal. This replaces the channels by a framed read/write by providing a very basic codec for JSON Lines. This is a direct follow-up of #2355.

## 🔗 Related links

- #2355 

## 🚫 Blocked by

- #2355 

## 🔍 What does this change?

- Implement `codec::JsonLines`, a thin wrapper around `serde_json`
- Replace the implementation of channels with framed reads/writes

## 🔍 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [ ] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [x] does not modify any publishable libraries
- [ ] I am unsure / need advice