### PR TITLE
GEN-93(b): Fix typo in migration

### DIFF
--- a/apps/hashdotdev/src/_pages/blog/0008_sensitivity-assessor.mdx
+++ b/apps/hashdotdev/src/_pages/blog/0008_sensitivity-assessor.mdx
@@ -188,7 +188,7 @@ VMASC is freely releasing its own-developed tooling for easily ingesting HASH si
 
 ### Step 1. obtain the JSON output of your simulation model
 
-The JSON output of HASH simulation experiment runs can be [downloaded within HASH Core](https://hash.ai/docs/simulation/creating-simulations/views/raw-data) or pulled directly from the generated `JSON-State` [output in HASH Engine](https://github.com/hashintel/libs/tree/main/apps/sim-engine#simulation-outputs)
+The JSON output of HASH simulation experiment runs can be [downloaded within HASH Core](https://hash.ai/docs/simulation/creating-simulations/views/raw-data) or pulled directly from the generated `JSON-State` [output in HASH Engine](https://github.com/hashintel/labs/tree/main/apps/sim-engine#simulation-outputs)
 
 ### Step 2. convert your output into a readable format
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes a broken link/typo that slipped in.