### PR TITLE
H-127: Add network timeout to Dockerfiles

### DIFF
--- a/apps/hash-graph/docker/Dockerfile
+++ b/apps/hash-graph/docker/Dockerfile
@@ -31,7 +31,8 @@ COPY --from=base /app/out/json/ .
 COPY --from=base /app/out/yarn.lock ./yarn.lock
 COPY --from=base /app/out/full/turbo.json turbo.json
 
-RUN yarn install --frozen-lockfile --prefer-offline && \
+RUN yarn config set network-timeout 300000 && \
+    yarn install --frozen-lockfile --prefer-offline && \
     yarn cache clean
 
 COPY --from=base /app/out/full/ .

--- a/infra/docker/api/prod/Dockerfile
+++ b/infra/docker/api/prod/Dockerfile
@@ -18,7 +18,8 @@ COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/yarn.lock yarn.lock
 COPY --from=builder /app/out/full/patches patches
 
-RUN yarn install --frozen-lockfile --prefer-offline \
+RUN yarn config set network-timeout 300000 && \
+    yarn install --frozen-lockfile --prefer-offline \
     && yarn cache clean
 
 COPY --from=builder /app/out/full/ .


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We encounter frequent timeouts when building the docker images for production, this provides a fix. Please see the linked linear issues for more details.

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] is internal and does not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] does not affect the execution graph

## 📹 Demo

[The CI](https://github.com/hashintel/hash/actions/runs/5529518791/jobs/10087696585) does not have timeouts anymore
