### PR TITLE
Implement `ToSql` and `FromSql` for `EntityProperties`

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -247,10 +247,6 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             .await
             .change_context(InsertionError)?;
 
-        let properties = serde_json::to_value(properties)
-            .into_report()
-            .change_context(InsertionError)?;
-
         let row = self
             .as_client()
             .query_one(
@@ -509,10 +505,6 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         let entity_type_ontology_id = self
             .ontology_id_by_url(&entity_type_id)
             .await
-            .change_context(UpdateError)?;
-
-        let properties = serde_json::to_value(properties)
-            .into_report()
             .change_context(UpdateError)?;
 
         // The transaction is required to check if the update happened. If there is no returned

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -12,10 +12,7 @@ use crate::{
         account::AccountId,
         knowledge::{EntityId, EntityRecordId, EntityTemporalMetadata},
     },
-    knowledge::{
-        Entity, EntityLinkOrder, EntityMetadata, EntityProperties, EntityQueryPath, EntityUuid,
-        LinkData,
-    },
+    knowledge::{Entity, EntityLinkOrder, EntityMetadata, EntityQueryPath, EntityUuid, LinkData},
     ontology::EntityTypeQueryPath,
     provenance::{OwnedById, ProvenanceMetadata, RecordCreatedById},
     store::{
@@ -122,10 +119,6 @@ impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
             .change_context(QueryError)?
             .map(|row| row.into_report().change_context(QueryError))
             .and_then(move |row| async move {
-                let properties: EntityProperties =
-                    serde_json::from_value(row.get(properties_index))
-                        .into_report()
-                        .change_context(QueryError)?;
                 let entity_type_id = VersionedUrl::from_str(row.get(type_id_index))
                     .into_report()
                     .change_context(QueryError)?;
@@ -174,7 +167,7 @@ impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
                     RecordCreatedById::new(row.get(record_created_by_id_index));
 
                 Ok(Entity {
-                    properties,
+                    properties: row.get(properties_index),
                     link_data,
                     metadata: EntityMetadata::new(
                         EntityRecordId {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

While implementing the restore logic I noticed, that `postgres_types` provides a nice wrapper to allow converting to/from JSON. This avoids the need to convert the entity properties to a `serde_json::Value` and then convert it to the postgres representation.