### PR TITLE
H-249, H-256, H-272: Fix entity type entities tab table lazy loading, add basic loading indicator

### DIFF
--- a/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/entities-tab.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/entities-tab.tsx
@@ -153,8 +153,8 @@ export const EntitiesTab: FunctionComponent = () => {
           <FontAwesomeIcon icon={faCircleQuestion} sx={{ fontSize: 14 }} />
         }
       >
-        <Paper sx={{ overflow: "hidden" }}>
-          {isEmpty ? (
+        {isEmpty ? (
+          <Paper sx={{ overflow: "hidden" }}>
             <SectionEmptyState
               title="There are no entities of this type visible to you"
               titleIcon={
@@ -162,7 +162,13 @@ export const EntitiesTab: FunctionComponent = () => {
               }
               description="Assigning this type to an entity will result in it being shown here"
             />
-          ) : (
+          </Paper>
+        ) : (
+          <Box
+            sx={{
+              height: "50vh",
+            }}
+          >
             <Grid
               showSearch={showSearch}
               onSearchClose={() => setShowSearch(false)}
@@ -171,8 +177,8 @@ export const EntitiesTab: FunctionComponent = () => {
               createGetCellContent={createGetCellContent}
               customRenderers={[renderTextIconCell]}
             />
-          )}
-        </Paper>
+          </Box>
+        )}
       </SectionWrapper>
     </Box>
   );

--- a/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/entity-type-tabs.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/entity-type-tabs.tsx
@@ -29,7 +29,7 @@ export const EntityTypeTabs = ({ isDraft }: { isDraft: boolean }) => {
     name: "properties.length",
   });
 
