### PR TITLE
Revert "H-220: Use `file` storage for local vault"

### DIFF
--- a/apps/hash-external-services/docker-compose.yml
+++ b/apps/hash-external-services/docker-compose.yml
@@ -398,8 +398,8 @@ services:
     ports:
       - "${HASH_VAULT_PORT}:8200"
     volumes:
-      - hash-vault-data:/vault/file:rw
-      - ./vault/config:/vault/config:rw
+      - hash-postgres-data:/vault/file:rw
+      # - ./vault/config:/vault/config:rw - for when we need a config file
     cap_add:
       - IPC_LOCK
     environment:

--- a/apps/hash-external-services/vault/config/storage.hcl
+++ b/apps/hash-external-services/vault/config/storage.hcl
@@ -1,3 +1,0 @@
-storage "file" {
-  path = "/vault/file"
-}


### PR DESCRIPTION
Reverts hashintel/hash#2825

It looks like some additional steps will be needed for persisted dev local Vault to avoid a 'Vault already initialized' error on start up – reverting this for now so that usage of Vault in dev is unblocked until the additional config is added.

This means that Vault secrets will be lost when rebooting the container, and integrations will have to be recreated to work. 