### PR TITLE
Support deletion of test-data

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/error.rs
+++ b/apps/hash-graph/lib/graph/src/store/error.rs
@@ -51,6 +51,18 @@ impl Context for UpdateError {}
 
 #[derive(Debug)]
 #[must_use]
+pub struct DeletionError;
+
+impl fmt::Display for DeletionError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.write_str("Could not delete from the store")
+    }
+}
+
+impl Context for DeletionError {}
+
+#[derive(Debug)]
+#[must_use]
 pub struct BaseUrlAlreadyExists;
 
 impl fmt::Display for BaseUrlAlreadyExists {

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology.rs
@@ -4,10 +4,15 @@ mod ontology_id;
 mod property_type;
 mod read;
 
+use error_stack::{IntoReport, Result, ResultExt};
+use tokio_postgres::Transaction;
 use type_system::{DataType, EntityType, PropertyType};
 
 pub use self::ontology_id::OntologyId;
-use crate::{ontology::OntologyType, store::postgres::query::PostgresRecord};
+use crate::{
+    ontology::OntologyType,
+    store::{error::DeletionError, postgres::query::PostgresRecord, AsClient, PostgresStore},
+};
 
 /// Provides an abstraction over elements of the Type System stored in the Database.
 ///
@@ -32,5 +37,69 @@ impl OntologyDatabaseType for PropertyType {
 impl OntologyDatabaseType for EntityType {
     fn table() -> &'static str {
         "entity_types"
+    }
+}
+
+impl PostgresStore<Transaction<'_>> {
+    #[tracing::instrument(level = "trace", skip(self))]
+    #[cfg(hash_graph_test_environment)]
+    pub async fn delete_ontology_ids(
+        &self,
+        ontology_ids: &[OntologyId],
+    ) -> Result<(), DeletionError> {
+        self.as_client()
+            .query(
+                r"
+                    DELETE FROM ontology_owned_metadata
+                    WHERE ontology_id = ANY($1)
+                ",
+                &[&ontology_ids],
+            )
+            .await
+            .into_report()
+            .change_context(DeletionError)?;
+
+        self.as_client()
+            .query(
+                r"
+                    DELETE FROM ontology_external_metadata
+                    WHERE ontology_id = ANY($1)
+                ",
+                &[&ontology_ids],
+            )
+            .await
+            .into_report()
+            .change_context(DeletionError)?;
+
+        let base_urls = self
+            .as_client()
+            .query(
+                r"
+                    DELETE FROM ontology_ids
+                    WHERE ontology_id = ANY($1)
+                    RETURNING base_url
+                ",
+                &[&ontology_ids],
+            )
+            .await
+            .into_report()
+            .change_context(DeletionError)?
+            .into_iter()
+            .filter_map(|row| row.get(0))
+            .collect::<Vec<String>>();
+
+        self.as_client()
+            .query(
+                r"
+                    DELETE FROM base_urls
+                    WHERE base_url = ANY($1)
+                ",
+                &[&base_urls],
+            )
+            .await
+            .into_report()
+            .change_context(DeletionError)?;
+
+        Ok(())
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -1,15 +1,19 @@
 use std::{borrow::Borrow, mem};
 
 use async_trait::async_trait;
-use error_stack::{Result, ResultExt};
+use error_stack::{IntoReport, Result, ResultExt};
 use type_system::PropertyType;
 
 use crate::{
     ontology::{DataTypeWithMetadata, OntologyElementMetadata, PropertyTypeWithMetadata},
     provenance::RecordCreatedById,
     store::{
-        crud::Read, postgres::TraversalContext, query::Filter, AsClient, ConflictBehavior,
-        InsertionError, PostgresStore, PropertyTypeStore, QueryError, Record, UpdateError,
+        crud::Read,
+        error::DeletionError,
+        postgres::{ontology::OntologyId, TraversalContext},
+        query::Filter,
+        AsClient, ConflictBehavior, InsertionError, PostgresStore, PropertyTypeStore, QueryError,
+        Record, UpdateError,
     },
     subgraph::{
         edges::{EdgeDirection, GraphResolveDepths, OntologyEdgeKind},
@@ -117,6 +121,46 @@ impl<C: AsClient> PostgresStore<C> {
 
         self.traverse_data_types(data_type_queue, traversal_context, subgraph)
             .await?;
+
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
+    #[cfg(hash_graph_test_environment)]
+    pub async fn delete_property_types(&mut self) -> Result<(), DeletionError> {
+        let transaction = self.transaction().await.change_context(DeletionError)?;
+
+        transaction
+            .as_client()
+            .simple_query(
+                r"
+                    DELETE FROM property_type_constrains_properties_on;
+                    DELETE FROM property_type_constrains_values_on;
+                ",
+            )
+            .await
+            .into_report()
+            .change_context(DeletionError)?;
+
+        let property_types = transaction
+            .as_client()
+            .query(
+                r"
+                    DELETE FROM property_types
+                    RETURNING ontology_id
+                ",
+                &[],
+            )
+            .await
+            .into_report()
+            .change_context(DeletionError)?
+            .into_iter()
+            .filter_map(|row| row.get(0))
+            .collect::<Vec<OntologyId>>();
+
+        transaction.delete_ontology_ids(&property_types).await?;
+
+        transaction.commit().await.change_context(DeletionError)?;
 
         Ok(())
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When running a test with a test data batch (inserted via the `snapshot` endpoint), we want to be able to remove the test data and insert a new batch afterward. This implements deletion, which is gated behind the `--cfg` flag to avoid having it available in a production environment.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204260760205594/1204407146528683/f) _(internal)_

## 🔍 What does this change?

Implement deletion for
- entities
- entity-types
- property-types
- data-types
- accounts

## 🚀 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [ ] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [ ] modifies a **block** that will need publishing via GitHub action once merged
- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing
- [ ] I am unsure / need advice
