### PR TITLE
Allow Report to be thrown as a JS error with wasm

### DIFF
--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -23,6 +23,7 @@ anyhow = { version = "1.0.70", default-features = false, optional = true }
 eyre = { version = "0.6", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true }
 spin = { version = "0.9", default-features = false, optional = true, features = ['rwlock', 'once'] }
+wasm-bindgen = { version = "0.2", optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0.159", features = ["derive"] }
@@ -51,6 +52,7 @@ std = ["anyhow?/std"]
 eyre = ["dep:eyre", "std"]
 serde = ["dep:serde"]
 hooks = ['dep:spin']
+wasm = ['dep:wasm-bindgen']
 
 [package.metadata.docs.rs]
 all-features = true

--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "wasm")]
+use alloc::string::ToString;
 use alloc::{boxed::Box, vec, vec::Vec};
 #[cfg(nightly)]
 use core::error::Error;
@@ -11,6 +13,8 @@ use std::process::ExitCode;
 
 #[cfg(feature = "spantrace")]
 use tracing_error::{SpanTrace, SpanTraceStatus};
+#[cfg(feature = "wasm")]
+use wasm_bindgen::JsValue;
 
 #[cfg(nightly)]
 use crate::iter::{RequestRef, RequestValue};
@@ -724,5 +728,12 @@ impl<Context> Extend<Self> for Report<Context> {
         for item in iter {
             self.extend_one(item);
         }
+    }
+}
+
+#[cfg(feature = "wasm")]
+impl<Context> From<Report<Context>> for JsValue {
+    fn from(report: Report<Context>) -> Self {
+        JsValue::from_str(&report.to_string())
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This allows `Report` to be thrown as a JS error, allowing the use of this library with wasm.

## 🔍 What does this change?

- New `wasm` feature that adds the optional `wasm-bindgen` dependency.
- Implements `Into<JsValue>` for `Report<Context>`, which subsequently allows the implementation of the [`ReturnWasmAbi`](https://docs.rs/wasm-bindgen/latest/wasm_bindgen/convert/trait.ReturnWasmAbi.html) trait for `error_stack::Result`.

## 📜 Does this require a change to the docs?

- The docs for `error-stack` need updating to explain that users who would like to throw `Report` as a JS error need to enable the `wasm` feature
