### PR TITLE
Move back `HEALTHCHECK` to docker compose file

### DIFF
--- a/apps/hash-external-services/docker-compose.yml
+++ b/apps/hash-external-services/docker-compose.yml
@@ -163,6 +163,11 @@ services:
       RUST_BACKTRACE: 1
     ports:
       - "${HASH_GRAPH_API_PORT}:4000"
+    healthcheck:
+      test: ["CMD", "/hash-graph", "server", "--healthcheck"]
+      interval: 2s
+      timeout: 2s
+      retries: 10
 
   hash-dev-redis:
     image: redis:6.2

--- a/apps/hash-graph/docker/Dockerfile
+++ b/apps/hash-graph/docker/Dockerfile
@@ -67,6 +67,4 @@ COPY --from=builder /out/ /
 
 USER nobody:nobody
 
-HEALTHCHECK --interval=2s --timeout=2s --retries=10 CMD ["/hash-graph", "server", "--healthcheck"]
-
 ENTRYPOINT ["/hash-graph"]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

https://github.com/hashintel/hash/pull/2374 moved the health check for the server to the dockerfile. Unfortunately I forgot, that this is not possible as the healthcheck specified in the Dockerfile should not be tied to a specific subcommand and we don't have a general `--healthcheck` flag in the server, which we could use.

## 🔗 Related links

- https://github.com/hashintel/hash/pull/2374

## 🚀 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [ ] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [ ] modifies a **block** that will need publishing via GitHub action once merged
- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing
- [ ] I am unsure / need advice