### PR TITLE
H-76: Display header on canvas pages

### DIFF
--- a/apps/hash-frontend/src/pages/[shortname]/[page-slug].page/canvas-page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/[page-slug].page/canvas-page.tsx
@@ -6,6 +6,7 @@ import {
   ComponentIdHashBlockMap,
   fetchBlock,
 } from "@local/hash-isomorphic-utils/blocks";
+import { Box } from "@mui/material";
 import { TldrawEditorConfig } from "@tldraw/editor";
 import {
   App,
@@ -20,6 +21,8 @@ import { useEffect, useState } from "react";
 
 import { useUserBlocks } from "../../../blocks/user-blocks";
 import { PageContentItem } from "../../../graphql/api-types.gen";
+import { HEADER_HEIGHT } from "../../../shared/layout/layout-with-header/page-header";
+import { TOP_CONTEXT_BAR_HEIGHT } from "../../shared/top-context-bar";
 import { BlockCreationDialog } from "./canvas-page/block-creation-dialog";
 import { BlockShapeDef, BlockTool } from "./canvas-page/block-shape";
 import { LockedCanvas } from "./canvas-page/locked-canvas";
@@ -121,7 +124,12 @@ export const CanvasPageBlock = ({
   };
 
   return (
-    <div style={{ height: "100%", width: "100%", position: "absolute" }}>
+    <Box
+      sx={{
+        height: `calc(100vh - ${HEADER_HEIGHT}px - ${TOP_CONTEXT_BAR_HEIGHT}px)`,
+        width: "100%",
+      }}
+    >
       <Tldraw
         config={config}
         onMount={handleMount}
@@ -158,6 +166,6 @@ export const CanvasPageBlock = ({
           },
         }}
       />
-    </div>
+    </Box>
   );
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR adjusts the height of the TLDraw canvas component so that the relevant headers remain in view on the page.


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Checkout the branch, login, and view a page in canvas mode to ensure that the headers remain visible

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

<img width="1258" alt="image" src="https://github.com/hashintel/hash/assets/42802102/6f1b1da6-f431-4a2c-b57a-7dafeff4990b">
