### PR TITLE
H-312: Temporarily hide 'use HASH' CTA on roadmap page

### DIFF
--- a/apps/hashdotdev/src/pages/roadmap.page.tsx
+++ b/apps/hashdotdev/src/pages/roadmap.page.tsx
@@ -166,52 +166,52 @@ const GetInvolved: FunctionComponent = () => (
       />
       Become an early adopter
     </Typography>
-    <Typography marginBottom={1}>
-      <strong>Interested in using HASH?</strong>
-    </Typography>
-    <Box
-      component="ul"
-      sx={{
-        marginTop: 0,
-        marginBottom: 2,
-        listStyle: "none",
-        paddingLeft: 0,
-        "> li": {
-          marginBottom: 0.5,
-          svg: {
-            position: "relative",
-            top: 7,
-            marginRight: 2,
-            fontSize: 16,
-          },
-        },
-      }}
-    >
-      <Box component="li" display="flex">
-        <FaIcon name="arrow-right" type="regular" />
-        <Typography>
-          <Link href="https://app.hash.ai/signup" openInNew>
-            <strong>Create an account</strong>
-          </Link>{" "}
-          to try out the hosted version of HASH
-        </Typography>
-      </Box>
-      <Box component="li" display="flex">
-        <FaIcon name="arrow-right" type="regular" />
-        <Typography>
-          View the developer docs to{" "}
-          <Link href="https://github.com/hashintel/hash" openInNew>
-            <strong>self-host HASH</strong>
-          </Link>
-          .
-        </Typography>
-      </Box>
-    </Box>
+    {/* <Typography marginBottom={1}> */}
+    {/*  <strong>Interested in using HASH?</strong> */}
+    {/* </Typography> */}
+    {/* <Box */}
+    {/*  component="ul" */}
+    {/*  sx={{ */}
+    {/*    marginTop: 0, */}
+    {/*    marginBottom: 2, */}
+    {/*    listStyle: "none", */}
+    {/*    paddingLeft: 0, */}
+    {/*    "> li": { */}
+    {/*      marginBottom: 0.5, */}
+    {/*      svg: { */}
+    {/*        position: "relative", */}
+    {/*        top: 7, */}
+    {/*        marginRight: 2, */}
+    {/*        fontSize: 16, */}
+    {/*      }, */}
+    {/*    }, */}
+    {/*  }} */}
+    {/* > */}
+    {/*  <Box component="li" display="flex"> */}
+    {/*    <FaIcon name="arrow-right" type="regular" /> */}
+    {/*    <Typography> */}
+    {/*      <Link href="https://app.hash.ai/signup" openInNew> */}
+    {/*        <strong>Create an account</strong> */}
+    {/*      </Link>{" "} */}
+    {/*      to try out the hosted version of HASH */}
+    {/*    </Typography> */}
+    {/*  </Box> */}
+    {/*  <Box component="li" display="flex"> */}
+    {/*    <FaIcon name="arrow-right" type="regular" /> */}
+    {/*    <Typography> */}
+    {/*      View the developer docs to{" "} */}
+    {/*      <Link href="https://github.com/hashintel/hash" openInNew> */}
+    {/*        <strong>self-host HASH</strong> */}
+    {/*      </Link> */}
+    {/*      . */}
+    {/*    </Typography> */}
+    {/*  </Box> */}
+    {/* </Box> */}
     <Typography marginBottom={1}>
       <strong>Got a use case in mind?</strong>
     </Typography>
     <Typography>
-      Discuss your use case with us, or get support by{" "}
+      Discuss your use case by {/* , or get support by{" "} */}
       <Link href="https://hash.ai/contact" openInNew>
         <strong>contacting us</strong>
       </Link>{" "}
@@ -232,18 +232,18 @@ const GetInvolved: FunctionComponent = () => (
       >
         <Typography>Join our Discord</Typography>
       </Button>
-      <Button
-        variant="primarySquare"
-        size="medium"
-        color="blue"
-        href="https://app.hash.ai"
-        startIcon={<FaIcon name="arrow-right-to-bracket" type="solid" />}
-        sx={{ width: { xs: "100%", sm: "auto" } }}
-      >
-        <Typography>
-          Use at <strong>app.hash.ai</strong>
-        </Typography>
-      </Button>
+      {/* <Button */}
+      {/*  variant="primarySquare" */}
+      {/*  size="medium" */}
+      {/*  color="blue" */}
+      {/*  href="https://app.hash.ai" */}
+      {/*  startIcon={<FaIcon name="arrow-right-to-bracket" type="solid" />} */}
+      {/*  sx={{ width: { xs: "100%", sm: "auto" } }} */}
+      {/* > */}
+      {/*  <Typography> */}
+      {/*    Use at <strong>app.hash.ai</strong> */}
+      {/*  </Typography> */}
+      {/* </Button> */}
       <Button
         variant="primarySquare"
         size="medium"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The live site is not quite ready for people to try out. This PR hides the CTA to do so on the hash.dev roadmap page until it is.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
![Screenshot 2023-08-04 at 13 56 50](https://github.com/hashintel/hash/assets/37743469/982f9a7d-fab8-49e0-a719-827aa5b63593)
