### PR TITLE
H-294: Align ontology queries to temporal data

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/postgres/query/condition.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/condition.rs
@@ -132,7 +132,6 @@ mod tests {
             postgres::query::{SelectCompiler, Transpile},
             query::{Filter, FilterExpression, Parameter},
         },
-        subgraph::temporal_axes::QueryTemporalAxesUnresolved,
     };
 
     fn test_condition<'p, 'f: 'p>(
@@ -140,8 +139,7 @@ mod tests {
         rendered: &'static str,
         parameters: &[&'p dyn ToSql],
     ) {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
-        let mut compiler = SelectCompiler::new(Some(&temporal_axes));
+        let mut compiler = SelectCompiler::new(None);
         let condition = compiler.compile_filter(filter);
 
         assert_eq!(condition.transpile_to_string(), rendered);
@@ -173,7 +171,7 @@ mod tests {
                 Some(FilterExpression::Path(DataTypeQueryPath::Description)),
                 None,
             ),
-            r#""data_types_0_0_0"."schema"->>'description' IS NULL"#,
+            r#""data_types_0_1_0"."schema"->>'description' IS NULL"#,
             &[],
         );
 
@@ -182,7 +180,7 @@ mod tests {
                 None,
                 Some(FilterExpression::Path(DataTypeQueryPath::Description)),
             ),
-            r#""data_types_0_0_0"."schema"->>'description' IS NULL"#,
+            r#""data_types_0_1_0"."schema"->>'description' IS NULL"#,
             &[],
         );
 
@@ -193,7 +191,7 @@ mod tests {
                 Some(FilterExpression::Path(DataTypeQueryPath::Description)),
                 None,
             ),
-            r#""data_types_0_0_0"."schema"->>'description' IS NOT NULL"#,
+            r#""data_types_0_1_0"."schema"->>'description' IS NOT NULL"#,
             &[],
         );
 
@@ -202,7 +200,7 @@ mod tests {
                 None,
                 Some(FilterExpression::Path(DataTypeQueryPath::Description)),
             ),
-            r#""data_types_0_0_0"."schema"->>'description' IS NOT NULL"#,
+            r#""data_types_0_1_0"."schema"->>'description' IS NOT NULL"#,
             &[],
         );
 
@@ -218,7 +216,7 @@ mod tests {
                     "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
                 )))),
             )]),
-            r#"("data_types_0_0_0"."schema"->>'$id' = $1)"#,
+            r#"("data_types_0_1_0"."schema"->>'$id' = $1)"#,
             &[&"https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"],
         );
 
@@ -252,7 +250,7 @@ mod tests {
                     "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
                 )))),
             )]),
-            r#"("data_types_0_0_0"."schema"->>'$id' = $1)"#,
+            r#"("data_types_0_1_0"."schema"->>'$id' = $1)"#,
             &[&"https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"],
         );
 
@@ -286,7 +284,7 @@ mod tests {
                     "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
                 )))),
             ))),
-            r#"NOT("data_types_0_0_0"."schema"->>'$id' = $1)"#,
+            r#"NOT("data_types_0_1_0"."schema"->>'$id' = $1)"#,
             &[&"https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"],
         );
     }
@@ -298,7 +296,7 @@ mod tests {
                 Some(FilterExpression::Path(DataTypeQueryPath::Description)),
                 Some(FilterExpression::Path(DataTypeQueryPath::Title)),
             )]),
-            r#"("data_types_0_0_0"."schema"->>'description' = "data_types_0_0_0"."schema"->>'title')"#,
+            r#"("data_types_0_1_0"."schema"->>'description' = "data_types_0_1_0"."schema"->>'title')"#,
             &[],
         );
     }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/data_type.rs
@@ -14,7 +14,7 @@ use crate::{
 
 impl PostgresRecord for DataTypeWithMetadata {
     fn base_table() -> Table {
-        Table::DataTypes
+        Table::OntologyTemporalMetadata
     }
 }
 
@@ -26,15 +26,15 @@ impl PostgresQueryPath for DataTypeQueryPath<'_> {
             | Self::Description
             | Self::Type
             | Self::OntologyId
-            | Self::Schema(_) => vec![],
+            | Self::Schema(_) => vec![Relation::DataTypeIds],
             Self::BaseUrl
             | Self::Version
             | Self::RecordCreatedById
             | Self::OwnedById
             | Self::AdditionalMetadata(_) => {
-                vec![Relation::DataTypeIds]
+                vec![Relation::OntologyIds]
             }
-            Self::TransactionTime => vec![Relation::DataTypeTemporalMetadata],
+            Self::TransactionTime => vec![],
             Self::PropertyTypeEdge {
                 edge_kind: OntologyEdgeKind::ConstrainsValuesOn,
                 path,

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
@@ -14,7 +14,7 @@ use crate::{
 
 impl PostgresRecord for EntityTypeWithMetadata {
     fn base_table() -> Table {
-        Table::EntityTypes
+        Table::OntologyTemporalMetadata
     }
 }
 
@@ -29,15 +29,15 @@ impl PostgresQueryPath for EntityTypeQueryPath<'_> {
             | Self::Required
             | Self::OntologyId
             | Self::LabelProperty
-            | Self::Schema(_) => vec![],
+            | Self::Schema(_) => vec![Relation::EntityTypeIds],
             Self::BaseUrl
             | Self::Version
             | Self::RecordCreatedById
             | Self::OwnedById
             | Self::AdditionalMetadata(_) => {
-                vec![Relation::EntityTypeIds]
+                vec![Relation::OntologyIds]
             }
-            Self::TransactionTime => vec![Relation::EntityTypeTemporalMetadata],
+            Self::TransactionTime => vec![],
             Self::PropertyTypeEdge {
                 edge_kind: OntologyEdgeKind::ConstrainsPropertiesOn,
                 path,

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
@@ -92,7 +92,7 @@ mod tests {
             trim_whitespace(
                 r#"
                 WHERE "ontology_id_with_metadata_0_1_0"."version" = "ontology_id_with_metadata_0_1_0"."latest_version"
-                  AND ("ontology_id_with_metadata_0_1_0"."base_url" = $1) AND ("ontology_id_with_metadata_0_1_0"."version" = $2)"#
+                  AND ("ontology_id_with_metadata_0_1_0"."base_url" = $2) AND ("ontology_id_with_metadata_0_1_0"."version" = $3)"#
             )
         );
 
@@ -107,8 +107,8 @@ mod tests {
             trim_whitespace(
                 r#"
                 WHERE "ontology_id_with_metadata_0_1_0"."version" = "ontology_id_with_metadata_0_1_0"."latest_version"
-                  AND ("ontology_id_with_metadata_0_1_0"."base_url" = $1) AND ("ontology_id_with_metadata_0_1_0"."version" = $2)
-                  AND "data_types_0_0_0"."schema"->>'description' IS NOT NULL"#
+                  AND ("ontology_id_with_metadata_0_1_0"."base_url" = $2) AND ("ontology_id_with_metadata_0_1_0"."version" = $3)
+                  AND "data_types_0_1_0"."schema"->>'description' IS NOT NULL"#
             )
         );
 
@@ -133,9 +133,9 @@ mod tests {
             trim_whitespace(
                 r#"
                 WHERE "ontology_id_with_metadata_0_1_0"."version" = "ontology_id_with_metadata_0_1_0"."latest_version"
-                  AND ("ontology_id_with_metadata_0_1_0"."base_url" = $1) AND ("ontology_id_with_metadata_0_1_0"."version" = $2)
-                  AND "data_types_0_0_0"."schema"->>'description' IS NOT NULL
-                  AND (("data_types_0_0_0"."schema"->>'title' = $3) OR ("data_types_0_0_0"."schema"->>'description' = $4))"#
+                  AND ("ontology_id_with_metadata_0_1_0"."base_url" = $2) AND ("ontology_id_with_metadata_0_1_0"."version" = $3)
+                  AND "data_types_0_1_0"."schema"->>'description' IS NOT NULL
+                  AND (("data_types_0_1_0"."schema"->>'title' = $4) OR ("data_types_0_1_0"."schema"->>'description' = $5))"#
             )
         );
 
@@ -145,7 +145,9 @@ mod tests {
             .iter()
             .map(|parameter| format!("{parameter:?}"))
             .collect::<Vec<_>>();
+
         assert_eq!(parameters, &[
+            format!("{:?}", temporal_axes.pinned_timestamp()).as_str(),
             "\"https://blockprotocol.org/@blockprotocol/types/data-type/text/\"",
             "1",
             "\"some title\"",

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/property_type.rs
@@ -14,7 +14,7 @@ use crate::{
 
 impl PostgresRecord for PropertyTypeWithMetadata {
     fn base_table() -> Table {
-        Table::PropertyTypes
+        Table::OntologyTemporalMetadata
     }
 }
 
@@ -25,15 +25,15 @@ impl PostgresQueryPath for PropertyTypeQueryPath<'_> {
             | Self::Title
             | Self::Description
             | Self::OntologyId
-            | Self::Schema(_) => vec![],
+            | Self::Schema(_) => vec![Relation::PropertyTypeIds],
             Self::BaseUrl
             | Self::Version
             | Self::RecordCreatedById
             | Self::OwnedById
             | Self::AdditionalMetadata(_) => {
-                vec![Relation::PropertyTypeIds]
+                vec![Relation::OntologyIds]
             }
-            Self::TransactionTime => vec![Relation::PropertyTypeTemporalMetadata],
+            Self::TransactionTime => vec![],
             Self::DataTypeEdge {
                 edge_kind: OntologyEdgeKind::ConstrainsValuesOn,
                 path,

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -128,7 +128,7 @@ mod tests {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
         test_compilation(
             &SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes)),
-            r#"SELECT * FROM "data_types" AS "data_types_0_0_0""#,
+            r#"SELECT * FROM "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_0_0""#,
             &[],
         );
     }
@@ -136,6 +136,7 @@ mod tests {
     #[test]
     fn simple_expression() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler =
             SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
         compiler.add_filter(&Filter::Equal(
@@ -148,10 +149,16 @@ mod tests {
             &compiler,
             r#"
             SELECT *
-            FROM "data_types" AS "data_types_0_0_0"
-            WHERE "data_types_0_0_0"."schema"->>'$id' = $1
+            FROM "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_0_0"
+            INNER JOIN "data_types" AS "data_types_0_1_0"
+              ON "data_types_0_1_0"."ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
+            WHERE "ontology_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "data_types_0_1_0"."schema"->>'$id' = $2
             "#,
-            &[&"https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"],
+            &[
+                &pinned_timestamp,
+                &"https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
+            ],
         );
     }
 
@@ -203,6 +210,7 @@ mod tests {
     #[test]
     fn specific_version() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler =
             SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
@@ -224,12 +232,14 @@ mod tests {
             &compiler,
             r#"
             SELECT *
-            FROM "data_types" AS "data_types_0_0_0"
+            FROM "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_0_0"
             INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_1_0"
-              ON "ontology_id_with_metadata_0_1_0"."ontology_id" = "data_types_0_0_0"."ontology_id"
-            WHERE ("ontology_id_with_metadata_0_1_0"."base_url" = $1) AND ("ontology_id_with_metadata_0_1_0"."version" = $2)
+              ON "ontology_id_with_metadata_0_1_0"."ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
+            WHERE "ontology_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND ("ontology_id_with_metadata_0_1_0"."base_url" = $2) AND ("ontology_id_with_metadata_0_1_0"."version" = $3)
             "#,
             &[
+                &pinned_timestamp,
                 &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
                 &1,
             ],
@@ -239,6 +249,7 @@ mod tests {
     #[test]
     fn latest_version() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler =
             SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
@@ -254,18 +265,20 @@ mod tests {
             r#"
             WITH "ontology_id_with_metadata" AS (SELECT *, MAX("ontology_id_with_metadata_0_0_0"."version") OVER (PARTITION BY "ontology_id_with_metadata_0_0_0"."base_url") AS "latest_version" FROM "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_0_0")
             SELECT *
-            FROM "data_types" AS "data_types_0_0_0"
+            FROM "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_0_0"
             INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_1_0"
-              ON "ontology_id_with_metadata_0_1_0"."ontology_id" = "data_types_0_0_0"."ontology_id"
-            WHERE "ontology_id_with_metadata_0_1_0"."version" = "ontology_id_with_metadata_0_1_0"."latest_version"
+              ON "ontology_id_with_metadata_0_1_0"."ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
+            WHERE "ontology_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "ontology_id_with_metadata_0_1_0"."version" = "ontology_id_with_metadata_0_1_0"."latest_version"
             "#,
-            &[],
+            &[&pinned_timestamp],
         );
     }
 
     #[test]
     fn not_latest_version() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler =
             SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
@@ -281,18 +294,20 @@ mod tests {
             r#"
             WITH "ontology_id_with_metadata" AS (SELECT *, MAX("ontology_id_with_metadata_0_0_0"."version") OVER (PARTITION BY "ontology_id_with_metadata_0_0_0"."base_url") AS "latest_version" FROM "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_0_0")
             SELECT *
-            FROM "data_types" AS "data_types_0_0_0"
+            FROM "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_0_0"
             INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_1_0"
-              ON "ontology_id_with_metadata_0_1_0"."ontology_id" = "data_types_0_0_0"."ontology_id"
-            WHERE "ontology_id_with_metadata_0_1_0"."version" != "ontology_id_with_metadata_0_1_0"."latest_version"
+              ON "ontology_id_with_metadata_0_1_0"."ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
+            WHERE "ontology_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "ontology_id_with_metadata_0_1_0"."version" != "ontology_id_with_metadata_0_1_0"."latest_version"
             "#,
-            &[],
+            &[&pinned_timestamp],
         );
     }
 
     #[test]
     fn property_type_by_referenced_data_types() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler =
             SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
@@ -312,14 +327,18 @@ mod tests {
             &compiler,
             r#"
             SELECT *
-            FROM "property_types" AS "property_types_0_0_0"
+            FROM "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_0_0"
             INNER JOIN "property_type_constrains_values_on" AS "property_type_constrains_values_on_0_1_0"
-              ON "property_type_constrains_values_on_0_1_0"."source_property_type_ontology_id" = "property_types_0_0_0"."ontology_id"
-            INNER JOIN "data_types" AS "data_types_0_2_0"
-              ON "data_types_0_2_0"."ontology_id" = "property_type_constrains_values_on_0_1_0"."target_data_type_ontology_id"
-            WHERE "data_types_0_2_0"."schema"->>'title' = $1
+              ON "property_type_constrains_values_on_0_1_0"."source_property_type_ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
+            INNER JOIN "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_2_0"
+              ON "ontology_temporal_metadata_0_2_0"."ontology_id" = "property_type_constrains_values_on_0_1_0"."target_data_type_ontology_id"
+            INNER JOIN "data_types" AS "data_types_0_3_0"
+              ON "data_types_0_3_0"."ontology_id" = "ontology_temporal_metadata_0_2_0"."ontology_id"
+            WHERE "ontology_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "ontology_temporal_metadata_0_2_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "data_types_0_3_0"."schema"->>'title' = $2
             "#,
-            &[&"Text"],
+            &[&pinned_timestamp, &"Text"],
         );
 
         let filter = Filter::All(vec![
@@ -349,22 +368,28 @@ mod tests {
         test_compilation(
             &compiler,
             r#"
-            SELECT * FROM "property_types" AS "property_types_0_0_0"
+            SELECT *
+            FROM "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_0_0"
             INNER JOIN "property_type_constrains_values_on" AS "property_type_constrains_values_on_0_1_0"
-              ON "property_type_constrains_values_on_0_1_0"."source_property_type_ontology_id" = "property_types_0_0_0"."ontology_id"
-            INNER JOIN "data_types" AS "data_types_0_2_0"
-              ON "data_types_0_2_0"."ontology_id" = "property_type_constrains_values_on_0_1_0"."target_data_type_ontology_id"
+              ON "property_type_constrains_values_on_0_1_0"."source_property_type_ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
+            INNER JOIN "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_2_0"
+              ON "ontology_temporal_metadata_0_2_0"."ontology_id" = "property_type_constrains_values_on_0_1_0"."target_data_type_ontology_id"
+            INNER JOIN "data_types" AS "data_types_0_3_0"
+              ON "data_types_0_3_0"."ontology_id" = "ontology_temporal_metadata_0_2_0"."ontology_id"
             INNER JOIN "property_type_constrains_values_on" AS "property_type_constrains_values_on_1_1_0"
-              ON "property_type_constrains_values_on_1_1_0"."source_property_type_ontology_id" = "property_types_0_0_0"."ontology_id"
-            INNER JOIN "data_types" AS "data_types_1_2_0"
-              ON "data_types_1_2_0"."ontology_id" = "property_type_constrains_values_on_1_1_0"."target_data_type_ontology_id"
+              ON "property_type_constrains_values_on_1_1_0"."source_property_type_ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
+            INNER JOIN "ontology_temporal_metadata" AS "ontology_temporal_metadata_1_2_0"
+              ON "ontology_temporal_metadata_1_2_0"."ontology_id" = "property_type_constrains_values_on_1_1_0"."target_data_type_ontology_id"
             INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_1_3_0"
-              ON "ontology_id_with_metadata_1_3_0"."ontology_id" = "data_types_1_2_0"."ontology_id"
-            WHERE "data_types_0_2_0"."schema"->>'title' = $1
-              AND ("ontology_id_with_metadata_1_3_0"."base_url" = $2)
-              AND ("ontology_id_with_metadata_1_3_0"."version" = $3)
+              ON "ontology_id_with_metadata_1_3_0"."ontology_id" = "ontology_temporal_metadata_1_2_0"."ontology_id"
+            WHERE "ontology_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "ontology_temporal_metadata_0_2_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "data_types_0_3_0"."schema"->>'title' = $2
+              AND "ontology_temporal_metadata_1_2_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND ("ontology_id_with_metadata_1_3_0"."base_url" = $3) AND ("ontology_id_with_metadata_1_3_0"."version" = $4)
             "#,
             &[
+                &pinned_timestamp,
                 &"Text",
                 &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
                 &1,
@@ -375,6 +400,7 @@ mod tests {
     #[test]
     fn property_type_by_referenced_property_types() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler =
             SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
@@ -396,20 +422,25 @@ mod tests {
             &compiler,
             r#"
             SELECT *
-            FROM "property_types" AS "property_types_0_0_0"
+            FROM "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_0_0"
             INNER JOIN "property_type_constrains_properties_on" AS "property_type_constrains_properties_on_0_1_0"
-              ON "property_type_constrains_properties_on_0_1_0"."source_property_type_ontology_id" = "property_types_0_0_0"."ontology_id"
-            INNER JOIN "property_types" AS "property_types_0_2_0"
-              ON "property_types_0_2_0"."ontology_id" = "property_type_constrains_properties_on_0_1_0"."target_property_type_ontology_id"
-            WHERE "property_types_0_2_0"."schema"->>'title' = $1
+              ON "property_type_constrains_properties_on_0_1_0"."source_property_type_ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
+            INNER JOIN "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_2_0"
+              ON "ontology_temporal_metadata_0_2_0"."ontology_id" = "property_type_constrains_properties_on_0_1_0"."target_property_type_ontology_id"
+            INNER JOIN "property_types" AS "property_types_0_3_0"
+              ON "property_types_0_3_0"."ontology_id" = "ontology_temporal_metadata_0_2_0"."ontology_id"
+            WHERE "ontology_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "ontology_temporal_metadata_0_2_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "property_types_0_3_0"."schema"->>'title' = $2
             "#,
-            &[&"Text"],
+            &[&pinned_timestamp, &"Text"],
         );
     }
 
     #[test]
     fn entity_type_by_referenced_property_types() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler =
             SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
@@ -430,20 +461,25 @@ mod tests {
             &compiler,
             r#"
             SELECT *
-            FROM "entity_types" AS "entity_types_0_0_0"
+            FROM "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_0_0"
             INNER JOIN "entity_type_constrains_properties_on" AS "entity_type_constrains_properties_on_0_1_0"
-              ON "entity_type_constrains_properties_on_0_1_0"."source_entity_type_ontology_id" = "entity_types_0_0_0"."ontology_id"
-            INNER JOIN "property_types" AS "property_types_0_2_0"
-              ON "property_types_0_2_0"."ontology_id" = "entity_type_constrains_properties_on_0_1_0"."target_property_type_ontology_id"
-            WHERE "property_types_0_2_0"."schema"->>'title' = $1
+              ON "entity_type_constrains_properties_on_0_1_0"."source_entity_type_ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
+            INNER JOIN "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_2_0"
+              ON "ontology_temporal_metadata_0_2_0"."ontology_id" = "entity_type_constrains_properties_on_0_1_0"."target_property_type_ontology_id"
+            INNER JOIN "property_types" AS "property_types_0_3_0"
+              ON "property_types_0_3_0"."ontology_id" = "ontology_temporal_metadata_0_2_0"."ontology_id"
+            WHERE "ontology_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "ontology_temporal_metadata_0_2_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "property_types_0_3_0"."schema"->>'title' = $2
             "#,
-            &[&"Name"],
+            &[&pinned_timestamp, &"Name"],
         );
     }
 
     #[test]
     fn entity_type_by_referenced_link_types() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler =
             SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
@@ -469,24 +505,31 @@ mod tests {
             &compiler,
             r#"
             SELECT *
-            FROM "entity_types" AS "entity_types_0_0_0"
+            FROM "ontology_temporal_metadata"
+              AS "ontology_temporal_metadata_0_0_0"
             INNER JOIN "entity_type_constrains_links_on" AS "entity_type_constrains_links_on_0_1_0"
-              ON "entity_type_constrains_links_on_0_1_0"."source_entity_type_ontology_id" = "entity_types_0_0_0"."ontology_id"
-            INNER JOIN "entity_types" AS "entity_types_0_2_0"
-              ON "entity_types_0_2_0"."ontology_id" = "entity_type_constrains_links_on_0_1_0"."target_entity_type_ontology_id"
+              ON "entity_type_constrains_links_on_0_1_0"."source_entity_type_ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
+            INNER JOIN "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_2_0"
+              ON "ontology_temporal_metadata_0_2_0"."ontology_id" = "entity_type_constrains_links_on_0_1_0"."target_entity_type_ontology_id"
             INNER JOIN "entity_type_constrains_links_on" AS "entity_type_constrains_links_on_0_3_0"
-              ON "entity_type_constrains_links_on_0_3_0"."source_entity_type_ontology_id" = "entity_types_0_2_0"."ontology_id"
-            INNER JOIN "entity_types" AS "entity_types_0_4_0"
-              ON "entity_types_0_4_0"."ontology_id" = "entity_type_constrains_links_on_0_3_0"."target_entity_type_ontology_id"
-            WHERE "entity_types_0_4_0"."schema"->>'title' = $1
+              ON "entity_type_constrains_links_on_0_3_0"."source_entity_type_ontology_id" = "ontology_temporal_metadata_0_2_0"."ontology_id"
+            INNER JOIN "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_4_0"
+              ON "ontology_temporal_metadata_0_4_0"."ontology_id" = "entity_type_constrains_links_on_0_3_0"."target_entity_type_ontology_id"
+            INNER JOIN "entity_types" AS "entity_types_0_5_0"
+              ON "entity_types_0_5_0"."ontology_id" = "ontology_temporal_metadata_0_4_0"."ontology_id"
+            WHERE "ontology_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "ontology_temporal_metadata_0_2_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "ontology_temporal_metadata_0_4_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "entity_types_0_5_0"."schema"->>'title' = $2
             "#,
-            &[&"Friend Of"],
+            &[&pinned_timestamp, &"Friend Of"],
         );
     }
 
     #[test]
     fn entity_type_by_inheritance() {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler =
             SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
@@ -508,16 +551,21 @@ mod tests {
             &compiler,
             r#"
             SELECT *
-            FROM "entity_types" AS "entity_types_0_0_0"
+            FROM "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_0_0"
             INNER JOIN "entity_type_inherits_from" AS "entity_type_inherits_from_0_1_0"
-              ON "entity_type_inherits_from_0_1_0"."source_entity_type_ontology_id" = "entity_types_0_0_0"."ontology_id"
-            INNER JOIN "entity_types" AS "entity_types_0_2_0"
-              ON "entity_types_0_2_0"."ontology_id" = "entity_type_inherits_from_0_1_0"."target_entity_type_ontology_id"
+              ON "entity_type_inherits_from_0_1_0"."source_entity_type_ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
+            INNER JOIN "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_2_0"
+              ON "ontology_temporal_metadata_0_2_0"."ontology_id" = "entity_type_inherits_from_0_1_0"."target_entity_type_ontology_id"
             INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_3_0"
-              ON "ontology_id_with_metadata_0_3_0"."ontology_id" = "entity_types_0_2_0"."ontology_id"
-            WHERE "ontology_id_with_metadata_0_3_0"."base_url" = $1
+              ON "ontology_id_with_metadata_0_3_0"."ontology_id" = "ontology_temporal_metadata_0_2_0"."ontology_id"
+            WHERE "ontology_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "ontology_temporal_metadata_0_2_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "ontology_id_with_metadata_0_3_0"."base_url" = $2
             "#,
-            &[&"https://blockprotocol.org/@blockprotocol/types/entity-type/link/"],
+            &[
+                &pinned_timestamp,
+                &"https://blockprotocol.org/@blockprotocol/types/entity-type/link/",
+            ],
         );
     }
 
@@ -893,10 +941,10 @@ mod tests {
              AND "entity_temporal_metadata_0_2_0"."entity_uuid" = "entity_has_left_entity_0_1_0"."left_entity_uuid"
             INNER JOIN "entity_is_of_type" AS "entity_is_of_type_0_3_0"
               ON "entity_is_of_type_0_3_0"."entity_edition_id" = "entity_temporal_metadata_0_2_0"."entity_edition_id"
-            INNER JOIN "entity_types" AS "entity_types_0_4_0"
-              ON "entity_types_0_4_0"."ontology_id" = "entity_is_of_type_0_3_0"."entity_type_ontology_id"
+            INNER JOIN "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_4_0"
+              ON "ontology_temporal_metadata_0_4_0"."ontology_id" = "entity_is_of_type_0_3_0"."entity_type_ontology_id"
             INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_5_0"
-              ON "ontology_id_with_metadata_0_5_0"."ontology_id" = "entity_types_0_4_0"."ontology_id"
+              ON "ontology_id_with_metadata_0_5_0"."ontology_id" = "ontology_temporal_metadata_0_4_0"."ontology_id"
             LEFT OUTER JOIN "entity_has_right_entity" AS "entity_has_right_entity_0_1_0"
               ON "entity_has_right_entity_0_1_0"."owned_by_id" = "entity_temporal_metadata_0_0_0"."owned_by_id"
              AND "entity_has_right_entity_0_1_0"."entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
@@ -905,16 +953,18 @@ mod tests {
              AND "entity_temporal_metadata_0_2_1"."entity_uuid" = "entity_has_right_entity_0_1_0"."right_entity_uuid"
             INNER JOIN "entity_is_of_type" AS "entity_is_of_type_0_3_1"
               ON "entity_is_of_type_0_3_1"."entity_edition_id" = "entity_temporal_metadata_0_2_1"."entity_edition_id"
-            INNER JOIN "entity_types" AS "entity_types_0_4_1"
-              ON "entity_types_0_4_1"."ontology_id" = "entity_is_of_type_0_3_1"."entity_type_ontology_id"
+            INNER JOIN "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_4_1"
+              ON "ontology_temporal_metadata_0_4_1"."ontology_id" = "entity_is_of_type_0_3_1"."entity_type_ontology_id"
             INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_5_1"
-              ON "ontology_id_with_metadata_0_5_1"."ontology_id" = "entity_types_0_4_1"."ontology_id"
+              ON "ontology_id_with_metadata_0_5_1"."ontology_id" = "ontology_temporal_metadata_0_4_1"."ontology_id"
             WHERE "entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
               AND "entity_temporal_metadata_0_0_0"."decision_time" && $2
               AND "entity_temporal_metadata_0_2_0"."transaction_time" @> $1::TIMESTAMPTZ
               AND "entity_temporal_metadata_0_2_0"."decision_time" && $2
+              AND "ontology_temporal_metadata_0_4_0"."transaction_time" @> $1::TIMESTAMPTZ
               AND "entity_temporal_metadata_0_2_1"."transaction_time" @> $1::TIMESTAMPTZ
               AND "entity_temporal_metadata_0_2_1"."decision_time" && $2
+              AND "ontology_temporal_metadata_0_4_1"."transaction_time" @> $1::TIMESTAMPTZ
               AND ("ontology_id_with_metadata_0_5_0"."base_url" = $3)
               AND ("ontology_id_with_metadata_0_5_1"."base_url" = $4)
             "#,
@@ -948,6 +998,7 @@ mod tests {
             };
 
             let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+            let pinned_timestamp = temporal_axes.pinned_timestamp();
             let mut compiler =
                 SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes));
 
@@ -958,12 +1009,14 @@ mod tests {
                 &compiler,
                 r#"
                 SELECT *
-                FROM "data_types" AS "data_types_0_0_0"
+                FROM "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_0_0"
                 INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_1_0"
-                  ON "ontology_id_with_metadata_0_1_0"."ontology_id" = "data_types_0_0_0"."ontology_id"
-                WHERE ("ontology_id_with_metadata_0_1_0"."base_url" = $1) AND ("ontology_id_with_metadata_0_1_0"."version" = $2)
+                  ON "ontology_id_with_metadata_0_1_0"."ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
+                WHERE "ontology_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+                  AND ("ontology_id_with_metadata_0_1_0"."base_url" = $2) AND ("ontology_id_with_metadata_0_1_0"."version" = $3)
                 "#,
                 &[
+                    &pinned_timestamp,
                     &url.base_url.as_str(),
                     &OntologyTypeVersion::new(url.version),
                 ],

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
@@ -45,37 +45,37 @@ impl ReferenceTable {
     pub const fn source_relation(self) -> ForeignKeyReference {
         match self {
             Self::PropertyTypeConstrainsValuesOn => ForeignKeyReference::Single {
-                on: Column::PropertyTypes(PropertyTypes::OntologyId),
+                on: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
                 join: Column::PropertyTypeConstrainsValuesOn(
                     PropertyTypeConstrainsValuesOn::SourcePropertyTypeOntologyId,
                 ),
             },
             Self::PropertyTypeConstrainsPropertiesOn => ForeignKeyReference::Single {
-                on: Column::PropertyTypes(PropertyTypes::OntologyId),
+                on: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
                 join: Column::PropertyTypeConstrainsPropertiesOn(
                     PropertyTypeConstrainsPropertiesOn::SourcePropertyTypeOntologyId,
                 ),
             },
             Self::EntityTypeConstrainsPropertiesOn => ForeignKeyReference::Single {
-                on: Column::EntityTypes(EntityTypes::OntologyId),
+                on: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
                 join: Column::EntityTypeConstrainsPropertiesOn(
                     EntityTypeConstrainsPropertiesOn::SourceEntityTypeOntologyId,
                 ),
             },
             Self::EntityTypeInheritsFrom => ForeignKeyReference::Single {
-                on: Column::EntityTypes(EntityTypes::OntologyId),
+                on: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
                 join: Column::EntityTypeInheritsFrom(
                     EntityTypeInheritsFrom::SourceEntityTypeOntologyId,
                 ),
             },
             Self::EntityTypeConstrainsLinksOn => ForeignKeyReference::Single {
-                on: Column::EntityTypes(EntityTypes::OntologyId),
+                on: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
                 join: Column::EntityTypeConstrainsLinksOn(
                     EntityTypeConstrainsLinksOn::SourceEntityTypeOntologyId,
                 ),
             },
             Self::EntityTypeConstrainsLinkDestinationsOn => ForeignKeyReference::Single {
-                on: Column::EntityTypes(EntityTypes::OntologyId),
+                on: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
                 join: Column::EntityTypeConstrainsLinkDestinationsOn(
                     EntityTypeConstrainsLinkDestinationsOn::SourceEntityTypeOntologyId,
                 ),
@@ -113,41 +113,41 @@ impl ReferenceTable {
                 on: Column::PropertyTypeConstrainsValuesOn(
                     PropertyTypeConstrainsValuesOn::TargetDataTypeOntologyId,
                 ),
-                join: Column::DataTypes(DataTypes::OntologyId),
+                join: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
             },
             Self::PropertyTypeConstrainsPropertiesOn => ForeignKeyReference::Single {
                 on: Column::PropertyTypeConstrainsPropertiesOn(
                     PropertyTypeConstrainsPropertiesOn::TargetPropertyTypeOntologyId,
                 ),
-                join: Column::PropertyTypes(PropertyTypes::OntologyId),
+                join: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
             },
             Self::EntityTypeConstrainsPropertiesOn => ForeignKeyReference::Single {
                 on: Column::EntityTypeConstrainsPropertiesOn(
                     EntityTypeConstrainsPropertiesOn::TargetPropertyTypeOntologyId,
                 ),
-                join: Column::PropertyTypes(PropertyTypes::OntologyId),
+                join: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
             },
             Self::EntityTypeInheritsFrom => ForeignKeyReference::Single {
                 on: Column::EntityTypeInheritsFrom(
                     EntityTypeInheritsFrom::TargetEntityTypeOntologyId,
                 ),
-                join: Column::EntityTypes(EntityTypes::OntologyId),
+                join: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
             },
             Self::EntityTypeConstrainsLinksOn => ForeignKeyReference::Single {
                 on: Column::EntityTypeConstrainsLinksOn(
                     EntityTypeConstrainsLinksOn::TargetEntityTypeOntologyId,
                 ),
-                join: Column::EntityTypes(EntityTypes::OntologyId),
+                join: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
             },
             Self::EntityTypeConstrainsLinkDestinationsOn => ForeignKeyReference::Single {
                 on: Column::EntityTypeConstrainsLinkDestinationsOn(
                     EntityTypeConstrainsLinkDestinationsOn::TargetEntityTypeOntologyId,
                 ),
-                join: Column::EntityTypes(EntityTypes::OntologyId),
+                join: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
             },
             Self::EntityIsOfType => ForeignKeyReference::Single {
                 on: Column::EntityIsOfType(EntityIsOfType::EntityTypeOntologyId),
-                join: Column::EntityTypes(EntityTypes::OntologyId),
+                join: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
             },
             Self::EntityHasLeftEntity => ForeignKeyReference::Double {
                 on: [
@@ -1069,12 +1069,10 @@ impl Transpile for AliasedColumn {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Relation {
+    OntologyIds,
     DataTypeIds,
-    DataTypeTemporalMetadata,
     PropertyTypeIds,
-    PropertyTypeTemporalMetadata,
     EntityTypeIds,
-    EntityTypeTemporalMetadata,
     EntityEditions,
     LeftEntity,
     RightEntity,
@@ -1140,36 +1138,22 @@ impl Iterator for ForeignKeyJoin {
 impl Relation {
     pub fn joins(self) -> impl Iterator<Item = ForeignKeyReference> {
         match self {
+            Self::OntologyIds => ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
+                on: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
+                join: Column::OntologyIds(OntologyIds::OntologyId),
+            }),
             Self::DataTypeIds => ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
-                on: Column::DataTypes(DataTypes::OntologyId),
-                join: Column::OntologyIds(OntologyIds::OntologyId),
+                on: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
+                join: Column::DataTypes(DataTypes::OntologyId),
             }),
-            Self::DataTypeTemporalMetadata => {
-                ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
-                    on: Column::DataTypes(DataTypes::OntologyId),
-                    join: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
-                })
-            }
             Self::PropertyTypeIds => ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
-                on: Column::PropertyTypes(PropertyTypes::OntologyId),
-                join: Column::OntologyIds(OntologyIds::OntologyId),
+                on: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
+                join: Column::PropertyTypes(PropertyTypes::OntologyId),
             }),
-            Self::PropertyTypeTemporalMetadata => {
-                ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
-                    on: Column::PropertyTypes(PropertyTypes::OntologyId),
-                    join: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
-                })
-            }
             Self::EntityTypeIds => ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
-                on: Column::EntityTypes(EntityTypes::OntologyId),
-                join: Column::OntologyIds(OntologyIds::OntologyId),
+                on: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
+                join: Column::EntityTypes(EntityTypes::OntologyId),
             }),
-            Self::EntityTypeTemporalMetadata => {
-                ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
-                    on: Column::EntityTypes(EntityTypes::OntologyId),
-                    join: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
-                })
-            }
             Self::EntityEditions => ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
                 on: Column::EntityTemporalMetadata(EntityTemporalMetadata::EditionId),
                 join: Column::EntityEditions(EntityEditions::EditionId),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When doing nested queries in a structural query it does not necessarily take the time bounds into account - depending on the requested data. By making the ontology_temporal_metadata the entry table for ontology types this is solved.

Note: For entities, we use the same behavior.

## 🚫 Blocked by

- #2844 

## 🔍 What does this change?

- Make `ontology_temporal_metadata` the main table for ontology types - the same behavior as for entities
- Adjust the test outputs -  this mainly adds the `WHERE` clauses to the tables

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

