### PR TITLE
H-202: Add `linearTeams` GraphQL resolver

### DIFF
--- a/apps/hash-api/src/graph/knowledge/system-types/linear-user-secret.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/linear-user-secret.ts
@@ -1,0 +1,114 @@
+import {
+  AccountId,
+  Entity,
+  EntityRootType,
+  Subgraph,
+} from "@local/hash-subgraph";
+import { getRoots } from "@local/hash-subgraph/stdlib";
+
+import { EntityTypeMismatchError, NotFoundError } from "../../../lib/error";
+import {
+  currentTimeInstantTemporalAxes,
+  ImpureGraphFunction,
+  PureGraphFunction,
+  zeroedGraphResolveDepths,
+} from "../..";
+import { SYSTEM_TYPES } from "../../system-types";
+
+export type LinearUserSecret = {
+  connectionSourceName: string;
+  vaultPath: string;
+  linearOrgId: string;
+};
+
+export const getLinearUserSecretFromEntity: PureGraphFunction<
+  { entity: Entity },
+  LinearUserSecret
+> = ({ entity }) => {
+  if (
+    entity.metadata.entityTypeId !==
+    SYSTEM_TYPES.entityType.linearUserSecret.schema.$id
+  ) {
+    throw new EntityTypeMismatchError(
+      entity.metadata.recordId.entityId,
+      SYSTEM_TYPES.entityType.user.schema.$id,
+      entity.metadata.entityTypeId,
+    );
+  }
+
+  const connectionSourceName = entity.properties[
+    SYSTEM_TYPES.propertyType.connectionSourceName.metadata.recordId.baseUrl
+  ] as string;
+
+  const vaultPath = entity.properties[
+    SYSTEM_TYPES.propertyType.vaultPath.metadata.recordId.baseUrl
+  ] as string;
+
+  const linearOrgId = entity.properties[
+    SYSTEM_TYPES.propertyType.linearOrgId.metadata.recordId.baseUrl
+  ] as string;
+
+  return {
+    connectionSourceName,
+    vaultPath,
+    linearOrgId,
+  };
+};
+
+/**
+ * Get a linear user secret by the linear org ID
+ */
+export const getLinearUserSecretByLinearOrgId: ImpureGraphFunction<
+  { userAccountId: AccountId; linearOrgId: string },
+  Promise<LinearUserSecret>
+> = async ({ graphApi }, { userAccountId, linearOrgId }) => {
+  const entities = await graphApi
+    .getEntitiesByQuery({
+      filter: {
+        all: [
+          {
+            equal: [{ path: ["ownedById"] }, { parameter: userAccountId }],
+          },
+          {
+            equal: [
+              { path: ["type", "versionedUrl"] },
+              {
+                parameter: SYSTEM_TYPES.entityType.linearUserSecret.schema.$id,
+              },
+            ],
+          },
+          {
+            equal: [
+              {
+                path: [
+                  "properties",
+                  SYSTEM_TYPES.propertyType.linearOrgId.metadata.recordId
+                    .baseUrl,
+                ],
+              },
+              { parameter: linearOrgId },
+            ],
+          },
+        ],
+      },
+      graphResolveDepths: zeroedGraphResolveDepths,
+      temporalAxes: currentTimeInstantTemporalAxes,
+    })
+    .then(({ data }) => getRoots(data as Subgraph<EntityRootType>));
+
+  if (entities.length > 1) {
+    throw new Error(
+      `More than one linear user secret found for the user with the linear org ID ${linearOrgId}`,
+    );
+  }
+
+  const entity = entities[0];
+
+  if (!entity) {
+    throw new NotFoundError(
+      `Could not find a linear user secret for the user with the linear org ID ${linearOrgId}`,
+    );
+  }
+
+  return getLinearUserSecretFromEntity({ entity });
+};

--- a/apps/hash-api/src/graph/system-types.ts
+++ b/apps/hash-api/src/graph/system-types.ts
@@ -59,6 +59,7 @@ export let SYSTEM_TYPES: {
 
     // Secret storage related
     vaultPath: PropertyTypeWithMetadata;
+    linearOrgId: PropertyTypeWithMetadata;
 
     // HASH Instance related
     userSelfRegistrationIsEnabled: PropertyTypeWithMetadata;
@@ -81,7 +82,7 @@ export let SYSTEM_TYPES: {
     page: EntityTypeWithMetadata;
     text: EntityTypeWithMetadata;
     file: EntityTypeWithMetadata;
-    userSecret: EntityTypeWithMetadata;
+    linearUserSecret: EntityTypeWithMetadata;
   };
   linkEntityType: {
     // HASHInstance-related
@@ -580,7 +581,14 @@ const vaultPathPropertyTypeInitializer = propertyTypeInitializer({
   possibleValues: [{ primitiveDataType: "text" }],
 });
 
-const userSecretEntityTypeInitializer = async (context: ImpureGraphContext) => {
+const linearOrgIdPropertyTypeInitializer = propertyTypeInitializer({
+  ...types.propertyType.linearOrgId,
+  possibleValues: [{ primitiveDataType: "text" }],
+});
+
+const linearUserSecretEntityTypeInitializer = async (
+  context: ImpureGraphContext,
+) => {
   /* eslint-disable @typescript-eslint/no-use-before-define */
 
   const expiredAtPropertyType =
@@ -595,14 +603,18 @@ const userSecretEntityTypeInitializer = async (context: ImpureGraphContext) => {
   const authorizesDataFromLinkEntityType =
     await SYSTEM_TYPES_INITIALIZERS.linkEntityType.authorizesDataFrom(context);
 
+  const linearOrgIdPropertyType =
+    await SYSTEM_TYPES_INITIALIZERS.propertyType.linearOrgId(context);
+
   /* eslint-enable @typescript-eslint/no-use-before-define */
 
   return entityTypeInitializer({
-    ...types.entityType.userSecret,
+    ...types.entityType.linearUserSecret,
     properties: [
       { propertyType: expiredAtPropertyType },
       { propertyType: connectionSourceNamePropertyType, required: true },
       { propertyType: vaultPathEntityType, required: true },
+      { propertyType: linearOrgIdPropertyType, required: true },
     ],
     outgoingLinks: [
       {
@@ -821,6 +833,7 @@ export const SYSTEM_TYPES_INITIALIZERS: FlattenAndPromisify<
 
     connectionSourceName: connectionSourceNamePropertyTypeInitializer,
     vaultPath: vaultPathPropertyTypeInitializer,
+    linearOrgId: linearOrgIdPropertyTypeInitializer,
 
     userSelfRegistrationIsEnabled:
       userSelfRegistrationIsEnabledPropertyTypeInitializer,
@@ -844,7 +857,7 @@ export const SYSTEM_TYPES_INITIALIZERS: FlattenAndPromisify<
     comment: commentEntityTypeInitializer,
     text: textEntityTypeInitializer,
     file: fileEntityTypeInitializer,
-    userSecret: userSecretEntityTypeInitializer,
+    linearUserSecret: linearUserSecretEntityTypeInitializer,
   },
   linkEntityType: {
     admin: adminLinkEntityTypeInitializer,

--- a/apps/hash-api/src/graphql/resolvers/index.ts
+++ b/apps/hash-api/src/graphql/resolvers/index.ts
@@ -2,6 +2,7 @@ import { JSONObjectResolver } from "graphql-scalars";
 
 import { getBlockProtocolBlocksResolver } from "./blockprotocol/get-block";
 import { embedCode } from "./embed";
+import { linearTeamsResolver } from "./integrations/linear/linear-teams";
 import { blocksResolver } from "./knowledge/block/block";
 import { blockChildEntityResolver } from "./knowledge/block/data-entity";
 import { commentAuthorResolver } from "./knowledge/comment/author";
@@ -88,6 +89,8 @@ export const resolvers = {
     getEntity: getEntityResolver,
     queryEntities: queryEntitiesResolver,
     hashInstanceEntity: hashInstanceEntityResolver,
+    // Integration
+    linearTeams: loggedInAndSignedUpMiddleware(linearTeamsResolver),
   },
 
   Mutation: {

--- a/apps/hash-api/src/graphql/resolvers/integrations/linear/linear-teams.ts
+++ b/apps/hash-api/src/graphql/resolvers/integrations/linear/linear-teams.ts
@@ -1,0 +1,45 @@
+import { getLinearUserSecretByLinearOrgId } from "../../../../graph/knowledge/system-types/linear-user-secret";
+import { listTeams } from "../../../../integrations/linear";
+import {
+  LinearTeam,
+  QueryLinearTeamsArgs,
+  ResolverFn,
+} from "../../../api-types.gen";
+import { LoggedInGraphQLContext } from "../../../context";
+
+export const linearTeamsResolver: ResolverFn<
+  Promise<LinearTeam[]>,
+  {},
+  LoggedInGraphQLContext,
+  QueryLinearTeamsArgs
+> = async (_, params, { dataSources, user, vault }) => {
+  const linearSecretEntity = await getLinearUserSecretByLinearOrgId(
+    dataSources,
+    {
+      userAccountId: user.accountId,
+      linearOrgId: params.linearOrgId,
+    },
+  );
+
+  if (!vault) {
+    throw new Error("No vault available.");
+  }
+
+  const vaultSecret = await vault.read<{ value: string }>({
+    secretMountPath: "secret",
+    path: linearSecretEntity.vaultPath,
+  });
+
+  const teams = await listTeams({ apiKey: vaultSecret.data.value });
+
+  return teams.map(
+    ({ id, name, description, color, icon, private: _private }) => ({
+      id,
+      name,
+      description,
+      color,
+      icon,
+      private: _private,
+    }),
+  );
+};

--- a/apps/hash-api/src/integrations/linear.ts
+++ b/apps/hash-api/src/integrations/linear.ts
@@ -1,12 +1,14 @@
 import { LinearClient, Team } from "@linear/sdk";
-import { getRequiredEnv } from "@local/hash-backend-utils/environment";
 
 import { TemporalClient } from "../temporal";
 
-export const listTeams = async (): Promise<Team[]> => {
-  const linearClient = new LinearClient({
-    apiKey: getRequiredEnv("HASH_LINEAR_API_KEY"),
-  });
+export const listTeams = async (params: {
+  apiKey: string;
+}): Promise<Team[]> => {
+  const { apiKey } = params;
+
+  const linearClient = new LinearClient({ apiKey });
+
   let teamsConnection = await linearClient.teams();
   const teams = teamsConnection.nodes;
   while (teamsConnection.pageInfo.hasNextPage) {

--- a/apps/hash-api/src/integrations/linear/oauth.ts
+++ b/apps/hash-api/src/integrations/linear/oauth.ts
@@ -210,15 +210,15 @@ export const oAuthLinearCallback: RequestHandler<
         expiredAt.toISOString(),
       [SYSTEM_TYPES.propertyType.vaultPath.metadata.recordId.baseUrl]:
         vaultPath,
-      // @todo create a Linear Workspace entity and create an authorizesDataFrom link to it instead of doing this
-      "https://example.com/property-types/linear-org-id/": linearOrgId,
+      [SYSTEM_TYPES.propertyType.linearOrgId.metadata.recordId.baseUrl]:
+        linearOrgId,
     };
 
     const secretEntity = await createEntity(req.context, {
       actorId: extractEntityUuidFromEntityId(
         actorEntityId,
       ) as Uuid as AccountId,
-      entityTypeId: SYSTEM_TYPES.entityType.userSecret.schema.$id,
+      entityTypeId: SYSTEM_TYPES.entityType.linearUserSecret.schema.$id,
       ownedById: ownedById as Uuid as OwnedById,
       properties: secretMetadata,
     });

--- a/libs/@local/hash-graphql-shared/src/graphql/type-defs/integration/linear.typedef.ts
+++ b/libs/@local/hash-graphql-shared/src/graphql/type-defs/integration/linear.typedef.ts
@@ -1,0 +1,34 @@
+import { gql } from "apollo-server-express";
+
+export const linearTypedef = gql`
+  type LinearTeam {
+    id: ID!
+    """
+    The team's name.
+    """
+    name: String!
+    """
+    The team's description.
+    """
+    description: String
+    """
+    The team's color.
+    """
+    color: String
+    """
+    The icon of the team.
+    """
+    icon: String
+    """
+    Whether the team is private or not.
+    """
+    private: Boolean!
+  }
+
+  extend type Query {
+    """
+    Get the linear teams in a linear org
+    """
+    linearTeams(linearOrgId: ID!): [LinearTeam!]!
+  }
+`;

--- a/libs/@local/hash-graphql-shared/src/graphql/type-defs/schema.ts
+++ b/libs/@local/hash-graphql-shared/src/graphql/type-defs/schema.ts
@@ -3,6 +3,7 @@ import { gql } from "apollo-server-express";
 import { blockprotocolTypedef } from "./blockprotocol.typedef";
 import { deprecatedTypedef } from "./deprecated.typedef";
 import { embedTypeDef } from "./embed.typedef";
+import { linearTypedef } from "./integration/linear.typedef";
 import { blockTypedef } from "./knowledge/block.typedef";
 import { commentTypedef } from "./knowledge/comment.typedef";
 import { entityTypedef } from "./knowledge/entity.typedef";
@@ -61,5 +62,6 @@ export const schema = [
   deprecatedTypedef,
   ...ontology,
   ...knowledge,
+  linearTypedef,
   subgraphTypedef,
 ];

--- a/libs/@local/hash-isomorphic-utils/src/ontology-types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/ontology-types.ts
@@ -134,9 +134,9 @@ const systemEntityTypes = {
     title: "File",
     description: "A file.",
   },
-  userSecret: {
-    title: "User Secret",
-    description: "A secret or credential belonging to a user",
+  linearUserSecret: {
+    title: "Linear User Secret",
+    description: "A linear secret or credential belonging to a user",
   },
 } as const;
 
@@ -259,6 +259,10 @@ const systemPropertyTypes = {
   vaultPath: {
     title: "Vault Path",
     description: "The path to a secret in Hashicorp Vault.",
+  },
+  linearOrgId: {
+    title: "Linear Org Id",
+    description: "The unique identifier for an org in Linear.",
   },
   fileUrl: {
     title: "File URL",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR adds a `linearTeams` GQL resolver that obtains the linear teams in a linear org using the user's linear user secret stored in vault.


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

Add it to the FE

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

<img width="1134" alt="image" src="https://github.com/hashintel/hash/assets/42802102/4e0d6217-bfc4-4149-b063-1c9c86299219">

