### PR TITLE
Fix OpenAPI generation

### DIFF
--- a/apps/hash-graph/lib/graph/src/api/rest/account.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/account.rs
@@ -43,7 +43,7 @@ impl RoutedResource for AccountResource {
     path = "/accounts",
     tag = "Account",
     responses(
-        (status = 201, content_type = "application/json", description = "The schema of the created account", body = AccountId),
+        (status = 200, content_type = "application/json", description = "The schema of the created account", body = AccountId),
 
         (status = 500, description = "Store error occurred"),
     )

--- a/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
@@ -80,7 +80,7 @@ struct CreateDataTypeRequest {
     request_body = CreateDataTypeRequest,
     tag = "DataType",
     responses(
-        (status = 201, content_type = "application/json", description = "The metadata of the created data type", body = MaybeListOfOntologyElementMetadata),
+        (status = 200, content_type = "application/json", description = "The metadata of the created data type", body = MaybeListOfOntologyElementMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 409, description = "Unable to create data type in the store as the base data type URL already exists"),

--- a/apps/hash-graph/lib/graph/src/api/rest/entity.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/entity.rs
@@ -96,7 +96,7 @@ struct CreateEntityRequest {
     request_body = CreateEntityRequest,
     tag = "Entity",
     responses(
-        (status = 201, content_type = "application/json", description = "The metadata of the created entity", body = EntityMetadata),
+        (status = 200, content_type = "application/json", description = "The metadata of the created entity", body = EntityMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 404, description = "Entity Type URL was not found"),

--- a/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
@@ -90,7 +90,7 @@ struct CreateEntityTypeRequest {
     request_body = CreateEntityTypeRequest,
     tag = "EntityType",
     responses(
-        (status = 201, content_type = "application/json", description = "The metadata of the created entity type", body = MaybeListOfOntologyElementMetadata),
+        (status = 200, content_type = "application/json", description = "The metadata of the created entity type", body = MaybeListOfOntologyElementMetadata),
         (status = 400, content_type = "application/json", description = "Provided request body is invalid", body = VAR_STATUS),
 
         (status = 409, content_type = "application/json", description = "Unable to create entity type in the datastore as the base entity type ID already exists", body = VAR_STATUS),

--- a/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
@@ -83,7 +83,7 @@ struct CreatePropertyTypeRequest {
     request_body = CreatePropertyTypeRequest,
     tag = "PropertyType",
     responses(
-        (status = 201, content_type = "application/json", description = "The metadata of the created property type", body = MaybeListOfOntologyElementMetadata),
+        (status = 200, content_type = "application/json", description = "The metadata of the created property type", body = MaybeListOfOntologyElementMetadata),
         (status = 422, content_type = "text/plain", description = "Provided request body is invalid"),
 
         (status = 409, description = "Unable to create property type in the store as the base property type ID already exists"),

--- a/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef.rs
@@ -40,7 +40,7 @@ impl ToSchema<'_> for MaybeListOfOntologyElementMetadata {
 pub type MaybeListOfDataType = ListOrValue<repr::DataType>;
 impl ToSchema<'_> for MaybeListOfDataType {
     fn schema() -> (&'static str, RefOr<Schema>) {
-        ("MaybeListOf", Self::generate_schema("DataType"))
+        ("MaybeListOf", Self::generate_schema("data_type"))
     }
 }
 
@@ -49,7 +49,7 @@ impl ToSchema<'_> for MaybeListOfPropertyType {
     fn schema() -> (&'static str, RefOr<Schema>) {
         (
             "MaybeListOfPropertyType",
-            Self::generate_schema("PropertyType"),
+            Self::generate_schema("property_type"),
         )
     }
 }
@@ -57,7 +57,10 @@ impl ToSchema<'_> for MaybeListOfPropertyType {
 pub type MaybeListOfEntityType = ListOrValue<repr::EntityType>;
 impl ToSchema<'_> for MaybeListOfEntityType {
     fn schema() -> (&'static str, RefOr<Schema>) {
-        ("MaybeListOfEntityType", Self::generate_schema("EntityType"))
+        (
+            "MaybeListOfEntityType",
+            Self::generate_schema("entity_type"),
+        )
     }
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

While playing around with the OpenAPI I noticed some inconsistencies in the OpenAPI specs we generate.

## 🔍 What does this change?

- Change the response code to `200`. Even though it's supposed to be `201`, we are actually returning `200`
- fix the schema names for ontology types

## 🚀 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [ ] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [ ] modifies a **block** that will need publishing via GitHub action once merged
- [x] does not modify any publishable blocks or libraries
- [ ] I am unsure / need advice