### PR TITLE
H-306: Make `RecordArchivedById` available in TS and make it queryable

### DIFF
--- a/apps/hash-graph/lib/graph/src/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/data_type.rs
@@ -123,6 +123,15 @@ pub enum DataTypeQueryPath<'p> {
     RecordCreatedById,
     /// The [`RecordArchivedById`] of the [`ProvenanceMetadata`] belonging to the [`DataType`].
     ///
+    /// ```rust
+    /// # use serde::Deserialize;
+    /// # use serde_json::json;
+    /// # use graph::ontology::DataTypeQueryPath;
+    /// let path = DataTypeQueryPath::deserialize(json!(["recordArchivedById"]))?;
+    /// assert_eq!(path, DataTypeQueryPath::RecordArchivedById);
+    /// # Ok::<(), serde_json::Error>(())
+    /// ```
+    ///
     /// [`DataType`]: type_system::DataType
     /// [`RecordArchivedById`]: crate::provenance::RecordArchivedById
     /// [`ProvenanceMetadata`]: crate::provenance::ProvenanceMetadata
@@ -285,6 +294,7 @@ pub enum DataTypeQueryToken {
     VersionedUrl,
     OwnedById,
     RecordCreatedById,
+    RecordArchivedById,
     Title,
     Description,
     Type,
@@ -300,8 +310,8 @@ pub struct DataTypeQueryPathVisitor {
 
 impl DataTypeQueryPathVisitor {
     pub const EXPECTING: &'static str = "one of `baseUrl`, `version`, `versionedUrl`, \
-                                         `ownedById`, `recordCreatedById`, `title`, \
-                                         `description`, `type`";
+                                         `ownedById`, `recordCreatedById`, `recordArchivedById`, \
+                                         `title`, `description`, `type`";
 
     #[must_use]
     pub const fn new(position: usize) -> Self {
@@ -328,6 +338,7 @@ impl<'de> Visitor<'de> for DataTypeQueryPathVisitor {
         Ok(match token {
             DataTypeQueryToken::OwnedById => DataTypeQueryPath::OwnedById,
             DataTypeQueryToken::RecordCreatedById => DataTypeQueryPath::RecordCreatedById,
+            DataTypeQueryToken::RecordArchivedById => DataTypeQueryPath::RecordArchivedById,
             DataTypeQueryToken::BaseUrl => DataTypeQueryPath::BaseUrl,
             DataTypeQueryToken::VersionedUrl => DataTypeQueryPath::VersionedUrl,
             DataTypeQueryToken::Version => DataTypeQueryPath::Version,

--- a/apps/hash-graph/lib/graph/src/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/entity_type.rs
@@ -118,6 +118,15 @@ pub enum EntityTypeQueryPath<'p> {
     RecordCreatedById,
     /// The [`RecordArchivedById`] of the [`ProvenanceMetadata`] belonging to the [`EntityType`].
     ///
+    /// ```rust
+    /// # use serde::Deserialize;
+    /// # use serde_json::json;
+    /// # use graph::ontology::EntityTypeQueryPath;
+    /// let path = EntityTypeQueryPath::deserialize(json!(["recordArchivedById"]))?;
+    /// assert_eq!(path, EntityTypeQueryPath::RecordArchivedById);
+    /// # Ok::<(), serde_json::Error>(())
+    /// ```
+    ///
     /// [`EntityType`]: type_system::EntityType
     /// [`RecordArchivedById`]: crate::provenance::RecordArchivedById
     /// [`ProvenanceMetadata`]: crate::provenance::ProvenanceMetadata
@@ -449,6 +458,7 @@ pub enum EntityTypeQueryToken {
     VersionedUrl,
     OwnedById,
     RecordCreatedById,
+    RecordArchivedById,
     Title,
     Description,
     Examples,
@@ -469,9 +479,9 @@ pub struct EntityTypeQueryPathVisitor {
 
 impl EntityTypeQueryPathVisitor {
     pub const EXPECTING: &'static str = "one of `baseUrl`, `version`, `versionedUrl`, \
-                                         `ownedById`, `recordCreatedById`, `title`, \
-                                         `description`, `examples`, `properties`, `required`, \
-                                         `labelProperty`, `links`, `inheritsFrom`";
+                                         `ownedById`, `recordCreatedById`, `recordArchivedById`, \
+                                         `title`, `description`, `examples`, `properties`, \
+                                         `required`, `labelProperty`, `links`, `inheritsFrom`";
 
     #[must_use]
     pub const fn new(position: usize) -> Self {
@@ -498,6 +508,7 @@ impl<'de> Visitor<'de> for EntityTypeQueryPathVisitor {
         Ok(match token {
             EntityTypeQueryToken::OwnedById => EntityTypeQueryPath::OwnedById,
             EntityTypeQueryToken::RecordCreatedById => EntityTypeQueryPath::RecordCreatedById,
+            EntityTypeQueryToken::RecordArchivedById => EntityTypeQueryPath::RecordArchivedById,
             EntityTypeQueryToken::BaseUrl => EntityTypeQueryPath::BaseUrl,
             EntityTypeQueryToken::VersionedUrl => EntityTypeQueryPath::VersionedUrl,
             EntityTypeQueryToken::Version => EntityTypeQueryPath::Version,

--- a/apps/hash-graph/lib/graph/src/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/property_type.rs
@@ -104,6 +104,15 @@ pub enum PropertyTypeQueryPath<'p> {
     RecordCreatedById,
     /// The [`RecordArchivedById`] of the [`ProvenanceMetadata`] belonging to the [`PropertyType`].
     ///
+    /// ```rust
+    /// # use serde::Deserialize;
+    /// # use serde_json::json;
+    /// # use graph::ontology::PropertyTypeQueryPath;
+    /// let path = PropertyTypeQueryPath::deserialize(json!(["recordArchivedById"]))?;
+    /// assert_eq!(path, PropertyTypeQueryPath::RecordArchivedById);
+    /// # Ok::<(), serde_json::Error>(())
+    /// ```
+    ///
     /// [`PropertyType`]: type_system::PropertyType
     /// [`RecordArchivedById`]: crate::provenance::RecordArchivedById
     /// [`ProvenanceMetadata`]: crate::provenance::ProvenanceMetadata
@@ -349,6 +358,7 @@ pub enum PropertyTypeQueryToken {
     VersionedUrl,
     OwnedById,
     RecordCreatedById,
+    RecordArchivedById,
     Title,
     Description,
     DataTypes,
@@ -365,8 +375,8 @@ pub struct PropertyTypeQueryPathVisitor {
 
 impl PropertyTypeQueryPathVisitor {
     pub const EXPECTING: &'static str = "one of `baseUrl`, `version`, `versionedUrl`, \
-                                         `ownedById`, `recordCreatedById`, `title`, \
-                                         `description`, `dataTypes`, `propertyTypes`";
+                                         `ownedById`, `recordCreatedById`, `recordArchivedById`, \
+                                         `title`, `description`, `dataTypes`, `propertyTypes`";
 
     #[must_use]
     pub const fn new(position: usize) -> Self {
@@ -393,6 +403,7 @@ impl<'de> Visitor<'de> for PropertyTypeQueryPathVisitor {
         Ok(match token {
             PropertyTypeQueryToken::OwnedById => PropertyTypeQueryPath::OwnedById,
             PropertyTypeQueryToken::RecordCreatedById => PropertyTypeQueryPath::RecordCreatedById,
+            PropertyTypeQueryToken::RecordArchivedById => PropertyTypeQueryPath::RecordArchivedById,
             PropertyTypeQueryToken::BaseUrl => PropertyTypeQueryPath::BaseUrl,
             PropertyTypeQueryToken::VersionedUrl => PropertyTypeQueryPath::VersionedUrl,
             PropertyTypeQueryToken::Version => PropertyTypeQueryPath::Version,

--- a/apps/hash-graph/lib/graph/src/shared/provenance.rs
+++ b/apps/hash-graph/lib/graph/src/shared/provenance.rs
@@ -69,6 +69,6 @@ define_provenance_id!(RecordArchivedById);
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct ProvenanceMetadata {
     pub record_created_by_id: RecordCreatedById,
-    #[serde(skip)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub record_archived_by_id: Option<RecordArchivedById>,
 }

--- a/apps/hash-graph/openapi/openapi.json
+++ b/apps/hash-graph/openapi/openapi.json
@@ -1230,6 +1230,7 @@
           "versionedUrl",
           "ownedById",
           "recordCreatedById",
+          "recordArchivedById",
           "title",
           "description",
           "type"
@@ -1516,6 +1517,7 @@
           "versionedUrl",
           "ownedById",
           "recordCreatedById",
+          "recordArchivedById",
           "title",
           "description",
           "examples",
@@ -2336,6 +2338,7 @@
           "versionedUrl",
           "ownedById",
           "recordCreatedById",
+          "recordArchivedById",
           "title",
           "description",
           "dataTypes",
@@ -2397,6 +2400,14 @@
           "recordCreatedById"
         ],
         "properties": {
+          "recordArchivedById": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RecordArchivedById"
+              }
+            ],
+            "nullable": true
+          },
           "recordCreatedById": {
             "$ref": "#/components/schemas/RecordCreatedById"
           }

--- a/libs/@local/hash-subgraph/src/types/shared.ts
+++ b/libs/@local/hash-subgraph/src/types/shared.ts
@@ -1,8 +1,9 @@
-import { RecordCreatedById } from "./shared/branded";
+import { RecordArchivedById, RecordCreatedById } from "./shared/branded";
 
 export * from "./shared/branded";
 export * from "./shared/temporal-versioning";
 
 export type ProvenanceMetadata = {
   recordCreatedById: RecordCreatedById;
+  recordArchivedById?: RecordArchivedById;
 };

--- a/libs/@local/hash-subgraph/src/types/shared/branded.ts
+++ b/libs/@local/hash-subgraph/src/types/shared/branded.ts
@@ -66,6 +66,9 @@ export const extractEntityUuidFromEntityId = (
 /** An account ID of an actor that has created a record */
 export type RecordCreatedById = Brand<AccountId, "RecordCreatedById">;
 
+/** An account ID of an actor that has created a record */
+export type RecordArchivedById = Brand<AccountId, "RecordArchivedById">;
+
 /** An `EntityId` which is the base of an Account Entity */
 export type AccountEntityId = Brand<EntityId, "AccountEntityId">;
 

--- a/libs/@local/hash-subgraph/tests/compatibility.test/map-vertices.ts
+++ b/libs/@local/hash-subgraph/tests/compatibility.test/map-vertices.ts
@@ -38,6 +38,7 @@ import {
   OntologyTypeRecordId,
   OntologyVertex,
   ProvenanceMetadata,
+  RecordArchivedById,
   RecordCreatedById,
   Timestamp,
   Vertices,
@@ -104,6 +105,7 @@ const mapProvenanceMetadata = (
 ): ProvenanceMetadata => {
   return {
     recordCreatedById: metadata.recordCreatedById as RecordCreatedById,
+    recordArchivedById: metadata.recordArchivedById as RecordArchivedById,
   };
 };
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`RecordArchivedById ` is available in the Graph and can easily be exposed to the backend. Making it queryable from structural queries is also easy to just enable it.

## 🚫 Blocked by

- #2856 

## Pre-Merge Checklist :rocket:

### :ship: Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### :scroll: Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### :spider_web: Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph