### PR TITLE
Prevent 'add a property' button from appearing over the 'allow multiple' menu

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,8 +12,7 @@
     "@local/*",
     "@tests/*",
     "error-stack",
-    "deer",
-    "antsi"
+    "deer"
   ],
   "snapshot": {
     "useCalculatedVersion": true

--- a/.changeset/empty-trainers-think.md
+++ b/.changeset/empty-trainers-think.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/type-editor": patch
+---
+
+Prevent 'add a property' button from appearing over the 'allow multiple' menu

--- a/libs/@hashintel/type-editor/src/entity-type-editor/shared/multiple-values-cell.tsx
+++ b/libs/@hashintel/type-editor/src/entity-type-editor/shared/multiple-values-cell.tsx
@@ -277,7 +277,7 @@ export const MultipleValuesCell = ({
           placement="bottom"
           sx={{
             width: 1,
-            zIndex: 1,
+            zIndex: ({ zIndex }) => zIndex.drawer + 2,
           }}
           transition
           // Attempt to prevent this messing with the edit bar scroll freezing


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
This PR fixes a visual bug in the entity type editor where the "add a property" button appears on top of the "Allow multiple" menu.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204274556967336/1204521839453643/f) _(internal)_

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

The "add a property" button table cell has `zIndex: theme.zIndex.drawer + 1` so in order for the "allow multiple" menu to appear on top its zIndex has ben set to `theme.zIndex.drawer + 2`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**

<!-- - [x] modifies a **Cargo**-publishable library and **I have amended the version** -->

<!-- - [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish** -->

<!-- - [x] modifies a **block** that will need publishing via GitHub action once merged -->

<!-- - [x] does not modify any publishable blocks or libraries, or modifications do not need publishing -->

<!-- - [x] I am unsure / need advice -->

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

- [x] is internal and does not require a docs change

<!-- - [x] is in a state where docs changes are not _yet_ required but will be
  - this is tracked within: [Insert Link Here](link) -->

<!-- - [x] requires changes to docs
  - <CHANGES TO DOCS EXPLAINED HERE> -->

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:


<!-- - [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this -->
 - [x] does not affect the execution graph

<!-- - [x] I am unsure / need advice -->

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
Before:
![image](https://user-images.githubusercontent.com/37453800/236636345-55464136-7c44-4b2c-a90b-92e839326115.png)


After:
![image](https://user-images.githubusercontent.com/37453800/236636318-4c30c53d-6a31-485c-9806-c6c6c27ee21f.png)

