### PR TITLE
Fix CIDR block in egress for temporal workers

### DIFF
--- a/infra/terraform/hash/hash_application/main.tf
+++ b/infra/terraform/hash/hash_application/main.tf
@@ -445,7 +445,7 @@ resource "aws_security_group" "app_sg" {
     to_port     = var.temporal_port
     protocol    = "tcp"
     description = "Allow outbound GRPC connections to Temporal"
-    cidr_blocks = [var.vpc.cidr_block]
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   ingress {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

I cannot precisely tell why this is required and will investigate this at some later point but it appears to require a more general CIDR is required for `egress` to connect the temporal workers to the temporal service.