### PR TITLE
H-69: Move the "archived page" banner above the page/canvas switcher bar

### DIFF
--- a/apps/hash-frontend/src/pages/[shortname]/[page-slug].page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/[page-slug].page.tsx
@@ -403,6 +403,7 @@ const Page: NextPageWithLayout<PageProps> = ({
             backgroundColor: palette.white,
           })}
         >
+          <PageNotificationBanner archived={!!archived} />
           <TopContextBar
             crumbs={generateCrumbsFromPages({
               pages: accountPages,
@@ -412,7 +413,6 @@ const Page: NextPageWithLayout<PageProps> = ({
             isBlockPage
             scrollToTop={scrollToTop}
           />
-          <PageNotificationBanner archived={!!archived} />
         </Box>
 
         {!canvasPage && (


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR moves the `PageNotificationBanner` above the `TopContextBar` component, so that the "archived page" banner appears above the page/canvas switcher bar.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Checkout the branch locally, archive a page, and ensure the "This pages is archived" banner appears above the page/canvas switcher.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

<img width="1257" alt="image" src="https://github.com/hashintel/hash/assets/42802102/0b9719c4-f347-4027-b5ad-e48553b7b8bd">

