### PR TITLE
H-196: Provide functionality to list existing Linear teams

### DIFF
--- a/apps/hash-api/package.json
+++ b/apps/hash-api/package.json
@@ -23,6 +23,7 @@
     "@blockprotocol/core": "0.1.2",
     "@blockprotocol/type-system": "0.1.1",
     "@graphql-tools/schema": "8.5.0",
+    "@linear/sdk": "6.0.0",
     "@local/advanced-types": "0.0.0-private",
     "@local/hash-backend-utils": "0.0.0-private",
     "@local/hash-graph-client": "0.0.0-private",

--- a/apps/hash-api/src/integrations/linear.ts
+++ b/apps/hash-api/src/integrations/linear.ts
@@ -1,0 +1,19 @@
+import { Team } from "@linear/sdk";
+
+import { TemporalClient } from "../temporal";
+import { genId } from "../util";
+
+export class Linear {
+  private readonly temporalClient: TemporalClient;
+
+  constructor(temporalClient: TemporalClient) {
+    this.temporalClient = temporalClient;
+  }
+
+  public async teams(): Promise<Team[]> {
+    return this.temporalClient.workflow.execute("linearListTeams", {
+      taskQueue: "integration",
+      workflowId: `linearTeams-${genId()}`,
+    });
+  }
+}

--- a/apps/hash-integration-worker/src/workflows.ts
+++ b/apps/hash-integration-worker/src/workflows.ts
@@ -25,9 +25,6 @@ export const linear = proxyActivities<
   },
 });
 
-export const linearListTeams = async (): Promise<LinearTeam[]> =>
-  await linear.teams();
-
 export const linearMe = async (): Promise<LinearUser> => await linear.me();
 export const linearOrganization = async (): Promise<LinearOrganization> =>
   await linear.organization();

--- a/apps/hash-integration-worker/src/workflows.ts
+++ b/apps/hash-integration-worker/src/workflows.ts
@@ -25,6 +25,9 @@ export const linear = proxyActivities<
   },
 });
 
+export const linearListTeams = async (): Promise<LinearTeam[]> =>
+  await linear.teams();
+
 export const linearMe = async (): Promise<LinearUser> => await linear.me();
 export const linearOrganization = async (): Promise<LinearOrganization> =>
   await linear.organization();


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To allow picking a list of teams to integrate into HASH this provides a functionality to list all available linear teams

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph