### PR TITLE
H-666: Hide 'General' from use case list

### DIFF
--- a/apps/hashdotdev/src/pages/roadmap.page.tsx
+++ b/apps/hashdotdev/src/pages/roadmap.page.tsx
@@ -129,43 +129,45 @@ const UseCases: FunctionComponent = () => (
       flexWrap="wrap"
       sx={{ justifyContent: { xs: "space-between", sm: "flex-start" } }}
     >
-      {useCases.map(({ name, icon }) => (
-        /** @todo: make clickable when docs pages exist for each item */
-        // <Link key={name} href={href}>
-        <Box
-          key={name?.toString()}
-          sx={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            width: ({ spacing }) => ({
-              xs: `calc(50% - ${spacing(1)})`,
-              sm: 135,
-            }),
-            padding: ({ spacing }) => spacing(2, 1.5),
-            borderRadius: "8px",
-            borderStyle: "solid",
-            borderWidth: 1,
-            borderColor: ({ palette }) => palette.gray[30],
-          }}
-        >
-          {icon}
-          <Typography
+      {useCases.map(({ id, name, icon }) =>
+        id === "general" ? null : (
+          /** @todo: make clickable when docs pages exist for each item */
+          // <Link key={name} href={href}>
+          <Box
+            key={name?.toString()}
             sx={{
-              marginTop: 1.25,
-              textAlign: "center",
-              fontSize: 15,
-              fontWeight: 500,
-              color: ({ palette }) => palette.gray[80],
-              lineHeight: 1.2,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              width: ({ spacing }) => ({
+                xs: `calc(50% - ${spacing(1)})`,
+                sm: 135,
+              }),
+              padding: ({ spacing }) => spacing(2, 1.5),
+              borderRadius: "8px",
+              borderStyle: "solid",
+              borderWidth: 1,
+              borderColor: ({ palette }) => palette.gray[30],
             }}
           >
-            {name}
-          </Typography>
-        </Box>
-        // </Link>
-      ))}
+            {icon}
+            <Typography
+              sx={{
+                marginTop: 1.25,
+                textAlign: "center",
+                fontSize: 15,
+                fontWeight: 500,
+                color: ({ palette }) => palette.gray[80],
+                lineHeight: 1.2,
+              }}
+            >
+              {name}
+            </Typography>
+          </Box>
+          // </Link>
+        ),
+      )}
     </Box>
   </Container>
 );


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

On the hash.dev [roadmap page](https://hash.dev/roadmap), there's a 'General' category of feature area – this is meant to be a method of categorising and filtering roadmap items, but not listed as a 'Use case'. This PR fixes that by hiding it from the 'Use case' list.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  View the deployment


## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
![Screenshot 2023-08-31 at 09 28 30](https://github.com/hashintel/hash/assets/37743469/6b5f6907-b09d-4efb-bc87-d5be792b97c0)
