### PR TITLE
H-469: Support creating new relationships

### DIFF
--- a/apps/hash-graph/lib/authorization/src/backend.rs
+++ b/apps/hash-graph/lib/authorization/src/backend.rs
@@ -6,22 +6,47 @@ use std::error::Error;
 use error_stack::Report;
 
 pub use self::spicedb::{SpiceDb, SpiceDbConfig};
-use crate::zanzibar::{Affiliation, Consistency, Resource, StringTuple, Subject, Zookie};
+use crate::zanzibar::{Affiliation, Consistency, Relation, Resource, StringTuple, Subject, Zookie};
 
 /// A backend for interacting with an authorization system based on the Zanzibar model.
 pub trait AuthorizationBackend {
-    /// Returns if the [`Subject`] has the specified permission or relation to an [`Resource`].
-    async fn check<S, A, R>(
+    /// Creates a new relation between a [`Subject`] and an [`Resource`] with the specified
+    /// [`Affiliation`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the relation already exists or could not be created.
+    async fn create_relation<R, A, S>(
         &self,
-        subject: &S,
-        affiliation: &A,
         resource: &R,
+        affiliation: &A,
+        subject: &S,
+    ) -> Result<CreateRelationResponse, Report<CreateRelationError>>
+    where
+        R: Resource + ?Sized + Sync,
+        A: Relation<R> + ?Sized + Sync,
+        S: Subject + ?Sized + Sync;
+
+    /// Returns if the [`Subject`] has the specified permission or relation to an [`Resource`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the check could not be performed.
+    ///
+    /// Note, that this will not fail if the [`Subject`] does not have the specified permission or
+    /// relation to the [`Resource`]. Instead, the [`CheckResponse::has_permission`] field will be
+    /// set to `false`.
+    async fn check<R, P, S>(
+        &self,
+        resource: &R,
+        permission: &P,
+        subject: &S,
         consistency: Consistency<'_>,
     ) -> Result<CheckResponse, Report<CheckError>>
     where
-        S: Subject + Sync,
-        A: Affiliation<R> + Sync,
-        R: Resource + Sync;
+        R: Resource + ?Sized + Sync,
+        P: Affiliation<R> + ?Sized + Sync,
+        S: Subject + ?Sized + Sync;
 }
 
 /// Return value for [`AuthorizationBackend::check`].
@@ -45,3 +70,23 @@ impl fmt::Display for CheckError {
 }
 
 impl Error for CheckError {}
+
+/// Return value for [`AuthorizationBackend::create_relation`].
+#[derive(Debug)]
+pub struct CreateRelationResponse {
+    /// A token to determine the time at which the relation was created.
+    pub written_at: Zookie<'static>,
+}
+
+#[derive(Debug)]
+pub struct CreateRelationError {
+    pub tuple: StringTuple,
+}
+
+impl fmt::Display for CreateRelationError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "failed to create relation: `{}`", self.tuple)
+    }
+}
+
+impl Error for CreateRelationError {}

--- a/apps/hash-graph/lib/authorization/src/lib.rs
+++ b/apps/hash-graph/lib/authorization/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(async_fn_in_trait)]
 #![feature(impl_trait_in_assoc_type)]
+#![feature(lint_reasons)]
 
 pub mod backend;
 

--- a/apps/hash-graph/lib/authorization/src/zanzibar.rs
+++ b/apps/hash-graph/lib/authorization/src/zanzibar.rs
@@ -221,6 +221,33 @@ pub type StringTuple = Tuple<
     GenericSubject<GenericResource<String, String>, GenericAffiliation<String>>,
 >;
 
+impl StringTuple {
+    #[must_use]
+    pub(crate) fn from_tuple<R, A, S>(resource: &R, affiliation: &A, subject: &S) -> Self
+    where
+        R: Resource + ?Sized,
+        A: Affiliation<R> + ?Sized,
+        S: Subject + ?Sized,
+    {
+        Self {
+            resource: GenericResource {
+                namespace: resource.namespace().to_string(),
+                id: resource.id().to_string(),
+            },
+            affiliation: GenericAffiliation(affiliation.to_string()),
+            subject: GenericSubject {
+                resource: GenericResource {
+                    namespace: subject.resource().namespace().to_string(),
+                    id: subject.resource().id().to_string(),
+                },
+                affiliation: subject
+                    .affiliation()
+                    .map(|affiliation| GenericAffiliation(affiliation.to_string())),
+            },
+        }
+    }
+}
+
 /// Provide causality metadata between Write and Check requests.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(transparent)]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

New relations should be able to be added from the Graph.

## 🔍 What does this change?

- Adds new function `update_relationship` and expose it as `create_relation`
- Make ordering of parameters consistent: 1. resource, 2. affiliation, 3. subject. This makes it consistent with a `Tuple` and across different functions 
- Make it possible to pass unsized types to the functions

## 🚫 Blocked By

- #3014 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph