### PR TITLE
H-88: Fix Terraform state to allow `--refresh=true`

### DIFF
--- a/.github/actions/terraform-exec/action.yml
+++ b/.github/actions/terraform-exec/action.yml
@@ -72,7 +72,7 @@ runs:
         VAULT_ADDR: ${{ inputs.vault-address }}
       working-directory: ${{ inputs.working-directory }}
       shell: bash
-      run: terraform ${{ inputs.command == 'plan' && 'plan' || 'apply -auto-approve' }} -no-color -var-file=${{ inputs.env }}-usea1.tfvars -refresh=false| tee cmd.out
+      run: terraform ${{ inputs.command == 'plan' && 'plan' || 'apply -auto-approve' }} -no-color -var-file=${{ inputs.env }}-usea1.tfvars | tee cmd.out
 
     - uses: actions/github-script@v6
       with:

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -112,13 +112,6 @@ $ terraform apply --var-file prod-usea1.tfvars
 ..
 ```
 
-Note that it may be required to disable refreshing state for subsequent applies (because of the Postgres SSH tunnel. Data sources are deferred to the apply phase, usually).
-
-```console
-$ terraform apply --var-file prod-usea1.tfvars --refresh=false
-..
-```
-
 ## 2. Migrate databases
 
 Once the terraform infrastructure is deployed, you should have an RDS Postgres database accessible from the bastion host with `graph` and `kratos` users/dbs. These need to be migrated locally in preparation for starting the services.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The Terraform state was missing some crucial part of our infrastructure (the bastion host), so refreshing was not possible. The issue is resolved and the state is fixed. This PR removes the mentioning of `--refresh=false` in the documentation and CI.

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] is internal and does not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] does not affect the execution graph