### PR TITLE
`deer`: implement `Deserialize` for `core::mem`

### DIFF
--- a/libs/deer/src/impls/core.rs
+++ b/libs/deer/src/impls/core.rs
@@ -3,6 +3,7 @@ mod atomic;
 mod bool;
 mod floating;
 mod integral;
+mod mem;
 mod non_zero;
 mod string;
 mod unit;

--- a/libs/deer/src/impls/core/mem.rs
+++ b/libs/deer/src/impls/core/mem.rs
@@ -4,14 +4,8 @@ use error_stack::Result;
 
 use crate::{error::DeserializeError, Deserialize, Deserializer, Document, Reflection, Schema};
 
-impl<T: Reflection + ?Sized> Reflection for ManuallyDrop<T> {
-    fn schema(doc: &mut Document) -> Schema {
-        T::schema(doc)
-    }
-}
-
 impl<'de, T: Deserialize<'de>> Deserialize<'de> for ManuallyDrop<T> {
-    type Reflection = ManuallyDrop<T::Reflection>;
+    type Reflection = T::Reflection;
 
     fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, DeserializeError> {
         T::deserialize(de).map(Self::new)

--- a/libs/deer/src/impls/core/mem.rs
+++ b/libs/deer/src/impls/core/mem.rs
@@ -1,0 +1,19 @@
+use core::mem::ManuallyDrop;
+
+use error_stack::Result;
+
+use crate::{error::DeserializeError, Deserialize, Deserializer, Document, Reflection, Schema};
+
+impl<T: Reflection + ?Sized> Reflection for ManuallyDrop<T> {
+    fn schema(doc: &mut Document) -> Schema {
+        T::schema(doc)
+    }
+}
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for ManuallyDrop<T> {
+    type Reflection = ManuallyDrop<T::Reflection>;
+
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, DeserializeError> {
+        T::deserialize(de).map(Self::new)
+    }
+}

--- a/libs/deer/src/impls/core/mem.rs
+++ b/libs/deer/src/impls/core/mem.rs
@@ -2,7 +2,7 @@ use core::mem::ManuallyDrop;
 
 use error_stack::Result;
 
-use crate::{error::DeserializeError, Deserialize, Deserializer, Document, Reflection, Schema};
+use crate::{error::DeserializeError, Deserialize, Deserializer};
 
 impl<'de, T: Deserialize<'de>> Deserialize<'de> for ManuallyDrop<T> {
     type Reflection = T::Reflection;

--- a/libs/deer/tests/test_impls_core_mem.rs
+++ b/libs/deer/tests/test_impls_core_mem.rs
@@ -1,0 +1,30 @@
+use core::mem::ManuallyDrop;
+
+use deer::Deserialize;
+use deer_desert::{assert_tokens, Token};
+use proptest::prelude::*;
+use serde::Serialize;
+use similar_asserts::assert_serde_eq;
+
+proptest! {
+    #[test]
+    fn manually_drop_ok(value in any::<u8>()) {
+        assert_tokens(&ManuallyDrop::new(value), &[Token::Number(value.into())]);
+    }
+}
+
+fn assert_json(lhs: impl Serialize, rhs: impl Serialize) {
+    let lhs = serde_json::to_value(lhs).expect("should be able to serialize lhs");
+    let rhs = serde_json::to_value(rhs).expect("should be able to serialize rhs");
+
+    assert_serde_eq!(lhs, rhs);
+}
+
+// test that the `Reflection` of all types are the same as their underlying type
+#[test]
+fn manually_drop_reflection_same() {
+    let lhs = ManuallyDrop::<u8>::reflection();
+    let rhs = u8::reflection();
+
+    assert_json(lhs, rhs);
+}

--- a/libs/deer/tests/test_impls_core_mem.rs
+++ b/libs/deer/tests/test_impls_core_mem.rs
@@ -6,6 +6,7 @@ use proptest::prelude::*;
 use serde::Serialize;
 use similar_asserts::assert_serde_eq;
 
+#[cfg(not(miri))]
 proptest! {
     #[test]
     fn manually_drop_ok(value in any::<u8>()) {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Implements `Deserialize` for:

* `core::mem::ManuallyDrop`

taken from #1875 

## 🔗 Related links

* #1875 
* #1700 

## 🔍 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [ ] modifies a **block** that will need publishing via GitHub action once merged
- [ ] does not modify any publishable blocks or libraries
- [ ] I am unsure / need advice
