### PR TITLE
Remove global `.yml` and `.json` filter for `area: infra` label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -34,9 +34,7 @@
 
 "area: infra":
   - "infra/**"
-  - "**/*.json"
   - "**/*.md"
-  - "**/*.yml"
   - "**/.changeset/config.json"
   - "**/.github/**"
   - "**/.*ignore"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

There are JSON or YAML files, which are not infra-related. Infra-related files should be explicitly captured.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph