### PR TITLE
Retry `warm-up` step in CI if installing failed

### DIFF
--- a/.github/actions/warm-up-repo/action.yml
+++ b/.github/actions/warm-up-repo/action.yml
@@ -27,10 +27,18 @@ runs:
         cache: poetry
 
     - run: yarn install
-      shell: bash
-      env:
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: ${{ inputs.playwright-deps == '' }}
+      uses: nick-fields/retry@v2.8.3
+      with:
+        max_attempts: 3
+        shell: bash
+        command: |
+          export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD="${{ inputs.playwright-deps == '' }}"
+          yarn install
 
-    - run: yarn playwright install-deps ${{ inputs.playwright-deps }}
+    - run: yarn playwright install-deps
       if: ${{ inputs.playwright-deps != '' }}
-      shell: bash
+      uses: nick-fields/retry@v2.8.3
+      with:
+        max_attempts: 3
+        shell: bash
+        command: yarn playwright install-deps ${{ inputs.playwright-deps }}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Recently we encountered a lot of CI failures because it was not possible to download a package from yarn. This is a very likely a flaky error and instead of aborting the full job (or even canceling a merge queue run) it's sensible to just retry it.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph