### PR TITLE
H-606: Fix Semgrep Action on main branch

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -32,8 +32,8 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         name: Check-out Git project source
 
-      - run: semgrep ci --sarif --output=semgrep.sarif
-        name: Run Semgrep
+      - name: Run Semgrep
+        run: semgrep ci --sarif --output=semgrep.sarif || true
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Semgrep fails on main as it is detecting errors. This implies that it cannot upload the SARIF file as it fails before. This allows errors as the errors are already on main. The CI is not running on a PR.