### PR TITLE
H-48: Build and push all docker images from GitHub Actions

### DIFF
--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -32,6 +32,7 @@ env:
 
   HASH_ECS_CLUSTER_NAME: ${{ secrets.HASH_ECS_CLUSTER_NAME }}
   HASH_APP_SERVICE_NAME: ${{ secrets.HASH_APP_SERVICE_NAME }}
+  HASH_TEMPORAL_SERVICE_NAME: h-temporal-prod-usea1-svc
 
 name: HASH backend deployment
 jobs:
@@ -365,5 +366,7 @@ jobs:
         env:
           HASH_ECS_CLUSTER_NAME: ${{ env.HASH_ECS_CLUSTER_NAME }}
           HASH_APP_SERVICE_NAME: ${{ env.HASH_APP_SERVICE_NAME }}
+          HASH_TEMPORAL_SERVICE_NAME: ${{ env.HASH_TEMPORAL_SERVICE_NAME }}
         run: |
+          aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_APP_SERVICE_NAME }} --force-new-deployment 1> /dev/null
           aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_APP_SERVICE_NAME }} --force-new-deployment 1> /dev/null

--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -22,8 +22,8 @@ env:
   HASH_API_RESOURCE_NAME: ${{ secrets.HASH_API_RESOURCE_NAME }}
   HASH_GRAPH_RESOURCE_NAME: ${{ secrets.HASH_GRAPH_RESOURCE_NAME }}
   HASH_KRATOS_RESOURCE_NAME: ${{ secrets.HASH_KRATOS_RESOURCE_NAME }}
-  HASH_TEMPORAL_AI_TS_WORKER_RESOURCE_NAME: ${{ secrets.HASH_TEMPORAL_AI_TS_WORKER_RESOURCE_NAME }}
-  HASH_TEMPORAL_AI_PY_WORKER_RESOURCE_NAME: ${{ secrets.HASH_TEMPORAL_AI_PY_WORKER_RESOURCE_NAME }}
+  HASH_TEMPORAL_AI_TS_WORKER_RESOURCE_NAME: h-hash-prod-usea1-temporalworkeraits
+  HASH_TEMPORAL_AI_PY_WORKER_RESOURCE_NAME: h-hash-prod-usea1-temporalworkeraipy
 
   HASH_ECS_CLUSTER_NAME: ${{ secrets.HASH_ECS_CLUSTER_NAME }}
   HASH_APP_SERVICE_NAME: ${{ secrets.HASH_APP_SERVICE_NAME }}
@@ -240,6 +240,8 @@ jobs:
       - build-graph
       - build-api
       - build-kratos
+      - build-ts-worker
+      - build-py-worker
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -34,6 +34,8 @@ env:
 
   HASH_ECS_CLUSTER_NAME: ${{ secrets.HASH_ECS_CLUSTER_NAME }}
   HASH_APP_SERVICE_NAME: ${{ secrets.HASH_APP_SERVICE_NAME }}
+
+  HASH_TEMPORAL_ECS_CLUSTER_NAME: h-temporal-prod-usea1-ecs
   HASH_TEMPORAL_SERVICE_NAME: h-temporal-prod-usea1-svc
 
 name: HASH backend deployment
@@ -405,7 +407,7 @@ jobs:
 
       - name: Redeploy api service
         env:
-          HASH_ECS_CLUSTER_NAME: ${{ env.HASH_ECS_CLUSTER_NAME }}
+          HASH_TEMPORAL_ECS_CLUSTER_NAME: ${{ env.HASH_TEMPORAL_ECS_CLUSTER_NAME }}
           HASH_TEMPORAL_SERVICE_NAME: ${{ env.HASH_TEMPORAL_SERVICE_NAME }}
         run: |
           aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_TEMPORAL_SERVICE_NAME }} --force-new-deployment 1> /dev/null

--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -8,6 +8,8 @@ on:
       - "apps/hash-graph/**"
       - "apps/hash-api/**"
       - "apps/hash-external-services/kratos/**"
+      - "apps/hash-ai-worker-ts/**"
+      - "apps/hash-ai-worker-py/**"
       - "libs/@local/hash-backend-utils-utils/**"
       - "libs/@local/hash-isomorphic-utils/**"
       - "libs/@local/status/**"

--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -186,7 +186,7 @@ jobs:
         uses: ./.github/actions/docker-build-push
         id: build
         with:
-          SHORTNAME: "kratos"
+          SHORTNAME: "temporal-worker-ai-ts"
           CONTEXT_PATH: ${{ github.workspace }}
           DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-ai-worker-ts/docker/Dockerfile
           AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
@@ -224,7 +224,7 @@ jobs:
         uses: ./.github/actions/docker-build-push
         id: build
         with:
-          SHORTNAME: "kratos"
+          SHORTNAME: "temporal-worker-ai-py"
           CONTEXT_PATH: ${{ github.workspace }}
           DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-ai-worker-py/docker/Dockerfile
           AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
@@ -262,7 +262,7 @@ jobs:
         uses: ./.github/actions/docker-build-push
         id: build
         with:
-          SHORTNAME: "kratos"
+          SHORTNAME: "temporal-migrate"
           CONTEXT_PATH: ${{ github.workspace }}//apps/hash-external-services/temporal
           DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/temporal/migrate.Dockerfile
           AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
@@ -303,7 +303,7 @@ jobs:
         uses: ./.github/actions/docker-build-push
         id: build
         with:
-          SHORTNAME: "kratos"
+          SHORTNAME: "temporal-setup"
           CONTEXT_PATH: ${{ github.workspace }}//apps/hash-external-services/temporal
           DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/temporal/setup.Dockerfile
           AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
@@ -353,7 +353,7 @@ jobs:
           AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
           AWS_REGION: ${{ env.AWS_REGION }}
 
-      - name: Redeploy api service
+      - name: Redeploy HASH backend service
         run: |
           aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_APP_SERVICE_NAME }} --force-new-deployment 1> /dev/null
 
@@ -391,6 +391,6 @@ jobs:
           AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
           AWS_REGION: ${{ env.AWS_REGION }}
 
-      - name: Redeploy api service
+      - name: Redeploy Temporal service
         run: |
           aws ecs update-service --cluster ${{ env.HASH_TEMPORAL_ECS_CLUSTER_NAME }} --service ${{ env.HASH_TEMPORAL_SERVICE_NAME }} --force-new-deployment 1> /dev/null

--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -5,12 +5,12 @@ on:
     branches:
       - main
     paths:
+      - "apps/hash-ai-worker-py/**"
+      - "apps/hash-ai-worker-ts/**"
       - "apps/hash-graph/**"
       - "apps/hash-api/**"
-      - "apps/hash-external-services/kratos/**"
-      - "apps/hash-ai-worker-ts/**"
-      - "apps/hash-ai-worker-py/**"
       - "apps/hash-external-services/temporal/**"
+      - "apps/hash-external-services/kratos/**"
       - "libs/@local/hash-backend-utils-utils/**"
       - "libs/@local/hash-isomorphic-utils/**"
       - "libs/@local/status/**"
@@ -28,6 +28,7 @@ env:
   HASH_KRATOS_RESOURCE_NAME: ${{ secrets.HASH_KRATOS_RESOURCE_NAME }}
   HASH_TEMPORAL_AI_TS_WORKER_RESOURCE_NAME: h-hash-prod-usea1-temporalworkeraits
   HASH_TEMPORAL_AI_PY_WORKER_RESOURCE_NAME: h-hash-prod-usea1-temporalworkeraipy
+
   HASH_TEMPORAL_SETUP_RESOURCE_NAME: h-temporal-prod-usea1-setup
   HASH_TEMPORAL_MIGRATE_RESOURCE_NAME: h-temporal-prod-usea1-migrate
   HASH_TEMPORAL_VERSION: 1.21.0.0
@@ -67,8 +68,6 @@ jobs:
       - name: Docker image build through docker-build-push
         uses: ./.github/actions/docker-build-push
         id: build
-        env:
-          IMAGE_NAME: ${{ env.HASH_GRAPH_RESOURCE_NAME }}
         with:
           SHORTNAME: "graph"
           CONTEXT_PATH: ${{ github.workspace }}/
@@ -78,7 +77,7 @@ jobs:
           AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
           AWS_REGION: ${{ env.AWS_REGION }}
           AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
-          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          IMAGE_NAME: ${{ env.HASH_GRAPH_RESOURCE_NAME }}
 
   build-api:
     name: Build and push HASH api image
@@ -107,8 +106,6 @@ jobs:
       - name: Docker image build through docker-build-push
         uses: ./.github/actions/docker-build-push
         id: build
-        env:
-          IMAGE_NAME: ${{ env.HASH_API_RESOURCE_NAME }}
         with:
           SHORTNAME: "api"
           CONTEXT_PATH: ${{ github.workspace }}
@@ -118,7 +115,7 @@ jobs:
           AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
           AWS_REGION: ${{ env.AWS_REGION }}
           AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
-          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          IMAGE_NAME: ${{ env.HASH_API_RESOURCE_NAME }}
 
   build-kratos:
     name: Build and push Kratos image
@@ -147,8 +144,6 @@ jobs:
       - name: Docker image build through docker-build-push
         uses: ./.github/actions/docker-build-push
         id: build
-        env:
-          IMAGE_NAME: ${{ env.HASH_KRATOS_RESOURCE_NAME }}
         with:
           SHORTNAME: "kratos"
           CONTEXT_PATH: ${{ github.workspace }}/apps/hash-external-services/kratos
@@ -158,7 +153,7 @@ jobs:
           AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
           AWS_REGION: ${{ env.AWS_REGION }}
           AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
-          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          IMAGE_NAME: ${{ env.HASH_KRATOS_RESOURCE_NAME }}
           BUILD_ARGS: |
             ENV=prod
             API_SECRET=${{ secrets.HASH_KRATOS_API_SECRET }}
@@ -190,8 +185,6 @@ jobs:
       - name: Docker image build through docker-build-push
         uses: ./.github/actions/docker-build-push
         id: build
-        env:
-          IMAGE_NAME: ${{ env.HASH_TEMPORAL_AI_TS_WORKER_RESOURCE_NAME }}
         with:
           SHORTNAME: "kratos"
           CONTEXT_PATH: ${{ github.workspace }}
@@ -201,7 +194,7 @@ jobs:
           AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
           AWS_REGION: ${{ env.AWS_REGION }}
           AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
-          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          IMAGE_NAME: ${{ env.HASH_TEMPORAL_AI_TS_WORKER_RESOURCE_NAME }}
 
   build-py-worker:
     name: Build and push Temporal PY AI Worker
@@ -230,8 +223,6 @@ jobs:
       - name: Docker image build through docker-build-push
         uses: ./.github/actions/docker-build-push
         id: build
-        env:
-          IMAGE_NAME: ${{ env.HASH_TEMPORAL_AI_PY_WORKER_RESOURCE_NAME }}
         with:
           SHORTNAME: "kratos"
           CONTEXT_PATH: ${{ github.workspace }}
@@ -241,7 +232,7 @@ jobs:
           AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
           AWS_REGION: ${{ env.AWS_REGION }}
           AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
-          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          IMAGE_NAME: ${{ env.HASH_TEMPORAL_AI_PY_WORKER_RESOURCE_NAME }}
 
   build-temporal-migrate:
     name: Build and push Temporal Migrate image
@@ -270,8 +261,6 @@ jobs:
       - name: Docker image build through docker-build-push
         uses: ./.github/actions/docker-build-push
         id: build
-        env:
-          IMAGE_NAME: ${{ env.HASH_TEMPORAL_MIGRATE_RESOURCE_NAME }}
         with:
           SHORTNAME: "kratos"
           CONTEXT_PATH: ${{ github.workspace }}//apps/hash-external-services/temporal
@@ -281,7 +270,7 @@ jobs:
           AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
           AWS_REGION: ${{ env.AWS_REGION }}
           AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
-          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          IMAGE_NAME: ${{ env.HASH_TEMPORAL_MIGRATE_RESOURCE_NAME }}
           IMAGE_TAG: ${{ env.HASH_TEMPORAL_VERSION }}
           BUILD_ARGS: |
             TEMPORAL_VERSION=${{ env.HASH_TEMPORAL_VERSION }}
@@ -313,8 +302,6 @@ jobs:
       - name: Docker image build through docker-build-push
         uses: ./.github/actions/docker-build-push
         id: build
-        env:
-          IMAGE_NAME: ${{ env.HASH_TEMPORAL_SETUP_RESOURCE_NAME }}
         with:
           SHORTNAME: "kratos"
           CONTEXT_PATH: ${{ github.workspace }}//apps/hash-external-services/temporal
@@ -324,7 +311,7 @@ jobs:
           AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
           AWS_REGION: ${{ env.AWS_REGION }}
           AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
-          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          IMAGE_NAME: ${{ env.HASH_TEMPORAL_SETUP_RESOURCE_NAME }}
           IMAGE_TAG: ${{ env.HASH_TEMPORAL_VERSION }}
           BUILD_ARGS: |
             TEMPORAL_VERSION=${{ env.HASH_TEMPORAL_VERSION }}
@@ -336,45 +323,6 @@ jobs:
       - build-graph
       - build-api
       - build-kratos
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@v2
-        with:
-          exportToken: true
-          url: ${{ env.VAULT_ADDR }}
-          method: jwt
-          role: prod
-          # Even though it could look like separate calls to fetch the secrets
-          # the responses here are cached, so we're only issuing a single set of credentials
-          secrets: |
-            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
-
-      - uses: ./.github/actions/docker-ecr-login
-        with:
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.AWS_REGION }}
-
-      - name: Redeploy api service
-        env:
-          HASH_ECS_CLUSTER_NAME: ${{ env.HASH_ECS_CLUSTER_NAME }}
-          HASH_APP_SERVICE_NAME: ${{ env.HASH_APP_SERVICE_NAME }}
-        run: |
-          aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_APP_SERVICE_NAME }} --force-new-deployment 1> /dev/null
-
-  deploy-temporal:
-    name: Deploy Temporal images
-    runs-on: ubuntu-latest
-    needs:
       - build-ts-worker
       - build-py-worker
     permissions:
@@ -406,8 +354,43 @@ jobs:
           AWS_REGION: ${{ env.AWS_REGION }}
 
       - name: Redeploy api service
-        env:
-          HASH_TEMPORAL_ECS_CLUSTER_NAME: ${{ env.HASH_TEMPORAL_ECS_CLUSTER_NAME }}
-          HASH_TEMPORAL_SERVICE_NAME: ${{ env.HASH_TEMPORAL_SERVICE_NAME }}
         run: |
-          aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_TEMPORAL_SERVICE_NAME }} --force-new-deployment 1> /dev/null
+          aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_APP_SERVICE_NAME }} --force-new-deployment 1> /dev/null
+
+  deploy-temporal:
+    name: Deploy Temporal images
+    runs-on: ubuntu-latest
+    needs:
+      - build-temporal-migrate
+      - build-temporal-setup
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Authenticate Vault
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          exportToken: true
+          url: ${{ env.VAULT_ADDR }}
+          method: jwt
+          role: prod
+          # Even though it could look like separate calls to fetch the secrets
+          # the responses here are cached, so we're only issuing a single set of credentials
+          secrets: |
+            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+
+      - uses: ./.github/actions/docker-ecr-login
+        with:
+          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+
+      - name: Redeploy api service
+        run: |
+          aws ecs update-service --cluster ${{ env.HASH_TEMPORAL_ECS_CLUSTER_NAME }} --service ${{ env.HASH_TEMPORAL_SERVICE_NAME }} --force-new-deployment 1> /dev/null

--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -370,7 +370,7 @@ jobs:
           aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_APP_SERVICE_NAME }} --force-new-deployment 1> /dev/null
 
   deploy-temporal:
-    name: Deploy HASH images
+    name: Deploy Temporal images
     runs-on: ubuntu-latest
     needs:
       - build-ts-worker

--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -22,6 +22,8 @@ env:
   HASH_API_RESOURCE_NAME: ${{ secrets.HASH_API_RESOURCE_NAME }}
   HASH_GRAPH_RESOURCE_NAME: ${{ secrets.HASH_GRAPH_RESOURCE_NAME }}
   HASH_KRATOS_RESOURCE_NAME: ${{ secrets.HASH_KRATOS_RESOURCE_NAME }}
+  HASH_TEMPORAL_AI_TS_WORKER_RESOURCE_NAME: ${{ secrets.HASH_TEMPORAL_AI_TS_WORKER_RESOURCE_NAME }}
+  HASH_TEMPORAL_AI_PY_WORKER_RESOURCE_NAME: ${{ secrets.HASH_TEMPORAL_AI_PY_WORKER_RESOURCE_NAME }}
 
   HASH_ECS_CLUSTER_NAME: ${{ secrets.HASH_ECS_CLUSTER_NAME }}
   HASH_APP_SERVICE_NAME: ${{ secrets.HASH_APP_SERVICE_NAME }}
@@ -150,6 +152,86 @@ jobs:
           BUILD_ARGS: |
             ENV=prod
             API_SECRET=${{ secrets.HASH_KRATOS_API_SECRET }}
+
+  build-ts-worker:
+    name: Build and push Temporal TS AI Worker
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Authenticate Vault
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          exportToken: true
+          url: ${{ env.VAULT_ADDR }}
+          method: jwt
+          role: prod
+          # Even though it could look like separate calls to fetch the secrets
+          # the responses here are cached, so we're only issuing a single set of credentials
+          secrets: |
+            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+
+      - name: Docker image build through docker-build-push
+        uses: ./.github/actions/docker-build-push
+        id: build
+        env:
+          IMAGE_NAME: ${{ env.HASH_TEMPORAL_AI_TS_WORKER_RESOURCE_NAME }}
+        with:
+          SHORTNAME: "kratos"
+          CONTEXT_PATH: ${{ github.workspace }}
+          DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-ai-worker-ts/docker/Dockerfile
+          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+          AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+
+  build-py-worker:
+    name: Build and push Temporal PY AI Worker
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Authenticate Vault
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          exportToken: true
+          url: ${{ env.VAULT_ADDR }}
+          method: jwt
+          role: prod
+          # Even though it could look like separate calls to fetch the secrets
+          # the responses here are cached, so we're only issuing a single set of credentials
+          secrets: |
+            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+
+      - name: Docker image build through docker-build-push
+        uses: ./.github/actions/docker-build-push
+        id: build
+        env:
+          IMAGE_NAME: ${{ env.HASH_TEMPORAL_AI_PY_WORKER_RESOURCE_NAME }}
+        with:
+          SHORTNAME: "kratos"
+          CONTEXT_PATH: ${{ github.workspace }}
+          DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-ai-worker-py/docker/Dockerfile
+          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+          AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
 
   deploy:
     name: Deploy HASH images

--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -266,7 +266,7 @@ jobs:
         uses: ./.github/actions/docker-build-push
         id: build
         env:
-          IMAGE_NAME: ${{ env.TEMPORAL_MIGRATE_RESOURCE_NAME }}
+          IMAGE_NAME: ${{ env.HASH_TEMPORAL_MIGRATE_RESOURCE_NAME }}
         with:
           SHORTNAME: "kratos"
           CONTEXT_PATH: ${{ github.workspace }}//apps/hash-external-services/temporal
@@ -309,7 +309,7 @@ jobs:
         uses: ./.github/actions/docker-build-push
         id: build
         env:
-          IMAGE_NAME: ${{ env.TEMPORAL_SETUP_RESOURCE_NAME }}
+          IMAGE_NAME: ${{ env.HASH_TEMPORAL_SETUP_RESOURCE_NAME }}
         with:
           SHORTNAME: "kratos"
           CONTEXT_PATH: ${{ github.workspace }}//apps/hash-external-services/temporal

--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -26,6 +26,9 @@ env:
   HASH_KRATOS_RESOURCE_NAME: ${{ secrets.HASH_KRATOS_RESOURCE_NAME }}
   HASH_TEMPORAL_AI_TS_WORKER_RESOURCE_NAME: h-hash-prod-usea1-temporalworkeraits
   HASH_TEMPORAL_AI_PY_WORKER_RESOURCE_NAME: h-hash-prod-usea1-temporalworkeraipy
+  HASH_TEMPORAL_SETUP_RESOURCE_NAME: h-temporal-prod-usea1-setup
+  HASH_TEMPORAL_MIGRATE_RESOURCE_NAME: h-temporal-prod-usea1-migrate
+  HASH_TEMPORAL_VERSION: 1.21.0.0
 
   HASH_ECS_CLUSTER_NAME: ${{ secrets.HASH_ECS_CLUSTER_NAME }}
   HASH_APP_SERVICE_NAME: ${{ secrets.HASH_APP_SERVICE_NAME }}
@@ -234,6 +237,92 @@ jobs:
           AWS_REGION: ${{ env.AWS_REGION }}
           AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
+
+  build-temporal-migrate:
+    name: Build and push Temporal Migrate image
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Authenticate Vault
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          exportToken: true
+          url: ${{ env.VAULT_ADDR }}
+          method: jwt
+          role: prod
+          # Even though it could look like separate calls to fetch the secrets
+          # the responses here are cached, so we're only issuing a single set of credentials
+          secrets: |
+            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+
+      - name: Docker image build through docker-build-push
+        uses: ./.github/actions/docker-build-push
+        id: build
+        env:
+          IMAGE_NAME: ${{ env.TEMPORAL_MIGRATE_RESOURCE_NAME }}
+        with:
+          SHORTNAME: "kratos"
+          CONTEXT_PATH: ${{ github.workspace }}//apps/hash-external-services/temporal
+          DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/temporal/migrate.Dockerfile
+          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+          AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          IMAGE_TAG: ${{ env.HASH_TEMPORAL_VERSION }}
+          BUILD_ARGS: |
+            TEMPORAL_VERSION=${{ env.HASH_TEMPORAL_VERSION }}
+
+  build-temporal-setup:
+    name: Build and push Temporal Setup image
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Authenticate Vault
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          exportToken: true
+          url: ${{ env.VAULT_ADDR }}
+          method: jwt
+          role: prod
+          # Even though it could look like separate calls to fetch the secrets
+          # the responses here are cached, so we're only issuing a single set of credentials
+          secrets: |
+            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+
+      - name: Docker image build through docker-build-push
+        uses: ./.github/actions/docker-build-push
+        id: build
+        env:
+          IMAGE_NAME: ${{ env.TEMPORAL_SETUP_RESOURCE_NAME }}
+        with:
+          SHORTNAME: "kratos"
+          CONTEXT_PATH: ${{ github.workspace }}//apps/hash-external-services/temporal
+          DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/temporal/setup.Dockerfile
+          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+          AWS_ECR_URL: ${{ env.AWS_ECR_URL }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          IMAGE_TAG: ${{ env.HASH_TEMPORAL_VERSION }}
+          BUILD_ARGS: |
+            TEMPORAL_VERSION=${{ env.HASH_TEMPORAL_VERSION }}
 
   deploy:
     name: Deploy HASH images

--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -10,9 +10,11 @@ on:
       - "apps/hash-external-services/kratos/**"
       - "apps/hash-ai-worker-ts/**"
       - "apps/hash-ai-worker-py/**"
+      - "apps/hash-external-services/temporal/**"
       - "libs/@local/hash-backend-utils-utils/**"
       - "libs/@local/hash-isomorphic-utils/**"
       - "libs/@local/status/**"
+      - "infra/docker/api/prod/**"
 
 env:
   VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
@@ -325,13 +327,52 @@ jobs:
           BUILD_ARGS: |
             TEMPORAL_VERSION=${{ env.HASH_TEMPORAL_VERSION }}
 
-  deploy:
+  deploy-app:
     name: Deploy HASH images
     runs-on: ubuntu-latest
     needs:
       - build-graph
       - build-api
       - build-kratos
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Authenticate Vault
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          exportToken: true
+          url: ${{ env.VAULT_ADDR }}
+          method: jwt
+          role: prod
+          # Even though it could look like separate calls to fetch the secrets
+          # the responses here are cached, so we're only issuing a single set of credentials
+          secrets: |
+            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
+            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
+            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+
+      - uses: ./.github/actions/docker-ecr-login
+        with:
+          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+
+      - name: Redeploy api service
+        env:
+          HASH_ECS_CLUSTER_NAME: ${{ env.HASH_ECS_CLUSTER_NAME }}
+          HASH_APP_SERVICE_NAME: ${{ env.HASH_APP_SERVICE_NAME }}
+        run: |
+          aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_APP_SERVICE_NAME }} --force-new-deployment 1> /dev/null
+
+  deploy-temporal:
+    name: Deploy HASH images
+    runs-on: ubuntu-latest
+    needs:
       - build-ts-worker
       - build-py-worker
     permissions:
@@ -365,8 +406,6 @@ jobs:
       - name: Redeploy api service
         env:
           HASH_ECS_CLUSTER_NAME: ${{ env.HASH_ECS_CLUSTER_NAME }}
-          HASH_APP_SERVICE_NAME: ${{ env.HASH_APP_SERVICE_NAME }}
           HASH_TEMPORAL_SERVICE_NAME: ${{ env.HASH_TEMPORAL_SERVICE_NAME }}
         run: |
-          aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_APP_SERVICE_NAME }} --force-new-deployment 1> /dev/null
-          aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_APP_SERVICE_NAME }} --force-new-deployment 1> /dev/null
+          aws ecs update-service --cluster ${{ env.HASH_ECS_CLUSTER_NAME }} --service ${{ env.HASH_TEMPORAL_SERVICE_NAME }} --force-new-deployment 1> /dev/null

--- a/infra/terraform/hash/temporal/main.tf
+++ b/infra/terraform/hash/temporal/main.tf
@@ -122,11 +122,6 @@ resource "aws_ecs_task_definition" "task" {
   execution_role_arn       = aws_iam_role.execution_role.arn
   task_role_arn            = aws_iam_role.task_role.arn
   container_definitions    = jsonencode(local.task_definitions)
-
-  runtime_platform {
-    operating_system_family = "LINUX"
-    cpu_architecture        = "ARM64"
-  }
 }
 
 resource "aws_ecs_service" "svc" {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To avoid manually pushing the worker images and temporal script images after each commit this builds the images as part of CD. This incorporates #2754 to avoid unnecessary merge conflicts. 

## 🚫 Blocked by

- #2752 

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] is internal and does not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] does not affect the execution graph