### PR TITLE
H-305: Split the `ontology_ids_with_metadata` view

### DIFF
--- a/apps/hash-graph/lib/graph/src/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/data_type.rs
@@ -164,8 +164,6 @@ pub enum DataTypeQueryPath<'p> {
     OntologyId,
     /// Only used internally and not available for deserialization.
     Schema(Option<JsonPath<'p>>),
-    /// Only used internally and not available for deserialization.
-    AdditionalMetadata(Option<JsonPath<'p>>),
     /// A reversed edge from a [`PropertyType`] to this [`DataType`] using an [`OntologyEdgeKind`].
     ///
     /// The corresponding edge is [`PropertyTypeQueryPath::DataTypeEdge`].
@@ -182,6 +180,8 @@ pub enum DataTypeQueryPath<'p> {
         edge_kind: OntologyEdgeKind,
         path: Box<PropertyTypeQueryPath<'p>>,
     },
+    /// Only used internally and not available for deserialization.
+    AdditionalMetadata,
 }
 
 impl OntologyQueryPath for DataTypeQueryPath<'_> {
@@ -214,7 +214,7 @@ impl OntologyQueryPath for DataTypeQueryPath<'_> {
     }
 
     fn additional_metadata() -> Self {
-        Self::AdditionalMetadata(None)
+        Self::AdditionalMetadata
     }
 }
 
@@ -222,7 +222,7 @@ impl QueryPath for DataTypeQueryPath<'_> {
     fn expected_type(&self) -> ParameterType {
         match self {
             Self::OntologyId | Self::OwnedById | Self::RecordCreatedById => ParameterType::Uuid,
-            Self::Schema(_) | Self::AdditionalMetadata(_) => ParameterType::Any,
+            Self::Schema(_) | Self::AdditionalMetadata => ParameterType::Object,
             Self::BaseUrl => ParameterType::BaseUrl,
             Self::VersionedUrl => ParameterType::VersionedUrl,
             Self::TransactionTime => ParameterType::TimeInterval,
@@ -248,8 +248,7 @@ impl fmt::Display for DataTypeQueryPath<'_> {
             Self::Title => fmt.write_str("title"),
             Self::Description => fmt.write_str("description"),
             Self::Type => fmt.write_str("type"),
-            Self::AdditionalMetadata(Some(path)) => write!(fmt, "additionalMetadata.{path}"),
-            Self::AdditionalMetadata(None) => fmt.write_str("additionalMetadata"),
+            Self::AdditionalMetadata => fmt.write_str("additionalMetadata"),
             #[expect(
                 clippy::use_debug,
                 reason = "We don't have a `Display` impl for `OntologyEdgeKind` and this should \

--- a/apps/hash-graph/lib/graph/src/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/entity_type.rs
@@ -309,7 +309,7 @@ pub enum EntityTypeQueryPath<'p> {
     /// Only used internally and not available for deserialization.
     Schema(Option<JsonPath<'p>>),
     /// Only used internally and not available for deserialization.
-    AdditionalMetadata(Option<JsonPath<'p>>),
+    AdditionalMetadata,
 }
 
 impl OntologyQueryPath for EntityTypeQueryPath<'_> {
@@ -342,7 +342,7 @@ impl OntologyQueryPath for EntityTypeQueryPath<'_> {
     }
 
     fn additional_metadata() -> Self {
-        Self::AdditionalMetadata(None)
+        Self::AdditionalMetadata
     }
 }
 
@@ -350,9 +350,8 @@ impl QueryPath for EntityTypeQueryPath<'_> {
     fn expected_type(&self) -> ParameterType {
         match self {
             Self::OntologyId | Self::OwnedById | Self::RecordCreatedById => ParameterType::Uuid,
-            Self::Schema(_) | Self::AdditionalMetadata(_) | Self::Examples | Self::Required => {
-                ParameterType::Any
-            }
+            Self::Schema(_) | Self::AdditionalMetadata => ParameterType::Object,
+            Self::Examples | Self::Required => ParameterType::Any,
             Self::BaseUrl | Self::LabelProperty => ParameterType::BaseUrl,
             Self::VersionedUrl => ParameterType::VersionedUrl,
             Self::Version => ParameterType::OntologyTypeVersion,
@@ -422,8 +421,7 @@ impl fmt::Display for EntityTypeQueryPath<'_> {
                 path,
                 ..
             } => write!(fmt, "isTypeOf.{path}"),
-            Self::AdditionalMetadata(Some(path)) => write!(fmt, "additionalMetadata.{path}"),
-            Self::AdditionalMetadata(None) => fmt.write_str("additionalMetadata"),
+            Self::AdditionalMetadata => fmt.write_str("additionalMetadata"),
         }
     }
 }

--- a/apps/hash-graph/lib/graph/src/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/property_type.rs
@@ -220,7 +220,7 @@ pub enum PropertyTypeQueryPath<'p> {
     /// Only used internally and not available for deserialization.
     Schema(Option<JsonPath<'p>>),
     /// Only used internally and not available for deserialization.
-    AdditionalMetadata(Option<JsonPath<'p>>),
+    AdditionalMetadata,
 }
 
 impl OntologyQueryPath for PropertyTypeQueryPath<'_> {
@@ -253,7 +253,7 @@ impl OntologyQueryPath for PropertyTypeQueryPath<'_> {
     }
 
     fn additional_metadata() -> Self {
-        Self::AdditionalMetadata(None)
+        Self::AdditionalMetadata
     }
 }
 
@@ -261,7 +261,7 @@ impl QueryPath for PropertyTypeQueryPath<'_> {
     fn expected_type(&self) -> ParameterType {
         match self {
             Self::OntologyId | Self::OwnedById | Self::RecordCreatedById => ParameterType::Uuid,
-            Self::Schema(_) | Self::AdditionalMetadata(_) => ParameterType::Any,
+            Self::Schema(_) | Self::AdditionalMetadata => ParameterType::Object,
             Self::BaseUrl => ParameterType::BaseUrl,
             Self::VersionedUrl => ParameterType::VersionedUrl,
             Self::Version => ParameterType::OntologyTypeVersion,
@@ -322,8 +322,7 @@ impl fmt::Display for PropertyTypeQueryPath<'_> {
             Self::EntityTypeEdge {
                 edge_kind, path, ..
             } => write!(fmt, "<{edge_kind:?}>.{path}"),
-            Self::AdditionalMetadata(Some(path)) => write!(fmt, "additionalMetadata.{path}"),
-            Self::AdditionalMetadata(None) => fmt.write_str("additionalMetadata"),
+            Self::AdditionalMetadata => fmt.write_str("additionalMetadata"),
         }
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -206,7 +206,7 @@ impl<C: AsClient> Read<OntologyTypeSnapshotRecord<EntityType>> for PostgresStore
         let record_created_by_id_path_index =
             compiler.add_selection_path(&EntityTypeQueryPath::RecordCreatedById);
         let additional_metadata_index =
-            compiler.add_selection_path(&EntityTypeQueryPath::AdditionalMetadata(None));
+            compiler.add_selection_path(&EntityTypeQueryPath::AdditionalMetadata);
         let transaction_time_index =
             compiler.add_selection_path(&EntityTypeQueryPath::TransactionTime);
         let label_property_index = compiler.add_selection_path(&EntityTypeQueryPath::LabelProperty);

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/condition.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/condition.rs
@@ -233,7 +233,7 @@ mod tests {
                     Some(FilterExpression::Parameter(Parameter::Number(1))),
                 ),
             ]),
-            r#"("ontology_id_with_metadata_0_1_0"."base_url" = $1) AND ("ontology_id_with_metadata_0_1_0"."version" = $2)"#,
+            r#"("ontology_ids_0_1_0"."base_url" = $1) AND ("ontology_ids_0_1_0"."version" = $2)"#,
             &[
                 &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
                 &1,
@@ -267,7 +267,7 @@ mod tests {
                     Some(FilterExpression::Parameter(Parameter::Number(1))),
                 ),
             ]),
-            r#"(("ontology_id_with_metadata_0_1_0"."base_url" = $1) OR ("ontology_id_with_metadata_0_1_0"."version" = $2))"#,
+            r#"(("ontology_ids_0_1_0"."base_url" = $1) OR ("ontology_ids_0_1_0"."version" = $2))"#,
             &[
                 &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
                 &1,

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/data_type.rs
@@ -4,8 +4,8 @@ use crate::{
     ontology::{DataTypeQueryPath, DataTypeWithMetadata},
     store::postgres::query::{
         table::{
-            Column, DataTypes, JsonField, OntologyIds, OntologyTemporalMetadata, ReferenceTable,
-            Relation,
+            Column, DataTypes, JsonField, OntologyAdditionalMetadata, OntologyIds,
+            OntologyOwnedMetadata, OntologyTemporalMetadata, ReferenceTable, Relation,
         },
         PostgresQueryPath, PostgresRecord, Table,
     },
@@ -27,13 +27,9 @@ impl PostgresQueryPath for DataTypeQueryPath<'_> {
             | Self::Type
             | Self::OntologyId
             | Self::Schema(_) => vec![Relation::DataTypeIds],
-            Self::BaseUrl
-            | Self::Version
-            | Self::RecordCreatedById
-            | Self::OwnedById
-            | Self::AdditionalMetadata(_) => {
-                vec![Relation::OntologyIds]
-            }
+            Self::BaseUrl | Self::Version | Self::RecordCreatedById => vec![Relation::OntologyIds],
+            Self::OwnedById => vec![Relation::OntologyOwnedMetadata],
+            Self::AdditionalMetadata => vec![Relation::OntologyAdditionalMetadata],
             Self::TransactionTime => vec![],
             Self::PropertyTypeEdge {
                 edge_kind: OntologyEdgeKind::ConstrainsValuesOn,
@@ -55,9 +51,7 @@ impl PostgresQueryPath for DataTypeQueryPath<'_> {
             Self::TransactionTime => {
                 Column::OntologyTemporalMetadata(OntologyTemporalMetadata::TransactionTime)
             }
-            Self::OwnedById => Column::OntologyIds(OntologyIds::AdditionalMetadata(Some(
-                JsonField::StaticText("owned_by_id"),
-            ))),
+            Self::OwnedById => Column::OntologyOwnedMetadata(OntologyOwnedMetadata::OwnedById),
             Self::RecordCreatedById => Column::OntologyIds(OntologyIds::RecordCreatedById),
             Self::OntologyId => Column::DataTypes(DataTypes::OntologyId),
             Self::Schema(path) => path
@@ -76,14 +70,9 @@ impl PostgresQueryPath for DataTypeQueryPath<'_> {
                 "description",
             )))),
             Self::PropertyTypeEdge { path, .. } => path.terminating_column(),
-            Self::AdditionalMetadata(path) => path.as_ref().map_or(
-                Column::OntologyIds(OntologyIds::AdditionalMetadata(None)),
-                |path| {
-                    Column::OntologyIds(OntologyIds::AdditionalMetadata(Some(JsonField::JsonPath(
-                        path,
-                    ))))
-                },
-            ),
+            Self::AdditionalMetadata => {
+                Column::OntologyAdditionalMetadata(OntologyAdditionalMetadata::AdditionalMetadata)
+            }
         }
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/conditional.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/conditional.rs
@@ -156,7 +156,7 @@ mod tests {
     fn transpile_window_expression() {
         assert_eq!(
             max_version_expression().transpile_to_string(),
-            r#"MAX("ontology_id_with_metadata_0_0_0"."version") OVER (PARTITION BY "ontology_id_with_metadata_0_0_0"."base_url")"#
+            r#"MAX("ontology_ids_0_0_0"."version") OVER (PARTITION BY "ontology_ids_0_0_0"."base_url")"#
         );
     }
 
@@ -173,7 +173,7 @@ mod tests {
                     })
             ))))
             .transpile_to_string(),
-            r#"MIN("ontology_id_with_metadata_1_2_3"."version")"#
+            r#"MIN("ontology_ids_1_2_3"."version")"#
         );
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/join_clause.rs
@@ -142,7 +142,7 @@ mod tests {
                 }
             )
             .transpile_to_string(),
-            r#"INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_1_2" ON "ontology_id_with_metadata_0_1_2"."ontology_id" = "data_types_1_2_3"."ontology_id""#
+            r#"INNER JOIN "ontology_ids" AS "ontology_ids_0_1_2" ON "ontology_ids_0_1_2"."ontology_id" = "data_types_1_2_3"."ontology_id""#
         );
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/order_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/order_clause.rs
@@ -68,7 +68,7 @@ mod tests {
         );
         assert_eq!(
             order_by_expression.transpile_to_string(),
-            r#"ORDER BY "ontology_id_with_metadata_1_2_3"."version" ASC"#
+            r#"ORDER BY "ontology_ids_1_2_3"."version" ASC"#
         );
     }
 
@@ -97,7 +97,7 @@ mod tests {
         assert_eq!(
             trim_whitespace(order_by_expression.transpile_to_string()),
             trim_whitespace(
-                r#"ORDER BY "ontology_id_with_metadata_1_2_3"."base_url" ASC,
+                r#"ORDER BY "ontology_ids_1_2_3"."base_url" ASC,
                 "data_types_4_5_6"."schema"->>'type' DESC"#
             )
         );

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/select_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/select_clause.rs
@@ -53,7 +53,7 @@ mod tests {
                 None
             )
             .transpile_to_string(),
-            r#""ontology_id_with_metadata_1_2_3"."base_url""#
+            r#""ontology_ids_1_2_3"."base_url""#
         );
 
         assert_eq!(
@@ -98,7 +98,7 @@ mod tests {
                 Some("latest_version")
             )
             .transpile_to_string(),
-            r#"MAX("ontology_id_with_metadata_1_2_3"."version") OVER (PARTITION BY "ontology_id_with_metadata_1_2_3"."base_url") AS "latest_version""#
+            r#"MAX("ontology_ids_1_2_3"."version") OVER (PARTITION BY "ontology_ids_1_2_3"."base_url") AS "latest_version""#
         );
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/where_clause.rs
@@ -70,7 +70,7 @@ mod tests {
 
         assert_eq!(
             where_clause.transpile_to_string(),
-            r#"WHERE "ontology_id_with_metadata_0_1_0"."version" = "ontology_id_with_metadata_0_1_0"."latest_version""#
+            r#"WHERE "ontology_ids_0_1_0"."version" = "ontology_ids_0_1_0"."latest_version""#
         );
 
         let filter_b = Filter::All(vec![
@@ -91,8 +91,8 @@ mod tests {
             trim_whitespace(where_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WHERE "ontology_id_with_metadata_0_1_0"."version" = "ontology_id_with_metadata_0_1_0"."latest_version"
-                  AND ("ontology_id_with_metadata_0_1_0"."base_url" = $2) AND ("ontology_id_with_metadata_0_1_0"."version" = $3)"#
+                WHERE "ontology_ids_0_1_0"."version" = "ontology_ids_0_1_0"."latest_version"
+                  AND ("ontology_ids_0_1_0"."base_url" = $2) AND ("ontology_ids_0_1_0"."version" = $3)"#
             )
         );
 
@@ -106,8 +106,8 @@ mod tests {
             trim_whitespace(where_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WHERE "ontology_id_with_metadata_0_1_0"."version" = "ontology_id_with_metadata_0_1_0"."latest_version"
-                  AND ("ontology_id_with_metadata_0_1_0"."base_url" = $2) AND ("ontology_id_with_metadata_0_1_0"."version" = $3)
+                WHERE "ontology_ids_0_1_0"."version" = "ontology_ids_0_1_0"."latest_version"
+                  AND ("ontology_ids_0_1_0"."base_url" = $2) AND ("ontology_ids_0_1_0"."version" = $3)
                   AND "data_types_0_1_0"."schema"->>'description' IS NOT NULL"#
             )
         );
@@ -132,8 +132,8 @@ mod tests {
             trim_whitespace(where_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WHERE "ontology_id_with_metadata_0_1_0"."version" = "ontology_id_with_metadata_0_1_0"."latest_version"
-                  AND ("ontology_id_with_metadata_0_1_0"."base_url" = $2) AND ("ontology_id_with_metadata_0_1_0"."version" = $3)
+                WHERE "ontology_ids_0_1_0"."version" = "ontology_ids_0_1_0"."latest_version"
+                  AND ("ontology_ids_0_1_0"."base_url" = $2) AND ("ontology_ids_0_1_0"."version" = $3)
                   AND "data_types_0_1_0"."schema"->>'description' IS NOT NULL
                   AND (("data_types_0_1_0"."schema"->>'title' = $4) OR ("data_types_0_1_0"."schema"->>'description' = $5))"#
             )

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/expression/with_clause.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/expression/with_clause.rs
@@ -86,7 +86,7 @@ mod tests {
             trim_whitespace(with_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WITH "ontology_id_with_metadata" AS (SELECT *, MAX("ontology_id_with_metadata_0_0_0"."version") OVER (PARTITION BY "ontology_id_with_metadata_0_0_0"."base_url") AS "latest_version" FROM "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_0_0")"#
+                WITH "ontology_ids" AS (SELECT *, MAX("ontology_ids_0_0_0"."version") OVER (PARTITION BY "ontology_ids_0_0_0"."base_url") AS "latest_version" FROM "ontology_ids" AS "ontology_ids_0_0_0")"#
             )
         );
 
@@ -108,7 +108,7 @@ mod tests {
             trim_whitespace(with_clause.transpile_to_string()),
             trim_whitespace(
                 r#"
-                WITH "ontology_id_with_metadata" AS (SELECT *, MAX("ontology_id_with_metadata_0_0_0"."version") OVER (PARTITION BY "ontology_id_with_metadata_0_0_0"."base_url") AS "latest_version" FROM "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_0_0"),
+                WITH "ontology_ids" AS (SELECT *, MAX("ontology_ids_0_0_0"."version") OVER (PARTITION BY "ontology_ids_0_0_0"."base_url") AS "latest_version" FROM "ontology_ids" AS "ontology_ids_0_0_0"),
                      "data_types" AS (SELECT * FROM "data_types" AS "data_types_3_4_5")"#
             )
         );

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/statement/select.rs
@@ -233,10 +233,10 @@ mod tests {
             r#"
             SELECT *
             FROM "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_0_0"
-            INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_1_0"
-              ON "ontology_id_with_metadata_0_1_0"."ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
+            INNER JOIN "ontology_ids" AS "ontology_ids_0_1_0"
+              ON "ontology_ids_0_1_0"."ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
             WHERE "ontology_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
-              AND ("ontology_id_with_metadata_0_1_0"."base_url" = $2) AND ("ontology_id_with_metadata_0_1_0"."version" = $3)
+              AND ("ontology_ids_0_1_0"."base_url" = $2) AND ("ontology_ids_0_1_0"."version" = $3)
             "#,
             &[
                 &pinned_timestamp,
@@ -263,13 +263,13 @@ mod tests {
         test_compilation(
             &compiler,
             r#"
-            WITH "ontology_id_with_metadata" AS (SELECT *, MAX("ontology_id_with_metadata_0_0_0"."version") OVER (PARTITION BY "ontology_id_with_metadata_0_0_0"."base_url") AS "latest_version" FROM "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_0_0")
+            WITH "ontology_ids" AS (SELECT *, MAX("ontology_ids_0_0_0"."version") OVER (PARTITION BY "ontology_ids_0_0_0"."base_url") AS "latest_version" FROM "ontology_ids" AS "ontology_ids_0_0_0")
             SELECT *
             FROM "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_0_0"
-            INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_1_0"
-              ON "ontology_id_with_metadata_0_1_0"."ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
+            INNER JOIN "ontology_ids" AS "ontology_ids_0_1_0"
+              ON "ontology_ids_0_1_0"."ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
             WHERE "ontology_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
-              AND "ontology_id_with_metadata_0_1_0"."version" = "ontology_id_with_metadata_0_1_0"."latest_version"
+              AND "ontology_ids_0_1_0"."version" = "ontology_ids_0_1_0"."latest_version"
             "#,
             &[&pinned_timestamp],
         );
@@ -292,13 +292,13 @@ mod tests {
         test_compilation(
             &compiler,
             r#"
-            WITH "ontology_id_with_metadata" AS (SELECT *, MAX("ontology_id_with_metadata_0_0_0"."version") OVER (PARTITION BY "ontology_id_with_metadata_0_0_0"."base_url") AS "latest_version" FROM "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_0_0")
+            WITH "ontology_ids" AS (SELECT *, MAX("ontology_ids_0_0_0"."version") OVER (PARTITION BY "ontology_ids_0_0_0"."base_url") AS "latest_version" FROM "ontology_ids" AS "ontology_ids_0_0_0")
             SELECT *
             FROM "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_0_0"
-            INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_1_0"
-              ON "ontology_id_with_metadata_0_1_0"."ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
+            INNER JOIN "ontology_ids" AS "ontology_ids_0_1_0"
+              ON "ontology_ids_0_1_0"."ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
             WHERE "ontology_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
-              AND "ontology_id_with_metadata_0_1_0"."version" != "ontology_id_with_metadata_0_1_0"."latest_version"
+              AND "ontology_ids_0_1_0"."version" != "ontology_ids_0_1_0"."latest_version"
             "#,
             &[&pinned_timestamp],
         );
@@ -380,13 +380,13 @@ mod tests {
               ON "property_type_constrains_values_on_1_1_0"."source_property_type_ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
             INNER JOIN "ontology_temporal_metadata" AS "ontology_temporal_metadata_1_2_0"
               ON "ontology_temporal_metadata_1_2_0"."ontology_id" = "property_type_constrains_values_on_1_1_0"."target_data_type_ontology_id"
-            INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_1_3_0"
-              ON "ontology_id_with_metadata_1_3_0"."ontology_id" = "ontology_temporal_metadata_1_2_0"."ontology_id"
+            INNER JOIN "ontology_ids" AS "ontology_ids_1_3_0"
+              ON "ontology_ids_1_3_0"."ontology_id" = "ontology_temporal_metadata_1_2_0"."ontology_id"
             WHERE "ontology_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
               AND "ontology_temporal_metadata_0_2_0"."transaction_time" @> $1::TIMESTAMPTZ
               AND "data_types_0_3_0"."schema"->>'title' = $2
               AND "ontology_temporal_metadata_1_2_0"."transaction_time" @> $1::TIMESTAMPTZ
-              AND ("ontology_id_with_metadata_1_3_0"."base_url" = $3) AND ("ontology_id_with_metadata_1_3_0"."version" = $4)
+              AND ("ontology_ids_1_3_0"."base_url" = $3) AND ("ontology_ids_1_3_0"."version" = $4)
             "#,
             &[
                 &pinned_timestamp,
@@ -556,11 +556,11 @@ mod tests {
               ON "entity_type_inherits_from_0_1_0"."source_entity_type_ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
             INNER JOIN "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_2_0"
               ON "ontology_temporal_metadata_0_2_0"."ontology_id" = "entity_type_inherits_from_0_1_0"."target_entity_type_ontology_id"
-            INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_3_0"
-              ON "ontology_id_with_metadata_0_3_0"."ontology_id" = "ontology_temporal_metadata_0_2_0"."ontology_id"
+            INNER JOIN "ontology_ids" AS "ontology_ids_0_3_0"
+              ON "ontology_ids_0_3_0"."ontology_id" = "ontology_temporal_metadata_0_2_0"."ontology_id"
             WHERE "ontology_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
               AND "ontology_temporal_metadata_0_2_0"."transaction_time" @> $1::TIMESTAMPTZ
-              AND "ontology_id_with_metadata_0_3_0"."base_url" = $2
+              AND "ontology_ids_0_3_0"."base_url" = $2
             "#,
             &[
                 &pinned_timestamp,
@@ -943,8 +943,8 @@ mod tests {
               ON "entity_is_of_type_0_3_0"."entity_edition_id" = "entity_temporal_metadata_0_2_0"."entity_edition_id"
             INNER JOIN "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_4_0"
               ON "ontology_temporal_metadata_0_4_0"."ontology_id" = "entity_is_of_type_0_3_0"."entity_type_ontology_id"
-            INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_5_0"
-              ON "ontology_id_with_metadata_0_5_0"."ontology_id" = "ontology_temporal_metadata_0_4_0"."ontology_id"
+            INNER JOIN "ontology_ids" AS "ontology_ids_0_5_0"
+              ON "ontology_ids_0_5_0"."ontology_id" = "ontology_temporal_metadata_0_4_0"."ontology_id"
             LEFT OUTER JOIN "entity_has_right_entity" AS "entity_has_right_entity_0_1_0"
               ON "entity_has_right_entity_0_1_0"."owned_by_id" = "entity_temporal_metadata_0_0_0"."owned_by_id"
              AND "entity_has_right_entity_0_1_0"."entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
@@ -955,8 +955,8 @@ mod tests {
               ON "entity_is_of_type_0_3_1"."entity_edition_id" = "entity_temporal_metadata_0_2_1"."entity_edition_id"
             INNER JOIN "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_4_1"
               ON "ontology_temporal_metadata_0_4_1"."ontology_id" = "entity_is_of_type_0_3_1"."entity_type_ontology_id"
-            INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_5_1"
-              ON "ontology_id_with_metadata_0_5_1"."ontology_id" = "ontology_temporal_metadata_0_4_1"."ontology_id"
+            INNER JOIN "ontology_ids" AS "ontology_ids_0_5_1"
+              ON "ontology_ids_0_5_1"."ontology_id" = "ontology_temporal_metadata_0_4_1"."ontology_id"
             WHERE "entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
               AND "entity_temporal_metadata_0_0_0"."decision_time" && $2
               AND "entity_temporal_metadata_0_2_0"."transaction_time" @> $1::TIMESTAMPTZ
@@ -965,8 +965,8 @@ mod tests {
               AND "entity_temporal_metadata_0_2_1"."transaction_time" @> $1::TIMESTAMPTZ
               AND "entity_temporal_metadata_0_2_1"."decision_time" && $2
               AND "ontology_temporal_metadata_0_4_1"."transaction_time" @> $1::TIMESTAMPTZ
-              AND ("ontology_id_with_metadata_0_5_0"."base_url" = $3)
-              AND ("ontology_id_with_metadata_0_5_1"."base_url" = $4)
+              AND ("ontology_ids_0_5_0"."base_url" = $3)
+              AND ("ontology_ids_0_5_1"."base_url" = $4)
             "#,
             &[
                 &pinned_timestamp,
@@ -1010,10 +1010,10 @@ mod tests {
                 r#"
                 SELECT *
                 FROM "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_0_0"
-                INNER JOIN "ontology_id_with_metadata" AS "ontology_id_with_metadata_0_1_0"
-                  ON "ontology_id_with_metadata_0_1_0"."ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
+                INNER JOIN "ontology_ids" AS "ontology_ids_0_1_0"
+                  ON "ontology_ids_0_1_0"."ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
                 WHERE "ontology_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
-                  AND ("ontology_id_with_metadata_0_1_0"."base_url" = $2) AND ("ontology_id_with_metadata_0_1_0"."version" = $3)
+                  AND ("ontology_ids_0_1_0"."base_url" = $2) AND ("ontology_ids_0_1_0"."version" = $3)
                 "#,
                 &[
                     &pinned_timestamp,

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
@@ -20,6 +20,9 @@ use crate::{
 pub enum Table {
     OntologyIds,
     OntologyTemporalMetadata,
+    OntologyOwnedMetadata,
+    OntologyExternalMetadata,
+    OntologyAdditionalMetadata,
     DataTypes,
     PropertyTypes,
     EntityTypes,
@@ -198,8 +201,12 @@ impl Table {
 
     const fn as_str(self) -> &'static str {
         match self {
-            Self::OntologyIds => "ontology_id_with_metadata",
+            Self::OntologyIds => "ontology_ids",
             Self::OntologyTemporalMetadata => "ontology_temporal_metadata",
+            Self::OntologyOwnedMetadata => "ontology_owned_metadata",
+            Self::OntologyExternalMetadata => "ontology_external_metadata",
+            // TODO: Rename to `ontology_additional_metadata`
+            Self::OntologyAdditionalMetadata => "ontology_id_with_metadata",
             Self::DataTypes => "data_types",
             Self::PropertyTypes => "property_types",
             Self::EntityTypes => "entity_types",
@@ -247,13 +254,30 @@ pub enum StaticJsonField {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum OntologyIds<'p> {
+pub enum OntologyIds {
     OntologyId,
     BaseUrl,
     Version,
     RecordCreatedById,
     LatestVersion,
-    AdditionalMetadata(Option<JsonField<'p>>),
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum OntologyOwnedMetadata {
+    OntologyId,
+    OwnedById,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum OntologyExternalMetadata {
+    OntologyId,
+    FetchedAt,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum OntologyAdditionalMetadata {
+    OntologyId,
+    AdditionalMetadata,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -286,38 +310,14 @@ fn transpile_json_field(
     }
 }
 
-impl<'p> OntologyIds<'p> {
-    pub const fn into_owned(
-        self,
-        current_parameter_index: usize,
-    ) -> (OntologyIds<'static>, Option<&'p (dyn ToSql + Sync)>) {
-        match self {
-            Self::OntologyId => (OntologyIds::OntologyId, None),
-            Self::BaseUrl => (OntologyIds::BaseUrl, None),
-            Self::Version => (OntologyIds::Version, None),
-            Self::RecordCreatedById => (OntologyIds::RecordCreatedById, None),
-            Self::LatestVersion => (OntologyIds::LatestVersion, None),
-            Self::AdditionalMetadata(None) => (OntologyIds::AdditionalMetadata(None), None),
-            Self::AdditionalMetadata(Some(path)) => {
-                let (path, parameter) = path.into_owned(current_parameter_index);
-                (OntologyIds::AdditionalMetadata(Some(path)), parameter)
-            }
-        }
-    }
-}
-
-impl OntologyIds<'static> {
-    fn transpile_column(&self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
+impl OntologyIds {
+    fn transpile_column(self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
         let column = match self {
             Self::OntologyId => "ontology_id",
             Self::BaseUrl => "base_url",
             Self::Version => "version",
             Self::LatestVersion => "latest_version",
             Self::RecordCreatedById => "record_created_by_id",
-            Self::AdditionalMetadata(None) => "additional_metadata",
-            Self::AdditionalMetadata(Some(path)) => {
-                return transpile_json_field(path, "additional_metadata", table, fmt);
-            }
         };
         table.transpile(fmt)?;
         write!(fmt, r#"."{column}""#)
@@ -328,7 +328,59 @@ impl OntologyIds<'static> {
             Self::OntologyId | Self::RecordCreatedById => ParameterType::Uuid,
             Self::BaseUrl => ParameterType::Text,
             Self::Version | Self::LatestVersion => ParameterType::OntologyTypeVersion,
-            Self::AdditionalMetadata(_) => ParameterType::Any,
+        }
+    }
+}
+
+impl OntologyOwnedMetadata {
+    fn transpile_column(self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let column = match self {
+            Self::OntologyId => "ontology_id",
+            Self::OwnedById => "owned_by_id",
+        };
+        table.transpile(fmt)?;
+        write!(fmt, r#"."{column}""#)
+    }
+
+    pub const fn parameter_type(self) -> ParameterType {
+        match self {
+            Self::OntologyId | Self::OwnedById => ParameterType::Uuid,
+        }
+    }
+}
+
+impl OntologyExternalMetadata {
+    fn transpile_column(self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let column = match self {
+            Self::OntologyId => "ontology_id",
+            Self::FetchedAt => "fetched_at",
+        };
+        table.transpile(fmt)?;
+        write!(fmt, r#"."{column}""#)
+    }
+
+    pub const fn parameter_type(self) -> ParameterType {
+        match self {
+            Self::OntologyId => ParameterType::Uuid,
+            Self::FetchedAt => ParameterType::Timestamp,
+        }
+    }
+}
+
+impl OntologyAdditionalMetadata {
+    fn transpile_column(self, table: &impl Transpile, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let column = match self {
+            Self::OntologyId => "ontology_id",
+            Self::AdditionalMetadata => "additional_metadata",
+        };
+        table.transpile(fmt)?;
+        write!(fmt, r#"."{column}""#)
+    }
+
+    pub const fn parameter_type(self) -> ParameterType {
+        match self {
+            Self::OntologyId => ParameterType::Uuid,
+            Self::AdditionalMetadata => ParameterType::Object,
         }
     }
 }
@@ -819,8 +871,11 @@ impl EntityTypeConstrainsLinkDestinationsOn {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Column<'p> {
-    OntologyIds(OntologyIds<'p>),
+    OntologyIds(OntologyIds),
     OntologyTemporalMetadata(OntologyTemporalMetadata),
+    OntologyOwnedMetadata(OntologyOwnedMetadata),
+    OntologyExternalMetadata(OntologyExternalMetadata),
+    OntologyAdditionalMetadata(OntologyAdditionalMetadata),
     DataTypes(DataTypes<'p>),
     PropertyTypes(PropertyTypes<'p>),
     EntityTypes(EntityTypes<'p>),
@@ -842,6 +897,9 @@ impl<'p> Column<'p> {
         match self {
             Self::OntologyIds(_) => Table::OntologyIds,
             Self::OntologyTemporalMetadata(_) => Table::OntologyTemporalMetadata,
+            Self::OntologyOwnedMetadata(_) => Table::OntologyOwnedMetadata,
+            Self::OntologyExternalMetadata(_) => Table::OntologyExternalMetadata,
+            Self::OntologyAdditionalMetadata(_) => Table::OntologyAdditionalMetadata,
             Self::DataTypes(_) => Table::DataTypes,
             Self::PropertyTypes(_) => Table::PropertyTypes,
             Self::EntityTypes(_) => Table::EntityTypes,
@@ -877,7 +935,10 @@ impl<'p> Column<'p> {
             Self::PropertyTypes(column) => column.nullable(),
             Self::EntityTypes(column) => column.nullable(),
             Self::EntityEditions(column) => column.nullable(),
-            Self::EntityHasLeftEntity(_) | Self::EntityHasRightEntity(_) => true,
+            Self::EntityHasLeftEntity(_)
+            | Self::EntityHasRightEntity(_)
+            | Self::OntologyOwnedMetadata(_)
+            | Self::OntologyExternalMetadata(_) => true,
             _ => false,
         }
     }
@@ -887,12 +948,16 @@ impl<'p> Column<'p> {
         current_parameter_index: usize,
     ) -> (Column<'static>, Option<&'p (dyn ToSql + Sync)>) {
         match self {
-            Self::OntologyIds(column) => {
-                let (column, parameter) = column.into_owned(current_parameter_index);
-                (Column::OntologyIds(column), parameter)
-            }
+            Self::OntologyIds(column) => (Column::OntologyIds(column), None),
             Self::OntologyTemporalMetadata(column) => {
                 (Column::OntologyTemporalMetadata(column), None)
+            }
+            Self::OntologyOwnedMetadata(column) => (Column::OntologyOwnedMetadata(column), None),
+            Self::OntologyExternalMetadata(column) => {
+                (Column::OntologyExternalMetadata(column), None)
+            }
+            Self::OntologyAdditionalMetadata(column) => {
+                (Column::OntologyAdditionalMetadata(column), None)
             }
             Self::DataTypes(column) => {
                 let (column, parameter) = column.into_owned(current_parameter_index);
@@ -946,6 +1011,9 @@ impl Column<'static> {
         match self {
             Self::OntologyIds(column) => column.transpile_column(table, fmt),
             Self::OntologyTemporalMetadata(column) => column.transpile_column(table, fmt),
+            Self::OntologyOwnedMetadata(column) => column.transpile_column(table, fmt),
+            Self::OntologyExternalMetadata(column) => column.transpile_column(table, fmt),
+            Self::OntologyAdditionalMetadata(column) => column.transpile_column(table, fmt),
             Self::DataTypes(column) => column.transpile_column(table, fmt),
             Self::PropertyTypes(column) => column.transpile_column(table, fmt),
             Self::EntityTypes(column) => column.transpile_column(table, fmt),
@@ -969,6 +1037,9 @@ impl Column<'static> {
         match self {
             Self::OntologyIds(column) => column.parameter_type(),
             Self::OntologyTemporalMetadata(column) => column.parameter_type(),
+            Self::OntologyOwnedMetadata(column) => column.parameter_type(),
+            Self::OntologyExternalMetadata(column) => column.parameter_type(),
+            Self::OntologyAdditionalMetadata(column) => column.parameter_type(),
             Self::DataTypes(column) => column.parameter_type(),
             Self::PropertyTypes(column) => column.parameter_type(),
             Self::EntityTypes(column) => column.parameter_type(),
@@ -1070,6 +1141,9 @@ impl Transpile for AliasedColumn {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Relation {
     OntologyIds,
+    OntologyOwnedMetadata,
+    OntologyExternalMetadata,
+    OntologyAdditionalMetadata,
     DataTypeIds,
     PropertyTypeIds,
     EntityTypeIds,
@@ -1142,6 +1216,26 @@ impl Relation {
                 on: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
                 join: Column::OntologyIds(OntologyIds::OntologyId),
             }),
+            Self::OntologyOwnedMetadata => {
+                ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
+                    on: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
+                    join: Column::OntologyOwnedMetadata(OntologyOwnedMetadata::OntologyId),
+                })
+            }
+            Self::OntologyExternalMetadata => {
+                ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
+                    on: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
+                    join: Column::OntologyExternalMetadata(OntologyExternalMetadata::OntologyId),
+                })
+            }
+            Self::OntologyAdditionalMetadata => {
+                ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
+                    on: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
+                    join: Column::OntologyAdditionalMetadata(
+                        OntologyAdditionalMetadata::OntologyId,
+                    ),
+                })
+            }
             Self::DataTypeIds => ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
                 on: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
                 join: Column::DataTypes(DataTypes::OntologyId),
@@ -1194,7 +1288,7 @@ mod tests {
     fn transpile_table() {
         assert_eq!(
             Table::OntologyIds.transpile_to_string(),
-            r#""ontology_id_with_metadata""#
+            r#""ontology_ids""#
         );
         assert_eq!(Table::DataTypes.transpile_to_string(), r#""data_types""#);
     }
@@ -1209,7 +1303,7 @@ mod tests {
                     number: 3,
                 })
                 .transpile_to_string(),
-            r#""ontology_id_with_metadata_1_2_3""#
+            r#""ontology_ids_1_2_3""#
         );
     }
 

--- a/apps/hash-graph/lib/graph/src/store/query.rs
+++ b/apps/hash-graph/lib/graph/src/store/query.rs
@@ -23,6 +23,8 @@ pub enum ParameterType {
     BaseUrl,
     VersionedUrl,
     TimeInterval,
+    Timestamp,
+    Object,
     Any,
 }
 
@@ -37,6 +39,8 @@ impl fmt::Display for ParameterType {
             Self::BaseUrl => fmt.write_str("base URL"),
             Self::VersionedUrl => fmt.write_str("versioned URL"),
             Self::TimeInterval => fmt.write_str("time interval"),
+            Self::Timestamp => fmt.write_str("timestamp"),
+            Self::Object => fmt.write_str("object"),
             Self::Any => fmt.write_str("any"),
         }
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The view currently contains all metadata of an ontology type. This is bad as different archivals and unarchivals could have been done by different persons. This needs fixing for [H-303](https://linear.app/hash/issue/H-303) and this is a good opportunity to properly use the `ontology_owned_metadata` and `ontology_external_metadata` tables instead of the view as the exact same code needs adjustment in any case.

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- Various tests in the Graph API