### PR TITLE
Avoid multiple CI runs for same job in same PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ env:
   TURBO_TEAM: hashintel
   TURBO_REMOTE_ONLY: true
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   linting:
     name: Linting


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Similar to the Rust CI, this cancels CI runs on previous commits in the same PR

## 🚀 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [ ] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [ ] modifies a **block** that will need publishing via GitHub action once merged
- [X] does not modify any publishable blocks or libraries, or modifications do not need publishing
- [ ] I am unsure / need advice