### PR TITLE
Ignore doc-snapshot outputs on non-nightly compiler

### DIFF
--- a/libs/error-stack/src/fmt.rs
+++ b/libs/error-stack/src/fmt.rs
@@ -40,8 +40,8 @@
 //! ## Example
 //!
 //! ```rust
-//! # // we only test with Rust 1.65, which means that `render()` is unused on earlier version
-//! # #![cfg_attr(not(rust_1_65), allow(dead_code, unused_variables, unused_imports))]
+//! # // we only test with nightly, which means that `render()` is unused on earlier version
+//! # #![cfg_attr(not(nightly), allow(dead_code, unused_variables, unused_imports))]
 //! use std::fmt::{Display, Formatter};
 //! use std::io::{Error, ErrorKind};
 //! use error_stack::Report;
@@ -110,12 +110,12 @@
 //! #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
 //! # }
 //! #
-//! # #[cfg(rust_1_65)]
+//! # #[cfg(nightly)]
 //! # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__doc.snap")].assert_eq(&render(format!("{report:?}")));
 //! #
 //! println!("{report:?}");
 //!
-//! # #[cfg(rust_1_65)]
+//! # #[cfg(nightly)]
 //! # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt_doc_alt.snap")].assert_eq(&render(format!("{report:#?}")));
 //! #
 //! println!("{report:#?}");

