### PR TITLE
H-721: Replace almost all `#[async_trait]` usages with native `async trait`

### DIFF
--- a/apps/hash-graph/lib/graph/src/api/rest.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest.rs
@@ -18,9 +18,8 @@ mod entity;
 mod entity_type;
 mod property_type;
 
-use std::{fs, io, sync::Arc};
+use std::{fs, future::Future, io, sync::Arc};
 
-use async_trait::async_trait;
 use axum::{
     extract::Path,
     http::StatusCode,
@@ -81,17 +80,15 @@ use crate::{
     },
 };
 
-#[async_trait]
 pub trait RestApiStore: Store + TypeFetcher {
-    async fn load_external_type(
+    fn load_external_type(
         &mut self,
         domain_validator: &DomainValidator,
         reference: OntologyTypeReference<'_>,
         actor_id: RecordCreatedById,
-    ) -> Result<OntologyElementMetadata, StatusCode>;
+    ) -> impl Future<Output = Result<OntologyElementMetadata, StatusCode>> + Send;
 }
 
-#[async_trait]
 impl<S> RestApiStore for S
 where
     S: Store + TypeFetcher + Send,

--- a/apps/hash-graph/lib/graph/src/lib.rs
+++ b/apps/hash-graph/lib/graph/src/lib.rs
@@ -10,6 +10,7 @@
 #![feature(type_alias_impl_trait)]
 #![feature(hash_raw_entry)]
 #![feature(bound_map)]
+#![feature(async_fn_in_trait, return_position_impl_trait_in_trait)]
 #![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
 #![cfg_attr(not(miri), doc(test(attr(deny(warnings, clippy::all)))))]
 

--- a/apps/hash-graph/lib/graph/src/store/account.rs
+++ b/apps/hash-graph/lib/graph/src/store/account.rs
@@ -1,16 +1,19 @@
-use async_trait::async_trait;
+use std::future::Future;
+
 use error_stack::Result;
 use graph_types::account::AccountId;
 
 use crate::store::InsertionError;
 
 /// Describes the API of a store implementation for accounts.
-#[async_trait]
 pub trait AccountStore {
     /// Inserts the specified [`AccountId`] into the database.
     ///
     /// # Errors
     ///
     /// - if insertion failed, e.g. because the [`AccountId`] already exists.
-    async fn insert_account_id(&mut self, account_id: AccountId) -> Result<(), InsertionError>;
+    fn insert_account_id(
+        &mut self,
+        account_id: AccountId,
+    ) -> impl Future<Output = Result<(), InsertionError>> + Send;
 }

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -735,7 +735,6 @@ where
     }
 }
 
-#[async_trait]
 impl<S, A> EntityStore for FetchingStore<S, A>
 where
     S: DataTypeStore + PropertyTypeStore + EntityTypeStore + EntityStore + Send,
@@ -806,7 +805,10 @@ where
             .await
     }
 
-    async fn get_entity(&self, query: &StructuralQuery<Entity>) -> Result<Subgraph, QueryError> {
+    async fn get_entity(
+        &self,
+        query: &StructuralQuery<'_, Entity>,
+    ) -> Result<Subgraph, QueryError> {
         self.store.get_entity(query).await
     }
 

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -544,7 +544,6 @@ where
     }
 }
 
-#[async_trait]
 impl<S, A> DataTypeStore for FetchingStore<S, A>
 where
     S: DataTypeStore + PropertyTypeStore + EntityTypeStore + Send,
@@ -568,7 +567,7 @@ where
 
     async fn get_data_type(
         &self,
-        query: &StructuralQuery<DataTypeWithMetadata>,
+        query: &StructuralQuery<'_, DataTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError> {
         self.store.get_data_type(query).await
     }

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -380,9 +380,7 @@ where
         &mut self,
         ontology_types: impl IntoIterator<Item = (&'o T, RecordCreatedById), IntoIter: Send> + Send,
     ) -> Result<(), InsertionError> {
-        // Without collecting it first, we get a "Higher-ranked lifetime error" because of the
-        // limitations of Rust being able to look into a `Pin<Box<dyn Future>>`, which is returned
-        // by `#[async_trait]` methods.
+        // TODO: Figure out how to avoid collecting the iterator first.
         let ontology_types = ontology_types.into_iter().collect::<Vec<_>>();
 
         let mut partitioned_ontology_types = HashMap::<RecordCreatedById, Vec<VersionedUrl>>::new();

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
+    future::Future,
     iter::once,
     mem,
 };
