### PR TITLE
H-646: Use artifacts to pass around docker images

### DIFF
--- a/.github/actions/build-docker-images/action.yml
+++ b/.github/actions/build-docker-images/action.yml
@@ -110,7 +110,7 @@ runs:
       if: inputs.hash-graph == 'true'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
-        name: hash-graph
+        name: hash-ai-worker-ts
         path: /tmp/hash-ai-worker-ts.tar
 
     - name: Build hash-ai-worker-py image
@@ -135,7 +135,7 @@ runs:
       if: inputs.hash-graph == 'true'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
-        name: hash-graph
+        name: hash-ai-worker-py
         path: /tmp/hash-ai-worker-py.tar
 
     - name: Build hash-integration-worker image
@@ -160,5 +160,5 @@ runs:
       if: inputs.hash-graph == 'true'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
-        name: hash-graph
+        name: hash-integration-worker
         path: /tmp/hash-integration-worker.tar

--- a/.github/actions/build-docker-images/action.yml
+++ b/.github/actions/build-docker-images/action.yml
@@ -62,7 +62,7 @@ runs:
       with:
         context: .
         file: apps/hash-graph/docker/Dockerfile
-        tags: ghcr.io/hashintel/hash-graph${{ env.IMAGE_TAG }}
+        tags: hash-graph
         cache-from: |
           type=registry,ref=ghcr.io/hashintel/hash-graph${{ env.IMAGE_TAG }}
           type=registry,ref=ghcr.io/hashintel/hash-graph
@@ -94,7 +94,7 @@ runs:
       with:
         context: .
         file: apps/hash-ai-worker-ts/docker/Dockerfile
-        tags: ghcr.io/hashintel/hash-ai-worker-ts${{ env.IMAGE_TAG }}
+        tags: hash-ai-worker-ts
         cache-from: |
           type=registry,ref=ghcr.io/hashintel/hash-ai-worker-ts${{ env.IMAGE_TAG }}
           type=registry,ref=ghcr.io/hashintel/hash-ai-worker-ts
@@ -119,7 +119,7 @@ runs:
       with:
         context: .
         file: apps/hash-ai-worker-py/docker/Dockerfile
-        tags: ghcr.io/hashintel/hash-ai-worker-py${{ env.IMAGE_TAG }}
+        tags: hash-ai-worker-py
         cache-from: |
           type=registry,ref=ghcr.io/hashintel/hash-ai-worker-py${{ env.IMAGE_TAG }}
           type=registry,ref=ghcr.io/hashintel/hash-ai-worker-py
@@ -144,7 +144,7 @@ runs:
       with:
         context: .
         file: apps/hash-integration-worker/docker/Dockerfile
-        tags: ghcr.io/hashintel/hash-integration-worker${{ env.IMAGE_TAG }}
+        tags: hash-integration-worker
         cache-from: |
           type=registry,ref=ghcr.io/hashintel/hash-integration-worker${{ env.IMAGE_TAG }}
           type=registry,ref=ghcr.io/hashintel/hash-integration-worker

--- a/.github/actions/build-docker-images/action.yml
+++ b/.github/actions/build-docker-images/action.yml
@@ -29,27 +29,21 @@ runs:
       run: |
         if [[ "${{ github.ref_name }}" == "main" ]]; then
           IMAGE_TAG=""
-          BUILD_CACHE_TAG=":build-cache"
         elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
           PR_NUMBER="${{ github.event.pull_request.number }}"
           IMAGE_TAG=":pr-$PR_NUMBER"
-          BUILD_CACHE_TAG="${IMAGE_TAG}_build-cache"
         elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
           # e.g. gh-readonly-queue/main/pr-1234-<SHA>
           PR_NUMBER=$(echo "${{ github.ref_name }}" | cut -d/ -f3 | cut -d- -f2)
           IMAGE_TAG=":pr-$PR_NUMBER"
-          BUILD_CACHE_TAG="${IMAGE_TAG}_build-cache"
         else
           IMAGE_TAG=":$(echo ${{ github.ref_name }} | sed 's|/|-|g')"
-          BUILD_CACHE_TAG="${IMAGE_TAG}_build-cache"
         fi
 
         GRAPH_PROFILE="$([ "${{ github.ref_name }}" == "main" ] && echo "release" || echo "dev")"
 
         set -x
         echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
-        echo "BUILD_CACHE_TAG=$BUILD_CACHE_TAG" >> $GITHUB_ENV
-        echo "BUILD_CACHE_FALLBACK_TAG=:build-cache" >> $GITHUB_ENV
         echo "GRAPH_PROFILE=$GRAPH_PROFILE" >> $GITHUB_ENV
 
     - name: Set up Docker Buildx
@@ -70,11 +64,11 @@ runs:
         file: apps/hash-graph/docker/Dockerfile
         tags: ghcr.io/hashintel/hash-graph${{ env.IMAGE_TAG }}
         cache-from: |
-          type=registry,ref=ghcr.io/hashintel/hash-graph${{ env.BUILD_CACHE_TAG }}
-          type=registry,ref=ghcr.io/hashintel/hash-graph${{ env.BUILD_CACHE_FALLBACK_TAG }}
+          type=registry,ref=ghcr.io/hashintel/hash-graph${{ env.IMAGE_TAG }}
+          type=registry,ref=ghcr.io/hashintel/hash-graph
         cache-to: |
-          type=registry,ref=ghcr.io/hashintel/hash-graph${{ env.BUILD_CACHE_TAG }},mode=max
-        push: true
+          type=registry,ref=ghcr.io/hashintel/hash-graph${{ env.IMAGE_TAG }},mode=max
+        outputs: type=docker,dest=/tmp/hash-graph.tar
         labels: |
           org.opencontainers.image.source="https://github.com/hashintel/hash"
           org.opencontainers.image.licenses="AGPL-3.0-only,"
@@ -87,6 +81,13 @@ runs:
           ENABLE_TYPE_FETCHER=yes
           ENABLE_TEST_SERVER=yes
 
+    - name: Upload artifact
+      if: inputs.hash-graph == 'true'
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      with:
+        name: hash-graph
+        path: /tmp/hash-graph.tar
+
     - name: Build hash-ai-worker-ts image
       if: inputs.hash-ai-worker-ts == 'true'
       uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
@@ -95,15 +96,22 @@ runs:
         file: apps/hash-ai-worker-ts/docker/Dockerfile
         tags: ghcr.io/hashintel/hash-ai-worker-ts${{ env.IMAGE_TAG }}
         cache-from: |
-          type=registry,ref=ghcr.io/hashintel/hash-ai-worker-ts${{ env.BUILD_CACHE_TAG }}
-          type=registry,ref=ghcr.io/hashintel/hash-ai-worker-ts${{ env.BUILD_CACHE_FALLBACK_TAG }}
+          type=registry,ref=ghcr.io/hashintel/hash-ai-worker-ts${{ env.IMAGE_TAG }}
+          type=registry,ref=ghcr.io/hashintel/hash-ai-worker-ts
         cache-to: |
-          type=registry,ref=ghcr.io/hashintel/hash-ai-worker-ts${{ env.BUILD_CACHE_TAG }},mode=max
-        push: true
+          type=registry,ref=ghcr.io/hashintel/hash-ai-worker-ts${{ env.IMAGE_TAG }},mode=max
+        outputs: type=docker,dest=/tmp/hash-ai-worker-ts.tar
         labels: |
           org.opencontainers.image.source="https://github.com/hashintel/hash"
           org.opencontainers.image.licenses="AGPL-3.0-only,"
           org.opencontainers.image.description="A TypeScript 'AI' worker for HASH"
+
+    - name: Upload artifact
+      if: inputs.hash-graph == 'true'
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      with:
+        name: hash-graph
+        path: /tmp/hash-ai-worker-ts.tar
 
     - name: Build hash-ai-worker-py image
       if: inputs.hash-ai-worker-py == 'true'
@@ -113,15 +121,22 @@ runs:
         file: apps/hash-ai-worker-py/docker/Dockerfile
         tags: ghcr.io/hashintel/hash-ai-worker-py${{ env.IMAGE_TAG }}
         cache-from: |
-          type=registry,ref=ghcr.io/hashintel/hash-ai-worker-py${{ env.BUILD_CACHE_TAG }}
-          type=registry,ref=ghcr.io/hashintel/hash-ai-worker-py${{ env.BUILD_CACHE_FALLBACK_TAG }}
+          type=registry,ref=ghcr.io/hashintel/hash-ai-worker-py${{ env.IMAGE_TAG }}
+          type=registry,ref=ghcr.io/hashintel/hash-ai-worker-py
         cache-to: |
