### PR TITLE
GEN-103: Bump `error-stack` to v0.4.1

### DIFF
--- a/libs/error-stack/CHANGELOG.md
+++ b/libs/error-stack/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to `error-stack` will be documented in this file.
 
 - Support for [`defmt`](https://defmt.ferrous-systems.com)
 
+## [0.4.1](https://github.com/hashintel/hash/tree/error-stack%400.4.1/libs/error-stack) - 2023-09-04
+
+### Fixes
+
+- Fix deprecation warning typo for `IntoReport` ([#3088](https://github.com/hashintel/hash/pull/3088))
+
 ## [0.4.0](https://github.com/hashintel/hash/tree/error-stack%400.4.0/libs/error-stack) - 2023-08-23
 
 ### Breaking Changes

--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["package.json", ".config/lints.toml"]
 
 [package]
 name = "error-stack"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["HASH"]
 edition = "2021"
 rust-version = "1.63.0"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To avoid further confusion with the deprecation warning this is worth bumping the version.

## 🚫 Blocked by

- #3088 

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies a **Cargo**-publishable library and **I have amended the version**

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph