### PR TITLE
[H-4] Add blurhash to hash.dev slide component

### DIFF
--- a/apps/hashdotdev/src/components/mdx-talk-slide.tsx
+++ b/apps/hashdotdev/src/components/mdx-talk-slide.tsx
@@ -2,6 +2,8 @@ import { Box, Typography } from "@mui/material";
 import Image, { ImageProps } from "next/legacy/image";
 import { FunctionComponent, ReactNode } from "react";
 
+import { useBlogPostPhotos } from "./blog-post";
+
 export const MdxTalkSlide: FunctionComponent<
   Pick<ImageProps, "width" | "height"> & {
     children?: ReactNode;
@@ -9,6 +11,8 @@ export const MdxTalkSlide: FunctionComponent<
     video?: boolean;
   }
 > = ({ children, src, video = false, width, height }) => {
+  const { post } = useBlogPostPhotos();
+
   return (
     <Box
       sx={{
@@ -27,7 +31,14 @@ export const MdxTalkSlide: FunctionComponent<
         {video ? (
           <Box component="video" width="100%" src={src} controls />
         ) : (
-          <Image src={src} width={width} height={height} />
+          <Image
+            {...post}
+            src={src}
+            width={width}
+            height={height}
+            layout="responsive"
+            placeholder="blur"
+          />
         )}
       </Box>
       <Box

--- a/apps/hashdotdev/src/components/mdx-talk-slide.tsx
+++ b/apps/hashdotdev/src/components/mdx-talk-slide.tsx
@@ -11,7 +11,8 @@ export const MdxTalkSlide: FunctionComponent<
     video?: boolean;
   }
 > = ({ children, src, video = false, width, height }) => {
-  const { post } = useBlogPostPhotos();
+  const { body } = useBlogPostPhotos();
+  const details = body[src];
 
   return (
     <Box
@@ -32,7 +33,7 @@ export const MdxTalkSlide: FunctionComponent<
           <Box component="video" width="100%" src={src} controls />
         ) : (
           <Image
-            {...post}
+            {...details}
             src={src}
             width={width}
             height={height}


### PR DESCRIPTION
🌟 What is the purpose of this PR?
---
The aim of this pull request is to resolve the issue of the presentation slides not appearing until they have loaded in completely, by implementing a consistent approach that uses blurhashes, which is consistent with the existing approach of using blurhashes on other Images which improves the loading experience for users.

🔗  Related links
---
- [Github](https://github.com/hashintel/hash/issues/2323)

❓How to test this?
---
https://www.loom.com/share/b98bfd6e2bcb41418658c8e949ffc16e

---
This code was written and reviewed by GitStart Community. Growing future engineers, one PR at a time.