### PR TITLE
Disable caching of `.venv`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,6 @@ jobs:
         run: |
           yarn poetry:install-dev
           yarn poetry:install-lint-tools
-          yarn poetry:install-build-tools
 
       - name: Run yarn lint:dependency-version-consistency
         if: ${{ success() || failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,12 @@ jobs:
       - uses: ./.github/actions/warm-up-repo
         if: ${{ success() || failure() }}
 
+      - name: Setup python
+        run: |
+          yarn poetry:install-dev
+          yarn poetry:install-lint-tools
+          yarn poetry:install-build-tools
+
       - name: Run yarn lint:dependency-version-consistency
         if: ${{ success() || failure() }}
         run: |

--- a/apps/hash-ai-worker-py/turbo.json
+++ b/apps/hash-ai-worker-py/turbo.json
@@ -24,32 +24,25 @@
       "cache": false
     },
     "fix:black": {
-      "dependsOn": ["poetry:install-lint-tools"],
       "inputs": ["./**/*.py", "pyproject.toml"]
     },
     "fix:ruff": {
-      "dependsOn": ["poetry:install-lint-tools"],
       "inputs": ["./**/*.py", "pyproject.toml"]
     },
     "fix:lock-files": {
-      "dependsOn": ["poetry:install-lint-tools"],
       "inputs": ["poetry.lock", "pyproject.toml"],
       "outputs": ["poetry.lock"]
     },
     "lint:black": {
-      "dependsOn": ["poetry:install-lint-tools"],
       "inputs": ["./**/*.py", "pyproject.toml"]
     },
     "lint:lock-files": {
-      "dependsOn": ["poetry:install-lint-tools"],
       "inputs": ["poetry.lock", "pyproject.toml"]
     },
     "lint:ruff": {
-      "dependsOn": ["poetry:install-lint-tools"],
       "inputs": ["./**/*.py", "pyproject.toml"]
     },
     "lint:mypy": {
-      "dependsOn": ["poetry:install-lint-tools", "poetry:install-dev"],
       "inputs": ["./**/*.py", "pyproject.toml"]
     }
   }

--- a/apps/hash-ai-worker-py/turbo.json
+++ b/apps/hash-ai-worker-py/turbo.json
@@ -6,24 +6,19 @@
       "persistent": true
     },
     "poetry:venv": {
-      "outputs": ["./.venv/**"],
-      "inputs": ["pyproject.toml", "poetry.lock"]
+      "cache": false
     },
     "poetry:install-dev": {
-      "outputs": ["./.venv/**"],
-      "inputs": ["pyproject.toml", "poetry.lock"]
+      "cache": false
     },
     "poetry:install-production": {
-      "outputs": ["./.venv/**"],
-      "inputs": ["pyproject.toml", "poetry.lock"]
+      "cache": false
     },
     "poetry:install-lint-tools": {
-      "outputs": ["./.venv/**"],
-      "inputs": ["pyproject.toml", "poetry.lock"]
+      "cache": false
     },
     "poetry:install-build-tools": {
-      "outputs": ["./.venv/**"],
-      "inputs": ["pyproject.toml", "poetry.lock"]
+      "cache": false
     },
     "build:docker": {
       "cache": false

--- a/apps/hash-ai-worker-py/turbo.json
+++ b/apps/hash-ai-worker-py/turbo.json
@@ -2,7 +2,7 @@
   "extends": ["//"],
   "pipeline": {
     "dev": {
-      "dependsOn": ["^build", "codegen", "poetry:install-dev"],
+      "dependsOn": ["^build", "codegen"],
       "persistent": true
     },
     "poetry:venv": {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We have a caching setup for `.venv`, however, it does not seems to work properly with different entries for the same output. At least [a recent Action failed due to this](https://github.com/hashintel/hash/actions/runs/5422658218/jobs/9859681702?pr=2699). To avoid spending much time on figuring out this, this PR removes caching of `.venv`.

## 🔗 Related links

- #2699

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] is internal and does not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] does not affect the execution graph