### PR TITLE
H-307: Make `actor_id` required in archival and unarchival operations

### DIFF
--- a/apps/hash-api/src/graph/ontology/primitive/data-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/data-type.ts
@@ -223,10 +223,11 @@ export const archiveDataType: ImpureGraphFunction<
   },
   Promise<OntologyTemporalMetadata>
 > = async ({ graphApi }, params) => {
-  const { dataTypeId } = params;
+  const { dataTypeId, actorId } = params;
 
   const { data: temporalMetadata } = await graphApi.archiveDataType({
     typeToArchive: dataTypeId,
+    actorId,
   });
 
   return temporalMetadata;
@@ -245,10 +246,11 @@ export const unarchiveDataType: ImpureGraphFunction<
   },
   Promise<OntologyTemporalMetadata>
 > = async ({ graphApi }, params) => {
-  const { dataTypeId } = params;
+  const { dataTypeId, actorId } = params;
 
   const { data: temporalMetadata } = await graphApi.unarchiveDataType({
     typeToUnarchive: dataTypeId,
+    actorId,
   });
 
   return temporalMetadata;

--- a/apps/hash-api/src/graph/ontology/primitive/entity-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/entity-type.ts
@@ -243,10 +243,11 @@ export const archiveEntityType: ImpureGraphFunction<
   },
   Promise<OntologyTemporalMetadata>
 > = async ({ graphApi }, params) => {
-  const { entityTypeId } = params;
+  const { entityTypeId, actorId } = params;
 
   const { data: temporalMetadata } = await graphApi.archiveEntityType({
     typeToArchive: entityTypeId,
+    actorId,
   });
 
   return temporalMetadata;
@@ -265,10 +266,11 @@ export const unarchiveEntityType: ImpureGraphFunction<
   },
   Promise<OntologyTemporalMetadata>
 > = async ({ graphApi }, params) => {
-  const { entityTypeId } = params;
+  const { entityTypeId, actorId } = params;
 
   const { data: temporalMetadata } = await graphApi.unarchiveEntityType({
     typeToUnarchive: entityTypeId,
+    actorId,
   });
 
   return temporalMetadata;

--- a/apps/hash-api/src/graph/ontology/primitive/property-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/property-type.ts
@@ -217,10 +217,11 @@ export const archivePropertyType: ImpureGraphFunction<
   },
   Promise<OntologyTemporalMetadata>
 > = async ({ graphApi }, params) => {
-  const { propertyTypeId } = params;
+  const { propertyTypeId, actorId } = params;
 
   const { data: temporalMetadata } = await graphApi.archivePropertyType({
     typeToArchive: propertyTypeId,
+    actorId,
   });
 
   return temporalMetadata;
@@ -239,10 +240,11 @@ export const unarchivePropertyType: ImpureGraphFunction<
   },
   Promise<OntologyTemporalMetadata>
 > = async ({ graphApi }, params) => {
-  const { propertyTypeId } = params;
+  const { propertyTypeId, actorId } = params;
 
   const { data: temporalMetadata } = await graphApi.unarchivePropertyType({
     typeToUnarchive: propertyTypeId,
+    actorId,
   });
 
   return temporalMetadata;

--- a/apps/hash-graph/lib/graph/src/api/rest.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest.rs
@@ -64,7 +64,7 @@ use crate::{
         EntityTypeMetadata, OntologyElementMetadata, OntologyTemporalMetadata,
         OntologyTypeReference, Selector,
     },
-    provenance::{OwnedById, ProvenanceMetadata, RecordCreatedById},
+    provenance::{OwnedById, ProvenanceMetadata, RecordArchivedById, RecordCreatedById},
     store::{error::VersionedUrlAlreadyExists, QueryError, Store, StorePool, TypeFetcher},
     subgraph::{
         edges::{
@@ -236,6 +236,7 @@ async fn serve_static_schema(Path(path): Path<String>) -> Result<Response, Statu
         schemas(
             OwnedById,
             RecordCreatedById,
+            RecordArchivedById,
             ProvenanceMetadata,
             OntologyTypeRecordId,
             OntologyElementMetadata,

--- a/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/data_type.rs
@@ -27,7 +27,7 @@ use crate::{
         OntologyTemporalMetadata, OntologyTypeReference, PartialCustomOntologyMetadata,
         PartialOntologyElementMetadata,
     },
-    provenance::{OwnedById, ProvenanceMetadata, RecordCreatedById},
+    provenance::{OwnedById, ProvenanceMetadata, RecordArchivedById, RecordCreatedById},
     store::{
         error::VersionedUrlAlreadyExists, BaseUrlAlreadyExists, ConflictBehavior, DataTypeStore,
         OntologyVersionDoesNotExist, StorePool,
@@ -342,6 +342,8 @@ async fn update_data_type<P: StorePool + Send>(
 struct ArchiveDataTypeRequest {
     #[schema(value_type = String)]
     type_to_archive: VersionedUrl,
+    #[expect(dead_code)]
+    actor_id: RecordArchivedById,
 }
 
 #[utoipa::path(
@@ -363,7 +365,9 @@ async fn archive_data_type<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
     body: Json<ArchiveDataTypeRequest>,
 ) -> Result<Json<OntologyTemporalMetadata>, StatusCode> {
-    let Json(ArchiveDataTypeRequest { type_to_archive }) = body;
+    let Json(ArchiveDataTypeRequest {
+        type_to_archive, ..
+    }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
@@ -394,6 +398,8 @@ async fn archive_data_type<P: StorePool + Send>(
 struct UnarchiveDataTypeRequest {
     #[schema(value_type = String)]
     type_to_unarchive: VersionedUrl,
+    #[expect(dead_code)]
+    actor_id: RecordCreatedById,
 }
 
 #[utoipa::path(
@@ -415,7 +421,9 @@ async fn unarchive_data_type<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
     body: Json<UnarchiveDataTypeRequest>,
 ) -> Result<Json<OntologyTemporalMetadata>, StatusCode> {
-    let Json(UnarchiveDataTypeRequest { type_to_unarchive }) = body;
+    let Json(UnarchiveDataTypeRequest {
+        type_to_unarchive, ..
+    }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");

--- a/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/entity_type.rs
@@ -35,7 +35,7 @@ use crate::{
         OntologyElementMetadata, OntologyTemporalMetadata, OntologyTypeReference,
         PartialCustomEntityTypeMetadata, PartialCustomOntologyMetadata, PartialEntityTypeMetadata,
     },
-    provenance::{OwnedById, ProvenanceMetadata, RecordCreatedById},
+    provenance::{OwnedById, ProvenanceMetadata, RecordArchivedById, RecordCreatedById},
     store::{
         error::{BaseUrlAlreadyExists, OntologyVersionDoesNotExist, VersionedUrlAlreadyExists},
         ConflictBehavior, EntityTypeStore, StorePool,
@@ -488,6 +488,8 @@ async fn update_entity_type<P: StorePool + Send>(
 struct ArchiveEntityTypeRequest {
     #[schema(value_type = String)]
     type_to_archive: VersionedUrl,
+    #[expect(dead_code)]
+    actor_id: RecordArchivedById,
 }
 
 #[utoipa::path(
@@ -509,7 +511,9 @@ async fn archive_entity_type<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
     body: Json<ArchiveEntityTypeRequest>,
 ) -> Result<Json<OntologyTemporalMetadata>, StatusCode> {
-    let Json(ArchiveEntityTypeRequest { type_to_archive }) = body;
+    let Json(ArchiveEntityTypeRequest {
+        type_to_archive, ..
+    }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
@@ -540,6 +544,8 @@ async fn archive_entity_type<P: StorePool + Send>(
 struct UnarchiveEntityTypeRequest {
     #[schema(value_type = String)]
     type_to_unarchive: VersionedUrl,
+    #[expect(dead_code)]
+    actor_id: RecordCreatedById,
 }
 
 #[utoipa::path(
@@ -561,7 +567,9 @@ async fn unarchive_entity_type<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
     body: Json<UnarchiveEntityTypeRequest>,
 ) -> Result<Json<OntologyTemporalMetadata>, StatusCode> {
-    let Json(UnarchiveEntityTypeRequest { type_to_unarchive }) = body;
+    let Json(UnarchiveEntityTypeRequest {
+        type_to_unarchive, ..
+    }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");

--- a/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest/property_type.rs
@@ -27,7 +27,7 @@ use crate::{
         OntologyTypeReference, PartialCustomOntologyMetadata, PartialOntologyElementMetadata,
         PropertyTypeQueryToken, PropertyTypeWithMetadata,
     },
-    provenance::{OwnedById, ProvenanceMetadata, RecordCreatedById},
+    provenance::{OwnedById, ProvenanceMetadata, RecordArchivedById, RecordCreatedById},
     store::{
         error::VersionedUrlAlreadyExists, BaseUrlAlreadyExists, ConflictBehavior,
         OntologyVersionDoesNotExist, PropertyTypeStore, StorePool,
@@ -349,6 +349,8 @@ async fn update_property_type<P: StorePool + Send>(
 struct ArchivePropertyTypeRequest {
     #[schema(value_type = String)]
     type_to_archive: VersionedUrl,
+    #[expect(dead_code)]
+    actor_id: RecordArchivedById,
 }
 
 #[utoipa::path(
@@ -370,7 +372,9 @@ async fn archive_property_type<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
     body: Json<ArchivePropertyTypeRequest>,
 ) -> Result<Json<OntologyTemporalMetadata>, StatusCode> {
-    let Json(ArchivePropertyTypeRequest { type_to_archive }) = body;
+    let Json(ArchivePropertyTypeRequest {
+        type_to_archive, ..
+    }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");
@@ -401,6 +405,8 @@ async fn archive_property_type<P: StorePool + Send>(
 struct UnarchivePropertyTypeRequest {
     #[schema(value_type = String)]
     type_to_unarchive: VersionedUrl,
+    #[expect(dead_code)]
+    actor_id: RecordCreatedById,
 }
 
 #[utoipa::path(
@@ -422,7 +428,9 @@ async fn unarchive_property_type<P: StorePool + Send>(
     pool: Extension<Arc<P>>,
     body: Json<UnarchivePropertyTypeRequest>,
 ) -> Result<Json<OntologyTemporalMetadata>, StatusCode> {
-    let Json(UnarchivePropertyTypeRequest { type_to_unarchive }) = body;
+    let Json(UnarchivePropertyTypeRequest {
+        type_to_unarchive, ..
+    }) = body;
 
     let mut store = pool.acquire().await.map_err(|report| {
         tracing::error!(error=?report, "Could not acquire store");

--- a/apps/hash-graph/lib/graph/src/shared/provenance.rs
+++ b/apps/hash-graph/lib/graph/src/shared/provenance.rs
@@ -60,6 +60,7 @@ macro_rules! define_provenance_id {
 
 define_provenance_id!(OwnedById);
 define_provenance_id!(RecordCreatedById);
+define_provenance_id!(RecordArchivedById);
 
 // TODO: Make fields `pub` when `#[feature(mut_restriction)]` is available.
 //   see https://github.com/rust-lang/rust/issues/105077

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -926,9 +926,13 @@
       "ArchiveDataTypeRequest": {
         "type": "object",
         "required": [
-          "typeToArchive"
+          "typeToArchive",
+          "actorId"
         ],
         "properties": {
+          "actorId": {
+            "$ref": "#/components/schemas/RecordArchivedById"
+          },
           "typeToArchive": {
             "type": "string"
           }
@@ -937,9 +941,13 @@
       "ArchiveEntityTypeRequest": {
         "type": "object",
         "required": [
-          "typeToArchive"
+          "typeToArchive",
+          "actorId"
         ],
         "properties": {
+          "actorId": {
+            "$ref": "#/components/schemas/RecordArchivedById"
+          },
           "typeToArchive": {
             "type": "string"
           }
@@ -948,9 +956,13 @@
       "ArchivePropertyTypeRequest": {
         "type": "object",
         "required": [
-          "typeToArchive"
+          "typeToArchive",
+          "actorId"
         ],
         "properties": {
+          "actorId": {
+            "$ref": "#/components/schemas/RecordArchivedById"
+          },
           "typeToArchive": {
             "type": "string"
           }
@@ -2562,6 +2574,10 @@
         ],
         "description": "Defines the two possible combinations of pinned/variable temporal axes that are used in queries\nthat return [`Subgraph`]s.\n\nThe [`VariableTemporalAxisUnresolved`] is optionally bounded, in the absence of provided\nbounds an inclusive bound at the timestamp at point of resolving is assumed.\n\n[`Subgraph`]: crate::subgraph::Subgraph"
       },
+      "RecordArchivedById": {
+        "type": "string",
+        "format": "uuid"
+      },
       "RecordCreatedById": {
         "type": "string",
         "format": "uuid"
@@ -2712,9 +2728,13 @@
       "UnarchiveDataTypeRequest": {
         "type": "object",
         "required": [
-          "typeToUnarchive"
+          "typeToUnarchive",
+          "actorId"
         ],
         "properties": {
+          "actorId": {
+            "$ref": "#/components/schemas/RecordCreatedById"
+          },
           "typeToUnarchive": {
             "type": "string"
           }
@@ -2723,9 +2743,13 @@
       "UnarchiveEntityTypeRequest": {
         "type": "object",
         "required": [
-          "typeToUnarchive"
+          "typeToUnarchive",
+          "actorId"
         ],
         "properties": {
+          "actorId": {
+            "$ref": "#/components/schemas/RecordCreatedById"
+          },
           "typeToUnarchive": {
             "type": "string"
           }
@@ -2734,9 +2758,13 @@
       "UnarchivePropertyTypeRequest": {
         "type": "object",
         "required": [
-          "typeToUnarchive"
+          "typeToUnarchive",
+          "actorId"
         ],
         "properties": {
+          "actorId": {
+            "$ref": "#/components/schemas/RecordCreatedById"
+          },
           "typeToUnarchive": {
             "type": "string"
           }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We want to track the actor when archiving or restoring ontology types.

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph