### PR TITLE
H-205: Add Linear integration entity type and other type changes

### DIFF
--- a/apps/hash-api/src/graph/knowledge/system-types/linear-user-secret.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/linear-user-secret.ts
@@ -27,7 +27,7 @@ export const getLinearUserSecretFromEntity: PureGraphFunction<
 > = ({ entity }) => {
   if (
     entity.metadata.entityTypeId !==
-    SYSTEM_TYPES.entityType.linearUserSecret.schema.$id
+    SYSTEM_TYPES.entityType.userSecret.schema.$id
   ) {
     throw new EntityTypeMismatchError(
       entity.metadata.recordId.entityId,
@@ -73,7 +73,7 @@ export const getLinearUserSecretByLinearOrgId: ImpureGraphFunction<
             equal: [
               { path: ["type", "versionedUrl"] },
               {
-                parameter: SYSTEM_TYPES.entityType.linearUserSecret.schema.$id,
+                parameter: SYSTEM_TYPES.entityType.userSecret.schema.$id,
               },
             ],
           },

--- a/apps/hash-api/src/graph/util.ts
+++ b/apps/hash-api/src/graph/util.ts
@@ -221,7 +221,7 @@ export type EntityTypeCreatorParams = {
     array?: { minItems?: number; maxItems?: number } | boolean;
   }[];
   outgoingLinks?: {
-    linkEntityType: EntityTypeWithMetadata;
+    linkEntityType: EntityTypeWithMetadata | VersionedUrl;
     destinationEntityTypes?: [
       linkDestinationConstraint,
       ...linkDestinationConstraint[],
@@ -287,7 +287,9 @@ export const generateSystemEntityTypeSchema = (
         },
       ): EntityType["links"] => ({
         ...prev,
-        [linkEntityType.schema.$id]: {
+        [typeof linkEntityType === "object"
+          ? linkEntityType.schema.$id
+          : linkEntityType]: {
           type: "array",
           ordered,
           items: destinationEntityTypes

--- a/apps/hash-frontend/src/pages/integrations/linear.page.tsx
+++ b/apps/hash-frontend/src/pages/integrations/linear.page.tsx
@@ -1,13 +1,59 @@
 import { apiOrigin } from "@local/hash-graphql-shared/environment";
+import { types } from "@local/hash-isomorphic-utils/ontology-types";
+import { Entity } from "@local/hash-subgraph";
+import { getRoots } from "@local/hash-subgraph/stdlib";
 import { Box, Container, Typography } from "@mui/material";
-import { useContext } from "react";
+import { useContext, useEffect, useState } from "react";
 
+import { useBlockProtocolQueryEntities } from "../../components/hooks/block-protocol-functions/knowledge/use-block-protocol-query-entities";
 import { getLayoutWithSidebar, NextPageWithLayout } from "../../shared/layout";
 import { Button } from "../../shared/ui/button";
+import { useAuthenticatedUser } from "../shared/auth-info-context";
 import { WorkspaceContext } from "../shared/workspace-context";
 
 const Page: NextPageWithLayout = () => {
+  const { authenticatedUser } = useAuthenticatedUser();
   const { activeWorkspace } = useContext(WorkspaceContext);
+  const { queryEntities } = useBlockProtocolQueryEntities();
+
+  const [linearIntegrationEntities, setLinearIntegrationEntities] = useState<
+    Entity[]
+  >([]);
+
+  useEffect(() => {
+    const init = async () => {
+      const { data } = await queryEntities({
+        data: {
+          operation: {
+            multiFilter: {
+              filters: [
+                {
+                  field: ["ownedById"],
+                  operator: "EQUALS",
+                  value: authenticatedUser.accountId,
+                },
+                {
+                  field: ["metadata", "entityTypeId"],
+                  operator: "EQUALS",
+                  value: types.entityType.linearIntegration.entityTypeId,
+                },
+              ],
+              operator: "AND",
+            },
+          },
+        },
+      });
+
+      if (data) {
+        setLinearIntegrationEntities(getRoots(data));
+      }
+    };
+
+    void init();
+  }, [queryEntities, authenticatedUser]);
+
+  // eslint-disable-next-line no-console
+  console.log({ linearIntegrationEntities });
 
   if (!activeWorkspace) {
     return <>Loading workspace...</>;

--- a/libs/@local/hash-isomorphic-utils/src/ontology-types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/ontology-types.ts
@@ -145,9 +145,13 @@ const systemEntityTypes = {
     title: "File",
     description: "A file.",
   },
-  linearUserSecret: {
-    title: "Linear User Secret",
-    description: "A linear secret or credential belonging to a user",
+  userSecret: {
+    title: "User Secret",
+    description: "A secret or credential belonging to a user.",
+  },
+  linearIntegration: {
+    title: "Linear Integration",
+    description: "An instance of an integration with Linear.",
   },
 } as const;
 
@@ -296,6 +300,10 @@ const systemPropertyTypes = {
     description:
       "Key used to uniquely identify a file in a third-party system.",
   },
+  linearTeamId: {
+    title: "Linear Team Id",
+    description: "The unique identifier for a team in Linear.",
+  },
 } as const;
 
 type SystemPropertyTypeKey = keyof typeof systemPropertyTypes;
@@ -335,10 +343,13 @@ const systemLinkEntityTypes = {
     title: "Admin",
     description: "The admin of something.",
   },
-  authorizesDataFrom: {
-    title: "Authorizes Data From",
-    description:
-      "The thing that data access is authorized from (e.g. data from a specific workspace, account, or team is authorized).",
+  syncLinearDataWith: {
+    title: "Sync Linear Data With",
+    description: "Something that syncs linear data with something.",
+  },
+  usesUserSecret: {
+    title: "Uses User Secret",
+    description: "Something that uses a user secret.",
   },
 } as const;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR adds a `Linear Integration` entity type, and reverts the `linearUserSecret` type to the `userSecret` type by moving the `linearOrgId` property type.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

<img width="629" alt="image" src="https://github.com/hashintel/hash/assets/42802102/aad2da7d-5c07-4bb4-8caa-dda88349656b">
