### PR TITLE
Make PR template checkbox completion easier

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,15 +34,15 @@
 
 This PR:
 
-- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
+- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing
 
-- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
+- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**
 
-- [ ] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
+- [x] modifies a **Cargo**-publishable library and **I have amended the version**
 
-- [ ] modifies a **block** that will need publishing via GitHub action once merged
+- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
 
-- [ ] does not modify any publishable blocks or libraries, or modifications do not need publishing
+- [x] modifies a **block** that will need publishing via GitHub action once merged
 
 - [x] I am unsure / need advice
 
@@ -53,15 +53,15 @@ This PR:
 
 The changes in this PR:
 
-- [ ] are internal and do not require a docs change
+- [x] are internal and do not require a docs change
 
-- [ ] are in a state where docs changes are not _yet_ required but will be
+- [x] are in a state where docs changes are not _yet_ required but will be
 
   - this is tracked in: [Insert Link Here](link)
 
-- [ ] require changes to docs which **are made** as part of this PR
+- [x] require changes to docs which **are made** as part of this PR
 
-- [ ] require changes to docs which are **not** made in this PR
+- [x] require changes to docs which are **not** made in this PR
 
   - _Provide more detail here_
 
@@ -74,9 +74,9 @@ The changes in this PR:
 
 The changes in this PR:
 
-- [ ] affected the execution graph, and the `turbo.json`'s have been updated to reflect this
+- [x] do not affect the execution graph
 
-- [ ] do not affect the execution graph
+- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this
 
 - [x] I am unsure / need advice
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Our PR template has some checkboxes, under 'Pre-merge checklist', that contributors are required to delete and check as appropriate.

Most of the time all three sub-sections are likely to require the 'no action required' checkbox only to be present and checked, which was previously fiddly to do.

This PR makes it easier by:
1. Checking all boxes by default, so you only need to delete the inappropriate ones, not additionally check the remaining ones
2. Moves the 'no action required' boxes to the top of each sub-section, so that it's easier to select the remainder and delete them


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  You could open the amended file in an editor and check that it seems easier to end up with only the 'no action required' boxes than it was before
