### PR TITLE
Avoid warning on resolver not specified

### DIFF
--- a/apps/hash-graph/Cargo.toml
+++ b/apps/hash-graph/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = ["lib/*", "bin/*", "bench", "tests/*"]
 default-members = ["bin/*", "lib/*"]
+resolver = "2"
 
 [workspace.package]
 description = "The entity-graph query-layer for the HASH datastore"

--- a/apps/hash-graph/lib/graph/src/shared/identifier/time/interval.rs
+++ b/apps/hash-graph/lib/graph/src/shared/identifier/time/interval.rs
@@ -44,7 +44,10 @@ where
     S: IntervalBound<Timestamp<A>> + fmt::Debug,
     E: IntervalBound<Timestamp<A>> + fmt::Debug,
 {
-    postgres_types::accepts!(TSTZ_RANGE);
+
+    fn accepts(ty: &Type) -> bool {
+        *ty == Type::TSTZ_RANGE
+    }
 
     postgres_types::to_sql_checked!();
 
@@ -128,7 +131,7 @@ where
     }
 
     fn accepts(ty: &Type) -> bool {
-        matches!(ty, &Type::TSTZ_RANGE)
+        *ty == Type::TSTZ_RANGE
     }
 }
 

--- a/apps/hash-graph/lib/graph/src/shared/identifier/time/interval.rs
+++ b/apps/hash-graph/lib/graph/src/shared/identifier/time/interval.rs
@@ -44,12 +44,11 @@ where
     S: IntervalBound<Timestamp<A>> + fmt::Debug,
     E: IntervalBound<Timestamp<A>> + fmt::Debug,
 {
+    postgres_types::to_sql_checked!();
 
     fn accepts(ty: &Type) -> bool {
         *ty == Type::TSTZ_RANGE
     }
-
-    postgres_types::to_sql_checked!();
 
     fn to_sql(
         &self,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Since recently, `clippy` will warn if the resolver is not set for the workspace.

Crates with the edition set to `2021` will default to `resolver = "2"`, but virtual workspaces - as they don't specify an addition - defaults to `resolver = "1"`. To avoid this issue, this sets the `workspace.resolver` variable.

```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

<!-- - [x] modifies an **npm**-publishable library and **I have added a changeset file(s)** -->

<!-- - [x] modifies a **Cargo**-publishable library and **I have amended the version** -->

<!-- - [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish** -->

<!-- - [x] modifies a **block** that will need publishing via GitHub action once merged -->

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing 

<!-- - [x] I am unsure / need advice -->

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

- [x] is internal and does not require a docs change

<!-- - [x] is in a state where docs changes are not _yet_ required but will be
  - this is tracked within: [Insert Link Here](link) -->

<!-- - [x] requires changes to docs
  - <CHANGES TO DOCS EXPLAINED HERE> -->

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

<!-- - [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this -->

 - [x] does not affect the execution graph 

<!-- - [x] I am unsure / need advice -->