### PR TITLE
H-159: Add support to query entity types by label in Structural Queries

### DIFF
--- a/apps/hash-graph/lib/graph/src/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/entity_type.rs
@@ -170,7 +170,14 @@ pub enum EntityTypeQueryPath<'p> {
     Required,
     /// The label property metadata of the entity type.
     ///
-    /// Only used internally and not available for deserialization, yet.
+    /// ```rust
+    /// # use serde::Deserialize;
+    /// # use serde_json::json;
+    /// # use graph::ontology::EntityTypeQueryPath;
+    /// let path = EntityTypeQueryPath::deserialize(json!(["labelProperty"]))?;
+    /// assert_eq!(path, EntityTypeQueryPath::LabelProperty);
+    /// # Ok::<(), serde_json::Error>(())
+    /// ```
     LabelProperty,
     /// An edge to a [`PropertyType`] using an [`OntologyEdgeKind`].
     ///
@@ -435,6 +442,7 @@ pub enum EntityTypeQueryToken {
     Examples,
     Properties,
     Required,
+    LabelProperty,
     Links,
     InheritsFrom,
     #[serde(skip)]
@@ -448,9 +456,10 @@ pub struct EntityTypeQueryPathVisitor {
 }
 
 impl EntityTypeQueryPathVisitor {
-    pub const EXPECTING: &'static str =
-        "one of `baseUrl`, `version`, `versionedUrl`, `ownedById`, `recordCreatedById`, `title`, \
-         `description`, `examples`, `properties`, `required`, `links`, `inheritsFrom`";
+    pub const EXPECTING: &'static str = "one of `baseUrl`, `version`, `versionedUrl`, \
+                                         `ownedById`, `recordCreatedById`, `title`, \
+                                         `description`, `examples`, `properties`, `required`, \
+                                         `labelProperty`, `links`, `inheritsFrom`";
 
     #[must_use]
     pub const fn new(position: usize) -> Self {
@@ -494,6 +503,7 @@ impl<'de> Visitor<'de> for EntityTypeQueryPathVisitor {
                 }
             }
             EntityTypeQueryToken::Required => EntityTypeQueryPath::Required,
+            EntityTypeQueryToken::LabelProperty => EntityTypeQueryPath::LabelProperty,
             EntityTypeQueryToken::Links => {
                 seq.next_element::<Selector>()?
                     .ok_or_else(|| de::Error::invalid_length(self.position, &self))?;

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -1224,6 +1224,7 @@
           "examples",
           "properties",
           "required",
+          "labelProperty",
           "links",
           "inheritsFrom"
         ]

--- a/apps/hash-graph/tests/friendship.http
+++ b/apps/hash-graph/tests/friendship.http
@@ -684,20 +684,89 @@ Content-Type: application/json
     "variable": {
       "axis": "decisionTime",
       "interval": {
-          "start": {
+        "start": {
           "kind": "unbounded"
-          },
-          "end": null
+        },
+        "end": null
       }
     }
   }
 }
 
 > {%
-    client.test("status", function() {
-        client.assert(response.status === 200, "Response status is not 200");
-        client.assert(response.body.roots.length === 3, "Unexpected number of entity types");
-    });
+  client.test("status", function() {
+    client.assert(response.status === 200, "Response status is not 200");
+    client.assert(response.body.roots.length === 3, "Unexpected number of entity types");
+  });
+%}
+
+### Get entity types by label property
+POST http://127.0.0.1:4000/entity-types/query
+Content-Type: application/json
+
+{
+  "filter": {
+    "equal": [
+      {
+        "path": [
+          "labelProperty"
+        ]
+      },
+      {
+        "parameter": "http://localhost:3000/@alice/types/property-type/name/"
+      }
+    ]
+  },
+  "graphResolveDepths": {
+    "inheritsFrom": {
+      "outgoing": 0
+    },
+    "constrainsValuesOn": {
+      "outgoing": 0
+    },
+    "constrainsPropertiesOn": {
+      "outgoing": 0
+    },
+    "constrainsLinksOn": {
+      "outgoing": 0
+    },
+    "constrainsLinkDestinationsOn": {
+      "outgoing": 0
+    },
+    "isOfType": {
+      "outgoing": 0
+    },
+    "hasLeftEntity": {
+      "incoming": 0,
+      "outgoing": 0
+    },
+    "hasRightEntity": {
+      "incoming": 0,
+      "outgoing": 0
+    }
+  },
+  "temporalAxes": {
+    "pinned": {
+      "axis": "transactionTime",
+      "timestamp": null
+    },
+    "variable": {
+      "axis": "decisionTime",
+      "interval": {
+        "start": {
+          "kind": "unbounded"
+        },
+        "end": null
+      }
+    }
+  }
+}
+
+> {%
+  client.test("status", function() {
+    client.assert(response.status === 200, "Response status is not 200");
+    client.assert(response.body.roots.length === 1, "Unexpected number of entity types");
+  });
 %}
 
 ### Get all link entity type


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Exposes the `labelProperty` metadata as query parameter

## 🚫 Blocked by

- #2775 
- #2778 
- #2782 
- #2783 
- #2784 

## 🔍 What does this change?

- Allow `labelProperty` in structure queries
- Add a doc-test
- Add REST endpoint test

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph