### PR TITLE
GEN-53: Upgrade `error-stack` toolchain and use `Error::provide`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -205,6 +205,11 @@
       "matchPackagePatterns": ["^tracing[-_]?"],
       "excludePackageNames": ["tracing-opentelemetry"],
       "groupName": "`tracing` crates"
+    },
+    {
+      "matchManagers": ["cargo"],
+      "matchFileNames": ["libs/error-stack/Cargo.toml"],
+      "excludeDepNames": ["anyhow"]
     }
   ],
   "regexManagers": [

--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["rust-patterns", "no-std"]
 
 [dependencies]
 tracing-error = { version = "0.2", optional = true, default_features = false }
-anyhow = { version = ">=1.0.65, <=1.0.72", default-features = false, optional = true }
+anyhow = { version = ">=1.0.73", default-features = false, optional = true }
 eyre = { version = "0.6", default-features = false, optional = true }
 serde = { version = "1", default-features = false, optional = true }
 spin = { version = "0.9", default-features = false, optional = true, features = ['rwlock', 'once'] }

--- a/libs/error-stack/README.md
+++ b/libs/error-stack/README.md
@@ -8,7 +8,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/error-stack)][crates.io]
 [![libs.rs](https://img.shields.io/badge/libs.rs-error--stack-orange)][libs.rs]
-[![rust-version](https://img.shields.io/static/v1?label=Rust&message=1.63.0/nightly-2023-08-14&color=blue)][rust-version]
+[![rust-version](https://img.shields.io/static/v1?label=Rust&message=1.63.0/nightly-2023-08-15&color=blue)][rust-version]
 [![documentation](https://img.shields.io/docsrs/error-stack)][documentation]
 [![license](https://img.shields.io/crates/l/error-stack)][license]
 [![discord](https://img.shields.io/discord/840573247803097118)][discord]

--- a/libs/error-stack/macros/Cargo.toml
+++ b/libs/error-stack/macros/Cargo.toml
@@ -18,4 +18,4 @@ proc-macro = true
 [dependencies]
 
 [dev-dependencies]
-error-stack = { version = "0.3.1", default-features = false }
+error-stack = { path = "..", default-features = false }

--- a/libs/error-stack/macros/README.md
+++ b/libs/error-stack/macros/README.md
@@ -7,7 +7,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/error-stack-macros)][crates.io]
 [![libs.rs](https://img.shields.io/badge/libs.rs-error--stack--macros-orange)][libs.rs]
-[![rust-version](https://img.shields.io/static/v1?label=Rust&message=1.63.0/nightly-2023-08-14&color=blue)][rust-version]
+[![rust-version](https://img.shields.io/static/v1?label=Rust&message=1.63.0/nightly-2023-08-15&color=blue)][rust-version]
 [![documentation](https://img.shields.io/docsrs/error-stack-macros)][documentation]
 [![license](https://img.shields.io/crates/l/error-stack)][license]
 [![discord](https://img.shields.io/discord/840573247803097118)][discord]

--- a/libs/error-stack/rust-toolchain.toml
+++ b/libs/error-stack/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # Please also update the badges in `README.md`s (`error-stack` and `error-stack-macros`), and `src/lib.rs`
-channel = "nightly-2023-08-14"
+channel = "nightly-2023-08-15"
 components = ['rustfmt', 'clippy', 'llvm-tools-preview', 'miri', 'rust-src']

--- a/libs/error-stack/src/context.rs
+++ b/libs/error-stack/src/context.rs
@@ -1,6 +1,6 @@
-use core::fmt;
 #[cfg(nightly)]
-use core::{any::Demand, error::Error};
+use core::error::{Error, Request};
+use core::fmt;
 #[cfg(all(not(nightly), feature = "std"))]
 use std::error::Error;
 
@@ -61,7 +61,7 @@ pub trait Context: fmt::Display + fmt::Debug + Send + Sync + 'static {
     /// Provide values which can then be requested by [`Report`].
     #[cfg(nightly)]
     #[allow(unused_variables)]
-    fn provide<'a>(&'a self, demand: &mut Demand<'a>) {}
+    fn provide<'a>(&'a self, request: &mut Request<'a>) {}
 }
 
 impl<C> From<C> for Report<C>
@@ -78,7 +78,7 @@ where
 #[cfg(any(nightly, feature = "std"))]
 impl<C: Error + Send + Sync + 'static> Context for C {
     #[cfg(nightly)]
-    fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
-        Error::provide(self, demand);
+    fn provide<'a>(&'a self, request: &mut Request<'a>) {
+        Error::provide(self, request);
     }
 }

--- a/libs/error-stack/src/error.rs
+++ b/libs/error-stack/src/error.rs
@@ -1,9 +1,6 @@
-use core::fmt;
 #[cfg(nightly)]
-use core::{
-    any::{Demand, Provider},
-    error::Error,
-};
+use core::error::{Error, Request};
+use core::fmt;
 #[cfg(not(nightly))]
 use std::error::Error;
 
@@ -37,7 +34,9 @@ impl<C> fmt::Display for ReportError<C> {
 
 impl<C> Error for ReportError<C> {
     #[cfg(nightly)]
-    fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
-        self.0.frames().for_each(|frame| frame.provide(demand));
+    fn provide<'a>(&'a self, request: &mut Request<'a>) {
+        self.0
+            .frames()
+            .for_each(|frame| frame.as_error().provide(request));
     }
 }

--- a/libs/error-stack/src/fmt.rs
+++ b/libs/error-stack/src/fmt.rs
@@ -18,10 +18,10 @@
 //! [`Report::install_debug_hook`] calls determines the order of the rendered output. Note, that
 //! Hooks get called on all values provided by [`Context::provide`], but not on the [`Context`]
 //! object itself. Therefore if you want to call a hook on a [`Context`] to print in addition to its
-//! [`Display`] implementation, you may want to call [`demand.provide_ref(self)`] inside of
+//! [`Display`] implementation, you may want to call [`request.provide_ref(self)`] inside of
 //! [`Context::provide`].
 //!
-//! [`demand.provide_ref(self)`]: core::any::Demand::provide_ref
+//! [`request.provide_ref(self)`]: core::error::Request::provide_ref
 //!
 //! Hook functions need to be [`Fn`] and **not** [`FnMut`], which means they are unable to directly
 //! mutate state outside of the closure.

--- a/libs/error-stack/src/frame.rs
+++ b/libs/error-stack/src/frame.rs
@@ -3,7 +3,7 @@ mod kind;
 
 use alloc::boxed::Box;
 #[cfg(nightly)]
-use core::any::{self, Demand, Provider};
+use core::error::{self, Error};
 use core::{any::TypeId, fmt};
 
 use self::frame_impl::FrameImpl;
@@ -59,7 +59,7 @@ impl Frame {
     where
         T: ?Sized + 'static,
     {
-        any::request_ref(self)
+        error::request_ref(self.as_error())
     }
 
     /// Requests the value of `T` from the `Frame` if provided.
@@ -69,7 +69,7 @@ impl Frame {
     where
         T: 'static,
     {
-        any::request_value(self)
+        error::request_value(self.as_error())
     }
 
     /// Returns if `T` is the held context or attachment by this frame.
@@ -95,12 +95,10 @@ impl Frame {
     pub fn type_id(&self) -> TypeId {
         self.frame.as_any().type_id()
     }
-}
 
-#[cfg(nightly)]
-impl Provider for Frame {
-    fn provide<'a>(&'a self, demand: &mut Demand<'a>) {
-        self.frame.provide(demand);
+    #[cfg(nightly)]
+    pub(crate) fn as_error(&self) -> &impl Error {
+        &self.frame
     }
 }
 

--- a/libs/error-stack/src/hook.rs
+++ b/libs/error-stack/src/hook.rs
@@ -74,15 +74,14 @@ impl Report<()> {
     /// ```rust
     /// # // this is a lot of boilerplate, if you find a better way, please change this!
     /// # // with #![cfg(nightly)] docsrs will complain that there's no main in non-nightly
-    /// # #![cfg_attr(nightly, feature(error_generic_member_access, provide_any))]
+    /// # #![cfg_attr(nightly, feature(error_in_core, error_generic_member_access))]
     /// # const _: &'static str = r#"
-    /// #![feature(error_generic_member_access, provide_any)]
+    /// #![feature(error_generic_member_access)]
     /// # "#;
     ///
     /// # #[cfg(nightly)]
     /// # mod nightly {
-    /// use std::any::Demand;
-    /// use std::error::Error;
+    /// use std::error::{Request, Error};
     /// use std::fmt::{Display, Formatter};
     /// use error_stack::{Report, report};
     ///
@@ -104,7 +103,7 @@ impl Report<()> {
     /// }
     ///
     /// impl Error for UserError {
-    ///  fn provide<'a>(&'a self, req: &mut Demand<'a>) {
+    ///  fn provide<'a>(&'a self, req: &mut Request<'a>) {
     ///    req.provide_value(Suggestion("try better next time!"));
     ///    req.provide_ref(&self.code);
     ///  }

--- a/libs/error-stack/src/lib.rs
+++ b/libs/error-stack/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! [![crates.io](https://img.shields.io/crates/v/error-stack)][crates.io]
 //! [![libs.rs](https://img.shields.io/badge/libs.rs-error--stack-orange)][libs.rs]
-//! [![rust-version](https://img.shields.io/static/v1?label=Rust&message=1.63.0/nightly-2023-08-14&color=blue)][rust-version]
+//! [![rust-version](https://img.shields.io/static/v1?label=Rust&message=1.63.0/nightly-2023-08-15&color=blue)][rust-version]
 //! [![discord](https://img.shields.io/discord/840573247803097118)][discord]
 //!
 //! [crates.io]: https://crates.io/crates/error-stack
@@ -428,10 +428,7 @@
 //! [`Debug`]: core::fmt::Debug
 //! [`SpanTrace`]: tracing_error::SpanTrace
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(
-    nightly,
-    feature(provide_any, error_in_core, error_generic_member_access)
-)]
+#![cfg_attr(nightly, feature(error_in_core, error_generic_member_access))]
 #![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
 #![cfg_attr(all(nightly, feature = "std"), feature(backtrace_frames))]
 #![cfg_attr(

--- a/libs/error-stack/tests/common.rs
+++ b/libs/error-stack/tests/common.rs
@@ -49,9 +49,9 @@ impl fmt::Display for ContextA {
 
 impl Context for ContextA {
     #[cfg(nightly)]
-    fn provide<'a>(&'a self, demand: &mut core::any::Demand<'a>) {
-        demand.provide_ref(&self.0);
-        demand.provide_value(u64::from(self.0));
+    fn provide<'a>(&'a self, request: &mut core::error::Request<'a>) {
+        request.provide_ref(&self.0);
+        request.provide_value(u64::from(self.0));
     }
 }
 
@@ -66,9 +66,9 @@ impl fmt::Display for ContextB {
 
 impl Context for ContextB {
     #[cfg(nightly)]
-    fn provide<'a>(&'a self, demand: &mut core::any::Demand<'a>) {
-        demand.provide_ref(&self.0);
-        demand.provide_value(i64::from(self.0));
+    fn provide<'a>(&'a self, request: &mut core::error::Request<'a>) {
+        request.provide_ref(&self.0);
+        request.provide_value(i64::from(self.0));
     }
 }
 
@@ -93,8 +93,8 @@ impl fmt::Display for ErrorA {
 #[cfg(feature = "spantrace")]
 impl Context for ErrorA {
     #[cfg(nightly)]
-    fn provide<'a>(&'a self, demand: &mut core::any::Demand<'a>) {
-        demand.provide_ref(&self.1);
+    fn provide<'a>(&'a self, request: &mut core::error::Request<'a>) {
+        request.provide_ref(&self.1);
     }
 }
 
@@ -118,8 +118,8 @@ impl fmt::Display for ErrorB {
 
 #[cfg(all(nightly, feature = "std"))]
 impl std::error::Error for ErrorB {
-    fn provide<'a>(&'a self, demand: &mut core::any::Demand<'a>) {
-        demand.provide_ref(&self.1);
+    fn provide<'a>(&'a self, request: &mut core::error::Request<'a>) {
+        request.provide_ref(&self.1);
     }
 }
 

--- a/libs/error-stack/tests/snapshots/doc/hook__debug_hook_provide.snap
+++ b/libs/error-stack/tests/snapshots/doc/hook__debug_hook_provide.snap
@@ -1,7 +1,7 @@
 <b>invalid user input</b>
 ├╴suggestion: try better next time!
 ├╴error code: 420
-├╴at <i>src/hook.rs:50:14</i>
+├╴at <i>src/hook.rs:49:14</i>
 ╰╴backtrace (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/libs/error-stack/tests/snapshots/test_debug__full__complex.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__full__complex.snap
@@ -3,7 +3,7 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴at tests/test_debug.rs:434:14
+├╴at tests/test_debug.rs:433:14
 ├╴printable A
 │
 ╰┬▶ root error

--- a/libs/error-stack/tests/snapshots/test_debug__full__hook_provider.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__full__hook_provider.snap
@@ -5,7 +5,7 @@ expression: "format!(\"{report:?}\")"
 context D
 ├╴usize: 420
 ├╴&'static str: Invalid User Input
-├╴at tests/test_debug.rs:589:38
+├╴at tests/test_debug.rs:588:38
 │
 ╰─▶ root error
     ├╴at tests/common.rs:4:5

--- a/libs/error-stack/tests/snapshots/test_debug__full__linear.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__full__linear.snap
@@ -3,11 +3,11 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context B
-├╴at tests/test_debug.rs:279:14
+├╴at tests/test_debug.rs:278:14
 ├╴printable C
 │
 ├─▶ context A
-│   ├╴at tests/test_debug.rs:276:14
+│   ├╴at tests/test_debug.rs:275:14
 │   ├╴printable B
 │   ╰╴1 additional opaque attachment
 │

--- a/libs/error-stack/tests/snapshots/test_debug__full__linear_ext.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__full__linear_ext.snap
@@ -3,11 +3,11 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 context B
-├╴at tests/test_debug.rs:296:14
+├╴at tests/test_debug.rs:295:14
 ├╴printable C
 │
 ├─▶ context A
-│   ├╴at tests/test_debug.rs:293:14
+│   ├╴at tests/test_debug.rs:292:14
 │   ├╴printable B
 │   ╰╴1 additional opaque attachment
 │

--- a/libs/error-stack/tests/snapshots/test_debug__full__multiline_context.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__full__multiline_context.snap
@@ -3,20 +3,20 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 context B
-├╴at tests/test_debug.rs:321:14
+├╴at tests/test_debug.rs:320:14
 ├╴printable C
 │
 ├─▶ A multiline
 │   context that might have
 │   a bit more info
-│   ├╴at tests/test_debug.rs:318:14
+│   ├╴at tests/test_debug.rs:317:14
 │   ├╴printable B
 │   ╰╴1 additional opaque attachment
 │
 ╰─▶ A multiline
     context that might have
     a bit more info
-    ├╴at tests/test_debug.rs:317:22
+    ├╴at tests/test_debug.rs:316:22
     ╰╴backtrace (1)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/libs/error-stack/tests/snapshots/test_debug__full__sources.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__full__sources.snap
@@ -3,7 +3,7 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴at tests/test_debug.rs:366:14
+├╴at tests/test_debug.rs:365:14
 ├╴1 additional opaque attachment
 │
 ╰┬▶ root error

--- a/libs/error-stack/tests/snapshots/test_debug__full__sources_transparent.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__full__sources_transparent.snap
@@ -3,7 +3,7 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴at tests/test_debug.rs:407:18
+├╴at tests/test_debug.rs:406:18
 ├╴1 additional opaque attachment
 │
 ╰┬▶ root error

--- a/libs/error-stack/tests/snapshots/test_debug__sources_nested.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__sources_nested.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴at tests/test_debug.rs:207:10
+├╴at tests/test_debug.rs:206:10
 ├╴2
 ├╴1
 │
 ╰┬▶ context A
- │  ├╴at tests/test_debug.rs:201:10
+ │  ├╴at tests/test_debug.rs:200:10
  │  ├╴4
  │  ├╴3
  │  │
@@ -17,16 +17,16 @@ context A
  │      ╰╴6
  │
  ╰▶ context A
-    ├╴at tests/test_debug.rs:196:10
+    ├╴at tests/test_debug.rs:195:10
     ├╴5
     ├╴3
     │
     ├─▶ context A
-    │   ├╴at tests/test_debug.rs:194:10
+    │   ├╴at tests/test_debug.rs:193:10
     │   ╰╴7
     │
     ╰┬▶ context A
-     │  ├╴at tests/test_debug.rs:185:34
+     │  ├╴at tests/test_debug.rs:184:34
      │  ├╴9
      │  ├╴8
      │  │
@@ -34,7 +34,7 @@ context A
      │      ╰╴at tests/common.rs:4:5
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:179:10
+     │  ├╴at tests/test_debug.rs:178:10
      │  ├╴13
      │  ├╴10
      │  ├╴16
@@ -45,7 +45,7 @@ context A
      │      ╰╴at tests/common.rs:4:5
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:165:10
+     │  ├╴at tests/test_debug.rs:164:10
      │  ├╴15
      │  ├╴14
      │  ├╴10
@@ -57,7 +57,7 @@ context A
      │      ╰╴at tests/common.rs:4:5
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:175:10
+     │  ├╴at tests/test_debug.rs:174:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
@@ -66,13 +66,13 @@ context A
      │      ╰╴at tests/common.rs:4:5
      │
      ╰▶ context A
-        ├╴at tests/test_debug.rs:171:10
+        ├╴at tests/test_debug.rs:170:10
         ├╴12
         ├╴9
         ├╴8
         │
         ├─▶ context A
-        │   ╰╴at tests/test_debug.rs:170:10
+        │   ╰╴at tests/test_debug.rs:169:10
         │
         ╰─▶ root error
             ╰╴at tests/common.rs:4:5

--- a/libs/error-stack/tests/snapshots/test_debug__sources_nested@backtrace.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__sources_nested@backtrace.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴at tests/test_debug.rs:207:10
+├╴at tests/test_debug.rs:206:10
 ├╴2
 ├╴1
 │
 ╰┬▶ context A
- │  ├╴at tests/test_debug.rs:201:10
+ │  ├╴at tests/test_debug.rs:200:10
  │  ├╴4
  │  ├╴3
  │  │
@@ -18,16 +18,16 @@ context A
  │      ╰╴6
  │
  ╰▶ context A
-    ├╴at tests/test_debug.rs:196:10
+    ├╴at tests/test_debug.rs:195:10
     ├╴5
     ├╴3
     │
     ├─▶ context A
-    │   ├╴at tests/test_debug.rs:194:10
+    │   ├╴at tests/test_debug.rs:193:10
     │   ╰╴7
     │
     ╰┬▶ context A
-     │  ├╴at tests/test_debug.rs:185:34
+     │  ├╴at tests/test_debug.rs:184:34
      │  ├╴9
      │  ├╴8
      │  │
@@ -36,7 +36,7 @@ context A
      │      ╰╴backtrace (2)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:179:10
+     │  ├╴at tests/test_debug.rs:178:10
      │  ├╴13
      │  ├╴10
      │  ├╴16
@@ -48,7 +48,7 @@ context A
      │      ╰╴backtrace (3)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:165:10
+     │  ├╴at tests/test_debug.rs:164:10
      │  ├╴15
      │  ├╴14
      │  ├╴10
@@ -61,7 +61,7 @@ context A
      │      ╰╴backtrace (4)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:175:10
+     │  ├╴at tests/test_debug.rs:174:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
@@ -71,13 +71,13 @@ context A
      │      ╰╴backtrace (5)
      │
      ╰▶ context A
-        ├╴at tests/test_debug.rs:171:10
+        ├╴at tests/test_debug.rs:170:10
         ├╴12
         ├╴9
         ├╴8
         │
         ├─▶ context A
-        │   ╰╴at tests/test_debug.rs:170:10
+        │   ╰╴at tests/test_debug.rs:169:10
         │
         ╰─▶ root error
             ├╴at tests/common.rs:4:5

--- a/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace-backtrace.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace-backtrace.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴at tests/test_debug.rs:207:10
+├╴at tests/test_debug.rs:206:10
 ├╴2
 ├╴1
 │
 ╰┬▶ context A
- │  ├╴at tests/test_debug.rs:201:10
+ │  ├╴at tests/test_debug.rs:200:10
  │  ├╴4
  │  ├╴3
  │  │
@@ -19,16 +19,16 @@ context A
  │      ╰╴6
  │
  ╰▶ context A
-    ├╴at tests/test_debug.rs:196:10
+    ├╴at tests/test_debug.rs:195:10
     ├╴5
     ├╴3
     │
     ├─▶ context A
-    │   ├╴at tests/test_debug.rs:194:10
+    │   ├╴at tests/test_debug.rs:193:10
     │   ╰╴7
     │
     ╰┬▶ context A
-     │  ├╴at tests/test_debug.rs:185:34
+     │  ├╴at tests/test_debug.rs:184:34
      │  ├╴9
      │  ├╴8
      │  │
@@ -38,7 +38,7 @@ context A
      │      ╰╴span trace with 2 frames (2)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:179:10
+     │  ├╴at tests/test_debug.rs:178:10
      │  ├╴13
      │  ├╴10
      │  ├╴16
@@ -51,7 +51,7 @@ context A
      │      ╰╴span trace with 2 frames (3)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:165:10
+     │  ├╴at tests/test_debug.rs:164:10
      │  ├╴15
      │  ├╴14
      │  ├╴10
@@ -65,7 +65,7 @@ context A
      │      ╰╴span trace with 2 frames (4)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:175:10
+     │  ├╴at tests/test_debug.rs:174:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
@@ -76,13 +76,13 @@ context A
      │      ╰╴span trace with 2 frames (5)
      │
      ╰▶ context A
-        ├╴at tests/test_debug.rs:171:10
+        ├╴at tests/test_debug.rs:170:10
         ├╴12
         ├╴9
         ├╴8
         │
         ├─▶ context A
-        │   ╰╴at tests/test_debug.rs:170:10
+        │   ╰╴at tests/test_debug.rs:169:10
         │
         ╰─▶ root error
             ├╴at tests/common.rs:4:5

--- a/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__sources_nested@spantrace.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:?}\")"
 ---
 context A
-├╴at tests/test_debug.rs:207:10
+├╴at tests/test_debug.rs:206:10
 ├╴2
 ├╴1
 │
 ╰┬▶ context A
- │  ├╴at tests/test_debug.rs:201:10
+ │  ├╴at tests/test_debug.rs:200:10
  │  ├╴4
  │  ├╴3
  │  │
@@ -18,16 +18,16 @@ context A
  │      ╰╴6
  │
  ╰▶ context A
-    ├╴at tests/test_debug.rs:196:10
+    ├╴at tests/test_debug.rs:195:10
     ├╴5
     ├╴3
     │
     ├─▶ context A
-    │   ├╴at tests/test_debug.rs:194:10
+    │   ├╴at tests/test_debug.rs:193:10
     │   ╰╴7
     │
     ╰┬▶ context A
-     │  ├╴at tests/test_debug.rs:185:34
+     │  ├╴at tests/test_debug.rs:184:34
      │  ├╴9
      │  ├╴8
      │  │
@@ -36,7 +36,7 @@ context A
      │      ╰╴span trace with 2 frames (2)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:179:10
+     │  ├╴at tests/test_debug.rs:178:10
      │  ├╴13
      │  ├╴10
      │  ├╴16
@@ -48,7 +48,7 @@ context A
      │      ╰╴span trace with 2 frames (3)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:165:10
+     │  ├╴at tests/test_debug.rs:164:10
      │  ├╴15
      │  ├╴14
      │  ├╴10
@@ -61,7 +61,7 @@ context A
      │      ╰╴span trace with 2 frames (4)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:175:10
+     │  ├╴at tests/test_debug.rs:174:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
@@ -71,13 +71,13 @@ context A
      │      ╰╴span trace with 2 frames (5)
      │
      ╰▶ context A
-        ├╴at tests/test_debug.rs:171:10
+        ├╴at tests/test_debug.rs:170:10
         ├╴12
         ├╴9
         ├╴8
         │
         ├─▶ context A
-        │   ╰╴at tests/test_debug.rs:170:10
+        │   ╰╴at tests/test_debug.rs:169:10
         │
         ╰─▶ root error
             ├╴at tests/common.rs:4:5

--- a/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 context A
-├╴at tests/test_debug.rs:207:10
+├╴at tests/test_debug.rs:206:10
 ├╴2
 ├╴1
 │
 ╰┬▶ context A
- │  ├╴at tests/test_debug.rs:201:10
+ │  ├╴at tests/test_debug.rs:200:10
  │  ├╴4
  │  ├╴3
  │  │
@@ -17,16 +17,16 @@ context A
  │      ╰╴6
  │
  ╰▶ context A
-    ├╴at tests/test_debug.rs:196:10
+    ├╴at tests/test_debug.rs:195:10
     ├╴5
     ├╴3
     │
     ├─▶ context A
-    │   ├╴at tests/test_debug.rs:194:10
+    │   ├╴at tests/test_debug.rs:193:10
     │   ╰╴7
     │
     ╰┬▶ context A
-     │  ├╴at tests/test_debug.rs:185:34
+     │  ├╴at tests/test_debug.rs:184:34
      │  ├╴9
      │  ├╴8
      │  │
@@ -34,7 +34,7 @@ context A
      │      ╰╴at tests/common.rs:4:5
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:179:10
+     │  ├╴at tests/test_debug.rs:178:10
      │  ├╴13
      │  ├╴10
      │  ├╴16
@@ -45,7 +45,7 @@ context A
      │      ╰╴at tests/common.rs:4:5
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:165:10
+     │  ├╴at tests/test_debug.rs:164:10
      │  ├╴15
      │  ├╴14
      │  ├╴10
@@ -57,7 +57,7 @@ context A
      │      ╰╴at tests/common.rs:4:5
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:175:10
+     │  ├╴at tests/test_debug.rs:174:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
@@ -66,13 +66,13 @@ context A
      │      ╰╴at tests/common.rs:4:5
      │
      ╰▶ context A
-        ├╴at tests/test_debug.rs:171:10
+        ├╴at tests/test_debug.rs:170:10
         ├╴12
         ├╴9
         ├╴8
         │
         ├─▶ context A
-        │   ╰╴at tests/test_debug.rs:170:10
+        │   ╰╴at tests/test_debug.rs:169:10
         │
         ╰─▶ root error
             ╰╴at tests/common.rs:4:5

--- a/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@backtrace.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@backtrace.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 context A
-├╴at tests/test_debug.rs:207:10
+├╴at tests/test_debug.rs:206:10
 ├╴2
 ├╴1
 │
 ╰┬▶ context A
- │  ├╴at tests/test_debug.rs:201:10
+ │  ├╴at tests/test_debug.rs:200:10
  │  ├╴4
  │  ├╴3
  │  │
@@ -18,16 +18,16 @@ context A
  │      ╰╴6
  │
  ╰▶ context A
-    ├╴at tests/test_debug.rs:196:10
+    ├╴at tests/test_debug.rs:195:10
     ├╴5
     ├╴3
     │
     ├─▶ context A
-    │   ├╴at tests/test_debug.rs:194:10
+    │   ├╴at tests/test_debug.rs:193:10
     │   ╰╴7
     │
     ╰┬▶ context A
-     │  ├╴at tests/test_debug.rs:185:34
+     │  ├╴at tests/test_debug.rs:184:34
      │  ├╴9
      │  ├╴8
      │  │
@@ -36,7 +36,7 @@ context A
      │      ╰╴backtrace (2)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:179:10
+     │  ├╴at tests/test_debug.rs:178:10
      │  ├╴13
      │  ├╴10
      │  ├╴16
@@ -48,7 +48,7 @@ context A
      │      ╰╴backtrace (3)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:165:10
+     │  ├╴at tests/test_debug.rs:164:10
      │  ├╴15
      │  ├╴14
      │  ├╴10
@@ -61,7 +61,7 @@ context A
      │      ╰╴backtrace (4)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:175:10
+     │  ├╴at tests/test_debug.rs:174:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
@@ -71,13 +71,13 @@ context A
      │      ╰╴backtrace (5)
      │
      ╰▶ context A
-        ├╴at tests/test_debug.rs:171:10
+        ├╴at tests/test_debug.rs:170:10
         ├╴12
         ├╴9
         ├╴8
         │
         ├─▶ context A
-        │   ╰╴at tests/test_debug.rs:170:10
+        │   ╰╴at tests/test_debug.rs:169:10
         │
         ╰─▶ root error
             ├╴at tests/common.rs:4:5

--- a/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace-backtrace.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace-backtrace.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 context A
-├╴at tests/test_debug.rs:207:10
+├╴at tests/test_debug.rs:206:10
 ├╴2
 ├╴1
 │
 ╰┬▶ context A
- │  ├╴at tests/test_debug.rs:201:10
+ │  ├╴at tests/test_debug.rs:200:10
  │  ├╴4
  │  ├╴3
  │  │
@@ -19,16 +19,16 @@ context A
  │      ╰╴6
  │
  ╰▶ context A
-    ├╴at tests/test_debug.rs:196:10
+    ├╴at tests/test_debug.rs:195:10
     ├╴5
     ├╴3
     │
     ├─▶ context A
-    │   ├╴at tests/test_debug.rs:194:10
+    │   ├╴at tests/test_debug.rs:193:10
     │   ╰╴7
     │
     ╰┬▶ context A
-     │  ├╴at tests/test_debug.rs:185:34
+     │  ├╴at tests/test_debug.rs:184:34
      │  ├╴9
      │  ├╴8
      │  │
@@ -38,7 +38,7 @@ context A
      │      ╰╴span trace with 2 frames (2)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:179:10
+     │  ├╴at tests/test_debug.rs:178:10
      │  ├╴13
      │  ├╴10
      │  ├╴16
@@ -51,7 +51,7 @@ context A
      │      ╰╴span trace with 2 frames (3)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:165:10
+     │  ├╴at tests/test_debug.rs:164:10
      │  ├╴15
      │  ├╴14
      │  ├╴10
@@ -65,7 +65,7 @@ context A
      │      ╰╴span trace with 2 frames (4)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:175:10
+     │  ├╴at tests/test_debug.rs:174:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
@@ -76,13 +76,13 @@ context A
      │      ╰╴span trace with 2 frames (5)
      │
      ╰▶ context A
-        ├╴at tests/test_debug.rs:171:10
+        ├╴at tests/test_debug.rs:170:10
         ├╴12
         ├╴9
         ├╴8
         │
         ├─▶ context A
-        │   ╰╴at tests/test_debug.rs:170:10
+        │   ╰╴at tests/test_debug.rs:169:10
         │
         ╰─▶ root error
             ├╴at tests/common.rs:4:5

--- a/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace.snap
+++ b/libs/error-stack/tests/snapshots/test_debug__sources_nested_alternate@spantrace.snap
@@ -3,12 +3,12 @@ source: tests/test_debug.rs
 expression: "format!(\"{report:#?}\")"
 ---
 context A
-├╴at tests/test_debug.rs:207:10
+├╴at tests/test_debug.rs:206:10
 ├╴2
 ├╴1
 │
 ╰┬▶ context A
- │  ├╴at tests/test_debug.rs:201:10
+ │  ├╴at tests/test_debug.rs:200:10
  │  ├╴4
  │  ├╴3
  │  │
@@ -18,16 +18,16 @@ context A
  │      ╰╴6
  │
  ╰▶ context A
-    ├╴at tests/test_debug.rs:196:10
+    ├╴at tests/test_debug.rs:195:10
     ├╴5
     ├╴3
     │
     ├─▶ context A
-    │   ├╴at tests/test_debug.rs:194:10
+    │   ├╴at tests/test_debug.rs:193:10
     │   ╰╴7
     │
     ╰┬▶ context A
-     │  ├╴at tests/test_debug.rs:185:34
+     │  ├╴at tests/test_debug.rs:184:34
      │  ├╴9
      │  ├╴8
      │  │
@@ -36,7 +36,7 @@ context A
      │      ╰╴span trace with 2 frames (2)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:179:10
+     │  ├╴at tests/test_debug.rs:178:10
      │  ├╴13
      │  ├╴10
      │  ├╴16
@@ -48,7 +48,7 @@ context A
      │      ╰╴span trace with 2 frames (3)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:165:10
+     │  ├╴at tests/test_debug.rs:164:10
      │  ├╴15
      │  ├╴14
      │  ├╴10
@@ -61,7 +61,7 @@ context A
      │      ╰╴span trace with 2 frames (4)
      │
      ├▶ context A
-     │  ├╴at tests/test_debug.rs:175:10
+     │  ├╴at tests/test_debug.rs:174:10
      │  ├╴11
      │  ├╴9
      │  ├╴8
@@ -71,13 +71,13 @@ context A
      │      ╰╴span trace with 2 frames (5)
      │
      ╰▶ context A
-        ├╴at tests/test_debug.rs:171:10
+        ├╴at tests/test_debug.rs:170:10
         ├╴12
         ├╴9
         ├╴8
         │
         ├─▶ context A
-        │   ╰╴at tests/test_debug.rs:170:10
+        │   ╰╴at tests/test_debug.rs:169:10
         │
         ╰─▶ root error
             ├╴at tests/common.rs:4:5

--- a/libs/error-stack/tests/test_attach.rs
+++ b/libs/error-stack/tests/test_attach.rs
@@ -1,5 +1,4 @@
-#![cfg_attr(nightly, feature(provide_any))]
-#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
+#![cfg_attr(nightly, feature(error_in_core, error_generic_member_access))]
 
 #[macro_use]
 mod common;

--- a/libs/error-stack/tests/test_attach_printable.rs
+++ b/libs/error-stack/tests/test_attach_printable.rs
@@ -1,5 +1,4 @@
-#![cfg_attr(nightly, feature(provide_any))]
-#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
+#![cfg_attr(nightly, feature(error_in_core, error_generic_member_access))]
 
 #[macro_use]
 mod common;

--- a/libs/error-stack/tests/test_backtrace.rs
+++ b/libs/error-stack/tests/test_backtrace.rs
@@ -1,7 +1,7 @@
 #![cfg(all(rust_1_65, feature = "std"))]
 #![cfg_attr(
     nightly,
-    feature(provide_any, backtrace_frames, error_generic_member_access)
+    feature(error_in_core, backtrace_frames, error_generic_member_access)
 )]
 
 mod common;

--- a/libs/error-stack/tests/test_change_context.rs
+++ b/libs/error-stack/tests/test_change_context.rs
@@ -1,5 +1,4 @@
-#![cfg_attr(nightly, feature(provide_any))]
-#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
+#![cfg_attr(nightly, feature(error_in_core, error_generic_member_access))]
 
 #[macro_use]
 mod common;

--- a/libs/error-stack/tests/test_conversion.rs
+++ b/libs/error-stack/tests/test_conversion.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "std")]
-#![cfg_attr(nightly, feature(provide_any, error_generic_member_access))]
+#![cfg_attr(nightly, feature(error_in_core, error_generic_member_access))]
 
 use std::io;
 
@@ -38,7 +38,7 @@ fn boxed_error() {
 
     #[cfg(nightly)]
     assert_eq!(
-        *core::any::request_ref::<u32>(report.as_ref()).expect("requested value not found"),
+        *core::error::request_ref::<u32>(report.as_ref()).expect("requested value not found"),
         10
     );
 }

--- a/libs/error-stack/tests/test_debug.rs
+++ b/libs/error-stack/tests/test_debug.rs
@@ -1,6 +1,5 @@
-#![cfg_attr(nightly, feature(provide_any))]
 #![cfg(not(miri))] // debug formatting does not utilize any unsafe code
-#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
+#![cfg_attr(nightly, feature(error_in_core, error_generic_member_access))]
 #![allow(clippy::std_instead_of_core)]
 mod common;
 
@@ -255,7 +254,7 @@ mod full {
     //! There are still some big snapshot tests, which are used evaluate all of the above.
 
     #[cfg(nightly)]
-    use std::any::Demand;
+    use std::error::Request;
     use std::{
         error::Error,
         fmt::{Display, Formatter},
@@ -575,7 +574,7 @@ mod full {
 
     #[cfg(nightly)]
     impl Error for ContextD {
-        fn provide<'a>(&'a self, req: &mut Demand<'a>) {
+        fn provide<'a>(&'a self, req: &mut Request<'a>) {
             req.provide_ref(&self.code);
             req.provide_ref(&self.reason);
         }

--- a/libs/error-stack/tests/test_display.rs
+++ b/libs/error-stack/tests/test_display.rs
@@ -1,5 +1,4 @@
-#![cfg_attr(nightly, feature(provide_any))]
-#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
+#![cfg_attr(nightly, feature(error_in_core, error_generic_member_access))]
 
 mod common;
 

--- a/libs/error-stack/tests/test_downcast.rs
+++ b/libs/error-stack/tests/test_downcast.rs
@@ -1,5 +1,4 @@
-#![cfg_attr(nightly, feature(provide_any))]
-#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
+#![cfg_attr(nightly, feature(error_in_core, error_generic_member_access))]
 
 mod common;
 

--- a/libs/error-stack/tests/test_extend.rs
+++ b/libs/error-stack/tests/test_extend.rs
@@ -1,5 +1,4 @@
-#![cfg_attr(nightly, feature(provide_any))]
-#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
+#![cfg_attr(nightly, feature(error_in_core, error_generic_member_access))]
 
 mod common;
 use core::fmt::{Display, Formatter};

--- a/libs/error-stack/tests/test_frame.rs
+++ b/libs/error-stack/tests/test_frame.rs
@@ -1,5 +1,4 @@
-#![cfg_attr(nightly, feature(provide_any))]
-#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
+#![cfg_attr(nightly, feature(error_in_core, error_generic_member_access))]
 
 mod common;
 

--- a/libs/error-stack/tests/test_iter.rs
+++ b/libs/error-stack/tests/test_iter.rs
@@ -1,8 +1,6 @@
-#![cfg_attr(nightly, feature(provide_any))]
-#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
+#![cfg_attr(nightly, feature(error_in_core, error_generic_member_access))]
 
 extern crate alloc;
-extern crate core;
 
 use core::fmt::{Display, Formatter, Write};
 

--- a/libs/error-stack/tests/test_macros.rs
+++ b/libs/error-stack/tests/test_macros.rs
@@ -1,5 +1,4 @@
-#![cfg_attr(nightly, feature(provide_any))]
-#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
+#![cfg_attr(nightly, feature(error_in_core, error_generic_member_access))]
 
 mod common;
 

--- a/libs/error-stack/tests/test_provision.rs
+++ b/libs/error-stack/tests/test_provision.rs
@@ -1,6 +1,5 @@
 #![cfg(nightly)]
-#![feature(provide_any)]
-#![cfg_attr(feature = "std", feature(error_generic_member_access))]
+#![cfg_attr(nightly, feature(error_in_core, error_generic_member_access))]
 
 mod common;
 

--- a/libs/error-stack/tests/test_serialize.rs
+++ b/libs/error-stack/tests/test_serialize.rs
@@ -4,8 +4,7 @@
 // can be considered safe, because we only check the output, which in itself does not use **any**
 // unsafe code.
 #![cfg(not(miri))]
-#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
-#![cfg_attr(nightly, feature(provide_any))]
+#![cfg_attr(nightly, feature(error_in_core, error_generic_member_access))]
 #![allow(clippy::std_instead_of_core)]
 
 use insta::assert_ron_snapshot;

--- a/libs/error-stack/tests/test_span_trace.rs
+++ b/libs/error-stack/tests/test_span_trace.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "spantrace")]
-#![cfg_attr(nightly, feature(provide_any))]
-#![cfg_attr(all(nightly, feature = "std"), feature(error_generic_member_access))]
+#![cfg_attr(nightly, feature(error_in_core, error_generic_member_access))]
 
 mod common;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The Error::provide API has changed. To avoid conflicts with the recent Rust toolchain and maintain compatibility we need to update the toolchain. This reverts #2906 (GEN-52).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:


- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph