### PR TITLE
`deer`: implement `Deserialize` for `core::option`

### DIFF
--- a/libs/deer/src/impls/core.rs
+++ b/libs/deer/src/impls/core.rs
@@ -4,5 +4,6 @@ mod bool;
 mod floating;
 mod integral;
 mod non_zero;
+mod option;
 mod string;
 mod unit;

--- a/libs/deer/src/impls/core/option.rs
+++ b/libs/deer/src/impls/core/option.rs
@@ -38,9 +38,11 @@ pub struct OptionReflection<T: ?Sized>(PhantomData<fn() -> *const T>);
 
 impl<T: Reflection + ?Sized> Reflection for OptionReflection<T> {
     fn schema(doc: &mut Document) -> Schema {
-        // TODO: how?!
-        // needs to be oneOf null/none/T
-        todo!()
+        // TODO: an accurate reflection is not really possible right now
+        //  we need to do oneOf null/none/T and `Schema` does not support it right now
+        //  this needs to be fixed until `0.1`
+        // For now we just fallback to `T`
+        T::schema(doc)
     }
 }
 

--- a/libs/deer/src/impls/core/option.rs
+++ b/libs/deer/src/impls/core/option.rs
@@ -1,0 +1,53 @@
+use core::marker::PhantomData;
+
+use error_stack::{Result, ResultExt};
+
+use crate::{
+    error::{DeserializeError, VisitorError},
+    Deserialize, Deserializer, Document, OptionalVisitor, Reflection, Schema,
+};
+
+struct OptionVisitor<T>(PhantomData<fn() -> *const T>);
+
+impl<'de, T: Deserialize<'de>> OptionalVisitor<'de> for OptionVisitor<T> {
+    type Value = Option<T>;
+
+    fn expecting(&self) -> Document {
+        Self::Value::reflection()
+    }
+
+    fn visit_none(self) -> Result<Self::Value, VisitorError> {
+        Ok(None)
+    }
+
+    fn visit_null(self) -> Result<Self::Value, VisitorError> {
+        Ok(None)
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, VisitorError>
+    where
+        D: Deserializer<'de>,
+    {
+        T::deserialize(deserializer)
+            .change_context(VisitorError)
+            .map(Some)
+    }
+}
+
+pub struct OptionReflection<T: ?Sized>(PhantomData<fn() -> *const T>);
+
+impl<T: Reflection + ?Sized> Reflection for OptionReflection<T> {
+    fn schema(doc: &mut Document) -> Schema {
+        // TODO: how?!
+        todo!()
+    }
+}
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for Option<T> {
+    type Reflection = OptionReflection<T::Reflection>;
+
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, DeserializeError> {
+        de.deserialize_optional(OptionVisitor(PhantomData))
+            .change_context(DeserializeError)
+    }
+}

--- a/libs/deer/src/impls/core/option.rs
+++ b/libs/deer/src/impls/core/option.rs
@@ -39,6 +39,7 @@ pub struct OptionReflection<T: ?Sized>(PhantomData<fn() -> *const T>);
 impl<T: Reflection + ?Sized> Reflection for OptionReflection<T> {
     fn schema(doc: &mut Document) -> Schema {
         // TODO: how?!
+        // needs to be oneOf null/none/T
         todo!()
     }
 }

--- a/libs/deer/tests/test_impls_core_option.rs
+++ b/libs/deer/tests/test_impls_core_option.rs
@@ -1,0 +1,15 @@
+use deer_desert::{assert_tokens, Token};
+use proptest::prelude::*;
+
+#[cfg(not(miri))]
+proptest! {
+    #[test]
+    fn option_some_ok(value in any::<u8>()) {
+        assert_tokens(&Some(value), &[Token::Number(value.into())]);
+    }
+}
+
+#[test]
+fn option_none_ok() {
+    assert_tokens(&None::<u8>, &[Token::Null]);
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Implements `Deserialize` for:

* `core::option::Option`

Taken from #1875 

## ❗ Known Limitations

The current schema is problematic; it cannot accurately represent `oneOf`, and two different proposals to solve this are available as a prototype.

## 🔗 Related links

* #1875 
* #1700 

## 🔍 Has this modified a publishable library?

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [ ] modifies a **block** that will need publishing via GitHub action once merged
- [ ] does not modify any publishable blocks or libraries
- [ ] I am unsure / need advice

