### PR TITLE
H-451: Fix "View all types" page in production

### DIFF
--- a/apps/hash-frontend/src/pages/shared/auth-info-context.tsx
+++ b/apps/hash-frontend/src/pages/shared/auth-info-context.tsx
@@ -53,39 +53,40 @@ export const AuthInfoProvider: FunctionComponent<AuthInfoProviderProps> = ({
 
   const [getMe] = useLazyQuery<MeQuery>(meQuery, { fetchPolicy: "no-cache" });
 
-  const refetch = useCallback<RefetchAuthInfoFunction>(async () => {
-    const [subgraph, kratosSession] = await Promise.all([
-      getMe()
-        .then(({ data }) => data?.me)
-        .catch(() => undefined),
-      fetchKratosSession(),
-    ]);
+  const fetchAuthenticatedUser =
+    useCallback<RefetchAuthInfoFunction>(async () => {
+      const [subgraph, kratosSession] = await Promise.all([
+        getMe()
+          .then(({ data }) => data?.me)
+          .catch(() => undefined),
+        fetchKratosSession(),
+      ]);
 
-    if (!subgraph || !kratosSession) {
-      setAuthenticatedUser(undefined);
-      return {};
-    }
-    const userEntity = getRoots(subgraph as Subgraph<EntityRootType>)[0]!;
+      if (!subgraph || !kratosSession) {
+        setAuthenticatedUser(undefined);
+        return {};
+      }
+      const userEntity = getRoots(subgraph as Subgraph<EntityRootType>)[0]!;
 
-    const latestAuthenticatedUser = constructAuthenticatedUser({
-      userEntity: userEntity as Entity<UserProperties>,
-      subgraph,
-      kratosSession,
-    });
+      const latestAuthenticatedUser = constructAuthenticatedUser({
+        userEntity: userEntity as Entity<UserProperties>,
+        subgraph,
+        kratosSession,
+      });
 
-    setAuthenticatedUser(latestAuthenticatedUser);
+      setAuthenticatedUser(latestAuthenticatedUser);
 
-    return {
-      authenticatedUser: latestAuthenticatedUser,
-    };
-  }, [getMe]);
+      return {
+        authenticatedUser: latestAuthenticatedUser,
+      };
+    }, [getMe]);
 
   const value = useMemo(
     () => ({
       authenticatedUser,
-      refetch,
+      refetch: fetchAuthenticatedUser,
     }),
-    [authenticatedUser, refetch],
+    [authenticatedUser, fetchAuthenticatedUser],
   );
 
   return (

--- a/apps/hash-frontend/src/pages/types/[[...type-kind]].page.tsx
+++ b/apps/hash-frontend/src/pages/types/[[...type-kind]].page.tsx
@@ -1,7 +1,7 @@
 import { DataTypeRootType, DataTypeWithMetadata } from "@local/hash-subgraph";
 import { getRoots } from "@local/hash-subgraph/stdlib";
 import { Box, Container, Typography } from "@mui/material";
-import { GetStaticPaths, GetStaticProps } from "next";
+import { GetServerSideProps } from "next";
 import { NextSeo } from "next-seo";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -31,24 +31,17 @@ type ParsedQueryParams = {
   ["type-kind"]?: ParsedQueryKindParam[];
 };
 
-export const getStaticPaths: GetStaticPaths<ParsedQueryParams> = () => ({
-  paths: [
-    { params: { "type-kind": [] } },
-    ...parsedQueryParams.map((kind) => ({ params: { "type-kind": [kind] } })),
-  ],
-  fallback: false,
-});
-
 export type TabId = "all" | ParsedQueryKindParam;
 
 type TypesPageProps = {
   currentTab: TabId;
 };
 
-export const getStaticProps: GetStaticProps<
+export const getServerSideProps: GetServerSideProps<
   TypesPageProps,
   ParsedQueryParams
-> = ({ params }) => {
+  // eslint-disable-next-line @typescript-eslint/require-await
+> = async ({ params }) => {
   const currentTab = params?.["type-kind"]?.[0] ?? "all";
 
   return { props: { currentTab } };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR fixes the "View all types" page in production, which currently does not display correctly in production because the `authenticatedUser` is set to `undefined` on the `/types` page even when the user is logged in.

This was occurring because `getInitialProps` in `_app.page.tsx` is not compatible with `getStaticProps` in `/types`. This PR addresses this by replacing `getStaticProps` with `getServerSideProps` in the `/types` page.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Click on the deployment, login, and go to the "View all types" page. Ensure the sidebar doesn't disappear, and the table is displaying as expected.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

<img width="1512" alt="image" src="https://github.com/hashintel/hash/assets/42802102/22fc0f60-4a88-4dce-9993-4a4ff8495f31">

