### PR TITLE
Fix `turbo.json` for lock-file linting

### DIFF
--- a/apps/hash-ai-worker-py/turbo.json
+++ b/apps/hash-ai-worker-py/turbo.json
@@ -47,7 +47,7 @@
     },
     "lint:lock-files": {
       "dependsOn": ["poetry:install-lint-tools"],
-      "inputs": ["./**/*.py", "pyproject.toml"]
+      "inputs": ["poetry.lock", "pyproject.toml"]
     },
     "lint:ruff": {
       "dependsOn": ["poetry:install-lint-tools"],


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

https://github.com/hashintel/hash/pull/2697#discussion_r1247626994 accidentally introduced a copy-paste error, this fixes it.