### PR TITLE
Require a `'static` lifetime for transpiling

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/postgres/query.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query.rs
@@ -44,7 +44,7 @@ pub trait PostgresQueryPath {
 }
 
 /// Renders the object into a Postgres compatible format.
-pub trait Transpile {
+pub trait Transpile: 'static {
     /// Renders the value using the given [`Formatter`].
     fn transpile(&self, fmt: &mut Formatter) -> fmt::Result;
 
@@ -75,7 +75,7 @@ mod test_helper {
             .join(" ")
     }
 
-    pub fn max_version_expression() -> Expression<'static> {
+    pub fn max_version_expression() -> Expression {
         Expression::Window(
             Box::new(Expression::Function(Function::Max(Box::new(
                 Expression::Column(DataTypeQueryPath::Version.terminating_column().aliased(

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/compile.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashSet, fmt::Display, marker::PhantomData};
+use std::{collections::HashSet, fmt::Display, marker::PhantomData};
 
 use postgres_types::ToSql;
 use tokio_postgres::row::RowIndex;
@@ -6,10 +6,7 @@ use tokio_postgres::row::RowIndex;
 use crate::{
     store::{
         postgres::query::{
-            table::{
-                DataTypes, EntityEditions, EntityTemporalMetadata, EntityTypes, JsonField,
-                OntologyIds, PropertyTypes,
-            },
+            table::{EntityTemporalMetadata, OntologyIds},
             Alias, AliasedColumn, AliasedTable, Column, Condition, Distinctness, EqualityOperator,
             Expression, Function, JoinExpression, OrderByExpression, Ordering, PostgresQueryPath,
             PostgresRecord, SelectExpression, SelectStatement, Table, Transpile, WhereExpression,
@@ -38,14 +35,14 @@ pub struct CompilerArtifacts<'p> {
     temporal_tables: Option<TemporalTableInfo>,
 }
 
-pub struct SelectCompiler<'c, 'p, T> {
-    statement: SelectStatement<'c>,
+pub struct SelectCompiler<'p, T> {
+    statement: SelectStatement,
     artifacts: CompilerArtifacts<'p>,
     temporal_axes: Option<&'p QueryTemporalAxes>,
     _marker: PhantomData<fn(*const T)>,
 }
 
-impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
+impl<'p, R: PostgresRecord> SelectCompiler<'p, R> {
     /// Creates a new, empty compiler.
     pub fn new(temporal_axes: Option<&'p QueryTemporalAxes>) -> Self {
         Self {
@@ -141,16 +138,15 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
     /// and [`Ordering`].
     pub fn add_selection_path<'q>(
         &mut self,
-        path: &'c R::QueryPath<'q>,
+        path: &'p R::QueryPath<'q>,
     ) -> impl RowIndex + Display + Copy
     where
         R::QueryPath<'q>: PostgresQueryPath,
     {
-        let alias = self.add_join_statements(path);
-        self.statement.selects.push(SelectExpression::from_column(
-            path.terminating_column().aliased(alias),
-            None,
-        ));
+        let column = self.compile_path_column(path);
+        self.statement
+            .selects
+            .push(SelectExpression::from_column(column, None));
         self.statement.selects.len() - 1
     }
 
@@ -160,16 +156,14 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
     /// and [`Ordering`].
     pub fn add_distinct_selection_with_ordering<'q>(
         &mut self,
-        path: &'c R::QueryPath<'q>,
+        path: &'p R::QueryPath<'q>,
         distinctness: Distinctness,
         ordering: Option<Ordering>,
     ) -> impl RowIndex + Display + Copy
     where
         R::QueryPath<'q>: PostgresQueryPath,
     {
-        let column = path
-            .terminating_column()
-            .aliased(self.add_join_statements(path));
+        let column = self.compile_path_column(path);
         if distinctness == Distinctness::Distinct {
             self.statement.distinct.push(column);
         }
@@ -201,7 +195,7 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
     }
 
     /// Compiles a [`Filter`] to a `Condition`.
-    pub fn compile_filter<'f: 'p>(&mut self, filter: &'p Filter<'f, R>) -> Condition<'c>
+    pub fn compile_filter<'f: 'p>(&mut self, filter: &'p Filter<'f, R>) -> Condition
     where
         R::QueryPath<'f>: PostgresQueryPath,
     {
@@ -246,7 +240,7 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
         &mut self,
         path: &R::QueryPath<'q>,
         operator: EqualityOperator,
-    ) -> Condition<'c>
+    ) -> Condition
     where
         R::QueryPath<'q>: PostgresQueryPath,
     {
@@ -274,7 +268,7 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
                                     .aliased(version_column.alias),
                             ),
                         ),
-                        Some(Cow::Borrowed("latest_version")),
+                        Some("latest_version"),
                     ),
                 ],
                 from: version_column.table(),
@@ -305,7 +299,7 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
     ///
     /// The following [`Filter`]s will be special cased:
     /// - Comparing the `"version"` field on [`Table::OntologyIds`] with `"latest"` for equality.
-    fn compile_special_filter<'f: 'p>(&mut self, filter: &Filter<'f, R>) -> Option<Condition<'c>>
+    fn compile_special_filter<'f: 'p>(&mut self, filter: &Filter<'f, R>) -> Option<Condition>
     where
         R::QueryPath<'f>: PostgresQueryPath,
     {
@@ -341,38 +335,16 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
         }
     }
 
-    pub fn compile_path_column<'q>(&mut self, path: &'p R::QueryPath<'q>) -> AliasedColumn<'c>
+    pub fn compile_path_column<'q>(&mut self, path: &'p R::QueryPath<'q>) -> AliasedColumn
     where
         R::QueryPath<'q>: PostgresQueryPath,
     {
-        let column = match path.terminating_column() {
-            Column::DataTypes(DataTypes::Schema(Some(JsonField::JsonPath(field)))) => {
-                self.artifacts.parameters.push(field);
-                Column::DataTypes(DataTypes::Schema(Some(JsonField::JsonPathParameter(
-                    self.artifacts.parameters.len(),
-                ))))
-            }
-            Column::PropertyTypes(PropertyTypes::Schema(Some(JsonField::JsonPath(field)))) => {
-                self.artifacts.parameters.push(field);
-                Column::PropertyTypes(PropertyTypes::Schema(Some(JsonField::JsonPathParameter(
-                    self.artifacts.parameters.len(),
-                ))))
-            }
-            Column::EntityTypes(EntityTypes::Schema(Some(JsonField::JsonPath(field)))) => {
-                self.artifacts.parameters.push(field);
-                Column::EntityTypes(EntityTypes::Schema(Some(JsonField::JsonPathParameter(
-                    self.artifacts.parameters.len(),
-                ))))
-            }
-            Column::EntityEditions(EntityEditions::Properties(Some(JsonField::JsonPath(
-                field,
-            )))) => {
-                self.artifacts.parameters.push(field);
-                Column::EntityEditions(EntityEditions::Properties(Some(
-                    JsonField::JsonPathParameter(self.artifacts.parameters.len()),
-                )))
-            }
-            column => column,
+        let (column, parameter) = path
+            .terminating_column()
+            .into_owned(self.artifacts.parameters.len() + 1);
+
+        if let Some(parameter) = parameter {
+            self.artifacts.parameters.push(parameter);
         };
 
         let alias = self.add_join_statements(path);
@@ -386,7 +358,7 @@ impl<'c, 'p: 'c, R: PostgresRecord> SelectCompiler<'c, 'p, R> {
     pub fn compile_filter_expression<'f: 'p>(
         &mut self,
         expression: &'p FilterExpression<'f, R>,
-    ) -> Expression<'c>
+    ) -> Expression
     where
         R::QueryPath<'f>: PostgresQueryPath,
     {

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/condition.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/condition.rs
@@ -6,14 +6,14 @@ use crate::store::postgres::query::{Expression, Transpile};
 ///
 /// [`Filter`]: crate::store::query::Filter
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub enum Condition<'p> {
+pub enum Condition {
     All(Vec<Self>),
     Any(Vec<Self>),
     Not(Box<Self>),
-    Equal(Option<Expression<'p>>, Option<Expression<'p>>),
-    NotEqual(Option<Expression<'p>>, Option<Expression<'p>>),
-    TimeIntervalContainsTimestamp(Expression<'p>, Expression<'p>),
-    Overlap(Expression<'p>, Expression<'p>),
+    Equal(Option<Expression>, Option<Expression>),
+    NotEqual(Option<Expression>, Option<Expression>),
+    TimeIntervalContainsTimestamp(Expression, Expression),
+    Overlap(Expression, Expression),
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -22,12 +22,12 @@ pub enum EqualityOperator {
     NotEqual,
 }
 
-impl Transpile for Condition<'_> {
+impl Transpile for Condition {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Condition::All(conditions) if conditions.is_empty() => fmt.write_str("TRUE"),
-            Condition::Any(conditions) if conditions.is_empty() => fmt.write_str("FALSE"),
-            Condition::All(conditions) => {
+            Self::All(conditions) if conditions.is_empty() => fmt.write_str("TRUE"),
+            Self::Any(conditions) if conditions.is_empty() => fmt.write_str("FALSE"),
+            Self::All(conditions) => {
                 for (idx, condition) in conditions.iter().enumerate() {
                     if idx > 0 {
                         fmt.write_str(" AND ")?;
@@ -38,7 +38,7 @@ impl Transpile for Condition<'_> {
                 }
                 Ok(())
             }
-            Condition::Any(conditions) => {
+            Self::Any(conditions) => {
                 if conditions.len() > 1 {
                     fmt.write_char('(')?;
                 }
@@ -55,36 +55,36 @@ impl Transpile for Condition<'_> {
                 }
                 Ok(())
             }
-            Condition::Not(condition) => {
+            Self::Not(condition) => {
                 fmt.write_str("NOT(")?;
                 condition.transpile(fmt)?;
                 fmt.write_char(')')
             }
-            Condition::Equal(value, None) | Condition::Equal(None, value) => {
+            Self::Equal(value, None) | Self::Equal(None, value) => {
                 value.transpile(fmt)?;
                 fmt.write_str(" IS NULL")
             }
-            Condition::Equal(lhs, rhs) => {
+            Self::Equal(lhs, rhs) => {
                 lhs.transpile(fmt)?;
                 fmt.write_str(" = ")?;
                 rhs.transpile(fmt)
             }
-            Condition::NotEqual(value, None) | Condition::NotEqual(None, value) => {
+            Self::NotEqual(value, None) | Self::NotEqual(None, value) => {
                 value.transpile(fmt)?;
                 fmt.write_str(" IS NOT NULL")
             }
-            Condition::NotEqual(lhs, rhs) => {
+            Self::NotEqual(lhs, rhs) => {
                 lhs.transpile(fmt)?;
                 fmt.write_str(" != ")?;
                 rhs.transpile(fmt)
             }
-            Condition::TimeIntervalContainsTimestamp(lhs, rhs) => {
+            Self::TimeIntervalContainsTimestamp(lhs, rhs) => {
                 lhs.transpile(fmt)?;
                 fmt.write_str(" @> ")?;
                 rhs.transpile(fmt)?;
                 fmt.write_str("::TIMESTAMPTZ")
             }
-            Condition::Overlap(lhs, rhs) => {
+            Self::Overlap(lhs, rhs) => {
                 lhs.transpile(fmt)?;
                 fmt.write_str(" && ")?;
                 rhs.transpile(fmt)

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/conditional.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/conditional.rs
@@ -3,19 +3,19 @@ use std::fmt::{self, Write};
 use crate::store::postgres::query::{AliasedColumn, Transpile, WindowStatement};
 
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub enum Function<'p> {
-    Min(Box<Expression<'p>>),
-    Max(Box<Expression<'p>>),
-    JsonExtractPath(Vec<Expression<'p>>),
-    JsonContains(Box<Expression<'p>>, Box<Expression<'p>>),
-    JsonBuildArray(Vec<Expression<'p>>),
-    JsonBuildObject(Vec<(Expression<'p>, Expression<'p>)>),
-    Lower(Box<Expression<'p>>),
-    Upper(Box<Expression<'p>>),
+pub enum Function {
+    Min(Box<Expression>),
+    Max(Box<Expression>),
+    JsonExtractPath(Vec<Expression>),
+    JsonContains(Box<Expression>, Box<Expression>),
+    JsonBuildArray(Vec<Expression>),
+    JsonBuildObject(Vec<(Expression, Expression)>),
+    Lower(Box<Expression>),
+    Upper(Box<Expression>),
     Now,
 }
 
-impl Transpile for Function<'_> {
+impl Transpile for Function {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Min(expression) => {
@@ -99,19 +99,19 @@ impl Transpile for Constant {
 
 /// A compiled expression in Postgres.
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub enum Expression<'p> {
+pub enum Expression {
     Asterisk,
-    Column(AliasedColumn<'p>),
+    Column(AliasedColumn),
     /// A parameter are transpiled as a placeholder, e.g. `$1`, in order to prevent SQL injection.
     Parameter(usize),
     /// [`Constant`]s are directly transpiled into the SQL query. Caution has to be taken to
     /// prevent SQL injection and no user input should ever be used as a [`Constant`].
     Constant(Constant),
-    Function(Function<'p>),
-    Window(Box<Self>, WindowStatement<'p>),
+    Function(Function),
+    Window(Box<Self>, WindowStatement),
 }
 
-impl Transpile for Expression<'_> {
+impl Transpile for Expression {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Asterisk => fmt.write_char('*'),
@@ -129,7 +129,7 @@ impl Transpile for Expression<'_> {
     }
 }
 
-impl Transpile for Option<Expression<'_>> {
+impl Transpile for Option<Expression> {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Some(value) => value.transpile(fmt),

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
@@ -43,20 +43,20 @@ impl JoinType {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub struct JoinOn<'p> {
-    pub join: Column<'p>,
-    pub on: Column<'p>,
+pub struct JoinOn {
+    pub join: Column<'static>,
+    pub on: Column<'static>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub struct JoinExpression<'p> {
+pub struct JoinExpression {
     pub join: JoinType,
     pub table: AliasedTable,
     pub on_alias: Alias,
-    pub on: Vec<JoinOn<'p>>,
+    pub on: Vec<JoinOn>,
 }
 
-impl<'p> JoinExpression<'p> {
+impl JoinExpression {
     pub fn from_foreign_key(
         foreign_key_reference: ForeignKeyReference,
         on_alias: Alias,
@@ -94,7 +94,7 @@ impl<'p> JoinExpression<'p> {
     }
 }
 
-impl Transpile for JoinExpression<'_> {
+impl Transpile for JoinExpression {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         self.join.transpile(fmt)?;
         fmt.write_char(' ')?;

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/order_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/order_clause.rs
@@ -9,12 +9,12 @@ pub enum Ordering {
 }
 
 #[derive(Debug, Default, PartialEq, Eq, Hash)]
-pub struct OrderByExpression<'p> {
-    columns: Vec<(AliasedColumn<'p>, Ordering)>,
+pub struct OrderByExpression {
+    columns: Vec<(AliasedColumn, Ordering)>,
 }
 
-impl<'p> OrderByExpression<'p> {
-    pub fn push(&mut self, column: AliasedColumn<'p>, ordering: Ordering) {
+impl OrderByExpression {
+    pub fn push(&mut self, column: AliasedColumn, ordering: Ordering) {
         self.columns.push((column, ordering));
     }
 
@@ -23,7 +23,7 @@ impl<'p> OrderByExpression<'p> {
     }
 }
 
-impl Transpile for OrderByExpression<'_> {
+impl Transpile for OrderByExpression {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         if self.columns.is_empty() {
             return Ok(());

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/select_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/select_clause.rs
@@ -1,27 +1,27 @@
-use std::{borrow::Cow, fmt};
+use std::fmt;
 
 use crate::store::postgres::query::{AliasedColumn, Expression, Transpile};
 
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub struct SelectExpression<'p> {
-    expression: Expression<'p>,
-    alias: Option<Cow<'p, str>>,
+pub struct SelectExpression {
+    expression: Expression,
+    alias: Option<&'static str>,
 }
 
-impl<'p> SelectExpression<'p> {
+impl SelectExpression {
     #[must_use]
     #[inline]
-    pub const fn new(expression: Expression<'p>, alias: Option<Cow<'p, str>>) -> Self {
+    pub const fn new(expression: Expression, alias: Option<&'static str>) -> Self {
         Self { expression, alias }
     }
 
     #[must_use]
-    pub const fn from_column(column: AliasedColumn<'p>, alias: Option<Cow<'p, str>>) -> Self {
+    pub const fn from_column(column: AliasedColumn, alias: Option<&'static str>) -> Self {
         Self::new(Expression::Column(column), alias)
     }
 }
 
-impl Transpile for SelectExpression<'_> {
+impl Transpile for SelectExpression {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         self.expression.transpile(fmt)?;
         if let Some(alias) = &self.alias {
@@ -65,7 +65,7 @@ mod tests {
                         chain_depth: 2,
                         number: 3,
                     }),
-                Some(Cow::Borrowed("versionedUrl"))
+                Some("versionedUrl")
             )
             .transpile_to_string(),
             r#""data_types_1_2_3"."schema"->>'$id' AS "versionedUrl""#
@@ -95,7 +95,7 @@ mod tests {
                             })
                     )
                 ),
-                Some(Cow::Borrowed("latest_version"))
+                Some("latest_version")
             )
             .transpile_to_string(),
             r#"MAX("ontology_id_with_metadata_1_2_3"."version") OVER (PARTITION BY "ontology_id_with_metadata_1_2_3"."base_url") AS "latest_version""#

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
@@ -3,12 +3,12 @@ use std::fmt;
 use crate::store::postgres::query::{Condition, Transpile};
 
 #[derive(Debug, Default, PartialEq, Eq, Hash)]
-pub struct WhereExpression<'p> {
-    conditions: Vec<Condition<'p>>,
+pub struct WhereExpression {
+    conditions: Vec<Condition>,
 }
 
-impl<'p> WhereExpression<'p> {
-    pub fn add_condition(&mut self, condition: Condition<'p>) {
+impl WhereExpression {
+    pub fn add_condition(&mut self, condition: Condition) {
         self.conditions.push(condition);
     }
 
@@ -21,7 +21,7 @@ impl<'p> WhereExpression<'p> {
     }
 }
 
-impl Transpile for WhereExpression<'_> {
+impl Transpile for WhereExpression {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         if self.conditions.is_empty() {
             return Ok(());

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/with_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/with_clause.rs
@@ -3,18 +3,18 @@ use std::fmt::{self, Write};
 use crate::store::postgres::query::{Statement, Table, Transpile};
 
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub struct CommonTableExpression<'p> {
+pub struct CommonTableExpression {
     table: Table,
-    statement: Statement<'p>,
+    statement: Statement,
 }
 
 #[derive(Default, Debug, PartialEq, Eq, Hash)]
-pub struct WithExpression<'p> {
-    common_table_expressions: Vec<CommonTableExpression<'p>>,
+pub struct WithExpression {
+    common_table_expressions: Vec<CommonTableExpression>,
 }
 
-impl<'p> WithExpression<'p> {
-    pub fn add_statement(&mut self, table: Table, statement: impl Into<Statement<'p>>) {
+impl WithExpression {
+    pub fn add_statement(&mut self, table: Table, statement: impl Into<Statement>) {
         self.common_table_expressions.push(CommonTableExpression {
             table,
             statement: statement.into(),
@@ -30,7 +30,7 @@ impl<'p> WithExpression<'p> {
     }
 }
 
-impl Transpile for WithExpression<'_> {
+impl Transpile for WithExpression {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         if self.common_table_expressions.is_empty() {
             return Ok(());
@@ -53,8 +53,6 @@ impl Transpile for WithExpression<'_> {
 
 #[cfg(test)]
 mod tests {
-    use std::borrow::Cow;
-
     use super::*;
     use crate::store::postgres::query::{
         expression::OrderByExpression,
@@ -72,10 +70,7 @@ mod tests {
             distinct: Vec::new(),
             selects: vec![
                 SelectExpression::new(Expression::Asterisk, None),
-                SelectExpression::new(
-                    max_version_expression(),
-                    Some(Cow::Borrowed("latest_version")),
-                ),
+                SelectExpression::new(max_version_expression(), Some("latest_version")),
             ],
             from: Table::OntologyIds.aliased(Alias {
                 condition_index: 0,

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/statement.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/statement.rs
@@ -10,21 +10,21 @@ pub use self::{
 use crate::store::postgres::query::Transpile;
 
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub enum Statement<'p> {
-    Select(SelectStatement<'p>),
+pub enum Statement {
+    Select(SelectStatement),
 }
 
-impl Transpile for Statement<'_> {
+impl Transpile for Statement {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Statement::Select(statement) => statement.transpile(fmt),
+            Self::Select(statement) => statement.transpile(fmt),
         }
     }
 }
 
-impl<'p> From<SelectStatement<'p>> for Statement<'p> {
+impl From<SelectStatement> for Statement {
     #[inline]
-    fn from(statement: SelectStatement<'p>) -> Self {
+    fn from(statement: SelectStatement) -> Self {
         Self::Select(statement)
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -6,14 +6,14 @@ use crate::store::postgres::query::{
 };
 
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub struct SelectStatement<'p> {
-    pub with: WithExpression<'p>,
-    pub distinct: Vec<AliasedColumn<'p>>,
-    pub selects: Vec<SelectExpression<'p>>,
+pub struct SelectStatement {
+    pub with: WithExpression,
+    pub distinct: Vec<AliasedColumn>,
+    pub selects: Vec<SelectExpression>,
     pub from: AliasedTable,
-    pub joins: Vec<JoinExpression<'p>>,
-    pub where_expression: WhereExpression<'p>,
-    pub order_by_expression: OrderByExpression<'p>,
+    pub joins: Vec<JoinExpression>,
+    pub where_expression: WhereExpression,
+    pub order_by_expression: OrderByExpression,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -22,7 +22,7 @@ pub enum Distinctness {
     Distinct,
 }
 
-impl Transpile for SelectStatement<'_> {
+impl Transpile for SelectStatement {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         if !self.with.is_empty() {
             self.with.transpile(fmt)?;
@@ -99,10 +99,10 @@ mod tests {
         },
     };
 
-    fn test_compilation<'f, 'p: 'f, T: PostgresRecord + 'static>(
-        compiler: &SelectCompiler<'f, 'p, T>,
+    fn test_compilation<'p, T: PostgresRecord + 'static>(
+        compiler: &SelectCompiler<'p, T>,
         expected_statement: &'static str,
-        expected_parameters: &[&'f dyn ToSql],
+        expected_parameters: &[&'p dyn ToSql],
     ) {
         let (compiled_statement, compiled_parameters) = compiler.compile();
 

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/statement/window.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/statement/window.rs
@@ -3,19 +3,19 @@ use std::fmt;
 use crate::store::postgres::query::{AliasedColumn, Expression, Transpile};
 
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub struct WindowStatement<'p> {
-    partition: Vec<Expression<'p>>,
+pub struct WindowStatement {
+    partition: Vec<Expression>,
 }
 
-impl<'p> WindowStatement<'p> {
-    pub fn partition_by(column: AliasedColumn<'p>) -> Self {
+impl WindowStatement {
+    pub fn partition_by(column: AliasedColumn) -> Self {
         Self {
             partition: vec![Expression::Column(column)],
         }
     }
 }
 
-impl Transpile for WindowStatement<'_> {
+impl Transpile for WindowStatement {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("PARTITION BY ")?;
         for (idx, partition) in self.partition.iter().enumerate() {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We want to avoid user-inserted strings to be directly inserted into the database. Up until now we errored as soon as the compiler tried to transpire a string, which was user provided. With this change, it's becoming a compile time error as soon as an implementation is added to transpire a non-static string.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204086167143889/1203821263193164/f) _(internal)_

## 🔍 What does this change?

Most notably:
```diff
- pub trait Transpile
+ pub trait Transpile: 'static
```

In order to achieve this, a `into_owned` method was added to `Column` which makes an expression `'static` by moving out the dynamic part and storing an index into the parameters array. With this change, the `'c` lifetime could be removed from the compiler!

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

- [x] is internal and does not require a docs change 

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

- [x] does not affect the execution graph -

## 🛡 What tests cover this?

There are a bunch of tests for the compiler (probably the area in the Graph which is most tested). Also, every integration test which is querying the graph will implicitly test this.
