### PR TITLE
change emoji in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,7 @@
 
 - ...
 
-## 🔍 Has this modified a publishable library?
+## 🚀 Has this modified a publishable library?
 
 <!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
 <!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This is very small change, but changes the emoji of the "has this modified a publishable library" from 🔍 to 🚀. I have been creating quite a few PRs today, and the fact that both sections "What does this change?" and "Has this modified a publishable library?" has somewhat annoyed me because I often orient myself on these emoji when scanning a PR^^ (This is also why I am using 📋 for todos and ❓ for open questions and ❗ for problems, etc. if the existing sections are not sufficient).

I thought a 🚀 might be more suitable for the section, as I've seen it used for releases/deployments. As an alternative, we could also use 🚢  (as in [_ship it_](https://www.youtube.com/watch?v=82ANkjVEpYk)), which might also work.

## 🔍 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [ ] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [ ] modifies a **block** that will need publishing via GitHub action once merged
- [x] does not modify any publishable blocks or libraries
- [ ] I am unsure / need advice
