### PR TITLE
GEN-38: Minor improvements of code quality

### DIFF
--- a/libs/error-stack/src/compat.rs
+++ b/libs/error-stack/src/compat.rs
@@ -1,8 +1,6 @@
 //! Compatibility module to convert errors from other libraries into [`Report`].
 //!
 //! In order to convert these error types, use [`IntoReportCompat::into_report()`].
-//!
-//! [`Report`]: crate::Report
 
 use crate::Report;
 
@@ -19,7 +17,6 @@ mod eyre;
 /// would imply an implementation for [`Context`]. This also implies, that it's not possible to
 /// implement [`ResultExt`] from within `error-stack`.
 ///
-/// [`Report`]: Report
 /// [`ResultExt`]: crate::ResultExt
 /// [`Context`]: crate::Context
 /// [`Error`]: core::error::Error

--- a/libs/error-stack/src/context.rs
+++ b/libs/error-stack/src/context.rs
@@ -1,8 +1,6 @@
-#[cfg(nightly)]
-use core::any::Demand;
-#[cfg(nightly)]
-use core::error::Error;
 use core::fmt;
+#[cfg(nightly)]
+use core::{any::Demand, error::Error};
 #[cfg(all(not(nightly), feature = "std"))]
 use std::error::Error;
 
@@ -13,14 +11,11 @@ use crate::Report;
 /// When in a `std` environment or on a nightly toolchain, every [`Error`] is a valid `Context`.
 /// This trait is not limited to [`Error`]s and can also be manually implemented on a type.
 ///
-/// [`Error`]: core::error::Error
-///
 /// ## Example
 ///
 /// Used for creating a [`Report`] or for switching the [`Report`]'s context:
 ///
 /// ```rust
-/// # #![cfg_attr(any(not(feature = "std"), miri), allow(unused_imports))]
 /// use std::{fmt, fs, io};
 ///
 /// use error_stack::{Context, Result, ResultExt, Report};
@@ -32,7 +27,7 @@ use crate::Report;
 /// }
 ///
 /// impl fmt::Display for ConfigError {
-///     # #[allow(unused_variables)]
+///     # #[allow(unused_variables)] // `fmt` is not used in this example
 ///     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
 ///         # const _: &str = stringify! {
 ///         ...
@@ -44,9 +39,6 @@ use crate::Report;
 /// // `Context` manually.
 /// impl Context for ConfigError {}
 ///
-/// # #[cfg(any(not(feature = "std"), miri))]
-/// # pub fn read_file(_: &str) -> Result<String, ConfigError> { error_stack::bail!(ConfigError::ParseError) }
-/// # #[cfg(all(feature = "std", not(miri)))]
 /// pub fn read_file(path: &str) -> Result<String, io::Error> {
 ///     // Creates a `Report` from `io::Error`, the current context is `io::Error`
 ///     fs::read_to_string(path).map_err(Report::from)
@@ -62,7 +54,6 @@ use crate::Report;
 ///     # }; Ok(())
 /// }
 /// # let err = parse_config("invalid-path").unwrap_err();
-/// # #[cfg(all(feature = "std", not(miri)))]
 /// # assert!(err.contains::<io::Error>());
 /// # assert!(err.contains::<ConfigError>());
 /// ```

--- a/libs/error-stack/src/fmt.rs
+++ b/libs/error-stack/src/fmt.rs
@@ -320,7 +320,7 @@ pub use hook::HookContext;
 #[cfg(any(feature = "std", feature = "hooks"))]
 pub(crate) use hook::{install_builtin_hooks, Format, Hooks};
 #[cfg(not(any(feature = "std", feature = "hooks")))]
