### PR TITLE
H-704: Add `HASH_INTEGRATION_QUEUE_NAME` to production `hash-api` service

### DIFF
--- a/apps/hash-external-services/docker-compose.prod.yml
+++ b/apps/hash-external-services/docker-compose.prod.yml
@@ -248,6 +248,7 @@ services:
       HASH_REDIS_PORT: "6379"
 
       HASH_OPENSEARCH_ENABLED: "false"
+      HASH_INTEGRATION_QUEUE_NAME: "${HASH_INTEGRATION_QUEUE_NAME}"
 
       ORY_KRATOS_PUBLIC_URL: "http://kratos:4433"
       ORY_KRATOS_ADMIN_URL: "http://kratos:4434"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This simply adds `HASH_INTEGRATION_QUEUE_NAME` to the `hash-api` service in the `docker-compose.prod.yml`, as otherwise start-up in production environments would fail.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

