### PR TITLE
Revert "IN-12: Change containers to linux/arm64"

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -74,7 +74,6 @@ runs:
         tags: ${{ inputs.AWS_ECR_URL }}/${{ inputs.IMAGE_NAME }}:${{ inputs.IMAGE_TAG }} , ${{ inputs.AWS_ECR_URL }}/${{ inputs.IMAGE_NAME }}:run-${{ env.GH_RUN_ID }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
-        platforms: linux/arm64
 
     # Make sure that cache doesn't get too bloated.
     - name: Move cache

--- a/infra/terraform/hash/hash_application/main.tf
+++ b/infra/terraform/hash/hash_application/main.tf
@@ -330,11 +330,6 @@ resource "aws_ecs_task_definition" "task" {
   task_role_arn            = aws_iam_role.task_role.arn
   container_definitions    = jsonencode([for task_def in local.task_defs : task_def.task_def])
   tags                     = {}
-
-  runtime_platform {
-    operating_system_family = "LINUX"
-    cpu_architecture        = "ARM64"
-  }
 }
 
 resource "aws_ecs_service" "svc" {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The CI workers are [extremly slow](https://github.com/hashintel/hash/actions/runs/5529518791/jobs/10087696585) when compiling x86->arm so we chose to revert #2749.