@@ -50,14 +51,13 @@ use crate::{
     },
 };
 
-#[async_trait]
 pub trait TypeFetcher {
     /// Fetches the provided type reference and inserts it to the Graph.
-    async fn insert_external_ontology_type(
+    fn insert_external_ontology_type(
         &mut self,
         reference: OntologyTypeReference<'_>,
         actor_id: RecordCreatedById,
-    ) -> Result<OntologyElementMetadata, InsertionError>;
+    ) -> impl Future<Output = Result<OntologyElementMetadata, InsertionError>> + Send;
 }
 
 #[derive(Clone)]
@@ -485,7 +485,6 @@ where
     }
 }
 
-#[async_trait]
 impl<S, A> TypeFetcher for FetchingStore<S, A>
 where
     A: ToSocketAddrs + Send + Sync,

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -602,7 +602,6 @@ where
     }
 }
 
-#[async_trait]
 impl<S, A> PropertyTypeStore for FetchingStore<S, A>
 where
     S: DataTypeStore + PropertyTypeStore + EntityTypeStore + Send,
@@ -633,7 +632,7 @@ where
 
     async fn get_property_type(
         &self,
-        query: &StructuralQuery<PropertyTypeWithMetadata>,
+        query: &StructuralQuery<'_, PropertyTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError> {
         self.store.get_property_type(query).await
     }

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -95,7 +95,6 @@ where
     }
 }
 
-#[async_trait]
 impl<P, A> StorePool for FetchingPool<P, A>
 where
     P: StorePool + Send + Sync,

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -669,7 +669,6 @@ where
     }
 }
 
-#[async_trait]
 impl<S, A> EntityTypeStore for FetchingStore<S, A>
 where
     S: DataTypeStore + PropertyTypeStore + EntityTypeStore + Send,
@@ -698,7 +697,7 @@ where
 
     async fn get_entity_type(
         &self,
-        query: &StructuralQuery<EntityTypeWithMetadata>,
+        query: &StructuralQuery<'_, EntityTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError> {
         self.store.get_entity_type(query).await
     }

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -534,7 +534,6 @@ where
     }
 }
 
-#[async_trait]
 impl<S, A> AccountStore for FetchingStore<S, A>
 where
     S: AccountStore + Send,

--- a/apps/hash-graph/lib/graph/src/store/migration.rs
+++ b/apps/hash-graph/lib/graph/src/store/migration.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use error_stack::Result;
 
 use super::error::MigrationError;
@@ -54,8 +53,7 @@ impl Migration {
 ///
 /// In addition to the errors described in the methods of this trait, further errors might also be
 /// raised depending on the implementation, e.g. connection issues.
-#[async_trait]
-pub trait StoreMigration: Sync {
+pub trait StoreMigration {
     async fn run_migrations(&mut self) -> Result<Vec<Migration>, MigrationError>;
 
     async fn all_migrations(&mut self) -> Result<Vec<Migration>, MigrationError>;

--- a/apps/hash-graph/lib/graph/src/store/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/store/ontology.rs
@@ -103,7 +103,6 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
 }
 
 /// Describes the API of a store implementation for [`PropertyType`]s.
-#[async_trait]
 pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     /// Creates a new [`PropertyType`].
     ///
@@ -133,57 +132,57 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     /// - if any [`BaseUrl`] of the property type already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    async fn create_property_types(
+    fn create_property_types(
         &mut self,
         property_types: impl IntoIterator<
             Item = (PropertyType, PartialOntologyElementMetadata),
             IntoIter: Send,
         > + Send,
         on_conflict: ConflictBehavior,
-    ) -> Result<Vec<OntologyElementMetadata>, InsertionError>;
+    ) -> impl Future<Output = Result<Vec<OntologyElementMetadata>, InsertionError>> + Send;
 
     /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`PropertyType`] doesn't exist.
-    async fn get_property_type(
+    fn get_property_type(
         &self,
         query: &StructuralQuery<PropertyTypeWithMetadata>,
-    ) -> Result<Subgraph, QueryError>;
+    ) -> impl Future<Output = Result<Subgraph, QueryError>> + Send;
 
     /// Update the definition of an existing [`PropertyType`].
     ///
     /// # Errors
     ///
     /// - if the [`PropertyType`] doesn't exist.
-    async fn update_property_type(
+    fn update_property_type(
         &mut self,
         property_type: PropertyType,
         actor_id: RecordCreatedById,
-    ) -> Result<OntologyElementMetadata, UpdateError>;
+    ) -> impl Future<Output = Result<OntologyElementMetadata, UpdateError>> + Send;
 
     /// Archives the definition of an existing [`PropertyType`].
     ///
     /// # Errors
     ///
     /// - if the [`PropertyType`] doesn't exist.
-    async fn archive_property_type(
+    fn archive_property_type(
         &mut self,
         id: &VersionedUrl,
         actor_id: RecordArchivedById,
-    ) -> Result<OntologyTemporalMetadata, UpdateError>;
+    ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
 
     /// Restores the definition of an existing [`PropertyType`].
     ///
     /// # Errors
     ///
     /// - if the [`PropertyType`] doesn't exist.
-    async fn unarchive_property_type(
+    fn unarchive_property_type(
         &mut self,
         id: &VersionedUrl,
         actor_id: RecordCreatedById,
-    ) -> Result<OntologyTemporalMetadata, UpdateError>;
+    ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
 }
 
 /// Describes the API of a store implementation for [`EntityType`]s.

--- a/apps/hash-graph/lib/graph/src/store/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/store/ontology.rs
@@ -1,4 +1,4 @@
-use std::iter;
+use std::{future::Future, iter};
 
 use async_trait::async_trait;
 use error_stack::Result;
@@ -187,7 +187,6 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
 }
 
 /// Describes the API of a store implementation for [`EntityType`]s.
-#[async_trait]
 pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     /// Creates a new [`EntityType`].
     ///
@@ -217,54 +216,54 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     /// - if any [`BaseUrl`] of the entity type already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    async fn create_entity_types(
+    fn create_entity_types(
         &mut self,
         entity_types: impl IntoIterator<Item = (EntityType, PartialEntityTypeMetadata), IntoIter: Send>
         + Send,
         on_conflict: ConflictBehavior,
-    ) -> Result<Vec<EntityTypeMetadata>, InsertionError>;
+    ) -> impl Future<Output = Result<Vec<EntityTypeMetadata>, InsertionError>> + Send;
 
     /// Get the [`Subgraph`]s specified by the [`StructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`EntityType`] doesn't exist.
-    async fn get_entity_type(
+    fn get_entity_type(
         &self,
         query: &StructuralQuery<EntityTypeWithMetadata>,
-    ) -> Result<Subgraph, QueryError>;
+    ) -> impl Future<Output = Result<Subgraph, QueryError>> + Send;
 
     /// Update the definition of an existing [`EntityType`].
     ///
     /// # Errors
     ///
     /// - if the [`EntityType`] doesn't exist.
-    async fn update_entity_type(
+    fn update_entity_type(
         &mut self,
         entity_type: EntityType,
         actor_id: RecordCreatedById,
         label_property: Option<BaseUrl>,
-    ) -> Result<EntityTypeMetadata, UpdateError>;
+    ) -> impl Future<Output = Result<EntityTypeMetadata, UpdateError>> + Send;
 
     /// Archives the definition of an existing [`EntityType`].
     ///
     /// # Errors
     ///
     /// - if the [`EntityType`] doesn't exist.
