### PR TITLE
[H-12] Change title of hash.dev/blog/[post] pages

### DIFF
--- a/apps/hashdotdev/src/components/blog-post.tsx
+++ b/apps/hashdotdev/src/components/blog-post.tsx
@@ -71,7 +71,7 @@ export const BlogPostHead: FunctionComponent<{
 }) => {
   const photos = useBlogPostPhotos();
 
-  const fullTitle = `${pageTitle ? `${pageTitle} – ` : ""}HASH for Developers`;
+  const fullTitle = `${pageTitle ? `${pageTitle} – ` : ""}HASH Developer Blog`;
 
   const date = dateInput ? new Date(dateInput) : null;
   const dateIso = date ? date.toISOString() : null;


### PR DESCRIPTION
🌟 What is the purpose of this PR?
---
The aim of this pull request is to change title of hash.dev/blog/[post] pages. It should read "[post name] - HASH Developer Blog".

🔗  Related links
---
- [Github](https://github.com/hashintel/hash/issues/2439)

❓How to test this?
---
<img width="1659" alt="Screenshot 2023-04-19 at 09 14 49" src="https://user-images.githubusercontent.com/54555805/233012403-29ebfe37-4810-4714-87fa-603ab0e51aa1.png">

---
This code was written and reviewed by GitStart Community. Growing future engineers, one PR at a time.