### PR TITLE
Ignore `clippy::too-many-lines` on `FilterSchemaAddon`

### DIFF
--- a/apps/hash-graph/lib/graph/src/api/rest.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest.rs
@@ -422,6 +422,7 @@ impl Modify for OperationGraphTagAddon {
 struct FilterSchemaAddon;
 
 impl Modify for FilterSchemaAddon {
+    #[expect(clippy::too_many_lines)]
     fn modify(&self, openapi: &mut openapi::OpenApi) {
         // This magically generates `any`, which is the closest representation we found working
         // with the OpenAPI generator.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

https://github.com/hashintel/hash/pull/1844 added four lines to the `modify` method, which triggers the clippy lint. Generally, the lint is reasonable, but in this case, having it all in one function is more readable as the builders of `utoipa` are pretty verbose and boiler platy

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

<!-- - [x] I am unsure / need advice -->

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] is internal and does not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

- [x] does not affect the execution graph
