### PR TITLE
Simplify some trait boilerplate by using Deref

### DIFF
--- a/apps/engine/lib/execution/src/package/simulation/comms.rs
+++ b/apps/engine/lib/execution/src/package/simulation/comms.rs
@@ -2,7 +2,7 @@ use stateful::field::PackageId;
 
 use crate::{
     package::simulation::{PackageTask, SimulationId},
-    task::{ActiveTask, StoreAccessValidator, TaskId, TaskSharedStore},
+    task::{ActiveTask, TaskId, TaskSharedStore},
     worker_pool,
     worker_pool::comms::{
         main::MainMsgSend,

--- a/apps/engine/lib/execution/src/worker.rs
+++ b/apps/engine/lib/execution/src/worker.rs
@@ -495,7 +495,7 @@ impl Worker {
         source: Language,
     ) -> Result<()> {
         if let Some(pending) = self.tasks.inner.get_mut(&msg.task_id) {
-            let next = WorkerHandler::handle_worker_message(&mut pending.task, msg.payload)?;
+            let next = WorkerHandler::handle_worker_message(&mut *pending.task, msg.payload)?;
             match next.target {
                 MessageTarget::Rust => {
                     let inbound = InboundToRunnerMsgPayload::TaskMsg(RunnerTaskMessage {
@@ -626,7 +626,7 @@ impl Worker {
     /// [`PartialSharedState::split_into_individual_per_group()`]: crate::task::PartialSharedState::split_into_individual_per_group
     async fn spawn_task(&mut self, sim_id: SimulationId, task: WorkerTask) -> Result<()> {
         let task_id = task.task_id;
-        let msg = WorkerHandler::start_message(&task.task)?;
+        let msg = WorkerHandler::start_message(&*task.task)?;
 
         let context = task.shared_store.context().clone();
         let shared_stores = match task.shared_store.state {

--- a/apps/engine/lib/execution/src/worker_pool.rs
+++ b/apps/engine/lib/execution/src/worker_pool.rs
@@ -49,7 +49,7 @@ pub use self::{
 use crate::{
     package::simulation::{PackageTask, SimulationId},
     runner::comms::{ExperimentInitRunnerMsg, ExperimentInitRunnerMsgBase, NewSimulationRun},
-    task::{Task, TaskDistributionConfig, TaskId, TaskSharedStore},
+    task::{TaskDistributionConfig, TaskId, TaskSharedStore},
     worker::{SyncPayload, Worker, WorkerConfig, WorkerTask},
     Error, Result,
 };

--- a/apps/engine/lib/execution/src/worker_pool/pending.rs
+++ b/apps/engine/lib/execution/src/worker_pool/pending.rs
@@ -6,7 +6,7 @@ use crate::{
     package::simulation::PackageTask,
     task::{CancelTask, TaskId, TaskMessage, TaskResultOrCancelled},
     worker::WorkerTaskResultOrCancelled,
-    worker_pool::{comms::active::ActiveTaskExecutorComms, WorkerIndex, WorkerPoolHandler},
+    worker_pool::{comms::active::ActiveTaskExecutorComms, WorkerIndex},
     Error, Result,
 };
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

I noticed an opportunity to remove some boilerplate. This pattern is used a number of times throughout the repo, and I find it to be somewhat cumbersome, so this is just a suggested way to get around having this kind of indirection. I also recognize this is probably a matter of opinion, which is why I only gave this treatment to one enum rather than overzealously applying it across the repo (also, I'm not familiar enough with the files to remember all the places I've seen it). What do you think?

On a technical level, it swaps enum-oriented dynamicism for vtable lookups. I haven't profiled it or anything, but it seems like it would be a very minor penalty if a penalty at all.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**

### 📜 Does this require a change to the docs?

- [x] is internal and does not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

- [x] does not affect the execution graph

## 🐾 Next steps

We could apply this to other similar enums

## 🛡 What tests cover this?

Dunno 😬 I assume all of them

## ❓ How to test this?

I just tried it on a couple of projects; I'd expect it to fail instantly on any project if there were some kind of issue. Please advise if there's an easy set of tests I could run or where I should put unit/integration tests that might be relevant.