### PR TITLE
Use caching for hash-graph docker image

### DIFF
--- a/.github/actions/build-docker-images/action.yml
+++ b/.github/actions/build-docker-images/action.yml
@@ -1,0 +1,31 @@
+name: Build docker images
+description: "Build docker images"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build images
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: apps/hash-graph/docker/Dockerfile
+        tags: hash-graph
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        outputs: type=docker,dest=/tmp/hash-graph.tar
+        # `dev` is large (~400 MB), slow, and fast to build
+        # `production` is small (~10 MB), fast, and slow to build (a few minutes linking time due to LTO)
+        # `release` is a compromise between the two (~30 MB, no LTO)
+        build-args: |
+          PROFILE=release
+          ENABLE_TYPE_FETCHER=yes
+          ENABLE_TEST_SERVER=yes
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: hash-graph
+        path: /tmp/hash-graph.tar

--- a/.github/actions/load-docker-images/action.yml
+++ b/.github/actions/load-docker-images/action.yml
@@ -1,0 +1,20 @@
+name: Load docker images
+description: "Load docker images"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Download hash-graph image
+      uses: actions/download-artifact@v3
+      with:
+        name: hash-graph
+        path: /tmp
+
+    - name: Load hash-graph image
+      shell: bash
+      run: |
+        docker load --input /tmp/hash-graph.tar
+        docker image ls -a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-deployment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build images
+        uses: ./.github/actions/build-docker-images
+
   linting:
     name: Linting
     runs-on: ubuntu-latest
@@ -154,6 +163,7 @@ jobs:
 
   backend-integration-tests:
     name: Backend integration tests
+    needs: build-deployment
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -163,18 +173,17 @@ jobs:
       - name: Create temp files and folders
         run: mkdir -p var/logs
 
+      - name: Load Docker images
+        uses: ./.github/actions/load-docker-images
+
       - name: Launch external services
-        if: ${{ success() || failure() }}
-        run: |
-          yarn external-services:test up --detach
+        run: yarn workspace @apps/hash-external-services deploy up --detach
 
       - run: yarn test:backend-integration
-        if: ${{ success() || failure() }}
         env:
           TEST_COVERAGE: true
 
       - uses: codecov/codecov-action@v3
-        if: ${{ success() || failure() }}
         name: Upload coverage to https://app.codecov.io/gh/hashintel/hash
         with:
           ## Temporarily disabled until https://github.com/codecov/codecov-action/issues/720 is resolved, and/or we rely
@@ -202,6 +211,7 @@ jobs:
 
   playwright-tests:
     name: Playwright tests
+    needs: build-deployment
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -221,10 +231,11 @@ jobs:
       - name: Create temp files and folders
         run: mkdir -p var/logs
 
+      - name: Load Docker images
+        uses: ./.github/actions/load-docker-images
+
       - name: Launch external services
-        if: ${{ success() || failure() }}
-        run: |
-          yarn external-services up --detach
+        run: yarn workspace @apps/hash-external-services deploy up --detach
 
       ## @todo: re-implement seed-data scripts for the new type system, so that they can be used here. Can potentially be addressed as part of https://app.asana.com/0/1202805690238892/1203106234191606/f
       # - name: Seed data
@@ -233,20 +244,17 @@ jobs:
       #     yarn seed-data
 
       - name: Launch backend
-        if: ${{ success() || failure() }}
         run: |
           yarn dev:backend 2>&1 | tee var/logs/backend.log & ## ampersand enables background mode
           yarn wait-on --timeout 60000 http://0.0.0.0:5001
 
       - name: Build and launch frontend
-        if: ${{ success() || failure() }}
         run: |
           yarn workspace @apps/hash-frontend next build
           yarn workspace @apps/hash-frontend start 2>&1 | tee var/logs/frontend.log & ## ampersand enables background mode
           yarn wait-on --timeout 30000 http://0.0.0.0:3000
 
       - name: Run Playwright tests
-        if: ${{ success() || failure() }}
         run: |
           yarn test:playwright
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,7 @@ jobs:
       test: ${{ steps.crates.outputs.test }}
       coverage: ${{ steps.crates.outputs.coverage }}
       publish: ${{ steps.crates.outputs.publish }}
+      build: ${{ steps.crates.outputs.build }}
       samples: ${{ steps.samples.outputs.samples }}
     steps:
       - name: Checkout source code
@@ -56,6 +57,21 @@ jobs:
           else
             echo "samples=10" >> $GITHUB_OUTPUT
           fi
+
+  build:
+    name: build
+    needs: setup
+    if: needs.setup.outputs.build != '{}'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.setup.outputs.build) }}
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+
+      - name: Build images
+        uses: ./.github/actions/build-docker-images
 
   lint:
     name: lint
@@ -150,8 +166,8 @@ jobs:
 
   test:
     name: test
-    needs: setup
-    if: needs.setup.outputs.test != '{}'
+    needs: [setup, build]
+    if: always() && needs.setup.outputs.test != '{}'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -167,6 +183,14 @@ jobs:
       - name: Warm-up repository
         uses: ./.github/actions/warm-up-repo
         if: matrix.directory == 'apps/hash-graph'
+
+      - name: Load Docker images
+        uses: ./.github/actions/load-docker-images
+        if: matrix.directory == 'apps/hash-graph'
+
+      - name: Launch external services
+        if: matrix.directory == 'apps/hash-graph'
+        run: yarn workspace @apps/hash-external-services deploy up graph --wait
 
       - name: Install Rust toolchain
         uses: ./.github/actions/install-rust-toolchain
@@ -231,8 +255,8 @@ jobs:
 
   coverage:
     name: coverage
-    needs: setup
-    if: needs.setup.outputs.coverage != '{}'
+    needs: [setup, build]
+    if: always() && needs.setup.outputs.coverage != '{}'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -244,6 +268,14 @@ jobs:
       - name: Warm-up repository
         uses: ./.github/actions/warm-up-repo
         if: matrix.directory == 'apps/hash-graph'
+
+      - name: Load Docker images
+        uses: ./.github/actions/load-docker-images
+        if: matrix.directory == 'apps/hash-graph'
+
+      - name: Launch external services
+        if: matrix.directory == 'apps/hash-graph'
+        run: yarn workspace @apps/hash-external-services deploy up graph --wait
 
       - name: Install Rust toolchain
         uses: ./.github/actions/install-rust-toolchain


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

As mentioned in #2428, this uses caching for the `hash-graph` docker image, as this is currently one of the slowest part in CI.

This PR immensely speeds up CI times.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204260760205594/1204367340604860/f) _(internal)_

## 🚫 Blocked by

- #2419 
- #2426 
- #2427 
- #2428

## 🔍 What does this change?

- Add a composite action to build the `hash-graph` image
- Add a composite action to load the image back into Docker
- Add a configuration to `setup.py` to filter by `hash-graph`
- Use the composite action to build the image in the `CI` and `Rust` workflows
- Use the cached artifact to speed up external services

## 🚀 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [ ] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [ ] modifies a **block** that will need publishing via GitHub action once merged
- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing
- [ ] I am unsure / need advice