### PR TITLE
Disable semantic commits for renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,7 @@
   "postUpdateOptions": ["yarnDedupeFewer"],
   "rangeStrategy": "bump",
   "rebaseWhen": "conflicted",
+  "semanticCommits": "disabled",
   "packageRules": [
     {
       "enabled": true,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

For some reason renovated auto-detects semantic commits for this repository, most probably due to #2388, however, we *don't* use semantic commits.

## 🔗 Related links

- #1481 
- #2405
- #2406