### PR TITLE
H-157: Expose label property from the Database to the Graph API

### DIFF
--- a/apps/hash-graph/bin/cli/src/subcommand/server.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/server.rs
@@ -13,7 +13,8 @@ use graph::{
     identifier::account::AccountId,
     logging::{init_logger, LoggingArgs},
     ontology::{
-        domain_validator::DomainValidator, CustomOntologyMetadata, OntologyElementMetadata,
+        domain_validator::DomainValidator, CustomEntityTypeMetadata, CustomOntologyMetadata,
+        EntityTypeMetadata, OntologyElementMetadata,
     },
     provenance::{ProvenanceMetadata, RecordCreatedById},
     store::{
@@ -273,12 +274,15 @@ async fn stop_gap_setup(pool: &PostgresStorePool<NoTls>) -> Result<(), GraphErro
         Vec::default(),
     );
 
-    let link_entity_type_metadata = OntologyElementMetadata {
+    let link_entity_type_metadata = EntityTypeMetadata {
         record_id: link_entity_type.id().clone().into(),
-        custom: CustomOntologyMetadata::External {
-            provenance: ProvenanceMetadata::new(RecordCreatedById::new(root_account_id)),
-            temporal_versioning: None,
-            fetched_at: OffsetDateTime::now_utc(),
+        custom: CustomEntityTypeMetadata {
+            common: CustomOntologyMetadata::External {
+                provenance: ProvenanceMetadata::new(RecordCreatedById::new(root_account_id)),
+                temporal_versioning: None,
+                fetched_at: OffsetDateTime::now_utc(),
+            },
+            label_property: None,
         },
     };
 

--- a/apps/hash-graph/lib/graph/src/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/entity_type.rs
@@ -168,6 +168,10 @@ pub enum EntityTypeQueryPath<'p> {
     ///
     /// [`EntityType::required()`]: type_system::EntityType::required
     Required,
+    /// The label property metadata of the entity type.
+    ///
+    /// Only used internally and not available for deserialization, yet.
+    LabelProperty,
     /// An edge to a [`PropertyType`] using an [`OntologyEdgeKind`].
     ///
     /// The corresponding reversed edge is [`PropertyTypeQueryPath::EntityTypeEdge`].
@@ -342,7 +346,7 @@ impl QueryPath for EntityTypeQueryPath<'_> {
             Self::Schema(_) | Self::AdditionalMetadata(_) | Self::Examples | Self::Required => {
                 ParameterType::Any
             }
-            Self::BaseUrl => ParameterType::BaseUrl,
+            Self::BaseUrl | Self::LabelProperty => ParameterType::BaseUrl,
             Self::VersionedUrl => ParameterType::VersionedUrl,
             Self::Version => ParameterType::OntologyTypeVersion,
             Self::TransactionTime => ParameterType::TimeInterval,
@@ -370,6 +374,7 @@ impl fmt::Display for EntityTypeQueryPath<'_> {
             Self::Description => fmt.write_str("description"),
             Self::Examples => fmt.write_str("examples"),
             Self::Required => fmt.write_str("required"),
+            Self::LabelProperty => fmt.write_str("labelProperty"),
             Self::PropertyTypeEdge {
                 edge_kind: OntologyEdgeKind::ConstrainsPropertiesOn,
                 path,

--- a/apps/hash-graph/lib/graph/src/store/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/store/ontology.rs
@@ -2,11 +2,11 @@ use std::{borrow::Borrow, iter};
 
 use async_trait::async_trait;
 use error_stack::Result;
-use type_system::{DataType, EntityType, PropertyType};
+use type_system::{url::BaseUrl, DataType, EntityType, PropertyType};
 
 use crate::{
     ontology::{
-        DataTypeWithMetadata, EntityTypeWithMetadata, OntologyElementMetadata,
+        DataTypeWithMetadata, EntityTypeMetadata, EntityTypeWithMetadata, OntologyElementMetadata,
         PropertyTypeWithMetadata,
     },
     provenance::RecordCreatedById,
@@ -149,7 +149,7 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     async fn create_entity_type(
         &mut self,
         schema: EntityType,
-        metadata: &OntologyElementMetadata,
+        metadata: &EntityTypeMetadata,
     ) -> Result<(), InsertionError> {
         self.create_entity_types(iter::once((schema, metadata)), ConflictBehavior::Fail)
             .await
@@ -166,10 +166,7 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     async fn create_entity_types(
         &mut self,
         entity_types: impl IntoIterator<
-            Item = (
-                EntityType,
-                impl Borrow<OntologyElementMetadata> + Send + Sync,
-            ),
+            Item = (EntityType, impl Borrow<EntityTypeMetadata> + Send + Sync),
             IntoIter: Send,
         > + Send,
         on_conflict: ConflictBehavior,
@@ -194,5 +191,6 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
         &mut self,
         entity_type: EntityType,
         actor_id: RecordCreatedById,
-    ) -> Result<OntologyElementMetadata, UpdateError>;
+        label_property: Option<BaseUrl>,
+    ) -> Result<EntityTypeMetadata, UpdateError>;
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -3,12 +3,15 @@ use std::{borrow::Borrow, collections::HashMap};
 use async_trait::async_trait;
 use error_stack::{IntoReport, Report, Result, ResultExt};
 use futures::{stream, TryStreamExt};
-use type_system::EntityType;
+use type_system::{url::BaseUrl, EntityType};
 
 use crate::{
-    identifier::time::RightBoundedTemporalInterval,
-    ontology::{EntityTypeWithMetadata, OntologyElementMetadata},
-    provenance::RecordCreatedById,
+    identifier::{ontology::OntologyTypeRecordId, time::RightBoundedTemporalInterval},
+    ontology::{
+        CustomEntityTypeMetadata, CustomOntologyMetadata, EntityTypeMetadata,
+        EntityTypeWithMetadata, OntologyElementMetadata,
+    },
+    provenance::{ProvenanceMetadata, RecordCreatedById},
     store::{
         crud::Read,
         error::DeletionError,
@@ -193,10 +196,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
     async fn create_entity_types(
         &mut self,
         entity_types: impl IntoIterator<
-            Item = (
-                EntityType,
-                impl Borrow<OntologyElementMetadata> + Send + Sync,
-            ),
+            Item = (EntityType, impl Borrow<EntityTypeMetadata> + Send + Sync),
             IntoIter: Send,
         > + Send,
         on_conflict: ConflictBehavior,
@@ -206,10 +206,23 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
 
         let mut inserted_entity_types = Vec::with_capacity(entity_types.size_hint().0);
         for (schema, metadata) in entity_types {
+            let metadata = metadata.borrow();
+            let ontology_metadata = OntologyElementMetadata {
+                record_id: metadata.record_id.clone(),
+                custom: metadata.custom.common.clone(),
+            };
             if let Some(ontology_id) = transaction
-                .create(schema.clone(), metadata.borrow(), on_conflict)
+                .create_ontology_metadata(&ontology_metadata, on_conflict)
                 .await?
             {
+                transaction
+                    .insert_entity_type_with_id(
+                        ontology_id,
+                        schema.clone(),
+                        metadata.custom.label_property.as_ref(),
+                    )
+                    .await?;
+
                 inserted_entity_types.push((ontology_id, schema));
             }
         }
@@ -300,15 +313,32 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         &mut self,
         entity_type: EntityType,
         record_created_by_id: RecordCreatedById,
-    ) -> Result<OntologyElementMetadata, UpdateError> {
+        label_property: Option<BaseUrl>,
+    ) -> Result<EntityTypeMetadata, UpdateError> {
         let transaction = self.transaction().await.change_context(UpdateError)?;
 
-        // This clone is currently necessary because we extract the references as we insert them.
-        // We can only insert them after the type has been created, and so we currently extract them
-        // after as well. See `insert_entity_type_references` taking `&entity_type`
-        let (ontology_id, metadata) = transaction
-            .update::<EntityType>(entity_type.clone(), record_created_by_id)
+        let url = entity_type.id();
+        let record_id = OntologyTypeRecordId::from(url.clone());
+
+        let (ontology_id, owned_by_id) = transaction
+            .update_owned_ontology_id(url, record_created_by_id)
             .await?;
+        transaction
+            .insert_entity_type_with_id(ontology_id, entity_type.clone(), label_property.as_ref())
+            .await
+            .change_context(UpdateError)?;
+
+        let metadata = EntityTypeMetadata {
+            record_id,
+            custom: CustomEntityTypeMetadata {
+                common: CustomOntologyMetadata::Owned {
+                    provenance: ProvenanceMetadata::new(record_created_by_id),
+                    owned_by_id,
+                    temporal_versioning: None,
+                },
+                label_property,
+            },
+        };
 
         transaction
             .insert_entity_type_references(&entity_type, ontology_id)

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -190,9 +190,13 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         let mut inserted_property_types = Vec::with_capacity(property_types.size_hint().0);
         for (schema, metadata) in property_types {
             if let Some(ontology_id) = transaction
-                .create(schema.clone(), metadata.borrow(), on_conflict)
+                .create_ontology_metadata(metadata.borrow(), on_conflict)
                 .await?
             {
+                transaction
+                    .insert_with_id(ontology_id, schema.clone())
+                    .await?;
+
                 inserted_property_types.push((ontology_id, schema));
             }
         }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
@@ -25,6 +25,7 @@ impl PostgresQueryPath for EntityTypeQueryPath<'_> {
             | Self::Examples
             | Self::Required
             | Self::OntologyId
+            | Self::LabelProperty
             | Self::Schema(_) => vec![],
             Self::BaseUrl
             | Self::Version
@@ -116,6 +117,7 @@ impl PostgresQueryPath for EntityTypeQueryPath<'_> {
             Self::Required => {
                 Column::EntityTypes(EntityTypes::Schema(Some(JsonField::StaticText("required"))))
             }
+            Self::LabelProperty => Column::EntityTypes(EntityTypes::LabelProperty),
             Self::PropertyTypeEdge { path, .. } => path.terminating_column(),
             Self::EntityTypeEdge { path, .. } => path.terminating_column(),
             Self::EntityEdge { path, .. } => path.terminating_column(),

--- a/apps/hash-graph/tests/integration/postgres/lib.rs
+++ b/apps/hash-graph/tests/integration/postgres/lib.rs
@@ -27,8 +27,9 @@ use graph::{
         LinkData,
     },
     ontology::{
-        CustomOntologyMetadata, DataTypeWithMetadata, EntityTypeQueryPath, EntityTypeWithMetadata,
-        OntologyElementMetadata, PropertyTypeWithMetadata,
+        CustomEntityTypeMetadata, CustomOntologyMetadata, DataTypeWithMetadata, EntityTypeMetadata,
+        EntityTypeQueryPath, EntityTypeWithMetadata, OntologyElementMetadata,
+        PropertyTypeWithMetadata,
     },
     provenance::{OwnedById, ProvenanceMetadata, RecordCreatedById},
     store::{
@@ -170,12 +171,15 @@ impl DatabaseTestWrapper {
             let entity_type =
                 EntityType::try_from(entity_type_repr).expect("could not parse entity type");
 
-            let metadata = OntologyElementMetadata {
+            let metadata = EntityTypeMetadata {
                 record_id: entity_type.id().clone().into(),
-                custom: CustomOntologyMetadata::Owned {
-                    provenance: ProvenanceMetadata::new(RecordCreatedById::new(account_id)),
-                    temporal_versioning: None,
-                    owned_by_id: OwnedById::new(account_id),
+                custom: CustomEntityTypeMetadata {
+                    common: CustomOntologyMetadata::Owned {
+                        provenance: ProvenanceMetadata::new(RecordCreatedById::new(account_id)),
+                        temporal_versioning: None,
+                        owned_by_id: OwnedById::new(account_id),
+                    },
+                    label_property: None,
                 },
             };
 
@@ -329,13 +333,16 @@ impl DatabaseApi<'_> {
     pub async fn create_entity_type(
         &mut self,
         entity_type: EntityType,
-    ) -> Result<OntologyElementMetadata, InsertionError> {
-        let metadata = OntologyElementMetadata {
+    ) -> Result<EntityTypeMetadata, InsertionError> {
+        let metadata = EntityTypeMetadata {
             record_id: entity_type.id().clone().into(),
-            custom: CustomOntologyMetadata::Owned {
-                provenance: ProvenanceMetadata::new(RecordCreatedById::new(self.account_id)),
-                temporal_versioning: None,
-                owned_by_id: OwnedById::new(self.account_id),
+            custom: CustomEntityTypeMetadata {
+                common: CustomOntologyMetadata::Owned {
+                    provenance: ProvenanceMetadata::new(RecordCreatedById::new(self.account_id)),
+                    temporal_versioning: None,
+                    owned_by_id: OwnedById::new(self.account_id),
+                },
+                label_property: None,
             },
         };
 
@@ -373,9 +380,9 @@ impl DatabaseApi<'_> {
     pub async fn update_entity_type(
         &mut self,
         entity_type: EntityType,
-    ) -> Result<OntologyElementMetadata, UpdateError> {
+    ) -> Result<EntityTypeMetadata, UpdateError> {
         self.store
-            .update_entity_type(entity_type, RecordCreatedById::new(self.account_id))
+            .update_entity_type(entity_type, RecordCreatedById::new(self.account_id), None)
             .await
     }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The database was adjusted in H-156, this PR adjusts the Graph API to allow reading/writing the new property.

## 🚫 Blocked by

- #2775 
- #2775 
- #2782 

## 🔍 What does this change?

- Make the Query Compiler aware of the new metadata field
- Adjust the creation and updating methods for entity types to include the newly added metadata field
## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph