### PR TITLE
GEN-52: Limit version of `anyhow` to `1.0.72`

### DIFF
--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["rust-patterns", "no-std"]
 
 [dependencies]
 tracing-error = { version = "0.2", optional = true, default_features = false }
-anyhow = { version = "1.0.72", default-features = false, optional = true }
+anyhow = { version = ">=1.0.65, <=1.0.72", default-features = false, optional = true }
 eyre = { version = "0.6", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true }
 spin = { version = "0.9", default-features = false, optional = true, features = ['rwlock', 'once'] }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The latest toolchain updated the `Error::provide` API. `anyhow` already updated to the latest nightly, which implies that we cannot use their latest version. This PR limits the `anyhow` version to the compatible range.

## 🔗 Related links

- https://github.com/dtolnay/anyhow/pull/319
- https://github.com/rust-lang/rust/pull/113464

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

- [GEN-53: Update to latest `Error::provide` version](https://linear.app/hash/issue/GEN-53) _(internal)_