### PR TITLE
H-207: Allow creating and updating from Linear webhooks

### DIFF
--- a/apps/hash-api/src/integrations/linear/webhook.ts
+++ b/apps/hash-api/src/integrations/linear/webhook.ts
@@ -2,6 +2,10 @@ import crypto from "node:crypto";
 
 import { RequestHandler } from "express";
 
+import { logger } from "../../logger";
+import { createTemporalClient } from "../../temporal";
+import { genId, getRequiredEnv } from "../../util";
+
 type LinearWebhookPayloadBase = {
   action: string;
   createdAt: string; // ISO timestamp when the action took place.
@@ -45,9 +49,32 @@ export const linearWebhook: RequestHandler<{}, "ok", string> = async (
     return;
   }
 
-  const _payload = JSON.parse(req.body) as LinearWebhookPayload;
+  const payload = JSON.parse(req.body) as LinearWebhookPayload;
 
-  // @todo trigger update to HASH entities based on the payload
+  const temporalClient = await createTemporalClient(logger, {
+    host: getRequiredEnv("HASH_TEMPORAL_SERVER_HOST"),
+    port: parseInt(process.env.HASH_TEMPORAL_SERVER_PORT || "7233", 10),
+    namespace: "HASH",
+  });
+
+  if (
+    ["create", "update"].includes(payload.action) &&
+    ["Issue", "User"].includes(payload.type)
+  ) {
+    const workflow = `${payload.action}${payload.type}`;
+    await temporalClient.workflow.execute(workflow, {
+      taskQueue: "integration",
+      args: [
+        {
+          // @todo Use correct account IDs
+          actorId: "00000000-0000-0000-0000-000000000000",
+          ownedById: "00000000-0000-0000-0000-000000000000",
+          issue: (payload as LinearWebhookPayloadChange).data,
+        },
+      ],
+      workflowId: `${workflow}-${genId()}`,
+    });
+  }
 
   res.send("ok");
 };

--- a/apps/hash-api/src/integrations/linear/webhook.ts
+++ b/apps/hash-api/src/integrations/linear/webhook.ts
@@ -69,7 +69,7 @@ export const linearWebhook: RequestHandler<{}, "ok", string> = async (
           // @todo Use correct account IDs
           actorId: "00000000-0000-0000-0000-000000000000",
           ownedById: "00000000-0000-0000-0000-000000000000",
-          issue: (payload as LinearWebhookPayloadChange).data,
+          payload: (payload as LinearWebhookPayloadChange).data,
         },
       ],
       workflowId: `${workflow}-${genId()}`,

--- a/apps/hash-integration-worker/src/activities.ts
+++ b/apps/hash-integration-worker/src/activities.ts
@@ -9,7 +9,7 @@ import {
 import { GraphApi } from "@local/hash-graph-client";
 import { linearTypes } from "@local/hash-isomorphic-utils/ontology-types";
 import { EntityRootType, Subgraph } from "@local/hash-subgraph";
-import { getRoots } from "@local/hash-subgraph/src/stdlib";
+import { getRoots } from "@local/hash-subgraph/stdlib";
 import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
 
 import {
@@ -43,7 +43,7 @@ const updateEntity = async (params: {
         all: [
           {
             equal: [
-              { path: ["versionedUrl"] },
+              { path: ["type", "versionedUrl"] },
               { parameter: params.entity.entityTypeId },
             ],
           },
@@ -140,19 +140,21 @@ export const createLinearIntegrationActivities = ({
     return linearClient.organization.then(organizationToEntity);
   },
 
-  async createUsers(params: {
-    users: User[];
+  async createUser(params: {
+    user: User;
     actorId: string;
     ownedById: string;
   }): Promise<void> {
-    await this.createPartialEntities({
-      entities: params.users.map(userToEntity),
+    const entity = userToEntity(params.user);
+    await graphApiClient.createEntity({
       actorId: params.actorId,
       ownedById: params.ownedById,
+      entityTypeId: entity.entityTypeId,
+      properties: entity.properties,
     });
   },
 
-  async updateUsers(params: { user: User; actorId: string }): Promise<void> {
+  async updateUser(params: { user: User; actorId: string }): Promise<void> {
     await updateEntity({
       graphApiClient,
       entity: userToEntity(params.user),
@@ -167,15 +169,17 @@ export const createLinearIntegrationActivities = ({
       .then((users) => users.map(userToEntity));
   },
 
-  async createIssues(params: {
-    issues: Issue[];
+  async createIssue(params: {
+    issue: Issue;
     actorId: string;
     ownedById: string;
   }): Promise<void> {
-    await this.createPartialEntities({
-      entities: params.issues.map(issueToEntity),
+    const entity = issueToEntity(params.issue);
+    await graphApiClient.createEntity({
       actorId: params.actorId,
       ownedById: params.ownedById,
+      entityTypeId: entity.entityTypeId,
+      properties: entity.properties,
     });
   },
 

--- a/apps/hash-integration-worker/src/mappings.ts
+++ b/apps/hash-integration-worker/src/mappings.ts
@@ -31,11 +31,11 @@ export const userToEntity = (user: User): PartialEntity => {
       [extractBaseUrl(linearTypes.propertyType.admin.propertyTypeId)]:
         user.admin,
       [extractBaseUrl(linearTypes.propertyType.archivedAt.propertyTypeId)]:
-        user.archivedAt?.toISOString(),
+        user.archivedAt?.toString(),
       [extractBaseUrl(linearTypes.propertyType.avatarUrl.propertyTypeId)]:
         user.avatarUrl,
       [extractBaseUrl(linearTypes.propertyType.createdAt.propertyTypeId)]:
-        user.createdAt.toISOString(),
+        user.createdAt.toString(),
       [extractBaseUrl(
         linearTypes.propertyType.createdIssueCount.propertyTypeId,
       )]: user.createdIssueCount,
@@ -52,17 +52,17 @@ export const userToEntity = (user: User): PartialEntity => {
       [extractBaseUrl(linearTypes.propertyType.id.propertyTypeId)]: user.id,
       [extractBaseUrl(linearTypes.propertyType.isMe.propertyTypeId)]: user.isMe,
       [extractBaseUrl(linearTypes.propertyType.lastSeen.propertyTypeId)]:
-        user.lastSeen?.toISOString(),
+        user.lastSeen?.toString(),
       [extractBaseUrl(linearTypes.propertyType.statusEmoji.propertyTypeId)]:
         user.statusEmoji,
       [extractBaseUrl(linearTypes.propertyType.statusLabel.propertyTypeId)]:
         user.statusLabel,
       [extractBaseUrl(linearTypes.propertyType.statusUntilAt.propertyTypeId)]:
-        user.statusUntilAt?.toISOString(),
+        user.statusUntilAt?.toString(),
       [extractBaseUrl(linearTypes.propertyType.timezone.propertyTypeId)]:
         user.timezone,
       [extractBaseUrl(linearTypes.propertyType.updatedAt.propertyTypeId)]:
-        user.updatedAt.toISOString(),
+        user.updatedAt.toString(),
       [extractBaseUrl(linearTypes.propertyType.url.propertyTypeId)]: user.url,
     },
   };
@@ -78,15 +78,15 @@ export const organizationToEntity = (
         linearTypes.propertyType.allowedAuthService.propertyTypeId,
       )]: organization.allowedAuthServices,
       [extractBaseUrl(linearTypes.propertyType.archivedAt.propertyTypeId)]:
-        organization.archivedAt?.toISOString(),
+        organization.archivedAt?.toString(),
       [extractBaseUrl(linearTypes.propertyType.createdAt.propertyTypeId)]:
-        organization.createdAt.toISOString(),
+        organization.createdAt.toString(),
       [extractBaseUrl(
         linearTypes.propertyType.createdIssueCount.propertyTypeId,
       )]: organization.createdIssueCount,
       [extractBaseUrl(
         linearTypes.propertyType.deletionRequestedAt.propertyTypeId,
-      )]: organization.deletionRequestedAt?.toISOString(),
+      )]: organization.deletionRequestedAt?.toString(),
       [extractBaseUrl(linearTypes.propertyType.gitBranchFormat.propertyTypeId)]:
         organization.gitBranchFormat,
       [extractBaseUrl(
@@ -118,9 +118,9 @@ export const organizationToEntity = (
       [extractBaseUrl(linearTypes.propertyType.scimEnabled.propertyTypeId)]:
         organization.scimEnabled,
       [extractBaseUrl(linearTypes.propertyType.trialEndsAt.propertyTypeId)]:
-        organization.trialEndsAt?.toISOString(),
+        organization.trialEndsAt?.toString(),
       [extractBaseUrl(linearTypes.propertyType.updatedAt.propertyTypeId)]:
-        organization.updatedAt.toISOString(),
+        organization.updatedAt.toString(),
       [extractBaseUrl(linearTypes.propertyType.urlKey.propertyTypeId)]:
         organization.urlKey,
       [extractBaseUrl(linearTypes.propertyType.userCount.propertyTypeId)]:
@@ -138,19 +138,19 @@ export const issueToEntity = (issue: Issue): PartialEntity => {
     entityTypeId: linearTypes.entityType.organization.entityTypeId,
     properties: {
       [extractBaseUrl(linearTypes.propertyType.archivedAt.propertyTypeId)]:
-        issue.archivedAt?.toISOString(),
+        issue.archivedAt?.toString(),
       [extractBaseUrl(linearTypes.propertyType.autoArchivedAt.propertyTypeId)]:
-        issue.autoArchivedAt?.toISOString(),
+        issue.autoArchivedAt?.toString(),
       [extractBaseUrl(linearTypes.propertyType.autoClosedAt.propertyTypeId)]:
-        issue.autoClosedAt?.toISOString(),
+        issue.autoClosedAt?.toString(),
       [extractBaseUrl(linearTypes.propertyType.branchName.propertyTypeId)]:
         issue.branchName,
       [extractBaseUrl(linearTypes.propertyType.canceledAt.propertyTypeId)]:
-        issue.canceledAt?.toISOString(),
+        issue.canceledAt?.toString(),
       [extractBaseUrl(linearTypes.propertyType.completedAt.propertyTypeId)]:
-        issue.completedAt?.toISOString(),
+        issue.completedAt?.toString(),
       [extractBaseUrl(linearTypes.propertyType.createdAt.propertyTypeId)]:
-        issue.createdAt.toISOString(),
+        issue.createdAt.toString(),
       [extractBaseUrl(
         linearTypes.propertyType.customerTicketCount.propertyTypeId,
       )]: issue.customerTicketCount,
@@ -174,13 +174,13 @@ export const issueToEntity = (issue: Issue): PartialEntity => {
       [extractBaseUrl(linearTypes.propertyType.priorityLabel.propertyTypeId)]:
         issue.priorityLabel,
       [extractBaseUrl(linearTypes.propertyType.snoozedUntilAt.propertyTypeId)]:
-        issue.snoozedUntilAt?.toISOString(),
+        issue.snoozedUntilAt?.toString(),
       [extractBaseUrl(linearTypes.propertyType.sortOrder.propertyTypeId)]:
         issue.sortOrder,
       [extractBaseUrl(linearTypes.propertyType.startedAt.propertyTypeId)]:
-        issue.startedAt?.toISOString(),
+        issue.startedAt?.toString(),
       [extractBaseUrl(linearTypes.propertyType.startedTriageAt.propertyTypeId)]:
-        issue.startedTriageAt?.toISOString(),
+        issue.startedTriageAt?.toString(),
       [extractBaseUrl(
         linearTypes.propertyType.subIssueSortOrder.propertyTypeId,
       )]: issue.subIssueSortOrder,
@@ -189,9 +189,9 @@ export const issueToEntity = (issue: Issue): PartialEntity => {
       [extractBaseUrl(linearTypes.propertyType.trashed.propertyTypeId)]:
         issue.trashed,
       [extractBaseUrl(linearTypes.propertyType.triagedAt.propertyTypeId)]:
-        issue.triagedAt?.toISOString(),
+        issue.triagedAt?.toString(),
       [extractBaseUrl(linearTypes.propertyType.updatedAt.propertyTypeId)]:
-        issue.updatedAt.toISOString(),
+        issue.updatedAt.toString(),
       [extractBaseUrl(linearTypes.propertyType.url.propertyTypeId)]: issue.url,
     },
   };

--- a/apps/hash-integration-worker/src/workflows.ts
+++ b/apps/hash-integration-worker/src/workflows.ts
@@ -51,23 +51,33 @@ export const createUser = async (params: {
   ownedById: string;
   actorId: string;
 }): Promise<void> => {
-  await linear.createUsers({
-    users: [params.user],
+  await linear.createUser({
+    user: params.user,
     ownedById: params.ownedById,
     actorId: params.actorId,
   });
 };
+
+export const updateUser = async (params: {
+  user: User;
+  actorId: string;
+}): Promise<void> => linear.updateUser(params);
 
 export const createIssue = async (params: {
   issue: Issue;
   ownedById: string;
   actorId: string;
 }): Promise<void> => {
-  await linear.createIssues({
-    issues: [params.issue],
+  await linear.createIssue({
+    issue: params.issue,
     ownedById: params.ownedById,
     actorId: params.actorId,
   });
 };
+
+export const updateIssue = async (params: {
+  issue: Issue;
+  actorId: string;
+}): Promise<void> => linear.updateIssue(params);
 
 export const linearTeams = async (): Promise<Team[]> => linear.readTeams();

--- a/apps/hash-integration-worker/src/workflows.ts
+++ b/apps/hash-integration-worker/src/workflows.ts
@@ -47,37 +47,45 @@ export const linearImport = async (params: {
 };
 
 export const createUser = async (params: {
-  user: User;
+  payload: User;
   ownedById: string;
   actorId: string;
 }): Promise<void> => {
   await linear.createUser({
-    user: params.user,
+    user: params.payload,
     ownedById: params.ownedById,
     actorId: params.actorId,
   });
 };
 
 export const updateUser = async (params: {
-  user: User;
+  payload: User;
   actorId: string;
-}): Promise<void> => linear.updateUser(params);
+}): Promise<void> =>
+  linear.updateUser({
+    user: params.payload,
+    actorId: params.actorId,
+  });
 
 export const createIssue = async (params: {
-  issue: Issue;
+  payload: Issue;
   ownedById: string;
   actorId: string;
 }): Promise<void> => {
   await linear.createIssue({
-    issue: params.issue,
+    issue: params.payload,
     ownedById: params.ownedById,
     actorId: params.actorId,
   });
 };
 
 export const updateIssue = async (params: {
-  issue: Issue;
+  payload: Issue;
   actorId: string;
-}): Promise<void> => linear.updateIssue(params);
+}): Promise<void> =>
+  linear.updateIssue({
+    issue: params.payload,
+    actorId: params.actorId,
+  });
 
 export const linearTeams = async (): Promise<Team[]> => linear.readTeams();


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This adds functionality to update issues and connects both, creation and updating, to webhooks

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- The data passed in webhooks differs from the data passed from the linear node sdk, for example the web hook data does not contain the issue identifier (e.g. `H-207`). 
- the web hook data is in plain JSON, so only primitive datatypes are used, such as ISO strings for dates instead of the `Date` type. 

I will address these issues in a follow-up PR.