### PR TITLE
Move reading vertices until after traversal is finished

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/postgres.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres.rs
@@ -4,6 +4,7 @@ mod ontology;
 mod migration;
 mod pool;
 mod query;
+mod traversal_context;
 
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
@@ -15,7 +16,10 @@ use type_system::{
     PropertyTypeReference,
 };
 
-pub use self::pool::{AsClient, PostgresStorePool};
+pub use self::{
+    pool::{AsClient, PostgresStorePool},
+    traversal_context::TraversalContext,
+};
 use crate::{
     identifier::{
         account::AccountId,
@@ -43,9 +47,6 @@ use crate::{
     },
     knowledge::{EntityProperties, LinkOrder},
 };
-
-#[derive(Default)]
-pub struct TraversalContext;
 
 /// A Postgres-backed store
 pub struct PostgresStore<C> {

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -512,7 +512,9 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
         )
         .await?;
 
-        traversal_context.load_vertices(self, &mut subgraph).await?;
+        traversal_context
+            .read_traversed_vertices(self, &mut subgraph)
+            .await?;
 
         Ok(subgraph)
     }

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -171,7 +171,7 @@ impl<C: AsClient> PostgresStore<C> {
                             entity_type_vertex_id.clone(),
                         );
 
-                        subgraph.insert_vertex(&entity_type_vertex_id, entity_type);
+                        traversal_context.add_entity_type_id(entity_type_vertex_id.clone());
 
                         entity_type_queue.push((
                             entity_type_vertex_id,
@@ -490,6 +490,8 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
             subgraph.roots.insert((*vertex_id).into());
         }
 
+        let mut traversal_context = TraversalContext::default();
+
         // TODO: We currently pass in the subgraph as mutable reference, thus we cannot borrow the
         //       vertices and have to `.collect()` the keys.
         self.traverse_entities(
@@ -505,10 +507,12 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                     )
                 })
                 .collect(),
-            &mut TraversalContext,
+            &mut traversal_context,
             &mut subgraph,
         )
         .await?;
+
+        traversal_context.load_vertices(self, &mut subgraph).await?;
 
         Ok(subgraph)
     }

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -122,6 +122,8 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
             subgraph.roots.insert(vertex_id.clone().into());
         }
 
+        let mut traversal_context = TraversalContext::default();
+
         // TODO: We currently pass in the subgraph as mutable reference, thus we cannot borrow the
         //       vertices and have to `.collect()` the keys.
         self.traverse_data_types(
@@ -137,10 +139,12 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
                     )
                 })
                 .collect(),
-            &mut TraversalContext,
+            &mut traversal_context,
             &mut subgraph,
         )
         .await?;
+
+        traversal_context.load_vertices(self, &mut subgraph).await?;
 
         Ok(subgraph)
     }

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -144,7 +144,9 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
         )
         .await?;
 
-        traversal_context.load_vertices(self, &mut subgraph).await?;
+        traversal_context
+            .read_traversed_vertices(self, &mut subgraph)
+            .await?;
 
         Ok(subgraph)
     }

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -339,7 +339,9 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         )
         .await?;
 
-        traversal_context.load_vertices(self, &mut subgraph).await?;
+        traversal_context
+            .read_traversed_vertices(self, &mut subgraph)
+            .await?;
 
         Ok(subgraph)
     }

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -70,7 +70,7 @@ impl<C: AsClient> PostgresStore<C> {
                             property_type_vertex_id.clone(),
                         );
 
-                        subgraph.insert_vertex(&property_type_vertex_id, property_type);
+                        traversal_context.add_property_type_id(property_type_vertex_id.clone());
 
                         property_type_queue.push((
                             property_type_vertex_id,
@@ -106,7 +106,7 @@ impl<C: AsClient> PostgresStore<C> {
                             referenced_entity_type_vertex_id.clone(),
                         );
 
-                        subgraph.insert_vertex(&referenced_entity_type_vertex_id, referenced_entity_type);
+                        traversal_context.add_entity_type_id(referenced_entity_type_vertex_id.clone());
 
                         entity_type_queue.push((
                             referenced_entity_type_vertex_id,
@@ -142,7 +142,7 @@ impl<C: AsClient> PostgresStore<C> {
                             referenced_entity_type_vertex_id.clone(),
                         );
 
-                        subgraph.insert_vertex(&referenced_entity_type_vertex_id, referenced_entity_type);
+                        traversal_context.add_entity_type_id(referenced_entity_type_vertex_id.clone());
 
                         entity_type_queue.push((
                             referenced_entity_type_vertex_id,
@@ -178,7 +178,7 @@ impl<C: AsClient> PostgresStore<C> {
                             referenced_entity_type_vertex_id.clone(),
                         );
 
-                        subgraph.insert_vertex(&referenced_entity_type_vertex_id, referenced_entity_type);
+                        traversal_context.add_entity_type_id(referenced_entity_type_vertex_id.clone());
 
                         entity_type_queue.push((
                             referenced_entity_type_vertex_id,
@@ -317,6 +317,8 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
             subgraph.roots.insert(vertex_id.clone().into());
         }
 
+        let mut traversal_context = TraversalContext::default();
+
         // TODO: We currently pass in the subgraph as mutable reference, thus we cannot borrow the
         //       vertices and have to `.collect()` the keys.
         self.traverse_entity_types(
@@ -332,10 +334,12 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
                     )
                 })
                 .collect(),
-            &mut TraversalContext,
+            &mut traversal_context,
             &mut subgraph,
         )
         .await?;
+
+        traversal_context.load_vertices(self, &mut subgraph).await?;
 
         Ok(subgraph)
     }

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -70,7 +70,7 @@ impl<C: AsClient> PostgresStore<C> {
                             data_type_vertex_id.clone(),
                         );
 
-                        subgraph.insert_vertex(&data_type_vertex_id, data_type);
+                        traversal_context.add_data_type_id(data_type_vertex_id.clone());
 
                         data_type_queue.push((
                             data_type_vertex_id,
@@ -106,8 +106,7 @@ impl<C: AsClient> PostgresStore<C> {
                             referenced_property_type_vertex_id.clone(),
                         );
 
-                        subgraph
-                            .insert_vertex(&referenced_property_type_vertex_id, referenced_property_type);
+                        traversal_context.add_property_type_id(referenced_property_type_vertex_id.clone());
 
                         property_type_queue.push((
                             referenced_property_type_vertex_id,
@@ -244,6 +243,8 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
             subgraph.roots.insert(vertex_id.clone().into());
         }
 
+        let mut traversal_context = TraversalContext::default();
+
         // TODO: We currently pass in the subgraph as mutable reference, thus we cannot borrow the
         //       vertices and have to `.collect()` the keys.
         self.traverse_property_types(
@@ -259,10 +260,12 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                     )
                 })
                 .collect(),
-            &mut TraversalContext,
+            &mut traversal_context,
             &mut subgraph,
         )
         .await?;
+
+        traversal_context.load_vertices(self, &mut subgraph).await?;
 
         Ok(subgraph)
     }

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -265,7 +265,9 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         )
         .await?;
 
-        traversal_context.load_vertices(self, &mut subgraph).await?;
+        traversal_context
+            .read_traversed_vertices(self, &mut subgraph)
+            .await?;
 
         Ok(subgraph)
     }

--- a/apps/hash-graph/lib/graph/src/store/postgres/traversal_context.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/traversal_context.rs
@@ -1,0 +1,188 @@
+use std::collections::HashSet;
+
+use error_stack::Result;
+
+use crate::{
+    identifier::knowledge::EntityEditionId,
+    knowledge::{Entity, EntityQueryPath},
+    ontology::{DataTypeWithMetadata, EntityTypeWithMetadata, PropertyTypeWithMetadata},
+    store::{
+        crud::Read,
+        query::{Filter, FilterExpression, Parameter},
+        AsClient, PostgresStore, QueryError, Record,
+    },
+    subgraph::{
+        identifier::{DataTypeVertexId, EntityTypeVertexId, PropertyTypeVertexId},
+        Subgraph,
+    },
+};
+
+impl<C: AsClient> PostgresStore<C> {
+    async fn read_data_types_by_ids(
+        &self,
+        vertex_ids: impl IntoIterator<Item = &DataTypeVertexId, IntoIter: Send> + Send,
+        subgraph: &mut Subgraph,
+    ) -> Result<(), QueryError> {
+        for vertex_id in vertex_ids {
+            for data_type in <Self as Read<DataTypeWithMetadata>>::read_vec(
+                self,
+                &DataTypeWithMetadata::create_filter_for_vertex_id(vertex_id),
+                Some(&subgraph.temporal_axes.resolved),
+            )
+            .await?
+            {
+                subgraph.insert_vertex(vertex_id, data_type);
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn read_property_types_by_ids(
+        &self,
+        vertex_ids: impl IntoIterator<Item = &PropertyTypeVertexId, IntoIter: Send> + Send,
+        subgraph: &mut Subgraph,
+    ) -> Result<(), QueryError> {
+        for vertex_id in vertex_ids {
+            for property_type in <Self as Read<PropertyTypeWithMetadata>>::read_vec(
+                self,
+                &PropertyTypeWithMetadata::create_filter_for_vertex_id(vertex_id),
+                Some(&subgraph.temporal_axes.resolved),
+            )
+            .await?
+            {
+                subgraph.insert_vertex(vertex_id, property_type);
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn read_entity_types_by_ids(
+        &self,
+        vertex_ids: impl IntoIterator<Item = &EntityTypeVertexId, IntoIter: Send> + Send,
+        subgraph: &mut Subgraph,
+    ) -> Result<(), QueryError> {
+        for vertex_id in vertex_ids {
+            for enttity_type in <Self as Read<EntityTypeWithMetadata>>::read_vec(
+                self,
+                &EntityTypeWithMetadata::create_filter_for_vertex_id(vertex_id),
+                Some(&subgraph.temporal_axes.resolved),
+            )
+            .await?
+            {
+                subgraph.insert_vertex(vertex_id, enttity_type);
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn read_entities_by_ids(
+        &self,
+        vertex_ids: impl IntoIterator<Item = &EntityEditionId, IntoIter: Send> + Send,
+        subgraph: &mut Subgraph,
+    ) -> Result<(), QueryError> {
+        for edition_id in vertex_ids {
+            for entity in <Self as Read<Entity>>::read_vec(
+                self,
+                &Filter::<Entity>::Equal(
+                    Some(FilterExpression::Path(EntityQueryPath::EditionId)),
+                    Some(FilterExpression::Parameter(Parameter::Uuid(
+                        edition_id.as_uuid(),
+                    ))),
+                ),
+                Some(&subgraph.temporal_axes.resolved),
+            )
+            .await?
+            {
+                subgraph.insert_vertex(
+                    &entity.vertex_id(subgraph.temporal_axes.resolved.variable_time_axis()),
+                    entity,
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct OntologyTraversalContext<R: Record> {
+    vertex_ids: HashSet<R::VertexId>,
+}
+
+impl<R: Record> Default for OntologyTraversalContext<R> {
+    fn default() -> Self {
+        Self {
+            vertex_ids: HashSet::new(),
+        }
+    }
+}
+
+impl<R: Record> OntologyTraversalContext<R>
+where
+    R::VertexId: Clone + Eq + std::hash::Hash,
+{
+    pub fn add_id(&mut self, vertex_id: R::VertexId) {
+        self.vertex_ids.insert(vertex_id);
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct EntityTraversalContext {
+    edition_ids: HashSet<EntityEditionId>,
+}
+
+impl EntityTraversalContext {
+    pub fn add_id(&mut self, edition_id: EntityEditionId) {
+        self.edition_ids.insert(edition_id);
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct TraversalContext {
+    data_types: OntologyTraversalContext<DataTypeWithMetadata>,
+    property_types: OntologyTraversalContext<PropertyTypeWithMetadata>,
+    entity_types: OntologyTraversalContext<EntityTypeWithMetadata>,
+    entities: EntityTraversalContext,
+}
+
+impl TraversalContext {
+    pub async fn load_vertices<C: AsClient>(
+        &self,
+        store: &PostgresStore<C>,
+        subgraph: &mut Subgraph,
+    ) -> Result<(), QueryError> {
+        store
+            .read_data_types_by_ids(&self.data_types.vertex_ids, subgraph)
+            .await?;
+        store
+            .read_property_types_by_ids(&self.property_types.vertex_ids, subgraph)
+            .await?;
+        store
+            .read_entity_types_by_ids(&self.entity_types.vertex_ids, subgraph)
+            .await?;
+        store
+            .read_entities_by_ids(&self.entities.edition_ids, subgraph)
+            .await?;
+
+        Ok(())
+    }
+
+    pub fn add_data_type_id(&mut self, vertex_id: DataTypeVertexId) {
+        self.data_types.add_id(vertex_id);
+    }
+
+    pub fn add_property_type_id(&mut self, vertex_id: PropertyTypeVertexId) {
+        self.property_types.add_id(vertex_id);
+    }
+
+    pub fn add_entity_type_id(&mut self, vertex_id: EntityTypeVertexId) {
+        self.entity_types.add_id(vertex_id);
+    }
+
+    pub fn add_entity_id(&mut self, edition_id: EntityEditionId) {
+        self.entities.add_id(edition_id);
+    }
+}

--- a/apps/hash-graph/lib/graph/src/store/postgres/traversal_context.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/traversal_context.rs
@@ -149,7 +149,7 @@ pub struct TraversalContext {
 }
 
 impl TraversalContext {
-    pub async fn load_vertices<C: AsClient>(
+    pub async fn read_traversed_vertices<C: AsClient>(
         &self,
         store: &PostgresStore<C>,
         subgraph: &mut Subgraph,

--- a/apps/hash-graph/lib/graph/src/store/postgres/traversal_context.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/traversal_context.rs
@@ -64,14 +64,14 @@ impl<C: AsClient> PostgresStore<C> {
         subgraph: &mut Subgraph,
     ) -> Result<(), QueryError> {
         for vertex_id in vertex_ids {
-            for enttity_type in <Self as Read<EntityTypeWithMetadata>>::read_vec(
+            for entity_type in <Self as Read<EntityTypeWithMetadata>>::read_vec(
                 self,
                 &EntityTypeWithMetadata::create_filter_for_vertex_id(vertex_id),
                 Some(&subgraph.temporal_axes.resolved),
             )
             .await?
             {
-                subgraph.insert_vertex(vertex_id, enttity_type);
+                subgraph.insert_vertex(vertex_id, entity_type);
             }
         }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The traversal logic is currently in the process of being optimized. The first goal in order to make optimization possible the reading of vertices is going to be deferred to the end. With this, it's possible to only read the edge information while traversing instead of reading the whole record.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1200211978612931/1204117845662853/f) _(internal)_

## 🔍 What does this change?

- Store entity edition ids and ontology vertex ids in `TraversalContext`
- Create a new traversal context when starting a traversal
- Read vertices after traversing is finished

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

<!-- - [x] modifies an **npm**-publishable library and **I have added a changeset file(s)** -->

<!-- - [x] modifies a **Cargo**-publishable library and **I have amended the version** -->

<!-- - [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish** -->

<!-- - [x] modifies a **block** that will need publishing via GitHub action once merged -->

 - [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

<!-- - [x] I am unsure / need advice -->

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:


 - [x] is internal and does not require a docs change

<!-- - [x] is in a state where docs changes are not _yet_ required but will be
  - this is tracked within: [Insert Link Here](link) -->

<!-- - [x] requires changes to docs
  - <CHANGES TO DOCS EXPLAINED HERE> -->

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

<!-- - [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this -->

- [x] does not affect the execution graph

<!-- - [x] I am unsure / need advice -->

## ⚠️ Known issues

- This will currently double the amount of queries being done to the graph as each record is read one by one. This will be addressed in a direct follow-up.

## 🐾 Next steps

As mentioned above, the direct follow-up will add functionality to read all records at once. Further follow-ups will also enable batched reading of edges, which is more complicated as this requires either a manual SQL statement or decent changes to the structural queries. 

## 🛡 What tests cover this?

- Directly:
    - The HASH Graph API Rest-tests
    - The BE Integration test suite
- Indirectly:
    - Every other test which depends on the Graph

## ❓ How to test this?

- Make sure the subgraph returned is the same as before