### PR TITLE
H-287: Return transaction time when creating ontology type

### DIFF
--- a/apps/hash-graph/bench/util.rs
+++ b/apps/hash-graph/bench/util.rs
@@ -3,8 +3,8 @@ use std::mem::ManuallyDrop;
 use graph::{
     identifier::account::AccountId,
     ontology::{
-        CustomEntityTypeMetadata, CustomOntologyMetadata, EntityTypeMetadata,
-        OntologyElementMetadata,
+        PartialCustomEntityTypeMetadata, PartialCustomOntologyMetadata, PartialEntityTypeMetadata,
+        PartialOntologyElementMetadata,
     },
     provenance::{OwnedById, ProvenanceMetadata, RecordCreatedById},
     store::{
@@ -202,11 +202,10 @@ pub async fn seed<D, P, E, C>(
         let data_type = DataType::try_from(data_type_repr).expect("could not parse data type");
 
         match store
-            .create_data_type(data_type.clone(), &OntologyElementMetadata {
+            .create_data_type(data_type.clone(), PartialOntologyElementMetadata {
                 record_id: data_type.id().clone().into(),
-                custom: CustomOntologyMetadata::Owned {
+                custom: PartialCustomOntologyMetadata::Owned {
                     provenance: ProvenanceMetadata::new(RecordCreatedById::new(account_id)),
-                    temporal_versioning: None,
                     owned_by_id: OwnedById::new(account_id),
                 },
             })
@@ -233,11 +232,10 @@ pub async fn seed<D, P, E, C>(
             PropertyType::try_from(property_typee_repr).expect("could not parse property type");
 
         match store
-            .create_property_type(property_type.clone(), &OntologyElementMetadata {
+            .create_property_type(property_type.clone(), PartialOntologyElementMetadata {
                 record_id: property_type.id().clone().into(),
-                custom: CustomOntologyMetadata::Owned {
+                custom: PartialCustomOntologyMetadata::Owned {
                     provenance: ProvenanceMetadata::new(RecordCreatedById::new(account_id)),
-                    temporal_versioning: None,
                     owned_by_id: OwnedById::new(account_id),
                 },
             })
@@ -264,12 +262,11 @@ pub async fn seed<D, P, E, C>(
             EntityType::try_from(entity_type_repr).expect("could not parse entity type");
 
         match store
-            .create_entity_type(entity_type.clone(), &EntityTypeMetadata {
+            .create_entity_type(entity_type.clone(), PartialEntityTypeMetadata {
                 record_id: entity_type.id().clone().into(),
-                custom: CustomEntityTypeMetadata {
-                    common: CustomOntologyMetadata::Owned {
+                custom: PartialCustomEntityTypeMetadata {
+                    common: PartialCustomOntologyMetadata::Owned {
                         provenance: ProvenanceMetadata::new(RecordCreatedById::new(account_id)),
-                        temporal_versioning: None,
                         owned_by_id: OwnedById::new(account_id),
                     },
                     label_property: None,

--- a/apps/hash-graph/bin/cli/src/subcommand/server.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/server.rs
@@ -13,8 +13,8 @@ use graph::{
     identifier::account::AccountId,
     logging::{init_logger, LoggingArgs},
     ontology::{
-        domain_validator::DomainValidator, CustomEntityTypeMetadata, CustomOntologyMetadata,
-        EntityTypeMetadata, OntologyElementMetadata,
+        domain_validator::DomainValidator, PartialCustomEntityTypeMetadata,
+        PartialCustomOntologyMetadata, PartialEntityTypeMetadata, PartialOntologyElementMetadata,
     },
     provenance::{ProvenanceMetadata, RecordCreatedById},
     store::{
@@ -235,17 +235,16 @@ async fn stop_gap_setup(pool: &PostgresStorePool<NoTls>) -> Result<(), GraphErro
     for data_type in [text, number, boolean, empty_list, object, null] {
         let title = data_type.title().to_owned();
 
-        let data_type_metadata = OntologyElementMetadata {
+        let data_type_metadata = PartialOntologyElementMetadata {
             record_id: data_type.id().clone().into(),
-            custom: CustomOntologyMetadata::External {
+            custom: PartialCustomOntologyMetadata::External {
                 provenance: ProvenanceMetadata::new(RecordCreatedById::new(root_account_id)),
-                temporal_versioning: None,
                 fetched_at: OffsetDateTime::now_utc(),
             },
         };
 
         if let Err(error) = connection
-            .create_data_type(data_type, &data_type_metadata)
+            .create_data_type(data_type, data_type_metadata)
             .await
             .change_context(GraphError)
         {
@@ -274,12 +273,11 @@ async fn stop_gap_setup(pool: &PostgresStorePool<NoTls>) -> Result<(), GraphErro
         Vec::default(),
     );
 
-    let link_entity_type_metadata = EntityTypeMetadata {
+    let link_entity_type_metadata = PartialEntityTypeMetadata {
         record_id: link_entity_type.id().clone().into(),
-        custom: CustomEntityTypeMetadata {
-            common: CustomOntologyMetadata::External {
+        custom: PartialCustomEntityTypeMetadata {
+            common: PartialCustomOntologyMetadata::External {
                 provenance: ProvenanceMetadata::new(RecordCreatedById::new(root_account_id)),
-                temporal_versioning: None,
                 fetched_at: OffsetDateTime::now_utc(),
             },
             label_property: None,
@@ -289,7 +287,7 @@ async fn stop_gap_setup(pool: &PostgresStorePool<NoTls>) -> Result<(), GraphErro
     let title = link_entity_type.title().to_owned();
 
     if let Err(error) = connection
-        .create_entity_type(link_entity_type, &link_entity_type_metadata)
+        .create_entity_type(link_entity_type, link_entity_type_metadata)
         .await
     {
         if error.contains::<VersionedUrlAlreadyExists>() {

--- a/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
@@ -19,8 +19,9 @@ use crate::{
     },
     ontology::{
         domain_validator::{DomainValidator, ValidateOntologyType},
-        patch_id_and_parse, CustomOntologyMetadata, OntologyElementMetadata, OntologyTypeReference,
-        PropertyTypeQueryToken, PropertyTypeWithMetadata,
+        patch_id_and_parse, OntologyElementMetadata, OntologyTypeReference,
+        PartialCustomOntologyMetadata, PartialOntologyElementMetadata, PropertyTypeQueryToken,
+        PropertyTypeWithMetadata,
     },
     provenance::{OwnedById, ProvenanceMetadata, RecordCreatedById},
     store::{
@@ -121,7 +122,7 @@ where
 
     let schema_iter = schema.into_iter();
     let mut property_types = Vec::with_capacity(schema_iter.size_hint().0);
-    let mut metadata = Vec::with_capacity(schema_iter.size_hint().0);
+    let mut partial_metadata = Vec::with_capacity(schema_iter.size_hint().0);
 
     for schema in schema_iter {
         let property_type: PropertyType = schema.try_into().into_report().map_err(|report| {
@@ -138,11 +139,10 @@ where
                 StatusCode::UNPROCESSABLE_ENTITY
             })?;
 
-        metadata.push(OntologyElementMetadata {
+        partial_metadata.push(PartialOntologyElementMetadata {
             record_id: property_type.id().clone().into(),
-            custom: CustomOntologyMetadata::Owned {
+            custom: PartialCustomOntologyMetadata::Owned {
                 provenance: ProvenanceMetadata::new(actor_id),
-                temporal_versioning: None,
                 owned_by_id,
             },
         });
@@ -150,9 +150,9 @@ where
         property_types.push(property_type);
     }
 
-    store
+    let mut metadata = store
         .create_property_types(
-            property_types.into_iter().zip(metadata.iter()),
+            property_types.into_iter().zip(partial_metadata),
             ConflictBehavior::Fail,
         )
         .await

--- a/apps/hash-graph/lib/graph/src/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/ontology.rs
@@ -216,6 +216,7 @@ impl ToSchema<'static> for CustomEntityTypeMetadata {
                                 "temporalVersioning",
                                 Ref::from_schema_name(OntologyTemporalMetadata::schema().0),
                             )
+                            .required("temporalVersioning")
                             .property("ownedById", Ref::from_schema_name(OwnedById::schema().0))
                             .required("ownedById")
                             .build(),
@@ -232,6 +233,7 @@ impl ToSchema<'static> for CustomEntityTypeMetadata {
                                 "temporalVersioning",
                                 Ref::from_schema_name(OntologyTemporalMetadata::schema().0),
                             )
+                            .required("temporalVersioning")
                             .property(
                                 "fetchedAt",
                                 schema::ObjectBuilder::new()

--- a/apps/hash-graph/lib/graph/src/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/ontology.rs
@@ -181,6 +181,13 @@ impl OntologyType for PropertyType {
     }
 }
 
+/// A [`CustomEntityTypeMetadata`] that has not yet been fully resolved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PartialCustomEntityTypeMetadata {
+    pub label_property: Option<BaseUrl>,
+    pub common: PartialCustomOntologyMetadata,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CustomEntityTypeMetadata {
@@ -240,11 +247,62 @@ impl ToSchema<'static> for CustomEntityTypeMetadata {
     }
 }
 
+/// An [`EntityTypeMetadata`] that has not yet been fully resolved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PartialEntityTypeMetadata {
+    pub record_id: OntologyTypeRecordId,
+    pub custom: PartialCustomEntityTypeMetadata,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct EntityTypeMetadata {
     pub record_id: OntologyTypeRecordId,
     pub custom: CustomEntityTypeMetadata,
+}
+
+impl EntityTypeMetadata {
+    #[must_use]
+    pub fn from_partial(
+        partial: PartialEntityTypeMetadata,
+        transaction_time: LeftClosedTemporalInterval<TransactionTime>,
+    ) -> Self {
+        Self {
+            record_id: partial.record_id,
+            custom: match partial.custom {
+                PartialCustomEntityTypeMetadata {
+                    label_property,
+                    common:
+                        PartialCustomOntologyMetadata::Owned {
+                            provenance,
+                            owned_by_id,
+                        },
+                } => CustomEntityTypeMetadata {
+                    label_property,
+                    common: CustomOntologyMetadata::Owned {
+                        provenance,
+                        temporal_versioning: OntologyTemporalMetadata { transaction_time },
+                        owned_by_id,
+                    },
+                },
+                PartialCustomEntityTypeMetadata {
+                    label_property,
+                    common:
+                        PartialCustomOntologyMetadata::External {
+                            provenance,
+                            fetched_at,
+                        },
+                } => CustomEntityTypeMetadata {
+                    label_property,
+                    common: CustomOntologyMetadata::External {
+                        provenance,
+                        temporal_versioning: OntologyTemporalMetadata { transaction_time },
+                        fetched_at,
+                    },
+                },
+            },
+        }
+    }
 }
 
 impl OntologyType for EntityType {
@@ -285,6 +343,28 @@ pub struct OntologyTemporalMetadata {
     pub transaction_time: LeftClosedTemporalInterval<TransactionTime>,
 }
 
+/// A [`CustomOntologyMetadata`] that has not yet been fully resolved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PartialCustomOntologyMetadata {
+    Owned {
+        provenance: ProvenanceMetadata,
+        owned_by_id: OwnedById,
+    },
+    External {
+        provenance: ProvenanceMetadata,
+        fetched_at: OffsetDateTime,
+    },
+}
+
+impl PartialCustomOntologyMetadata {
+    #[must_use]
+    pub const fn provenance(&self) -> ProvenanceMetadata {
+        let (Self::External { provenance, .. } | Self::Owned { provenance, .. }) = self;
+
+        *provenance
+    }
+}
+
 // TODO: Restrict mutable access when `#[feature(mut_restriction)]` is available.
 //   see https://github.com/rust-lang/rust/issues/105077
 //   see https://app.asana.com/0/0/1203977361907407/f
@@ -295,27 +375,25 @@ pub enum CustomOntologyMetadata {
     #[serde(rename_all = "camelCase")]
     Owned {
         provenance: ProvenanceMetadata,
-        temporal_versioning: Option<OntologyTemporalMetadata>,
+        temporal_versioning: OntologyTemporalMetadata,
         owned_by_id: OwnedById,
     },
     #[schema(title = "CustomExternalOntologyElementMetadata")]
     #[serde(rename_all = "camelCase")]
     External {
         provenance: ProvenanceMetadata,
-        temporal_versioning: Option<OntologyTemporalMetadata>,
+        temporal_versioning: OntologyTemporalMetadata,
         #[schema(value_type = String)]
         #[serde(with = "crate::serde::time")]
         fetched_at: OffsetDateTime,
     },
 }
 
-impl CustomOntologyMetadata {
-    #[must_use]
-    pub const fn provenance(&self) -> ProvenanceMetadata {
-        let (Self::External { provenance, .. } | Self::Owned { provenance, .. }) = self;
-
-        *provenance
-    }
+/// An [`OntologyElementMetadata`] that has not yet been fully resolved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PartialOntologyElementMetadata {
+    pub record_id: OntologyTypeRecordId,
+    pub custom: PartialCustomOntologyMetadata,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
@@ -323,6 +401,45 @@ impl CustomOntologyMetadata {
 pub struct OntologyElementMetadata {
     pub record_id: OntologyTypeRecordId,
     pub custom: CustomOntologyMetadata,
+}
+
+impl From<EntityTypeMetadata> for OntologyElementMetadata {
+    fn from(value: EntityTypeMetadata) -> Self {
+        Self {
+            record_id: value.record_id,
+            custom: value.custom.common,
+        }
+    }
+}
+
+impl OntologyElementMetadata {
+    #[must_use]
+    pub fn from_partial(
+        partial: PartialOntologyElementMetadata,
+        transaction_time: LeftClosedTemporalInterval<TransactionTime>,
+    ) -> Self {
+        Self {
+            record_id: partial.record_id,
+            custom: match partial.custom {
+                PartialCustomOntologyMetadata::Owned {
+                    provenance,
+                    owned_by_id,
+                } => CustomOntologyMetadata::Owned {
+                    provenance,
+                    temporal_versioning: OntologyTemporalMetadata { transaction_time },
+                    owned_by_id,
+                },
+                PartialCustomOntologyMetadata::External {
+                    provenance,
+                    fetched_at,
+                } => CustomOntologyMetadata::External {
+                    provenance,
+                    temporal_versioning: OntologyTemporalMetadata { transaction_time },
+                    fetched_at,
+                },
+            },
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/apps/hash-graph/lib/graph/src/snapshot/ontology/metadata/channel.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/ontology/metadata/channel.rs
@@ -113,7 +113,7 @@ impl Sink<(Uuid, OntologyElementMetadata)> for OntologyTypeMetadataSender {
         self.temporal_metadata
             .start_send(OntologyTemporalMetadataRow {
                 ontology_id,
-                transaction_time: temporal_versioning.map(|t| t.transaction_time),
+                transaction_time: temporal_versioning.transaction_time,
             })
             .into_report()
             .change_context(SnapshotRestoreError::Read)

--- a/apps/hash-graph/lib/graph/src/snapshot/ontology/table.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/ontology/table.rs
@@ -38,7 +38,7 @@ pub struct OntologyExternalMetadataRow {
 #[postgres(name = "ontology_temporal_metadata")]
 pub struct OntologyTemporalMetadataRow {
     pub ontology_id: Uuid,
-    pub transaction_time: Option<LeftClosedTemporalInterval<TransactionTime>>,
+    pub transaction_time: LeftClosedTemporalInterval<TransactionTime>,
 }
 
 #[derive(Debug, ToSql)]

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -1,5 +1,4 @@
 use std::{
-    borrow::Borrow,
     collections::{HashMap, HashSet},
     iter::once,
     mem,
@@ -25,9 +24,10 @@ use crate::{
     },
     knowledge::{Entity, EntityLinkOrder, EntityMetadata, EntityProperties, EntityUuid, LinkData},
     ontology::{
-        domain_validator::DomainValidator, CustomEntityTypeMetadata, CustomOntologyMetadata,
-        DataTypeWithMetadata, EntityTypeMetadata, EntityTypeWithMetadata, OntologyElementMetadata,
-        OntologyTypeReference, PropertyTypeWithMetadata,
+        domain_validator::DomainValidator, DataTypeWithMetadata, EntityTypeMetadata,
+        EntityTypeWithMetadata, OntologyElementMetadata, OntologyTypeReference,
+        PartialCustomEntityTypeMetadata, PartialCustomOntologyMetadata, PartialEntityTypeMetadata,
+        PartialOntologyElementMetadata, PropertyTypeWithMetadata,
     },
     provenance::{OwnedById, ProvenanceMetadata, RecordCreatedById},
     store::{
@@ -155,9 +155,9 @@ where
 
 #[derive(Default)]
 struct FetchedOntologyTypes {
-    data_types: Vec<(DataType, OntologyElementMetadata)>,
-    property_types: Vec<(PropertyType, OntologyElementMetadata)>,
-    entity_types: Vec<(EntityType, EntityTypeMetadata)>,
+    data_types: Vec<(DataType, PartialOntologyElementMetadata)>,
+    property_types: Vec<(PropertyType, PartialOntologyElementMetadata)>,
+    entity_types: Vec<(EntityType, PartialEntityTypeMetadata)>,
 }
 
 enum FetchBehavior {
@@ -287,12 +287,11 @@ where
                         let data_type = DataType::try_from(data_type_repr)
                             .into_report()
                             .change_context(StoreError)?;
-                        let metadata = OntologyElementMetadata {
+                        let metadata = PartialOntologyElementMetadata {
                             record_id: data_type.id().clone().into(),
-                            custom: CustomOntologyMetadata::External {
+                            custom: PartialCustomOntologyMetadata::External {
                                 provenance: provenance_metadata,
                                 fetched_at,
-                                temporal_versioning: None,
                             },
                         };
 
@@ -315,12 +314,11 @@ where
                         let property_type = PropertyType::try_from(property_type)
                             .into_report()
                             .change_context(StoreError)?;
-                        let metadata = OntologyElementMetadata {
+                        let metadata = PartialOntologyElementMetadata {
                             record_id: property_type.id().clone().into(),
-                            custom: CustomOntologyMetadata::External {
+                            custom: PartialCustomOntologyMetadata::External {
                                 provenance: provenance_metadata,
                                 fetched_at,
-                                temporal_versioning: None,
                             },
                         };
 
@@ -343,12 +341,11 @@ where
                         let entity_type = EntityType::try_from(entity_type)
                             .into_report()
                             .change_context(StoreError)?;
-                        let metadata = OntologyElementMetadata {
+                        let metadata = PartialOntologyElementMetadata {
                             record_id: entity_type.id().clone().into(),
-                            custom: CustomOntologyMetadata::External {
+                            custom: PartialCustomOntologyMetadata::External {
                                 provenance: provenance_metadata,
                                 fetched_at,
-                                temporal_versioning: None,
                             },
                         };
 
@@ -365,9 +362,9 @@ where
 
                         fetched_ontology_types.entity_types.push((
                             entity_type,
-                            EntityTypeMetadata {
+                            PartialEntityTypeMetadata {
                                 record_id: metadata.record_id,
-                                custom: CustomEntityTypeMetadata {
+                                custom: PartialCustomEntityTypeMetadata {
                                     common: metadata.custom,
                                     label_property: None,
                                 },
@@ -459,41 +456,31 @@ where
                 .await
                 .change_context(InsertionError)?;
 
-            let metadata = fetched_ontology_types
-                .data_types
-                .iter()
-                .map(|(_, metadata)| metadata.clone())
-                .chain(
-                    fetched_ontology_types
-                        .property_types
-                        .iter()
-                        .map(|(_, metadata)| metadata.clone()),
-                )
-                .chain(
-                    fetched_ontology_types
-                        .entity_types
-                        .iter()
-                        .map(|(_, metadata)| OntologyElementMetadata {
-                            record_id: metadata.record_id.clone(),
-                            custom: metadata.custom.common.clone(),
-                        }),
-                )
-                .collect::<Vec<_>>();
-
-            self.store
+            let created_data_types = self
+                .store
                 .create_data_types(fetched_ontology_types.data_types, ConflictBehavior::Skip)
                 .await?;
-            self.store
+            let created_property_types = self
+                .store
                 .create_property_types(
                     fetched_ontology_types.property_types,
                     ConflictBehavior::Skip,
                 )
                 .await?;
-            self.store
+            let created_entity_types = self
+                .store
                 .create_entity_types(fetched_ontology_types.entity_types, ConflictBehavior::Skip)
                 .await?;
 
-            Ok(metadata)
+            Ok(created_data_types
+                .into_iter()
+                .chain(created_property_types)
+                .chain(
+                    created_entity_types
+                        .into_iter()
+                        .map(OntologyElementMetadata::from),
+                )
+                .collect())
         } else {
             Ok(Vec::new())
         }
@@ -569,18 +556,16 @@ where
 {
     async fn create_data_types(
         &mut self,
-        data_types: impl IntoIterator<
-            Item = (DataType, impl Borrow<OntologyElementMetadata> + Send + Sync),
-            IntoIter: Send,
-        > + Send,
+        data_types: impl IntoIterator<Item = (DataType, PartialOntologyElementMetadata), IntoIter: Send>
+        + Send,
         on_conflict: ConflictBehavior,
-    ) -> Result<(), InsertionError> {
+    ) -> Result<Vec<OntologyElementMetadata>, InsertionError> {
         let data_types = data_types.into_iter().collect::<Vec<_>>();
 
         self.insert_external_types(data_types.iter().map(|(data_type, metadata)| {
             (
                 data_type,
-                metadata.borrow().custom.provenance().record_created_by_id(),
+                metadata.custom.provenance().record_created_by_id(),
             )
         }))
         .await?;
@@ -617,20 +602,17 @@ where
     async fn create_property_types(
         &mut self,
         property_types: impl IntoIterator<
-            Item = (
-                PropertyType,
-                impl Borrow<OntologyElementMetadata> + Send + Sync,
-            ),
+            Item = (PropertyType, PartialOntologyElementMetadata),
             IntoIter: Send,
         > + Send,
         on_conflict: ConflictBehavior,
-    ) -> Result<(), InsertionError> {
+    ) -> Result<Vec<OntologyElementMetadata>, InsertionError> {
         let property_types = property_types.into_iter().collect::<Vec<_>>();
 
         self.insert_external_types(property_types.iter().map(|(property_type, metadata)| {
             (
                 property_type,
-                metadata.borrow().custom.provenance().record_created_by_id(),
+                metadata.custom.provenance().record_created_by_id(),
             )
         }))
         .await?;
@@ -670,23 +652,16 @@ where
 {
     async fn create_entity_types(
         &mut self,
-        entity_types: impl IntoIterator<
-            Item = (EntityType, impl Borrow<EntityTypeMetadata> + Send + Sync),
-            IntoIter: Send,
-        > + Send,
+        entity_types: impl IntoIterator<Item = (EntityType, PartialEntityTypeMetadata), IntoIter: Send>
+        + Send,
         on_conflict: ConflictBehavior,
-    ) -> Result<(), InsertionError> {
+    ) -> Result<Vec<EntityTypeMetadata>, InsertionError> {
         let entity_types = entity_types.into_iter().collect::<Vec<_>>();
 
         self.insert_external_types(entity_types.iter().map(|(entity_type, metadata)| {
             (
                 entity_type,
-                metadata
-                    .borrow()
-                    .custom
-                    .common
-                    .provenance()
-                    .record_created_by_id(),
+                metadata.custom.common.provenance().record_created_by_id(),
             )
         }))
         .await?;

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -144,14 +144,14 @@ where
                     AdditionalOntologyMetadata::Owned { owned_by_id } => {
                         CustomOntologyMetadata::Owned {
                             provenance,
-                            temporal_versioning: Some(temporal_versioning),
+                            temporal_versioning,
                             owned_by_id,
                         }
                     }
                     AdditionalOntologyMetadata::External { fetched_at } => {
                         CustomOntologyMetadata::External {
                             provenance,
-                            temporal_versioning: Some(temporal_versioning),
+                            temporal_versioning,
                             fetched_at,
                         }
                     }
@@ -237,14 +237,14 @@ impl<C: AsClient> Read<OntologyTypeSnapshotRecord<EntityType>> for PostgresStore
                     AdditionalOntologyMetadata::Owned { owned_by_id } => {
                         CustomOntologyMetadata::Owned {
                             provenance,
-                            temporal_versioning: Some(temporal_versioning),
+                            temporal_versioning,
                             owned_by_id,
                         }
                     }
                     AdditionalOntologyMetadata::External { fetched_at } => {
                         CustomOntologyMetadata::External {
                             provenance,
-                            temporal_versioning: Some(temporal_versioning),
+                            temporal_versioning,
                             fetched_at,
                         }
                     }

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -879,6 +879,7 @@
             "title": "CustomOwnedOntologyElementMetadata",
             "required": [
               "provenance",
+              "temporalVersioning",
               "ownedById"
             ],
             "properties": {
@@ -889,12 +890,7 @@
                 "$ref": "#/components/schemas/ProvenanceMetadata"
               },
               "temporalVersioning": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/OntologyTemporalMetadata"
-                  }
-                ],
-                "nullable": true
+                "$ref": "#/components/schemas/OntologyTemporalMetadata"
               }
             }
           },
@@ -903,6 +899,7 @@
             "title": "CustomExternalOntologyElementMetadata",
             "required": [
               "provenance",
+              "temporalVersioning",
               "fetchedAt"
             ],
             "properties": {
@@ -913,12 +910,7 @@
                 "$ref": "#/components/schemas/ProvenanceMetadata"
               },
               "temporalVersioning": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/OntologyTemporalMetadata"
-                  }
-                ],
-                "nullable": true
+                "$ref": "#/components/schemas/OntologyTemporalMetadata"
               }
             }
           }

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -832,6 +832,7 @@
             "type": "object",
             "required": [
               "provenance",
+              "temporalVersioning",
               "ownedById"
             ],
             "properties": {
@@ -853,6 +854,7 @@
             "type": "object",
             "required": [
               "provenance",
+              "temporalVersioning",
               "fetchedAt"
             ],
             "properties": {

--- a/apps/hash-graph/tests/integration/postgres/lib.rs
+++ b/apps/hash-graph/tests/integration/postgres/lib.rs
@@ -27,9 +27,9 @@ use graph::{
         LinkData,
     },
     ontology::{
-        CustomEntityTypeMetadata, CustomOntologyMetadata, DataTypeWithMetadata, EntityTypeMetadata,
-        EntityTypeQueryPath, EntityTypeWithMetadata, OntologyElementMetadata,
-        PropertyTypeWithMetadata,
+        DataTypeWithMetadata, EntityTypeMetadata, EntityTypeQueryPath, EntityTypeWithMetadata,
+        OntologyElementMetadata, PartialCustomEntityTypeMetadata, PartialCustomOntologyMetadata,
+        PartialEntityTypeMetadata, PartialOntologyElementMetadata, PropertyTypeWithMetadata,
     },
     provenance::{OwnedById, ProvenanceMetadata, RecordCreatedById},
     store::{
@@ -129,11 +129,10 @@ impl DatabaseTestWrapper {
                 .expect("could not parse data type representation");
             let data_type = DataType::try_from(data_type_repr).expect("could not parse data type");
 
-            let metadata = OntologyElementMetadata {
+            let metadata = PartialOntologyElementMetadata {
                 record_id: data_type.id().clone().into(),
-                custom: CustomOntologyMetadata::Owned {
+                custom: PartialCustomOntologyMetadata::Owned {
                     provenance: ProvenanceMetadata::new(RecordCreatedById::new(account_id)),
-                    temporal_versioning: None,
                     owned_by_id: OwnedById::new(account_id),
                 },
             };
@@ -150,11 +149,10 @@ impl DatabaseTestWrapper {
             let property_type =
                 PropertyType::try_from(property_type_repr).expect("could not parse property type");
 
-            let metadata = OntologyElementMetadata {
+            let metadata = PartialOntologyElementMetadata {
                 record_id: property_type.id().clone().into(),
-                custom: CustomOntologyMetadata::Owned {
+                custom: PartialCustomOntologyMetadata::Owned {
                     provenance: ProvenanceMetadata::new(RecordCreatedById::new(account_id)),
-                    temporal_versioning: None,
                     owned_by_id: OwnedById::new(account_id),
                 },
             };
@@ -171,12 +169,11 @@ impl DatabaseTestWrapper {
             let entity_type =
                 EntityType::try_from(entity_type_repr).expect("could not parse entity type");
 
-            let metadata = EntityTypeMetadata {
+            let metadata = PartialEntityTypeMetadata {
                 record_id: entity_type.id().clone().into(),
-                custom: CustomEntityTypeMetadata {
-                    common: CustomOntologyMetadata::Owned {
+                custom: PartialCustomEntityTypeMetadata {
+                    common: PartialCustomOntologyMetadata::Owned {
                         provenance: ProvenanceMetadata::new(RecordCreatedById::new(account_id)),
-                        temporal_versioning: None,
                         owned_by_id: OwnedById::new(account_id),
                     },
                     label_property: None,
@@ -212,36 +209,30 @@ impl DatabaseApi<'_> {
         &mut self,
         data_type: DataType,
     ) -> Result<OntologyElementMetadata, InsertionError> {
-        let metadata = OntologyElementMetadata {
+        let metadata = PartialOntologyElementMetadata {
             record_id: data_type.id().clone().into(),
-            custom: CustomOntologyMetadata::Owned {
+            custom: PartialCustomOntologyMetadata::Owned {
                 provenance: ProvenanceMetadata::new(RecordCreatedById::new(self.account_id)),
-                temporal_versioning: None,
                 owned_by_id: OwnedById::new(self.account_id),
             },
         };
 
-        self.store.create_data_type(data_type, &metadata).await?;
-
-        Ok(metadata)
+        self.store.create_data_type(data_type, metadata).await
     }
 
     pub async fn create_external_data_type(
         &mut self,
         data_type: DataType,
     ) -> Result<OntologyElementMetadata, InsertionError> {
-        let metadata = OntologyElementMetadata {
+        let metadata = PartialOntologyElementMetadata {
             record_id: data_type.id().clone().into(),
-            custom: CustomOntologyMetadata::External {
+            custom: PartialCustomOntologyMetadata::External {
                 provenance: ProvenanceMetadata::new(RecordCreatedById::new(self.account_id)),
-                temporal_versioning: None,
                 fetched_at: OffsetDateTime::now_utc(),
             },
         };
 
-        self.store.create_data_type(data_type, &metadata).await?;
-
-        Ok(metadata)
+        self.store.create_data_type(data_type, metadata).await
     }
 
     pub async fn get_data_type(
@@ -281,20 +272,17 @@ impl DatabaseApi<'_> {
         &mut self,
         property_type: PropertyType,
     ) -> Result<OntologyElementMetadata, InsertionError> {
-        let metadata = OntologyElementMetadata {
+        let metadata = PartialOntologyElementMetadata {
             record_id: property_type.id().clone().into(),
-            custom: CustomOntologyMetadata::Owned {
+            custom: PartialCustomOntologyMetadata::Owned {
                 provenance: ProvenanceMetadata::new(RecordCreatedById::new(self.account_id)),
-                temporal_versioning: None,
                 owned_by_id: OwnedById::new(self.account_id),
             },
         };
 
         self.store
-            .create_property_type(property_type, &metadata)
-            .await?;
-
-        Ok(metadata)
+            .create_property_type(property_type, metadata)
+            .await
     }
 
     pub async fn get_property_type(
@@ -334,23 +322,18 @@ impl DatabaseApi<'_> {
         &mut self,
         entity_type: EntityType,
     ) -> Result<EntityTypeMetadata, InsertionError> {
-        let metadata = EntityTypeMetadata {
+        let metadata = PartialEntityTypeMetadata {
             record_id: entity_type.id().clone().into(),
-            custom: CustomEntityTypeMetadata {
-                common: CustomOntologyMetadata::Owned {
+            custom: PartialCustomEntityTypeMetadata {
+                common: PartialCustomOntologyMetadata::Owned {
                     provenance: ProvenanceMetadata::new(RecordCreatedById::new(self.account_id)),
-                    temporal_versioning: None,
                     owned_by_id: OwnedById::new(self.account_id),
                 },
                 label_property: None,
             },
         };
 
-        self.store
-            .create_entity_type(entity_type, &metadata)
-            .await?;
-
-        Ok(metadata)
+        self.store.create_entity_type(entity_type, metadata).await
     }
 
     pub async fn get_entity_type(

--- a/libs/@local/hash-subgraph/src/types/element/ontology.ts
+++ b/libs/@local/hash-subgraph/src/types/element/ontology.ts
@@ -14,7 +14,16 @@ import {
 import { Brand } from "@local/advanced-types/brand";
 import { Subtype } from "@local/advanced-types/subtype";
 
-import { BaseUrl, OwnedById, ProvenanceMetadata, Timestamp } from "../shared";
+import {
+  BaseUrl,
+  ExclusiveLimitedTemporalBound,
+  InclusiveLimitedTemporalBound,
+  OwnedById,
+  ProvenanceMetadata,
+  TimeInterval,
+  Timestamp,
+  Unbounded,
+} from "../shared";
 
 /**
  * The second component of the [{@link BaseUrl}, RevisionId] tuple needed to identify a specific ontology type vertex
@@ -56,6 +65,12 @@ export type OwnedOntologyElementMetadata = {
   custom: {
     ownedById: OwnedById;
     provenance: ProvenanceMetadata;
+    temporalVersioning: {
+      transactionTime: TimeInterval<
+        InclusiveLimitedTemporalBound,
+        ExclusiveLimitedTemporalBound | Unbounded
+      >;
+    };
   };
 };
 
@@ -64,6 +79,12 @@ export type ExternalOntologyElementMetadata = {
   custom: {
     fetchedAt: Timestamp;
     provenance: ProvenanceMetadata;
+    temporalVersioning: {
+      transactionTime: TimeInterval<
+        InclusiveLimitedTemporalBound,
+        ExclusiveLimitedTemporalBound | Unbounded
+      >;
+    };
   };
 };
 

--- a/libs/@local/hash-subgraph/tests/compatibility.test/map-vertices.ts
+++ b/libs/@local/hash-subgraph/tests/compatibility.test/map-vertices.ts
@@ -14,6 +14,7 @@ import {
   EntityRecordId as EntityRecordIdGraphApi,
   EntityTemporalMetadata as EntityTemporalMetadataGraphApi,
   EntityType as EntityTypeGraphApi,
+  EntityTypeMetadata as EntityTypeMetadataGraphApi,
   KnowledgeGraphVertex as KnowledgeGraphVertexGraphApi,
   LinkData as LinkDataGraphApi,
   OntologyElementMetadata as OntologyElementMetadataGraphApi,
@@ -29,6 +30,7 @@ import {
   EntityPropertiesObject,
   EntityRecordId,
   EntityTemporalVersioningMetadata,
+  EntityTypeMetadata,
   isEntityId,
   KnowledgeGraphVertex,
   LinkData,
@@ -117,6 +119,67 @@ const mapOntologyMetadata = (
         : ({} as {
             fetchedAt: Timestamp;
           })),
+      temporalVersioning: {
+        transactionTime: {
+          start: {
+            kind: metadata.custom.temporalVersioning.transactionTime.start.kind,
+            limit: metadata.custom.temporalVersioning.transactionTime.start
+              .limit as Timestamp,
+          },
+          end:
+            metadata.custom.temporalVersioning.transactionTime.end.kind ===
+            "unbounded"
+              ? {
+                  kind: metadata.custom.temporalVersioning.transactionTime.end
+                    .kind,
+                }
+              : {
+                  kind: metadata.custom.temporalVersioning.transactionTime.end
+                    .kind,
+                  limit: metadata.custom.temporalVersioning.transactionTime.end
+                    .limit as Timestamp,
+                },
+        },
+      },
+    },
+  };
+};
+
+const mapEntityTypeMetadata = (
+  metadata: EntityTypeMetadataGraphApi,
+): EntityTypeMetadata => {
+  return {
+    recordId: mapOntologyTypeRecordId(metadata.recordId),
+    custom: {
+      provenance: mapProvenanceMetadata(metadata.custom.provenance),
+      ...("fetchedAt" in metadata.custom
+        ? { fetchedAt: metadata.custom.fetchedAt as Timestamp }
+        : ({} as {
+            fetchedAt: Timestamp;
+          })),
+      temporalVersioning: {
+        transactionTime: {
+          start: {
+            kind: metadata.custom.temporalVersioning.transactionTime.start.kind,
+            limit: metadata.custom.temporalVersioning.transactionTime.start
+              .limit as Timestamp,
+          },
+          end:
+            metadata.custom.temporalVersioning.transactionTime.end.kind ===
+            "unbounded"
+              ? {
+                  kind: metadata.custom.temporalVersioning.transactionTime.end
+                    .kind,
+                }
+              : {
+                  kind: metadata.custom.temporalVersioning.transactionTime.end
+                    .kind,
+                  limit: metadata.custom.temporalVersioning.transactionTime.end
+                    .limit as Timestamp,
+                },
+        },
+      },
+      labelProperty: metadata.custom.labelProperty as BaseUrl,
     },
   };
 };
@@ -145,7 +208,7 @@ const mapOntologyVertex = (vertex: OntologyVertexGraphApi): OntologyVertex => {
       return {
         kind: vertex.kind,
         inner: {
-          metadata: mapOntologyMetadata(vertex.inner.metadata),
+          metadata: mapEntityTypeMetadata(vertex.inner.metadata),
           schema: mapEntityType(vertex.inner.schema),
         },
       };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, the transaction time is not returned when creating an ontology type so a type has to be queried before the transaction time is available. As this information is present when creating a type it should be returned.

## 🚫 Blocked by

- #2840 
- https://github.com/hashintel/hash/pull/2849

## 🔍 What does this change?

- Introduce a partially resolved metadata struct, which does not contain information which is only available after creating the ontology type (currently only the transaction time, maybe more in the future)
- Make the transaction time required for metadata

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph