### PR TITLE
Revert "H-721: Replace almost all `#[async_trait]` usages with native `async trait` (#3099)"

### DIFF
--- a/apps/hash-graph/lib/graph/src/api/rest.rs
+++ b/apps/hash-graph/lib/graph/src/api/rest.rs
@@ -18,8 +18,9 @@ mod entity;
 mod entity_type;
 mod property_type;
 
-use std::{fs, future::Future, io, sync::Arc};
+use std::{fs, io, sync::Arc};
 
+use async_trait::async_trait;
 use axum::{
     extract::Path,
     http::StatusCode,
@@ -80,15 +81,17 @@ use crate::{
     },
 };
 
+#[async_trait]
 pub trait RestApiStore: Store + TypeFetcher {
-    fn load_external_type(
+    async fn load_external_type(
         &mut self,
         domain_validator: &DomainValidator,
         reference: OntologyTypeReference<'_>,
         actor_id: RecordCreatedById,
-    ) -> impl Future<Output = Result<OntologyElementMetadata, StatusCode>> + Send;
+    ) -> Result<OntologyElementMetadata, StatusCode>;
 }
 
+#[async_trait]
 impl<S> RestApiStore for S
 where
     S: Store + TypeFetcher + Send,

--- a/apps/hash-graph/lib/graph/src/lib.rs
+++ b/apps/hash-graph/lib/graph/src/lib.rs
@@ -10,7 +10,6 @@
 #![feature(type_alias_impl_trait)]
 #![feature(hash_raw_entry)]
 #![feature(bound_map)]
-#![feature(async_fn_in_trait, return_position_impl_trait_in_trait)]
 #![cfg_attr(all(doc, nightly), feature(doc_auto_cfg))]
 #![cfg_attr(not(miri), doc(test(attr(deny(warnings, clippy::all)))))]
 

--- a/apps/hash-graph/lib/graph/src/store/account.rs
+++ b/apps/hash-graph/lib/graph/src/store/account.rs
@@ -1,19 +1,16 @@
-use std::future::Future;
-
+use async_trait::async_trait;
 use error_stack::Result;
 use graph_types::account::AccountId;
 
 use crate::store::InsertionError;
 
 /// Describes the API of a store implementation for accounts.
+#[async_trait]
 pub trait AccountStore {
     /// Inserts the specified [`AccountId`] into the database.
     ///
     /// # Errors
     ///
     /// - if insertion failed, e.g. because the [`AccountId`] already exists.
-    fn insert_account_id(
-        &mut self,
-        account_id: AccountId,
-    ) -> impl Future<Output = Result<(), InsertionError>> + Send;
+    async fn insert_account_id(&mut self, account_id: AccountId) -> Result<(), InsertionError>;
 }

--- a/apps/hash-graph/lib/graph/src/store/fetcher.rs
+++ b/apps/hash-graph/lib/graph/src/store/fetcher.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::{HashMap, HashSet},
-    future::Future,
     iter::once,
     mem,
 };
@@ -51,13 +50,14 @@ use crate::{
     },
 };
 
+#[async_trait]
 pub trait TypeFetcher {
     /// Fetches the provided type reference and inserts it to the Graph.
-    fn insert_external_ontology_type(
+    async fn insert_external_ontology_type(
         &mut self,
         reference: OntologyTypeReference<'_>,
         actor_id: RecordCreatedById,
-    ) -> impl Future<Output = Result<OntologyElementMetadata, InsertionError>> + Send;
+    ) -> Result<OntologyElementMetadata, InsertionError>;
 }
 
 #[derive(Clone)]
@@ -95,6 +95,7 @@ where
     }
 }
 
+#[async_trait]
 impl<P, A> StorePool for FetchingPool<P, A>
 where
     P: StorePool + Send + Sync,
@@ -380,7 +381,9 @@ where
         &mut self,
         ontology_types: impl IntoIterator<Item = (&'o T, RecordCreatedById), IntoIter: Send> + Send,
     ) -> Result<(), InsertionError> {
-        // TODO: Figure out how to avoid collecting the iterator first.
+        // Without collecting it first, we get a "Higher-ranked lifetime error" because of the
+        // limitations of Rust being able to look into a `Pin<Box<dyn Future>>`, which is returned
+        // by `#[async_trait]` methods.
         let ontology_types = ontology_types.into_iter().collect::<Vec<_>>();
 
         let mut partitioned_ontology_types = HashMap::<RecordCreatedById, Vec<VersionedUrl>>::new();
@@ -483,6 +486,7 @@ where
     }
 }
 
+#[async_trait]
 impl<S, A> TypeFetcher for FetchingStore<S, A>
 where
     A: ToSocketAddrs + Send + Sync,
@@ -532,6 +536,7 @@ where
     }
 }
 
+#[async_trait]
 impl<S, A> AccountStore for FetchingStore<S, A>
 where
     S: AccountStore + Send,
@@ -542,6 +547,7 @@ where
     }
 }
 
+#[async_trait]
 impl<S, A> DataTypeStore for FetchingStore<S, A>
 where
     S: DataTypeStore + PropertyTypeStore + EntityTypeStore + Send,
@@ -565,7 +571,7 @@ where
 
     async fn get_data_type(
         &self,
-        query: &StructuralQuery<'_, DataTypeWithMetadata>,
+        query: &StructuralQuery<DataTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError> {
         self.store.get_data_type(query).await
     }
@@ -599,6 +605,7 @@ where
     }
 }
 
+#[async_trait]
 impl<S, A> PropertyTypeStore for FetchingStore<S, A>
 where
     S: DataTypeStore + PropertyTypeStore + EntityTypeStore + Send,
@@ -629,7 +636,7 @@ where
 
     async fn get_property_type(
         &self,
-        query: &StructuralQuery<'_, PropertyTypeWithMetadata>,
+        query: &StructuralQuery<PropertyTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError> {
         self.store.get_property_type(query).await
     }
@@ -665,6 +672,7 @@ where
     }
 }
 
+#[async_trait]
 impl<S, A> EntityTypeStore for FetchingStore<S, A>
 where
     S: DataTypeStore + PropertyTypeStore + EntityTypeStore + Send,
@@ -693,7 +701,7 @@ where
 
     async fn get_entity_type(
         &self,
-        query: &StructuralQuery<'_, EntityTypeWithMetadata>,
+        query: &StructuralQuery<EntityTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError> {
         self.store.get_entity_type(query).await
     }
@@ -730,6 +738,7 @@ where
     }
 }
 
+#[async_trait]
 impl<S, A> EntityStore for FetchingStore<S, A>
 where
     S: DataTypeStore + PropertyTypeStore + EntityTypeStore + EntityStore + Send,
@@ -800,10 +809,7 @@ where
             .await
     }
 
-    async fn get_entity(
-        &self,
-        query: &StructuralQuery<'_, Entity>,
-    ) -> Result<Subgraph, QueryError> {
+    async fn get_entity(&self, query: &StructuralQuery<Entity>) -> Result<Subgraph, QueryError> {
         self.store.get_entity(query).await
     }
 

--- a/apps/hash-graph/lib/graph/src/store/knowledge.rs
+++ b/apps/hash-graph/lib/graph/src/store/knowledge.rs
@@ -1,5 +1,4 @@
-use std::future::Future;
-
+use async_trait::async_trait;
 use error_stack::Result;
 use graph_types::{
     knowledge::{
@@ -19,6 +18,7 @@ use crate::{
 /// Describes the API of a store implementation for [Entities].
 ///
 /// [Entities]: Entity
+#[async_trait]
 pub trait EntityStore: crud::Read<Entity> {
     /// Creates a new [`Entity`].
     ///
@@ -31,7 +31,7 @@ pub trait EntityStore: crud::Read<Entity> {
     ///
     /// [`EntityType`]: type_system::EntityType
     #[expect(clippy::too_many_arguments)]
-    fn create_entity(
+    async fn create_entity(
         &mut self,
         owned_by_id: OwnedById,
         entity_uuid: Option<EntityUuid>,
@@ -41,7 +41,7 @@ pub trait EntityStore: crud::Read<Entity> {
         entity_type_id: VersionedUrl,
         properties: EntityProperties,
         link_data: Option<LinkData>,
-    ) -> impl Future<Output = Result<EntityMetadata, InsertionError>> + Send;
+    ) -> Result<EntityMetadata, InsertionError>;
 
     /// Inserts the entities with the specified [`EntityType`] into the `Store`.
     ///
@@ -62,7 +62,7 @@ pub trait EntityStore: crud::Read<Entity> {
     /// [`EntityType`]: type_system::EntityType
     #[doc(hidden)]
     #[cfg(hash_graph_test_environment)]
-    fn insert_entities_batched_by_type(
+    async fn insert_entities_batched_by_type(
         &mut self,
         entities: impl IntoIterator<
             Item = (
@@ -76,17 +76,14 @@ pub trait EntityStore: crud::Read<Entity> {
         > + Send,
         actor_id: RecordCreatedById,
         entity_type_id: &VersionedUrl,
-    ) -> impl Future<Output = Result<Vec<EntityMetadata>, InsertionError>> + Send;
+    ) -> Result<Vec<EntityMetadata>, InsertionError>;
 
     /// Get the [`Subgraph`]s specified by the [`StructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`Entity`] doesn't exist
-    fn get_entity(
-        &self,
-        query: &StructuralQuery<Entity>,
-    ) -> impl Future<Output = Result<Subgraph, QueryError>> + Send;
+    async fn get_entity(&self, query: &StructuralQuery<Entity>) -> Result<Subgraph, QueryError>;
 
     /// Update an existing [`Entity`].
     ///
@@ -99,7 +96,7 @@ pub trait EntityStore: crud::Read<Entity> {
     ///
     /// [`EntityType`]: type_system::EntityType
     #[expect(clippy::too_many_arguments)]
-    fn update_entity(
+    async fn update_entity(
         &mut self,
         entity_id: EntityId,
         decision_time: Option<Timestamp<DecisionTime>>,
@@ -108,5 +105,5 @@ pub trait EntityStore: crud::Read<Entity> {
         entity_type_id: VersionedUrl,
         properties: EntityProperties,
         link_order: EntityLinkOrder,
-    ) -> impl Future<Output = Result<EntityMetadata, UpdateError>> + Send;
+    ) -> Result<EntityMetadata, UpdateError>;
 }

--- a/apps/hash-graph/lib/graph/src/store/migration.rs
+++ b/apps/hash-graph/lib/graph/src/store/migration.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use error_stack::Result;
 
 use super::error::MigrationError;
@@ -53,7 +54,8 @@ impl Migration {
 ///
 /// In addition to the errors described in the methods of this trait, further errors might also be
 /// raised depending on the implementation, e.g. connection issues.
-pub trait StoreMigration {
+#[async_trait]
+pub trait StoreMigration: Sync {
     async fn run_migrations(&mut self) -> Result<Vec<Migration>, MigrationError>;
 
     async fn all_migrations(&mut self) -> Result<Vec<Migration>, MigrationError>;

--- a/apps/hash-graph/lib/graph/src/store/ontology.rs
+++ b/apps/hash-graph/lib/graph/src/store/ontology.rs
@@ -1,5 +1,6 @@
-use std::{future::Future, iter};
+use std::iter;
 
+use async_trait::async_trait;
 use error_stack::Result;
 use graph_types::{
     ontology::{
@@ -20,6 +21,7 @@ use crate::{
 };
 
 /// Describes the API of a store implementation for [`DataType`]s.
+#[async_trait]
 pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     /// Creates a new [`DataType`].
     ///
@@ -49,58 +51,59 @@ pub trait DataTypeStore: crud::Read<DataTypeWithMetadata> {
     /// - if any [`BaseUrl`] of the data type already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    fn create_data_types(
+    async fn create_data_types(
         &mut self,
         data_types: impl IntoIterator<Item = (DataType, PartialOntologyElementMetadata), IntoIter: Send>
         + Send,
         on_conflict: ConflictBehavior,
-    ) -> impl Future<Output = Result<Vec<OntologyElementMetadata>, InsertionError>> + Send;
+    ) -> Result<Vec<OntologyElementMetadata>, InsertionError>;
 
     /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`DataType`] doesn't exist.
-    fn get_data_type(
+    async fn get_data_type(
         &self,
-        query: &StructuralQuery<'_, DataTypeWithMetadata>,
-    ) -> impl Future<Output = Result<Subgraph, QueryError>> + Send;
+        query: &StructuralQuery<DataTypeWithMetadata>,
+    ) -> Result<Subgraph, QueryError>;
 
     /// Update the definition of an existing [`DataType`].
     ///
     /// # Errors
     ///
     /// - if the [`DataType`] doesn't exist.
-    fn update_data_type(
+    async fn update_data_type(
         &mut self,
         data_type: DataType,
         actor_id: RecordCreatedById,
-    ) -> impl Future<Output = Result<OntologyElementMetadata, UpdateError>> + Send;
+    ) -> Result<OntologyElementMetadata, UpdateError>;
 
     /// Archives the definition of an existing [`DataType`].
     ///
     /// # Errors
     ///
     /// - if the [`DataType`] doesn't exist.
-    fn archive_data_type(
+    async fn archive_data_type(
         &mut self,
         id: &VersionedUrl,
         actor_id: RecordArchivedById,
-    ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
+    ) -> Result<OntologyTemporalMetadata, UpdateError>;
 
     /// Restores the definition of an existing [`DataType`].
     ///
     /// # Errors
     ///
     /// - if the [`DataType`] doesn't exist.
-    fn unarchive_data_type(
+    async fn unarchive_data_type(
         &mut self,
         id: &VersionedUrl,
         actor_id: RecordCreatedById,
-    ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
+    ) -> Result<OntologyTemporalMetadata, UpdateError>;
 }
 
 /// Describes the API of a store implementation for [`PropertyType`]s.
+#[async_trait]
 pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     /// Creates a new [`PropertyType`].
     ///
@@ -130,60 +133,61 @@ pub trait PropertyTypeStore: crud::Read<PropertyTypeWithMetadata> {
     /// - if any [`BaseUrl`] of the property type already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    fn create_property_types(
+    async fn create_property_types(
         &mut self,
         property_types: impl IntoIterator<
             Item = (PropertyType, PartialOntologyElementMetadata),
             IntoIter: Send,
         > + Send,
         on_conflict: ConflictBehavior,
-    ) -> impl Future<Output = Result<Vec<OntologyElementMetadata>, InsertionError>> + Send;
+    ) -> Result<Vec<OntologyElementMetadata>, InsertionError>;
 
     /// Get the [`Subgraph`] specified by the [`StructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`PropertyType`] doesn't exist.
-    fn get_property_type(
+    async fn get_property_type(
         &self,
         query: &StructuralQuery<PropertyTypeWithMetadata>,
-    ) -> impl Future<Output = Result<Subgraph, QueryError>> + Send;
+    ) -> Result<Subgraph, QueryError>;
 
     /// Update the definition of an existing [`PropertyType`].
     ///
     /// # Errors
     ///
     /// - if the [`PropertyType`] doesn't exist.
-    fn update_property_type(
+    async fn update_property_type(
         &mut self,
         property_type: PropertyType,
         actor_id: RecordCreatedById,
-    ) -> impl Future<Output = Result<OntologyElementMetadata, UpdateError>> + Send;
+    ) -> Result<OntologyElementMetadata, UpdateError>;
 
     /// Archives the definition of an existing [`PropertyType`].
     ///
     /// # Errors
     ///
     /// - if the [`PropertyType`] doesn't exist.
-    fn archive_property_type(
+    async fn archive_property_type(
         &mut self,
         id: &VersionedUrl,
         actor_id: RecordArchivedById,
-    ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
+    ) -> Result<OntologyTemporalMetadata, UpdateError>;
 
     /// Restores the definition of an existing [`PropertyType`].
     ///
     /// # Errors
     ///
     /// - if the [`PropertyType`] doesn't exist.
-    fn unarchive_property_type(
+    async fn unarchive_property_type(
         &mut self,
         id: &VersionedUrl,
         actor_id: RecordCreatedById,
-    ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
+    ) -> Result<OntologyTemporalMetadata, UpdateError>;
 }
 
 /// Describes the API of a store implementation for [`EntityType`]s.
+#[async_trait]
 pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     /// Creates a new [`EntityType`].
     ///
@@ -213,54 +217,54 @@ pub trait EntityTypeStore: crud::Read<EntityTypeWithMetadata> {
     /// - if any [`BaseUrl`] of the entity type already exists.
     ///
     /// [`BaseUrl`]: type_system::url::BaseUrl
-    fn create_entity_types(
+    async fn create_entity_types(
         &mut self,
         entity_types: impl IntoIterator<Item = (EntityType, PartialEntityTypeMetadata), IntoIter: Send>
         + Send,
         on_conflict: ConflictBehavior,
-    ) -> impl Future<Output = Result<Vec<EntityTypeMetadata>, InsertionError>> + Send;
+    ) -> Result<Vec<EntityTypeMetadata>, InsertionError>;
 
     /// Get the [`Subgraph`]s specified by the [`StructuralQuery`].
     ///
     /// # Errors
     ///
     /// - if the requested [`EntityType`] doesn't exist.
-    fn get_entity_type(
+    async fn get_entity_type(
         &self,
         query: &StructuralQuery<EntityTypeWithMetadata>,
-    ) -> impl Future<Output = Result<Subgraph, QueryError>> + Send;
+    ) -> Result<Subgraph, QueryError>;
 
     /// Update the definition of an existing [`EntityType`].
     ///
     /// # Errors
     ///
     /// - if the [`EntityType`] doesn't exist.
-    fn update_entity_type(
+    async fn update_entity_type(
         &mut self,
         entity_type: EntityType,
         actor_id: RecordCreatedById,
         label_property: Option<BaseUrl>,
-    ) -> impl Future<Output = Result<EntityTypeMetadata, UpdateError>> + Send;
+    ) -> Result<EntityTypeMetadata, UpdateError>;
 
     /// Archives the definition of an existing [`EntityType`].
     ///
     /// # Errors
     ///
     /// - if the [`EntityType`] doesn't exist.
-    fn archive_entity_type(
+    async fn archive_entity_type(
         &mut self,
         id: &VersionedUrl,
         actor_id: RecordArchivedById,
-    ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
+    ) -> Result<OntologyTemporalMetadata, UpdateError>;
 
     /// Restores the definition of an existing [`EntityType`].
     ///
     /// # Errors
     ///
     /// - if the [`EntityType`] doesn't exist.
-    fn unarchive_entity_type(
+    async fn unarchive_entity_type(
         &mut self,
         id: &VersionedUrl,
         actor_id: RecordCreatedById,
-    ) -> impl Future<Output = Result<OntologyTemporalMetadata, UpdateError>> + Send;
+    ) -> Result<OntologyTemporalMetadata, UpdateError>;
 }

--- a/apps/hash-graph/lib/graph/src/store/pool.rs
+++ b/apps/hash-graph/lib/graph/src/store/pool.rs
@@ -1,10 +1,10 @@
-use std::future::Future;
-
+use async_trait::async_trait;
 use error_stack::Result;
 
 use crate::store::Store;
 
 /// Managed pool to keep track about [`Store`]s.
+#[async_trait]
 pub trait StorePool: Sync {
     /// The error returned when acquiring a [`Store`].
     type Error;
@@ -13,14 +13,12 @@ pub trait StorePool: Sync {
     type Store<'pool>: Store + Send;
 
     /// Retrieves a [`Store`] from the pool.
-    fn acquire(&self) -> impl Future<Output = Result<Self::Store<'_>, Self::Error>> + Send;
+    async fn acquire(&self) -> Result<Self::Store<'_>, Self::Error>;
 
     /// Retrieves an owned [`Store`] from the pool.
     ///
     /// Using an owned [`Store`] makes it easier to leak the connection pool. Therefore,
     /// [`StorePool::acquire`] (which stores a lifetime-bound reference to the `StorePool`) should
     /// be preferred whenever possible.
-    fn acquire_owned(
-        &self,
-    ) -> impl Future<Output = Result<Self::Store<'static>, Self::Error>> + Send;
+    async fn acquire_owned(&self) -> Result<Self::Store<'static>, Self::Error>;
 }

--- a/apps/hash-graph/lib/graph/src/store/postgres.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres.rs
@@ -6,6 +6,7 @@ mod pool;
 mod query;
 mod traversal_context;
 
+use async_trait::async_trait;
 use error_stack::{Report, Result, ResultExt};
 #[cfg(hash_graph_test_environment)]
 use graph_types::knowledge::{
@@ -1196,6 +1197,7 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
     }
 }
 
+#[async_trait]
 impl<C: AsClient> AccountStore for PostgresStore<C> {
     #[tracing::instrument(level = "info", skip(self))]
     async fn insert_account_id(&mut self, account_id: AccountId) -> Result<(), InsertionError> {

--- a/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/knowledge/entity.rs
@@ -2,6 +2,7 @@ mod read;
 
 use std::collections::HashMap;
 
+use async_trait::async_trait;
 use error_stack::{Report, Result, ResultExt};
 use graph_types::{
     knowledge::{
@@ -211,6 +212,7 @@ impl<C: AsClient> PostgresStore<C> {
     }
 }
 
+#[async_trait]
 impl<C: AsClient> EntityStore for PostgresStore<C> {
     #[tracing::instrument(level = "info", skip(self, properties))]
     async fn create_entity(
@@ -502,10 +504,7 @@ impl<C: AsClient> EntityStore for PostgresStore<C> {
     }
 
     #[tracing::instrument(level = "info", skip(self))]
-    async fn get_entity(
-        &self,
-        query: &StructuralQuery<'_, Entity>,
-    ) -> Result<Subgraph, QueryError> {
+    async fn get_entity(&self, query: &StructuralQuery<Entity>) -> Result<Subgraph, QueryError> {
         let StructuralQuery {
             ref filter,
             graph_resolve_depths,

--- a/apps/hash-graph/lib/graph/src/store/postgres/migration.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/migration.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use error_stack::{Result, ResultExt};
 use tokio_postgres::Client;
 
@@ -13,6 +14,7 @@ mod embedded {
     embed_migrations!("../../postgres_migrations");
 }
 
+#[async_trait]
 impl<C: AsClient<Client = Client>> StoreMigration for PostgresStore<C> {
     async fn run_migrations(&mut self) -> Result<Vec<Migration>, MigrationError> {
         Ok(embedded::migrations::runner()

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/data_type.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use async_trait::async_trait;
 use error_stack::{Report, Result, ResultExt};
 use futures::{stream, TryStreamExt};
 use graph_types::{
@@ -76,6 +77,7 @@ impl<C: AsClient> PostgresStore<C> {
     }
 }
 
+#[async_trait]
 impl<C: AsClient> DataTypeStore for PostgresStore<C> {
     #[tracing::instrument(level = "info", skip(self, data_types))]
     async fn create_data_types(
@@ -110,7 +112,7 @@ impl<C: AsClient> DataTypeStore for PostgresStore<C> {
     #[tracing::instrument(level = "info", skip(self))]
     async fn get_data_type(
         &self,
-        query: &StructuralQuery<'_, DataTypeWithMetadata>,
+        query: &StructuralQuery<DataTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError> {
         let StructuralQuery {
             ref filter,

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/entity_type.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use async_trait::async_trait;
 use error_stack::{Report, Result, ResultExt};
 use futures::{stream, TryStreamExt};
 use graph_types::{
@@ -201,6 +202,7 @@ impl<C: AsClient> PostgresStore<C> {
     }
 }
 
+#[async_trait]
 impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
     #[tracing::instrument(level = "info", skip(self, entity_types))]
     async fn create_entity_types(
@@ -256,7 +258,7 @@ impl<C: AsClient> EntityTypeStore for PostgresStore<C> {
     #[tracing::instrument(level = "info", skip(self))]
     async fn get_entity_type(
         &self,
-        query: &StructuralQuery<'_, EntityTypeWithMetadata>,
+        query: &StructuralQuery<EntityTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError> {
         let StructuralQuery {
             ref filter,

--- a/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/ontology/property_type.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use async_trait::async_trait;
 use error_stack::{Report, Result, ResultExt};
 use futures::{stream, TryStreamExt};
 use graph_types::{
@@ -173,6 +174,7 @@ impl<C: AsClient> PostgresStore<C> {
     }
 }
 
+#[async_trait]
 impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
     #[tracing::instrument(level = "info", skip(self, property_types))]
     async fn create_property_types(
@@ -228,7 +230,7 @@ impl<C: AsClient> PropertyTypeStore for PostgresStore<C> {
     #[tracing::instrument(level = "info", skip(self))]
     async fn get_property_type(
         &self,
-        query: &StructuralQuery<'_, PropertyTypeWithMetadata>,
+        query: &StructuralQuery<PropertyTypeWithMetadata>,
     ) -> Result<Subgraph, QueryError> {
         let StructuralQuery {
             ref filter,

--- a/apps/hash-graph/lib/graph/src/store/postgres/pool.rs
+++ b/apps/hash-graph/lib/graph/src/store/postgres/pool.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use bb8_postgres::{
     bb8::{ErrorSink, ManageConnection, Pool, PooledConnection, RunError},
     PostgresConnectionManager,
@@ -65,6 +66,7 @@ where
     }
 }
 
+#[async_trait]
 impl<Tls: Clone + Send + Sync + 'static> StorePool for PostgresStorePool<Tls>
 where
     Tls: MakeTlsConnect<


### PR DESCRIPTION
This reverts commit 52dfa7ed50426e6c7799fbf771cc6fecb43cb018.

## 🌟 What is the purpose of this PR?

It's amazing that `async trait` is there, now, but we encounter a huge impact on compile times. A build on my machine built in 15 seconds previously, with H-721 merged, takes 1m 6s.