### PR TITLE
H-422: Fix `dev:*` jobs not marked as persistent

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -22,6 +22,26 @@
       "persistent": true,
       "dependsOn": ["^build", "codegen"]
     },
+    "dev:backend": {
+      "persistent": true,
+      "dependsOn": ["^build", "codegen"]
+    },
+    "dev:api": {
+      "persistent": true,
+      "dependsOn": ["^build", "codegen"]
+    },
+    "dev:realtime": {
+      "persistent": true,
+      "dependsOn": ["^build", "codegen"]
+    },
+    "dev:search-loader": {
+      "persistent": true,
+      "dependsOn": ["^build", "codegen"]
+    },
+    "dev:frontend": {
+      "persistent": true,
+      "dependsOn": ["^build", "codegen"]
+    },
     "start": {
       "persistent": true,
       "dependsOn": ["^build", "codegen"]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The top-level jobs `dev:*` are not marked as persistent and also don't depend on `^build` and `codegen`.


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing
### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this