### PR TITLE
Bump `type-system` crate to `cdde49`

### DIFF
--- a/apps/hash-graph/Cargo.lock
+++ b/apps/hash-graph/Cargo.lock
@@ -2783,7 +2783,7 @@ dependencies = [
 [[package]]
 name = "type-system"
 version = "0.0.0"
-source = "git+https://github.com/blockprotocol/blockprotocol?rev=808753#8087535943f6c8fdfdaac2c205fdcc64aa4bb080"
+source = "git+https://github.com/blockprotocol/blockprotocol?rev=cdde49#cdde4909f36e6208bb075ed624c7fc7ff70507b9"
 dependencies = [
  "console_error_panic_hook",
  "serde",

--- a/apps/hash-graph/bench/Cargo.toml
+++ b/apps/hash-graph/bench/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
 tokio = { version = "1.28.1", features = ["rt-multi-thread", "macros"] }
 tokio-postgres = { version = "0.7.8", default-features = false }
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "808753" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "cdde49" }
 uuid = { version = "1.3.3", features = ["v4", "serde"] }
 
 [[bench]]

--- a/apps/hash-graph/bin/cli/Cargo.toml
+++ b/apps/hash-graph/bin/cli/Cargo.toml
@@ -26,7 +26,7 @@ tokio-postgres = { version = "0.7.8", default-features = false }
 tokio-serde = { version = "0.8", features = ["json"], optional = true }
 tokio-util = { version = "0.7.8", default-features = false, features = ["codec"] }
 tracing = "0.1.37"
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "808753" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "cdde49" }
 uuid = "1.3.3"
 
 # Remove again when the type fetcher is used in the graph

--- a/apps/hash-graph/lib/graph/Cargo.toml
+++ b/apps/hash-graph/lib/graph/Cargo.toml
@@ -39,7 +39,7 @@ tonic = "0.8.3"
 opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
 opentelemetry-otlp = "0.11.0"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"] }
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "808753" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "cdde49" }
 uuid = { version = "1.3.3", features = ["v4", "serde"] }
 utoipa = { version = "3.3.0", features = ["uuid"] }
 include_dir = "0.7.3"

--- a/apps/hash-graph/lib/type-fetcher/Cargo.toml
+++ b/apps/hash-graph/lib/type-fetcher/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 description = "RPC service definition to fetch external BP types"
 
 [dependencies]
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "808753" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "cdde49" }
 
 serde = { version = "1.0.163", features = ["derive"] }
 time = { version = "0.3.21", features = ['serde'] }

--- a/apps/hash-graph/tests/integration/Cargo.toml
+++ b/apps/hash-graph/tests/integration/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = "1.0.96"
 time = "0.3.21"
 tokio = { version = "1.28.1", features = ["rt-multi-thread", "macros"] }
 tokio-postgres = { version = "0.7.8", default-features = false }
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "808753" }
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "cdde49" }
 uuid = { version = "1.3.3", features = ["v4", "serde"] }
 
 [[test]]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `type-system` crate was updated and to avoid falling out of sync this bumps the version.

## 🔗 Related links

- https://github.com/blockprotocol/blockprotocol/pull/1291

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing 

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] is internal and does not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] does not affect the execution graph 
