### PR TITLE
H-303: Add `RecordArchivedById` for archived ontology types

### DIFF
--- a/apps/hash-graph/bench/util.rs
+++ b/apps/hash-graph/bench/util.rs
@@ -205,7 +205,10 @@ pub async fn seed<D, P, E, C>(
             .create_data_type(data_type.clone(), PartialOntologyElementMetadata {
                 record_id: data_type.id().clone().into(),
                 custom: PartialCustomOntologyMetadata::Owned {
-                    provenance: ProvenanceMetadata::new(RecordCreatedById::new(account_id)),
+                    provenance: ProvenanceMetadata {
+                        record_created_by_id: RecordCreatedById::new(account_id),
+                        record_archived_by_id: None,
+                    },
                     owned_by_id: OwnedById::new(account_id),
                 },
             })
@@ -235,7 +238,10 @@ pub async fn seed<D, P, E, C>(
             .create_property_type(property_type.clone(), PartialOntologyElementMetadata {
                 record_id: property_type.id().clone().into(),
                 custom: PartialCustomOntologyMetadata::Owned {
-                    provenance: ProvenanceMetadata::new(RecordCreatedById::new(account_id)),
+                    provenance: ProvenanceMetadata {
+                        record_created_by_id: RecordCreatedById::new(account_id),
+                        record_archived_by_id: None,
+                    },
                     owned_by_id: OwnedById::new(account_id),
                 },
             })
@@ -266,7 +272,10 @@ pub async fn seed<D, P, E, C>(
                 record_id: entity_type.id().clone().into(),
                 custom: PartialCustomEntityTypeMetadata {
                     common: PartialCustomOntologyMetadata::Owned {
-                        provenance: ProvenanceMetadata::new(RecordCreatedById::new(account_id)),
+                        provenance: ProvenanceMetadata {
+                            record_created_by_id: RecordCreatedById::new(account_id),
+                            record_archived_by_id: None,
+                        },
                         owned_by_id: OwnedById::new(account_id),
                     },
                     label_property: None,

--- a/apps/hash-graph/bin/cli/src/subcommand/server.rs
+++ b/apps/hash-graph/bin/cli/src/subcommand/server.rs
@@ -238,7 +238,10 @@ async fn stop_gap_setup(pool: &PostgresStorePool<NoTls>) -> Result<(), GraphErro
         let data_type_metadata = PartialOntologyElementMetadata {
             record_id: data_type.id().clone().into(),
             custom: PartialCustomOntologyMetadata::External {
-                provenance: ProvenanceMetadata::new(RecordCreatedById::new(root_account_id)),
+                provenance: ProvenanceMetadata {
+                    record_created_by_id: RecordCreatedById::new(root_account_id),
+                    record_archived_by_id: None,
+                },
                 fetched_at: OffsetDateTime::now_utc(),
             },
         };
@@ -277,7 +280,10 @@ async fn stop_gap_setup(pool: &PostgresStorePool<NoTls>) -> Result<(), GraphErro
         record_id: link_entity_type.id().clone().into(),
         custom: PartialCustomEntityTypeMetadata {
             common: PartialCustomOntologyMetadata::External {
-                provenance: ProvenanceMetadata::new(RecordCreatedById::new(root_account_id)),
+                provenance: ProvenanceMetadata {
+                    record_created_by_id: RecordCreatedById::new(root_account_id),
+                    record_archived_by_id: None,
+                },
                 fetched_at: OffsetDateTime::now_utc(),
             },
             label_property: None,

--- a/apps/hash-graph/lib/graph/src/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/data_type.rs
@@ -121,6 +121,12 @@ pub enum DataTypeQueryPath<'p> {
     /// [`RecordCreatedById`]: crate::provenance::RecordCreatedById
     /// [`ProvenanceMetadata`]: crate::provenance::ProvenanceMetadata
     RecordCreatedById,
+    /// The [`RecordArchivedById`] of the [`ProvenanceMetadata`] belonging to the [`DataType`].
+    ///
+    /// [`DataType`]: type_system::DataType
+    /// [`RecordArchivedById`]: crate::provenance::RecordArchivedById
+    /// [`ProvenanceMetadata`]: crate::provenance::ProvenanceMetadata
+    RecordArchivedById,
     /// Corresponds to [`DataType::title()`].
     ///
     /// ```rust
@@ -209,6 +215,10 @@ impl OntologyQueryPath for DataTypeQueryPath<'_> {
         Self::RecordCreatedById
     }
 
+    fn record_archived_by_id() -> Self {
+        Self::RecordArchivedById
+    }
+
     fn schema() -> Self {
         Self::Schema(None)
     }
@@ -221,7 +231,10 @@ impl OntologyQueryPath for DataTypeQueryPath<'_> {
 impl QueryPath for DataTypeQueryPath<'_> {
     fn expected_type(&self) -> ParameterType {
         match self {
-            Self::OntologyId | Self::OwnedById | Self::RecordCreatedById => ParameterType::Uuid,
+            Self::OntologyId
+            | Self::OwnedById
+            | Self::RecordCreatedById
+            | Self::RecordArchivedById => ParameterType::Uuid,
             Self::Schema(_) | Self::AdditionalMetadata => ParameterType::Object,
             Self::BaseUrl => ParameterType::BaseUrl,
             Self::VersionedUrl => ParameterType::VersionedUrl,
@@ -243,6 +256,7 @@ impl fmt::Display for DataTypeQueryPath<'_> {
             Self::TransactionTime => fmt.write_str("transactionTime"),
             Self::OwnedById => fmt.write_str("ownedById"),
             Self::RecordCreatedById => fmt.write_str("recordCreatedById"),
+            Self::RecordArchivedById => fmt.write_str("recordArchivedById"),
             Self::Schema(Some(path)) => write!(fmt, "schema.{path}"),
             Self::Schema(None) => fmt.write_str("schema"),
             Self::Title => fmt.write_str("title"),

--- a/apps/hash-graph/lib/graph/src/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/entity_type.rs
@@ -116,6 +116,12 @@ pub enum EntityTypeQueryPath<'p> {
     /// [`RecordCreatedById`]: crate::provenance::RecordCreatedById
     /// [`ProvenanceMetadata`]: crate::provenance::ProvenanceMetadata
     RecordCreatedById,
+    /// The [`RecordArchivedById`] of the [`ProvenanceMetadata`] belonging to the [`EntityType`].
+    ///
+    /// [`EntityType`]: type_system::EntityType
+    /// [`RecordArchivedById`]: crate::provenance::RecordArchivedById
+    /// [`ProvenanceMetadata`]: crate::provenance::ProvenanceMetadata
+    RecordArchivedById,
     /// Corresponds to [`EntityType::title()`].
     ///
     /// ```rust
@@ -337,6 +343,10 @@ impl OntologyQueryPath for EntityTypeQueryPath<'_> {
         Self::RecordCreatedById
     }
 
+    fn record_archived_by_id() -> Self {
+        Self::RecordArchivedById
+    }
+
     fn schema() -> Self {
         Self::Schema(None)
     }
@@ -349,7 +359,10 @@ impl OntologyQueryPath for EntityTypeQueryPath<'_> {
 impl QueryPath for EntityTypeQueryPath<'_> {
     fn expected_type(&self) -> ParameterType {
         match self {
-            Self::OntologyId | Self::OwnedById | Self::RecordCreatedById => ParameterType::Uuid,
+            Self::OntologyId
+            | Self::OwnedById
+            | Self::RecordCreatedById
+            | Self::RecordArchivedById => ParameterType::Uuid,
             Self::Schema(_) | Self::AdditionalMetadata => ParameterType::Object,
             Self::Examples | Self::Required => ParameterType::Any,
             Self::BaseUrl | Self::LabelProperty => ParameterType::BaseUrl,
@@ -374,6 +387,7 @@ impl fmt::Display for EntityTypeQueryPath<'_> {
             Self::TransactionTime => fmt.write_str("transactionTime"),
             Self::OwnedById => fmt.write_str("ownedById"),
             Self::RecordCreatedById => fmt.write_str("recordCreatedById"),
+            Self::RecordArchivedById => fmt.write_str("recordArchivedById"),
             Self::Schema(Some(path)) => write!(fmt, "schema.{path}"),
             Self::Schema(None) => fmt.write_str("schema"),
             Self::Title => fmt.write_str("title"),

--- a/apps/hash-graph/lib/graph/src/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/property_type.rs
@@ -89,8 +89,6 @@ pub enum PropertyTypeQueryPath<'p> {
     OwnedById,
     /// The [`RecordCreatedById`] of the [`ProvenanceMetadata`] belonging to the [`PropertyType`].
     ///
-    /// [`PropertyType`]: type_system::PropertyType
-    ///
     /// ```rust
     /// # use serde::Deserialize;
     /// # use serde_json::json;
@@ -100,9 +98,16 @@ pub enum PropertyTypeQueryPath<'p> {
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     ///
+    /// [`PropertyType`]: type_system::PropertyType
     /// [`RecordCreatedById`]: crate::provenance::RecordCreatedById
     /// [`ProvenanceMetadata`]: crate::provenance::ProvenanceMetadata
     RecordCreatedById,
+    /// The [`RecordArchivedById`] of the [`ProvenanceMetadata`] belonging to the [`PropertyType`].
+    ///
+    /// [`PropertyType`]: type_system::PropertyType
+    /// [`RecordArchivedById`]: crate::provenance::RecordArchivedById
+    /// [`ProvenanceMetadata`]: crate::provenance::ProvenanceMetadata
+    RecordArchivedById,
     /// Corresponds to [`PropertyType::title()`].
     ///
     /// [`PropertyType::title()`]: type_system::PropertyType::title
@@ -248,6 +253,10 @@ impl OntologyQueryPath for PropertyTypeQueryPath<'_> {
         Self::RecordCreatedById
     }
 
+    fn record_archived_by_id() -> Self {
+        Self::RecordArchivedById
+    }
+
     fn schema() -> Self {
         Self::Schema(None)
     }
@@ -260,7 +269,10 @@ impl OntologyQueryPath for PropertyTypeQueryPath<'_> {
 impl QueryPath for PropertyTypeQueryPath<'_> {
     fn expected_type(&self) -> ParameterType {
         match self {
-            Self::OntologyId | Self::OwnedById | Self::RecordCreatedById => ParameterType::Uuid,
+            Self::OntologyId
+            | Self::OwnedById
+            | Self::RecordCreatedById
+            | Self::RecordArchivedById => ParameterType::Uuid,
             Self::Schema(_) | Self::AdditionalMetadata => ParameterType::Object,
             Self::BaseUrl => ParameterType::BaseUrl,
             Self::VersionedUrl => ParameterType::VersionedUrl,
@@ -284,6 +296,7 @@ impl fmt::Display for PropertyTypeQueryPath<'_> {
             Self::TransactionTime => fmt.write_str("transactionTime"),
             Self::OwnedById => fmt.write_str("ownedById"),
             Self::RecordCreatedById => fmt.write_str("recordCreatedById"),
+            Self::RecordArchivedById => fmt.write_str("recordArchivedById"),
             Self::Schema(Some(path)) => write!(fmt, "schema.{path}"),
             Self::Schema(None) => fmt.write_str("schema"),
             Self::Title => fmt.write_str("title"),

--- a/apps/hash-graph/lib/graph/src/shared/provenance.rs
+++ b/apps/hash-graph/lib/graph/src/shared/provenance.rs
@@ -69,18 +69,6 @@ define_provenance_id!(RecordArchivedById);
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct ProvenanceMetadata {
     pub record_created_by_id: RecordCreatedById,
-}
-
-impl ProvenanceMetadata {
-    #[must_use]
-    pub const fn new(record_created_by_id: RecordCreatedById) -> Self {
-        Self {
-            record_created_by_id,
-        }
-    }
-
-    #[must_use]
-    pub const fn record_created_by_id(&self) -> RecordCreatedById {
-        self.record_created_by_id
-    }
+    #[serde(skip)]
+    pub record_archived_by_id: Option<RecordArchivedById>,
 }

--- a/apps/hash-graph/lib/graph/src/snapshot/entity/channel.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/entity/channel.rs
@@ -113,7 +113,7 @@ impl Sink<EntitySnapshotRecord> for EntitySender {
                                 .as_account_id(),
                         )
                     },
-                    |p| p.record_created_by_id(),
+                    |p| p.record_created_by_id,
                 ),
                 archived: entity.metadata.custom.archived.unwrap_or(false),
                 entity_type_base_url: entity.metadata.entity_type_id.base_url.as_str().to_owned(),

--- a/apps/hash-graph/lib/graph/src/snapshot/ontology/metadata/channel.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/ontology/metadata/channel.rs
@@ -104,7 +104,6 @@ impl Sink<(Uuid, OntologyElementMetadata)> for OntologyTypeMetadataSender {
                 ontology_id,
                 base_url: metadata.record_id.base_url.as_str().to_owned(),
                 version: metadata.record_id.version,
-                record_created_by_id: provenance.record_created_by_id,
             })
             .into_report()
             .change_context(SnapshotRestoreError::Read)
@@ -114,6 +113,8 @@ impl Sink<(Uuid, OntologyElementMetadata)> for OntologyTypeMetadataSender {
             .start_send(OntologyTemporalMetadataRow {
                 ontology_id,
                 transaction_time: temporal_versioning.transaction_time,
+                record_created_by_id: provenance.record_created_by_id,
+                record_archived_by_id: provenance.record_archived_by_id,
             })
             .into_report()
             .change_context(SnapshotRestoreError::Read)

--- a/apps/hash-graph/lib/graph/src/snapshot/ontology/table.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/ontology/table.rs
@@ -8,7 +8,7 @@ use crate::{
         ontology::OntologyTypeVersion,
         time::{LeftClosedTemporalInterval, TransactionTime},
     },
-    provenance::{OwnedById, RecordCreatedById},
+    provenance::{OwnedById, RecordArchivedById, RecordCreatedById},
 };
 
 #[derive(Debug, ToSql)]
@@ -17,7 +17,6 @@ pub struct OntologyIdRow {
     pub ontology_id: Uuid,
     pub base_url: String,
     pub version: OntologyTypeVersion,
-    pub record_created_by_id: RecordCreatedById,
 }
 
 #[derive(Debug, ToSql)]
@@ -39,6 +38,8 @@ pub struct OntologyExternalMetadataRow {
 pub struct OntologyTemporalMetadataRow {
     pub ontology_id: Uuid,
     pub transaction_time: LeftClosedTemporalInterval<TransactionTime>,
+    pub record_created_by_id: RecordCreatedById,
+    pub record_archived_by_id: Option<RecordArchivedById>,
 }
 
 #[derive(Debug, ToSql)]

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -29,7 +29,7 @@ use crate::{
         OntologyTypeReference, PartialCustomEntityTypeMetadata, PartialCustomOntologyMetadata,
         PartialEntityTypeMetadata, PartialOntologyElementMetadata, PropertyTypeWithMetadata,
     },
-    provenance::{OwnedById, ProvenanceMetadata, RecordCreatedById},
+    provenance::{OwnedById, ProvenanceMetadata, RecordArchivedById, RecordCreatedById},
     store::{
         crud::Read,
         query::{Filter, OntologyQueryPath},
@@ -254,7 +254,10 @@ where
         actor_id: RecordCreatedById,
         fetch_behavior: FetchBehavior,
     ) -> Result<FetchedOntologyTypes, StoreError> {
-        let provenance_metadata = ProvenanceMetadata::new(actor_id);
+        let provenance_metadata = ProvenanceMetadata {
+            record_created_by_id: actor_id,
+            record_archived_by_id: None,
+        };
 
         let mut queue = ontology_type_references;
         let mut seen = match fetch_behavior {
@@ -563,10 +566,7 @@ where
         let data_types = data_types.into_iter().collect::<Vec<_>>();
 
         self.insert_external_types(data_types.iter().map(|(data_type, metadata)| {
-            (
-                data_type,
-                metadata.custom.provenance().record_created_by_id(),
-            )
+            (data_type, metadata.custom.provenance().record_created_by_id)
         }))
         .await?;
 
@@ -595,15 +595,17 @@ where
     async fn archive_data_type(
         &mut self,
         id: &VersionedUrl,
+        actor_id: RecordArchivedById,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
-        self.store.archive_data_type(id).await
+        self.store.archive_data_type(id, actor_id).await
     }
 
     async fn unarchive_data_type(
         &mut self,
         id: &VersionedUrl,
+        actor_id: RecordCreatedById,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
-        self.store.unarchive_data_type(id).await
+        self.store.unarchive_data_type(id, actor_id).await
     }
 }
 
@@ -626,7 +628,7 @@ where
         self.insert_external_types(property_types.iter().map(|(property_type, metadata)| {
             (
                 property_type,
-                metadata.custom.provenance().record_created_by_id(),
+                metadata.custom.provenance().record_created_by_id,
             )
         }))
         .await?;
@@ -660,15 +662,17 @@ where
     async fn archive_property_type(
         &mut self,
         id: &VersionedUrl,
+        actor_id: RecordArchivedById,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
-        self.store.archive_property_type(id).await
+        self.store.archive_property_type(id, actor_id).await
     }
 
     async fn unarchive_property_type(
         &mut self,
         id: &VersionedUrl,
+        actor_id: RecordCreatedById,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
-        self.store.unarchive_property_type(id).await
+        self.store.unarchive_property_type(id, actor_id).await
     }
 }
 
@@ -689,7 +693,7 @@ where
         self.insert_external_types(entity_types.iter().map(|(entity_type, metadata)| {
             (
                 entity_type,
-                metadata.custom.common.provenance().record_created_by_id(),
+                metadata.custom.common.provenance().record_created_by_id,
             )
         }))
         .await?;
@@ -724,15 +728,17 @@ where
     async fn archive_entity_type(
         &mut self,
         id: &VersionedUrl,
+        actor_id: RecordArchivedById,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
-        self.store.archive_entity_type(id).await
+        self.store.archive_entity_type(id, actor_id).await
     }
 
     async fn unarchive_entity_type(
         &mut self,
         id: &VersionedUrl,
+        actor_id: RecordCreatedById,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
-        self.store.unarchive_entity_type(id).await
+        self.store.unarchive_entity_type(id, actor_id).await
     }
 }
 

--- a/apps/hash-graph/lib/graph/src/store/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/store/ontology.rs
@@ -13,7 +13,7 @@ use crate::{
         OntologyTemporalMetadata, PartialEntityTypeMetadata, PartialOntologyElementMetadata,
         PropertyTypeWithMetadata,
     },
-    provenance::RecordCreatedById,
+    provenance::{RecordArchivedById, RecordCreatedById},
     store::{crud, ConflictBehavior, InsertionError, QueryError, UpdateError},
     subgraph::{query::StructuralQuery, Subgraph},
 };
@@ -85,6 +85,7 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     async fn archive_data_type(
         &mut self,
         id: &VersionedUrl,
+        actor_id: RecordArchivedById,
     ) -> Result<OntologyTemporalMetadata, UpdateError>;
 
     /// Restores the definition of an existing [`DataType`].
@@ -95,6 +96,7 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     async fn unarchive_data_type(
         &mut self,
         id: &VersionedUrl,
+        actor_id: RecordCreatedById,
     ) -> Result<OntologyTemporalMetadata, UpdateError>;
 }
 
@@ -167,6 +169,7 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     async fn archive_property_type(
         &mut self,
         id: &VersionedUrl,
+        actor_id: RecordArchivedById,
     ) -> Result<OntologyTemporalMetadata, UpdateError>;
 
     /// Restores the definition of an existing [`PropertyType`].
@@ -177,6 +180,7 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     async fn unarchive_property_type(
         &mut self,
         id: &VersionedUrl,
+        actor_id: RecordCreatedById,
     ) -> Result<OntologyTemporalMetadata, UpdateError>;
 }
 
@@ -248,6 +252,7 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     async fn archive_entity_type(
         &mut self,
         id: &VersionedUrl,
+        actor_id: RecordArchivedById,
     ) -> Result<OntologyTemporalMetadata, UpdateError>;
 
     /// Restores the definition of an existing [`EntityType`].
@@ -258,5 +263,6 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     async fn unarchive_entity_type(
         &mut self,
         id: &VersionedUrl,
+        actor_id: RecordCreatedById,
     ) -> Result<OntologyTemporalMetadata, UpdateError>;
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres.rs
@@ -32,7 +32,7 @@ use crate::{
         CustomOntologyMetadata, OntologyElementMetadata, OntologyTemporalMetadata,
         PartialCustomOntologyMetadata,
     },
-    provenance::{OwnedById, ProvenanceMetadata, RecordCreatedById},
+    provenance::{OwnedById, ProvenanceMetadata, RecordArchivedById, RecordCreatedById},
     store::{
         error::{OntologyTypeIsNotOwned, OntologyVersionDoesNotExist, VersionedUrlAlreadyExists},
         postgres::ontology::{OntologyDatabaseType, OntologyId},
@@ -154,7 +154,6 @@ where
     async fn create_ontology_id(
         &self,
         record_id: &OntologyTypeRecordId,
-        record_created_by_id: RecordCreatedById,
         on_conflict: ConflictBehavior,
     ) -> Result<Option<OntologyId>, InsertionError> {
         let query: &str = match on_conflict {
@@ -163,9 +162,8 @@ where
                   INSERT INTO ontology_ids (
                     ontology_id,
                     base_url,
-                    version,
-                    record_created_by_id
-                  ) VALUES (gen_random_uuid(), $1, $2, $3)
+                    version
+                  ) VALUES (gen_random_uuid(), $1, $2)
                   ON CONFLICT DO NOTHING
                   RETURNING ontology_ids.ontology_id;
                 "#
@@ -175,19 +173,14 @@ where
                   INSERT INTO ontology_ids (
                     ontology_id,
                     base_url,
-                    version,
-                    record_created_by_id
-                  ) VALUES (gen_random_uuid(), $1, $2, $3)
+                    version
+                  ) VALUES (gen_random_uuid(), $1, $2)
                   RETURNING ontology_ids.ontology_id;
                 "#
             }
         };
         self.as_client()
-            .query_opt(query, &[
-                &record_id.base_url.as_str(),
-                &record_id.version,
-                &record_created_by_id,
-            ])
+            .query_opt(query, &[&record_id.base_url.as_str(), &record_id.version])
             .await
             .into_report()
             .map_err(|report| match report.current_context().code() {
@@ -205,17 +198,19 @@ where
     async fn create_ontology_temporal_metadata(
         &self,
         ontology_id: OntologyId,
+        record_created_by_id: RecordCreatedById,
     ) -> Result<LeftClosedTemporalInterval<TransactionTime>, InsertionError> {
         let query: &str = r#"
               INSERT INTO ontology_temporal_metadata (
                 ontology_id,
-                transaction_time
-              ) VALUES ($1, tstzrange(now(), NULL, '[)'))
+                transaction_time,
+                record_created_by_id
+              ) VALUES ($1, tstzrange(now(), NULL, '[)'), $2)
               RETURNING transaction_time;
             "#;
 
         self.as_client()
-            .query_one(query, &[&ontology_id])
+            .query_one(query, &[&ontology_id, &record_created_by_id])
             .await
             .into_report()
             .change_context(InsertionError)
@@ -225,10 +220,13 @@ where
     async fn archive_ontology_type(
         &self,
         id: &VersionedUrl,
+        record_archived_by_id: RecordArchivedById,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
         let query: &str = r#"
           UPDATE ontology_temporal_metadata
-          SET transaction_time = tstzrange(lower(transaction_time), now(), '[)')
+          SET
+            transaction_time = tstzrange(lower(transaction_time), now(), '[)'),
+            record_archived_by_id = $3
           WHERE ontology_id = (
             SELECT ontology_id
             FROM ontology_ids
@@ -242,6 +240,7 @@ where
             .query_opt(query, &[
                 &id.base_url.as_str(),
                 &OntologyTypeVersion::new(id.version),
+                &record_archived_by_id,
             ])
             .await
             .into_report()
@@ -283,14 +282,17 @@ where
     async fn unarchive_ontology_type(
         &self,
         id: &VersionedUrl,
+        record_created_by_id: RecordCreatedById,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
         let query: &str = r#"
           INSERT INTO ontology_temporal_metadata (
             ontology_id,
-            transaction_time
+            transaction_time,
+            record_created_by_id
           ) VALUES (
             (SELECT ontology_id FROM ontology_ids WHERE base_url = $1 AND version = $2),
-            tstzrange(now(), NULL, '[)')
+            tstzrange(now(), NULL, '[)'),
+            $3
           )
           RETURNING transaction_time;
         "#;
@@ -301,6 +303,7 @@ where
                 .query_one(query, &[
                     &id.base_url.as_str(),
                     &OntologyTypeVersion::new(id.version),
+                    &record_created_by_id,
                 ])
                 .await
                 .into_report()
@@ -726,12 +729,14 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
             } => {
                 self.create_base_url(&record_id.base_url, on_conflict, OntologyLocation::Owned)
                     .await?;
-                let ontology_id = self
-                    .create_ontology_id(record_id, provenance.record_created_by_id, on_conflict)
-                    .await?;
+                let ontology_id = self.create_ontology_id(record_id, on_conflict).await?;
                 if let Some(ontology_id) = ontology_id {
-                    let transaction_time =
-                        self.create_ontology_temporal_metadata(ontology_id).await?;
+                    let transaction_time = self
+                        .create_ontology_temporal_metadata(
+                            ontology_id,
+                            provenance.record_created_by_id,
+                        )
+                        .await?;
                     self.create_ontology_owned_metadata(ontology_id, *owned_by_id)
                         .await?;
                     Ok(Some((ontology_id, transaction_time)))
@@ -749,12 +754,14 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
                     OntologyLocation::External,
                 )
                 .await?;
-                let ontology_id = self
-                    .create_ontology_id(record_id, provenance.record_created_by_id, on_conflict)
-                    .await?;
+                let ontology_id = self.create_ontology_id(record_id, on_conflict).await?;
                 if let Some(ontology_id) = ontology_id {
-                    let transaction_time =
-                        self.create_ontology_temporal_metadata(ontology_id).await?;
+                    let transaction_time = self
+                        .create_ontology_temporal_metadata(
+                            ontology_id,
+                            provenance.record_created_by_id,
+                        )
+                        .await?;
                     self.create_ontology_external_metadata(ontology_id, *fetched_at)
                         .await?;
                     Ok(Some((ontology_id, transaction_time)))
@@ -798,7 +805,10 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
         Ok((ontology_id, OntologyElementMetadata {
             record_id,
             custom: CustomOntologyMetadata::Owned {
-                provenance: ProvenanceMetadata::new(record_created_by_id),
+                provenance: ProvenanceMetadata {
+                    record_created_by_id,
+                    record_archived_by_id: None,
+                },
                 owned_by_id,
                 temporal_versioning: OntologyTemporalMetadata { transaction_time },
             },
@@ -875,7 +885,6 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
         let ontology_id = self
             .create_ontology_id(
                 &OntologyTypeRecordId::from(url.clone()),
-                record_created_by_id,
                 ConflictBehavior::Fail,
             )
             .await
@@ -883,7 +892,7 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
             .expect("ontology id should have been created");
 
         let transaction_time = self
-            .create_ontology_temporal_metadata(ontology_id)
+            .create_ontology_temporal_metadata(ontology_id, record_created_by_id)
             .await
             .change_context(UpdateError)?;
         self.create_ontology_owned_metadata(ontology_id, owned_by_id)

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -296,7 +296,10 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 transaction_time: row.get(2),
             },
             entity_type_id,
-            ProvenanceMetadata::new(record_created_by_id),
+            ProvenanceMetadata {
+                record_created_by_id,
+                record_archived_by_id: None,
+            },
             archived,
         ))
     }
@@ -415,7 +418,10 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                     },
                     entity_version,
                     entity_type_id.clone(),
-                    ProvenanceMetadata::new(actor_id),
+                    ProvenanceMetadata {
+                        record_created_by_id: actor_id,
+                        record_archived_by_id: None,
+                    },
                     false,
                 )
             })
@@ -574,7 +580,10 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
                 transaction_time: row.get(2),
             },
             entity_type_id,
-            ProvenanceMetadata::new(record_created_by_id),
+            ProvenanceMetadata {
+                record_created_by_id,
+                record_archived_by_id: None,
+            },
             archived,
         ))
     }

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity/read.rs
@@ -192,7 +192,10 @@ impl<C: AsClient> crud::Read<Entity> for PostgresStore<C> {
                             transaction_time: row.get(transaction_time_index),
                         },
                         entity_type_id,
-                        ProvenanceMetadata::new(record_created_by_id),
+                        ProvenanceMetadata {
+                            record_created_by_id,
+                            record_archived_by_id: None,
+                        },
                         row.get(archived_index),
                     ),
                 })

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -13,7 +13,7 @@ use crate::{
         DataTypeWithMetadata, OntologyElementMetadata, OntologyTemporalMetadata,
         PartialOntologyElementMetadata,
     },
-    provenance::RecordCreatedById,
+    provenance::{RecordArchivedById, RecordCreatedById},
     store::{
         crud::Read,
         postgres::{ontology::OntologyId, TraversalContext},
@@ -190,14 +190,16 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
     async fn archive_data_type(
         &mut self,
         id: &VersionedUrl,
+        record_archived_by_id: RecordArchivedById,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
-        self.archive_ontology_type(id).await
+        self.archive_ontology_type(id, record_archived_by_id).await
     }
 
     async fn unarchive_data_type(
         &mut self,
         id: &VersionedUrl,
+        record_created_by_id: RecordCreatedById,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
-        self.unarchive_ontology_type(id).await
+        self.unarchive_ontology_type(id, record_created_by_id).await
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -18,7 +18,7 @@ use crate::{
         EntityTypeMetadata, EntityTypeWithMetadata, OntologyTemporalMetadata,
         PartialCustomEntityTypeMetadata, PartialCustomOntologyMetadata, PartialEntityTypeMetadata,
     },
-    provenance::{ProvenanceMetadata, RecordCreatedById},
+    provenance::{ProvenanceMetadata, RecordArchivedById, RecordCreatedById},
     store::{
         crud::Read,
         postgres::{
@@ -335,7 +335,10 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
             record_id,
             custom: PartialCustomEntityTypeMetadata {
                 common: PartialCustomOntologyMetadata::Owned {
-                    provenance: ProvenanceMetadata::new(record_created_by_id),
+                    provenance: ProvenanceMetadata {
+                        record_created_by_id,
+                        record_archived_by_id: None,
+                    },
                     owned_by_id,
                 },
                 label_property,
@@ -362,14 +365,16 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
     async fn archive_entity_type(
         &mut self,
         id: &VersionedUrl,
+        record_archived_by_id: RecordArchivedById,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
-        self.archive_ontology_type(id).await
+        self.archive_ontology_type(id, record_archived_by_id).await
     }
 
     async fn unarchive_entity_type(
         &mut self,
         id: &VersionedUrl,
+        record_created_by_id: RecordCreatedById,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
-        self.unarchive_ontology_type(id).await
+        self.unarchive_ontology_type(id, record_created_by_id).await
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -15,7 +15,7 @@ use crate::{
         OntologyElementMetadata, OntologyTemporalMetadata, PartialOntologyElementMetadata,
         PropertyTypeWithMetadata,
     },
-    provenance::RecordCreatedById,
+    provenance::{RecordArchivedById, RecordCreatedById},
     store::{
         crud::Read,
         postgres::{
@@ -326,14 +326,16 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
     async fn archive_property_type(
         &mut self,
         id: &VersionedUrl,
+        record_archived_by_id: RecordArchivedById,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
-        self.archive_ontology_type(id).await
+        self.archive_ontology_type(id, record_archived_by_id).await
     }
 
     async fn unarchive_property_type(
         &mut self,
         id: &VersionedUrl,
+        record_created_by_id: RecordCreatedById,
     ) -> Result<OntologyTemporalMetadata, UpdateError> {
-        self.unarchive_ontology_type(id).await
+        self.unarchive_ontology_type(id, record_created_by_id).await
     }
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/data_type.rs
@@ -21,16 +21,16 @@ impl PostgresRecord for DataTypeWithMetadata {
 impl PostgresQueryPath for DataTypeQueryPath<'_> {
     fn relations(&self) -> Vec<Relation> {
         match self {
-            Self::VersionedUrl
+            Self::OntologyId
+            | Self::VersionedUrl
             | Self::Title
             | Self::Description
             | Self::Type
-            | Self::OntologyId
             | Self::Schema(_) => vec![Relation::DataTypeIds],
-            Self::BaseUrl | Self::Version | Self::RecordCreatedById => vec![Relation::OntologyIds],
+            Self::BaseUrl | Self::Version => vec![Relation::OntologyIds],
             Self::OwnedById => vec![Relation::OntologyOwnedMetadata],
             Self::AdditionalMetadata => vec![Relation::OntologyAdditionalMetadata],
-            Self::TransactionTime => vec![],
+            Self::TransactionTime | Self::RecordCreatedById | Self::RecordArchivedById => vec![],
             Self::PropertyTypeEdge {
                 edge_kind: OntologyEdgeKind::ConstrainsValuesOn,
                 path,
@@ -52,7 +52,12 @@ impl PostgresQueryPath for DataTypeQueryPath<'_> {
                 Column::OntologyTemporalMetadata(OntologyTemporalMetadata::TransactionTime)
             }
             Self::OwnedById => Column::OntologyOwnedMetadata(OntologyOwnedMetadata::OwnedById),
-            Self::RecordCreatedById => Column::OntologyIds(OntologyIds::RecordCreatedById),
+            Self::RecordCreatedById => {
+                Column::OntologyTemporalMetadata(OntologyTemporalMetadata::RecordCreatedById)
+            }
+            Self::RecordArchivedById => {
+                Column::OntologyTemporalMetadata(OntologyTemporalMetadata::RecordArchivedById)
+            }
             Self::OntologyId => Column::DataTypes(DataTypes::OntologyId),
             Self::Schema(path) => path
                 .as_ref()

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/entity_type.rs
@@ -22,18 +22,18 @@ impl PostgresQueryPath for EntityTypeQueryPath<'_> {
     /// Returns the relations that are required to access the path.
     fn relations(&self) -> Vec<Relation> {
         match self {
-            Self::VersionedUrl
+            Self::OntologyId
+            | Self::VersionedUrl
             | Self::Title
             | Self::Description
             | Self::Examples
             | Self::Required
-            | Self::OntologyId
             | Self::LabelProperty
             | Self::Schema(_) => vec![Relation::EntityTypeIds],
-            Self::BaseUrl | Self::Version | Self::RecordCreatedById => vec![Relation::OntologyIds],
+            Self::BaseUrl | Self::Version => vec![Relation::OntologyIds],
             Self::OwnedById => vec![Relation::OntologyOwnedMetadata],
             Self::AdditionalMetadata => vec![Relation::OntologyAdditionalMetadata],
-            Self::TransactionTime => vec![],
+            Self::TransactionTime | Self::RecordCreatedById | Self::RecordArchivedById => vec![],
             Self::PropertyTypeEdge {
                 edge_kind: OntologyEdgeKind::ConstrainsPropertiesOn,
                 path,
@@ -94,7 +94,12 @@ impl PostgresQueryPath for EntityTypeQueryPath<'_> {
                 Column::OntologyTemporalMetadata(OntologyTemporalMetadata::TransactionTime)
             }
             Self::OwnedById => Column::OntologyOwnedMetadata(OntologyOwnedMetadata::OwnedById),
-            Self::RecordCreatedById => Column::OntologyIds(OntologyIds::RecordCreatedById),
+            Self::RecordCreatedById => {
+                Column::OntologyTemporalMetadata(OntologyTemporalMetadata::RecordCreatedById)
+            }
+            Self::RecordArchivedById => {
+                Column::OntologyTemporalMetadata(OntologyTemporalMetadata::RecordArchivedById)
+            }
             Self::OntologyId => Column::EntityTypes(EntityTypes::OntologyId),
             Self::Schema(path) => path
                 .as_ref()

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/property_type.rs
@@ -21,15 +21,15 @@ impl PostgresRecord for PropertyTypeWithMetadata {
 impl PostgresQueryPath for PropertyTypeQueryPath<'_> {
     fn relations(&self) -> Vec<Relation> {
         match self {
-            Self::VersionedUrl
+            Self::OntologyId
+            | Self::VersionedUrl
             | Self::Title
             | Self::Description
-            | Self::OntologyId
             | Self::Schema(_) => vec![Relation::PropertyTypeIds],
-            Self::BaseUrl | Self::Version | Self::RecordCreatedById => vec![Relation::OntologyIds],
+            Self::BaseUrl | Self::Version => vec![Relation::OntologyIds],
             Self::OwnedById => vec![Relation::OntologyOwnedMetadata],
             Self::AdditionalMetadata => vec![Relation::OntologyAdditionalMetadata],
-            Self::TransactionTime => vec![],
+            Self::TransactionTime | Self::RecordCreatedById | Self::RecordArchivedById => vec![],
             Self::DataTypeEdge {
                 edge_kind: OntologyEdgeKind::ConstrainsValuesOn,
                 path,
@@ -70,7 +70,12 @@ impl PostgresQueryPath for PropertyTypeQueryPath<'_> {
                 Column::OntologyTemporalMetadata(OntologyTemporalMetadata::TransactionTime)
             }
             Self::OwnedById => Column::OntologyOwnedMetadata(OntologyOwnedMetadata::OwnedById),
-            Self::RecordCreatedById => Column::OntologyIds(OntologyIds::RecordCreatedById),
+            Self::RecordCreatedById => {
+                Column::OntologyTemporalMetadata(OntologyTemporalMetadata::RecordCreatedById)
+            }
+            Self::RecordArchivedById => {
+                Column::OntologyTemporalMetadata(OntologyTemporalMetadata::RecordArchivedById)
+            }
             Self::OntologyId => Column::PropertyTypes(PropertyTypes::OntologyId),
             Self::Schema(path) => {
                 path.as_ref()

--- a/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/query/table.rs
@@ -205,8 +205,7 @@ impl Table {
             Self::OntologyTemporalMetadata => "ontology_temporal_metadata",
             Self::OntologyOwnedMetadata => "ontology_owned_metadata",
             Self::OntologyExternalMetadata => "ontology_external_metadata",
-            // TODO: Rename to `ontology_additional_metadata`
-            Self::OntologyAdditionalMetadata => "ontology_id_with_metadata",
+            Self::OntologyAdditionalMetadata => "ontology_additional_metadata",
             Self::DataTypes => "data_types",
             Self::PropertyTypes => "property_types",
             Self::EntityTypes => "entity_types",
@@ -258,7 +257,6 @@ pub enum OntologyIds {
     OntologyId,
     BaseUrl,
     Version,
-    RecordCreatedById,
     LatestVersion,
 }
 
@@ -284,6 +282,8 @@ pub enum OntologyAdditionalMetadata {
 pub enum OntologyTemporalMetadata {
     OntologyId,
     TransactionTime,
+    RecordCreatedById,
+    RecordArchivedById,
 }
 
 fn transpile_json_field(
@@ -317,7 +317,6 @@ impl OntologyIds {
             Self::BaseUrl => "base_url",
             Self::Version => "version",
             Self::LatestVersion => "latest_version",
-            Self::RecordCreatedById => "record_created_by_id",
         };
         table.transpile(fmt)?;
         write!(fmt, r#"."{column}""#)
@@ -325,7 +324,7 @@ impl OntologyIds {
 
     pub const fn parameter_type(self) -> ParameterType {
         match self {
-            Self::OntologyId | Self::RecordCreatedById => ParameterType::Uuid,
+            Self::OntologyId => ParameterType::Uuid,
             Self::BaseUrl => ParameterType::Text,
             Self::Version | Self::LatestVersion => ParameterType::OntologyTypeVersion,
         }
@@ -390,6 +389,8 @@ impl OntologyTemporalMetadata {
         let column = match self {
             Self::OntologyId => "ontology_id",
             Self::TransactionTime => "transaction_time",
+            Self::RecordCreatedById => "record_created_by_id",
+            Self::RecordArchivedById => "record_archived_by_id",
         };
         table.transpile(fmt)?;
         write!(fmt, r#"."{column}""#)
@@ -397,7 +398,9 @@ impl OntologyTemporalMetadata {
 
     pub const fn parameter_type(self) -> ParameterType {
         match self {
-            Self::OntologyId => ParameterType::Uuid,
+            Self::OntologyId | Self::RecordCreatedById | Self::RecordArchivedById => {
+                ParameterType::Uuid
+            }
             Self::TransactionTime => ParameterType::TimeInterval,
         }
     }

--- a/apps/hash-graph/lib/graph/src/store/query.rs
+++ b/apps/hash-graph/lib/graph/src/store/query.rs
@@ -73,6 +73,11 @@ pub trait OntologyQueryPath {
     /// [`RecordCreatedById`]: crate::provenance::RecordCreatedById
     fn record_created_by_id() -> Self;
 
+    /// Returns the path identifying the [`RecordArchivedById`].
+    ///
+    /// [`RecordArchivedById`]: crate::provenance::RecordArchivedById
+    fn record_archived_by_id() -> Self;
+
     /// Returns the path identifying the schema.
     fn schema() -> Self;
 

--- a/apps/hash-graph/postgres_migrations/V11__archival_provenance.sql
+++ b/apps/hash-graph/postgres_migrations/V11__archival_provenance.sql
@@ -1,0 +1,54 @@
+ALTER TABLE
+  "ontology_temporal_metadata"
+ADD COLUMN
+  "record_created_by_id" UUID REFERENCES "accounts";
+
+UPDATE
+  "ontology_temporal_metadata"
+SET
+  "record_created_by_id" = "ontology_ids"."record_created_by_id"
+FROM
+  "ontology_ids"
+WHERE
+  "ontology_temporal_metadata"."ontology_id" = "ontology_ids"."ontology_id";
+
+ALTER TABLE
+  "ontology_temporal_metadata"
+ALTER COLUMN
+  "record_created_by_id"
+SET NOT NULL
+,
+ADD COLUMN
+  "record_archived_by_id" UUID REFERENCES "accounts",
+ADD
+  CONSTRAINT "record_archived_transaction_check" CHECK (
+    ("record_archived_by_id" IS NULL) = (UPPER("transaction_time") IS NULL)
+  );
+
+DROP VIEW
+  "ontology_id_with_metadata";
+
+ALTER TABLE
+  "ontology_ids"
+DROP COLUMN
+  "record_created_by_id";
+
+CREATE VIEW
+  "ontology_additional_metadata" AS
+SELECT
+  "ontology_id",
+  JSONB_BUILD_OBJECT(
+    'owned_by_id',
+    ontology_owned_metadata.owned_by_id
+  ) AS "additional_metadata"
+FROM
+  ontology_owned_metadata
+UNION ALL
+SELECT
+  "ontology_id",
+  JSONB_BUILD_OBJECT(
+    'fetched_at',
+    ontology_external_metadata.fetched_at
+  ) AS "additional_metadata"
+FROM
+  ontology_external_metadata;

--- a/apps/hash-graph/tests/integration/postgres/lib.rs
+++ b/apps/hash-graph/tests/integration/postgres/lib.rs
@@ -132,7 +132,10 @@ impl DatabaseTestWrapper {
             let metadata = PartialOntologyElementMetadata {
                 record_id: data_type.id().clone().into(),
                 custom: PartialCustomOntologyMetadata::Owned {
-                    provenance: ProvenanceMetadata::new(RecordCreatedById::new(account_id)),
+                    provenance: ProvenanceMetadata {
+                        record_created_by_id: RecordCreatedById::new(account_id),
+                        record_archived_by_id: None,
+                    },
                     owned_by_id: OwnedById::new(account_id),
                 },
             };
@@ -152,7 +155,10 @@ impl DatabaseTestWrapper {
             let metadata = PartialOntologyElementMetadata {
                 record_id: property_type.id().clone().into(),
                 custom: PartialCustomOntologyMetadata::Owned {
-                    provenance: ProvenanceMetadata::new(RecordCreatedById::new(account_id)),
+                    provenance: ProvenanceMetadata {
+                        record_created_by_id: RecordCreatedById::new(account_id),
+                        record_archived_by_id: None,
+                    },
                     owned_by_id: OwnedById::new(account_id),
                 },
             };
@@ -173,7 +179,10 @@ impl DatabaseTestWrapper {
                 record_id: entity_type.id().clone().into(),
                 custom: PartialCustomEntityTypeMetadata {
                     common: PartialCustomOntologyMetadata::Owned {
-                        provenance: ProvenanceMetadata::new(RecordCreatedById::new(account_id)),
+                        provenance: ProvenanceMetadata {
+                            record_created_by_id: RecordCreatedById::new(account_id),
+                            record_archived_by_id: None,
+                        },
                         owned_by_id: OwnedById::new(account_id),
                     },
                     label_property: None,
@@ -212,7 +221,10 @@ impl DatabaseApi<'_> {
         let metadata = PartialOntologyElementMetadata {
             record_id: data_type.id().clone().into(),
             custom: PartialCustomOntologyMetadata::Owned {
-                provenance: ProvenanceMetadata::new(RecordCreatedById::new(self.account_id)),
+                provenance: ProvenanceMetadata {
+                    record_created_by_id: RecordCreatedById::new(self.account_id),
+                    record_archived_by_id: None,
+                },
                 owned_by_id: OwnedById::new(self.account_id),
             },
         };
@@ -227,7 +239,10 @@ impl DatabaseApi<'_> {
         let metadata = PartialOntologyElementMetadata {
             record_id: data_type.id().clone().into(),
             custom: PartialCustomOntologyMetadata::External {
-                provenance: ProvenanceMetadata::new(RecordCreatedById::new(self.account_id)),
+                provenance: ProvenanceMetadata {
+                    record_created_by_id: RecordCreatedById::new(self.account_id),
+                    record_archived_by_id: None,
+                },
                 fetched_at: OffsetDateTime::now_utc(),
             },
         };
@@ -275,7 +290,10 @@ impl DatabaseApi<'_> {
         let metadata = PartialOntologyElementMetadata {
             record_id: property_type.id().clone().into(),
             custom: PartialCustomOntologyMetadata::Owned {
-                provenance: ProvenanceMetadata::new(RecordCreatedById::new(self.account_id)),
+                provenance: ProvenanceMetadata {
+                    record_created_by_id: RecordCreatedById::new(self.account_id),
+                    record_archived_by_id: None,
+                },
                 owned_by_id: OwnedById::new(self.account_id),
             },
         };
@@ -326,7 +344,10 @@ impl DatabaseApi<'_> {
             record_id: entity_type.id().clone().into(),
             custom: PartialCustomEntityTypeMetadata {
                 common: PartialCustomOntologyMetadata::Owned {
-                    provenance: ProvenanceMetadata::new(RecordCreatedById::new(self.account_id)),
+                    provenance: ProvenanceMetadata {
+                        record_created_by_id: RecordCreatedById::new(self.account_id),
+                        record_archived_by_id: None,
+                    },
                     owned_by_id: OwnedById::new(self.account_id),
                 },
                 label_property: None,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Implements the first approach of [H-298](https://linear.app/hash/issue/H-298) as the short-term solution to be able to record provenance data.

## 🚫 Blocked by

- #2853 
- #2854 

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph