### PR TITLE
H-78: Host Temporal UI

### DIFF
--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -107,6 +107,7 @@ module "temporal" {
   memory                = 512
   # TODO: provide by the HASH variables.tf
   temporal_version      = "1.21.0.0"
+  temporal_ui_version   = "2.16.2"
 
   postgres_host = module.postgres.pg_host
   postgres_port = module.postgres.pg_port

--- a/infra/terraform/hash/temporal/main.tf
+++ b/infra/terraform/hash/temporal/main.tf
@@ -171,17 +171,30 @@ resource "aws_security_group" "app_sg" {
     description = "Allow outbound HTTPS connections"
     cidr_blocks = ["0.0.0.0/0"]
   }
-  egress {
-    from_port   = 5432
-    to_port     = 5432
-    protocol    = "tcp"
-    description = "Allow connections to Postgres within the VPC"
-    cidr_blocks = [var.vpc.cidr_block]
-  }
 
   ingress {
     from_port   = 7233
     to_port     = 7233
+    protocol    = "tcp"
+    description = "Allow connections to Temporal within the VPC"
+    # TODO: Consider changing this to `"0.0.0.0/0"` and setup authentication
+    # description = "Allow connections to Temporal from anywhere (rely on authentication to restrict access)"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  egress {
+    from_port   = 7233
+    to_port     = 7233
+    protocol    = "tcp"
+    description = "Allow connections from Temporal within the VPC"
+    # TODO: Consider changing this to `"0.0.0.0/0"` and setup authentication
+    # description = "Allow connections from Temporal from anywhere (rely on authentication to restrict access)"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  ingress {
+    from_port   = 8080
+    to_port     = 8080
     protocol    = "tcp"
     description = "Allow connections to Temporal within the VPC"
     # TODO: Consider changing this to `"0.0.0.0/0"` and setup authentication

--- a/infra/terraform/hash/temporal/variables.tf
+++ b/infra/terraform/hash/temporal/variables.tf
@@ -47,6 +47,11 @@ variable "temporal_version" {
   description = "Docker container tag for temporal containers"
 }
 
+variable "temporal_ui_version" {
+  type        = string
+  description = "Docker container tag for temporal UI container"
+}
+
 variable "postgres_host" {
   type        = string
   description = "The hostname of the postgres database"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To troubleshoot problems this sets up the Temporal UI

## 🔍 What does this change?

- Add UI configuration
- Drive-by: Remove old egress rule for Postgres container (we use RDS now)

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] is internal and does not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] does not affect the execution graph