### PR TITLE
`deer`:  improve how integrals are handled

### DIFF
--- a/libs/deer/src/impls/core/integral.rs
+++ b/libs/deer/src/impls/core/integral.rs
@@ -1,65 +1,246 @@
-use error_stack::ResultExt;
+use error_stack::{IntoReport, Report, Result, ResultExt};
+use num_traits::ToPrimitive;
 
 use crate::{
-    error::{DeserializeError, VisitorError},
-    Deserialize, Deserializer, Document, Reflection, Schema, Visitor,
+    error::{DeserializeError, ExpectedType, ReceivedValue, ValueError, Variant, VisitorError},
+    Deserialize, Deserializer, Document, Number, Reflection, Schema, Visitor,
 };
 
-macro_rules! impl_integral {
-    (@num $name:ident, $visit:ident, $deser:ident, $typ:ty) => {
-        struct $name;
-
-        impl<'de> Visitor<'de> for $name {
-            type Value = $typ;
-
-            fn expecting(&self) -> Document {
-                <$typ>::reflection()
-            }
-
-            fn $visit(self, v: $typ) -> error_stack::Result<Self::Value, VisitorError> {
-                Ok(v)
-            }
-        }
-
-        impl Reflection for $typ {
+macro_rules! impl_num {
+    (
+        $primitive:ident:: $deserialize:ident; $($method:ident !($($val:ident:: $visit:ident),*);)*
+    ) => {
+        impl Reflection for $primitive {
             fn schema(_: &mut Document) -> Schema {
                 Schema::new("integer")
-                    .with("minimum", <$typ>::MIN)
-                    .with("maximum", <$typ>::MAX)
+                    .with("minimum", Self::MIN)
+                    .with("maximum", Self::MAX)
             }
         }
 
-        impl<'de> Deserialize<'de> for $typ {
+        impl<'de> Deserialize<'de> for $primitive {
             type Reflection = Self;
 
-            fn deserialize<D: Deserializer<'de>>(
-                de: D,
-            ) -> error_stack::Result<Self, DeserializeError> {
-                de.$deser($name).change_context(DeserializeError)
+            fn deserialize<D>(de: D) -> Result<Self, DeserializeError>
+            where
+                D: Deserializer<'de>,
+            {
+                struct PrimitiveVisitor;
+
+                impl<'de> Visitor<'de> for PrimitiveVisitor {
+                    type Value = $primitive;
+
+                    fn expecting(&self) -> Document {
+                        Self::Value::reflection()
+                    }
+
+                    $($($method!($val :: $visit);)*)*
+                }
+
+                de.$deserialize(PrimitiveVisitor).change_context(DeserializeError)
             }
         }
-    };
-
-    ($($typ:ident:: $fun:ident() <- $name:ident. $visit:ident()),*$(,)?) => {
-        $(impl_integral!(@num $name, $visit, $fun, $typ);)*
     };
 }
 
-// TODO: fit smaller values (visit) into them / try to fit them
-impl_integral![
-    u8::deserialize_u8() <- U8Visitor.visit_u8(),
-    u16::deserialize_u16() <- U16Visitor.visit_u16(),
-    u32::deserialize_u32() <- U32Visitor.visit_u32(),
-    u64::deserialize_u64() <- U64Visitor.visit_u64(),
-    u128::deserialize_u128() <- U128Visitor.visit_u128(),
-    usize::deserialize_usize() <- USizeVisitor.visit_usize(),
-];
+macro_rules! num_self {
+    ($primitive:ident:: $visit:ident) => {
+        fn $visit(self, v: $primitive) -> Result<Self::Value, VisitorError> {
+            Ok(v)
+        }
+    };
+}
 
-impl_integral![
-    i8::deserialize_i8() <- I8Visitor.visit_i8(),
-    i16::deserialize_i16() <- I16Visitor.visit_i16(),
-    i32::deserialize_i32() <- I32Visitor.visit_i32(),
-    i64::deserialize_i64() <- I64Visitor.visit_i64(),
-    i128::deserialize_i128() <- I128Visitor.visit_i128(),
-    isize::deserialize_isize() <- ISizeVisitor.visit_isize(),
-];
+macro_rules! num_from {
+    ($primitive:ident:: $visit:ident) => {
+        fn $visit(self, v: $primitive) -> Result<Self::Value, VisitorError> {
+            Ok(Self::Value::from(v))
+        }
+    };
+}
+
+macro_rules! num_try_from {
+    ($primitive:ident:: $visit:ident) => {
+        fn $visit(self, v: $primitive) -> Result<Self::Value, VisitorError> {
+            Self::Value::try_from(v)
+                .into_report()
+                .change_context(ValueError.into_error())
+                .attach(ExpectedType::new(self.expecting()))
+                .attach(ReceivedValue::new(v))
+                .change_context(VisitorError)
+        }
+    };
+}
+
+macro_rules! num_number {
+    ($primitive:ident:: $to:ident) => {
+        fn visit_number(self, v: Number) -> Result<Self::Value, VisitorError> {
+            v.$to().ok_or_else(|| {
+                Report::new(ValueError.into_error())
+                    .attach(ExpectedType::new(self.expecting()))
+                    .attach(ReceivedValue::new(v))
+                    .change_context(VisitorError)
+            })
+        }
+    };
+}
+
+impl_num!(
+    u8::deserialize_u8;
+    num_self!(u8::visit_u8);
+    num_try_from!(i8::visit_i8, i16::visit_i16, i32::visit_i32, i64::visit_i64, i128::visit_i128, u16::visit_u16, u32::visit_u32, u64::visit_u64, u128::visit_u128);
+    num_number!(u8::to_u8);
+);
+
+impl_num!(
+    u16::deserialize_u16;
+    num_self!(u16::visit_u16);
+    num_from!(u8::visit_u8);
+    num_try_from!(i8::visit_i8, i16::visit_i16, i32::visit_i32, i64::visit_i64, i128::visit_i128, u32::visit_u32, u64::visit_u64, u128::visit_u128);
+    num_number!(u16::to_u16);
+);
+
+impl_num!(
+    u32::deserialize_u32;
+    num_self!(u32::visit_u32);
+    num_from!(u8::visit_u8, u16::visit_u16);
+    num_try_from!(i8::visit_i8, i16::visit_i16, i32::visit_i32, i64::visit_i64, i128::visit_i128, u64::visit_u64, u128::visit_u128);
+    num_number!(u32::to_u32);
+);
+
+impl_num!(
+    u64::deserialize_u64;
+    num_self!(u64::visit_u64);
+    num_from!(u16::visit_u16, u32::visit_u32);
+    num_try_from!(i8::visit_i8, i16::visit_i16, i32::visit_i32, i64::visit_i64, i128::visit_i128, u128::visit_u128);
+    num_number!(u64::to_u64);
+);
+
+impl_num!(
+    u128::deserialize_u128;
+    num_self!(u128::visit_u128);
+    num_from!(u16::visit_u16, u32::visit_u32, u64::visit_u64);
+    num_try_from!(i8::visit_i8, i16::visit_i16, i32::visit_i32, i64::visit_i64, i128::visit_i128);
+    num_number!(u128::to_u128);
+);
+
+impl_num!(
+    i8::deserialize_i8;
+    num_self!(i8::visit_i8);
+    num_try_from!(i16::visit_i16, i32::visit_i32, i64::visit_i64, i128::visit_i128, u8::visit_u8, u16::visit_u16, u32::visit_u32, u64::visit_u64, u128::visit_u128);
+    num_number!(i8::to_i8);
+);
+
+impl_num!(
+    i16::deserialize_i16;
+    num_self!(i16::visit_i16);
+    num_from!(i8::visit_i8);
+    num_try_from!(i32::visit_i32, i64::visit_i64, i128::visit_i128, u8::visit_u8, u16::visit_u16, u32::visit_u32, u64::visit_u64, u128::visit_u128);
+    num_number!(i16::to_i16);
+);
+
+impl_num!(
+    i32::deserialize_i32;
+    num_self!(i32::visit_i32);
+    num_from!(i8::visit_i8, i16::visit_i16);
+    num_try_from!(i64::visit_i64, i128::visit_i128, u8::visit_u8, u16::visit_u16, u32::visit_u32, u64::visit_u64, u128::visit_u128);
+    num_number!(i32::to_i32);
+);
+
+impl_num!(
+    i64::deserialize_i64;
+    num_self!(i64::visit_i64);
+    num_from!(i8::visit_i8, i16::visit_i16, i32::visit_i32);
+    num_try_from!(i128::visit_i128, u8::visit_u8, u16::visit_u16, u32::visit_u32, u64::visit_u64, u128::visit_u128);
+    num_number!(i64::to_i64);
+);
+
+impl_num!(
+    i128::deserialize_i64;
+    num_self!(i128::visit_i128);
+    num_from!(i8::visit_i8, i16::visit_i16, i32::visit_i32, i64::visit_i64);
+    num_try_from!(u8::visit_u8, u16::visit_u16, u32::visit_u32, u64::visit_u64, u128::visit_u128);
+    num_number!(i128::to_i128);
+);
+
+impl Reflection for usize {
+    fn schema(_: &mut Document) -> Schema {
+        Schema::new("integer")
+            .with("minimum", Self::MIN)
+            .with("maximum", Self::MAX)
+    }
+}
+
+// Reason: code is architecture dependent, therefore truncation is not possible
+#[allow(clippy::cast_possible_truncation)]
+impl<'de> Deserialize<'de> for usize {
+    type Reflection = Self;
+
+    #[cfg(target_pointer_width = "16")]
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, DeserializeError> {
+        u16::deserialize(de).map(|value| value as Self)
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, DeserializeError> {
+        u32::deserialize(de).map(|value| value as Self)
+    }
+
+    // #[cfg(target_pointer_width = "64")]
+    // The default if not other architecture is chosen, should there every be a case of a usize that
+    // has not the "default" pointer widths, even 128 is quite unlikely
+    #[cfg(not(any(
+        target_pointer_width = "16",
+        target_pointer_width = "32",
+        target_pointer_width = "128"
+    )))]
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, DeserializeError> {
+        u64::deserialize(de).map(|value| value as Self)
+    }
+
+    #[cfg(target_pointer_width = "128")]
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, DeserializeError> {
+        u128::deserialize(de).map(|value| value as Self)
+    }
+}
+
+impl Reflection for isize {
+    fn schema(_: &mut Document) -> Schema {
+        Schema::new("integer")
+            .with("minimum", Self::MIN)
+            .with("maximum", Self::MAX)
+    }
+}
+
+// Reason: code is architecture dependent, therefore truncation is not possible
+#[allow(clippy::cast_possible_truncation)]
+impl<'de> Deserialize<'de> for isize {
+    type Reflection = Self;
+
+    #[cfg(target_pointer_width = "16")]
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, DeserializeError> {
+        i16::deserialize(de).map(|value| value as Self)
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, DeserializeError> {
+        i32::deserialize(de).map(|value| value as Self)
+    }
+
+    // #[cfg(target_pointer_width = "64")]
+    // The default if not other architecture is chosen, should there every be a case of a isize that
+    // has not the "default" pointer widths, even 128 is quite unlikely
+    #[cfg(not(any(
+        target_pointer_width = "16",
+        target_pointer_width = "32",
+        target_pointer_width = "128"
+    )))]
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, DeserializeError> {
+        i64::deserialize(de).map(|value| value as Self)
+    }
+
+    #[cfg(target_pointer_width = "128")]
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, DeserializeError> {
+        i128::deserialize(de).map(|value| value as Self)
+    }
+}

