### PR TITLE
H-50: Provide example worker hosted on ECS

### DIFF
--- a/apps/hash-ai-worker-py/app/__main__.py
+++ b/apps/hash-ai-worker-py/app/__main__.py
@@ -60,7 +60,7 @@ async def main() -> None:
     runner = web.AppRunner(app)
     await runner.setup()
     port = 4200
-    site = web.TCPSite(runner, "::", port)
+    site = web.TCPSite(runner, "127.0.0.1", port)
     print(f"HTTP server listening on port {port}")  # noqa: T201
 
     stop_worker = asyncio.Event()

--- a/apps/hash-ai-worker-py/docker/Dockerfile
+++ b/apps/hash-ai-worker-py/docker/Dockerfile
@@ -95,7 +95,8 @@ WORKDIR "/usr/local/src/hash/apps/hash-ai-worker-py"
 
 
 RUN apt-get update && \
-    apt-get install -y curl && \
+    apt-get install -y --no-install-recommends curl && \
+    rm -rf /var/lib/apt/lists/* && \
     groupadd --system --gid 60000 hash && \
     useradd --system pyworker -G hash && \
     install -d -m 0775 -o pyworker -g hash /log

--- a/apps/hash-ai-worker-ts/docker/Dockerfile
+++ b/apps/hash-ai-worker-ts/docker/Dockerfile
@@ -30,11 +30,14 @@ WORKDIR /usr/local/src/apps/hash-ai-worker-ts
 ENTRYPOINT [ "yarn", "--cache-folder", "/tmp/yarn-cache", "--global-folder", "/tmp/yarn-global" ]
 CMD ["start"]
 
-# Run as a non-root user
-RUN groupadd --system --gid 60000 hash \
-    && useradd --system worker -g hash
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd --system --gid 60000 hash && \
+    useradd --system tsworker -G hash && \
+    install -d -m 0775 -o tsworker -g hash /log
 
-USER worker:hash
+USER tsworker:hash
 ENV NODE_ENV production
 
 HEALTHCHECK --interval=5s --timeout=3s --start-period=10s --retries=3 CMD curl -f http://localhost:4100/health || exit 1

--- a/apps/hash-graph/.gitignore
+++ b/apps/hash-graph/.gitignore
@@ -1,4 +1,0 @@
-# Rust artifacts
-target/
-
-log/

--- a/apps/hash-graph/lib/graph/src/logging/args.rs
+++ b/apps/hash-graph/lib/graph/src/logging/args.rs
@@ -100,7 +100,7 @@ pub struct LoggingArgs {
         feature = "clap",
         clap(
             long,
-            default_value = "./log",
+            default_value = "./logs",
             env = "HASH_GRAPH_LOG_FOLDER",
             global = true
         )

--- a/infra/terraform/hash/hash_application/ai_worker.tf
+++ b/infra/terraform/hash/hash_application/ai_worker.tf
@@ -1,0 +1,35 @@
+module "worker_task_ts" {
+  source           = "../../modules/temporal_worker"
+  prefix           = var.prefix
+  param_prefix     = var.param_prefix
+  subnets          = var.subnets
+  vpc              = var.vpc
+  env              = var.env
+  region           = var.region
+  cpu              = 256
+  memory           = 512
+  worker_name      = "aits"
+  temporal_host    = var.temporal_host
+  temporal_port    = var.temporal_port
+  env_vars         = concat([{ name = "OPENAI_API_KEY", secret = true, value = var.openai_api_key }], var.api_env_vars)
+  cluster_arn      = data.aws_ecs_cluster.ecs.arn
+  ecs_health_check = ["CMD", "/bin/sh", "-c", "curl -f http://localhost:4100/health || exit 1"]
+}
+
+module "worker_task_py" {
+  source           = "../../modules/temporal_worker"
+  prefix           = var.prefix
+  param_prefix     = var.param_prefix
+  subnets          = var.subnets
+  vpc              = var.vpc
+  env              = var.env
+  region           = var.region
+  cpu              = 256
+  memory           = 512
+  worker_name      = "aipy"
+  temporal_host    = var.temporal_host
+  temporal_port    = var.temporal_port
+  env_vars         = [{ name = "OPENAI_API_KEY", secret = true, value = var.openai_api_key }]
+  cluster_arn      = data.aws_ecs_cluster.ecs.arn
+  ecs_health_check = ["CMD", "/bin/sh", "-c", "curl -f http://localhost:4200/health || exit 1"]
+}

--- a/infra/terraform/hash/hash_application/variables.tf
+++ b/infra/terraform/hash/hash_application/variables.tf
@@ -115,3 +115,19 @@ variable "ses_verified_domain_identity" {
   type        = string
   description = "A verified AWS SES identity to use for email sending in the application."
 }
+
+variable "temporal_host" {
+  type        = string
+  description = "The hostname of the Temporal cluster to connect to."
+}
+
+variable "temporal_port" {
+  type        = string
+  default     = "7233"
+  description = "The port of the Temporal cluster to connect to."
+}
+
+variable "openai_api_key" {
+  type        = string
+  description = "The OpenAI API key to use for the application."
+}

--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -236,4 +236,7 @@ module "application" {
     { name = "HASH_REDIS_HOST", secret = false, value = module.redis.node.address },
     { name = "HASH_REDIS_PORT", secret = false, value = module.redis.node.port },
   ])
+  temporal_host = module.temporal.host
+  temporal_port = module.temporal.temporal_port
+  openai_api_key = sensitive(data.vault_kv_secret_v2.secrets.data["hash_openai_api_key"])
 }

--- a/infra/terraform/hash/temporal/main.tf
+++ b/infra/terraform/hash/temporal/main.tf
@@ -2,7 +2,6 @@ locals {
   prefix           = var.prefix
   log_group_name   = "${local.prefix}-log"
   param_prefix     = var.param_prefix
-  temporal_version = var.temporal_version
 }
 
 module "migrate_ecr" {
@@ -186,8 +185,8 @@ resource "aws_security_group" "app_sg" {
   }
 
   ingress {
-    from_port   = 7233
-    to_port     = 7233
+    from_port   = local.temporal_port
+    to_port     = local.temporal_port
     protocol    = "tcp"
     description = "Allow connections to Temporal server within the VPC"
     # TODO: Consider changing this to `"0.0.0.0/0"` and setup authentication
@@ -196,20 +195,24 @@ resource "aws_security_group" "app_sg" {
   }
 
   egress {
-    from_port   = 7233
-    to_port     = 7233
+    from_port   = local.temporal_port
+    to_port     = local.temporal_port
     protocol    = "tcp"
     description = "Allow connections from Temporal server within the VPC"
     cidr_blocks = [var.vpc.cidr_block]
+    # To make UI available from the web:
+    # cidr_blocks = ["0.0.0.0/0"]
   }
 
   ingress {
-    from_port   = 8080
-    to_port     = 8080
+    from_port   = local.temporal_ui_port
+    to_port     = local.temporal_ui_port
     protocol    = "tcp"
     description = "Allow connections to Temporal UI within the VPC"
     # TODO: Consider changing this to `"0.0.0.0/0"` and setup authentication
     # description = "Allow connections to Temporal from anywhere (rely on authentication to restrict access)"
     cidr_blocks = [var.vpc.cidr_block]
+    # To make UI available from the web:
+    # cidr_blocks = ["0.0.0.0/0"]
   }
 }

--- a/infra/terraform/hash/temporal/output.tf
+++ b/infra/terraform/hash/temporal/output.tf
@@ -12,3 +12,18 @@ output "temporal_private_hostname" {
   description = "The private hostname of the Temporal server used with Service Discovery"
   value       = aws_lb.net_alb.dns_name
 }
+
+output "host" {
+  description = "The hostname of the Temporal cluster to connect to."
+  value       = aws_lb.net_alb.dns_name
+}
+
+output "temporal_port" {
+  description = "The port of the Temporal cluster to connect to."
+  value       = local.temporal_port
+}
+
+output "temporal_ui_port" {
+  description = "The port of the Temporal cluster to connect to."
+  value       = local.temporal_ui_port
+}

--- a/infra/terraform/hash/temporal/task_definitions.tf
+++ b/infra/terraform/hash/temporal/task_definitions.tf
@@ -90,7 +90,8 @@ locals {
         local.temporal_shared_env_vars,
         local.temporal_migration_env_vars,
         [
-          { name = "TEMPORAL_BROADCAST_ADDRESS", value = "${aws_lb.net_alb.dns_name}:${local.temporal_port}" },
+          # Adjust when setting up the cluster
+          { name = "TEMPORAL_BROADCAST_ADDRESS", value = "127.0.0.1" },
         ]
       )
 

--- a/infra/terraform/modules/temporal_worker/variables.tf
+++ b/infra/terraform/modules/temporal_worker/variables.tf
@@ -69,7 +69,7 @@ variable "temporal_port" {
 
 variable "ecs_health_check" {
   type        = list(string)
-  description = "The ECS Task Definiton Health Check command for the image."
+  description = "The ECS Task Definition Health Check command for the image."
 }
 
 variable "env_vars" {
@@ -81,4 +81,10 @@ variable "env_vars" {
 
   default     = []
   description = "The environment variables and secrets to pass to the container"
+}
+
+variable "desired_count" {
+  type        = number
+  default     = 1
+  description = "The number of instances of the task to run"
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds the worker configurations to the TF config.


## 🔍 What does this change?

- Drive-by: Fix `apps/hash-graph/log/*` was part of the docker context (this were > 5 GB for me locally)
- Add the Worker configuration to TF
- Fix TS Worker: `curl` was missing for healthcheck
- Fix PY Worker: healthcheck was checking for IPv4 while the server listened to IPv6

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] is internal and does not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] does not affect the execution graph