### PR TITLE
H-216: Make sure the same format is used for dates in linear integration

### DIFF
--- a/apps/hash-integration-worker/src/mappings.ts
+++ b/apps/hash-integration-worker/src/mappings.ts
@@ -22,6 +22,13 @@ export type PartialEntity = {
   entityTypeId: VersionedUrl;
 };
 
+const toIsoString = (date: string | Date): string => {
+  if (typeof date === "string") {
+    return date;
+  }
+  return date.toISOString();
+};
+
 export const userToEntity = (user: User): PartialEntity => {
   return {
     entityTypeId: linearTypes.entityType.user.entityTypeId,
@@ -31,11 +38,11 @@ export const userToEntity = (user: User): PartialEntity => {
       [extractBaseUrl(linearTypes.propertyType.admin.propertyTypeId)]:
         user.admin,
       [extractBaseUrl(linearTypes.propertyType.archivedAt.propertyTypeId)]:
-        user.archivedAt?.toString(),
+        user.archivedAt ? toIsoString(user.archivedAt) : undefined,
       [extractBaseUrl(linearTypes.propertyType.avatarUrl.propertyTypeId)]:
         user.avatarUrl,
       [extractBaseUrl(linearTypes.propertyType.createdAt.propertyTypeId)]:
-        user.createdAt.toString(),
+        toIsoString(user.createdAt),
       [extractBaseUrl(
         linearTypes.propertyType.createdIssueCount.propertyTypeId,
       )]: user.createdIssueCount,
@@ -52,17 +59,17 @@ export const userToEntity = (user: User): PartialEntity => {
       [extractBaseUrl(linearTypes.propertyType.id.propertyTypeId)]: user.id,
       [extractBaseUrl(linearTypes.propertyType.isMe.propertyTypeId)]: user.isMe,
       [extractBaseUrl(linearTypes.propertyType.lastSeen.propertyTypeId)]:
-        user.lastSeen?.toString(),
+        user.lastSeen ? toIsoString(user.lastSeen) : undefined,
       [extractBaseUrl(linearTypes.propertyType.statusEmoji.propertyTypeId)]:
         user.statusEmoji,
       [extractBaseUrl(linearTypes.propertyType.statusLabel.propertyTypeId)]:
         user.statusLabel,
       [extractBaseUrl(linearTypes.propertyType.statusUntilAt.propertyTypeId)]:
-        user.statusUntilAt?.toString(),
+        user.statusUntilAt ? toIsoString(user.statusUntilAt) : undefined,
       [extractBaseUrl(linearTypes.propertyType.timezone.propertyTypeId)]:
         user.timezone,
       [extractBaseUrl(linearTypes.propertyType.updatedAt.propertyTypeId)]:
-        user.updatedAt.toString(),
+        toIsoString(user.updatedAt),
       [extractBaseUrl(linearTypes.propertyType.url.propertyTypeId)]: user.url,
     },
   };
@@ -78,15 +85,19 @@ export const organizationToEntity = (
         linearTypes.propertyType.allowedAuthService.propertyTypeId,
       )]: organization.allowedAuthServices,
       [extractBaseUrl(linearTypes.propertyType.archivedAt.propertyTypeId)]:
-        organization.archivedAt?.toString(),
+        organization.archivedAt
+          ? toIsoString(organization.archivedAt)
+          : undefined,
       [extractBaseUrl(linearTypes.propertyType.createdAt.propertyTypeId)]:
-        organization.createdAt.toString(),
+        toIsoString(organization.createdAt),
       [extractBaseUrl(
         linearTypes.propertyType.createdIssueCount.propertyTypeId,
       )]: organization.createdIssueCount,
       [extractBaseUrl(
         linearTypes.propertyType.deletionRequestedAt.propertyTypeId,
-      )]: organization.deletionRequestedAt?.toString(),
+      )]: organization.deletionRequestedAt
+        ? toIsoString(organization.deletionRequestedAt)
+        : undefined,
       [extractBaseUrl(linearTypes.propertyType.gitBranchFormat.propertyTypeId)]:
         organization.gitBranchFormat,
       [extractBaseUrl(
@@ -118,9 +129,11 @@ export const organizationToEntity = (
       [extractBaseUrl(linearTypes.propertyType.scimEnabled.propertyTypeId)]:
         organization.scimEnabled,
       [extractBaseUrl(linearTypes.propertyType.trialEndsAt.propertyTypeId)]:
-        organization.trialEndsAt?.toString(),
+        organization.trialEndsAt
+          ? toIsoString(organization.trialEndsAt)
+          : undefined,
       [extractBaseUrl(linearTypes.propertyType.updatedAt.propertyTypeId)]:
-        organization.updatedAt.toString(),
+        toIsoString(organization.updatedAt),
       [extractBaseUrl(linearTypes.propertyType.urlKey.propertyTypeId)]:
         organization.urlKey,
       [extractBaseUrl(linearTypes.propertyType.userCount.propertyTypeId)]:
@@ -138,19 +151,19 @@ export const issueToEntity = (issue: Issue): PartialEntity => {
     entityTypeId: linearTypes.entityType.organization.entityTypeId,
     properties: {
       [extractBaseUrl(linearTypes.propertyType.archivedAt.propertyTypeId)]:
-        issue.archivedAt?.toString(),
+        issue.archivedAt ? toIsoString(issue.archivedAt) : undefined,
       [extractBaseUrl(linearTypes.propertyType.autoArchivedAt.propertyTypeId)]:
-        issue.autoArchivedAt?.toString(),
+        issue.autoArchivedAt ? toIsoString(issue.autoArchivedAt) : undefined,
       [extractBaseUrl(linearTypes.propertyType.autoClosedAt.propertyTypeId)]:
-        issue.autoClosedAt?.toString(),
+        issue.autoClosedAt ? toIsoString(issue.autoClosedAt) : undefined,
       [extractBaseUrl(linearTypes.propertyType.branchName.propertyTypeId)]:
         issue.branchName,
       [extractBaseUrl(linearTypes.propertyType.canceledAt.propertyTypeId)]:
-        issue.canceledAt?.toString(),
+        issue.canceledAt ? toIsoString(issue.canceledAt) : undefined,
       [extractBaseUrl(linearTypes.propertyType.completedAt.propertyTypeId)]:
-        issue.completedAt?.toString(),
+        issue.completedAt ? toIsoString(issue.completedAt) : undefined,
       [extractBaseUrl(linearTypes.propertyType.createdAt.propertyTypeId)]:
-        issue.createdAt.toString(),
+        toIsoString(issue.createdAt),
       [extractBaseUrl(
         linearTypes.propertyType.customerTicketCount.propertyTypeId,
       )]: issue.customerTicketCount,
@@ -174,13 +187,13 @@ export const issueToEntity = (issue: Issue): PartialEntity => {
       [extractBaseUrl(linearTypes.propertyType.priorityLabel.propertyTypeId)]:
         issue.priorityLabel,
       [extractBaseUrl(linearTypes.propertyType.snoozedUntilAt.propertyTypeId)]:
-        issue.snoozedUntilAt?.toString(),
+        issue.snoozedUntilAt ? toIsoString(issue.snoozedUntilAt) : undefined,
       [extractBaseUrl(linearTypes.propertyType.sortOrder.propertyTypeId)]:
         issue.sortOrder,
       [extractBaseUrl(linearTypes.propertyType.startedAt.propertyTypeId)]:
-        issue.startedAt?.toString(),
+        issue.startedAt ? toIsoString(issue.startedAt) : undefined,
       [extractBaseUrl(linearTypes.propertyType.startedTriageAt.propertyTypeId)]:
-        issue.startedTriageAt?.toString(),
+        issue.startedTriageAt ? toIsoString(issue.startedTriageAt) : undefined,
       [extractBaseUrl(
         linearTypes.propertyType.subIssueSortOrder.propertyTypeId,
       )]: issue.subIssueSortOrder,
@@ -189,9 +202,9 @@ export const issueToEntity = (issue: Issue): PartialEntity => {
       [extractBaseUrl(linearTypes.propertyType.trashed.propertyTypeId)]:
         issue.trashed,
       [extractBaseUrl(linearTypes.propertyType.triagedAt.propertyTypeId)]:
-        issue.triagedAt?.toString(),
+        issue.triagedAt ? toIsoString(issue.triagedAt) : undefined,
       [extractBaseUrl(linearTypes.propertyType.updatedAt.propertyTypeId)]:
-        issue.updatedAt.toString(),
+        toIsoString(issue.updatedAt),
       [extractBaseUrl(linearTypes.propertyType.url.propertyTypeId)]: issue.url,
     },
   };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The Node SDK of linear returns a Date object while the webhooks passes an ISO string. Depending where the data comes from the correct conversion needs to be done.

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph