### PR TITLE
GEN-77: Bump `error-stack` to 0.4

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -353,7 +353,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
         uses: taiki-e/install-action@v2
         with:
-          tool: just@1.13.0,cargo-hack@0.5.26,cargo-nextest@0.9.37,rust-script@0.23.0,cargo-semver-checks@0.17.0
+          tool: just@1.13.0,cargo-hack@0.5.26,cargo-nextest@0.9.37,rust-script@0.23.0,cargo-semver-checks
 
       - name: Run lints
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
@@ -377,7 +377,8 @@ jobs:
           # Only run semver checks if this is not the initial release
           grep '^version' Cargo.toml | grep -q -v 0.0.0-reserved || exit 0
 
-          cargo +${{ matrix.toolchain }} semver-checks check-release
+          # Temporarily disabled as `error-stack@0.3.1` does not compile on the current nightly toolchain
+          # cargo +${{ matrix.toolchain }} semver-checks check-release
 
       - name: Publish (dry run)
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}

--- a/libs/error-stack/CHANGELOG.md
+++ b/libs/error-stack/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to `error-stack` will be documented in this file.
 
 - Support for [`defmt`](https://defmt.ferrous-systems.com)
 
-## 0.4.0 - unreleased
+## [0.4.0](https://github.com/hashintel/hash/tree/error-stack%400.4.0/libs/error-stack) - 2023-08-23
 
 ### Breaking Changes
 

--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["package.json", ".config/lints.toml"]
 
 [package]
 name = "error-stack"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["HASH"]
 edition = "2021"
 rust-version = "1.63.0"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

With the latest nightly change it's required to set a `git` dependency for error-stack if a nightly compiler is used.

## 🔍 What does this change?

- Bump version of `error-stack` to `0.4.0`
- Adjust changelog to point to the upcoming release tag
- `error-stack@0.3.1` does not compile on the current nightly channel (the main reason for this release), so the SemVer check cannot pass. I temporarily disabled it. I will enable it again after this PR is merged.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies a **Cargo**-publishable library and **I have amended the version**

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph