### PR TITLE
Add Qdrant to prototype Docker compose

### DIFF
--- a/apps/hash-external-services/docker-compose.prototype.yml
+++ b/apps/hash-external-services/docker-compose.prototype.yml
@@ -1,0 +1,18 @@
+version: "3.9"
+
+volumes:
+  hash-qdrant:
+
+services:
+  hash-qdrant:
+    image: qdrant/qdrant:v1.1.0
+    init: true
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    volumes:
+      - hash-qdrant:/qdrant/storage
+    tmpfs:
+      - /qdrant/snapshots
+    ports:
+      - "6333:6333"

--- a/apps/hash-external-services/package.json
+++ b/apps/hash-external-services/package.json
@@ -7,6 +7,7 @@
     "codegen": "touch ../../.env.local",
     "deploy": "docker compose --project-name hash-external-services --file docker-compose.yml --file docker-compose.type-fetcher.yml --env-file ../../.env --env-file ../../.env.local",
     "deploy:offline": "docker compose --project-name hash-external-services --file docker-compose.yml --env-file ../../.env --env-file ../../.env.local",
+    "deploy:prototype": "docker compose --project-name hash-prototype-services --file docker-compose.prototype.yml --env-file ../../.env --env-file ../../.env.local",
     "deploy:test": "docker compose --project-name hash-external-services --file docker-compose.yml --file docker-compose.type-fetcher.yml --file docker-compose.test.yml --env-file ../../.env --env-file ../../.env.local"
   },
   "devDependencies": {

--- a/apps/hash-external-services/turbo.json
+++ b/apps/hash-external-services/turbo.json
@@ -30,6 +30,9 @@
         "@apps/hash-ai-worker-ts#build:docker",
         "codegen"
       ]
+    },
+    "deploy:prototype": {
+      "cache": false
     }
   }
 }

--- a/apps/hash/README.md
+++ b/apps/hash/README.md
@@ -190,6 +190,17 @@ See the [Developing Blocks](https://blockprotocol.org/docs/developing-blocks) pa
 
 HASH's primary datastore is an entity graph. The service that provides this is located within the `/apps/hash-graph` folder. The README contains more information for development. You do not need to visit that README or folder unless you want to amend the graph service.
 
+### LLM prototyping
+
+HASH contains an experimental Docker compose file for prototyping LLM applications using relevant external services such as a vector database. This is located in the `/apps/hash-external-services` folder.
+You'll be able to execute the following command to start the prototyping external services:
+
+```sh
+yarn external-services:prototype up
+```
+
+Similarly to the external services used for HASH, the arguments passed after the script name are arguments for `docker compose`.
+
 ## Testing
 
 ### Debug mode

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "external-services": "turbo deploy --filter '@apps/hash-external-services' --",
     "external-services:offline": "turbo deploy:offline --filter '@apps/hash-external-services' --",
     "external-services:test": "turbo deploy:test --filter '@apps/hash-external-services' --",
+    "external-services:prototype": "turbo deploy:prototype --filter '@apps/hash-external-services' --",
     "fix": "npm-run-all --continue-on-error \"fix:*\"",
     "@TODO.1": "Upgrade or remove these blocks and remove the --ignore-package options (also @TODO.2)",
     "fix:black": "turbo fix:black",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
This PR adds a `external-services:prototype` task to the monorepo that is separate from the rest of the HASH dev infrastructure. For now the prototype external services compose contains a VectorDB that is easily set up and operate locally (https://qdrant.tech/)

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->



## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->


## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Adds new root package.json script
- Adds new docker compose

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

This PR:


<!-- - [x] modifies an **npm**-publishable library and **I have added a changeset file(s)** -->

<!-- - [x] modifies a **Cargo**-publishable library and **I have amended the version** -->

<!-- - [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish** -->

<!-- - [x] modifies a **block** that will need publishing via GitHub action once merged -->

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

<!-- - [x] I am unsure / need advice -->

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

- [x] is internal and does not require a docs change 

<!-- - [x] is in a state where docs changes are not _yet_ required but will be
  - this is tracked within: [Insert Link Here](link) -->

<!-- - [x] requires changes to docs
  - <CHANGES TO DOCS EXPLAINED HERE> -->

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this

<!-- - [x] does not affect the execution graph -->

<!-- - [x] I am unsure / need advice -->

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->
More of an open question, do we want to merge this into main?

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

To develop prototypes

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- None required

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch
1.  Run `yarn external-services:prototype up`. This acts similarly to the other external service scripts in that they allow 
1.  Confirm that qdrant is running by going to http://localhost:6333/telemetry

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
