### PR TITLE
Support batched reading for ontology-ontology edges

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -1,23 +1,26 @@
-use std::{borrow::Borrow, mem};
+use std::{borrow::Borrow, collections::HashMap};
 
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
-use type_system::PropertyType;
+use type_system::{url::VersionedUrl, PropertyType};
 
 use crate::{
-    ontology::{DataTypeWithMetadata, OntologyElementMetadata, PropertyTypeWithMetadata},
+    ontology::{OntologyElementMetadata, PropertyTypeWithMetadata},
     provenance::RecordCreatedById,
     store::{
         crud::Read,
         error::DeletionError,
-        postgres::{ontology::OntologyId, TraversalContext},
-        query::Filter,
+        postgres::{
+            ontology::{read::OntologyTypeTraversalData, OntologyId},
+            query::ReferenceTable,
+            TraversalContext,
+        },
         AsClient, ConflictBehavior, InsertionError, PostgresStore, PropertyTypeStore, QueryError,
         Record, UpdateError,
     },
     subgraph::{
         edges::{EdgeDirection, GraphResolveDepths, OntologyEdgeKind},
-        identifier::PropertyTypeVertexId,
+        identifier::{DataTypeVertexId, PropertyTypeVertexId},
         query::StructuralQuery,
         temporal_axes::QueryTemporalAxes,
         Subgraph,
@@ -35,87 +38,82 @@ impl<C: AsClient> PostgresStore<C> {
         traversal_context: &mut TraversalContext,
         subgraph: &mut Subgraph,
     ) -> Result<(), QueryError> {
-        let time_axis = subgraph.temporal_axes.resolved.variable_time_axis();
-
         let mut data_type_queue = Vec::new();
+        let mut edges_to_traverse = HashMap::<OntologyEdgeKind, OntologyTypeTraversalData>::new();
 
         while !property_type_queue.is_empty() {
-            // TODO: We could re-use the memory here but we expect to batch the processing of this
-            //       for-loop. See https://app.asana.com/0/0/1204117847656663/f
+            edges_to_traverse.clear();
+
+            #[expect(clippy::iter_with_drain, reason = "false positive, vector is reused")]
             for (property_type_vertex_id, graph_resolve_depths, temporal_axes) in
-                mem::take(&mut property_type_queue)
+                property_type_queue.drain(..)
             {
-                if let Some(new_graph_resolve_depths) = graph_resolve_depths
-                    .decrement_depth_for_edge(
-                        OntologyEdgeKind::ConstrainsValuesOn,
-                        EdgeDirection::Outgoing,
-                    )
-                {
-                    for data_type in <Self as Read<DataTypeWithMetadata>>::read_vec(
-                        self,
-                        &Filter::<DataTypeWithMetadata>::for_ontology_edge_by_property_type_vertex_id(
-                            &property_type_vertex_id,
-                            OntologyEdgeKind::ConstrainsValuesOn,
-                        ),
-                        Some(&temporal_axes),
-                    )
-                    .await?
+                for edge_kind in [
+                    OntologyEdgeKind::ConstrainsValuesOn,
+                    OntologyEdgeKind::ConstrainsPropertiesOn,
+                ] {
+                    if let Some(new_graph_resolve_depths) = graph_resolve_depths
+                        .decrement_depth_for_edge(edge_kind, EdgeDirection::Outgoing)
                     {
-                        let data_type_vertex_id = data_type.vertex_id(time_axis);
-
-                        subgraph.insert_edge(
-                            &property_type_vertex_id,
-                            OntologyEdgeKind::ConstrainsValuesOn,
-                            EdgeDirection::Outgoing,
-                            data_type_vertex_id.clone(),
-                        );
-
-                        traversal_context.add_data_type_id(data_type_vertex_id.clone());
-
-                        data_type_queue.push((
-                            data_type_vertex_id,
-                            new_graph_resolve_depths,
-                            temporal_axes.clone()
-                        ));
-                    }
-                }
-
-                if let Some(new_graph_resolve_depths) = graph_resolve_depths
-                    .decrement_depth_for_edge(
-                        OntologyEdgeKind::ConstrainsPropertiesOn,
-                        EdgeDirection::Outgoing,
-                    )
-                {
-                    for referenced_property_type in <Self as Read<PropertyTypeWithMetadata>>::read_vec(
-                        self,
-                        &Filter::<PropertyTypeWithMetadata>::for_ontology_edge_by_property_type_vertex_id(
-                            &property_type_vertex_id,
-                            OntologyEdgeKind::ConstrainsPropertiesOn,
-                            EdgeDirection::Incoming,
-                        ),
-                        Some(&temporal_axes),
-                    )
-                    .await?
-                    {
-                        let referenced_property_type_vertex_id = referenced_property_type.vertex_id(time_axis);
-
-                        subgraph.insert_edge(
-                            &property_type_vertex_id,
-                            OntologyEdgeKind::ConstrainsPropertiesOn,
-                            EdgeDirection::Outgoing,
-                            referenced_property_type_vertex_id.clone(),
-                        );
-
-                        traversal_context.add_property_type_id(referenced_property_type_vertex_id.clone());
-
-                        property_type_queue.push((
-                            referenced_property_type_vertex_id,
+                        edges_to_traverse.entry(edge_kind).or_default().push(
+                            &VersionedUrl {
+                                base_url: property_type_vertex_id.base_id.clone(),
+                                version: property_type_vertex_id.revision_id.inner(),
+                            },
                             new_graph_resolve_depths,
                             temporal_axes.clone(),
-                        ));
+                        );
                     }
                 }
             }
+
+            if let Some(traversal_data) =
+                edges_to_traverse.get(&OntologyEdgeKind::ConstrainsValuesOn)
+            {
+                data_type_queue.extend(
+                    self.read_ontology_edges::<PropertyTypeVertexId, DataTypeVertexId>(
+                        traversal_data,
+                        ReferenceTable::PropertyTypeConstrainsValuesOn,
+                    )
+                    .await?
+                    .map(|edge| {
+                        traversal_context.add_data_type_id(edge.right_endpoint.clone());
+
+                        subgraph.insert_edge(
+                            &edge.left_endpoint,
+                            OntologyEdgeKind::ConstrainsValuesOn,
+                            EdgeDirection::Outgoing,
+                            edge.right_endpoint.clone(),
+                        );
+
+                        (edge.right_endpoint, edge.resolve_depths, edge.temporal_axes)
+                    }),
+                );
+            }
+
+            if let Some(traversal_data) =
+                edges_to_traverse.get(&OntologyEdgeKind::ConstrainsPropertiesOn)
+            {
+                property_type_queue.extend(
+                    self.read_ontology_edges::<PropertyTypeVertexId, PropertyTypeVertexId>(
+                        traversal_data,
+                        ReferenceTable::PropertyTypeConstrainsValuesOn,
+                    )
+                    .await?
+                    .map(|edge| {
+                        subgraph.insert_edge(
+                            &edge.left_endpoint,
+                            OntologyEdgeKind::ConstrainsPropertiesOn,
+                            EdgeDirection::Outgoing,
+                            edge.right_endpoint.clone(),
+                        );
+
+                        traversal_context.add_property_type_id(edge.right_endpoint.clone());
+
+                        (edge.right_endpoint, edge.resolve_depths, edge.temporal_axes)
+                    }),
+                );
+            };
         }
 
         self.traverse_data_types(data_type_queue, traversal_context, subgraph)

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -97,7 +97,7 @@ impl<C: AsClient> PostgresStore<C> {
                 property_type_queue.extend(
                     self.read_ontology_edges::<PropertyTypeVertexId, PropertyTypeVertexId>(
                         traversal_data,
-                        ReferenceTable::PropertyTypeConstrainsValuesOn,
+                        ReferenceTable::PropertyTypeConstrainsPropertiesOn,
                     )
                     .await?
                     .map(|edge| {

--- a/apps/hash-graph/lib/graph/src/store/postgres/query.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query.rs
@@ -22,7 +22,7 @@ pub use self::{
         SelectExpression, WhereExpression, WithExpression,
     },
     statement::{Distinctness, SelectStatement, Statement, WindowStatement},
-    table::{Alias, AliasedColumn, AliasedTable, Table},
+    table::{Alias, AliasedColumn, AliasedTable, ForeignKeyReference, ReferenceTable, Table},
 };
 use crate::store::{
     postgres::query::table::{Column, Relation},


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This is the first PR which actively improves performance on the traversal logic. This starts by batching together edge lookups for ontology-to-ontology edges based on the edge kind.

Note, that I have not precisely measured the performance improvement. In general the number of queries is reduced which directly impacts performance. A summary will be posted in a follow-up PR.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204315348455207/1204117847656663/f) _(internal)_

## 🚫 Blocked by

- #2612
- #2614

## 🔍 What does this change?

- Add function to read ontology-to-ontology edges based on a reference table
- Use that function to read as many ontology edges withing the same Query as possible


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

 - [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

 - [x] is internal and does not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] does not affect the execution graph

## 🐾 Next steps

Do the same for
- knowledge -> ontology (different due to temporal axes)
- kowledge -> knowledge (complicated due to temporal axes)

## 🛡 What tests cover this?

- Directly:
    - The HASH Graph API Rest-tests
    - The BE Integration test suite
- Indirectly:
    - Every other test which depends on the Graph

## ❓ How to test this?

Make sure the subgraph looks exactly as before