### PR TITLE
H-226: Use `apiOrigin` instead of `localhost:5001` for OAuth callback

### DIFF
--- a/apps/hash-api/src/integrations/linear/oauth.ts
+++ b/apps/hash-api/src/integrations/linear/oauth.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 
 import { LinearClient } from "@linear/sdk";
+import { apiOrigin } from "@local/hash-graphql-shared/environment";
 import { frontendUrl } from "@local/hash-isomorphic-utils/environment";
 import {
   AccountId,
@@ -27,8 +28,7 @@ const linearClientId = process.env.LINEAR_CLIENT_ID;
 const linearClientSecret = process.env.LINEAR_CLIENT_SECRET;
 
 const linearOAuthCallbackUrl =
-  process.env.LINEAR_OAUTH_CALLBACK_URL ??
-  "http://localhost:5001/oauth/linear/callback";
+  process.env.LINEAR_OAUTH_CALLBACK_URL ?? `${apiOrigin}/oauth/linear/callback`;
 
 /**
  * @todo oauth state will need to be store somewhere other than memory if we need:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The redirect url in prod still points to `localhost:5001`

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph