### PR TITLE
H-52: `graph`: Fix OpenAPI spec inconsistencies

### DIFF
--- a/apps/hash-graph/lib/graph/src/api/rest.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest.rs
@@ -18,7 +18,7 @@ mod entity;
 mod entity_type;
 mod property_type;
 
-use std::{collections::HashMap, fs, io, sync::Arc};
+use std::{fs, io, sync::Arc};
 
 use async_trait::async_trait;
 use axum::{
@@ -30,7 +30,6 @@ use axum::{
 };
 use error_stack::{IntoReport, Report, ResultExt};
 use include_dir::{include_dir, Dir};
-use serde::Serialize;
 use utoipa::{
     openapi::{
         self, schema, ArrayBuilder, KnownFormat, Object, ObjectBuilder, OneOfBuilder, Ref, RefOr,

--- a/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef.rs
@@ -9,6 +9,7 @@ use crate::ontology::OntologyElementMetadata;
 
 pub mod subgraph;
 
+#[derive(Debug, Copy, Clone)]
 enum Action {
     Load,
     Reference,
@@ -24,7 +25,7 @@ pub enum ListOrValue<T> {
 // Utoipa doesn't seem to be able to generate sensible interfaces for this, it gets confused by
 // the generic
 impl<T> ListOrValue<T> {
-    fn generate_schema(schema_name: &'static str, action: &Action) -> RefOr<Schema> {
+    fn generate_schema(schema_name: &'static str, action: Action) -> RefOr<Schema> {
         let schema_name = match action {
             Action::Load => format!("VAR_{schema_name}"),
             Action::Reference => schema_name.to_owned(),
@@ -42,7 +43,7 @@ impl ToSchema<'_> for MaybeListOfOntologyElementMetadata {
     fn schema() -> (&'static str, RefOr<Schema>) {
         (
             "MaybeListOfOntologyElementMetadata",
-            Self::generate_schema(OntologyElementMetadata::schema().0, &Action::Reference),
+            Self::generate_schema(OntologyElementMetadata::schema().0, Action::Reference),
         )
     }
 }
@@ -52,7 +53,7 @@ impl ToSchema<'_> for MaybeListOfDataType {
     fn schema() -> (&'static str, RefOr<Schema>) {
         (
             "MaybeListOf",
-            Self::generate_schema("data_type", &Action::Load),
+            Self::generate_schema("data_type", Action::Load),
         )
     }
 }
@@ -62,7 +63,7 @@ impl ToSchema<'_> for MaybeListOfPropertyType {
     fn schema() -> (&'static str, RefOr<Schema>) {
         (
             "MaybeListOfPropertyType",
-            Self::generate_schema("property_type", &Action::Load),
+            Self::generate_schema("property_type", Action::Load),
         )
     }
 }
@@ -72,7 +73,7 @@ impl ToSchema<'_> for MaybeListOfEntityType {
     fn schema() -> (&'static str, RefOr<Schema>) {
         (
             "MaybeListOfEntityType",
-            Self::generate_schema("entity_type", &Action::Load),
+            Self::generate_schema("entity_type", Action::Load),
         )
     }
 }

--- a/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef.rs
@@ -20,8 +20,10 @@ pub enum ListOrValue<T> {
 // the generic
 impl<T> ListOrValue<T> {
     pub(crate) fn generate_schema(schema_name: &'static str) -> RefOr<Schema> {
+        let schema_name = format!("VAR_{schema_name}");
+
         OneOfBuilder::new()
-            .item(Ref::from_schema_name(schema_name))
+            .item(Ref::from_schema_name(&schema_name))
             .item(Ref::from_schema_name(schema_name).to_array_builder())
             .into()
     }

--- a/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/utoipa_typedef.rs
@@ -19,8 +19,12 @@ pub enum ListOrValue<T> {
 // Utoipa doesn't seem to be able to generate sensible interfaces for this, it gets confused by
 // the generic
 impl<T> ListOrValue<T> {
-    pub(crate) fn generate_schema(schema_name: &'static str) -> RefOr<Schema> {
-        let schema_name = format!("VAR_{schema_name}");
+    pub(crate) fn generate_schema(schema_name: &'static str, replace: bool) -> RefOr<Schema> {
+        let schema_name = if replace {
+            format!("VAR_{schema_name}")
+        } else {
+            schema_name.to_owned()
+        };
 
         OneOfBuilder::new()
             .item(Ref::from_schema_name(&schema_name))
@@ -34,7 +38,7 @@ impl ToSchema<'_> for MaybeListOfOntologyElementMetadata {
     fn schema() -> (&'static str, RefOr<Schema>) {
         (
             "MaybeListOfOntologyElementMetadata",
-            Self::generate_schema(OntologyElementMetadata::schema().0),
+            Self::generate_schema(OntologyElementMetadata::schema().0, false),
         )
     }
 }
@@ -42,7 +46,7 @@ impl ToSchema<'_> for MaybeListOfOntologyElementMetadata {
 pub type MaybeListOfDataType = ListOrValue<repr::DataType>;
 impl ToSchema<'_> for MaybeListOfDataType {
     fn schema() -> (&'static str, RefOr<Schema>) {
-        ("MaybeListOf", Self::generate_schema("data_type"))
+        ("MaybeListOf", Self::generate_schema("data_type", true))
     }
 }
 
@@ -51,7 +55,7 @@ impl ToSchema<'_> for MaybeListOfPropertyType {
     fn schema() -> (&'static str, RefOr<Schema>) {
         (
             "MaybeListOfPropertyType",
-            Self::generate_schema("property_type"),
+            Self::generate_schema("property_type", true),
         )
     }
 }
@@ -61,7 +65,7 @@ impl ToSchema<'_> for MaybeListOfEntityType {
     fn schema() -> (&'static str, RefOr<Schema>) {
         (
             "MaybeListOfEntityType",
-            Self::generate_schema("entity_type"),
+            Self::generate_schema("entity_type", true),
         )
     }
 }

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -711,12 +711,12 @@
           "schema": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/data_type"
+                "$ref": "./models/data_type.json"
               },
               {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/data_type"
+                  "$ref": "./models/data_type.json"
                 }
               }
             ]
@@ -777,12 +777,12 @@
           "schema": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/entity_type"
+                "$ref": "./models/entity_type.json"
               },
               {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/entity_type"
+                  "$ref": "./models/entity_type.json"
                 }
               }
             ]
@@ -806,12 +806,12 @@
           "schema": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/property_type"
+                "$ref": "./models/property_type.json"
               },
               {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/property_type"
+                  "$ref": "./models/property_type.json"
                 }
               }
             ]
@@ -1371,16 +1371,7 @@
               "parameter"
             ],
             "properties": {
-              "parameter": {
-                "oneOf": [
-                  {
-                    "type": "object",
-                    "additionalProperties": {
-                      "$ref": "#/components/schemas/Any"
-                    }
-                  }
-                ]
-              }
+              "parameter": {}
             }
           }
         ]

--- a/libs/@local/hash-graph-client/openapitools.json
+++ b/libs/@local/hash-graph-client/openapitools.json
@@ -2,7 +2,7 @@
   "$schema": "../../../node_modules/@openapitools/openapi-generator-cli/config.schema.json",
   "spaces": 2,
   "generator-cli": {
-    "version": "6.0.1",
+    "version": "6.6.0",
     "generators": {
       "ts": {
         "generateAliasAsModel": true,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

While trying to generate an OpenAPI client with a new version of openapi-generator I found that the OpenAPI spec is malformed (in 6.2.0 of the generator, some critical dependencies got upgraded). Basically we exploited some bugs in the previous versions to generate the typescript client 😅 

This included:

* `components.schemas.FilterExpression` referencing `#/components/schemas/Any` (which did not exist)
* `components.schemas.CreatePropertyTypeRequest`, referencing `#/components/schemas/property_type` (which did not exist)
* `components.schemas.CreateDataTypeRequest`, referencing `#/components/schemas/data_type` (which did not exist)
* `components.schemas.CreateEntityTypeRequest`, referencing `#/components/schemas/entity_type` (which did not exist)

Thanks to @TimDiekmann for guidance as to how to solve these issues!

As a drive-by, I upgraded the client generator to `6.6.0` (the latest version).


## 🔍 What does this change?

* `#/components/schemas/Any` has been removed, in favor of just allowing the value
* `*_type` now reference to their respective json schemas in the `./models` folder

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

<!-- - [x] modifies an **npm**-publishable library and **I have added a changeset file(s)** -->

<!-- - [x] modifies a **Cargo**-publishable library and **I have amended the version** -->

<!-- - [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish** -->

<!-- - [x] modifies a **block** that will need publishing via GitHub action once merged -->

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

<!-- - [x] I am unsure / need advice -->

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

- [x] is internal and does not require a docs change

<!-- - [x] is in a state where docs changes are not _yet_ required but will be
  - this is tracked within: [Insert Link Here](link) -->

<!-- - [x] requires changes to docs
  - <CHANGES TO DOCS EXPLAINED HERE> -->

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

<!-- - [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this -->

- [x] does not affect the execution graph

<!-- - [x] I am unsure / need advice -->

