### PR TITLE
Return an empty subgraph if ontology type queried by its ID does not exist

### DIFF
--- a/apps/hash-api/src/graph/ontology/primitive/data-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/data-type.ts
@@ -158,10 +158,6 @@ export const getDataTypeSubgraphById: ImpureGraphFunction<
     });
   }
 
-  if (subgraph.roots.length === 0) {
-    throw new NotFoundError(`Could not find data type with ID "${dataTypeId}"`);
-  }
-
   return subgraph;
 };
 

--- a/apps/hash-api/src/graph/ontology/primitive/entity-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/entity-type.ts
@@ -160,12 +160,6 @@ export const getEntityTypeSubgraphById: ImpureGraphFunction<
     });
   }
 
-  if (subgraph.roots.length === 0) {
-    throw new NotFoundError(
-      `Could not find entity type with ID "${entityTypeId}"`,
-    );
-  }
-
   return subgraph;
 };
 

--- a/apps/hash-api/src/graph/ontology/primitive/property-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/property-type.ts
@@ -159,12 +159,6 @@ export const getPropertyTypeSubgraphById: ImpureGraphFunction<
     });
   }
 
-  if (subgraph.roots.length === 0) {
-    throw new NotFoundError(
-      `Could not find property type with ID "${propertyTypeId}"`,
-    );
-  }
-
   return subgraph;
 };
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

I accidentally changed the behavior of the GQL resolvers to error if a type does not exist.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->
- [Slack thread 1](https://hashintel.slack.com/archives/C022217GAHF/p1684912726686829)
- [Slack thread 2](https://hashintel.slack.com/archives/C022217GAHF/p1685010273602719)
