### PR TITLE
H-200: Make Graph API available in integration worker

### DIFF
--- a/apps/hash-integration-worker/package.json
+++ b/apps/hash-integration-worker/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": "./src/main.ts",
     "./workflows": "./src/workflows.ts",
-    "./activities": "./src/activities.ts"
+    "./activities": "./src/activities.ts",
+    "./graph": "./src/graph.ts"
   },
   "typesVersions": {
     "*": {
@@ -19,6 +20,9 @@
       ],
       "activities": [
         "./src/activities.ts"
+      ],
+      "graph": [
+        "./src/graph.ts"
       ]
     }
   },

--- a/apps/hash-integration-worker/package.json
+++ b/apps/hash-integration-worker/package.json
@@ -35,9 +35,12 @@
   "dependencies": {
     "@linear/sdk": "6.0.0",
     "@local/hash-backend-utils": "0.0.0-private",
+    "@local/hash-graph-client": "0.0.0-private",
     "@temporalio/activity": "1.8.1",
     "@temporalio/worker": "1.8.1",
     "@temporalio/workflow": "1.8.1",
+    "agentkeepalive": "4.2.1",
+    "axios": "0.27.2",
     "dotenv-flow": "3.2.0",
     "ts-node": "10.9.1",
     "typescript": "5.0.4"

--- a/apps/hash-integration-worker/src/activities.ts
+++ b/apps/hash-integration-worker/src/activities.ts
@@ -29,6 +29,7 @@ const readNodes = async <T>(connection: Connection<T>): Promise<T[]> => {
 
 export const createLinearIntegrationActivities = ({
   linearClient,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   graphApiClient,
 }: {
   linearClient: LinearClient;

--- a/apps/hash-integration-worker/src/activities.ts
+++ b/apps/hash-integration-worker/src/activities.ts
@@ -15,6 +15,7 @@ import {
   Team,
   User,
 } from "@linear/sdk";
+import { GraphApi } from "@local/hash-graph-client";
 
 const readNodes = async <T>(connection: Connection<T>): Promise<T[]> => {
   const nodes = connection.nodes;
@@ -28,8 +29,10 @@ const readNodes = async <T>(connection: Connection<T>): Promise<T[]> => {
 
 export const createLinearIntegrationActivities = ({
   linearClient,
+  graphApiClient,
 }: {
   linearClient: LinearClient;
+  graphApiClient: GraphApi;
 }) => ({
   async me(): Promise<User> {
     return await linearClient.viewer;

--- a/apps/hash-integration-worker/src/graph.ts
+++ b/apps/hash-integration-worker/src/graph.ts
@@ -5,10 +5,13 @@ import axios from "axios";
 
 // TODO: Mostly copied from `hash-api`. Instead of importing `hash-api` or reimplementing the logic here we should
 //       probably move out shared code into a separate package.
-export const createGraphClient = (
-  _logger: Logger,
-  { host, port }: { host: string; port: number },
-): GraphApi => {
+export const createGraphClient = ({
+  host,
+  port,
+}: {
+  host: string;
+  port: number;
+}): GraphApi => {
   const agentConfig = {
     maxSockets: 128,
     maxFreeSockets: 20,

--- a/apps/hash-integration-worker/src/graph.ts
+++ b/apps/hash-integration-worker/src/graph.ts
@@ -1,0 +1,41 @@
+import { Logger } from "@local/hash-backend-utils/logger";
+import { Configuration, GraphApi } from "@local/hash-graph-client";
+import HttpAgent, { HttpsAgent } from "agentkeepalive";
+import axios from "axios";
+
+// TODO: Mostly copied from `hash-api`. Instead of importing `hash-api` or reimplementing the logic here we should
+//       probably move out shared code into a separate package.
+export const createGraphClient = (
+  _logger: Logger,
+  { host, port }: { host: string; port: number },
+): GraphApi => {
+  const agentConfig = {
+    maxSockets: 128,
+    maxFreeSockets: 20,
+    timeout: 60 * 1000, // ms
+    freeSocketTimeout: 30 * 1000, // ms
+  };
+
+  const httpAgent = new HttpAgent(agentConfig);
+  const httpsAgent = new HttpsAgent(agentConfig);
+
+  const axiosInstance = axios.create({
+    httpAgent,
+    httpsAgent,
+  });
+
+  axiosInstance.interceptors.response.use(
+    (response) => response,
+    (error: Error) => {
+      // TODO: Error handling, we maybe can reuse the error handling from `hash-api` and improve that instead of
+      //       reimplementing it here.
+      return Promise.reject(error);
+    },
+  );
+
+  const basePath = `http://${host}:${port}`;
+
+  const config = new Configuration({ basePath });
+
+  return new GraphApi(config, basePath, axiosInstance);
+};

--- a/apps/hash-integration-worker/src/graph.ts
+++ b/apps/hash-integration-worker/src/graph.ts
@@ -1,4 +1,3 @@
-import { Logger } from "@local/hash-backend-utils/logger";
 import { Configuration, GraphApi } from "@local/hash-graph-client";
 import HttpAgent, { HttpsAgent } from "agentkeepalive";
 import axios from "axios";

--- a/apps/hash-integration-worker/src/main.ts
+++ b/apps/hash-integration-worker/src/main.ts
@@ -7,6 +7,7 @@ import { NativeConnection, Worker } from "@temporalio/worker";
 import { config } from "dotenv-flow";
 
 import * as activities from "./activities";
+import { createGraphClient } from "./graph";
 
 export const monorepoRootDir = path.resolve(__dirname, "../../..");
 
@@ -51,9 +52,17 @@ const workflowOption = () =>
 async function run() {
   const linearClient = createLinearClient();
 
+  const graphApiClient = createGraphClient({
+    host: getRequiredEnv("HASH_GRAPH_API_HOST"),
+    port: parseInt(getRequiredEnv("HASH_GRAPH_API_PORT"), 10),
+  });
+
   const worker = await Worker.create({
     ...workflowOption(),
-    activities: activities.createLinearIntegrationActivities({ linearClient }),
+    activities: activities.createLinearIntegrationActivities({
+      linearClient,
+      graphApiClient,
+    }),
     connection: await NativeConnection.connect({
       address: `${TEMPORAL_HOST}:${TEMPORAL_PORT}`,
     }),

--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -273,6 +273,8 @@ module "application" {
   temporal_worker_integration_env_vars = [
     # TODO: Going to be replaced by the OAuth authentication method
     { name = "HASH_LINEAR_API_KEY", secret = true, value = sensitive(data.vault_kv_secret_v2.secrets.data["hash_linear_api_key"]) },
+    { name = "HASH_GRAPH_API_HOST", secret = false, value = "localhost" },
+    { name = "HASH_GRAPH_API_PORT", secret = false, value = "4000" },
   ]
   temporal_host = module.temporal.host
   temporal_port = module.temporal.temporal_port


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To allow creating/reading entities in/from the Graph, the API needs to be available in the integration worker.
## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph