### PR TITLE
Provide conversion on `RestApiStore` to simplify interfacing with the `TypeFetcher`

### DIFF
--- a/apps/hash-graph/lib/graph/src/api/rest.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest.rs
@@ -20,6 +20,8 @@ mod property_type;
 
 use std::{collections::HashMap, fs, io, sync::Arc};
 
+#[cfg(feature = "type-fetcher")]
+use async_trait::async_trait;
 use axum::{
     extract::Path,
     http::StatusCode,
@@ -39,8 +41,6 @@ use utoipa::{
 };
 
 use self::{api_resource::RoutedResource, middleware::span_trace_layer};
-#[cfg(feature = "type-fetcher")]
-use crate::store::TypeFetcher;
 use crate::{
     api::rest::{
         middleware::log_request_and_response,
@@ -79,11 +79,56 @@ use crate::{
         temporal_axes::{QueryTemporalAxes, QueryTemporalAxesUnresolved, SubgraphTemporalAxes},
     },
 };
+#[cfg(feature = "type-fetcher")]
+use crate::{
+    ontology::OntologyTypeReference,
+    store::{error::VersionedUrlAlreadyExists, TypeFetcher},
+};
 
 #[cfg(feature = "type-fetcher")]
-pub trait RestApiStore: Store + TypeFetcher {}
+#[async_trait]
+pub trait RestApiStore: Store + TypeFetcher {
+    async fn load_external_type(
+        &mut self,
+        domain_validator: &DomainValidator,
+        reference: OntologyTypeReference<'_>,
+        actor_id: RecordCreatedById,
+    ) -> Result<OntologyElementMetadata, StatusCode>;
+}
+
 #[cfg(feature = "type-fetcher")]
-impl<S> RestApiStore for S where S: Store + TypeFetcher {}
+#[async_trait]
+impl<S> RestApiStore for S
+where
+    S: Store + TypeFetcher + Send,
+{
+    async fn load_external_type(
+        &mut self,
+        domain_validator: &DomainValidator,
+        reference: OntologyTypeReference<'_>,
+        actor_id: RecordCreatedById,
+    ) -> Result<OntologyElementMetadata, StatusCode> {
+        if domain_validator.validate_url(reference.url().base_url.as_str()) {
+            tracing::error!(id=%reference.url(), "Ontology type is not external");
+            return Err(StatusCode::UNPROCESSABLE_ENTITY);
+        }
+
+        self
+            .insert_external_ontology_type(
+                reference,
+                actor_id,
+            )
+            .await
+            .map_err(|report| {
+                tracing::error!(error=?report, id=%reference.url(), "Could not insert external type");
+                if report.contains::<VersionedUrlAlreadyExists>() {
+                    StatusCode::CONFLICT
+                } else {
+                    StatusCode::INTERNAL_SERVER_ERROR
+                }
+            })
+    }
+}
 
 #[cfg(not(feature = "type-fetcher"))]
 pub trait RestApiStore: Store {}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To avoid the same code for all ontology-type creation endpoints this adds a function to `RestApiStore` to call the `TypeFetcher`

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204315348455207/1204596705932067/f) _(internal)_

## 🚫 Blocked by

- https://github.com/hashintel/hash/pull/2573
- https://github.com/hashintel/hash/pull/2574

## 🔍 What does this change?

Add a function to:
- validate the domain. If the schema reference matches the domain regex it's not an external type and the function fails
- Call the underlying store and emit a `Conflict` error if the type already exists

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing 

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] is internal and does not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] does not affect the execution graph 

## 🐾 Next steps

- Use the provided logic to allow the insertion of external types
