### PR TITLE
Fix associated trait bound for `PostgresRecord`

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology.rs
@@ -11,13 +11,13 @@ use type_system::{DataType, EntityType, PropertyType};
 pub use self::ontology_id::OntologyId;
 use crate::{
     ontology::OntologyType,
-    store::{error::DeletionError, postgres::query::PostgresRecord, AsClient, PostgresStore},
+    store::{error::DeletionError, AsClient, PostgresStore},
 };
 
 /// Provides an abstraction over elements of the Type System stored in the Database.
 ///
 /// [`PostgresDatabase`]: crate::store::PostgresDatabase
-pub trait OntologyDatabaseType: OntologyType<WithMetadata: PostgresRecord> {
+pub trait OntologyDatabaseType: OntologyType {
     /// Returns the name of the table where this type is stored.
     fn table() -> &'static str;
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     store::{
         crud::Read,
-        postgres::query::{Distinctness, PostgresRecord, SelectCompiler},
+        postgres::query::{Distinctness, PostgresQueryPath, PostgresRecord, SelectCompiler},
         query::{Filter, OntologyQueryPath},
         AsClient, PostgresStore, QueryError, Record,
     },
@@ -59,7 +59,7 @@ impl<'a> FromSql<'a> for AdditionalOntologyMetadata {
 impl<C: AsClient, T> Read<OntologyTypeSnapshotRecord<T>> for PostgresStore<C>
 where
     T: OntologyType<WithMetadata: PostgresRecord, Representation: Send>,
-    for<'p> <T::WithMetadata as Record>::QueryPath<'p>: OntologyQueryPath,
+    for<'p> <T::WithMetadata as Record>::QueryPath<'p>: OntologyQueryPath + PostgresQueryPath,
 {
     type Record = T::WithMetadata;
 

--- a/apps/hash-graph/lib/graph/src/store/postgres/query.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query.rs
@@ -29,7 +29,7 @@ use crate::store::{
     Record,
 };
 
-pub trait PostgresRecord: for<'p> Record<QueryPath<'p>: PostgresQueryPath> {
+pub trait PostgresRecord: Record {
     /// The [`Table`] used for this `Query`.
     fn base_table() -> Table;
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We currently rely on the `associated_type_bounds` feature flag. This recently changed a little bit so it acts more intuitively (similar to `where` on traits). This addresses the issues and enables us to further update the toolchain to a more recent version.

## 🔗 Related links

- https://github.com/hashintel/hash/pull/2520

## 🔍 What does this change?

- Remove associated bound on `PostgresRecord`, it does not have the expected effect anymore (this was previously breaking intellisense in CLion, which is now fixed)
- Add the required links to the desired locations

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

<!-- - [x] modifies an **npm**-publishable library and **I have added a changeset file(s)** -->

<!-- - [x] modifies a **Cargo**-publishable library and **I have amended the version** -->

<!-- - [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish** -->

<!-- - [x] modifies a **block** that will need publishing via GitHub action once merged -->

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

<!-- - [x] I am unsure / need advice -->

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

- [x] is internal and does not require a docs change

<!-- - [x] is in a state where docs changes are not _yet_ required but will be
  - this is tracked within: [Insert Link Here](link) -->

<!-- - [x] requires changes to docs
  - <CHANGES TO DOCS EXPLAINED HERE> -->

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:
- [x] does not affect the execution graph

<!-- - [x] I am unsure / need advice -->
