### PR TITLE
H-612: Disable Semgrep in merge groups

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -10,7 +10,6 @@ on:
       - main
       - canary
       - dev/*
-  merge_group:
 
   schedule:
     - cron: "30 0 1,15 * *" # scheduled for 00:30 UTC on both the 1st and 15th of the month


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The Semgrep (main) check now passes, but the merge_group one does not because the branch does not exist anymore. We should probably just disable that one.