### PR TITLE
H-215: Enable querying by incoming/outgoing links via `queryEntities`

### DIFF
--- a/apps/hash-api/src/graph/knowledge/primitive/entity/query.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity/query.ts
@@ -195,8 +195,9 @@ const bpMultiFilterFieldPathToPathExpression = (
         }
       }
 
-      // case `IncomingLinks` - should be unreachable at present as the BP query syntax doesn't support filtering across links
-      // case `OutgoingLinks`  - should be unreachable at present as the BP query syntax doesn't support filtering across links
+      if (pathRoot === "incomingLinks" || pathRoot === "outgoingLinks") {
+        return field;
+      }
 
       throw new InvalidEntityQueryError(
         `Invalid filter field path, unknown field \`${pathRoot}\``,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The Graph API's structural querying supports filtering entities by their incoming and outgoing links. We previously didn't allow this when calling `queryEntities` via the Node API, on the basis that it isn't mentioned in the Block Protocol, but this is still useful for us when calling `queryEntities` from the HASH frontend (not blocks).


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

