### PR TITLE
H-375: Set form state properly when switching between organizations

### DIFF
--- a/apps/hash-frontend/src/pages/settings/organizations/[shortname]/general.page.tsx
+++ b/apps/hash-frontend/src/pages/settings/organizations/[shortname]/general.page.tsx
@@ -90,6 +90,7 @@ const OrgGeneralSettingsPage: NextPageWithLayout = () => {
         ref={topRef}
       >
         <OrgForm
+          key={org.entityRecordId.entityId}
           org={org}
           onSubmit={updateOrg}
           submitLabel="Update organization profile"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes a bug where the form state for organization general settings was not reset when switching between organizations.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Have multiple orgs, visit the settings page for one, then another, check the form shows the correct values for each

