### PR TITLE
H-662: Remove installation of `protoc`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -112,13 +112,6 @@ jobs:
         with:
           tool: just@1.13.0,cargo-hack@0.5.26,rust-script@0.23.0,clippy-sarif@0.3.7,sarif-fmt@0.3.7
 
-      # To be removed once https://github.com/open-telemetry/opentelemetry-rust/issues/934 is sorted
-      - name: Install Protoc
-        if: matrix.directory == 'apps/hash-graph'
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Check formatting
         working-directory: ${{ matrix.directory }}
         run: just format --check
@@ -225,13 +218,6 @@ jobs:
         with:
           tool: just@1.13.0,cargo-hack@0.5.26,cargo-nextest@0.9.37
 
-      # To be removed once https://github.com/open-telemetry/opentelemetry-rust/issues/934 is sorted
-      - name: Install Protoc
-        if: matrix.directory == 'apps/hash-graph'
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install Python
         if: matrix.directory == 'apps/engine'
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
@@ -329,13 +315,6 @@ jobs:
         uses: taiki-e/install-action@cc5a5c56a296ea597e6ea38f551f25dee8be1225 # v2.17.7
         with:
           tool: just@1.13.0,cargo-nextest@0.9.37,cargo-llvm-cov@0.5.9
-
-      # To be removed once https://github.com/open-telemetry/opentelemetry-rust/issues/934 is sorted
-      - name: Install Protoc
-        if: matrix.directory == 'apps/hash-graph'
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests
         working-directory: ${{ matrix.directory }}

--- a/apps/hash-graph/docker/Dockerfile
+++ b/apps/hash-graph/docker/Dockerfile
@@ -45,9 +45,6 @@ WORKDIR /usr/local/src/apps/hash-graph
 ARG PROFILE=production
 ARG ENABLE_TEST_SERVER=no
 
-# To be removed once https://github.com/open-telemetry/opentelemetry-rust/issues/934 is sorted
-RUN apk add --no-cache make protobuf-dev
-
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/usr/local/src/apps/hash-graph/target,sharing=locked \


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Previously, we required to install protoc in CI and in the Dockerfile but this is not needed anymore as the upstream issue is fixed.

## 🔗 Related links

- https://github.com/open-telemetry/opentelemetry-rust/issues/934
- https://github.com/hashintel/hash/pull/2987

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph