### PR TITLE
H-645: Attempt to figure out the reason why `spicedb-migrate` fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,7 @@ jobs:
 
       - name: Show container logs
         if: ${{ success() || failure() }}
-        run: yarn workspace @apps/hash-external-services deploy:test logs
+        run: yarn workspace @apps/hash-external-services deploy:test logs --timestamps
 
       - name: Upload artifact backend-integration-tests-var
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
@@ -394,12 +394,6 @@ jobs:
         run: |
           yarn test:playwright
 
-      - name: Show external services logs
-        if: ${{ success() || failure() }}
-        run: |
-          docker-compose --file apps/hash-external-services/docker-compose.yml logs 2>&1 | tee var/logs/hash-external-services.log
-          cat var/logs/hash-external-services.log
-
       - name: Show backend logs
         if: ${{ success() || failure() }}
         run: cat var/logs/backend.log
@@ -410,7 +404,7 @@ jobs:
 
       - name: Show container logs
         if: ${{ success() || failure() }}
-        run: yarn workspace @apps/hash-external-services deploy logs
+        run: yarn workspace @apps/hash-external-services deploy logs --timestamps
 
       - name: Upload artifact playwright-report
         if: ${{ success() || failure() }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -254,7 +254,7 @@ jobs:
 
       - name: Show container logs
         if: ${{ (success() || failure()) && matrix.directory == 'apps/hash-graph' }}
-        run: yarn workspace @apps/hash-external-services deploy logs
+        run: yarn workspace @apps/hash-external-services deploy logs --timestamps
 
       - name: Ensure empty git diff
         run: git --no-pager diff --exit-code --color
@@ -354,7 +354,7 @@ jobs:
 
       - name: Show container logs
         if: ${{ (success() || failure()) && matrix.directory == 'apps/hash-graph' }}
-        run: yarn workspace @apps/hash-external-services deploy logs
+        run: yarn workspace @apps/hash-external-services deploy logs --timestamps
 
   publish:
     name: publish

--- a/apps/hash-external-services/docker-compose.prod.yml
+++ b/apps/hash-external-services/docker-compose.prod.yml
@@ -32,7 +32,7 @@ services:
       - ./postgres/postgresql.conf:/etc/postgresql/postgresql.conf:ro
       - ./postgres/init-user-db.sh:/docker-entrypoint-initdb.d/init-user-db.sh:ro
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready --username ${POSTGRES_USER}"]
+      test: ["CMD", "pg_isready", "-q", "-h", "postgres"]
       interval: 2s
       timeout: 2s
       retries: 5

--- a/apps/hash-external-services/docker-compose.prod.yml
+++ b/apps/hash-external-services/docker-compose.prod.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 volumes:
   hash-postgres-data:
   logs:

--- a/apps/hash-external-services/docker-compose.prototype.yml
+++ b/apps/hash-external-services/docker-compose.prototype.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 volumes:
   hash-qdrant:
 

--- a/apps/hash-external-services/docker-compose.test.yml
+++ b/apps/hash-external-services/docker-compose.test.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   postgres:
     environment:

--- a/apps/hash-external-services/docker-compose.type-fetcher.yml
+++ b/apps/hash-external-services/docker-compose.type-fetcher.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   type-fetcher:
     init: true

--- a/apps/hash-external-services/docker-compose.yml
+++ b/apps/hash-external-services/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       - ./postgres/postgresql.conf:/etc/postgresql/postgresql.conf:ro
       - ./postgres/init-user-db.sh:/docker-entrypoint-initdb.d/init-user-db.sh:ro
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready --username ${POSTGRES_USER}"]
+      test: ["CMD", "pg_isready", "-q", "-h", "postgres"]
       interval: 2s
       timeout: 2s
       retries: 5

--- a/apps/hash-external-services/docker-compose.yml
+++ b/apps/hash-external-services/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 volumes:
   hash-postgres-data:
   hash-vault-data:
@@ -109,6 +107,7 @@ services:
     environment:
       SPICEDB_DATASTORE_ENGINE: postgres
       SPICEDB_DATASTORE_CONN_URI: "postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:${POSTGRES_PORT}/${HASH_SPICEDB_PG_DEV_DATABASE}"
+      SPICEDB_LOG_FORMAT: "console"
     read_only: true
     security_opt:
       - no-new-privileges:true

--- a/apps/hash-external-services/postgres/postgresql.conf
+++ b/apps/hash-external-services/postgres/postgresql.conf
@@ -1,6 +1,6 @@
 # Allow connections from all addresses
 listen_addresses = '*'
-log_min_messages = info
+log_min_messages = warning
 
 # Modules
 shared_preload_libraries = 'wal2json'

--- a/apps/hash-external-services/postgres/postgresql.conf
+++ b/apps/hash-external-services/postgres/postgresql.conf
@@ -1,6 +1,6 @@
 # Allow connections from all addresses
 listen_addresses = '*'
-log_min_messages = fatal
+log_min_messages = info
 
 # Modules
 shared_preload_libraries = 'wal2json'

--- a/apps/hash-graph/.justfile
+++ b/apps/hash-graph/.justfile
@@ -18,7 +18,7 @@ run *arguments:
   cargo run --profile {{profile}} --bin hash-graph -- {{arguments}}
 
 
-# Generates the OpenAPI client for the Graph REST API
+# Generates the OpenAPI specifications and the clients
 generate-openapi-specs:
   cargo run --bin hash-graph -- server --write-openapi-specs
   just yarn codegen --filter @local/hash-graph-client-python


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `spicedb-migrate` jobs fails because it may run before postgres is up.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph