### PR TITLE
H-372: Work around that subgraph can only contain a single ontology type per versioned URL, 2nd Attempt

### DIFF
--- a/apps/hash-graph/lib/graph/src/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/ontology.rs
@@ -393,22 +393,6 @@ pub enum CustomOntologyMetadata {
     },
 }
 
-impl CustomOntologyMetadata {
-    #[must_use]
-    pub const fn temporal_versioning(&self) -> &OntologyTemporalMetadata {
-        match self {
-            Self::Owned {
-                temporal_versioning,
-                ..
-            }
-            | Self::External {
-                temporal_versioning,
-                ..
-            } => temporal_versioning,
-        }
-    }
-}
-
 /// An [`OntologyElementMetadata`] that has not yet been fully resolved.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PartialOntologyElementMetadata {

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -140,6 +140,8 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
                     .await?
                     .into_iter()
                     .filter_map(|data_type| {
+                        // The records are already sorted by time, so we can just take the first
+                        // one
                         visited_ontology_ids
                             .insert(data_type.vertex_id(time_axis))
                             .then(|| (data_type.vertex_id(time_axis), data_type))

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use async_trait::async_trait;
 #[cfg(hash_graph_test_environment)]
 use error_stack::IntoReport;
@@ -129,11 +131,19 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
         );
 
         if graph_resolve_depths.is_empty() {
+            // TODO: Remove again when subgraph logic was revisited
+            //   see https://linear.app/hash/issue/H-297
+            let mut visited_ontology_ids = HashSet::new();
+
             subgraph.vertices.data_types =
                 Read::<DataTypeWithMetadata>::read_vec(self, filter, Some(&temporal_axes))
                     .await?
                     .into_iter()
-                    .map(|data_type| (data_type.vertex_id(time_axis), data_type))
+                    .filter_map(|data_type| {
+                        visited_ontology_ids
+                            .insert(data_type.vertex_id(time_axis))
+                            .then(|| (data_type.vertex_id(time_axis), data_type))
+                    })
                     .collect();
             for vertex_id in subgraph.vertices.data_types.keys() {
                 subgraph.roots.insert(vertex_id.clone().into());

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -279,6 +279,8 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
                     .await?
                     .into_iter()
                     .filter_map(|entity_type| {
+                        // The records are already sorted by time, so we can just take the first
+                        // one
                         visited_ontology_ids
                             .insert(entity_type.vertex_id(time_axis))
                             .then(|| (entity_type.vertex_id(time_axis), entity_type))

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
 #[cfg(hash_graph_test_environment)]
@@ -270,11 +270,19 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
         );
 
         if graph_resolve_depths.is_empty() {
+            // TODO: Remove again when subgraph logic was revisited
+            //   see https://linear.app/hash/issue/H-297
+            let mut visited_ontology_ids = HashSet::new();
+
             subgraph.vertices.entity_types =
                 Read::<EntityTypeWithMetadata>::read_vec(self, filter, Some(&temporal_axes))
                     .await?
                     .into_iter()
-                    .map(|entity_type| (entity_type.vertex_id(time_axis), entity_type))
+                    .filter_map(|entity_type| {
+                        visited_ontology_ids
+                            .insert(entity_type.vertex_id(time_axis))
+                            .then(|| (entity_type.vertex_id(time_axis), entity_type))
+                    })
                     .collect();
             for vertex_id in subgraph.vertices.entity_types.keys() {
                 subgraph.roots.insert(vertex_id.clone().into());

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -259,6 +259,8 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
                     .await?
                     .into_iter()
                     .filter_map(|property_type| {
+                        // The records are already sorted by time, so we can just take the first
+                        // one
                         visited_ontology_ids
                             .insert(property_type.vertex_id(time_axis))
                             .then(|| (property_type.vertex_id(time_axis), property_type))

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
 #[cfg(hash_graph_test_environment)]
@@ -250,11 +250,19 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
         );
 
         if graph_resolve_depths.is_empty() {
+            // TODO: Remove again when subgraph logic was revisited
+            //   see https://linear.app/hash/issue/H-297
+            let mut visited_ontology_ids = HashSet::new();
+
             subgraph.vertices.property_types =
                 Read::<PropertyTypeWithMetadata>::read_vec(self, filter, Some(&temporal_axes))
                     .await?
                     .into_iter()
-                    .map(|property_type| (property_type.vertex_id(time_axis), property_type))
+                    .filter_map(|property_type| {
+                        visited_ontology_ids
+                            .insert(property_type.vertex_id(time_axis))
+                            .then(|| (property_type.vertex_id(time_axis), property_type))
+                    })
                     .collect();
             for vertex_id in subgraph.vertices.property_types.keys() {
                 subgraph.roots.insert(vertex_id.clone().into());

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -30,7 +30,7 @@ use crate::{
         postgres::{
             ontology::OntologyId,
             query::{
-                Distinctness, ForeignKeyReference, PostgresQueryPath, PostgresRecord,
+                Distinctness, ForeignKeyReference, Ordering, PostgresQueryPath, PostgresRecord,
                 ReferenceTable, SelectCompiler, Table, Transpile,
             },
         },
@@ -115,13 +115,17 @@ where
             Distinctness::Distinct,
             None,
         );
+        let transaction_time_index = compiler.add_distinct_selection_with_ordering(
+            &transaction_time_path,
+            Distinctness::Distinct,
+            Some(Ordering::Descending),
+        );
         let schema_index = compiler.add_selection_path(&schema_path);
         let record_created_by_id_path_index =
             compiler.add_selection_path(&record_created_by_id_path);
         let record_archived_by_id_path_index =
             compiler.add_selection_path(&record_archived_by_id_path);
         let additional_metadata_index = compiler.add_selection_path(&additional_metadata_path);
-        let transaction_time_index = compiler.add_selection_path(&transaction_time_path);
 
         compiler.add_filter(filter);
         let (statement, parameters) = compiler.compile();

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -115,6 +115,8 @@ where
             Distinctness::Distinct,
             None,
         );
+        // It's possible to have multiple records with the same transaction time. We order them
+        // descending so that the most recent record is returned first.
         let transaction_time_index = compiler.add_distinct_selection_with_ordering(
             &transaction_time_path,
             Distinctness::Distinct,
@@ -216,6 +218,8 @@ impl<C: AsClient> Read<OntologyTypeSnapshotRecord<EntityType>> for PostgresStore
             Distinctness::Distinct,
             None,
         );
+        // It's possible to have multiple records with the same transaction time. We order them
+        // descending so that the most recent record is returned first.
         let transaction_time_index = compiler.add_distinct_selection_with_ordering(
             &EntityTypeQueryPath::TransactionTime,
             Distinctness::Distinct,

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/read.rs
@@ -216,6 +216,11 @@ impl<C: AsClient> Read<OntologyTypeSnapshotRecord<EntityType>> for PostgresStore
             Distinctness::Distinct,
             None,
         );
+        let transaction_time_index = compiler.add_distinct_selection_with_ordering(
+            &EntityTypeQueryPath::TransactionTime,
+            Distinctness::Distinct,
+            Some(Ordering::Descending),
+        );
         let schema_index = compiler.add_selection_path(&EntityTypeQueryPath::Schema(None));
         let record_created_by_id_path_index =
             compiler.add_selection_path(&EntityTypeQueryPath::RecordCreatedById);
@@ -223,8 +228,6 @@ impl<C: AsClient> Read<OntologyTypeSnapshotRecord<EntityType>> for PostgresStore
             compiler.add_selection_path(&EntityTypeQueryPath::RecordArchivedById);
         let additional_metadata_index =
             compiler.add_selection_path(&EntityTypeQueryPath::AdditionalMetadata);
-        let transaction_time_index =
-            compiler.add_selection_path(&EntityTypeQueryPath::TransactionTime);
         let label_property_index = compiler.add_selection_path(&EntityTypeQueryPath::LabelProperty);
 
         compiler.add_filter(filter);

--- a/apps/hash-graph/lib/graph/src/store/postgres/traversal_context.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/traversal_context.rs
@@ -1,15 +1,9 @@
-use std::{
-    collections::{hash_map::RawEntryMut, HashMap},
-    hash::Hash,
-};
+use std::{collections::HashMap, hash::Hash};
 
 use error_stack::Result;
 
 use crate::{
-    identifier::{
-        knowledge::EntityEditionId,
-        time::{ClosedTemporalBound, RightBoundedTemporalInterval},
-    },
+    identifier::{knowledge::EntityEditionId, time::RightBoundedTemporalInterval},
     knowledge::{Entity, EntityQueryPath},
     ontology::{
         DataTypeQueryPath, DataTypeWithMetadata, EntityTypeQueryPath, EntityTypeWithMetadata,
@@ -45,37 +39,10 @@ impl<C: AsClient> PostgresStore<C> {
         )
         .await?
         {
-            // TODO: Use `subgraph.insert_vertex` again
-            //   see https://linear.app/hash/issue/H-297
-            // subgraph.insert_vertex(
-            //     data_type.vertex_id(subgraph.temporal_axes.resolved.variable_time_axis()),
-            //     data_type,
-            // );
-            let vertex_id =
-                data_type.vertex_id(subgraph.temporal_axes.resolved.variable_time_axis());
-            match subgraph.vertex_entry_mut(&vertex_id) {
-                RawEntryMut::Vacant(entry) => {
-                    entry.insert(vertex_id, data_type);
-                }
-                RawEntryMut::Occupied(mut entry) => {
-                    let ClosedTemporalBound::Inclusive(stored_time) = entry
-                        .get()
-                        .metadata
-                        .custom
-                        .temporal_versioning()
-                        .transaction_time
-                        .start();
-                    let ClosedTemporalBound::Inclusive(new_time) = data_type
-                        .metadata
-                        .custom
-                        .temporal_versioning()
-                        .transaction_time
-                        .start();
-                    if new_time > stored_time {
-                        entry.insert(data_type);
-                    }
-                }
-            }
+            subgraph.insert_vertex(
+                data_type.vertex_id(subgraph.temporal_axes.resolved.variable_time_axis()),
+                data_type,
+            );
         }
 
         Ok(())
@@ -101,37 +68,10 @@ impl<C: AsClient> PostgresStore<C> {
         )
         .await?
         {
-            // TODO: Use `subgraph.insert_vertex` again
-            //   see https://linear.app/hash/issue/H-297
-            // subgraph.insert_vertex(
-            //     property_type.vertex_id(subgraph.temporal_axes.resolved.variable_time_axis()),
-            //     property_type,
-            // );
-            let vertex_id =
-                property_type.vertex_id(subgraph.temporal_axes.resolved.variable_time_axis());
-            match subgraph.vertex_entry_mut(&vertex_id) {
-                RawEntryMut::Vacant(entry) => {
-                    entry.insert(vertex_id, property_type);
-                }
-                RawEntryMut::Occupied(mut entry) => {
-                    let ClosedTemporalBound::Inclusive(stored_time) = entry
-                        .get()
-                        .metadata
-                        .custom
-                        .temporal_versioning()
-                        .transaction_time
-                        .start();
-                    let ClosedTemporalBound::Inclusive(new_time) = property_type
-                        .metadata
-                        .custom
-                        .temporal_versioning()
-                        .transaction_time
-                        .start();
-                    if new_time > stored_time {
-                        entry.insert(property_type);
-                    }
-                }
-            }
+            subgraph.insert_vertex(
+                property_type.vertex_id(subgraph.temporal_axes.resolved.variable_time_axis()),
+                property_type,
+            );
         }
 
         Ok(())
@@ -157,39 +97,10 @@ impl<C: AsClient> PostgresStore<C> {
         )
         .await?
         {
-            // TODO: Use `subgraph.insert_vertex` again
-            //   see https://linear.app/hash/issue/H-297
-            // subgraph.insert_vertex(
-            //     entity_type.vertex_id(subgraph.temporal_axes.resolved.variable_time_axis()),
-            //     entity_type,
-            // );
-            let vertex_id =
-                entity_type.vertex_id(subgraph.temporal_axes.resolved.variable_time_axis());
-            match subgraph.vertex_entry_mut(&vertex_id) {
-                RawEntryMut::Vacant(entry) => {
-                    entry.insert(vertex_id, entity_type);
-                }
-                RawEntryMut::Occupied(mut entry) => {
-                    let ClosedTemporalBound::Inclusive(stored_time) = entry
-                        .get()
-                        .metadata
-                        .custom
-                        .common
-                        .temporal_versioning()
-                        .transaction_time
-                        .start();
-                    let ClosedTemporalBound::Inclusive(new_time) = entity_type
-                        .metadata
-                        .custom
-                        .common
-                        .temporal_versioning()
-                        .transaction_time
-                        .start();
-                    if new_time > stored_time {
-                        entry.insert(entity_type);
-                    }
-                }
-            }
+            subgraph.insert_vertex(
+                entity_type.vertex_id(subgraph.temporal_axes.resolved.variable_time_axis()),
+                entity_type,
+            );
         }
 
         Ok(())

--- a/apps/hash-graph/lib/graph/src/subgraph.rs
+++ b/apps/hash-graph/lib/graph/src/subgraph.rs
@@ -54,9 +54,7 @@ impl Subgraph {
         }
     }
 
-    // TODO: Make private again
-    //   see https://linear.app/hash/issue/H-297
-    pub fn vertex_entry_mut<R: Record>(
+    fn vertex_entry_mut<R: Record>(
         &mut self,
         vertex_id: &R::VertexId,
     ) -> RawEntryMut<R::VertexId, R, RandomState> {

--- a/apps/hash-graph/lib/graph/src/subgraph.rs
+++ b/apps/hash-graph/lib/graph/src/subgraph.rs
@@ -65,16 +65,12 @@ impl Subgraph {
         vertex_id.subgraph_entry(&self.vertices)
     }
 
-    pub fn insert_vertex<R: Record>(&mut self, vertex_id: R::VertexId, record: R) -> Option<R>
+    pub fn insert_vertex<R: Record>(&mut self, vertex_id: R::VertexId, record: R)
     where
         R::VertexId: Eq + Hash,
     {
-        match self.vertex_entry_mut(&vertex_id) {
-            RawEntryMut::Occupied(mut entry) => Some(entry.insert(record)),
-            RawEntryMut::Vacant(entry) => {
-                entry.insert(vertex_id, record);
-                None
-            }
+        if let RawEntryMut::Vacant(entry) = self.vertex_entry_mut(&vertex_id) {
+            entry.insert(vertex_id, record);
         }
     }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#2879 did not cover all possible paths. Instead of manually comparing the time it will now rely on the ordering returned from the database. The latest record will always be returned first.

## 🔗 Related links

- Reverts #2879

## 🔍 What does this change?

Correctly pick the ontology type when traversing

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph