### PR TITLE
H-263: Support multiple transaction times for ontology types

### DIFF
--- a/apps/hash-graph/lib/graph/src/snapshot/ontology/metadata/channel.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/ontology/metadata/channel.rs
@@ -16,8 +16,8 @@ use crate::{
     snapshot::{
         account::AccountSender,
         ontology::{
-            OntologyExternalMetadataRow, OntologyIdRow, OntologyOwnedMetadataRow,
-            OntologyTypeMetadataRowBatch,
+            table::OntologyTemporalMetadataRow, OntologyExternalMetadataRow, OntologyIdRow,
+            OntologyOwnedMetadataRow, OntologyTypeMetadataRowBatch,
         },
         SnapshotRestoreError,
     },
@@ -27,6 +27,7 @@ use crate::{
 pub struct OntologyTypeMetadataSender {
     account: AccountSender,
     id: Sender<OntologyIdRow>,
+    temporal_metadata: Sender<OntologyTemporalMetadataRow>,
     owned_metadata: Sender<OntologyOwnedMetadataRow>,
     external_metadata: Sender<OntologyExternalMetadataRow>,
 }
@@ -41,6 +42,10 @@ impl Sink<(Uuid, OntologyElementMetadata)> for OntologyTypeMetadataSender {
             .into_report()
             .change_context(SnapshotRestoreError::Read)
             .attach_printable("could not poll id sender")?;
+        ready!(self.temporal_metadata.poll_ready_unpin(cx))
+            .into_report()
+            .change_context(SnapshotRestoreError::Read)
+            .attach_printable("could not poll temporal metadata sender")?;
         ready!(self.owned_metadata.poll_ready_unpin(cx))
             .into_report()
             .change_context(SnapshotRestoreError::Read)
@@ -99,12 +104,20 @@ impl Sink<(Uuid, OntologyElementMetadata)> for OntologyTypeMetadataSender {
                 ontology_id,
                 base_url: metadata.record_id.base_url.as_str().to_owned(),
                 version: metadata.record_id.version,
-                transaction_time: temporal_versioning.map(|t| t.transaction_time),
                 record_created_by_id: provenance.record_created_by_id,
             })
             .into_report()
             .change_context(SnapshotRestoreError::Read)
             .attach_printable("could not send id")?;
+
+        self.temporal_metadata
+            .start_send(OntologyTemporalMetadataRow {
+                ontology_id,
+                transaction_time: temporal_versioning.map(|t| t.transaction_time),
+            })
+            .into_report()
+            .change_context(SnapshotRestoreError::Read)
+            .attach_printable("could not send temporal metadata")?;
 
         Ok(())
     }
@@ -116,6 +129,10 @@ impl Sink<(Uuid, OntologyElementMetadata)> for OntologyTypeMetadataSender {
             .into_report()
             .change_context(SnapshotRestoreError::Read)
             .attach_printable("could not flush id sender")?;
+        ready!(self.temporal_metadata.poll_flush_unpin(cx))
+            .into_report()
+            .change_context(SnapshotRestoreError::Read)
+            .attach_printable("could not flush temporal metadata sender")?;
         ready!(self.owned_metadata.poll_flush_unpin(cx))
             .into_report()
             .change_context(SnapshotRestoreError::Read)
@@ -135,6 +152,10 @@ impl Sink<(Uuid, OntologyElementMetadata)> for OntologyTypeMetadataSender {
             .into_report()
             .change_context(SnapshotRestoreError::Read)
             .attach_printable("could not close id sender")?;
+        ready!(self.temporal_metadata.poll_close_unpin(cx))
+            .into_report()
+            .change_context(SnapshotRestoreError::Read)
+            .attach_printable("could not close temporal metadata sender")?;
         ready!(self.owned_metadata.poll_close_unpin(cx))
             .into_report()
             .change_context(SnapshotRestoreError::Read)
@@ -165,6 +186,7 @@ pub fn ontology_metadata_channel(
     account_sender: AccountSender,
 ) -> (OntologyTypeMetadataSender, OntologyTypeMetadataReceiver) {
     let (id_tx, id_rx) = mpsc::channel(chunk_size);
+    let (temporal_metadata_tx, temporal_metadata_rx) = mpsc::channel(chunk_size);
     let (owned_metadata_tx, owned_metadata_rx) = mpsc::channel(chunk_size);
     let (external_metadata_tx, external_metadata_rx) = mpsc::channel(chunk_size);
 
@@ -172,6 +194,7 @@ pub fn ontology_metadata_channel(
         OntologyTypeMetadataSender {
             account: account_sender,
             id: id_tx,
+            temporal_metadata: temporal_metadata_tx,
             owned_metadata: owned_metadata_tx,
             external_metadata: external_metadata_tx,
         },
@@ -180,6 +203,10 @@ pub fn ontology_metadata_channel(
                 id_rx
                     .ready_chunks(chunk_size)
                     .map(OntologyTypeMetadataRowBatch::Ids)
+                    .boxed(),
+                temporal_metadata_rx
+                    .ready_chunks(chunk_size)
+                    .map(OntologyTypeMetadataRowBatch::TemporalMetadata)
                     .boxed(),
                 owned_metadata_rx
                     .ready_chunks(chunk_size)

--- a/apps/hash-graph/lib/graph/src/snapshot/ontology/table.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/ontology/table.rs
@@ -17,7 +17,6 @@ pub struct OntologyIdRow {
     pub ontology_id: Uuid,
     pub base_url: String,
     pub version: OntologyTypeVersion,
-    pub transaction_time: Option<LeftClosedTemporalInterval<TransactionTime>>,
     pub record_created_by_id: RecordCreatedById,
 }
 
@@ -33,6 +32,13 @@ pub struct OntologyOwnedMetadataRow {
 pub struct OntologyExternalMetadataRow {
     pub ontology_id: Uuid,
     pub fetched_at: OffsetDateTime,
+}
+
+#[derive(Debug, ToSql)]
+#[postgres(name = "ontology_temporal_metadata")]
+pub struct OntologyTemporalMetadataRow {
+    pub ontology_id: Uuid,
+    pub transaction_time: Option<LeftClosedTemporalInterval<TransactionTime>>,
 }
 
 #[derive(Debug, ToSql)]

--- a/apps/hash-graph/lib/graph/src/store/postgres.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres.rs
@@ -7,7 +7,7 @@ mod query;
 mod traversal_context;
 
 use async_trait::async_trait;
-use error_stack::{IntoReport, Result, ResultExt};
+use error_stack::{IntoReport, Report, Result, ResultExt};
 use time::OffsetDateTime;
 #[cfg(hash_graph_test_environment)]
 use tokio_postgres::{binary_copy::BinaryCopyInWriter, types::Type};
@@ -51,175 +51,102 @@ pub struct PostgresStore<C> {
     client: C,
 }
 
-impl<C> PostgresStore<C>
-where
-    C: AsClient,
-{
-    /// Creates a new `PostgresDatabase` object.
-    #[must_use]
-    pub const fn new(client: C) -> Self {
-        Self { client }
-    }
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum OntologyLocation {
+    Owned,
+    External,
+}
 
-    /// Creates a new owned [`OntologyId`] from the provided [`VersionedUrl`].
-    ///
-    /// # Errors
-    ///
-    /// - if [`VersionedUrl::base_url`] did already exist in the database
-    #[tracing::instrument(level = "debug", skip(self))]
-    async fn create_owned_ontology_id(
-        &self,
-        record_id: &OntologyTypeRecordId,
-        provenance: ProvenanceMetadata,
-        owned_by_id: OwnedById,
+impl PostgresStore<tokio_postgres::Transaction<'_>> {
+    async fn create_base_url(
+        &mut self,
+        base_url: &BaseUrl,
         on_conflict: ConflictBehavior,
-    ) -> Result<OntologyId, InsertionError> {
-        self.as_client()
-            .query_one(
-                r#"
-                SELECT
-                    ontology_id
-                FROM create_owned_ontology_id(
-                    base_url := $1,
-                    version := $2,
-                    record_created_by_id := $3,
-                    owned_by_id := $4,
-                    resume_on_conflict := $5
-                );"#,
-                &[
-                    &record_id.base_url.as_str(),
-                    &record_id.version,
-                    &provenance.record_created_by_id(),
-                    &owned_by_id,
-                    &(on_conflict == ConflictBehavior::Skip),
-                ],
-            )
-            .await
-            .into_report()
-            .map(|row| row.get(0))
-            .map_err(|report| match report.current_context().code() {
-                Some(&SqlState::INVALID_PARAMETER_VALUE) => report
-                    .change_context(BaseUrlAlreadyExists)
-                    .attach_printable(record_id.base_url.clone())
-                    .change_context(InsertionError),
-                Some(&SqlState::UNIQUE_VIOLATION) => report
-                    .change_context(VersionedUrlAlreadyExists)
-                    .attach_printable(VersionedUrl::from(record_id.clone()))
-                    .change_context(InsertionError),
-                _ => report
-                    .change_context(InsertionError)
-                    .attach_printable(VersionedUrl::from(record_id.clone())),
-            })
-    }
+        location: OntologyLocation,
+    ) -> Result<(), InsertionError> {
+        const INSERTION_QUERY: &str = r#"
+            INSERT INTO base_urls (base_url) VALUES ($1);
+        "#;
+        match on_conflict {
+            ConflictBehavior::Fail => {
+                self.as_client()
+                    .query(INSERTION_QUERY, &[&base_url.as_str()])
+                    .await
+                    .into_report()
+                    .map_err(|report| match report.current_context().code() {
+                        Some(&SqlState::UNIQUE_VIOLATION) => report
+                            .change_context(BaseUrlAlreadyExists)
+                            .attach_printable(base_url.clone())
+                            .change_context(InsertionError),
+                        _ => report
+                            .change_context(InsertionError)
+                            .attach_printable(base_url.clone()),
+                    })?;
+            }
+            ConflictBehavior::Skip => {
+                let savepoint = self
+                    .client
+                    .savepoint("insert_base_url")
+                    .await
+                    .into_report()
+                    .change_context(InsertionError)?;
 
-    /// Creates a new external [`OntologyId`] from the provided [`VersionedUrl`].
-    ///
-    /// # Errors
-    ///
-    /// - [`BaseUrlAlreadyExists`] if [`VersionedUrl::base_url`] is an owned base url
-    /// - [`VersionedUrlAlreadyExists`] if [`VersionedUrl::version`] is already used for the base
-    ///   url
-    #[tracing::instrument(level = "debug", skip(self))]
-    async fn create_external_ontology_id(
-        &self,
-        record_id: &OntologyTypeRecordId,
-        provenance: ProvenanceMetadata,
-        fetched_at: OffsetDateTime,
-        on_conflict: ConflictBehavior,
-    ) -> Result<OntologyId, InsertionError> {
-        self.as_client()
-            .query_one(
-                r#"
-                SELECT
-                    ontology_id
-                FROM create_external_ontology_id(
-                    base_url := $1,
-                    version := $2,
-                    record_created_by_id := $3,
-                    fetched_at := $4,
-                    resume_on_conflict := $5
-                );"#,
-                &[
-                    &record_id.base_url.as_str(),
-                    &record_id.version,
-                    &provenance.record_created_by_id(),
-                    &fetched_at,
-                    &(on_conflict == ConflictBehavior::Skip),
-                ],
-            )
-            .await
-            .into_report()
-            .map(|row| row.get(0))
-            .map_err(|report| match report.current_context().code() {
-                Some(&SqlState::INVALID_PARAMETER_VALUE) => report
-                    .change_context(BaseUrlAlreadyExists)
-                    .attach_printable(record_id.base_url.clone())
-                    .change_context(InsertionError),
-                Some(&SqlState::UNIQUE_VIOLATION) => report
-                    .change_context(VersionedUrlAlreadyExists)
-                    .attach_printable(VersionedUrl::from(record_id.clone()))
-                    .change_context(InsertionError),
-                _ => report
-                    .change_context(InsertionError)
-                    .attach_printable(VersionedUrl::from(record_id.clone())),
-            })
-    }
+                let result = savepoint
+                    .as_client()
+                    .query(INSERTION_QUERY, &[&base_url.as_str()])
+                    .await;
 
-    /// Updates the latest version of [`VersionedUrl::base_url`] and creates a new [`OntologyId`]
-    /// for it.
-    ///
-    /// # Errors
-    ///
-    /// - [`VersionedUrlAlreadyExists`] if [`VersionedUrl`] does already exist in the database
-    /// - [`OntologyVersionDoesNotExist`] if the previous version does not exist
-    /// - [`OntologyTypeIsNotOwned`] if ontology type is an external ontology type
-    #[tracing::instrument(level = "debug", skip(self))]
-    async fn update_owned_ontology_id(
-        &self,
-        url: &VersionedUrl,
-        record_created_by_id: RecordCreatedById,
-    ) -> Result<(OntologyId, OwnedById), UpdateError> {
-        let row = self
-            .as_client()
-            .query_one(
-                r#"
-                SELECT
-                    ontology_id,
-                    owned_by_id
-                FROM update_owned_ontology_id(
-                    base_url := $1,
-                    version := $2,
-                    version_to_update := $3,
-                    record_created_by_id := $4
-                );"#,
-                &[
-                    &url.base_url.as_str(),
-                    &i64::from(url.version),
-                    &i64::from(url.version - 1),
-                    &record_created_by_id,
-                ],
-            )
-            .await
-            .into_report()
-            .map_err(|report| match report.current_context().code() {
-                Some(&SqlState::UNIQUE_VIOLATION) => report
-                    .change_context(VersionedUrlAlreadyExists)
-                    .attach_printable(url.clone())
-                    .change_context(UpdateError),
-                Some(&SqlState::INVALID_PARAMETER_VALUE) => report
-                    .change_context(OntologyVersionDoesNotExist)
-                    .attach_printable(url.base_url.clone())
-                    .change_context(UpdateError),
-                Some(&SqlState::RESTRICT_VIOLATION) => report
-                    .change_context(OntologyTypeIsNotOwned)
-                    .attach_printable(url.base_url.clone())
-                    .change_context(UpdateError),
-                _ => report
-                    .change_context(UpdateError)
-                    .attach_printable(url.clone()),
-            })?;
+                if let Err(error) = result {
+                    savepoint
+                        .rollback()
+                        .await
+                        .into_report()
+                        .change_context(InsertionError)?;
 
-        Ok((row.get(0), OwnedById::new(row.get(1))))
+                    if error.code() == Some(&SqlState::UNIQUE_VIOLATION) {
+                        let query = match location {
+                            OntologyLocation::Owned => {
+                                r#"
+                                    SELECT EXISTS (SELECT 1
+                                    FROM ontology_owned_metadata
+                                    NATURAL JOIN ontology_ids
+                                    WHERE base_url = $1);
+                                "#
+                            }
+                            OntologyLocation::External => {
+                                r#"
+                                    SELECT EXISTS (SELECT 1
+                                    FROM ontology_external_metadata
+                                    NATURAL JOIN ontology_ids
+                                    WHERE base_url = $1);
+                                "#
+                            }
+                        };
+
+                        let is_correct: bool = self
+                            .as_client()
+                            .query_one(query, &[&base_url.as_str()])
+                            .await
+                            .into_report()
+                            .change_context(InsertionError)
+                            .map(|row| row.get(0))?;
+                        if !is_correct {
+                            return Err(Report::new(BaseUrlAlreadyExists)
+                                .attach_printable(base_url.clone())
+                                .change_context(InsertionError));
+                        }
+                    }
+                } else {
+                    savepoint
+                        .commit()
+                        .await
+                        .into_report()
+                        .change_context(InsertionError)?;
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Inserts the specified [`OntologyDatabaseType`].
@@ -230,45 +157,68 @@ where
     ///
     /// # Errors
     ///
-    /// - If the [`BaseUrl`] already exists
+    /// - If the [`BaseUrl`] already exists and `on_conflict` is [`ConflictBehavior::Fail`]
+    /// - If the [`VersionedUrl`] already exists and `on_conflict` is [`ConflictBehavior::Fail`]
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
     #[tracing::instrument(level = "info", skip(self))]
     async fn create_ontology_metadata(
-        &self,
+        &mut self,
         metadata: &OntologyElementMetadata,
         on_conflict: ConflictBehavior,
     ) -> Result<Option<OntologyId>, InsertionError> {
-        let ontology_id = match metadata.custom {
+        match metadata.custom {
             CustomOntologyMetadata::Owned {
                 provenance,
                 owned_by_id,
                 ..
             } => {
-                self.create_owned_ontology_id(
-                    &metadata.record_id,
-                    provenance,
-                    owned_by_id,
+                self.create_base_url(
+                    &metadata.record_id.base_url,
                     on_conflict,
+                    OntologyLocation::Owned,
                 )
-                .await?
+                .await?;
+                let ontology_id = self
+                    .create_ontology_id(
+                        &metadata.record_id,
+                        provenance.record_created_by_id,
+                        on_conflict,
+                    )
+                    .await?;
+                if let Some(ontology_id) = ontology_id {
+                    self.create_ontology_temporal_metadata(ontology_id).await?;
+                    self.create_ontology_owned_metadata(ontology_id, owned_by_id)
+                        .await?;
+                }
+                Ok(ontology_id)
             }
             CustomOntologyMetadata::External {
                 provenance,
                 fetched_at,
                 ..
             } => {
-                self.create_external_ontology_id(
-                    &metadata.record_id,
-                    provenance,
-                    fetched_at,
-                    on_conflict,
+                self.create_base_url(
+                    &metadata.record_id.base_url,
+                    ConflictBehavior::Skip,
+                    OntologyLocation::External,
                 )
-                .await?
+                .await?;
+                let ontology_id = self
+                    .create_ontology_id(
+                        &metadata.record_id,
+                        provenance.record_created_by_id,
+                        on_conflict,
+                    )
+                    .await?;
+                if let Some(ontology_id) = ontology_id {
+                    self.create_ontology_temporal_metadata(ontology_id).await?;
+                    self.create_ontology_external_metadata(ontology_id, fetched_at)
+                        .await?;
+                }
+                Ok(ontology_id)
             }
-        };
-
-        Ok(Some(ontology_id))
+        }
     }
 
     /// Updates the specified [`OntologyDatabaseType`].
@@ -309,6 +259,210 @@ where
                 temporal_versioning: None,
             },
         }))
+    }
+
+    /// Updates the latest version of [`VersionedUrl::base_url`] and creates a new [`OntologyId`]
+    /// for it.
+    ///
+    /// # Errors
+    ///
+    /// - [`VersionedUrlAlreadyExists`] if [`VersionedUrl`] does already exist in the database
+    /// - [`OntologyVersionDoesNotExist`] if the previous version does not exist
+    /// - [`OntologyTypeIsNotOwned`] if ontology type is an external ontology type
+    #[tracing::instrument(level = "debug", skip(self))]
+    async fn update_owned_ontology_id(
+        &self,
+        url: &VersionedUrl,
+        record_created_by_id: RecordCreatedById,
+    ) -> Result<(OntologyId, OwnedById), UpdateError> {
+        let Some(owned_by_id) = self
+            .as_client()
+            .query_opt(
+                r#"
+                  SELECT owned_by_id
+                  FROM ontology_owned_metadata
+                  NATURAL JOIN ontology_ids
+                  WHERE base_url = $1
+                    AND version = $2
+                  LIMIT 1 -- There might be multiple versions of the same ontology, but we only
+                          -- care about the `owned_by_id` which does not change when (un-)archiving.
+                ;"#,
+                &[&url.base_url.as_str(), &i64::from(url.version - 1)],
+            )
+            .await
+            .into_report()
+            .change_context(UpdateError)?
+            .map(|row| row.get(0))
+        else {
+            let exists: bool = self
+                .as_client()
+                .query_one(
+                    r#"
+                  SELECT EXISTS (
+                    SELECT 1
+                    FROM ontology_ids
+                    WHERE base_url = $1
+                      AND version = $2
+                  );"#,
+                    &[&url.base_url.as_str(), &i64::from(url.version - 1)],
+                )
+                .await
+                .into_report()
+                .change_context(UpdateError)
+                .map(|row| row.get(0))?;
+            return Err(if exists {
+                Report::new(OntologyTypeIsNotOwned)
+                    .attach_printable(url.clone())
+                    .change_context(UpdateError)
+            } else {
+                Report::new(OntologyVersionDoesNotExist)
+                    .attach_printable(url.clone())
+                    .change_context(UpdateError)
+            });
+        };
+
+        let ontology_id = self
+            .create_ontology_id(
+                &OntologyTypeRecordId::from(url.clone()),
+                record_created_by_id,
+                ConflictBehavior::Fail,
+            )
+            .await
+            .change_context(UpdateError)?
+            .expect("ontology id should have been created");
+
+        self.create_ontology_temporal_metadata(ontology_id)
+            .await
+            .change_context(UpdateError)?;
+        self.create_ontology_owned_metadata(ontology_id, owned_by_id)
+            .await
+            .change_context(UpdateError)?;
+
+        Ok((ontology_id, owned_by_id))
+    }
+}
+
+impl<C> PostgresStore<C>
+where
+    C: AsClient,
+{
+    /// Creates a new `PostgresDatabase` object.
+    #[must_use]
+    pub const fn new(client: C) -> Self {
+        Self { client }
+    }
+
+    async fn create_ontology_id(
+        &self,
+        record_id: &OntologyTypeRecordId,
+        record_created_by_id: RecordCreatedById,
+        on_conflict: ConflictBehavior,
+    ) -> Result<Option<OntologyId>, InsertionError> {
+        let query: &str = match on_conflict {
+            ConflictBehavior::Skip => {
+                r#"
+                  INSERT INTO ontology_ids (
+                    ontology_id,
+                    base_url,
+                    version,
+                    record_created_by_id
+                  ) VALUES (gen_random_uuid(), $1, $2, $3)
+                  ON CONFLICT DO NOTHING
+                  RETURNING ontology_ids.ontology_id;
+                "#
+            }
+            ConflictBehavior::Fail => {
+                r#"
+                  INSERT INTO ontology_ids (
+                    ontology_id,
+                    base_url,
+                    version,
+                    record_created_by_id
+                  ) VALUES (gen_random_uuid(), $1, $2, $3)
+                  RETURNING ontology_ids.ontology_id;
+                "#
+            }
+        };
+        self.as_client()
+            .query_opt(query, &[
+                &record_id.base_url.as_str(),
+                &record_id.version,
+                &record_created_by_id,
+            ])
+            .await
+            .into_report()
+            .map_err(|report| match report.current_context().code() {
+                Some(&SqlState::UNIQUE_VIOLATION) => report
+                    .change_context(VersionedUrlAlreadyExists)
+                    .attach_printable(VersionedUrl::from(record_id.clone()))
+                    .change_context(InsertionError),
+                _ => report
+                    .change_context(InsertionError)
+                    .attach_printable(VersionedUrl::from(record_id.clone())),
+            })
+            .map(|optional| optional.map(|row| row.get(0)))
+    }
+
+    async fn create_ontology_temporal_metadata(
+        &self,
+        ontology_id: OntologyId,
+    ) -> Result<(), InsertionError> {
+        let query: &str = r#"
+              INSERT INTO ontology_temporal_metadata (
+                ontology_id,
+                transaction_time
+              ) VALUES ($1, tstzrange(now(), NULL, '[)'));
+            "#;
+
+        self.as_client()
+            .query(query, &[&ontology_id])
+            .await
+            .into_report()
+            .change_context(InsertionError)?;
+
+        Ok(())
+    }
+
+    async fn create_ontology_owned_metadata(
+        &self,
+        ontology_id: OntologyId,
+        owned_by_id: OwnedById,
+    ) -> Result<(), InsertionError> {
+        let query: &str = r#"
+              INSERT INTO ontology_owned_metadata (
+                ontology_id,
+                owned_by_id
+              ) VALUES ($1, $2);
+            "#;
+
+        self.as_client()
+            .query(query, &[&ontology_id, &owned_by_id])
+            .await
+            .into_report()
+            .change_context(InsertionError)?;
+
+        Ok(())
+    }
+
+    async fn create_ontology_external_metadata(
+        &self,
+        ontology_id: OntologyId,
+        fetched_at: OffsetDateTime,
+    ) -> Result<(), InsertionError> {
+        let query: &str = r#"
+              INSERT INTO ontology_external_metadata (
+                ontology_id,
+                fetched_at
+              ) VALUES ($1, $2);
+            "#;
+
+        self.as_client()
+            .query(query, &[&ontology_id, &fetched_at])
+            .await
+            .into_report()
+            .change_context(InsertionError)?;
+
+        Ok(())
     }
 
     /// Inserts an [`OntologyDatabaseType`] identified by [`OntologyId`], and associated with an

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology.rs
@@ -71,6 +71,18 @@ impl PostgresStore<Transaction<'_>> {
             .into_report()
             .change_context(DeletionError)?;
 
+        self.as_client()
+            .query(
+                r"
+                    DELETE FROM ontology_temporal_metadata
+                    WHERE ontology_id = ANY($1)
+                ",
+                &[&ontology_ids],
+            )
+            .await
+            .into_report()
+            .change_context(DeletionError)?;
+
         let base_urls = self
             .as_client()
             .query(

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -86,7 +86,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
         > + Send,
         on_conflict: ConflictBehavior,
     ) -> Result<(), InsertionError> {
-        let transaction = self.transaction().await.change_context(InsertionError)?;
+        let mut transaction = self.transaction().await.change_context(InsertionError)?;
 
         for (schema, metadata) in data_types {
             if let Some(ontology_id) = transaction

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -205,7 +205,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         on_conflict: ConflictBehavior,
     ) -> Result<(), InsertionError> {
         let entity_types = entity_types.into_iter();
-        let transaction = self.transaction().await.change_context(InsertionError)?;
+        let mut transaction = self.transaction().await.change_context(InsertionError)?;
 
         let mut inserted_entity_types = Vec::with_capacity(entity_types.size_hint().0);
         for (schema, metadata) in entity_types {

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -188,7 +188,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         on_conflict: ConflictBehavior,
     ) -> Result<(), InsertionError> {
         let property_types = property_types.into_iter();
-        let transaction = self.transaction().await.change_context(InsertionError)?;
+        let mut transaction = self.transaction().await.change_context(InsertionError)?;
 
         let mut inserted_property_types = Vec::with_capacity(property_types.size_hint().0);
         for (schema, metadata) in property_types {

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/data_type.rs
@@ -3,7 +3,10 @@ use std::iter::once;
 use crate::{
     ontology::{DataTypeQueryPath, DataTypeWithMetadata},
     store::postgres::query::{
-        table::{Column, DataTypes, JsonField, OntologyIds, ReferenceTable, Relation},
+        table::{
+            Column, DataTypes, JsonField, OntologyIds, OntologyTemporalMetadata, ReferenceTable,
+            Relation,
+        },
         PostgresQueryPath, PostgresRecord, Table,
     },
     subgraph::edges::{EdgeDirection, OntologyEdgeKind},
@@ -26,12 +29,12 @@ impl PostgresQueryPath for DataTypeQueryPath<'_> {
             | Self::Schema(_) => vec![],
             Self::BaseUrl
             | Self::Version
-            | Self::TransactionTime
             | Self::RecordCreatedById
             | Self::OwnedById
             | Self::AdditionalMetadata(_) => {
                 vec![Relation::DataTypeIds]
             }
+            Self::TransactionTime => vec![Relation::DataTypeTemporalMetadata],
             Self::PropertyTypeEdge {
                 edge_kind: OntologyEdgeKind::ConstrainsValuesOn,
                 path,
@@ -49,7 +52,9 @@ impl PostgresQueryPath for DataTypeQueryPath<'_> {
         match self {
             Self::BaseUrl => Column::OntologyIds(OntologyIds::BaseUrl),
             Self::Version => Column::OntologyIds(OntologyIds::Version),
-            Self::TransactionTime => Column::OntologyIds(OntologyIds::TransactionTime),
+            Self::TransactionTime => {
+                Column::OntologyTemporalMetadata(OntologyTemporalMetadata::TransactionTime)
+            }
             Self::OwnedById => Column::OntologyIds(OntologyIds::AdditionalMetadata(Some(
                 JsonField::StaticText("owned_by_id"),
             ))),

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
@@ -3,7 +3,10 @@ use std::iter::once;
 use crate::{
     ontology::{EntityTypeQueryPath, EntityTypeWithMetadata},
     store::postgres::query::{
-        table::{Column, EntityTypes, JsonField, OntologyIds, ReferenceTable, Relation},
+        table::{
+            Column, EntityTypes, JsonField, OntologyIds, OntologyTemporalMetadata, ReferenceTable,
+            Relation,
+        },
         PostgresQueryPath, PostgresRecord, Table,
     },
     subgraph::edges::{EdgeDirection, OntologyEdgeKind, SharedEdgeKind},
@@ -29,12 +32,12 @@ impl PostgresQueryPath for EntityTypeQueryPath<'_> {
             | Self::Schema(_) => vec![],
             Self::BaseUrl
             | Self::Version
-            | Self::TransactionTime
             | Self::RecordCreatedById
             | Self::OwnedById
             | Self::AdditionalMetadata(_) => {
                 vec![Relation::EntityTypeIds]
             }
+            Self::TransactionTime => vec![Relation::EntityTypeTemporalMetadata],
             Self::PropertyTypeEdge {
                 edge_kind: OntologyEdgeKind::ConstrainsPropertiesOn,
                 path,
@@ -91,7 +94,9 @@ impl PostgresQueryPath for EntityTypeQueryPath<'_> {
         match self {
             Self::BaseUrl => Column::OntologyIds(OntologyIds::BaseUrl),
             Self::Version => Column::OntologyIds(OntologyIds::Version),
-            Self::TransactionTime => Column::OntologyIds(OntologyIds::TransactionTime),
+            Self::TransactionTime => {
+                Column::OntologyTemporalMetadata(OntologyTemporalMetadata::TransactionTime)
+            }
             Self::OwnedById => Column::OntologyIds(OntologyIds::AdditionalMetadata(Some(
                 JsonField::StaticText("owned_by_id"),
             ))),

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/property_type.rs
@@ -3,7 +3,10 @@ use std::iter::once;
 use crate::{
     ontology::{PropertyTypeQueryPath, PropertyTypeWithMetadata},
     store::postgres::query::{
-        table::{Column, JsonField, OntologyIds, PropertyTypes, ReferenceTable, Relation},
+        table::{
+            Column, JsonField, OntologyIds, OntologyTemporalMetadata, PropertyTypes,
+            ReferenceTable, Relation,
+        },
         PostgresQueryPath, PostgresRecord, Table,
     },
     subgraph::edges::{EdgeDirection, OntologyEdgeKind},
@@ -25,12 +28,12 @@ impl PostgresQueryPath for PropertyTypeQueryPath<'_> {
             | Self::Schema(_) => vec![],
             Self::BaseUrl
             | Self::Version
-            | Self::TransactionTime
             | Self::RecordCreatedById
             | Self::OwnedById
             | Self::AdditionalMetadata(_) => {
                 vec![Relation::PropertyTypeIds]
             }
+            Self::TransactionTime => vec![Relation::PropertyTypeTemporalMetadata],
             Self::DataTypeEdge {
                 edge_kind: OntologyEdgeKind::ConstrainsValuesOn,
                 path,
@@ -67,7 +70,9 @@ impl PostgresQueryPath for PropertyTypeQueryPath<'_> {
         match self {
             Self::BaseUrl => Column::OntologyIds(OntologyIds::BaseUrl),
             Self::Version => Column::OntologyIds(OntologyIds::Version),
-            Self::TransactionTime => Column::OntologyIds(OntologyIds::TransactionTime),
+            Self::TransactionTime => {
+                Column::OntologyTemporalMetadata(OntologyTemporalMetadata::TransactionTime)
+            }
             Self::OwnedById => Column::OntologyIds(OntologyIds::AdditionalMetadata(Some(
                 JsonField::StaticText("owned_by_id"),
             ))),

--- a/apps/hash-graph/postgres_migrations/V10__ontology_type_archival.sql
+++ b/apps/hash-graph/postgres_migrations/V10__ontology_type_archival.sql
@@ -1,0 +1,88 @@
+CREATE TABLE IF NOT EXISTS
+  "ontology_temporal_metadata" (
+    "ontology_id" UUID NOT NULL REFERENCES "ontology_ids",
+    "transaction_time" tstzrange NOT NULL,
+    EXCLUDE USING gist (
+      ontology_id
+      WITH
+        =,
+        transaction_time
+      WITH
+        &&
+    )
+  );
+
+INSERT INTO
+  "ontology_temporal_metadata" ("ontology_id", "transaction_time")
+SELECT
+  "ontology_id",
+  "transaction_time"
+FROM
+  "ontology_ids";
+
+DROP VIEW
+  "ontology_id_with_metadata";
+
+ALTER TABLE
+  "ontology_ids"
+DROP COLUMN
+  "transaction_time";
+
+CREATE VIEW
+  "ontology_id_with_metadata" AS
+SELECT
+  "ontology_id",
+  "base_url",
+  "version",
+  "record_created_by_id",
+  "transaction_time",
+  JSONB_BUILD_OBJECT(
+    'owned_by_id',
+    ontology_owned_metadata.owned_by_id
+  ) AS "additional_metadata"
+FROM
+  ontology_ids
+  NATURAL JOIN ontology_owned_metadata
+  NATURAL JOIN ontology_temporal_metadata
+UNION ALL
+SELECT
+  "ontology_id",
+  "base_url",
+  "version",
+  "record_created_by_id",
+  "transaction_time",
+  JSONB_BUILD_OBJECT(
+    'fetched_at',
+    ontology_external_metadata.fetched_at
+  ) AS "additional_metadata"
+FROM
+  ontology_ids
+  NATURAL JOIN ontology_external_metadata
+  NATURAL JOIN ontology_temporal_metadata;
+
+DROP FUNCTION
+  "create_ontology_id";
+
+DROP FUNCTION
+  "create_owned_ontology_id";
+
+DROP FUNCTION
+  "create_external_ontology_id";
+
+DROP FUNCTION
+  update_ontology_id;
+
+DROP FUNCTION
+  update_owned_ontology_id;
+
+DROP TRIGGER
+  update_owned_ontology_metadata_trigger ON ontology_owned_metadata;
+
+DROP FUNCTION
+  update_owned_ontology_metadata_trigger;
+
+DROP TRIGGER
+  update_ontology_ids_trigger ON ontology_ids;
+
+DROP FUNCTION
+  update_ontology_ids_trigger;

--- a/apps/hash-graph/tests/integration/postgres/data_type.rs
+++ b/apps/hash-graph/tests/integration/postgres/data_type.rs
@@ -175,7 +175,7 @@ async fn wrong_update_order() {
         .expect_err("could create data type");
     assert!(
         report.contains::<OntologyVersionDoesNotExist>(),
-        "wrong error, expected `BaseUrlDoesNotExist`, got {report:?}"
+        "wrong error, expected `OntologyVersionDoesNotExist`, got {report:?}"
     );
 
     api.create_owned_data_type(object_dt_v1.clone())
@@ -245,7 +245,7 @@ async fn update_external_with_owned() {
         .await
         .expect_err("could update data type");
     assert!(
-        report.contains::<VersionedUrlAlreadyExists>(),
-        "wrong error, expected `VersionedUrlAlreadyExists`, got {report:?}"
+        report.contains::<OntologyTypeIsNotOwned>(),
+        "wrong error, expected `OntologyTypeIsNotOwned`, got {report:?}"
     );
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To allow unarchival of ontology types it's required to add more than one transaction time per ontology id.

## 🔍 What does this change?

- This moves the `transaction_time` out of the `ontology_ids` into a new `ontology_metadata_table` to allow multiple transaction times per ontology type
- All code paths has been adjusted to use the new table
- To allow insertion of the new tables I had two options:
    1. copy/paste all ontology functions from the migration files and adjust them
    2. Move the logic of the ontology functions from SQL to Rust.
    
  I chose the latter approach due to various reasons:
    - Easier to maintain (changes do not require a new migration file)
    - Better error handling possible (We are limited to a few error codes and strings in SQL)
    - more fine-grained control over the insertion logic

See the commit list for a step-by-step change list.

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

Add functions for (un-)archival (easy due to changes in this PR)

## 🛡 What tests cover this?

- REST endpoint tests
- Graph Integration tests (main test suite for these changes)
- Backend Integration tests