### PR TITLE
Make the type fetcher available to the Rest API through the `FetchingStore`

### DIFF
--- a/apps/hash-graph/lib/graph/src/api/rest/api_resource.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/api_resource.rs
@@ -1,6 +1,6 @@
 use axum::Router;
 
-use crate::store::StorePool;
+use crate::{api::rest::RestApiStore, store::StorePool};
 
 /// With REST, we define resources that can be acted on. These resources are defined through
 /// routes and HTTP methods.
@@ -9,7 +9,10 @@ use crate::store::StorePool;
 /// through a `Router`, making it explicitly clear we want to provide `OpenApi` specification as
 /// documentation for the routes.
 pub(super) trait RoutedResource: utoipa::OpenApi {
-    fn routes<P: StorePool + Send + 'static>() -> Router;
+    fn routes<P: StorePool + Send + 'static>() -> Router
+    where
+        for<'pool> P::Store<'pool>: RestApiStore;
+
     fn documentation() -> utoipa::openapi::OpenApi {
         Self::openapi()
     }

--- a/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
@@ -15,6 +15,7 @@ use crate::{
         json::Json,
         report_to_status_code,
         utoipa_typedef::{subgraph::Subgraph, ListOrValue, MaybeListOfDataType},
+        RestApiStore,
     },
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
@@ -54,7 +55,10 @@ pub struct DataTypeResource;
 
 impl RoutedResource for DataTypeResource {
     /// Create routes for interacting with data types.
-    fn routes<P: StorePool + Send + 'static>() -> Router {
+    fn routes<P: StorePool + Send + 'static>() -> Router
+    where
+        for<'pool> P::Store<'pool>: RestApiStore,
+    {
         // TODO: The URL format here is preliminary and will have to change.
         Router::new().nest(
             "/data-types",
@@ -93,7 +97,10 @@ async fn create_data_type<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
     domain_validator: Extension<DomainValidator>,
     body: Json<CreateDataTypeRequest>,
-) -> Result<Json<ListOrValue<OntologyElementMetadata>>, StatusCode> {
+) -> Result<Json<ListOrValue<OntologyElementMetadata>>, StatusCode>
+where
+    for<'pool> P::Store<'pool>: RestApiStore,
+{
     let Json(CreateDataTypeRequest {
         schema,
         owned_by_id,

--- a/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
@@ -21,6 +21,7 @@ use crate::{
             report_to_status_code,
             status::status_to_response,
             utoipa_typedef::{subgraph::Subgraph, ListOrValue, MaybeListOfEntityType},
+            RestApiStore,
         },
     },
     ontology::{
@@ -61,7 +62,10 @@ pub struct EntityTypeResource;
 
 impl RoutedResource for EntityTypeResource {
     /// Create routes for interacting with entity types.
-    fn routes<P: StorePool + Send + 'static>() -> Router {
+    fn routes<P: StorePool + Send + 'static>() -> Router
+    where
+        for<'pool> P::Store<'pool>: RestApiStore,
+    {
         // TODO: The URL format here is preliminary and will have to change.
         Router::new().nest(
             "/entity-types",
@@ -105,7 +109,10 @@ async fn create_entity_type<P: StorePool + Send>(
     body: Json<CreateEntityTypeRequest>,
     // TODO: We want to be able to return `Status` here we should try and create a general way to
     //  call `status_to_response` for our routes that return Status
-) -> Result<Json<ListOrValue<OntologyElementMetadata>>, Response> {
+) -> Result<Json<ListOrValue<OntologyElementMetadata>>, Response>
+where
+    for<'pool> P::Store<'pool>: RestApiStore,
+{
     let Json(CreateEntityTypeRequest {
         schema,
         owned_by_id,

--- a/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
@@ -15,6 +15,7 @@ use crate::{
         json::Json,
         report_to_status_code,
         utoipa_typedef::{subgraph::Subgraph, ListOrValue, MaybeListOfPropertyType},
+        RestApiStore,
     },
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
@@ -54,7 +55,10 @@ pub struct PropertyTypeResource;
 
 impl RoutedResource for PropertyTypeResource {
     /// Create routes for interacting with property types.
-    fn routes<P: StorePool + Send + 'static>() -> Router {
+    fn routes<P: StorePool + Send + 'static>() -> Router
+    where
+        for<'pool> P::Store<'pool>: RestApiStore,
+    {
         // TODO: The URL format here is preliminary and will have to change.
         Router::new().nest(
             "/property-types",
@@ -96,7 +100,10 @@ async fn create_property_type<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
     domain_validator: Extension<DomainValidator>,
     body: Json<CreatePropertyTypeRequest>,
-) -> Result<Json<ListOrValue<OntologyElementMetadata>>, StatusCode> {
+) -> Result<Json<ListOrValue<OntologyElementMetadata>>, StatusCode>
+where
+    for<'pool> P::Store<'pool>: RestApiStore,
+{
     let Json(CreatePropertyTypeRequest {
         schema,
         owned_by_id,

--- a/apps/hash-graph/lib/graph/src/store.rs
+++ b/apps/hash-graph/lib/graph/src/store.rs
@@ -17,7 +17,7 @@ mod postgres;
 use async_trait::async_trait;
 
 #[cfg(feature = "type-fetcher")]
-pub use self::fetcher::FetchingPool;
+pub use self::fetcher::{FetchingPool, TypeFetcher};
 pub use self::{
     account::AccountStore,
     config::{DatabaseConnectionInfo, DatabaseType},

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -48,6 +48,16 @@ use crate::{
     },
 };
 
+#[async_trait]
+pub trait TypeFetcher {
+    /// Fetches the provided type reference and inserts it to the Graph.
+    async fn insert_external_ontology_type(
+        &mut self,
+        reference: OntologyTypeReference<'_>,
+        actor_id: RecordCreatedById,
+    ) -> Result<OntologyElementMetadata, InsertionError>;
+}
+
 pub struct FetchingPool<P, A> {
     pool: P,
     address: A,
@@ -400,6 +410,22 @@ where
         }
 
         Ok(())
+    }
+}
+
+#[async_trait]
+impl<S, A> TypeFetcher for FetchingStore<S, A>
+where
+    A: ToSocketAddrs + Send + Sync,
+    S: DataTypeStore + PropertyTypeStore + EntityTypeStore + Send,
+{
+    #[expect(clippy::todo, unused_variables, reason = "Not implemented yet")]
+    async fn insert_external_ontology_type(
+        &mut self,
+        reference: OntologyTypeReference<'_>,
+        actor_id: RecordCreatedById,
+    ) -> Result<OntologyElementMetadata, InsertionError> {
+        todo!("https://app.asana.com/0/0/1204596705932067/f")
     }
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The type fetcher currently is an implementation detail on the store and is opaque to the Rest API. This PR conditionally makes the type fetcher available to the REST API.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204315348455207/1204596705932067/f) _(internal)_

## 🔍 What does this change?

- Add a `TypeFetcher` trait and implement it on `FetchingStore` (empty body)
- Add a `RestApiStore` trait which conditionally includes the `TypeFetcher` trait as a requirement. This way it's possible to specify a set of conditions for the REST API.
- Use the `RestApiStore` as bound for creation methods for ontology types

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing 

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

- [x] is internal and does not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

- [x] does not affect the execution graph 

## 🐾 Next steps

- Implement the logic on `TypeFetcher`
- Use the provided logic to allow insertion of external types