### PR TITLE
Categorize projects within directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,47 +53,13 @@ Browse the [HASH roadmap] for more information about upcoming features and relea
 
 ## [![a](/.github/assets/gh_icon_repo-structure_20px-base.svg)][gh-repo-structure] &nbsp; About this repository
 
-### Top-level layout
-
 This repository's contents is divided across several primary sections:
 
-- [**`/apps`**](/apps) contains the primary code powering our runnable [applications](#applications)
-- [**`/blocks`**](/blocks) contains our public _Block Protocol_ [blocks](#blocks)
-- [**`/infra`**](/infra) houses deployment scripts, utilities and other [infrastructure](#infrastructure) useful in running our apps
-- [**`/libs`**](/libs) contains [libraries](#libraries) including npm packages and Rust crates
+- [**`/apps`**](/apps) contains the primary code powering our runnable [applications](https://github.com/hashintel/hash/tree/main/apps#applications)
+- [**`/blocks`**](/blocks) contains our public _Block Protocol_ [blocks](https://github.com/hashintel/hash/tree/main/blocks#blocks)
+- [**`/infra`**](/infra) houses deployment scripts, utilities and other [infrastructure](https://github.com/hashintel/hash/tree/main/infra#infrastructure) useful in running our apps
+- [**`/libs`**](/libs) contains [libraries](https://github.com/hashintel/hash/tree/main/libs/README.md#libraries) including npm packages and Rust crates
 - [**`/tests`**](/tests) contains end-to-end and integration tests that span across one or more apps, blocks or libs
-
-Key projects within are summarized below.
-
-### Applications
-
-- [`hash`](apps/hash): entry-point for **[HASH]**, our data-driven, all-in-one AI workspace
-- [`engine`](apps/engine): experimental version of **[HASH Engine]**, a versatile agent-based simulation engine written in Rust
-
-### Blocks
-
-- Various directories containing the source code for all of HASH's open-source [Block Protocol] (**Þ**) blocks, summarized in a [handy table](https://github.com/hashintel/hash/tree/main/blocks#blocks). Please note: this table/directory contains HASH-published blocks only, and does not contain the full extent of available Þ blocks.
-
-### Infrastructure
-
-- [`docker`](infra/docker): Docker assets relating to HASH
-- [`terraform`](infra/terraform): Terraform modules for deploying HASH on AWS
-
-### Libraries
-
-#### Rust crates
-
-- [`antsi`](libs/antsi): Rust crate supporting Select Graphic Rendition (as defined in ISO 6429) without external dependencies
-- [`deer`](libs/deer): fail-slow deserialization framework for Rust, featuring meaningful error messages and context
-- [`error-stack`](libs/error-stack): context-aware error-handling library for Rust which supports attaching arbitrary user data
-- [`sarif`](libs/sarif): representation of the SARIF specification in Rust
-
-#### npm packages
-
-- [`@hashintel/block-design-system`](libs/@hashintel/block-design-system): a relatively unopinionated design system for [Block Protocol] blocks
-- [`@hashintel/design-system`](libs/@hashintel/design-system): the design system for [HASH] and our [hash.ai] website
-- [`@hashintel/query-editor`](libs/@hashintel/query-editor): editing interface for [HASH Graph] queries
-- [`@hashintel/type-editor`](libs/@hashintel/type-editor): editing interface for [Block Protocol types]
 
 ## [![a](/.github/assets/gh_icon_contributing_20px-base.svg)][gh-contributing] &nbsp; Contributing
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -21,9 +21,11 @@ This `apps` directory contains the source-code and/or content for a number of HA
 
 ## HASH
 
-[HASH] is a block-based, data-centric "super app".
+[HASH] is a block-based, data-centric, AI-enabled "super app".
 
-The HASH app [`README`](hash/README.md) provides a holistic description of the app, and instructions for running it. The application depends on a suite of constituent services, which are briefly described below. Please note that these are not designed or guaranteed to be useful when ran independently.
+The [README in the `hash` directory](hash/README.md) provides a more detailed overview of the app, and instructions for running it.
+
+The application depends on a suite of constituent services, which are briefly described below. Please note that these are not designed or guaranteed to be useful when ran independently.
 
 | Subdirectory             | Description                                                                                                                                                                  |
 | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -40,7 +42,7 @@ The [HASH] app seeks to enable its users to make better decisions by utilizing a
 
 | Subdirectory                             | Description                                                                                                |
 | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| [`engine`](engine)                   | Codebase for the alpha version of [HASH Engine], a versatile agent-based simulation engine written in Rust |
+| [`engine`](engine)                   | Codebase for the standalone alpha version of [HASH Engine], a versatile agent-based simulation engine written in Rust |
 | [`sim-core`](sim-core)                       | Codebase for an open-source, locally-runnable version of [HASH Core] |
 
 ## HASH Agents

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,5 +1,5 @@
 [blockprotocol/blockprotocol repo]: https://github.com/blockprotocol/blockprotocol
-[contributing guidelines]: https://github.com/hashintel/hash/blob/main/.github/CONTRIBUTING.md
+[repository guidelines]: https://github.com/hashintel/hash/blob/main/.github/CONTRIBUTING.md
 [discord]: https://hash.ai/discord?utm_medium=organic&utm_source=github_readme_hash-repo_apps
 [github_banner]: https://hash.dev/?utm_medium=organic&utm_source=github_readme_hash-repo_apps
 [github_star]: https://github.com/hashintel/hash/tree/main/apps#
@@ -21,20 +21,35 @@ This `apps` directory contains the source-code and/or content for a number of HA
 
 ## HASH
 
-[HASH], is a block-based, data-centric, all-in-one workspace.
+[HASH] is a block-based, data-centric "super app".
 
-See the [`README`](hash/README.md) in the [`hash`](hash) folder for a holistic description of the workspace, and instructions for running it or testing it.
-
-The workspace depends on a suite of constituent services, which are briefly described below, keep in mind that they are not guaranteed to be useful when ran independently.
+The HASH app [`README`](hash/README.md) provides a holistic description of the app, and instructions for running it. The application depends on a suite of constituent services, which are briefly described below. Please note that these are not designed or guaranteed to be useful when ran independently.
 
 | Subdirectory             | Description                                                                                                                                                                  |
 | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `hash-frontend`          | The main entrypoint for the Next.js frontend (graphical user interface) of the HASH workspace application.                                                                   |
-| `hash-api`               | The main entrypoint for the Node.js server that serves the core of the backend API of HASH.                                                                                  |
-| `hash-graph`             | The query layer over the main datastore of HASH, its strongly-typed graph.                                                                                                   |
-| `hash-external-services` | Defines the running configurations of external (not internally-developed) services that HASH depends on, such as Postgres, Ory Kratos, and Temporal. _(pending refactoring)_ |
-| `hash-realtime`          | Implements a different view over the graph datastore that allows services to subscribe to realtime updates on entities.                                                      |
-| `hash-search-loader`     | Loads the change-stream published by the realtime service into a search index.                                                                                               |
+| [`hash-api`](hash-api)                             | The main entrypoint for the Node.js server that serves the core of the backend API of HASH.                                                                                  |
+| [`hash-external-services`](hash-external-services) | Defines the running configurations of external (not internally-developed) services that HASH depends on, such as Postgres, Ory Kratos, and Temporal. _(pending refactoring)_ |
+| [`hash-frontend`](hash-frontend)                   | The main entrypoint for the Next.js frontend (graphical user interface) of the HASH workspace application.                                                                   |
+| [`hash-graph`](hash-graph)                         | The query layer over the main datastore of HASH, its strongly-typed graph.                                                                                                   |
+| [`hash-realtime`](hash-realtime)                   | Implements a different view over the graph datastore that allows services to subscribe to realtime updates on entities.                                                      |
+| [`hash-search-loader`](hash-search-loader)         | Loads the change-stream published by the realtime service into a search index.                                                                                               |
+
+## HASH Simulations
+
+The [HASH] app seeks to enable its users to make better decisions by utilizing all of the information available to them. Generative simulation is a core part of realizing this vision. We have published a variety of experimental tools for agent-based modeling in anticipation of this. These simulation tools are currently unsupported, but we are open to accepting contributions to these in line with our general [repository guidelines].
+
+| Subdirectory                             | Description                                                                                                |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| [`engine`](engine)                   | Codebase for the alpha version of [HASH Engine], a versatile agent-based simulation engine written in Rust |
+| [`sim-core`](sim-core)                       | Codebase for an open-source, locally-runnable version of [HASH Core] |
+
+## HASH Agents
+
+| Subdirectory                             | Description                                                                                                |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| [`hash-agents`](hash-agents)             | An experimental setup for writing Python-based 'agents' that interface with LLMs                           |
+| [`hash-ai-worker-py`](hash-ai-worker-py) | A Python-based [Temporal](temporal.io) worker, tasked with executing AI-powered workflows                  |
+| [`hash-ai-worker-ts`](hash-ai-worker-ts) | A TypeScript-based [Temporal](temporal.io) worker, tasked with executing AI-powered workflows              |
 
 ## Websites
 
@@ -44,16 +59,12 @@ The workspace depends on a suite of constituent services, which are briefly desc
 | [hashdotdesign](hashdotdesign) | Source code and content related to our [hash.design] designer-focused website |
 | [hashdotdev](hashdotdev)       | Source code and content related to our [hash.dev] developer-focused website   |
 
-## Other projects
-
-The following applications are available but currently unsupported. However, as with our main projects, we remain open to accepting contributions to these in accordance with our [contributing guidelines].
+## Plugins
 
 | Subdirectory                             | Description                                                                                                |
 | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| [`engine`](engine)                       | Codebase for the alpha version of [HASH Engine], a versatile agent-based simulation engine written in Rust |
 | [`intellij-plugin`](intellij-plugin)     | Plugin for JetBrains IntelliJ-based IDEs to assist development in common HASH workflows                    |
-| [`hash-agents`](hash-agents)             | An experimental setup for writing Python-based 'agents' that interface with LLMs                           |
-| [`hash-ai-worker-py`](hash-ai-worker-py) | A Python-based [Temporal](temporal.io) worker, tasked with executing AI-powered workflows                  |
-| [`hash-ai-worker-ts`](hash-ai-worker-ts) | A TypeScript-based [Temporal](temporal.io) worker, tasked with executing AI-powered workflows              |
+
+## Block Protocol
 
 Source code for the _Block Protocol_ can be found separately in the [blockprotocol/blockprotocol repo] on GitHub.

--- a/apps/sim-core/README.md
+++ b/apps/sim-core/README.md
@@ -1,0 +1,8 @@
+[hash]: https://hash.ai/platform/hash?utm_medium=organic&utm_source=github_readme_hash-repo_root
+[hash engine]: https://hash.ai/platform/engine?utm_medium=organic&utm_source=github_readme_hash-repo_root
+
+# HASH Core
+
+[HASH Core](https://hash.ai/platform/core?utm_medium=organic&utm_source=github_readme_core) (**hCore**) is a self-contained, in-browser environment for building and interfacing with agent-based simulations compatible with [HASH].
+
+It uses a legacy version of hEngine which is no longer maintained, separate from the primary [HASH Engine] (**hEngine**) found in this repository.

--- a/apps/sim-core/README.md
+++ b/apps/sim-core/README.md
@@ -1,8 +1,9 @@
-[hash]: https://hash.ai/platform/hash?utm_medium=organic&utm_source=github_readme_hash-repo_root
-[hash engine]: https://hash.ai/platform/engine?utm_medium=organic&utm_source=github_readme_hash-repo_root
+[hash]: https://hash.ai/platform/hash?utm_medium=organic&utm_source=github_readme_core
+[hash core]: https://hash.ai/platform/core?utm_medium=organic&utm_source=github_readme_core
+[hash engine]: https://hash.ai/platform/engine?utm_medium=organic&utm_source=github_readme_core
 
 # HASH Core
 
-[HASH Core](https://hash.ai/platform/core?utm_medium=organic&utm_source=github_readme_core) (**hCore**) is a self-contained, in-browser environment for building and interfacing with agent-based simulations compatible with [HASH].
+[HASH Core] (**hCore**) is a self-contained, in-browser environment for building and interfacing with agent-based simulations compatible with [HASH].
 
 It uses a legacy version of hEngine which is no longer maintained, separate from the primary [HASH Engine] (**hEngine**) found in this repository.

--- a/blocks/README.md
+++ b/blocks/README.md
@@ -34,6 +34,8 @@ This directory contains the source code for all HASH-developed public [Block Pro
 
 You can live preview most of these on the [`@hash`](https://blockprotocol.org/@hash/blocks) page in the [Þ Hub](https://blockprotocol.org/hub), and direct links are provided below.
 
+**Please note:** this table/directory contains HASH-published blocks only, and does not contain the full extent of available Þ blocks.
+
 | Directory        | Spec Target | Status         | Þ Hub URL                                                                        | Description |
 | ---------------- | ----------- | -------------- | -------------------------------------------------------------------------------- | ----------- |
 | [`address`]      | 0.3         | **Maintained** | [@hash/blocks/address](https://blockprotocol.org/@hash/blocks/address)           |             |

--- a/libs/README.md
+++ b/libs/README.md
@@ -1,3 +1,4 @@
+[block protocol]: https://blockprotocol.org/?utm_medium=organic&utm_source=github_readme_hash-repo_libs
 [discord]: https://hash.ai/discord?utm_medium=organic&utm_source=github_readme_hash-repo_libs
 [hash.ai]: https://hash.ai/?utm_medium=organic&utm_source=github_readme_hash-repo_libs
 [HASH website for developers]: https://hash.dev/?utm_medium=organic&utm_source=github_readme_hash-repo_libs
@@ -29,8 +30,8 @@ Contains the source code for software development libraries which HASH has publi
 | [deer]                     | Rust        | [Crates.io](https://crates.io/crates/deer)                    | [Docs.rs](https://docs.rs/deer/latest/deer/)               | **Experimental** backend-agnostic deserialization framework, featuring meaningful error messages and context and fail-slow behavior by default       |
 | [error-stack]              | Rust        | [Crates.io](https://crates.io/crates/error-stack)             | [Docs.rs](https://docs.rs/error-stack/latest/error_stack/) | Context-aware error-handling library that supports arbitrary attached user data                                                                      |
 | [sarif]                    | Rust        | [Crates.io](https://crates.io/crates/sarif)                   | [Docs.rs](https://docs.rs/sarif/latest/sarif/)             | Representation of the SARIF specification in Rust                                                                                                    |
-| [@hashintel/type-editor]   | TypeScript  | [npm](https://www.npmjs.com/package/@hashintel/type-editor)   | To be written                                              | A user interface for editing entity types defined according to the [Block Protocol's Type System](https://blockprotocol.org/docs/working-with-types) |
-| [@hashintel/query-editor]  | TypeScript  | [npm](https://www.npmjs.com/package/@hashintel/query-editor)  | To be written                                              | A user interface for editing queries (a specific entity type used heavily inside of [HASH]) |
+| [@hashintel/type-editor]   | TypeScript  | [npm](https://www.npmjs.com/package/@hashintel/type-editor)   | To be written                                              | UI for editing entity types defined according to the [Block Protocol's Type System](https://blockprotocol.org/docs/working-with-types) |
+| [@hashintel/query-editor]  | TypeScript  | [npm](https://www.npmjs.com/package/@hashintel/query-editor)  | To be written                                              | UI for editing queries (a specific entity type used heavily inside of [HASH]) |
 
 ## Internal Libraries
 

--- a/libs/README.md
+++ b/libs/README.md
@@ -1,13 +1,18 @@
+[discord]: https://hash.ai/discord?utm_medium=organic&utm_source=github_readme_hash-repo_libs
+[hash.ai]: https://hash.ai/?utm_medium=organic&utm_source=github_readme_hash-repo_libs
 [HASH website for developers]: https://hash.dev/?utm_medium=organic&utm_source=github_readme_hash-repo_libs
 [github_banner]: https://hash.dev/?utm_medium=organic&utm_source=github_readme_hash-repo_libs
+
 [github_star]: https://github.com/hashintel/hash/tree/main/libs#
-[discord]: https://hash.ai/discord?utm_medium=organic&utm_source=github_readme_hash-repo_libs
+[hash]: https://github.com/hashintel/hash/tree/main/apps/hash
 [antsi]: antsi
 [deer]: deer
 [error-stack]: error-stack
 [sarif]: sarif
 [@hashintel/type-editor]: @hashintel/type-editor
+[@hashintel/query-editor]: @hashintel/query-editor
 [@hashintel/design-system]: @hashintel/design-system
+[@hashintel/block-design-system]: @hashintel/block-design-system
 
 [![github_banner](https://hash.ai/cdn-cgi/imagedelivery/EipKtqu98OotgfhvKf6Eew/f4e5e79c-077f-4b30-9170-e25b91286300/github)][github_banner]
 
@@ -17,14 +22,24 @@
 
 Contains the source code for software development libraries which HASH has published for general use. Full write-ups of most can be found on the [HASH website for developers], and a summary table is included below for convenience.
 
+## General Libraries
 | Directory                  | Language(s) | Publication URL                                               | Docs URL                                                   | Description                                                                                                                                          |
 | -------------------------- | ----------- | ------------------------------------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [antsi]                    | Rust        | [Crates.io](https://crates.io/crates/antsi)                   | [Docs.rs](https://docs.rs/antsi/latest/antsi/)             | Supports coloring Select Graphic Rendition (as defined in ISO 6429) with no external dependencies                                                    |
 | [deer]                     | Rust        | [Crates.io](https://crates.io/crates/deer)                    | [Docs.rs](https://docs.rs/deer/latest/deer/)               | **Experimental** backend-agnostic deserialization framework, featuring meaningful error messages and context and fail-slow behavior by default       |
 | [error-stack]              | Rust        | [Crates.io](https://crates.io/crates/error-stack)             | [Docs.rs](https://docs.rs/error-stack/latest/error_stack/) | Context-aware error-handling library that supports arbitrary attached user data                                                                      |
 | [sarif]                    | Rust        | [Crates.io](https://crates.io/crates/sarif)                   | [Docs.rs](https://docs.rs/sarif/latest/sarif/)             | Representation of the SARIF specification in Rust                                                                                                    |
-| [@hashintel/design-system] | TypeScript  | [npm](https://www.npmjs.com/package/@hashintel/design-system) | To be written                                              | Reusable UI primitives                                                                                                                               |
 | [@hashintel/type-editor]   | TypeScript  | [npm](https://www.npmjs.com/package/@hashintel/type-editor)   | To be written                                              | A user interface for editing entity types defined according to the [Block Protocol's Type System](https://blockprotocol.org/docs/working-with-types) |
+| [@hashintel/query-editor]  | TypeScript  | [npm](https://www.npmjs.com/package/@hashintel/query-editor)  | To be written                                              | A user interface for editing queries (a specific entity type used heavily inside of [HASH]) |
+
+## Internal Libraries
+
+Although open-source, the following libraries were developed for internal use and may be subject to breaking changes. External consumers should be especially careful when using or upgrading these.
+
+| Directory                  | Language(s) | Publication URL                                               | Docs URL                                                   | Description                                                                                                                                          |
+| -------------------------- | ----------- | ------------------------------------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [@hashintel/design-system] | TypeScript  | [npm](https://www.npmjs.com/package/@hashintel/design-system) | To be written                                              | A collection of styleguide-aligned reusable UI primitives for [HASH] and our [hash.ai] website                                                        |
+| [@hashintel/block-design-system] | TypeScript  | [npm](https://www.npmjs.com/package/@hashintel/block-design-system) | To be written                                              | A relatively unopinionated set of reusable UI primitives for use in building [Block Protocol] blocks                                            |
 
 ## Contributing
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Splits `libs` and `apps` into distinct categories, and removes the lists of them from the root README, helping avoid duplication and ensure references/descriptions live in a single location only.