-    async fn archive_entity_type(
+    fn archive_entity_type(
         &mut self,
         id: &VersionedUrl,
         actor_id: RecordArchivedById,
-    ) -> Result<OntologyTemporalMetadata, UpdateError>;
+    ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
 
     /// Restores the definition of an existing [`EntityType`].
     ///
     /// # Errors
     ///
     /// - if the [`EntityType`] doesn't exist.
-    async fn unarchive_entity_type(
+    fn unarchive_entity_type(
         &mut self,
         id: &VersionedUrl,
         actor_id: RecordCreatedById,
-    ) -> Result<OntologyTemporalMetadata, UpdateError>;
+    ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
 }

--- a/apps/hash-graph/lib/graph/src/store/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/store/ontology.rs
@@ -1,6 +1,5 @@
 use std::{future::Future, iter};
 
-use async_trait::async_trait;
 use error_stack::Result;
 use graph_types::{
     ontology::{
@@ -21,7 +20,6 @@ use crate::{
 };
 
 /// Describes the API of a store implementation for [`DataType`]s.
-#[async_trait]
 pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     /// Creates a new [`DataType`].
     ///
@@ -51,55 +49,55 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     /// - if any [`BaseUrl`] of the data type already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    async fn create_data_types(
+    fn create_data_types(
         &mut self,
         data_types: impl IntoIterator<Item = (DataType, PartialOntologyElementMetadata), IntoIter: Send>
         + Send,
         on_conflict: ConflictBehavior,
-    ) -> Result<Vec<OntologyElementMetadata>, InsertionError>;
+    ) -> impl Future<Output = Result<Vec<OntologyElementMetadata>, InsertionError>> + Send;
 
     /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`DataType`] doesn't exist.
-    async fn get_data_type(
+    fn get_data_type(
         &self,
-        query: &StructuralQuery<DataTypeWithMetadata>,
-    ) -> Result<Subgraph, QueryError>;
+        query: &StructuralQuery<'_, DataTypeWithMetadata>,
+    ) -> impl Future<Output = Result<Subgraph, QueryError>> + Send;
 
     /// Update the definition of an existing [`DataType`].
     ///
     /// # Errors
     ///
     /// - if the [`DataType`] doesn't exist.
-    async fn update_data_type(
+    fn update_data_type(
         &mut self,
         data_type: DataType,
         actor_id: RecordCreatedById,
-    ) -> Result<OntologyElementMetadata, UpdateError>;
+    ) -> impl Future<Output = Result<OntologyElementMetadata, UpdateError>> + Send;
 
     /// Archives the definition of an existing [`DataType`].
     ///
     /// # Errors
     ///
     /// - if the [`DataType`] doesn't exist.
-    async fn archive_data_type(
+    fn archive_data_type(
         &mut self,
         id: &VersionedUrl,
         actor_id: RecordArchivedById,
-    ) -> Result<OntologyTemporalMetadata, UpdateError>;
+    ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
 
     /// Restores the definition of an existing [`DataType`].
     ///
     /// # Errors
     ///
     /// - if the [`DataType`] doesn't exist.
-    async fn unarchive_data_type(
+    fn unarchive_data_type(
         &mut self,
         id: &VersionedUrl,
         actor_id: RecordCreatedById,
-    ) -> Result<OntologyTemporalMetadata, UpdateError>;
+    ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
 }
 
 /// Describes the API of a store implementation for [`PropertyType`]s.

--- a/apps/hash-graph/lib/graph/src/store/pool.rs
+++ b/apps/hash-graph/lib/graph/src/store/pool.rs
@@ -1,10 +1,10 @@
-use async_trait::async_trait;
+use std::future::Future;
+
 use error_stack::Result;
 
 use crate::store::Store;
 
 /// Managed pool to keep track about [`Store`]s.
-#[async_trait]
 pub trait StorePool: Sync {
     /// The error returned when acquiring a [`Store`].
     type Error;
@@ -13,12 +13,14 @@ pub trait StorePool: Sync {
     type Store<'pool>: Store + Send;
 
     /// Retrieves a [`Store`] from the pool.
-    async fn acquire(&self) -> Result<Self::Store<'_>, Self::Error>;
+    fn acquire(&self) -> impl Future<Output = Result<Self::Store<'_>, Self::Error>> + Send;
 
     /// Retrieves an owned [`Store`] from the pool.
     ///
     /// Using an owned [`Store`] makes it easier to leak the connection pool. Therefore,
     /// [`StorePool::acquire`] (which stores a lifetime-bound reference to the `StorePool`) should
     /// be preferred whenever possible.
-    async fn acquire_owned(&self) -> Result<Self::Store<'static>, Self::Error>;
+    fn acquire_owned(
+        &self,
+    ) -> impl Future<Output = Result<Self::Store<'static>, Self::Error>> + Send;
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres.rs
@@ -6,7 +6,6 @@ mod pool;
 mod query;
 mod traversal_context;
 
-use async_trait::async_trait;
 use error_stack::{Report, Result, ResultExt};
 #[cfg(hash_graph_test_environment)]
 use graph_types::knowledge::{
@@ -1197,7 +1196,6 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
     }
 }
 
-#[async_trait]
 impl<C: AsClient> AccountStore for PostgresStore<C> {
     #[tracing::instrument(level = "info", skip(self))]
     async fn insert_account_id(&mut self, account_id: AccountId) -> Result<(), InsertionError> {

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -2,7 +2,6 @@ mod read;
 
 use std::collections::HashMap;
 
-use async_trait::async_trait;
 use error_stack::{Report, Result, ResultExt};
 use graph_types::{
     knowledge::{
@@ -212,7 +211,6 @@ impl<C: AsClient> PostgresStore<C> {
     }
 }
 
-#[async_trait]
 impl<C: AsClient> EntityStore for PostgresStore<C> {
     #[tracing::instrument(level = "info", skip(self, properties))]
     async fn create_entity(
@@ -504,7 +502,10 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
     }
 
     #[tracing::instrument(level = "info", skip(self))]
-    async fn get_entity(&self, query: &StructuralQuery<Entity>) -> Result<Subgraph, QueryError> {
+    async fn get_entity(
+        &self,
+        query: &StructuralQuery<'_, Entity>,
+    ) -> Result<Subgraph, QueryError> {
         let StructuralQuery {
             ref filter,
             graph_resolve_depths,

--- a/apps/hash-graph/lib/graph/src/store/postgres/migration.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/migration.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use error_stack::{Result, ResultExt};
 use tokio_postgres::Client;
 
@@ -14,7 +13,6 @@ mod embedded {
     embed_migrations!("../../postgres_migrations");
 }
 
-#[async_trait]
 impl<C: AsClient<Client = Client>> StoreMigration for PostgresStore<C> {
     async fn run_migrations(&mut self) -> Result<Vec<Migration>, MigrationError> {
         Ok(embedded::migrations::runner()

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 
-use async_trait::async_trait;
 use error_stack::{Report, Result, ResultExt};
 use futures::{stream, TryStreamExt};
 use graph_types::{
@@ -77,7 +76,6 @@ impl<C: AsClient> PostgresStore<C> {
     }
 }
 
-#[async_trait]
 impl<C: AsClient> DataTypeStore for PostgresStore<C> {
     #[tracing::instrument(level = "info", skip(self, data_types))]
     async fn create_data_types(
@@ -112,7 +110,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
     #[tracing::instrument(level = "info", skip(self))]
     async fn get_data_type(
         &self,
-        query: &StructuralQuery<DataTypeWithMetadata>,
+        query: &StructuralQuery<'_, DataTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError> {
         let StructuralQuery {
             ref filter,

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet};
 
-use async_trait::async_trait;
 use error_stack::{Report, Result, ResultExt};
 use futures::{stream, TryStreamExt};
 use graph_types::{
@@ -202,7 +201,6 @@ impl<C: AsClient> PostgresStore<C> {
     }
 }
 
-#[async_trait]
 impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
     #[tracing::instrument(level = "info", skip(self, entity_types))]
     async fn create_entity_types(
@@ -258,7 +256,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
     #[tracing::instrument(level = "info", skip(self))]
     async fn get_entity_type(
         &self,
-        query: &StructuralQuery<EntityTypeWithMetadata>,
+        query: &StructuralQuery<'_, EntityTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError> {
         let StructuralQuery {
             ref filter,

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet};
 
-use async_trait::async_trait;
 use error_stack::{Report, Result, ResultExt};
 use futures::{stream, TryStreamExt};
 use graph_types::{
@@ -174,7 +173,6 @@ impl<C: AsClient> PostgresStore<C> {
     }
 }
 
-#[async_trait]
 impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
     #[tracing::instrument(level = "info", skip(self, property_types))]
     async fn create_property_types(
@@ -230,7 +228,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
     #[tracing::instrument(level = "info", skip(self))]
     async fn get_property_type(
         &self,
-        query: &StructuralQuery<PropertyTypeWithMetadata>,
+        query: &StructuralQuery<'_, PropertyTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError> {
         let StructuralQuery {
             ref filter,

--- a/apps/hash-graph/lib/graph/src/store/postgres/pool.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/pool.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use bb8_postgres::{
     bb8::{ErrorSink, ManageConnection, Pool, PooledConnection, RunError},
     PostgresConnectionManager,
@@ -66,7 +65,6 @@ where
     }
 }
 
-#[async_trait]
 impl<Tls: Clone + Send + Sync + 'static> StorePool for PostgresStorePool<Tls>
 where
     Tls: MakeTlsConnect<


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

On `nightly` it's possible to replace the amazing `#[async_trait]` by the native implementation.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
## ⚠️ Known issues

Replacing `Read` - the last remaining `trait` using `#[async_trait]` - is left as an exercise for the reader/reviewer.