### PR TITLE
Avoid emitting 6-digit years in the Graph

### DIFF
--- a/apps/hash-graph/lib/graph/Cargo.toml
+++ b/apps/hash-graph/lib/graph/Cargo.toml
@@ -13,7 +13,7 @@ axum = "0.6.18"
 bb8-postgres = "0.8.1"
 bytes = "1.4.0"
 clap = { version = "4.3.0", features = ["derive", "env"], optional = true }
-time = { version = "0.3.21", features = ['serde', 'serde-well-known'] }
+time = { version = "0.3.21", features = ["serde", "formatting", "macros"] }
 derivative = "2.2.0"
 error-stack = { version = "0.3.1", features = ["spantrace"] }
 futures = "0.3.28"

--- a/apps/hash-graph/lib/graph/src/lib.rs
+++ b/apps/hash-graph/lib/graph/src/lib.rs
@@ -21,6 +21,8 @@ pub mod knowledge;
 pub mod ontology;
 pub mod subgraph;
 
+mod serde;
+
 pub mod store;
 
 pub mod snapshot;

--- a/apps/hash-graph/lib/graph/src/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/ontology.rs
@@ -286,7 +286,7 @@ pub struct ExternalOntologyElementMetadata {
     #[serde(rename = "provenance")]
     provenance_metadata: ProvenanceMetadata,
     #[schema(value_type = String)]
-    #[serde(with = "time::serde::iso8601")]
+    #[serde(with = "crate::serde::time")]
     fetched_at: OffsetDateTime,
 }
 

--- a/apps/hash-graph/lib/graph/src/serde.rs
+++ b/apps/hash-graph/lib/graph/src/serde.rs
@@ -6,6 +6,7 @@ const CONFIG: iso8601::EncodedConfig = iso8601::Config::DEFAULT
 const FORMAT: Iso8601<CONFIG> = Iso8601::<CONFIG>;
 ::time::serde::format_description!(time_format, OffsetDateTime, FORMAT);
 
+// The macro above creates a private macro so we re-export it here publicly.
 pub mod time {
     pub use super::time_format::*;
 

--- a/apps/hash-graph/lib/graph/src/serde.rs
+++ b/apps/hash-graph/lib/graph/src/serde.rs
@@ -1,0 +1,15 @@
+use ::time::format_description::well_known::{iso8601, Iso8601};
+
+const CONFIG: iso8601::EncodedConfig = iso8601::Config::DEFAULT
+    .set_year_is_six_digits(false)
+    .encode();
+const FORMAT: Iso8601<CONFIG> = Iso8601::<CONFIG>;
+::time::serde::format_description!(time_format, OffsetDateTime, FORMAT);
+
+pub mod time {
+    pub use super::time_format::*;
+
+    pub mod option {
+        pub use super::super::time_format::option::*;
+    }
+}

--- a/apps/hash-graph/lib/graph/src/shared/identifier/time/timestamp.rs
+++ b/apps/hash-graph/lib/graph/src/shared/identifier/time/timestamp.rs
@@ -4,7 +4,7 @@ use std::{error::Error, marker::PhantomData, str::FromStr, time::SystemTime};
 use derivative::Derivative;
 use postgres_types::{private::BytesMut, FromSql, ToSql, Type};
 use serde::{Deserialize, Serialize};
-use time::{format_description::well_known::Iso8601, serde::iso8601, OffsetDateTime};
+use time::{format_description::well_known::Iso8601, OffsetDateTime};
 use utoipa::{openapi, ToSchema};
 
 use crate::identifier::time::axis::TemporalTagged;
@@ -30,7 +30,7 @@ use crate::identifier::time::axis::TemporalTagged;
 pub struct Timestamp<A> {
     #[serde(skip)]
     axis: PhantomData<A>,
-    #[serde(with = "iso8601")]
+    #[serde(with = "crate::serde::time")]
     time: OffsetDateTime,
 }
 

--- a/apps/hash-graph/lib/graph/src/snapshot/ontology/record.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/ontology/record.rs
@@ -28,7 +28,7 @@ pub struct CustomOntologyMetadata {
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
-        with = "time::serde::iso8601::option"
+        with = "crate::serde::time::option"
     )]
     pub fetched_at: Option<OffsetDateTime>,
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -36,7 +36,7 @@ enum AdditionalOntologyMetadata {
         owned_by_id: OwnedById,
     },
     External {
-        #[serde(with = "time::serde::iso8601")]
+        #[serde(with = "crate::serde::time")]
         fetched_at: OffsetDateTime,
     },
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In the TS subgraph library, we use string comparison to compare dates. Emitting 6 digits for years is causing problems so the fastest way to fix issues is to not emit 6 digits for years.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Slack comment](https://hashintel.slack.com/archives/C03F7V6DU9M/p1684771514926419?thread_ts=1684767942.699619&cid=C03F7V6DU9M) _(internal)_

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

- [ ] ...

## 🔍 What does this change?

- Define a serde-module to contain the format of the expected output (iso8601 without 6-digit years)
- Use the module to (de-)serialize

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

<!-- - [x] modifies an **npm**-publishable library and **I have added a changeset file(s)** -->

<!-- - [x] modifies a **Cargo**-publishable library and **I have amended the version** -->

<!-- - [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish** -->

<!-- - [x] modifies a **block** that will need publishing via GitHub action once merged -->

 - [x] does not modify any publishable blocks or libraries, or modifications do not need publishing 

<!-- - [x] I am unsure / need advice -->

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

 - [x] is internal and does not require a docs change 

<!-- - [x] is in a state where docs changes are not _yet_ required but will be
  - this is tracked within: [Insert Link Here](link) -->

<!-- - [x] requires changes to docs
  - <CHANGES TO DOCS EXPLAINED HERE> -->

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

<!-- - [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this -->

- [x] does not affect the execution graph 

<!-- - [x] I am unsure / need advice -->