### PR TITLE
H-79: Switch to `linux/arm64` ECS containers

### DIFF
--- a/infra/terraform/hash/temporal/main.tf
+++ b/infra/terraform/hash/temporal/main.tf
@@ -123,6 +123,11 @@ resource "aws_ecs_task_definition" "task" {
   execution_role_arn       = aws_iam_role.execution_role.arn
   task_role_arn            = aws_iam_role.task_role.arn
   container_definitions    = jsonencode(local.task_definitions)
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "ARM64"
+  }
 }
 
 resource "aws_ecs_service" "svc" {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`arm64` is cheaper and often less resource intensive.

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] is internal and does not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] does not affect the execution graph