--- a/libs/deer/src/impls/core/integral.rs
+++ b/libs/deer/src/impls/core/integral.rs
@@ -156,7 +156,7 @@ impl_num!(
 );
 
 impl_num!(
-    i128::deserialize_i64;
+    i128::deserialize_i128;
     num_self!(i128::visit_i128);
     num_from!(i8::visit_i8, i16::visit_i16, i32::visit_i32, i64::visit_i64);
     num_try_from!(u8::visit_u8, u16::visit_u16, u32::visit_u32, u64::visit_u64, u128::visit_u128);

--- a/libs/deer/src/impls/core/integral.rs
+++ b/libs/deer/src/impls/core/integral.rs
@@ -1,4 +1,6 @@
-use error_stack::{IntoReport, Report, Result, ResultExt};
+#[cfg(any(nightly, feature = "std"))]
+use error_stack::IntoReport;
+use error_stack::{Report, Result, ResultExt};
 use num_traits::ToPrimitive;
 
 use crate::{
@@ -59,6 +61,7 @@ macro_rules! num_from {
     };
 }
 
+#[cfg(any(nightly, feature = "std"))]
 macro_rules! num_try_from {
     ($primitive:ident:: $visit:ident) => {
         fn $visit(self, v: $primitive) -> Result<Self::Value, VisitorError> {
@@ -68,6 +71,23 @@ macro_rules! num_try_from {
                 .attach(ExpectedType::new(self.expecting()))
                 .attach(ReceivedValue::new(v))
                 .change_context(VisitorError)
+        }
+    };
+}
+
+// error_in_core is not stabilized just yet
+#[cfg(all(not(nightly), not(feature = "std")))]
+macro_rules! num_try_from {
+    ($primitive:ident:: $visit:ident) => {
+        fn $visit(self, v: $primitive) -> Result<Self::Value, VisitorError> {
+            if let Ok(value) = Self::Value::try_from(v) {
+                Ok(value)
+            } else {
+                Err(Report::new(ValueError.into_error())
+                    .attach(ExpectedType::new(self.expecting()))
+                    .attach(ReceivedValue::new(v))
+                    .change_context(VisitorError))
+            }
         }
     };
 }

--- a/libs/deer/src/impls/core/integral.rs
+++ b/libs/deer/src/impls/core/integral.rs
@@ -187,8 +187,8 @@ impl<'de> Deserialize<'de> for usize {
     }
 
     // #[cfg(target_pointer_width = "64")]
-    // The default if not other architecture is chosen, should there every be a case of a usize that
-    // has not the "default" pointer widths, even 128 is quite unlikely
+    // The default if no other architecture is chosen, should there ever be a case of a `usize` that
+    // does not have the "default" pointer width, even 128 is quite unlikely
     #[cfg(not(any(
         target_pointer_width = "16",
         target_pointer_width = "32",

--- a/libs/deer/src/impls/core/integral.rs
+++ b/libs/deer/src/impls/core/integral.rs
@@ -228,8 +228,8 @@ impl<'de> Deserialize<'de> for isize {
     }
 
     // #[cfg(target_pointer_width = "64")]
-    // The default if not other architecture is chosen, should there every be a case of a isize that
-    // has not the "default" pointer widths, even 128 is quite unlikely
+    // The default if no other architecture is chosen, should there ever be a case of a `usize` that
+    // does not have the "default" pointer width, even 128 is quite unlikely
     #[cfg(not(any(
         target_pointer_width = "16",
         target_pointer_width = "32",

--- a/libs/deer/src/impls/core/integral.rs
+++ b/libs/deer/src/impls/core/integral.rs
@@ -111,7 +111,7 @@ impl_num!(
 impl_num!(
     u64::deserialize_u64;
     num_self!(u64::visit_u64);
-    num_from!(u16::visit_u16, u32::visit_u32);
+    num_from!(u8::visit_u8, u16::visit_u16, u32::visit_u32);
     num_try_from!(i8::visit_i8, i16::visit_i16, i32::visit_i32, i64::visit_i64, i128::visit_i128, u128::visit_u128);
     num_number!(u64::to_u64);
 );
@@ -119,7 +119,7 @@ impl_num!(
 impl_num!(
     u128::deserialize_u128;
     num_self!(u128::visit_u128);
-    num_from!(u16::visit_u16, u32::visit_u32, u64::visit_u64);
+    num_from!(u8::visit_u8, u16::visit_u16, u32::visit_u32, u64::visit_u64);
     num_try_from!(i8::visit_i8, i16::visit_i16, i32::visit_i32, i64::visit_i64, i128::visit_i128);
     num_number!(u128::to_u128);
 );

--- a/libs/deer/tests/test_impls_core_integral.rs
+++ b/libs/deer/tests/test_impls_core_integral.rs
@@ -8,6 +8,10 @@ use serde_json::json;
 
 // we do not test atomics, as they only delegate to `Atomic*` and are not `PartialEq`
 
+macro_rules! proptest_integral {
+    ($primitive:ident) => {};
+}
+
 #[cfg(not(miri))]
 proptest! {
     #[test]

--- a/libs/deer/tests/test_value.rs
+++ b/libs/deer/tests/test_value.rs
@@ -62,20 +62,21 @@ macro_rules! generate_proptest {
     };
 }
 
-generate_proptest!(u8, not(u16));
-generate_proptest!(u16, not(u32));
-generate_proptest!(u32, not(u64));
-generate_proptest!(u64, not(u128));
-generate_proptest!(u128, not(u8));
-generate_proptest!(usize, not(u8));
-generate_proptest!(i8, not(i16));
-generate_proptest!(i16, not(i32));
-generate_proptest!(i32, not(i64));
-generate_proptest!(i64, not(i128));
-generate_proptest!(i128, not(i8));
-generate_proptest!(isize, not(i8));
-generate_proptest!(f32, not(i8));
-generate_proptest!(f64, not(i8));
+// TODO: reinstante tests
+// generate_proptest!(u8, not(u16));
+// generate_proptest!(u16, not(u32));
+// generate_proptest!(u32, not(u64));
+// generate_proptest!(u64, not(u128));
+// generate_proptest!(u128, not(u8));
+// generate_proptest!(usize, not(u8));
+// generate_proptest!(i8, not(i16));
+// generate_proptest!(i16, not(i32));
+// generate_proptest!(i32, not(i64));
+// generate_proptest!(i64, not(i128));
+// generate_proptest!(i128, not(i8));
+// generate_proptest!(isize, not(i8));
+// generate_proptest!(f32, not(i8));
+// generate_proptest!(f64, not(i8));
 generate_proptest!(bool, not(i8));
 generate_proptest!(char, not(i8));
 

--- a/libs/deer/tests/test_value.rs
+++ b/libs/deer/tests/test_value.rs
@@ -62,21 +62,20 @@ macro_rules! generate_proptest {
     };
 }
 
-// TODO: reinstante tests
-// generate_proptest!(u8, not(u16));
-// generate_proptest!(u16, not(u32));
-// generate_proptest!(u32, not(u64));
-// generate_proptest!(u64, not(u128));
-// generate_proptest!(u128, not(u8));
-// generate_proptest!(usize, not(u8));
-// generate_proptest!(i8, not(i16));
-// generate_proptest!(i16, not(i32));
-// generate_proptest!(i32, not(i64));
-// generate_proptest!(i64, not(i128));
-// generate_proptest!(i128, not(i8));
-// generate_proptest!(isize, not(i8));
-// generate_proptest!(f32, not(i8));
-// generate_proptest!(f64, not(i8));
+generate_proptest!(u8, not(char));
+generate_proptest!(u16, not(char));
+generate_proptest!(u32, not(char));
+generate_proptest!(u64, not(char));
+generate_proptest!(u128, not(char));
+generate_proptest!(usize, not(char));
+generate_proptest!(i8, not(char));
+generate_proptest!(i16, not(char));
+generate_proptest!(i32, not(char));
+generate_proptest!(i64, not(char));
+generate_proptest!(i128, not(char));
+generate_proptest!(isize, not(char));
+generate_proptest!(f32, not(char));
+generate_proptest!(f64, not(char));
 generate_proptest!(bool, not(i8));
 generate_proptest!(char, not(i8));
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This is the first in a (probably) three-step PR chain.

This PR resolves one of the long overdue TODOs in the code and makes the deserializer of all numbers less punishing. The end goal is to remove the `usize` and `isize` types in our data scheme.

This means that everything is more in line with `serde` and that a `u32` can be deserialized using `U32Deserializer` into `u64`.

Note: We determine the size of `*size` using `target_pointer_width`, `serde` internally handles all `usize` as `u64`. We correctly determine the size of the target and set conversion functions appropriately this means that conversions would truncate w/ `serde` on 16-bit or 32-bit systems, while 🦌 correctly errors out.

## 🚀 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [ ] modifies a **block** that will need publishing via GitHub action once merged
- [ ] does not modify any publishable blocks or libraries, or modifications do not need publishing
- [ ] I am unsure / need advice