-  const { entities } = useEntityTypeEntities();
+  const { entities, loading } = useEntityTypeEntities();
 
   const baseUrl = getEntityTypeBaseUrl(
     router.query["slug-maybe-version"]![0] as string,
@@ -92,6 +92,7 @@ export const EntityTypeTabs = ({ isDraft }: { isDraft: boolean }) => {
                 value={getTabValue("entities")}
                 href={getTabUrl(baseUrl, "entities")}
                 label="Entities"
+                loading={loading}
                 count={entities?.length ?? 0}
                 active={currentTab === "entities"}
               />,

--- a/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/entity-type-tabs/tab-link.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/entity-type-tabs/tab-link.tsx
@@ -1,3 +1,4 @@
+import { LoadingSpinner, theme } from "@hashintel/design-system";
 import {
   Box,
   SxProps,
@@ -16,6 +17,7 @@ export type TabLinkProps = {
   value: string;
   count?: number;
   icon?: ReactElement;
+  loading?: boolean;
   active?: boolean;
   sx?: SxProps<Theme>;
 };
@@ -25,6 +27,7 @@ export const TabLink: FunctionComponent<TabLinkProps> = ({
   href,
   value,
   count,
+  loading,
   active,
   icon,
   sx,
@@ -48,7 +51,15 @@ export const TabLink: FunctionComponent<TabLinkProps> = ({
       </Typography>
     }
     icon={
-      typeof count === "number" ? (
+      loading ? (
+        <Box ml={1}>
+          <LoadingSpinner
+            color={theme.palette.gray[30]}
+            size={18}
+            thickness={6}
+          />
+        </Box>
+      ) : typeof count === "number" ? (
         <Box
           sx={({ palette }) => ({
             display: "flex",

--- a/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/entity-type-tabs/tab-link.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/entity-type-tabs/tab-link.tsx
@@ -51,33 +51,35 @@ export const TabLink: FunctionComponent<TabLinkProps> = ({
       </Typography>
     }
     icon={
-      loading ? (
-        <Box ml={1}>
-          <LoadingSpinner
-            color={theme.palette.gray[30]}
-            size={18}
-            thickness={6}
-          />
-        </Box>
-      ) : typeof count === "number" ? (
+      typeof count === "number" ? (
         <Box
           sx={({ palette }) => ({
             display: "flex",
-            paddingX: 1,
-            paddingY: 0.25,
+            paddingX: loading ? 0.5 : 1,
+            paddingY: loading ? 0.5 : 0.25,
             borderRadius: 30,
-            background: active ? palette.blue[20] : palette.gray[20],
+            background: active ? palette.blue[20] : palette.gray[30],
           })}
         >
-          <Typography
-            variant="microText"
-            sx={({ palette }) => ({
-              fontWeight: 500,
-              color: active ? palette.primary.main : palette.gray[80],
-            })}
-          >
-            {count}
-          </Typography>
+          {loading ? (
+            <LoadingSpinner
+              color={
+                active ? theme.palette.primary.main : theme.palette.gray[60]
+              }
+              size={14}
+              thickness={6}
+            />
+          ) : (
+            <Typography
+              variant="microText"
+              sx={({ palette }) => ({
+                fontWeight: 500,
+                color: active ? palette.primary.main : palette.gray[80],
+              })}
+            >
+              {count}
+            </Typography>
+          )}
         </Box>
       ) : (
         icon ?? undefined

--- a/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/shared/entity-type-entities-context.ts
+++ b/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/shared/entity-type-entities-context.ts
@@ -5,6 +5,7 @@ import { createContext, useContext } from "react";
 export type EntityTypeEntitiesContextValue = {
   entities?: Entity[];
   entityTypes?: EntityType[];
+  loading: boolean;
   propertyTypes?: PropertyType[];
   subgraph?: Subgraph<EntityRootType>;
 };

--- a/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/use-entity-type-entities-context-value.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/use-entity-type-entities-context-value.tsx
@@ -14,6 +14,7 @@ import { EntityTypeEntitiesContextValue } from "./shared/entity-type-entities-co
 export const useEntityTypeEntitiesContextValue = (
   typeBaseUrl: BaseUrl | null,
 ): EntityTypeEntitiesContextValue => {
+  const [loading, setLoading] = useState(false);
   const [subgraph, setSubgraph] = useState<Subgraph<EntityRootType>>();
   const { queryEntities } = useBlockProtocolQueryEntities();
 
@@ -21,6 +22,8 @@ export const useEntityTypeEntitiesContextValue = (
     if (!typeBaseUrl) {
       return;
     }
+
+    setLoading(true);
 
     void queryEntities({
       data: {
@@ -41,11 +44,13 @@ export const useEntityTypeEntitiesContextValue = (
           isOfType: { outgoing: 1 },
         },
       },
-    }).then((res) => {
-      if (res.data) {
-        setSubgraph(res.data);
-      }
-    });
+    })
+      .then((res) => {
+        if (res.data) {
+          setSubgraph(res.data);
+        }
+      })
+      .finally(() => setLoading(false));
   }, [queryEntities, typeBaseUrl]);
 
   const [entities, entityTypes, propertyTypes] =
@@ -95,6 +100,7 @@ export const useEntityTypeEntitiesContextValue = (
   return {
     entities,
     entityTypes,
+    loading,
     propertyTypes,
     subgraph,
   };

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar.tsx
@@ -91,6 +91,7 @@ export const LayoutWithSidebar: FunctionComponent<LayoutWithSidebarProps> = ({
               ...(!fullWidth && {
                 padding: spacing(7, 10),
               }),
+              overflowY: "scroll",
             })}
             ref={setMain}
           >


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The entity type editor has an 'entities' tab which shows a table of entities assigned to that type.

This table's height was unconstrained, meaning that all elements were rendered at once, causing a crash in Firefox and poor performance in other browsers.

This PR introduces a cap on the table height which allows Glide's `DataEditor` component to lazily render rows when they are in view, as it is supposed to.

I've also taken this opportunity to introduce a basic loading indicator in place of the entities count, while the data is loading. It was previously misleadingly showing `0` entities when the loading was taking place. See demo below.


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->
Later on, add better empty state on the entities tab while data is loading, e.g. a loading skeleton (H-256). 

Also ideally we would:
1. Get a count of entities before the entities themselves 
2. Paginate the data

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  You can make a bunch of data load in the table by editing line 87 in `use-entities-table.tsx`
```ts
      new Array(500_000).fill(entities[0]).map((entity) => {
```


## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

Demo shows loading state and 2 million entities in table

https://github.com/hashintel/hash/assets/37743469/9845c182-56a0-41a9-b108-275e09cdbc5e

