### PR TITLE
Update PR template checkboxes to 'tick & delete' rather than 'uncomment'

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,55 +30,55 @@
 ### 🚢 Has this modified a publishable library?
 
 <!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
-<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->
+<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->
 
 This PR:
 
-- [ ] **⚠️ This is a placeholder, please uncomment at least one of the lines following this one and then delete this. ⚠️**
+- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
 
-<!-- - [x] modifies an **npm**-publishable library and **I have added a changeset file(s)** -->
+- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
 
-<!-- - [x] modifies a **Cargo**-publishable library and **I have amended the version** -->
+- [ ] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
 
-<!-- - [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish** -->
+- [ ] modifies a **block** that will need publishing via GitHub action once merged
 
-<!-- - [x] modifies a **block** that will need publishing via GitHub action once merged -->
+- [ ] does not modify any publishable blocks or libraries, or modifications do not need publishing
 
-<!-- - [x] does not modify any publishable blocks or libraries, or modifications do not need publishing -->
-
-<!-- - [x] I am unsure / need advice -->
+- [x] I am unsure / need advice
 
 ### 📜 Does this require a change to the docs?
 
 <!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
-<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->
+<!-- Tick ONE box and delete the rest. Do not delete this section! -->
 
 The changes in this PR:
 
-- [ ] **⚠️ This is a placeholder, please uncomment at least one of the lines following this one and then delete this. ⚠️**
+- [ ] are internal and do not require a docs change
 
-<!-- - [x] is internal and does not require a docs change -->
+- [ ] are in a state where docs changes are not _yet_ required but will be
 
-<!-- - [x] is in a state where docs changes are not _yet_ required but will be
-  - this is tracked within: [Insert Link Here](link) -->
+  - this is tracked in: [Insert Link Here](link)
 
-<!-- - [x] requires changes to docs
-  - <CHANGES TO DOCS EXPLAINED HERE> -->
+- [ ] require changes to docs which **are made** as part of this PR
+
+- [ ] require changes to docs which are **not** made in this PR
+
+  - _Provide more detail here_
+
+- [x] I am unsure / need advice
 
 ### 🕸️ Does this require a change to the Turbo Graph?
 
 <!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
-<!-- Remove the initial placeholder, and uncomment AT LEAST ONE of these, filling in information as necessary. This MUST be done prior to merging. Do not delete this section! see libs/README.md for info on publishing -->
+<!-- Tick ONE box and delete the rest. Do not delete this section! -->
 
 The changes in this PR:
 
-- [ ] **⚠️ This is a placeholder, please uncomment at least one of the lines following this one and then delete this. ⚠️**
+- [ ] affected the execution graph, and the `turbo.json`'s have been updated to reflect this
 
-<!-- - [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this -->
+- [ ] do not affect the execution graph
 
-<!-- - [x] does not affect the execution graph -->
-
-<!-- - [x] I am unsure / need advice -->
+- [x] I am unsure / need advice
 
 ## ⚠️ Known issues
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We moved the PR template checkboxes from 'check as appropriate and delete the rest' to 'uncomment as appropriate' as it was less likely that PR descriptions ended up with unnecessary checkboxes appearing as tasks to complete in the PR.

Uncommenting the checkboxes is fiddly and annoying, and so this PR goes back to 'check and delete as appropriate'.

At some point GitHub [Tasklists](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-tasklists) feature might stop checkboxes appearing as tasks unless they're explicitly marked as tasks, although in the private beta it currently only applies to Issues, not PRs.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
