### PR TITLE
Add a basic batch-filter for structural queries

### DIFF
--- a/apps/hash-graph/lib/graph/src/shared/identifier/knowledge.rs
+++ b/apps/hash-graph/lib/graph/src/shared/identifier/knowledge.rs
@@ -122,7 +122,7 @@ impl EntityEditionId {
     }
 
     #[must_use]
-    pub const fn as_uuid(&self) -> Uuid {
+    pub const fn as_uuid(self) -> Uuid {
         self.0
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -89,7 +89,7 @@ impl<C: AsClient> PostgresStore<C> {
                 );
 
                 let edge_entity_vertex_id = edge_entity.vertex_id(time_axis);
-                subgraph.insert_vertex(&edge_entity_vertex_id, edge_entity);
+                subgraph.insert_vertex(edge_entity_vertex_id, edge_entity);
 
                 items.push((
                     edge_entity_vertex_id,

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/condition.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/condition.rs
@@ -12,6 +12,7 @@ pub enum Condition {
     Not(Box<Self>),
     Equal(Option<Expression>, Option<Expression>),
     NotEqual(Option<Expression>, Option<Expression>),
+    In(Expression, Expression),
     TimeIntervalContainsTimestamp(Expression, Expression),
     Overlap(Expression, Expression),
     StartsWith(Expression, Expression),
@@ -80,6 +81,12 @@ impl Transpile for Condition {
                 lhs.transpile(fmt)?;
                 fmt.write_str(" != ")?;
                 rhs.transpile(fmt)
+            }
+            Self::In(lhs, rhs) => {
+                lhs.transpile(fmt)?;
+                fmt.write_str(" = ANY(")?;
+                rhs.transpile(fmt)?;
+                fmt.write_char(')')
             }
             Self::TimeIntervalContainsTimestamp(lhs, rhs) => {
                 lhs.transpile(fmt)?;

--- a/apps/hash-graph/lib/graph/src/store/postgres/traversal_context.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/traversal_context.rs
@@ -5,10 +5,13 @@ use error_stack::Result;
 use crate::{
     identifier::knowledge::EntityEditionId,
     knowledge::{Entity, EntityQueryPath},
-    ontology::{DataTypeWithMetadata, EntityTypeWithMetadata, PropertyTypeWithMetadata},
+    ontology::{
+        DataTypeQueryPath, DataTypeWithMetadata, EntityTypeQueryPath, EntityTypeWithMetadata,
+        PropertyTypeQueryPath, PropertyTypeWithMetadata,
+    },
     store::{
         crud::Read,
-        query::{Filter, FilterExpression, Parameter},
+        query::{Filter, FilterExpression, ParameterList},
         AsClient, PostgresStore, QueryError, Record,
     },
     subgraph::{
@@ -23,16 +26,25 @@ impl<C: AsClient> PostgresStore<C> {
         vertex_ids: impl IntoIterator<Item = &DataTypeVertexId, IntoIter: Send> + Send,
         subgraph: &mut Subgraph,
     ) -> Result<(), QueryError> {
-        for vertex_id in vertex_ids {
-            for data_type in <Self as Read<DataTypeWithMetadata>>::read_vec(
-                self,
-                &DataTypeWithMetadata::create_filter_for_vertex_id(vertex_id),
-                Some(&subgraph.temporal_axes.resolved),
-            )
-            .await?
-            {
-                subgraph.insert_vertex(vertex_id, data_type);
-            }
+        let ids = vertex_ids
+            .into_iter()
+            .map(|id| format!("{}v/{}", id.base_id, id.revision_id.inner()))
+            .collect::<Vec<_>>();
+
+        for data_type in <Self as Read<DataTypeWithMetadata>>::read_vec(
+            self,
+            &Filter::<DataTypeWithMetadata>::In(
+                FilterExpression::Path(DataTypeQueryPath::VersionedUrl),
+                ParameterList::VersionedUrls(&ids),
+            ),
+            Some(&subgraph.temporal_axes.resolved),
+        )
+        .await?
+        {
+            subgraph.insert_vertex(
+                data_type.vertex_id(subgraph.temporal_axes.resolved.variable_time_axis()),
+                data_type,
+            );
         }
 
         Ok(())
@@ -43,16 +55,25 @@ impl<C: AsClient> PostgresStore<C> {
         vertex_ids: impl IntoIterator<Item = &PropertyTypeVertexId, IntoIter: Send> + Send,
         subgraph: &mut Subgraph,
     ) -> Result<(), QueryError> {
-        for vertex_id in vertex_ids {
-            for property_type in <Self as Read<PropertyTypeWithMetadata>>::read_vec(
-                self,
-                &PropertyTypeWithMetadata::create_filter_for_vertex_id(vertex_id),
-                Some(&subgraph.temporal_axes.resolved),
-            )
-            .await?
-            {
-                subgraph.insert_vertex(vertex_id, property_type);
-            }
+        let ids = vertex_ids
+            .into_iter()
+            .map(|id| format!("{}v/{}", id.base_id, id.revision_id.inner()))
+            .collect::<Vec<_>>();
+
+        for property_type in <Self as Read<PropertyTypeWithMetadata>>::read_vec(
+            self,
+            &Filter::<PropertyTypeWithMetadata>::In(
+                FilterExpression::Path(PropertyTypeQueryPath::VersionedUrl),
+                ParameterList::VersionedUrls(&ids),
+            ),
+            Some(&subgraph.temporal_axes.resolved),
+        )
+        .await?
+        {
+            subgraph.insert_vertex(
+                property_type.vertex_id(subgraph.temporal_axes.resolved.variable_time_axis()),
+                property_type,
+            );
         }
 
         Ok(())
@@ -63,16 +84,25 @@ impl<C: AsClient> PostgresStore<C> {
         vertex_ids: impl IntoIterator<Item = &EntityTypeVertexId, IntoIter: Send> + Send,
         subgraph: &mut Subgraph,
     ) -> Result<(), QueryError> {
-        for vertex_id in vertex_ids {
-            for entity_type in <Self as Read<EntityTypeWithMetadata>>::read_vec(
-                self,
-                &EntityTypeWithMetadata::create_filter_for_vertex_id(vertex_id),
-                Some(&subgraph.temporal_axes.resolved),
-            )
-            .await?
-            {
-                subgraph.insert_vertex(vertex_id, entity_type);
-            }
+        let ids = vertex_ids
+            .into_iter()
+            .map(|id| format!("{}v/{}", id.base_id, id.revision_id.inner()))
+            .collect::<Vec<_>>();
+
+        for entity_type in <Self as Read<EntityTypeWithMetadata>>::read_vec(
+            self,
+            &Filter::<EntityTypeWithMetadata>::In(
+                FilterExpression::Path(EntityTypeQueryPath::VersionedUrl),
+                ParameterList::VersionedUrls(&ids),
+            ),
+            Some(&subgraph.temporal_axes.resolved),
+        )
+        .await?
+        {
+            subgraph.insert_vertex(
+                entity_type.vertex_id(subgraph.temporal_axes.resolved.variable_time_axis()),
+                entity_type,
+            );
         }
 
         Ok(())
@@ -80,27 +110,28 @@ impl<C: AsClient> PostgresStore<C> {
 
     async fn read_entities_by_ids(
         &self,
-        vertex_ids: impl IntoIterator<Item = &EntityEditionId, IntoIter: Send> + Send,
+        edition_ids: impl IntoIterator<Item = EntityEditionId, IntoIter: Send> + Send,
         subgraph: &mut Subgraph,
     ) -> Result<(), QueryError> {
-        for edition_id in vertex_ids {
-            for entity in <Self as Read<Entity>>::read_vec(
-                self,
-                &Filter::<Entity>::Equal(
-                    Some(FilterExpression::Path(EntityQueryPath::EditionId)),
-                    Some(FilterExpression::Parameter(Parameter::Uuid(
-                        edition_id.as_uuid(),
-                    ))),
-                ),
-                Some(&subgraph.temporal_axes.resolved),
-            )
-            .await?
-            {
-                subgraph.insert_vertex(
-                    &entity.vertex_id(subgraph.temporal_axes.resolved.variable_time_axis()),
-                    entity,
-                );
-            }
+        let ids = edition_ids
+            .into_iter()
+            .map(EntityEditionId::as_uuid)
+            .collect::<Vec<_>>();
+
+        for entity in <Self as Read<Entity>>::read_vec(
+            self,
+            &Filter::<Entity>::In(
+                FilterExpression::Path(EntityQueryPath::EditionId),
+                ParameterList::Uuid(&ids),
+            ),
+            Some(&subgraph.temporal_axes.resolved),
+        )
+        .await?
+        {
+            subgraph.insert_vertex(
+                entity.vertex_id(subgraph.temporal_axes.resolved.variable_time_axis()),
+                entity,
+            );
         }
 
         Ok(())
@@ -154,18 +185,27 @@ impl TraversalContext {
         store: &PostgresStore<C>,
         subgraph: &mut Subgraph,
     ) -> Result<(), QueryError> {
-        store
-            .read_data_types_by_ids(&self.data_types.vertex_ids, subgraph)
-            .await?;
-        store
-            .read_property_types_by_ids(&self.property_types.vertex_ids, subgraph)
-            .await?;
-        store
-            .read_entity_types_by_ids(&self.entity_types.vertex_ids, subgraph)
-            .await?;
-        store
-            .read_entities_by_ids(&self.entities.edition_ids, subgraph)
-            .await?;
+        if !self.data_types.vertex_ids.is_empty() {
+            store
+                .read_data_types_by_ids(&self.data_types.vertex_ids, subgraph)
+                .await?;
+        }
+        if !self.property_types.vertex_ids.is_empty() {
+            store
+                .read_property_types_by_ids(&self.property_types.vertex_ids, subgraph)
+                .await?;
+        }
+        if !self.entity_types.vertex_ids.is_empty() {
+            store
+                .read_entity_types_by_ids(&self.entity_types.vertex_ids, subgraph)
+                .await?;
+        }
+
+        if !self.entities.edition_ids.is_empty() {
+            store
+                .read_entities_by_ids(self.entities.edition_ids.iter().copied(), subgraph)
+                .await?;
+        }
 
         Ok(())
     }

--- a/apps/hash-graph/lib/graph/src/store/query.rs
+++ b/apps/hash-graph/lib/graph/src/store/query.rs
@@ -4,7 +4,7 @@ mod path;
 use std::fmt;
 
 pub use self::{
-    filter::{Filter, FilterExpression, Parameter, ParameterConversionError},
+    filter::{Filter, FilterExpression, Parameter, ParameterConversionError, ParameterList},
     path::{JsonPath, PathToken},
 };
 

--- a/apps/hash-graph/lib/graph/src/subgraph.rs
+++ b/apps/hash-graph/lib/graph/src/subgraph.rs
@@ -65,14 +65,14 @@ impl Subgraph {
         vertex_id.subgraph_entry(&self.vertices)
     }
 
-    pub fn insert_vertex<R: Record>(&mut self, vertex_id: &R::VertexId, record: R) -> Option<R>
+    pub fn insert_vertex<R: Record>(&mut self, vertex_id: R::VertexId, record: R) -> Option<R>
     where
-        R::VertexId: Eq + Clone + Hash,
+        R::VertexId: Eq + Hash,
     {
-        match self.vertex_entry_mut(vertex_id) {
+        match self.vertex_entry_mut(&vertex_id) {
             RawEntryMut::Occupied(mut entry) => Some(entry.insert(record)),
             RawEntryMut::Vacant(entry) => {
-                entry.insert(vertex_id.clone(), record);
+                entry.insert(vertex_id, record);
                 None
             }
         }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#2612 moved the lookup of vertices to until after the traversal. To avoid reading every every vertex one-by-one this changes the implementation to read all at the same time.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204315348455207/1204117845662866/f) _(internal)_

## 🚫 Blocked by

- #2612

## 🔍 What does this change?

- [Add a basic batch-filter for structural queries](https://github.com/hashintel/hash/commit/bddd63a3fb34ea067ac3c56cb65b522dd76c0c26)
- [Use batched reading for vertices](https://github.com/hashintel/hash/commit/4e99735e36f16d658d55881708c79f93ffc9001d)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

<!-- - [x] modifies an **npm**-publishable library and **I have added a changeset file(s)** -->

<!-- - [x] modifies a **Cargo**-publishable library and **I have amended the version** -->

<!-- - [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish** -->

<!-- - [x] modifies a **block** that will need publishing via GitHub action once merged -->

 - [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

<!-- - [x] I am unsure / need advice -->

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:


 - [x] is internal and does not require a docs change

<!-- - [x] is in a state where docs changes are not _yet_ required but will be
  - this is tracked within: [Insert Link Here](link) -->

<!-- - [x] requires changes to docs
  - <CHANGES TO DOCS EXPLAINED HERE> -->

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

<!-- - [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this -->

- [x] does not affect the execution graph

<!-- - [x] I am unsure / need advice -->

## ⚠️ Known issues

- It's not easy to filter by two distinct parameter lists at once and, in addition, `ToSql` neither implemented for `BaseUrl`, nor for `VersionedUrl`. Thus, this converts the parameters to strings and does a string comparison with the `$id` field of the schema. At a later stage, I'm going to replace this by looking up the internal ontology id.

## 🐾 Next steps

As a next step, I'm going to replace the edge lookup logic to also use batched reading. At that stage it won't be possible anymore to see the full vertex.

## 🛡 What tests cover this?

- Directly:
    - The HASH Graph API Rest-tests
    - The BE Integration test suite
- Indirectly:
    - Every other test which depends on the Graph

## ❓ How to test this?

- Make sure the subgraph returned is the same as before