--- a/libs/error-stack/src/fmt/charset.rs
+++ b/libs/error-stack/src/fmt/charset.rs
@@ -59,8 +59,8 @@ impl Report<()> {
     /// # Example
     ///
     /// ```
-    /// # // we only test the snapshot on rust 1.65, therefore report is unused (so is render)
-    /// # #![cfg_attr(not(rust_1_65), allow(dead_code, unused_variables, unused_imports))]
+    /// # // we only test the snapshot on nightly, therefore report is unused (so is render)
+    /// # #![cfg_attr(not(nightly), allow(dead_code, unused_variables, unused_imports))]
     /// use std::io::{Error, ErrorKind};
     ///
     /// use error_stack::{report, Report};
@@ -90,12 +90,12 @@ impl Report<()> {
     /// #
     /// Report::set_charset(Charset::Utf8);
     /// println!("{report:?}");
-    /// # #[cfg(rust_1_65)]
+    /// # #[cfg(nightly)]
     /// # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__charset_utf8.snap")].assert_eq(&render(format!("{report:?}")));
     ///
     /// Report::set_charset(Charset::Ascii);
     /// println!("{report:?}");
-    /// # #[cfg(rust_1_65)]
+    /// # #[cfg(nightly)]
     /// # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__charset_ascii.snap")].assert_eq(&render(format!("{report:?}")));
     /// ```
     ///

--- a/libs/error-stack/src/fmt/color.rs
+++ b/libs/error-stack/src/fmt/color.rs
@@ -68,8 +68,8 @@ impl Report<()> {
     /// # Example
     ///
     /// ```
-    /// # // we only test the snapshot on rust 1.65, therefore report is unused (so is render)
-    /// # #![cfg_attr(not(rust_1_65), allow(dead_code, unused_variables, unused_imports))]
+    /// # // we only test the snapshot on nightly, therefore report is unused (so is render)
+    /// # #![cfg_attr(not(nightly), allow(dead_code, unused_variables, unused_imports))]
     /// use std::io::{Error, ErrorKind};
     /// use owo_colors::OwoColorize;
     ///
@@ -102,17 +102,17 @@ impl Report<()> {
     /// #
     /// Report::set_color_mode(ColorMode::None);
     /// println!("{report:?}");
-    /// # #[cfg(rust_1_65)]
+    /// # #[cfg(nightly)]
     /// # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__preference_none.snap")].assert_eq(&render(format!("{report:?}")));
     ///
     /// Report::set_color_mode(ColorMode::Emphasis);
     /// println!("{report:?}");
-    /// # #[cfg(rust_1_65)]
+    /// # #[cfg(nightly)]
     /// # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__preference_emphasis.snap")].assert_eq(&render(format!("{report:?}")));
     ///
     /// Report::set_color_mode(ColorMode::Color);
     /// println!("{report:?}");
-    /// # #[cfg(rust_1_65)]
+    /// # #[cfg(nightly)]
     /// # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__preference_color.snap")].assert_eq(&render(format!("{report:?}")));
     /// ```
     ///

--- a/libs/error-stack/src/fmt/hook.rs
+++ b/libs/error-stack/src/fmt/hook.rs
@@ -64,8 +64,8 @@ crate::hook::context::impl_hook_context! {
     /// ### Example
     ///
     /// ```rust
-    /// # // we only test with Rust 1.65, which means that `render()` is unused on earlier version
-    /// # #![cfg_attr(not(rust_1_65), allow(dead_code, unused_variables, unused_imports))]
+    /// # // we only test with nightly, which means that `render()` is unused on earlier version
+    /// # #![cfg_attr(not(nightly), allow(dead_code, unused_variables, unused_imports))]
     /// use std::io::{Error, ErrorKind};
     ///
     /// use error_stack::Report;
@@ -130,12 +130,12 @@ crate::hook::context::impl_hook_context! {
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
     /// # }
     /// #
-    /// # #[cfg(rust_1_65)]
+    /// # #[cfg(nightly)]
     /// # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__emit.snap")].assert_eq(&render(format!("{report:?}")));
     /// #
     /// println!("{report:?}");
     ///
-    /// # #[cfg(rust_1_65)]
+    /// # #[cfg(nightly)]
     /// # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__emit_alt.snap")].assert_eq(&render(format!("{report:#?}")));
     /// #
     /// println!("{report:#?}");
@@ -168,8 +168,8 @@ crate::hook::context::impl_hook_context! {
     /// ### Example
     ///
     /// ```rust
-    /// # // we only test with Rust 1.65, which means that `render()` is unused on earlier version
-    /// # #![cfg_attr(not(rust_1_65), allow(dead_code, unused_variables, unused_imports))]
+    /// # // we only test with nightly, which means that `render()` is unused on earlier version
+    /// # #![cfg_attr(not(nightly), allow(dead_code, unused_variables, unused_imports))]
     /// use std::io::ErrorKind;
     ///
     /// use error_stack::Report;
@@ -210,7 +210,7 @@ crate::hook::context::impl_hook_context! {
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
     /// # }
     /// #
-    /// # #[cfg(rust_1_65)]
+    /// # #[cfg(nightly)]
     /// # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_storage.snap")].assert_eq(&render(format!("{report:?}")));
     /// #
     /// println!("{report:?}");
@@ -255,8 +255,8 @@ impl<T> HookContext<T> {
     /// # Example
     ///
     /// ```rust
-    /// # // we only test with Rust 1.65, which means that `render()` is unused on earlier version
-    /// # #![cfg_attr(not(rust_1_65), allow(dead_code, unused_variables, unused_imports))]
+    /// # // we only test with nightly, which means that `render()` is unused on earlier version
+    /// # #![cfg_attr(not(nightly), allow(dead_code, unused_variables, unused_imports))]
     /// use std::io::ErrorKind;
     ///
     /// use error_stack::Report;
@@ -296,7 +296,7 @@ impl<T> HookContext<T> {
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
     /// # }
     /// #
-    /// # #[cfg(rust_1_65)]
+    /// # #[cfg(nightly)]
     /// # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_emit.snap")].assert_eq(&render(format!("{report:#?}")));
     /// #
     /// println!("{report:#?}");
@@ -314,8 +314,8 @@ impl<T> HookContext<T> {
     /// # Example
     ///
     /// ```rust
-    /// # // we only test with Rust 1.65, which means that `render()` is unused on earlier version
-    /// # #![cfg_attr(not(rust_1_65), allow(dead_code, unused_variables, unused_imports))]
+    /// # // we only test with nightly, which means that `render()` is unused on earlier version
+    /// # #![cfg_attr(not(nightly), allow(dead_code, unused_variables, unused_imports))]
     /// use std::io;
     ///
     /// use error_stack::Report;
@@ -343,7 +343,7 @@ impl<T> HookContext<T> {
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
     /// # }
     /// #
-    /// # #[cfg(rust_1_65)]
+    /// # #[cfg(nightly)]
     /// # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__diagnostics_add.snap")].assert_eq(&render(format!("{report:?}")));
     /// #
     /// println!("{report:?}");

--- a/libs/error-stack/src/hook.rs
+++ b/libs/error-stack/src/hook.rs
@@ -28,8 +28,8 @@ impl Report<()> {
     /// # Examples
     ///
     /// ```
-    /// # // we only test the snapshot on rust 1.65, therefore report is unused (so is render)
-    /// # #![cfg_attr(not(rust_1_65), allow(dead_code, unused_variables, unused_imports))]
+    /// # // we only test the snapshot on nightly, therefore report is unused (so is render)
+    /// # #![cfg_attr(not(nightly), allow(dead_code, unused_variables, unused_imports))]
     /// use std::io::{Error, ErrorKind};
     ///
     /// use error_stack::{
@@ -56,7 +56,7 @@ impl Report<()> {
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
     /// # }
     /// #
-    /// # #[cfg(rust_1_65)]
+    /// # #[cfg(nightly)]
     /// # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/hook__debug_hook.snap")].assert_eq(&render(format!("{report:?}")));
     /// #
     /// println!("{report:?}");

--- a/libs/error-stack/src/hook/context.rs
+++ b/libs/error-stack/src/hook/context.rs
@@ -114,8 +114,8 @@ impl<T> HookContext<T> {
     /// ### Example
     ///
     /// ```rust
-    /// # // we only test with Rust 1.65, which means that `render()` is unused on earlier version
-    /// # #![cfg_attr(not(rust_1_65), allow(dead_code, unused_variables, unused_imports))]
+    /// # // we only test with nightly, which means that `render()` is unused on earlier version
+    /// # #![cfg_attr(not(nightly), allow(dead_code, unused_variables, unused_imports))]
     /// use std::io::ErrorKind;
     ///
     /// use error_stack::Report;
@@ -153,7 +153,7 @@ impl<T> HookContext<T> {
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
     /// # }
     /// #
-    /// # #[cfg(rust_1_65)]
+    /// # #[cfg(nightly)]
     /// # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_cast.snap")].assert_eq(&render(format!("{report:?}")));
     /// #
     /// println!("{report:?}");
@@ -235,8 +235,8 @@ impl<T: 'static> HookContext<T> {
     /// increment a counter, if the counter wasn't initialized this method will return `0`.
     ///
     /// ```rust
-    /// # // we only test with Rust 1.65, which means that `render()` is unused on earlier version
-    /// # #![cfg_attr(not(rust_1_65), allow(dead_code, unused_variables, unused_imports))]
+    /// # // we only test with nightly, which means that `render()` is unused on earlier version
+    /// # #![cfg_attr(not(nightly), allow(dead_code, unused_variables, unused_imports))]
     /// use std::io::ErrorKind;
     ///
     /// use error_stack::Report;
@@ -263,7 +263,7 @@ impl<T: 'static> HookContext<T> {
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
     /// # }
     /// #
-    /// # #[cfg(rust_1_65)]
+    /// # #[cfg(nightly)]
     /// # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_increment.snap")].assert_eq(&render(format!("{report:?}")));
     /// #
     /// println!("{report:?}");
@@ -302,8 +302,8 @@ impl<T: 'static> HookContext<T> {
     /// consistent with [`HookContext::increment_counter`].
     ///
     /// ```rust
-    /// # // we only test with Rust 1.65, which means that `render()` is unused on earlier version
-    /// # #![cfg_attr(not(rust_1_65), allow(dead_code, unused_variables, unused_imports))]
+    /// # // we only test with nightly, which means that `render()` is unused on earlier version
+    /// # #![cfg_attr(not(nightly), allow(dead_code, unused_variables, unused_imports))]
     /// use std::io::ErrorKind;
     ///
     /// use error_stack::Report;
@@ -330,7 +330,7 @@ impl<T: 'static> HookContext<T> {
     /// #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
     /// # }
     /// #
-    /// # #[cfg(rust_1_65)]
+    /// # #[cfg(nightly)]
     /// # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/fmt__hookcontext_decrement.snap")].assert_eq(&render(format!("{report:?}")));
     /// #
     /// println!("{report:?}");

--- a/libs/error-stack/src/lib.rs
+++ b/libs/error-stack/src/lib.rs
@@ -151,8 +151,8 @@
 //! [`Report::attach()`] and [`Report::attach_printable()`]:
 //!
 //! ```rust
-//! # // we only test the snapshot on rust 1.65, therefore report is unused (so is render)
-//! # #![cfg_attr(not(rust_1_65), allow(dead_code, unused_variables, unused_imports))]
+//! # // we only test the snapshot on nightly, therefore report is unused (so is render)
+//! # #![cfg_attr(not(nightly), allow(dead_code, unused_variables, unused_imports))]
 //! # use std::{fs, path::Path};
 //! # use error_stack::{Context, IntoReport, Report, ResultExt};
 //! # pub type Config = String;
@@ -198,7 +198,7 @@
 //! #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
 //! # }
 //! #
-//! # #[cfg(rust_1_65)]
+//! # #[cfg(nightly)]
 //! # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/lib__suggestion.snap")].assert_eq(&render(format!("{report:?}")));
 //! ```
 //!

--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -169,7 +169,7 @@ use crate::{
 ///     # assert!(report.contains::<ConfigError>());
 ///     # assert_eq!(report.downcast_ref::<RuntimeError>(), Some(&RuntimeError::InvalidConfig(PathBuf::from("./path/to/config.file"))));
 ///     # Report::set_color_mode(error_stack::fmt::ColorMode::Emphasis);
-///     # #[cfg(rust_1_65)]
+///     # #[cfg(nightly)]
 ///     # fn render(value: String) -> String {
 ///     #     let backtrace = regex::Regex::new(r"backtrace no\. (\d+)\n(?:  .*\n)*  .*").unwrap();
 ///     #     let backtrace_info = regex::Regex::new(r"backtrace( with (\d+) frames)? \((\d+)\)").unwrap();
@@ -179,11 +179,11 @@ use crate::{
 ///     #
 ///     #     ansi_to_html::convert_escaped(value.as_ref()).unwrap()
 ///     # }
-///     # #[cfg(rust_1_65)]
+///     # #[cfg(nightly)]
 ///     # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/report_display__doc.snap")].assert_eq(&render(format!("{report}")));
-///     # #[cfg(rust_1_65)]
+///     # #[cfg(nightly)]
 ///     # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/report_display_alt__doc.snap")].assert_eq(&render(format!("{report:#}")));
-///     # #[cfg(rust_1_65)]
+///     # #[cfg(nightly)]
 ///     # expect_test::expect_file![concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/doc/report_debug__doc.snap")].assert_eq(&render(format!("{report:?}")));
 ///     # Ok(())
 /// }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The line-number in doc-test changed in a recent nightly compiler version so the lines do not align on `1.65` and the current nightly compiler. This only runs the snapshot tests on a nightly toolchain. There are still plenty of tests, which are covered on the stable toolchain.

## 🔗 Related links

- #2521 

## 🔍 What does this change?

- Only run doc-snapshot tests on nightly

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

<!-- - [x] modifies an **npm**-publishable library and **I have added a changeset file(s)** -->

<!-- - [x] modifies a **Cargo**-publishable library and **I have amended the version** -->

- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

- [x] does not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:
- [x] does not affect the execution graph