### PR TITLE
Reset databases after running BE tests

### DIFF
--- a/apps/hash-api/src/auth/ory-kratos.ts
+++ b/apps/hash-api/src/auth/ory-kratos.ts
@@ -42,3 +42,11 @@ export const createKratosIdentity = async (
 
   return kratosUserIdentity;
 };
+
+export const deleteKratosIdentity = async (params: {
+  kratosIdentityId: string;
+}): Promise<void> => {
+  await kratosIdentityApi.deleteIdentity({
+    id: params.kratosIdentityId,
+  });
+};

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/primitive/entity.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/primitive/entity.test.ts
@@ -1,3 +1,4 @@
+import { deleteKratosIdentity } from "@apps/hash-api/src/auth/ory-kratos";
 import {
   currentTimeInstantTemporalAxes,
   ensureSystemGraphIsInitialized,
@@ -16,6 +17,7 @@ import { User } from "@apps/hash-api/src/graph/knowledge/system-types/user";
 import { createDataType } from "@apps/hash-api/src/graph/ontology/primitive/data-type";
 import { createEntityType } from "@apps/hash-api/src/graph/ontology/primitive/entity-type";
 import { createPropertyType } from "@apps/hash-api/src/graph/ontology/primitive/property-type";
+import { systemUser } from "@apps/hash-api/src/graph/system-user";
 import { generateSystemEntityTypeSchema } from "@apps/hash-api/src/graph/util";
 import { TypeSystemInitializer } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
@@ -33,6 +35,7 @@ import {
 } from "@local/hash-subgraph";
 import { getRoots } from "@local/hash-subgraph/stdlib";
 
+import { resetGraph } from "../../../test-server";
 import { createTestImpureGraphContext, createTestUser } from "../../../util";
 
 jest.setTimeout(60000);
@@ -147,6 +150,20 @@ describe("Entity CRU", () => {
       }),
       actorId: testUser.accountId,
     });
+  });
+
+  afterAll(async () => {
+    await deleteKratosIdentity({
+      kratosIdentityId: testUser.kratosIdentityId,
+    });
+    await deleteKratosIdentity({
+      kratosIdentityId: testUser2.kratosIdentityId,
+    });
+    await deleteKratosIdentity({
+      kratosIdentityId: systemUser.kratosIdentityId,
+    });
+
+    await resetGraph();
   });
 
   let createdEntity: Entity;

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/primitive/link-entity.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/primitive/link-entity.test.ts
@@ -1,3 +1,4 @@
+import { deleteKratosIdentity } from "@apps/hash-api/src/auth/ory-kratos";
 import {
   ensureSystemGraphIsInitialized,
   ImpureGraphContext,
@@ -15,6 +16,7 @@ import {
 } from "@apps/hash-api/src/graph/knowledge/primitive/link-entity";
 import { User } from "@apps/hash-api/src/graph/knowledge/system-types/user";
 import { createEntityType } from "@apps/hash-api/src/graph/ontology/primitive/entity-type";
+import { systemUser } from "@apps/hash-api/src/graph/system-user";
 import {
   EntityTypeCreatorParams,
   generateSystemEntityTypeSchema,
@@ -29,6 +31,7 @@ import {
   OwnedById,
 } from "@local/hash-subgraph";
 
+import { resetGraph } from "../../../test-server";
 import { createTestImpureGraphContext, createTestUser } from "../../../util";
 
 jest.setTimeout(60000);
@@ -150,6 +153,17 @@ describe("Link entity", () => {
         acquaintanceRightEntity = entity;
       }),
     ]);
