### PR TITLE
H-476: Fix internal link detection in hash.dev

### DIFF
--- a/apps/hashdotdev/src/util/mdx-components.tsx
+++ b/apps/hashdotdev/src/util/mdx-components.tsx
@@ -114,7 +114,7 @@ export const mdxComponents: Record<string, ComponentType<any>> = {
   a: (props: HTMLProps<HTMLAnchorElement>) => {
     const { href, ref: _ref, ...rest } = props;
     return href ? (
-      <Link {...rest} href={href.replace("https://blockprotocol.org", "")} />
+      <Link {...rest} href={href.replace("https://hash.dev", "")} />
     ) : (
       // eslint-disable-next-line jsx-a11y/anchor-has-content -- special case for creating bookmarks (for cross-linking)
       <a id={props.id} />


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The anchor tag handling in hash.dev was rewriting https://blockprotocol.org links as internal, when they aren't. This PR fixes that.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph



## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Go to a page containing links to the BP site, e.g. `/blog/block-protocol-0-3-wordpress`
2. Check that a link to a BP URL works correctly

