### PR TITLE
H-149: Hide hotkey cheat sheet

### DIFF
--- a/apps/hash-frontend/src/shared/command-bar.tsx
+++ b/apps/hash-frontend/src/shared/command-bar.tsx
@@ -32,7 +32,7 @@ import { useKeys } from "rooks";
 import { useAccountPages } from "../components/hooks/use-account-pages";
 import { useCreatePage } from "../components/hooks/use-create-page";
 import { WorkspaceContext } from "../pages/shared/workspace-context";
-import { CheatSheet } from "./command-bar/cheat-sheet";
+// import { CheatSheet } from "./command-bar/cheat-sheet";
 import {
   // childMenu,
   CommandBarOption,
@@ -501,7 +501,7 @@ export const CommandBar: FunctionComponent = () => {
           </CustomScreenContext.Provider>
         </CenterContainer>
       </Modal>
-      <CheatSheet />
+      {/* <CheatSheet /> */}
     </>
   );
 };

--- a/apps/hash-frontend/src/shared/command-bar/cheat-sheet.tsx
+++ b/apps/hash-frontend/src/shared/command-bar/cheat-sheet.tsx
@@ -35,7 +35,11 @@ export const CheatSheet = () => {
     ["?"],
     (evt) => {
       // Hack to detect if pressed inside an input or textarea
-      if (!("defaultValue" in (evt.target as any))) {
+      if (
+        evt.target &&
+        !("defaultValue" in evt.target) &&
+        !(evt.target as HTMLElement).isContentEditable
+      ) {
         setOpen(true);
       }
     },

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar.tsx
@@ -68,7 +68,6 @@ export const PageSidebar: FunctionComponent = () => {
         icon={faHome}
         title="Home"
         href="/"
-        tooltipTitle="View your inbox and latest activity"
         active={router.pathname === "/[shortname]"}
       />
       {/* 

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar.tsx
@@ -68,6 +68,7 @@ export const PageSidebar: FunctionComponent = () => {
         icon={faHome}
         title="Home"
         href="/"
+        tooltipTitle=""
         active={router.pathname === "/[shortname]"}
       />
       {/* 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

There's a command bar which appears if you hit cmd/ctrl + K. There's also a hotkey cheat sheet which appears if you press ?. This happens even if you press ? inside contenteditables, which is not the desired behaviour.

This PR fixes that bug, but also hides the cheat sheet entirely, as it doesn't serve much purpose at the moment, since the hot keys are already shown on the command bar. Its use would be to be able to display _all_ hot keys, even ones which are not applicable in the current context, but since we don't have many at the moment and the cheat sheet requires styling, it's not worth it.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
