### PR TITLE
H-141: Expose `labelProperty` to GraphQL

### DIFF
--- a/apps/hash-api/src/graph/ontology/primitive/entity-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/entity-type.ts
@@ -1,4 +1,5 @@
 import {
+  BaseUrl,
   ENTITY_TYPE_META_SCHEMA,
   VersionedUrl,
 } from "@blockprotocol/type-system";
@@ -44,10 +45,11 @@ export const createEntityType: ImpureGraphFunction<
     ownedById: OwnedById;
     schema: ConstructEntityTypeParams;
     actorId: AccountId;
+    labelProperty?: BaseUrl;
   },
   Promise<EntityTypeWithMetadata>
 > = async (ctx, params) => {
-  const { ownedById, actorId } = params;
+  const { ownedById, actorId, labelProperty } = params;
   const namespace = await getNamespaceOfAccountOwner(ctx, {
     ownerId: params.ownedById,
   });
@@ -71,6 +73,7 @@ export const createEntityType: ImpureGraphFunction<
     actorId,
     ownedById,
     schema,
+    labelProperty,
   });
 
   return { schema, metadata: metadata as EntityTypeMetadata };
@@ -176,10 +179,11 @@ export const updateEntityType: ImpureGraphFunction<
     entityTypeId: VersionedUrl;
     schema: ConstructEntityTypeParams;
     actorId: AccountId;
+    labelProperty?: BaseUrl;
   },
   Promise<EntityTypeWithMetadata>
 > = async ({ graphApi }, params) => {
-  const { entityTypeId, schema, actorId } = params;
+  const { entityTypeId, schema, actorId, labelProperty } = params;
   const updateArguments: UpdateEntityTypeRequest = {
     actorId,
     typeToUpdate: entityTypeId,
@@ -188,6 +192,7 @@ export const updateEntityType: ImpureGraphFunction<
       $schema: ENTITY_TYPE_META_SCHEMA,
       ...schema,
     },
+    labelProperty,
   };
 
   const { data: metadata } = await graphApi.updateEntityType(updateArguments);
@@ -201,7 +206,7 @@ export const updateEntityType: ImpureGraphFunction<
       ...schema,
       $id: ontologyTypeRecordIdToVersionedUrl(recordId as OntologyTypeRecordId),
     },
-    metadata: metadata as OntologyElementMetadata,
+    metadata: metadata as EntityTypeMetadata,
   };
 };
 

--- a/apps/hash-api/src/graph/ontology/primitive/entity-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/entity-type.ts
@@ -16,7 +16,6 @@ import {
   EntityTypeRootType,
   EntityTypeWithMetadata,
   linkEntityTypeUrl,
-  OntologyElementMetadata,
   OntologyTypeRecordId,
   ontologyTypeRecordIdToVersionedUrl,
   OwnedById,

--- a/libs/@local/hash-graphql-shared/src/graphql/scalar-mapping.ts
+++ b/libs/@local/hash-graphql-shared/src/graphql/scalar-mapping.ts
@@ -1,4 +1,6 @@
 export const scalars = {
+  BaseUrl: "@blockprotocol/type-system#BaseUrl",
+
   Date: "string",
 
   JSONObject: "@blockprotocol/core#JsonObject",

--- a/libs/@local/hash-graphql-shared/src/graphql/type-defs/ontology/entity-type.typedef.ts
+++ b/libs/@local/hash-graphql-shared/src/graphql/type-defs/ontology/entity-type.typedef.ts
@@ -3,6 +3,7 @@ import { gql } from "apollo-server-express";
 export const entityTypeTypedef = gql`
   scalar ConstructEntityTypeParams
   scalar EntityTypeWithMetadata
+  scalar BaseUrl
 
   extend type Query {
     """
@@ -38,6 +39,10 @@ export const entityTypeTypedef = gql`
       """
       ownedById: OwnedById
       entityType: ConstructEntityTypeParams!
+      """
+      The label which is used as the label property for the entity type.
+      """
+      labelProperty: BaseUrl
     ): EntityTypeWithMetadata!
 
     """
@@ -52,6 +57,10 @@ export const entityTypeTypedef = gql`
       New entity type schema contents to be used.
       """
       updatedEntityType: ConstructEntityTypeParams!
+      """
+      The label which is used as the label property for the entity type.
+      """
+      labelProperty: BaseUrl
     ): EntityTypeWithMetadata!
   }
 `;

--- a/libs/@local/hash-graphql-shared/src/graphql/type-defs/ontology/entity-type.typedef.ts
+++ b/libs/@local/hash-graphql-shared/src/graphql/type-defs/ontology/entity-type.typedef.ts
@@ -40,7 +40,7 @@ export const entityTypeTypedef = gql`
       ownedById: OwnedById
       entityType: ConstructEntityTypeParams!
       """
-      The label which is used as the label property for the entity type.
+      The property which should be used as the label for entities of this type.
       """
       labelProperty: BaseUrl
     ): EntityTypeWithMetadata!
@@ -58,7 +58,7 @@ export const entityTypeTypedef = gql`
       """
       updatedEntityType: ConstructEntityTypeParams!
       """
-      The label which is used as the label property for the entity type.
+      The property which should be used as the label for entities of this type.
       """
       labelProperty: BaseUrl
     ): EntityTypeWithMetadata!


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The HASH Backend is aware of the label property. In order to make it available to the frontend, it has to be exposed to GraphQL.

## 🚫 Blocked by

- #2775 
- #2778 
- #2782 
- #2783 
- #2784 
- #2785 

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph