### PR TITLE
`hash-agents`: rework the CLI

### DIFF
--- a/apps/hash-agents/app/agents/__init__.py
+++ b/apps/hash-agents/app/agents/__init__.py
@@ -25,7 +25,7 @@ class InvalidAgentOutputError(ValueError):
 
 @beartype
 async def call_agent(name: str, **kwargs: dict) -> Coroutine[None, None, dict]:
-    allowed_agents = {k.split('.')[-1]: v for k, v in Agent.find().items()}
+    allowed_agents = {k: v for k, v in Agent.find().items()}
 
     agent: Agent | None = allowed_agents.get(name)
 

--- a/apps/hash-agents/app/agents/__main__.py
+++ b/apps/hash-agents/app/agents/__main__.py
@@ -1,20 +1,14 @@
 import inspect
 
 import anyio
+from argdantic import ArgParser
 from beartype import beartype
 from rich.pretty import pprint
-from typer import Typer
 
 from .. import setup
 from . import Agent, call_agent
 
-app = Typer()
-
-
-@app.command()
-def help():
-    # always here because typer is otherwise short-circuits
-    print("use --help to get help")
+app = ArgParser()
 
 
 @beartype

--- a/apps/hash-agents/app/agents/__main__.py
+++ b/apps/hash-agents/app/agents/__main__.py
@@ -11,6 +11,11 @@ from . import Agent, call_agent
 app = ArgParser()
 
 
+@app.command()
+def help():
+    print("use --help for help")
+
+
 @beartype
 def register_command(name: str, agent: Agent):
     @app.command(name, singleton=True)

--- a/apps/hash-agents/app/agents/__main__.py
+++ b/apps/hash-agents/app/agents/__main__.py
@@ -3,6 +3,7 @@ import json
 
 import anyio
 from beartype import beartype
+from rich.pretty import pprint
 from typer import Typer
 
 from .. import setup
@@ -32,14 +33,12 @@ def register_command(name: str, agent: Agent):
         except Exception as e:
             agent_output = {"error": str(e)}
 
-        print(json.dumps(agent_output))  # noqa: T201
+        pprint(agent_output)
 
     signature = inspect.signature(invoke)
     invoke.__signature__ = signature.replace(
         parameters=[
-            inspect.Parameter(
-                name=k, kind=inspect.Parameter.POSITIONAL_ONLY, annotation=v
-            )
+            inspect.Parameter(name=k, kind=inspect.Parameter.KEYWORD_ONLY, annotation=v)
             for k, v in args
         ]
     )

--- a/apps/hash-agents/app/agents/__main__.py
+++ b/apps/hash-agents/app/agents/__main__.py
@@ -1,5 +1,4 @@
 import inspect
-import json
 
 import anyio
 from beartype import beartype

--- a/apps/hash-agents/app/agents/__main__.py
+++ b/apps/hash-agents/app/agents/__main__.py
@@ -13,67 +13,19 @@ app = ArgParser()
 
 @beartype
 def register_command(name: str, agent: Agent):
-    """
-    Register a new command
-
-    Typer doesn't support creating commands directly from models,
-    therefore, we need to employ a bit of trickery.
-
-    This function takes a function that takes any arguments (`invoke`)
-    and transforms it in a way that typer recognizes each of the `Input` arguments.
-    """
-
-    # each pydantic models has an attribute `__fields__` which is a dict with the name
-    # and type of the field (resolved annotation).
-    fields = agent.Input.__fields__
-    args = ((name, field.type_) for name, field in fields.items())
-
-    def invoke(**kwargs: dict):
+    @app.command(name, singleton=True)
+    def invoke(input: agent.Input):
         try:
 
             async def run():
                 # we know that kwargs will be a valid Input, due to Typer
-                return await call_agent(name, **kwargs)
+                return await call_agent(name, **input.dict())
 
             agent_output = anyio.run(run)
         except Exception as e:
             agent_output = {"error": str(e)}
 
         pprint(agent_output)
-
-    # `inspect` caches the signature of a function using the `__signature__` key, which
-    # typer uses to figure out which arguments are allowed.
-    #
-    # Example:
-    # ```
-    # class Input(BaseModel):
-    #   expression: str
-    #
-    # def invoke(**kwargs):
-    #    ...
-    # ```
-    #
-    # here in this example kwargs can be any value, which removes one of the major
-    # benefits of typer, what we do instead is replace the **signature**
-    # (not the actual signature definition) to:
-    #
-    # ```
-    # def invoke(*, expression: str):
-    #   ...
-    # ```
-    #
-    # Nothing in the behaviour has changed, but now anything that inspects the signature
-    # (like typer) will see a typed representation of the kwargs attribute that we're
-    # expecting.
-    signature = inspect.signature(invoke)
-    invoke.__signature__ = signature.replace(
-        parameters=[
-            inspect.Parameter(name=k, kind=inspect.Parameter.KEYWORD_ONLY, annotation=v)
-            for k, v in args
-        ]
-    )
-
-    app.command(name)(invoke)
 
 
 if __name__ == '__main__':