-use location::LocationDisplay;
+use location::LocationAttachment;
 
 use crate::{
     fmt::{
@@ -864,7 +864,7 @@ fn debug_attachments_invoke<'a>(
             FrameKind::Attachment(AttachmentKind::Opaque(_)) => frame
                 .downcast_ref::<core::panic::Location<'static>>()
                 .map(|location| {
-                    vec![LocationDisplay::new(location, config.color_mode()).to_string()]
+                    vec![LocationAttachment::new(location, config.color_mode()).to_string()]
                 }),
         })
         .flat_map(|body| {

--- a/libs/error-stack/src/fmt/charset.rs
+++ b/libs/error-stack/src/fmt/charset.rs
@@ -58,7 +58,7 @@ impl Report<()> {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```rust
     /// # // we only test the snapshot on nightly, therefore report is unused (so is render)
     /// # #![cfg_attr(not(nightly), allow(dead_code, unused_variables, unused_imports))]
     /// use std::io::{Error, ErrorKind};

--- a/libs/error-stack/src/fmt/color.rs
+++ b/libs/error-stack/src/fmt/color.rs
@@ -67,7 +67,7 @@ impl Report<()> {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```rust
     /// # // we only test the snapshot on nightly, therefore report is unused (so is render)
     /// # #![cfg_attr(not(nightly), allow(dead_code, unused_variables, unused_imports))]
     /// use std::io::{Error, ErrorKind};

--- a/libs/error-stack/src/fmt/config.rs
+++ b/libs/error-stack/src/fmt/config.rs
@@ -43,9 +43,7 @@ pub(crate) struct Config {
 
 #[cfg(not(any(feature = "std", feature = "hooks")))]
 impl Config {
-    // alternate is still provided, as it is used in the hook counterpart
-    #[allow(unused)]
-    pub(crate) const fn new(color_mode: ColorMode, charset: Charset, alternate: bool) -> Self {
+    pub(crate) const fn new(color_mode: ColorMode, charset: Charset, _alternate: bool) -> Self {
         Self {
             color_mode,
             charset,

--- a/libs/error-stack/src/fmt/hook.rs
+++ b/libs/error-stack/src/fmt/hook.rs
@@ -468,7 +468,7 @@ mod default {
     use tracing_error::SpanTrace;
 
     use crate::{
-        fmt::{hook::HookContext, location::LocationDisplay},
+        fmt::{hook::HookContext, location::LocationAttachment},
         Report,
     };
 
@@ -507,7 +507,7 @@ mod default {
     }
 
     fn location(location: &Location<'static>, context: &mut HookContext<Location<'static>>) {
-        context.push_body(LocationDisplay::new(location, context.color_mode()).to_string());
+        context.push_body(LocationAttachment::new(location, context.color_mode()).to_string());
     }
 
     #[cfg(all(feature = "std", rust_1_65))]

--- a/libs/error-stack/src/fmt/location.rs
+++ b/libs/error-stack/src/fmt/location.rs
@@ -1,28 +1,21 @@
-use core::{
-    fmt,
-    fmt::{Display, Formatter},
-    panic::Location,
-};
+use core::{fmt, panic::Location};
 
-use crate::fmt::{
-    color::{Color, DisplayStyle, Style},
-    ColorMode,
-};
+use crate::fmt::color::{Color, ColorMode, DisplayStyle, Style};
 
-pub(super) struct LocationDisplay<'a> {
-    location: &'a Location<'static>,
+pub(super) struct LocationAttachment<'a, 'loc> {
+    location: &'a Location<'loc>,
     mode: ColorMode,
 }
 
-impl<'a> LocationDisplay<'a> {
+impl<'a, 'loc> LocationAttachment<'a, 'loc> {
     #[must_use]
-    pub(super) const fn new(location: &'a Location<'static>, mode: ColorMode) -> Self {
+    pub(super) const fn new(location: &'a Location<'loc>, mode: ColorMode) -> Self {
         Self { location, mode }
     }
 }
 
-impl<'a> Display for LocationDisplay<'a> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl fmt::Display for LocationAttachment<'_, '_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let location = self.location;
 
         let mut style = Style::new();

--- a/libs/error-stack/src/hook.rs
+++ b/libs/error-stack/src/hook.rs
@@ -27,7 +27,7 @@ impl Report<()> {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```rust
     /// # // we only test the snapshot on nightly, therefore report is unused (so is render)
     /// # #![cfg_attr(not(nightly), allow(dead_code, unused_variables, unused_imports))]
     /// use std::io::{Error, ErrorKind};
@@ -71,7 +71,7 @@ impl Report<()> {
     /// This example showcases the ability of hooks to be invoked for values provided via the
     /// Provider API using [`Error::provide`].
     ///
-    /// ```
+    /// ```rust
     /// # // this is a lot of boilerplate, if you find a better way, please change this!
     /// # // with #![cfg(nightly)] docsrs will complain that there's no main in non-nightly
     /// # #![cfg_attr(nightly, feature(error_generic_member_access, provide_any))]

--- a/libs/error-stack/src/iter.rs
+++ b/libs/error-stack/src/iter.rs
@@ -5,7 +5,6 @@ use alloc::{vec, vec::Vec};
 use core::marker::PhantomData;
 use core::{
     fmt,
-    fmt::Formatter,
     iter::FusedIterator,
     slice::{Iter, IterMut},
 };
@@ -104,7 +103,7 @@ impl<'r> Iterator for Frames<'r> {
 impl<'r> FusedIterator for Frames<'r> {}
 
 impl fmt::Debug for Frames<'_> {
-    fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_list().entries(self.clone()).finish()
     }
 }
@@ -205,7 +204,7 @@ impl<'r, T> fmt::Debug for RequestRef<'r, T>
 where
     T: ?Sized + fmt::Debug + 'static,
 {
-    fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_list().entries(self.clone()).finish()
     }
 }
@@ -263,7 +262,7 @@ impl<'r, T> fmt::Debug for RequestValue<'r, T>
 where
     T: fmt::Debug + 'static,
 {
-    fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_list().entries(self.clone()).finish()
     }
 }

--- a/libs/error-stack/src/lib.rs
+++ b/libs/error-stack/src/lib.rs
@@ -69,7 +69,6 @@
 //! existing [`Error`]:
 //!
 //! ```rust
-//! # #[cfg(all(not(miri), feature = "std"))] {
 //! use std::{fs, io, path::Path};
 //!
 //! use error_stack::Report;
@@ -85,7 +84,6 @@
 //! }
 //! # let report = read_file("test.txt").unwrap_err();
 //! # assert!(report.contains::<io::Error>());
-//! # }
 //! ```
 //!
 //! ## Using and Expanding the Report
@@ -105,7 +103,6 @@
 //! (Again, for convenience, using [`ResultExt`] will do that on the [`Err`] variant)
 //!
 //! ```rust
-//! # #![cfg_attr(not(feature = "std"), allow(dead_code, unused_variables, unused_imports))]
 //! # use std::{fmt, fs, io, path::Path};
 //! use error_stack::{Context, Result, ResultExt};
 //! # pub type Config = String;
@@ -122,7 +119,6 @@
 //! // It's also possible to implement `Error` instead.
 //! impl Context for ParseConfigError {}
 //!
-//! # #[cfg(all(not(miri), feature = "std"))] {
 //! // For clarification, this example is not using `error_stack::Result`.
 //! fn parse_config(path: impl AsRef<Path>) -> Result<Config, ParseConfigError> {
 //!     let content = fs::read_to_string(path.as_ref())
@@ -135,7 +131,6 @@
 //! # let report = parse_config("test.txt").unwrap_err();
 //! # assert!(report.contains::<io::Error>());
 //! # assert!(report.contains::<ParseConfigError>());
-//! # }
 //! ```
 //!
 //! ### Building up the Report - Attachments
@@ -226,7 +221,6 @@
 //! [`extend_one()`]: Report::extend_one
 //!
 //! ```rust
-//! # #![cfg_attr(not(feature = "std"), allow(dead_code, unused_variables, unused_imports))]
 //! # use std::{fs, path::Path};
 //! # use error_stack::Report;
 //! # pub type Config = String;

--- a/libs/error-stack/src/macros.rs
+++ b/libs/error-stack/src/macros.rs
@@ -79,8 +79,7 @@ pub mod __private {
 ///
 /// Create a [`Report`] from [`Error`]:
 ///
-/// ```
-/// # #[cfg(all(not(miri), feature = "std"))] {
+/// ```rust
 /// use std::fs;
 ///
 /// use error_stack::report;
@@ -91,12 +90,12 @@ pub mod __private {
 ///     Err(err) => return Err(report!(err)),
 /// }
 /// # Ok(()) }
-/// # assert!(wrapper().unwrap_err().contains::<std::io::Error>()); }
+/// # assert!(wrapper().unwrap_err().contains::<std::io::Error>());
 /// ```
 ///
 /// Create a [`Report`] from [`Context`]:
 ///
-/// ```
+/// ```rust
 /// # fn has_permission(_: &u32, _: &u32) -> bool { true }
 /// # type User = u32;
 /// # let user = 0;
@@ -147,7 +146,6 @@ macro_rules! report {
 /// [`Error`]: core::error::Error
 ///
 /// ```
-/// # #[cfg(all(not(miri), feature = "std"))] {
 /// use std::fs;
 ///
 /// use error_stack::bail;
@@ -157,14 +155,14 @@ macro_rules! report {
 ///     Err(err) => bail!(err),
 /// }
 /// # Ok(()) }
-/// # assert!(wrapper().unwrap_err().contains::<std::io::Error>()); }
+/// # assert!(wrapper().unwrap_err().contains::<std::io::Error>());
 /// ```
 ///
 /// Create a [`Report`] from [`Context`]:
 ///
 /// [`Context`]: crate::Context
 ///
-/// ```
+/// ```rust
 /// # fn has_permission(_: &u32, _: &u32) -> bool { true }
 /// # type User = u32;
 /// # let user = 0;
@@ -213,7 +211,7 @@ macro_rules! bail {
 /// [`Report`]: crate::Report
 /// [`Context`]: crate::Context
 ///
-/// ```
+/// ```rust
 /// # fn has_permission(_: &u32, _: &u32) -> bool { true }
 /// # type User = u32;
 /// # let user = 0;

--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -81,8 +81,7 @@ use crate::{
 ///
 /// ## Provide a context for an error
 ///
-/// ```
-/// # #[cfg(all(not(miri), feature = "std"))] {
+/// ```rust
 /// use error_stack::{ResultExt, Result};
 ///
 /// # #[allow(dead_code)]
@@ -94,15 +93,13 @@ use crate::{
 /// # const _: &str = stringify! {
 /// ...
 /// # }; Ok(content) }
-/// # }
 /// ```
 ///
 /// ## Enforce a context for an error
 ///
-/// ```
+/// ```rust
 /// use std::{fmt, path::{Path, PathBuf}};
 ///
-/// # #[cfg_attr(any(miri, not(feature = "std")), allow(unused_imports))]
 /// use error_stack::{Context, Report, ResultExt};
 ///
 /// #[derive(Debug)]
@@ -147,9 +144,6 @@ use crate::{
 ///
 /// # #[allow(unused_variables)]
 /// fn read_config(path: impl AsRef<Path>) -> Result<String, Report<ConfigError>> {
-///     # #[cfg(any(miri, not(feature = "std")))]
-///     # return Err(error_stack::report!(ConfigError::IoError).attach_printable("Not supported"));
-///     # #[cfg(all(not(miri), feature = "std"))]
 ///     std::fs::read_to_string(path.as_ref()).change_context(ConfigError::IoError)
 /// }
 ///
@@ -211,7 +205,7 @@ use crate::{
 ///
 /// ## Get the attached [`Backtrace`] and [`SpanTrace`]:
 ///
-/// ```should_panic
+/// ```rust,should_panic
 /// use error_stack::{ResultExt, Result};
 ///
 /// # #[allow(unused_variables)]
@@ -222,12 +216,12 @@ use crate::{
 ///
 /// let content = match content {
 ///     Err(err) => {
-///         # #[cfg(all(nightly, feature = "std"))]
+///         # #[cfg(nightly)]
 ///         for backtrace in err.request_ref::<std::backtrace::Backtrace>() {
 ///             println!("backtrace: {backtrace}");
 ///         }
 ///
-///         # #[cfg(all(nightly, feature = "spantrace"))]
+///         # #[cfg(nightly)]
 ///         for span_trace in err.request_ref::<tracing_error::SpanTrace>() {
 ///             println!("span trace: {span_trace}")
 ///         }
@@ -424,7 +418,6 @@ impl<C> Report<C> {
     /// ## Example
     ///
     /// ```rust
-    /// # #[cfg(all(feature = "std", not(miri)))] {
     /// use std::{fmt, fs};
     ///
     /// use error_stack::ResultExt;
@@ -447,7 +440,7 @@ impl<C> Report<C> {
     ///
     /// # #[cfg(nightly)]
     /// assert_eq!(suggestion.0, "better use a file which exists next time!");
-    /// # }
+    /// ```
     #[track_caller]
     pub fn attach_printable<A>(mut self, attachment: A) -> Self
     where
@@ -536,7 +529,6 @@ impl<C> Report<C> {
     /// ## Example
     ///
     /// ```rust
-    /// # #[cfg(all(not(miri), feature = "std"))] {
     /// # use std::{fs, io, path::Path};
     /// # use error_stack::Report;
     /// fn read_file(path: impl AsRef<Path>) -> Result<String, Report<io::Error>> {
@@ -548,7 +540,6 @@ impl<C> Report<C> {
     ///
     /// let report = read_file("test.txt").unwrap_err();
     /// assert!(report.contains::<io::Error>());
-    /// # }
     /// ```
     #[must_use]
     pub fn contains<T: Send + Sync + 'static>(&self) -> bool {
@@ -563,7 +554,6 @@ impl<C> Report<C> {
     /// ## Example
     ///
     /// ```rust
-    /// # #[cfg(all(not(miri), feature = "std"))] {
     /// # use std::{fs, path::Path};
     /// # use error_stack::Report;
     /// use std::io;
@@ -578,7 +568,6 @@ impl<C> Report<C> {
     /// let report = read_file("test.txt").unwrap_err();
     /// let io_error = report.downcast_ref::<io::Error>().unwrap();
     /// assert_eq!(io_error.kind(), io::ErrorKind::NotFound);
-    /// # }
     /// ```
     #[must_use]
     pub fn downcast_ref<T: Send + Sync + 'static>(&self) -> Option<&T> {
@@ -606,7 +595,6 @@ impl<C> Report<C> {
     /// ## Example
     ///
     /// ```rust
-    /// # #[cfg(all(not(miri), feature = "std"))] {
     /// # use std::{fs, path::Path};
     /// # use error_stack::Report;
     /// use std::io;
@@ -621,7 +609,6 @@ impl<C> Report<C> {
     /// let report = read_file("test.txt").unwrap_err();
     /// let io_error = report.current_context();
     /// assert_eq!(io_error.kind(), io::ErrorKind::NotFound);
-    /// # }
     /// ```
     #[must_use]
     pub fn current_context(&self) -> &C

--- a/libs/error-stack/src/result.rs
+++ b/libs/error-stack/src/result.rs
@@ -13,7 +13,7 @@ use crate::{Context, Report};
 ///
 /// `Result` can also be used in `fn main()`:
 ///
-/// ```
+/// ```rust
 /// # fn has_permission(_: usize, _: usize) -> bool { true }
 /// # fn get_user() -> Result<usize, AccessError> { Ok(0) }
 /// # fn get_resource() -> Result<usize, AccessError> { Ok(0) }

--- a/libs/error-stack/tests/snapshots/doc/report_debug__doc.snap
+++ b/libs/error-stack/tests/snapshots/doc/report_debug__doc.snap
@@ -1,11 +1,11 @@
 <b>could not parse &quot;./path/to/config.file&quot;</b>
-├╴at <i>src/report.rs:62:14</i>
+├╴at <i>src/report.rs:58:14</i>
 │
 ├─▶ <b>config file is invalid</b>
-│   ╰╴at <i>src/report.rs:54:44</i>
+│   ╰╴at <i>src/report.rs:50:44</i>
 │
 ╰─▶ <b>No such file or directory (os error 2)</b>
-    ├╴at <i>src/report.rs:54:44</i>
+    ├╴at <i>src/report.rs:50:44</i>
     ╰╴backtrace (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

There are a bunch of locations in `error-stack` which could be improved slightly. The amount of changes adds up and it's worth doing this in a separate PR.

## 🔍 What does this change?

- Clean up imports
- Remove unneeded `repr(C)` (we don't rely on it anymore and if we would we should use `repr(transparent)`
- Remove feature flags in doc test except for `nightly` checks (we only run doc tests for stable+nightly with `--all-features`; no `miri` and no feature permutations
- Some other minor changes

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph