### PR TITLE
Prototype select existing property types when suggesting them for an entity type

### DIFF
--- a/apps/hash-agents/app/agents/generate-entity-type-property-types/__main__.py
+++ b/apps/hash-agents/app/agents/generate-entity-type-property-types/__main__.py
@@ -2,34 +2,83 @@ import json
 
 import structlog.stdlib
 from langchain.chat_models import ChatOpenAI
+from langchain.embeddings.openai import OpenAIEmbeddings
 from langchain.schema import HumanMessage, SystemMessage
+from qdrant_client import QdrantClient
+from qdrant_client.http import models
 
 from .io_types import Input, Output, PropertyTypeDefinition
 
 logger = structlog.stdlib.get_logger(__name__)
 
-SYSTEM_MESSAGE_CONTENT = (
-    "You are an entity type generator. Given a title and description of an entity"
-    " type, generate relevant property types for the entity. Respond to any user"
-    " prompts in a minified JSON array format (no whitespace), where each item in the"
-    " array represents a property type for the entity type where each property type has"
-    " a `title`, `description`, and a `dataType` (one of `text`, `number` or"
-    " `boolean`)."
-)
 
-
-def main(agent_input: Input) -> Output:
-    # TODO - add support for querying existing property types so
-    # that they can be re-used
+def are_property_types_semantically_the_same(property_type_1, property_type_2):
     chat = ChatOpenAI(model_name="gpt-3.5-turbo", temperature=0)
 
     messages = [
-        SystemMessage(content=SYSTEM_MESSAGE_CONTENT),
+        SystemMessage(
+            content=(
+                "You are an ontology tool used to determine whether the semantic"
+                " meaning of two property types is the same. The title or descriptions"
+                " may not identical but they can convey the same semantic meaning. The"
+                " input will be an array of two property types with a `title` and"
+                " `description`, and you must respond to any user prompts in a minified"
+                " JSON format (no whitespace), with a `result` boolean field indicating"
+                " whether the property types are semantically the same, and a `reason`"
+                " string field giving an explanation."
+            )
+        ),
+        HumanMessage(
+            content=json.dumps(
+                [
+                    {
+                        "title": property_type_1["title"],
+                        "description": property_type_1["description"],
+                    },
+                    {
+                        "title": property_type_2["title"],
+                        "description": property_type_2["description"],
+                    },
+                ]
+            )
+        ),
+    ]
+
+    response = chat(messages)
+
+    try:
+        response_content = json.loads(response.content)
+    except json.JSONDecodeError as e:
+        # TODO - handle the JSON decoding error using some form of retry logic
+        raise json.JsonParsingError("Failed to parse OpenAI JSON data") from e
+
+    # TODO - validate the structure of the generated JSON data, and handle
+    # any errors using some form of retry logic
+
+    result = response_content["result"]
+
+    return result
+
+
+def generate_property_types(entity_type_title, entity_type_description):
+    chat = ChatOpenAI(model_name="gpt-3.5-turbo", temperature=0)
+
+    messages = [
+        SystemMessage(
+            content=(
+                "You are an entity type generator. Given a title and description of an"
+                " entity type, generate relevant property types for the entity. Respond"
+                " to any user prompts in a minified JSON array format (no whitespace),"
+                " where each item in the array represents a property type for the"
+                " entity type where each property type has a `title`, `description`,"
+                " and a `dataType` (one of `text`, `number` or `boolean`)."
+            )
+        ),
         HumanMessage(
             content=json.dumps(
                 {
-                    "title": agent_input.entity_type_title,
-                    "description": agent_input.entity_type_description,
+                    "title": entity_type_title,
+                    "description": entity_type_description,
                 }
             )
         ),
@@ -38,7 +87,7 @@ def main(agent_input: Input) -> Output:
     response = chat(messages)
 
     try:
-        property_type_definitions = json.loads(response.content)
+        generated_property_type_definitions = json.loads(response.content)
     except json.JSONDecodeError as e:
         # TODO - handle the JSON decoding error using some form of retry logic
         raise json.JsonParsingError("Failed to parse OpenAI JSON data") from e
@@ -46,10 +95,47 @@ def main(agent_input: Input) -> Output:
     # TODO - validate the structure of the generated JSON data, and handle
     # any errors using some form of retry logic
 
-    logger.info(property_type_definitions=property_type_definitions)
+    return generated_property_type_definitions
+
+
+def main(agent_input: Input, qdrant_host: str) -> Output:
+    # TODO - add support for querying existing property types so
+    # that they can be re-used
+
+    qdrant_client = QdrantClient(host=qdrant_host, port=6333)
+
+    embeddings = OpenAIEmbeddings(model="text-embedding-ada-002")
+
+    generated_property_type_definitions = generate_property_types(
+        agent_input.entity_type_title, agent_input.entity_type_description
+    )
+
+    property_type_definitions = []
+
+    # TODO - process these simultaneously
+    for generated_property_type_definition in generated_property_type_definitions:
+        vector = embeddings.embed_query(json.dumps(generated_property_type_definition))
+
+        search_results = qdrant_client.search(
+            collection_name="property_types",
+            search_params=models.SearchParams(hnsw_ef=128, exact=False),
+            query_vector=vector,
+            limit=1,
+        )
+
+        closest_matching_property_type = json.loads(
+            search_results[0].payload["metadata"]["schema"]
+        )
+
+        if are_property_types_semantically_the_same(
+            generated_property_type_definition, closest_matching_property_type
+        ):
+            property_type_definitions.append(closest_matching_property_type)
+        else:
+            property_type_definitions.append(generated_property_type_definition)
 
     return Output(
-        [
+        property_type_definitions=[
             PropertyTypeDefinition.from_dict(property_type)
             for property_type in property_type_definitions
         ]
@@ -58,7 +144,7 @@ def main(agent_input: Input) -> Output:
 
 if __name__ == "HASH":
     global IN, OUT
-    OUT = main(IN)  # noqa: F821
+    OUT = main(IN, "hash-qdrant")  # noqa: F821
 
 if __name__ == "__main__":
     from ... import setup
@@ -69,7 +155,8 @@ if __name__ == "__main__":
         Input(
             entity_type_description="A station that is in space.",
             entity_type_title="Space Station",
-        )
+        ),
+        "localhost",
     )
 
     logger.info(output=output)

--- a/apps/hash-agents/app/agents/generate-entity-type-property-types/io_types.ts
+++ b/apps/hash-agents/app/agents/generate-entity-type-property-types/io_types.ts
@@ -12,10 +12,12 @@ export type Input = {
   entityTypeDescription: string;
 };
 
+type NewPropertyTypeDefinition = {
+  title: string;
+  description: string;
+  dataType: "text" | "number" | "boolean";
+};
+
 export type Output = {
-  propertyTypeDefinitions: {
-    title: string;
-    description: string;
-    dataType: "text" | "number" | "boolean";
-  }[];
+  propertyTypeDefinitions: NewPropertyTypeDefinition[];
 };

--- a/apps/hash-agents/app/agents/generate-text-from-prompt/__main__.py
+++ b/apps/hash-agents/app/agents/generate-text-from-prompt/__main__.py
@@ -1,4 +1,3 @@
-
 import structlog.stdlib
 from langchain.chat_models import ChatOpenAI
 from langchain.schema import HumanMessage, SystemMessage
@@ -13,16 +12,13 @@ SYSTEM_MESSAGE_CONTENT = (
     " question. You must be concise."
 )
 
+
 def main(agent_input: Input) -> Output:
     chat = ChatOpenAI(model_name="gpt-3.5-turbo", temperature=0)
 
     messages = [
-        SystemMessage(
-            content=SYSTEM_MESSAGE_CONTENT
-        ),
-        HumanMessage(
-            content=agent_input.prompt
-        ),
+        SystemMessage(content=SYSTEM_MESSAGE_CONTENT),
+        HumanMessage(content=agent_input.prompt),
     ]
 
     response = chat(messages)
@@ -43,10 +39,6 @@ if __name__ == "__main__":
 
     setup("dev")
 
-    output = main(
-        Input(
-            prompt="What is the meaning of life?"
-        )
-    )
+    output = main(Input(prompt="What is the meaning of life?"))
 
     logger.info(output=output)


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR implements basic functionality for re-using existing property types in the `generate-entity-type-property-types` agent. It does this by:
1. Generating property type definitions for the given entity type
2. For each property type definition:
   a. Generate an embedding for the title and description
   b. Use the vector database to obtain the closest matching existing property type
   c. Use a GPT 3.5 powered method to determine whether the existing property type definition is semantically the same as the generated one
   d. If they are semantically the same, re-use the existing type definition. And if they are not, use the generated type definition

⚠️ This PR breaks the existing implementation in the `prototype` branch, because the agent returns `None` instead of the expected property type definitions. Therefore it requires additional work before merging into either the `prototype` branch or `main`.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204260760205594/1204455398280036/f) _(internal)_