--- a/apps/hash-agents/app/agents/__main__.py
+++ b/apps/hash-agents/app/agents/__main__.py
@@ -20,21 +20,58 @@ def help():
 
 @beartype
 def register_command(name: str, agent: Agent):
+    """
+    Register a new command
+
+    Typer doesn't support creating commands directly from models,
+    therefore, we need to employ a bit of trickery.
+
+    This function takes a function that takes any arguments (`invoke`)
+    and transforms it in a way that typer recognizes each of the `Input` arguments.
+    """
+
+    # each pydantic models has an attribute `__fields__` which is a dict with the name
+    # and type of the field (resolved annotation).
     fields = agent.Input.__fields__
     args = ((name, field.type_) for name, field in fields.items())
 
     def invoke(**kwargs: dict):
         try:
 
-            async def wrap():
+            async def run():
+                # we know that kwargs will be a valid Input, due to Typer
                 return await call_agent(name, **kwargs)
 
-            agent_output = anyio.run(wrap)
+            agent_output = anyio.run(run)
         except Exception as e:
             agent_output = {"error": str(e)}
 
         pprint(agent_output)
 
+    # `inspect` caches the signature of a function using the `__signature__` key, which
+    # typer uses to figure out which arguments are allowed.
+    #
+    # Example:
+    # ```
+    # class Input(BaseModel):
+    #   expression: str
+    #
+    # def invoke(**kwargs):
+    #    ...
+    # ```
+    #
+    # here in this example kwargs can be any value, which removes one of the major
+    # benefits of typer, what we do instead is replace the **signature**
+    # (not the actual signature definition) to:
+    #
+    # ```
+    # def invoke(*, expression: str):
+    #   ...
+    # ```
+    #
+    # Nothing in the behaviour has changed, but now anything that inspects the signature
+    # (like typer) will see a typed representation of the kwargs attribute that we're
+    # expecting.
     signature = inspect.signature(invoke)
     invoke.__signature__ = signature.replace(
         parameters=[

--- a/apps/hash-agents/app/logger/langchain.py
+++ b/apps/hash-agents/app/logger/langchain.py
@@ -44,7 +44,7 @@ class LoggingCallbackHandler(BaseCallbackHandler):
     def on_chain_error(
         self, error: Exception | KeyboardInterrupt, **kwargs: Any
     ) -> Any:
-        self.logger.error("chain_error", error=error, kwargs=kwargs)
+        self.logger.error("chain_error", error=error, kwargs=kwargs, stack=True)
 
     def on_tool_start(
         self, serialized: dict[str, Any], input_str: str, **kwargs: Any

--- a/apps/hash-agents/poetry.lock
+++ b/apps/hash-agents/poetry.lock
@@ -161,6 +161,31 @@ files = [
 test = ["coverage", "mypy", "pexpect", "ruff", "wheel"]
 
 [[package]]
+name = "argdantic"
+version = "0.4.0"
+description = "Typed command line interfaces with argparse and pydantic"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "argdantic-0.4.0-py2.py3-none-any.whl", hash = "sha256:e4b340f355894844b513dd9c89796243e1f60d45f2ebaa902065542187133307"},
+    {file = "argdantic-0.4.0.tar.gz", hash = "sha256:9bbc8d0a8b128ac56107a137a3f9b067340925c16cec806f7cb69eefbbea61d1"},
+]
+
+[package.dependencies]
+pydantic = ">=1.10.0"
+
+[package.extras]
+all = ["orjson (>=3.6.4,<4.0)", "python-dotenv (>=0.19.0,<1.0)", "pyyaml (>=6.0.0,<7.0)", "tomli (>=2.0,<3.0)"]
+dev = ["black (>=23.1.0,<24.0)", "flake8 (>=6.0.0,<7.0)", "isort (>=5.10.0,<6.0)"]
+docs = ["mdx-include (>=1.4.0,<2.0)", "mkdocs (>=1.4.0,<2.0)", "mkdocs-material (>=8.5.0,<9.0)"]
+env = ["python-dotenv (>=0.19.0,<1.0)"]
+json = ["orjson (>=3.6.4,<4.0)"]
+test = ["coverage (>=6.1.2,<7.0)", "mock (>=4.0.0,<5.0)", "pytest (>=6.2.5,<7.0)", "pytest-cov (>=3.0.0,<3.2)", "pytest-xdist (>=2.5.0,<3.0)"]
+toml = ["tomli (>=2.0,<3.0)"]
+yaml = ["pyyaml (>=6.0.0,<7.0)"]
+
+[[package]]
 name = "asgi-correlation-id"
 version = "4.1.0"
 description = "Middleware correlating project logs to individual requests"
@@ -1934,27 +1959,6 @@ slack = ["slack-sdk"]
 telegram = ["requests"]
 
 [[package]]
-name = "typer"
-version = "0.7.0"
-description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
-category = "main"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "typer-0.7.0-py3-none-any.whl", hash = "sha256:b5e704f4e48ec263de1c0b3a2387cd405a13767d2f907f44c1a08cbad96f606d"},
-    {file = "typer-0.7.0.tar.gz", hash = "sha256:ff797846578a9f2a201b53442aedeb543319466870fbe1c701eab66dd7681165"},
-]
-
-[package.dependencies]
-click = ">=7.1.1,<9.0.0"
-
-[package.extras]
-all = ["colorama (>=0.4.3,<0.5.0)", "rich (>=10.11.0,<13.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
-dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "pre-commit (>=2.17.0,<3.0.0)"]
-doc = ["cairosvg (>=2.5.2,<3.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "pillow (>=9.3.0,<10.0.0)"]
-test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.910)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "rich (>=10.11.0,<13.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
-
-[[package]]
 name = "typing-extensions"
 version = "4.5.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -2109,4 +2113,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "301200c7127e639abf070bdc69ad163874ce0ad5589abf2393b053575c814705"
