### PR TITLE
[H-13] hash.dev: appropriately comma separate author names when articles have 3 or more

### DIFF
--- a/apps/hashdotdev/src/pages/blog/[...blog-slug].page.tsx
+++ b/apps/hashdotdev/src/pages/blog/[...blog-slug].page.tsx
@@ -12,7 +12,7 @@ import { MdxPageContent } from "../../components/mdx-page-content";
 import { getAllPageHrefs, getSerializedPage } from "../../util/mdx-util";
 import { getPhoto } from "./shared/get-photo";
 
-type BlogPostAuthorWithPhotoSrc = {
+export type BlogPostAuthorWithPhotoSrc = {
   name: string;
   jobTitle: string;
   photo: string;

--- a/apps/hashdotdev/src/pages/blog/index.page.tsx
+++ b/apps/hashdotdev/src/pages/blog/index.page.tsx
@@ -20,7 +20,10 @@ import { Subscribe } from "../../components/pre-footer";
 import { parseNameFromFileName } from "../../util/client-mdx-util";
 import { getAllPages, Page } from "../../util/mdx-util";
 import { NextPageWithLayout } from "../../util/next-types";
-import { BlogPostProps } from "./[...blog-slug].page";
+import {
+  BlogPostAuthorWithPhotoSrc,
+  BlogPostProps,
+} from "./[...blog-slug].page";
 import { getPhoto } from "./shared/get-photo";
 
 type BlogIndividualPage = Page<BlogPostProps> & {
@@ -149,6 +152,18 @@ const BigPost: FunctionComponent<{ page: BlogIndividualPage }> = ({ page }) => (
   </Stack>
 );
 
+const formatAuthorsName = (authors: BlogPostAuthorWithPhotoSrc[]): string => {
+  const authorNames = authors.map((author) => author.name);
+  const formattedAuthorsName =
+    authorNames.length > 1
+      ? authorNames
+          .slice(0, -1)
+          .join(", ")
+          .concat(` & ${authorNames.slice(-1)}`)
+      : authorNames.join(" & ");
+  return formattedAuthorsName;
+};
+
 const Post: FunctionComponent<{
   post: BlogIndividualPage;
   collapsed?: boolean;
@@ -167,7 +182,7 @@ const Post: FunctionComponent<{
     >
       {post.data.authors ? (
         <BlogPostAuthor small>
-          {post.data.authors.map((author) => author.name).join(" & ")}
+          {formatAuthorsName(post.data.authors)}
         </BlogPostAuthor>
       ) : null}
       {post.data.title ? (


### PR DESCRIPTION
🌟 What is the purpose of this PR?
---
The aim of this pull request is to enhance the presentation of author names on the `hash.dev/blog` website by introducing a more suitable formatting approach. Currently, the author names are separated by an "&" symbol. However, the desired formatting is to use commas between all author names except for the last two, which should be separated by " &".

🔗  Related links
---
- [Github](https://github.com/hashintel/hash/issues/2466)

❓How to test this?
---
**Before**
<img width="670" alt="Capture 2023-03-31 at 20 11 04@2x" src="https://private-user-images.githubusercontent.com/57623705/237688403-da6626a4-9aea-4708-a100-700c441e153c.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJrZXkxIiwiZXhwIjoxNjg0MTYxMDg3LCJuYmYiOjE2ODQxNjA3ODcsInBhdGgiOiIvNTc2MjM3MDUvMjM3Njg4NDAzLWRhNjYyNmE0LTlhZWEtNDcwOC1hMTAwLTcwMGM0NDFlMTUzYy5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBSVdOSllBWDRDU1ZFSDUzQSUyRjIwMjMwNTE1JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDIzMDUxNVQxNDI2MjdaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT0wZTUxNmI5NzlkN2I3N2ZkOGExNTVmMjliMWEzZWU3Mzg3MWNmNTU4NWVjMGFiYzNmMDRjNTZhNzQ3MWJlMWIyJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.wdqPE8UXrL9804mumFdX30D7hCy3EWmPf6ZiTfLF0n4">


**After**
<img width="575" alt="Screenshot 2023-05-11 at 13 27 01" src="https://private-user-images.githubusercontent.com/57623705/237686820-6e07e77d-ee44-4907-adfb-9a07df82f1fa.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJrZXkxIiwiZXhwIjoxNjg0MTYxMDg3LCJuYmYiOjE2ODQxNjA3ODcsInBhdGgiOiIvNTc2MjM3MDUvMjM3Njg2ODIwLTZlMDdlNzdkLWVlNDQtNDkwNy1hZGZiLTlhMDdkZjgyZjFmYS5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBSVdOSllBWDRDU1ZFSDUzQSUyRjIwMjMwNTE1JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDIzMDUxNVQxNDI2MjdaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT0zY2Y1ZGNjMDc5YjczZjM1MWVlNzkxYzJmMzEwZjAwM2Y3MGYzNTNiOTNjNjc4NjkxNDkwZmQ3OGMyYmI1YjQ4JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.tvt7nTwgAslopQvCAGjy_f9eUelrgRKLSuQ9e6LWkxU">


---
This code was written and reviewed by GitStart Community. Growing future engineers, one PR at a time.