### PR TITLE
H-33: Use RDS for Temporal

### DIFF
--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -92,10 +92,20 @@ module "temporal" {
   vpc                   = module.networking.vpc
   env                   = local.env
   region                = local.region
-  cpu                   = 512
-  memory                = 1024
+  cpu                   = 256
+  memory                = 512
   # TODO: provide by the HASH variables.tf
   temporal_version      = "1.21.0.0"
+
+  postgres_host = module.postgres.pg_host
+  postgres_port = module.postgres.pg_port
+  postgres_db = "temporal"
+  postgres_visibility_db = "temporal_visibility"
+  postgres_user = "temporal"
+  postgres_password  = sensitive(data.vault_kv_secret_v2.secrets.data["pg_temporal_user_password_raw"])
+
+  postgres_superuser = "superuser"
+  postgres_superuser_password = sensitive(data.vault_kv_secret_v2.secrets.data["pg_superuser_password"])
 }
 
 
@@ -129,6 +139,7 @@ module "postgres_roles" {
 
   pg_kratos_user_password_hash = data.vault_kv_secret_v2.secrets.data["pg_kratos_user_password_hash"]
   pg_graph_user_password_hash  = data.vault_kv_secret_v2.secrets.data["pg_graph_user_password_hash"]
+  pg_temporal_user_password_hash = data.vault_kv_secret_v2.secrets.data["pg_temporal_user_password_hash"]
 }
 
 module "redis" {

--- a/infra/terraform/hash/outputs.tf
+++ b/infra/terraform/hash/outputs.tf
@@ -17,3 +17,7 @@ output "prefix" {
 output "rds_hostname" {
   value = module.postgres.pg_host
 }
+
+output "temporal_hostname" {
+  value = module.temporal.temporal_private_hostname
+}

--- a/infra/terraform/hash/postgres_roles/postgres_roles.tf
+++ b/infra/terraform/hash/postgres_roles/postgres_roles.tf
@@ -141,8 +141,7 @@ resource "postgresql_role" "temporal_user" {
   login          = true
   password       = var.pg_temporal_user_password_hash
   inherit        = true
-  roles          = [postgresql_role.readwrite.name]
-  skip_drop_role = true
+  skip_drop_role = false
 }
 
 resource "postgresql_database" "temporal" {

--- a/infra/terraform/hash/postgres_roles/postgres_roles.tf
+++ b/infra/terraform/hash/postgres_roles/postgres_roles.tf
@@ -135,4 +135,52 @@ resource "postgresql_database" "graph" {
   allow_connections = true
 }
 
+# Temporal
+resource "postgresql_role" "temporal_user" {
+  name           = "temporal"
+  login          = true
+  password       = var.pg_temporal_user_password_hash
+  inherit        = true
+  roles          = [postgresql_role.readwrite.name]
+  skip_drop_role = true
+}
+
+resource "postgresql_database" "temporal" {
+  name              = "temporal"
+  owner             = var.pg_superuser_username
+  template          = "template0"
+  lc_collate        = "C"
+  connection_limit  = -1
+  allow_connections = true
+}
+
+resource "postgresql_default_privileges" "temporal_readwrite_tables" {
+  owner       = var.pg_superuser_username
+  role        = postgresql_role.temporal_user.name
+  database    = postgresql_database.temporal.name
+  schema      = "public"
+
+  object_type = "table"
+  privileges  = ["SELECT", "INSERT", "UPDATE", "DELETE"]
+}
+
+resource "postgresql_database" "temporal_visibility" {
+  name              = "temporal_visibility"
+  owner             = var.pg_superuser_username
+  template          = "template0"
+  lc_collate        = "C"
+  connection_limit  = -1
+  allow_connections = true
+}
+
+resource "postgresql_default_privileges" "temporal_visibility_readwrite_tables" {
+  owner       = var.pg_superuser_username
+  role        = postgresql_role.temporal_user.name
+  database    = postgresql_database.temporal_visibility.name
+  schema      = "public"
+
+  object_type = "table"
+  privileges  = ["SELECT", "INSERT", "UPDATE", "DELETE"]
+}
+
 

--- a/infra/terraform/hash/postgres_roles/variables.tf
+++ b/infra/terraform/hash/postgres_roles/variables.tf
@@ -26,3 +26,9 @@ variable "pg_graph_user_password_hash" {
   sensitive   = true
   description = "Hashed form of the 'graph' user Postgres password."
 }
+
+variable "pg_temporal_user_password_hash" {
+  type        = string
+  sensitive   = true
+  description = "Hashed form of the 'temporal' user Postgres password."
+}

--- a/infra/terraform/modules/temporal/main.tf
+++ b/infra/terraform/modules/temporal/main.tf
@@ -55,14 +55,14 @@ resource "aws_iam_role" "execution_role" {
           {
             Effect   = "Allow"
             Action   = ["ssm:GetParameters"]
-            Resource = [for _, env_var in aws_ssm_parameter.temporal_migration_env_vars : env_var.arn]
+            Resource = [for _, env_var in aws_ssm_parameter.temporal_setup_secrets : env_var.arn]
           }
         ],
         [
           {
             Effect   = "Allow"
             Action   = ["ssm:GetParameters"]
-            Resource = [for _, env_var in aws_ssm_parameter.temporal_env_vars : env_var.arn]
+            Resource = [for _, env_var in aws_ssm_parameter.temporal_secrets : env_var.arn]
           }
         ]
       ])

--- a/infra/terraform/modules/temporal/main.tf
+++ b/infra/terraform/modules/temporal/main.tf
@@ -51,11 +51,20 @@ resource "aws_iam_role" "execution_role" {
             Resource = ["*"]
           }
         ],
