### PR TITLE
Set cache sharing of rust docker builds to `locked`

### DIFF
--- a/apps/hash-graph/docker/Dockerfile
+++ b/apps/hash-graph/docker/Dockerfile
@@ -45,9 +45,9 @@ ARG TYPE_FETCHER=yes
 # To be removed once https://github.com/open-telemetry/opentelemetry-rust/issues/934 is sorted
 RUN apk add --no-cache make protobuf-dev
 
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/usr/local/apps/hash-graph/target \
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/usr/local/apps/hash-graph/target,sharing=locked \
     if [[ ${TYPE_FETCHER^^} == Y* || ${TYPE_FETCHER^^} == T* || $TYPE_FETCHER == 1 ]] ; then  \
       cargo install --path bin/cli --profile $PROFILE --features type-fetcher --locked; \
     else \


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We encounter weird issues fetching the old revision in CI. This is an attempt to fix this issue.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Slack thread](https://hashintel.slack.com/archives/C022217GAHF/p1680780643701939) _(internal)_

## 🔍 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [ ] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [x] does not modify any publishable libraries
- [ ] I am unsure / need advice
