### PR TITLE
H-642: Allow mass creation/deletion of relationships

### DIFF
--- a/apps/hash-graph/lib/authorization/src/backend.rs
+++ b/apps/hash-graph/lib/authorization/src/backend.rs
@@ -39,16 +39,18 @@ pub trait AuthorizationApi {
     /// # Errors
     ///
     /// Returns an error if the relation already exists or could not be created.
-    async fn create_relation<R, A, S>(
+    async fn create_relation<'p, R, A, S, P>(
         &mut self,
         resource: &R,
         relation: &A,
         subject: &S,
+        preconditions: P,
     ) -> Result<CreateRelationResponse, Report<CreateRelationError>>
     where
-        R: Resource + ?Sized + Sync,
+        R: Resource + ?Sized + Sync + 'p,
         A: Relation<R> + ?Sized + Sync,
-        S: Subject + ?Sized + Sync;
+        S: Subject + ?Sized + Sync,
+        P: IntoIterator<Item = Precondition<'p, R>, IntoIter: Send> + Send + 'p;
 
     /// Deletes a relation between a [`Subject`] and an [`Resource`] with the specified
     /// [`Relation`].
@@ -56,16 +58,18 @@ pub trait AuthorizationApi {
     /// # Errors
     ///
     /// Returns an error if the relation does not exist or could not be deleted.
-    async fn delete_relation<R, A, S>(
+    async fn delete_relation<'p, R, A, S, P>(
         &mut self,
         resource: &R,
         relation: &A,
         subject: &S,
+        preconditions: P,
     ) -> Result<DeleteRelationResponse, Report<DeleteRelationError>>
     where
-        R: Resource + ?Sized + Sync,
+        R: Resource + ?Sized + Sync + 'p,
         A: Relation<R> + ?Sized + Sync,
-        S: Subject + ?Sized + Sync;
+        S: Subject + ?Sized + Sync,
+        P: IntoIterator<Item = Precondition<'p, R>, IntoIter: Send> + Send + 'p;
 
     /// Deletes all relations matching the specified [`RelationFilter`].
     ///

--- a/apps/hash-graph/lib/authorization/src/backend.rs
+++ b/apps/hash-graph/lib/authorization/src/backend.rs
@@ -36,22 +36,26 @@ pub trait AuthorizationApi {
     /// # Errors
     ///
     /// Returns an error if the relation already exists or could not be created.
-    async fn create_relation<'p>(
+    async fn create_relation<'p, 't, T>(
         &mut self,
-        tuple: impl Tuple + Send + Sync,
+        tuples: impl IntoIterator<Item = &'t T, IntoIter: Send> + Send,
         preconditions: impl IntoIterator<Item = Precondition<'p>, IntoIter: Send> + Send + 'p,
-    ) -> Result<CreateRelationResponse, Report<CreateRelationError>>;
+    ) -> Result<CreateRelationResponse, Report<CreateRelationError>>
+    where
+        T: Tuple + Send + Sync + 't;
 
     /// Deletes the relation specified by the [`Tuple`].
     ///
     /// # Errors
     ///
     /// Returns an error if the relation does not exist or could not be deleted.
-    async fn delete_relation<'p>(
+    async fn delete_relation<'p, 't, T>(
         &mut self,
-        tuple: &(impl Tuple + Sync),
+        tuples: impl IntoIterator<Item = &'t T, IntoIter: Send> + Send,
         preconditions: impl IntoIterator<Item = Precondition<'p>, IntoIter: Send> + Send + 'p,
-    ) -> Result<DeleteRelationResponse, Report<DeleteRelationError>>;
+    ) -> Result<DeleteRelationResponse, Report<DeleteRelationError>>
+    where
+        T: Tuple + Send + Sync + 't;
 
     /// Deletes all relations matching the specified [`RelationFilter`].
     ///
@@ -130,13 +134,11 @@ pub struct CreateRelationResponse {
 
 /// Error returned from [`AuthorizationApi::create_relation`].
 #[derive(Debug)]
-pub struct CreateRelationError {
-    pub tuple: UntypedTuple<'static>,
-}
+pub struct CreateRelationError;
 
 impl fmt::Display for CreateRelationError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "failed to create relation: `{}`", self.tuple)
+        fmt.write_str("failed to create relations")
     }
 }
 
@@ -151,13 +153,11 @@ pub struct DeleteRelationResponse {
 
 /// Error returned from [`AuthorizationApi::delete_relation`].
 #[derive(Debug)]
-pub struct DeleteRelationError {
-    pub tuple: UntypedTuple<'static>,
-}
+pub struct DeleteRelationError;
 
 impl fmt::Display for DeleteRelationError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "failed to delete relation: `{}`", self.tuple)
+        fmt.write_str("failed to delete relation")
     }
 }
 

--- a/apps/hash-graph/lib/authorization/src/backend/spicedb/model.rs
+++ b/apps/hash-graph/lib/authorization/src/backend/spicedb/model.rs
@@ -24,7 +24,7 @@ pub struct ObjectReference<'r> {
 impl<'r, R: zanzibar::Resource + ?Sized> From<&'r R> for ObjectReference<'r> {
     fn from(resource: &'r R) -> Self {
         Self {
-            object_type: resource.namespace().as_ref(),
+            object_type: resource.namespace(),
             object_id: resource.id().as_ref(),
         }
     }
@@ -36,15 +36,6 @@ pub struct SubjectReference<'a> {
     pub object: ObjectReference<'a>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub optional_relation: Option<&'a str>,
-}
-
-impl<'s, S: zanzibar::Subject + ?Sized> From<&'s S> for SubjectReference<'s> {
-    fn from(value: &'s S) -> Self {
-        Self {
-            object: ObjectReference::from(value.resource()),
-            optional_relation: value.affiliation().map(AsRef::as_ref),
-        }
-    }
 }
 
 pub struct Consistency<'z>(zanzibar::Consistency<'z>);
@@ -120,12 +111,10 @@ pub struct RelationshipFilter<'a> {
     pub optional_subject_filter: Option<SubjectFilter<'a>>,
 }
 
-impl<'f, R: zanzibar::Resource + ?Sized> From<backend::RelationFilter<'f, R>>
-    for RelationshipFilter<'f>
-{
-    fn from(filter: backend::RelationFilter<'f, R>) -> Self {
+impl<'f> From<backend::RelationFilter<'f>> for RelationshipFilter<'f> {
+    fn from(filter: backend::RelationFilter<'f>) -> Self {
         Self {
-            resource_type: filter.namespace.as_ref(),
+            resource_type: filter.namespace,
             optional_resource_id: filter.id.map(AsRef::as_ref),
             optional_relation: filter.affiliation,
             optional_subject_filter: filter.subject.map(|subject| SubjectFilter {
@@ -158,8 +147,8 @@ pub struct Precondition<'a> {
     pub filter: RelationshipFilter<'a>,
 }
 
-impl<'f, R: zanzibar::Resource + ?Sized> From<backend::Precondition<'f, R>> for Precondition<'f> {
-    fn from(precondition: backend::Precondition<'f, R>) -> Self {
+impl<'f> From<backend::Precondition<'f>> for Precondition<'f> {
+    fn from(precondition: backend::Precondition<'f>) -> Self {
         let operation = if precondition.must_match {
             PreconditionOperation::MustMatch
         } else {

--- a/apps/hash-graph/lib/authorization/src/backend/spicedb/model.rs
+++ b/apps/hash-graph/lib/authorization/src/backend/spicedb/model.rs
@@ -162,7 +162,7 @@ impl<'f> From<backend::Precondition<'f>> for Precondition<'f> {
 }
 
 /// Used for mutating a single relationship within the service.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Copy, Clone, Serialize)]
 pub enum RelationshipUpdateOperation {
     /// Create the relationship only if it doesn't exist, and error otherwise.
     #[serde(rename = "OPERATION_CREATE")]

--- a/apps/hash-graph/lib/authorization/src/zanzibar.rs
+++ b/apps/hash-graph/lib/authorization/src/zanzibar.rs
@@ -8,9 +8,6 @@ use serde::{Deserialize, Serialize};
 /// The relation or permission of a [`Resource`] to another [`Resource`].
 pub trait Affiliation<R: Resource + ?Sized>: AsRef<str> {}
 
-impl<A: Affiliation<R>, R: Resource> Affiliation<R> for &A {}
-// impl<A: Affiliation<R>, R: Resource> Affiliation<&R> for A {}
-
 /// A computed set of [`Resource`]s for another particular [`Resource`].
 pub trait Permission<R: Resource + ?Sized>: Affiliation<R> {}
 

--- a/apps/hash-graph/lib/authorization/tests/schema.rs
+++ b/apps/hash-graph/lib/authorization/tests/schema.rs
@@ -8,7 +8,6 @@ pub const BOB: Account = Account("bob");
 
 impl Resource for Account {
     type Id = str;
-    type Namespace = str;
 
     fn namespace(&self) -> &'static str {
         "graph/account"
@@ -26,7 +25,6 @@ pub const ENTITY_A: Entity = Entity("a");
 
 impl Resource for Entity {
     type Id = str;
-    type Namespace = str;
 
     fn namespace(&self) -> &'static str {
         "graph/entity"

--- a/apps/hash-graph/lib/authorization/tests/simple.rs
+++ b/apps/hash-graph/lib/authorization/tests/simple.rs
@@ -16,16 +16,14 @@ async fn plain_permissions() -> Result<(), Box<dyn Error>> {
     api.import_schema(include_str!("schemas/simple.zed"))
         .await?;
 
-    api.create_relation(&ENTITY_A, &EntityRelation::Writer, &ALICE, [])
+    api.create_relation((ENTITY_A, EntityRelation::Writer, ALICE), [])
         .await?;
-    api.create_relation(&ENTITY_A, &EntityRelation::Reader, &BOB, [])
+    api.create_relation((ENTITY_A, EntityRelation::Reader, BOB), [])
         .await?;
 
     assert!(
         api.check(
-            &ENTITY_A,
-            &EntityRelation::Writer,
-            &ALICE,
+            &(ENTITY_A, EntityRelation::Writer, ALICE),
             Consistency::FullyConsistent
         )
         .await?
@@ -34,9 +32,7 @@ async fn plain_permissions() -> Result<(), Box<dyn Error>> {
 
     assert!(
         api.check(
-            &ENTITY_A,
-            &EntityPermission::Edit,
-            &ALICE,
+            &(ENTITY_A, EntityPermission::Edit, ALICE),
             Consistency::FullyConsistent
         )
         .await?
@@ -45,9 +41,7 @@ async fn plain_permissions() -> Result<(), Box<dyn Error>> {
 
     assert!(
         api.check(
-            &ENTITY_A,
-            &EntityPermission::View,
-            &ALICE,
+            &(ENTITY_A, EntityPermission::View, ALICE),
             Consistency::FullyConsistent
         )
         .await?
@@ -56,9 +50,7 @@ async fn plain_permissions() -> Result<(), Box<dyn Error>> {
 
     assert!(
         !api.check(
-            &ENTITY_A,
-            &EntityPermission::Edit,
-            &BOB,
+            &(ENTITY_A, EntityPermission::Edit, BOB),
             Consistency::FullyConsistent
         )
         .await?
@@ -67,9 +59,7 @@ async fn plain_permissions() -> Result<(), Box<dyn Error>> {
 
     assert!(
         api.check(
-            &ENTITY_A,
-            &EntityPermission::View,
-            &BOB,
+            &(ENTITY_A, EntityPermission::View, BOB),
             Consistency::FullyConsistent
         )
         .await?
@@ -77,15 +67,13 @@ async fn plain_permissions() -> Result<(), Box<dyn Error>> {
     );
 
     let token = api
-        .delete_relation(&ENTITY_A, &EntityRelation::Reader, &BOB, [])
+        .delete_relation(&(ENTITY_A, EntityRelation::Reader, BOB), [])
         .await?
         .deleted_at;
 
     assert!(
         !api.check(
-            &ENTITY_A,
-            &EntityPermission::View,
-            &BOB,
+            &(ENTITY_A, EntityPermission::View, BOB),
             Consistency::AtLeastAsFresh(token)
         )
         .await?

--- a/apps/hash-graph/lib/authorization/tests/simple.rs
+++ b/apps/hash-graph/lib/authorization/tests/simple.rs
@@ -16,9 +16,9 @@ async fn plain_permissions() -> Result<(), Box<dyn Error>> {
     api.import_schema(include_str!("schemas/simple.zed"))
         .await?;
 
-    api.create_relation(&ENTITY_A, &EntityRelation::Writer, &ALICE)
+    api.create_relation(&ENTITY_A, &EntityRelation::Writer, &ALICE, [])
         .await?;
-    api.create_relation(&ENTITY_A, &EntityRelation::Reader, &BOB)
+    api.create_relation(&ENTITY_A, &EntityRelation::Reader, &BOB, [])
         .await?;
 
     assert!(
@@ -77,7 +77,7 @@ async fn plain_permissions() -> Result<(), Box<dyn Error>> {
     );
 
     let token = api
-        .delete_relation(&ENTITY_A, &EntityRelation::Reader, &BOB)
+        .delete_relation(&ENTITY_A, &EntityRelation::Reader, &BOB, [])
         .await?
         .deleted_at;
 

--- a/apps/hash-graph/lib/authorization/tests/simple.rs
+++ b/apps/hash-graph/lib/authorization/tests/simple.rs
@@ -16,10 +16,14 @@ async fn plain_permissions() -> Result<(), Box<dyn Error>> {
     api.import_schema(include_str!("schemas/simple.zed"))
         .await?;
 
-    api.create_relation((ENTITY_A, EntityRelation::Writer, ALICE), [])
-        .await?;
-    api.create_relation((ENTITY_A, EntityRelation::Reader, BOB), [])
-        .await?;
+    api.create_relation(
+        [
+            &(ENTITY_A, EntityRelation::Writer, ALICE),
+            &(ENTITY_A, EntityRelation::Reader, BOB),
+        ],
+        [],
+    )
+    .await?;
 
     assert!(
         api.check(
@@ -67,7 +71,7 @@ async fn plain_permissions() -> Result<(), Box<dyn Error>> {
     );
 
     let token = api
-        .delete_relation(&(ENTITY_A, EntityRelation::Reader, BOB), [])
+        .delete_relation([&(ENTITY_A, EntityRelation::Reader, BOB)], [])
         .await?
         .deleted_at;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

SpiceDB allows to modify (touch, create, delete) relations. For simplicity we only expose a non-batched version yet. This PR improves some DX issues we had previously (discussed offline) and allows multiple tuples to be inserted/deleted at the same time.

## 🔍 What does this change?

- Support preconditions in modification endpoints
- Simplify interface to improve DX and probably compile time
- Allow multiple tuples to be passed in modification endpoints

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

The authorization integration tests uses the new batch creation/deletion methods