### PR TITLE
H-351: Use `hash-graph-types` to create entities

### DIFF
--- a/libs/@local/hash-graph-sdk/python/graph_sdk/client/blocking.py
+++ b/libs/@local/hash-graph-sdk/python/graph_sdk/client/blocking.py
@@ -10,19 +10,23 @@ from typing import Self, TypeVar
 from uuid import UUID
 
 from graph_client.models import (
+    LinkData,
     MaybeListOfOntologyElementMetadata,
     OntologyElementMetadata,
     Subgraph,
 )
 from graph_types import DataTypeSchema, EntityTypeSchema, PropertyTypeSchema
+from graph_types.base import EntityType as GraphEntityType
 from yarl import URL
 
 from graph_sdk.client.concurrent import HASHClient as ConcurrentHASHClient
+from graph_sdk.entity import Entity
 from graph_sdk.options import Options
 from graph_sdk.query import BaseFilter
 from graph_sdk.utils import async_to_sync
 
 T = TypeVar("T")
+U = TypeVar("U", bound=GraphEntityType)
 
 
 class HASHClient:
@@ -108,3 +112,19 @@ class HASHClient:
     def query_entities(self, query: BaseFilter, options: Options) -> Subgraph:
         """Query entities."""
         return async_to_sync(self.inner.query_entities(query, options))
+
+    def create_entity(
+        self,
+        properties: U,
+        *,
+        link: LinkData | None = None,
+        owned_by_id: UUID,
+    ) -> Entity[U]:
+        """Create an entity."""
+        return async_to_sync(
+            self.inner.create_entity(properties, link=link, owned_by_id=owned_by_id),
+        )
+
+    def update_entity(self, entity: Entity[U]) -> None:
+        """Update an entity."""
+        return async_to_sync(self.inner.update_entity(entity))

--- a/libs/@local/hash-graph-sdk/python/graph_sdk/entity.py
+++ b/libs/@local/hash-graph-sdk/python/graph_sdk/entity.py
@@ -1,18 +1,22 @@
-from typing import TypeVar, Generic, Self
+"""Definition of high-level entities.
 
-from graph_client import EntityMetadata
+Entities are instantiated objects that are stored in the graph,
+they can be created through the graph client.
+"""
+from typing import Generic, Self, TypeVar
+
 from graph_client.models import (
-    ProvenanceMetadata,
-    EntityTemporalMetadata,
+    EntityId,
+    EntityLinkOrder,
+    EntityMetadata,
     EntityRecordId,
+    EntityTemporalMetadata,
     LinkData,
     LinkOrder,
-    EntityLinkOrder,
-    EntityId,
+    ProvenanceMetadata,
 )
-from pydantic import BaseModel
-
 from graph_types.base import EntityType
+from pydantic import BaseModel
 
 T = TypeVar("T", bound=EntityType)
 
@@ -20,8 +24,8 @@ T = TypeVar("T", bound=EntityType)
 class Link(BaseModel):
     """Aggregated link information for an entity."""
 
-    left: EntityId | "Entity" = None
-    right: EntityId | "Entity" = None
+    left: EntityId | "Entity" | None = None
+    right: EntityId | "Entity" | None = None
 
     left_to_right_order: LinkOrder | None = None
     right_to_left_order: LinkOrder | None = None
@@ -64,11 +68,14 @@ class Entity(BaseModel, Generic[T]):
 
         self.archived = metadata.archived
         self.provenance = metadata.provenance
-        self.temporal = metadata.temporal
+        self.temporal = metadata.temporal_versioning
 
     @classmethod
     def from_create(
-        cls, meta: EntityMetadata, link: LinkData | None, properties: T
+        cls,
+        meta: EntityMetadata,
+        link: LinkData | None,
+        properties: T,
     ) -> Self:
         """Create an entity from FFI data."""
         return cls(
@@ -77,5 +84,5 @@ class Entity(BaseModel, Generic[T]):
             link=Link.from_ffi(link, None),
             archived=meta.archived,
             provenance=meta.provenance,
-            temporal=meta.temporal,
+            temporal=meta.temporal_versioning,
         )

--- a/libs/@local/hash-graph-sdk/python/graph_sdk/entity.py
+++ b/libs/@local/hash-graph-sdk/python/graph_sdk/entity.py
@@ -1,0 +1,81 @@
+from typing import TypeVar, Generic, Self
+
+from graph_client import EntityMetadata
+from graph_client.models import (
+    ProvenanceMetadata,
+    EntityTemporalMetadata,
+    EntityRecordId,
+    LinkData,
+    LinkOrder,
+    EntityLinkOrder,
+    EntityId,
+)
+from pydantic import BaseModel
+
+from graph_types.base import EntityType
+
+T = TypeVar("T", bound=EntityType)
+
+
+class Link(BaseModel):
+    """Aggregated link information for an entity."""
+
+    left: EntityId | "Entity" = None
+    right: EntityId | "Entity" = None
+
+    left_to_right_order: LinkOrder | None = None
+    right_to_left_order: LinkOrder | None = None
+
+    @classmethod
+    def from_ffi(cls, data: LinkData | None, order: EntityLinkOrder | None) -> Self:
+        """Create a link from FFI data."""
+        return cls(
+            left=data.left_entity_id if data else None,
+            right=data.right_entity_id if data else None,
+            left_to_right_order=order.left_to_right_order if order else None,
+            right_to_left_order=order.right_to_left_order if order else None,
+        )
+
+
+class Entity(BaseModel, Generic[T]):
+    """An instantiated entity."""
+
+    id: EntityRecordId  # noqa: A003
+
+    properties: T
+
+    link: Link | None = None
+
+    archived: bool = False
+    provenance: ProvenanceMetadata
+    temporal: EntityTemporalMetadata
+
+    def apply_metadata(self, metadata: EntityMetadata) -> None:
+        """Apply metadata to the entity."""
+        if self.properties.info.identifier != metadata.entity_type_id:
+            msg = (
+                f"Expected entity type {metadata.entity_type_id}, got"
+                f" {self.properties.info.identifier}"
+            )
+
+            raise TypeError(msg)
+
+        self.id = metadata.record_id
+
+        self.archived = metadata.archived
+        self.provenance = metadata.provenance
+        self.temporal = metadata.temporal
+
+    @classmethod
+    def from_create(
+        cls, meta: EntityMetadata, link: LinkData | None, properties: T
+    ) -> Self:
+        """Create an entity from FFI data."""
+        return cls(
+            id=meta.record_id,
+            properties=properties,
+            link=Link.from_ffi(link, None),
+            archived=meta.archived,
+            provenance=meta.provenance,
+            temporal=meta.temporal,
+        )

--- a/libs/@local/hash-graph-sdk/python/scripts/generate_blocking.py
+++ b/libs/@local/hash-graph-sdk/python/scripts/generate_blocking.py
@@ -191,7 +191,10 @@ for method in client_ast.body:
                                         arg=keyword.arg,
                                         value=ast.Name(keyword.arg, ctx=ast.Load()),
                                     )
-                                    for keyword in (method_args.kwarg or [])
+                                    for keyword in (
+                                        (method_args.kwarg or [])
+                                        + (method_args.kwonlyargs or [])
+                                    )
                                 ],
                             )
                         ],


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Implement higher-level operations on the graph by using `hash-graph-types` on entities.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

Before this gets ready for tests I need to first write an example to verify the code actually works.

There is also no truly convenient way to get all entities from the graph yet, this will need to be fixed before this is ready.

Next PR will introduce real tests.