### PR TITLE
`deer`: implement various helpers

### DIFF
--- a/libs/deer/desert/src/deserializer.rs
+++ b/libs/deer/desert/src/deserializer.rs
@@ -2,6 +2,7 @@ use alloc::borrow::ToOwned;
 
 use deer::{
     error::{DeserializerError, ExpectedType, MissingError, ReceivedType, TypeError, Variant},
+    helpers::EnumObjectVisitor,
     value::NoneDeserializer,
     Context, EnumVisitor, OptionalVisitor, StructVisitor, Visitor,
 };
@@ -99,40 +100,17 @@ impl<'a, 'de> deer::Deserializer<'de> for &mut Deserializer<'a, 'de> {
     {
         let token = self.peek();
 
-        let is_map = match token {
-            Token::Object { .. } => {
-                // eat the token so that we're at the key
-                self.next();
-                true
-            }
-            _ => false,
-        };
-
-        let discriminant = visitor
-            .visit_discriminant(&mut *self)
-            .change_context(DeserializerError)?;
-
-        let value = if is_map {
-            visitor.visit_value(discriminant, &mut *self)
+        if matches!(token, Token::Object { .. }) {
+            self.deserialize_object(EnumObjectVisitor::new(visitor))
         } else {
-            visitor.visit_value(discriminant, NoneDeserializer::new(self.context))
-        }
-        .change_context(DeserializerError)?;
+            let discriminant = visitor
+                .visit_discriminant(&mut *self)
+                .change_context(DeserializerError)?;
 
-        if is_map {
-            // make sure that we're close and that we have nothing dangling
-            if self.peek() == Token::ObjectEnd {
-                self.next();
-            } else {
-                // we received a unit type, therefore error should be a type error
-                // we cannot determine the type we received, just that it is a map
-                // TODO: once HashMap has a reflection use it here as ReceivedType (or
-                //  UnknownObjectSchema?)
-                return Err(Report::new(TypeError.into_error()).change_context(DeserializerError));
-            }
+            visitor
+                .visit_value(discriminant, NoneDeserializer::new(self.context))
+                .change_context(DeserializerError)
         }
-
-        Ok(value)
     }
 
     fn deserialize_struct<V>(self, visitor: V) -> Result<V::Value, DeserializerError>

--- a/libs/deer/src/error/type.rs
+++ b/libs/deer/src/error/type.rs
@@ -1,8 +1,11 @@
 use alloc::format;
-use core::fmt::{Display, Formatter};
+use core::{
+    any::TypeId,
+    fmt::{Display, Formatter},
+};
 
 use super::{ErrorProperties, ErrorProperty, Id, Namespace, Variant, NAMESPACE};
-use crate::{error::Location, id, schema::Document};
+use crate::{error::Location, helpers::ExpectNone, id, schema::Document};
 
 #[derive(serde::Serialize)]
 pub struct ExpectedType(Document);
@@ -26,7 +29,9 @@ impl ErrorProperty for ExpectedType {
     }
 
     fn value<'a>(mut stack: impl Iterator<Item = &'a Self>) -> Self::Value<'a> {
-        stack.next()
+        // TODO: once 0.2 drops with correct schemas remove this hack, this special cases
+        //  `ExpectNone` and will effectively drop it from the chain.
+        stack.find(|frame| frame.document().id != TypeId::of::<ExpectNone>())
     }
 }
 

--- a/libs/deer/src/helpers.rs
+++ b/libs/deer/src/helpers.rs
@@ -1,0 +1,125 @@
+use error_stack::{Result, ResultExt};
+
+use crate::{
+    error::{DeserializeError, VisitorError},
+    ext::TupleExt,
+    Deserialize, Deserializer, Document, EnumVisitor, FieldVisitor, ObjectAccess, Reflection,
+    Schema, Visitor,
+};
+
+struct EnumObjectFieldVisitor<T> {
+    visitor: T,
+}
+
+impl<'de, T> FieldVisitor<'de> for EnumObjectFieldVisitor<T>
+where
+    T: EnumVisitor<'de>,
+{
+    type Key = T::Discriminant;
+    type Value = T::Value;
+
+    fn visit_key<D>(&self, deserializer: D) -> Result<Self::Key, VisitorError>
+    where
+        D: Deserializer<'de>,
+    {
+        self.visitor.visit_discriminant(deserializer)
+    }
+
+    fn visit_value<D>(self, key: Self::Key, deserializer: D) -> Result<Self::Value, VisitorError>
+    where
+        D: Deserializer<'de>,
+    {
+        self.visitor.visit_value(key, deserializer)
+    }
+}
+
+pub struct EnumObjectVisitor<T> {
+    visitor: T,
+}
+
+impl<T> EnumObjectVisitor<T> {
+    #[must_use]
+    pub const fn new(visitor: T) -> Self {
+        Self { visitor }
+    }
+}
+
+impl<'de, T> Visitor<'de> for EnumObjectVisitor<T>
+where
+    T: EnumVisitor<'de>,
+{
+    type Value = T::Value;
+
+    fn expecting(&self) -> Document {
+        self.visitor.expecting()
+    }
+
+    fn visit_object<A>(self, object: A) -> Result<Self::Value, VisitorError>
+    where
+        A: ObjectAccess<'de>,
+    {
+        let mut object = object.into_bound(1).change_context(VisitorError)?;
+
+        let Some(value) = object
+            .field(EnumObjectFieldVisitor {
+                visitor: self.visitor,
+            }) else {
+            // `into_bound` guarantees that we can call exactly `n` times (here `1`) and we
+            // will always get exactly `n` `Some` back, this means getting to this point is UB and
+            // theoretically, due to the fact that `BoundObjectAccess` is controlled by `deer`
+            // impossible.
+            unreachable!();
+        };
+
+        let end = object.end();
+
+        (value, end)
+            .fold_reports()
+            .map(|(value, _)| value)
+            .change_context(VisitorError)
+    }
+}
+
+struct ExpectNoneVisitor;
+
+impl<'de> Visitor<'de> for ExpectNoneVisitor {
+    type Value = ExpectNone;
+
+    fn expecting(&self) -> Document {
+        Self::Value::reflection()
+    }
+
+    fn visit_none(self) -> Result<Self::Value, VisitorError> {
+        Ok(ExpectNone)
+    }
+}
+
+// special type that is used to `Skip` / expect None
+pub struct ExpectNone;
+
+impl Reflection for ExpectNone {
+    fn schema(_: &mut Document) -> Schema {
+        // TODO: for now we are unable to model the reflection of the absence of a value
+        Schema::new("none")
+    }
+}
+
+impl<'de> Deserialize<'de> for ExpectNone {
+    type Reflection = Self;
+
+    fn deserialize<D>(deserializer: D) -> Result<Self, DeserializeError>
+    where
+        D: Deserializer<'de>,
+    {
+        // There is no way to directly `deserialize_none` (for good reason), so instead we say:
+        // `deserialize_any`, this is okay, because we expect both self-describing formats and non
+        // self-describing formats (if they are called from this method) to fail.
+        // Other functions to `deserialize_any` could aid in recovery, but that isn't really
+        // possible with non self-describing formats anyway.
+        deserializer
+            .deserialize_any(ExpectNoneVisitor)
+            .change_context(DeserializeError)
+    }
+}
+
+// TODO: consider adding an error attachment marker type for "short-circuit"

--- a/libs/deer/src/lib.rs
+++ b/libs/deer/src/lib.rs
@@ -41,6 +41,7 @@ mod impls;
 mod macros;
 mod bound;
 mod ext;
+pub mod helpers;
 mod number;
 pub mod schema;
 pub mod value;
