### PR TITLE
H-557: Fix snapshot restore for big snapshots

### DIFF
--- a/apps/hash-graph/lib/graph/src/snapshot/entity/batch.rs
+++ b/apps/hash-graph/lib/graph/src/snapshot/entity/batch.rs
@@ -72,6 +72,7 @@ impl<C: AsClient> WriteBatch<C> for EntityRowBatch {
                         r"
                             INSERT INTO entity_ids_tmp
                             SELECT DISTINCT * FROM UNNEST($1::entity_ids[])
+                            ON CONFLICT DO NOTHING
                             RETURNING 1;
                         ",
                         &[ids],
@@ -88,6 +89,7 @@ impl<C: AsClient> WriteBatch<C> for EntityRowBatch {
                         r"
                             INSERT INTO entity_editions_tmp
                             SELECT DISTINCT * FROM UNNEST($1::entity_editions_tmp[])
+                            ON CONFLICT DO NOTHING
                             RETURNING 1;
                         ",
                         &[editions],


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We insert the data of snapshot in batches. Entity IDs and edition may occur multiple times as for each version the full entity is emitted. If the entities are inserted in the same batch they are deduplicated but not if they are inserted in different batches. This results in a primary key error.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

Ideally, the checks would only ignore the action if the full row is a duplicate, not only of the primary key constraint fails. This is not easily possible and can be ignored for now