### PR TITLE
Implement logic on `TypeFetcher` to load provided URL

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use error_stack::{IntoReport, Result, ResultExt};
+use error_stack::{IntoReport, Report, Result, ResultExt};
 use tarpc::context;
 use tokio::net::ToSocketAddrs;
 use tokio_serde::formats::Json;
@@ -143,6 +143,11 @@ struct FetchedOntologyTypes {
     entity_types: Vec<(EntityType, OntologyElementMetadata)>,
 }
 
+enum FetchBehavior {
+    IncludeProvidedReferences,
+    ExcludeProvidedReferences,
+}
+
 impl<'t, S, A> FetchingStore<S, A>
 where
     A: ToSocketAddrs + Send + Sync,
@@ -221,11 +226,17 @@ where
         &self,
         ontology_type_references: Vec<VersionedUrl>,
         actor_id: RecordCreatedById,
+        fetch_behavior: FetchBehavior,
     ) -> Result<FetchedOntologyTypes, StoreError> {
         let provenance_metadata = ProvenanceMetadata::new(actor_id);
 
         let mut queue = ontology_type_references;
-        let mut seen = queue.iter().cloned().collect::<HashSet<_>>();
+        let mut seen = match fetch_behavior {
+            FetchBehavior::IncludeProvidedReferences => HashSet::new(),
+            FetchBehavior::ExcludeProvidedReferences => {
+                queue.iter().cloned().collect::<HashSet<_>>()
+            }
+        };
 
         let mut fetched_ontology_types = FetchedOntologyTypes::default();
 
@@ -359,7 +370,11 @@ where
 
         for (actor_id, ontology_types_to_fetch) in partitioned_ontology_types {
             let fetched_ontology_types = self
-                .fetch_external_ontology_types(ontology_types_to_fetch, actor_id)
+                .fetch_external_ontology_types(
+                    ontology_types_to_fetch,
+                    actor_id,
+                    FetchBehavior::ExcludeProvidedReferences,
+                )
                 .await
                 .change_context(InsertionError)?;
 
@@ -384,16 +399,41 @@ where
         &mut self,
         reference: OntologyTypeReference<'_>,
         actor_id: RecordCreatedById,
-    ) -> Result<(), InsertionError> {
-        if !self
-            .contains_ontology_type(reference)
-            .await
-            .change_context(InsertionError)?
+        on_conflict: ConflictBehavior,
+        fetch_behavior: FetchBehavior,
+    ) -> Result<Vec<OntologyElementMetadata>, InsertionError> {
+        if on_conflict == ConflictBehavior::Fail
+            || !self
+                .contains_ontology_type(reference)
+                .await
+                .change_context(InsertionError)?
         {
             let fetched_ontology_types = self
-                .fetch_external_ontology_types(vec![reference.url().clone()], actor_id)
+                .fetch_external_ontology_types(
+                    vec![reference.url().clone()],
+                    actor_id,
+                    fetch_behavior,
+                )
                 .await
                 .change_context(InsertionError)?;
+
+            let metadata = fetched_ontology_types
+                .data_types
+                .iter()
+                .map(|(_, metadata)| metadata.clone())
+                .chain(
+                    fetched_ontology_types
+                        .property_types
+                        .iter()
+                        .map(|(_, metadata)| metadata.clone()),
+                )
+                .chain(
+                    fetched_ontology_types
+                        .entity_types
+                        .iter()
+                        .map(|(_, metadata)| metadata.clone()),
+                )
+                .collect::<Vec<_>>();
 
             self.store
                 .create_data_types(fetched_ontology_types.data_types, ConflictBehavior::Skip)
@@ -407,9 +447,11 @@ where
             self.store
                 .create_entity_types(fetched_ontology_types.entity_types, ConflictBehavior::Skip)
                 .await?;
-        }
 
-        Ok(())
+            Ok(metadata)
+        } else {
+            Ok(Vec::new())
+        }
     }
 }
 
@@ -419,13 +461,29 @@ where
     A: ToSocketAddrs + Send + Sync,
     S: DataTypeStore + PropertyTypeStore + EntityTypeStore + Send,
 {
-    #[expect(clippy::todo, unused_variables, reason = "Not implemented yet")]
     async fn insert_external_ontology_type(
         &mut self,
         reference: OntologyTypeReference<'_>,
         actor_id: RecordCreatedById,
     ) -> Result<OntologyElementMetadata, InsertionError> {
-        todo!("https://app.asana.com/0/0/1204596705932067/f")
+        self.insert_external_types_by_reference(
+            reference,
+            actor_id,
+            ConflictBehavior::Fail,
+            FetchBehavior::IncludeProvidedReferences,
+        )
+        .await?
+        .into_iter()
+        .find(|metadata| {
+            metadata.record_id().base_url == reference.url().base_url
+                && metadata.record_id().version.inner() == reference.url().version
+        })
+        .ok_or_else(|| {
+            Report::new(InsertionError).attach_printable(format!(
+                "external type was not fetched: {}",
+                reference.url()
+            ))
+        })
     }
 }
 
@@ -641,6 +699,8 @@ where
         self.insert_external_types_by_reference(
             OntologyTypeReference::EntityTypeReference(&entity_type_reference),
             record_created_by_id,
+            ConflictBehavior::Skip,
+            FetchBehavior::ExcludeProvidedReferences,
         )
         .await?;
 
@@ -679,6 +739,8 @@ where
         self.insert_external_types_by_reference(
             OntologyTypeReference::EntityTypeReference(&entity_type_reference),
             actor_id,
+            ConflictBehavior::Skip,
+            FetchBehavior::ExcludeProvidedReferences,
         )
         .await?;
 
@@ -705,6 +767,8 @@ where
         self.insert_external_types_by_reference(
             OntologyTypeReference::EntityTypeReference(&entity_type_reference),
             record_created_by_id,
+            ConflictBehavior::Skip,
+            FetchBehavior::ExcludeProvidedReferences,
         )
         .await
         .change_context(UpdateError)?;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `FetchingStore` currently only resolves referenced types but cannot resolve a specific type on request. This adds an implementation via the `TypeFetcher` trait interface to add this functionality.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204315348455207/1204596705932067/f) _(internal)_

## 🚫 Blocked by

- https://github.com/hashintel/hash/pull/2573

## 🔍 What does this change?

- Add `FetchBehavior` enumeration to reuse existing function to either resolve all types or only the references
- Make `insert_external_types_by_reference` aware of the conflict and fetching behavior
- Implement the function on `TypeFetcher`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing 

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] is internal and does not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] does not affect the execution graph 

## 🐾 Next steps

- Use the provided logic to allow the insertion of external types