+content-hash = "82633ebfafdb299981a13cf87edad4d9b77713c5d41f49d0c9934ff80364c6f9"

--- a/apps/hash-agents/poetry.lock
+++ b/apps/hash-agents/poetry.lock
@@ -1934,6 +1934,27 @@ slack = ["slack-sdk"]
 telegram = ["requests"]
 
 [[package]]
+name = "typer"
+version = "0.7.0"
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "typer-0.7.0-py3-none-any.whl", hash = "sha256:b5e704f4e48ec263de1c0b3a2387cd405a13767d2f907f44c1a08cbad96f606d"},
+    {file = "typer-0.7.0.tar.gz", hash = "sha256:ff797846578a9f2a201b53442aedeb543319466870fbe1c701eab66dd7681165"},
+]
+
+[package.dependencies]
+click = ">=7.1.1,<9.0.0"
+
+[package.extras]
+all = ["colorama (>=0.4.3,<0.5.0)", "rich (>=10.11.0,<13.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
+dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "pre-commit (>=2.17.0,<3.0.0)"]
+doc = ["cairosvg (>=2.5.2,<3.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "pillow (>=9.3.0,<10.0.0)"]
+test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.910)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "rich (>=10.11.0,<13.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
+
+[[package]]
 name = "typing-extensions"
 version = "4.5.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -2088,4 +2109,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "0409c1e1e2c7c712a90c1100716bcef3b2334b7981a8ec778064347427ff66d7"
+content-hash = "301200c7127e639abf070bdc69ad163874ce0ad5589abf2393b053575c814705"

--- a/apps/hash-agents/pyproject.toml
+++ b/apps/hash-agents/pyproject.toml
@@ -20,6 +20,7 @@ uvicorn = "^0.21.1"
 structlog = "^23.1.0"
 asgi-correlation-id = "^4.1.0"
 rich = "^13.3.4"
+typer = {extras = ["rich"], version = "^0.7.0"}
 
 [tool.poetry.group.dev.dependencies]
 setuptools = "^67.7.1"

--- a/apps/hash-agents/pyproject.toml
+++ b/apps/hash-agents/pyproject.toml
@@ -20,7 +20,7 @@ uvicorn = "^0.21.1"
 structlog = "^23.1.0"
 asgi-correlation-id = "^4.1.0"
 rich = "^13.3.4"
-typer = {extras = ["rich"], version = "^0.7.0"}
+argdantic = "^0.4.0"
 
 [tool.poetry.group.dev.dependencies]
 setuptools = "^67.7.1"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This reworks the CLI to use typer and typed arguments, this enables templates with different fields to properly be called and also upgrades the CLI in a major way.


## 🚀 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [ ] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [ ] modifies a **block** that will need publishing via GitHub action once merged
- [ ] does not modify any publishable blocks or libraries, or modifications do not need publishing
- [x] I am unsure / need advice


## 📹 Demo

<img width="941" alt="image" src="https://user-images.githubusercontent.com/7252775/234006355-723903ac-780a-45a5-a8a3-8d33b260f129.png">

<img width="1120" alt="image" src="https://user-images.githubusercontent.com/7252775/234006396-36569302-f6df-4b67-8ac8-3f139dee0405.png">

<img width="892" alt="image" src="https://user-images.githubusercontent.com/7252775/234006464-71765026-f1c5-42a1-9c61-ba3c1dcc58f6.png">

