### PR TITLE
H-296: Make 'Fix' workflow trigger CI again

### DIFF
--- a/.github/workflows/dispatch-fix.yml
+++ b/.github/workflows/dispatch-fix.yml
@@ -6,6 +6,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.MACHINE_USER_TOKEN }}
 
       - name: Warm up repo
         uses: ./.github/actions/warm-up-repo
@@ -20,3 +22,5 @@ jobs:
           git add .
           git commit -m '`yarn fix`'
           git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.MACHINE_USER_TOKEN }}

--- a/.github/workflows/dispatch-fix.yml
+++ b/.github/workflows/dispatch-fix.yml
@@ -12,6 +12,9 @@ jobs:
       - name: Warm up repo
         uses: ./.github/actions/warm-up-repo
 
+      - name: Setup python
+        run: yarn poetry:install
+
       - name: Fix
         run: yarn fix
 

--- a/apps/hash/README.md
+++ b/apps/hash/README.md
@@ -289,6 +289,10 @@ We use [Yarn Workspaces](https://classic.yarnpkg.com/en/docs/workspaces) to work
 
 ## Troubleshooting
 
+### Command not found: ruff
+
+Run `yarn poetry:install` before running `yarn lint` or `yarn fix` for the first time.
+
 ### eslint `parserOptions.project`
 
 There is a mismatch between VSCode's eslint plugin and the eslint cli tool. Specifically the option

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-    "description": "HASH monorepo",
+  "description": "HASH monorepo",
   "workspaces": {
     "packages": [
       "apps/*",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We have a 'Fix' workflow that can be used to manually trigger linting auto-fixes on branches in GitHub, to save people having to checkout the branch and do so locally. This is useful to fix formatting when amendments are made to docs directly in GitHub, for example.

[By design](https://github.com/orgs/community/discussions/25702#discussioncomment-3248819), any actions using the default `GITHUB_TOKEN` that workflow runners are supplied will not trigger further workflow runs, defeating the point of fixing linting.

This PR updates the fix action to use another GitHub access token, which triggers CI again.

It also fixes the action to run `yarn poetry:install` and additionally adds a menu of this requirement for fixing/linting commands to the README.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Slack thread](https://hashintel.slack.com/archives/C02TWBTT3ED/p1690967291531229?thread_ts=1690918011.271779&cid=C02TWBTT3ED)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Confirm that actions run as a result of the Fix action I triggered

## 📹 Demo
<img width="474" alt="Screenshot 2023-08-02 at 17 16 46" src="https://github.com/hashintel/hash/assets/37743469/4b9f4a85-4a87-4f03-b0b5-369e29159afe">