+  });
+
+  afterAll(async () => {
+    await deleteKratosIdentity({
+      kratosIdentityId: testUser.kratosIdentityId,
+    });
+    await deleteKratosIdentity({
+      kratosIdentityId: systemUser.kratosIdentityId,
+    });
+
+    await resetGraph();
   });
 
   let linkEntityFriend: LinkEntity;

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/block.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/block.test.ts
@@ -1,3 +1,4 @@
+import { deleteKratosIdentity } from "@apps/hash-api/src/auth/ory-kratos";
 import {
   ensureSystemGraphIsInitialized,
   ImpureGraphContext,
@@ -12,6 +13,7 @@ import {
 } from "@apps/hash-api/src/graph/knowledge/system-types/block";
 import { User } from "@apps/hash-api/src/graph/knowledge/system-types/user";
 import { createEntityType } from "@apps/hash-api/src/graph/ontology/primitive/entity-type";
+import { systemUser } from "@apps/hash-api/src/graph/system-user";
 import { generateSystemEntityTypeSchema } from "@apps/hash-api/src/graph/util";
 import { TypeSystemInitializer } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
@@ -22,6 +24,7 @@ import {
   OwnedById,
 } from "@local/hash-subgraph";
 
+import { resetGraph } from "../../../test-server";
 import { createTestImpureGraphContext, createTestUser } from "../../../util";
 
 jest.setTimeout(60000);
@@ -76,6 +79,17 @@ describe("Block", () => {
       entityTypeId: dummyEntityType.schema.$id,
       actorId: testUser.accountId,
     });
+  });
+
+  afterAll(async () => {
+    await deleteKratosIdentity({
+      kratosIdentityId: testUser.kratosIdentityId,
+    });
+    await deleteKratosIdentity({
+      kratosIdentityId: systemUser.kratosIdentityId,
+    });
+
+    await resetGraph();
   });
 
   it("can create a Block", async () => {

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/comment.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/comment.test.ts
@@ -1,3 +1,4 @@
+import { deleteKratosIdentity } from "@apps/hash-api/src/auth/ory-kratos";
 import {
   ensureSystemGraphIsInitialized,
   ImpureGraphContext,
@@ -15,10 +16,12 @@ import {
 } from "@apps/hash-api/src/graph/knowledge/system-types/comment";
 import { User } from "@apps/hash-api/src/graph/knowledge/system-types/user";
 import { SYSTEM_TYPES } from "@apps/hash-api/src/graph/system-types";
+import { systemUser } from "@apps/hash-api/src/graph/system-user";
 import { TypeSystemInitializer } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
 import { OwnedById } from "@local/hash-subgraph";
 
+import { resetGraph } from "../../../test-server";
 import { createTestImpureGraphContext, createTestUser } from "../../../util";
 
 jest.setTimeout(60000);
@@ -58,6 +61,17 @@ describe("Comment", () => {
       blockData: textEntity,
       actorId: testUser.accountId,
     });
+  });
+
+  afterAll(async () => {
+    await deleteKratosIdentity({
+      kratosIdentityId: testUser.kratosIdentityId,
+    });
+    await deleteKratosIdentity({
+      kratosIdentityId: systemUser.kratosIdentityId,
+    });
+
+    await resetGraph();
   });
 
   it("createComment method can create a comment", async () => {

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/file.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/file.test.ts
@@ -1,3 +1,4 @@
+import { deleteKratosIdentity } from "@apps/hash-api/src/auth/ory-kratos";
 import {
   ensureSystemGraphIsInitialized,
   ImpureGraphContext,
@@ -8,11 +9,13 @@ import {
 } from "@apps/hash-api/src/graph/knowledge/system-types/file";
 import { User } from "@apps/hash-api/src/graph/knowledge/system-types/user";
 import { SYSTEM_TYPES } from "@apps/hash-api/src/graph/system-types";
+import { systemUser } from "@apps/hash-api/src/graph/system-user";
 import { StorageType } from "@apps/hash-api/src/storage";
 import { TypeSystemInitializer } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
 import { OwnedById } from "@local/hash-subgraph";
 
+import { resetGraph } from "../../../test-server";
 import { createTestImpureGraphContext, createTestUser } from "../../../util";
 
 jest.setTimeout(60000);
@@ -34,6 +37,17 @@ describe("File", () => {
     await ensureSystemGraphIsInitialized({ logger, context: graphContext });
 
     testUser = await createTestUser(graphContext, "fileTest", logger);
+  });
+
+  afterAll(async () => {
+    await deleteKratosIdentity({
+      kratosIdentityId: testUser.kratosIdentityId,
+    });
+    await deleteKratosIdentity({
+      kratosIdentityId: systemUser.kratosIdentityId,
+    });
+
+    await resetGraph();
   });
 
   it("createFileFromUploadRequest can create a file entity from a file", async () => {

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/hash-instance.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/hash-instance.test.ts
@@ -1,3 +1,4 @@
+import { deleteKratosIdentity } from "@apps/hash-api/src/auth/ory-kratos";
 import {
   ensureSystemGraphIsInitialized,
   ImpureGraphContext,
@@ -15,10 +16,14 @@ import {
   User,
 } from "@apps/hash-api/src/graph/knowledge/system-types/user";
 import { SYSTEM_TYPES } from "@apps/hash-api/src/graph/system-types";
-import { systemUserAccountId } from "@apps/hash-api/src/graph/system-user";
+import {
+  systemUser,
+  systemUserAccountId,
+} from "@apps/hash-api/src/graph/system-user";
 import { TypeSystemInitializer } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
 
+import { resetGraph } from "../../../test-server";
 import { createTestImpureGraphContext, createTestUser } from "../../../util";
 
 jest.setTimeout(60000);
@@ -35,6 +40,14 @@ describe("Hash Instance", () => {
   beforeAll(async () => {
     await TypeSystemInitializer.initialize();
     await ensureSystemGraphIsInitialized({ logger, context: graphContext });
+  });
+
+  afterAll(async () => {
+    await deleteKratosIdentity({
+      kratosIdentityId: systemUser.kratosIdentityId,
+    });
+
+    await resetGraph();
   });
 
   let hashInstance: HashInstance;

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/org-membership.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/org-membership.test.ts
@@ -1,3 +1,4 @@
+import { deleteKratosIdentity } from "@apps/hash-api/src/auth/ory-kratos";
 import {
   ensureSystemGraphIsInitialized,
   ImpureGraphContext,
@@ -10,9 +11,11 @@ import {
   OrgMembership,
 } from "@apps/hash-api/src/graph/knowledge/system-types/org-membership";
 import { User } from "@apps/hash-api/src/graph/knowledge/system-types/user";
+import { systemUser } from "@apps/hash-api/src/graph/system-user";
 import { TypeSystemInitializer } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
 
+import { resetGraph } from "../../../test-server";
 import {
   createTestImpureGraphContext,
   createTestOrg,
@@ -41,6 +44,17 @@ describe("OrgMembership", () => {
     testUser = await createTestUser(graphContext, "orgMembershipTest", logger);
 
     testOrg = await createTestOrg(graphContext, "orgMembershipTest", logger);
+  });
+
+  afterAll(async () => {
+    await deleteKratosIdentity({
+      kratosIdentityId: systemUser.kratosIdentityId,
+    });
+    await deleteKratosIdentity({
+      kratosIdentityId: testUser.kratosIdentityId,
+    });
+
+    await resetGraph();
   });
 
   let testOrgMembership: OrgMembership;

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/org.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/org.test.ts
@@ -1,3 +1,4 @@
+import { deleteKratosIdentity } from "@apps/hash-api/src/auth/ory-kratos";
 import {
   ensureSystemGraphIsInitialized,
   ImpureGraphContext,
@@ -8,10 +9,14 @@ import {
   updateOrgName,
   updateOrgShortname,
 } from "@apps/hash-api/src/graph/knowledge/system-types/org";
-import { systemUserAccountId } from "@apps/hash-api/src/graph/system-user";
+import {
+  systemUser,
+  systemUserAccountId,
+} from "@apps/hash-api/src/graph/system-user";
 import { TypeSystemInitializer } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
 
+import { resetGraph } from "../../../test-server";
 import {
   createTestImpureGraphContext,
   createTestOrg,
@@ -32,6 +37,14 @@ describe("Org", () => {
   beforeAll(async () => {
     await TypeSystemInitializer.initialize();
     await ensureSystemGraphIsInitialized({ logger, context: graphContext });
+  });
+
+  afterAll(async () => {
+    await deleteKratosIdentity({
+      kratosIdentityId: systemUser.kratosIdentityId,
+    });
+
+    await resetGraph();
   });
 
   let createdOrg: Org;

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/page.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/page.test.ts
@@ -1,3 +1,4 @@
+import { deleteKratosIdentity } from "@apps/hash-api/src/auth/ory-kratos";
 import {
   ensureSystemGraphIsInitialized,
   ImpureGraphContext,
@@ -21,10 +22,12 @@ import {
 } from "@apps/hash-api/src/graph/knowledge/system-types/page";
 import { User } from "@apps/hash-api/src/graph/knowledge/system-types/user";
 import { SYSTEM_TYPES } from "@apps/hash-api/src/graph/system-types";
+import { systemUser } from "@apps/hash-api/src/graph/system-user";
 import { TypeSystemInitializer } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
 import { OwnedById } from "@local/hash-subgraph";
 
+import { resetGraph } from "../../../test-server";
 import { createTestImpureGraphContext, createTestUser } from "../../../util";
 
 jest.setTimeout(60000);
@@ -45,6 +48,17 @@ describe("Page", () => {
     await ensureSystemGraphIsInitialized({ logger, context: graphContext });
 
     testUser = await createTestUser(graphContext, "pageTest", logger);
+  });
+
+  afterAll(async () => {
+    await deleteKratosIdentity({
+      kratosIdentityId: systemUser.kratosIdentityId,
+    });
+    await deleteKratosIdentity({
+      kratosIdentityId: testUser.kratosIdentityId,
+    });
+
+    await resetGraph();
   });
 
   const createTestBlock = async () =>

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/user.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/user.test.ts
@@ -1,5 +1,6 @@
 import {
   createKratosIdentity,
+  deleteKratosIdentity,
   kratosIdentityApi,
 } from "@apps/hash-api/src/auth/ory-kratos";
 import {
@@ -16,11 +17,15 @@ import {
   updateUserShortname,
   User,
 } from "@apps/hash-api/src/graph/knowledge/system-types/user";
-import { systemUserAccountId } from "@apps/hash-api/src/graph/system-user";
+import {
+  systemUser,
+  systemUserAccountId,
+} from "@apps/hash-api/src/graph/system-user";
 import { TypeSystemInitializer } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
 import { extractEntityUuidFromEntityId } from "@local/hash-subgraph";
 
+import { resetGraph } from "../../../test-server";
 import {
   createTestImpureGraphContext,
   createTestOrg,
@@ -43,6 +48,14 @@ describe("User model class", () => {
   beforeAll(async () => {
     await TypeSystemInitializer.initialize();
     await ensureSystemGraphIsInitialized({ logger, context: graphContext });
+  });
+
+  afterAll(async () => {
+    await deleteKratosIdentity({
+      kratosIdentityId: systemUser.kratosIdentityId,
+    });
+
+    await resetGraph();
   });
 
   let createdUser: User;

--- a/tests/hash-backend-integration/src/tests/graph/ontology/primitive/data-type.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/ontology/primitive/data-type.test.ts
@@ -1,3 +1,4 @@
+import { deleteKratosIdentity } from "@apps/hash-api/src/auth/ory-kratos";
 import {
   ensureSystemGraphIsInitialized,
   ImpureGraphContext,
@@ -8,6 +9,7 @@ import {
   getDataTypeById,
   updateDataType,
 } from "@apps/hash-api/src/graph/ontology/primitive/data-type";
+import { systemUser } from "@apps/hash-api/src/graph/system-user";
 import { TypeSystemInitializer } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
 import { ConstructDataTypeParams } from "@local/hash-graphql-shared/graphql/types";
@@ -17,6 +19,7 @@ import {
   OwnedById,
 } from "@local/hash-subgraph";
 
+import { resetGraph } from "../../../test-server";
 import { createTestImpureGraphContext, createTestUser } from "../../../util";
 
 jest.setTimeout(60000);
@@ -43,6 +46,20 @@ beforeAll(async () => {
 
   testUser = await createTestUser(graphContext, "data-type-test-1", logger);
   testUser2 = await createTestUser(graphContext, "data-type-test-2", logger);
+});
+
+afterAll(async () => {
+  await deleteKratosIdentity({
+    kratosIdentityId: systemUser.kratosIdentityId,
+  });
+  await deleteKratosIdentity({
+    kratosIdentityId: testUser.kratosIdentityId,
+  });
+  await deleteKratosIdentity({
+    kratosIdentityId: testUser2.kratosIdentityId,
+  });
+
+  await resetGraph();
 });
 
 describe("Data type CRU", () => {

--- a/tests/hash-backend-integration/src/tests/graph/ontology/primitive/entity-type.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/ontology/primitive/entity-type.test.ts
@@ -1,3 +1,4 @@
+import { deleteKratosIdentity } from "@apps/hash-api/src/auth/ory-kratos";
 import {
   ensureSystemGraphIsInitialized,
   ImpureGraphContext,
@@ -10,6 +11,7 @@ import {
   updateEntityType,
 } from "@apps/hash-api/src/graph/ontology/primitive/entity-type";
 import { createPropertyType } from "@apps/hash-api/src/graph/ontology/primitive/property-type";
+import { systemUser } from "@apps/hash-api/src/graph/system-user";
 import { TypeSystemInitializer } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
 import {
@@ -25,6 +27,7 @@ import {
   PropertyTypeWithMetadata,
 } from "@local/hash-subgraph";
 
+import { resetGraph } from "../../../test-server";
 import { createTestImpureGraphContext, createTestUser } from "../../../util";
 
 jest.setTimeout(60000);
@@ -164,6 +167,20 @@ beforeAll(async () => {
       },
     },
   };
+});
+
+afterAll(async () => {
+  await deleteKratosIdentity({
+    kratosIdentityId: systemUser.kratosIdentityId,
+  });
+  await deleteKratosIdentity({
+    kratosIdentityId: testUser.kratosIdentityId,
+  });
+  await deleteKratosIdentity({
+    kratosIdentityId: testUser2.kratosIdentityId,
+  });
+
+  await resetGraph();
 });
 
 describe("Entity type CRU", () => {

--- a/tests/hash-backend-integration/src/tests/graph/ontology/primitive/property-type.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/ontology/primitive/property-type.test.ts
@@ -1,3 +1,4 @@
+import { deleteKratosIdentity } from "@apps/hash-api/src/auth/ory-kratos";
 import {
   ensureSystemGraphIsInitialized,
   ImpureGraphContext,
@@ -9,6 +10,7 @@ import {
   getPropertyTypeById,
   updatePropertyType,
 } from "@apps/hash-api/src/graph/ontology/primitive/property-type";
+import { systemUser } from "@apps/hash-api/src/graph/system-user";
 import { TypeSystemInitializer } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
 import { ConstructPropertyTypeParams } from "@local/hash-graphql-shared/graphql/types";
@@ -19,6 +21,7 @@ import {
   PropertyTypeWithMetadata,
 } from "@local/hash-subgraph";
 
+import { resetGraph } from "../../../test-server";
 import { createTestImpureGraphContext, createTestUser } from "../../../util";
 
 jest.setTimeout(60000);
@@ -61,6 +64,20 @@ beforeAll(async () => {
       },
     ],
   };
+});
+
+afterAll(async () => {
+  await deleteKratosIdentity({
+    kratosIdentityId: systemUser.kratosIdentityId,
+  });
+  await deleteKratosIdentity({
+    kratosIdentityId: testUser.kratosIdentityId,
+  });
+  await deleteKratosIdentity({
+    kratosIdentityId: testUser2.kratosIdentityId,
+  });
+
+  await resetGraph();
 });
 
 describe("Property type CRU", () => {

--- a/tests/hash-backend-integration/src/tests/subgraph/simple.test.ts
+++ b/tests/hash-backend-integration/src/tests/subgraph/simple.test.ts
@@ -1,25 +1,29 @@
 import path from "node:path";
 
-import { resetToSnapshot } from "../test-server";
+import { resetGraph, restoreSnapshot } from "../test-server";
 
 jest.setTimeout(60000);
+
+afterAll(async () => {
+  await resetGraph();
+});
 
 describe("Empty snapshot", () => {
   it("can upload a snapshot", async () => {
     await expect(
-      resetToSnapshot(path.join(__dirname, "pass", "empty.jsonl")),
+      restoreSnapshot(path.join(__dirname, "pass", "empty.jsonl")),
     ).resolves.not.toThrowError();
   });
 
   it("cannot upload a snapshot without metadata", async () => {
     await expect(
-      resetToSnapshot(path.join(__dirname, "fail", "empty.jsonl")),
+      restoreSnapshot(path.join(__dirname, "fail", "empty.jsonl")),
     ).rejects.toThrow("does not contain metadata");
   });
 
   it("cannot upload a snapshot with wrong version", async () => {
     await expect(
-      resetToSnapshot(path.join(__dirname, "fail", "wrong-version.jsonl")),
+      restoreSnapshot(path.join(__dirname, "fail", "wrong-version.jsonl")),
     ).rejects.toThrow("contains unsupported entries");
   });
 });

--- a/tests/hash-backend-integration/src/tests/test-server.ts
+++ b/tests/hash-backend-integration/src/tests/test-server.ts
@@ -75,17 +75,14 @@ export const restoreSnapshot = async (snapshotPath: string) => {
 };
 
 /**
- * Reset the Graph to the state of the snapshot.
+ * Reset the Graph.
  *
- * This is a convenience function for deleting all entities, entity types, property types, data types, and accounts, and
- * then restoring the snapshot.
+ * This is a convenience function for deleting all entities, entity types, property types, data types, and accounts.
  */
-export const resetToSnapshot = async (snapshotPath: string) => {
+export const resetGraph = async () => {
   await deleteEntities();
   await deleteEntityTypes();
   await deletePropertyTypes();
   await deleteDataTypes();
   await deleteAccounts();
-
-  await restoreSnapshot(snapshotPath);
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Some BE tests requires a clean database to avoid tests interfering each other. This PR cleans up the databases after running the tests.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204315348455207/1204596705932035/f) _(internal)_

## 🔍 What does this change?

- Add function to remove a kratos identifier
- Add `afterAll` call to BE tests

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

- [x] is internal and does not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

 - [x] does not affect the execution graph 

## ⚠️ Known issues

Currently, each user has to be deleted manually. Ideally, the database would just be reset.