### PR TITLE
H-301: Fix `input` in `turbo.json` in hash-graph-client

### DIFF
--- a/libs/@local/hash-graph-client/typescript/turbo.json
+++ b/libs/@local/hash-graph-client/typescript/turbo.json
@@ -6,7 +6,7 @@
     //   "dependsOn": ["@apps/hash-graph#codegen:generate-openapi-specs"]
     // },
     "codegen": {
-      "inputs": ["../../../apps/hash-graph/openapi/openapi.json"],
+      "inputs": ["../../../../apps/hash-graph/openapi/openapi.json"],
       "outputs": [
         ".npmignore",
         "api.ts",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

[https://github.com/hashintel/hash/pull/2841](https://github.com/hashintel/hash/pull/2841/files) moved the hash-graph-client but the turbo.json was not adjusted properly as the input points to a non-existing file.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this