### PR TITLE
H-230: Share Temporal types with API

### DIFF
--- a/apps/hash-api/src/graphql/resolvers/integrations/linear/sync-workspaces-with-teams.ts
+++ b/apps/hash-api/src/graphql/resolvers/integrations/linear/sync-workspaces-with-teams.ts
@@ -1,7 +1,9 @@
 import {
+  AccountId,
   Entity,
   extractEntityUuidFromEntityId,
   extractOwnedByIdFromEntityId,
+  Uuid,
 } from "@local/hash-subgraph";
 
 import { archiveEntity } from "../../../../graph/knowledge/primitive/entity";
@@ -82,8 +84,9 @@ export const syncLinearIntegrationWithWorkspacesMutation: ResolverFn<
       }),
     ),
     ...syncWithWorkspaces.map(async ({ workspaceEntityId, linearTeamIds }) => {
-      const workspaceAccountId =
-        extractEntityUuidFromEntityId(workspaceEntityId);
+      const workspaceAccountId = extractEntityUuidFromEntityId(
+        workspaceEntityId,
+      ) as Uuid as AccountId;
       return Promise.all([
         linearClient.triggerWorkspaceSync({
           workspaceAccountId,

--- a/apps/hash-api/src/integrations/linear.ts
+++ b/apps/hash-api/src/integrations/linear.ts
@@ -1,5 +1,6 @@
 import { LinearClient, Organization, Team } from "@linear/sdk";
 import { SyncWorkspaceWorkflow } from "@local/hash-backend-utils/temporal-workflow-types";
+import { AccountId } from "@local/hash-subgraph";
 
 import { TemporalClient } from "../temporal";
 import { genId } from "../util";
@@ -42,8 +43,8 @@ export class Linear {
   }
 
   public async triggerWorkspaceSync(params: {
-    workspaceAccountId: string;
-    actorId: string;
+    workspaceAccountId: AccountId;
+    actorId: AccountId;
     teamIds: string[];
   }): Promise<void> {
     // TODO: Implement error handling

--- a/apps/hash-api/src/integrations/linear.ts
+++ b/apps/hash-api/src/integrations/linear.ts
@@ -1,4 +1,5 @@
 import { LinearClient, Organization, Team } from "@linear/sdk";
+import { SyncWorkspaceWorkflow } from "@local/hash-backend-utils/temporal-workflow-types";
 
 import { TemporalClient } from "../temporal";
 import { genId } from "../util";
@@ -46,15 +47,18 @@ export class Linear {
     teamIds: string[];
   }): Promise<void> {
     // TODO: Implement error handling
-    await this.temporalClient.workflow.start("syncWorkspace", {
-      taskQueue: "integration",
-      args: [
-        {
-          apiKey: this.apiKey,
-          ...params,
-        },
-      ],
-      workflowId: `syncWorkspace-${genId()}`,
-    });
+    await this.temporalClient.workflow.start<SyncWorkspaceWorkflow>(
+      "syncWorkspace",
+      {
+        taskQueue: "integration",
+        args: [
+          {
+            apiKey: this.apiKey,
+            ...params,
+          },
+        ],
+        workflowId: `syncWorkspace-${genId()}`,
+      },
+    );
   }
 }

--- a/apps/hash-api/src/integrations/linear/sync-back.ts
+++ b/apps/hash-api/src/integrations/linear/sync-back.ts
@@ -1,3 +1,4 @@
+import { UpdateLinearIssueWorkflow } from "@local/hash-backend-utils/temporal-workflow-types";
 import { GraphApi } from "@local/hash-graph-client";
 import { linearTypes } from "@local/hash-isomorphic-utils/ontology-types";
 import {
@@ -70,11 +71,20 @@ export const processEntityChange = async (
 
   switch (entityTypeId) {
     case linearTypes.entityType.issue.entityTypeId: {
-      await temporalClient.workflow.start("updateLinearIssue", {
-        workflowId: genId(),
-        taskQueue: "integration",
-        args: [linearApiKey, resourceId, entity.properties],
-      });
+      await temporalClient.workflow.start<UpdateLinearIssueWorkflow>(
+        "updateLinearIssue",
+        {
+          workflowId: genId(),
+          taskQueue: "integration",
+          args: [
+            {
+              apiKey: linearApiKey,
+              issueId: resourceId as string,
+              payload: entity.properties,
+            },
+          ],
+        },
+      );
     }
   }
 };

--- a/apps/hash-api/src/integrations/linear/webhook.ts
+++ b/apps/hash-api/src/integrations/linear/webhook.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 
 import { tupleIncludes } from "@local/advanced-types/includes";
 import { WorkflowTypeMap } from "@local/hash-backend-utils/temporal-workflow-types";
+import { AccountId, OwnedById } from "@local/hash-subgraph";
 import { RequestHandler } from "express";
 
 import { logger } from "../../logger";
@@ -75,8 +76,8 @@ export const linearWebhook: RequestHandler<{}, string, string> = async (
         args: [
           {
             // @todo Use correct account IDs
-            actorId: "00000000-0000-0000-0000-000000000000",
-            ownedById: "00000000-0000-0000-0000-000000000000",
+            actorId: "00000000-0000-0000-0000-000000000000" as AccountId,
+            ownedById: "00000000-0000-0000-0000-000000000000" as OwnedById,
             payload: payload.data,
           },
         ],

--- a/apps/hash-api/src/integrations/linear/webhook.ts
+++ b/apps/hash-api/src/integrations/linear/webhook.ts
@@ -1,35 +1,28 @@
 import crypto from "node:crypto";
 
+import { tupleIncludes } from "@local/advanced-types/includes";
+import { WorkflowTypeMap } from "@local/hash-backend-utils/temporal-workflow-types";
 import { RequestHandler } from "express";
 
 import { logger } from "../../logger";
 import { createTemporalClient } from "../../temporal";
 import { genId } from "../../util";
 
-type LinearWebhookPayloadBase = {
-  action: string;
+type LinearWebhookPayload = {
+  action: "create" | "update" | "delete";
   createdAt: string; // ISO timestamp when the action took place.
+  data?: any; // The serialized value of the subject entity.
   organizationId: string;
-  type: "Cycle" | "Issue" | "Project" | "Reaction";
+  type: "Cycle" | "Issue" | "Project" | "Reaction" | "User";
   url: string; // The URL of the subject entity.
-
+  updatedFrom?: any; // an object containing the previous values of updated properties;
   webhookId: string;
   webhookTimestamp: number; // UNIX timestamp of webhook delivery in milliseconds.
 };
 
-type LinearWebhookPayloadChange = LinearWebhookPayloadBase & {
-  action: "create" | "update" | "delete";
-  data: any; // The serialized value of the subject entity.
-  updatedFrom?: any; // an object containing the previous values of updated properties;
-};
-
-type LinearWebhookPayload =
-  | LinearWebhookPayloadBase
-  | LinearWebhookPayloadChange;
-
 // @todo upgrade to Express 5 which handles async controllers automatically
 // eslint-disable-next-line @typescript-eslint/no-misused-promises
-export const linearWebhook: RequestHandler<{}, "ok", string> = async (
+export const linearWebhook: RequestHandler<{}, string, string> = async (
   req,
   res,
 ) => {
@@ -60,22 +53,36 @@ export const linearWebhook: RequestHandler<{}, "ok", string> = async (
   }
 
   if (
-    ["create", "update"].includes(payload.action) &&
-    ["Issue", "User"].includes(payload.type)
+    tupleIncludes(["create", "update"] as const, payload.action) &&
+    tupleIncludes(["Issue", "User"] as const, payload.type)
   ) {
-    const workflow = `${payload.action}${payload.type}`;
-    await temporalClient.workflow.execute(workflow, {
-      taskQueue: "integration",
-      args: [
-        {
-          // @todo Use correct account IDs
-          actorId: "00000000-0000-0000-0000-000000000000",
-          ownedById: "00000000-0000-0000-0000-000000000000",
-          payload: (payload as LinearWebhookPayloadChange).data,
-        },
-      ],
-      workflowId: `${workflow}-${genId()}`,
-    });
+    if (!payload.data) {
+      res
+        .status(400)
+        .send(
+          `No data sent with ${payload.action} ${payload.type} webhook payload`,
+        );
+      return;
+    }
+
+    const workflow =
+      `${payload.action}Hash${payload.type}` as const satisfies keyof WorkflowTypeMap;
+
+    await temporalClient.workflow.start<WorkflowTypeMap[typeof workflow]>(
+      workflow,
+      {
+        taskQueue: "integration",
+        args: [
+          {
+            // @todo Use correct account IDs
+            actorId: "00000000-0000-0000-0000-000000000000",
+            ownedById: "00000000-0000-0000-0000-000000000000",
+            payload: payload.data,
+          },
+        ],
+        workflowId: `${workflow}-${genId()}`,
+      },
+    );
   }
 
   res.send("ok");

--- a/apps/hash-frontend/src/pages/account/integrations/select-linear-teams-table.tsx
+++ b/apps/hash-frontend/src/pages/account/integrations/select-linear-teams-table.tsx
@@ -132,14 +132,9 @@ export const mapLinearOrganizationToSyncWithWorkspacesInputVariable = (params: {
         )
         .map(({ id }) => id);
 
-      /** @todo: allow the user to decide whether to sync future teams */
-      const syncAllTeams =
-        params.linearOrganization.teams.length === linearTeamIds.length;
+      /** @todo: allow the user to opt-in to sync with future teams in the linear organization */
 
-      return {
-        workspaceEntityId,
-        linearTeamIds: syncAllTeams ? [] : linearTeamIds,
-      };
+      return { workspaceEntityId, linearTeamIds };
     });
 
 export const SelectLinearTeamsTable: FunctionComponent<{

--- a/apps/hash-integration-worker/src/activities.ts
+++ b/apps/hash-integration-worker/src/activities.ts
@@ -6,6 +6,7 @@ import {
   Team,
   User,
 } from "@linear/sdk";
+import { PartialEntity } from "@local/hash-backend-utils/temporal-workflow-types";
 import { GraphApi } from "@local/hash-graph-client";
 import { linearTypes } from "@local/hash-isomorphic-utils/ontology-types";
 import {
@@ -26,13 +27,12 @@ import {
   issueLabelToEntity,
   issueToEntity,
   organizationToEntity,
-  PartialEntity,
   projectMilestoneToEntity,
   projectToEntity,
   userToEntity,
 } from "./mappings";
 
-const createOrUpdateEntity = async (params: {
+const createOrUpdateHashEntity = async (params: {
   graphApiClient: GraphApi;
   entity: PartialEntity;
   actorId: string;
@@ -160,7 +160,7 @@ export const createLinearIntegrationActivities = ({
   }): Promise<void> {
     await Promise.all(
       params.entities.map((entity) =>
-        createOrUpdateEntity({
+        createOrUpdateHashEntity({
           graphApiClient,
           actorId: params.actorId,
           workspaceAccountId: params.workspaceAccountId,
@@ -170,19 +170,19 @@ export const createLinearIntegrationActivities = ({
     );
   },
 
-  async readOrganization({
+  async readLinearOrganization({
     apiKey,
   }: ParamsWithApiKey<{}>): Promise<PartialEntity> {
     return createLinearClient(apiKey).organization.then(organizationToEntity);
   },
 
-  async createUser(params: {
+  async createHashUser(params: {
     user: User;
     actorId: string;
     workspaceAccountId: string;
   }): Promise<void> {
     const entity = userToEntity(params.user);
-    await createOrUpdateEntity({
+    await createOrUpdateHashEntity({
       graphApiClient,
       actorId: params.actorId,
       workspaceAccountId: params.workspaceAccountId,
@@ -190,28 +190,30 @@ export const createLinearIntegrationActivities = ({
     });
   },
 
-  async updateUser(params: { user: User; actorId: string }): Promise<void> {
-    await createOrUpdateEntity({
+  async updateHashUser(params: { user: User; actorId: string }): Promise<void> {
+    await createOrUpdateHashEntity({
       graphApiClient,
       entity: userToEntity(params.user),
       actorId: params.actorId,
     });
   },
 
-  async readUsers({ apiKey }: ParamsWithApiKey): Promise<PartialEntity[]> {
+  async readLinearUsers({
+    apiKey,
+  }: ParamsWithApiKey): Promise<PartialEntity[]> {
     return createLinearClient(apiKey)
       .users()
       .then(readNodes)
       .then((users) => users.map(userToEntity));
   },
 
-  async createIssue(params: {
+  async createHashIssue(params: {
     issue: Issue;
     actorId: string;
     workspaceAccountId: string;
   }): Promise<void> {
     const entity = issueToEntity(params.issue);
-    await createOrUpdateEntity({
+    await createOrUpdateHashEntity({
       graphApiClient,
       actorId: params.actorId,
       workspaceAccountId: params.workspaceAccountId,
@@ -219,7 +221,7 @@ export const createLinearIntegrationActivities = ({
     });
   },
 
-  async readIssues({
+  async readLinearIssues({
     apiKey,
     filter,
   }: ParamsWithApiKey<{ filter?: { teamId?: string } }>): Promise<
@@ -237,19 +239,22 @@ export const createLinearIntegrationActivities = ({
       .then((issues) => issues.map(issueToEntity));
   },
 
-  async updateIssue(params: { issue: Issue; actorId: string }): Promise<void> {
-    await createOrUpdateEntity({
+  async updateHashIssue(params: {
+    issue: Issue;
+    actorId: string;
+  }): Promise<void> {
+    await createOrUpdateHashEntity({
       graphApiClient,
       entity: issueToEntity(params.issue),
       actorId: params.actorId,
     });
   },
 
-  async readTeams({ apiKey }: ParamsWithApiKey): Promise<Team[]> {
+  async readLinearTeams({ apiKey }: ParamsWithApiKey): Promise<Team[]> {
     return createLinearClient(apiKey).teams().then(readNodes);
   },
 
-  async readCycles({
+  async readLinearCycles({
     apiKey,
     filter,
   }: ParamsWithApiKey<{ filter?: { teamId?: string } }>): Promise<object[]> {
@@ -279,7 +284,7 @@ export const createLinearIntegrationActivities = ({
       .then((projects) => projects.map(projectToEntity));
   },
 
-  async readComments({
+  async readLinearComments({
     apiKey,
     filter,
   }: ParamsWithApiKey<{ filter?: { teamId?: string } }>): Promise<object[]> {
@@ -297,7 +302,9 @@ export const createLinearIntegrationActivities = ({
       .then((comments) => comments.map(commentToEntity));
   },
 
-  async readProjectMilestones({ apiKey }: ParamsWithApiKey): Promise<object[]> {
+  async readLinearProjectMilestones({
+    apiKey,
+  }: ParamsWithApiKey): Promise<object[]> {
     const linearClient = createLinearClient(apiKey);
 
     return (
@@ -317,14 +324,14 @@ export const createLinearIntegrationActivities = ({
     ).flat();
   },
 
-  async readDocuments({ apiKey }: ParamsWithApiKey): Promise<object[]> {
+  async readLinearDocuments({ apiKey }: ParamsWithApiKey): Promise<object[]> {
     return createLinearClient(apiKey)
       .documents()
       .then(readNodes)
       .then((documents) => documents.map(documentToEntity));
   },
 
-  async readIssueLabels({
+  async readLinearIssueLabels({
     apiKey,
     filter,
   }: ParamsWithApiKey<{ filter?: { teamId?: string } }>): Promise<object[]> {
@@ -341,21 +348,25 @@ export const createLinearIntegrationActivities = ({
       .then((issueLabels) => issueLabels.map(issueLabelToEntity));
   },
 
-  async readAttachments({ apiKey }: ParamsWithApiKey): Promise<object[]> {
+  async readLinearAttachments({ apiKey }: ParamsWithApiKey): Promise<object[]> {
     return createLinearClient(apiKey)
       .attachments()
       .then(readNodes)
       .then((attachments) => attachments.map(attachmentToEntity));
   },
 
-  async updateLinearIssue(
-    apiKey: string,
-    issueId: Issue["id"],
-    update: EntityPropertiesObject,
-  ): Promise<PartialEntity | undefined> {
+  async updateLinearIssue({
+    apiKey,
+    issueId,
+    payload,
+  }: {
+    apiKey: string;
+    issueId: Issue["id"];
+    payload: EntityPropertiesObject;
+  }): Promise<PartialEntity | undefined> {
     const client = createLinearClient(apiKey);
 
-    const linearUpdate = entityPropertiesToIssueUpdate(update);
+    const linearUpdate = entityPropertiesToIssueUpdate(payload);
 
     const updatedIssue = await client
       .updateIssue(issueId, linearUpdate)

--- a/apps/hash-integration-worker/src/activities.ts
+++ b/apps/hash-integration-worker/src/activities.ts
@@ -10,6 +10,7 @@ import { PartialEntity } from "@local/hash-backend-utils/temporal-workflow-types
 import { GraphApi } from "@local/hash-graph-client";
 import { linearTypes } from "@local/hash-isomorphic-utils/ontology-types";
 import {
+  AccountId,
   EntityPropertiesObject,
   EntityRootType,
   Subgraph,
@@ -35,8 +36,8 @@ import {
 const createOrUpdateHashEntity = async (params: {
   graphApiClient: GraphApi;
   entity: PartialEntity;
-  actorId: string;
-  workspaceAccountId?: string;
+  actorId: AccountId;
+  workspaceAccountId?: AccountId;
 }): Promise<void> => {
   const idBaseUrl = extractBaseUrl(linearTypes.propertyType.id.propertyTypeId);
   const updatedAtBaseUrl = extractBaseUrl(
@@ -155,8 +156,8 @@ export const createLinearIntegrationActivities = ({
 }) => ({
   async createPartialEntities(params: {
     entities: PartialEntity[];
-    actorId: string;
-    workspaceAccountId: string;
+    actorId: AccountId;
+    workspaceAccountId: AccountId;
   }): Promise<void> {
     await Promise.all(
       params.entities.map((entity) =>
@@ -178,8 +179,8 @@ export const createLinearIntegrationActivities = ({
 
   async createHashUser(params: {
     user: User;
-    actorId: string;
-    workspaceAccountId: string;
+    actorId: AccountId;
+    workspaceAccountId: AccountId;
   }): Promise<void> {
     const entity = userToEntity(params.user);
     await createOrUpdateHashEntity({
@@ -190,7 +191,10 @@ export const createLinearIntegrationActivities = ({
     });
   },
 
-  async updateHashUser(params: { user: User; actorId: string }): Promise<void> {
+  async updateHashUser(params: {
+    user: User;
+    actorId: AccountId;
+  }): Promise<void> {
     await createOrUpdateHashEntity({
       graphApiClient,
       entity: userToEntity(params.user),
@@ -209,8 +213,8 @@ export const createLinearIntegrationActivities = ({
 
   async createHashIssue(params: {
     issue: Issue;
-    actorId: string;
-    workspaceAccountId: string;
+    actorId: AccountId;
+    workspaceAccountId: AccountId;
   }): Promise<void> {
     const entity = issueToEntity(params.issue);
     await createOrUpdateHashEntity({
@@ -241,7 +245,7 @@ export const createLinearIntegrationActivities = ({
 
   async updateHashIssue(params: {
     issue: Issue;
-    actorId: string;
+    actorId: AccountId;
   }): Promise<void> {
     await createOrUpdateHashEntity({
       graphApiClient,

--- a/apps/hash-integration-worker/src/main.ts
+++ b/apps/hash-integration-worker/src/main.ts
@@ -2,11 +2,18 @@ import * as http from "node:http";
 import * as path from "node:path";
 
 import { getRequiredEnv } from "@local/hash-backend-utils/environment";
+import { WorkflowTypeMap } from "@local/hash-backend-utils/temporal-workflow-types";
 import { NativeConnection, Worker } from "@temporalio/worker";
 import { config } from "dotenv-flow";
 
 import * as activities from "./activities";
 import { createGraphClient } from "./graph";
+import * as workflows from "./workflows";
+
+// This is a workaround to ensure that all functions defined in WorkflowTypeMap are exported from the workflows file
+// They must be individually exported from the file, and it's impossible to check completeness of exports in the file itself
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const exportMap: WorkflowTypeMap = workflows;
 
 export const monorepoRootDir = path.resolve(__dirname, "../../..");
 

--- a/apps/hash-integration-worker/src/mappings.ts
+++ b/apps/hash-integration-worker/src/mappings.ts
@@ -1,4 +1,3 @@
-import { VersionedUrl } from "@blockprotocol/type-system";
 import {
   Attachment,
   Comment,
@@ -14,14 +13,10 @@ import {
   Team,
   User,
 } from "@linear/sdk";
+import { PartialEntity } from "@local/hash-backend-utils/temporal-workflow-types";
 import { linearTypes } from "@local/hash-isomorphic-utils/ontology-types";
-import { Entity, EntityPropertiesObject } from "@local/hash-subgraph";
+import { EntityPropertiesObject } from "@local/hash-subgraph";
 import { extractBaseUrl } from "@local/hash-subgraph/type-system-patch";
-
-export type PartialEntity = {
-  properties: Partial<Entity["properties"]>;
-  entityTypeId: VersionedUrl;
-};
 
 const toIsoString = (date: string | Date): string => {
   if (typeof date === "string") {

--- a/apps/hash-integration-worker/src/workflows.ts
+++ b/apps/hash-integration-worker/src/workflows.ts
@@ -88,5 +88,5 @@ export const readLinearTeams: ReadLinearTeamsWorkflow = async ({ apiKey }) =>
   linear.readLinearTeams({ apiKey });
 
 export const updateLinearIssue: UpdateLinearIssueWorkflow = async (params) => {
-  return await linear.updateLinearIssue(params);
+  await linear.updateLinearIssue(params);
 };

--- a/apps/hash-integration-worker/src/workflows.ts
+++ b/apps/hash-integration-worker/src/workflows.ts
@@ -1,4 +1,11 @@
-import { Issue, Team, User } from "@linear/sdk";
+import {
+  CreateHashIssueWorkflow,
+  CreateHashUserWorkflow,
+  ReadLinearTeamsWorkflow,
+  SyncWorkspaceWorkflow,
+  UpdateHashUserWorkflow,
+  UpdateLinearIssueWorkflow,
+} from "@local/hash-backend-utils/temporal-workflow-types";
 import { proxyActivities } from "@temporalio/workflow";
 
 import { createLinearIntegrationActivities } from "./activities";
@@ -12,16 +19,11 @@ const linear = proxyActivities<
   },
 });
 
-export const syncWorkspace = async (params: {
-  apiKey: string;
-  workspaceAccountId: string;
-  actorId: string;
-  teamIds: string[];
-}): Promise<void> => {
+export const syncWorkspace: SyncWorkspaceWorkflow = async (params) => {
   const { apiKey, workspaceAccountId, actorId, teamIds } = params;
 
   const organization = linear
-    .readOrganization({ apiKey })
+    .readLinearOrganization({ apiKey })
     .then((organizationEntity) =>
       linear.createPartialEntities({
         workspaceAccountId,
@@ -30,7 +32,7 @@ export const syncWorkspace = async (params: {
       }),
     );
 
-  const users = linear.readUsers({ apiKey }).then((userEntities) =>
+  const users = linear.readLinearUsers({ apiKey }).then((userEntities) =>
     linear.createPartialEntities({
       workspaceAccountId,
       actorId,
@@ -39,68 +41,45 @@ export const syncWorkspace = async (params: {
   );
 
   const issues = teamIds.map((teamId) =>
-    linear.readIssues({ apiKey, filter: { teamId } }).then((issueEntities) =>
-      linear.createPartialEntities({
-        workspaceAccountId,
-        actorId,
-        entities: issueEntities,
-      }),
-    ),
+    linear
+      .readLinearIssues({ apiKey, filter: { teamId } })
+      .then((issueEntities) =>
+        linear.createPartialEntities({
+          workspaceAccountId,
+          actorId,
+          entities: issueEntities,
+        }),
+      ),
   );
 
   await Promise.all([organization, users, ...issues]);
 };
 
-export const createUser = async (params: {
-  payload: User;
-  ownedById: string;
-  actorId: string;
-}): Promise<void> => {
-  await linear.createUser({
+export const createLinearUser: CreateHashUserWorkflow = async (params) => {
+  await linear.createHashUser({
     user: params.payload,
     workspaceAccountId: params.ownedById,
     actorId: params.actorId,
   });
 };
 
-export const updateUser = async (params: {
-  payload: User;
-  actorId: string;
-}): Promise<void> =>
-  linear.updateUser({
+export const updateHashUser: UpdateHashUserWorkflow = async (params) =>
+  linear.updateHashUser({
     user: params.payload,
     actorId: params.actorId,
   });
 
-export const createIssue = async (params: {
-  payload: Issue;
-  ownedById: string;
-  actorId: string;
-}): Promise<void> => {
-  await linear.createIssue({
+export const createLHashIssue: CreateHashIssueWorkflow = async (params) => {
+  await linear.createHashIssue({
     issue: params.payload,
     workspaceAccountId: params.ownedById,
     actorId: params.actorId,
   });
 };
 
-export const updateIssue = async (params: {
-  payload: Issue;
-  actorId: string;
-}): Promise<void> =>
-  linear.updateIssue({
-    issue: params.payload,
-    actorId: params.actorId,
-  });
+export const readLinearTeams: ReadLinearTeamsWorkflow = async ({ apiKey }) =>
+  linear.readLinearTeams({ apiKey });
 
-export const linearTeams = async ({
-  apiKey,
-}: {
-  apiKey: string;
-}): Promise<Team[]> => linear.readTeams({ apiKey });
-
-export const updateLinearIssue = async (
-  ...args: Parameters<typeof linear.updateLinearIssue>
-) => {
-  await linear.updateLinearIssue(...args);
+export const updateLinearIssue: UpdateLinearIssueWorkflow = async (params) => {
+  return await linear.updateLinearIssue(params);
 };

--- a/apps/hash-integration-worker/src/workflows.ts
+++ b/apps/hash-integration-worker/src/workflows.ts
@@ -3,6 +3,7 @@ import {
   CreateHashUserWorkflow,
   ReadLinearTeamsWorkflow,
   SyncWorkspaceWorkflow,
+  UpdateHashIssueWorkflow,
   UpdateHashUserWorkflow,
   UpdateLinearIssueWorkflow,
 } from "@local/hash-backend-utils/temporal-workflow-types";
@@ -55,7 +56,7 @@ export const syncWorkspace: SyncWorkspaceWorkflow = async (params) => {
   await Promise.all([organization, users, ...issues]);
 };
 
-export const createLinearUser: CreateHashUserWorkflow = async (params) => {
+export const createHashUser: CreateHashUserWorkflow = async (params) => {
   await linear.createHashUser({
     user: params.payload,
     workspaceAccountId: params.ownedById,
@@ -69,13 +70,19 @@ export const updateHashUser: UpdateHashUserWorkflow = async (params) =>
     actorId: params.actorId,
   });
 
-export const createLHashIssue: CreateHashIssueWorkflow = async (params) => {
+export const createHashIssue: CreateHashIssueWorkflow = async (params) => {
   await linear.createHashIssue({
     issue: params.payload,
     workspaceAccountId: params.ownedById,
     actorId: params.actorId,
   });
 };
+
+export const updateHashIssue: UpdateHashIssueWorkflow = async (params) =>
+  linear.updateHashIssue({
+    issue: params.payload,
+    actorId: params.actorId,
+  });
 
 export const readLinearTeams: ReadLinearTeamsWorkflow = async ({ apiKey }) =>
   linear.readLinearTeams({ apiKey });

--- a/libs/@local/advanced-types/src/includes.ts
+++ b/libs/@local/advanced-types/src/includes.ts
@@ -1,0 +1,12 @@
+/**
+ * Narrows the type of a search term to a member of T
+ *
+ * Array MUST be passed as a tuple
+ * @example includes(["foo", "bar"] as const, "foo") // true
+ */
+export function tupleIncludes<T>(
+  array: readonly T[],
+  searchElement: unknown,
+): searchElement is T {
+  return array.includes(searchElement as T);
+}

--- a/libs/@local/hash-backend-utils/package.json
+++ b/libs/@local/hash-backend-utils/package.json
@@ -22,7 +22,10 @@
   },
   "dependencies": {
     "@blockprotocol/core": "0.1.2",
+    "@blockprotocol/type-system": "0.1.1",
+    "@linear/sdk": "6.0.0",
     "@opensearch-project/opensearch": "1.1.0",
+    "@temporalio/client": "1.8.1",
     "apollo-datasource": "3.3.2",
     "dotenv-flow": "3.2.0",
     "redis": "3.1.2",

--- a/libs/@local/hash-backend-utils/src/temporal-workflow-types.ts
+++ b/libs/@local/hash-backend-utils/src/temporal-workflow-types.ts
@@ -1,6 +1,11 @@
 import { VersionedUrl } from "@blockprotocol/type-system";
 import { Issue, Team, User } from "@linear/sdk";
-import { Entity, EntityPropertiesObject } from "@local/hash-subgraph";
+import {
+  AccountId,
+  Entity,
+  EntityPropertiesObject,
+  OwnedById,
+} from "@local/hash-subgraph";
 
 export type PartialEntity = {
   properties: Partial<Entity["properties"]>;
@@ -9,14 +14,14 @@ export type PartialEntity = {
 
 export type CreateHashIssueWorkflow = (params: {
   payload: Issue;
-  ownedById: string;
-  actorId: string;
+  ownedById: OwnedById;
+  actorId: AccountId;
 }) => Promise<void>;
 
 export type CreateHashUserWorkflow = (params: {
   payload: User;
-  ownedById: string;
-  actorId: string;
+  ownedById: OwnedById;
+  actorId: AccountId;
 }) => Promise<void>;
 
 export type ReadLinearTeamsWorkflow = (params: {
@@ -25,14 +30,14 @@ export type ReadLinearTeamsWorkflow = (params: {
 
 export type SyncWorkspaceWorkflow = (params: {
   apiKey: string;
-  workspaceAccountId: string;
-  actorId: string;
+  workspaceAccountId: AccountId;
+  actorId: AccountId;
   teamIds: string[];
 }) => Promise<void>;
 
 export type UpdateHashIssueWorkflow = (params: {
   payload: Issue;
-  actorId: string;
+  actorId: AccountId;
 }) => Promise<void>;
 
 export type UpdateLinearIssueWorkflow = (params: {
@@ -43,7 +48,7 @@ export type UpdateLinearIssueWorkflow = (params: {
 
 export type UpdateHashUserWorkflow = (params: {
   payload: User;
-  actorId: string;
+  actorId: AccountId;
 }) => Promise<void>;
 
 export type WorkflowTypeMap = {

--- a/libs/@local/hash-backend-utils/src/temporal-workflow-types.ts
+++ b/libs/@local/hash-backend-utils/src/temporal-workflow-types.ts
@@ -39,7 +39,7 @@ export type UpdateLinearIssueWorkflow = (params: {
   apiKey: string;
   issueId: Issue["id"];
   payload: EntityPropertiesObject;
-}) => Promise<PartialEntity | undefined>;
+}) => Promise<void>;
 
 export type UpdateHashUserWorkflow = (params: {
   payload: User;

--- a/libs/@local/hash-backend-utils/src/temporal-workflow-types.ts
+++ b/libs/@local/hash-backend-utils/src/temporal-workflow-types.ts
@@ -49,6 +49,7 @@ export type UpdateHashUserWorkflow = (params: {
 export type WorkflowTypeMap = {
   createHashIssue: CreateHashIssueWorkflow;
   createHashUser: CreateHashUserWorkflow;
+  readLinearTeams: ReadLinearTeamsWorkflow;
   syncWorkspace: SyncWorkspaceWorkflow;
   updateHashIssue: UpdateHashIssueWorkflow;
   updateHashUser: UpdateHashUserWorkflow;

--- a/libs/@local/hash-backend-utils/src/temporal-workflow-types.ts
+++ b/libs/@local/hash-backend-utils/src/temporal-workflow-types.ts
@@ -1,0 +1,56 @@
+import { VersionedUrl } from "@blockprotocol/type-system";
+import { Issue, Team, User } from "@linear/sdk";
+import { Entity, EntityPropertiesObject } from "@local/hash-subgraph";
+
+export type PartialEntity = {
+  properties: Partial<Entity["properties"]>;
+  entityTypeId: VersionedUrl;
+};
+
+export type CreateHashIssueWorkflow = (params: {
+  payload: Issue;
+  ownedById: string;
+  actorId: string;
+}) => Promise<void>;
+
+export type CreateHashUserWorkflow = (params: {
+  payload: User;
+  ownedById: string;
+  actorId: string;
+}) => Promise<void>;
+
+export type ReadLinearTeamsWorkflow = (params: {
+  apiKey: string;
+}) => Promise<Team[]>;
+
+export type SyncWorkspaceWorkflow = (params: {
+  apiKey: string;
+  workspaceAccountId: string;
+  actorId: string;
+  teamIds: string[];
+}) => Promise<void>;
+
+export type UpdateHashIssueWorkflow = (params: {
+  payload: Issue;
+  actorId: string;
+}) => Promise<void>;
+
+export type UpdateLinearIssueWorkflow = (params: {
+  apiKey: string;
+  issueId: Issue["id"];
+  payload: EntityPropertiesObject;
+}) => Promise<PartialEntity | undefined>;
+
+export type UpdateHashUserWorkflow = (params: {
+  payload: User;
+  actorId: string;
+}) => Promise<void>;
+
+export type WorkflowTypeMap = {
+  createHashIssue: CreateHashIssueWorkflow;
+  createHashUser: CreateHashUserWorkflow;
+  syncWorkspace: SyncWorkspaceWorkflow;
+  updateHashIssue: UpdateHashIssueWorkflow;
+  updateHashUser: UpdateHashUserWorkflow;
+  updateLinearIssue: UpdateLinearIssueWorkflow;
+};


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We want to share the types of Temporal workflows with the API, so that the arguments (and where relevant) return types have type safety.

One of way of doing this is to import the workflow functions themselves when starting a workflow, but this is undesirable because:
1. It requires evaluating all the code in the workflows and their supporting activities, just to get their types – potentially leading to errors
2. The design of the repo is that shared code should go in `libs/` rather than apps importing from one another

This PR introduces shared types in `@local/hash-backend-utils`

## 🔍 What does this change?

- Adds shared types
- Renames some workflow functions to make clear whether they're updating a HASH resource or a Linear resource
- Ensures that the webhook uses a correct workflow name, and simplifies the webhook payload type to make this easier
- Ensures that the functions exported from the workflows file match the expected ones from the types 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:



- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing



### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:


- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Rebuild `external-services`
2. Check the integration still works
