### PR TITLE
Use `turbo` in `Dockerfile` to prune unneeded content

### DIFF
--- a/apps/hash-graph/docker/Dockerfile
+++ b/apps/hash-graph/docker/Dockerfile
@@ -1,3 +1,12 @@
+FROM node:16.18.1-alpine AS base
+
+WORKDIR /app
+
+RUN yarn global add turbo
+COPY . .
+RUN turbo prune --scope='@apps/hash-graph' --docker
+
+
 FROM node:16.18.1-alpine AS rust
 
 WORKDIR /usr/local/
@@ -6,7 +15,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=:$PATH:/usr/local/cargo/bin
 
-COPY apps/hash-graph/rust-toolchain.toml .
+COPY --from=base /app/out/full/apps/hash-graph/rust-toolchain.toml .
 RUN apk add --no-cache gcc musl-dev bash && \
     wget -q -O- https://sh.rustup.rs | sh -s -- -y --default-toolchain none --profile minimal && \
     rustup show
@@ -14,30 +23,23 @@ RUN apk add --no-cache gcc musl-dev bash && \
 SHELL ["bash", "-c"]
 
 
-FROM rust as node_base
+FROM rust as installer
 
-WORKDIR /usr/local/
+WORKDIR /usr/local/src/
 
-# Ensure that the node module layer can be cached
-COPY package.json .
-COPY yarn.lock .
+COPY --from=base /app/out/json/ .
+COPY --from=base /app/out/yarn.lock ./yarn.lock
+COPY --from=base /app/out/full/turbo.json turbo.json
 
-COPY ./libs/@local/status/. /usr/local/libs/@local/status
+RUN yarn install --frozen-lockfile --prefer-offline && \
+    yarn cache clean
 
-COPY libs/@local/eslint-config libs/@local/eslint-config
-COPY libs/@local/tsconfig libs/@local/tsconfig
-
-RUN yarn workspace @local/status install --frozen-lockfile --ignore-scripts --prefer-offline
+COPY --from=base /app/out/full/ .
 
 
-FROM node_base AS builder
+FROM installer AS builder
 
-WORKDIR /usr/local/
-COPY ./apps/hash-graph/. ./apps/hash-graph/
-
-RUN yarn workspace @apps/hash-graph install --frozen-lockfile --ignore-scripts --prefer-offline
-
-WORKDIR /usr/local/apps/hash-graph
+WORKDIR /usr/local/src/apps/hash-graph
 
 ARG PROFILE=production
 ARG ENABLE_TYPE_FETCHER=no
@@ -48,7 +50,7 @@ RUN apk add --no-cache make protobuf-dev
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/usr/local/apps/hash-graph/target,sharing=locked \
+    --mount=type=cache,target=/usr/local/src/apps/hash-graph/target,sharing=locked \
     FEATURES=(); \
     if [[ ${ENABLE_TYPE_FETCHER^^} == Y* || ${ENABLE_TYPE_FETCHER^^} == T* || $ENABLE_TYPE_FETCHER == 1 ]]; then \
       FEATURES+=("type-fetcher"); \


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

It's possible to better utilize the docker-layer-caching by using `turbo prune`. This command will remove unneeded clutter and write it into `out/`. Based on this the dependencies can be cached if the package.json, yarn.lock, and turbo.json did not change.

## 🔗 Related links

- [Turbo documentation: Deploying with Docker](https://turbo.build/repo/docs/handbook/deploying-with-docker)

## 🚫 Blocked by

- #2419 
- #2426

## 🚀 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [ ] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [ ] modifies a **block** that will need publishing via GitHub action once merged
- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing
- [ ] I am unsure / need advice