### PR TITLE
Fix output for `@apps/hash-frontend` in `turbo.json`

### DIFF
--- a/apps/hash-frontend/turbo.json
+++ b/apps/hash-frontend/turbo.json
@@ -7,7 +7,7 @@
       "dependsOn": ["^build"]
     },
     "build": {
-      "outputs": ["./.next"],
+      "outputs": ["./.next/**"],
       "dependsOn": ["^build", "codegen"]
     }
   }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `outputs` field in `turbo.json` was not set correctly, so turbo did not output the directory but a single file instead.

## 🚀 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [ ] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [ ] modifies a **block** that will need publishing via GitHub action once merged
- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing
- [ ] I am unsure / need advice
