### PR TITLE
H-277: Fix hotkeys detected as being pressed when they aren't

### DIFF
--- a/apps/hash-frontend/src/shared/command-bar/cheat-sheet.tsx
+++ b/apps/hash-frontend/src/shared/command-bar/cheat-sheet.tsx
@@ -1,6 +1,5 @@
 import { Box, Typography } from "@mui/material";
 import { useEffect, useReducer, useState } from "react";
-import { useKeys } from "rooks";
 
 import { Modal } from "../ui/modal";
 import { CommandBarOption, menu } from "./command-bar-options";
@@ -32,20 +31,25 @@ export const CheatSheet = () => {
     {},
   );
 
-  useKeys(
-    ["?"],
-    (evt) => {
-      // Hack to detect if pressed inside an input or textarea
-      if (
-        evt.target &&
-        !("defaultValue" in evt.target) &&
-        !(evt.target as HTMLElement).isContentEditable
-      ) {
-        setOpen(true);
-      }
-    },
-    {},
-  );
+  /**
+   * @todo reinstate this
+   * when doing so, check if https://github.com/imbhargav5/rooks/issues/1730 has been fixed
+   * if it has, upgrade rooks. if not, either implement our own version of useKeys (command-bar has one) or patch rooks
+   */
+  // useKeys(
+  //   ["?"],
+  //   (evt) => {
+  //     // Hack to detect if pressed inside an input or textarea
+  //     if (
+  //       evt.target &&
+  //       !("defaultValue" in evt.target) &&
+  //       !(evt.target as HTMLElement).isContentEditable
+  //     ) {
+  //       setOpen(true);
+  //     }
+  //   },
+  //   {},
+  // );
 
   return (
     <Modal open={open} onClose={() => setOpen(false)}>

--- a/apps/hash-frontend/src/shared/layout/layout-with-header/search-bar/search-input.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-header/search-bar/search-input.tsx
@@ -8,7 +8,6 @@ import {
   Typography,
 } from "@mui/material";
 import { FunctionComponent, useCallback, useEffect, useRef } from "react";
-import { useKeys } from "rooks";
 
 import { SearchIcon } from "../../../icons";
 
@@ -87,12 +86,17 @@ export const SearchInput: FunctionComponent<{
 
   const inputRef = useRef<HTMLInputElement>(null);
 
-  useKeys(["ControlLeft", "KeyP"], (event) => {
-    event.preventDefault();
-    if (!isMac) {
-      inputRef.current?.focus();
-    }
-  });
+  /**
+   * @todo reinstate this
+   * when doing so, check if https://github.com/imbhargav5/rooks/issues/1730 has been fixed
+   * if it has, upgrade rooks. if not, either implement our own version of useKeys (command-bar has one) or patch rooks
+   */
+  // useKeys(["ControlLeft", "KeyP"], (event) => {
+  //   event.preventDefault();
+  //   if (!isMac) {
+  //     inputRef.current?.focus();
+  //   }
+  // });
 
   useEffect(() => {
     function checkSearchKey(event: KeyboardEvent) {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes a bug whereby hotkeys could apparently randomly be detected as pressed when they weren't.

The easiest recreation is to press CTRL + F to bring up the browser's find window, and click back in the page, then press K – the command bar will appear.

The underlying issue is described in https://github.com/imbhargav5/rooks/issues/1730

This PR fixes it by adding a listener for when the window loses focus, and clearing the 'pressed keys' map. We already had our own adaption of `useKeys` which could be further adapted to do this.

There are a couple of other places where we use `rooks`'s `useKeys`, but these are in components that currently aren't used (hotkey cheatsheet, and search bar). I've commented the hotkey functionality out in those so that it's obvious there is a bug to be fixed when we come to reinstate them.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- Manual

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  See description for recreation case – test it doesn't occur in this branch.
