### PR TITLE
Use `OntologyId` instead of allocating a `VersionedUri` when traversing edges

### DIFF
--- a/apps/hash-graph/lib/graph/src/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/data_type.rs
@@ -187,6 +187,10 @@ pub enum DataTypeQueryPath<'p> {
 }
 
 impl OntologyQueryPath for DataTypeQueryPath<'_> {
+    fn ontology_id() -> Self {
+        Self::OntologyId
+    }
+
     fn base_url() -> Self {
         Self::BaseUrl
     }

--- a/apps/hash-graph/lib/graph/src/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/entity_type.rs
@@ -304,6 +304,10 @@ pub enum EntityTypeQueryPath<'p> {
 }
 
 impl OntologyQueryPath for EntityTypeQueryPath<'_> {
+    fn ontology_id() -> Self {
+        Self::OntologyId
+    }
+
     fn base_url() -> Self {
         Self::BaseUrl
     }

--- a/apps/hash-graph/lib/graph/src/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/property_type.rs
@@ -226,6 +226,10 @@ pub enum PropertyTypeQueryPath<'p> {
 }
 
 impl OntologyQueryPath for PropertyTypeQueryPath<'_> {
+    fn ontology_id() -> Self {
+        Self::OntologyId
+    }
+
     fn base_url() -> Self {
         Self::BaseUrl
     }

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -202,7 +202,7 @@ impl<C: AsClient> PostgresStore<C> {
                         );
 
                         traversal_context.add_entity_type_id(
-                            &edge.right_endpoint,
+                            edge.right_endpoint_ontology_id,
                             edge.resolve_depths,
                             edge.traversal_interval,
                         )

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/ontology_id.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/ontology_id.rs
@@ -5,10 +5,18 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema, FromSql, ToSql)]
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema, FromSql, ToSql,
+)]
 #[repr(transparent)]
 #[postgres(transparent)]
 pub struct OntologyId(Uuid);
+
+impl OntologyId {
+    pub const fn as_uuid(self) -> Uuid {
+        self.0
+    }
+}
 
 impl fmt::Display for OntologyId {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -2,7 +2,8 @@ use std::{borrow::Borrow, collections::HashMap};
 
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
-use type_system::{url::VersionedUrl, PropertyType};
+use futures::TryStreamExt;
+use type_system::PropertyType;
 
 use crate::{
     identifier::time::RightBoundedTemporalInterval,
@@ -36,7 +37,7 @@ impl<C: AsClient> PostgresStore<C> {
     pub(crate) async fn traverse_property_types(
         &self,
         mut property_type_queue: Vec<(
-            PropertyTypeVertexId,
+            OntologyId,
             GraphResolveDepths,
             RightBoundedTemporalInterval<VariableAxis>,
         )>,
@@ -50,7 +51,7 @@ impl<C: AsClient> PostgresStore<C> {
             edges_to_traverse.clear();
 
             #[expect(clippy::iter_with_drain, reason = "false positive, vector is reused")]
-            for (property_type_vertex_id, graph_resolve_depths, traversal_interval) in
+            for (property_type_ontology_id, graph_resolve_depths, traversal_interval) in
                 property_type_queue.drain(..)
             {
                 for edge_kind in [
@@ -61,10 +62,7 @@ impl<C: AsClient> PostgresStore<C> {
                         .decrement_depth_for_edge(edge_kind, EdgeDirection::Outgoing)
                     {
                         edges_to_traverse.entry(edge_kind).or_default().push(
-                            &VersionedUrl {
-                                base_url: property_type_vertex_id.base_id.clone(),
-                                version: property_type_vertex_id.revision_id.inner(),
-                            },
+                            property_type_ontology_id,
                             new_graph_resolve_depths,
                             traversal_interval,
                         );
@@ -90,7 +88,7 @@ impl<C: AsClient> PostgresStore<C> {
                         );
 
                         traversal_context.add_data_type_id(
-                            &edge.right_endpoint,
+                            edge.right_endpoint_ontology_id,
                             edge.resolve_depths,
                             edge.traversal_interval,
                         )
@@ -116,7 +114,7 @@ impl<C: AsClient> PostgresStore<C> {
                         );
 
                         traversal_context.add_property_type_id(
-                            &edge.right_endpoint,
+                            edge.right_endpoint_ontology_id,
                             edge.resolve_depths,
                             edge.traversal_interval,
                         )
@@ -232,49 +230,46 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         let temporal_axes = unresolved_temporal_axes.clone().resolve();
         let time_axis = temporal_axes.variable_time_axis();
 
-        let property_types =
-            Read::<PropertyTypeWithMetadata>::read_vec(self, filter, Some(&temporal_axes))
-                .await?
-                .into_iter()
-                .map(|entity| (entity.vertex_id(time_axis), entity))
-                .collect();
-
         let mut subgraph = Subgraph::new(
             graph_resolve_depths,
             unresolved_temporal_axes.clone(),
             temporal_axes.clone(),
         );
-        subgraph.vertices.property_types = property_types;
 
-        for vertex_id in subgraph.vertices.property_types.keys() {
-            subgraph.roots.insert(vertex_id.clone().into());
-        }
-
-        let mut traversal_context = TraversalContext::default();
-
-        // TODO: We currently pass in the subgraph as mutable reference, thus we cannot borrow the
-        //       vertices and have to `.collect()` the keys.
-        self.traverse_property_types(
-            subgraph
-                .vertices
-                .property_types
-                .keys()
-                .map(|id| {
+        if graph_resolve_depths.is_empty() {
+            subgraph.vertices.property_types =
+                Read::<PropertyTypeWithMetadata>::read_vec(self, filter, Some(&temporal_axes))
+                    .await?
+                    .into_iter()
+                    .map(|property_type| (property_type.vertex_id(time_axis), property_type))
+                    .collect();
+            for vertex_id in subgraph.vertices.property_types.keys() {
+                subgraph.roots.insert(vertex_id.clone().into());
+            }
+        } else {
+            let traversal_data = self
+                .read_ontology_ids::<PropertyTypeWithMetadata>(filter, Some(&temporal_axes))
+                .await?
+                .map_ok(|(vertex_id, ontology_id)| {
+                    subgraph.roots.insert(vertex_id.into());
                     (
-                        id.clone(),
-                        subgraph.depths,
-                        subgraph.temporal_axes.resolved.variable_interval(),
+                        ontology_id,
+                        graph_resolve_depths,
+                        temporal_axes.variable_interval(),
                     )
                 })
-                .collect(),
-            &mut traversal_context,
-            &mut subgraph,
-        )
-        .await?;
+                .try_collect::<Vec<_>>()
+                .await?;
 
-        traversal_context
-            .read_traversed_vertices(self, &mut subgraph)
-            .await?;
+            let mut traversal_context = TraversalContext::default();
+
+            self.traverse_property_types(traversal_data, &mut traversal_context, &mut subgraph)
+                .await?;
+
+            traversal_context
+                .read_traversed_vertices(self, &mut subgraph)
+                .await?;
+        }
 
         Ok(subgraph)
     }

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 
 use async_trait::async_trait;
 use error_stack::{IntoReport, Result, ResultExt};
-use futures::{StreamExt, TryStreamExt};
+use futures::{Stream, StreamExt, TryStreamExt};
 use postgres_types::{FromSql, Type};
 use serde::Deserialize;
 use time::OffsetDateTime;
@@ -25,9 +25,12 @@ use crate::{
     },
     store::{
         crud::Read,
-        postgres::query::{
-            Distinctness, ForeignKeyReference, PostgresQueryPath, PostgresRecord, ReferenceTable,
-            SelectCompiler, Table, Transpile,
+        postgres::{
+            ontology::OntologyId,
+            query::{
+                Distinctness, ForeignKeyReference, PostgresQueryPath, PostgresRecord,
+                ReferenceTable, SelectCompiler, Table, Transpile,
+            },
         },
         query::{Filter, OntologyQueryPath},
         AsClient, PostgresStore, QueryError, Record,
@@ -232,8 +235,7 @@ where
 
 #[derive(Debug, Default)]
 pub struct OntologyTypeTraversalData {
-    base_urls: Vec<String>,
-    versions: Vec<OntologyTypeVersion>,
+    ontology_ids: Vec<OntologyId>,
     resolve_depths: Vec<GraphResolveDepths>,
     traversal_intervals: Vec<RightBoundedTemporalInterval<VariableAxis>>,
 }
@@ -241,13 +243,11 @@ pub struct OntologyTypeTraversalData {
 impl OntologyTypeTraversalData {
     pub fn push(
         &mut self,
-        versioned_url: &VersionedUrl,
+        ontology_id: OntologyId,
         resolve_depth: GraphResolveDepths,
         traversal_interval: RightBoundedTemporalInterval<VariableAxis>,
     ) {
-        self.base_urls.push(versioned_url.base_url.to_string());
-        self.versions
-            .push(OntologyTypeVersion::new(versioned_url.version));
+        self.ontology_ids.push(ontology_id);
         self.resolve_depths.push(resolve_depth);
         self.traversal_intervals.push(traversal_interval);
     }
@@ -256,11 +256,58 @@ impl OntologyTypeTraversalData {
 pub struct OntologyEdgeTraversal<L, R> {
     pub left_endpoint: L,
     pub right_endpoint: R,
+    pub right_endpoint_ontology_id: OntologyId,
     pub resolve_depths: GraphResolveDepths,
     pub traversal_interval: RightBoundedTemporalInterval<VariableAxis>,
 }
 
 impl<C: AsClient> PostgresStore<C> {
+    pub(crate) async fn read_ontology_ids<R>(
+        &self,
+        filter: &Filter<'_, R>,
+        temporal_axes: Option<&QueryTemporalAxes>,
+    ) -> Result<impl Stream<Item = Result<(R::VertexId, OntologyId), QueryError>>, QueryError>
+    where
+        R: for<'p> Record<QueryPath<'p>: PostgresQueryPath + OntologyQueryPath> + PostgresRecord,
+        R::VertexId: From<VersionedUrl>,
+    {
+        let mut compiler = SelectCompiler::new(temporal_axes);
+
+        let ontology_id_path = <R::QueryPath<'static> as OntologyQueryPath>::ontology_id();
+        let base_url_path = <R::QueryPath<'static> as OntologyQueryPath>::base_url();
+        let version_path = <R::QueryPath<'static> as OntologyQueryPath>::version();
+
+        let ontology_id_index = compiler.add_distinct_selection_with_ordering(
+            &ontology_id_path,
+            Distinctness::Distinct,
+            None,
+        );
+        let base_url_index = compiler.add_selection_path(&base_url_path);
+        let version_index = compiler.add_selection_path(&version_path);
+
+        compiler.add_filter(filter);
+        let (statement, parameters) = compiler.compile();
+
+        Ok(self
+            .as_client()
+            .query_raw(&statement, parameters.iter().copied())
+            .await
+            .into_report()
+            .change_context(QueryError)?
+            .map(|row| row.into_report().change_context(QueryError))
+            .map_ok(move |row| {
+                (
+                    VersionedUrl {
+                        base_url: BaseUrl::new(row.get(base_url_index))
+                            .expect("Ontology type record base URL should always be a valid URL"),
+                        version: row.get::<_, OntologyTypeVersion>(version_index).inner(),
+                    }
+                    .into(),
+                    row.get(ontology_id_index),
+                )
+            }))
+    }
+
     pub(crate) async fn read_ontology_edges<'r, L, R>(
         &self,
         record_ids: &'r OntologyTypeTraversalData,
@@ -291,26 +338,26 @@ impl<C: AsClient> PostgresStore<C> {
                 &format!(
                     r#"
                         SELECT
-                            filter.idx      AS idx,
-                            source.base_url AS source_base_url,
-                            source.version  AS source_version,
-                            target.base_url AS target_base_url,
-                            target.version  AS target_version
+                            filter.idx         AS idx,
+                            source.base_url    AS source_base_url,
+                            source.version     AS source_version,
+                            target.base_url    AS target_base_url,
+                            target.version     AS target_version,
+                            target.ontology_id AS target_ontology_id
                         FROM {table}
 
                         JOIN ontology_ids as source
                           ON {source} = source.ontology_id
 
-                        JOIN unnest($1::text[], $2::int8[])
-                             WITH ORDINALITY AS filter(url, version, idx)
-                          ON filter.url = source.base_url
-                         AND filter.version = source.version
+                        JOIN unnest($1::uuid[])
+                             WITH ORDINALITY AS filter(id, idx)
+                          ON filter.id = source.ontology_id
 
                         JOIN ontology_ids as target
                           ON {target} = target.ontology_id;
                     "#
                 ),
-                &[&record_ids.base_urls, &record_ids.versions],
+                &[&record_ids.ontology_ids],
             )
             .await
             .into_report()
@@ -338,6 +385,7 @@ impl<C: AsClient> PostgresStore<C> {
                         }),
                         version: row.get::<_, OntologyTypeVersion>(4).inner(),
                     }),
+                    right_endpoint_ontology_id: row.get(5),
                     resolve_depths: record_ids.resolve_depths[index],
                     traversal_interval: record_ids.traversal_intervals[index],
                 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/compile.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/compile.rs
@@ -463,10 +463,6 @@ impl<'p, R: PostgresRecord> SelectCompiler<'p, R> {
         parameters: &'p ParameterList<'f>,
     ) -> (Expression, ParameterType) {
         let parameter_type = match parameters {
-            ParameterList::VersionedUrls(ontology_ids) => {
-                self.artifacts.parameters.push(ontology_ids);
-                ParameterType::Text
-            }
             ParameterList::Uuid(uuids) => {
                 self.artifacts.parameters.push(uuids);
                 ParameterType::Uuid

--- a/apps/hash-graph/lib/graph/src/store/query.rs
+++ b/apps/hash-graph/lib/graph/src/store/query.rs
@@ -43,6 +43,9 @@ impl fmt::Display for ParameterType {
 }
 
 pub trait OntologyQueryPath {
+    /// Returns the path identifying the internal ontology id.
+    fn ontology_id() -> Self;
+
     /// Returns the path identifying the [`BaseUrl`].
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl

--- a/apps/hash-graph/lib/graph/src/store/query/filter.rs
+++ b/apps/hash-graph/lib/graph/src/store/query/filter.rs
@@ -446,9 +446,6 @@ where
             Self::In(lhs, rhs) => {
                 if let FilterExpression::Parameter(parameter) = lhs {
                     match rhs {
-                        ParameterList::VersionedUrls(_) => {
-                            parameter.convert_to_parameter_type(ParameterType::Text)?;
-                        }
                         ParameterList::Uuid(_) => {
                             parameter.convert_to_parameter_type(ParameterType::Uuid)?;
                         }
@@ -502,8 +499,6 @@ pub enum Parameter<'p> {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ParameterList<'p> {
-    // TODO: Use the internal ontology id instead to avoid allocating a string
-    VersionedUrls(&'p [String]),
     Uuid(&'p [Uuid]),
 }
 

--- a/apps/hash-graph/lib/graph/src/subgraph/edges/kind.rs
+++ b/apps/hash-graph/lib/graph/src/subgraph/edges/kind.rs
@@ -192,6 +192,11 @@ pub struct GraphResolveDepths {
 
 impl GraphResolveDepths {
     #[must_use]
+    pub fn is_empty(self) -> bool {
+        self == Self::default()
+    }
+
+    #[must_use]
     pub fn contains(self, other: Self) -> bool {
         [
             self.inherits_from.contains(other.inherits_from),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In #2614 `ParameterList::VersionedUrl` was introduced which requires allocating a `String` per lookup. The allocation and full string comparison in Postgres can be avoided.

This generally slightly improves the performance by 5-10%.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204610208832639/1204692442679557/f) _(internal)_

## 🚫 Blocked by

- #2625
- #2626
- #2627 
- #2628

## 🔍 What does this change?

- Add function to read the `OntologyId` using a `Filter`
- Change the ontology-edge-traversal to use the ontology id instead of a full string comparison
- Change the traversal entry to only run if there is a resolve depth > 0 (This slightly improves the performance by ~2% for queries with a resolve depths of 0)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

 - [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

 - [x] is internal and does not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] does not affect the execution graph

## 🛡 What tests cover this?

- Directly:
    - The HASH Graph API Rest-tests
    - The BE Integration test suite
- Indirectly:
    - Every other test which depends on the Graph

## ❓ How to test this?

Make sure the subgraph looks exactly as before