### PR TITLE
H-649: Support deletion of relationships

### DIFF
--- a/apps/hash-graph/lib/authorization/src/backend.rs
+++ b/apps/hash-graph/lib/authorization/src/backend.rs
@@ -32,7 +32,7 @@ pub trait AuthorizationBackend {
     ///
     /// # Errors
     ///
-    /// Returns an error if the relation already exists or could not be created.
+    /// Returns an error if the relation does not exist or could not be deleted.
     async fn delete_relation<R, A, S>(
         &self,
         resource: &R,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Similar to the creation of relationships, the deletion is fundamental for a permission system.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph