### PR TITLE
H-156: Adjust database to support label properties for entity types

### DIFF
--- a/apps/hash-graph/lib/graph/src/snapshot/ontology/entity_type/channel.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/ontology/entity_type/channel.rs
@@ -76,6 +76,10 @@ impl Sink<OntologyTypeSnapshotRecord<EntityType>> for EntityTypeSender {
         Poll::Ready(Ok(()))
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Add better functions to the `type-system` crate to easier read link mappings"
+    )]
     fn start_send(
         mut self: Pin<&mut Self>,
         entity_type: OntologyTypeSnapshotRecord<EntityType>,
@@ -181,13 +185,11 @@ impl Sink<OntologyTypeSnapshotRecord<EntityType>> for EntityTypeSender {
             .start_send_unpin(EntityTypeRow {
                 ontology_id,
                 schema: Json(schema.into()),
-                // TODO: Add label property to database
-                //   see https://linear.app/hash/issue/H-156
-                // label_property: entity_type
-                //     .metadata
-                //     .custom
-                //     .label_property
-                //     .map(|label_property| label_property.to_string()),
+                label_property: entity_type
+                    .metadata
+                    .custom
+                    .label_property
+                    .map(|label_property| label_property.to_string()),
             })
             .into_report()
             .change_context(SnapshotRestoreError::Read)

--- a/apps/hash-graph/lib/graph/src/snapshot/ontology/table.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/ontology/table.rs
@@ -70,9 +70,7 @@ pub struct PropertyTypeConstrainsPropertiesOnRow {
 pub struct EntityTypeRow {
     pub ontology_id: Uuid,
     pub schema: Json<repr::EntityType>,
-    // TODO: Add label property to database
-    //   see https://linear.app/hash/issue/H-156
-    // pub label_property: Option<String>,
+    pub label_property: Option<String>,
 }
 
 #[derive(Debug, ToSql)]

--- a/apps/hash-graph/postgres_migrations/V9__label_property.sql
+++ b/apps/hash-graph/postgres_migrations/V9__label_property.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+  entity_types
+ADD COLUMN
+  "label_property" TEXT REFERENCES "base_urls";


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds the `label_property` column to the entity type database table

## 🚫 Blocked by

- #2775 
- #2778 

## 🔍 What does this change?

- Adds the `label_property` column to the entity type database table
- Adjust the snapshot API to allow the backend integration tests to continue passing. This is currently the only location where it's possible to write the label property. A follow-up PR will expose this to the REST API as well.

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph