### PR TITLE
GEN-71: Fix CI for `deer`

### DIFF
--- a/libs/deer/desert/src/lib.rs
+++ b/libs/deer/desert/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+// #![no_std]
 
 extern crate alloc;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `no_std` causes problem. I'm not going to track down why this is the case because this PR needs to be merged ASAP to unblock other PRs.