### PR TITLE
GEN-97: Add recommended VSCode lint and test plugins

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,9 @@
 {
   "recommendations": [
+    "Codecov.codecov",
     "davidanson.vscode-markdownlint",
     "esbenp.prettier-vscode",
-    "ms-playwright.playwright"
+    "ms-playwright.playwright",
+    "orta.vscode-jest"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,11 @@
     "davidanson.vscode-markdownlint",
     "esbenp.prettier-vscode",
     "ms-playwright.playwright",
-    "orta.vscode-jest"
+    "orta.vscode-jest",
+    "dbaeumer.vscode-eslint",
+    "GraphQL.vscode-graphql",
+    "GraphQL.vscode-graphql-syntax",
+    "hashicorp.terraform",
+    "ms-vscode.vscode-typescript-next"
   ]
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds actively used lint and test tools we use within the monorepo to the `.vscode/extensions.json` recommendations file where plugins exist for them.

We were already recommending some test tools (e.g. Playwright) and linters (e.g. markdownlint) so this just makes it consistent. Alternatively, if we don't want these, we should consider removing the `.vscode` config directory entirely. It's a bit frustrating we can't achieve this via stadardized `EditorConfig` or by nesting the `vscode` prefs within our general top-level `.config` dir, but I think these plugins represent useful helper utils.