### PR TITLE
H-87: Upgrade Ory Kratos

### DIFF
--- a/apps/hash-api/package.json
+++ b/apps/hash-api/package.json
@@ -41,7 +41,7 @@
     "@opentelemetry/sdk-trace-base": "1.0",
     "@opentelemetry/sdk-trace-node": "1.0",
     "@ory/client": "1.1.33",
-    "@ory/kratos-client": "0.11.0",
+    "@ory/kratos-client": "0.13.1",
     "@snowplow/node-tracker": "3.3.1",
     "agentkeepalive": "4.2.1",
     "apollo-datasource": "3.3.2",

--- a/apps/hash-external-services/kratos/Dockerfile
+++ b/apps/hash-external-services/kratos/Dockerfile
@@ -1,4 +1,4 @@
-FROM oryd/kratos:v0.11.0
+FROM oryd/kratos:v0.13.0
 
 USER root
 

--- a/apps/hash-external-services/kratos/kratos.dev.yml
+++ b/apps/hash-external-services/kratos/kratos.dev.yml
@@ -1,4 +1,4 @@
-version: v0.11.0
+version: v0.13.0
 
 serve:
   public:

--- a/apps/hash-external-services/kratos/kratos.prod.yml
+++ b/apps/hash-external-services/kratos/kratos.prod.yml
@@ -1,4 +1,4 @@
-version: v0.11.0
+version: v0.13.0
 
 serve:
   public:

--- a/apps/hash-external-services/kratos/templates/README.md
+++ b/apps/hash-external-services/kratos/templates/README.md
@@ -2,4 +2,4 @@
 
 These folders contain email templates for Kratos emails. They copy the default directory layout that Kratos will look for. Only the email flows we're using are present here.
 
-Kratos default templates are located here: https://github.com/ory/kratos/tree/v0.11.0/courier/template/courier/builtin/templates and may change between versions of Kratos.
+Kratos default templates are located here: https://github.com/ory/kratos/tree/v0.13.0/courier/template/courier/builtin/templates and may change between versions of Kratos.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5525,10 +5525,10 @@
     set-cookie-parser "^2.4.8"
     tldjs "^2.3.1"
 
-"@ory/kratos-client@0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@ory/kratos-client/-/kratos-client-0.11.0.tgz#87b60cb5bd649d3e01b6d518be1a69e10f6af9e4"
-  integrity "sha1-h7YMtb1knT4BttUYvhpp4Q9q+eQ= sha512-A+BVVE+mokwuDxXUr8XTHIVgP0jdIT4vZJIc38+3Q8JS3KkTYZat6zxzI5lDPN6nEl42CNgfBZvjvpL/rSC0IQ=="
+"@ory/kratos-client@0.13.1":
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/@ory/kratos-client/-/kratos-client-0.13.1.tgz#80681817ff5c76138f4c9e45d8d8b12f937ecb93"
+  integrity sha512-s5HHJDvCMkrHq2r5i7g+Snt82mT9vffGlpkhAjuskiWGZ8s1CI9bFAl9XWYydDFZLUb0EyuDc5GfgQa1O4yQ1g==
   dependencies:
     axios "^0.21.4"
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

As part of investigating performance of the deployed app, I noticed that calls to Ory's `whoami` can be very slow (sometimes 6-7s). 

The `0.13` release of Ory Kratos [specifically mentions](https://github.com/ory/kratos/releases/tag/v0.13.0) optimising `whoami` calls, so I'm upgrading to see what benefit this brings.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

<!-- - [x] modifies an **npm**-publishable library and **I have added a changeset file(s)** -->

<!-- - [x] modifies a **Cargo**-publishable library and **I have amended the version** -->

<!-- - [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish** -->

<!-- - [x] modifies a **block** that will need publishing via GitHub action once merged -->

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

<!-- - [x] I am unsure / need advice -->

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->

The changes in this PR:

- [x] are internal and do not require a docs change

<!-- - [x] is in a state where docs changes are not _yet_ required but will be
  - this is tracked within: [Insert Link Here](link) -->

<!-- - [x] requires changes to docs
  - <CHANGES TO DOCS EXPLAINED HERE> -->

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

<!-- - [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this -->

- [x] do not affect the execution graph

<!-- - [x] I am unsure / need advice -->

## 🐾 Next steps

- If this does not solve the `whoami` performance issues, my next target will be looking at [the post-registration hook](https://github.com/hashintel/hash/blob/main/apps/hash-external-services/kratos/hooks/after.registration.jsonnet) in case that is the bottleneck somehow.

## ❓ How to test this?

1.  Checkout the branch
1. Rebuild `external-services` fully (i.e. get rid of the underlying Ory Kratos image at least)
1. Check login / logout still works
