### PR TITLE
Track snapshot metadata and fail restoring if missing

### DIFF
--- a/apps/hash-graph/lib/graph/src/snapshot.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot.rs
@@ -285,8 +285,6 @@ impl<C: AsClient> SnapshotStore<C> {
             }
             found_metadata = true;
 
-            tracing::info!("found metadata record in the snapshot: {:?}", metadata);
-
             ensure!(
                 metadata.block_protocol_module_versions.graph == semver::Version::new(0, 3, 0),
                 SnapshotRestoreError::Unsupported

--- a/apps/hash-graph/lib/graph/src/snapshot/error.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/error.rs
@@ -22,6 +22,7 @@ impl Error for SnapshotDumpError {}
 #[derive(Debug)]
 pub enum SnapshotRestoreError {
     Unsupported,
+    MissingMetadata,
     Read,
     Buffer,
     Write,
@@ -31,6 +32,7 @@ impl fmt::Display for SnapshotRestoreError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Unsupported => write!(f, "The snapshot contains unsupported entries"),
+            Self::MissingMetadata => write!(f, "The snapshot does not contain metadata"),
             Self::Read => write!(f, "could not read a snapshot entry"),
             Self::Buffer => write!(f, "could not buffer a snapshot entry"),
             Self::Write => write!(f, "could not write a snapshot entry into the store"),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, we allow specifying global metadata in a snapshot but don't really use them besides checking the version. This PR enhances the restoring logic to track the snapshot metadata and fail if it's not present.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204274556967336/1204549651666217/f) _(internal)_

## 🔍 What does this change?

- Adds an unbounded channel to track metadata. There is no real point in making it bounded as it's expected to have small amounts of data (usually exactly 1)
- Collect metadata values and ensures, that at least one entry exists

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing -->

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

 - [x] is internal and does not require a docs change -->

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

- [x] does not affect the execution graph -->

## 🛡 What tests cover this?

- The backend integration tests are expected to fail in a follow-up PR if this data is missing

## ❓ How to test this?

- Try to restore a snapshot with an empty snapshot

## 📹 Demo

```
Could not restore snapshot, error: The snapshot does not contain metadata
├╴at lib/graph/src/snapshot.rs:291:9
├╴backtrace with 157 frames (1)
╰╴span trace with 1 frames (1)
```
