### PR TITLE
GEN-71: Fix `deer` CI failure

### DIFF
--- a/libs/deer/desert/Cargo.toml
+++ b/libs/deer/desert/Cargo.toml
@@ -18,5 +18,6 @@ num-traits = "0.2.15"
 similar-asserts = { version = "1.4.2", default_features = false, features = ['serde'], optional = true }
 
 [features]
+std = ['deer/std']
 default = ['pretty']
-pretty = ['dep:similar-asserts']
+pretty = ['std', 'dep:similar-asserts']

--- a/libs/deer/desert/src/assert.rs
+++ b/libs/deer/desert/src/assert.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "pretty")]
-use alloc::format;
 use core::fmt::Debug;
 
 use deer::{

--- a/libs/deer/desert/src/assert.rs
+++ b/libs/deer/desert/src/assert.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "pretty")]
+use alloc::format;
 use core::fmt::Debug;
 
 use deer::{

--- a/libs/deer/desert/src/lib.rs
+++ b/libs/deer/desert/src/lib.rs
@@ -1,4 +1,4 @@
-// #![no_std]
+#![no_std]
 
 extern crate alloc;
 

--- a/libs/deer/desert/src/lib.rs
+++ b/libs/deer/desert/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This fixes the CI failure exhibited because `similar-assert` `1.5` has been released; the change made it so that the macro now invokes another macro (instead of a function), leading to `similar-assert` calling the `format!` macro in client code instead of library code.


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

