### PR TITLE
`deer`: add `*Access::context()`

### DIFF
--- a/libs/deer/desert/src/array.rs
+++ b/libs/deer/desert/src/array.rs
@@ -3,7 +3,7 @@ use deer::{
         ArrayAccessError, ArrayLengthError, BoundedContractViolationError, ExpectedLength,
         ReceivedLength, Variant,
     },
-    Deserialize, Deserializer as _,
+    Context, Deserialize, Deserializer as _,
 };
 use error_stack::{Report, Result, ResultExt};
 
@@ -57,6 +57,10 @@ impl<'a, 'b, 'de> ArrayAccess<'a, 'b, 'de> {
 }
 
 impl<'de> deer::ArrayAccess<'de> for ArrayAccess<'_, '_, 'de> {
+    fn context(&self) -> &Context {
+        self.deserializer.context()
+    }
+
     fn set_bounded(&mut self, length: usize) -> Result<(), ArrayAccessError> {
         if self.consumed > 0 {
             return Err(

--- a/libs/deer/desert/src/object.rs
+++ b/libs/deer/desert/src/object.rs
@@ -3,7 +3,7 @@ use deer::{
         BoundedContractViolationError, ExpectedLength, ObjectAccessError, ObjectLengthError,
         ReceivedLength, Variant,
     },
-    Deserializer as _, FieldVisitor,
+    Context, Deserializer as _, FieldVisitor,
 };
 use error_stack::{Report, Result, ResultExt};
 
@@ -57,6 +57,10 @@ impl<'a, 'b, 'de: 'a> ObjectAccess<'a, 'b, 'de> {
 }
 
 impl<'de> deer::ObjectAccess<'de> for ObjectAccess<'_, '_, 'de> {
+    fn context(&self) -> &Context {
+        self.deserializer.context()
+    }
+
     fn set_bounded(&mut self, length: usize) -> Result<(), ObjectAccessError> {
         if self.consumed > 0 {
             return Err(

--- a/libs/deer/json/src/lib.rs
+++ b/libs/deer/json/src/lib.rs
@@ -455,6 +455,10 @@ impl<'a> ArrayAccess<'a> {
 }
 
 impl<'a, 'de> deer::ArrayAccess<'de> for ArrayAccess<'a> {
+    fn context(&self) -> &Context {
+        self.context
+    }
+
     fn set_bounded(&mut self, length: usize) -> Result<(), ArrayAccessError> {
         if self.dirty {
             return Err(
@@ -550,6 +554,10 @@ impl<'a> ObjectAccess<'a> {
 }
 
 impl<'a, 'de> deer::ObjectAccess<'de> for ObjectAccess<'a> {
+    fn context(&self) -> &Context {
+        self.context
+    }
+
     fn set_bounded(&mut self, length: usize) -> Result<(), ObjectAccessError> {
         if self.dirty {
             return Err(

--- a/libs/deer/src/lib.rs
+++ b/libs/deer/src/lib.rs
@@ -66,6 +66,8 @@ type FieldValue<'de, F> = <F as FieldVisitor<'de>>::Value;
 type FieldResult<'de, F> = Option<Result<FieldValue<'de, F>, ObjectAccessError>>;
 
 pub trait ObjectAccess<'de> {
+    fn context(&self) -> &Context;
+
     /// This enables bound-checking for [`ObjectAccess`].
     ///
     /// After calling this [`ObjectAccess`] will
@@ -115,6 +117,8 @@ pub trait FieldVisitor<'de> {
 }
 
 pub trait ArrayAccess<'de> {
+    fn context(&self) -> &Context;
+
     /// Enables bound-checking for [`ArrayAccess`].
     ///
     /// After calling this [`ArrayAccess`] will


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR adds `ArrayAccess::context()` and `ObjectAccess::context()` which roughly are equivalent to `DeserializeSeed` in `serde`. This enables inner methods of `ArrayAccess` and `ObjectAccess` to modify/access the context, but also call other deserializers (like `NoneDeserializer`)

## 🔗 Related links

* need was discovered in #2437 

## 🚀 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [ ] modifies a **block** that will need publishing via GitHub action once merged
- [ ] does not modify any publishable blocks or libraries, or modifications do not need publishing
- [ ] I am unsure / need advice

<!-- Add a screenshot or video showcasing your work -->
