### PR TITLE
H-708, H-709: Avoid hardcoding instances of the FE domain, redundant type version increments

### DIFF
--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor-page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/entity-editor-page.tsx
@@ -1,4 +1,5 @@
 import { OntologyChip } from "@hashintel/design-system";
+import { frontendDomain } from "@local/hash-isomorphic-utils/environment";
 import { EntityPropertiesObject } from "@local/hash-subgraph";
 import { Typography } from "@mui/material";
 import { NextSeo } from "next-seo";
@@ -74,7 +75,7 @@ export const EntityEditorPage = ({
               editBar={editBar}
               chip={
                 <OntologyChip
-                  domain="hash.ai"
+                  domain={frontendDomain}
                   path={
                     <Typography>
                       <Typography

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/query-editor-page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/query-editor-page.tsx
@@ -1,6 +1,7 @@
 import { MultiFilter } from "@blockprotocol/graph";
 import { OntologyChip } from "@hashintel/design-system";
 import { EntityQueryEditor } from "@hashintel/query-editor";
+import { frontendDomain } from "@local/hash-isomorphic-utils/environment";
 import { zeroedGraphResolveDepths } from "@local/hash-isomorphic-utils/graph-queries";
 import { getRoots } from "@local/hash-subgraph/stdlib";
 import { Box, Typography } from "@mui/material";
@@ -87,7 +88,7 @@ export const QueryEditorPage = (props: QueryEditorPageProps) => {
             entityLabel={entityLabel}
             chip={
               <OntologyChip
-                domain="hash.ai"
+                domain={frontendDomain}
                 path={
                   <Typography>
                     <Typography

--- a/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/select-entity-type-page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/entities/[entity-uuid].page/select-entity-type-page.tsx
@@ -5,6 +5,7 @@ import {
   OntologyChip,
   WhiteCard,
 } from "@hashintel/design-system";
+import { frontendDomain } from "@local/hash-isomorphic-utils/environment";
 import { Box, Divider, Typography } from "@mui/material";
 import { useRouter } from "next/router";
 import { useContext, useState } from "react";
@@ -39,7 +40,7 @@ export const SelectEntityTypePage = () => {
           lightTitle
           chip={
             <OntologyChip
-              domain="hash.ai"
+              domain={frontendDomain}
               path={
                 <>
                   <Typography

--- a/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
+++ b/apps/hash-frontend/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
@@ -13,6 +13,7 @@ import {
   useEntityTypeForm,
   useEntityTypeFormWatch,
 } from "@hashintel/type-editor";
+import { frontendDomain } from "@local/hash-isomorphic-utils/environment";
 import { linkEntityTypeUrl, OwnedById } from "@local/hash-subgraph";
 import { Box, Container, Theme, Typography } from "@mui/material";
 import { GlobalStyles } from "@mui/system";
@@ -151,7 +152,14 @@ const Page: NextPageWithLayout = () => {
     [entityType, remotePropertyTypes],
   );
 
+  const isDirty = formMethods.formState.isDirty;
+
   const handleSubmit = wrapHandleSubmit(async (data) => {
+    if (!isDirty) {
+      // prevent creating new types when there are no changes
+      return;
+    }
+
     const entityTypeSchema = getSchemaFromFormData(data);
 
     if (isDraft) {
@@ -222,8 +230,6 @@ const Page: NextPageWithLayout = () => {
       throw new Error("Could not publish changes");
     }
   });
-
-  const isDirty = formMethods.formState.isDirty;
 
   return (
     <>
@@ -319,7 +325,7 @@ const Page: NextPageWithLayout = () => {
                     isDraft={isDraft}
                     ontologyChip={
                       <OntologyChip
-                        domain="hash.ai"
+                        domain={frontendDomain}
                         path={
                           <>
                             <Typography

--- a/apps/hash-frontend/src/pages/new/types/entity-type.page.tsx
+++ b/apps/hash-frontend/src/pages/new/types/entity-type.page.tsx
@@ -1,5 +1,6 @@
 import { VersionedUrl } from "@blockprotocol/type-system/slim";
 import { OntologyChip } from "@hashintel/design-system";
+import { frontendDomain } from "@local/hash-isomorphic-utils/environment";
 import { Box, Container, Stack, Typography } from "@mui/material";
 import { useRouter } from "next/router";
 import { useContext } from "react";
@@ -50,7 +51,7 @@ const Page: NextPageWithLayout = () => {
         <Box py={3.75}>
           <Container>
             <OntologyChip
-              domain="hash.ai"
+              domain={frontendDomain}
               path={
                 <Typography color={(theme) => theme.palette.blue[70]}>
                   <Typography


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

1. Stop hardcoding 'hash.ai' as the domain for display in certain paths, and use the `frontendDomain` instead, which is derived as follows:
```ts
export const frontendUrl =
  process.env.NEXT_PUBLIC_FRONTEND_URL ??
  (process.env.NEXT_PUBLIC_VERCEL_URL
    ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
    : process.env.FRONTEND_URL ?? "http://localhost:3000");

export const frontendDomain = new URL(frontendUrl).hostname;
```

2. Prevent creation of new versions of an entity type unless the form is dirty, as a safety fallback – mysterious unprompted form submission has been witnessed in the past. We should figure out what could have caused this (H-706), but in the meantime this might prevent whatever the underlying bug is from causing versions to be created when they shouldn't

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
