### PR TITLE
H-81: Fix `egress` for Postgres in Temporal missing

### DIFF
--- a/infra/terraform/hash/temporal/main.tf
+++ b/infra/terraform/hash/temporal/main.tf
@@ -177,6 +177,14 @@ resource "aws_security_group" "app_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  egress {
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    description = "Allow connections to Postgres within the VPC"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
   ingress {
     from_port   = 7233
     to_port     = 7233


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We expected that it's not needed but it is.

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] is internal and does not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] does not affect the execution graph
