### PR TITLE
H-364: Work around that subgraph can only contain a single ontology type per versioned URL

### DIFF
--- a/apps/hash-graph/lib/graph/src/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/ontology.rs
@@ -393,6 +393,22 @@ pub enum CustomOntologyMetadata {
     },
 }
 
+impl CustomOntologyMetadata {
+    #[must_use]
+    pub const fn temporal_versioning(&self) -> &OntologyTemporalMetadata {
+        match self {
+            Self::Owned {
+                temporal_versioning,
+                ..
+            }
+            | Self::External {
+                temporal_versioning,
+                ..
+            } => temporal_versioning,
+        }
+    }
+}
+
 /// An [`OntologyElementMetadata`] that has not yet been fully resolved.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PartialOntologyElementMetadata {

--- a/apps/hash-graph/lib/graph/src/subgraph.rs
+++ b/apps/hash-graph/lib/graph/src/subgraph.rs
@@ -54,7 +54,9 @@ impl Subgraph {
         }
     }
 
-    fn vertex_entry_mut<R: Record>(
+    // TODO: Make private again
+    //   see https://linear.app/hash/issue/H-297
+    pub fn vertex_entry_mut<R: Record>(
         &mut self,
         vertex_id: &R::VertexId,
     ) -> RawEntryMut<R::VertexId, R, RandomState> {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

With archived types it's possible to have multiple types returned but the subgraph layout does not support this. The subgraph is supposed to only return the most recent record.

## 🔗 Related links

- [Slack thread](https://hashintel.slack.com/archives/C022217GAHF/p1691592695326169) _(internal)_

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph