### PR TITLE
Return a `Stream` instead of taking a `Sink` in `dump_snapshot`

### DIFF
--- a/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/snapshot.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use error_stack::{Result, ResultExt};
+use futures::{SinkExt, StreamExt, TryStreamExt};
 use graph::{
     logging::{init_logger, LoggingArgs},
     snapshot::{codec, SnapshotEntry, SnapshotStore},
@@ -58,13 +59,24 @@ pub async fn snapshot(args: SnapshotArgs) -> Result<(), GraphError> {
     match args.command {
         SnapshotCommand::Dump(_) => {
             store
-                .dump_snapshot(FramedWrite::new(
-                    io::BufWriter::new(io::stdout()),
-                    codec::JsonLinesEncoder::default(),
-                ))
-                .await
-                .change_context(GraphError)
-                .attach_printable("Failed to produce snapshot dump")?;
+                .dump_snapshot()
+                .map_err(|report| {
+                    report
+                        .change_context(GraphError)
+                        .attach_printable("Failed to produce snapshot dump")
+                })
+                .forward(
+                    FramedWrite::new(
+                        io::BufWriter::new(io::stdout()),
+                        codec::JsonLinesEncoder::default(),
+                    )
+                    .sink_map_err(|report| {
+                        report
+                            .change_context(GraphError)
+                            .attach_printable("Failed to write snapshot dump")
+                    }),
+                )
+                .await?;
 
             tracing::info!("Snapshot dumped successfully");
         }

--- a/apps/hash-graph/lib/graph/src/snapshot.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot.rs
@@ -7,11 +7,9 @@ mod metadata;
 mod ontology;
 mod restore;
 
-use std::pin::pin;
-
 use async_trait::async_trait;
 use error_stack::{Context, IntoReport, Report, Result, ResultExt};
-use futures::{Sink, SinkExt, Stream, StreamExt, TryStreamExt};
+use futures::{stream, SinkExt, Stream, StreamExt, TryFutureExt, TryStreamExt};
 use serde::{Deserialize, Serialize};
 use type_system::{DataType, EntityType, PropertyType};
 
@@ -133,53 +131,44 @@ impl<C: AsClient> SnapshotStore<C> {
     ///
     /// - If reading a record from the datastore fails
     /// - If writing a record into the sink fails
-    pub async fn dump_snapshot(
+    pub fn dump_snapshot(
         &self,
-        sink: impl Sink<SnapshotEntry, Error = Report<impl Context>> + Send,
-    ) -> Result<(), SnapshotDumpError> {
-        let mut sink =
-            pin!(sink.sink_map_err(|report| report.change_context(SnapshotDumpError::Write)));
-
-        sink.send(SnapshotEntry::Snapshot(SnapshotMetadata {
-            block_protocol_module_versions: BlockProtocolModuleVersions {
-                graph: semver::Version::new(0, 3, 0),
-            },
-            custom: CustomGlobalMetadata,
-        }))
-        .await?;
-
+    ) -> impl Stream<Item = Result<SnapshotEntry, SnapshotDumpError>> + '_ {
         // TODO: Postgres does not allow to have multiple queries open at the same time. This means
         //       that each stream needs to be fully processed before the next one can be created.
         //       We might want to work around this by using a single stream that yields all the
         //       entries or even use multiple connections to the database.
         //   see https://app.asana.com/0/0/1204347352251098/f
 
-        let data_type_stream = pin!(
+        stream::once(async {
+            SnapshotEntry::Snapshot(SnapshotMetadata {
+                block_protocol_module_versions: BlockProtocolModuleVersions {
+                    graph: semver::Version::new(0, 3, 0),
+                },
+                custom: CustomGlobalMetadata,
+            })
+        })
+        .map(Ok)
+        .chain(
             self.create_dump_stream::<OntologyTypeSnapshotRecord<DataType>>()
-                .await?
-        );
-        sink.send_all(&mut data_type_stream.map_ok(SnapshotEntry::DataType))
-            .await?;
-
-        let property_type_stream = pin!(
+                .try_flatten_stream()
+                .map_ok(SnapshotEntry::DataType),
+        )
+        .chain(
             self.create_dump_stream::<OntologyTypeSnapshotRecord<PropertyType>>()
-                .await?
-        );
-        sink.send_all(&mut property_type_stream.map_ok(SnapshotEntry::PropertyType))
-            .await?;
-
-        let entity_type_stream = pin!(
+                .try_flatten_stream()
+                .map_ok(SnapshotEntry::PropertyType),
+        )
+        .chain(
             self.create_dump_stream::<OntologyTypeSnapshotRecord<EntityType>>()
-                .await?
-        );
-        sink.send_all(&mut entity_type_stream.map_ok(SnapshotEntry::EntityType))
-            .await?;
-
-        let entity_stream = pin!(self.create_dump_stream::<Entity>().await?);
-        sink.send_all(&mut entity_stream.map_ok(|entity| SnapshotEntry::Entity(entity.into())))
-            .await?;
-
-        Ok(())
+                .try_flatten_stream()
+                .map_ok(SnapshotEntry::EntityType),
+        )
+        .chain(
+            self.create_dump_stream::<Entity>()
+                .try_flatten_stream()
+                .map_ok(|entity| SnapshotEntry::Entity(entity.into())),
+        )
     }
 
     /// Reads the snapshot from from the stream into the store.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Eventually, we want to expose dumping snapshots to the REST endpoints as well. As `axum` has no supports for `Sink`s, this changes the return type for `dump_snapshot` to be a `Stream` instead of requiring a `Sink` to be passed in. Generally, this simplifies the usage as the function is not `async` anymore. In the CLI interface it's still possible to use a sink by just `forward`ing it into the `Sink`.