@@ -550,6 +551,10 @@ macro_rules! derive_from_number {
 /// [`serde`]: https://serde.rs/
 pub trait Deserializer<'de>: Sized {
     fn context(&self) -> &Context;
+
+    fn is_human_readable(&self) -> bool {
+        true
+    }
 
     /// Require the [`Deserializer`] to figure out **how** to drive the visitor based on input data.
     ///

--- a/libs/deer/src/schema.rs
+++ b/libs/deer/src/schema.rs
@@ -160,7 +160,7 @@ impl Serialize for SerializeDefinitions<'_> {
 }
 
 pub struct Document {
-    id: TypeId,
+    pub(crate) id: TypeId,
     schemas: BTreeMap<TypeId, Schema>,
     references: BTreeMap<TypeId, Reference>,
 

--- a/libs/deer/tests/test_enum_visitor.rs
+++ b/libs/deer/tests/test_enum_visitor.rs
@@ -4,6 +4,7 @@ use deer::{
         ObjectLengthError, ReceivedLength, ReceivedVariant, UnknownVariantError, Variant,
         VisitorError,
     },
+    helpers::ExpectNone,
     schema::Reference,
     Deserialize, Deserializer, Document, EnumVisitor, FieldVisitor, ObjectAccess, Reflection,
     Schema, Visitor,
@@ -67,13 +68,15 @@ impl<'de> EnumVisitor<'de> for UnitEnumVisitor {
     fn visit_value<D>(
         self,
         discriminant: Self::Discriminant,
-        _: D,
+        deserializer: D,
     ) -> Result<Self::Value, VisitorError>
     where
         D: Deserializer<'de>,
     {
         match discriminant {
-            Discriminant::Variant => Ok(UnitEnum::Variant),
+            Discriminant::Variant => ExpectNone::deserialize(deserializer)
+                .map(|_| UnitEnum::Variant)
+                .change_context(VisitorError),
         }
     }
 }
@@ -105,7 +108,7 @@ fn unit_variant() {
                 properties: {
                     "expected": null,
                     "location": [],
-                    "received": null
+                    "received": bool::reflection()
                 }
             }
         ]),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Mostly cleanup and implements various helpers for deserializer(s).

This includes:
* `ExpectNone` (to be used when deserializing unit enum variants)
* `EnumObjectVisitor` generalizes over the `{"Variant": "Value"}` deserialize calls by using `.into_bound(1)`, unifying even more of the API surface (which is good)
* `is_human_readable`, used for deserializers to decide which format to use, has equivalent in `serde`

Under consideration:
* `deserialize_ignored_any` (opinions welcome!) opts into efficient data discarding, also exists in serde; do we need it? This**might** be useful for `ExpectNone` as we currently use `deserialize_any`.


> There are some new TODOs scattered around, because I currently lack a good way to communicate those otherwise _virtual fingerguns_

## 🔗 Related links

* [`deserialize_ignored_any`](https://docs.rs/serde/latest/serde/trait.Deserializer.html#tymethod.deserialize_ignored_any)
* [`is_human_readable`](https://docs.rs/serde/latest/serde/trait.Deserializer.html#method.is_human_readable)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

<!-- - [x] modifies an **npm**-publishable library and **I have added a changeset file(s)** -->

<!-- - [x] modifies a **Cargo**-publishable library and **I have amended the version** -->

- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**

<!-- - [x] modifies a **block** that will need publishing via GitHub action once merged -->

<!-- - [x] does not modify any publishable blocks or libraries, or modifications do not need publishing -->

<!-- - [x] I am unsure / need advice -->

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:


<!-- - [x] is internal and does not require a docs change -->

- [x] is in a state where docs changes are not _yet_ required but will be

<!-- - [x] requires changes to docs
  - <CHANGES TO DOCS EXPLAINED HERE> -->

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

<!-- - [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this -->

- [x] does not affect the execution graph

<!-- - [x] I am unsure / need advice -->


## 🛡 What tests cover this?

Existing tests
