### PR TITLE
Provide `Timestamp::UNIX_EPOCH` as constant

### DIFF
--- a/apps/hash-graph/lib/graph/src/shared/identifier/time/timestamp.rs
+++ b/apps/hash-graph/lib/graph/src/shared/identifier/time/timestamp.rs
@@ -59,6 +59,11 @@ impl<A> TemporalTagged for Timestamp<A> {
 }
 
 impl<A> Timestamp<A> {
+    pub const UNIX_EPOCH: Self = Self {
+        axis: PhantomData,
+        time: OffsetDateTime::UNIX_EPOCH,
+    };
+
     #[must_use]
     pub fn now() -> Self {
         Self {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

While implementing the restore logic I had to take into account that the temporal metadata may not exist. In this case, we want to fallback to a sensible time for the decision time, and `UNIX_EPOCH` makes sense here. Currently, we don't really have a way to create a `Timestamp` other than deserializing, so this adds the `UNIX_EPOCH` constant.