### PR TITLE
H-71: When creating new page, start text cursor in title, not body

### DIFF
--- a/apps/hash-frontend/src/blocks/page/component-view.tsx
+++ b/apps/hash-frontend/src/blocks/page/component-view.tsx
@@ -92,6 +92,7 @@ export class ComponentView implements NodeView {
     private readonly block: HashBlock,
     private readonly manager: ProsemirrorManager,
     private readonly readonly: boolean,
+    private readonly isInitialPageTitleEmpty: boolean,
   ) {
     this.dom.setAttribute("data-dom", "true");
     this.contentDOM.setAttribute("data-contentDOM", "true");
@@ -100,6 +101,8 @@ export class ComponentView implements NodeView {
     this.dom.appendChild(this.target);
 
     this.dom.contentEditable = "false";
+
+    this.isInitialPageTitleEmpty = isInitialPageTitleEmpty;
 
     this.store = entityStorePluginState(editorView.state).store;
     this.unsubscribe = subscribeToEntityStore(this.editorView, (store) => {
@@ -271,7 +274,8 @@ export class ComponentView implements NodeView {
     const isTheOnlyChild = this.editorView.state.doc.childCount === 1;
     const isEmpty = this.node.content.size === 0;
 
-    const shouldFocusOnLoad = isParagraph && isTheOnlyChild && isEmpty;
+    const shouldFocusOnLoad =
+      isParagraph && isTheOnlyChild && isEmpty && !this.isInitialPageTitleEmpty;
 
     if (shouldFocusOnLoad) {
       this.editorView.focus();

--- a/apps/hash-frontend/src/blocks/page/create-editor-view.ts
+++ b/apps/hash-frontend/src/blocks/page/create-editor-view.ts
@@ -197,6 +197,8 @@ export const createEditorView = (
         throw new Error("Invalid config for nodeview");
       }
 
+      const isInitialPageTitleEmpty = pageTitleRef.current?.value === "";
+
       return new ComponentView(
         node,
         editorView,
@@ -205,6 +207,7 @@ export const createEditorView = (
         block,
         manager,
         readonly,
+        isInitialPageTitleEmpty,
       );
     },
   );

--- a/apps/hash-frontend/src/blocks/page/page-title/page-title.tsx
+++ b/apps/hash-frontend/src/blocks/page/page-title/page-title.tsx
@@ -5,6 +5,7 @@ import {
   FocusEventHandler,
   FunctionComponent,
   KeyboardEventHandler,
+  useEffect,
   useState,
 } from "react";
 
@@ -108,6 +109,12 @@ export const PageTitle: FunctionComponent<PageTitleProps> = ({
     setPrevValue(value);
     setInputValue(value);
   }
+
+  useEffect(() => {
+    if (pageTitleRef.current && pageTitleRef.current.value === "") {
+      pageTitleRef.current.focus();
+    }
+  }, [pageTitleRef]);
 
   // TODO: Assign appropriate a11y attributes
   return (


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR focuses the title input of a page when it is empty, instead of always focusing the first empty paragraph.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Create a new page and ensure the title is focused instead of the body. Then check a page with a filled title, and ensure the body is focused instead.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->


https://github.com/hashintel/hash/assets/42802102/cc2ebe72-db5d-418a-a81d-27ccd7c86587


