### PR TITLE
Adjust ontology creation methods to load external types

### DIFF
--- a/.github/actions/install-rust-toolchain/action.yml
+++ b/.github/actions/install-rust-toolchain/action.yml
@@ -25,10 +25,6 @@ runs:
         # extract components from the rust-toolchain.toml 
         COMPONENTS=$(cat rust-toolchain.toml | yq -p toml '.toolchain.components[]')
 
-        rm /home/runner/.cargo/bin/rust-analyzer || true
-        rm /home/runner/.cargo/bin/cargo-fmt || true
-        rm /home/runner/.cargo/bin/rustfmt || true
-
         rustup toolchain install "${{ inputs.toolchain }}"
 
         for component in $COMPONENTS; do

--- a/.github/actions/install-rust-toolchain/action.yml
+++ b/.github/actions/install-rust-toolchain/action.yml
@@ -25,6 +25,10 @@ runs:
         # extract components from the rust-toolchain.toml 
         COMPONENTS=$(cat rust-toolchain.toml | yq -p toml '.toolchain.components[]')
 
+        rm /home/runner/.cargo/bin/rust-analyzer || true
+        rm /home/runner/.cargo/bin/cargo-fmt || true
+        rm /home/runner/.cargo/bin/rustfmt || true
+
         rustup toolchain install "${{ inputs.toolchain }}"
 
         for component in $COMPONENTS; do

--- a/apps/hash-graph/.justfile
+++ b/apps/hash-graph/.justfile
@@ -20,7 +20,7 @@ run *arguments:
 
 # Generates the OpenAPI client for the Graph REST API
 generate-openapi-specs:
-  @just run server --write-openapi-specs
+  cargo run --features type-fetcher --bin hash-graph -- server --write-openapi-specs
 
 [private]
 test *arguments:

--- a/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
@@ -94,7 +94,7 @@ struct CreateOwnedDataTypeRequest {
 #[serde(rename_all = "camelCase")]
 struct CreateExternalDataTypeRequest {
     #[schema(value_type = String)]
-    schema: VersionedUrl,
+    data_type_id: VersionedUrl,
     actor_id: RecordCreatedById,
 }
 
@@ -139,7 +139,7 @@ where
                 store
                     .load_external_type(
                         &domain_validator,
-                        OntologyTypeReference::DataTypeReference((&request.schema).into()),
+                        OntologyTypeReference::DataTypeReference((&request.data_type_id).into()),
                         request.actor_id,
                     )
                     .await?,

--- a/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
@@ -10,6 +10,8 @@ use type_system::{url::VersionedUrl, DataType};
 use utoipa::{OpenApi, ToSchema};
 
 use super::api_resource::RoutedResource;
+#[cfg(feature = "type-fetcher")]
+use crate::ontology::OntologyTypeReference;
 use crate::{
     api::rest::{
         json::Json,
@@ -70,11 +72,26 @@ impl RoutedResource for DataTypeResource {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase", untagged)]
+enum CreateDataTypeRequest {
+    Owned(CreateOwnedDataTypeRequest),
+    #[cfg(feature = "type-fetcher")]
+    External(CreateExternalDataTypeRequest),
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-struct CreateDataTypeRequest {
+struct CreateOwnedDataTypeRequest {
     #[schema(inline)]
     schema: MaybeListOfDataType,
     owned_by_id: OwnedById,
+    actor_id: RecordCreatedById,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct CreateExternalDataTypeRequest {
+    schema: VersionedUrl,
     actor_id: RecordCreatedById,
 }
 
@@ -101,11 +118,31 @@ async fn create_data_type<P: StorePool + Send>(
 where
     for<'pool> P::Store<'pool>: RestApiStore,
 {
-    let Json(CreateDataTypeRequest {
+    let mut store = pool.acquire().await.map_err(|report| {
+        tracing::error!(error=?report, "Could not acquire store");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    #[allow(clippy::infallible_destructuring_match)]
+    let CreateOwnedDataTypeRequest {
         schema,
         owned_by_id,
         actor_id,
-    }) = body;
+    } = match body.0 {
+        CreateDataTypeRequest::Owned(request) => request,
+        #[cfg(feature = "type-fetcher")]
+        CreateDataTypeRequest::External(request) => {
+            return Ok(Json(ListOrValue::Value(
+                store
+                    .load_external_type(
+                        &domain_validator,
+                        OntologyTypeReference::DataTypeReference((&request.schema).into()),
+                        request.actor_id,
+                    )
+                    .await?,
+            )));
+        }
+    };
 
     let is_list = matches!(&schema, ListOrValue::List(_));
 
@@ -136,11 +173,6 @@ where
 
         data_types.push(data_type);
     }
-
-    let mut store = pool.acquire().await.map_err(|report| {
-        tracing::error!(error=?report, "Could not acquire store");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
 
     store
         .create_data_types(

--- a/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
@@ -44,6 +44,8 @@ use crate::{
             DataTypeWithMetadata,
 
             CreateDataTypeRequest,
+            CreateOwnedDataTypeRequest,
+            CreateExternalDataTypeRequest,
             UpdateDataTypeRequest,
             DataTypeQueryToken,
             DataTypeStructuralQuery,
@@ -91,6 +93,7 @@ struct CreateOwnedDataTypeRequest {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 struct CreateExternalDataTypeRequest {
+    #[schema(value_type = String)]
     schema: VersionedUrl,
     actor_id: RecordCreatedById,
 }

--- a/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
@@ -104,7 +104,7 @@ struct CreateOwnedEntityTypeRequest {
 #[serde(rename_all = "camelCase")]
 struct CreateExternalEntityTypeRequest {
     #[schema(value_type = String)]
-    schema: VersionedUrl,
+    entity_type_id: VersionedUrl,
     actor_id: RecordCreatedById,
 }
 
@@ -168,7 +168,7 @@ where
                 store
                     .load_external_type(
                         &domain_validator,
-                        OntologyTypeReference::DataTypeReference((&request.schema).into()),
+                        OntologyTypeReference::EntityTypeReference((&request.entity_type_id).into()),
                         request.actor_id,
                     )
                     .await

--- a/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
@@ -51,6 +51,8 @@ use crate::{
             EntityTypeWithMetadata,
 
             CreateEntityTypeRequest,
+            CreateOwnedEntityTypeRequest,
+            CreateExternalEntityTypeRequest,
             UpdateEntityTypeRequest,
             EntityTypeQueryToken,
             EntityTypeStructuralQuery,
@@ -101,6 +103,7 @@ struct CreateOwnedEntityTypeRequest {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 struct CreateExternalEntityTypeRequest {
+    #[schema(value_type = String)]
     schema: VersionedUrl,
     actor_id: RecordCreatedById,
 }

--- a/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
@@ -168,7 +168,9 @@ where
                 store
                     .load_external_type(
                         &domain_validator,
-                        OntologyTypeReference::EntityTypeReference((&request.entity_type_id).into()),
+                        OntologyTypeReference::EntityTypeReference(
+                            (&request.entity_type_id).into(),
+                        ),
                         request.actor_id,
                     )
                     .await

--- a/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
@@ -12,6 +12,8 @@ use type_system::{
 };
 use utoipa::{OpenApi, ToSchema};
 
+#[cfg(feature = "type-fetcher")]
+use crate::ontology::OntologyTypeReference;
 use crate::{
     api::{
         error::{ErrorInfo, Status, StatusPayloads},
@@ -80,11 +82,26 @@ impl RoutedResource for EntityTypeResource {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase", untagged)]
+enum CreateEntityTypeRequest {
+    Owned(CreateOwnedEntityTypeRequest),
+    #[cfg(feature = "type-fetcher")]
+    External(CreateExternalEntityTypeRequest),
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-struct CreateEntityTypeRequest {
+struct CreateOwnedEntityTypeRequest {
     #[schema(inline)]
     schema: MaybeListOfEntityType,
     owned_by_id: OwnedById,
+    actor_id: RecordCreatedById,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct CreateExternalEntityTypeRequest {
+    schema: VersionedUrl,
     actor_id: RecordCreatedById,
 }
 
@@ -113,11 +130,66 @@ async fn create_entity_type<P: StorePool + Send>(
 where
     for<'pool> P::Store<'pool>: RestApiStore,
 {
-    let Json(CreateEntityTypeRequest {
+    let mut store = pool.acquire().await.map_err(|report| {
+        tracing::error!(error=?report, "Could not acquire store");
+        status_to_response(Status::new(
+            hash_status::StatusCode::Internal,
+            Some(
+                "Could not acquire store. This is an internal error, please report to the \
+                 developers of the HASH Graph with whatever information you can provide including \
+                 request details and logs."
+                    .to_owned(),
+            ),
+            vec![StatusPayloads::ErrorInfo(ErrorInfo::new(
+                // TODO: add information from the report here
+                //   https://app.asana.com/0/1203363157432094/1203639884730779/f
+                HashMap::new(),
+                // TODO: We should encapsulate these Reasons within the type system, perhaps
+                //  requiring top level contexts to implement a trait `ErrorReason::to_reason`
+                //  or perhaps as a big enum, or as an attachment
+                "STORE_ACQUISITION_FAILURE".to_owned(),
+            ))],
+        ))
+    })?;
+
+    #[allow(clippy::infallible_destructuring_match)]
+    let CreateOwnedEntityTypeRequest {
         schema,
         owned_by_id,
         actor_id,
-    }) = body;
+    } = match body.0 {
+        CreateEntityTypeRequest::Owned(request) => request,
+        #[cfg(feature = "type-fetcher")]
+        CreateEntityTypeRequest::External(request) => {
+            return Ok(Json(ListOrValue::Value(
+                store
+                    .load_external_type(
+                        &domain_validator,
+                        OntologyTypeReference::DataTypeReference((&request.schema).into()),
+                        request.actor_id,
+                    )
+                    .await
+                    .map_err(|error| {
+                        if error == StatusCode::CONFLICT {
+                            status_to_response(Status::new(
+                                hash_status::StatusCode::AlreadyExists,
+                                Some("Provided schema entity type does already exist.".to_owned()),
+                                vec![],
+                            ))
+                        } else {
+                            status_to_response(Status::new(
+                                hash_status::StatusCode::AlreadyExists,
+                                Some(
+                                    "Unknown error occurred when loading external entity type."
+                                        .to_owned(),
+                                ),
+                                vec![],
+                            ))
+                        }
+                    })?,
+            )));
+        }
+    };
 
     let is_list = matches!(&schema, ListOrValue::List(_));
 
@@ -176,28 +248,6 @@ where
 
         entity_types.push(entity_type);
     }
-
-    let mut store = pool.acquire().await.map_err(|report| {
-        tracing::error!(error=?report, "Could not acquire store");
-        status_to_response(Status::new(
-            hash_status::StatusCode::Internal,
-            Some(
-                "Could not acquire store. This is an internal error, please report to the \
-                 developers of the HASH Graph with whatever information you can provide including \
-                 request details and logs."
-                    .to_owned(),
-            ),
-            vec![StatusPayloads::ErrorInfo(ErrorInfo::new(
-                // TODO: add information from the report here
-                //   https://app.asana.com/0/1203363157432094/1203639884730779/f
-                HashMap::new(),
-                // TODO: We should encapsulate these Reasons within the type system, perhaps
-                //  requiring top level contexts to implement a trait `ErrorReason::to_reason`
-                //  or perhaps as a big enum, or as an attachment
-                "STORE_ACQUISITION_FAILURE".to_owned(),
-            ))],
-        ))
-    })?;
 
     store
         .create_entity_types(

--- a/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
@@ -44,6 +44,8 @@ use crate::{
             PropertyTypeWithMetadata,
 
             CreatePropertyTypeRequest,
+            CreateOwnedPropertyTypeRequest,
+            CreateExternalPropertyTypeRequest,
             UpdatePropertyTypeRequest,
             PropertyTypeQueryToken,
             PropertyTypeStructuralQuery,
@@ -93,6 +95,7 @@ struct CreateOwnedPropertyTypeRequest {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 struct CreateExternalPropertyTypeRequest {
+    #[schema(value_type = String)]
     schema: VersionedUrl,
     actor_id: RecordCreatedById,
 }

--- a/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
@@ -96,7 +96,7 @@ struct CreateOwnedPropertyTypeRequest {
 #[serde(rename_all = "camelCase")]
 struct CreateExternalPropertyTypeRequest {
     #[schema(value_type = String)]
-    schema: VersionedUrl,
+    property_type_id: VersionedUrl,
     actor_id: RecordCreatedById,
 }
 
@@ -141,7 +141,7 @@ where
                 store
                     .load_external_type(
                         &domain_validator,
-                        OntologyTypeReference::DataTypeReference((&request.schema).into()),
+                        OntologyTypeReference::PropertyTypeReference((&request.property_type_id).into()),
                         request.actor_id,
                     )
                     .await?,

--- a/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
@@ -141,7 +141,9 @@ where
                 store
                     .load_external_type(
                         &domain_validator,
-                        OntologyTypeReference::PropertyTypeReference((&request.property_type_id).into()),
+                        OntologyTypeReference::PropertyTypeReference(
+                            (&request.property_type_id).into(),
+                        ),
                         request.actor_id,
                     )
                     .await?,

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -554,33 +554,14 @@
         }
       },
       "CreateDataTypeRequest": {
-        "type": "object",
-        "required": [
-          "schema",
-          "ownedById",
-          "actorId"
-        ],
-        "properties": {
-          "actorId": {
-            "$ref": "#/components/schemas/RecordCreatedById"
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CreateOwnedDataTypeRequest"
           },
-          "ownedById": {
-            "$ref": "#/components/schemas/OwnedById"
-          },
-          "schema": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/data_type"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/data_type"
-                }
-              }
-            ]
+          {
+            "$ref": "#/components/schemas/CreateExternalDataTypeRequest"
           }
-        }
+        ]
       },
       "CreateEntityRequest": {
         "type": "object",
@@ -620,6 +601,90 @@
         }
       },
       "CreateEntityTypeRequest": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CreateOwnedEntityTypeRequest"
+          },
+          {
+            "$ref": "#/components/schemas/CreateExternalEntityTypeRequest"
+          }
+        ]
+      },
+      "CreateExternalDataTypeRequest": {
+        "type": "object",
+        "required": [
+          "schema",
+          "actorId"
+        ],
+        "properties": {
+          "actorId": {
+            "$ref": "#/components/schemas/RecordCreatedById"
+          },
+          "schema": {
+            "type": "string"
+          }
+        }
+      },
+      "CreateExternalEntityTypeRequest": {
+        "type": "object",
+        "required": [
+          "schema",
+          "actorId"
+        ],
+        "properties": {
+          "actorId": {
+            "$ref": "#/components/schemas/RecordCreatedById"
+          },
+          "schema": {
+            "type": "string"
+          }
+        }
+      },
+      "CreateExternalPropertyTypeRequest": {
+        "type": "object",
+        "required": [
+          "schema",
+          "actorId"
+        ],
+        "properties": {
+          "actorId": {
+            "$ref": "#/components/schemas/RecordCreatedById"
+          },
+          "schema": {
+            "type": "string"
+          }
+        }
+      },
+      "CreateOwnedDataTypeRequest": {
+        "type": "object",
+        "required": [
+          "schema",
+          "ownedById",
+          "actorId"
+        ],
+        "properties": {
+          "actorId": {
+            "$ref": "#/components/schemas/RecordCreatedById"
+          },
+          "ownedById": {
+            "$ref": "#/components/schemas/OwnedById"
+          },
+          "schema": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/data_type"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/data_type"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "CreateOwnedEntityTypeRequest": {
         "type": "object",
         "required": [
           "schema",
@@ -648,7 +713,7 @@
           }
         }
       },
-      "CreatePropertyTypeRequest": {
+      "CreateOwnedPropertyTypeRequest": {
         "type": "object",
         "required": [
           "schema",
@@ -676,6 +741,16 @@
             ]
           }
         }
+      },
+      "CreatePropertyTypeRequest": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CreateOwnedPropertyTypeRequest"
+          },
+          {
+            "$ref": "#/components/schemas/CreateExternalPropertyTypeRequest"
+          }
+        ]
       },
       "DataTypeQueryToken": {
         "type": "string",

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -613,14 +613,14 @@
       "CreateExternalDataTypeRequest": {
         "type": "object",
         "required": [
-          "schema",
+          "dataTypeId",
           "actorId"
         ],
         "properties": {
           "actorId": {
             "$ref": "#/components/schemas/RecordCreatedById"
           },
-          "schema": {
+          "dataTypeId": {
             "type": "string"
           }
         }
@@ -628,14 +628,14 @@
       "CreateExternalEntityTypeRequest": {
         "type": "object",
         "required": [
-          "schema",
+          "entityTypeId",
           "actorId"
         ],
         "properties": {
           "actorId": {
             "$ref": "#/components/schemas/RecordCreatedById"
           },
-          "schema": {
+          "entityTypeId": {
             "type": "string"
           }
         }
@@ -643,14 +643,14 @@
       "CreateExternalPropertyTypeRequest": {
         "type": "object",
         "required": [
-          "schema",
+          "propertyTypeId",
           "actorId"
         ],
         "properties": {
           "actorId": {
             "$ref": "#/components/schemas/RecordCreatedById"
           },
-          "schema": {
+          "propertyTypeId": {
             "type": "string"
           }
         }

--- a/apps/hash-graph/tests/rest-test.http
+++ b/apps/hash-graph/tests/rest-test.http
@@ -111,7 +111,7 @@ Accept: application/json
 
 {
   "actorId": "{{account_id}}",
-  "schema": "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1"
+  "dataTypeId": "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1"
 }
 
 > {%

--- a/apps/hash-graph/tests/rest-test.http
+++ b/apps/hash-graph/tests/rest-test.http
@@ -70,7 +70,7 @@ Content-Type: application/json
     });
 %}
 
-### Insert Text data type
+### Insert owned data types
 POST http://127.0.0.1:4000/data-types
 Content-Type: application/json
 Accept: application/json
@@ -102,6 +102,23 @@ Accept: application/json
     });
     client.global.set("text_data_type_id", `${response.body[0].recordId.baseUrl}v/${response.body[0].recordId.version}`);
     client.assert(response.body.length === 2, "Unexpected number of data types");
+%}
+
+### Insert external data types
+POST http://127.0.0.1:4000/data-types
+Content-Type: application/json
+Accept: application/json
+
+{
+  "actorId": "{{account_id}}",
+  "schema": "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1"
+}
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+    });
+    client.global.set("text_data_type_id", `${response.body.recordId.baseUrl}v/${response.body.recordId.version}`);
 %}
 
 ### Get Text data type


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This changes the endpoints to allow to either pass an ontology-type schema URI (without the owner id) or to pass the schema (with the owner id). If in the former case a type is passed which matches the current domain, it will fail, otherwise the type will be fetched and inserted as external type.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204315348455207/1204596705932067/f) _(internal)_

## 🚫 Blocked by

- https://github.com/hashintel/hash/pull/2573
- https://github.com/hashintel/hash/pull/2574
- https://github.com/hashintel/hash/pull/2575

## 🔍 What does this change?

- Change the creation request parameters
- Adjust the OpenAPI spec (all changes are completely type safe)
- Adjust the `.justfile` as the `type-fetcher` feature has to be enabled

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing 

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] is internal and does not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] does not affect the execution graph 

## 🐾 Next steps

- Use these changes in the `hash-api` to insert external types if they don't exist


## 🛡 What tests cover this?

- A small endpoint test was added

## ❓ How to test this?

Use the rest endpoint test file and test various queries with external types.