-        length(local.shared_secrets) > 0 ? [{
-          Effect   = "Allow"
-          Action   = ["ssm:GetParameters"]
-          Resource = [for _, env_var in local.shared_secrets : env_var.valueFrom]
-        }] : []
+        [
+          {
+            Effect   = "Allow"
+            Action   = ["ssm:GetParameters"]
+            Resource = [for _, env_var in aws_ssm_parameter.temporal_migration_env_vars : env_var.arn]
+          }
+        ],
+        [
+          {
+            Effect   = "Allow"
+            Action   = ["ssm:GetParameters"]
+            Resource = [for _, env_var in aws_ssm_parameter.temporal_env_vars : env_var.arn]
+          }
+        ]
       ])
     })
   }
@@ -122,7 +131,7 @@ resource "aws_ecs_service" "svc" {
   cluster                = module.temporal_ecs.ecs_cluster_arn
   task_definition        = aws_ecs_task_definition.task.arn
   enable_execute_command = true
-  desired_count          = 0
+  desired_count          = 1
   launch_type            = "FARGATE"
 
   network_configuration {
@@ -174,8 +183,9 @@ resource "aws_security_group" "app_sg" {
     from_port   = 7233
     to_port     = 7233
     protocol    = "tcp"
-    description = "Allow connections to Temporal from anywhere (rely on authentication to restrict access)"
-    # TODO: Consider changing this to `var.vpc.cidr_block`
-    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow connections to Temporal within the VPC"
+    # TODO: Consider changing this to `"0.0.0.0/0"` and setup authentication
+    # description = "Allow connections to Temporal from anywhere (rely on authentication to restrict access)"
+    cidr_blocks = [var.vpc.cidr_block]
   }
 }

--- a/infra/terraform/modules/temporal/task_definitions.tf
+++ b/infra/terraform/modules/temporal/task_definitions.tf
@@ -9,68 +9,23 @@ locals {
 
   task_definitions = [
     {
-
-      # To remove, only for testing.
-      essential = true
-      name      = "${local.prefix}pgtemporary"
-      image     = "postgres:15"
-      environment = [
-        { name = "POSTGRES_DB", value = "temporal" },
-        { name = "POSTGRES_USER", value = "postgres" },
-        { name = "POSTGRES_PASSWORD", value = "postgres" },
-      ]
-
-      logConfiguration = {
-        logDriver = "awslogs"
-        options = {
-          "awslogs-create-group"  = "true"
-          "awslogs-group"         = local.log_group_name
-          "awslogs-stream-prefix" = "pg"
-          "awslogs-region"        = var.region
-        }
-      }
-      portMappings = [
-        {
-          appProtocol   = "http"
-          containerPort = 5432
-          hostPort      = 5432
-          protocol      = "tcp"
-        },
-      ]
-      healthCheck = {
-        command     = ["CMD-SHELL", "pg_isready"]
-        startPeriod = 10
-        interval    = 5
-        retries     = 10
-        timeout     = 5
-      }
-
-    },
-    {
       readonlyRootFilesystem = true
 
       essential = false
       name      = "${local.prefix}${local.migrate_service_name}"
       image     = "${module.migrate.url}:${local.temporal_version}"
       cpu       = 0 # let ECS divvy up the available CPU
-      dependsOn = [
-        # to delete
-        { condition = "HEALTHY", containerName = "${local.prefix}pgtemporary" },
+
+      environment = concat(local.temporal_shared_env_vars, local.temporal_migration_env_vars)
+
+      secrets = [
+        for env_name, ssm_param in aws_ssm_parameter.temporal_migration_env_vars :
+        { name = env_name, valueFrom = ssm_param.arn }
       ]
-
-      environment = concat(local.shared_env_vars,
-        # container specific env vars go here
-        [
-          { name = "SKIP_DB_CREATE", value = "true" },
-          { name = "SKIP_VISIBILITY_DB_CREATE", value = "false" },
-        ]
-      )
-
-      secrets = local.shared_secrets
 
       logConfiguration = {
         logDriver = "awslogs"
-        options = {
+        options   = {
           "awslogs-create-group"  = "true"
           "awslogs-group"         = local.log_group_name
           "awslogs-stream-prefix" = local.migrate_service_name
@@ -79,30 +34,31 @@ locals {
       }
     },
     {
-      essential = true
-      name      = "${local.prefix}${local.temporal_service_name}"
-      image     = "temporalio/server:${local.temporal_version}"
-      cpu       = 0 # let ECS divvy up the available CPU
-      dependsOn = [{ condition = "SUCCESS", containerName = "${local.prefix}${local.migrate_service_name}" }]
+      essential   = true
+      name        = "${local.prefix}${local.temporal_service_name}"
+      image       = "temporalio/server:${local.temporal_version}"
+      cpu         = 0 # let ECS divvy up the available CPU
+      dependsOn   = [{ condition = "SUCCESS", containerName = "${local.prefix}${local.migrate_service_name}" }]
       healthCheck = {
         # If we just want to for when the socket accepts connections, we can use this:
         # command     = ["CMD", "/bin/sh", "-c", "nc -z $(hostname) 7233"]
 
         # This checks that the server is up and running
-        command     = ["CMD", "/bin/sh", "-c", "temporal operator cluster health --address $(hostname):7233 | grep -q SERVING"]
+        command     = [
+          "CMD", "/bin/sh", "-c", "temporal operator cluster health --address $(hostname):7233 | grep -q SERVING"
+        ]
         startPeriod = 10
         interval    = 5
         retries     = 10
         timeout     = 5
       }
 
-      environment = concat(local.shared_env_vars,
-        # container specific env vars go here
-        [
-        ]
-      )
+      environment = concat(local.temporal_shared_env_vars, local.temporal_env_vars)
 
-      secrets = local.shared_secrets
+      secrets = [
+        for env_name, ssm_param in aws_ssm_parameter.temporal_env_vars :
+        { name = env_name, valueFrom = ssm_param.arn }
+      ]
 
       portMappings = [
         {
@@ -115,7 +71,7 @@ locals {
 
       logConfiguration = {
         logDriver = "awslogs"
-        options = {
+        options   = {
           "awslogs-create-group"  = "true"
           "awslogs-group"         = local.log_group_name
           "awslogs-stream-prefix" = local.temporal_service_name
@@ -134,17 +90,17 @@ locals {
         { condition = "START", containerName = "${local.prefix}${local.temporal_service_name}" },
       ]
 
-      environment = concat(local.shared_env_vars,
-        # container specific env vars go here
-        [
-        ]
-      )
+      environment = concat(local.temporal_shared_env_vars, local.temporal_migration_env_vars)
 
-      secrets = local.shared_secrets
+      secrets = [
+        for env_name, ssm_param in aws_ssm_parameter.temporal_migration_env_vars :
+        { name = env_name, valueFrom = ssm_param.arn }
+      ]
+
 
       logConfiguration = {
         logDriver = "awslogs"
-        options = {
+        options   = {
           "awslogs-create-group"  = "true"
           "awslogs-group"         = local.log_group_name
           "awslogs-stream-prefix" = local.setup_service_name
@@ -154,30 +110,53 @@ locals {
     },
   ]
 
-  shared_env_vars = [
+  temporal_shared_env_vars = [
     { name = "DB", value = "postgres12" }, # For PostgreSQL v12 and later, see https://docs.temporal.io/cluster-deployment-guide#postgresql
-    { name = "DB_PORT", value = "5432" },
-    { name = "DBNAME", value = "temporal" },
-    { name = "VISIBILITY_DBNAME", value = "high_vis" },
+
+    { name = "POSTGRES_SEEDS", value = var.postgres_host },
+    { name = "DB_PORT", value = tostring(var.postgres_port) },
+    { name = "DBNAME", value = var.postgres_db },
+    { name = "VISIBILITY_DBNAME", value = var.postgres_visibility_db },
   ]
 
-  secret_raw_vars = [
-    # TODO: parameterize module
-    { name = "POSTGRES_USER", value = "postgres" },
-    { name = "POSTGRES_PWD", value = "postgres" },
-    { name = "POSTGRES_SEEDS", value = "localhost" },
+  temporal_migration_env_vars = [
+#    { name = "POSTGRES_USER", value = var.postgres_user },
+    { name = "POSTGRES_USER", value = var.postgres_superuser },
+#    { name = "SKIP_DB_CREATE", value = "true" },
+#    { name = "SKIP_VISIBILITY_DB_CREATE", value = "false" },
   ]
 
-  shared_secrets = [for env_name, ssm_param in aws_ssm_parameter.secret_env_vars :
-  { name = env_name, valueFrom = ssm_param.arn }]
+  temporal_env_vars = [
+    { name = "POSTGRES_USER", value = var.postgres_user },
+  ]
+
+  temporal_migration_secrets = [
+    { name = "POSTGRES_PWD", value = var.postgres_superuser_password },
+#    { name = "POSTGRES_PWD", value = var.postgres_password },
+  ]
+
+  temporal_secrets = [
+    { name = "POSTGRES_PWD", value = var.postgres_password },
+  ]
 }
 
-
-resource "aws_ssm_parameter" "secret_env_vars" {
+resource "aws_ssm_parameter" "temporal_env_vars" {
   # Only put secrets into SSM
-  for_each = { for env_var in local.secret_raw_vars : env_var.name => env_var }
+  for_each = { for env_var in local.temporal_secrets : env_var.name => env_var }
 
   name = "${local.param_prefix}/${each.value.name}"
+  # Still supports non-secret values
+  type      = "SecureString"
+  value     = sensitive(each.value.value)
+  overwrite = true
+  tags      = {}
+}
+
+resource "aws_ssm_parameter" "temporal_migration_env_vars" {
+  # Only put secrets into SSM
+  for_each = { for env_var in local.temporal_migration_secrets : env_var.name => env_var }
+
+  name = "${local.param_prefix}/migration/${each.value.name}"
   # Still supports non-secret values
   type      = "SecureString"
   value     = sensitive(each.value.value)

--- a/infra/terraform/modules/temporal/task_definitions.tf
+++ b/infra/terraform/modules/temporal/task_definitions.tf
@@ -19,7 +19,7 @@ locals {
       environment = concat(local.temporal_shared_env_vars, local.temporal_migration_env_vars)
 
       secrets = [
-        for env_name, ssm_param in aws_ssm_parameter.temporal_migration_env_vars :
+        for env_name, ssm_param in aws_ssm_parameter.temporal_setup_secrets :
         { name = env_name, valueFrom = ssm_param.arn }
       ]
 
@@ -56,7 +56,7 @@ locals {
       environment = concat(local.temporal_shared_env_vars, local.temporal_env_vars)
 
       secrets = [
-        for env_name, ssm_param in aws_ssm_parameter.temporal_env_vars :
+        for env_name, ssm_param in aws_ssm_parameter.temporal_secrets :
         { name = env_name, valueFrom = ssm_param.arn }
       ]
 
@@ -93,7 +93,7 @@ locals {
       environment = concat(local.temporal_shared_env_vars, local.temporal_migration_env_vars)
 
       secrets = [
-        for env_name, ssm_param in aws_ssm_parameter.temporal_migration_env_vars :
+        for env_name, ssm_param in aws_ssm_parameter.temporal_setup_secrets :
         { name = env_name, valueFrom = ssm_param.arn }
       ]
 
@@ -136,7 +136,7 @@ locals {
   ]
 }
 
-resource "aws_ssm_parameter" "temporal_env_vars" {
+resource "aws_ssm_parameter" "temporal_secrets" {
   # Only put secrets into SSM
   for_each = { for env_var in local.temporal_secrets : env_var.name => env_var }
 
@@ -148,7 +148,7 @@ resource "aws_ssm_parameter" "temporal_env_vars" {
   tags      = {}
 }
 
-resource "aws_ssm_parameter" "temporal_migration_env_vars" {
+resource "aws_ssm_parameter" "temporal_setup_secrets" {
   # Only put secrets into SSM
   for_each = { for env_var in local.temporal_migration_secrets : env_var.name => env_var }
 

--- a/infra/terraform/modules/temporal/task_definitions.tf
+++ b/infra/terraform/modules/temporal/task_definitions.tf
@@ -120,10 +120,7 @@ locals {
   ]
 
   temporal_migration_env_vars = [
-#    { name = "POSTGRES_USER", value = var.postgres_user },
     { name = "POSTGRES_USER", value = var.postgres_superuser },
-#    { name = "SKIP_DB_CREATE", value = "true" },
-#    { name = "SKIP_VISIBILITY_DB_CREATE", value = "false" },
   ]
 
   temporal_env_vars = [
@@ -132,7 +129,6 @@ locals {
 
   temporal_migration_secrets = [
     { name = "POSTGRES_PWD", value = var.postgres_superuser_password },
-#    { name = "POSTGRES_PWD", value = var.postgres_password },
   ]
 
   temporal_secrets = [

--- a/infra/terraform/modules/temporal/variables.tf
+++ b/infra/terraform/modules/temporal/variables.tf
@@ -46,3 +46,43 @@ variable "temporal_version" {
   type        = string
   description = "Docker container tag for temporal containers"
 }
+
+variable "postgres_host" {
+  type        = string
+  description = "The hostname of the postgres database"
+}
+
+variable "postgres_port" {
+  type        = number
+  description = "The port of the postgres database"
+}
+
+variable "postgres_db" {
+  type        = string
+  description = "The name of the postgres database"
+}
+
+variable "postgres_visibility_db" {
+  type        = string
+  description = "The name of the postgres visibility database"
+}
+
+variable "postgres_user" {
+  type        = string
+  description = "The username for the postgres database"
+}
+
+variable "postgres_password" {
+  type        = string
+  description = "The password for the postgres database"
+}
+
+variable "postgres_superuser" {
+  type        = string
+  description = "The username for the postgres superuser"
+}
+
+variable "postgres_superuser_password" {
+  type        = string
+  description = "The password for the postgres superuser"
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, we use a Docker container to run Postgres. This changes the Postgres instance to live in RDS instead

## 🔍 What does this change?

- Setup Postgres rules for `temporal` and `temporal_visibility`.
- Associate the Temporal service the RDS instance and remove old docker container
- For the purpose of easier and more secure testing I limited the Temporal service to the CIDR block

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] is internal and does not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] does not affect the execution graph

## 🐾 Next steps

Probably
- Setup authentication
- Setup visibility service
- Address TODOs in Temporal TF code 