### PR TITLE
`deer`: implement `Deserialize` for `core::cmp`

### DIFF
--- a/libs/deer/src/impls/core.rs
+++ b/libs/deer/src/impls/core.rs
@@ -1,6 +1,7 @@
 mod array;
 mod atomic;
 mod bool;
+mod cmp;
 mod floating;
 mod integral;
 mod non_zero;

--- a/libs/deer/src/impls/core/cmp.rs
+++ b/libs/deer/src/impls/core/cmp.rs
@@ -1,0 +1,16 @@
+use core::cmp::{Ordering, Reverse};
+
+use error_stack::Result;
+
+use crate::{
+    error::{DeserializeError, VisitorError},
+    Deserialize, Deserializer, Document, Reflection, Schema, Visitor,
+};
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for Reverse<T> {
+    type Reflection = T::Reflection;
+
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, DeserializeError> {
+        T::deserialize(de).map(Reverse)
+    }
+}

--- a/libs/deer/src/impls/core/cmp.rs
+++ b/libs/deer/src/impls/core/cmp.rs
@@ -1,9 +1,12 @@
 use core::cmp::{Ordering, Reverse};
 
-use error_stack::Result;
+use error_stack::{Report, Result, ResultExt};
 
 use crate::{
-    error::{DeserializeError, VisitorError},
+    error::{
+        DeserializeError, ExpectedVariant, ReceivedVariant, UnknownVariantError, Variant,
+        VisitorError,
+    },
     Deserialize, Deserializer, Document, Reflection, Schema, Visitor,
 };
 
@@ -12,5 +15,65 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for Reverse<T> {
 
     fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, DeserializeError> {
         T::deserialize(de).map(Reverse)
+    }
+}
+
+struct OrderingVisitor;
+
+impl<'de> Visitor<'de> for OrderingVisitor {
+    type Value = Ordering;
+
+    fn expecting(&self) -> Document {
+        Ordering::reflection()
+    }
+
+    fn visit_str(self, v: &str) -> Result<Self::Value, VisitorError> {
+        match v {
+            "Less" => Ok(Ordering::Less),
+            "Equal" => Ok(Ordering::Equal),
+            "Greater" => Ok(Ordering::Greater),
+            _ => Err(Report::new(UnknownVariantError.into_error())
+                .attach(ReceivedVariant::new(v))
+                .attach(ExpectedVariant::new("Less"))
+                .attach(ExpectedVariant::new("Equal"))
+                .attach(ExpectedVariant::new("Greater"))
+                .change_context(VisitorError)),
+        }
+    }
+
+    fn visit_bytes(self, v: &[u8]) -> Result<Self::Value, VisitorError> {
+        match v {
+            b"Less" => Ok(Ordering::Less),
+            b"Equal" => Ok(Ordering::Equal),
+            b"Greater" => Ok(Ordering::Greater),
+            _ => {
+                let mut error = Report::new(UnknownVariantError.into_error())
+                    .attach(ExpectedVariant::new("Less"))
+                    .attach(ExpectedVariant::new("Equal"))
+                    .attach(ExpectedVariant::new("Greater"));
+
+                if let Ok(received) = core::str::from_utf8(v) {
+                    error = error.attach(ReceivedVariant::new(received));
+                }
+
+                Err(error.change_context(VisitorError))
+            }
+        }
+    }
+}
+
+impl Reflection for Ordering {
+    fn schema(_: &mut Document) -> Schema {
+        Schema::new("string").with("oneOf", ["Less", "Equal", "Greater"])
+    }
+}
+
+// we can directly call `deserialize_str` because we only have identifier with no data
+impl<'de> Deserialize<'de> for Ordering {
+    type Reflection = Self;
+
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, DeserializeError> {
+        de.deserialize_str(OrderingVisitor)
+            .change_context(DeserializeError)
     }
 }

--- a/libs/deer/tests/test_impls_core_cmp.rs
+++ b/libs/deer/tests/test_impls_core_cmp.rs
@@ -1,0 +1,26 @@
+use core::cmp::{Ordering, Reverse};
+
+use deer_desert::{assert_tokens, Token};
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn reverse_ok(value in any::<u8>()) {
+        assert_tokens(&Reverse(value), &[Token::Number(value.into())]);
+    }
+}
+
+#[test]
+fn ordering_less_ok() {
+    assert_tokens(&Ordering::Less, &[Token::String("Less")]);
+}
+
+#[test]
+fn ordering_equal_ok() {
+    assert_tokens(&Ordering::Equal, &[Token::String("Equal")]);
+}
+
+#[test]
+fn ordering_greater_ok() {
+    assert_tokens(&Ordering::Greater, &[Token::String("Greater")]);
+}

--- a/libs/deer/tests/test_impls_core_cmp.rs
+++ b/libs/deer/tests/test_impls_core_cmp.rs
@@ -1,7 +1,10 @@
 use core::cmp::{Ordering, Reverse};
 
+use deer::Deserialize;
 use deer_desert::{assert_tokens, Token};
 use proptest::prelude::*;
+use serde::Serialize;
+use similar_asserts::assert_serde_eq;
 
 proptest! {
     #[test]
@@ -23,4 +26,20 @@ fn ordering_equal_ok() {
 #[test]
 fn ordering_greater_ok() {
     assert_tokens(&Ordering::Greater, &[Token::String("Greater")]);
+}
+
+fn assert_json(lhs: impl Serialize, rhs: impl Serialize) {
+    let lhs = serde_json::to_value(lhs).expect("should be able to serialize lhs");
+    let rhs = serde_json::to_value(rhs).expect("should be able to serialize rhs");
+
+    assert_serde_eq!(lhs, rhs);
+}
+
+// test that the `Reflection` of all types are the same as their underlying type
+#[test]
+fn reverse_reflection_same() {
+    let lhs = Reverse::<u8>::reflection();
+    let rhs = u8::reflection();
+
+    assert_json(lhs, rhs);
 }

--- a/libs/deer/tests/test_impls_core_cmp.rs
+++ b/libs/deer/tests/test_impls_core_cmp.rs
@@ -6,6 +6,7 @@ use proptest::prelude::*;
 use serde::Serialize;
 use similar_asserts::assert_serde_eq;
 
+#[cfg(not(miri))]
 proptest! {
     #[test]
     fn reverse_ok(value in any::<u8>()) {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Implements `Deserialize` for:

* `core::cmp::Reverse` (taken from #1875)
* `core::cmp::Ordering` (new, not included in `serde`)

## 🔗 Related links

* #1875 
* #1700 

## 🔍 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [ ] modifies a **block** that will need publishing via GitHub action once merged
- [ ] does not modify any publishable blocks or libraries
- [ ] I am unsure / need advice
