### PR TITLE
GEN-102: Fix deprecation warning typo for `IntoReport`

### DIFF
--- a/libs/error-stack/src/result.rs
+++ b/libs/error-stack/src/result.rs
@@ -269,7 +269,7 @@ where
 /// Extends [`Result`] to convert the [`Err`] variant to a [`Report`]
 #[deprecated(
     since = "0.4.0",
-    note = "Use `ReportExt` or `From` via `Result::map_err(Report::from)` instead"
+    note = "Use `ResultExt` or `From` via `Result::map_err(Report::from)` instead"
 )]
 pub trait IntoReport: Sized {
     /// Type of the [`Ok`] value in the [`Result`]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The deprecation warning mentioned `ReportExt` instead of `ResultExt` which might be confusing.

## 🔗 Related links

- Closes https://github.com/hashintel/hash/issues/3087

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph