### PR TITLE
Remove the `merging-enabled` CI job

### DIFF
--- a/.github/scripts/rust/setup.py
+++ b/.github/scripts/rust/setup.py
@@ -19,7 +19,7 @@ from pygit2 import Repository, Commit
 CWD = Path.cwd()
 
 # All jobs for all crates will run if any of these paths change
-ALWAYS_RUN_PATTERNS = [".github/**", ".config/**", ".cargo/**"]
+ALWAYS_RUN_PATTERNS = [".config/**", ".cargo/**"]
 
 # Toolchains used for the specified crates in addition to the toolchain which is defined in
 # rust-toolchain.toml

--- a/.github/scripts/rust/setup.py
+++ b/.github/scripts/rust/setup.py
@@ -19,7 +19,7 @@ from pygit2 import Repository, Commit
 CWD = Path.cwd()
 
 # All jobs for all crates will run if any of these paths change
-ALWAYS_RUN_PATTERNS = [".config/**", ".cargo/**"]
+ALWAYS_RUN_PATTERNS = [".github/**", ".config/**", ".cargo/**"]
 
 # Toolchains used for the specified crates in addition to the toolchain which is defined in
 # rust-toolchain.toml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -383,25 +383,3 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         working-directory: ${{ matrix.directory }}
         run: cargo +${{ matrix.toolchain }} publish --all-features
-
-  merging-enabled:
-    name: Merging enabled
-    needs: [setup, lint, test, coverage, publish]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: check setup
-        run: |
-          [[ ${{ needs.setup.result }} = success ]]
-      - name: check lint
-        run: |
-          [[ ${{ needs.lint.result }} =~ success|skipped ]]
-      - name: check test
-        run: |
-          [[ ${{ needs.test.result }} =~ success|skipped ]]
-      - name: check coverage
-        run: |
-          [[ ${{ needs.coverage.result }} =~ success|skipped ]]
-      - name: check publish
-        run: |
-          [[ ${{ needs.publish.result }} =~ success|skipped ]]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

It appears that a job, which was skipped, counts as "success" for required jobs.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203193968491715/1204291503420531/f) _(internal)_
- [GitHub documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks#handling-skipped-but-required-checks)

## 🔍 What does this change?

- Removes the `merging-enabled` job

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR is internal and does not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR does not affect the execution graph 