### PR TITLE
Use `workspace` to define some common dependencies

### DIFF
--- a/apps/hash-graph/Cargo.toml
+++ b/apps/hash-graph/Cargo.toml
@@ -13,6 +13,11 @@ license-file = "LICENSE.md"
 publish = false
 repository = "https://github.com/hashintel/hash/tree/main/apps/hash-graph"
 
+[workspace.dependencies]
+type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "cdde49" }
+hash-status = { path = "../../libs/@local/status/crate" }
+error-stack = { version = "0.3.1", features = ["spantrace"] }
+
 [profile.production]
 inherits = "release"
 lto = "fat"

--- a/apps/hash-graph/bench/Cargo.toml
+++ b/apps/hash-graph/bench/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.171", features = ["derive"] }
 serde_json = "1.0.103"
 tokio = { version = "1.29.1", features = ["rt-multi-thread", "macros"] }
 tokio-postgres = { version = "0.7.8", default-features = false }
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "cdde49" }
+type-system = { workspace = true }
 uuid = { version = "1.4.1", features = ["v4", "serde"] }
 
 [[bench]]

--- a/apps/hash-graph/bin/cli/Cargo.toml
+++ b/apps/hash-graph/bin/cli/Cargo.toml
@@ -11,12 +11,12 @@ description = "The entity-graph query-layer for the HASH datastore"
 graph = { path = "../../lib/graph", features = ["clap"] }
 type-fetcher = { path = "../../lib/type-fetcher" }
 
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "cdde49" }
+error-stack = { workspace = true }
+type-system = { workspace = true }
 
 axum = "0.6.19"
 clap = { version = "4.3.16", features = ["cargo", "derive", "env", "wrap_help"] }
 clap_complete = "4.3.2"
-error-stack = { version = "0.3.1", features = ["spantrace"] }
 futures = { version = "0.3.28" }
 regex = "1.9.1"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }

--- a/apps/hash-graph/lib/graph/Cargo.toml
+++ b/apps/hash-graph/lib/graph/Cargo.toml
@@ -6,10 +6,11 @@ publish = false
 description = "HASH Graph API"
 
 [dependencies]
-hash-status = { path = "../../../../libs/@local/status/crate" }
 type-fetcher = { path = "../type-fetcher" }
 
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "cdde49" }
+error-stack = { workspace = true }
+hash-status = { workspace = true }
+type-system = { workspace = true }
 
 async-trait = "0.1.71"
 axum = "0.6.19"
@@ -17,7 +18,6 @@ bb8-postgres = "0.8.1"
 bytes = "1.4.0"
 clap = { version = "4.3.16", features = ["derive", "env"], optional = true }
 derivative = "2.2.0"
-error-stack = { version = "0.3.1", features = ["spantrace"] }
 futures = "0.3.28"
 hyper = "0.14.27"
 include_dir = "0.7.3"

--- a/apps/hash-graph/lib/type-fetcher/Cargo.toml
+++ b/apps/hash-graph/lib/type-fetcher/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 description = "RPC service definition to fetch external BP types"
 
 [dependencies]
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "cdde49" }
+type-system = { workspace = true }
 
 serde = { version = "1.0.171", features = ["derive"] }
 time = { version = "0.3.23", features = ['serde'] }

--- a/apps/hash-graph/tests/integration/Cargo.toml
+++ b/apps/hash-graph/tests/integration/Cargo.toml
@@ -8,7 +8,8 @@ publish = false
 graph = { path = "../../lib/graph" }
 graph-test-data = { path = "../test_data" }
 
-error-stack = "0.3.1"
+error-stack = { workspace = true }
+
 futures = "0.3.28"
 rand = "0.8.5"
 serde = { version = "1.0.171", features = ["derive"] }
@@ -16,7 +17,7 @@ serde_json = "1.0.103"
 time = "0.3.23"
 tokio = { version = "1.29.1", features = ["rt-multi-thread", "macros"] }
 tokio-postgres = { version = "0.7.8", default-features = false }
-type-system = { git = "https://github.com/blockprotocol/blockprotocol", rev = "cdde49" }
+type-system = { workspace = true }
 uuid = { version = "1.4.1", features = ["v4", "serde"] }
 
 [[test]]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When changing dependencies in Cargo.toml every Cargo.toml in a workspace has to be adjusted to use the correct dependencies. This should be moved to the top-level manifest instead.

## 🔍 What does this change?

- With some revision bumps for the `type-system` package in the next hours this will simplify the changes required for it.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
