### PR TITLE
Use Temporal Terraform module in `hash`

### DIFF
--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -45,9 +45,9 @@ provider "aws" {
   default_tags {
     tags = {
       project             = "hash"
-      region              = "${local.region}"
-      environment         = "${local.env}"
-      terraform_workspace = "${terraform.workspace}"
+      region              = local.region
+      environment         = local.env
+      terraform_workspace = terraform.workspace
     }
   }
 }
@@ -81,6 +81,21 @@ module "postgres" {
   instance_class        = "db.t3.small"
   pg_superuser_username = "superuser"
   pg_superuser_password = sensitive(data.vault_kv_secret_v2.secrets.data["pg_superuser_password"])
+}
+
+module "temporal" {
+  depends_on            = [module.networking, module.postgres]
+  source                = "../modules/temporal"
+  prefix                = local.prefix
+  param_prefix          = local.param_prefix
+  subnets               = module.networking.snpub
+  vpc                   = module.networking.vpc
+  env                   = local.env
+  region                = local.region
+  cpu                   = 512
+  memory                = 1024
+  # TODO: provide by the HASH variables.tf
+  temporal_version      = "1.21.0.0"
 }
 
 

--- a/infra/terraform/modules/container_registry/main.tf
+++ b/infra/terraform/modules/container_registry/main.tf
@@ -2,7 +2,7 @@
   * # Terraform AWS module: Container Registry
   *
   * Module responsible for creating container registries.
-  * We use ECR for our container regestries, and this module can create 
+  * We use ECR for our container registries, and this module can create
   * ECR repository with our desired lifecycle policy.
   */
 

--- a/infra/terraform/modules/temporal/main.tf
+++ b/infra/terraform/modules/temporal/main.tf
@@ -122,7 +122,7 @@ resource "aws_ecs_service" "svc" {
   cluster                = module.temporal_ecs.ecs_cluster_arn
   task_definition        = aws_ecs_task_definition.task.arn
   enable_execute_command = true
-  desired_count          = 1
+  desired_count          = 0
   launch_type            = "FARGATE"
 
   network_configuration {


### PR DESCRIPTION
🌟 What is the purpose of this PR?

https://github.com/hashintel/hash/pull/2713 introduced the Terraform module for Temporal. This will add the module to the `hash` module, which implies the creation of the required infrastructure to use it.

## 🚫 Blocked by

- https://github.com/hashintel/hash/pull/2713

## 🔍 What does this change?

- Add the `terraform` module to hash
- Set the desired tasks count in `temporal` to `0` to avoid it being hosted
- Drive-by: Fix a typo
- Drive-by: Use proper variable substitution

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] is internal and does not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] does not affect the execution graph

## ⚠️ Known issues

This PR is required to do this as a separated step before doing further work as this will create the ECR repositories for the temporal images, which have to be uploaded separately.

## 🐾 Next steps

Add RDS instance to be used instead of the Postgres Docker container

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch
1. Login to Vault: `vault login -method github`
1. Go to `/infra/terraform/hash`
1. `terraform init`
1. `terraform plan -var-file ./prod-usea1.tfvars -refresh=false`

