### PR TITLE
H-623: Zoom to correct position in roadmap

### DIFF
--- a/apps/hashdotdev/src/pages/roadmap/technology-tree.tsx
+++ b/apps/hashdotdev/src/pages/roadmap/technology-tree.tsx
@@ -160,21 +160,28 @@ export const TechnologyTree: FunctionComponent = () => {
       const graphWrapper = select(graphWrapperRef.current);
       const graph = select(graphRef.current);
 
-      const { height: graphWrapperHeight, width: graphWrapperWidth } =
+      const { height: initialWrapperHeight } =
         graphWrapperRef.current.getBoundingClientRect();
 
       const zoom = d3zoom()
         .scaleExtent([
-          0.25 * (layoutHeight / graphWrapperHeight),
-          layoutHeight / graphWrapperHeight,
+          0.25 * (layoutHeight / initialWrapperHeight),
+          layoutHeight / initialWrapperHeight,
         ])
         .on("zoom", (event: { transform: ZoomTransform }) => {
+          if (!graphWrapperRef.current) {
+            return;
+          }
+
+          const { height: currentWrapperHeight, width: currentWrapperWidth } =
+            graphWrapperRef.current.getBoundingClientRect();
+
           graph.style(
             "transform",
-            `translate(${event.transform.x - graphWrapperWidth / 2}px, ${
-              event.transform.y + (graphWrapperHeight / 2 - layoutHeight / 2)
+            `translate(${event.transform.x - currentWrapperWidth / 2}px, ${
+              event.transform.y - layoutHeight / 2
             }px) scale(${
-              event.transform.k * (graphWrapperHeight / layoutHeight)
+              event.transform.k * (currentWrapperHeight / layoutHeight)
             })`,
           );
         });
@@ -183,7 +190,7 @@ export const TechnologyTree: FunctionComponent = () => {
 
       const initialTranslateX = 0;
 
-      const initialTranslateY = 0;
+      const initialTranslateY = initialWrapperHeight / 2;
 
       graphWrapper.call((selection) =>
         zoom.transform(
@@ -195,6 +202,8 @@ export const TechnologyTree: FunctionComponent = () => {
       );
 
       graphWrapper.call(zoom);
+
+      // @todo fix selection / zoom issues after resizing/fullscreen switch
     }
   }, [layoutHeight, layoutWidth, fullScreenHandle.active]);
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes an issue whereby zooming on the roadmap wouldn't zoom at the cursor position.

There's now a different issue, which is that after resizing the window, the very first pan or zoom will jump to a different position.

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

- [ ] Fixing the issue described above, unless we think this is a net improvement we should get in first.

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Use fresh values for wrapper height/width in the 'on zoom' callback.
- Change how initial height and height offset on zooming works.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- See description.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Zoom and pan the roadmap in the following conditions:
  - on page load
  - after resizing
  - after switching between fullscreen and back again
  - refreshing at different sizes