### PR TITLE
Add a dispatchable workflow to run `yarn fix`

### DIFF
--- a/.github/workflows/dispatch-fix.yml
+++ b/.github/workflows/dispatch-fix.yml
@@ -1,0 +1,22 @@
+name: Fix
+on: workflow_dispatch
+jobs:
+  yarn:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Warm up repo
+        uses: ./.github/actions/warm-up-repo
+
+      - name: Fix
+        run: yarn fix
+
+      - name: Commit
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          git commit -m '`yarn fix`'
+          git push

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 <!-- markdownlint-disable link-fragments -->
 
+
 [github_banner]: #hash
 [github_star]: https://github.com/hashintel/hash#
 [gh-what-is-hash]: #--what-is-hash

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 
 <!-- markdownlint-disable link-fragments -->
 
-
 [github_banner]: #hash
 [github_star]: https://github.com/hashintel/hash#
 [gh-what-is-hash]: #--what-is-hash


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This adds a workflow which is dispatchable and should be able to fix any auto-fixable lints (like prettier).

## 🔗 Related links

- [GitHub Actions documentation](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow)
- [checkout action readme](https://github.com/actions/checkout#push-a-commit-using-the-built-in-token)

## 🚫 Blocked by

## 🚀 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [ ] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [ ] modifies a **block** that will need publishing via GitHub action once merged
- [x] does not modify any publishable blocks or libraries
- [ ] I am unsure / need advice

## ⚠️ Known issues

I'm currently not able to test it as

> To trigger the `workflow_dispatch` event, **your workflow must be in the default branch**

## 🐾 Next steps

Test this workflow when this PR has been merged