### PR TITLE
Correct Heading block name

### DIFF
--- a/blocks/heading/package.json
+++ b/blocks/heading/package.json
@@ -51,7 +51,7 @@
     "blockType": {
       "entryPoint": "react"
     },
-    "name": "heading",
+    "name": "@hash/heading",
     "displayName": "Heading",
     "icon": "public/h1.svg",
     "image": "public/preview.svg",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We use the `name` field in `package.json["blockprotocol"]` to determine which API key to use when publishing blocks.

The `heading` block was missing the namespace prefix, which meant that automatic publishing was failing (see [here](https://github.com/hashintel/hash/actions/runs/4731993373/jobs/8397662623#step:5:15)).

## 🚀 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies a **block** that will need publishing via GitHub action once merged

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

The `chart` block publishing is failing because it is published under a different namespace, for which we haven't entered an API key, but since it's outdated this is less important to address.

## 🐾 Next steps

I will re-run publishing for the `heading` block.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Look at a few `package.json`s for other blocks and see that this PR makes them consistent.
