### PR TITLE
GEN-57: Run BE-Test and PW-Test only if needed in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,16 +38,22 @@ jobs:
         id: packages
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # `github.event.pull_request.base.sha` does not give the SHA of the last common ancestor but the most recent
+            # commit on the base branch. This is not what we want, so we use `git merge-base` instead.
             TURBO_REF_FILTER="$(git merge-base ${{ github.event.pull_request.base.ref }} ${{ github.event.pull_request.head.ref }})"
           else
+            # `github.event.before` gives back the most recent commit on the base branch.
             TURBO_REF_FILTER="${{ github.event.before }}$"
           fi
+
+          # We filter by the package we want to test. If the package is not changed, we don't need to run the tests.
           BE_TESTS=$(turbo run test --filter "@tests/hash-backend-integration...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
           PW_TESTS=$(turbo run test --filter "@tests/hash-playwright...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
           BUILD_AI_WORKER_TS=$(turbo run build:docker --filter "@apps/hash-ai-worker-ts...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
           BUILD_AI_WORKER_PY=$(turbo run build:docker --filter "@apps/hash-ai-worker-py...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
           BUILD_INTEGRATION_WORKER=$(turbo run build:docker --filter "@apps/hash-integration-worker...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
 
+          # Output some information for debugging purposes
           echo "Checking packages against SHA $TURBO_REF_FILTER:"
           echo "- Backend Integration Tests: $BE_TESTS"
           echo "- Playwright Tests:          $PW_TESTS"
@@ -55,6 +61,7 @@ jobs:
           echo "- AI Worker PY:              $BUILD_AI_WORKER_PY"
           echo "- Integration Worker:        $BUILD_INTEGRATION_WORKER"
 
+          # Output the results to the GitHub Actions output
           echo "be-tests=$BE_TESTS" >> $GITHUB_OUTPUT
           echo "pw-tests=$PW_TESTS" >> $GITHUB_OUTPUT
           echo "ai-worker-ts=$BUILD_AI_WORKER_TS" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,11 @@ jobs:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PREVIOUS_SHA: ${{ github.event.before }}
         run: |
+          set -x
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
             # `github.event.pull_request.base.sha` does not give the SHA of the last common ancestor but the most recent
             # commit on the base branch. This is not what we want, so we use `git merge-base` instead.
-            TURBO_REF_FILTER=$(git merge-base "$BASE_REF" "$HEAD_REF")
+            TURBO_REF_FILTER=$(git merge-base "$HEAD_REF" "$BASE_REF")
           else
             TURBO_REF_FILTER="$PREVIOUS_SHA"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,14 +36,18 @@ jobs:
 
       - name: Check changed packages
         id: packages
+        env:
+          GITHUB_EVENT_PULL_REQUEST_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          GITHUB_EVENT_PULL_REQUEST_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          GITHUB_EVENT_BEFORE: ${{ github.event.before }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
             # `github.event.pull_request.base.sha` does not give the SHA of the last common ancestor but the most recent
             # commit on the base branch. This is not what we want, so we use `git merge-base` instead.
-            TURBO_REF_FILTER="$(git merge-base ${{ github.event.pull_request.base.ref }} ${{ github.event.pull_request.head.ref }})"
+            TURBO_REF_FILTER="$(git merge-base GITHUB_EVENT_PULL_REQUEST_BASE_REF GITHUB_EVENT_PULL_REQUEST_HEAD_REF)"
           else
             # `github.event.before` gives back the most recent commit on the base branch.
-            TURBO_REF_FILTER="${{ github.event.before }}$"
+            TURBO_REF_FILTER="$GITHUB_EVENT_BEFORE"
           fi
 
           # We filter by the package we want to test. If the package is not changed, we don't need to run the tests.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,29 +36,16 @@ jobs:
 
       - name: Check changed packages
         id: packages
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          PREVIOUS_SHA: ${{ github.event.before }}
         run: |
-          set -x
-          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            # `github.event.pull_request.base.sha` does not give the SHA of the last common ancestor but the most recent
-            # commit on the base branch. This is not what we want, so we use `git merge-base` instead.
-            TURBO_REF_FILTER=$(git merge-base HEAD $BASE_SHA)
-          else
-            TURBO_REF_FILTER="$PREVIOUS_SHA"
-          fi
-
           # We filter by the package we want to test. If the package is not changed, we don't need to run the tests.
-          BE_TESTS=$(turbo run test --filter "@tests/hash-backend-integration...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
-          PW_TESTS=$(turbo run test --filter "@tests/hash-playwright...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
-          BUILD_AI_WORKER_TS=$(turbo run build:docker --filter "@apps/hash-ai-worker-ts...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
-          BUILD_AI_WORKER_PY=$(turbo run build:docker --filter "@apps/hash-ai-worker-py...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
-          BUILD_INTEGRATION_WORKER=$(turbo run build:docker --filter "@apps/hash-integration-worker...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
+          BE_TESTS=$(turbo run test --filter "@tests/hash-backend-integration...[HEAD^]" --dry-run=json | jq -r '.packages != []')
+          PW_TESTS=$(turbo run test --filter "@tests/hash-playwright...[HEAD^]" --dry-run=json | jq -r '.packages != []')
+          BUILD_AI_WORKER_TS=$(turbo run build:docker --filter "@apps/hash-ai-worker-ts...[HEAD^]" --dry-run=json | jq -r '.packages != []')
+          BUILD_AI_WORKER_PY=$(turbo run build:docker --filter "@apps/hash-ai-worker-py...[HEAD^]" --dry-run=json | jq -r '.packages != []')
+          BUILD_INTEGRATION_WORKER=$(turbo run build:docker --filter "@apps/hash-integration-worker...[HEAD^]" --dry-run=json | jq -r '.packages != []')
 
           # Output some information for debugging purposes
-          echo "Checking packages against SHA $TURBO_REF_FILTER:"
+          echo "Checking packages:"
           echo "- Backend Integration Tests: $BE_TESTS"
           echo "- Playwright Tests:          $PW_TESTS"
           echo "- AI Worker TS:              $BUILD_AI_WORKER_TS"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
   build-hash-integration-worker:
     runs-on: ubuntu-latest
     needs: [setup]
-    if: needs.setup.outputs.integration-worker == 'true' || needs.setup.outputs.be-tests == 'true'
+    if: needs.setup.outputs.integration-worker == 'true' || needs.setup.outputs.pw-tests == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-        with:
-          fetch-depth: 2
 
       - name: Install turbo
         run: yarn global add turbo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,17 +37,16 @@ jobs:
       - name: Check changed packages
         id: packages
         env:
-          GITHUB_EVENT_PULL_REQUEST_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          GITHUB_EVENT_PULL_REQUEST_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PREVIOUS_SHA: ${{ github.event.before }}
         run: |
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
             # `github.event.pull_request.base.sha` does not give the SHA of the last common ancestor but the most recent
             # commit on the base branch. This is not what we want, so we use `git merge-base` instead.
-            TURBO_REF_FILTER="$(git merge-base GITHUB_EVENT_PULL_REQUEST_BASE_REF GITHUB_EVENT_PULL_REQUEST_HEAD_REF)"
+            TURBO_REF_FILTER="$(git merge-base BASE_REF HEAD_REF)"
           else
-            # `github.event.before` gives back the most recent commit on the base branch.
-            TURBO_REF_FILTER="$GITHUB_EVENT_BEFORE"
+            TURBO_REF_FILTER="PREVIOUS_SHA"
           fi
 
           # We filter by the package we want to test. If the package is not changed, we don't need to run the tests.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
             # commit on the base branch. This is not what we want, so we use `git merge-base` instead.
             TURBO_REF_FILTER=$(git merge-base "$BASE_REF" "$HEAD_REF")
           else
-            TURBO_REF_FILTER="PREVIOUS_SHA"
+            TURBO_REF_FILTER="$PREVIOUS_SHA"
           fi
 
           # We filter by the package we want to test. If the package is not changed, we don't need to run the tests.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
             # `github.event.pull_request.base.sha` does not give the SHA of the last common ancestor but the most recent
             # commit on the base branch. This is not what we want, so we use `git merge-base` instead.
-            TURBO_REF_FILTER=$(git merge-base "origin/$HEAD_REF" "origin/$BASE_REF")
+            TURBO_REF_FILTER=$(git merge-base HEAD "origin/$BASE_REF")
           else
             TURBO_REF_FILTER="$PREVIOUS_SHA"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
     outputs:
       be-tests: ${{ steps.packages.outputs.be-tests }}
       pw-tests: ${{ steps.packages.outputs.pw-tests }}
+      ai-worker-ts: ${{ steps.packages.outputs.ai-worker-ts }}
+      ai-worker-py: ${{ steps.packages.outputs.ai-worker-py }}
+      integration-worker: ${{ steps.packages.outputs.integration_worker }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -38,10 +41,16 @@ jobs:
         run: |
           BE_TESTS=$(turbo run test --filter "@tests/hash-backend-integration...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
           PW_TESTS=$(turbo run test --filter "@tests/hash-playwright...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
+          BUILD_AI_WORKER_TS=$(turbo run build:docker --filter "@apps/hash-ai-worker-ts...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
+          BUILD_AI_WORKER_PY=$(turbo run build:docker --filter "@apps/hash-ai-worker-py...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
+          BUILD_INTEGRATION_WORKER=$(turbo run build:docker --filter "@apps/hash-integration-worker...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
 
           set -x
           echo "be-tests=$BE_TESTS" >> $GITHUB_OUTPUT
           echo "pw-tests=$PW_TESTS" >> $GITHUB_OUTPUT
+          echo "ai-worker-ts=$BUILD_AI_WORKER_TS" >> $GITHUB_OUTPUT
+          echo "ai-worker-py=$BUILD_AI_WORKER_PY" >> $GITHUB_OUTPUT
+          echo "integration-worker=$BUILD_INTEGRATION_WORKER" >> $GITHUB_OUTPUT
 
   build-hash-graph:
     runs-on: ubuntu-latest
@@ -60,7 +69,7 @@ jobs:
   build-hash-ai-worker-ts:
     runs-on: ubuntu-latest
     needs: [setup]
-    if: needs.setup.outputs.pw-tests == 'true'
+    if: needs.setup.outputs.ai-worker-ts == 'true' || needs.setup.outputs.pw-tests == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -74,7 +83,7 @@ jobs:
   build-hash-ai-worker-py:
     runs-on: ubuntu-latest
     needs: [setup]
-    if: needs.setup.outputs.pw-tests == 'true'
+    if: needs.setup.outputs.ai-worker-py == 'true' || needs.setup.outputs.pw-tests == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -88,7 +97,7 @@ jobs:
   build-hash-integration-worker:
     runs-on: ubuntu-latest
     needs: [setup]
-    if: needs.setup.outputs.pw-tests == 'true'
+    if: needs.setup.outputs.integration-worker == 'true' || needs.setup.outputs.be-tests == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 2
 
       - name: Install turbo
-        uses: yarn global add turbo
+        run: yarn global add turbo
 
       - name: Check changed packages
         id: packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
             # `github.event.pull_request.base.sha` does not give the SHA of the last common ancestor but the most recent
             # commit on the base branch. This is not what we want, so we use `git merge-base` instead.
-            TURBO_REF_FILTER="$(git merge-base BASE_REF HEAD_REF)"
+            TURBO_REF_FILTER=$(git merge-base "$BASE_REF" "$HEAD_REF")
           else
             TURBO_REF_FILTER="PREVIOUS_SHA"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Check changed packages
         id: packages
         env:
-          TURBO_REF_FILTER: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          TURBO_REF_FILTER: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.before }}
         run: |
           BE_TESTS=$(turbo run test --filter "@tests/hash-backend-integration...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
           PW_TESTS=$(turbo run test --filter "@tests/hash-playwright...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Install turbo
         run: yarn global add turbo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
             # `github.event.pull_request.base.sha` does not give the SHA of the last common ancestor but the most recent
             # commit on the base branch. This is not what we want, so we use `git merge-base` instead.
-            TURBO_REF_FILTER=$(git merge-base "$HEAD_REF" "$BASE_REF")
+            TURBO_REF_FILTER=$(git merge-base "origin/$HEAD_REF" "origin/$BASE_REF")
           else
             TURBO_REF_FILTER="$PREVIOUS_SHA"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  setup:
+    runs-on: ubuntu-22.04
+    outputs:
+      be-tests: ${{ steps.packages.outputs.be-tests }}
+      pw-tests: ${{ steps.packages.outputs.pw-tests }}
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          fetch-depth: 2
+
+      - name: Install turbo
+        uses: yarn global add turbo
+
+      - name: Check changed packages
+        id: packages
+        env:
+          TURBO_REF_FILTER: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          BE_TESTS=$(turbo run test --filter "@tests/hash-backend-integration...[$TURBO_REF_FILTER]" --dry-run=json | jq .packages)
+          PW_TESTS=$(turbo run test --filter "@tests/hash-playwright...[$TURBO_REF_FILTER]" --dry-run=json | jq .packages)
+
+          set -x
+          echo "be-tests=$BE_TESTS" >> $GITHUB_OUTPUT
+          echo "pw-tests=$PW_TESTS" >> $GITHUB_OUTPUT
+
   build-hash-graph:
     runs-on: ubuntu-latest
+    if: needs.setup.outputs.be-tests == 'true' || needs.setup.outputs.pw-tests == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -31,6 +58,7 @@ jobs:
 
   build-hash-ai-worker-ts:
     runs-on: ubuntu-latest
+    if: needs.setup.outputs.pw-tests == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -43,6 +71,7 @@ jobs:
 
   build-hash-ai-worker-py:
     runs-on: ubuntu-latest
+    if: needs.setup.outputs.pw-tests == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -55,6 +84,7 @@ jobs:
 
   build-hash-integration-worker:
     runs-on: ubuntu-latest
+    if: needs.setup.outputs.pw-tests == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -269,14 +299,8 @@ jobs:
 
   backend-integration-tests:
     name: Backend integration tests
-    needs:
-      [
-        build-hash-graph,
-        build-hash-ai-worker-ts,
-        build-hash-ai-worker-py,
-        build-hash-integration-worker,
-      ]
-    if: always()
+    needs: [build-hash-graph]
+    if: always() && needs.setup.outputs.be-tests == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -291,14 +315,11 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           hash-graph: true
-          hash-ai-worker-ts: true
-          hash-ai-worker-py: true
-          hash-integration-worker: true
 
       - name: Launch external services
         run: |
           yarn turbo codegen --filter '@apps/hash-external-services'
-          yarn workspace @apps/hash-external-services deploy:test up --detach
+          yarn workspace @apps/hash-external-services deploy:test up graph kratos --wait
 
       - run: yarn test:backend-integration
         env:
@@ -338,7 +359,7 @@ jobs:
         build-hash-ai-worker-py,
         build-hash-integration-worker,
       ]
-    if: always()
+    if: always() && needs.setup.outputs.pw-tests == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,16 +36,19 @@ jobs:
 
       - name: Check changed packages
         id: packages
-        env:
-          TURBO_REF_FILTER: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.before }}
         run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            TURBO_REF_FILTER="$(git merge-base ${{ github.event.pull_request.base.ref }} ${{ github.event.pull_request.head.ref }})"
+          else
+            TURBO_REF_FILTER="${{ github.event.before }}$"
+          fi
           BE_TESTS=$(turbo run test --filter "@tests/hash-backend-integration...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
           PW_TESTS=$(turbo run test --filter "@tests/hash-playwright...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
           BUILD_AI_WORKER_TS=$(turbo run build:docker --filter "@apps/hash-ai-worker-ts...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
           BUILD_AI_WORKER_PY=$(turbo run build:docker --filter "@apps/hash-ai-worker-py...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
           BUILD_INTEGRATION_WORKER=$(turbo run build:docker --filter "@apps/hash-integration-worker...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
 
-          echo "Checking packages for $TURBO_REF_FILTER:"
+          echo "Checking packages against SHA $TURBO_REF_FILTER:"
           echo "- Backend Integration Tests: $BE_TESTS"
           echo "- Playwright Tests:          $PW_TESTS"
           echo "- AI Worker TS:              $BUILD_AI_WORKER_TS"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          fetch-depth: 0
 
       - name: Install turbo
         run: yarn global add turbo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
 
   build-hash-graph:
     runs-on: ubuntu-latest
+    needs: [setup]
     if: needs.setup.outputs.be-tests == 'true' || needs.setup.outputs.pw-tests == 'true'
     steps:
       - name: Checkout
@@ -58,6 +59,7 @@ jobs:
 
   build-hash-ai-worker-ts:
     runs-on: ubuntu-latest
+    needs: [setup]
     if: needs.setup.outputs.pw-tests == 'true'
     steps:
       - name: Checkout
@@ -71,6 +73,7 @@ jobs:
 
   build-hash-ai-worker-py:
     runs-on: ubuntu-latest
+    needs: [setup]
     if: needs.setup.outputs.pw-tests == 'true'
     steps:
       - name: Checkout
@@ -84,6 +87,7 @@ jobs:
 
   build-hash-integration-worker:
     runs-on: ubuntu-latest
+    needs: [setup]
     if: needs.setup.outputs.pw-tests == 'true'
     steps:
       - name: Checkout
@@ -299,7 +303,7 @@ jobs:
 
   backend-integration-tests:
     name: Backend integration tests
-    needs: [build-hash-graph]
+    needs: [setup, build-hash-graph]
     if: always() && needs.setup.outputs.be-tests == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -354,6 +358,7 @@ jobs:
     name: Playwright tests
     needs:
       [
+        setup,
         build-hash-graph,
         build-hash-ai-worker-ts,
         build-hash-ai-worker-py,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
         env:
           TURBO_REF_FILTER: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
         run: |
-          BE_TESTS=$(turbo run test --filter "@tests/hash-backend-integration...[$TURBO_REF_FILTER]" --dry-run=json | jq .packages)
-          PW_TESTS=$(turbo run test --filter "@tests/hash-playwright...[$TURBO_REF_FILTER]" --dry-run=json | jq .packages)
+          BE_TESTS=$(turbo run test --filter "@tests/hash-backend-integration...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
+          PW_TESTS=$(turbo run test --filter "@tests/hash-playwright...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
 
           set -x
           echo "be-tests=$BE_TESTS" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,13 @@ jobs:
           BUILD_AI_WORKER_PY=$(turbo run build:docker --filter "@apps/hash-ai-worker-py...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
           BUILD_INTEGRATION_WORKER=$(turbo run build:docker --filter "@apps/hash-integration-worker...[$TURBO_REF_FILTER]" --dry-run=json | jq -r '.packages != []')
 
-          set -x
+          echo "Checking packages for $TURBO_REF_FILTER:"
+          echo "- Backend Integration Tests: $BE_TESTS"
+          echo "- Playwright Tests:          $PW_TESTS"
+          echo "- AI Worker TS:              $BUILD_AI_WORKER_TS"
+          echo "- AI Worker PY:              $BUILD_AI_WORKER_PY"
+          echo "- Integration Worker:        $BUILD_INTEGRATION_WORKER"
+
           echo "be-tests=$BE_TESTS" >> $GITHUB_OUTPUT
           echo "pw-tests=$PW_TESTS" >> $GITHUB_OUTPUT
           echo "ai-worker-ts=$BUILD_AI_WORKER_TS" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Check changed packages
         id: packages
         env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PREVIOUS_SHA: ${{ github.event.before }}
         run: |
@@ -45,7 +45,7 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
             # `github.event.pull_request.base.sha` does not give the SHA of the last common ancestor but the most recent
             # commit on the base branch. This is not what we want, so we use `git merge-base` instead.
-            TURBO_REF_FILTER=$(git merge-base HEAD "origin/$BASE_REF")
+            TURBO_REF_FILTER=$(git merge-base HEAD $BASE_SHA)
           else
             TURBO_REF_FILTER="$PREVIOUS_SHA"
           fi

--- a/apps/hash-ai-worker-py/docker/Dockerfile
+++ b/apps/hash-ai-worker-py/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11.3-slim-bullseye as python-base
 
-FROM node:16.18.1-bullseye-slim AS base
+FROM node:18.15-slim AS base
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \

--- a/apps/hash-ai-worker-py/docker/Dockerfile
+++ b/apps/hash-ai-worker-py/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11.3-slim-bullseye as python-base
 
-FROM node:18.15-slim AS base
+FROM node:16.18.1-bullseye-slim AS base
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \

--- a/apps/hash-external-services/docker-compose.test.yml
+++ b/apps/hash-external-services/docker-compose.test.yml
@@ -19,10 +19,6 @@ services:
     environment:
       HASH_GRAPH_PG_DATABASE: "${HASH_GRAPH_PG_TEST_DATABASE}"
 
-  graph:
-    environment:
-      HASH_GRAPH_PG_DATABASE: "${HASH_GRAPH_PG_TEST_DATABASE}"
-
   graph-test-server:
     init: true
     depends_on:
@@ -64,6 +60,13 @@ services:
       interval: 2s
       timeout: 2s
       retries: 10
+
+  graph:
+    environment:
+      HASH_GRAPH_PG_DATABASE: "${HASH_GRAPH_PG_TEST_DATABASE}"
+    depends_on:
+      graph-test-server:
+        condition: service_healthy
 
   kratos-migrate:
     environment:

--- a/apps/hash-frontend/package.json
+++ b/apps/hash-frontend/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@apollo/client": "3.6.9",
+    "@apps/hash-api": "0.0.0-private",
     "@blockprotocol/core": "0.1.2",
     "@blockprotocol/graph": "0.3.1-canary-20230803163819",
     "@blockprotocol/hook": "0.1.3",

--- a/apps/hash-graph/lib/graph/src/store/postgres.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres.rs
@@ -9,12 +9,12 @@ mod traversal_context;
 use async_trait::async_trait;
 use error_stack::{Report, Result, ResultExt};
 #[cfg(hash_graph_test_environment)]
-use graph_types::knowledge::entity::{
-    EntityEditionId, EntityId, EntityProperties, EntityTemporalMetadata,
+use graph_types::knowledge::{
+    entity::{EntityEditionId, EntityId, EntityProperties, EntityTemporalMetadata},
+    link::LinkOrder,
 };
 use graph_types::{
     account::AccountId,
-    knowledge::link::LinkOrder,
     ontology::{
         CustomOntologyMetadata, OntologyElementMetadata, OntologyTemporalMetadata,
         OntologyTypeRecordId, OntologyTypeVersion, PartialCustomOntologyMetadata,

--- a/apps/hash-graph/lib/graph/src/store/postgres.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres.rs
@@ -9,12 +9,12 @@ mod traversal_context;
 use async_trait::async_trait;
 use error_stack::{Report, Result, ResultExt};
 #[cfg(hash_graph_test_environment)]
-use graph_types::knowledge::{
-    entity::{EntityEditionId, EntityId, EntityProperties, EntityTemporalMetadata},
-    link::LinkOrder,
+use graph_types::knowledge::entity::{
+    EntityEditionId, EntityId, EntityProperties, EntityTemporalMetadata,
 };
 use graph_types::{
     account::AccountId,
+    knowledge::link::LinkOrder,
     ontology::{
         CustomOntologyMetadata, OntologyElementMetadata, OntologyTemporalMetadata,
         OntologyTypeRecordId, OntologyTypeVersion, PartialCustomOntologyMetadata,

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -15,6 +15,7 @@ use graph_types::{
     provenance::{OwnedById, ProvenanceMetadata, RecordCreatedById},
 };
 use temporal_versioning::{DecisionTime, RightBoundedTemporalInterval, Timestamp};
+#[cfg(hash_graph_test_environment)]
 use tokio_postgres::GenericClient;
 use type_system::url::VersionedUrl;
 use uuid::Uuid;

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -15,7 +15,6 @@ use graph_types::{
     provenance::{OwnedById, ProvenanceMetadata, RecordCreatedById},
 };
 use temporal_versioning::{DecisionTime, RightBoundedTemporalInterval, Timestamp};
-#[cfg(hash_graph_test_environment)]
 use tokio_postgres::GenericClient;
 use type_system::url::VersionedUrl;
 use uuid::Uuid;

--- a/tests/hash-playwright/package.json
+++ b/tests/hash-playwright/package.json
@@ -9,6 +9,7 @@
     "test": "playwright test --project chromium"
   },
   "dependencies": {
+    "@apps/hash-frontend": "0.0.0-private",
     "@local/eslint-config": "0.0.0-private",
     "@local/hash-backend-utils": "0.0.0-private",
     "@local/hash-isomorphic-utils": "0.0.0-private",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The current `CI` workflow always runs regardless of the changes. improves the behavior to only run it if needed. This can be optimized further such as only lint and run the unit tests if needed but the BE and PW tests requires a big setup this this is the first step to improve the behavior

## 🔍 What does this change?

- Adds a dependency for the PW tests on the frontend and make the API a dependency of the frontend which implies a chain of dependencies
- Check for changes in CI
- Run the bespoken jobs only if required

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this