### PR TITLE
GEN-101: Add HDEV redirect and opt out of `poweredByHeader`

### DIFF
--- a/apps/hashdotdev/next.config.js
+++ b/apps/hashdotdev/next.config.js
@@ -2,6 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   pageExtensions: ["page.tsx", "page.ts", "page.jsx", "page.jsx"],
+  poweredByHeader: false,
 
   // We call linters in GitHub Actions for all pull requests. By not linting
   // again during `next build`, we save CI minutes and unlock more feedback.
@@ -11,6 +12,16 @@ const nextConfig = {
   typescript: { ignoreBuildErrors: true },
   images: {
     domains: ["hash.ai"],
+  },
+
+  async redirects() {
+    return [
+      {
+        source: "/labs",
+        destination: "/blog?label=labs",
+        permanent: false,
+      },
+    ],
   },
 
   experimental: {

--- a/apps/hashdotdev/next.config.js
+++ b/apps/hashdotdev/next.config.js
@@ -21,7 +21,7 @@ const nextConfig = {
         destination: "/blog?label=labs",
         permanent: false,
       },
-    ],
+    ];
   },
 
   experimental: {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Updates `next.config.js` to set `poweredByHeader` to `false` and ensures `hash.dev/labs` redirects correctly without relying on Cloudflare Rules.


## 🔗 Related links

- [poweredByHeader](https://nextjs.org/docs/app/api-reference/next-config-js/poweredByHeader) in the `Next.js` docs