### PR TITLE
H-123: Fix loading an entity into a block

### DIFF
--- a/apps/hash-frontend/src/blocks/page/block-context-menu/block-context-menu.tsx
+++ b/apps/hash-frontend/src/blocks/page/block-context-menu/block-context-menu.tsx
@@ -20,11 +20,7 @@ import { FontAwesomeIcon } from "@hashintel/design-system";
 import { isHashTextBlock } from "@local/hash-isomorphic-utils/blocks";
 import { BlockEntity } from "@local/hash-isomorphic-utils/entity";
 import { DraftEntity } from "@local/hash-isomorphic-utils/entity-store";
-import {
-  EntityPropertiesObject,
-  EntityRootType,
-  Subgraph,
-} from "@local/hash-subgraph";
+import { EntityRootType, Subgraph } from "@local/hash-subgraph";
 import { Box, Divider, Menu, Typography } from "@mui/material";
 import { bindMenu } from "material-ui-popup-state";
 import { PopupState } from "material-ui-popup-state/hooks";
@@ -84,26 +80,25 @@ const BlockContextMenu: ForwardRefRenderFunction<
 
   const menuItems = useMemo(() => {
     /** @todo properly type this part of the DraftEntity type https://app.asana.com/0/0/1203099452204542/f */
-    const hasChildEntity =
-      !!(blockEntity?.properties as DraftEntity["properties"] | undefined)
-        ?.entity &&
-      Object.keys(
-        (
-          (blockEntity!.properties as DraftEntity["properties"]).entity as {
-            properties: EntityPropertiesObject;
-          }
-        ).properties,
-      ).length > 0;
+    const hasChildEntityWithData =
+      Object.keys(blockEntity?.blockChildEntity?.properties ?? []).length > 0;
     const items = [
       ...(currentComponentId && !isHashTextBlock(currentComponentId)
         ? [
             {
               key: "set-entity",
-              title: hasChildEntity ? "Swap Entity" : "Add an entity",
+              title: hasChildEntityWithData ? "Swap Entity" : "Add an entity",
               icon: <FontAwesomeIcon icon={faAdd} />,
               subMenu: (
                 <LoadEntityMenuContent
                   blockEntityId={entityId}
+                  childEntityEntityTypeId={
+                    blockEntity?.blockChildEntity?.metadata.entityTypeId ?? null
+                  }
+                  childEntityEntityId={
+                    blockEntity?.blockChildEntity?.metadata.recordId.entityId ??
+                    null
+                  }
                   closeParentContextMenu={() => popupState.close()}
                 />
               ),

--- a/apps/hash-frontend/src/blocks/page/block-context-menu/load-entity-menu-content.tsx
+++ b/apps/hash-frontend/src/blocks/page/block-context-menu/load-entity-menu-content.tsx
@@ -1,14 +1,14 @@
+import { useQuery } from "@apollo/client";
+import { VersionedUrl } from "@blockprotocol/type-system/slim";
 import { faAsterisk, faSearch } from "@fortawesome/free-solid-svg-icons";
 import {
   FontAwesomeIcon,
   LoadingSpinner,
   TextField,
 } from "@hashintel/design-system";
-import {
-  DraftEntity,
-  EntityStoreType,
-} from "@local/hash-isomorphic-utils/entity-store";
-import { EntityId } from "@local/hash-subgraph";
+import { EntityStoreType } from "@local/hash-isomorphic-utils/entity-store";
+import { Entity, EntityId, EntityRootType } from "@local/hash-subgraph";
+import { getRoots } from "@local/hash-subgraph/stdlib";
 import {
   Box,
   InputAdornment,
@@ -26,31 +26,59 @@ import {
   useRef,
 } from "react";
 
+import {
+  QueryEntitiesQuery,
+  QueryEntitiesQueryVariables,
+} from "../../../graphql/api-types.gen";
+import { queryEntitiesQuery } from "../../../graphql/queries/knowledge/entity.queries";
 import { generateEntityLabel } from "../../../lib/entities";
+import { entityHasEntityTypeByBaseUrlFilter } from "../../../shared/filters";
 import { MenuItem } from "../../../shared/ui";
 import { useBlockView } from "../block-view";
 
 type LoadEntityMenuContentProps = {
   blockEntityId: EntityId | null;
+  childEntityEntityTypeId: VersionedUrl | null;
+  childEntityEntityId: EntityId | null;
   closeParentContextMenu: () => void;
   popupState?: PopupState;
 };
 
 export const LoadEntityMenuContent: FunctionComponent<
   LoadEntityMenuContentProps
-> = ({ blockEntityId, closeParentContextMenu, popupState }) => {
+> = ({
+  blockEntityId,
+  childEntityEntityTypeId,
+  childEntityEntityId,
+  closeParentContextMenu,
+  popupState,
+}) => {
+  const { data: queryResult, loading } = useQuery<
+    QueryEntitiesQuery,
+    QueryEntitiesQueryVariables
+  >(queryEntitiesQuery, {
+    variables: {
+      operation: {
+        multiFilter: {
+          filters: [
+            ...(childEntityEntityTypeId
+              ? [entityHasEntityTypeByBaseUrlFilter(childEntityEntityTypeId)]
+              : []),
+          ],
+          operator: "AND",
+        },
+      },
+      constrainsValuesOn: { outgoing: 0 },
+      constrainsPropertiesOn: { outgoing: 0 },
+      constrainsLinksOn: { outgoing: 0 },
+      constrainsLinkDestinationsOn: { outgoing: 0 },
+      isOfType: { outgoing: 1 },
+      hasLeftEntity: { incoming: 0, outgoing: 0 },
+      hasRightEntity: { incoming: 0, outgoing: 0 },
+    },
+  });
+
   const blockView = useBlockView();
-  const loading: boolean = true;
-
-  // This depends on state external to react without subscribing to it
-  // and this can cause some bugs.
-  // @todo make this a subscription
-  // const entityStore = entityStorePluginState(blockView.editorView.state).store;
-
-  // savedEntity and blockEntity are the same. savedEntity variable
-  // is needed to get proper typing on blockEntity
-  // const savedEntity = blockEntityId ? entityStore.saved[blockEntityId] : null;
-  // const blockEntity = isBlockEntity(savedEntity) ? savedEntity : null;
 
   const searchInputRef = useRef<HTMLInputElement>(null);
   const popupWasOpen = useRef<boolean>(false);
@@ -65,10 +93,11 @@ export const LoadEntityMenuContent: FunctionComponent<
   }, [popupState]);
 
   const swapEntity = useCallback(
-    (targetEntity: DraftEntity["properties"]["entity"]) => {
+    (targetEntity: Entity) => {
       if (!blockEntityId) {
         return;
       }
+
       /** @todo properly type this part of the DraftEntity type https://app.asana.com/0/0/1203099452204542/f */
       blockView.manager.replaceBlockChildEntity(
         blockEntityId,
@@ -78,8 +107,31 @@ export const LoadEntityMenuContent: FunctionComponent<
     [blockView, blockEntityId],
   );
 
-  // TODO: get actual entities.
-  const filteredEntities = useMemo(() => [], []);
+  const filteredEntities = useMemo(() => {
+    const uniqueEntityIds = new Set();
+
+    const entities = queryResult?.queryEntities
+      ? getRoots<EntityRootType>(queryResult.queryEntities as any)
+      : [];
+
+    return entities.filter((entity) => {
+      const targetEntityId = entity.metadata.recordId.entityId;
+
+      // don't include the current entity the block is tied to
+      if (targetEntityId === childEntityEntityId) {
+        return false;
+      }
+
+      // don't include duplicates
+      if (uniqueEntityIds.has(targetEntityId)) {
+        return false;
+      }
+
+      uniqueEntityIds.add(targetEntityId);
+
+      return true;
+    });
+  }, [queryResult, childEntityEntityId]);
 
   return (
     <MenuList>
@@ -98,7 +150,7 @@ export const LoadEntityMenuContent: FunctionComponent<
                 <FontAwesomeIcon icon={faSearch} />
               </InputAdornment>
             ),
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- @todo improve logic or types to remove this comment
+
             endAdornment: loading ? (
               <InputAdornment position="start">
                 <LoadingSpinner size={12} thickness={4} />
@@ -107,37 +159,38 @@ export const LoadEntityMenuContent: FunctionComponent<
           }}
         />
       </Box>
-      {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- @todo improve logic or types to remove this comment */}
       {loading ? (
         <Box padding={2}>
           <LoadingSpinner size={16} thickness={4} />
         </Box>
       ) : null}
-      {filteredEntities.map((entity) => {
-        return (
-          <MenuItem
-            key={(entity as any).entityId}
-            onClick={() => {
-              swapEntity(entity);
-              closeParentContextMenu();
-            }}
-          >
-            <ListItemIcon>
-              <FontAwesomeIcon icon={faAsterisk} />
-            </ListItemIcon>
-            <Tooltip
-              title={JSON.stringify((entity as any).properties, undefined, 2)}
+      {queryResult &&
+        filteredEntities.map((entity) => {
+          return (
+            <MenuItem
+              key={entity.metadata.recordId.entityId}
+              onClick={() => {
+                swapEntity(entity);
+                closeParentContextMenu();
+              }}
             >
-              <ListItemText
-                primary={generateEntityLabel(entity)}
-                primaryTypographyProps={{
-                  noWrap: true,
-                }}
-              />
-            </Tooltip>
-          </MenuItem>
-        );
-      })}
+              <ListItemIcon>
+                <FontAwesomeIcon icon={faAsterisk} />
+              </ListItemIcon>
+              <Tooltip title={JSON.stringify(entity.properties, undefined, 2)}>
+                <ListItemText
+                  primary={generateEntityLabel(
+                    queryResult.queryEntities as any,
+                    entity,
+                  )}
+                  primaryTypographyProps={{
+                    noWrap: true,
+                  }}
+                />
+              </Tooltip>
+            </MenuItem>
+          );
+        })}
     </MenuList>
   );
 };

--- a/apps/hash-frontend/src/blocks/page/block-handle.tsx
+++ b/apps/hash-frontend/src/blocks/page/block-handle.tsx
@@ -55,12 +55,12 @@ const BlockHandle: ForwardRefRenderFunction<
 
   const updateChildEntity = (properties: JsonObject) => {
     /** @todo properly type this part of the DraftEntity type https://app.asana.com/0/0/1203099452204542/f */
-    const childEntity = blockEntity?.properties.entity;
+    const childEntity = blockEntity?.blockChildEntity;
     if (!childEntity) {
       throw new Error(`No child entity on block to update`);
     }
     blockView.manager.updateEntityProperties(
-      childEntity.metadata.recordId.entityId!,
+      childEntity.metadata.recordId.entityId,
       properties,
     );
   };

--- a/apps/hash-frontend/src/blocks/page/block-view.tsx
+++ b/apps/hash-frontend/src/blocks/page/block-view.tsx
@@ -368,7 +368,7 @@ export class BlockView implements NodeView {
         .insertBlock(blockMeta.componentId, variant, newPosition)
         .then(({ tr }) => {
           /**
-           * calculate nextPosition to correctly focus the to the component inside, not the wrapper
+           * calculate nextPosition to correctly focus the component inside, not the wrapper
            * */
           const $pos = tr.doc.resolve(newPosition + 1);
           const nextPosition = findComponentNode(

--- a/apps/hash-frontend/src/blocks/page/create-suggester/create-suggester.tsx
+++ b/apps/hash-frontend/src/blocks/page/create-suggester/create-suggester.tsx
@@ -354,7 +354,7 @@ export const createSuggester = (
                   },
                 ]}
                 anchorEl={anchorNode}
-                style={{ zIndex: 1 }}
+                style={{ zIndex: 2000 }}
               >
                 {jsx}
               </Popper>,

--- a/apps/hash-frontend/src/blocks/page/create-suggester/use-filtered-blocks.tsx
+++ b/apps/hash-frontend/src/blocks/page/create-suggester/use-filtered-blocks.tsx
@@ -14,15 +14,20 @@ export const useFilteredBlocks = (
   compatibleBlocks: HashBlock[],
 ) => {
   return useMemo(() => {
-    const allOptions: Option[] = compatibleBlocks.flatMap(({ meta }) =>
-      // Assumes that variants have been built for all blocks in toBlockConfig
-      // any required changes to block metadata should happen there
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- improve logic or types to remove this comment
-      (meta.variants ?? []).map((variant) => ({
-        variant,
-        meta,
-      })),
-    );
+    const allOptions: Option[] = compatibleBlocks
+      .sort(
+        (a, b) =>
+          a.meta.displayName?.localeCompare(b.meta.displayName ?? "") ?? 0,
+      )
+      .flatMap(({ meta }) =>
+        // Assumes that variants have been built for all blocks in toBlockConfig
+        // any required changes to block metadata should happen there
+
+        meta.variants.map((variant) => ({
+          variant,
+          meta,
+        })),
+      );
 
     return fuzzySearchBy(
       allOptions,

--- a/apps/hash-frontend/src/pages/[shortname]/[page-slug].page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/[page-slug].page.tsx
@@ -374,7 +374,7 @@ const Page: NextPageWithLayout<PageProps> = ({
   return (
     <>
       <Head>
-        <title>{pageTitle} | Page | HASH</title>
+        <title>{pageTitle || "Untitled"} | HASH</title>
 
         {/*
           Rendering favicon.png again even if it's already defined on _document.page.tsx,

--- a/apps/hash-frontend/src/shared/filters.tsx
+++ b/apps/hash-frontend/src/shared/filters.tsx
@@ -1,5 +1,5 @@
 import { MultiFilter } from "@blockprotocol/graph";
-import { VersionedUrl } from "@blockprotocol/type-system";
+import { extractBaseUrl, VersionedUrl } from "@blockprotocol/type-system";
 
 type Filter = NonNullable<MultiFilter["filters"]>[number];
 
@@ -9,4 +9,12 @@ export const entityHasEntityTypeByVersionedUrlFilter = (
   field: ["metadata", "entityTypeId"],
   operator: "EQUALS",
   value: entityTypeId,
+});
+
+export const entityHasEntityTypeByBaseUrlFilter = (
+  entityTypeId: VersionedUrl,
+): Filter => ({
+  field: ["metadata", "entityTypeBaseUrl"],
+  operator: "EQUALS",
+  value: extractBaseUrl(entityTypeId),
 });

--- a/libs/@local/hash-isomorphic-utils/src/entity-store-plugin.ts
+++ b/libs/@local/hash-isomorphic-utils/src/entity-store-plugin.ts
@@ -193,8 +193,7 @@ const setBlockChildEntity = (
     targetEntity.metadata.recordId.entityId,
   );
 
-  // Add target entity to draft store if it is not
-  // present there
+  // Add target entity to draft store if it is not present there
   // @todo consider moving this to ProseMirrorSchemaManager.updateBlockData
   if (!targetDraftEntity) {
     const targetEntityDraftId = generateDraftIdForEntity(
@@ -223,7 +222,8 @@ const setBlockChildEntity = (
     );
   }
 
-  draftBlockEntity.properties.entity = targetDraftEntity;
+  // @todo sort out entity store types – search https://app.asana.com/0/0/1203099452204542/f
+  draftBlockEntity.blockChildEntity = targetDraftEntity as any;
 };
 
 /**
@@ -577,13 +577,13 @@ class ProsemirrorStateChangeHandler {
     // Block -> Entity -> Entity -> Component node
     //  firstChild refers to ^
     //  firstchild.firstChild refers to  ^
-    // and we'd like to update the child entity's text contents approrpiately.
+    // and we'd like to update the child entity's text contents appropriately.
 
     if (
       isTextEntity(childEntity) &&
       node.firstChild &&
       node.firstChild.firstChild &&
-      // Check if the next next entity node's child is a component node
+      // Check if the next entity node's child is a component node
       isComponentNode(node.firstChild.firstChild)
     ) {
       const nextProps = textBlockNodeToEntityProperties(node.firstChild);

--- a/libs/@local/hash-isomorphic-utils/src/entity-store.ts
+++ b/libs/@local/hash-isomorphic-utils/src/entity-store.ts
@@ -32,7 +32,7 @@ export type DraftEntity<Type extends EntityStoreType = EntityStoreType> = {
   };
   /** @todo properly type this part of the DraftEntity type https://app.asana.com/0/0/1203099452204542/f */
   blockChildEntity?: Type & { draftId?: string };
-  properties: EntityPropertiesObject & { entity?: DraftEntity };
+  properties: EntityPropertiesObject;
   linkData?: LinkData;
 
   componentId?: string;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes a few bugs / broken features – one commit each.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Makes the 'add / swap entity in block' context menu item functional. Currently limited to the same entity type as the block (any version)
- Sorts the block list alphabetically in the block selector
- Fixes the z-index of the block selector (it could be covered by the page header)
- Use 'Untitled' as a fallback in the HTML title

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Load two blocks of the same type in a page. Put data in one. Try loading that entity into the other

## 📹 Demo

https://github.com/hashintel/hash/assets/37743469/34a94d56-b88b-40c7-a4b7-6dac50bf81bd


<!-- Add a screenshot or video showcasing your work -->
