### PR TITLE
GEN-37: Combine `IntoReport` and `ResultExt`

### DIFF
--- a/libs/error-stack/CHANGELOG.md
+++ b/libs/error-stack/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to `error-stack` will be documented in this file.
 
 - Support for [`defmt`](https://defmt.ferrous-systems.com)
 
+## 0.4.0 - unreleased
+
+### Breaking Changes
+
+- Add `ResultExt::Context` as associated type ([#2883](https://github.com/hashintel/hash/pull/2883))
+
+### Features
+
+- Implement `ResultExt` for `Result` even if the `Err`-variant is not `Report<C>` but only `C: Context` ([#2883](https://github.com/hashintel/hash/pull/2883))
+
+### Deprecations
+
+- `IntoReport`: Use `ReportExt` or `From` via `Result::map_err(Report::from)` instead ([#2883](https://github.com/hashintel/hash/pull/2883))
+
 ## [0.3.1](https://github.com/hashintel/hash/tree/error-stack%400.3.1/libs/error-stack) - 2023-02-08
 
 - Fix multiline attachments not being aligned ([#2022](https://github.com/hashintel/hash/pull/2022))

--- a/libs/error-stack/README.md
+++ b/libs/error-stack/README.md
@@ -26,7 +26,7 @@ The library enables building a `Report` around an error as it propagates:
 ```rust
 use std::fmt;
 
-use error_stack::{Context, IntoReport, Report, Result, ResultExt};
+use error_stack::{Context, Report, Result, ResultExt};
 
 #[derive(Debug)]
 struct ParseExperimentError;
@@ -41,8 +41,7 @@ impl Context for ParseExperimentError {}
 
 fn parse_experiment(description: &str) -> Result<(u64, u64), ParseExperimentError> {
     let value = description
-        .parse()
-        .into_report()
+        .parse::<u64>()
         .attach_printable_lazy(|| format!("{description:?} could not be parsed as experiment"))
         .change_context(ParseExperimentError)?;
 
@@ -97,11 +96,11 @@ This will most likely result in an error and print
 
 <pre>
 Error: <b>experiment error: could not run experiment</b>
-&#x251C;&#x2574;at <i>examples/demo.rs:51:18</i>
+&#x251C;&#x2574;at <i>examples/demo.rs:50:18</i>
 &#x251C;&#x2574;unable to set up experiments
 &#x2502;
 &#x251C;&#x2500;&#x25B6; <b>invalid experiment description</b>
-&#x2502;   &#x251C;&#x2574;at <i>examples/demo.rs:21:10</i>
+&#x2502;   &#x251C;&#x2574;at <i>examples/demo.rs:20:10</i>
 &#x2502;   &#x2570;&#x2574;experiment 2 could not be parsed
 &#x2502;
 &#x2570;&#x2500;&#x25B6; <b>invalid digit found in string</b>
@@ -113,23 +112,27 @@ Error: <b>experiment error: could not run experiment</b>
 
 backtrace no. 1
    0: std::backtrace_rs::backtrace::libunwind::trace
-             at /rustc/e972bc8083d5228536dfd42913c8778b6bb04c8e/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
+             at /rustc/f3623871cfa0763c95ebd6ceafaa6dc2e44ca68f/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
    1: std::backtrace_rs::backtrace::trace_unsynchronized
-             at /rustc/e972bc8083d5228536dfd42913c8778b6bb04c8e/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
+             at /rustc/f3623871cfa0763c95ebd6ceafaa6dc2e44ca68f/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
    2: std::backtrace::Backtrace::create
-             at /rustc/e972bc8083d5228536dfd42913c8778b6bb04c8e/library/std/src/backtrace.rs:332:13
+             at /rustc/f3623871cfa0763c95ebd6ceafaa6dc2e44ca68f/library/std/src/backtrace.rs:331:13
    3: core::ops::function::FnOnce::call_once
-             at /rustc/e972bc8083d5228536dfd42913c8778b6bb04c8e/library/core/src/ops/function.rs:250:5
+             at /rustc/f3623871cfa0763c95ebd6ceafaa6dc2e44ca68f/library/core/src/ops/function.rs:250:5
    4: core::bool::&lt;impl bool&gt;::then
-             at /rustc/e972bc8083d5228536dfd42913c8778b6bb04c8e/library/core/src/bool.rs:71:24
+             at /rustc/f3623871cfa0763c95ebd6ceafaa6dc2e44ca68f/library/core/src/bool.rs:60:24
    5: error_stack::report::Report&lt;C&gt;::from_frame
-             at ./src/report.rs:288:25
+             at ./src/report.rs:286:25
    6: error_stack::report::Report&lt;C&gt;::new
-             at ./src/report.rs:274:9
-   7: error_stack::context::&lt;impl core::convert::From&lt;C&gt; for error_stack::report::Report&lt;C&gt;&gt;::from
+             at ./src/report.rs:272:9
+   7: error_stack::context::&lt;impl core::convert::From&lt;C&lt; for error_stack::report::Report&lt;C&gt;&gt;::from
              at ./src/context.rs:83:9
-   8: &lt;core::result::Result&lt;T,E&gt; as error_stack::result::IntoReport&gt;::into_report
-             at ./src/result.rs:203:31
+   8: &lt;core::result::Result&lt;T,C&lt; as error_stack::result::ResultExt&lt;::attach_printable_lazy
+             at ./src/result.rs:158:31
+   9: demo::parse_experiment
+             at demo.rs:17:17
+  10: demo::start_experiments::{{closure}}
+             at demo.rs:48:30
    (<b>For this example:</b> additional frames have been removed)
 </pre>
 

--- a/libs/error-stack/examples/demo.rs
+++ b/libs/error-stack/examples/demo.rs
@@ -12,7 +12,7 @@
 
 use std::fmt;
 
-use error_stack::{Context, IntoReport, Report, Result, ResultExt};
+use error_stack::{Context, Report, Result, ResultExt};
 
 #[derive(Debug)]
 struct ParseExperimentError;
@@ -33,7 +33,6 @@ fn parse_experiment(description: &str) -> Result<Vec<(u64, u64)>, ParseExperimen
         .map(|value| {
             value
                 .parse::<u64>()
-                .into_report()
                 .attach_printable_lazy(|| format!("{value:?} could not be parsed as experiment"))
         })
         .map(|value| value.map(|ok| (ok, 2 * ok)))

--- a/libs/error-stack/examples/parse_config.rs
+++ b/libs/error-stack/examples/parse_config.rs
@@ -12,7 +12,7 @@
 
 use std::{fmt, fs, path::Path};
 
-use error_stack::{Context, IntoReport, Report, ResultExt};
+use error_stack::{Context, Report, ResultExt};
 
 pub type Config = String;
 
@@ -40,7 +40,6 @@ fn parse_config(path: impl AsRef<Path>) -> Result<Config, Report<ParseConfigErro
     let path = path.as_ref();
 
     let content = fs::read_to_string(path)
-        .into_report()
         .change_context(ParseConfigError::new())
         .attach(Suggestion("use a file you can read next time!"))
         .attach_printable_lazy(|| format!("could not read file {path:?}"))?;

--- a/libs/error-stack/src/compat.rs
+++ b/libs/error-stack/src/compat.rs
@@ -13,13 +13,12 @@ mod eyre;
 
 /// Compatibility trait to convert from external libraries to [`Report`].
 ///
-/// *Note*: It's not possible to implement [`IntoReport`] or [`Context`] on other error libraries'
-/// types as both traits have blanket implementation relying on [`Error`]. Thus, implementing either
-/// trait would violate the orphan rule; the upstream crate could implement [`Error`] and this would
-/// imply an implementation for [`IntoReport`]/[`Context`].
+/// *Note*: It's not possible to implement [`Context`] on other error libraries' types as the trait
+/// has a blanket implementation relying on [`Error`]. Thus, implementing the trait would violate
+/// the orphan rule; the upstream crate could implement [`Error`] and this would imply an
+/// implementation for [`Context`].
 ///
 /// [`Report`]: crate::Report
-/// [`IntoReport`]: crate::IntoReport
 /// [`Context`]: crate::Context
 /// [`Error`]: core::error::Error
 pub trait IntoReportCompat: Sized {

--- a/libs/error-stack/src/compat.rs
+++ b/libs/error-stack/src/compat.rs
@@ -13,12 +13,14 @@ mod eyre;
 
 /// Compatibility trait to convert from external libraries to [`Report`].
 ///
-/// *Note*: It's not possible to implement [`Context`] on other error libraries' types as the trait
-/// has a blanket implementation relying on [`Error`]. Thus, implementing the trait would violate
-/// the orphan rule; the upstream crate could implement [`Error`] and this would imply an
-/// implementation for [`Context`].
+/// **Note**: It's not possible to implement [`Context`] on other error libraries' types from within
+/// `error-stack` as the trait has a blanket implementation relying on [`Error`]. Thus, implementing
+/// the trait would violate the orphan rule; the upstream crate could implement [`Error`] and this
+/// would imply an implementation for [`Context`]. This also implies, that it's not possible to
+/// implement [`ResultExt`] from within `error-stack`.
 ///
-/// [`Report`]: crate::Report
+/// [`Report`]: Report
+/// [`ResultExt`]: crate::ResultExt
 /// [`Context`]: crate::Context
 /// [`Error`]: core::error::Error
 pub trait IntoReportCompat: Sized {

--- a/libs/error-stack/src/context.rs
+++ b/libs/error-stack/src/context.rs
@@ -23,7 +23,7 @@ use crate::Report;
 /// # #![cfg_attr(any(not(feature = "std"), miri), allow(unused_imports))]
 /// use std::{fmt, fs, io};
 ///
-/// use error_stack::{Context, IntoReport, Result, ResultExt};
+/// use error_stack::{Context, Result, ResultExt, Report};
 ///
 /// # type Config = ();
 /// #[derive(Debug)]
@@ -49,7 +49,7 @@ use crate::Report;
 /// # #[cfg(all(feature = "std", not(miri)))]
 /// pub fn read_file(path: &str) -> Result<String, io::Error> {
 ///     // Creates a `Report` from `io::Error`, the current context is `io::Error`
-///     fs::read_to_string(path).into_report()
+///     fs::read_to_string(path).map_err(Report::from)
 /// }
 ///
 /// pub fn parse_config(path: &str) -> Result<Config, ConfigError> {

--- a/libs/error-stack/src/future.rs
+++ b/libs/error-stack/src/future.rs
@@ -101,28 +101,28 @@ implement_future_adaptor!(
     FutureWithAttachment,
     attach,
     Send + Sync + 'static,
-    Fut::Output
+    Result<<Fut::Output as ResultExt>::Ok, <Fut::Output as ResultExt>::Context>
 );
 
 implement_lazy_future_adaptor!(
     FutureWithLazyAttachment,
     attach_lazy,
     Send + Sync + 'static,
-    Fut::Output
+    Result<<Fut::Output as ResultExt>::Ok, <Fut::Output as ResultExt>::Context>
 );
 
 implement_future_adaptor!(
     FutureWithPrintableAttachment,
     attach_printable,
     Display + Debug + Send + Sync + 'static,
-    Fut::Output
+    Result<<Fut::Output as ResultExt>::Ok, <Fut::Output as ResultExt>::Context>
 );
 
 implement_lazy_future_adaptor!(
     FutureWithLazyPrintableAttachment,
     attach_printable_lazy,
     Display + Debug + Send + Sync + 'static,
-    Fut::Output
+    Result<<Fut::Output as ResultExt>::Ok, <Fut::Output as ResultExt>::Context>
 );
 
 implement_future_adaptor!(

--- a/libs/error-stack/src/lib.rs
+++ b/libs/error-stack/src/lib.rs
@@ -228,7 +228,7 @@
 //! ```rust
 //! # #![cfg_attr(not(feature = "std"), allow(dead_code, unused_variables, unused_imports))]
 //! # use std::{fs, path::Path};
-//! # use error_stack::{Report};
+//! # use error_stack::Report;
 //! # pub type Config = String;
 //!
 //! fn parse_configs(paths: &[impl AsRef<Path>]) -> Result<Vec<Config>, Report<std::io::Error>> {

--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -427,7 +427,7 @@ impl<C> Report<C> {
     /// # #[cfg(all(feature = "std", not(miri)))] {
     /// use std::{fmt, fs};
     ///
-    /// use error_stack::{ResultExt};
+    /// use error_stack::ResultExt;
     ///
     /// #[derive(Debug)]
     /// pub struct Suggestion(&'static str);

--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -83,13 +83,12 @@ use crate::{
 ///
 /// ```
 /// # #[cfg(all(not(miri), feature = "std"))] {
-/// use error_stack::{IntoReport, ResultExt, Result};
+/// use error_stack::{ResultExt, Result};
 ///
 /// # #[allow(dead_code)]
 /// # fn fake_main() -> Result<String, std::io::Error> {
 /// let config_path = "./path/to/config.file";
 /// let content = std::fs::read_to_string(config_path)
-///     .into_report()
 ///     .attach_printable_lazy(|| format!("failed to read config file {config_path:?}"))?;
 ///
 /// # const _: &str = stringify! {
@@ -104,7 +103,7 @@ use crate::{
 /// use std::{fmt, path::{Path, PathBuf}};
 ///
 /// # #[cfg_attr(any(miri, not(feature = "std")), allow(unused_imports))]
-/// use error_stack::{Context, IntoReport, Report, ResultExt};
+/// use error_stack::{Context, Report, ResultExt};
 ///
 /// #[derive(Debug)]
 /// # #[derive(PartialEq)]
@@ -151,7 +150,7 @@ use crate::{
 ///     # #[cfg(any(miri, not(feature = "std")))]
 ///     # return Err(error_stack::report!(ConfigError::IoError).attach_printable("Not supported"));
 ///     # #[cfg(all(not(miri), feature = "std"))]
-///     std::fs::read_to_string(path.as_ref()).into_report().change_context(ConfigError::IoError)
+///     std::fs::read_to_string(path.as_ref()).change_context(ConfigError::IoError)
 /// }
 ///
 /// fn main() -> Result<(), Report<RuntimeError>> {
@@ -213,13 +212,12 @@ use crate::{
 /// ## Get the attached [`Backtrace`] and [`SpanTrace`]:
 ///
 /// ```should_panic
-/// use error_stack::{IntoReport, ResultExt, Result};
+/// use error_stack::{ResultExt, Result};
 ///
 /// # #[allow(unused_variables)]
 /// # fn main() -> Result<(), std::io::Error> {
 /// let config_path = "./path/to/config.file";
 /// let content = std::fs::read_to_string(config_path)
-///     .into_report()
 ///     .attach_printable_lazy(|| format!("failed to read config file {config_path:?}"));
 ///
 /// let content = match content {
@@ -341,7 +339,7 @@ impl<C> Report<C> {
     ///     path::Path,
     /// };
     ///
-    /// use error_stack::{Context, Report, IntoReport, ResultExt};
+    /// use error_stack::{Context, Report, ResultExt};
     ///
     /// #[derive(Debug)]
     /// struct IoError;
@@ -363,7 +361,6 @@ impl<C> Report<C> {
     ///     # return Err(error_stack::report!(IoError).attach_printable("Not supported"));
     ///     # #[cfg(all(not(miri), feature = "std"))]
     ///     std::fs::read_to_string(path.as_ref())
-    ///         .into_report()
     ///         .change_context(IoError)
     /// }
     ///
@@ -430,7 +427,7 @@ impl<C> Report<C> {
     /// # #[cfg(all(feature = "std", not(miri)))] {
     /// use std::{fmt, fs};
     ///
-    /// use error_stack::{IntoReport, ResultExt};
+    /// use error_stack::{ResultExt};
     ///
     /// #[derive(Debug)]
     /// pub struct Suggestion(&'static str);
@@ -442,7 +439,6 @@ impl<C> Report<C> {
     /// }
     ///
     /// let error = fs::read_to_string("config.txt")
-    ///     .into_report()
     ///     .attach(Suggestion("better use a file which exists next time!"));
     /// # #[cfg_attr(not(nightly), allow(unused_variables))]
     /// let report = error.unwrap_err();
@@ -542,12 +538,12 @@ impl<C> Report<C> {
     /// ```rust
     /// # #[cfg(all(not(miri), feature = "std"))] {
     /// # use std::{fs, io, path::Path};
-    /// # use error_stack::{IntoReport, Report};
+    /// # use error_stack::Report;
     /// fn read_file(path: impl AsRef<Path>) -> Result<String, Report<io::Error>> {
     ///     # const _: &str = stringify! {
     ///     ...
     ///     # };
-    ///     # fs::read_to_string(path.as_ref()).into_report()
+    ///     # fs::read_to_string(path.as_ref()).map_err(Report::from)
     /// }
     ///
     /// let report = read_file("test.txt").unwrap_err();
@@ -569,14 +565,14 @@ impl<C> Report<C> {
     /// ```rust
     /// # #[cfg(all(not(miri), feature = "std"))] {
     /// # use std::{fs, path::Path};
-    /// # use error_stack::{IntoReport, Report};
+    /// # use error_stack::Report;
     /// use std::io;
     ///
     /// fn read_file(path: impl AsRef<Path>) -> Result<String, Report<io::Error>> {
     ///     # const _: &str = stringify! {
     ///     ...
     ///     # };
-    ///     # fs::read_to_string(path.as_ref()).into_report()
+    ///     # fs::read_to_string(path.as_ref()).map_err(Report::from)
     /// }
     ///
     /// let report = read_file("test.txt").unwrap_err();
@@ -612,14 +608,14 @@ impl<C> Report<C> {
     /// ```rust
     /// # #[cfg(all(not(miri), feature = "std"))] {
     /// # use std::{fs, path::Path};
-    /// # use error_stack::{IntoReport, Report};
+    /// # use error_stack::Report;
     /// use std::io;
     ///
     /// fn read_file(path: impl AsRef<Path>) -> Result<String, Report<io::Error>> {
     ///     # const _: &str = stringify! {
     ///     ...
     ///     # };
-    ///     # fs::read_to_string(path.as_ref()).into_report()
+    ///     # fs::read_to_string(path.as_ref()).map_err(Report::from)
     /// }
     ///
     /// let report = read_file("test.txt").unwrap_err();

--- a/libs/error-stack/src/result.rs
+++ b/libs/error-stack/src/result.rs
@@ -43,22 +43,26 @@ pub type Result<T, C> = core::result::Result<T, Report<C>>;
 /// Extension trait for [`Result`][core::result::Result] to provide context information on
 /// [`Report`]s.
 pub trait ResultExt {
+    /// The [`Context`] type of the [`Result`].
+    type Context: Context;
+
     /// Type of the [`Ok`] value in the [`Result`]
     type Ok;
 
     /// Adds a new attachment to the [`Report`] inside the [`Result`].
     ///
     /// Applies [`Report::attach`] on the [`Err`] variant, refer to it for more information.
-    #[must_use]
-    fn attach<A>(self, attachment: A) -> Self
+    fn attach<A>(self, attachment: A) -> core::result::Result<Self::Ok, Report<Self::Context>>
     where
         A: Send + Sync + 'static;
 
     /// Lazily adds a new attachment to the [`Report`] inside the [`Result`].
     ///
     /// Applies [`Report::attach`] on the [`Err`] variant, refer to it for more information.
-    #[must_use]
-    fn attach_lazy<A, F>(self, attachment: F) -> Self
+    fn attach_lazy<A, F>(
+        self,
+        attachment: F,
+    ) -> core::result::Result<Self::Ok, Report<Self::Context>>
     where
         A: Send + Sync + 'static,
         F: FnOnce() -> A;
@@ -67,8 +71,10 @@ pub trait ResultExt {
     ///
     /// Applies [`Report::attach_printable`] on the [`Err`] variant, refer to it for more
     /// information.
-    #[must_use]
-    fn attach_printable<A>(self, attachment: A) -> Self
+    fn attach_printable<A>(
+        self,
+        attachment: A,
+    ) -> core::result::Result<Self::Ok, Report<Self::Context>>
     where
         A: fmt::Display + fmt::Debug + Send + Sync + 'static;
 
@@ -76,8 +82,10 @@ pub trait ResultExt {
     ///
     /// Applies [`Report::attach_printable`] on the [`Err`] variant, refer to it for more
     /// information.
-    #[must_use]
-    fn attach_printable_lazy<A, F>(self, attachment: F) -> Self
+    fn attach_printable_lazy<A, F>(
+        self,
+        attachment: F,
+    ) -> core::result::Result<Self::Ok, Report<Self::Context>>
     where
         A: fmt::Display + fmt::Debug + Send + Sync + 'static,
         F: FnOnce() -> A;
@@ -85,20 +93,101 @@ pub trait ResultExt {
     /// Changes the context of the [`Report`] inside the [`Result`].
     ///
     /// Applies [`Report::change_context`] on the [`Err`] variant, refer to it for more information.
-    fn change_context<C>(self, context: C) -> Result<Self::Ok, C>
+    fn change_context<C>(self, context: C) -> core::result::Result<Self::Ok, Report<C>>
     where
         C: Context;
 
     /// Lazily changes the context of the [`Report`] inside the [`Result`].
     ///
     /// Applies [`Report::change_context`] on the [`Err`] variant, refer to it for more information.
-    fn change_context_lazy<C, F>(self, context: F) -> Result<Self::Ok, C>
+    fn change_context_lazy<C, F>(self, context: F) -> core::result::Result<Self::Ok, Report<C>>
     where
         C: Context,
         F: FnOnce() -> C;
 }
 
-impl<T, C> ResultExt for Result<T, C> {
+impl<T, C> ResultExt for core::result::Result<T, C>
+where
+    C: Context,
+{
+    type Context = C;
+    type Ok = T;
+
+    #[track_caller]
+    fn attach<A>(self, attachment: A) -> Result<T, C>
+    where
+        A: Send + Sync + 'static,
+    {
+        match self {
+            Ok(value) => Ok(value),
+            Err(error) => Err(Report::from(error).attach(attachment)),
+        }
+    }
+
+    #[track_caller]
+    fn attach_lazy<A, F>(self, attachment: F) -> Result<T, C>
+    where
+        A: Send + Sync + 'static,
+        F: FnOnce() -> A,
+    {
+        match self {
+            Ok(value) => Ok(value),
+            Err(error) => Err(Report::from(error).attach(attachment())),
+        }
+    }
+
+    #[track_caller]
+    fn attach_printable<A>(self, attachment: A) -> Result<T, C>
+    where
+        A: fmt::Display + fmt::Debug + Send + Sync + 'static,
+    {
+        match self {
+            Ok(value) => Ok(value),
+            Err(error) => Err(Report::from(error).attach_printable(attachment)),
+        }
+    }
+
+    #[track_caller]
+    fn attach_printable_lazy<A, F>(self, attachment: F) -> Result<T, C>
+    where
+        A: fmt::Display + fmt::Debug + Send + Sync + 'static,
+        F: FnOnce() -> A,
+    {
+        match self {
+            Ok(value) => Ok(value),
+            Err(error) => Err(Report::from(error).attach_printable(attachment())),
+        }
+    }
+
+    #[track_caller]
+    fn change_context<C2>(self, context: C2) -> Result<T, C2>
+    where
+        C2: Context,
+    {
+        match self {
+            Ok(value) => Ok(value),
+            Err(error) => Err(Report::from(error).change_context(context)),
+        }
+    }
+
+    #[track_caller]
+    fn change_context_lazy<C2, F>(self, context: F) -> Result<T, C2>
+    where
+        C2: Context,
+        F: FnOnce() -> C2,
+    {
+        match self {
+            Ok(value) => Ok(value),
+            Err(error) => Err(Report::from(error).change_context(context())),
+        }
+    }
+}
+
+impl<T, C> ResultExt for Result<T, C>
+where
+    C: Context,
+{
+    type Context = C;
     type Ok = T;
 
     #[track_caller]
@@ -178,6 +267,10 @@ impl<T, C> ResultExt for Result<T, C> {
 }
 
 /// Extends [`Result`] to convert the [`Err`] variant to a [`Report`]
+#[deprecated(
+    since = "0.4.0",
+    note = "Use `ReportExt` or `From` via `Result::map_err(Report::from)` instead"
+)]
 pub trait IntoReport: Sized {
     /// Type of the [`Ok`] value in the [`Result`]
     type Ok;
@@ -189,6 +282,7 @@ pub trait IntoReport: Sized {
     fn into_report(self) -> Result<Self::Ok, Self::Err>;
 }
 
+#[allow(deprecated)]
 impl<T, E> IntoReport for core::result::Result<T, E>
 where
     Report<E>: From<E>,

--- a/libs/error-stack/tests/snapshots/doc/lib__suggestion.snap
+++ b/libs/error-stack/tests/snapshots/doc/lib__suggestion.snap
@@ -1,5 +1,5 @@
 <b>could not parse configuration file</b>
-├╴at <i>src/lib.rs:26:10</i>
+├╴at <i>src/lib.rs:25:10</i>
 ├╴could not read file &quot;test.txt&quot;
 ├╴1 additional opaque attachment
 │

--- a/libs/error-stack/tests/snapshots/doc/report_debug__doc.snap
+++ b/libs/error-stack/tests/snapshots/doc/report_debug__doc.snap
@@ -2,7 +2,7 @@
 ├╴at <i>src/report.rs:62:14</i>
 │
 ├─▶ <b>config file is invalid</b>
-│   ╰╴at <i>src/report.rs:54:58</i>
+│   ╰╴at <i>src/report.rs:54:44</i>
 │
 ╰─▶ <b>No such file or directory (os error 2)</b>
     ├╴at <i>src/report.rs:54:44</i>

--- a/libs/error-stack/tests/test_compatibility.rs
+++ b/libs/error-stack/tests/test_compatibility.rs
@@ -10,7 +10,7 @@ mod common;
 #[allow(clippy::wildcard_imports)]
 use common::*;
 use error_stack::IntoReportCompat;
-#[cfg(feature = "std")]
+#[cfg(nightly)]
 use error_stack::Report;
 
 #[test]

--- a/libs/error-stack/tests/test_compatibility.rs
+++ b/libs/error-stack/tests/test_compatibility.rs
@@ -10,7 +10,7 @@ mod common;
 #[allow(clippy::wildcard_imports)]
 use common::*;
 use error_stack::IntoReportCompat;
-#[cfg(nightly)]
+#[cfg(all(nightly, feature = "std"))]
 use error_stack::Report;
 
 #[test]

--- a/libs/error-stack/tests/test_conversion.rs
+++ b/libs/error-stack/tests/test_conversion.rs
@@ -3,7 +3,7 @@
 
 use std::io;
 
-use error_stack::{IntoReport, ResultExt};
+use error_stack::{Report, ResultExt};
 
 fn io_error() -> Result<(), io::Error> {
     Err(io::Error::from(io::ErrorKind::Other))
@@ -11,20 +11,20 @@ fn io_error() -> Result<(), io::Error> {
 
 #[test]
 fn report() {
-    let report = io_error().into_report().expect_err("not an error");
+    let report = io_error().map_err(Report::new).expect_err("not an error");
     assert!(report.contains::<io::Error>());
     assert_eq!(report.current_context().kind(), io::ErrorKind::Other);
 }
 
 #[test]
 fn into_report() {
-    let report = io_error().into_report().expect_err("not an error");
+    let report = io_error().map_err(Report::from).expect_err("not an error");
     assert!(report.contains::<io::Error>());
     assert_eq!(report.current_context().kind(), io::ErrorKind::Other);
 }
 
 fn returning_boxed_error() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    io_error().into_report().attach(10_u32)?;
+    io_error().attach(10_u32)?;
     Ok(())
 }
 

--- a/libs/error-stack/tests/ui/into_report.rs
+++ b/libs/error-stack/tests/ui/into_report.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use core::fmt;
 
 use error_stack::{Context, IntoReport, Report};

--- a/libs/error-stack/tests/ui/into_report.stderr
+++ b/libs/error-stack/tests/ui/into_report.stderr
@@ -1,7 +1,7 @@
 error[E0599]: the method `into_report` exists for enum `Result<(), Report<RootError>>`, but its trait bounds were not satisfied
-  --> tests/ui/into_report.rs:22:20
+  --> tests/ui/into_report.rs:24:20
    |
-22 |     let _ = result.into_report();
+24 |     let _ = result.into_report();
    |                    ^^^^^^^^^^^ method cannot be called on `Result<(), Report<RootError>>` due to unsatisfied trait bounds
    |
   ::: $RUST/core/src/result.rs


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

After a lot of back and forth and various discussions (internally and on GitHub and other public platforms), we decided to merge the functionality of `IntoReport` into `ResultExt`.

## 🔗 Related links

- Closes https://github.com/hashintel/hash/issues/1968

## 🔍 What does this change?

- Extend `ResultExt` by a `type Context: Context` associated type (technically a breaking change likely has no impact) - requires a minor version bump
- Implement `ResultExt` for `core::result::Result<T, C> where C: Context`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- We still have `IntoReportCompat` but due to the Orphan rule it's not possible to implement `ResultExt` on `eyre` or `anyhow` errors.
