### PR TITLE
H-210: Allow `ownedById` in blockprotocol queries

### DIFF
--- a/apps/hash-api/src/graph/knowledge/primitive/entity/query.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity/query.ts
@@ -26,6 +26,11 @@ const bpMultiFilterFieldPathToPathExpression = (
         return ["properties", ...rest];
       }
 
+      // case `EntityQueryToken.OwnedById`
+      if (pathRoot === "ownedById") {
+        return ["properties", ...rest];
+      }
+
       if (pathRoot === "metadata") {
         if (rest.length === 0) {
           throw new InvalidEntityQueryError(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`ownedByid` is not part of the BP specs thus it's not possible to specify it as a path in the GraphQL queries.

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph