### PR TITLE
Move `graph-test-server` to `docker-compose.test.yml`

### DIFF
--- a/apps/hash-external-services/docker-compose.test.yml
+++ b/apps/hash-external-services/docker-compose.test.yml
@@ -17,8 +17,46 @@ services:
       HASH_GRAPH_PG_DATABASE: "${HASH_GRAPH_PG_TEST_DATABASE}"
 
   graph-test-server:
+    init: true
+    depends_on:
+      postgres:
+        condition: service_healthy
+      graph-migrate:
+        condition: service_completed_successfully
+    image: hash-graph
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    volumes:
+      - log:/log
+    command: test-server
     environment:
+      HASH_GRAPH_PG_USER: "${POSTGRES_USER}"
+      HASH_GRAPH_PG_PASSWORD: "${POSTGRES_PASSWORD}"
+      HASH_GRAPH_PG_HOST: "postgres"
+      HASH_GRAPH_PG_PORT: "5432"
       HASH_GRAPH_PG_DATABASE: "${HASH_GRAPH_PG_TEST_DATABASE}"
+      HASH_GRAPH_LOG_FORMAT: "${HASH_GRAPH_LOG_FORMAT:-pretty}"
+      HASH_GRAPH_LOG_FOLDER: "/log/graph-test-service"
+      HASH_GRAPH_API_HOST: "0.0.0.0"
+      HASH_GRAPH_API_PORT: "4000"
+      RUST_LOG: "info"
+      RUST_BACKTRACE: 1
+    ports:
+      - "${HASH_GRAPH_TEST_API_PORT}:4000"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "/hash-graph",
+          "test-server",
+          "--healthcheck",
+          "--api-port",
+          "4000",
+        ]
+      interval: 2s
+      timeout: 2s
+      retries: 10
 
   kratos-migrate:
     environment:

--- a/apps/hash-external-services/docker-compose.yml
+++ b/apps/hash-external-services/docker-compose.yml
@@ -123,48 +123,6 @@ services:
     environment:
       COLLECTOR_OTLP_ENABLED: "true"
 
-  graph-test-server:
-    init: true
-    depends_on:
-      postgres:
-        condition: service_healthy
-      graph-migrate:
-        condition: service_completed_successfully
-    image: hash-graph
-    read_only: true
-    security_opt:
-      - no-new-privileges:true
-    volumes:
-      - log:/log
-    command: test-server
-    environment:
-      HASH_GRAPH_PG_USER: "${POSTGRES_USER}"
-      HASH_GRAPH_PG_PASSWORD: "${POSTGRES_PASSWORD}"
-      HASH_GRAPH_PG_HOST: "postgres"
-      HASH_GRAPH_PG_PORT: "5432"
-      HASH_GRAPH_PG_DATABASE: "${HASH_GRAPH_PG_DEV_DATABASE}"
-      HASH_GRAPH_LOG_FORMAT: "${HASH_GRAPH_LOG_FORMAT:-pretty}"
-      HASH_GRAPH_LOG_FOLDER: "/log/graph-test-service"
-      HASH_GRAPH_API_HOST: "0.0.0.0"
-      HASH_GRAPH_API_PORT: "4000"
-      RUST_LOG: "info"
-      RUST_BACKTRACE: 1
-    ports:
-      - "${HASH_GRAPH_TEST_API_PORT}:4000"
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "/hash-graph",
-          "test-server",
-          "--healthcheck",
-          "--api-port",
-          "4000",
-        ]
-      interval: 2s
-      timeout: 2s
-      retries: 10
-
   graph:
     init: true
     depends_on:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

It's not possible to run the graph test server from `yarn external-services` as the docker image does not contain the test server. This moves the test server to the test-compose file.

## 🔗 Related links

- [Slack thread](https://hashintel.slack.com/archives/C03F7V6DU9M/p1683040225572009) _(internal)_

## 🔍 What does this change?

- Move the `graph-test-server` service without changing it

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

 - [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

- [x] is internal and does not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:
 - [x] does not affect the execution graph