### PR TITLE
H-219: Provide hash-graph environment variables for integration worker

### DIFF
--- a/apps/hash-external-services/docker-compose.yml
+++ b/apps/hash-external-services/docker-compose.yml
@@ -385,6 +385,8 @@ services:
         condition: service_healthy
     environment:
       HASH_TEMPORAL_HOST: "temporal"
+      HASH_GRAPH_API_HOST: graph
+      HASH_GRAPH_API_PORT: "${HASH_GRAPH_API_PORT}"
     tmpfs:
       - /tmp
     read_only: true


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `HASH_GRAPH_API_*` environment variables need to be set in order to allow connecting from external services

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph