### PR TITLE
H-423: Make BE tests and PW tests depend on the integration worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,13 @@ jobs:
 
   backend-integration-tests:
     name: Backend integration tests
-    needs: [build-hash-graph, build-hash-ai-worker-ts, build-hash-ai-worker-py]
+    needs:
+      [
+        build-hash-graph,
+        build-hash-ai-worker-ts,
+        build-hash-ai-worker-py,
+        build-hash-integration-worker,
+      ]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -321,7 +327,13 @@ jobs:
 
   playwright-tests:
     name: Playwright tests
-    needs: [build-hash-graph, build-hash-ai-worker-ts, build-hash-ai-worker-py]
+    needs:
+      [
+        build-hash-graph,
+        build-hash-ai-worker-ts,
+        build-hash-ai-worker-py,
+        build-hash-integration-worker,
+      ]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The external services require the integration worker. Until now it never happened (to my knowledge) that the BE tests or PW tests started before the integration worker completed but it just happened for the first time and to avoid issues in the future, it should be made sure that the tests are waiting for the worker to be built.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing
### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph