### PR TITLE
Correctly use the `FRONTEND_URL` variable in the `hash-api` package

### DIFF
--- a/apps/hash-api/src/graph/ontology/primitive/data-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/data-type.ts
@@ -4,6 +4,7 @@ import {
 } from "@blockprotocol/type-system";
 import { DataTypeStructuralQuery } from "@local/hash-graph-client";
 import { ConstructDataTypeParams } from "@local/hash-graphql-shared/graphql/types";
+import { frontendUrl } from "@local/hash-isomorphic-utils/environment";
 import { generateTypeId } from "@local/hash-isomorphic-utils/ontology-types";
 import {
   AccountId,
@@ -24,8 +25,6 @@ import {
   zeroedGraphResolveDepths,
 } from "../..";
 import { getNamespaceOfAccountOwner } from "./util";
-
-const { FRONTEND_URL } = require("../../../lib/config");
 
 /**
  * Create a data type.
@@ -148,7 +147,7 @@ export const getDataTypeSubgraphById: ImpureGraphFunction<
     query,
   });
 
-  if (subgraph.roots.length === 0 && !dataTypeId.startsWith(FRONTEND_URL)) {
+  if (subgraph.roots.length === 0 && !dataTypeId.startsWith(frontendUrl)) {
     await context.graphApi.createDataType({
       actorId,
       dataTypeId,

--- a/apps/hash-api/src/graph/ontology/primitive/entity-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/entity-type.ts
@@ -7,6 +7,7 @@ import {
   UpdateEntityTypeRequest,
 } from "@local/hash-graph-client";
 import { ConstructEntityTypeParams } from "@local/hash-graphql-shared/graphql/types";
+import { frontendUrl } from "@local/hash-isomorphic-utils/environment";
 import { generateTypeId } from "@local/hash-isomorphic-utils/ontology-types";
 import {
   AccountId,
@@ -29,8 +30,6 @@ import {
   zeroedGraphResolveDepths,
 } from "../..";
 import { getNamespaceOfAccountOwner } from "./util";
-
-const { FRONTEND_URL } = require("../../../lib/config");
 
 /**
  * Create an entity type.
@@ -150,7 +149,7 @@ export const getEntityTypeSubgraphById: ImpureGraphFunction<
     query,
   });
 
-  if (subgraph.roots.length === 0 && !entityTypeId.startsWith(FRONTEND_URL)) {
+  if (subgraph.roots.length === 0 && !entityTypeId.startsWith(frontendUrl)) {
     await context.graphApi.createEntityType({
       actorId,
       entityTypeId,

--- a/apps/hash-api/src/graph/ontology/primitive/property-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/property-type.ts
@@ -7,6 +7,7 @@ import {
   UpdatePropertyTypeRequest,
 } from "@local/hash-graph-client";
 import { ConstructPropertyTypeParams } from "@local/hash-graphql-shared/graphql/types";
+import { frontendUrl } from "@local/hash-isomorphic-utils/environment";
 import { generateTypeId } from "@local/hash-isomorphic-utils/ontology-types";
 import {
   AccountId,
@@ -27,8 +28,6 @@ import {
   zeroedGraphResolveDepths,
 } from "../..";
 import { getNamespaceOfAccountOwner } from "./util";
-
-const { FRONTEND_URL } = require("../../../lib/config");
 
 /**
  * Create a property type.
@@ -149,7 +148,7 @@ export const getPropertyTypeSubgraphById: ImpureGraphFunction<
     query,
   });
 
-  if (subgraph.roots.length === 0 && !propertyTypeId.startsWith(FRONTEND_URL)) {
+  if (subgraph.roots.length === 0 && !propertyTypeId.startsWith(frontendUrl)) {
     await context.graphApi.createPropertyType({
       actorId,
       propertyTypeId,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In a previous PR I used the wrong way to read `$FRONTEND_URL`. This implies, that instead of failing with an error immediately the API tries to load an ontology type instead. This will fail if the ontology type is not eternal.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Slack thread](https://hashintel.slack.com/archives/C022217GAHF/p1684868701217229) _(internal)_

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

<!-- - [x] modifies an **npm**-publishable library and **I have added a changeset file(s)** -->

<!-- - [x] modifies a **Cargo**-publishable library and **I have amended the version** -->

<!-- - [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish** -->

<!-- - [x] modifies a **block** that will need publishing via GitHub action once merged -->

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing 

<!-- - [x] I am unsure / need advice -->

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

- [x] is internal and does not require a docs change

<!-- - [x] is in a state where docs changes are not _yet_ required but will be
  - this is tracked within: [Insert Link Here](link) -->

<!-- - [x] requires changes to docs
  - <CHANGES TO DOCS EXPLAINED HERE> -->

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:


<!-- - [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this -->

- [x] does not affect the execution graph