### PR TITLE
H-630: Show container logs in CI after running jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,10 +314,9 @@ jobs:
           flags: backend-integration-tests
           token: ${{ secrets.CODECOV_TOKEN }} ## not required for public repos, can be removed when https://github.com/codecov/codecov-action/issues/837 is resolved
 
-      - name: Show external services logs
+      - name: Show container logs
         if: ${{ success() || failure() }}
-        run: |
-          docker-compose --file apps/hash-external-services/docker-compose.yml logs 2>&1 | tee var/logs/hash-external-services.log
+        run: yarn workspace @apps/hash-external-services deploy:test logs
 
       - name: Upload artifact backend-integration-tests-var
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
@@ -408,6 +407,10 @@ jobs:
       - name: Show frontend logs
         if: ${{ success() || failure() }}
         run: cat var/logs/frontend.log
+
+      - name: Show container logs
+        if: ${{ success() || failure() }}
+        run: yarn workspace @apps/hash-external-services deploy logs
 
       - name: Upload artifact playwright-report
         if: ${{ success() || failure() }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -252,6 +252,10 @@ jobs:
         working-directory: ${{ matrix.directory }}
         run: just miri --no-fail-fast
 
+      - name: Show container logs
+        if: ${{ success() || failure() }}
+        run: yarn workspace @apps/hash-external-services deploy logs
+
       - name: Ensure empty git diff
         run: git --no-pager diff --exit-code --color
 
@@ -347,6 +351,10 @@ jobs:
           files: ${{ matrix.directory }}/lcov.info
           flags: ${{ matrix.name }}
           token: ${{ secrets.CODECOV_TOKEN }} ## not required for public repos, can be removed when https://github.com/codecov/codecov-action/issues/837 is resolved
+
+      - name: Show container logs
+        if: ${{ success() || failure() }}
+        run: yarn workspace @apps/hash-external-services deploy logs
 
   publish:
     name: publish


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We encounter regular failures when launching external services. This is an attempt to at least see the logging output so it's possible to investigate the issue further.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph