### PR TITLE
H-426: Extend structural queries to allow specifying inheritance depth

### DIFF
--- a/apps/hash-graph/lib/graph/src/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/ontology/entity_type.rs
@@ -231,7 +231,7 @@ pub enum EntityTypeQueryPath<'p> {
     ///
     /// ### Specifying the inheritance depth
     ///
-    /// By passing `inheritanceDepths` as paramteer it's possible to limit the searched depth:
+    /// By passing `inheritanceDepth` as a parameter it's possible to limit the searched depth:
     ///
     /// ```rust
     /// # use serde::Deserialize;
@@ -298,7 +298,7 @@ pub enum EntityTypeQueryPath<'p> {
     ///
     /// ### Specifying the inheritance depth
     ///
-    /// By passing `inheritanceDepths` as paramteer it's possible to limit the searched depth:
+    /// By passing `inheritanceDepth` as a parameter it's possible to limit the searched depth:
     ///
     /// ```rust
     /// # use serde::Deserialize;
@@ -348,7 +348,7 @@ pub enum EntityTypeQueryPath<'p> {
     ///
     /// ### Specifying the inheritance depth
     ///
-    /// By passing `inheritanceDepths` as paramteer it's possible to limit the searched depth:
+    /// By passing `inheritanceDepth` as a parameter it's possible to limit the searched depth:
     ///
     /// ```rust
     /// # use serde::Deserialize;

--- a/apps/hash-graph/lib/graph/src/store/query.rs
+++ b/apps/hash-graph/lib/graph/src/store/query.rs
@@ -30,14 +30,12 @@ pub fn parse_query_token<'de, T: Deserialize<'de>, E: de::Error>(
     token: &'de str,
 ) -> Result<(T, HashMap<&str, &str>), E> {
     let Some((token, parameters)) = token.split_once('(') else {
-          return T::deserialize(token.into_deserializer()).map(|token| (token, HashMap::new()));
+        return T::deserialize(token.into_deserializer()).map(|token| (token, HashMap::new()));
     };
 
     let parameters = parameters
         .strip_suffix(')')
-        .ok_or_else(|| E::custom("missing closing parenthesis"))?;
-
-    let parameters = parameters
+        .ok_or_else(|| E::custom("missing closing parenthesis"))?
         .split(',')
         .filter(|parameter| !parameter.trim().is_empty())
         .map(|parameter| {

--- a/apps/hash-graph/lib/graph/src/store/query.rs
+++ b/apps/hash-graph/lib/graph/src/store/query.rs
@@ -1,7 +1,12 @@
 mod filter;
 mod path;
 
-use std::fmt;
+use std::{collections::HashMap, fmt};
+
+use serde::{
+    de::{self, IntoDeserializer},
+    Deserialize,
+};
 
 pub use self::{
     filter::{Filter, FilterExpression, Parameter, ParameterConversionError, ParameterList},
@@ -11,6 +16,39 @@ pub use self::{
 pub trait QueryPath {
     /// Returns what type this resolved `Path` has.
     fn expected_type(&self) -> ParameterType;
+}
+
+/// Parses a query token of the form `token(key=value)`.
+///
+/// Whitespaces are ignored and multiple parameters are supported.
+///
+/// # Errors
+///
+/// - If the token is not of the form `token`, `token()`, or `token(key=value)`
+/// - If `token` can not be deserialized into `T`
+pub fn parse_query_token<'de, T: Deserialize<'de>, E: de::Error>(
+    token: &'de str,
+) -> Result<(T, HashMap<&str, &str>), E> {
+    if let Some((token, parameters)) = token.split_once('(') {
+        let parameters = parameters
+            .strip_suffix(')')
+            .ok_or_else(|| E::custom("missing closing parenthesis"))?;
+
+        let parameters = parameters
+            .split(',')
+            .filter(|parameter| !parameter.trim().is_empty())
+            .map(|parameter| {
+                let (key, value) = parameter
+                    .split_once('=')
+                    .ok_or_else(|| E::custom("missing parameter value, expected `key=value`"))?;
+                Ok((key.trim(), value.trim()))
+            })
+            .collect::<Result<_, _>>()?;
+
+        T::deserialize(token.into_deserializer()).map(|token| (token, parameters))
+    } else {
+        T::deserialize(token.into_deserializer()).map(|token| (token, HashMap::new()))
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, by default, the maximum inheritance depth is used for query parameters. To allow specifying it a parameter may be passed to the query token, e.g. instead of `["type", "versionedUrl"]` it can be specified as `["type(inheritanceDepth = 5)", "versionedUrl]`.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph