### PR TITLE
H-211: Fix `ownedById` in queries returns `properties`

### DIFF
--- a/apps/hash-api/src/graph/knowledge/primitive/entity/query.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity/query.ts
@@ -28,7 +28,12 @@ const bpMultiFilterFieldPathToPathExpression = (
 
       // case `EntityQueryToken.OwnedById`
       if (pathRoot === "ownedById") {
-        return ["properties", ...rest];
+        if (rest.length !== 0) {
+          throw new InvalidEntityQueryError(
+            `Invalid filter field path, unable to add more filters on top of \`ownedById\``,
+          );
+        }
+        return ["ownedById"];
       }
 
       if (pathRoot === "metadata") {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Hotfix for #2813

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph