### PR TITLE
H-213: Fix updating linear entities if they exist in different workspaces

### DIFF
--- a/apps/hash-integration-worker/src/activities.ts
+++ b/apps/hash-integration-worker/src/activities.ts
@@ -37,7 +37,7 @@ const updateEntity = async (params: {
   if (!linearId) {
     throw new Error(`No linear id found.`);
   }
-  const [entity, ...unexpectedEntities] = await params.graphApiClient
+  const entities = await params.graphApiClient
     .getEntitiesByQuery({
       filter: {
         all: [
@@ -85,21 +85,15 @@ const updateEntity = async (params: {
       getRoots(linearEntities as Subgraph<EntityRootType>),
     );
 
-  if (unexpectedEntities.length > 0) {
-    throw new Error(`More than one entities returned.`);
+  for (const entity of entities) {
+    await params.graphApiClient.updateEntity({
+      actorId: params.actorId,
+      archived: false,
+      entityId: entity.metadata.recordId.entityId,
+      entityTypeId: entity.metadata.entityTypeId,
+      properties: params.entity.properties,
+    });
   }
-
-  if (!entity) {
-    throw new Error(`No entity returned.`);
-  }
-
-  await params.graphApiClient.updateEntity({
-    actorId: params.actorId,
-    archived: false,
-    entityId: entity.metadata.recordId.entityId,
-    entityTypeId: entity.metadata.entityTypeId,
-    properties: params.entity.properties,
-  });
 };
 
 const readNodes = async <T>(connection: Connection<T>): Promise<T[]> => {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When updating e.g. a linear Issue and the issue was imported in different workspaces in HASH all of those entities should be updated. Currently, it fails if more than one entity with the same linear ID is updating.

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph