### PR TITLE
H-238: Implement type (un-)archival in the Graph

### DIFF
--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -25,9 +25,9 @@ use crate::{
     knowledge::{Entity, EntityLinkOrder, EntityMetadata, EntityProperties, EntityUuid, LinkData},
     ontology::{
         domain_validator::DomainValidator, DataTypeWithMetadata, EntityTypeMetadata,
-        EntityTypeWithMetadata, OntologyElementMetadata, OntologyTypeReference,
-        PartialCustomEntityTypeMetadata, PartialCustomOntologyMetadata, PartialEntityTypeMetadata,
-        PartialOntologyElementMetadata, PropertyTypeWithMetadata,
+        EntityTypeWithMetadata, OntologyElementMetadata, OntologyTemporalMetadata,
+        OntologyTypeReference, PartialCustomEntityTypeMetadata, PartialCustomOntologyMetadata,
+        PartialEntityTypeMetadata, PartialOntologyElementMetadata, PropertyTypeWithMetadata,
     },
     provenance::{OwnedById, ProvenanceMetadata, RecordCreatedById},
     store::{
@@ -591,6 +591,20 @@ where
 
         self.store.update_data_type(data_type, actor_id).await
     }
+
+    async fn archive_data_type(
+        &mut self,
+        id: &VersionedUrl,
+    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+        self.store.archive_data_type(id).await
+    }
+
+    async fn unarchive_data_type(
+        &mut self,
+        id: &VersionedUrl,
+    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+        self.store.unarchive_data_type(id).await
+    }
 }
 
 #[async_trait]
@@ -642,6 +656,20 @@ where
             .update_property_type(property_type, actor_id)
             .await
     }
+
+    async fn archive_property_type(
+        &mut self,
+        id: &VersionedUrl,
+    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+        self.store.archive_property_type(id).await
+    }
+
+    async fn unarchive_property_type(
+        &mut self,
+        id: &VersionedUrl,
+    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+        self.store.unarchive_property_type(id).await
+    }
 }
 
 #[async_trait]
@@ -691,6 +719,20 @@ where
         self.store
             .update_entity_type(entity_type, actor_id, label_property)
             .await
+    }
+
+    async fn archive_entity_type(
+        &mut self,
+        id: &VersionedUrl,
+    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+        self.store.archive_entity_type(id).await
+    }
+
+    async fn unarchive_entity_type(
+        &mut self,
+        id: &VersionedUrl,
+    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+        self.store.unarchive_entity_type(id).await
     }
 }
 

--- a/apps/hash-graph/lib/graph/src/store/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/store/ontology.rs
@@ -2,12 +2,16 @@ use std::iter;
 
 use async_trait::async_trait;
 use error_stack::Result;
-use type_system::{url::BaseUrl, DataType, EntityType, PropertyType};
+use type_system::{
+    url::{BaseUrl, VersionedUrl},
+    DataType, EntityType, PropertyType,
+};
 
 use crate::{
     ontology::{
         DataTypeWithMetadata, EntityTypeMetadata, EntityTypeWithMetadata, OntologyElementMetadata,
-        PartialEntityTypeMetadata, PartialOntologyElementMetadata, PropertyTypeWithMetadata,
+        OntologyTemporalMetadata, PartialEntityTypeMetadata, PartialOntologyElementMetadata,
+        PropertyTypeWithMetadata,
     },
     provenance::RecordCreatedById,
     store::{crud, ConflictBehavior, InsertionError, QueryError, UpdateError},
@@ -72,6 +76,26 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
         data_type: DataType,
         actor_id: RecordCreatedById,
     ) -> Result<OntologyElementMetadata, UpdateError>;
+
+    /// Archives the definition of an existing [`DataType`].
+    ///
+    /// # Errors
+    ///
+    /// - if the [`DataType`] doesn't exist.
+    async fn archive_data_type(
+        &mut self,
+        id: &VersionedUrl,
+    ) -> Result<OntologyTemporalMetadata, UpdateError>;
+
+    /// Restores the definition of an existing [`DataType`].
+    ///
+    /// # Errors
+    ///
+    /// - if the [`DataType`] doesn't exist.
+    async fn unarchive_data_type(
+        &mut self,
+        id: &VersionedUrl,
+    ) -> Result<OntologyTemporalMetadata, UpdateError>;
 }
 
 /// Describes the API of a store implementation for [`PropertyType`]s.
@@ -134,6 +158,26 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
         property_type: PropertyType,
         actor_id: RecordCreatedById,
     ) -> Result<OntologyElementMetadata, UpdateError>;
+
+    /// Archives the definition of an existing [`PropertyType`].
+    ///
+    /// # Errors
+    ///
+    /// - if the [`PropertyType`] doesn't exist.
+    async fn archive_property_type(
+        &mut self,
+        id: &VersionedUrl,
+    ) -> Result<OntologyTemporalMetadata, UpdateError>;
+
+    /// Restores the definition of an existing [`PropertyType`].
+    ///
+    /// # Errors
+    ///
+    /// - if the [`PropertyType`] doesn't exist.
+    async fn unarchive_property_type(
+        &mut self,
+        id: &VersionedUrl,
+    ) -> Result<OntologyTemporalMetadata, UpdateError>;
 }
 
 /// Describes the API of a store implementation for [`EntityType`]s.
@@ -195,4 +239,24 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
         actor_id: RecordCreatedById,
         label_property: Option<BaseUrl>,
     ) -> Result<EntityTypeMetadata, UpdateError>;
+
+    /// Archives the definition of an existing [`EntityType`].
+    ///
+    /// # Errors
+    ///
+    /// - if the [`EntityType`] doesn't exist.
+    async fn archive_entity_type(
+        &mut self,
+        id: &VersionedUrl,
+    ) -> Result<OntologyTemporalMetadata, UpdateError>;
+
+    /// Restores the definition of an existing [`EntityType`].
+    ///
+    /// # Errors
+    ///
+    /// - if the [`EntityType`] doesn't exist.
+    async fn unarchive_entity_type(
+        &mut self,
+        id: &VersionedUrl,
+    ) -> Result<OntologyTemporalMetadata, UpdateError>;
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -3,13 +3,16 @@ use async_trait::async_trait;
 use error_stack::IntoReport;
 use error_stack::{Report, Result, ResultExt};
 use futures::{stream, TryStreamExt};
-use type_system::DataType;
+use type_system::{url::VersionedUrl, DataType};
 
 #[cfg(hash_graph_test_environment)]
 use crate::store::error::DeletionError;
 use crate::{
     identifier::time::RightBoundedTemporalInterval,
-    ontology::{DataTypeWithMetadata, OntologyElementMetadata, PartialOntologyElementMetadata},
+    ontology::{
+        DataTypeWithMetadata, OntologyElementMetadata, OntologyTemporalMetadata,
+        PartialOntologyElementMetadata,
+    },
     provenance::RecordCreatedById,
     store::{
         crud::Read,
@@ -182,5 +185,19 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
         transaction.commit().await.change_context(UpdateError)?;
 
         Ok(metadata)
+    }
+
+    async fn archive_data_type(
+        &mut self,
+        id: &VersionedUrl,
+    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+        self.archive_ontology_type(id).await
+    }
+
+    async fn unarchive_data_type(
+        &mut self,
+        id: &VersionedUrl,
+    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+        self.unarchive_ontology_type(id).await
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -5,15 +5,18 @@ use async_trait::async_trait;
 use error_stack::IntoReport;
 use error_stack::{Report, Result, ResultExt};
 use futures::{stream, TryStreamExt};
-use type_system::{url::BaseUrl, EntityType};
+use type_system::{
+    url::{BaseUrl, VersionedUrl},
+    EntityType,
+};
 
 #[cfg(hash_graph_test_environment)]
 use crate::store::error::DeletionError;
 use crate::{
     identifier::{ontology::OntologyTypeRecordId, time::RightBoundedTemporalInterval},
     ontology::{
-        EntityTypeMetadata, EntityTypeWithMetadata, PartialCustomEntityTypeMetadata,
-        PartialCustomOntologyMetadata, PartialEntityTypeMetadata,
+        EntityTypeMetadata, EntityTypeWithMetadata, OntologyTemporalMetadata,
+        PartialCustomEntityTypeMetadata, PartialCustomOntologyMetadata, PartialEntityTypeMetadata,
     },
     provenance::{ProvenanceMetadata, RecordCreatedById},
     store::{
@@ -354,5 +357,19 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         transaction.commit().await.change_context(UpdateError)?;
 
         Ok(EntityTypeMetadata::from_partial(metadata, transaction_time))
+    }
+
+    async fn archive_entity_type(
+        &mut self,
+        id: &VersionedUrl,
+    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+        self.archive_ontology_type(id).await
+    }
+
+    async fn unarchive_entity_type(
+        &mut self,
+        id: &VersionedUrl,
+    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+        self.unarchive_ontology_type(id).await
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -5,13 +5,16 @@ use async_trait::async_trait;
 use error_stack::IntoReport;
 use error_stack::{Report, Result, ResultExt};
 use futures::{stream, TryStreamExt};
-use type_system::PropertyType;
+use type_system::{url::VersionedUrl, PropertyType};
 
 #[cfg(hash_graph_test_environment)]
 use crate::store::error::DeletionError;
 use crate::{
     identifier::time::RightBoundedTemporalInterval,
-    ontology::{OntologyElementMetadata, PartialOntologyElementMetadata, PropertyTypeWithMetadata},
+    ontology::{
+        OntologyElementMetadata, OntologyTemporalMetadata, PartialOntologyElementMetadata,
+        PropertyTypeWithMetadata,
+    },
     provenance::RecordCreatedById,
     store::{
         crud::Read,
@@ -318,5 +321,19 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         transaction.commit().await.change_context(UpdateError)?;
 
         Ok(metadata)
+    }
+
+    async fn archive_property_type(
+        &mut self,
+        id: &VersionedUrl,
+    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+        self.archive_ontology_type(id).await
+    }
+
+    async fn unarchive_property_type(
+        &mut self,
+        id: &VersionedUrl,
+    ) -> Result<OntologyTemporalMetadata, UpdateError> {
+        self.unarchive_ontology_type(id).await
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Implements the Graph functionality to archive or unarchive ontology types.

## 🚫 Blocked by

- #2845 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph