### PR TITLE
H-80: Configure namespaces in hosted Temporal instance

### DIFF
--- a/apps/hash-ai-worker-py/app/__main__.py
+++ b/apps/hash-ai-worker-py/app/__main__.py
@@ -23,7 +23,7 @@ async def run_worker(stop_event: asyncio.Event) -> None:
 
     client = await Client.connect(
         temporal_target,
-        namespace="default",
+        namespace="HASH",
         data_converter=pydantic_data_converter,
     )
 

--- a/apps/hash-ai-worker-ts/src/main.ts
+++ b/apps/hash-ai-worker-ts/src/main.ts
@@ -52,6 +52,7 @@ async function run() {
     connection: await NativeConnection.connect({
       address: `${TEMPORAL_HOST}:${TEMPORAL_PORT}`,
     }),
+    namespace: "HASH",
     taskQueue: "ai",
   });
 

--- a/apps/hash-ai-worker-ts/src/workflows.ts
+++ b/apps/hash-ai-worker-ts/src/workflows.ts
@@ -20,6 +20,10 @@ export const {
   },
 });
 
+// Simple workflow to test worker functionality
+export const HelloWorld = async (): Promise<string> =>
+  Promise.resolve("Hello Temporal!");
+
 export const getDataType = async (params: {
   dataTypeId: VersionedUrl;
   actorId: AccountId;

--- a/apps/hash-external-services/docker-compose.yml
+++ b/apps/hash-external-services/docker-compose.yml
@@ -336,6 +336,12 @@ services:
     environment:
       HASH_TEMPORAL_HOST: "temporal"
       OPENAI_API_KEY: "${OPENAI_API_KEY}"
+      HASH_GRAPH_API_HOST: graph
+      HASH_GRAPH_API_PORT: "${HASH_GRAPH_API_PORT}"
+      # TODO: Remove once they're not needed anymore
+      #   see https://linear.app/hash/issue/H-55/avoid-ory-kratos-environment-to-be-required-for-hash-api
+      ORY_KRATOS_PUBLIC_URL: "${ORY_KRATOS_PUBLIC_URL}"
+      ORY_KRATOS_ADMIN_URL: "${ORY_KRATOS_ADMIN_URL}"
     tmpfs:
       - /tmp
     read_only: true

--- a/apps/hash-external-services/docker-compose.yml
+++ b/apps/hash-external-services/docker-compose.yml
@@ -258,7 +258,16 @@ services:
         condition: service_started
     healthcheck:
       test:
-        ["CMD", "temporal", "workflow", "list", "--address", "temporal:7233"]
+        [
+          "CMD",
+          "temporal",
+          "workflow",
+          "list",
+          "--namespace",
+          "HASH",
+          "--address",
+          "temporal:7233",
+        ]
       interval: 10s
       timeout: 2s
       retries: 10

--- a/apps/hash-external-services/temporal/setup.sh
+++ b/apps/hash-external-services/temporal/setup.sh
@@ -17,8 +17,6 @@ set -eux -o pipefail
 : "${TEMPORAL_ADDRESS:=}"
 
 : "${SKIP_DEFAULT_NAMESPACE_CREATION:=false}"
-: "${DEFAULT_NAMESPACE:=default}"
-: "${DEFAULT_NAMESPACE_RETENTION:=1}"
 
 # === Helper functions ===
 
@@ -38,14 +36,14 @@ validate_db_env() {
 
 # === Server setup ===
 
-register_default_namespace() {
-  echo "Registering default namespace: ${DEFAULT_NAMESPACE}."
-  if ! temporal operator namespace describe "${DEFAULT_NAMESPACE}"; then
-    echo "Default namespace ${DEFAULT_NAMESPACE} not found. Creating..."
-    temporal operator namespace create --retention "${DEFAULT_NAMESPACE_RETENTION}" --description "Default namespace for Temporal Server." "${DEFAULT_NAMESPACE}"
-    echo "Default namespace ${DEFAULT_NAMESPACE} registration complete."
+register_hash_namespace() {
+  echo "Registering namespace: \`HASH\`"
+  if ! temporal operator namespace describe HASH; then
+    echo "Default namespace \`HASH\` not found. Creating..."
+    temporal operator namespace create --retention 1 --description "HASH namespace for Temporal Server." HASH
+    echo "Default namespace \`HASH\` registration complete."
   else
-    echo "Default namespace ${DEFAULT_NAMESPACE} already registered."
+    echo "Default namespace \`HASH\` already registered."
   fi
 }
 
@@ -58,8 +56,8 @@ setup_server() {
   done
   echo "Temporal server started."
 
-  if [[ ${SKIP_DEFAULT_NAMESPACE_CREATION} != true ]]; then
-    register_default_namespace
+  if [[ ${SKIP_DEFAULT_NAMESPACE_CREATION} == false ]]; then
+    register_hash_namespace
   fi
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We don't want a `default` namespace around in the hosted version of Temporal so this sets the "default" namespace to `HASH`. This also adjusts the worker and the Dockerfiles to use the new namespaces. As a drive-by this adds a very simple workflow for testing purposes.

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] is internal and does not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] does not affect the execution graph