### PR TITLE
Use a stream instead of reading a snapshot into memory

### DIFF
--- a/tests/hash-backend-integration/src/tests/test-server.ts
+++ b/tests/hash-backend-integration/src/tests/test-server.ts
@@ -1,4 +1,4 @@
-import { promises as fs } from "node:fs";
+import { createReadStream } from "node:fs";
 
 import { GraphStatus } from "@apps/hash-graph/type-defs/status";
 import fetch from "node-fetch";
@@ -63,22 +63,15 @@ export const deleteEntities = async () => {
  * Restore a snapshot from a file.
  */
 export const restoreSnapshot = async (snapshotPath: string) => {
-  await fs
-    .readFile(snapshotPath)
-    .then((snapshot) =>
-      fetch("http://127.0.0.1:4001/snapshot", {
-        method: "POST",
-        body: snapshot,
-      }),
-    )
-    .then(async (response) => {
-      const status: GraphStatus = await response.json();
-      if (status.code !== "OK") {
-        throw new Error(
-          `Snapshot restoration error: ${JSON.stringify(status)}`,
-        );
-      }
-    });
+  await fetch("http://127.0.0.1:4001/snapshot", {
+    method: "POST",
+    body: createReadStream(snapshotPath),
+  }).then(async (response) => {
+    const status: GraphStatus = await response.json();
+    if (status.code !== "OK") {
+      throw new Error(`Snapshot restoration error: ${JSON.stringify(status)}`);
+    }
+  });
 };
 
 /**


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, snapshots are read into memory before passing them to the test server. This changes the behavior to stream the snapshots.