### PR TITLE
Implement data encoder for Pydantic

### DIFF
--- a/apps/hash-ai-worker-py/app/__main__.py
+++ b/apps/hash-ai-worker-py/app/__main__.py
@@ -8,6 +8,7 @@ from temporalio.client import Client
 from temporalio.worker import Worker
 
 from app.activities import complete
+from app.encoding import pydantic_data_converter
 from app.workflows import DataTypeWorkflow, EntityTypeWorkflow, PropertyTypeWorkflow
 
 load_dotenv()
@@ -23,6 +24,7 @@ async def run_worker(stop_event: asyncio.Event) -> None:
     client = await Client.connect(
         temporal_target,
         namespace="default",
+        data_converter=pydantic_data_converter,
     )
 
     worker = Worker(

--- a/apps/hash-ai-worker-py/app/encoding.py
+++ b/apps/hash-ai-worker-py/app/encoding.py
@@ -1,0 +1,74 @@
+"""Conversion utilities for Pydantic."""
+
+
+# Inspired by https://github.com/temporalio/samples-python/blob/main/pydantic_converter/converter.py
+
+import json
+from typing import Any
+
+from pydantic import BaseModel
+from pydantic.json import pydantic_encoder
+from temporalio.api.common.v1 import Payload
+from temporalio.converter import (
+    CompositePayloadConverter,
+    DataConverter,
+    DefaultPayloadConverter,
+    JSONPlainPayloadConverter,
+)
+
+__all__ = ["pydantic_data_converter"]
+
+
+class PydanticJSONPayloadConverter(JSONPlainPayloadConverter):
+    """Pydantic JSON payload converter.
+
+    This extends the :py:class:`JSONPlainPayloadConverter` to override
+    :py:meth:`to_payload` using the Pydantic encoder.
+    """
+
+    def to_payload(self, value: Any) -> Payload | None:  # noqa: ANN401
+        """Convert all values with Pydantic encoder or fail.
+
+        Like the base class, we fail if we cannot convert. This payload
+        converter is expected to be the last in the chain, so it can fail if
+        unable to convert.
+        """
+
+        def encoder(obj: Any) -> Any:  # noqa: ANN401
+            if isinstance(obj, BaseModel):
+                return obj.dict(by_alias=True, exclude_none=True)
+
+            return pydantic_encoder(obj)
+
+        # We let JSON conversion errors be thrown to caller
+        return Payload(
+            metadata={"encoding": self.encoding.encode()},
+            data=json.dumps(
+                value,
+                separators=(",", ":"),
+                sort_keys=True,
+                default=encoder,
+            ).encode(),
+        )
+
+
+class PydanticPayloadConverter(CompositePayloadConverter):
+    """Payload converter to replace Temporal JSON conversion with Pydantic."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            *(
+                (
+                    c
+                    if not isinstance(c, JSONPlainPayloadConverter)
+                    else PydanticJSONPayloadConverter()
+                )
+                for c in DefaultPayloadConverter.default_encoding_payload_converters
+            ),
+        )
+
+
+pydantic_data_converter = DataConverter(
+    payload_converter_class=PydanticPayloadConverter,
+)
+"""Data converter using Pydantic JSON conversion."""

--- a/apps/hash-ai-worker-py/app/workflows.py
+++ b/apps/hash-ai-worker-py/app/workflows.py
@@ -1,6 +1,5 @@
 """Temporal workflow definitions."""
 
-from typing import Any
 from uuid import UUID
 
 from pydantic import BaseModel, Extra, Field
@@ -21,20 +20,18 @@ class DataTypeWorkflowParameters(BaseModel, extra=Extra.forbid):
 class DataTypeWorkflow:
     """A workflow that reads a data type from the provided URL."""
 
-    # TODO: Use Temporal's guide to convert between JSON and Pydantic objects.
-    # https://github.com/temporalio/samples-python/tree/main/pydantic_converter
     @workflow.run
     async def get_data_type(
         self,
         params: DataTypeWorkflowParameters,
-    ) -> dict[str, Any]:
+    ) -> DataTypeSchema:
         """Calls the Graph API to get a data type schema."""
         data_type_schema = DataTypeSchema(
             **(
                 await workflow.execute_child_workflow(
                     task_queue="ai",
                     workflow="getDataType",
-                    arg=params.dict(by_alias=True, exclude_none=True),
+                    arg=params,
                 )
             )["schema"],
         )
@@ -45,7 +42,7 @@ class DataTypeWorkflow:
                 indent=2,
             ),
         )
-        return data_type_schema.model_dump(by_alias=True, exclude_none=True)
+        return data_type_schema
 
 
 class PropertyTypeWorkflowParameters(BaseModel, extra=Extra.forbid):
@@ -59,20 +56,18 @@ class PropertyTypeWorkflowParameters(BaseModel, extra=Extra.forbid):
 class PropertyTypeWorkflow:
     """A workflow that reads a property type from the provided URL."""
 
-    # TODO: Use Temporal's guide to convert between JSON and Pydantic objects.
-    # https://github.com/temporalio/samples-python/tree/main/pydantic_converter
     @workflow.run
     async def get_property_type(
         self,
         params: PropertyTypeWorkflowParameters,
-    ) -> dict[str, Any]:
+    ) -> PropertyTypeSchema:
         """Calls the Graph API to get a property type schema."""
         property_type_schema = PropertyTypeSchema(
             **(
                 await workflow.execute_child_workflow(
                     task_queue="ai",
                     workflow="getPropertyType",
-                    arg=params.dict(by_alias=True, exclude_none=True),
+                    arg=params,
                 )
             )["schema"],
         )
@@ -83,7 +78,7 @@ class PropertyTypeWorkflow:
                 indent=2,
             ),
         )
-        return property_type_schema.model_dump(by_alias=True, exclude_none=True)
+        return property_type_schema
 
 
 class EntityTypeWorkflowParameters(BaseModel, extra=Extra.forbid):
@@ -97,20 +92,18 @@ class EntityTypeWorkflowParameters(BaseModel, extra=Extra.forbid):
 class EntityTypeWorkflow:
     """A workflow that reads an entity type from the provided URL."""
 
-    # TODO: Use Temporal's guide to convert between JSON and Pydantic objects.
-    # https://github.com/temporalio/samples-python/tree/main/pydantic_converter
     @workflow.run
     async def get_entity_type(
         self,
         params: EntityTypeWorkflowParameters,
-    ) -> dict[str, Any]:
+    ) -> EntityTypeSchema:
         """Calls the Graph API to get an entity type schema."""
         entity_type_schema = EntityTypeSchema(
             **(
                 await workflow.execute_child_workflow(
                     task_queue="ai",
                     workflow="getEntityType",
-                    arg=params.dict(by_alias=True, exclude_none=True),
+                    arg=params,
                 )
             )["schema"],
         )
@@ -121,4 +114,4 @@ class EntityTypeWorkflow:
                 indent=2,
             ),
         )
-        return entity_type_schema.model_dump(by_alias=True, exclude_none=True)
+        return entity_type_schema


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Temporal suggests to use a data encoder to convert between Pydantic and JSON objects. This avoids unnecessary calls in workflows and allows Pydantic models in workflow signatures.

## 🔗 Related links

- Part of [this Asana task](https://app.asana.com/0/1204727813960182/1204904869169432/f) _(internal)_

## 🚫 Blocked by

- https://github.com/hashintel/hash/pull/2693
- https://github.com/hashintel/hash/pull/2695
- https://github.com/hashintel/hash/pull/2696 (CI will fail until merged)
- https://github.com/hashintel/hash/pull/2699
- https://github.com/hashintel/hash/pull/2702 (CI is likely to fail until merged)

## 🔍 What does this change?

- Add `encoding` module
- Use the added encoder in the worker
- Remove unneeded calls and make sure the workflow will fail on wrong parameters

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] is internal and does not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] does not affect the execution graph

## 🛡 What tests cover this?

This is currently not tested automatically

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch / view the deployment
1.  Start external services (`temporal-setup`, `hash-temporal-worker-ts`, `hash-temporal-worker-py`, `graph`)
1.  Create an account or use an existing one (here: `00000000-0000-0000-0000-000000000000`)
1.  Confirm the following workflow returns the (recursive) person entity type:

    ```
    temporal workflow execute -t aipy --type getEntityType -i '{ "entityTypeId": "https://blockprotocol.org/@examples/types/entity-type/person/v/1", "actorId": "00000000-0000-0000-0000-000000000000" }'
    ```

1. Test other URLs and ontology types

## 📹 Demo

```
Running execution:
  WorkflowId  086ec237-66a6-40be-9096-75d57848a167                                                                                                    
  RunId       af1a7f0b-41c8-4379-bc17-72690a0860d1                                                                                                    
  Type        getEntityType                                                                                                                           
  Namespace   default                                                                                                                                 
  TaskQueue   aipy                                                                                                                                    
  Args        [{"actorId":"00000000-0000-0000-0000-000000000000","entityTypeId":"https://blockprotocol.org/@examples/types/entity-type/person/v/1"}]  

Progress:
  ID          Time                          Type                  
   1  2023-06-30T12:13:08Z  WorkflowExecutionStarted              
   2  2023-06-30T12:13:08Z  WorkflowTaskScheduled                 
   3  2023-06-30T12:13:08Z  WorkflowTaskStarted                   
   4  2023-06-30T12:13:08Z  WorkflowTaskCompleted                 
   5  2023-06-30T12:13:08Z  StartChildWorkflowExecutionInitiated  
   6  2023-06-30T12:13:08Z  ChildWorkflowExecutionStarted         
   7  2023-06-30T12:13:08Z  WorkflowTaskScheduled                 
   8  2023-06-30T12:13:08Z  WorkflowTaskStarted                   
   9  2023-06-30T12:13:08Z  WorkflowTaskCompleted                 
  10  2023-06-30T12:13:08Z  ChildWorkflowExecutionCompleted       
  11  2023-06-30T12:13:08Z  WorkflowTaskScheduled                 
  12  2023-06-30T12:13:08Z  WorkflowTaskStarted                   
  13  2023-06-30T12:13:08Z  WorkflowTaskCompleted                 
  14  2023-06-30T12:13:08Z  WorkflowExecutionCompleted            

Result:
  Run Time: 1 seconds
  Status: COMPLETED
  Output: [{"$id":"https://blockprotocol.org/@examples/types/entity-type/person/v/1","$schema":"https://blockprotocol.org/types/modules/graph/0.3/schema/entity-type","description":"An extremely simplified representation of a person or human being.","kind":"entityType","links":{"https://blockprotocol.org/@examples/types/entity-type/employed-by/v/1":{"items":{"oneOf":[{"$ref":"https://blockprotocol.org/@examples/types/entity-type/company/v/1"}]},"minItems":0,"type":"array"}},"properties":{"https://blockprotocol.org/@blockprotocol/types/property-type/name/":{"$ref":"https://blockprotocol.org/@blockprotocol/types/property-type/name/v/1"},"https://blockprotocol.org/@examples/types/property-type/e-mail/":{"$ref":"https://blockprotocol.org/@examples/types/property-type/e-mail/v/1"}},"required":["https://blockprotocol.org/@blockprotocol/types/property-type/name/"],"title":"Person","type":"object"}]
```
