### PR TITLE
Exclude `.config/lints.toml` from publishing

### DIFF
--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 members = [".", "macros"]
 default-members = ["."]
-exclude = ["package.json"]
+exclude = ["package.json", ".config/lints.toml"]
 
 [package]
 name = "error-stack"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Externally, the `.config/lints.toml` cannot be used.

Please note, that this PR is from a fork of the repository to test external contributions. 