### PR TITLE
H-528: Fix bugs when navigating between types

### DIFF
--- a/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
@@ -379,6 +379,7 @@ const Page: NextPageWithLayout = () => {
 
       {previewEntityTypeUrl ? (
         <TypePreviewSlide
+          key={previewEntityTypeUrl}
           onClose={() => setPreviewEntityTypeUrl(null)}
           onNavigateToType={onNavigateToType}
           typeUrl={previewEntityTypeUrl}

--- a/libs/@hashintel/type-editor/src/entity-type-editor/inheritance-row/inherited-type-card.tsx
+++ b/libs/@hashintel/type-editor/src/entity-type-editor/inheritance-row/inherited-type-card.tsx
@@ -5,6 +5,7 @@ import { useFormContext, useWatch } from "react-hook-form";
 
 import { useEntityTypesOptions } from "../../shared/entity-types-options-context";
 import { EntityTypeEditorFormData } from "../../shared/form-types";
+import { useIsReadonly } from "../../shared/read-only-context";
 import { Link } from "../shared/link";
 import { useTypeVersions } from "../shared/use-type-versions";
 
@@ -18,6 +19,8 @@ export const InheritedTypeCard = ({
 
   const [currentVersion, latestVersion] = useTypeVersions($id, entityTypes);
   const newVersion = currentVersion < latestVersion ? latestVersion : undefined;
+
+  const isReadOnly = useIsReadonly();
 
   const { control, setValue } = useFormContext<EntityTypeEditorFormData>();
   const directParentEntityTypeIds = useWatch({
@@ -53,7 +56,7 @@ export const InheritedTypeCard = ({
 
   return (
     <TypeCard
-      onDelete={removeType}
+      onDelete={isReadOnly ? undefined : removeType}
       LinkComponent={Link}
       newVersionConfig={
         newVersion


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR fixes two bugs related to the entity type form: a crash could occur when switching between viewing two different types in the form, either navigating via the sidebar (moving between pages for two different types), or navigating between types in the preview slide.

The crash was caused by a mismatch between the data loaded into the form, which contains references to property types, and the property type options available to the form: it was possible for the options to be missing the property types the form data referenced. The same is true for link types.

There were two variants of this:
**1.** In the preview slide, navigating from a type with any properties to another type which was missing at least one of those properties caused a crash because the property type options were changed before the form data. The PR fixes this by resetting the slide's state when the URL loaded into it changes, by adding a `key` to the component. This also has a UX benefit of causing the slideover animation to repeat when moving between types, making it clear to the user when the type in the slide has changed (rather than values changing, which can be hard to spot depending on how many values change). 

**2.** If viewing a type page which refers to a property type below that property type's latest version, navigating to another type's page via a link in the sidebar would cause a crash. This PR fixes that by changing when the form data resets so that the previous type's data isn't left in the form when the property type options have been changed (since are then missing the non-latest property type).

**Drive-by:** I noticed that the button to remove a type from the 'Extends' section was present in the preview slide, and have fixed that also.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Slack report](https://hashintel.slack.com/archives/C03TWBSRT8B/p1692691432748659) (internal)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->
You can recreate the bugs in `main` by doing the following, and then switching to the branch and confirming there is no crash:

**Bug 1**
1. Create Type A that has at least one property, and a link to another type Whatever (doesn't matter which)
2. Create Type B that links to Type A
3. From Type B's page, click Type A in the links to open the preview slide, and then from Type A click the link to Whatever – it should crash in `main` but not in the branch

**Bug 2**
1. Have any type which refers to a non-latest property type (e.g. go to Type B, add whatever property you added to Type A, and amend it so that it is no longer the latest on Type A)
2. Be on that type's page, and then click another type in the sidebar – it should crash in `main` but not in the branch

**Bug 3**
1. Load a type which extends another type in the preview slide and hover over the type in 'Extends' – the 'x' should appear in `main` but not in the branch