-          type=registry,ref=ghcr.io/hashintel/hash-ai-worker-py${{ env.BUILD_CACHE_TAG }},mode=max
-        push: true
+          type=registry,ref=ghcr.io/hashintel/hash-ai-worker-py${{ env.IMAGE_TAG }},mode=max
+        outputs: type=docker,dest=/tmp/hash-ai-worker-py.tar
         labels: |
           org.opencontainers.image.source="https://github.com/hashintel/hash"
           org.opencontainers.image.licenses="AGPL-3.0-only,"
           org.opencontainers.image.description="A Python 'AI' worker for HASH"
+
+    - name: Upload artifact
+      if: inputs.hash-graph == 'true'
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      with:
+        name: hash-graph
+        path: /tmp/hash-ai-worker-py.tar
 
     - name: Build hash-integration-worker image
       if: inputs.hash-integration-worker == 'true'
@@ -131,12 +146,19 @@ runs:
         file: apps/hash-integration-worker/docker/Dockerfile
         tags: ghcr.io/hashintel/hash-integration-worker${{ env.IMAGE_TAG }}
         cache-from: |
-          type=registry,ref=ghcr.io/hashintel/hash-integration-worker${{ env.BUILD_CACHE_TAG }}
-          type=registry,ref=ghcr.io/hashintel/hash-integration-worker${{ env.BUILD_CACHE_FALLBACK_TAG }}
+          type=registry,ref=ghcr.io/hashintel/hash-integration-worker${{ env.IMAGE_TAG }}
+          type=registry,ref=ghcr.io/hashintel/hash-integration-worker
         cache-to: |
-          type=registry,ref=ghcr.io/hashintel/hash-integration-worker${{ env.BUILD_CACHE_TAG }},mode=max
-        push: true
+          type=registry,ref=ghcr.io/hashintel/hash-integration-worker${{ env.IMAGE_TAG }},mode=max
+        outputs: type=docker,dest=/tmp/hash-integration-worker.tar
         labels: |
           org.opencontainers.image.source="https://github.com/hashintel/hash"
           org.opencontainers.image.licenses="AGPL-3.0-only,"
           org.opencontainers.image.description="A TypeScript worker for HASH for data integration"
+
+    - name: Upload artifact
+      if: inputs.hash-graph == 'true'
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      with:
+        name: hash-graph
+        path: /tmp/hash-integration-worker.tar

--- a/.github/actions/build-docker-images/action.yml
+++ b/.github/actions/build-docker-images/action.yml
@@ -82,7 +82,7 @@ runs:
           ENABLE_TEST_SERVER=yes
 
     - name: Upload artifact
-      if: inputs.hash-graph == 'true'
+      if: inputs.hash-ai-worker-ts == 'true'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: hash-graph
@@ -107,7 +107,7 @@ runs:
           org.opencontainers.image.description="A TypeScript 'AI' worker for HASH"
 
     - name: Upload artifact
-      if: inputs.hash-graph == 'true'
+      if: inputs.hash-ai-worker-py == 'true'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: hash-ai-worker-ts
@@ -132,7 +132,7 @@ runs:
           org.opencontainers.image.description="A Python 'AI' worker for HASH"
 
     - name: Upload artifact
-      if: inputs.hash-graph == 'true'
+      if: inputs.hash-integration-worker == 'true'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: hash-ai-worker-py

--- a/.github/actions/build-docker-images/action.yml
+++ b/.github/actions/build-docker-images/action.yml
@@ -43,7 +43,7 @@ runs:
         GRAPH_PROFILE="$([ "${{ github.ref_name }}" == "main" ] && echo "release" || echo "dev")"
 
         set -x
-        echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+        echo "IMAGE_TAG=-cache$IMAGE_TAG" >> $GITHUB_ENV
         echo "GRAPH_PROFILE=$GRAPH_PROFILE" >> $GITHUB_ENV
 
     - name: Set up Docker Buildx

--- a/.github/actions/build-docker-images/action.yml
+++ b/.github/actions/build-docker-images/action.yml
@@ -82,7 +82,7 @@ runs:
           ENABLE_TEST_SERVER=yes
 
     - name: Upload artifact
-      if: inputs.hash-ai-worker-ts == 'true'
+      if: inputs.hash-graph == 'true'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: hash-graph
@@ -107,7 +107,7 @@ runs:
           org.opencontainers.image.description="A TypeScript 'AI' worker for HASH"
 
     - name: Upload artifact
-      if: inputs.hash-ai-worker-py == 'true'
+      if: inputs.hash-ai-worker-ts == 'true'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: hash-ai-worker-ts
@@ -132,7 +132,7 @@ runs:
           org.opencontainers.image.description="A Python 'AI' worker for HASH"
 
     - name: Upload artifact
-      if: inputs.hash-integration-worker == 'true'
+      if: inputs.hash-ai-worker-py == 'true'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: hash-ai-worker-py
@@ -157,7 +157,7 @@ runs:
           org.opencontainers.image.description="A TypeScript worker for HASH for data integration"
 
     - name: Upload artifact
-      if: inputs.hash-graph == 'true'
+      if: inputs.hash-integration-worker == 'true'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: hash-integration-worker

--- a/.github/actions/load-docker-images/action.yml
+++ b/.github/actions/load-docker-images/action.yml
@@ -17,9 +17,6 @@ inputs:
     description: "Build hash-integration-worker image"
     required: false
     default: "false"
-  repo-token:
-    description: "GitHub token"
-    required: true
 
 runs:
   using: "composite"
@@ -27,59 +24,58 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2.10.0
 
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+    - name: Download hash-graph image
+      if: inputs.hash-graph == 'true'
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ inputs.repo-token }}
-
-    - name: Load tags
-      shell: bash
-      run: |
-        if [[ "${{ github.ref_name }}" == "main" ]]; then
-          IMAGE_TAG=":latest"
-        elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          IMAGE_TAG=":pr-$PR_NUMBER"
-        elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
-          PR_NUMBER=$(echo "${{ github.ref_name }}" | cut -d/ -f3 | cut -d- -f2)
-          IMAGE_TAG=":pr-$PR_NUMBER"
-        else
-          IMAGE_TAG=":$(echo ${{ github.ref_name }} | sed 's|/|-|g')"
-        fi
-
-        set -x
-        echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+        name: hash-graph
+        path: /tmp
 
     - name: Load hash-graph image
       if: inputs.hash-graph == 'true'
       shell: bash
       run: |
-        TAG="ghcr.io/hashintel/hash-graph${{ env.IMAGE_TAG }}"
-        docker pull $TAG
-        docker tag $TAG hash-graph
+        docker load --input /tmp/hash-graph.tar
+        docker image ls -a
+
+    - name: Download hash-ai-worker-ts image
+      if: inputs.hash-ai-worker-ts == 'true'
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      with:
+        name: hash-ai-worker-ts
+        path: /tmp
 
     - name: Load hash-ai-worker-ts image
       if: inputs.hash-ai-worker-ts == 'true'
       shell: bash
       run: |
-        TAG="ghcr.io/hashintel/hash-ai-worker-ts${{ env.IMAGE_TAG }}"
-        docker pull $TAG
-        docker tag $TAG hash-ai-worker-ts
+        docker load --input /tmp/hash-ai-worker-ts.tar
+        docker image ls -a
+
+    - name: Download hash-ai-worker-py image
+      if: inputs.hash-ai-worker-py == 'true'
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      with:
+        name: hash-ai-worker-py
+        path: /tmp
 
     - name: Load hash-ai-worker-py image
       if: inputs.hash-ai-worker-py == 'true'
       shell: bash
       run: |
-        TAG="ghcr.io/hashintel/hash-ai-worker-ts${{ env.IMAGE_TAG }}"
-        docker pull $TAG
-        docker tag $TAG hash-ai-worker-py
+        docker load --input /tmp/hash-ai-worker-py.tar
+        docker image ls -a
+
+    - name: Download hash-integration-worker image
+      if: inputs.hash-integration-worker == 'true'
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      with:
+        name: hash-integration-worker
+        path: /tmp
 
     - name: Load hash-integration-worker image
       if: inputs.hash-integration-worker == 'true'
       shell: bash
       run: |
-        TAG="ghcr.io/hashintel/hash-integration-worker${{ env.IMAGE_TAG }}"
-        docker pull $TAG
-        docker tag $TAG hash-integration-worker
+        docker load --input /tmp/hash-integration-worker.tar
+        docker image ls -a

--- a/.github/actions/load-docker-images/action.yml
+++ b/.github/actions/load-docker-images/action.yml
@@ -24,19 +24,30 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2.10.0
 
+    - name: Load tags
+      shell: bash
+      run: |
+        if [[ "${{ github.ref_name }}" == "main" ]]; then
+          IMAGE_TAG=":latest"
+        elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          IMAGE_TAG=":pr-$PR_NUMBER"
+        elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
+          PR_NUMBER=$(echo "${{ github.ref_name }}" | cut -d/ -f3 | cut -d- -f2)
+          IMAGE_TAG=":pr-$PR_NUMBER"
+        else
+          IMAGE_TAG=":$(echo ${{ github.ref_name }} | sed 's|/|-|g')"
+        fi
+
+        set -x
+        echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+
     - name: Download hash-graph image
       if: inputs.hash-graph == 'true'
       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: hash-graph
         path: /tmp
-
-    - name: Load hash-graph image
-      if: inputs.hash-graph == 'true'
-      shell: bash
-      run: |
-        docker load --input /tmp/hash-graph.tar
-        docker image ls -a
 
     - name: Download hash-ai-worker-ts image
       if: inputs.hash-ai-worker-ts == 'true'
@@ -45,26 +56,12 @@ runs:
         name: hash-ai-worker-ts
         path: /tmp
 
-    - name: Load hash-ai-worker-ts image
-      if: inputs.hash-ai-worker-ts == 'true'
-      shell: bash
-      run: |
-        docker load --input /tmp/hash-ai-worker-ts.tar
-        docker image ls -a
-
     - name: Download hash-ai-worker-py image
       if: inputs.hash-ai-worker-py == 'true'
       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: hash-ai-worker-py
         path: /tmp
-
-    - name: Load hash-ai-worker-py image
-      if: inputs.hash-ai-worker-py == 'true'
-      shell: bash
-      run: |
-        docker load --input /tmp/hash-ai-worker-py.tar
-        docker image ls -a
 
     - name: Download hash-integration-worker image
       if: inputs.hash-integration-worker == 'true'
@@ -73,9 +70,26 @@ runs:
         name: hash-integration-worker
         path: /tmp
 
+    - name: Load hash-graph image
+      if: inputs.hash-graph == 'true'
+      shell: bash
+      run: docker load --input /tmp/hash-graph.tar
+
+    - name: Load hash-ai-worker-ts image
+      if: inputs.hash-ai-worker-ts == 'true'
+      shell: bash
+      run: docker load --input /tmp/hash-ai-worker-ts.tar
+
+    - name: Load hash-ai-worker-py image
+      if: inputs.hash-ai-worker-py == 'true'
+      shell: bash
+      run: docker load --input /tmp/hash-ai-worker-py.tar
+
     - name: Load hash-integration-worker image
       if: inputs.hash-integration-worker == 'true'
       shell: bash
-      run: |
-        docker load --input /tmp/hash-integration-worker.tar
-        docker image ls -a
+      run: docker load --input /tmp/hash-integration-worker.tar
+
+    - name: Summarize docker images
+      shell: bash
+      run: docker image ls -a

--- a/.github/workflows/remove-obsolete-caches.yml
+++ b/.github/workflows/remove-obsolete-caches.yml
@@ -35,12 +35,11 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const pr_tag = "pr-${{ github.event.pull_request.number }}"
-            const pr_build_cache_tag = "pr-${{ github.event.pull_request.number }}_build-cache"
             for (const image of ["hash-graph", "hash-ai-worker-ts", "hash-ai-worker-py", "hash-integration-worker"]) {
               const url = "/orgs/hashintel/packages/container/" + image + "/versions";
               const response = await github.request("GET " + url, { per_page: 100 });
               for (const version of response.data) {
-                if (version.metadata.container.tags.length == 0 || version.metadata.container.tags.includes(pr_tag) || version.metadata.container.tags.includes(pr_build_cache_tag)) {
+                if (version.metadata.container.tags.length == 0 || version.metadata.container.tags.includes(pr_tag)) {
                   console.log("delete " + version.id)
                   const deleteResponse = await github.request("DELETE " + url + "/" + version.id, { });
                   console.log("status " + deleteResponse.status)


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We encountered a lot of issues when attempting to download a previously uploaded docker image. To mitigate this issue, the registry will now only be used for caching and for passing around the images, artifacts are used.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
